### PR TITLE
Make links clickable in source mode

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -607,6 +607,7 @@
                     onCursorChange={(info) => { cursorInfo = info; }}
                     onToolInvoke={handleToolInvoke}
                     onOpenConversation={openConversation}
+                    onNavigate={handleNavigate}
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -21,6 +21,7 @@
     insertWikiLink, insertTypedLinks,
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
+  import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
 
   export interface CursorInfo {
     line: number;
@@ -44,6 +45,7 @@
     onOpenConversation?: () => void;
     onBookmark?: () => void;
     onInsertQueryList?: () => void;
+    onNavigate?: (target: string) => void;
   }
 
   let {
@@ -59,6 +61,7 @@
     onOpenConversation,
     onBookmark,
     onInsertQueryList,
+    onNavigate,
   }: Props = $props();
 
   const analysisTools = getToolInfosByCategory('analysis');
@@ -67,7 +70,7 @@
   let editorContainer: HTMLDivElement;
   let view: EditorView;
   let ignoreNextUpdate = false;
-  let contextMenu = $state<{ x: number; y: number } | null>(null);
+  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null } | null>(null);
 
   const fontSizeCompartment = new Compartment();
   const themeCompartment = new Compartment();
@@ -183,12 +186,35 @@
 
   function showContextMenu(e: MouseEvent) {
     e.preventDefault();
-    contextMenu = { x: e.clientX, y: e.clientY };
+    let link: LinkRange | null = null;
+    if (view) {
+      const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+      if (pos != null) link = findLinkAt(view.state, pos);
+    }
+    contextMenu = { x: e.clientX, y: e.clientY, link };
     const close = () => {
       contextMenu = null;
       window.removeEventListener('click', close);
     };
     setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  function openLink(link: LinkRange) {
+    if (link.kind === 'wiki') {
+      onNavigate?.(link.href);
+    } else {
+      api.shell.openExternal(link.href);
+    }
+    contextMenu = null;
+  }
+
+  function editLink(link: LinkRange) {
+    if (!view) return;
+    view.dispatch({
+      selection: { anchor: link.editFrom, head: link.editTo },
+    });
+    view.focus();
+    contextMenu = null;
   }
 
   function execCommand(cmd: string) {
@@ -223,6 +249,14 @@
       '.cm-gutters': { display: 'none' },
     })),
     whitespaceCompartment.of(initSettings.showWhitespace ? highlightWhitespace() : []),
+    linkDecorations({
+      onOpenNote: (target: string) => {
+        if (onNavigate) onNavigate(target);
+      },
+      onOpenExternal: (url: string) => {
+        api.shell.openExternal(url);
+      },
+    }),
     EditorView.domEventHandlers({
       contextmenu: (e) => {
         showContextMenu(e);
@@ -418,6 +452,11 @@
     style:left="{contextMenu.x}px"
     style:top="{contextMenu.y}px"
   >
+    {#if contextMenu.link}
+      <button onclick={() => openLink(contextMenu!.link!)}>Open Link</button>
+      <button onclick={() => editLink(contextMenu!.link!)}>Edit Link</button>
+      <div class="separator"></div>
+    {/if}
     <button onclick={() => execCommand('cut')}>Cut</button>
     <button onclick={() => execCommand('copy')}>Copy</button>
     <button onclick={() => execCommand('paste')}>Paste</button>

--- a/src/renderer/lib/editor/link-decorations.ts
+++ b/src/renderer/lib/editor/link-decorations.ts
@@ -1,0 +1,227 @@
+import {
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  Decoration,
+  type DecorationSet,
+} from '@codemirror/view';
+import { RangeSetBuilder } from '@codemirror/state';
+import type { EditorState } from '@codemirror/state';
+
+export type LinkKind = 'wiki' | 'markdown' | 'url';
+
+export interface LinkRange {
+  from: number;
+  to: number;
+  kind: LinkKind;
+  /** Where the link points — note path for wiki, URL otherwise. */
+  href: string;
+  /**
+   * Range of the "editable target" inside the link, used by Edit Link.
+   * For wiki: the bare target (after `type::`, before `|`).
+   * For markdown: the URL inside `(...)`.
+   * For bare URL: the whole URL.
+   */
+  editFrom: number;
+  editTo: number;
+}
+
+interface LinkOptions {
+  onOpenNote: (target: string) => void;
+  onOpenExternal: (url: string) => void;
+}
+
+// [[target]] | [[target|display]] | [[type::target]] | [[type::target|display]]
+// The inner cannot contain `[` or `]` to keep the match well-defined.
+const WIKI_RE = /\[\[([^\[\]\n]+)\]\]/g;
+// [text](url) — text can't contain `]` or newline, url can't contain `)`, whitespace, or newline.
+const MARKDOWN_LINK_RE = /\[([^\]\n]+)\]\(([^)\s\n]+)\)/g;
+// Bare http(s) URL. Cut off common trailing punctuation ("See https://foo." → don't include the period).
+const BARE_URL_RE = /\bhttps?:\/\/[^\s<>()\[\]{}"'`]+/g;
+
+function parseWikiInner(inner: string): { target: string; targetStart: number; targetEnd: number } {
+  // inner is the content between [[ and ]]
+  const pipe = inner.indexOf('|');
+  const beforePipe = pipe >= 0 ? inner.slice(0, pipe) : inner;
+  const typeSep = beforePipe.indexOf('::');
+  const targetStart = typeSep >= 0 ? typeSep + 2 : 0;
+  const targetEnd = pipe >= 0 ? pipe : inner.length;
+  return {
+    target: inner.slice(targetStart, targetEnd).trim(),
+    targetStart,
+    targetEnd,
+  };
+}
+
+/** Strip trailing punctuation that a user almost never means as part of the URL. */
+function trimUrlTail(url: string): string {
+  return url.replace(/[.,;:!?)\]}'"]+$/, '');
+}
+
+function scanLinks(text: string, offset: number): LinkRange[] {
+  const ranges: LinkRange[] = [];
+
+  // Markdown links first — they need to shadow any bare URL that lives inside.
+  for (const m of text.matchAll(MARKDOWN_LINK_RE)) {
+    const matchFrom = offset + (m.index ?? 0);
+    const matchTo = matchFrom + m[0].length;
+    // Positions of the URL inside the match: after `](`
+    const urlOpenIdx = m[0].indexOf('](') + 2;
+    const urlStart = matchFrom + urlOpenIdx;
+    const urlEnd = urlStart + m[2].length;
+    ranges.push({
+      from: matchFrom,
+      to: matchTo,
+      kind: 'markdown',
+      href: m[2],
+      editFrom: urlStart,
+      editTo: urlEnd,
+    });
+  }
+
+  for (const m of text.matchAll(WIKI_RE)) {
+    const matchFrom = offset + (m.index ?? 0);
+    const matchTo = matchFrom + m[0].length;
+    const inner = m[1];
+    const parsed = parseWikiInner(inner);
+    ranges.push({
+      from: matchFrom,
+      to: matchTo,
+      kind: 'wiki',
+      href: parsed.target,
+      editFrom: matchFrom + 2 + parsed.targetStart, // +2 for `[[`
+      editTo: matchFrom + 2 + parsed.targetEnd,
+    });
+  }
+
+  for (const m of text.matchAll(BARE_URL_RE)) {
+    const rawFrom = offset + (m.index ?? 0);
+    const trimmed = trimUrlTail(m[0]);
+    const rawTo = rawFrom + trimmed.length;
+    // Skip if inside a markdown link we already captured.
+    if (ranges.some(r => r.kind === 'markdown' && r.from <= rawFrom && r.to >= rawTo)) continue;
+    ranges.push({
+      from: rawFrom,
+      to: rawTo,
+      kind: 'url',
+      href: trimmed,
+      editFrom: rawFrom,
+      editTo: rawTo,
+    });
+  }
+
+  return ranges;
+}
+
+/**
+ * Scan the line at `pos` for any link whose range contains `pos`.
+ * Used by the editor context menu to decide whether to show "Edit Link".
+ */
+export function findLinkAt(state: EditorState, pos: number): LinkRange | null {
+  const line = state.doc.lineAt(pos);
+  const ranges = scanLinks(line.text, line.from);
+  return ranges.find(r => pos >= r.from && pos <= r.to) ?? null;
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const all: LinkRange[] = [];
+  for (const { from, to } of view.visibleRanges) {
+    const text = view.state.doc.sliceString(from, to);
+    all.push(...scanLinks(text, from));
+  }
+  // RangeSetBuilder requires non-overlapping ranges sorted by `from`.
+  all.sort((a, b) => a.from - b.from || a.to - b.to);
+  const nonOverlapping: LinkRange[] = [];
+  for (const r of all) {
+    const last = nonOverlapping[nonOverlapping.length - 1];
+    if (!last || last.to <= r.from) nonOverlapping.push(r);
+  }
+
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const r of nonOverlapping) {
+    builder.add(
+      r.from,
+      r.to,
+      Decoration.mark({
+        class: 'cm-clickable-link',
+        attributes: {
+          'data-link-kind': r.kind,
+          'data-link-href': r.href,
+        },
+      }),
+    );
+  }
+  return builder.finish();
+}
+
+const linkTheme = EditorView.theme({
+  '.cm-clickable-link': {
+    color: 'var(--accent)',
+    textDecoration: 'underline',
+    textDecorationColor: 'color-mix(in srgb, var(--accent) 50%, transparent)',
+    textUnderlineOffset: '2px',
+    cursor: 'pointer',
+  },
+  '.cm-clickable-link:hover': {
+    textDecorationColor: 'var(--accent)',
+  },
+});
+
+export function linkDecorations(opts: LinkOptions) {
+  function hasModifier(e: MouseEvent): boolean {
+    return e.metaKey || e.ctrlKey;
+  }
+
+  function linkElFromEvent(e: MouseEvent): HTMLElement | null {
+    const target = e.target as HTMLElement | null;
+    if (!target) return null;
+    return target.closest('.cm-clickable-link') as HTMLElement | null;
+  }
+
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      constructor(view: EditorView) {
+        this.decorations = buildDecorations(view);
+      }
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged) {
+          this.decorations = buildDecorations(update.view);
+        }
+      }
+    },
+    {
+      decorations: v => v.decorations,
+      eventHandlers: {
+        // Intercept mousedown so CodeMirror doesn't move the caret into the
+        // link on plain-click. Holding ⌘/Ctrl lets the caret land normally.
+        mousedown(event: MouseEvent) {
+          if (event.button !== 0) return false;
+          if (hasModifier(event)) return false;
+          const el = linkElFromEvent(event);
+          if (!el) return false;
+          event.preventDefault();
+          return true;
+        },
+        click(event: MouseEvent) {
+          if (event.button !== 0) return false;
+          if (hasModifier(event)) return false;
+          const el = linkElFromEvent(event);
+          if (!el) return false;
+          const kind = el.getAttribute('data-link-kind') as LinkKind | null;
+          const href = el.getAttribute('data-link-href');
+          if (!kind || !href) return false;
+          event.preventDefault();
+          if (kind === 'wiki') {
+            opts.onOpenNote(href);
+          } else {
+            opts.onOpenExternal(href);
+          }
+          return true;
+        },
+      },
+    },
+  );
+
+  return [plugin, linkTheme];
+}


### PR DESCRIPTION
## Summary

Obsidian-style link interaction in the CodeMirror editor:
- Plain left-click on a wiki-link (`[[...]]`), a markdown link (`[text](url)`), or a bare `http(s)://` URL navigates (opens the target note or launches the URL in the default browser).
- Cmd/Ctrl-click is an escape hatch — caret lands normally, no navigation.
- Right-click on a link shows new **Open Link** and **Edit Link** items at the top of the context menu. Edit Link selects the editable target (the bare target for wiki-links, the URL for markdown links, the whole URL for bare URLs) so typing replaces it.

Implementation is a CodeMirror `ViewPlugin` (`src/renderer/lib/editor/link-decorations.ts`) that regex-scans the visible viewport, applies `Decoration.mark` with `data-link-kind` / `data-link-href`, and intercepts `mousedown` + `click`. No new deps.

## Test plan

- [ ] Plain-click `[[note-name]]` in source mode — opens that note.
- [ ] Plain-click `[text](https://example.com)` — opens URL in default browser.
- [ ] Plain-click bare `https://example.com` in text — opens URL.
- [ ] Hold ⌘ and click a link — caret moves into the link, no navigation.
- [ ] Right-click a link — Open Link / Edit Link appear above the normal menu; Edit Link places selection on the editable target.
- [ ] Right-click outside a link — normal context menu with no link items.
- [ ] Hover a link — accent underline darkens, pointer cursor.
- [ ] Trailing punctuation on bare URLs (`See https://example.com.`) is excluded from the match.