### PR TITLE
Sources in the tag system + stock queries for sources

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -536,7 +536,7 @@ export function removeNote(relativePath: string): void {
 // node's URI is `${baseUri}source/<id>`; inside meta.ttl, `this:` resolves
 // to that URI so users can write `this: a thought:Article ; dc:title ...`.
 
-export function indexSource(sourceId: string, metaTtl: string): void {
+export function indexSource(sourceId: string, metaTtl: string, bodyMd?: string): void {
   if (!store) return;
 
   const subject = sourceUri(sourceId);
@@ -556,6 +556,39 @@ export function indexSource(sourceId: string, metaTtl: string): void {
     $rdf.parse(prefixed, store, graph.value, 'text/turtle');
   } catch (e) {
     console.error(`[minerva] Failed to parse source meta.ttl for ${sourceId}:`, e instanceof Error ? e.message : e);
+  }
+
+  if (bodyMd) indexSourceBody(sourceId, bodyMd, subject, graph);
+}
+
+/** Parse body.md for a source — tags and wiki-links attach to the source URI. */
+function indexSourceBody(
+  _sourceId: string,
+  bodyMd: string,
+  subject: $rdf.NamedNode,
+  graph: $rdf.NamedNode,
+): void {
+  if (!store) return;
+  const parsed = parseMarkdown(bodyMd);
+
+  // Body tags → hasTag edges on the source.
+  const tags = new Set(parsed.tags);
+  const fmTags = parsed.frontmatter.tags;
+  if (fmTags !== undefined) {
+    for (const t of flattenFrontmatterStrings(fmTags)) if (t) tags.add(t);
+  }
+  for (const tag of tags) {
+    const tagNode = tagUri(tag);
+    ensureTag(tagNode, tag);
+    store.add(subject, MINERVA('hasTag'), tagNode, graph);
+  }
+
+  // Body wiki-links → typed edges on the source (same plumbing as notes).
+  for (const link of parsed.links) {
+    const linkType = getLinkType(link.type);
+    const predicate = linkPredicate(linkType);
+    const targetNode = resolveLinkTarget(linkType, link.target);
+    store.add(subject, predicate, targetNode, graph);
   }
 }
 
@@ -717,9 +750,12 @@ async function walkAndIndexSources(rootPath: string): Promise<number> {
     if (!entry.isDirectory()) continue;
     const sourceId = entry.name;
     const metaPath = path.join(sourcesRoot, sourceId, 'meta.ttl');
+    const bodyPath = path.join(sourcesRoot, sourceId, 'body.md');
     try {
-      const content = await fs.readFile(metaPath, 'utf-8');
-      indexSource(sourceId, content);
+      const metaContent = await fs.readFile(metaPath, 'utf-8');
+      let bodyContent: string | undefined;
+      try { bodyContent = await fs.readFile(bodyPath, 'utf-8'); } catch { /* body optional */ }
+      indexSource(sourceId, metaContent, bodyContent);
       count++;
     } catch {
       // No meta.ttl in this directory — skip
@@ -796,7 +832,7 @@ export async function queryGraph(sparql: string): Promise<{ results: unknown[] }
 
 // ── Tag queries ─────────────────────────────────────────────────────────────
 
-import type { TagInfo, TaggedNote } from '../../shared/types';
+import type { TagInfo, TaggedNote, TaggedSource } from '../../shared/types';
 
 export function listTags(): TagInfo[] {
   if (!store) return [];
@@ -820,15 +856,39 @@ export function notesByTag(tag: string): TaggedNote[] {
 
   const tagNode = tagUri(tag);
   const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
-  return stmts.map((st) => {
+  return stmts.flatMap((st) => {
     const subject = st.subject;
+    // Sources also carry hasTag edges (body.md tags); filter them out —
+    // sourcesByTag handles those.
+    const isNote = store!.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
+    if (!isNote) return [];
     const titleStmts = store!.statementsMatching(subject, DC('title'), undefined);
     const pathStmts = store!.statementsMatching(subject, MINERVA('relativePath'), undefined);
-    return {
+    const relativePath = pathStmts[0]?.object.value ?? '';
+    if (!relativePath) return [];
+    return [{
       title: titleStmts[0]?.object.value ?? subject.value,
-      relativePath: pathStmts[0]?.object.value ?? '',
-    };
-  }).filter((n) => n.relativePath);
+      relativePath,
+    }];
+  });
+}
+
+export function sourcesByTag(tag: string): TaggedSource[] {
+  if (!store) return [];
+
+  const tagNode = tagUri(tag);
+  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
+  return stmts.flatMap((st) => {
+    const subject = st.subject;
+    const idStmts = store!.statementsMatching(subject, MINERVA('sourceId'), undefined);
+    const sourceId = idStmts[0]?.object.value;
+    if (!sourceId) return [];
+    const titleStmts = store!.statementsMatching(subject, DC('title'), undefined);
+    return [{
+      sourceId,
+      title: titleStmts[0]?.object.value ?? sourceId,
+    }];
+  });
 }
 
 export function allTags(): string[] {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -324,6 +324,10 @@ export function registerIpcHandlers(): void {
     return graph.notesByTag(tag);
   });
 
+  ipcMain.handle(Channels.TAGS_SOURCES_BY_TAG, (_e, tag: string) => {
+    return graph.sourcesByTag(tag);
+  });
+
   ipcMain.handle(Channels.TAGS_ALL_NAMES, () => {
     return graph.allTags();
   });

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -23,11 +23,12 @@ interface WatcherPair {
 
 const watchers = new Map<number, WatcherPair>();
 
-const SOURCE_META_RE = /(?:^|[/\\])\.minerva[/\\]sources[/\\]([^/\\]+)[/\\]meta\.ttl$/;
+const SOURCE_DIR_RE = /(?:^|[/\\])\.minerva[/\\]sources[/\\]([^/\\]+)[/\\](meta\.ttl|body\.md)$/;
 const EXCERPT_RE = /(?:^|[/\\])\.minerva[/\\]excerpts[/\\]([^/\\]+)\.ttl$/;
 
+/** Returns the source id if the path is .minerva/sources/<id>/{meta.ttl,body.md}. */
 function extractSourceId(absPath: string): string | null {
-  const m = absPath.match(SOURCE_META_RE);
+  const m = absPath.match(SOURCE_DIR_RE);
   return m ? m[1] : null;
 }
 

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -166,11 +166,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     },
     onSourceMetaChanged: async (sourceId) => {
       try {
-        const relPath = `.minerva/sources/${sourceId}/meta.ttl`;
-        const content = await notebaseFs.readFile(rootPath, relPath);
-        graph.indexSource(sourceId, content);
+        const metaContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
+        let bodyContent: string | undefined;
+        try {
+          bodyContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/body.md`);
+        } catch { /* body optional */ }
+        graph.indexSource(sourceId, metaContent, bodyContent);
         debouncedPersist();
-      } catch { /* file may have been deleted between events */ }
+      } catch { /* meta.ttl may have been deleted between events */ }
     },
     onSourceMetaDeleted: (sourceId) => {
       graph.removeSource(sourceId);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -65,6 +65,7 @@ contextBridge.exposeInMainWorld('api', {
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),
     notesByTag: (tag: string) => ipcRenderer.invoke(Channels.TAGS_NOTES_BY_TAG, tag),
+    sourcesByTag: (tag: string) => ipcRenderer.invoke(Channels.TAGS_SOURCES_BY_TAG, tag),
     allNames: () => ipcRenderer.invoke(Channels.TAGS_ALL_NAMES),
   },
   export: {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -564,6 +564,7 @@
           onPaste={handlePaste}
           onMove={handleMove}
           onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl)$/, '') ?? path, path)}
+          onSourceSelect={(id) => handleOpenSource(id)}
           canPaste={clipboardItem !== null}
         />
       {/if}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -18,10 +18,11 @@
     onPaste: (destDirectory: string) => void;
     onMove: (srcPath: string, destDirectory: string) => void;
     onBookmark?: (relativePath: string) => void;
+    onSourceSelect?: (sourceId: string) => void;
     canPaste?: boolean;
   }
 
-  let { files, activeFilePath, onFileSelect, onOpenFolder, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, canPaste = false }: Props = $props();
+  let { files, activeFilePath, onFileSelect, onOpenFolder, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, canPaste = false }: Props = $props();
   let rootDropHover = $state(false);
   let tagPanel = $state<TagPanel>();
   let searchPanel = $state<SearchPanel>();
@@ -74,7 +75,7 @@
     >
       <FileTree {files} {activeFilePath} {canPaste} {onFileSelect} {onNewNote} {onNewFolder} {onDelete} {onRename} {onCut} {onCopy} {onPaste} {onMove} {onBookmark} />
     </div>
-    <TagPanel bind:this={tagPanel} {onFileSelect} />
+    <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />
   {:else}
     <div class="empty" oncontextmenu={handleContextMenu}>
       <p>No notes yet</p>

--- a/src/renderer/lib/components/TagPanel.svelte
+++ b/src/renderer/lib/components/TagPanel.svelte
@@ -1,22 +1,23 @@
 <script lang="ts">
-  import type { TagInfo, TaggedNote } from '../../../shared/types';
+  import type { TagInfo, TaggedNote, TaggedSource } from '../../../shared/types';
   import { api } from '../ipc/client';
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
+    onSourceSelect?: (sourceId: string) => void;
   }
 
-  let { onFileSelect }: Props = $props();
+  let { onFileSelect, onSourceSelect }: Props = $props();
 
   let tags = $state<TagInfo[]>([]);
   let activeTag = $state<string | null>(null);
   let taggedNotes = $state<TaggedNote[]>([]);
+  let taggedSources = $state<TaggedSource[]>([]);
+  let showSources = $state(true);
 
   export async function refresh() {
     tags = await api.tags.list();
-    if (activeTag) {
-      taggedNotes = await api.tags.notesByTag(activeTag);
-    }
+    if (activeTag) await loadForTag(activeTag);
   }
 
   export function selectTag(tag: string) {
@@ -27,15 +28,31 @@
     if (activeTag === tag) {
       activeTag = null;
       taggedNotes = [];
+      taggedSources = [];
       return;
     }
     activeTag = tag;
-    taggedNotes = await api.tags.notesByTag(tag);
+    await loadForTag(tag);
+  }
+
+  async function loadForTag(tag: string) {
+    const [notes, sources] = await Promise.all([
+      api.tags.notesByTag(tag),
+      api.tags.sourcesByTag(tag),
+    ]);
+    taggedNotes = notes;
+    taggedSources = sources;
   }
 </script>
 
 <div class="tag-panel">
-  <div class="panel-header">Tags</div>
+  <div class="panel-header">
+    <span>Tags</span>
+    <label class="sources-toggle" title="Include sources in tag results">
+      <input type="checkbox" bind:checked={showSources} />
+      <span>sources</span>
+    </label>
+  </div>
 
   {#if tags.length === 0}
     <div class="empty">No tags yet</div>
@@ -54,18 +71,33 @@
     </div>
   {/if}
 
-  {#if activeTag && taggedNotes.length > 0}
-    <div class="notes-section">
-      <div class="notes-header">Notes tagged #{activeTag}</div>
-      {#each taggedNotes as note}
-        <button
-          class="note-item"
-          onclick={() => onFileSelect(note.relativePath)}
-        >
-          {note.title}
-        </button>
-      {/each}
-    </div>
+  {#if activeTag}
+    {@const visibleSources = showSources ? taggedSources : []}
+    {#if taggedNotes.length > 0 || visibleSources.length > 0}
+      <div class="notes-section">
+        <div class="notes-header">
+          Tagged #{activeTag}
+        </div>
+        {#each taggedNotes as note}
+          <button
+            class="note-item"
+            onclick={() => onFileSelect(note.relativePath)}
+          >
+            <span>{note.title}</span>
+          </button>
+        {/each}
+        {#each visibleSources as source}
+          <button
+            class="note-item"
+            onclick={() => onSourceSelect?.(source.sourceId)}
+            title={`Source: ${source.sourceId}`}
+          >
+            <span class="kind-tag">SRC</span>
+            <span>{source.title}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
   {/if}
 </div>
 
@@ -84,6 +116,24 @@
     text-transform: uppercase;
     color: var(--text-muted);
     letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sources-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 400;
+    text-transform: lowercase;
+    letter-spacing: 0;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .sources-toggle input {
+    cursor: pointer;
   }
 
   .empty {
@@ -140,7 +190,9 @@
   }
 
   .note-item {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 6px;
     width: 100%;
     padding: 4px 12px;
     border: none;
@@ -153,5 +205,16 @@
 
   .note-item:hover {
     background: var(--bg-button);
+  }
+
+  .kind-tag {
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    padding: 1px 4px;
+    border-radius: 2px;
+    background: var(--bg-button);
+    color: var(--text-muted);
+    flex-shrink: 0;
   }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings } from '../../../shared/tools/types';
 
 export interface NotebaseApi {
@@ -55,6 +55,7 @@ export interface GraphApi {
 export interface TagsApi {
   list(): Promise<TagInfo[]>;
   notesByTag(tag: string): Promise<TaggedNote[]>;
+  sourcesByTag(tag: string): Promise<TaggedSource[]>;
   allNames(): Promise<string[]>;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -40,6 +40,7 @@ export const Channels = {
   // Tags
   TAGS_LIST: 'tags:list',
   TAGS_NOTES_BY_TAG: 'tags:notesByTag',
+  TAGS_SOURCES_BY_TAG: 'tags:sourcesByTag',
   TAGS_ALL_NAMES: 'tags:allNames',
 
   // Menu → renderer events (main sends, renderer listens)

--- a/src/shared/stock-queries.ts
+++ b/src/shared/stock-queries.ts
@@ -136,6 +136,88 @@ SELECT ?targetTitle ?linkType ?sourceTitle WHERE {
 ORDER BY ?targetTitle ?linkType`,
   },
   {
+    name: 'Sources: all with authors and year',
+    description: 'Every indexed Source with its title, first author, and year',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+SELECT ?sourceId ?title ?creator ?year WHERE {
+  ?src minerva:sourceId ?sourceId .
+  OPTIONAL { ?src dc:title ?title }
+  OPTIONAL { ?src dc:creator ?creator }
+  OPTIONAL { ?src dc:issued ?issued . BIND(SUBSTR(STR(?issued), 1, 4) AS ?year) }
+}
+ORDER BY ?sourceId`,
+  },
+  {
+    name: 'Sources: most-cited',
+    description: 'Sources ranked by the number of distinct notes citing or quoting them',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+SELECT ?sourceId ?title (COUNT(DISTINCT ?note) AS ?citations) WHERE {
+  ?src minerva:sourceId ?sourceId .
+  OPTIONAL { ?src dc:title ?title }
+  {
+    ?note thought:cites ?src .
+  } UNION {
+    ?note thought:quotes ?excerpt .
+    ?excerpt thought:fromSource ?src .
+  }
+}
+GROUP BY ?src ?sourceId ?title
+ORDER BY DESC(?citations)`,
+  },
+  {
+    name: 'Sources: cited by N or more notes',
+    description: 'Sources that cross a citation threshold (edit MIN_COUNT)',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+# Edit MIN_COUNT to change the threshold.
+SELECT ?sourceId ?title (COUNT(DISTINCT ?note) AS ?citations) WHERE {
+  ?src minerva:sourceId ?sourceId .
+  OPTIONAL { ?src dc:title ?title }
+  {
+    ?note thought:cites ?src .
+  } UNION {
+    ?note thought:quotes ?excerpt .
+    ?excerpt thought:fromSource ?src .
+  }
+}
+GROUP BY ?src ?sourceId ?title
+HAVING (COUNT(DISTINCT ?note) >= 2)
+ORDER BY DESC(?citations)`,
+  },
+  {
+    name: 'Sources: most-quoted',
+    description: 'Sources ranked by the number of linked Excerpts',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+SELECT ?sourceId ?title (COUNT(?excerpt) AS ?excerptCount) WHERE {
+  ?src minerva:sourceId ?sourceId .
+  OPTIONAL { ?src dc:title ?title }
+  ?excerpt thought:fromSource ?src .
+}
+GROUP BY ?src ?sourceId ?title
+ORDER BY DESC(?excerptCount)`,
+  },
+  {
+    name: 'Sources: missing metadata',
+    description: 'Sources that are missing a title, an author, or both (stub records)',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+SELECT ?sourceId ?title ?creator WHERE {
+  ?src minerva:sourceId ?sourceId .
+  OPTIONAL { ?src dc:title ?title }
+  OPTIONAL { ?src dc:creator ?creator }
+  FILTER(!BOUND(?title) || !BOUND(?creator))
+}
+ORDER BY ?sourceId`,
+  },
+  {
     name: 'Trust: Unreviewed LLM writes',
     description: 'Components attributed to an LLM without a corresponding approved proposal (trust principle violations)',
     query: `${PREFIXES}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,6 +20,11 @@ export interface TaggedNote {
   relativePath: string;
 }
 
+export interface TaggedSource {
+  title: string;
+  sourceId: string;
+}
+
 export interface SavedQuery {
   id: string;
   name: string;

--- a/tests/fixtures/sample-project/.minerva/sources/brooks-1986/body.md
+++ b/tests/fixtures/sample-project/.minerva/sources/brooks-1986/body.md
@@ -1,0 +1,14 @@
+---
+tags: [software-engineering, classics]
+---
+
+# Notes on "No Silver Bullet"
+
+Brooks distinguishes two kinds of complexity in software:
+
+- **Essential**: the intrinsic conceptual structure of the problem domain — what the software must model.
+- **Accidental**: the complexity imposed by our tools, languages, and implementation substrate.
+
+His central claim is that no single productivity advance attacking only accidental complexity can yield an order-of-magnitude gain, because essence now dominates.
+
+This argument has held up remarkably well for forty years and remains the best #epistemology lens for evaluating new programming-productivity claims.

--- a/tests/main/graph/source-tags.test.ts
+++ b/tests/main/graph/source-tags.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexAllNotes,
+  indexSource,
+  listTags,
+  notesByTag,
+  sourcesByTag,
+  indexNote,
+} from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-source-tags-test-'));
+}
+
+function writeSourceMeta(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+
+function writeSourceBody(root: string, id: string, md: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'body.md'), md, 'utf-8');
+}
+
+const META = `
+this: a thought:Article ;
+    dc:title "Example paper" ;
+    dc:creator "Alice Smith" .
+`;
+
+describe('Source participation in tag system (issue #118)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('picks up body #tags on the source URI during indexAllNotes', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    writeSourceBody(root, 'smith-2023', '# Notes\n\nThis is great #research stuff #epistemology.');
+    await indexAllNotes(root);
+
+    const sources = sourcesByTag('research');
+    expect(sources).toHaveLength(1);
+    expect(sources[0].sourceId).toBe('smith-2023');
+    expect(sources[0].title).toBe('Example paper');
+
+    const epistemology = sourcesByTag('epistemology');
+    expect(epistemology.map(s => s.sourceId)).toEqual(['smith-2023']);
+  });
+
+  it('picks up frontmatter tags: [...] on the source URI', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    writeSourceBody(root, 'smith-2023', '---\ntags: [research, epistemology]\n---\n# Notes\n');
+    await indexAllNotes(root);
+
+    const sources = sourcesByTag('research');
+    expect(sources.map(s => s.sourceId)).toEqual(['smith-2023']);
+  });
+
+  it('listTags counts both notes and sources that share a tag', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    writeSourceBody(root, 'smith-2023', '# x\n\n#research');
+    await indexAllNotes(root);
+    await indexNote('notes/overview.md', '# Overview\n\n#research');
+
+    const info = listTags().find(t => t.tag === 'research');
+    expect(info?.count).toBe(2);
+  });
+
+  it('notesByTag excludes sources (no misleading relativePath)', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    writeSourceBody(root, 'smith-2023', '# x\n\n#research');
+    await indexAllNotes(root);
+    await indexNote('notes/overview.md', '# Overview\n\n#research');
+
+    const notes = notesByTag('research');
+    expect(notes.map(n => n.relativePath)).toEqual(['notes/overview.md']);
+  });
+
+  it('sourcesByTag returns empty when no sources are tagged', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    // No body.md at all
+    await indexAllNotes(root);
+    await indexNote('notes/overview.md', '# x\n\n#research');
+
+    expect(sourcesByTag('research')).toEqual([]);
+  });
+
+  it('re-indexing replaces the source tags (no stale triples)', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    writeSourceBody(root, 'smith-2023', '# x\n\n#research');
+    await indexAllNotes(root);
+
+    // Simulate body edit: drop #research, add #methodology
+    indexSource('smith-2023', META, '# x\n\n#methodology');
+
+    expect(sourcesByTag('research')).toEqual([]);
+    expect(sourcesByTag('methodology').map(s => s.sourceId)).toEqual(['smith-2023']);
+  });
+});


### PR DESCRIPTION
Closes #117 and #118. Wraps up the sources-model + organization outstanding items before the next epic.

## #118 — Source tag participation
- \`indexSource\` now also reads \`.minerva/sources/<id>/body.md\` when present. Body \`#tags\` and frontmatter \`tags: [...]\` attach \`minerva:hasTag\` edges to the source URI, so sources land in the same tag bucket as notes.
- \`notesByTag\` filters to real Notes; the new \`sourcesByTag\` returns \`TaggedSource[]\` (sourceId + title).
- TagPanel gets a \"sources\" toggle and lists tagged sources beside notes; clicking a source opens its source-detail tab.
- Source watcher now covers \`body.md\` as well as \`meta.ttl\`.

## #117 — Stock queries for sources
Adds five queries to Graph → Stock Queries:
- Sources: all with authors and year
- Sources: most-cited (by distinct citing/quoting notes)
- Sources: cited by N or more notes (parameterized HAVING)
- Sources: most-quoted (by excerpt count)
- Sources: missing metadata

Skipped the reading-queue-dependent queries from #117's scope (\"unread sources\", \"cited but not read\") — those wait on #116.

## Sample project
Added a small \`body.md\` for \`brooks-1986\` demonstrating tag participation with both frontmatter tags and body \`#epistemology\`.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 248 pass (+6 source-tag tests)
- [ ] Manual: open the sample project, select the \"epistemology\" tag in the side panel, confirm Brooks appears with an SRC badge; click → source-detail opens
- [ ] Manual: toggle \"sources\" off and confirm only notes remain