### PR TITLE
Add source file layout and [[cite::id]] link type

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -5,7 +5,7 @@ import fsSync from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { parseMarkdown, type ParsedTable } from './parser';
-import { getLinkType } from '../../shared/link-types';
+import { getLinkType, type LinkType } from '../../shared/link-types';
 import * as uriHelpers from './uri-helpers';
 
 import * as N3 from 'n3';
@@ -140,6 +140,14 @@ function folderUri(relativePath: string): $rdf.NamedNode {
   return $rdf.sym(uriHelpers.folderUri(baseUri, relativePath));
 }
 
+function sourceUri(sourceId: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.sourceUri(baseUri, sourceId));
+}
+
+function linkPredicate(lt: LinkType) {
+  return lt.predicateNamespace === 'thought' ? THOUGHT(lt.predicate) : MINERVA(lt.predicate);
+}
+
 function projectUri(): $rdf.NamedNode {
   return $rdf.sym(uriHelpers.projectUri(baseUri));
 }
@@ -157,6 +165,8 @@ const STANDARD_PREFIXES: [string, string][] = [
   ['xsd', 'http://www.w3.org/2001/XMLSchema#'],
   ['csvw', 'http://www.w3.org/ns/csvw#'],
   ['prov', 'http://www.w3.org/ns/prov#'],
+  ['bibo', 'http://purl.org/ontology/bibo/'],
+  ['schema', 'http://schema.org/'],
 ];
 
 function injectPrefixes(turtle: string, noteIri: string): string {
@@ -288,9 +298,12 @@ export async function indexNote(relativePath: string, content: string): Promise<
 
   // Wiki-links — typed predicates
   for (const link of parsed.links) {
-    const target = link.target.endsWith('.md') ? link.target : `${link.target}.md`;
     const linkType = getLinkType(link.type);
-    store.add(subject, MINERVA(linkType.predicate), noteUri(target), graph);
+    const predicate = linkPredicate(linkType);
+    const targetNode = linkType.targetKind === 'source'
+      ? sourceUri(link.target)
+      : noteUri(link.target.endsWith('.md') ? link.target : `${link.target}.md`);
+    store.add(subject, predicate, targetNode, graph);
   }
 
   // Frontmatter as dc: or minerva: properties
@@ -407,6 +420,53 @@ export function removeNote(relativePath: string): void {
   store.removeMatches(subject, undefined, undefined);
 }
 
+// ── Source indexing ─────────────────────────────────────────────────────────
+// A "source" is a citable external work (Article, Book, WebPage, …) whose
+// canonical metadata lives at .minerva/sources/<id>/meta.ttl. The source
+// node's URI is `${baseUri}source/<id>`; inside meta.ttl, `this:` resolves
+// to that URI so users can write `this: a thought:Article ; dc:title ...`.
+
+export function indexSource(sourceId: string, metaTtl: string): void {
+  if (!store) return;
+
+  const subject = sourceUri(sourceId);
+  const graph = subject;
+  const relativePath = `${uriHelpers.SOURCES_DIR}/${sourceId}/meta.ttl`;
+
+  store.removeMatches(undefined, undefined, undefined, graph);
+  store.removeMatches(subject, undefined, undefined);
+
+  store.add(subject, MINERVA('sourceId'), $rdf.lit(sourceId), graph);
+  store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
+  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  store.add(projectUri(), MINERVA('containsSource'), subject, graph);
+
+  try {
+    const prefixed = injectPrefixes(metaTtl, subject.value);
+    $rdf.parse(prefixed, store, graph.value, 'text/turtle');
+  } catch (e) {
+    console.error(`[minerva] Failed to parse source meta.ttl for ${sourceId}:`, e instanceof Error ? e.message : e);
+  }
+}
+
+export function removeSource(sourceId: string): void {
+  if (!store) return;
+  const subject = sourceUri(sourceId);
+  store.removeMatches(undefined, undefined, undefined, subject);
+  store.removeMatches(subject, undefined, undefined);
+}
+
+/** Parse `<id>` out of `.minerva/sources/<id>/meta.ttl`. Returns null for other paths. */
+export function parseSourceIdFromPath(relativePath: string): string | null {
+  const normalized = relativePath.replace(/\\/g, '/');
+  const prefix = `${uriHelpers.SOURCES_DIR}/`;
+  if (!normalized.startsWith(prefix)) return null;
+  if (!normalized.endsWith('/meta.ttl')) return null;
+  const id = normalized.slice(prefix.length, -'/meta.ttl'.length);
+  if (!id || id.includes('/')) return null;
+  return id;
+}
+
 function ensureTag(tagNode: $rdf.NamedNode, tagName: string): void {
   if (!store) return;
   const existing = store.statementsMatching(tagNode, RDF('type'), MINERVA('Tag'));
@@ -458,6 +518,7 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
 
   let count = 0;
   await walkAndIndex(rootPath, rootPath);
+  count += await walkAndIndexSources(rootPath);
   await persistGraph();
 
   async function walkAndIndex(dirPath: string, root: string) {
@@ -478,6 +539,30 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
     }
   }
 
+  return count;
+}
+
+async function walkAndIndexSources(rootPath: string): Promise<number> {
+  const sourcesRoot = path.join(rootPath, uriHelpers.SOURCES_DIR);
+  let count = 0;
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(sourcesRoot, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const sourceId = entry.name;
+    const metaPath = path.join(sourcesRoot, sourceId, 'meta.ttl');
+    try {
+      const content = await fs.readFile(metaPath, 'utf-8');
+      indexSource(sourceId, content);
+      count++;
+    } catch {
+      // No meta.ttl in this directory — skip
+    }
+  }
   return count;
 }
 
@@ -585,15 +670,16 @@ export function outgoingLinks(relativePath: string): OutgoingLink[] {
   const results: OutgoingLink[] = [];
 
   for (const lt of LINK_TYPES) {
-    const stmts = store.statementsMatching(subject, MINERVA(lt.predicate), undefined);
+    const stmts = store.statementsMatching(subject, linkPredicate(lt), undefined);
     for (const st of stmts) {
       const targetNode = st.object as $rdf.NamedNode;
       const pathStmts = store.statementsMatching(targetNode, MINERVA('relativePath'), undefined);
       const titleStmts = store.statementsMatching(targetNode, DC('title'), undefined);
-      const typeStmts = store.statementsMatching(targetNode, RDF('type'), MINERVA('Note'));
+      const existsPredicate = lt.targetKind === 'source' ? MINERVA('sourceId') : MINERVA('relativePath');
+      const typeStmts = store.statementsMatching(targetNode, existsPredicate, undefined);
 
       results.push({
-        target: pathStmts[0]?.object.value ?? '',
+        target: pathStmts[0]?.object.value ?? (lt.targetKind === 'source' ? targetNode.value : ''),
         targetTitle: titleStmts[0]?.object.value ?? targetNode.value,
         linkType: lt.name,
         linkLabel: lt.label,
@@ -613,7 +699,7 @@ export function backlinks(relativePath: string): Backlink[] {
   const results: Backlink[] = [];
 
   for (const lt of LINK_TYPES) {
-    const stmts = store.statementsMatching(undefined, MINERVA(lt.predicate), target);
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), target);
     for (const st of stmts) {
       const sourceNode = st.subject;
       const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);

--- a/src/main/graph/uri-helpers.ts
+++ b/src/main/graph/uri-helpers.ts
@@ -21,6 +21,12 @@ export function folderUri(baseUri: string, relativePath: string): string {
   return `${baseUri}folder/${relativePath}`;
 }
 
+export function sourceUri(baseUri: string, sourceId: string): string {
+  return `${baseUri}source/${encodeURIComponent(sourceId)}`;
+}
+
+export const SOURCES_DIR = '.minerva/sources';
+
 export function projectUri(baseUri: string): string {
   return baseUri.replace(/\/$/, '');
 }

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -1,4 +1,5 @@
 import { watch, type FSWatcher } from 'chokidar';
+import fs from 'node:fs';
 import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { Channels } from '../../shared/channels';
@@ -9,9 +10,23 @@ export interface WatcherCallbacks {
   onFileChanged: (relativePath: string) => void;
   onFileCreated: (relativePath: string) => void;
   onFileDeleted: (relativePath: string) => void;
+  onSourceMetaChanged?: (sourceId: string) => void;
+  onSourceMetaDeleted?: (sourceId: string) => void;
 }
 
-const watchers = new Map<number, FSWatcher>();
+interface WatcherPair {
+  notes: FSWatcher;
+  sources: FSWatcher;
+}
+
+const watchers = new Map<number, WatcherPair>();
+
+const SOURCE_META_RE = /(?:^|[/\\])\.minerva[/\\]sources[/\\]([^/\\]+)[/\\]meta\.ttl$/;
+
+function extractSourceId(absPath: string): string | null {
+  const m = absPath.match(SOURCE_META_RE);
+  return m ? m[1] : null;
+}
 
 export function startWatching(
   rootPath: string,
@@ -21,7 +36,7 @@ export function startWatching(
 ): void {
   stopWatching(id);
 
-  const watcher = watch(rootPath, {
+  const notes = watch(rootPath, {
     ignored: [
       /(^|[/\\])\./,
       '**/node_modules/**',
@@ -31,7 +46,7 @@ export function startWatching(
     ignoreInitial: true,
   });
 
-  watcher.on('change', (filePath) => {
+  notes.on('change', (filePath) => {
     if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
@@ -39,7 +54,7 @@ export function startWatching(
     }
   });
 
-  watcher.on('add', (filePath) => {
+  notes.on('add', (filePath) => {
     if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
@@ -47,7 +62,7 @@ export function startWatching(
     }
   });
 
-  watcher.on('unlink', (filePath) => {
+  notes.on('unlink', (filePath) => {
     if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_DELETED, relative);
@@ -55,13 +70,37 @@ export function startWatching(
     }
   });
 
-  watchers.set(id, watcher);
+  // Separate watcher scoped to .minerva/sources so meta.ttl changes reindex
+  // without un-ignoring all of .minerva (bookmarks, tabs, graph.ttl, etc.).
+  const sourcesRoot = path.join(rootPath, '.minerva', 'sources');
+  // chokidar can miss directories that don't exist at startup, so materialize
+  // the tree before registering. Safe: recursive mkdir no-ops if present.
+  try { fs.mkdirSync(sourcesRoot, { recursive: true }); } catch { /* ignore */ }
+  const sources = watch(sourcesRoot, {
+    persistent: true,
+    ignoreInitial: true,
+    depth: 2,
+  });
+
+  const handleSourceEvent = (filePath: string, kind: 'upsert' | 'delete') => {
+    const sourceId = extractSourceId(filePath);
+    if (!sourceId || win.isDestroyed()) return;
+    if (kind === 'upsert') callbacks?.onSourceMetaChanged?.(sourceId);
+    else callbacks?.onSourceMetaDeleted?.(sourceId);
+  };
+
+  sources.on('change', (filePath) => handleSourceEvent(filePath, 'upsert'));
+  sources.on('add', (filePath) => handleSourceEvent(filePath, 'upsert'));
+  sources.on('unlink', (filePath) => handleSourceEvent(filePath, 'delete'));
+
+  watchers.set(id, { notes, sources });
 }
 
 export function stopWatching(id: number): void {
-  const watcher = watchers.get(id);
-  if (watcher) {
-    watcher.close();
+  const pair = watchers.get(id);
+  if (pair) {
+    pair.notes.close();
+    pair.sources.close();
     watchers.delete(id);
   }
 }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -164,6 +164,18 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       graph.removeNote(relativePath);
       debouncedPersist();
     },
+    onSourceMetaChanged: async (sourceId) => {
+      try {
+        const relPath = `.minerva/sources/${sourceId}/meta.ttl`;
+        const content = await notebaseFs.readFile(rootPath, relPath);
+        graph.indexSource(sourceId, content);
+        debouncedPersist();
+      } catch { /* file may have been deleted between events */ }
+    },
+    onSourceMetaDeleted: (sourceId) => {
+      graph.removeSource(sourceId);
+      debouncedPersist();
+    },
   });
   watchers.set(win.id, rootPath);
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -18,6 +18,9 @@
   // Query result cache: query text → results (survives re-renders)
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
 
+  // Cite-label cache: sourceId → resolved label text (survives re-renders)
+  const citeLabelCache = new Map<string, string>();
+
   const QUERY_PREFIXES = `PREFIX minerva: <https://minerva.dev/ontology#>
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 PREFIX dc: <http://purl.org/dc/terms/>
@@ -67,8 +70,16 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // Plain links render as before
       return `<a class="wiki-link" data-target="${escapeAttr(target)}">${escapeHtml(display)}</a>`;
     }
+    // Cite links get a placeholder class so the post-render effect can
+    // swap the display text for "Title — Author (Year)" when the user
+    // didn't supply their own |display override.
+    const extraClasses = linkType.targetKind === 'source' ? ' cite-link' : '';
+    const hasOverride = display !== target;
+    const citeData = linkType.targetKind === 'source'
+      ? ` data-source-id="${escapeAttr(target)}" data-display-override="${hasOverride ? '1' : '0'}"`
+      : '';
     // Typed links render with a colored badge
-    return `<a class="wiki-link typed-link" data-target="${escapeAttr(target)}" style="--link-color: ${linkType.color}"><span class="link-type-badge" style="background: ${linkType.color}">${escapeHtml(linkType.label)}</span>${escapeHtml(display)}</a>`;
+    return `<a class="wiki-link typed-link${extraClasses}" data-target="${escapeAttr(target)}"${citeData} style="--link-color: ${linkType.color}"><span class="link-type-badge" style="background: ${linkType.color}">${escapeHtml(linkType.label)}</span><span class="link-display">${escapeHtml(display)}</span></a>`;
   };
 
   // Tag plugin: #tag (but not inside URLs or after non-whitespace)
@@ -186,8 +197,52 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     requestAnimationFrame(() => {
       const blocks = previewEl?.querySelectorAll('.query-block');
       blocks?.forEach((el) => executeQueryBlock(el as HTMLElement));
+      const cites = previewEl?.querySelectorAll('.cite-link');
+      cites?.forEach((el) => resolveCiteLabel(el as HTMLElement));
     });
   });
+
+  async function resolveCiteLabel(el: HTMLElement) {
+    const sourceId = el.dataset.sourceId;
+    if (!sourceId) return;
+    // Don't overwrite user-supplied [[cite::id|display]] text.
+    if (el.dataset.displayOverride === '1') return;
+
+    const displayEl = el.querySelector<HTMLSpanElement>('.link-display');
+    if (!displayEl) return;
+
+    const cached = citeLabelCache.get(sourceId);
+    if (cached) { displayEl.textContent = cached; return; }
+
+    try {
+      const idEsc = sourceId.replace(/"/g, '\\"');
+      const sparql = `SELECT ?title ?creator ?issued WHERE {
+        ?src minerva:sourceId "${idEsc}" .
+        OPTIONAL { ?src dc:title ?title }
+        OPTIONAL { ?src dc:creator ?creator }
+        OPTIONAL { ?src dc:issued ?issued }
+      } LIMIT 1`;
+      const response = await api.graph.query(QUERY_PREFIXES + sparql);
+      const row = response.results[0] as Record<string, string> | undefined;
+      const label = formatCiteLabel(sourceId, row);
+      citeLabelCache.set(sourceId, label);
+      displayEl.textContent = label;
+    } catch {
+      // Fall back to the source-id already rendered.
+    }
+  }
+
+  function formatCiteLabel(sourceId: string, row: Record<string, string> | undefined): string {
+    if (!row) return sourceId;
+    const title = row.title;
+    const creator = row.creator;
+    const year = row.issued ? row.issued.slice(0, 4) : '';
+    const byline = creator && year ? `${creator} (${year})` : creator || (year ? `(${year})` : '');
+    if (title && byline) return `${title} — ${byline}`;
+    if (title) return title;
+    if (byline) return byline;
+    return sourceId;
+  }
 
   async function executeQueryBlock(el: HTMLElement) {
     const query = el.dataset.query;

--- a/src/shared/link-types.ts
+++ b/src/shared/link-types.ts
@@ -10,8 +10,12 @@ export interface LinkType {
   name: string;
   /** Human-readable label */
   label: string;
-  /** OWL predicate local name (appended to minerva: namespace) */
+  /** OWL predicate local name (appended to predicateNamespace, default minerva:) */
   predicate: string;
+  /** Namespace the predicate belongs to. Default: 'minerva'. */
+  predicateNamespace?: 'minerva' | 'thought';
+  /** What the target resolves to. Default: 'note'. */
+  targetKind?: 'note' | 'source';
   /** CSS color for preview rendering */
   color: string;
 }
@@ -70,6 +74,14 @@ export const LINK_TYPES: LinkType[] = [
     label: 'Related To',
     predicate: 'relatedTo',
     color: '#9399b2', // grey
+  },
+  {
+    name: 'cite',
+    label: 'Cites',
+    predicate: 'cites',
+    predicateNamespace: 'thought',
+    targetKind: 'source',
+    color: '#94e2d5', // teal-green — distinct from references/implements
   },
 ];
 

--- a/tests/main/graph/cite-indexing.test.ts
+++ b/tests/main/graph/cite-indexing.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  indexAllNotes,
+  queryGraph,
+  outgoingLinks,
+} from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cite-test-'));
+}
+
+function writeSourceMeta(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+
+const ARTICLE_TTL = `
+this: a thought:Article ;
+    dc:title "On the structure of knowledge graphs" ;
+    dc:creator "Alice Smith" ;
+    dc:issued "2023-07-15"^^xsd:date .
+`;
+
+describe('[[cite::source-id]] link (issue #91)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('writes a thought:cites edge from the note to the source URI', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    const noteContent = '# My thoughts\n\nAs [[cite::smith-2023]] argues, knowledge graphs…';
+    await indexNote('thoughts.md', noteContent);
+
+    const { results } = await queryGraph(`
+      SELECT ?src WHERE {
+        ?note minerva:relativePath "thoughts.md" .
+        ?note thought:cites ?src .
+        ?src minerva:sourceId "smith-2023" .
+      }
+    `);
+    expect(results).toHaveLength(1);
+  });
+
+  it('does not route cite targets through the note URI namespace', async () => {
+    await indexNote('thoughts.md', 'See [[cite::smith-2023]].');
+
+    const { results } = await queryGraph(`
+      SELECT ?path WHERE {
+        ?note minerva:relativePath "thoughts.md" .
+        ?note thought:cites ?src .
+        OPTIONAL { ?src minerva:relativePath ?path }
+      }
+    `);
+    const row = (results as Array<{ path?: string }>)[0];
+    expect(row).toBeDefined();
+    expect(row.path).toBeUndefined();
+  });
+
+  it('uses thought:cites (not minerva:cites)', async () => {
+    await indexNote('thoughts.md', 'See [[cite::smith-2023]].');
+
+    const { results: withThought } = await queryGraph(`
+      SELECT ?src WHERE {
+        ?note minerva:relativePath "thoughts.md" .
+        ?note thought:cites ?src .
+      }
+    `);
+    expect(withThought).toHaveLength(1);
+
+    const { results: withMinerva } = await queryGraph(`
+      SELECT ?src WHERE {
+        ?note minerva:relativePath "thoughts.md" .
+        ?note minerva:cites ?src .
+      }
+    `);
+    expect(withMinerva).toHaveLength(0);
+  });
+
+  it('reports cite links via outgoingLinks with linkType "cite"', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+    await indexNote('thoughts.md', 'See [[cite::smith-2023]].');
+
+    const links = outgoingLinks('thoughts.md');
+    const cite = links.find(l => l.linkType === 'cite');
+    expect(cite).toBeDefined();
+    expect(cite!.exists).toBe(true);
+  });
+
+  it('existing note-typed links (supports, references, …) still work', async () => {
+    await indexNote('a.md', '# A\n\nClaim A.');
+    await indexNote('b.md', '# B\n\n[[supports::a]] is the ground.');
+
+    const { results } = await queryGraph(`
+      SELECT ?target WHERE {
+        ?note minerva:relativePath "b.md" .
+        ?note minerva:supports ?target .
+      }
+    `);
+    expect(results).toHaveLength(1);
+  });
+});

--- a/tests/main/graph/sources-index.test.ts
+++ b/tests/main/graph/sources-index.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexAllNotes,
+  indexSource,
+  removeSource,
+  queryGraph,
+  parseSourceIdFromPath,
+} from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sources-test-'));
+}
+
+function writeSourceMeta(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+
+const ARTICLE_TTL = `
+this: a thought:Article ;
+    dc:title "On the structure of knowledge graphs" ;
+    dc:creator "Alice Smith" ;
+    dc:issued "2023-07-15"^^xsd:date ;
+    bibo:doi "10.1038/s41586-023-0001-0" .
+`;
+
+const WEBPAGE_TTL = `
+this: a thought:WebPage ;
+    dc:title "Example page" ;
+    dc:creator "Ada Lovelace" ;
+    bibo:uri <https://example.com/page> .
+`;
+
+describe('source indexing (issue #89)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('indexAllNotes picks up hand-placed sources under .minerva/sources/', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    writeSourceMeta(root, 'example-page', WEBPAGE_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      SELECT ?id ?title WHERE {
+        ?src minerva:sourceId ?id ; dc:title ?title .
+      } ORDER BY ?id
+    `);
+    const rows = results as Array<{ id: string; title: string }>;
+    expect(rows).toHaveLength(2);
+    expect(rows.map(r => r.id).sort()).toEqual(['example-page', 'smith-2023']);
+  });
+
+  it('stores the source subtype from meta.ttl', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      SELECT ?type WHERE {
+        ?src minerva:sourceId "smith-2023" ; a ?type .
+        FILTER(STRSTARTS(STR(?type), "https://minerva.dev/ontology/thought#"))
+      }
+    `);
+    const types = (results as Array<{ type: string }>).map(r => r.type);
+    expect(types).toContain('https://minerva.dev/ontology/thought#Article');
+  });
+
+  it('exposes source metadata (title, creator, doi) on the source node', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      PREFIX bibo: <http://purl.org/ontology/bibo/>
+      SELECT ?title ?creator ?doi WHERE {
+        ?src minerva:sourceId "smith-2023" .
+        OPTIONAL { ?src dc:title ?title }
+        OPTIONAL { ?src dc:creator ?creator }
+        OPTIONAL { ?src bibo:doi ?doi }
+      } LIMIT 1
+    `);
+    const row = (results as Array<{ title: string; creator: string; doi: string }>)[0];
+    expect(row.title).toBe('On the structure of knowledge graphs');
+    expect(row.creator).toBe('Alice Smith');
+    expect(row.doi).toBe('10.1038/s41586-023-0001-0');
+  });
+
+  it('records relativePath pointing at .minerva/sources/<id>/meta.ttl', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      SELECT ?path WHERE { ?src minerva:sourceId "smith-2023" ; minerva:relativePath ?path . }
+    `);
+    const row = (results as Array<{ path: string }>)[0];
+    expect(row.path).toBe('.minerva/sources/smith-2023/meta.ttl');
+  });
+
+  it('removeSource drops the source from the graph', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    removeSource('smith-2023');
+    const { results } = await queryGraph(`
+      SELECT ?id WHERE { ?src minerva:sourceId ?id . }
+    `);
+    expect(results).toHaveLength(0);
+  });
+
+  it('re-indexing a source replaces its triples (no duplication)', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    const updated = `
+      this: a thought:Article ;
+          dc:title "A revised title" ;
+          dc:creator "Alice Smith" .
+    `;
+    indexSource('smith-2023', updated);
+
+    const { results } = await queryGraph(`
+      SELECT ?title WHERE { ?src minerva:sourceId "smith-2023" ; dc:title ?title . }
+    `);
+    const titles = (results as Array<{ title: string }>).map(r => r.title);
+    expect(titles).toEqual(['A revised title']);
+  });
+
+  it('parseSourceIdFromPath accepts canonical layout and rejects others', () => {
+    expect(parseSourceIdFromPath('.minerva/sources/smith-2023/meta.ttl')).toBe('smith-2023');
+    expect(parseSourceIdFromPath('.minerva/sources/smith-2023/body.md')).toBeNull();
+    expect(parseSourceIdFromPath('.minerva/sources/smith-2023/extra/meta.ttl')).toBeNull();
+    expect(parseSourceIdFromPath('notes/meta.ttl')).toBeNull();
+  });
+});

--- a/tests/main/graph/uri-helpers.test.ts
+++ b/tests/main/graph/uri-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { coinBaseUri, noteUri, tagUri, folderUri, projectUri } from '../../../src/main/graph/uri-helpers';
+import { coinBaseUri, noteUri, tagUri, folderUri, projectUri, sourceUri } from '../../../src/main/graph/uri-helpers';
 
 const BASE = 'https://project.minerva.dev/testuser/sample-project/';
 
@@ -61,5 +61,17 @@ describe('projectUri', () => {
   it('removes trailing slash from base', () => {
     const uri = projectUri(BASE);
     expect(uri).toBe(BASE.replace(/\/$/, ''));
+  });
+});
+
+describe('sourceUri', () => {
+  it('maps a simple id to a source URI', () => {
+    const uri = sourceUri(BASE, 'smith-2023');
+    expect(uri).toBe(`${BASE}source/smith-2023`);
+  });
+
+  it('encodes unsafe characters in the id', () => {
+    const uri = sourceUri(BASE, 'arxiv/2401.12345');
+    expect(uri).toBe(`${BASE}source/${encodeURIComponent('arxiv/2401.12345')}`);
   });
 });

--- a/tests/shared/link-types.test.ts
+++ b/tests/shared/link-types.test.ts
@@ -39,3 +39,16 @@ describe('LINK_TYPE_MAP', () => {
     expect(LINK_TYPE_MAP.get('nonexistent')).toBeUndefined();
   });
 });
+
+describe('cite link type', () => {
+  const cite = getLinkType('cite');
+
+  it('has predicate cites in the thought namespace', () => {
+    expect(cite.predicate).toBe('cites');
+    expect(cite.predicateNamespace).toBe('thought');
+  });
+
+  it('targets a source, not a note', () => {
+    expect(cite.targetKind).toBe('source');
+  });
+});


### PR DESCRIPTION
Closes #89, closes #91.

## Summary
- Sources now live at `.minerva/sources/<id>/meta.ttl` with URI `${baseUri}source/<id>`. A dedicated chokidar watcher on `.minerva/sources/` picks up add/change/unlink without un-ignoring the rest of `.minerva/`; `indexAllNotes` also walks the sources tree on rebuild.
- `LinkType` gained `predicateNamespace` and `targetKind`. A new `cite` entry writes `thought:cites` edges to source URIs, and the preview resolves `[[cite::id]]` labels asynchronously to "title — creator (year)" via SPARQL on `minerva:sourceId`.
- `bibo` and `schema` are now auto-injected prefixes so `meta.ttl` can use BIBO + schema.org terms unprefixed.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 197 pass (+ new `sources-index.test.ts`, `cite-indexing.test.ts`, and extensions to `uri-helpers` / `link-types` tests)
- [ ] Manual: hand-place `.minerva/sources/smith-2023/meta.ttl`, run Graph → Rebuild, confirm the source appears via SPARQL
- [ ] Manual: add `[[cite::smith-2023]]` to a note; preview shows "Title — Author (Year)" label once resolved

## Follow-ups
- Test fixtures helper to deduplicate tempdir+meta.ttl setup across source tests (punted per review)
- Canonical identifier rules (#90) and Excerpt node type (#92) still open in the epic