### PR TITLE
Click-through for cite and quote links

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -822,6 +822,156 @@ export function backlinks(relativePath: string): Backlink[] {
   return results;
 }
 
+// ── Source detail queries ───────────────────────────────────────────────────
+
+import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink } from '../../shared/types';
+
+const BIBO = $rdf.Namespace('http://purl.org/ontology/bibo/');
+
+export function getSourceDetail(sourceId: string): SourceDetail | null {
+  if (!store) return null;
+
+  const subject = sourceUri(sourceId);
+  // Probe for existence via sourceId triple (which indexSource always writes).
+  const exists = store.statementsMatching(subject, MINERVA('sourceId'), undefined).length > 0;
+  if (!exists) return null;
+
+  const metadata = collectSourceMetadata(sourceId, subject);
+  const excerpts = collectExcerptsForSource(subject);
+  const backlinks = collectSourceBacklinks(subject, excerpts);
+
+  return { metadata, excerpts, backlinks };
+}
+
+function collectSourceMetadata(sourceId: string, subject: $rdf.NamedNode): SourceMetadata {
+  if (!store) {
+    return {
+      sourceId, subtype: null, title: null, creators: [], year: null,
+      publisher: null, doi: null, uri: null, abstract: null,
+    };
+  }
+
+  // Pick the most specific thought:* type we recognize (not the generic Source).
+  let subtype: string | null = null;
+  const typeStmts = store.statementsMatching(subject, RDF('type'), undefined);
+  for (const st of typeStmts) {
+    const val = st.object.value;
+    if (!val.startsWith(THOUGHT('').value)) continue;
+    const local = val.slice(THOUGHT('').value.length);
+    if (local === 'Source' || local === 'Component') continue;
+    subtype = local;
+    break;
+  }
+
+  const creators: string[] = [];
+  for (const st of store.statementsMatching(subject, DC('creator'), undefined)) {
+    const v = st.object.value;
+    if (!creators.includes(v)) creators.push(v);
+  }
+
+  const first = (pred: ReturnType<typeof MINERVA>): string | null => {
+    const stmts = store!.statementsMatching(subject, pred, undefined);
+    return stmts[0]?.object.value ?? null;
+  };
+
+  const issued = first(DC('issued'));
+  return {
+    sourceId,
+    subtype,
+    title: first(DC('title')),
+    creators,
+    year: issued ? issued.slice(0, 4) : null,
+    publisher: first(DC('publisher')),
+    doi: first(BIBO('doi')),
+    uri: first(BIBO('uri')),
+    abstract: first(DC('abstract')),
+  };
+}
+
+function collectExcerptsForSource(sourceSubject: $rdf.NamedNode): SourceExcerpt[] {
+  if (!store) return [];
+
+  const excerpts: SourceExcerpt[] = [];
+  const seen = new Set<string>();
+  const stmts = store.statementsMatching(undefined, THOUGHT('fromSource'), sourceSubject);
+  for (const st of stmts) {
+    const ex = st.subject as $rdf.NamedNode;
+    const idStmts = store.statementsMatching(ex, MINERVA('excerptId'), undefined);
+    const id = idStmts[0]?.object.value;
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+
+    const first = (pred: ReturnType<typeof MINERVA>): string | null => {
+      const s = store!.statementsMatching(ex, pred, undefined);
+      return s[0]?.object.value ?? null;
+    };
+
+    excerpts.push({
+      excerptId: id,
+      citedText: first(THOUGHT('citedText')),
+      page: first(THOUGHT('page')),
+      pageRange: first(THOUGHT('pageRange')),
+      locationText: first(THOUGHT('locationText')),
+    });
+  }
+  excerpts.sort((a, b) => a.excerptId.localeCompare(b.excerptId));
+  return excerpts;
+}
+
+function collectSourceBacklinks(
+  sourceSubject: $rdf.NamedNode,
+  excerpts: SourceExcerpt[],
+): SourceBacklink[] {
+  if (!store) return [];
+
+  const results: SourceBacklink[] = [];
+  const seen = new Set<string>();
+
+  const pushBacklink = (noteSubject: $rdf.NamedNode, kind: 'cite' | 'quote', viaExcerptId?: string) => {
+    const pathStmts = store!.statementsMatching(noteSubject, MINERVA('relativePath'), undefined);
+    const relativePath = pathStmts[0]?.object.value;
+    if (!relativePath) return;
+    const key = `${kind}::${relativePath}::${viaExcerptId ?? ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const titleStmts = store!.statementsMatching(noteSubject, DC('title'), undefined);
+    results.push({
+      relativePath,
+      title: titleStmts[0]?.object.value ?? relativePath,
+      kind,
+      viaExcerptId,
+    });
+  };
+
+  // Direct cites
+  for (const st of store.statementsMatching(undefined, THOUGHT('cites'), sourceSubject)) {
+    pushBacklink(st.subject as $rdf.NamedNode, 'cite');
+  }
+
+  // Quotes of excerpts that belong to this source
+  for (const ex of excerpts) {
+    const exNode = excerptUri(ex.excerptId);
+    for (const st of store.statementsMatching(undefined, THOUGHT('quotes'), exNode)) {
+      pushBacklink(st.subject as $rdf.NamedNode, 'quote', ex.excerptId);
+    }
+  }
+
+  results.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return results;
+}
+
+/** Resolve an excerpt-id to the sourceId of its fromSource, or null if not found. */
+export function getExcerptSource(excerptId: string): { sourceId: string } | null {
+  if (!store) return null;
+  const ex = excerptUri(excerptId);
+  const stmts = store.statementsMatching(ex, THOUGHT('fromSource'), undefined);
+  const sourceNode = stmts[0]?.object as $rdf.NamedNode | undefined;
+  if (!sourceNode) return null;
+  const idStmts = store.statementsMatching(sourceNode, MINERVA('sourceId'), undefined);
+  const id = idStmts[0]?.object.value;
+  return id ? { sourceId: id } : null;
+}
+
 // ── Persistence & Export ────────────────────────────────────────────────────
 
 export async function persistGraph(): Promise<void> {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -307,6 +307,14 @@ export function registerIpcHandlers(): void {
     return graph.queryGraph(sparql);
   });
 
+  ipcMain.handle(Channels.GRAPH_SOURCE_DETAIL, (_e, sourceId: string) => {
+    return graph.getSourceDetail(sourceId);
+  });
+
+  ipcMain.handle(Channels.GRAPH_EXCERPT_SOURCE, (_e, excerptId: string) => {
+    return graph.getExcerptSource(excerptId);
+  });
+
   // Tags
   ipcMain.handle(Channels.TAGS_LIST, () => {
     return graph.listTags();

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -59,6 +59,8 @@ contextBridge.exposeInMainWorld('api', {
     inspections: () => ipcRenderer.invoke(Channels.INSPECTIONS_LIST),
     runInspections: () => ipcRenderer.invoke(Channels.INSPECTIONS_RUN),
     export: () => ipcRenderer.invoke(Channels.GRAPH_EXPORT),
+    sourceDetail: (sourceId: string) => ipcRenderer.invoke(Channels.GRAPH_SOURCE_DETAIL, sourceId),
+    excerptSource: (excerptId: string) => ipcRenderer.invoke(Channels.GRAPH_EXCERPT_SOURCE, excerptId),
   },
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -8,6 +8,7 @@
   import StatusBar from './lib/components/StatusBar.svelte';
   import type { CursorInfo } from './lib/components/Editor.svelte';
   import Preview from './lib/components/Preview.svelte';
+  import SourceDetail from './lib/components/SourceDetail.svelte';
   import { onMount, tick } from 'svelte';
   import { getNotebaseStore } from './lib/stores/notebase.svelte';
   import { getEditorStore } from './lib/stores/editor.svelte';
@@ -125,6 +126,18 @@
     const notePath = target.endsWith('.md') ? target : `${target}.md`;
     editor.openFile(notePath);
     nav.record({ type: 'note', relativePath: notePath, offset: 0 });
+  }
+
+  function handleOpenSource(sourceId: string, highlightExcerptId?: string) {
+    recordCurrentPosition();
+    editor.openSource(sourceId, { highlightExcerptId });
+    nav.record({ type: 'source', sourceId, highlightExcerptId });
+  }
+
+  async function handleOpenExcerpt(excerptId: string) {
+    const result = await api.graph.excerptSource(excerptId);
+    if (!result) return;
+    handleOpenSource(result.sourceId, excerptId);
   }
 
   function handleTagSelect(tag: string) {
@@ -273,6 +286,9 @@
         editorComponent?.gotoOffset(pos.offset);
         nav.doneNavigating();
       });
+    } else if (pos.type === 'source') {
+      editor.openSource(pos.sourceId, { highlightExcerptId: pos.highlightExcerptId });
+      nav.doneNavigating();
     } else {
       const idx = editor.tabs.findIndex((t) => t.type === 'query' && t.id === pos.tabId);
       if (idx >= 0) {
@@ -625,6 +641,8 @@
                   content={editor.content}
                   onNavigate={handleNavigate}
                   onTagSelect={handleTagSelect}
+                  onOpenSource={handleOpenSource}
+                  onOpenExcerpt={handleOpenExcerpt}
                 />
               </div>
             {/if}
@@ -661,6 +679,14 @@
               onNavigate={handleNavigate}
             />
           {/if}
+        {:else if editor.activeTab?.type === 'source'}
+          {#key editor.activeTab.sourceId}
+            <SourceDetail
+              sourceId={editor.activeTab.sourceId}
+              highlightExcerptId={editor.activeTab.highlightExcerptId}
+              onNavigate={handleNavigate}
+            />
+          {/key}
         {:else}
           <div class="no-file">
             <p>Select a note from the sidebar</p>

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -11,9 +11,11 @@
     content: string;
     onNavigate: (target: string) => void;
     onTagSelect?: (tag: string) => void;
+    onOpenSource?: (sourceId: string) => void;
+    onOpenExcerpt?: (excerptId: string) => void;
   }
 
-  let { content, onNavigate, onTagSelect }: Props = $props();
+  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt }: Props = $props();
 
   // Query result cache: query text → results (survives re-renders)
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
@@ -524,6 +526,22 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
   function handleClick(e: MouseEvent) {
     const el = e.target as HTMLElement;
+
+    const citeLink = el.closest<HTMLElement>('.cite-link');
+    if (citeLink) {
+      e.preventDefault();
+      const sourceId = citeLink.dataset.sourceId;
+      if (sourceId && onOpenSource) onOpenSource(sourceId);
+      return;
+    }
+
+    const quoteLink = el.closest<HTMLElement>('.quote-link');
+    if (quoteLink) {
+      e.preventDefault();
+      const excerptId = quoteLink.dataset.excerptId;
+      if (excerptId && onOpenExcerpt) onOpenExcerpt(excerptId);
+      return;
+    }
 
     const wikiLink = el.closest<HTMLElement>('.wiki-link');
     if (wikiLink) {

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import { api } from '../ipc/client';
+  import type { SourceDetail, SourceExcerpt, SourceBacklink } from '../../../shared/types';
+
+  interface Props {
+    sourceId: string;
+    highlightExcerptId?: string;
+    onNavigate: (target: string) => void;
+  }
+
+  let { sourceId, highlightExcerptId, onNavigate }: Props = $props();
+
+  let detail = $state<SourceDetail | null>(null);
+  let loading = $state(true);
+  let loadedId = $state<string | null>(null);
+
+  async function load(id: string) {
+    loading = true;
+    loadedId = id;
+    try {
+      detail = await api.graph.sourceDetail(id);
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    if (sourceId !== loadedId) {
+      load(sourceId);
+    }
+  });
+
+  // After render, if a specific excerpt was highlighted, scroll it into view.
+  $effect(() => {
+    if (!detail || !highlightExcerptId) return;
+    requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-excerpt-anchor="${CSS.escape(highlightExcerptId!)}"]`);
+      if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    });
+  });
+
+  function formatByline(creators: string[], year: string | null): string {
+    const who = creators.length === 0 ? ''
+      : creators.length === 1 ? creators[0]
+      : creators.length === 2 ? `${creators[0]} and ${creators[1]}`
+      : `${creators[0]} et al.`;
+    if (who && year) return `${who} (${year})`;
+    return who || (year ?? '');
+  }
+
+  function openExternal(url: string) {
+    api.shell.openExternal(url);
+  }
+
+  function excerptLocation(e: SourceExcerpt): string {
+    if (e.pageRange) return `pp. ${e.pageRange}`;
+    if (e.page) return `p. ${e.page}`;
+    if (e.locationText) return e.locationText;
+    return '';
+  }
+
+  function backlinkLabel(b: SourceBacklink): string {
+    return b.kind === 'cite' ? 'cites' : 'quotes';
+  }
+</script>
+
+<div class="source-detail">
+  {#if loading}
+    <p class="muted">Loading…</p>
+  {:else if !detail}
+    <div class="missing">
+      <h1>Source not found</h1>
+      <p class="muted">
+        No source with id <code>{sourceId}</code> is in the graph. Make sure
+        <code>.minerva/sources/{sourceId}/meta.ttl</code> exists and the graph has been rebuilt.
+      </p>
+    </div>
+  {:else}
+    <header>
+      <div class="subtype">{detail.metadata.subtype ?? 'Source'}</div>
+      <h1>{detail.metadata.title ?? sourceId}</h1>
+      {#if detail.metadata.creators.length || detail.metadata.year}
+        <div class="byline">{formatByline(detail.metadata.creators, detail.metadata.year)}</div>
+      {/if}
+    </header>
+
+    <section class="metadata">
+      {#if detail.metadata.publisher}
+        <div class="kv"><span class="k">Publisher</span><span class="v">{detail.metadata.publisher}</span></div>
+      {/if}
+      {#if detail.metadata.doi}
+        <div class="kv">
+          <span class="k">DOI</span>
+          <span class="v">
+            <a class="external" href={`https://doi.org/${detail.metadata.doi}`} onclick={(e) => { e.preventDefault(); openExternal(`https://doi.org/${detail.metadata.doi}`); }}>{detail.metadata.doi}</a>
+          </span>
+        </div>
+      {/if}
+      {#if detail.metadata.uri}
+        <div class="kv">
+          <span class="k">URL</span>
+          <span class="v">
+            <a class="external" href={detail.metadata.uri} onclick={(e) => { e.preventDefault(); openExternal(detail.metadata.uri!); }}>{detail.metadata.uri}</a>
+          </span>
+        </div>
+      {/if}
+      <div class="kv"><span class="k">Source id</span><span class="v mono">{detail.metadata.sourceId}</span></div>
+    </section>
+
+    {#if detail.metadata.abstract}
+      <section class="abstract">
+        <h2>Abstract</h2>
+        <p>{detail.metadata.abstract}</p>
+      </section>
+    {/if}
+
+    <section>
+      <h2>Excerpts ({detail.excerpts.length})</h2>
+      {#if detail.excerpts.length === 0}
+        <p class="muted">No excerpts linked to this source yet.</p>
+      {:else}
+        <ul class="excerpt-list">
+          {#each detail.excerpts as excerpt}
+            <li
+              data-excerpt-anchor={excerpt.excerptId}
+              class:highlighted={excerpt.excerptId === highlightExcerptId}
+            >
+              {#if excerpt.citedText}
+                <blockquote>{excerpt.citedText}</blockquote>
+              {:else}
+                <p class="muted">No cited text</p>
+              {/if}
+              <div class="excerpt-meta">
+                <span class="mono">{excerpt.excerptId}</span>
+                {#if excerptLocation(excerpt)}
+                  <span class="sep">·</span>
+                  <span>{excerptLocation(excerpt)}</span>
+                {/if}
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <section>
+      <h2>Referenced from ({detail.backlinks.length})</h2>
+      {#if detail.backlinks.length === 0}
+        <p class="muted">No notes reference this source.</p>
+      {:else}
+        <ul class="backlink-list">
+          {#each detail.backlinks as b}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <li onclick={() => onNavigate(b.relativePath)}>
+              <span class="backlink-title">{b.title}</span>
+              <span class="backlink-meta">
+                <span class="backlink-kind">{backlinkLabel(b)}</span>
+                {#if b.viaExcerptId}
+                  <span class="sep">·</span>
+                  <span class="mono">{b.viaExcerptId}</span>
+                {/if}
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .source-detail {
+    flex: 1;
+    overflow-y: auto;
+    padding: 32px 48px;
+    max-width: 820px;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--text);
+  }
+
+  header {
+    margin-bottom: 20px;
+  }
+
+  .subtype {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    background: var(--bg-button);
+    padding: 2px 8px;
+    border-radius: 3px;
+    margin-bottom: 8px;
+  }
+
+  h1 {
+    font-size: 26px;
+    font-weight: 600;
+    margin: 0 0 6px;
+  }
+
+  h2 {
+    font-size: 15px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin: 24px 0 12px;
+  }
+
+  .byline {
+    color: var(--text-muted);
+    font-size: 14px;
+  }
+
+  section {
+    margin-bottom: 12px;
+  }
+
+  .metadata {
+    border-top: 1px solid var(--border);
+    padding-top: 16px;
+    margin-top: 16px;
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 6px 16px;
+  }
+
+  .kv { display: contents; }
+  .k {
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+  .v {
+    font-size: 14px;
+    word-break: break-word;
+  }
+  .mono {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 13px;
+  }
+
+  .external {
+    color: var(--accent);
+    cursor: pointer;
+  }
+  .external:hover { text-decoration: underline; }
+
+  .abstract p {
+    font-size: 14px;
+    color: var(--text-muted);
+    margin: 0;
+  }
+
+  .muted {
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
+  .excerpt-list, .backlink-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .excerpt-list li {
+    border-left: 3px solid var(--border);
+    padding: 8px 12px;
+    margin: 0 0 12px;
+    transition: border-color 0.15s;
+  }
+  .excerpt-list li.highlighted {
+    border-left-color: var(--accent);
+    background: var(--bg-button);
+  }
+
+  .excerpt-list blockquote {
+    margin: 0 0 6px;
+    font-style: italic;
+    color: var(--text);
+  }
+
+  .excerpt-meta {
+    font-size: 12px;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .sep { opacity: 0.5; }
+
+  .backlink-list li {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .backlink-list li:hover { background: var(--bg-button); }
+  .backlink-list li:last-child { border-bottom: none; }
+
+  .backlink-title {
+    color: var(--accent);
+  }
+
+  .backlink-meta {
+    font-size: 12px;
+    color: var(--text-muted);
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .backlink-kind {
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.3px;
+    font-weight: 600;
+  }
+
+  code {
+    background: var(--bg-button);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 13px;
+  }
+
+  .missing h1 {
+    font-size: 18px;
+    margin-bottom: 8px;
+  }
+</style>

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -46,12 +46,17 @@
       onclick={() => onSwitch(i)}
       onauxclick={(e) => handleMiddleClick(e, i)}
       oncontextmenu={(e) => handleContextMenu(e, i)}
-      title={tab.type === 'note' ? tab.relativePath : tab.title}
+      title={tab.type === 'note' ? tab.relativePath : tab.type === 'query' ? tab.title : `Source: ${tab.sourceId}`}
       role="tab"
       tabindex="0"
     >
       {#if tab.type === 'query'}<span class="tab-icon">&#x25B7;</span>{/if}
-      <span class="tab-name">{tab.type === 'note' ? tab.fileName.replace(/\.md$/, '') : tab.title}</span>
+      {#if tab.type === 'source'}<span class="tab-icon">&#x1F4D6;</span>{/if}
+      <span class="tab-name">
+        {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
+        {:else if tab.type === 'query'}{tab.title}
+        {:else}{tab.sourceId}{/if}
+      </span>
       {#if tab.type === 'note' && tab.content !== tab.savedContent}
         <span class="dirty-dot"></span>
       {/if}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings } from '../../../shared/tools/types';
 
 export interface NotebaseApi {
@@ -48,6 +48,8 @@ export interface GraphApi {
   inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
   runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
   export(): Promise<void>;
+  sourceDetail(sourceId: string): Promise<SourceDetail | null>;
+  excerptSource(excerptId: string): Promise<{ sourceId: string } | null>;
 }
 
 export interface TagsApi {

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -25,12 +25,20 @@ export interface QueryTab {
   executionTime: number | null;
 }
 
-export type Tab = NoteTab | QueryTab;
+export interface SourceTab {
+  type: 'source';
+  sourceId: string;
+  /** If the user arrived via a [[quote::id]] click, highlight this excerpt in the detail view. */
+  highlightExcerptId?: string;
+}
+
+export type Tab = NoteTab | QueryTab | SourceTab;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function isNote(tab: Tab): tab is NoteTab { return tab.type === 'note'; }
 function isQuery(tab: Tab): tab is QueryTab { return tab.type === 'query'; }
+function isSource(tab: Tab): tab is SourceTab { return tab.type === 'source'; }
 
 let queryCounter = 0;
 
@@ -57,6 +65,32 @@ export function getEditorStore() {
   function activeQueryTab(): QueryTab | null {
     const tab = activeTab();
     return tab && isQuery(tab) ? tab : null;
+  }
+
+  function activeSourceTab(): SourceTab | null {
+    const tab = activeTab();
+    return tab && isSource(tab) ? tab : null;
+  }
+
+  // ── Source operations ───────────────────────────────────────────────────
+
+  function openSource(sourceId: string, opts?: { highlightExcerptId?: string }) {
+    const existing = tabs.findIndex((t) => isSource(t) && t.sourceId === sourceId);
+    if (existing !== -1) {
+      const existingTab = tabs[existing] as SourceTab;
+      existingTab.highlightExcerptId = opts?.highlightExcerptId;
+      activeIndex = existing;
+      schedulePersistTabs();
+      return;
+    }
+    const tab: SourceTab = {
+      type: 'source',
+      sourceId,
+      highlightExcerptId: opts?.highlightExcerptId,
+    };
+    tabs.push(tab);
+    activeIndex = tabs.length - 1;
+    schedulePersistTabs();
   }
 
   // ── Note operations ─────────────────────────────────────────────────────
@@ -137,8 +171,10 @@ export function getEditorStore() {
     const savedTabs: SavedTab[] = tabs.map((t): SavedTab => {
       if (isNote(t)) {
         return { type: 'note', relativePath: t.relativePath, cursorOffset: t.cursorOffset, scrollTop: t.scrollTop };
-      } else {
+      } else if (isQuery(t)) {
         return { type: 'query', title: t.title, query: t.query };
+      } else {
+        return { type: 'source', sourceId: t.sourceId, highlightExcerptId: t.highlightExcerptId };
       }
     });
     const session: TabSession = { activeIndex, tabs: savedTabs };
@@ -167,7 +203,7 @@ export function getEditorStore() {
         } catch {
           // File may have been deleted since last session
         }
-      } else {
+      } else if (saved.type === 'query') {
         queryCounter++;
         const tab: QueryTab = {
           type: 'query',
@@ -181,6 +217,12 @@ export function getEditorStore() {
           executionTime: null,
         };
         tabs.push(tab);
+      } else {
+        tabs.push({
+          type: 'source',
+          sourceId: saved.sourceId,
+          highlightExcerptId: saved.highlightExcerptId,
+        });
       }
     }
 
@@ -297,6 +339,7 @@ export function getEditorStore() {
     get activeTab() { return activeTab(); },
     get activeNoteTab() { return activeNoteTab(); },
     get activeQueryTab() { return activeQueryTab(); },
+    get activeSourceTab() { return activeSourceTab(); },
     get activeFilePath() { return activeNoteTab()?.relativePath ?? null; },
     get activeFileName() { return activeNoteTab()?.fileName ?? ''; },
     get content() { return activeNoteTab()?.content ?? ''; },
@@ -306,6 +349,7 @@ export function getEditorStore() {
     },
     get hasAnyDirty() { return tabs.some((t) => isNote(t) && t.content !== t.savedContent); },
     openFile,
+    openSource,
     save,
     setContent,
     flushAutoSave,

--- a/src/renderer/lib/stores/navigation.svelte.ts
+++ b/src/renderer/lib/stores/navigation.svelte.ts
@@ -9,7 +9,13 @@ export interface QueryNavPosition {
   tabId: string;
 }
 
-export type NavPosition = NoteNavPosition | QueryNavPosition;
+export interface SourceNavPosition {
+  type: 'source';
+  sourceId: string;
+  highlightExcerptId?: string;
+}
+
+export type NavPosition = NoteNavPosition | QueryNavPosition | SourceNavPosition;
 
 const MAX_HISTORY = 100;
 
@@ -42,6 +48,9 @@ export function getNavigationStore() {
     if (a.type === 'query' && b.type === 'query') return a.tabId === b.tabId;
     if (a.type === 'note' && b.type === 'note') {
       return a.relativePath === b.relativePath && Math.abs(a.offset - b.offset) < 20;
+    }
+    if (a.type === 'source' && b.type === 'source') {
+      return a.sourceId === b.sourceId && a.highlightExcerptId === b.highlightExcerptId;
     }
     return false;
   }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -34,6 +34,8 @@ export const Channels = {
 
   // Graph
   GRAPH_QUERY: 'graph:query',
+  GRAPH_SOURCE_DETAIL: 'graph:sourceDetail',
+  GRAPH_EXCERPT_SOURCE: 'graph:excerptSource',
 
   // Tags
   TAGS_LIST: 'tags:list',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,11 +66,52 @@ export interface SavedQueryTab {
   query: string;
 }
 
-export type SavedTab = SavedNoteTab | SavedQueryTab;
+export interface SavedSourceTab {
+  type: 'source';
+  sourceId: string;
+  highlightExcerptId?: string;
+}
+
+export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab;
 
 export interface TabSession {
   activeIndex: number;
   tabs: SavedTab[];
+}
+
+// ── Source detail ─────────────────────────────────────────────────────────
+
+export interface SourceMetadata {
+  sourceId: string;
+  subtype: string | null;
+  title: string | null;
+  creators: string[];
+  year: string | null;
+  publisher: string | null;
+  doi: string | null;
+  uri: string | null;
+  abstract: string | null;
+}
+
+export interface SourceExcerpt {
+  excerptId: string;
+  citedText: string | null;
+  page: string | null;
+  pageRange: string | null;
+  locationText: string | null;
+}
+
+export interface SourceBacklink {
+  relativePath: string;
+  title: string;
+  kind: 'cite' | 'quote';
+  viaExcerptId?: string;
+}
+
+export interface SourceDetail {
+  metadata: SourceMetadata;
+  excerpts: SourceExcerpt[];
+  backlinks: SourceBacklink[];
 }
 
 // ── Bookmarks ────────────────────────────────────────────────────────────

--- a/tests/main/graph/source-detail.test.ts
+++ b/tests/main/graph/source-detail.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  indexAllNotes,
+  getSourceDetail,
+  getExcerptSource,
+} from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-source-detail-test-'));
+}
+
+function writeSourceMeta(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+
+function writeExcerpt(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'excerpts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.ttl`), ttl, 'utf-8');
+}
+
+const ARTICLE_TTL = `
+this: a thought:Article ;
+    dc:title "On the structure of knowledge graphs" ;
+    dc:creator "Alice Smith", "Bob Jones" ;
+    dc:issued "2023-07-15"^^xsd:date ;
+    dc:publisher "Example Press" ;
+    dc:abstract "An abstract." ;
+    bibo:doi "10.1234/ex.2023.1" ;
+    bibo:uri <https://example.com/paper> .
+`;
+
+const EXCERPT_TTL = `
+this: a thought:Excerpt ;
+    thought:fromSource sources:smith-2023 ;
+    thought:citedText "Graphs are relational." ;
+    thought:page 42 .
+`;
+
+describe('getSourceDetail', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns null for an unknown source id', async () => {
+    await indexAllNotes(root);
+    expect(getSourceDetail('nope')).toBeNull();
+  });
+
+  it('returns structured metadata including subtype, creators, DOI', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+
+    const detail = getSourceDetail('smith-2023');
+    expect(detail).not.toBeNull();
+    expect(detail!.metadata.sourceId).toBe('smith-2023');
+    expect(detail!.metadata.subtype).toBe('Article');
+    expect(detail!.metadata.title).toBe('On the structure of knowledge graphs');
+    expect(detail!.metadata.creators.sort()).toEqual(['Alice Smith', 'Bob Jones']);
+    expect(detail!.metadata.year).toBe('2023');
+    expect(detail!.metadata.doi).toBe('10.1234/ex.2023.1');
+    expect(detail!.metadata.uri).toBe('https://example.com/paper');
+    expect(detail!.metadata.publisher).toBe('Example Press');
+    expect(detail!.metadata.abstract).toBe('An abstract.');
+  });
+
+  it('lists excerpts that belong to the source', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    writeExcerpt(root, 'p42-graphs', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    const detail = getSourceDetail('smith-2023');
+    expect(detail!.excerpts).toHaveLength(1);
+    expect(detail!.excerpts[0].excerptId).toBe('p42-graphs');
+    expect(detail!.excerpts[0].citedText).toBe('Graphs are relational.');
+    expect(detail!.excerpts[0].page).toBe('42');
+  });
+
+  it('returns cite backlinks from notes with [[cite::id]]', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(root);
+    await indexNote('a.md', '# A\n\nAs [[cite::smith-2023]] shows...');
+    await indexNote('b.md', '# B\n\nSee also [[cite::smith-2023]].');
+
+    const detail = getSourceDetail('smith-2023');
+    const cites = detail!.backlinks.filter(b => b.kind === 'cite');
+    expect(cites.map(b => b.relativePath).sort()).toEqual(['a.md', 'b.md']);
+  });
+
+  it('returns quote backlinks via excerpts, carrying the excerpt id', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    writeExcerpt(root, 'p42-graphs', EXCERPT_TTL);
+    await indexAllNotes(root);
+    await indexNote('c.md', '# C\n\n[[quote::p42-graphs]]');
+
+    const detail = getSourceDetail('smith-2023');
+    const quotes = detail!.backlinks.filter(b => b.kind === 'quote');
+    expect(quotes).toHaveLength(1);
+    expect(quotes[0].relativePath).toBe('c.md');
+    expect(quotes[0].viaExcerptId).toBe('p42-graphs');
+  });
+});
+
+describe('getExcerptSource', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves an excerpt to its source id via thought:fromSource', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    writeExcerpt(root, 'p42-graphs', EXCERPT_TTL);
+    await indexAllNotes(root);
+
+    expect(getExcerptSource('p42-graphs')).toEqual({ sourceId: 'smith-2023' });
+  });
+
+  it('returns null for an unknown excerpt', async () => {
+    await indexAllNotes(root);
+    expect(getExcerptSource('nope')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes the remainder of #131 (hover landed in #132).

## Summary
- **Click a \`[[cite::id]]\`** → opens a new \"source detail\" tab showing metadata, linked excerpts, and backlinks (notes that cite the source, notes that quote its excerpts).
- **Click a \`[[quote::id]]\`** → resolves the excerpt to its parent source via \`thought:fromSource\`, opens the same source detail tab with the excerpt highlighted and scrolled into view.
- Source tabs join notes and queries as a first-class tab kind: full back/forward nav, tab-bar entry, session-restore.

## Implementation notes
- **IPC**: two new graph endpoints. \`graph.sourceDetail(id)\` returns a \`{ metadata, excerpts, backlinks }\` bundle in one call; \`graph.excerptSource(id)\` resolves a quote target. Both are SPARQL-free direct store traversals — fast enough to use on click without debouncing.
- **Store**: \`SourceTab\` added alongside \`NoteTab\` and \`QueryTab\`; \`editor.openSource(id, { highlightExcerptId })\` finds-or-creates. \`SavedSourceTab\` extends the persistence union.
- **Nav**: new \`SourceNavPosition\` so back/forward traverses source detail symmetrically with notes and queries.
- **Preview click routing**: cite and quote now route through dedicated handlers (\`onOpenSource\` / \`onOpenExcerpt\`) instead of falling through to \`onNavigate\`. The old wiki-link path is preserved for note links.
- **\`SourceDetail.svelte\`**: title + subtype pill + byline, metadata grid (publisher/DOI/URI/source-id), abstract, excerpt list (highlighting the navigated-to one), backlink list grouped by kind.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 228 pass (+7 for new \`source-detail\` tests: metadata shape, excerpt listing, cite backlinks, quote backlinks via excerpt, excerpt→source resolution, 404 handling)
- [ ] Manual: open \`tests/fixtures/sample-project/research/essential-complexity.md\`, click \`[[cite::brooks-1986]]\` → source detail opens with title, DOI, two cite backlinks, zero excerpts for Brooks; click \`[[quote::brooks-essential-accidental]]\` → same tab, excerpt highlighted
- [ ] Manual: close and reopen the app, source tab restores
- [ ] Manual: back/forward traverses source → note → source correctly