### PR TITLE
Improve contrast-theme titlebar text readability

### DIFF
--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -203,12 +203,12 @@
   .tool-name {
     font-weight: 600;
     font-size: 13px;
-    color: var(--text);
+    color: var(--titlebar-text);
   }
 
   .tool-desc {
     font-size: 12px;
-    color: var(--text-muted);
+    color: var(--titlebar-text-muted);
   }
 
   .close-btn {
@@ -216,14 +216,14 @@
     border: none;
     border-radius: 3px;
     background: none;
-    color: var(--text-muted);
+    color: var(--titlebar-text-muted);
     cursor: pointer;
     font-size: 12px;
   }
 
   .close-btn:hover {
-    background: var(--bg-button);
-    color: var(--text);
+    background: var(--titlebar-button);
+    color: var(--titlebar-text);
   }
 
   .tool-body {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -40,8 +40,8 @@
   --text-muted: #6b6b80;
   --border: #d0d0d8;
   --accent: #1e66f5;
-  --titlebar-text: #cdd6f4;
-  --titlebar-text-muted: #6c7086;
+  --titlebar-text: #ffffff;
+  --titlebar-text-muted: #cdd6f4;
   --titlebar-button: #313244;
   --titlebar-button-hover: #45475a;
   --bg-tabbar: var(--bg-sidebar);


### PR DESCRIPTION
## Summary

- Contrast theme's dark titlebar (`#3a3a4a`) was paired with muted-gray titlebar text (`#6c7086`) and the ToolPanel header was pulling dark body-text colors — both effectively unreadable on the dark bar.
- Bumped `--titlebar-text` to pure white and `--titlebar-text-muted` to a near-white in the contrast theme.
- Pointed ToolPanel's header text and close button at the titlebar text vars so they render correctly on the dark header regardless of theme.

## Test plan

- [ ] Switch to the High Contrast theme — project/file name in the main titlebar should be white, not medium gray.
- [ ] Run a thinking tool (e.g. Steelman) in contrast mode — ToolPanel header title + description + close button should be readable white on dark.
- [ ] Switch to Dark and Light themes — no regression (titlebar and ToolPanel header look identical to before).