### PR TITLE
Extend thought ontology with Source subtypes and metadata predicates (#88)

### DIFF
--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -6,6 +6,8 @@
 @prefix minerva: <https://minerva.dev/ontology#> .
 @prefix thought: <https://minerva.dev/ontology/thought#> .
 @prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix bibo:    <http://purl.org/ontology/bibo/> .
+@prefix schema:  <http://schema.org/> .
 
 # ── Ontology ────────────────────────────────────────────────────────────────
 
@@ -141,7 +143,143 @@ thought:Implication a owl:Class ;
 thought:Source a owl:Class ;
     rdfs:subClassOf thought:Component ;
     rdfs:label "Source" ;
-    rdfs:comment "A cited or referenced external authority or text." .
+    rdfs:comment "A cited or referenced external authority or text. Abstract — instances typically use one of the subtypes (thought:WebPage, thought:Article, thought:Book, thought:Preprint, thought:Report, thought:PDFSource)." .
+
+# ── Source Subtypes ───────────────────────────────────────────────────────
+# Axis: what kind of work is this? Orthogonal to file format, except for
+# thought:PDFSource which is the catch-all for PDFs that don't fit elsewhere.
+
+thought:WebPage a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "Web Page" ;
+    rdfs:comment "A URL-addressable web resource — article, blog post, documentation page, etc." .
+
+thought:Article a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "Article" ;
+    rdfs:comment "A scholarly or journalistic article published in a journal, magazine, or periodical. Usually has a DOI and an inContainer relationship." .
+
+thought:Book a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "Book" ;
+    rdfs:comment "A book — scholarly monograph, textbook, or trade publication. Usually has an ISBN." .
+
+thought:Preprint a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "Preprint" ;
+    rdfs:comment "A scholarly work that has not (yet) undergone peer review, typically hosted on arXiv, bioRxiv, SSRN, or similar." .
+
+thought:Report a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "Report" ;
+    rdfs:comment "A technical report, white paper, or institutional publication — often a government, NGO, or corporate document." .
+
+thought:PDFSource a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "PDF Source" ;
+    rdfs:comment "Catch-all for a source distributed as a PDF that does not fit another subtype. Most scholarly PDFs should be classified as thought:Article / thought:Preprint / thought:Book instead; this class exists for the long tail." .
+
+# ── Source Metadata ───────────────────────────────────────────────────────
+# Predicates expected on Source instances. We reuse standard vocabularies
+# (Dublin Core Terms, BIBO, schema.org/ScholarlyArticle) directly rather
+# than minting our own IRIs, with rdfs:label / rdfs:comment annotations
+# here to make the schema self-documenting via describe_graph_schema.
+
+dc:title a owl:DatatypeProperty ;
+    rdfs:label "title" ;
+    rdfs:comment "The source's title." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+dc:creator a owl:DatatypeProperty ;
+    rdfs:label "creator (author)" ;
+    rdfs:comment "Author(s) of the source. Use one triple per author; order is not preserved by the graph, so for ordered authorship use a list with an auxiliary node when needed." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+dc:issued a owl:DatatypeProperty ;
+    rdfs:label "issued (publication date)" ;
+    rdfs:comment "When the source was published. Use xsd:date for a full date or xsd:gYear for year-only." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:date .
+
+dc:publisher a owl:DatatypeProperty ;
+    rdfs:label "publisher" ;
+    rdfs:comment "Publishing entity — journal, press, organization, or platform." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+dc:language a owl:DatatypeProperty ;
+    rdfs:label "language" ;
+    rdfs:comment "BCP-47 language tag of the source's primary language (e.g. 'en', 'fr-CA')." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+dc:abstract a owl:DatatypeProperty ;
+    rdfs:label "abstract" ;
+    rdfs:comment "Short summary of the source, typically 1–2 paragraphs." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+bibo:doi a owl:DatatypeProperty ;
+    rdfs:label "DOI" ;
+    rdfs:comment "Digital Object Identifier. Stored as the bare identifier (no 'doi:' prefix, no URL)." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+bibo:isbn a owl:DatatypeProperty ;
+    rdfs:label "ISBN" ;
+    rdfs:comment "International Standard Book Number (ISBN-10 or ISBN-13), digits only, no hyphens." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+bibo:uri a owl:DatatypeProperty ;
+    rdfs:label "canonical URI" ;
+    rdfs:comment "Canonical URL where the source can be accessed — publisher landing page, DOI-resolved URL, or arXiv abstract page." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:anyURI .
+
+bibo:numPages a owl:DatatypeProperty ;
+    rdfs:label "page count" ;
+    rdfs:comment "Total number of pages in the source. Use bibo:pages for a page range within a container." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:integer .
+
+bibo:pages a owl:DatatypeProperty ;
+    rdfs:label "page range" ;
+    rdfs:comment "Page range within a container (e.g. '245-267'). Used for articles and book chapters." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+bibo:volume a owl:DatatypeProperty ;
+    rdfs:label "volume" ;
+    rdfs:comment "Volume number within a serial publication." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+bibo:issue a owl:DatatypeProperty ;
+    rdfs:label "issue" ;
+    rdfs:comment "Issue number within a volume." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
+schema:inContainer a owl:ObjectProperty ;
+    rdfs:label "in container" ;
+    rdfs:comment "The larger work that contains this source — a journal for an article, a book for a chapter, a conference for a paper. Range is another Source (typically a Book, a Journal, or a generic Source)." ;
+    rdfs:domain thought:Source ;
+    rdfs:range thought:Source .
+
+thought:accessedAt a owl:DatatypeProperty ;
+    rdfs:label "accessed at" ;
+    rdfs:comment "Timestamp when the source was retrieved, important for volatile web resources." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:dateTime .
+
+thought:archivedAt a owl:DatatypeProperty ;
+    rdfs:label "archived at" ;
+    rdfs:comment "Thoughtbase-relative path to the local archival copy of the source (PDF, HTML snapshot, extracted markdown)." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
 
 thought:Finding a owl:Class ;
     rdfs:subClassOf thought:Component ;

--- a/tests/main/graph/source-ontology.test.ts
+++ b/tests/main/graph/source-ontology.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as $rdf from 'rdflib';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
+const RDF = $rdf.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+const RDFS = $rdf.Namespace('http://www.w3.org/2000/01/rdf-schema#');
+const OWL = $rdf.Namespace('http://www.w3.org/2002/07/owl#');
+const DC = $rdf.Namespace('http://purl.org/dc/terms/');
+const BIBO = $rdf.Namespace('http://purl.org/ontology/bibo/');
+const SCHEMA = $rdf.Namespace('http://schema.org/');
+
+const ONTOLOGY_PATH = path.join(__dirname, '../../../src/shared/ontology-thought.ttl');
+const ONTOLOGY_TTL = fs.readFileSync(ONTOLOGY_PATH, 'utf-8');
+
+function freshStore(): $rdf.IndexedFormula {
+  const store = $rdf.graph();
+  $rdf.parse(ONTOLOGY_TTL, store, THOUGHT('').value, 'text/turtle');
+  return store;
+}
+
+describe('Source subtypes in thought ontology', () => {
+  let store: $rdf.IndexedFormula;
+  beforeAll(() => {
+    store = freshStore();
+  });
+
+  for (const subtype of ['WebPage', 'Article', 'Book', 'Preprint', 'Report', 'PDFSource']) {
+    it(`declares thought:${subtype} as a subclass of thought:Source`, () => {
+      const matches = store.statementsMatching(
+        THOUGHT(subtype),
+        RDFS('subClassOf'),
+        THOUGHT('Source'),
+      );
+      expect(matches.length).toBe(1);
+    });
+
+    it(`declares thought:${subtype} as an owl:Class`, () => {
+      const matches = store.statementsMatching(THOUGHT(subtype), RDF('type'), OWL('Class'));
+      expect(matches.length).toBe(1);
+    });
+  }
+});
+
+describe('Source metadata predicates', () => {
+  let store: $rdf.IndexedFormula;
+  beforeAll(() => {
+    store = freshStore();
+  });
+
+  // Test that each expected predicate is declared with a domain of thought:Source.
+  const predicates: Array<{ ns: $rdf.Namespace; local: string; label: string }> = [
+    { ns: DC, local: 'title', label: 'title' },
+    { ns: DC, local: 'creator', label: 'creator' },
+    { ns: DC, local: 'issued', label: 'issued' },
+    { ns: DC, local: 'publisher', label: 'publisher' },
+    { ns: DC, local: 'language', label: 'language' },
+    { ns: DC, local: 'abstract', label: 'abstract' },
+    { ns: BIBO, local: 'doi', label: 'DOI' },
+    { ns: BIBO, local: 'isbn', label: 'ISBN' },
+    { ns: BIBO, local: 'uri', label: 'canonical URI' },
+    { ns: BIBO, local: 'numPages', label: 'page count' },
+    { ns: BIBO, local: 'pages', label: 'page range' },
+    { ns: BIBO, local: 'volume', label: 'volume' },
+    { ns: BIBO, local: 'issue', label: 'issue' },
+    { ns: SCHEMA, local: 'inContainer', label: 'in container' },
+    { ns: THOUGHT, local: 'accessedAt', label: 'accessed at' },
+    { ns: THOUGHT, local: 'archivedAt', label: 'archived at' },
+  ];
+
+  for (const { ns, local, label: _label } of predicates) {
+    it(`declares ${ns('').value.replace(/#$/, '').split('/').pop()}:${local} on domain thought:Source`, () => {
+      const matches = store.statementsMatching(
+        ns(local),
+        RDFS('domain'),
+        THOUGHT('Source'),
+      );
+      expect(matches.length).toBe(1);
+    });
+  }
+});
+
+describe('hand-authored source stubs parse and query cleanly', () => {
+  it('parses a web-page source stub', () => {
+    const store = freshStore();
+    const ttl = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      @prefix dc:      <http://purl.org/dc/terms/> .
+      @prefix bibo:    <http://purl.org/ontology/bibo/> .
+      @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+      <urn:src:example-article> a thought:WebPage ;
+        dc:title "An example article" ;
+        dc:creator "Ada Lovelace" ;
+        dc:issued "2026-04-12"^^xsd:date ;
+        bibo:uri <https://example.com/article> ;
+        thought:accessedAt "2026-04-19T10:00:00Z"^^xsd:dateTime .
+    `;
+    expect(() =>
+      $rdf.parse(ttl, store, 'urn:test:void', 'text/turtle'),
+    ).not.toThrow();
+
+    const src = $rdf.sym('urn:src:example-article');
+    expect(store.any(src, DC('title'))?.value).toBe('An example article');
+    expect(store.any(src, DC('creator'))?.value).toBe('Ada Lovelace');
+    // Confirm it inherits from Source via subClassOf (one-hop check).
+    const typeStmt = store.any(src, RDF('type'));
+    expect(typeStmt?.value).toBe(THOUGHT('WebPage').value);
+    const isSubclass = store.statementsMatching(
+      THOUGHT('WebPage'),
+      RDFS('subClassOf'),
+      THOUGHT('Source'),
+    ).length > 0;
+    expect(isSubclass).toBe(true);
+  });
+
+  it('parses an article stub with DOI, container, and page range', () => {
+    const store = freshStore();
+    const ttl = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      @prefix dc:      <http://purl.org/dc/terms/> .
+      @prefix bibo:    <http://purl.org/ontology/bibo/> .
+      @prefix schema:  <http://schema.org/> .
+      @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+      <urn:src:journal/nature> a thought:Source ;
+        dc:title "Nature" ;
+        dc:publisher "Springer Nature" .
+
+      <urn:src:smith-2023> a thought:Article ;
+        dc:title "On the structure of knowledge graphs" ;
+        dc:creator "Alice Smith" ,
+                   "Bob Jones" ;
+        dc:issued "2023-07-15"^^xsd:date ;
+        bibo:doi "10.1038/s41586-023-0001-0" ;
+        bibo:volume "619" ;
+        bibo:issue "7969" ;
+        bibo:pages "245-267" ;
+        schema:inContainer <urn:src:journal/nature> .
+    `;
+    $rdf.parse(ttl, store, 'urn:test:void', 'text/turtle');
+
+    const src = $rdf.sym('urn:src:smith-2023');
+    expect(store.any(src, BIBO('doi'))?.value).toBe('10.1038/s41586-023-0001-0');
+    expect(store.any(src, BIBO('pages'))?.value).toBe('245-267');
+    const creators = store.statementsMatching(src, DC('creator')).map(s => s.object.value);
+    expect(creators).toEqual(expect.arrayContaining(['Alice Smith', 'Bob Jones']));
+    // Container link resolves to another Source.
+    const container = store.any(src, SCHEMA('inContainer'));
+    expect(container?.value).toBe('urn:src:journal/nature');
+    expect(store.any($rdf.sym(container!.value), DC('title'))?.value).toBe('Nature');
+  });
+
+  it('parses a preprint stub with archivedAt pointing at a local PDF', () => {
+    const store = freshStore();
+    const ttl = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      @prefix dc:      <http://purl.org/dc/terms/> .
+      @prefix bibo:    <http://purl.org/ontology/bibo/> .
+      @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+      <urn:src:arxiv/2401.12345> a thought:Preprint ;
+        dc:title "A pre-printed paper" ;
+        dc:creator "Carol Example" ;
+        bibo:uri <https://arxiv.org/abs/2401.12345> ;
+        thought:archivedAt ".minerva/sources/arxiv-2401.12345/original.pdf" .
+    `;
+    $rdf.parse(ttl, store, 'urn:test:void', 'text/turtle');
+
+    const src = $rdf.sym('urn:src:arxiv/2401.12345');
+    expect(store.any(src, THOUGHT('archivedAt'))?.value).toBe(
+      '.minerva/sources/arxiv-2401.12345/original.pdf',
+    );
+  });
+
+  it('enables finding all Article sources by type', () => {
+    const store = freshStore();
+    const ttl = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      @prefix dc:      <http://purl.org/dc/terms/> .
+
+      <urn:src:a> a thought:Article ; dc:title "Paper A" .
+      <urn:src:b> a thought:Article ; dc:title "Paper B" .
+      <urn:src:c> a thought:Book ;    dc:title "Book C" .
+      <urn:src:d> a thought:WebPage ; dc:title "Page D" .
+    `;
+    $rdf.parse(ttl, store, 'urn:test:void', 'text/turtle');
+
+    const articles = store
+      .statementsMatching(undefined, RDF('type'), THOUGHT('Article'))
+      .map(s => store.any(s.subject, DC('title'))?.value)
+      .filter((v): v is string => typeof v === 'string');
+    expect(articles.sort()).toEqual(['Paper A', 'Paper B']);
+  });
+});


### PR DESCRIPTION
Closes #88.

## Summary

Bedrock for the research-library initiative. Every Source subtype we'll emit from ingestion is now declared, and the BIBO / Dublin Core / schema.org predicates we plan to attach to Source instances are documented in the ontology so \`describe_graph_schema\` can explain them to the LLM on demand.

### Classes
- \`thought:WebPage\`, \`thought:Article\`, \`thought:Book\`, \`thought:Preprint\`, \`thought:Report\`, \`thought:PDFSource\` — all \`rdfs:subClassOf thought:Source\`.
- \`PDFSource\` is the catch-all for PDFs that don't fit the other kinds; scholarly PDFs should classify as \`Article\` / \`Preprint\` / \`Book\` directly.

### Predicates declared with domain \`thought:Source\`
- **Dublin Core:** \`dc:title\`, \`dc:creator\`, \`dc:issued\`, \`dc:publisher\`, \`dc:language\`, \`dc:abstract\`.
- **BIBO:** \`bibo:doi\`, \`bibo:isbn\`, \`bibo:uri\`, \`bibo:numPages\`, \`bibo:pages\`, \`bibo:volume\`, \`bibo:issue\`.
- **schema.org:** \`schema:inContainer\` (Source → Source, so a journal can itself be a Source).
- **thought:** \`thought:accessedAt\`, \`thought:archivedAt\`.

Standard IRIs are reused directly rather than minting parallel thought: equivalents. rdfs annotations are added for self-documentation via \`describe_graph_schema\`; any conformant RDF tool that already knows BIBO or DC will interop automatically.

### describe_graph_schema
The tool loads the TTL verbatim (\`src/main/llm/tools.ts:6,219\`), so the new terms are exposed for free on the next LLM invocation.

## Test plan
- [x] \`tests/main/graph/source-ontology.test.ts\` — 32 tests covering subclass relationships, predicate declarations, and three hand-authored source stubs (web-page, article-in-container, preprint) that parse and query cleanly.
- [x] Full suite: 181 passing (was 149).
- [x] \`pnpm lint\`: clean.

## Out of scope (follow-on issues)
- Filesystem layout under \`.minerva/sources/\` → #89.
- \`[[cite::...]]\` link type → #91.