### PR TITLE
Wiki-link autocomplete: types, paths, anchors, block-ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@codemirror/autocomplete": "^6.20.1",
     "@comunica/query-sparql-rdfjs": "^5.1.3",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.90.0
         version: 0.90.0
+      '@codemirror/autocomplete':
+        specifier: ^6.20.1
+        version: 6.20.1
       '@comunica/query-sparql-rdfjs':
         specifier: ^5.1.3
         version: 5.1.3(encoding@0.1.13)

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -177,6 +177,19 @@
     handleOpenSource(result.sourceId, excerptId);
   }
 
+  /** Flatten the sidebar file tree to a list of indexable relative paths. */
+  function flattenNotePaths(files: import('../shared/types').NoteFile[]): string[] {
+    const out: string[] = [];
+    const walk = (xs: import('../shared/types').NoteFile[]) => {
+      for (const f of xs) {
+        if (f.isDirectory) walk(f.children ?? []);
+        else if (/\.(md|ttl)$/.test(f.relativePath)) out.push(f.relativePath);
+      }
+    };
+    walk(files);
+    return out;
+  }
+
   function handleTagSelect(tag: string) {
     sidebar?.refreshTags();
     setTimeout(() => sidebar?.selectTag(tag), 50);
@@ -693,6 +706,7 @@
                     onToolInvoke={handleToolInvoke}
                     onOpenConversation={openConversation}
                     onNavigate={handleNavigate}
+                    getNotePaths={() => flattenNotePaths(notebase.files)}
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -11,7 +11,7 @@
   import { indentUnit, foldEffect, unfoldEffect, foldedRanges } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
   import { search, openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
-  import { autocompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
+  import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
   import { api } from '../ipc/client';
   import { sortLines, selectionTracker } from '../editor/commands';
   import {
@@ -447,6 +447,10 @@
     const resolved = resolveKeyBindings();
     const appKeymap = Prec.highest(keymap.of([
       { key: 'Mod-s', run: () => { onSave(); return true; } },
+      // Tab accepts the active completion; acceptCompletion returns false
+      // when no completion panel is open, so Tab-for-indent still works
+      // everywhere else.
+      { key: 'Tab', run: acceptCompletion },
       ...resolved.map(({ key: k, command: run }) => ({ key: k, run })),
     ]));
 

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -22,6 +22,7 @@
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
+  import { linkCompletionSource } from '../editor/link-autocomplete';
 
   export interface CursorInfo {
     line: number;
@@ -46,6 +47,8 @@
     onBookmark?: () => void;
     onInsertQueryList?: () => void;
     onNavigate?: (target: string) => void;
+    /** Live list of note paths for wiki-link autocomplete. */
+    getNotePaths?: () => string[];
   }
 
   let {
@@ -62,6 +65,7 @@
     onBookmark,
     onInsertQueryList,
     onNavigate,
+    getNotePaths,
   }: Props = $props();
 
   const analysisTools = getToolInfosByCategory('analysis');
@@ -467,12 +471,18 @@
       }
     });
 
-    const tagAutocomplete = autocompletion({
-      override: [tagCompletion],
-      activateOnTyping: true,
+    const linkCompletion = linkCompletionSource({
+      getNotePaths: () => getNotePaths?.() ?? [],
+      readNote: (p) => api.notebase.readFile(p),
     });
 
-    const allExtensions = [...extensions, appKeymap, updateListener, tagAutocomplete];
+    const completion = autocompletion({
+      override: [tagCompletion, linkCompletion],
+      activateOnTyping: true,
+      closeOnBlur: true,
+    });
+
+    const allExtensions = [...extensions, appKeymap, updateListener, completion];
 
     const state = EditorState.create({ doc: content, extensions: allExtensions });
     view = new EditorView({ state, parent: editorContainer });

--- a/src/renderer/lib/editor/link-autocomplete.ts
+++ b/src/renderer/lib/editor/link-autocomplete.ts
@@ -1,0 +1,198 @@
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import { LINK_TYPES } from '../../../shared/link-types';
+import { extractAnchors } from './note-anchors';
+
+// ── Phase detection (pure) ─────────────────────────────────────────────────
+
+export type CompletionPhase =
+  | { kind: 'type-or-path'; innerStart: number; prefix: string }
+  | { kind: 'path'; innerStart: number; typePrefix: string; prefix: string }
+  | { kind: 'heading'; innerStart: number; targetPath: string; prefix: string }
+  | { kind: 'block'; innerStart: number; targetPath: string; prefix: string }
+  | { kind: 'none' };
+
+/**
+ * Inspect text before the cursor and decide what, if anything, should be
+ * completed. `pos` is the absolute cursor position so we can return the
+ * document `from` the caller needs.
+ */
+export function detectCompletionPhase(before: string, pos: number): CompletionPhase {
+  // We only care about text after the most-recent `[[`. Bail if a `]]`
+  // closed it, or if there's no `[[` at all.
+  const openIdx = before.lastIndexOf('[[');
+  if (openIdx < 0) return { kind: 'none' };
+  const closeIdx = before.lastIndexOf(']]');
+  if (closeIdx > openIdx) return { kind: 'none' };
+
+  const inner = before.slice(openIdx + 2);
+  // `[[` itself can't contain brackets or newlines in a well-formed link.
+  if (/[\[\]\n]/.test(inner)) return { kind: 'none' };
+
+  const innerStart = pos - inner.length;
+
+  // Once the user types `|`, completion stops — that's the display text.
+  const pipeIdx = inner.indexOf('|');
+  if (pipeIdx >= 0) return { kind: 'none' };
+
+  // Split off an optional `type::` prefix.
+  const typeMatch = inner.match(/^([a-z][\w-]*)::/);
+  let typePrefixLen = 0;
+  let typePrefix = '';
+  if (typeMatch) {
+    typePrefixLen = typeMatch[0].length;
+    typePrefix = typeMatch[1];
+  }
+  const pathAndAnchor = inner.slice(typePrefixLen);
+  const hashIdx = pathAndAnchor.indexOf('#');
+
+  if (hashIdx < 0) {
+    // No anchor yet — either typing type (only if we don't already have one)
+    // or typing the note path.
+    if (!typePrefix) {
+      return { kind: 'type-or-path', innerStart, prefix: pathAndAnchor };
+    }
+    return {
+      kind: 'path',
+      innerStart: innerStart + typePrefixLen,
+      typePrefix,
+      prefix: pathAndAnchor,
+    };
+  }
+
+  // `#` is present — anchor phase. Path is everything before `#`.
+  const targetPath = pathAndAnchor.slice(0, hashIdx);
+  const afterHash = pathAndAnchor.slice(hashIdx + 1);
+  if (afterHash.startsWith('^')) {
+    return {
+      kind: 'block',
+      innerStart: innerStart + typePrefixLen + hashIdx + 2, // +1 for `#`, +1 for `^`
+      targetPath,
+      prefix: afterHash.slice(1),
+    };
+  }
+  return {
+    kind: 'heading',
+    innerStart: innerStart + typePrefixLen + hashIdx + 1,
+    targetPath,
+    prefix: afterHash,
+  };
+}
+
+// ── Option building ────────────────────────────────────────────────────────
+
+/** Strip the `.md` extension — link targets are always extension-less. */
+function normalizeTarget(path: string): string {
+  return path.replace(/\.md$/, '');
+}
+
+function linkTypeOptions(): Completion[] {
+  return LINK_TYPES
+    .filter((lt) => lt.name !== 'references') // default type — no explicit prefix needed
+    .map((lt) => ({
+      label: `${lt.name}::`,
+      detail: lt.label,
+      type: 'keyword',
+      boost: 10,
+    }));
+}
+
+function notePathOptions(paths: string[]): Completion[] {
+  return paths.map((p) => {
+    const label = normalizeTarget(p);
+    return {
+      label,
+      detail: p,
+      type: 'namespace',
+    };
+  });
+}
+
+function headingOptions(anchors: { slug: string; text: string; level: number }[]): Completion[] {
+  return anchors.map((a) => ({
+    label: a.slug,
+    detail: a.text,
+    type: `heading${a.level}`,
+  }));
+}
+
+function blockIdOptions(ids: string[]): Completion[] {
+  return ids.map((id) => ({ label: id, type: 'property' }));
+}
+
+// ── Extension ──────────────────────────────────────────────────────────────
+
+export interface LinkAutocompleteOptions {
+  /** Returns the current list of note-file relativePaths in the thoughtbase. */
+  getNotePaths: () => string[];
+  /** Fetch raw markdown for a note so we can scan its headings + block-ids. */
+  readNote: (relativePath: string) => Promise<string>;
+}
+
+/**
+ * Build a CompletionSource for `[[…]]` wiki-links. Plug this into the
+ * existing `autocompletion({ override: [...] })` config in Editor.svelte
+ * alongside other sources (tags, etc.).
+ */
+export function linkCompletionSource(opts: LinkAutocompleteOptions) {
+  // Cache scanned anchors per path so consecutive keystrokes don't thrash.
+  const anchorCache = new Map<string, Promise<ReturnType<typeof extractAnchors>>>();
+
+  async function fetchAnchors(targetPath: string) {
+    const fullPath = targetPath.endsWith('.md') ? targetPath : `${targetPath}.md`;
+    let promise = anchorCache.get(fullPath);
+    if (!promise) {
+      promise = (async () => {
+        try {
+          const content = await opts.readNote(fullPath);
+          return extractAnchors(content);
+        } catch {
+          return { headings: [], blockIds: [] };
+        }
+      })();
+      anchorCache.set(fullPath, promise);
+      // Evict after a short window — the user may be editing the target.
+      setTimeout(() => anchorCache.delete(fullPath), 5_000);
+    }
+    return promise;
+  }
+
+  return async function source(ctx: CompletionContext): Promise<CompletionResult | null> {
+    const before = ctx.state.doc.sliceString(Math.max(0, ctx.pos - 500), ctx.pos);
+    const phase = detectCompletionPhase(before, ctx.pos);
+
+    if (phase.kind === 'none') return null;
+
+    const paths = opts.getNotePaths();
+
+    if (phase.kind === 'type-or-path') {
+      return {
+        from: phase.innerStart,
+        options: [...linkTypeOptions(), ...notePathOptions(paths)],
+        validFor: /^[a-z0-9_\-\/\.: ]*$/i,
+      };
+    }
+
+    if (phase.kind === 'path') {
+      return {
+        from: phase.innerStart,
+        options: notePathOptions(paths),
+        validFor: /^[a-z0-9_\-\/\. ]*$/i,
+      };
+    }
+
+    const anchors = await fetchAnchors(phase.targetPath);
+    if (phase.kind === 'heading') {
+      return {
+        from: phase.innerStart,
+        options: headingOptions(anchors.headings),
+        validFor: /^[a-z0-9_\-]*$/i,
+      };
+    }
+    // block
+    return {
+      from: phase.innerStart,
+      options: blockIdOptions(anchors.blockIds),
+      validFor: /^[a-z0-9_\-]*$/i,
+    };
+  };
+}

--- a/src/renderer/lib/editor/note-anchors.ts
+++ b/src/renderer/lib/editor/note-anchors.ts
@@ -1,0 +1,60 @@
+import { slugify } from '../../../shared/slug';
+
+export interface HeadingAnchor {
+  /** Slug used in the link target (`[[note#slug]]`). */
+  slug: string;
+  /** Original heading text for display in the completion list. */
+  text: string;
+  /** ATX level (1–6). */
+  level: number;
+}
+
+export interface NoteAnchors {
+  headings: HeadingAnchor[];
+  blockIds: string[];
+}
+
+const HEADING_LINE_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+const BLOCK_ID_LINE_RE = /\s\^([\w-]+)\s*$/;
+
+/**
+ * Scan markdown for every ATX heading and every `^block-id` marker at a
+ * paragraph's end. Caller uses these to populate the completion list for
+ * `[[note#…]]` and `[[note#^…]]` respectively. Fenced code blocks are
+ * skipped so sample YAML or code that happens to look like a heading
+ * doesn't pollute the list.
+ */
+export function extractAnchors(content: string): NoteAnchors {
+  const headings: HeadingAnchor[] = [];
+  const blockIds: string[] = [];
+  const seenSlugs = new Set<string>();
+  const seenBlocks = new Set<string>();
+  let inFence = false;
+
+  for (const line of content.split('\n')) {
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+
+    const h = line.match(HEADING_LINE_RE);
+    if (h) {
+      const text = h[2].trim();
+      const slug = slugify(text);
+      if (slug && !seenSlugs.has(slug)) {
+        seenSlugs.add(slug);
+        headings.push({ slug, text, level: h[1].length });
+      }
+      continue;
+    }
+
+    const b = line.match(BLOCK_ID_LINE_RE);
+    if (b) {
+      const id = b[1];
+      if (!seenBlocks.has(id)) {
+        seenBlocks.add(id);
+        blockIds.push(id);
+      }
+    }
+  }
+
+  return { headings, blockIds };
+}

--- a/tests/renderer/editor/link-autocomplete.test.ts
+++ b/tests/renderer/editor/link-autocomplete.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { detectCompletionPhase } from '../../../src/renderer/lib/editor/link-autocomplete';
+
+/**
+ * Helper: simulate a cursor at the end of `before`. The absolute position
+ * is just `before.length` since we're treating `before` as the start of doc.
+ */
+function phase(before: string) {
+  return detectCompletionPhase(before, before.length);
+}
+
+describe('detectCompletionPhase', () => {
+  it('returns none outside a wiki link', () => {
+    expect(phase('plain text here').kind).toBe('none');
+  });
+
+  it('returns none when the last [[ is already closed', () => {
+    expect(phase('[[foo]] then more').kind).toBe('none');
+  });
+
+  it('returns type-or-path right after [[', () => {
+    const p = phase('See [[');
+    expect(p.kind).toBe('type-or-path');
+    if (p.kind === 'type-or-path') {
+      expect(p.prefix).toBe('');
+      expect(p.innerStart).toBe('See [['.length);
+    }
+  });
+
+  it('returns type-or-path when typing a prefix with no :: yet', () => {
+    const p = phase('[[supp');
+    expect(p.kind).toBe('type-or-path');
+    if (p.kind === 'type-or-path') expect(p.prefix).toBe('supp');
+  });
+
+  it('returns path after a committed type::', () => {
+    const p = phase('[[supports::note');
+    expect(p.kind).toBe('path');
+    if (p.kind === 'path') {
+      expect(p.typePrefix).toBe('supports');
+      expect(p.prefix).toBe('note');
+      expect(p.innerStart).toBe('[[supports::'.length);
+    }
+  });
+
+  it('returns heading after # following a plain path', () => {
+    const p = phase('[[notes/foo#comp');
+    expect(p.kind).toBe('heading');
+    if (p.kind === 'heading') {
+      expect(p.targetPath).toBe('notes/foo');
+      expect(p.prefix).toBe('comp');
+      expect(p.innerStart).toBe('[[notes/foo#'.length);
+    }
+  });
+
+  it('returns heading after # with a typed-link prefix', () => {
+    const p = phase('[[supports::notes/foo#');
+    expect(p.kind).toBe('heading');
+    if (p.kind === 'heading') {
+      expect(p.targetPath).toBe('notes/foo');
+      expect(p.prefix).toBe('');
+    }
+  });
+
+  it('returns block for #^ anchor', () => {
+    const p = phase('[[notes/foo#^par');
+    expect(p.kind).toBe('block');
+    if (p.kind === 'block') {
+      expect(p.targetPath).toBe('notes/foo');
+      expect(p.prefix).toBe('par');
+      expect(p.innerStart).toBe('[[notes/foo#^'.length);
+    }
+  });
+
+  it('stops completing once the user types |', () => {
+    expect(phase('[[notes/foo|disp').kind).toBe('none');
+  });
+
+  it('returns none when inner contains a newline', () => {
+    expect(phase('[[first line\nsecond').kind).toBe('none');
+  });
+});

--- a/tests/renderer/editor/note-anchors.test.ts
+++ b/tests/renderer/editor/note-anchors.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { extractAnchors } from '../../../src/renderer/lib/editor/note-anchors';
+
+describe('extractAnchors', () => {
+  it('extracts ATX headings with slugs', () => {
+    const { headings } = extractAnchors('# Foo\n\n## Components & Parts\n\n### Nested');
+    expect(headings.map((h) => h.slug)).toEqual(['foo', 'components-parts', 'nested']);
+  });
+
+  it('includes heading level and original text', () => {
+    const { headings } = extractAnchors('## Hello World');
+    expect(headings[0]).toEqual({ slug: 'hello-world', text: 'Hello World', level: 2 });
+  });
+
+  it('deduplicates repeated heading slugs, keeping the first', () => {
+    const { headings } = extractAnchors('# Foo\n\n## Foo');
+    expect(headings.map((h) => h.slug)).toEqual(['foo']);
+  });
+
+  it('skips headings inside fenced code blocks', () => {
+    const { headings } = extractAnchors('# Real\n\n```\n## fake\n```\n\n## Also Real');
+    expect(headings.map((h) => h.slug)).toEqual(['real', 'also-real']);
+  });
+
+  it('extracts block ids from paragraph-end markers', () => {
+    const { blockIds } = extractAnchors('A paragraph. ^para-1\nAnother one. ^para-2');
+    expect(blockIds).toEqual(['para-1', 'para-2']);
+  });
+
+  it('deduplicates block ids', () => {
+    const { blockIds } = extractAnchors('First. ^dup\n\nSecond. ^dup');
+    expect(blockIds).toEqual(['dup']);
+  });
+});


### PR DESCRIPTION
Closes #143 and #43.

## Completion shapes

| You typed | You see |
|---|---|
| \`[[\` | link types (\`supports::\`, \`rebuts::\`, …) AND note paths, one fuzzy list |
| \`[[supp\` | types starting with \"supp\" + paths starting with \"supp\" |
| \`[[supports::\` | note paths only |
| \`[[notes/foo#\` | heading slugs from \`notes/foo.md\` |
| \`[[notes/foo#^\` | block ids defined in \`notes/foo.md\` |
| \`[[foo\|\` | nothing — after \`\|\` is display text |

Accepting a link type inserts \`::\` so the completion flow keeps going. Accepting a path inserts it verbatim (\`.md\` stripped, the parser convention).

## Implementation

- **\`src/renderer/lib/editor/link-autocomplete.ts\`** — exports \`detectCompletionPhase\` (pure, tests cover every shape) and \`linkCompletionSource(opts)\` which adapts it into a CodeMirror \`CompletionSource\`.
- **\`src/renderer/lib/editor/note-anchors.ts\`** — pure extractor for ATX headings + paragraph-end \`^block-id\` markers, skipping fenced code blocks. Reused from #137's slug convention so indexer and autocomplete stay in lockstep.
- Anchor suggestions read the target's markdown on demand via \`api.notebase.readFile\`, cached 5s per path so keystrokes don't thrash IPC.
- The completion source composes with the existing tag-completion: \`autocompletion({ override: [tagCompletion, linkCompletion] })\`. Both remain active.
- Note-path source comes from flattening the sidebar's already-live file tree in App.svelte; no new IPC.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 319 pass (+10 phase-detection tests covering every shape + negative cases, +6 anchor-extractor tests)
- [ ] Manual: open a note, type \`[[sup\` — see \`supports::\`, \`supersedes::\` with \"Supports\", \"Supersedes\" as details
- [ ] Manual: type \`[[notes/arch\` — see \`notes/architecture\` in the list
- [ ] Manual: type \`[[notes/architecture#\` — see the architecture note's headings, displayed as slug + text
- [ ] Manual: add \`^para-1\` to the end of a paragraph, type \`[[note#^\` in another note — the block id appears

## Out of scope
- Fuzzy ranking beyond prefix-match (CM's default fuzzy logic is fine for v1).
- Cross-project suggestions (thoughtbase-local only).
- Inline preview of the note's first-line or first-paragraph alongside the suggestion.