### PR TITLE
Add Excerpt node type and [[quote::id]] link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ coverage/
 .idea/
 *.log
 .DS_Store
+
+# Demo source/excerpt fixtures in the sample thoughtbase.
+# Everything else under sample-project/.minerva/ (bookmarks.json, tabs.json,
+# graph.ttl, conversations/, …) is still ignored — only the hand-authored
+# TTL fixtures that demonstrate [[cite::…]] / [[quote::…]] are tracked.
+!tests/fixtures/sample-project/.minerva/
+tests/fixtures/sample-project/.minerva/*
+!tests/fixtures/sample-project/.minerva/sources/
+!tests/fixtures/sample-project/.minerva/sources/**
+!tests/fixtures/sample-project/.minerva/excerpts/
+!tests/fixtures/sample-project/.minerva/excerpts/**

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -144,8 +144,24 @@ function sourceUri(sourceId: string): $rdf.NamedNode {
   return $rdf.sym(uriHelpers.sourceUri(baseUri, sourceId));
 }
 
+function excerptUri(excerptId: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.excerptUri(baseUri, excerptId));
+}
+
 function linkPredicate(lt: LinkType) {
   return lt.predicateNamespace === 'thought' ? THOUGHT(lt.predicate) : MINERVA(lt.predicate);
+}
+
+function resolveLinkTarget(lt: LinkType, target: string) {
+  if (lt.targetKind === 'source') return sourceUri(target);
+  if (lt.targetKind === 'excerpt') return excerptUri(target);
+  return noteUri(target.endsWith('.md') ? target : `${target}.md`);
+}
+
+function existsPredicateFor(lt: LinkType) {
+  if (lt.targetKind === 'source') return MINERVA('sourceId');
+  if (lt.targetKind === 'excerpt') return MINERVA('excerptId');
+  return MINERVA('relativePath');
 }
 
 function projectUri(): $rdf.NamedNode {
@@ -174,6 +190,16 @@ function injectPrefixes(turtle: string, noteIri: string): string {
   for (const [prefix, iri] of STANDARD_PREFIXES) {
     if (!turtle.includes(`@prefix ${prefix}:`)) {
       lines.push(`@prefix ${prefix}: <${iri}> .`);
+    }
+  }
+  // Project-scoped shortcuts for referring to other sources/excerpts in
+  // this thoughtbase by bare id: `sources:smith-2023`, `excerpts:p42`.
+  if (baseUri) {
+    if (!turtle.includes('@prefix sources:')) {
+      lines.push(`@prefix sources: <${baseUri}source/> .`);
+    }
+    if (!turtle.includes('@prefix excerpts:')) {
+      lines.push(`@prefix excerpts: <${baseUri}excerpt/> .`);
     }
   }
   if (!turtle.includes('@prefix this:')) {
@@ -300,9 +326,7 @@ export async function indexNote(relativePath: string, content: string): Promise<
   for (const link of parsed.links) {
     const linkType = getLinkType(link.type);
     const predicate = linkPredicate(linkType);
-    const targetNode = linkType.targetKind === 'source'
-      ? sourceUri(link.target)
-      : noteUri(link.target.endsWith('.md') ? link.target : `${link.target}.md`);
+    const targetNode = resolveLinkTarget(linkType, link.target);
     store.add(subject, predicate, targetNode, graph);
   }
 
@@ -467,6 +491,57 @@ export function parseSourceIdFromPath(relativePath: string): string | null {
   return id;
 }
 
+// ── Excerpt indexing ────────────────────────────────────────────────────────
+// An "excerpt" is a verbatim quotation lifted from a Source, stored at
+// .minerva/excerpts/<id>.ttl. The excerpt node's URI is `${baseUri}excerpt/<id>`.
+// Inside the .ttl file, `this:` resolves to that URI, and `sources:` resolves
+// to `${baseUri}source/`, so users can write:
+//   this: a thought:Excerpt ;
+//       thought:fromSource sources:smith-2023 ;
+//       thought:citedText "..." ;
+//       thought:page 42 .
+
+export function indexExcerpt(excerptId: string, metaTtl: string): void {
+  if (!store) return;
+
+  const subject = excerptUri(excerptId);
+  const graph = subject;
+  const relativePath = `${uriHelpers.EXCERPTS_DIR}/${excerptId}.ttl`;
+
+  store.removeMatches(undefined, undefined, undefined, graph);
+  store.removeMatches(subject, undefined, undefined);
+
+  store.add(subject, MINERVA('excerptId'), $rdf.lit(excerptId), graph);
+  store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
+  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  store.add(projectUri(), MINERVA('containsExcerpt'), subject, graph);
+
+  try {
+    const prefixed = injectPrefixes(metaTtl, subject.value);
+    $rdf.parse(prefixed, store, graph.value, 'text/turtle');
+  } catch (e) {
+    console.error(`[minerva] Failed to parse excerpt ttl for ${excerptId}:`, e instanceof Error ? e.message : e);
+  }
+}
+
+export function removeExcerpt(excerptId: string): void {
+  if (!store) return;
+  const subject = excerptUri(excerptId);
+  store.removeMatches(undefined, undefined, undefined, subject);
+  store.removeMatches(subject, undefined, undefined);
+}
+
+/** Parse `<id>` out of `.minerva/excerpts/<id>.ttl`. Returns null for other paths. */
+export function parseExcerptIdFromPath(relativePath: string): string | null {
+  const normalized = relativePath.replace(/\\/g, '/');
+  const prefix = `${uriHelpers.EXCERPTS_DIR}/`;
+  if (!normalized.startsWith(prefix)) return null;
+  if (!normalized.endsWith('.ttl')) return null;
+  const id = normalized.slice(prefix.length, -'.ttl'.length);
+  if (!id || id.includes('/')) return null;
+  return id;
+}
+
 function ensureTag(tagNode: $rdf.NamedNode, tagName: string): void {
   if (!store) return;
   const existing = store.statementsMatching(tagNode, RDF('type'), MINERVA('Tag'));
@@ -519,6 +594,7 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
   let count = 0;
   await walkAndIndex(rootPath, rootPath);
   count += await walkAndIndexSources(rootPath);
+  count += await walkAndIndexExcerpts(rootPath);
   await persistGraph();
 
   async function walkAndIndex(dirPath: string, root: string) {
@@ -561,6 +637,30 @@ async function walkAndIndexSources(rootPath: string): Promise<number> {
       count++;
     } catch {
       // No meta.ttl in this directory — skip
+    }
+  }
+  return count;
+}
+
+async function walkAndIndexExcerpts(rootPath: string): Promise<number> {
+  const excerptsRoot = path.join(rootPath, uriHelpers.EXCERPTS_DIR);
+  let count = 0;
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(excerptsRoot, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.ttl')) continue;
+    const excerptId = entry.name.slice(0, -'.ttl'.length);
+    const filePath = path.join(excerptsRoot, entry.name);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      indexExcerpt(excerptId, content);
+      count++;
+    } catch {
+      // Couldn't read — skip
     }
   }
   return count;
@@ -675,11 +775,12 @@ export function outgoingLinks(relativePath: string): OutgoingLink[] {
       const targetNode = st.object as $rdf.NamedNode;
       const pathStmts = store.statementsMatching(targetNode, MINERVA('relativePath'), undefined);
       const titleStmts = store.statementsMatching(targetNode, DC('title'), undefined);
-      const existsPredicate = lt.targetKind === 'source' ? MINERVA('sourceId') : MINERVA('relativePath');
+      const existsPredicate = existsPredicateFor(lt);
       const typeStmts = store.statementsMatching(targetNode, existsPredicate, undefined);
+      const isExternalTarget = lt.targetKind === 'source' || lt.targetKind === 'excerpt';
 
       results.push({
-        target: pathStmts[0]?.object.value ?? (lt.targetKind === 'source' ? targetNode.value : ''),
+        target: pathStmts[0]?.object.value ?? (isExternalTarget ? targetNode.value : ''),
         targetTitle: titleStmts[0]?.object.value ?? targetNode.value,
         linkType: lt.name,
         linkLabel: lt.label,

--- a/src/main/graph/uri-helpers.ts
+++ b/src/main/graph/uri-helpers.ts
@@ -25,7 +25,12 @@ export function sourceUri(baseUri: string, sourceId: string): string {
   return `${baseUri}source/${encodeURIComponent(sourceId)}`;
 }
 
+export function excerptUri(baseUri: string, excerptId: string): string {
+  return `${baseUri}excerpt/${encodeURIComponent(excerptId)}`;
+}
+
 export const SOURCES_DIR = '.minerva/sources';
+export const EXCERPTS_DIR = '.minerva/excerpts';
 
 export function projectUri(baseUri: string): string {
   return baseUri.replace(/\/$/, '');

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -12,19 +12,27 @@ export interface WatcherCallbacks {
   onFileDeleted: (relativePath: string) => void;
   onSourceMetaChanged?: (sourceId: string) => void;
   onSourceMetaDeleted?: (sourceId: string) => void;
+  onExcerptChanged?: (excerptId: string) => void;
+  onExcerptDeleted?: (excerptId: string) => void;
 }
 
 interface WatcherPair {
   notes: FSWatcher;
-  sources: FSWatcher;
+  minervaData: FSWatcher;
 }
 
 const watchers = new Map<number, WatcherPair>();
 
 const SOURCE_META_RE = /(?:^|[/\\])\.minerva[/\\]sources[/\\]([^/\\]+)[/\\]meta\.ttl$/;
+const EXCERPT_RE = /(?:^|[/\\])\.minerva[/\\]excerpts[/\\]([^/\\]+)\.ttl$/;
 
 function extractSourceId(absPath: string): string | null {
   const m = absPath.match(SOURCE_META_RE);
+  return m ? m[1] : null;
+}
+
+function extractExcerptId(absPath: string): string | null {
+  const m = absPath.match(EXCERPT_RE);
   return m ? m[1] : null;
 }
 
@@ -70,37 +78,48 @@ export function startWatching(
     }
   });
 
-  // Separate watcher scoped to .minerva/sources so meta.ttl changes reindex
-  // without un-ignoring all of .minerva (bookmarks, tabs, graph.ttl, etc.).
+  // Separate watcher scoped to .minerva/{sources,excerpts} so graph-backing
+  // .ttl changes reindex without un-ignoring all of .minerva (bookmarks,
+  // tabs, graph.ttl, etc.).
   const sourcesRoot = path.join(rootPath, '.minerva', 'sources');
+  const excerptsRoot = path.join(rootPath, '.minerva', 'excerpts');
   // chokidar can miss directories that don't exist at startup, so materialize
   // the tree before registering. Safe: recursive mkdir no-ops if present.
   try { fs.mkdirSync(sourcesRoot, { recursive: true }); } catch { /* ignore */ }
-  const sources = watch(sourcesRoot, {
+  try { fs.mkdirSync(excerptsRoot, { recursive: true }); } catch { /* ignore */ }
+  const minervaData = watch([sourcesRoot, excerptsRoot], {
     persistent: true,
     ignoreInitial: true,
     depth: 2,
   });
 
-  const handleSourceEvent = (filePath: string, kind: 'upsert' | 'delete') => {
+  const handleMinervaEvent = (filePath: string, kind: 'upsert' | 'delete') => {
+    if (win.isDestroyed()) return;
     const sourceId = extractSourceId(filePath);
-    if (!sourceId || win.isDestroyed()) return;
-    if (kind === 'upsert') callbacks?.onSourceMetaChanged?.(sourceId);
-    else callbacks?.onSourceMetaDeleted?.(sourceId);
+    if (sourceId) {
+      if (kind === 'upsert') callbacks?.onSourceMetaChanged?.(sourceId);
+      else callbacks?.onSourceMetaDeleted?.(sourceId);
+      return;
+    }
+    const excerptId = extractExcerptId(filePath);
+    if (excerptId) {
+      if (kind === 'upsert') callbacks?.onExcerptChanged?.(excerptId);
+      else callbacks?.onExcerptDeleted?.(excerptId);
+    }
   };
 
-  sources.on('change', (filePath) => handleSourceEvent(filePath, 'upsert'));
-  sources.on('add', (filePath) => handleSourceEvent(filePath, 'upsert'));
-  sources.on('unlink', (filePath) => handleSourceEvent(filePath, 'delete'));
+  minervaData.on('change', (filePath) => handleMinervaEvent(filePath, 'upsert'));
+  minervaData.on('add', (filePath) => handleMinervaEvent(filePath, 'upsert'));
+  minervaData.on('unlink', (filePath) => handleMinervaEvent(filePath, 'delete'));
 
-  watchers.set(id, { notes, sources });
+  watchers.set(id, { notes, minervaData });
 }
 
 export function stopWatching(id: number): void {
   const pair = watchers.get(id);
   if (pair) {
     pair.notes.close();
-    pair.sources.close();
+    pair.minervaData.close();
     watchers.delete(id);
   }
 }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -176,6 +176,18 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       graph.removeSource(sourceId);
       debouncedPersist();
     },
+    onExcerptChanged: async (excerptId) => {
+      try {
+        const relPath = `.minerva/excerpts/${excerptId}.ttl`;
+        const content = await notebaseFs.readFile(rootPath, relPath);
+        graph.indexExcerpt(excerptId, content);
+        debouncedPersist();
+      } catch { /* file may have been deleted between events */ }
+    },
+    onExcerptDeleted: (excerptId) => {
+      graph.removeExcerpt(excerptId);
+      debouncedPersist();
+    },
   });
   watchers.set(win.id, rootPath);
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -20,6 +20,8 @@
 
   // Cite-label cache: sourceId → resolved label text (survives re-renders)
   const citeLabelCache = new Map<string, string>();
+  // Quote-label cache: excerptId → resolved label text (survives re-renders)
+  const quoteLabelCache = new Map<string, string>();
 
   const QUERY_PREFIXES = `PREFIX minerva: <https://minerva.dev/ontology#>
 PREFIX thought: <https://minerva.dev/ontology/thought#>
@@ -70,16 +72,21 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // Plain links render as before
       return `<a class="wiki-link" data-target="${escapeAttr(target)}">${escapeHtml(display)}</a>`;
     }
-    // Cite links get a placeholder class so the post-render effect can
-    // swap the display text for "Title — Author (Year)" when the user
-    // didn't supply their own |display override.
-    const extraClasses = linkType.targetKind === 'source' ? ' cite-link' : '';
+    // Cite/quote links get a placeholder class so the post-render effect can
+    // swap the display text for resolved metadata when the user didn't supply
+    // their own |display override.
     const hasOverride = display !== target;
-    const citeData = linkType.targetKind === 'source'
-      ? ` data-source-id="${escapeAttr(target)}" data-display-override="${hasOverride ? '1' : '0'}"`
-      : '';
+    let extraClasses = '';
+    let resolveData = '';
+    if (linkType.targetKind === 'source') {
+      extraClasses = ' cite-link';
+      resolveData = ` data-source-id="${escapeAttr(target)}" data-display-override="${hasOverride ? '1' : '0'}"`;
+    } else if (linkType.targetKind === 'excerpt') {
+      extraClasses = ' quote-link';
+      resolveData = ` data-excerpt-id="${escapeAttr(target)}" data-display-override="${hasOverride ? '1' : '0'}"`;
+    }
     // Typed links render with a colored badge
-    return `<a class="wiki-link typed-link${extraClasses}" data-target="${escapeAttr(target)}"${citeData} style="--link-color: ${linkType.color}"><span class="link-type-badge" style="background: ${linkType.color}">${escapeHtml(linkType.label)}</span><span class="link-display">${escapeHtml(display)}</span></a>`;
+    return `<a class="wiki-link typed-link${extraClasses}" data-target="${escapeAttr(target)}"${resolveData} style="--link-color: ${linkType.color}"><span class="link-type-badge" style="background: ${linkType.color}">${escapeHtml(linkType.label)}</span><span class="link-display">${escapeHtml(display)}</span></a>`;
   };
 
   // Tag plugin: #tag (but not inside URLs or after non-whitespace)
@@ -199,6 +206,8 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       blocks?.forEach((el) => executeQueryBlock(el as HTMLElement));
       const cites = previewEl?.querySelectorAll('.cite-link');
       cites?.forEach((el) => resolveCiteLabel(el as HTMLElement));
+      const quotes = previewEl?.querySelectorAll('.quote-link');
+      quotes?.forEach((el) => resolveQuoteLabel(el as HTMLElement));
     });
   });
 
@@ -242,6 +251,54 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     if (title) return title;
     if (byline) return byline;
     return sourceId;
+  }
+
+  async function resolveQuoteLabel(el: HTMLElement) {
+    const excerptId = el.dataset.excerptId;
+    if (!excerptId) return;
+    if (el.dataset.displayOverride === '1') return;
+
+    const displayEl = el.querySelector<HTMLSpanElement>('.link-display');
+    if (!displayEl) return;
+
+    const cached = quoteLabelCache.get(excerptId);
+    if (cached) { displayEl.textContent = cached; return; }
+
+    try {
+      const idEsc = excerptId.replace(/"/g, '\\"');
+      const sparql = `SELECT ?citedText ?sourceTitle ?sourceCreator WHERE {
+        ?ex minerva:excerptId "${idEsc}" .
+        OPTIONAL { ?ex thought:citedText ?citedText }
+        OPTIONAL {
+          ?ex thought:fromSource ?src .
+          OPTIONAL { ?src dc:title ?sourceTitle }
+          OPTIONAL { ?src dc:creator ?sourceCreator }
+        }
+      } LIMIT 1`;
+      const response = await api.graph.query(QUERY_PREFIXES + sparql);
+      const row = response.results[0] as Record<string, string> | undefined;
+      const label = formatQuoteLabel(excerptId, row);
+      quoteLabelCache.set(excerptId, label);
+      displayEl.textContent = label;
+    } catch {
+      // Fall back to the excerpt-id already rendered.
+    }
+  }
+
+  function formatQuoteLabel(excerptId: string, row: Record<string, string> | undefined): string {
+    if (!row) return excerptId;
+    const quoted = row.citedText;
+    const src = row.sourceTitle || row.sourceCreator;
+    const snippet = quoted ? truncate(quoted, 80) : '';
+    if (snippet && src) return `“${snippet}” — ${src}`;
+    if (snippet) return `“${snippet}”`;
+    if (src) return src;
+    return excerptId;
+  }
+
+  function truncate(s: string, max: number): string {
+    if (s.length <= max) return s;
+    return s.slice(0, max - 1).trimEnd() + '…';
   }
 
   async function executeQueryBlock(el: HTMLElement) {

--- a/src/shared/link-types.ts
+++ b/src/shared/link-types.ts
@@ -15,7 +15,7 @@ export interface LinkType {
   /** Namespace the predicate belongs to. Default: 'minerva'. */
   predicateNamespace?: 'minerva' | 'thought';
   /** What the target resolves to. Default: 'note'. */
-  targetKind?: 'note' | 'source';
+  targetKind?: 'note' | 'source' | 'excerpt';
   /** CSS color for preview rendering */
   color: string;
 }
@@ -82,6 +82,14 @@ export const LINK_TYPES: LinkType[] = [
     predicateNamespace: 'thought',
     targetKind: 'source',
     color: '#94e2d5', // teal-green — distinct from references/implements
+  },
+  {
+    name: 'quote',
+    label: 'Quotes',
+    predicate: 'quotes',
+    predicateNamespace: 'thought',
+    targetKind: 'excerpt',
+    color: '#b4befe', // lavender — adjacent to cite but distinct
   },
 ];
 

--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -286,6 +286,77 @@ thought:Finding a owl:Class ;
     rdfs:label "Finding" ;
     rdfs:comment "A reported result from research or investigation." .
 
+# ── Excerpts ──────────────────────────────────────────────────────────────
+# An Excerpt is the atomic "I read this and pulled this out" unit: a verbatim
+# quotation from a Source, with enough location metadata to point back at
+# exactly where it came from. Claims cite Sources; they quote Excerpts.
+
+thought:Excerpt a owl:Class ;
+    rdfs:subClassOf thought:Component ;
+    rdfs:label "Excerpt" ;
+    rdfs:comment "A verbatim quotation lifted out of a Source. Excerpts are the atomic evidentiary unit — most claims that rest on external reading are supported via an Excerpt, which in turn knows its Source." .
+
+thought:fromSource a owl:ObjectProperty ;
+    rdfs:label "from source" ;
+    rdfs:comment "The Source that this Excerpt was lifted from." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range thought:Source .
+
+thought:citedText a owl:DatatypeProperty ;
+    rdfs:label "cited text" ;
+    rdfs:comment "The verbatim quoted passage. Should be exactly what appears in the source — not paraphrased." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:string .
+
+thought:quotes a owl:ObjectProperty ;
+    rdfs:label "quotes" ;
+    rdfs:comment "This component quotes / references the named Excerpt. The edge created by [[quote::excerpt-id]]." ;
+    rdfs:domain thought:Component ;
+    rdfs:range thought:Excerpt .
+
+# ── Excerpt Location ──────────────────────────────────────────────────────
+# Structured predicates for pinning an Excerpt to a spot in its Source.
+# These are compatible (a PDF excerpt can set both page and charStart/charEnd),
+# and locationText is the escape hatch for anything else. Distinct from
+# thought:sourceOffset / thought:sourceLength, which ground a component to
+# a character range inside a note in the thoughtbase.
+
+thought:page a owl:DatatypeProperty ;
+    rdfs:label "page" ;
+    rdfs:comment "Page number in the Source where this Excerpt begins (1-based)." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:integer .
+
+thought:pageRange a owl:DatatypeProperty ;
+    rdfs:label "page range" ;
+    rdfs:comment "Page range in the Source covered by this Excerpt (e.g. '42-45')." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:string .
+
+thought:charStart a owl:DatatypeProperty ;
+    rdfs:label "char start" ;
+    rdfs:comment "0-based character offset of the excerpt's first character within the Source's extracted body." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:integer .
+
+thought:charEnd a owl:DatatypeProperty ;
+    rdfs:label "char end" ;
+    rdfs:comment "Exclusive 0-based character offset of the excerpt's end within the Source's extracted body." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:integer .
+
+thought:selector a owl:DatatypeProperty ;
+    rdfs:label "selector" ;
+    rdfs:comment "CSS selector or XPath identifying the excerpt within an HTML Source." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:string .
+
+thought:locationText a owl:DatatypeProperty ;
+    rdfs:label "location text" ;
+    rdfs:comment "Free-form fallback location description for cases that don't fit the structured predicates (e.g. 'Chapter 3, §2.1' or 'timestamp 00:14:32')." ;
+    rdfs:domain thought:Excerpt ;
+    rdfs:range xsd:string .
+
 thought:Methodology a owl:Class ;
     rdfs:subClassOf thought:Component ;
     rdfs:label "Methodology" ;

--- a/tests/fixtures/sample-project/.minerva/excerpts/brooks-essential-accidental.ttl
+++ b/tests/fixtures/sample-project/.minerva/excerpts/brooks-essential-accidental.ttl
@@ -1,0 +1,5 @@
+this: a thought:Excerpt ;
+    thought:fromSource sources:brooks-1986 ;
+    thought:citedText "The essence of a software entity is a construct of interlocking concepts: data sets, relationships among data items, algorithms, and invocations of functions. This essence is abstract in that such a conceptual construct is the same under many different representations. It is nonetheless highly precise and richly detailed." ;
+    thought:page 11 ;
+    thought:locationText "Section: The Essential Difficulties" .

--- a/tests/fixtures/sample-project/.minerva/excerpts/toulmin-warrants-intro.ttl
+++ b/tests/fixtures/sample-project/.minerva/excerpts/toulmin-warrants-intro.ttl
@@ -1,0 +1,5 @@
+this: a thought:Excerpt ;
+    thought:fromSource sources:toulmin-1958 ;
+    thought:citedText "Data such as D entitle one to draw conclusions, or make claims such as C, only if one can appeal in their support to some general rule or warrant." ;
+    thought:pageRange "97-98" ;
+    thought:locationText "Chapter III, introducing warrants" .

--- a/tests/fixtures/sample-project/.minerva/sources/brooks-1986/meta.ttl
+++ b/tests/fixtures/sample-project/.minerva/sources/brooks-1986/meta.ttl
@@ -1,0 +1,11 @@
+this: a thought:Article ;
+    dc:title "No Silver Bullet — Essence and Accident in Software Engineering" ;
+    dc:creator "Frederick P. Brooks, Jr." ;
+    dc:issued "1987-04"^^xsd:gYearMonth ;
+    dc:publisher "IEEE" ;
+    bibo:doi "10.1109/MC.1987.1663532" ;
+    bibo:uri <https://doi.org/10.1109/MC.1987.1663532> ;
+    bibo:volume "20" ;
+    bibo:issue "4" ;
+    bibo:pages "10-19" ;
+    dc:abstract "Brooks's essay distinguishing essential complexity (inherent to the problem) from accidental complexity (arising from implementation), arguing that no single development advance will yield an order-of-magnitude productivity gain." .

--- a/tests/fixtures/sample-project/.minerva/sources/toulmin-1958/meta.ttl
+++ b/tests/fixtures/sample-project/.minerva/sources/toulmin-1958/meta.ttl
@@ -1,0 +1,8 @@
+this: a thought:Book ;
+    dc:title "The Uses of Argument" ;
+    dc:creator "Stephen E. Toulmin" ;
+    dc:issued "1958"^^xsd:gYear ;
+    dc:publisher "Cambridge University Press" ;
+    bibo:isbn "9780521534833" ;
+    bibo:numPages 262 ;
+    dc:abstract "Toulmin's analysis of everyday argumentation, introducing the claim / grounds / warrant / backing / qualifier / rebuttal schema that Minerva's thought ontology extends." .

--- a/tests/fixtures/sample-project/research/essential-complexity.md
+++ b/tests/fixtures/sample-project/research/essential-complexity.md
@@ -1,0 +1,42 @@
+---
+title: Essential complexity — notes
+description: Working notes on the essential/accidental complexity distinction, with a Toulmin-style justification of the claim that tooling alone cannot collapse essence.
+status: draft
+---
+
+# Essential complexity
+
+## The claim
+
+Most software productivity gains over the past fifty years have attacked
+**accidental** complexity — assemblers, garbage collection, high-level languages,
+IDEs — rather than the **essential** complexity of modelling the domain itself.
+Brooks's core thesis is that because the essential portion dominates modern
+systems, no further tooling improvement can produce an order-of-magnitude
+productivity jump.
+
+## Grounds
+
+Brooks frames this with a now-famous distinction:
+
+> [[quote::brooks-essential-accidental]]
+
+See [[cite::brooks-1986]] for the full argument.
+
+## Warrant
+
+Toulmin's framework is useful for articulating *why* the grounds above support
+the claim: we need an explicit warrant connecting "essence dominates accident"
+to "no single tooling improvement buys an order of magnitude."
+
+> [[quote::toulmin-warrants-intro]]
+
+The warrant here is something like: *productivity-gain advances that attack
+only the minority component of total effort cannot, by arithmetic alone, move
+the total by an order of magnitude.* That warrant is what justifies the
+inferential step from [[cite::brooks-1986]]'s data to the "no silver bullet"
+conclusion.
+
+## Tags
+
+#software-engineering #epistemology #toulmin

--- a/tests/main/graph/excerpt-index.test.ts
+++ b/tests/main/graph/excerpt-index.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  indexAllNotes,
+  indexExcerpt,
+  removeExcerpt,
+  queryGraph,
+  outgoingLinks,
+  parseExcerptIdFromPath,
+} from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-excerpt-test-'));
+}
+
+function writeSourceMeta(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+
+function writeExcerpt(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'excerpts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.ttl`), ttl, 'utf-8');
+}
+
+const SOURCE_TTL = `
+this: a thought:Article ;
+    dc:title "On the structure of knowledge graphs" ;
+    dc:creator "Alice Smith" ;
+    dc:issued "2023-07-15"^^xsd:date .
+`;
+
+const EXCERPT_TTL = `
+this: a thought:Excerpt ;
+    thought:fromSource sources:smith-2023 ;
+    thought:citedText "Graphs are inherently relational." ;
+    thought:page 42 ;
+    thought:charStart 1234 ;
+    thought:charEnd 1278 .
+`;
+
+describe('excerpt indexing (issue #92)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('indexAllNotes picks up hand-placed excerpts under .minerva/excerpts/', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      SELECT ?id WHERE { ?ex minerva:excerptId ?id . }
+    `);
+    const ids = (results as Array<{ id: string }>).map(r => r.id);
+    expect(ids).toEqual(['smith-2023-p42']);
+  });
+
+  it('resolves sources: prefix so thought:fromSource points at the Source URI', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      SELECT ?title WHERE {
+        ?ex minerva:excerptId "smith-2023-p42" ;
+            thought:fromSource ?src .
+        ?src minerva:sourceId "smith-2023" ;
+             dc:title ?title .
+      }
+    `);
+    const row = (results as Array<{ title: string }>)[0];
+    expect(row?.title).toBe('On the structure of knowledge graphs');
+  });
+
+  it('stores structured location predicates on the excerpt', async () => {
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    const { results } = await queryGraph(`
+      SELECT ?page ?charStart ?charEnd ?text WHERE {
+        ?ex minerva:excerptId "smith-2023-p42" ;
+            thought:page ?page ;
+            thought:charStart ?charStart ;
+            thought:charEnd ?charEnd ;
+            thought:citedText ?text .
+      } LIMIT 1
+    `);
+    const row = (results as Array<Record<string, string>>)[0];
+    expect(row.page).toBe('42');
+    expect(row.charStart).toBe('1234');
+    expect(row.charEnd).toBe('1278');
+    expect(row.text).toBe('Graphs are inherently relational.');
+  });
+
+  it('removeExcerpt drops the excerpt triples', async () => {
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    removeExcerpt('smith-2023-p42');
+    const { results } = await queryGraph(`SELECT ?id WHERE { ?ex minerva:excerptId ?id . }`);
+    expect(results).toHaveLength(0);
+  });
+
+  it('re-indexing an excerpt replaces its triples', async () => {
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    indexExcerpt('smith-2023-p42', `
+      this: a thought:Excerpt ;
+          thought:citedText "Revised quotation." .
+    `);
+
+    const { results } = await queryGraph(`
+      SELECT ?text WHERE { ?ex minerva:excerptId "smith-2023-p42" ; thought:citedText ?text . }
+    `);
+    const texts = (results as Array<{ text: string }>).map(r => r.text);
+    expect(texts).toEqual(['Revised quotation.']);
+  });
+
+  it('parseExcerptIdFromPath accepts canonical layout and rejects others', () => {
+    expect(parseExcerptIdFromPath('.minerva/excerpts/smith-2023-p42.ttl')).toBe('smith-2023-p42');
+    expect(parseExcerptIdFromPath('.minerva/excerpts/smith-2023-p42/meta.ttl')).toBeNull();
+    expect(parseExcerptIdFromPath('.minerva/sources/foo/meta.ttl')).toBeNull();
+    expect(parseExcerptIdFromPath('notes/foo.ttl')).toBeNull();
+  });
+});
+
+describe('[[quote::excerpt-id]] link and graph walk', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('writes a thought:quotes edge from the note to the excerpt URI', async () => {
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    await indexNote('argument.md', '# Argument\n\nAs [[quote::smith-2023-p42]] shows...');
+
+    const { results } = await queryGraph(`
+      SELECT ?ex WHERE {
+        ?note minerva:relativePath "argument.md" .
+        ?note thought:quotes ?ex .
+        ?ex minerva:excerptId "smith-2023-p42" .
+      }
+    `);
+    expect(results).toHaveLength(1);
+  });
+
+  it('walks claim → thought:quotes → excerpt → thought:fromSource → source', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+    await indexNote('argument.md', '# Argument\n\n[[quote::smith-2023-p42]]');
+
+    const { results } = await queryGraph(`
+      SELECT ?sourceTitle ?citedText WHERE {
+        ?note minerva:relativePath "argument.md" .
+        ?note thought:quotes ?ex .
+        ?ex thought:citedText ?citedText ;
+            thought:fromSource ?src .
+        ?src dc:title ?sourceTitle .
+      }
+    `);
+    const row = (results as Array<{ sourceTitle: string; citedText: string }>)[0];
+    expect(row.citedText).toBe('Graphs are inherently relational.');
+    expect(row.sourceTitle).toBe('On the structure of knowledge graphs');
+  });
+
+  it('outgoingLinks reports the quote edge with linkType "quote"', async () => {
+    writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
+    await indexAllNotes(root);
+    await indexNote('argument.md', '[[quote::smith-2023-p42]]');
+
+    const links = outgoingLinks('argument.md');
+    const quote = links.find(l => l.linkType === 'quote');
+    expect(quote).toBeDefined();
+    expect(quote!.exists).toBe(true);
+  });
+});

--- a/tests/main/graph/excerpt-ontology.test.ts
+++ b/tests/main/graph/excerpt-ontology.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as $rdf from 'rdflib';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
+const RDF = $rdf.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+const RDFS = $rdf.Namespace('http://www.w3.org/2000/01/rdf-schema#');
+const OWL = $rdf.Namespace('http://www.w3.org/2002/07/owl#');
+const DC = $rdf.Namespace('http://purl.org/dc/terms/');
+const XSD = $rdf.Namespace('http://www.w3.org/2001/XMLSchema#');
+
+const ONTOLOGY_PATH = path.join(__dirname, '../../../src/shared/ontology-thought.ttl');
+const ONTOLOGY_TTL = fs.readFileSync(ONTOLOGY_PATH, 'utf-8');
+
+function freshStore(): $rdf.IndexedFormula {
+  const store = $rdf.graph();
+  $rdf.parse(ONTOLOGY_TTL, store, THOUGHT('').value, 'text/turtle');
+  return store;
+}
+
+describe('Excerpt class and core predicates', () => {
+  let store: $rdf.IndexedFormula;
+  beforeAll(() => { store = freshStore(); });
+
+  it('declares thought:Excerpt as an owl:Class subclass of thought:Component', () => {
+    expect(store.statementsMatching(THOUGHT('Excerpt'), RDF('type'), OWL('Class'))).toHaveLength(1);
+    expect(store.statementsMatching(THOUGHT('Excerpt'), RDFS('subClassOf'), THOUGHT('Component'))).toHaveLength(1);
+  });
+
+  it('declares thought:fromSource from Excerpt to Source', () => {
+    expect(store.statementsMatching(THOUGHT('fromSource'), RDFS('domain'), THOUGHT('Excerpt'))).toHaveLength(1);
+    expect(store.statementsMatching(THOUGHT('fromSource'), RDFS('range'), THOUGHT('Source'))).toHaveLength(1);
+  });
+
+  it('declares thought:citedText as a string literal on Excerpt', () => {
+    expect(store.statementsMatching(THOUGHT('citedText'), RDFS('domain'), THOUGHT('Excerpt'))).toHaveLength(1);
+    expect(store.statementsMatching(THOUGHT('citedText'), RDFS('range'), XSD('string'))).toHaveLength(1);
+  });
+
+  it('declares thought:quotes from any Component to Excerpt', () => {
+    expect(store.statementsMatching(THOUGHT('quotes'), RDFS('domain'), THOUGHT('Component'))).toHaveLength(1);
+    expect(store.statementsMatching(THOUGHT('quotes'), RDFS('range'), THOUGHT('Excerpt'))).toHaveLength(1);
+  });
+});
+
+describe('Excerpt location predicates', () => {
+  let store: $rdf.IndexedFormula;
+  beforeAll(() => { store = freshStore(); });
+
+  const locationPredicates: Array<{ local: string; range: ReturnType<typeof XSD> }> = [
+    { local: 'page', range: XSD('integer') },
+    { local: 'pageRange', range: XSD('string') },
+    { local: 'charStart', range: XSD('integer') },
+    { local: 'charEnd', range: XSD('integer') },
+    { local: 'selector', range: XSD('string') },
+    { local: 'locationText', range: XSD('string') },
+  ];
+
+  for (const { local, range } of locationPredicates) {
+    it(`declares thought:${local} on Excerpt domain`, () => {
+      expect(store.statementsMatching(THOUGHT(local), RDFS('domain'), THOUGHT('Excerpt'))).toHaveLength(1);
+      expect(store.statementsMatching(THOUGHT(local), RDFS('range'), range)).toHaveLength(1);
+    });
+  }
+});
+
+describe('hand-authored excerpt stub parses cleanly', () => {
+  it('parses an excerpt with fromSource and structured location', () => {
+    const store = freshStore();
+    const ttl = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      @prefix dc:      <http://purl.org/dc/terms/> .
+      @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+      <urn:src:smith-2023> a thought:Article ;
+          dc:title "On the structure of knowledge graphs" .
+
+      <urn:ex:smith-2023-p42> a thought:Excerpt ;
+          thought:fromSource <urn:src:smith-2023> ;
+          thought:citedText "Graphs are inherently relational." ;
+          thought:page 42 ;
+          thought:charStart 1234 ;
+          thought:charEnd 1278 .
+    `;
+    expect(() => $rdf.parse(ttl, store, 'urn:test:void', 'text/turtle')).not.toThrow();
+
+    const ex = $rdf.sym('urn:ex:smith-2023-p42');
+    expect(store.any(ex, THOUGHT('citedText'))?.value).toBe('Graphs are inherently relational.');
+    expect(store.any(ex, THOUGHT('page'))?.value).toBe('42');
+    expect(store.any(ex, THOUGHT('fromSource'))?.value).toBe('urn:src:smith-2023');
+  });
+});

--- a/tests/main/graph/uri-helpers.test.ts
+++ b/tests/main/graph/uri-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { coinBaseUri, noteUri, tagUri, folderUri, projectUri, sourceUri } from '../../../src/main/graph/uri-helpers';
+import { coinBaseUri, noteUri, tagUri, folderUri, projectUri, sourceUri, excerptUri } from '../../../src/main/graph/uri-helpers';
 
 const BASE = 'https://project.minerva.dev/testuser/sample-project/';
 
@@ -73,5 +73,17 @@ describe('sourceUri', () => {
   it('encodes unsafe characters in the id', () => {
     const uri = sourceUri(BASE, 'arxiv/2401.12345');
     expect(uri).toBe(`${BASE}source/${encodeURIComponent('arxiv/2401.12345')}`);
+  });
+});
+
+describe('excerptUri', () => {
+  it('maps a simple id to an excerpt URI', () => {
+    const uri = excerptUri(BASE, 'smith-2023-p42');
+    expect(uri).toBe(`${BASE}excerpt/smith-2023-p42`);
+  });
+
+  it('encodes unsafe characters in the id', () => {
+    const uri = excerptUri(BASE, 'doc/quote#1');
+    expect(uri).toBe(`${BASE}excerpt/${encodeURIComponent('doc/quote#1')}`);
   });
 });

--- a/tests/shared/link-types.test.ts
+++ b/tests/shared/link-types.test.ts
@@ -52,3 +52,16 @@ describe('cite link type', () => {
     expect(cite.targetKind).toBe('source');
   });
 });
+
+describe('quote link type', () => {
+  const quote = getLinkType('quote');
+
+  it('has predicate quotes in the thought namespace', () => {
+    expect(quote.predicate).toBe('quotes');
+    expect(quote.predicateNamespace).toBe('thought');
+  });
+
+  it('targets an excerpt', () => {
+    expect(quote.targetKind).toBe('excerpt');
+  });
+});


### PR DESCRIPTION
Closes #92. Stacked on top of #129 (source layout + cite link).

## Summary
- `thought:Excerpt` subclass of `thought:Component`, with `thought:fromSource` → Source, `thought:citedText` (verbatim passage), and structured location predicates: `thought:page`, `pageRange`, `charStart`, `charEnd`, `selector`, plus a `locationText` free-form fallback.
- Excerpts live flat at `.minerva/excerpts/<id>.ttl`; URI is `\${baseUri}excerpt/<id>`.
- Auto-injected `sources:` and `excerpts:` prefixes so `meta.ttl` / excerpt `.ttl` files can write `thought:fromSource sources:smith-2023` without a header.
- `[[quote::excerpt-id]]` creates a `thought:quotes` edge (Component → Excerpt); preview resolves to "«truncated citedText» — Source title/creator" asynchronously.
- The .minerva watcher now covers both sources and excerpts in a single chokidar instance.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 221 pass, including new excerpt-ontology (11), excerpt-index (9), cite/quote link-type coverage, and a SPARQL walk test (note → quotes → excerpt → fromSource → source)
- [ ] Manual: hand-place `.minerva/sources/smith-2023/meta.ttl` and `.minerva/excerpts/smith-2023-p42.ttl`, Graph → Rebuild, confirm SPARQL walk works
- [ ] Manual: `[[quote::smith-2023-p42]]` in a note renders "«cited text» — Source title" after preview load

## Base branch
This PR targets `issue-89-91-sources-and-cite` (#129). Rebase / change base to `main` after #129 merges.