### PR TITLE
Fix ⌘-click on a link creating a phantom second cursor

### DIFF
--- a/src/renderer/lib/editor/link-decorations.ts
+++ b/src/renderer/lib/editor/link-decorations.ts
@@ -193,18 +193,29 @@ export function linkDecorations(opts: LinkOptions) {
     {
       decorations: v => v.decorations,
       eventHandlers: {
-        // Intercept mousedown so CodeMirror doesn't move the caret into the
-        // link on plain-click. Holding ⌘/Ctrl lets the caret land normally.
-        mousedown(event: MouseEvent) {
+        // Plain click: prevent caret from landing inside the link (we'll
+        //   treat it as a single-unit navigation in the click handler).
+        // ⌘/Ctrl-click: place a single caret at the click position so the
+        //   user can edit the link text. Without intercepting, CM6's default
+        //   would ADD a cursor (multi-cursor feature), leaving a phantom
+        //   caret at the prior selection that echoes every keystroke.
+        mousedown(event: MouseEvent, view: EditorView) {
           if (event.button !== 0) return false;
-          if (hasModifier(event)) return false;
           const el = linkElFromEvent(event);
           if (!el) return false;
+          if (hasModifier(event)) {
+            const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+            if (pos !== null) {
+              view.dispatch({ selection: { anchor: pos } });
+            }
+          }
           event.preventDefault();
           return true;
         },
         click(event: MouseEvent) {
           if (event.button !== 0) return false;
+          // ⌘/Ctrl-click is the edit gesture; caret was placed in mousedown,
+          // and the click handler must not also open the link.
           if (hasModifier(event)) return false;
           const el = linkElFromEvent(event);
           if (!el) return false;


### PR DESCRIPTION
## The bug

Cmd-click (or Ctrl-click) on a URL or wiki-link in the editor to edit it left the original caret in place as a **second cursor**. Typing into the link then echoed the same characters to wherever the caret was previously — the classic multi-cursor behavior, but unwanted here.

Surfaced while testing #146; unrelated to the anchor-link work.

## The fix

CodeMirror 6 interprets modifier-click as \"add a cursor at this position\" by default. Intercepting this in the clickable-link plugin's \`mousedown\` handler, dispatching a single-cursor selection via \`view.posAtCoords\`, and \`preventDefault\`ing bypasses the multi-cursor path entirely.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 290 pass
- [ ] Manual: ⌘-click on a URL or wiki-link in the editor — caret moves there (single cursor); typing modifies the link text only
- [ ] Manual: plain click on a link still opens it
- [ ] Manual: regular ⌘-click outside any link still behaves as CodeMirror's default add-cursor gesture