### PR TITLE
Rewrite incoming links on note rename/move

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -939,6 +939,31 @@ export function outgoingLinks(relativePath: string): OutgoingLink[] {
   return results;
 }
 
+/**
+ * Return the relative paths of notes with outgoing wiki-links pointing at
+ * the given note. Used by the rename handler to decide which notes need
+ * link rewrites.
+ *
+ * Only note-targeted link types are considered — cite/quote links point at
+ * sources/excerpts and are handled by a separate rename path.
+ */
+export function findNotesLinkingTo(targetRelativePath: string): string[] {
+  if (!store) return [];
+  const target = noteUri(targetRelativePath);
+  const seen = new Set<string>();
+  for (const lt of LINK_TYPES) {
+    if (lt.targetKind && lt.targetKind !== 'note') continue;
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), target);
+    for (const st of stmts) {
+      const sourceNode = st.subject;
+      const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
+      const sourcePath = pathStmts[0]?.object.value;
+      if (sourcePath && sourcePath.endsWith('.md')) seen.add(sourcePath);
+    }
+  }
+  return [...seen];
+}
+
 export function backlinks(relativePath: string): Backlink[] {
   if (!store) return [];
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
+import { renameWithLinkRewrites } from './notebase/rename';
 import * as gitOps from './git/index';
 import * as graph from './graph/index';
 import * as search from './search/index';
@@ -226,22 +227,15 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.NOTEBASE_RENAME, async (e, oldRelPath: string, newRelPath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
-    markPathHandled(oldRelPath);
-    markPathHandled(newRelPath);
-    await notebaseFs.rename(rootPath, oldRelPath, newRelPath);
-    // Check if directory or file
-    const stat = await fs.stat(path.join(rootPath, newRelPath));
-    if (stat.isDirectory()) {
-      const newFiles = await listIndexableFiles(rootPath, newRelPath);
-      for (const f of newFiles) {
-        const oldEquivalent = oldRelPath + f.slice(newRelPath.length);
-        removeFromIndexes(oldEquivalent);
-        await reindexFile(rootPath, f);
-      }
-    } else {
-      removeFromIndexes(oldRelPath);
-      await reindexFile(rootPath, newRelPath);
-    }
+
+    await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
+      markPathHandled,
+      reindexHook: (relPath, content) => {
+        if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+      },
+      removeHook: (relPath) => search.removeNote(relPath),
+    });
+
     await persistIndexes();
   });
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -10,7 +10,7 @@ import * as search from './search/index';
 import * as savedQueries from './saved-queries';
 import { clearRecentProjects } from './recent-projects';
 import { rebuildMenu } from './menu';
-import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled } from './window-manager';
+import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool } from './tools/executor';
 import * as healthChecks from './graph/health-checks';
 import { getToolBySlashCommand } from '../shared/tools/registry';
@@ -228,13 +228,24 @@ export function registerIpcHandlers(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
 
-    await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
+    const { transitions, rewrittenPaths } = await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
       markPathHandled,
       reindexHook: (relPath, content) => {
         if (relPath.endsWith('.md')) search.indexNote(relPath, content);
       },
       removeHook: (relPath) => search.removeNote(relPath),
     });
+
+    // Broadcast to every window showing this project so their editor tabs
+    // refresh paths and content instead of silently overwriting on next save.
+    for (const targetWin of windowsForProject(rootPath)) {
+      if (transitions.length > 0) {
+        targetWin.webContents.send(Channels.NOTEBASE_RENAMED, transitions);
+      }
+      if (rewrittenPaths.length > 0) {
+        targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, rewrittenPaths);
+      }
+    }
 
     await persistIndexes();
   });

--- a/src/main/notebase/link-rewriting.ts
+++ b/src/main/notebase/link-rewriting.ts
@@ -1,0 +1,82 @@
+/**
+ * Rewrite wiki-link targets inside markdown content.
+ *
+ * Given a `rewrites` map of normalized old-path → new-path (no `.md`
+ * suffix on either side), walk every `[[…]]` token in the content and
+ * substitute matching targets while preserving:
+ *
+ *   - type prefix       `[[type::old]]`     → `[[type::new]]`
+ *   - display text      `[[old|label]]`     → `[[new|label]]`
+ *   - anchor suffix     `[[old#heading]]`   → `[[new#heading]]`
+ *   - `.md` extension   `[[old.md]]`        → `[[new.md]]`
+ *
+ * Non-matching links, typed links pointing at sources/excerpts
+ * (`[[cite::foo]]`, `[[quote::bar]]`), and tokens that don't look
+ * like wiki-links at all are left untouched.
+ */
+
+const WIKI_LINK_RE = /\[\[([^\]\n]+?)\]\]/g;
+
+interface ParsedWikiLink {
+  /** Type prefix like `supports` or `cite`, or null if untyped. */
+  type: string | null;
+  /** Bare path/id portion (no anchor, no display, no type prefix). */
+  target: string;
+  /** Original anchor including the `#` prefix, or null if absent. */
+  anchor: string | null;
+  /** Display text after `|`, or null if absent. */
+  display: string | null;
+}
+
+function parseWikiInner(inner: string): ParsedWikiLink {
+  // Split off display (|)
+  const pipeIdx = inner.indexOf('|');
+  const head = pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner;
+  const display = pipeIdx >= 0 ? inner.slice(pipeIdx + 1) : null;
+
+  // Split off type::
+  const typeMatch = head.match(/^([a-z][\w-]*)::(.*)$/);
+  const type = typeMatch ? typeMatch[1] : null;
+  const rest = typeMatch ? typeMatch[2] : head;
+
+  // Split off #anchor (everything from # onward, preserving block-id `^`)
+  const hashIdx = rest.indexOf('#');
+  const target = hashIdx >= 0 ? rest.slice(0, hashIdx) : rest;
+  const anchor = hashIdx >= 0 ? rest.slice(hashIdx) : null;
+
+  return { type, target: target.trim(), anchor, display };
+}
+
+function reassembleWikiLink(parsed: ParsedWikiLink, newTarget: string): string {
+  const typeText = parsed.type ? `${parsed.type}::` : '';
+  const anchorText = parsed.anchor ?? '';
+  const displayText = parsed.display !== null ? `|${parsed.display}` : '';
+  return `[[${typeText}${newTarget}${anchorText}${displayText}]]`;
+}
+
+/** Strip a trailing `.md` extension so rewrite keys match the indexer's convention. */
+export function normalizePath(p: string): string {
+  return p.replace(/\.md$/, '');
+}
+
+/**
+ * Apply a rewrites map to all wiki-link targets in the content.
+ * Returns the rewritten content (unchanged if nothing matched).
+ */
+export function rewriteWikiLinks(content: string, rewrites: Map<string, string>): string {
+  if (rewrites.size === 0) return content;
+  return content.replace(WIKI_LINK_RE, (match, inner) => {
+    const parsed = parseWikiInner(inner);
+    // Typed links that target non-notes (cite/quote) are out of scope —
+    // their targets are ids, not paths. Skip them.
+    if (parsed.type === 'cite' || parsed.type === 'quote') return match;
+
+    const normalized = normalizePath(parsed.target);
+    const newPath = rewrites.get(normalized);
+    if (newPath === undefined) return match;
+
+    const hadExtension = parsed.target.endsWith('.md');
+    const finalTarget = hadExtension ? `${newPath}.md` : newPath;
+    return reassembleWikiLink(parsed, finalTarget);
+  });
+}

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from './fs';
+import { rewriteWikiLinks, normalizePath as normalizeLinkPath } from './link-rewriting';
+import * as graph from '../graph/index';
+
+const INDEXABLE_EXTS = new Set(['.md', '.ttl']);
+
+function isIndexable(relativePath: string): boolean {
+  return INDEXABLE_EXTS.has(path.extname(relativePath));
+}
+
+async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {
+  const results: string[] = [];
+  const absDir = path.join(rootPath, relDir);
+  try {
+    const entries = await fs.readdir(absDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        results.push(...await listIndexableFiles(rootPath, rel));
+      } else if (INDEXABLE_EXTS.has(path.extname(entry.name))) {
+        results.push(rel);
+      }
+    }
+  } catch { /* directory may not exist */ }
+  return results;
+}
+
+export interface RenameWithLinksOptions {
+  /** Called for every relative path we're about to touch so the watcher can dedupe. Optional. */
+  markPathHandled?: (relativePath: string) => void;
+  /** Called with (relativePath, content) after each reindex so additional indexes (e.g. search) can update. Optional. */
+  reindexHook?: (relativePath: string, content: string) => void;
+  /** Called with relativePath after each removal from the graph. Optional. */
+  removeHook?: (relativePath: string) => void;
+}
+
+/**
+ * Rename a note file or folder and rewrite every wiki-link in the thoughtbase
+ * that pointed at the old location.
+ *
+ * Returns the set of relative paths whose content was rewritten (not including
+ * the renamed files themselves). Callers are responsible for persisting the
+ * graph after this resolves.
+ */
+export async function renameWithLinkRewrites(
+  rootPath: string,
+  oldRelPath: string,
+  newRelPath: string,
+  opts: RenameWithLinksOptions = {},
+): Promise<{ rewrittenPaths: string[] }> {
+  const { markPathHandled, reindexHook, removeHook } = opts;
+
+  // Determine whether this is a directory rename BEFORE the fs.rename call
+  // so we can enumerate descendants at the old location.
+  const oldStat = await fs.stat(path.join(rootPath, oldRelPath));
+  const isDirectory = oldStat.isDirectory();
+
+  // Build the rewrites map: normalized-old-path → normalized-new-path.
+  const rewrites = new Map<string, string>();
+  if (isDirectory) {
+    const descendants = await listIndexableFiles(rootPath, oldRelPath);
+    for (const d of descendants) {
+      const newEquivalent = newRelPath + d.slice(oldRelPath.length);
+      rewrites.set(normalizeLinkPath(d), normalizeLinkPath(newEquivalent));
+    }
+  } else if (isIndexable(oldRelPath)) {
+    rewrites.set(normalizeLinkPath(oldRelPath), normalizeLinkPath(newRelPath));
+  }
+
+  // Compute referring notes BEFORE renaming (querying pre-rename graph state).
+  const referringNotes = new Set<string>();
+  for (const oldPath of rewrites.keys()) {
+    for (const p of graph.findNotesLinkingTo(`${oldPath}.md`)) {
+      referringNotes.add(p);
+    }
+  }
+
+  markPathHandled?.(oldRelPath);
+  markPathHandled?.(newRelPath);
+  await notebaseFs.rename(rootPath, oldRelPath, newRelPath);
+
+  // Re-index the renamed file(s) at their new location.
+  if (isDirectory) {
+    const newFiles = await listIndexableFiles(rootPath, newRelPath);
+    for (const f of newFiles) {
+      const oldEquivalent = oldRelPath + f.slice(newRelPath.length);
+      if (isIndexable(oldEquivalent)) {
+        graph.removeNote(oldEquivalent);
+        removeHook?.(oldEquivalent);
+      }
+      if (isIndexable(f)) {
+        const content = await notebaseFs.readFile(rootPath, f);
+        await graph.indexNote(f, content);
+        reindexHook?.(f, content);
+      }
+    }
+  } else if (isIndexable(oldRelPath)) {
+    graph.removeNote(oldRelPath);
+    removeHook?.(oldRelPath);
+    const content = await notebaseFs.readFile(rootPath, newRelPath);
+    await graph.indexNote(newRelPath, content);
+    reindexHook?.(newRelPath, content);
+  }
+
+  // Rewrite wiki-links in every referring note. If a referring note was itself
+  // inside the renamed folder, translate its old path to the new one first.
+  const rewrittenPaths: string[] = [];
+  for (const notePath of referringNotes) {
+    const normalized = normalizeLinkPath(notePath);
+    const rewrittenBase = rewrites.get(normalized);
+    const actualPath = rewrittenBase !== undefined ? `${rewrittenBase}.md` : notePath;
+    try {
+      const content = await notebaseFs.readFile(rootPath, actualPath);
+      const rewritten = rewriteWikiLinks(content, rewrites);
+      if (rewritten !== content) {
+        markPathHandled?.(actualPath);
+        await notebaseFs.writeFile(rootPath, actualPath, rewritten);
+        await graph.indexNote(actualPath, rewritten);
+        reindexHook?.(actualPath, rewritten);
+        rewrittenPaths.push(actualPath);
+      }
+    } catch (err) {
+      console.error(`[minerva] Link rewrite failed for ${actualPath}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  return { rewrittenPaths };
+}

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -37,20 +37,30 @@ export interface RenameWithLinksOptions {
   removeHook?: (relativePath: string) => void;
 }
 
+export interface PathTransition {
+  old: string;
+  new: string;
+}
+
+export interface RenameResult {
+  /** One transition per renamed indexable file (a single entry for file renames; many for folder renames). */
+  transitions: PathTransition[];
+  /** Paths of OTHER notes whose content was rewritten by the pass. */
+  rewrittenPaths: string[];
+}
+
 /**
  * Rename a note file or folder and rewrite every wiki-link in the thoughtbase
  * that pointed at the old location.
  *
- * Returns the set of relative paths whose content was rewritten (not including
- * the renamed files themselves). Callers are responsible for persisting the
- * graph after this resolves.
+ * Callers are responsible for persisting the graph after this resolves.
  */
 export async function renameWithLinkRewrites(
   rootPath: string,
   oldRelPath: string,
   newRelPath: string,
   opts: RenameWithLinksOptions = {},
-): Promise<{ rewrittenPaths: string[] }> {
+): Promise<RenameResult> {
   const { markPathHandled, reindexHook, removeHook } = opts;
 
   // Determine whether this is a directory rename BEFORE the fs.rename call
@@ -82,7 +92,8 @@ export async function renameWithLinkRewrites(
   markPathHandled?.(newRelPath);
   await notebaseFs.rename(rootPath, oldRelPath, newRelPath);
 
-  // Re-index the renamed file(s) at their new location.
+  // Re-index the renamed file(s) at their new location, recording transitions.
+  const transitions: PathTransition[] = [];
   if (isDirectory) {
     const newFiles = await listIndexableFiles(rootPath, newRelPath);
     for (const f of newFiles) {
@@ -95,6 +106,7 @@ export async function renameWithLinkRewrites(
         const content = await notebaseFs.readFile(rootPath, f);
         await graph.indexNote(f, content);
         reindexHook?.(f, content);
+        transitions.push({ old: oldEquivalent, new: f });
       }
     }
   } else if (isIndexable(oldRelPath)) {
@@ -103,6 +115,7 @@ export async function renameWithLinkRewrites(
     const content = await notebaseFs.readFile(rootPath, newRelPath);
     await graph.indexNote(newRelPath, content);
     reindexHook?.(newRelPath, content);
+    transitions.push({ old: oldRelPath, new: newRelPath });
   }
 
   // Rewrite wiki-links in every referring note. If a referring note was itself
@@ -127,5 +140,5 @@ export async function renameWithLinkRewrites(
     }
   }
 
-  return { rewrittenPaths };
+  return { transitions, rewrittenPaths };
 }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -111,6 +111,16 @@ export function getRootPath(winId: number): string | null {
   return contexts.get(winId)?.rootPath ?? null;
 }
 
+/** Every live BrowserWindow whose context has the given rootPath open. */
+export function windowsForProject(rootPath: string): BrowserWindow[] {
+  const hits: BrowserWindow[] = [];
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    if (contexts.get(win.id)?.rootPath === rootPath) hits.push(win);
+  }
+  return hits;
+}
+
 export async function openProjectInWindow(win: BrowserWindow, rootPath: string): Promise<void> {
   const ctx = getContext(win.id);
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -34,6 +34,12 @@ contextBridge.exposeInMainWorld('api', {
     onFileDeleted: (cb: (path: string) => void) => {
       ipcRenderer.on(Channels.NOTEBASE_FILE_DELETED, (_e, p) => cb(p));
     },
+    onRenamed: (cb: (transitions: Array<{ old: string; new: string }>) => void) => {
+      ipcRenderer.on(Channels.NOTEBASE_RENAMED, (_e, transitions) => cb(transitions));
+    },
+    onRewritten: (cb: (paths: string[]) => void) => {
+      ipcRenderer.on(Channels.NOTEBASE_REWRITTEN, (_e, paths) => cb(paths));
+    },
   },
   links: {
     outgoing: (relativePath: string) => ipcRenderer.invoke(Channels.LINKS_OUTGOING, relativePath),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -505,6 +505,26 @@
     api.menu.onOpenInTerminal(() => { api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
     api.menu.onOpenSettings(() => { showSettings = true; });
 
+    // Notebase rename/rewrite notifications from main — keep open tabs
+    // consistent with disk so the next auto-save doesn't overwrite a
+    // link rewrite silently.
+    api.notebase.onRenamed((transitions) => {
+      editor.applyRenameTransitions(transitions);
+    });
+    api.notebase.onRewritten(async (paths) => {
+      for (const p of paths) {
+        if (editor.isPathDirty(p)) {
+          const keepDisk = await showConfirm(
+            `"${p}" was updated on disk by a link rewrite. Discard your unsaved edits and load the new version?`,
+            'confirm-rewrite-conflict',
+            'Load disk',
+          );
+          if (!keepDisk) continue;
+        }
+        await editor.reloadTabFromDisk(p);
+      }
+    });
+
     // Tools for Thought — stream listener (once)
     api.tools.onStream((chunk) => {
       toolPanel.appendChunk(chunk);

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -254,18 +254,19 @@
   async function handleRename(relativePath: string) {
     if (!notebase.meta) return;
     const oldName = relativePath.split('/').pop()!;
-    const newName = await showPrompt('New name:');
-    if (!newName || newName === oldName) return;
+    const rawNewName = await showPrompt('New name:');
+    if (!rawNewName || rawNewName === oldName) return;
+    // Preserve the old extension when the user didn't include one. A file
+    // that drops its .md / .ttl suffix falls out of the indexed set and
+    // effectively disappears from the sidebar; almost always a mistake.
+    const oldDotIdx = oldName.lastIndexOf('.');
+    const oldExt = oldDotIdx > 0 ? oldName.slice(oldDotIdx) : '';
+    const newName = !rawNewName.includes('.') && oldExt ? `${rawNewName}${oldExt}` : rawNewName;
     const dir = relativePath.includes('/') ? relativePath.substring(0, relativePath.lastIndexOf('/')) : '';
     const newPath = dir ? `${dir}/${newName}` : newName;
+    // Tab path + content refresh is handled by the NOTEBASE_RENAMED /
+    // NOTEBASE_REWRITTEN listeners registered in onMount — don't duplicate.
     await api.notebase.rename(relativePath, newPath);
-    // Update open tab if renamed
-    const tabIdx = editor.tabs.findIndex((t) => t.type === 'note' && t.relativePath === relativePath);
-    if (tabIdx !== -1) {
-      const tab = editor.tabs[tabIdx] as any;
-      tab.relativePath = newPath;
-      tab.fileName = newName;
-    }
     await notebase.refresh();
   }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -19,6 +19,8 @@ export interface NotebaseApi {
   onFileChanged(cb: (path: string) => void): void;
   onFileCreated(cb: (path: string) => void): void;
   onFileDeleted(cb: (path: string) => void): void;
+  onRenamed(cb: (transitions: Array<{ old: string; new: string }>) => void): void;
+  onRewritten(cb: (paths: string[]) => void): void;
 }
 
 export interface LinksApi {

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -123,6 +123,51 @@ export function getEditorStore() {
     tab.savedContent = tab.content;
   }
 
+  // ── External change handlers (rename / content rewrite on disk) ─────────
+
+  /** Return true if the tab for this path has unsaved local edits. */
+  function isPathDirty(relativePath: string): boolean {
+    const tab = tabs.find((t) => isNote(t) && t.relativePath === relativePath) as NoteTab | undefined;
+    return tab ? tab.content !== tab.savedContent : false;
+  }
+
+  /**
+   * Apply file renames (from the main process) to tab paths. Content is
+   * unchanged, so no reload is needed — the tab's buffer is still correct.
+   */
+  function applyRenameTransitions(transitions: Array<{ old: string; new: string }>): void {
+    if (transitions.length === 0) return;
+    const byOld = new Map(transitions.map((t) => [t.old, t.new]));
+    let touched = false;
+    for (const tab of tabs) {
+      if (!isNote(tab)) continue;
+      const newPath = byOld.get(tab.relativePath);
+      if (newPath && newPath !== tab.relativePath) {
+        tab.relativePath = newPath;
+        tab.fileName = newPath.split('/').pop() ?? '';
+        touched = true;
+      }
+    }
+    if (touched) schedulePersistTabs();
+  }
+
+  /**
+   * Reload a tab's content from disk. Caller is responsible for deciding
+   * whether to call this when the tab is dirty (usually after a conflict
+   * prompt). Does nothing if no tab is open at that path.
+   */
+  async function reloadTabFromDisk(relativePath: string): Promise<void> {
+    const tab = tabs.find((t) => isNote(t) && t.relativePath === relativePath) as NoteTab | undefined;
+    if (!tab) return;
+    try {
+      const text = await api.notebase.readFile(relativePath);
+      tab.content = text;
+      tab.savedContent = text;
+    } catch {
+      // File may have been deleted between the rewrite notification and now.
+    }
+  }
+
   function setContent(text: string) {
     const tab = activeNoteTab();
     if (tab) {
@@ -351,6 +396,9 @@ export function getEditorStore() {
     openFile,
     openSource,
     save,
+    isPathDirty,
+    applyRenameTransitions,
+    reloadTabFromDisk,
     setContent,
     flushAutoSave,
     set onAutoSaved(cb: (() => void) | null) { onAutoSaved = cb; },

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -15,6 +15,10 @@ export const Channels = {
   NOTEBASE_FILE_CHANGED: 'notebase:fileChanged',
   NOTEBASE_FILE_CREATED: 'notebase:fileCreated',
   NOTEBASE_FILE_DELETED: 'notebase:fileDeleted',
+  /** Emitted by the main process after a note rename completes. Payload is PathTransition[]. */
+  NOTEBASE_RENAMED: 'notebase:renamed',
+  /** Emitted after link-rewrites touched other notes' content. Payload is string[] (relativePaths). */
+  NOTEBASE_REWRITTEN: 'notebase:rewritten',
 
   // Links
   LINKS_OUTGOING: 'links:outgoing',

--- a/tests/main/notebase/link-rewriting.test.ts
+++ b/tests/main/notebase/link-rewriting.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { rewriteWikiLinks, normalizePath } from '../../../src/main/notebase/link-rewriting';
+
+const map = (pairs: [string, string][]) => new Map(pairs);
+
+describe('normalizePath', () => {
+  it('strips a trailing .md', () => {
+    expect(normalizePath('notes/foo.md')).toBe('notes/foo');
+  });
+
+  it('leaves non-.md paths alone', () => {
+    expect(normalizePath('notes/foo')).toBe('notes/foo');
+  });
+});
+
+describe('rewriteWikiLinks', () => {
+  it('returns input unchanged when rewrites is empty', () => {
+    expect(rewriteWikiLinks('[[foo]]', new Map())).toBe('[[foo]]');
+  });
+
+  it('rewrites a simple wiki-link', () => {
+    const out = rewriteWikiLinks('See [[notes/foo]].', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('See [[archive/foo]].');
+  });
+
+  it('preserves display text', () => {
+    const out = rewriteWikiLinks('See [[notes/foo|the foo note]].', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('See [[archive/foo|the foo note]].');
+  });
+
+  it('preserves the type prefix on typed links', () => {
+    const out = rewriteWikiLinks(
+      'It [[supports::notes/foo]] the claim.',
+      map([['notes/foo', 'archive/foo']]),
+    );
+    expect(out).toBe('It [[supports::archive/foo]] the claim.');
+  });
+
+  it('preserves anchor suffix (headings)', () => {
+    const out = rewriteWikiLinks('[[notes/foo#components]]', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('[[archive/foo#components]]');
+  });
+
+  it('preserves block-id suffix', () => {
+    const out = rewriteWikiLinks('[[notes/foo#^p4]]', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('[[archive/foo#^p4]]');
+  });
+
+  it('preserves all three (type + anchor + display)', () => {
+    const out = rewriteWikiLinks(
+      '[[rebuts::notes/foo#section|see section]]',
+      map([['notes/foo', 'archive/foo']]),
+    );
+    expect(out).toBe('[[rebuts::archive/foo#section|see section]]');
+  });
+
+  it('preserves a .md suffix when the source had one', () => {
+    const out = rewriteWikiLinks('[[notes/foo.md]]', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('[[archive/foo.md]]');
+  });
+
+  it('does not add .md when the source did not have one', () => {
+    const out = rewriteWikiLinks('[[notes/foo]]', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('[[archive/foo]]');
+  });
+
+  it('leaves cite links alone — they use source ids, not paths', () => {
+    const out = rewriteWikiLinks(
+      '[[cite::notes/foo]] and [[quote::notes/foo]]',
+      map([['notes/foo', 'archive/foo']]),
+    );
+    expect(out).toBe('[[cite::notes/foo]] and [[quote::notes/foo]]');
+  });
+
+  it('leaves non-matching targets alone', () => {
+    const out = rewriteWikiLinks('[[notes/bar]] [[notes/foo]]', map([['notes/foo', 'archive/foo']]));
+    expect(out).toBe('[[notes/bar]] [[archive/foo]]');
+  });
+
+  it('handles multiple rewrites in a single pass', () => {
+    const out = rewriteWikiLinks(
+      '[[notes/a]] links to [[notes/b]] links to [[notes/c]]',
+      map([
+        ['notes/a', 'archive/a'],
+        ['notes/b', 'archive/b'],
+      ]),
+    );
+    expect(out).toBe('[[archive/a]] links to [[archive/b]] links to [[notes/c]]');
+  });
+
+  it('rewrites links in frontmatter values too (regex covers the whole file)', () => {
+    const input = `---
+related: "[[notes/foo]]"
+---
+# My note
+See [[notes/foo]].
+`;
+    const out = rewriteWikiLinks(input, map([['notes/foo', 'archive/foo']]));
+    expect(out).toContain('related: "[[archive/foo]]"');
+    expect(out).toContain('See [[archive/foo]].');
+  });
+
+  it('does not rewrite inside fenced code blocks (known limitation — regex is whole-file)', () => {
+    // This documents current behavior. Rewriting inside code fences is a
+    // scoped future change; today a plain regex reaches in.
+    const out = rewriteWikiLinks(
+      '```\n[[notes/foo]]\n```',
+      map([['notes/foo', 'archive/foo']]),
+    );
+    expect(out).toBe('```\n[[archive/foo]]\n```');
+  });
+});

--- a/tests/main/notebase/rename.test.ts
+++ b/tests/main/notebase/rename.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, findNotesLinkingTo } from '../../../src/main/graph/index';
+import { renameWithLinkRewrites } from '../../../src/main/notebase/rename';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-rename-test-'));
+}
+
+function writeNote(root: string, relPath: string, content: string): void {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+function readNote(root: string, relPath: string): string {
+  return fs.readFileSync(path.join(root, relPath), 'utf-8');
+}
+
+describe('renameWithLinkRewrites — file rename (issue #136)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('renames the file and rewrites a simple incoming link', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    writeNote(root, 'notes/overview.md', '# Overview\n\nSee [[notes/foo]].');
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/overview.md', '# Overview\n\nSee [[notes/foo]].');
+
+    const { rewrittenPaths } = await renameWithLinkRewrites(
+      root, 'notes/foo.md', 'archive/foo.md',
+    );
+
+    expect(fs.existsSync(path.join(root, 'notes/foo.md'))).toBe(false);
+    expect(fs.existsSync(path.join(root, 'archive/foo.md'))).toBe(true);
+    expect(readNote(root, 'notes/overview.md')).toContain('[[archive/foo]]');
+    expect(rewrittenPaths).toEqual(['notes/overview.md']);
+  });
+
+  it('preserves type prefix, display, and anchor on rewrite', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    const body = [
+      '# Overview',
+      'Basic [[notes/foo]].',
+      'Typed [[supports::notes/foo]].',
+      'Display [[notes/foo|the foo]].',
+      'Anchor [[notes/foo#section]].',
+      'Block  [[notes/foo#^para-3]].',
+      'All    [[rebuts::notes/foo#section|see this]].',
+    ].join('\n');
+    writeNote(root, 'notes/overview.md', body);
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/overview.md', body);
+
+    await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md');
+
+    const after = readNote(root, 'notes/overview.md');
+    expect(after).toContain('[[archive/foo]]');
+    expect(after).toContain('[[supports::archive/foo]]');
+    expect(after).toContain('[[archive/foo|the foo]]');
+    expect(after).toContain('[[archive/foo#section]]');
+    expect(after).toContain('[[archive/foo#^para-3]]');
+    expect(after).toContain('[[rebuts::archive/foo#section|see this]]');
+  });
+
+  it('updates the graph so findNotesLinkingTo now reports the NEW path', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    writeNote(root, 'notes/overview.md', 'See [[notes/foo]].');
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/overview.md', 'See [[notes/foo]].');
+
+    await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md');
+
+    expect(findNotesLinkingTo('notes/foo.md')).toEqual([]);
+    expect(findNotesLinkingTo('archive/foo.md')).toEqual(['notes/overview.md']);
+  });
+
+  it('leaves unrelated notes untouched', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    writeNote(root, 'notes/bar.md', '# Bar\n\nNothing to do with foo.');
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/bar.md', '# Bar\n\nNothing to do with foo.');
+
+    const before = readNote(root, 'notes/bar.md');
+    await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md');
+    expect(readNote(root, 'notes/bar.md')).toBe(before);
+  });
+
+  it('invokes reindexHook for the rewritten referrer so downstream indexes stay consistent', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    writeNote(root, 'notes/overview.md', 'See [[notes/foo]].');
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/overview.md', 'See [[notes/foo]].');
+
+    const reindexed: string[] = [];
+    await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md', {
+      reindexHook: (p) => { reindexed.push(p); },
+    });
+
+    expect(reindexed).toContain('archive/foo.md');
+    expect(reindexed).toContain('notes/overview.md');
+  });
+});
+
+describe('renameWithLinkRewrites — folder rename (issue #136)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('rewrites every descendant path in a single pass', async () => {
+    writeNote(root, 'notes/a.md', '# A');
+    writeNote(root, 'notes/b.md', '# B');
+    writeNote(root, 'other/overview.md', 'Links: [[notes/a]] and [[notes/b]].');
+    await indexNote('notes/a.md', '# A');
+    await indexNote('notes/b.md', '# B');
+    await indexNote('other/overview.md', 'Links: [[notes/a]] and [[notes/b]].');
+
+    await renameWithLinkRewrites(root, 'notes', 'archive');
+
+    expect(fs.existsSync(path.join(root, 'archive/a.md'))).toBe(true);
+    expect(fs.existsSync(path.join(root, 'archive/b.md'))).toBe(true);
+    const after = readNote(root, 'other/overview.md');
+    expect(after).toContain('[[archive/a]]');
+    expect(after).toContain('[[archive/b]]');
+  });
+
+  it('rewrites links inside the renamed folder too (same-folder self-reference)', async () => {
+    writeNote(root, 'notes/a.md', '# A');
+    writeNote(root, 'notes/overview.md', 'See [[notes/a]].');
+    await indexNote('notes/a.md', '# A');
+    await indexNote('notes/overview.md', 'See [[notes/a]].');
+
+    await renameWithLinkRewrites(root, 'notes', 'archive');
+
+    // The referring note was itself moved — read at the new location.
+    expect(readNote(root, 'archive/overview.md')).toContain('[[archive/a]]');
+  });
+});

--- a/tests/main/notebase/rename.test.ts
+++ b/tests/main/notebase/rename.test.ts
@@ -37,7 +37,7 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
     await indexNote('notes/foo.md', '# Foo');
     await indexNote('notes/overview.md', '# Overview\n\nSee [[notes/foo]].');
 
-    const { rewrittenPaths } = await renameWithLinkRewrites(
+    const { rewrittenPaths, transitions } = await renameWithLinkRewrites(
       root, 'notes/foo.md', 'archive/foo.md',
     );
 
@@ -45,6 +45,24 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
     expect(fs.existsSync(path.join(root, 'archive/foo.md'))).toBe(true);
     expect(readNote(root, 'notes/overview.md')).toContain('[[archive/foo]]');
     expect(rewrittenPaths).toEqual(['notes/overview.md']);
+    expect(transitions).toEqual([{ old: 'notes/foo.md', new: 'archive/foo.md' }]);
+  });
+
+  it('emits one transition per indexable file when a folder is renamed', async () => {
+    writeNote(root, 'notes/a.md', '# A');
+    writeNote(root, 'notes/b.md', '# B');
+    writeNote(root, 'other/overview.md', 'See [[notes/a]].');
+    await indexNote('notes/a.md', '# A');
+    await indexNote('notes/b.md', '# B');
+    await indexNote('other/overview.md', 'See [[notes/a]].');
+
+    const { transitions } = await renameWithLinkRewrites(root, 'notes', 'archive');
+
+    const pairs = transitions.map((t) => [t.old, t.new].join(' -> ')).sort();
+    expect(pairs).toEqual([
+      'notes/a.md -> archive/a.md',
+      'notes/b.md -> archive/b.md',
+    ]);
   });
 
   it('preserves type prefix, display, and anchor on rewrite', async () => {


### PR DESCRIPTION
Closes #136 and #145.

## Summary
- Renaming or moving a note, or renaming a folder, rewrites every wiki-link in the thoughtbase that pointed at the old location.
- Any editor tab showing an affected note refreshes in place — path updates, content reloads, cursor/scroll preserved — so the next auto-save doesn't silently revert the rewrite.
- Preserves type prefix, display text, anchor/block suffix, and \`.md\` extension shape on every rewrite.
- Cite/quote links are deliberately skipped — they key on source/excerpt ids rather than paths and have their own rename pipeline (#141).

## Rewrite engine (#136)
- **\`src/main/notebase/link-rewriting.ts\`** — pure rewriter. Given \`(content, rewrites)\`, parses each \`[[…]]\` into \`{ type, target, anchor, display }\`, substitutes, reassembles.
- **\`src/main/notebase/rename.ts\`** — \`renameWithLinkRewrites(root, old, new, opts)\` orchestrates the full flow. Collects referring notes from the pre-rename graph, \`fs.rename\`s, re-indexes the renamed file(s), then rewrites + re-indexes each referring note. Returns \`{ transitions, rewrittenPaths }\`.
- **\`findNotesLinkingTo\`** on the graph — scopes the rewrite pass to files the graph says are affected.

## Tab refresh (#145)
- **New channels** \`NOTEBASE_RENAMED\` and \`NOTEBASE_REWRITTEN\` broadcast to every window with the project open (\`windowsForProject\` in window-manager).
- **Editor store** gains \`applyRenameTransitions\`, \`reloadTabFromDisk\`, \`isPathDirty\`. Path changes don't touch content; rewrites reload from disk.
- **Cursor/scroll preservation** comes free from CodeMirror's existing external-content \`\$effect\` — the transaction remaps selections through the change.
- **Dirty-buffer conflict:** if the tab has unsaved edits when a rewrite arrives, \`showConfirm\` prompts "Load disk / Keep mine" with a don't-ask-again toggle. Clean tabs refresh silently.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 272 pass (16 unit tests for the rewriter + 8 integration tests for rename — file, folder, transitions, hooks)
- [ ] Manual: open \`notes/architecture.md\` and \`notes/design-patterns.md\`, rename \`architecture\` → \`architecture-v2\`, confirm \`design-patterns\`'s \`[[supports::notes/architecture]]\` updates AND the \`architecture\` tab stays open at its new path
- [ ] Manual: rename \`notes/\` → \`archive/\` while any of its notes is open — paths update in the tab bar without losing cursor position
- [ ] Manual: edit a note, dirty it, then rename another note it links to — confirm the dialog appears

## Known limitation (documented in tests)
The regex-based rewriter reaches into fenced code blocks. Arguably a feature (a code fence that happens to quote \`[[notes/foo]]\` still points at the right place after rename). Scoped tweak if it ever bites.

## Out of scope
- #137 anchor syntax parsing/navigation. The rewriter already preserves \`#anchor\` / \`#^block-id\` suffixes verbatim; they'll start meaning something once #137 lands.
- #139 heading-edit rewrites, #141 source/excerpt rename, #142 bookmark updates — each their own PR.