### PR TITLE
Source/excerpt rename + bookmark path updates

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -555,6 +555,35 @@ function detectHeadingRename(
   };
 }
 
+/** Notes with a `thought:cites` edge to the given source URI. */
+export function findNotesCitingSource(sourceId: string): string[] {
+  if (!store) return [];
+  const target = sourceUri(sourceId);
+  return collectNotePathsWithPredicate(THOUGHT('cites'), target);
+}
+
+/** Notes with a `thought:quotes` edge to the given excerpt URI. */
+export function findNotesQuotingExcerpt(excerptId: string): string[] {
+  if (!store) return [];
+  const target = excerptUri(excerptId);
+  return collectNotePathsWithPredicate(THOUGHT('quotes'), target);
+}
+
+function collectNotePathsWithPredicate(
+  predicate: ReturnType<typeof MINERVA>,
+  target: $rdf.NamedNode,
+): string[] {
+  if (!store) return [];
+  const stmts = store.statementsMatching(undefined, predicate, target);
+  const seen = new Set<string>();
+  for (const st of stmts) {
+    const pathStmts = store.statementsMatching(st.subject, MINERVA('relativePath'), undefined);
+    const p = pathStmts[0]?.object.value;
+    if (p && p.endsWith('.md')) seen.add(p);
+  }
+  return [...seen];
+}
+
 /** Like findNotesLinkingTo, but scoped to links whose anchor is exactly `slug`. */
 export function findNotesLinkingToAnchor(targetRelativePath: string, slug: string): string[] {
   if (!store) return [];

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,6 +5,7 @@ import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
 import { renameWithLinkRewrites } from './notebase/rename';
 import { renameAnchor } from './notebase/rename-anchor';
+import { renameSource, renameExcerpt } from './notebase/rename-source-excerpt';
 import * as gitOps from './git/index';
 import * as graph from './graph/index';
 import * as search from './search/index';
@@ -257,6 +258,41 @@ export function registerIpcHandlers(): void {
     }
 
     await persistIndexes();
+  });
+
+  const broadcastRewritten = (rootPath: string, paths: string[]) => {
+    if (paths.length === 0) return;
+    for (const targetWin of windowsForProject(rootPath)) {
+      targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, paths);
+    }
+  };
+
+  ipcMain.handle(Channels.NOTEBASE_RENAME_SOURCE, async (e, oldId: string, newId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const { rewrittenPaths } = await renameSource(rootPath, oldId, newId, {
+      markPathHandled,
+      reindexHook: (relPath, content) => {
+        if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+      },
+    });
+    broadcastRewritten(rootPath, rewrittenPaths);
+    await persistIndexes();
+    return { rewrittenPaths };
+  });
+
+  ipcMain.handle(Channels.NOTEBASE_RENAME_EXCERPT, async (e, oldId: string, newId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const { rewrittenPaths } = await renameExcerpt(rootPath, oldId, newId, {
+      markPathHandled,
+      reindexHook: (relPath, content) => {
+        if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+      },
+    });
+    broadcastRewritten(rootPath, rewrittenPaths);
+    await persistIndexes();
+    return { rewrittenPaths };
   });
 
   ipcMain.handle(

--- a/src/main/notebase/link-rewriting.ts
+++ b/src/main/notebase/link-rewriting.ts
@@ -82,6 +82,27 @@ export function rewriteWikiLinks(content: string, rewrites: Map<string, string>)
 }
 
 /**
+ * Rewrite the target id of every `[[<linkTypeName>::id]]` link whose id
+ * appears in the rewrites map. Used for cite/quote renames where the
+ * target is an id (not a path) and the type prefix is required to match.
+ * Preserves anchor and display.
+ */
+export function rewriteTypedIdLinks(
+  content: string,
+  linkTypeName: string,
+  rewrites: Map<string, string>,
+): string {
+  if (rewrites.size === 0) return content;
+  return content.replace(WIKI_LINK_RE, (match, inner) => {
+    const parsed = parseWikiInner(inner);
+    if (parsed.type !== linkTypeName) return match;
+    const newId = rewrites.get(parsed.target);
+    if (newId === undefined) return match;
+    return reassembleWikiLink(parsed, newId);
+  });
+}
+
+/**
  * Rewrite the anchor portion of every wiki-link whose target path matches
  * `targetPath` (normalized) AND whose anchor equals `oldAnchor`. Preserves
  * the target path (including `.md` extension shape), the type prefix, and

--- a/src/main/notebase/rename-source-excerpt.ts
+++ b/src/main/notebase/rename-source-excerpt.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from './fs';
+import { rewriteTypedIdLinks } from './link-rewriting';
+import * as graph from '../graph/index';
+
+export interface RenameIdOptions {
+  markPathHandled?: (relativePath: string) => void;
+  reindexHook?: (relativePath: string, content: string) => void;
+}
+
+export interface RenameIdResult {
+  rewrittenPaths: string[];
+}
+
+/**
+ * Rename a Source: rename the directory under `.minerva/sources/`, shift
+ * the graph entry to the new id, and rewrite every `[[cite::oldId]]` in
+ * the thoughtbase to `[[cite::newId]]`.
+ */
+export async function renameSource(
+  rootPath: string,
+  oldId: string,
+  newId: string,
+  opts: RenameIdOptions = {},
+): Promise<RenameIdResult> {
+  if (oldId === newId) return { rewrittenPaths: [] };
+  const { markPathHandled, reindexHook } = opts;
+
+  const oldDir = path.join(rootPath, '.minerva', 'sources', oldId);
+  const newDir = path.join(rootPath, '.minerva', 'sources', newId);
+
+  // Collect referring notes BEFORE the graph changes — query the old id.
+  const referringNotes = graph.findNotesCitingSource(oldId);
+
+  // Rename on disk.
+  await fs.mkdir(path.dirname(newDir), { recursive: true });
+  await fs.rename(oldDir, newDir);
+
+  // Swap graph: remove old, index new.
+  graph.removeSource(oldId);
+  try {
+    const metaContent = await fs.readFile(path.join(newDir, 'meta.ttl'), 'utf-8');
+    let bodyContent: string | undefined;
+    try {
+      bodyContent = await fs.readFile(path.join(newDir, 'body.md'), 'utf-8');
+    } catch { /* body optional */ }
+    graph.indexSource(newId, metaContent, bodyContent);
+  } catch {
+    // meta.ttl missing — source is effectively removed as far as the graph is concerned.
+  }
+
+  return rewriteReferringNotes(
+    rootPath,
+    referringNotes,
+    'cite',
+    new Map([[oldId, newId]]),
+    markPathHandled,
+    reindexHook,
+  );
+}
+
+/**
+ * Rename an Excerpt: rename the `.ttl` file under `.minerva/excerpts/`,
+ * shift the graph entry, and rewrite every `[[quote::oldId]]` to
+ * `[[quote::newId]]` across the thoughtbase.
+ */
+export async function renameExcerpt(
+  rootPath: string,
+  oldId: string,
+  newId: string,
+  opts: RenameIdOptions = {},
+): Promise<RenameIdResult> {
+  if (oldId === newId) return { rewrittenPaths: [] };
+  const { markPathHandled, reindexHook } = opts;
+
+  const oldPath = path.join(rootPath, '.minerva', 'excerpts', `${oldId}.ttl`);
+  const newPath = path.join(rootPath, '.minerva', 'excerpts', `${newId}.ttl`);
+
+  const referringNotes = graph.findNotesQuotingExcerpt(oldId);
+
+  await fs.mkdir(path.dirname(newPath), { recursive: true });
+  await fs.rename(oldPath, newPath);
+
+  graph.removeExcerpt(oldId);
+  try {
+    const content = await fs.readFile(newPath, 'utf-8');
+    graph.indexExcerpt(newId, content);
+  } catch {
+    // ttl missing — excerpt removed.
+  }
+
+  return rewriteReferringNotes(
+    rootPath,
+    referringNotes,
+    'quote',
+    new Map([[oldId, newId]]),
+    markPathHandled,
+    reindexHook,
+  );
+}
+
+async function rewriteReferringNotes(
+  rootPath: string,
+  referringNotes: string[],
+  linkTypeName: 'cite' | 'quote',
+  rewrites: Map<string, string>,
+  markPathHandled?: (relativePath: string) => void,
+  reindexHook?: (relativePath: string, content: string) => void,
+): Promise<RenameIdResult> {
+  const rewrittenPaths: string[] = [];
+  for (const notePath of referringNotes) {
+    try {
+      const content = await notebaseFs.readFile(rootPath, notePath);
+      const rewritten = rewriteTypedIdLinks(content, linkTypeName, rewrites);
+      if (rewritten === content) continue;
+      markPathHandled?.(notePath);
+      await notebaseFs.writeFile(rootPath, notePath, rewritten);
+      await graph.indexNote(notePath, rewritten);
+      reindexHook?.(notePath, rewritten);
+      rewrittenPaths.push(notePath);
+    } catch (err) {
+      console.error(`[minerva] ${linkTypeName} rewrite failed for ${notePath}:`, err instanceof Error ? err.message : err);
+    }
+  }
+  return { rewrittenPaths };
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -52,6 +52,10 @@ contextBridge.exposeInMainWorld('api', {
     },
     renameAnchor: (targetRelativePath: string, oldSlug: string, newSlug: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_RENAME_ANCHOR, targetRelativePath, oldSlug, newSlug),
+    renameSource: (oldId: string, newId: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_RENAME_SOURCE, oldId, newId),
+    renameExcerpt: (oldId: string, newId: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_RENAME_EXCERPT, oldId, newId),
   },
   links: {
     outgoing: (relativePath: string) => ipcRenderer.invoke(Channels.LINKS_OUTGOING, relativePath),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -561,6 +561,7 @@
     // link rewrite silently.
     api.notebase.onRenamed((transitions) => {
       editor.applyRenameTransitions(transitions);
+      bookmarkStore.applyRenameTransitions(transitions);
     });
     api.notebase.onRewritten(async (paths) => {
       for (const p of paths) {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -23,6 +23,8 @@ export interface NotebaseApi {
   onRewritten(cb: (paths: string[]) => void): void;
   onHeadingRenameSuggested(cb: (candidate: HeadingRenameCandidate) => void): void;
   renameAnchor(targetRelativePath: string, oldSlug: string, newSlug: string): Promise<{ rewrittenPaths: string[] }>;
+  renameSource(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
+  renameExcerpt(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
 }
 
 export interface HeadingRenameCandidate {

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -1,5 +1,6 @@
 import { api } from '../ipc/client';
 import type { BookmarkNode, Bookmark, BookmarkFolder } from '../../../shared/types';
+import { applyBookmarkPathTransitions } from '../../../shared/bookmark-transitions';
 
 let tree = $state<BookmarkNode[]>([]);
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -75,6 +76,13 @@ export function getBookmarksStore() {
     schedulePersist();
   }
 
+  /** Fold note rename/move path transitions into every matching bookmark. */
+  function applyRenameTransitions(transitions: Array<{ old: string; new: string }>) {
+    if (applyBookmarkPathTransitions(tree, transitions)) {
+      schedulePersist();
+    }
+  }
+
   function move(id: string, targetFolderId: string | null) {
     const node = findNode(tree, id);
     if (!node) return;
@@ -100,6 +108,7 @@ export function getBookmarksStore() {
     rename,
     remove,
     move,
+    applyRenameTransitions,
   };
 }
 

--- a/src/shared/bookmark-transitions.ts
+++ b/src/shared/bookmark-transitions.ts
@@ -1,0 +1,43 @@
+import type { BookmarkNode } from './types';
+
+/**
+ * Apply path transitions to every bookmark in the tree. Folders recurse;
+ * leaf Bookmarks have their `relativePath` updated when a transition
+ * matches their current path, or when they live inside a renamed folder.
+ *
+ * Mutates the tree in place. Returns true if any path was changed so the
+ * caller can skip the persist when nothing moved.
+ */
+export function applyBookmarkPathTransitions(
+  tree: BookmarkNode[],
+  transitions: Array<{ old: string; new: string }>,
+): boolean {
+  if (transitions.length === 0) return false;
+  // Longer old-paths first so folder prefixes don't shadow more-specific entries.
+  const sorted = [...transitions].sort((a, b) => b.old.length - a.old.length);
+  let changed = false;
+
+  const walk = (nodes: BookmarkNode[]) => {
+    for (const node of nodes) {
+      if (node.type === 'folder') {
+        walk(node.children);
+        continue;
+      }
+      for (const t of sorted) {
+        if (node.relativePath === t.old) {
+          node.relativePath = t.new;
+          changed = true;
+          break;
+        }
+        const prefix = t.old.endsWith('/') ? t.old : `${t.old}/`;
+        if (node.relativePath.startsWith(prefix)) {
+          node.relativePath = t.new + node.relativePath.slice(t.old.length);
+          changed = true;
+          break;
+        }
+      }
+    }
+  };
+  walk(tree);
+  return changed;
+}

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -23,6 +23,10 @@ export const Channels = {
   NOTEBASE_HEADING_RENAME_SUGGESTED: 'notebase:headingRenameSuggested',
   /** Renderer-initiated rewrite of `[[path#oldSlug]]` → `[[path#newSlug]]`. */
   NOTEBASE_RENAME_ANCHOR: 'notebase:renameAnchor',
+  /** Rename a Source (directory under `.minerva/sources/`) and rewrite `[[cite::id]]`. */
+  NOTEBASE_RENAME_SOURCE: 'notebase:renameSource',
+  /** Rename an Excerpt (file under `.minerva/excerpts/`) and rewrite `[[quote::id]]`. */
+  NOTEBASE_RENAME_EXCERPT: 'notebase:renameExcerpt',
 
   // Links
   LINKS_OUTGOING: 'links:outgoing',

--- a/tests/main/notebase/rename-source-excerpt.test.ts
+++ b/tests/main/notebase/rename-source-excerpt.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  indexAllNotes,
+  findNotesCitingSource,
+  findNotesQuotingExcerpt,
+} from '../../../src/main/graph/index';
+import { renameSource, renameExcerpt } from '../../../src/main/notebase/rename-source-excerpt';
+import { rewriteTypedIdLinks } from '../../../src/main/notebase/link-rewriting';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-src-rename-test-'));
+}
+
+function writeSourceMeta(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+
+function writeExcerpt(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'excerpts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.ttl`), ttl, 'utf-8');
+}
+
+function writeNote(root: string, relPath: string, content: string): void {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+function readNote(root: string, relPath: string): string {
+  return fs.readFileSync(path.join(root, relPath), 'utf-8');
+}
+
+const SOURCE_TTL = `
+this: a thought:Article ;
+    dc:title "A paper" ;
+    dc:creator "Ada Lovelace" .
+`;
+
+const EXCERPT_TTL = `
+this: a thought:Excerpt ;
+    thought:fromSource sources:smith-2023 ;
+    thought:citedText "Graphs are relational." ;
+    thought:page 42 .
+`;
+
+describe('renameSource (issue #141)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('renames the directory on disk and rewrites every [[cite::oldId]]', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeNote(root, 'a.md', 'As [[cite::smith-2023]] argues...');
+    writeNote(root, 'b.md', '[[cite::smith-2023|see the paper]] and [[cite::other-2020]]');
+    await indexAllNotes(root);
+
+    const { rewrittenPaths } = await renameSource(root, 'smith-2023', 'lovelace-2023');
+
+    expect(fs.existsSync(path.join(root, '.minerva/sources/smith-2023'))).toBe(false);
+    expect(fs.existsSync(path.join(root, '.minerva/sources/lovelace-2023/meta.ttl'))).toBe(true);
+
+    expect(readNote(root, 'a.md')).toContain('[[cite::lovelace-2023]]');
+    expect(readNote(root, 'b.md')).toContain('[[cite::lovelace-2023|see the paper]]');
+    expect(readNote(root, 'b.md')).toContain('[[cite::other-2020]]'); // untouched
+    expect(rewrittenPaths.sort()).toEqual(['a.md', 'b.md']);
+  });
+
+  it('shifts the graph so new id is citable and old id isn\'t', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeNote(root, 'a.md', 'As [[cite::smith-2023]] argues...');
+    await indexAllNotes(root);
+
+    await renameSource(root, 'smith-2023', 'lovelace-2023');
+
+    expect(findNotesCitingSource('smith-2023')).toEqual([]);
+    expect(findNotesCitingSource('lovelace-2023')).toEqual(['a.md']);
+  });
+
+  it('no-ops when oldId equals newId', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    await indexAllNotes(root);
+    const { rewrittenPaths } = await renameSource(root, 'smith-2023', 'smith-2023');
+    expect(rewrittenPaths).toEqual([]);
+  });
+});
+
+describe('renameExcerpt (issue #141)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('renames the .ttl file and rewrites every [[quote::oldId]]', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeExcerpt(root, 'p42', EXCERPT_TTL);
+    writeNote(root, 'a.md', '[[quote::p42]]');
+    writeNote(root, 'b.md', '[[quote::p42|on page 42]] and [[quote::other]]');
+    await indexAllNotes(root);
+
+    const { rewrittenPaths } = await renameExcerpt(root, 'p42', 'graphs-relational');
+
+    expect(fs.existsSync(path.join(root, '.minerva/excerpts/p42.ttl'))).toBe(false);
+    expect(fs.existsSync(path.join(root, '.minerva/excerpts/graphs-relational.ttl'))).toBe(true);
+
+    expect(readNote(root, 'a.md')).toContain('[[quote::graphs-relational]]');
+    expect(readNote(root, 'b.md')).toContain('[[quote::graphs-relational|on page 42]]');
+    expect(readNote(root, 'b.md')).toContain('[[quote::other]]');
+    expect(rewrittenPaths.sort()).toEqual(['a.md', 'b.md']);
+  });
+
+  it('shifts the graph so new id is the quote target', async () => {
+    writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
+    writeExcerpt(root, 'p42', EXCERPT_TTL);
+    writeNote(root, 'a.md', '[[quote::p42]]');
+    await indexAllNotes(root);
+
+    await renameExcerpt(root, 'p42', 'graphs-relational');
+
+    expect(findNotesQuotingExcerpt('p42')).toEqual([]);
+    expect(findNotesQuotingExcerpt('graphs-relational')).toEqual(['a.md']);
+  });
+});
+
+describe('rewriteTypedIdLinks (pure, #141)', () => {
+  it('only rewrites the requested link type', () => {
+    const out = rewriteTypedIdLinks(
+      '[[cite::a]] and [[quote::a]] and [[supports::a]]',
+      'cite',
+      new Map([['a', 'b']]),
+    );
+    expect(out).toBe('[[cite::b]] and [[quote::a]] and [[supports::a]]');
+  });
+
+  it('preserves display text', () => {
+    const out = rewriteTypedIdLinks('[[cite::a|see paper]]', 'cite', new Map([['a', 'b']]));
+    expect(out).toBe('[[cite::b|see paper]]');
+  });
+
+  it('leaves unrecognized ids alone', () => {
+    const out = rewriteTypedIdLinks('[[cite::a]] [[cite::c]]', 'cite', new Map([['a', 'b']]));
+    expect(out).toBe('[[cite::b]] [[cite::c]]');
+  });
+});

--- a/tests/shared/bookmark-transitions.test.ts
+++ b/tests/shared/bookmark-transitions.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { applyBookmarkPathTransitions } from '../../src/shared/bookmark-transitions';
+import type { BookmarkNode } from '../../src/shared/types';
+
+function bm(name: string, relativePath: string, id = `bm-${name}`): BookmarkNode {
+  return { type: 'bookmark', id, name, relativePath };
+}
+
+function folder(name: string, children: BookmarkNode[], id = `f-${name}`): BookmarkNode {
+  return { type: 'folder', id, name, children };
+}
+
+describe('applyBookmarkPathTransitions', () => {
+  it('returns false on empty transitions and leaves tree untouched', () => {
+    const tree = [bm('a', 'notes/a.md')];
+    expect(applyBookmarkPathTransitions(tree, [])).toBe(false);
+    expect((tree[0] as any).relativePath).toBe('notes/a.md');
+  });
+
+  it('rewrites an exact path match', () => {
+    const tree = [bm('a', 'notes/a.md')];
+    const changed = applyBookmarkPathTransitions(tree, [{ old: 'notes/a.md', new: 'archive/a.md' }]);
+    expect(changed).toBe(true);
+    expect((tree[0] as any).relativePath).toBe('archive/a.md');
+  });
+
+  it('rewrites bookmarks inside a renamed folder (prefix match)', () => {
+    const tree = [
+      bm('a', 'notes/sub/x.md'),
+      bm('b', 'notes/sub/y.md'),
+      bm('c', 'other/z.md'),
+    ];
+    const changed = applyBookmarkPathTransitions(tree, [
+      { old: 'notes/sub/x.md', new: 'archive/sub/x.md' },
+      { old: 'notes/sub/y.md', new: 'archive/sub/y.md' },
+    ]);
+    expect(changed).toBe(true);
+    expect((tree[0] as any).relativePath).toBe('archive/sub/x.md');
+    expect((tree[1] as any).relativePath).toBe('archive/sub/y.md');
+    expect((tree[2] as any).relativePath).toBe('other/z.md'); // untouched
+  });
+
+  it('recurses into folders', () => {
+    const tree = [folder('research', [bm('a', 'notes/a.md')])];
+    applyBookmarkPathTransitions(tree, [{ old: 'notes/a.md', new: 'archive/a.md' }]);
+    expect((tree[0] as any).children[0].relativePath).toBe('archive/a.md');
+  });
+
+  it('stops at the first matching transition (longer prefixes win)', () => {
+    // If both `notes/` and `notes/sub/x.md` are in the transitions, the
+    // longer (more specific) entry should win.
+    const tree = [bm('a', 'notes/sub/x.md')];
+    applyBookmarkPathTransitions(tree, [
+      { old: 'notes', new: 'archive' },
+      { old: 'notes/sub/x.md', new: 'archive/sub/new-x.md' },
+    ]);
+    expect((tree[0] as any).relativePath).toBe('archive/sub/new-x.md');
+  });
+
+  it('returns false when no bookmark matches any transition', () => {
+    const tree = [bm('a', 'notes/a.md')];
+    const changed = applyBookmarkPathTransitions(tree, [{ old: 'other/b.md', new: 'archive/b.md' }]);
+    expect(changed).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #141 and #142.

## #141 — Rename a Source or Excerpt
New IPC:
- \`api.notebase.renameSource(oldId, newId)\` — renames \`.minerva/sources/<oldId>/\` → \`.minerva/sources/<newId>/\`, shifts the graph entry, and rewrites every \`[[cite::oldId]]\` in the thoughtbase.
- \`api.notebase.renameExcerpt(oldId, newId)\` — same for \`.minerva/excerpts/<oldId>.ttl\` and \`[[quote::…]]\`.

Each reuses #145's \`NOTEBASE_REWRITTEN\` broadcast so open notes refresh without stomping the rewrite on the next auto-save.

No UI hook yet — these call paths are ready for a future source-management UI or for invocation from tools. Filesystem-level detection (unlink+add → rename) is also deferred; the programmatic IPC is the clean foundation.

## #142 — Bookmarks survive rename
\`applyBookmarkPathTransitions(tree, transitions)\` (pure, in \`src/shared/bookmark-transitions.ts\`) walks the bookmark tree and updates every leaf whose \`relativePath\` matches a transition — including descendants of a renamed folder. The bookmarks store consumes it via \`applyRenameTransitions\`, called from App.svelte's existing \`onRenamed\` listener alongside the editor store.

Went renderer-side rather than main-side because the store already owns the in-memory tree; main-side writes would race with store-initiated persists.

## New surface
- \`rewriteTypedIdLinks(content, linkType, rewrites)\` — pure rewriter, cite/quote analogue of \`rewriteWikiLinks\`.
- \`graph.findNotesCitingSource(id)\`, \`findNotesQuotingExcerpt(id)\` — backlink lookups scoping the rewrite pass.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 333 pass (+6 for bookmark transitions: exact + prefix match, folder recursion, longer-prefix-wins, no-op; +8 for source/excerpt rename: fs rename, graph shift, link rewrite, no-op, typed-link rewriter semantics)
- [ ] Manual: \`pnpm dev\` → in devtools run \`api.notebase.renameSource('brooks-1986', 'brooks-1987')\` in the sample project; open \`research/essential-complexity.md\` — its \`[[cite::brooks-1986]]\` has become \`[[cite::brooks-1987]]\`, and the source-detail tab updates on reload
- [ ] Manual: bookmark a note, rename the note via the sidebar, confirm the bookmark opens the new location
- [ ] Manual: bookmark a note inside \`notes/\`, rename the folder to \`archive/\`, confirm the bookmark follows

## Out of scope
- A source-management UI with rename/merge buttons. The IPC is the contract; the UI lands with (or near) #90 (canonical identifier rules) since that epic will mint a lot of renames.
- Filesystem-level rename detection (external \`mv\` under \`.minerva/sources/\`).