### PR TITLE
LLM tool use, tabbed settings, and inspections UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@comunica/query-sparql-rdfjs": "^5.1.3",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0
       '@comunica/query-sparql-rdfjs':
         specifier: ^5.1.3
         version: 5.1.3(encoding@0.1.13)
@@ -99,6 +102,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -3174,6 +3186,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -4201,6 +4217,9 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
@@ -4512,6 +4531,10 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/sdk@0.90.0':
+    dependencies:
+      json-schema-to-ts: 3.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -9960,6 +9983,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-stringify-safe@5.0.1:
@@ -11108,6 +11136,8 @@ snapshots:
       escape-string-regexp: 1.0.5
 
   triple-beam@1.4.1: {}
+
+  ts-algebra@2.0.0: {}
 
   type-fest@0.13.1:
     optional: true

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -180,14 +180,28 @@ import THOUGHT_ONTOLOGY_TTL from '../../shared/ontology-thought.ttl?raw';
 
 const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
 
+// Ontology triples are loaded fresh on every startup and are not persisted
+// to .minerva/graph.ttl. Holding the parsed statements lets us (1) self-heal
+// old graph.ttl files that included the ontology by removing any matching
+// triples, and (2) strip them before writing on persistGraph().
+let ontologyStatements: $rdf.Statement[] = [];
+
 function addOntologyToStore(): void {
   if (!store) return;
+  const tempStore = $rdf.graph();
   try {
-    $rdf.parse(ONTOLOGY_TTL, store, MINERVA('').value, 'text/turtle');
+    $rdf.parse(ONTOLOGY_TTL, tempStore, MINERVA('').value, 'text/turtle');
   } catch { /* ontology parse failure is non-fatal */ }
   try {
-    $rdf.parse(THOUGHT_ONTOLOGY_TTL, store, THOUGHT('').value, 'text/turtle');
+    $rdf.parse(THOUGHT_ONTOLOGY_TTL, tempStore, THOUGHT('').value, 'text/turtle');
   } catch { /* thought ontology parse failure is non-fatal */ }
+  ontologyStatements = tempStore.statements.slice();
+  for (const st of ontologyStatements) {
+    store.removeMatches(st.subject, st.predicate, st.object);
+  }
+  for (const st of ontologyStatements) {
+    store.add(st.subject, st.predicate, st.object, st.graph);
+  }
 }
 
 // ── Init ────────────────────────────────────────────────────────────────────
@@ -205,9 +219,6 @@ export async function initGraph(rootPath: string): Promise<void> {
   // Initialize Comunica engine
   if (!engine) engine = new QueryEngine();
 
-  // Load the ontology definitions into the store
-  addOntologyToStore();
-
   // Load persisted graph if it exists
   const graphPath = path.join(metaDir, 'graph.ttl');
   try {
@@ -216,6 +227,11 @@ export async function initGraph(rootPath: string): Promise<void> {
   } catch {
     // No persisted graph yet, start fresh
   }
+
+  // Load ontology last: addOntologyToStore() strips any matching triples
+  // before re-adding, which self-heals graph.ttl files written by older
+  // versions that persisted the ontology alongside the user's data.
+  addOntologyToStore();
 }
 
 // ── Indexing ────────────────────────────────────────────────────────────────
@@ -625,7 +641,16 @@ export async function persistGraph(): Promise<void> {
   if (!store || !currentRootPath) return;
 
   const graphPath = path.join(currentRootPath, '.minerva', 'graph.ttl');
+  // Strip ontology triples before serializing — they're re-loaded fresh
+  // from the embedded resource on startup, so persisting them would
+  // cause duplication on the next load.
+  for (const st of ontologyStatements) {
+    store.removeMatches(st.subject, st.predicate, st.object);
+  }
   const turtle = serializeGraph();
+  for (const st of ontologyStatements) {
+    store.add(st.subject, st.predicate, st.object, st.graph);
+  }
   await fs.writeFile(graphPath, turtle, 'utf-8');
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -26,6 +26,47 @@ function winFromEvent(e: Electron.IpcMainInvokeEvent): BrowserWindow {
   return BrowserWindow.fromWebContents(e.sender)!;
 }
 
+const DEFAULT_CONVERSATION_SYSTEM_PROMPT = [
+  'You are an assistant embedded in Minerva, a markdown-based thinking tool.',
+  'The user is working inside a thoughtbase: a collection of interlinked notes backed by an RDF knowledge graph.',
+  '',
+  'You have six tools. Prefer the thoughtbase tools for anything inside the user\'s notes; use the web tools for facts, events, documentation, or sources outside the thoughtbase.',
+  '',
+  'Thoughtbase tools:',
+  '- search_notes: full-text search across the thoughtbase.',
+  '- read_note: read a specific note by its relative path.',
+  '- query_graph: run a SPARQL query against the knowledge graph (minerva/thought prefixes are auto-injected).',
+  '- describe_graph_schema: fetch the full ontology TTL. Call this before writing a non-trivial SPARQL query if you are unsure about class or predicate names.',
+  '',
+  'Web tools:',
+  '- web_search: search the web for current information, news, documentation, or external references.',
+  '- web_fetch: fetch the contents of a specific URL — use this after web_search to read a promising result in full, or when the user gives you a URL directly.',
+  '',
+  'Usage guidance:',
+  '- For questions about the user\'s notes or ideas they\'ve captured, use search_notes and read_note.',
+  '- For structural questions (what links to what, which notes share a tag, which claims cite a source), use query_graph; fall back to describe_graph_schema if a query fails or you are guessing at predicates.',
+  '- For current events, external facts, recent research, or things outside the thoughtbase, use web_search.',
+  '- It\'s often useful to combine tools: search_notes to see what the user already has, then web_search to fill in what they don\'t. Cite your web sources.',
+  '',
+  'You cannot modify the graph or create notes. If the user asks you to change something, describe the change clearly so they can apply it — or note that an approval-gated proposal tool will be added later.',
+  '',
+  'Answer in GitHub-flavored markdown. When you reference a note, cite its relative path so the user can open it.',
+].join('\n');
+
+function buildConversationSystemPrompt(
+  userSystem: string | undefined,
+  contextBundle: ContextBundle,
+): string {
+  const parts = [DEFAULT_CONVERSATION_SYSTEM_PROMPT];
+  if (contextBundle.notePath) {
+    parts.push('', `The user started this conversation from the note: ${contextBundle.notePath}`);
+  }
+  if (userSystem && userSystem.trim()) {
+    parts.push('', userSystem.trim());
+  }
+  return parts.join('\n');
+}
+
 function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null {
   const win = winFromEvent(e);
   return getRootPath(win.id);
@@ -325,6 +366,20 @@ export function registerIpcHandlers(): void {
     }
   });
 
+  ipcMain.handle(Channels.SHELL_OPEN_EXTERNAL, async (_e, url: string) => {
+    // Only http(s) — don't let anyone (or the LLM) coerce us into opening
+    // file://, javascript:, etc.
+    if (typeof url !== 'string') return;
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
+    await shell.openExternal(parsed.toString());
+  });
+
   // Inspections
   ipcMain.handle(Channels.INSPECTIONS_LIST, () => healthChecks.getInspections());
   ipcMain.handle(Channels.INSPECTIONS_RUN, () => healthChecks.runAllChecks());
@@ -426,22 +481,28 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(Channels.CONVERSATION_SEND, async (e, convId: string, userMessage: string, systemPrompt?: string) => {
     const win = winFromEvent(e);
+    const rootPath = rootPathFromEvent(e);
     const controller = new AbortController();
     convAbortControllers.set(win.id, controller);
 
     try {
-      // Append user message
       const conv = await conversation.appendMessage(convId, 'user', userMessage);
 
-      // Build message history for the LLM
-      const { complete: llmComplete } = await import('./llm/index');
+      const { completeWithTools } = await import('./llm/index');
       const messages = conv.messages
         .filter(m => m.role !== 'system')
         .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }));
 
-      const output = await llmComplete('', {
-        system: systemPrompt,
+      const effectiveSystem = buildConversationSystemPrompt(systemPrompt, conv.contextBundle);
+
+      if (!rootPath) {
+        throw new Error('No thoughtbase is open — cannot send conversation message.');
+      }
+
+      const result = await completeWithTools({
+        system: effectiveSystem,
         messages,
+        toolContext: { rootPath },
         callbacks: {
           onChunk: (chunk: string) => {
             if (!win.isDestroyed()) {
@@ -452,8 +513,12 @@ export function registerIpcHandlers(): void {
         },
       });
 
-      // Append assistant response
-      const updated = await conversation.appendMessage(convId, 'assistant', output);
+      const updated = await conversation.appendMessage(
+        convId,
+        'assistant',
+        result.text,
+        { citations: result.citations },
+      );
       return updated;
     } finally {
       convAbortControllers.delete(win.id);

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -56,12 +56,21 @@ export async function appendMessage(
   id: string,
   role: ConversationMessage['role'],
   content: string,
+  extra?: Partial<Pick<ConversationMessage, 'citations'>>,
 ): Promise<Conversation> {
   const conv = await load(id);
   if (!conv) throw new Error(`Conversation not found: ${id}`);
   if (conv.status !== 'active') throw new Error(`Conversation ${id} is ${conv.status}, cannot append`);
 
-  conv.messages.push({ role, content, timestamp: new Date().toISOString() });
+  const message: ConversationMessage = {
+    role,
+    content,
+    timestamp: new Date().toISOString(),
+  };
+  if (extra?.citations && extra.citations.length > 0) {
+    message.citations = extra.citations;
+  }
+  conv.messages.push(message);
   await persist(conv);
   return conv;
 }

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -1,4 +1,12 @@
+import Anthropic from '@anthropic-ai/sdk';
 import { getSettings } from './settings';
+import {
+  buildConversationTools,
+  executeNotebaseTool,
+  type ToolContext,
+} from './tools';
+import type { Citation } from '../../shared/types';
+import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 
 export interface StreamCallbacks {
   onChunk: (text: string) => void;
@@ -11,108 +19,216 @@ export interface ChatMessage {
 }
 
 export interface CompleteOptions {
-  /** System prompt (sets context for the conversation) */
   system?: string;
-  /** Multi-turn message history (alternative to single prompt) */
   messages?: ChatMessage[];
-  /** Streaming callbacks */
   callbacks?: StreamCallbacks;
 }
 
-/**
- * Call the Anthropic Messages API.
- * Supports single prompt (backward-compatible) or multi-turn with system prompt.
- */
-export async function complete(prompt: string, callbacksOrOptions?: StreamCallbacks | CompleteOptions): Promise<string> {
+export interface CompleteWithToolsOptions {
+  system: string;
+  messages: Anthropic.MessageParam[];
+  toolContext: ToolContext;
+  callbacks?: StreamCallbacks;
+  /** Hard cap on tool-use iterations. Defaults to 10. */
+  maxIterations?: number;
+}
+
+export interface CompleteWithToolsResult {
+  text: string;
+  citations: Citation[];
+}
+
+async function getClient(): Promise<{
+  client: Anthropic;
+  model: string;
+  web: NonNullable<Awaited<ReturnType<typeof getSettings>>['web']>;
+}> {
   const settings = await getSettings();
-
   if (!settings.apiKey) {
-    throw new Error('Anthropic API key not configured. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.');
+    throw new Error(
+      'Anthropic API key not configured. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.',
+    );
   }
+  return {
+    client: new Anthropic({ apiKey: settings.apiKey }),
+    model: settings.model,
+    web: settings.web ?? { ...DEFAULT_WEB_SETTINGS },
+  };
+}
 
-  // Resolve overloaded second argument
+/**
+ * Single-shot completion. Preserves the original API used by the Thinking
+ * Tools executor and conversation slash commands — no tool use, streaming
+ * controlled by the caller.
+ */
+export async function complete(
+  prompt: string,
+  callbacksOrOptions?: StreamCallbacks | CompleteOptions,
+): Promise<string> {
+  const { client, model } = await getClient();
+
   let system: string | undefined;
-  let messages: { role: string; content: string }[];
+  let messages: Anthropic.MessageParam[];
   let callbacks: StreamCallbacks | undefined;
 
   if (callbacksOrOptions && 'onChunk' in callbacksOrOptions) {
-    // Legacy: complete(prompt, streamCallbacks)
     callbacks = callbacksOrOptions;
     messages = [{ role: 'user', content: prompt }];
   } else if (callbacksOrOptions) {
-    // New: complete(prompt, { system, messages, callbacks })
     const opts = callbacksOrOptions as CompleteOptions;
     system = opts.system;
     callbacks = opts.callbacks;
-    messages = opts.messages ?? [{ role: 'user', content: prompt }];
+    messages = (opts.messages ?? [{ role: 'user', content: prompt }]) as Anthropic.MessageParam[];
   } else {
     messages = [{ role: 'user', content: prompt }];
   }
 
-  const body: Record<string, unknown> = {
-    model: settings.model,
-    max_tokens: 4096,
-    stream: !!callbacks,
-    messages,
-  };
-  if (system) body.system = system;
+  if (!callbacks) {
+    const response = await client.messages.create({
+      model,
+      max_tokens: 16000,
+      ...(system ? { system } : {}),
+      messages,
+    });
+    return extractText(response.content);
+  }
 
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': settings.apiKey,
-      'anthropic-version': '2023-06-01',
+  const stream = client.messages.stream({
+    model,
+    max_tokens: 64000,
+    ...(system ? { system } : {}),
+    messages,
+  }, { signal: callbacks.signal });
+
+  stream.on('text', (delta) => callbacks!.onChunk(delta));
+  const finalMessage = await stream.finalMessage();
+  return extractText(finalMessage.content);
+}
+
+/**
+ * Tool-enabled completion with streaming. Runs an agentic loop: streams text
+ * deltas to the UI on each iteration, handles any tool_use blocks by
+ * executing them against the provided ToolContext, and loops until the
+ * model stops calling tools.
+ *
+ * The system prompt + tool schemas are cached (one cache_control breakpoint
+ * on the system block) so long conversations don't pay to re-send them.
+ */
+export async function completeWithTools(
+  options: CompleteWithToolsOptions,
+): Promise<CompleteWithToolsResult> {
+  const { client, model, web } = await getClient();
+  const { toolContext, callbacks, maxIterations = 10 } = options;
+  const messages: Anthropic.MessageParam[] = [...options.messages];
+
+  const system: Anthropic.TextBlockParam[] = [
+    {
+      type: 'text',
+      text: options.system,
+      cache_control: { type: 'ephemeral' },
     },
-    body: JSON.stringify(body),
-    signal: callbacks?.signal,
+  ];
+
+  const tools = buildConversationTools({
+    web: {
+      enabled: web.enabled,
+      allowedDomains: web.allowedDomains,
+      blockedDomains: web.blockedDomains,
+    },
   });
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Anthropic API error (${response.status}): ${errorText}`);
-  }
+  const textPieces: string[] = [];
+  const citationMap = new Map<string, Citation>();
 
-  if (!callbacks) {
-    const result = await response.json();
-    return result.content
-      .filter((block: { type: string }) => block.type === 'text')
-      .map((block: { text: string }) => block.text)
-      .join('');
-  }
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    const stream = client.messages.stream(
+      {
+        model,
+        max_tokens: 64000,
+        system,
+        tools,
+        messages,
+      },
+      { signal: callbacks?.signal },
+    );
 
-  // Streaming response
-  const reader = response.body?.getReader();
-  if (!reader) throw new Error('No response body for streaming');
+    if (callbacks) {
+      stream.on('text', (delta) => callbacks.onChunk(delta));
+    }
 
-  const decoder = new TextDecoder();
-  let accumulated = '';
-  let buffer = '';
+    const message = await stream.finalMessage();
+    messages.push({ role: 'assistant', content: message.content });
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n');
-    buffer = lines.pop() ?? '';
-
-    for (const line of lines) {
-      if (!line.startsWith('data: ')) continue;
-      const data = line.slice(6);
-      if (data === '[DONE]') continue;
-
-      try {
-        const event = JSON.parse(data);
-        if (event.type === 'content_block_delta' && event.delta?.text) {
-          accumulated += event.delta.text;
-          callbacks.onChunk(event.delta.text);
-        }
-      } catch {
-        // skip malformed SSE lines
+    for (const block of message.content) {
+      if (block.type === 'text') {
+        textPieces.push(block.text);
+        collectCitations(block, citationMap);
       }
     }
+
+    // Server-side tool loop (e.g. web_search) can hit its internal iteration
+    // cap and return pause_turn. The API expects us to re-send the same
+    // conversation so it can resume where it left off — no extra user message.
+    if (message.stop_reason === 'pause_turn') {
+      continue;
+    }
+
+    if (message.stop_reason !== 'tool_use') {
+      break;
+    }
+
+    const toolUses = message.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use',
+    );
+
+    // If the model stopped for tool_use but only emitted server_tool_use
+    // blocks (which we don't execute), we'd loop forever. Guard against it.
+    if (toolUses.length === 0) break;
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const use of toolUses) {
+      if (callbacks) {
+        callbacks.onChunk(`\n\n_Running \`${use.name}\`..._\n\n`);
+      }
+      const { content, isError } = await executeNotebaseTool(
+        toolContext,
+        use.name,
+        use.input,
+      );
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: use.id,
+        content,
+        ...(isError ? { is_error: true } : {}),
+      });
+    }
+
+    messages.push({ role: 'user', content: toolResults });
   }
 
-  return accumulated;
+  return { text: textPieces.join(''), citations: [...citationMap.values()] };
+}
+
+function collectCitations(
+  block: Anthropic.TextBlock,
+  acc: Map<string, Citation>,
+): void {
+  if (!block.citations) return;
+  for (const c of block.citations) {
+    if (c.type !== 'web_search_result_location') continue;
+    if (!c.url) continue;
+    if (acc.has(c.url)) continue;
+    acc.set(c.url, {
+      url: c.url,
+      title: c.title ?? undefined,
+      citedText: c.cited_text,
+    });
+  }
+}
+
+function extractText(content: Anthropic.ContentBlock[]): string {
+  return content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
 }

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -1,9 +1,30 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import type { LLMSettings } from '../../shared/tools/types';
+import type { LLMSettings, WebSettings } from '../../shared/tools/types';
+import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+
+const DEPRECATED_MODELS = new Set<string>([
+  'claude-sonnet-4-20250514',
+]);
+
+function resolveModel(stored: unknown): string {
+  if (typeof stored !== 'string' || !stored) return DEFAULT_MODEL;
+  if (DEPRECATED_MODELS.has(stored)) return DEFAULT_MODEL;
+  return stored;
+}
+
+function resolveWeb(stored: unknown): WebSettings {
+  if (!stored || typeof stored !== 'object') return { ...DEFAULT_WEB_SETTINGS };
+  const s = stored as Partial<WebSettings>;
+  return {
+    enabled: typeof s.enabled === 'boolean' ? s.enabled : DEFAULT_WEB_SETTINGS.enabled,
+    allowedDomains: Array.isArray(s.allowedDomains) ? s.allowedDomains.filter(d => typeof d === 'string' && d.trim()) : [],
+    blockedDomains: Array.isArray(s.blockedDomains) ? s.blockedDomains.filter(d => typeof d === 'string' && d.trim()) : [],
+  };
+}
 
 function settingsPath(): string {
   return path.join(app.getPath('userData'), 'llm-settings.json');
@@ -15,12 +36,14 @@ export async function getSettings(): Promise<LLMSettings> {
     const parsed = JSON.parse(raw);
     return {
       apiKey: parsed.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '',
-      model: parsed.model ?? DEFAULT_MODEL,
+      model: resolveModel(parsed.model),
+      web: resolveWeb(parsed.web),
     };
   } catch {
     return {
       apiKey: process.env.ANTHROPIC_API_KEY ?? '',
       model: DEFAULT_MODEL,
+      web: { ...DEFAULT_WEB_SETTINGS },
     };
   }
 }

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -1,0 +1,229 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import * as fs from '../notebase/fs';
+import * as graph from '../graph/index';
+import * as search from '../search/index';
+import ONTOLOGY_TTL from '../../shared/ontology.ttl?raw';
+import THOUGHT_ONTOLOGY_TTL from '../../shared/ontology-thought.ttl?raw';
+
+export interface ToolContext {
+  rootPath: string;
+}
+
+export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
+  {
+    name: 'search_notes',
+    description:
+      'Full-text search across all notes in the current thoughtbase. Returns ' +
+      'matching notes ranked by relevance, with title, relative path, and a ' +
+      'short snippet for each. Use this to find notes by keyword when you do ' +
+      'not already know the exact path.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search terms. MiniSearch syntax is supported.',
+        },
+        limit: {
+          type: 'integer',
+          description: 'Maximum number of results to return. Defaults to 10.',
+          minimum: 1,
+          maximum: 50,
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'read_note',
+    description:
+      'Read the full contents of a note by its thoughtbase-relative path ' +
+      '(e.g. "notes/topics/llm-trust.md"). Returns the raw markdown including ' +
+      'any frontmatter. Use this when you have a path from search_notes, from ' +
+      'a wiki-link in another note, or from a graph query, and need the full ' +
+      'text.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        relative_path: {
+          type: 'string',
+          description:
+            'Path relative to the thoughtbase root. Must include the file ' +
+            'extension. Path traversal (..) is rejected.',
+        },
+      },
+      required: ['relative_path'],
+    },
+  },
+  {
+    name: 'query_graph',
+    description:
+      'Run a SPARQL query against the thoughtbase knowledge graph. Standard ' +
+      'prefixes (minerva, thought, dc, rdf, rdfs, xsd, csvw, prov) are ' +
+      'auto-injected. The graph contains notes (minerva:Note), folders, tags, ' +
+      'typed wiki-links (supports, rebuts, references, etc.), frontmatter ' +
+      'metadata as minerva:meta-* predicates, and thought-ontology structures ' +
+      '(claims, proposals, conversations). Use SELECT for tabular results. ' +
+      'If you are unsure about predicate or class names, call ' +
+      'describe_graph_schema first.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        sparql: {
+          type: 'string',
+          description: 'A SPARQL query string (SELECT / ASK / CONSTRUCT).',
+        },
+      },
+      required: ['sparql'],
+    },
+  },
+  {
+    name: 'describe_graph_schema',
+    description:
+      'Return the full Minerva ontology as Turtle. Contains every class ' +
+      '(minerva:Note, minerva:Tag, thought:Claim, etc.) and every predicate ' +
+      '(minerva:supports, minerva:hasTag, dc:title, thought:hasClaim, etc.) ' +
+      'used in the graph, with rdfs:label and rdfs:comment for each. Call ' +
+      'this before writing a non-trivial SPARQL query if you are not sure ' +
+      'what the schema looks like. The returned text is authoritative.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+];
+
+/**
+ * Server-side tools run on Anthropic's infrastructure — we just declare them
+ * in the request and the API executes queries/fetches and returns structured
+ * citations. Version _20260209 bundles dynamic filtering (Claude filters
+ * results with code before they hit its context window).
+ *
+ * `allowed_domains` / `blocked_domains` are passed through per user setting;
+ * they're mutually exclusive from the model's perspective but the API accepts
+ * either independently.
+ */
+export function buildWebTools(opts: {
+  allowedDomains?: string[];
+  blockedDomains?: string[];
+}): Anthropic.Messages.ToolUnion[] {
+  const webSearch: Anthropic.Messages.WebSearchTool20260209 = {
+    type: 'web_search_20260209',
+    name: 'web_search',
+  };
+  if (opts.allowedDomains && opts.allowedDomains.length > 0) {
+    webSearch.allowed_domains = opts.allowedDomains;
+  } else if (opts.blockedDomains && opts.blockedDomains.length > 0) {
+    webSearch.blocked_domains = opts.blockedDomains;
+  }
+  const webFetch: Anthropic.Messages.WebFetchTool20260209 = {
+    type: 'web_fetch_20260209',
+    name: 'web_fetch',
+  };
+  if (opts.allowedDomains && opts.allowedDomains.length > 0) {
+    webFetch.allowed_domains = opts.allowedDomains;
+  } else if (opts.blockedDomains && opts.blockedDomains.length > 0) {
+    webFetch.blocked_domains = opts.blockedDomains;
+  }
+  return [webSearch, webFetch];
+}
+
+export interface ConversationToolOptions {
+  web: {
+    enabled: boolean;
+    allowedDomains?: string[];
+    blockedDomains?: string[];
+  };
+}
+
+export function buildConversationTools(
+  opts: ConversationToolOptions,
+): Anthropic.Messages.ToolUnion[] {
+  const tools: Anthropic.Messages.ToolUnion[] = [...NOTEBASE_TOOLS];
+  if (opts.web.enabled) {
+    tools.push(...buildWebTools({
+      allowedDomains: opts.web.allowedDomains,
+      blockedDomains: opts.web.blockedDomains,
+    }));
+  }
+  return tools;
+}
+
+export async function executeNotebaseTool(
+  ctx: ToolContext,
+  name: string,
+  input: unknown,
+): Promise<{ content: string; isError: boolean }> {
+  try {
+    switch (name) {
+      case 'search_notes':
+        return { content: await runSearch(input), isError: false };
+      case 'read_note':
+        return { content: await runRead(ctx, input), isError: false };
+      case 'query_graph':
+        return runQuery(input);
+      case 'describe_graph_schema':
+        return { content: runDescribeSchema(), isError: false };
+      default:
+        return { content: `Unknown tool: ${name}`, isError: true };
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { content: `Tool ${name} failed: ${message}`, isError: true };
+  }
+}
+
+async function runSearch(input: unknown): Promise<string> {
+  const { query, limit } = input as { query: string; limit?: number };
+  if (typeof query !== 'string' || !query.trim()) {
+    throw new Error('query is required');
+  }
+  const results = search.search(query, { limit: limit ?? 10 });
+  if (results.length === 0) {
+    return `No results for "${query}".`;
+  }
+  return results
+    .map((r, i) => {
+      const snippet = r.snippet.replace(/\s+/g, ' ').trim().slice(0, 240);
+      return `${i + 1}. ${r.title} (${r.relativePath})\n   ${snippet}`;
+    })
+    .join('\n');
+}
+
+async function runRead(ctx: ToolContext, input: unknown): Promise<string> {
+  const { relative_path } = input as { relative_path: string };
+  if (typeof relative_path !== 'string' || !relative_path) {
+    throw new Error('relative_path is required');
+  }
+  return fs.readFile(ctx.rootPath, relative_path);
+}
+
+async function runQuery(input: unknown): Promise<{ content: string; isError: boolean }> {
+  const { sparql } = input as { sparql: string };
+  if (typeof sparql !== 'string' || !sparql.trim()) {
+    throw new Error('sparql is required');
+  }
+  const response = await graph.queryGraph(sparql) as { results: unknown[]; error?: string };
+  if (response.error) {
+    return {
+      content: `SPARQL error: ${response.error}\n\nCall describe_graph_schema to see available classes and predicates.`,
+      isError: true,
+    };
+  }
+  if (response.results.length === 0) {
+    return { content: 'No bindings.', isError: false };
+  }
+  return { content: JSON.stringify(response.results, null, 2), isError: false };
+}
+
+function runDescribeSchema(): string {
+  return [
+    '# Minerva Core Ontology (minerva:)',
+    '',
+    ONTOLOGY_TTL,
+    '',
+    '# Thought Ontology (thought:)',
+    '',
+    THOUGHT_ONTOLOGY_TTL,
+  ].join('\n');
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -59,6 +59,12 @@ export function rebuildMenu(): void {
             submenu: [
               { role: 'about' as const },
               { type: 'separator' as const },
+              {
+                label: 'Preferences\u2026',
+                accelerator: 'Cmd+,',
+                click: () => send(Channels.MENU_OPEN_SETTINGS),
+              },
+              { type: 'separator' as const },
               { role: 'services' as const },
               { type: 'separator' as const },
               { role: 'hide' as const },
@@ -213,6 +219,16 @@ export function rebuildMenu(): void {
           label: 'Sort Lines',
           click: () => send(Channels.MENU_SORT_LINES),
         },
+        ...(!isMac
+          ? [
+              { type: 'separator' as const },
+              {
+                label: 'Preferences\u2026',
+                accelerator: 'Ctrl+,',
+                click: () => send(Channels.MENU_OPEN_SETTINGS),
+              },
+            ]
+          : []),
       ],
     },
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -75,6 +75,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SHELL_OPEN_IN_DEFAULT, relativePath),
     openInTerminal: (relativePath?: string) =>
       ipcRenderer.invoke(Channels.SHELL_OPEN_IN_TERMINAL, relativePath),
+    openExternal: (url: string) =>
+      ipcRenderer.invoke(Channels.SHELL_OPEN_EXTERNAL, url),
   },
   conversations: {
     create: (contextBundle: unknown, triggerNodeUri?: string, systemMessage?: string) =>
@@ -181,6 +183,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onSortLines: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SORT_LINES, () => cb());
+    },
+    onOpenSettings: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_OPEN_SETTINGS, () => cb());
     },
     onOpenProject: (cb: () => void) => {
       ipcRenderer.on('menu:openProject', () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -17,9 +17,11 @@
   import GotoNoteDialog from './lib/components/GotoNoteDialog.svelte';
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationDialog from './lib/components/ConversationDialog.svelte';
+  import SettingsDialog from './lib/components/SettingsDialog.svelte';
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
   import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
+  import { initAppearance } from './lib/appearance/settings';
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationStore } from './lib/stores/conversation.svelte';
   import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
@@ -36,6 +38,7 @@
   const convStore = getConversationStore();
   const bookmarkStore = getBookmarksStore();
   let showConversation = $state(false);
+  let showSettings = $state(false);
   let inspectionCount = $state(0);
 
   async function refreshInspectionCount() {
@@ -434,6 +437,7 @@
 
   onMount(() => {
     initTheme();
+    initAppearance();
 
     // Auto-save
     editor.onAutoSaved = () => {
@@ -483,6 +487,7 @@
     api.menu.onPrint(() => window.print());
     api.menu.onOpenInDefault(() => { if (editor.activeFilePath) api.shell.openInDefault(editor.activeFilePath); });
     api.menu.onOpenInTerminal(() => { api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
+    api.menu.onOpenSettings(() => { showSettings = true; });
 
     // Tools for Thought — stream listener (once)
     api.tools.onStream((chunk) => {
@@ -719,6 +724,16 @@
       confirmLabel={confirmDialog.confirmLabel}
       onConfirm={handleConfirmOk}
       onCancel={handleConfirmCancel}
+    />
+  {/if}
+  {#if showSettings}
+    <SettingsDialog
+      onApplyEditor={(s) => editorComponent?.applySettings(s)}
+      onThemeChanged={() => {
+        themeLabel = getThemeMode();
+        editorComponent?.updateTheme();
+      }}
+      onClose={() => { showSettings = false; }}
     />
   {/if}
 </div>

--- a/src/renderer/lib/appearance/settings.ts
+++ b/src/renderer/lib/appearance/settings.ts
@@ -1,0 +1,46 @@
+export type FontFamilyPreset = 'default' | 'system' | 'serif' | 'monospace';
+
+interface PresetDef {
+  label: string;
+  /** null means: don't set --content-font-family, let editor/preview defaults win. */
+  css: string | null;
+}
+
+export const FONT_FAMILY_PRESETS: Record<FontFamilyPreset, PresetDef> = {
+  default: { label: 'Default (editor: monospace, preview: system)', css: null },
+  system: {
+    label: 'System Sans',
+    css: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  },
+  serif: { label: 'Serif', css: 'Georgia, "Times New Roman", Cambria, serif' },
+  monospace: {
+    label: 'Monospace',
+    css: 'ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, monospace',
+  },
+};
+
+const STORAGE_KEY = 'fontFamily';
+
+export function getFontFamily(): FontFamilyPreset {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && stored in FONT_FAMILY_PRESETS) return stored as FontFamilyPreset;
+  return 'default';
+}
+
+export function setFontFamily(preset: FontFamilyPreset): void {
+  localStorage.setItem(STORAGE_KEY, preset);
+  applyFontFamily(preset);
+}
+
+export function applyFontFamily(preset: FontFamilyPreset): void {
+  const def = FONT_FAMILY_PRESETS[preset];
+  if (def.css) {
+    document.documentElement.style.setProperty('--content-font-family', def.css);
+  } else {
+    document.documentElement.style.removeProperty('--content-font-family');
+  }
+}
+
+export function initAppearance(): void {
+  applyFontFamily(getFontFamily());
+}

--- a/src/renderer/lib/components/ConversationDialog.svelte
+++ b/src/renderer/lib/components/ConversationDialog.svelte
@@ -118,6 +118,14 @@
     });
   });
 
+  function hostOfUrl(url: string): string {
+    try {
+      return new URL(url).host.replace(/^www\./, '');
+    } catch {
+      return url;
+    }
+  }
+
   async function handleSend() {
     const text = input.trim();
     if (!text || !conv.active || streaming) return;
@@ -273,6 +281,23 @@
           </div>
           {#if msg.role === 'assistant'}
             <div class="msg-content">{@html renderAnnotatedContent(msg.content)}</div>
+            {#if msg.citations && msg.citations.length > 0}
+              <ol class="citations">
+                {#each msg.citations as cite, i}
+                  <li>
+                    <button
+                      class="citation-link"
+                      onclick={() => api.shell.openExternal(cite.url)}
+                      title={cite.citedText}
+                    >
+                      <span class="citation-num">[{i + 1}]</span>
+                      <span class="citation-title">{cite.title ?? hostOfUrl(cite.url)}</span>
+                      <span class="citation-host">{hostOfUrl(cite.url)}</span>
+                    </button>
+                  </li>
+                {/each}
+              </ol>
+            {/if}
             <div class="msg-actions">
               <button class="msg-action-btn" onclick={() => { input = 'Tell me more about this.'; handleSend(); }} title="Continue exploring this topic">Explore Further</button>
               <button class="msg-action-btn" onclick={() => handleCrystallize(msg.content)} disabled={crystallizing} title="Extract thought components">{crystallizing ? 'Filing...' : 'File This'}</button>
@@ -476,6 +501,54 @@
     border-radius: 4px;
     font-size: 12px;
     color: var(--accent);
+  }
+
+  .citations {
+    list-style: none;
+    margin: 8px 0 4px 0;
+    padding: 6px 10px;
+    border-left: 2px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .citation-link {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    width: 100%;
+    padding: 2px 0;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 11px;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .citation-link:hover .citation-title {
+    text-decoration: underline;
+  }
+
+  .citation-num {
+    color: var(--text-muted);
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .citation-title {
+    color: var(--accent);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .citation-host {
+    color: var(--text-muted);
+    font-size: 10px;
+    flex-shrink: 0;
+    margin-left: auto;
   }
 
   .msg-actions {

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -8,7 +8,7 @@
   import { oneDark } from '@codemirror/theme-one-dark';
   import { getEffectiveTheme, getThemeMode } from '../theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
-  import { indentUnit } from '@codemirror/language';
+  import { indentUnit, foldEffect, unfoldEffect, foldedRanges } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
   import { search, openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
   import { autocompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
@@ -136,6 +136,49 @@
         whitespaceCompartment.reconfigure(settings.showWhitespace ? highlightWhitespace() : []),
       ],
     });
+    if (settings.alwaysCollapseFrontmatter) {
+      foldFrontmatter();
+    } else {
+      unfoldFrontmatter();
+    }
+  }
+
+  function findFrontmatterRange(): { from: number; to: number } | null {
+    if (!view) return null;
+    const doc = view.state.doc;
+    if (doc.lines < 2) return null;
+    const firstLine = doc.line(1);
+    if (firstLine.text.trim() !== '---') return null;
+    for (let i = 2; i <= doc.lines; i++) {
+      const line = doc.line(i);
+      if (line.text.trim() === '---') {
+        // Fold range spans the content between the --- markers, keeping
+        // both fences visible as "---" lines in the gutter-collapsed view.
+        return { from: firstLine.to, to: line.to };
+      }
+    }
+    return null;
+  }
+
+  function foldFrontmatter() {
+    if (!view) return;
+    const range = findFrontmatterRange();
+    if (!range) return;
+    // Avoid dispatching if already folded at that range.
+    const existing = foldedRanges(view.state);
+    let alreadyFolded = false;
+    existing.between(range.from, range.to, (from, to) => {
+      if (from === range.from && to === range.to) alreadyFolded = true;
+    });
+    if (alreadyFolded) return;
+    view.dispatch({ effects: foldEffect.of(range) });
+  }
+
+  function unfoldFrontmatter() {
+    if (!view) return;
+    const range = findFrontmatterRange();
+    if (!range) return;
+    view.dispatch({ effects: unfoldEffect.of(range) });
   }
 
   function showContextMenu(e: MouseEvent) {
@@ -313,6 +356,11 @@
 
     const state = EditorState.create({ doc: content, extensions: allExtensions });
     view = new EditorView({ state, parent: editorContainer });
+
+    if (initSettings.alwaysCollapseFrontmatter) {
+      // Defer so the folding extension is active before we dispatch
+      requestAnimationFrame(() => foldFrontmatter());
+    }
 
     // Track scrollTop continuously — by cleanup time the DOM may already be detached
     let lastScrollTop = 0;

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -373,6 +373,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     line-height: 1.7;
     color: var(--text);
     max-width: 800px;
+    font-family: var(--content-font-family, inherit);
   }
 
   .preview :global(h1) {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -1,0 +1,554 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getEditorSettings, type EditorSettings } from '../editor/settings';
+  import {
+    getFontFamily,
+    setFontFamily,
+    FONT_FAMILY_PRESETS,
+    type FontFamilyPreset,
+  } from '../appearance/settings';
+  import { getThemeMode, setThemeMode, type ThemeMode } from '../theme';
+  import { api } from '../ipc/client';
+  import type { LLMSettings, WebSettings } from '../../../shared/tools/types';
+
+  interface Props {
+    onApplyEditor: (s: EditorSettings) => void;
+    onThemeChanged: () => void;
+    onClose: () => void;
+  }
+
+  let { onApplyEditor, onThemeChanged, onClose }: Props = $props();
+
+  type TabId = 'editor' | 'appearance' | 'web' | 'ai';
+  const TABS: { id: TabId; label: string }[] = [
+    { id: 'editor', label: 'Editor' },
+    { id: 'appearance', label: 'Appearance' },
+    { id: 'web', label: 'Web' },
+    { id: 'ai', label: 'AI' },
+  ];
+  let activeTab = $state<TabId>('editor');
+
+  // Editor settings
+  let editor = $state<EditorSettings>(getEditorSettings());
+
+  // Appearance settings
+  let theme = $state<ThemeMode>(getThemeMode());
+  let fontFamily = $state<FontFamilyPreset>(getFontFamily());
+
+  // Font presets as an array for the select
+  const fontPresets = Object.entries(FONT_FAMILY_PRESETS).map(([id, def]) => ({
+    id: id as FontFamilyPreset,
+    label: def.label,
+  }));
+
+  const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
+    { value: 'dark', label: 'Dark' },
+    { value: 'light', label: 'Light' },
+    { value: 'contrast', label: 'High Contrast' },
+    { value: 'system', label: 'System' },
+  ];
+
+  // Web + AI settings (async-loaded from main process)
+  let webEnabled = $state(true);
+  let allowedDomainsText = $state('');
+  let blockedDomainsText = $state('');
+  let model = $state('claude-sonnet-4-6');
+  let apiKeyInput = $state('');
+  let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');
+  let clearApiKey = $state(false);
+
+  const MODEL_OPTIONS = [
+    { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+    { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+    { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+  ];
+
+  // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
+  let loadedLlm: LLMSettings | null = null;
+
+  onMount(async () => {
+    try {
+      const s = (await api.tools.getSettings()) as LLMSettings;
+      loadedLlm = s;
+      model = s.model;
+      apiKeyStatus = s.apiKey ? 'set' : 'unset';
+      const web = s.web ?? { enabled: true, allowedDomains: [], blockedDomains: [] } as WebSettings;
+      webEnabled = web.enabled;
+      allowedDomainsText = web.allowedDomains.join('\n');
+      blockedDomainsText = web.blockedDomains.join('\n');
+    } catch (e) {
+      console.error('[settings] failed to load LLM settings:', e);
+    }
+  });
+
+  function parseDomains(text: string): string[] {
+    return text
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onClose();
+  }
+
+  async function handleDone() {
+    // Editor — localStorage via Editor component
+    onApplyEditor(editor);
+
+    // Appearance — already applied live (theme + font) but persist just in case.
+    setThemeMode(theme);
+    setFontFamily(fontFamily);
+    onThemeChanged();
+
+    // Web + AI — build new LLMSettings and save
+    const newApiKey = clearApiKey
+      ? ''
+      : apiKeyInput
+        ? apiKeyInput
+        : loadedLlm?.apiKey ?? '';
+    const next: LLMSettings = {
+      apiKey: newApiKey,
+      model,
+      web: {
+        enabled: webEnabled,
+        allowedDomains: parseDomains(allowedDomainsText),
+        blockedDomains: parseDomains(blockedDomainsText),
+      },
+    };
+    try {
+      await api.tools.setSettings(next);
+    } catch (e) {
+      console.error('[settings] failed to save LLM settings:', e);
+    }
+
+    onClose();
+  }
+
+  // Live-apply theme and font changes as the user picks them, so they can
+  // preview without committing — mirrors how the status-bar cycle already
+  // applies immediately.
+  $effect(() => {
+    setThemeMode(theme);
+    onThemeChanged();
+  });
+  $effect(() => {
+    setFontFamily(fontFamily);
+  });
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="overlay"
+  onkeydown={handleKeydown}
+  onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+>
+  <div class="dialog" role="dialog" aria-label="Settings">
+    <header>
+      <h2>Settings</h2>
+    </header>
+    <div class="body">
+      <nav class="tabs" aria-label="Settings sections">
+        {#each TABS as tab}
+          <button
+            class="tab"
+            class:active={activeTab === tab.id}
+            onclick={() => { activeTab = tab.id; }}
+          >{tab.label}</button>
+        {/each}
+      </nav>
+      <section class="panel">
+        {#if activeTab === 'editor'}
+          <div class="field">
+            <label for="tab-size">Tab size</label>
+            <input
+              id="tab-size"
+              type="number"
+              min="1"
+              max="8"
+              bind:value={editor.tabSize}
+            />
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={editor.wordWrap} />
+              Word wrap
+            </label>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={editor.lineNumbers} />
+              Show line numbers
+            </label>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={editor.showWhitespace} />
+              Show whitespace
+            </label>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={editor.alwaysCollapseFrontmatter} />
+              Always collapse frontmatter
+            </label>
+            <p class="hint">
+              Automatically folds the YAML frontmatter block at the top of a note when it's opened.
+            </p>
+          </div>
+
+        {:else if activeTab === 'appearance'}
+          <div class="field">
+            <label for="theme">Theme</label>
+            <select id="theme" bind:value={theme}>
+              {#each THEME_OPTIONS as opt}
+                <option value={opt.value}>{opt.label}</option>
+              {/each}
+            </select>
+            <p class="hint">
+              You can also cycle themes from the status bar or with <kbd>⌘⇧T</kbd>.
+            </p>
+          </div>
+          <div class="field">
+            <label for="font-family">Content font</label>
+            <select id="font-family" bind:value={fontFamily}>
+              {#each fontPresets as p}
+                <option value={p.id}>{p.label}</option>
+              {/each}
+            </select>
+            <p class="hint">
+              Applies to the markdown editor and preview. App chrome always uses the system font.
+            </p>
+          </div>
+
+        {:else if activeTab === 'web'}
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={webEnabled} />
+              Enable web access for conversations
+            </label>
+            <p class="hint">
+              When off, the assistant cannot call <code>web_search</code> or <code>web_fetch</code>.
+            </p>
+          </div>
+          <div class="field" class:disabled={!webEnabled}>
+            <label for="allowed-domains">Allowed domains</label>
+            <textarea
+              id="allowed-domains"
+              rows="3"
+              bind:value={allowedDomainsText}
+              disabled={!webEnabled}
+              placeholder="One domain per line (e.g. arxiv.org)"
+            ></textarea>
+            <p class="hint">
+              If any domains are listed, web searches are restricted to them.
+              Leave blank to search the whole web.
+            </p>
+          </div>
+          <div class="field" class:disabled={!webEnabled}>
+            <label for="blocked-domains">Blocked domains</label>
+            <textarea
+              id="blocked-domains"
+              rows="3"
+              bind:value={blockedDomainsText}
+              disabled={!webEnabled}
+              placeholder="One domain per line"
+            ></textarea>
+            <p class="hint">
+              Ignored when an allowlist is set. The API accepts one or the other.
+            </p>
+          </div>
+
+        {:else if activeTab === 'ai'}
+          <div class="field">
+            <label for="model">Default model</label>
+            <select id="model" bind:value={model}>
+              {#each MODEL_OPTIONS as m}
+                <option value={m.value}>{m.label}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="field">
+            <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>
+              {#if apiKeyStatus === 'unknown'}
+                Loading…
+              {:else if clearApiKey}
+                API key will be cleared on save
+              {:else if apiKeyStatus === 'set'}
+                ✓ API key saved
+              {:else}
+                No API key set
+              {/if}
+            </div>
+            <label for="api-key">
+              Anthropic API key
+            </label>
+            <input
+              id="api-key"
+              type="password"
+              bind:value={apiKeyInput}
+              placeholder={apiKeyStatus === 'set' ? 'Type to replace existing key' : 'Enter Anthropic API key'}
+              autocomplete="off"
+              spellcheck="false"
+              autocapitalize="off"
+              oncopy={(e) => e.preventDefault()}
+              oncut={(e) => e.preventDefault()}
+              oncontextmenu={(e) => e.preventDefault()}
+              disabled={clearApiKey}
+            />
+            <p class="hint">
+              Keys are stored in your user data directory. The saved value is never displayed back.
+              You can also set <code>ANTHROPIC_API_KEY</code> as an environment variable.
+            </p>
+            {#if apiKeyStatus === 'set' && !clearApiKey}
+              <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
+                Clear saved key
+              </button>
+            {:else if clearApiKey}
+              <button class="link-btn" onclick={() => { clearApiKey = false; }}>
+                Cancel clear
+              </button>
+            {/if}
+          </div>
+        {/if}
+      </section>
+    </div>
+    <footer>
+      <button class="btn secondary" onclick={onClose}>Cancel</button>
+      <button class="btn primary" onclick={handleDone}>Done</button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    min-width: 560px;
+    max-width: 720px;
+    min-height: 420px;
+    max-height: 80vh;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  header h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  .body {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+  }
+
+  .tabs {
+    width: 140px;
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    padding: 8px 0;
+    background: var(--bg);
+    flex-shrink: 0;
+  }
+
+  .tab {
+    text-align: left;
+    padding: 7px 14px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+  }
+
+  .tab:hover {
+    background: var(--bg-button);
+  }
+
+  .tab.active {
+    background: var(--bg-button-hover);
+    border-left-color: var(--accent);
+    color: var(--text);
+  }
+
+  .panel {
+    flex: 1;
+    padding: 16px 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+
+  .field.disabled label,
+  .field.disabled .hint {
+    opacity: 0.5;
+  }
+
+  .field label {
+    color: var(--text);
+  }
+
+  .field.checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+
+  .field input[type="number"] {
+    width: 80px;
+    padding: 4px 6px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+  }
+
+  .field input[type="password"],
+  .field input[type="text"],
+  .field select,
+  .field textarea {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+
+  .field input[type="password"]:focus,
+  .field input[type="text"]:focus,
+  .field select:focus,
+  .field textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .field textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+
+  .field input[type="checkbox"] {
+    cursor: pointer;
+  }
+
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+
+  kbd {
+    background: var(--bg-button);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-family: ui-monospace, monospace;
+  }
+
+  .api-key-status {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+  }
+
+  .api-key-status.saved {
+    color: var(--accent);
+  }
+
+  .link-btn {
+    align-self: flex-start;
+    margin-top: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .link-btn:hover {
+    color: var(--text);
+  }
+
+  footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 10px 16px;
+    border-top: 1px solid var(--border);
+  }
+
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .secondary {
+    background: var(--bg-button);
+    color: var(--text);
+  }
+
+  .secondary:hover {
+    background: var(--bg-button-hover);
+  }
+
+  .primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+
+  .primary:hover {
+    opacity: 0.9;
+  }
+</style>

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -61,14 +61,14 @@
 
   async function handleSaveAsNote() {
     if (!panel.result) return;
-    await handleToolOutput(panel.result, 'newNote');
+    await handleToolOutput(panel.result, 'newNote', $state.snapshot(panel.context));
     onNoteCreated?.();
     panel.close();
   }
 
   async function handleAppend() {
     if (!panel.result) return;
-    await handleToolOutput(panel.result, 'appendToNote');
+    await handleToolOutput(panel.result, 'appendToNote', $state.snapshot(panel.context));
     panel.close();
   }
 

--- a/src/renderer/lib/editor/settings.ts
+++ b/src/renderer/lib/editor/settings.ts
@@ -3,6 +3,7 @@ export interface EditorSettings {
   wordWrap: boolean;
   lineNumbers: boolean;
   showWhitespace: boolean;
+  alwaysCollapseFrontmatter: boolean;
 }
 
 const STORAGE_KEY = 'editorSettings';
@@ -12,6 +13,7 @@ const DEFAULTS: EditorSettings = {
   wordWrap: true,
   lineNumbers: true,
   showWhitespace: false,
+  alwaysCollapseFrontmatter: false,
 };
 
 export function getEditorSettings(): EditorSettings {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -64,6 +64,7 @@ export interface ShellApi {
   revealFile(relativePath?: string): Promise<void>;
   openInDefault(relativePath: string): Promise<void>;
   openInTerminal(relativePath?: string): Promise<void>;
+  openExternal(url: string): Promise<void>;
 }
 
 export interface BookmarksApi {
@@ -128,6 +129,7 @@ export interface MenuApi {
   onSaveQuery(cb: () => void): void;
   onOpenStockQuery(cb: (query: string) => void): void;
   onSortLines(cb: () => void): void;
+  onOpenSettings(cb: () => void): void;
   onPrint(cb: () => void): void;
   onOpenInDefault(cb: () => void): void;
   onOpenInTerminal(cb: () => void): void;

--- a/src/renderer/lib/tools/output.ts
+++ b/src/renderer/lib/tools/output.ts
@@ -1,4 +1,4 @@
-import type { ToolExecutionResult, OutputMode } from '../../../shared/tools/types';
+import type { ToolExecutionResult, OutputMode, ToolContext } from '../../../shared/tools/types';
 import { getEditorStore } from '../stores/editor.svelte';
 import { api } from '../ipc/client';
 import { getNotebaseStore } from '../stores/notebase.svelte';
@@ -6,16 +6,20 @@ import { getNotebaseStore } from '../stores/notebase.svelte';
 export async function handleToolOutput(
   result: ToolExecutionResult,
   outputMode: OutputMode,
+  context: ToolContext = {},
 ): Promise<void> {
   const editor = getEditorStore();
   const notebase = getNotebaseStore();
 
   switch (outputMode) {
-    case 'newNote': {
-      const filename = result.suggestedFilename ?? `tool-output-${Date.now()}.md`;
-      const content = result.suggestedTitle
-        ? `# ${result.suggestedTitle}\n\n${result.output}`
-        : result.output;
+    case 'newNote':
+    case 'replaceSelection':
+    case 'insertAtCursor':
+    case 'multipleNotes': {
+      // replaceSelection / insertAtCursor / multipleNotes aren't implemented
+      // yet — they share the newNote path for now.
+      const sourcePath = context.fullNotePath ?? editor.activeFilePath ?? null;
+      const { filename, content } = buildNoteFile(result, sourcePath);
       await api.notebase.createFile(filename);
       await api.notebase.writeFile(filename, content);
       await notebase.refresh();
@@ -29,21 +33,64 @@ export async function handleToolOutput(
       }
       break;
     }
-    case 'replaceSelection':
-    case 'insertAtCursor':
-    case 'multipleNotes':
-      // These modes will be implemented in Phase 2+
-      // For now, fall back to creating a new note
-      {
-        const filename = result.suggestedFilename ?? `tool-output-${Date.now()}.md`;
-        const content = result.suggestedTitle
-          ? `# ${result.suggestedTitle}\n\n${result.output}`
-          : result.output;
-        await api.notebase.createFile(filename);
-        await api.notebase.writeFile(filename, content);
-        await notebase.refresh();
-        await editor.openFile(filename);
-      }
-      break;
   }
+}
+
+function buildNoteFile(
+  result: ToolExecutionResult,
+  sourcePath: string | null,
+): { filename: string; content: string } {
+  const baseName = result.suggestedFilename ?? `tool-output-${Date.now()}.md`;
+  const dir = sourcePath ? dirOf(sourcePath) : '';
+  const filename = dir ? `${dir}/${baseName}` : baseName;
+
+  const frontmatter = buildFrontmatter(result, sourcePath);
+  const body = buildBody(result, sourcePath);
+
+  return { filename, content: frontmatter + body };
+}
+
+function buildFrontmatter(
+  result: ToolExecutionResult,
+  sourcePath: string | null,
+): string {
+  const lines: string[] = ['---'];
+  if (result.suggestedTitle) {
+    lines.push(`title: ${yamlQuote(result.suggestedTitle)}`);
+  }
+  lines.push(`created: ${todayIso()}`);
+  lines.push(`tool: ${result.toolId}`);
+  if (sourcePath) lines.push(`source: ${sourcePath}`);
+  lines.push('---', '');
+  return lines.join('\n');
+}
+
+function buildBody(result: ToolExecutionResult, sourcePath: string | null): string {
+  const lines: string[] = [];
+  if (result.suggestedTitle) {
+    lines.push(`# ${result.suggestedTitle}`, '');
+  }
+  if (sourcePath) {
+    const linkTarget = sourcePath.replace(/\.md$/, '');
+    lines.push(`*Analysis of [[${linkTarget}]]*`, '');
+  }
+  lines.push(result.output);
+  return lines.join('\n');
+}
+
+function dirOf(relativePath: string): string {
+  const idx = relativePath.lastIndexOf('/');
+  return idx < 0 ? '' : relativePath.slice(0, idx);
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function yamlQuote(s: string): string {
+  // The project's frontmatter parser strips a single leading/trailing quote,
+  // so we quote values that contain a colon to keep the value intact for
+  // any YAML-aware consumer.
+  if (!/[:#]/.test(s)) return s;
+  return `"${s.replace(/"/g, '\\"')}"`;
 }

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -62,6 +62,10 @@ body {
   overflow: hidden;
 }
 
+.cm-content {
+  font-family: var(--content-font-family, monospace) !important;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -62,6 +62,7 @@ export const Channels = {
   MENU_JOIN_LINES: 'menu:joinLines',
   MENU_DUPLICATE_LINE: 'menu:duplicateLine',
   MENU_SORT_LINES: 'menu:sortLines',
+  MENU_OPEN_SETTINGS: 'menu:openSettings',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',
@@ -113,6 +114,7 @@ export const Channels = {
   SHELL_REVEAL_FILE: 'shell:revealFile',
   SHELL_OPEN_IN_DEFAULT: 'shell:openInDefault',
   SHELL_OPEN_IN_TERMINAL: 'shell:openInTerminal',
+  SHELL_OPEN_EXTERNAL: 'shell:openExternal',
   GRAPH_REBUILD: 'graph:rebuild',
   GRAPH_EXPORT: 'graph:export',
 } as const;

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -74,7 +74,20 @@ export interface ToolExecutionResult {
   sections?: { title: string; content: string }[];
 }
 
+export interface WebSettings {
+  enabled: boolean;
+  allowedDomains: string[];
+  blockedDomains: string[];
+}
+
 export interface LLMSettings {
   apiKey: string;
   model: string;
+  web?: WebSettings;
 }
+
+export const DEFAULT_WEB_SETTINGS: WebSettings = {
+  enabled: true,
+  allowedDomains: [],
+  blockedDomains: [],
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -109,10 +109,17 @@ export interface ContextBundle {
   notePath?: string;
 }
 
+export interface Citation {
+  url: string;
+  title?: string;
+  citedText: string;
+}
+
 export interface ConversationMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   timestamp: string;
+  citations?: Citation[];
 }
 
 export type ConversationStatus = 'active' | 'resolved' | 'abandoned';


### PR DESCRIPTION
## Summary

- **Inspections UI** (`33f1e0c`): right-sidebar panel and status-bar indicator for graph health checks.
- **LLM tool use** (`508d724`): migrate to `@anthropic-ai/sdk`, add notebase tools (`search_notes`, `read_note`, `query_graph`, `describe_graph_schema`) and server-side web tools (`web_search`, `web_fetch`) with citation footnotes in the conversation UI. Handles `pause_turn`; system-prompt prompt caching.
- **Tabbed Settings dialog** (⌘,): Editor, Appearance (theme + content font), Web (enable + allowed/blocked domains wired to `web_search`), AI (default model + write-only API key entry).
- **Frontmatter folding**: new editor setting folds YAML on note open.
- **Tool-output provenance**: notes saved from analysis/planning tools get frontmatter (title/created/tool/source) + wiki-link back to source + placement in source's folder.
- **TTL export doubling fix**: ontology is loaded fresh on startup and no longer persisted to `graph.ttl`; self-heals existing duplicates.
- **Default model** updated to `claude-sonnet-4-6`; deprecated sonnet IDs are silently migrated on load.
- **`shell.openExternal`** IPC (http/https only) for opening citation URLs in the default browser.

## Test plan

- [ ] Open Preferences (⌘,), switch themes + fonts — editor and preview update live.
- [ ] In Web tab, add `arxiv.org` to Allowed domains — conversation web searches should only return arxiv hits.
- [ ] In Web tab, uncheck Enable — model can no longer call `web_search`/`web_fetch`.
- [ ] AI tab: type a new API key, Done, reopen — status says ✓ saved, field empty. Hit "Clear saved key" → Done → status "No API key set".
- [ ] Ask the assistant a question about a note — should call `search_notes` / `read_note`.
- [ ] Ask a graph-structural question — should call `query_graph`, falling back to `describe_graph_schema` on failure.
- [ ] Ask a current-events question — should call `web_search`, footnotes appear, clicking opens default browser.
- [ ] Save a Steelman/Excavate result as a note — lands in source's folder with frontmatter + `[[source]]` wiki-link.
- [ ] Enable "Always collapse frontmatter", open a note with YAML frontmatter — should open folded.
- [ ] `Export as Turtle` from the Graph menu — no duplicate triples.