### PR TITLE
Rewrite anchored links on heading edit

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -300,6 +300,56 @@ function injectPrefixes(turtle: string, noteIri: string): string {
   return lines.join('\n') + turtle;
 }
 
+// ── Heading snapshots ──────────────────────────────────────────────────────
+// Per-note record of which headings are currently in a note, keyed by slug.
+// Used by indexNote to spot the case where a single heading was renamed so
+// we can offer to rewrite `[[note#oldSlug]]` links across the thoughtbase.
+// Cleared on initGraph so a reindex from empty doesn't surface phantom
+// renames for every note.
+
+interface HeadingSnapshot {
+  slug: string;
+  text: string;
+  level: number;
+}
+
+const headingsPerNote = new Map<string, HeadingSnapshot[]>();
+
+/** ATX-style headings only (`# …` — `###### …`). Setext headings are ignored in v1. */
+const HEADING_LINE_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+
+function extractHeadingsFromContent(content: string): HeadingSnapshot[] {
+  const out: HeadingSnapshot[] = [];
+  const seenSlugs = new Set<string>();
+  let inFence = false;
+  for (const line of content.split('\n')) {
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = line.match(HEADING_LINE_RE);
+    if (!m) continue;
+    const text = m[2].trim();
+    const slug = slugify(text);
+    if (!slug || seenSlugs.has(slug)) continue;
+    seenSlugs.add(slug);
+    out.push({ slug, text, level: m[1].length });
+  }
+  return out;
+}
+
+export interface HeadingRenameCandidate {
+  relativePath: string;
+  oldSlug: string;
+  oldText: string;
+  newSlug: string;
+  newText: string;
+  incomingLinkCount: number;
+}
+
+/** Return headings present in the last indexNote call for `relativePath`, or []. */
+export function headingsFor(relativePath: string): HeadingSnapshot[] {
+  return headingsPerNote.get(relativePath) ?? [];
+}
+
 // ── Ontology bootstrap ──────────────────────────────────────────────────────
 
 import ONTOLOGY_TTL from '../../shared/ontology.ttl?raw';
@@ -336,6 +386,7 @@ function addOntologyToStore(): void {
 export async function initGraph(rootPath: string): Promise<void> {
   store = $rdf.graph();
   currentRootPath = rootPath;
+  headingsPerNote.clear();
 
   const metaDir = path.join(rootPath, '.minerva');
   await fs.mkdir(metaDir, { recursive: true });
@@ -363,8 +414,11 @@ export async function initGraph(rootPath: string): Promise<void> {
 
 // ── Indexing ────────────────────────────────────────────────────────────────
 
-export async function indexNote(relativePath: string, content: string): Promise<void> {
-  if (!store) return;
+export async function indexNote(
+  relativePath: string,
+  content: string,
+): Promise<{ headingRenameCandidate?: HeadingRenameCandidate }> {
+  if (!store) return {};
 
   const subject = noteUri(relativePath);
   const graph = subject; // named graph = note URI, for clean removal on re-index
@@ -376,8 +430,18 @@ export async function indexNote(relativePath: string, content: string): Promise<
 
   if (relativePath.endsWith('.ttl')) {
     indexTurtleFile(relativePath, content, subject, graph);
-    return;
+    return {};
   }
+
+  // Diff headings against the previous snapshot BEFORE overwriting it so we
+  // can offer to rewrite `[[note#oldSlug]]` links when a single heading
+  // gets renamed. Initial index (no prior snapshot) never flags a rename.
+  const prevHeadings = headingsPerNote.get(relativePath);
+  const newHeadings = extractHeadingsFromContent(content);
+  const headingRenameCandidate = prevHeadings
+    ? detectHeadingRename(relativePath, prevHeadings, newHeadings)
+    : undefined;
+  headingsPerNote.set(relativePath, newHeadings);
 
   // Type
   store.add(subject, RDF('type'), MINERVA('Note'), graph);
@@ -455,6 +519,59 @@ export async function indexNote(relativePath: string, content: string): Promise<
   for (let ti = 0; ti < parsed.tables.length; ti++) {
     indexTable(parsed.tables[ti], ti, subject, graph);
   }
+
+  return headingRenameCandidate ? { headingRenameCandidate } : {};
+}
+
+/**
+ * Offer a rewrite suggestion only for the unambiguous case where exactly
+ * one heading slug disappeared AND exactly one appeared AND there are
+ * incoming anchored links to the old slug. Anything else (multiple
+ * removals, pure deletion, additions without removals) → no prompt.
+ */
+function detectHeadingRename(
+  relativePath: string,
+  prev: HeadingSnapshot[],
+  next: HeadingSnapshot[],
+): HeadingRenameCandidate | undefined {
+  const nextSlugs = new Set(next.map((h) => h.slug));
+  const prevSlugs = new Set(prev.map((h) => h.slug));
+  const removed = prev.filter((h) => !nextSlugs.has(h.slug));
+  const added = next.filter((h) => !prevSlugs.has(h.slug));
+  if (removed.length !== 1 || added.length !== 1) return undefined;
+
+  const old = removed[0];
+  const fresh = added[0];
+  const incoming = findNotesLinkingToAnchor(relativePath, old.slug).length;
+  if (incoming === 0) return undefined;
+
+  return {
+    relativePath,
+    oldSlug: old.slug,
+    oldText: old.text,
+    newSlug: fresh.slug,
+    newText: fresh.text,
+    incomingLinkCount: incoming,
+  };
+}
+
+/** Like findNotesLinkingTo, but scoped to links whose anchor is exactly `slug`. */
+export function findNotesLinkingToAnchor(targetRelativePath: string, slug: string): string[] {
+  if (!store) return [];
+  const exactTarget = `${noteUri(targetRelativePath).value}#${slug}`;
+  const seen = new Set<string>();
+  for (const lt of LINK_TYPES) {
+    if (lt.targetKind && lt.targetKind !== 'note') continue;
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
+    for (const st of stmts) {
+      if (st.object.value !== exactTarget) continue;
+      const sourceNode = st.subject;
+      const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
+      const sourcePath = pathStmts[0]?.object.value;
+      if (sourcePath && sourcePath.endsWith('.md')) seen.add(sourcePath);
+    }
+  }
+  return [...seen];
 }
 
 function indexTable(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
 import { renameWithLinkRewrites } from './notebase/rename';
+import { renameAnchor } from './notebase/rename-anchor';
 import * as gitOps from './git/index';
 import * as graph from './graph/index';
 import * as search from './search/index';
@@ -185,10 +186,18 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
     await notebaseFs.writeFile(rootPath, relativePath, content);
-    await graph.indexNote(relativePath, content);
+    const { headingRenameCandidate } = await graph.indexNote(relativePath, content);
     await graph.persistGraph();
     search.indexNote(relativePath, content);
     await search.persist();
+    // If a heading edit looks like a rename with affected incoming links,
+    // offer to rewrite them. The renderer pops the confirmation; approval
+    // routes back through NOTEBASE_RENAME_ANCHOR.
+    if (headingRenameCandidate) {
+      for (const targetWin of windowsForProject(rootPath)) {
+        targetWin.webContents.send(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, headingRenameCandidate);
+      }
+    }
   });
 
   ipcMain.handle(Channels.NOTEBASE_CREATE_FILE, async (e, relativePath: string) => {
@@ -249,6 +258,32 @@ export function registerIpcHandlers(): void {
 
     await persistIndexes();
   });
+
+  ipcMain.handle(
+    Channels.NOTEBASE_RENAME_ANCHOR,
+    async (e, targetRelativePath: string, oldSlug: string, newSlug: string) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+
+      const { rewrittenPaths } = await renameAnchor(rootPath, targetRelativePath, oldSlug, newSlug, {
+        markPathHandled,
+        reindexHook: (relPath, content) => {
+          if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+        },
+      });
+
+      // Same tab-refresh pipeline as #145 — open editors for rewritten notes
+      // refresh in place so the next auto-save doesn't undo the anchor rewrite.
+      if (rewrittenPaths.length > 0) {
+        for (const targetWin of windowsForProject(rootPath)) {
+          targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, rewrittenPaths);
+        }
+      }
+
+      await persistIndexes();
+      return { rewrittenPaths };
+    },
+  );
 
   ipcMain.handle(Channels.NOTEBASE_COPY, async (e, srcRelPath: string, destRelPath: string) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/main/notebase/link-rewriting.ts
+++ b/src/main/notebase/link-rewriting.ts
@@ -80,3 +80,30 @@ export function rewriteWikiLinks(content: string, rewrites: Map<string, string>)
     return reassembleWikiLink(parsed, finalTarget);
   });
 }
+
+/**
+ * Rewrite the anchor portion of every wiki-link whose target path matches
+ * `targetPath` (normalized) AND whose anchor equals `oldAnchor`. Preserves
+ * the target path (including `.md` extension shape), the type prefix, and
+ * the display text. Used when a heading in `targetPath` is renamed.
+ */
+export function rewriteAnchorInLinks(
+  content: string,
+  targetPath: string,
+  oldAnchor: string,
+  newAnchor: string,
+): string {
+  const normalizedTarget = normalizePath(targetPath);
+  return content.replace(WIKI_LINK_RE, (match, inner) => {
+    const parsed = parseWikiInner(inner);
+    if (parsed.type === 'cite' || parsed.type === 'quote') return match;
+    if (normalizePath(parsed.target) !== normalizedTarget) return match;
+    // Compare without the leading `#` so callers can pass slugs directly.
+    const currentAnchor = parsed.anchor?.startsWith('#') ? parsed.anchor.slice(1) : parsed.anchor;
+    if (currentAnchor !== oldAnchor) return match;
+    // Reassemble with the new anchor.
+    const newAnchorText = newAnchor ? `#${newAnchor}` : '';
+    const rewritten: typeof parsed = { ...parsed, anchor: newAnchorText || null };
+    return reassembleWikiLink(rewritten, parsed.target);
+  });
+}

--- a/src/main/notebase/rename-anchor.ts
+++ b/src/main/notebase/rename-anchor.ts
@@ -1,0 +1,48 @@
+import * as notebaseFs from './fs';
+import { rewriteAnchorInLinks } from './link-rewriting';
+import * as graph from '../graph/index';
+
+export interface RenameAnchorOptions {
+  markPathHandled?: (relativePath: string) => void;
+  reindexHook?: (relativePath: string, content: string) => void;
+}
+
+export interface RenameAnchorResult {
+  rewrittenPaths: string[];
+}
+
+/**
+ * Rewrite every `[[targetPath#oldSlug]]` wiki-link in the thoughtbase to
+ * point at `newSlug`. Called when a user confirms a heading-rename
+ * suggestion. Returns the list of notes whose content changed so the
+ * caller can emit a NOTEBASE_REWRITTEN notification.
+ */
+export async function renameAnchor(
+  rootPath: string,
+  targetRelativePath: string,
+  oldSlug: string,
+  newSlug: string,
+  opts: RenameAnchorOptions = {},
+): Promise<RenameAnchorResult> {
+  const { markPathHandled, reindexHook } = opts;
+
+  const referringNotes = graph.findNotesLinkingToAnchor(targetRelativePath, oldSlug);
+  const rewrittenPaths: string[] = [];
+
+  for (const notePath of referringNotes) {
+    try {
+      const content = await notebaseFs.readFile(rootPath, notePath);
+      const rewritten = rewriteAnchorInLinks(content, targetRelativePath, oldSlug, newSlug);
+      if (rewritten === content) continue;
+      markPathHandled?.(notePath);
+      await notebaseFs.writeFile(rootPath, notePath, rewritten);
+      await graph.indexNote(notePath, rewritten);
+      reindexHook?.(notePath, rewritten);
+      rewrittenPaths.push(notePath);
+    } catch (err) {
+      console.error(`[minerva] Anchor rewrite failed for ${notePath}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  return { rewrittenPaths };
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -40,6 +40,18 @@ contextBridge.exposeInMainWorld('api', {
     onRewritten: (cb: (paths: string[]) => void) => {
       ipcRenderer.on(Channels.NOTEBASE_REWRITTEN, (_e, paths) => cb(paths));
     },
+    onHeadingRenameSuggested: (cb: (candidate: {
+      relativePath: string;
+      oldSlug: string;
+      oldText: string;
+      newSlug: string;
+      newText: string;
+      incomingLinkCount: number;
+    }) => void) => {
+      ipcRenderer.on(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, (_e, c) => cb(c));
+    },
+    renameAnchor: (targetRelativePath: string, oldSlug: string, newSlug: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_RENAME_ANCHOR, targetRelativePath, oldSlug, newSlug),
   },
   links: {
     outgoing: (relativePath: string) => ipcRenderer.invoke(Channels.LINKS_OUTGOING, relativePath),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -563,6 +563,16 @@
       }
     });
 
+    api.notebase.onHeadingRenameSuggested(async (candidate) => {
+      const n = candidate.incomingLinkCount;
+      const msg =
+        `The heading "${candidate.oldText}" in ${candidate.relativePath} looks like it was renamed ` +
+        `to "${candidate.newText}". Update ${n} incoming link${n === 1 ? '' : 's'}?`;
+      const ok = await showConfirm(msg, 'heading-rename-suggestion', 'Update links');
+      if (!ok) return;
+      await api.notebase.renameAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
+    });
+
     // Tools for Thought — stream listener (once)
     api.tools.onStream((chunk) => {
       toolPanel.appendChunk(chunk);

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -21,6 +21,17 @@ export interface NotebaseApi {
   onFileDeleted(cb: (path: string) => void): void;
   onRenamed(cb: (transitions: Array<{ old: string; new: string }>) => void): void;
   onRewritten(cb: (paths: string[]) => void): void;
+  onHeadingRenameSuggested(cb: (candidate: HeadingRenameCandidate) => void): void;
+  renameAnchor(targetRelativePath: string, oldSlug: string, newSlug: string): Promise<{ rewrittenPaths: string[] }>;
+}
+
+export interface HeadingRenameCandidate {
+  relativePath: string;
+  oldSlug: string;
+  oldText: string;
+  newSlug: string;
+  newText: string;
+  incomingLinkCount: number;
 }
 
 export interface LinksApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -19,6 +19,10 @@ export const Channels = {
   NOTEBASE_RENAMED: 'notebase:renamed',
   /** Emitted after link-rewrites touched other notes' content. Payload is string[] (relativePaths). */
   NOTEBASE_REWRITTEN: 'notebase:rewritten',
+  /** Emitted when indexNote detects a single-heading rename with incoming links (main → renderer). */
+  NOTEBASE_HEADING_RENAME_SUGGESTED: 'notebase:headingRenameSuggested',
+  /** Renderer-initiated rewrite of `[[path#oldSlug]]` → `[[path#newSlug]]`. */
+  NOTEBASE_RENAME_ANCHOR: 'notebase:renameAnchor',
 
   // Links
   LINKS_OUTGOING: 'links:outgoing',

--- a/tests/main/graph/heading-rename.test.ts
+++ b/tests/main/graph/heading-rename.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  findNotesLinkingToAnchor,
+  headingsFor,
+} from '../../../src/main/graph/index';
+import { renameAnchor } from '../../../src/main/notebase/rename-anchor';
+import { rewriteAnchorInLinks } from '../../../src/main/notebase/link-rewriting';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-heading-rename-test-'));
+}
+
+function writeNote(root: string, relPath: string, content: string): void {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+function readNote(root: string, relPath: string): string {
+  return fs.readFileSync(path.join(root, relPath), 'utf-8');
+}
+
+describe('heading snapshots (issue #139)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('records headings after indexNote', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n## Overview\n\n## Components');
+    const headings = headingsFor('notes/foo.md');
+    expect(headings.map((h) => h.slug).sort()).toEqual(['components', 'foo', 'overview']);
+  });
+
+  it('does not flag a rename on the first indexNote call (initial index)', async () => {
+    // Pre-seed some incoming links, then first-index the target — should not prompt.
+    await indexNote('other.md', 'See [[notes/foo#overview]].');
+    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## Overview');
+    expect(headingRenameCandidate).toBeUndefined();
+  });
+
+  it('flags a single heading rename with >0 incoming anchored links', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n## Overview');
+    await indexNote('other.md', 'See [[notes/foo#overview]].');
+    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## Summary');
+    expect(headingRenameCandidate).toBeDefined();
+    expect(headingRenameCandidate!.oldSlug).toBe('overview');
+    expect(headingRenameCandidate!.newSlug).toBe('summary');
+    expect(headingRenameCandidate!.incomingLinkCount).toBe(1);
+  });
+
+  it('does not flag when there are no incoming links to the old slug', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n## Overview');
+    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## Summary');
+    expect(headingRenameCandidate).toBeUndefined();
+  });
+
+  it('does not flag ambiguous cases (multiple removals or additions)', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n## A\n\n## B');
+    await indexNote('other.md', '[[notes/foo#a]] [[notes/foo#b]]');
+    // Rename A→X and B→Y in the same edit — ambiguous, skip.
+    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## X\n\n## Y');
+    expect(headingRenameCandidate).toBeUndefined();
+  });
+
+  it('does not flag a pure deletion (one removal, no addition)', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n## Overview');
+    await indexNote('other.md', '[[notes/foo#overview]]');
+    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo');
+    expect(headingRenameCandidate).toBeUndefined();
+  });
+
+  it('ignores headings inside fenced code blocks', async () => {
+    await indexNote('notes/foo.md', '# Foo\n\n```\n## Not a heading\n```\n\n## Real');
+    const slugs = headingsFor('notes/foo.md').map((h) => h.slug);
+    expect(slugs).toContain('real');
+    expect(slugs).not.toContain('not-a-heading');
+  });
+});
+
+describe('findNotesLinkingToAnchor (issue #139)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns only notes with the exact anchor', async () => {
+    await indexNote('notes/foo.md', '# Foo');
+    await indexNote('a.md', '[[notes/foo#overview]]');
+    await indexNote('b.md', '[[notes/foo#other]]');
+    await indexNote('c.md', '[[notes/foo]]');  // no anchor
+
+    expect(findNotesLinkingToAnchor('notes/foo.md', 'overview').sort()).toEqual(['a.md']);
+    expect(findNotesLinkingToAnchor('notes/foo.md', 'other').sort()).toEqual(['b.md']);
+  });
+});
+
+describe('renameAnchor integration (issue #139)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('rewrites every anchored reference across the thoughtbase', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo\n\n## Summary');
+    writeNote(root, 'a.md', 'See [[notes/foo#overview]].');
+    writeNote(root, 'b.md', '[[supports::notes/foo#overview|rationale]]');
+    writeNote(root, 'c.md', '[[notes/foo#unrelated]]');
+    await indexNote('notes/foo.md', '# Foo\n\n## Summary');
+    await indexNote('a.md', 'See [[notes/foo#overview]].');
+    await indexNote('b.md', '[[supports::notes/foo#overview|rationale]]');
+    await indexNote('c.md', '[[notes/foo#unrelated]]');
+
+    const { rewrittenPaths } = await renameAnchor(root, 'notes/foo.md', 'overview', 'summary');
+
+    expect(rewrittenPaths.sort()).toEqual(['a.md', 'b.md']);
+    expect(readNote(root, 'a.md')).toContain('[[notes/foo#summary]]');
+    expect(readNote(root, 'b.md')).toContain('[[supports::notes/foo#summary|rationale]]');
+    // c.md had a different anchor; untouched.
+    expect(readNote(root, 'c.md')).toContain('[[notes/foo#unrelated]]');
+  });
+});
+
+describe('rewriteAnchorInLinks (issue #139, pure)', () => {
+  it('preserves type prefix and display text', () => {
+    const out = rewriteAnchorInLinks(
+      '[[rebuts::notes/foo#old|see here]]',
+      'notes/foo',
+      'old',
+      'new',
+    );
+    expect(out).toBe('[[rebuts::notes/foo#new|see here]]');
+  });
+
+  it('leaves block-id anchors alone when the slug form does not match', () => {
+    const out = rewriteAnchorInLinks('[[notes/foo#^p3]]', 'notes/foo', 'old', 'new');
+    expect(out).toBe('[[notes/foo#^p3]]');
+  });
+
+  it('preserves .md suffix when present', () => {
+    const out = rewriteAnchorInLinks('[[notes/foo.md#old]]', 'notes/foo', 'old', 'new');
+    expect(out).toBe('[[notes/foo.md#new]]');
+  });
+
+  it('never touches cite/quote links', () => {
+    const out = rewriteAnchorInLinks('[[cite::notes/foo#old]]', 'notes/foo', 'old', 'new');
+    expect(out).toBe('[[cite::notes/foo#old]]');
+  });
+});


### PR DESCRIPTION
Closes #139.

## Summary
Editing a heading in a note — changing "Components" to "Parts", say — now offers to update every \`[[note#components]]\` pointing at it across the thoughtbase. One confirmation, one rewrite pass, open tabs refresh in place.

## Flow
1. User saves a note. \`indexNote\` extracts the new ATX-heading slugs and diffs against the previous snapshot (captured on the prior save — first-index never prompts).
2. If *exactly one* slug disappeared AND *exactly one* appeared AND there's \`≥1\` incoming anchored link, the writeFile IPC handler emits \`NOTEBASE_HEADING_RENAME_SUGGESTED\`.
3. Renderer pops \`showConfirm\`: "The heading 'X' looks like it was renamed to 'Y'. Update N incoming links?" with don't-ask-again support.
4. On approval → \`api.notebase.renameAnchor(path, oldSlug, newSlug)\` rewrites every matching \`[[path#oldSlug]]\` across the base, reuses #145's \`NOTEBASE_REWRITTEN\` broadcast to refresh open tabs.

## What doesn't trigger
- Ambiguous diffs (multiple headings renamed in one save, or a pure deletion) — per the issue's "auto-apply is dangerous" note.
- Headings inside fenced code blocks.
- Block-id anchors (\`#^id\`) — they're stable across heading edits by design.
- The first-ever index of a note.
- Saves where nothing currently links to the old anchor.

## New surface
- \`graph.findNotesLinkingToAnchor(path, slug)\` — exact-anchor scoped variant of \`findNotesLinkingTo\`.
- \`rewriteAnchorInLinks(content, path, oldAnchor, newAnchor)\` — pure rewriter, parallel to \`rewriteWikiLinks\` but keyed on anchor. Preserves type prefix, display text, and \`.md\` shape.
- \`renameAnchor(root, path, oldSlug, newSlug, opts)\` — orchestrator in \`notebase/rename-anchor.ts\`.
- Channels: \`NOTEBASE_HEADING_RENAME_SUGGESTED\` (main→renderer), \`NOTEBASE_RENAME_ANCHOR\` (renderer→main).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 303 pass (+14: snapshot behavior, diff edge cases, findNotesLinkingToAnchor scoping, end-to-end rewrite, pure rewriter variants)
- [ ] Manual: in the sample project, rename \`## Components\` in architecture to \`## Parts\`, save — prompt appears; confirm → \`[[supports::notes/architecture#components]]\` in design-patterns becomes \`#parts\`
- [ ] Manual: check \"Don't ask again\" — subsequent renames auto-apply
- [ ] Manual: rename two headings at once — no prompt (ambiguous, correct)
- [ ] Manual: with the open editor on a note whose anchored link gets rewritten, confirm the tab refreshes without losing scroll position

## Out of scope
- Fuzzy-matching heuristics beyond the "one-in, one-out" rule. The issue allowed for Levenshtein / prefix matching but we decided the strict single-rename rule is unambiguous enough for v1.
- An opt-in "always auto-apply heading renames" setting — can land later; the don't-ask-again toggle covers the same UX for now.