### PR TITLE
Anchor-link syntax: [[note#heading]] and [[note#^block-id]]

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -7,6 +7,7 @@ import os from 'node:os';
 import { parseMarkdown, type ParsedTable, type FrontmatterValue } from './parser';
 import { getLinkType, type LinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
+import { slugify } from '../../shared/slug';
 import * as uriHelpers from './uri-helpers';
 
 import * as N3 from 'n3';
@@ -155,10 +156,22 @@ function linkPredicate(lt: LinkType) {
   return lt.predicateNamespace === 'thought' ? THOUGHT(lt.predicate) : MINERVA(lt.predicate);
 }
 
-function resolveLinkTarget(lt: LinkType, target: string) {
+function resolveLinkTarget(lt: LinkType, target: string, anchor?: string) {
   if (lt.targetKind === 'source') return sourceUri(target);
   if (lt.targetKind === 'excerpt') return excerptUri(target);
-  return noteUri(target.endsWith('.md') ? target : `${target}.md`);
+  const base = noteUri(target.endsWith('.md') ? target : `${target}.md`);
+  // Anchors append as an IRI fragment: headings become `#slug`, block-ids
+  // stay as `#^raw-id` (we don't slugify the `^` prefix or its payload so
+  // ids survive edits on the referenced block).
+  if (!anchor) return base;
+  const frag = anchor.startsWith('^') ? anchor : slugify(anchor);
+  return $rdf.sym(`${base.value}#${frag}`);
+}
+
+/** Strip an IRI fragment (`#…`) if present — use to find the note subject a link points at. */
+function stripFragment(uri: string): string {
+  const idx = uri.indexOf('#');
+  return idx < 0 ? uri : uri.slice(0, idx);
 }
 
 function existsPredicateFor(lt: LinkType) {
@@ -413,7 +426,7 @@ export async function indexNote(relativePath: string, content: string): Promise<
   for (const link of parsed.links) {
     const linkType = getLinkType(link.type);
     const predicate = linkPredicate(linkType);
-    const targetNode = resolveLinkTarget(linkType, link.target);
+    const targetNode = resolveLinkTarget(linkType, link.target, link.anchor);
     store.add(subject, predicate, targetNode, graph);
   }
 
@@ -587,7 +600,7 @@ function indexSourceBody(
   for (const link of parsed.links) {
     const linkType = getLinkType(link.type);
     const predicate = linkPredicate(linkType);
-    const targetNode = resolveLinkTarget(linkType, link.target);
+    const targetNode = resolveLinkTarget(linkType, link.target, link.anchor);
     store.add(subject, predicate, targetNode, graph);
   }
 }
@@ -919,10 +932,17 @@ export function outgoingLinks(relativePath: string): OutgoingLink[] {
     const stmts = store.statementsMatching(subject, linkPredicate(lt), undefined);
     for (const st of stmts) {
       const targetNode = st.object as $rdf.NamedNode;
-      const pathStmts = store.statementsMatching(targetNode, MINERVA('relativePath'), undefined);
-      const titleStmts = store.statementsMatching(targetNode, DC('title'), undefined);
+      // Note-typed link targets may carry a `#anchor` fragment. Look up the
+      // bare note's metadata, not the fragmented URI. Default (undefined)
+      // targetKind counts as 'note'.
+      const isNoteTarget = !lt.targetKind || lt.targetKind === 'note';
+      const bareNode = isNoteTarget && targetNode.value.includes('#')
+        ? $rdf.sym(stripFragment(targetNode.value))
+        : targetNode;
+      const pathStmts = store.statementsMatching(bareNode, MINERVA('relativePath'), undefined);
+      const titleStmts = store.statementsMatching(bareNode, DC('title'), undefined);
       const existsPredicate = existsPredicateFor(lt);
-      const typeStmts = store.statementsMatching(targetNode, existsPredicate, undefined);
+      const typeStmts = store.statementsMatching(bareNode, existsPredicate, undefined);
       const isExternalTarget = lt.targetKind === 'source' || lt.targetKind === 'excerpt';
 
       results.push({
@@ -949,12 +969,15 @@ export function outgoingLinks(relativePath: string): OutgoingLink[] {
  */
 export function findNotesLinkingTo(targetRelativePath: string): string[] {
   if (!store) return [];
-  const target = noteUri(targetRelativePath);
+  const targetBase = noteUri(targetRelativePath).value;
   const seen = new Set<string>();
   for (const lt of LINK_TYPES) {
     if (lt.targetKind && lt.targetKind !== 'note') continue;
-    const stmts = store.statementsMatching(undefined, linkPredicate(lt), target);
+    // Match both `<noteUri>` and `<noteUri>#<anchor>` targets.
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
     for (const st of stmts) {
+      const objValue = st.object.value;
+      if (objValue !== targetBase && !objValue.startsWith(`${targetBase}#`)) continue;
       const sourceNode = st.subject;
       const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
       const sourcePath = pathStmts[0]?.object.value;
@@ -967,12 +990,15 @@ export function findNotesLinkingTo(targetRelativePath: string): string[] {
 export function backlinks(relativePath: string): Backlink[] {
   if (!store) return [];
 
-  const target = noteUri(relativePath);
+  const targetBase = noteUri(relativePath).value;
   const results: Backlink[] = [];
 
   for (const lt of LINK_TYPES) {
-    const stmts = store.statementsMatching(undefined, linkPredicate(lt), target);
+    if (lt.targetKind && lt.targetKind !== 'note') continue;
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
     for (const st of stmts) {
+      const objValue = st.object.value;
+      if (objValue !== targetBase && !objValue.startsWith(`${targetBase}#`)) continue;
       const sourceNode = st.subject;
       const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
       const titleStmts = store.statementsMatching(sourceNode, DC('title'), undefined);

--- a/src/main/graph/parser.ts
+++ b/src/main/graph/parser.ts
@@ -1,8 +1,14 @@
 import YAML from 'yaml';
+import { splitAnchor } from '../../shared/slug';
 
 export interface ParsedLink {
+  /** Bare target path/id with any `#anchor` stripped. */
   target: string;
-  type: string;       // link type name (e.g. 'supports', 'references')
+  /** Raw anchor text (no leading `#`), or undefined if the link had no anchor. Block-id anchors keep their `^` prefix. */
+  anchor?: string;
+  /** Link type name (e.g. 'supports', 'references'). */
+  type: string;
+  /** Display text after `|`, if any. */
   displayText?: string;
 }
 
@@ -104,13 +110,17 @@ function extractLinks(content: string): ParsedLink[] {
 
     // Split rest on | for display text
     const pipeIdx = rest.indexOf('|');
-    const target = (pipeIdx >= 0 ? rest.slice(0, pipeIdx) : rest).trim();
+    const targetWithAnchor = (pipeIdx >= 0 ? rest.slice(0, pipeIdx) : rest).trim();
     const displayText = pipeIdx >= 0 ? rest.slice(pipeIdx + 1).trim() : undefined;
 
-    const key = `${type}::${target}`;
+    // Strip optional #anchor (heading) or #^block-id suffix from the target.
+    const { path, anchor } = splitAnchor(targetWithAnchor);
+    const target = path;
+
+    const key = `${type}::${target}::${anchor ?? ''}`;
     if (!seen.has(key)) {
       seen.add(key);
-      links.push({ target, type, displayText });
+      links.push({ target, type, displayText, ...(anchor !== null ? { anchor } : {}) });
     }
   }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -22,6 +22,7 @@
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
   import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
+  import { slugify } from '../shared/slug';
   import { initAppearance } from './lib/appearance/settings';
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationStore } from './lib/stores/conversation.svelte';
@@ -121,11 +122,47 @@
     }
   }
 
-  function handleNavigate(target: string) {
+  let pendingPreviewAnchor = $state<string | null>(null);
+
+  async function handleNavigate(target: string) {
     recordCurrentPosition();
-    const notePath = target.endsWith('.md') ? target : `${target}.md`;
-    editor.openFile(notePath);
+    const hashIdx = target.indexOf('#');
+    const pathPart = hashIdx >= 0 ? target.slice(0, hashIdx) : target;
+    const anchor = hashIdx >= 0 ? target.slice(hashIdx + 1) : null;
+    const notePath = pathPart.endsWith('.md') ? pathPart : `${pathPart}.md`;
+    await editor.openFile(notePath);
+    // Route anchors: preview scrolls by element id; editor jumps by doc offset.
+    if (anchor) {
+      pendingPreviewAnchor = anchor;
+      if (viewMode === 'source' || viewMode === 'split') {
+        const content = editor.content;
+        const offset = findAnchorOffset(content, anchor);
+        if (offset !== null) {
+          requestAnimationFrame(() => editorComponent?.gotoOffset(offset));
+        }
+      }
+    }
     nav.record({ type: 'note', relativePath: notePath, offset: 0 });
+  }
+
+  /**
+   * Locate a heading (by slug) or block-id inside raw markdown and return
+   * the character offset of its line. Shared between source and split modes.
+   */
+  function findAnchorOffset(text: string, anchor: string): number | null {
+    const isBlockId = anchor.startsWith('^');
+    const lines = text.split('\n');
+    let offset = 0;
+    for (const line of lines) {
+      if (isBlockId) {
+        if (line.trimEnd().endsWith(anchor)) return offset;
+      } else {
+        const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+        if (m && slugify(m[2]) === anchor) return offset;
+      }
+      offset += line.length + 1;
+    }
+    return null;
   }
 
   function handleOpenSource(sourceId: string, highlightExcerptId?: string) {
@@ -665,6 +702,8 @@
                   onTagSelect={handleTagSelect}
                   onOpenSource={handleOpenSource}
                   onOpenExcerpt={handleOpenExcerpt}
+                  pendingAnchor={pendingPreviewAnchor}
+                  onAnchorResolved={() => { pendingPreviewAnchor = null; }}
                 />
               </div>
             {/if}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -4,6 +4,7 @@
   import hljs from 'highlight.js';
   import 'highlight.js/styles/github-dark.min.css';
   import { getLinkType } from '../../../shared/link-types';
+  import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
   import { renderChart, type ChartHandle, type ChartConfig, type ChartSeries } from '../charts';
 
@@ -13,9 +14,13 @@
     onTagSelect?: (tag: string) => void;
     onOpenSource?: (sourceId: string) => void;
     onOpenExcerpt?: (excerptId: string) => void;
+    /** If set, the effect below will scroll the preview to the matching heading / block after render. */
+    pendingAnchor?: string | null;
+    /** Called when the effect successfully scrolls, so the caller can clear its pending state. */
+    onAnchorResolved?: () => void;
   }
 
-  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt }: Props = $props();
+  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved }: Props = $props();
 
   // Query result cache: query text → results (survives re-renders)
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
@@ -63,6 +68,47 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       return '';
     },
   });
+
+  // Give every heading an id derived from its text so [[note#heading]] anchor
+  // navigation can target it. Slugs must match the indexer's convention.
+  const defaultHeadingOpen = md.renderer.rules.heading_open;
+  md.renderer.rules.heading_open = (tokens, idx, options, env, self) => {
+    const inline = tokens[idx + 1];
+    const text = inline && inline.type === 'inline' ? inline.content : '';
+    const slug = slugify(text);
+    if (slug) tokens[idx].attrSet('id', slug);
+    return defaultHeadingOpen
+      ? defaultHeadingOpen(tokens, idx, options, env, self)
+      : self.renderToken(tokens, idx, options);
+  };
+
+  // Watch for block-id paragraphs (`^block-id` at paragraph end) and mirror
+  // them onto the rendered <p> so [[note#^id]] scrolls can find the target.
+  const BLOCK_ID_RE = /\s*\^([\w-]+)\s*$/;
+  const defaultParagraphOpen = md.renderer.rules.paragraph_open;
+  md.renderer.rules.paragraph_open = (tokens, idx, options, env, self) => {
+    const inline = tokens[idx + 1];
+    if (inline && inline.type === 'inline') {
+      const m = inline.content.match(BLOCK_ID_RE);
+      if (m) {
+        tokens[idx].attrSet('id', `^${m[1]}`);
+        // Strip the marker from what renders.
+        inline.content = inline.content.replace(BLOCK_ID_RE, '');
+        if (inline.children) {
+          for (let i = inline.children.length - 1; i >= 0; i--) {
+            const child = inline.children[i];
+            if (child.type === 'text') {
+              const stripped = child.content.replace(BLOCK_ID_RE, '');
+              if (stripped !== child.content) { child.content = stripped; break; }
+            }
+          }
+        }
+      }
+    }
+    return defaultParagraphOpen
+      ? defaultParagraphOpen(tokens, idx, options, env, self)
+      : self.renderToken(tokens, idx, options);
+  };
 
   // Wiki-link plugin: [[type::target|display]], [[type::target]], [[target|display]], [[target]]
   md.inline.ruler.push('wiki_link', (state, silent) => {
@@ -225,6 +271,21 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       cites?.forEach((el) => resolveCiteLabel(el as HTMLElement));
       const quotes = previewEl?.querySelectorAll('.quote-link');
       quotes?.forEach((el) => resolveQuoteLabel(el as HTMLElement));
+    });
+  });
+
+  // After render, if the caller asked us to jump to a heading or block, do it.
+  $effect(() => {
+    if (!pendingAnchor || !previewEl) return;
+    const anchor = pendingAnchor;
+    requestAnimationFrame(() => {
+      if (!previewEl) return;
+      const id = anchor.startsWith('^') ? anchor : slugify(anchor);
+      const target = previewEl.querySelector(`[id="${CSS.escape(id)}"]`);
+      if (target) {
+        target.scrollIntoView({ block: 'start', behavior: 'auto' });
+        onAnchorResolved?.();
+      }
     });
   });
 

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -1,0 +1,35 @@
+/**
+ * Slugify a heading or anchor string into the ID we use in link URIs and
+ * in the HTML heading `id` attribute.
+ *
+ * Rules:
+ * - Lowercase.
+ * - Strip anything that isn't a word char, a space, or an unambiguous ASCII
+ *   hyphen (the `^` is preserved so block-id anchors like `#^abc` keep their
+ *   marker when a caller chooses to slugify a full anchor).
+ * - Collapse whitespace runs into a single `-`.
+ * - Collapse multiple hyphens.
+ * - Trim leading/trailing hyphens.
+ *
+ * Idempotent: `slugify(slugify(x)) === slugify(x)` for all x.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s\-^]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Split a wiki-link target at the first `#` into its path and anchor parts.
+ * `anchor` is the text AFTER the `#` (no leading hash). For block-id links,
+ * the returned anchor still begins with `^` so callers can distinguish.
+ * Returns `{ path: target, anchor: null }` if no hash is present.
+ */
+export function splitAnchor(target: string): { path: string; anchor: string | null } {
+  const idx = target.indexOf('#');
+  if (idx < 0) return { path: target, anchor: null };
+  return { path: target.slice(0, idx), anchor: target.slice(idx + 1) };
+}

--- a/tests/main/graph/anchor-links.test.ts
+++ b/tests/main/graph/anchor-links.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  queryGraph,
+  findNotesLinkingTo,
+  outgoingLinks,
+  backlinks,
+} from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-anchor-test-'));
+}
+
+describe('anchor links (issue #137)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('indexes heading anchors as an IRI fragment (slug)', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n## Components');
+    await indexNote('notes/a.md', 'See [[notes/foo#Components]].');
+
+    const { results } = await queryGraph(`
+      SELECT ?target WHERE {
+        ?src minerva:relativePath "notes/a.md" .
+        ?src minerva:references ?target .
+      }
+    `);
+    const target = (results as Array<{ target: string }>)[0].target;
+    expect(target).toMatch(/note\/notes\/foo#components$/);
+  });
+
+  it('preserves block-id anchors verbatim (with ^ prefix, no slugification)', async () => {
+    await indexNote('notes/a.md', 'See [[notes/foo#^para-3]].');
+
+    const { results } = await queryGraph(`
+      SELECT ?target WHERE {
+        ?src minerva:relativePath "notes/a.md" ;
+             minerva:references ?target .
+      }
+    `);
+    const target = (results as Array<{ target: string }>)[0].target;
+    expect(target).toMatch(/note\/notes\/foo#\^para-3$/);
+  });
+
+  it('findNotesLinkingTo tolerates anchored links to the same note', async () => {
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/a.md', 'See [[notes/foo]].');
+    await indexNote('notes/b.md', 'See [[notes/foo#components]].');
+    await indexNote('notes/c.md', 'See [[notes/foo#^block-1]].');
+
+    const linkers = findNotesLinkingTo('notes/foo.md').sort();
+    expect(linkers).toEqual(['notes/a.md', 'notes/b.md', 'notes/c.md']);
+  });
+
+  it('backlinks reports anchored links as backlinks to the bare note', async () => {
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/a.md', 'See [[notes/foo#section]].');
+
+    const bl = backlinks('notes/foo.md');
+    expect(bl.map((b) => b.source)).toEqual(['notes/a.md']);
+  });
+
+  it('outgoingLinks resolves anchored targets to the bare note metadata', async () => {
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('notes/a.md', 'See [[notes/foo#section]].');
+
+    const out = outgoingLinks('notes/a.md');
+    expect(out).toHaveLength(1);
+    expect(out[0].target).toBe('notes/foo.md');
+    expect(out[0].exists).toBe(true);
+    expect(out[0].targetTitle).toBe('Foo');
+  });
+});

--- a/tests/main/graph/parser.test.ts
+++ b/tests/main/graph/parser.test.ts
@@ -142,6 +142,43 @@ describe('link extraction', () => {
     const result = parseMarkdown('No links here');
     expect(result.links).toEqual([]);
   });
+
+  it('splits off a heading anchor', () => {
+    const result = parseMarkdown('See [[notes/foo#components]].');
+    expect(result.links[0]).toEqual({
+      target: 'notes/foo',
+      type: 'references',
+      displayText: undefined,
+      anchor: 'components',
+    });
+  });
+
+  it('splits off a block-id anchor preserving the ^ prefix', () => {
+    const result = parseMarkdown('See [[notes/foo#^p4]].');
+    expect(result.links[0]).toEqual({
+      target: 'notes/foo',
+      type: 'references',
+      displayText: undefined,
+      anchor: '^p4',
+    });
+  });
+
+  it('handles typed-link + anchor + display together', () => {
+    const result = parseMarkdown('[[supports::notes/foo#c|see here]]');
+    expect(result.links[0]).toEqual({
+      target: 'notes/foo',
+      type: 'supports',
+      displayText: 'see here',
+      anchor: 'c',
+    });
+  });
+
+  it('treats same-target different-anchor as distinct links', () => {
+    const result = parseMarkdown('[[notes/foo#a]] and [[notes/foo#b]]');
+    expect(result.links).toHaveLength(2);
+    expect(result.links[0].anchor).toBe('a');
+    expect(result.links[1].anchor).toBe('b');
+  });
 });
 
 // ── Frontmatter extraction ──────────────────────────────────────────────────

--- a/tests/shared/slug.test.ts
+++ b/tests/shared/slug.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { slugify, splitAnchor } from '../../src/shared/slug';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('strips punctuation', () => {
+    expect(slugify("Don't stop!")).toBe('dont-stop');
+    expect(slugify('What is the (meaning) of this?')).toBe('what-is-the-meaning-of-this');
+  });
+
+  it('collapses repeated hyphens and trims edges', () => {
+    expect(slugify('  foo   bar  ')).toBe('foo-bar');
+    expect(slugify('--foo--bar--')).toBe('foo-bar');
+  });
+
+  it('is idempotent', () => {
+    const once = slugify('Some Long Heading — With dashes!');
+    expect(slugify(once)).toBe(once);
+  });
+
+  it('keeps underscores and numeric chars (word chars)', () => {
+    expect(slugify('foo_bar 42')).toBe('foo_bar-42');
+  });
+});
+
+describe('splitAnchor', () => {
+  it('returns null anchor when no # present', () => {
+    expect(splitAnchor('notes/foo')).toEqual({ path: 'notes/foo', anchor: null });
+  });
+
+  it('splits heading anchors', () => {
+    expect(splitAnchor('notes/foo#components')).toEqual({
+      path: 'notes/foo',
+      anchor: 'components',
+    });
+  });
+
+  it('splits block-id anchors (leading ^ preserved)', () => {
+    expect(splitAnchor('notes/foo#^p4')).toEqual({
+      path: 'notes/foo',
+      anchor: '^p4',
+    });
+  });
+
+  it('splits at first # if multiple exist', () => {
+    expect(splitAnchor('notes/foo#a#b')).toEqual({
+      path: 'notes/foo',
+      anchor: 'a#b',
+    });
+  });
+});


### PR DESCRIPTION
Closes #137. Unblocks #138 (#^block-id is accepted already; this PR also renders block-id paragraphs), #139, #143, and the heading-anchor half of #140.

## Summary
- Parser splits the optional \`#anchor\` suffix off the wiki-link target. \`ParsedLink\` gets an \`anchor\` field.
- Indexer emits anchored target URIs as IRI fragments: \`<noteUri>#slug\` for headings, \`<noteUri>#^id\` for block-ids (unslugified so they survive heading edits).
- Graph query helpers (\`findNotesLinkingTo\`, \`backlinks\`, \`outgoingLinks\`) tolerate both bare and anchored targets and resolve metadata on the fragment-stripped URI.
- Preview renders each heading with \`id=\"slug\"\` and each paragraph ending in \`^block-id\` with \`id=\"^block-id\"\` (marker stripped from display). New \`pendingAnchor\` prop → \`scrollIntoView\` after render.
- Source/split mode: \`handleNavigate\` splits the target, opens the note, and calls CodeMirror's \`gotoOffset\` for the matching heading line or \`^id\` paragraph. Shared slug function keeps indexer and source-mode scan in lockstep.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 290 pass (+5 slug/splitAnchor tests, +4 parser anchor tests, +5 indexer anchor-link + query-tolerance tests)
- [ ] Manual: click \`[[supports::notes/architecture#components]]\` in a note — preview opens Architecture and scrolls to the Components heading; source mode jumps the caret
- [ ] Manual: add \`^para-3\` at the end of a paragraph, link \`[[note#^para-3]]\` — preview scrolls to that paragraph
- [ ] Manual: rename a note referenced by an anchored link — #136's rewriter still preserves the anchor

## Block-id note
Block-id paragraphs (\`^id\` at end) now render without the marker in preview. This is the minimum required for #137; #138's full \"copy block link\" editor command and uniqueness validation still live in that separate issue.