### PR TITLE
Behaviors settings tab: manage don't-ask-again confirmations

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -27,6 +27,8 @@
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationStore } from './lib/stores/conversation.svelte';
   import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
+  import { getConfirmSuppressionStore } from './lib/stores/confirm-suppression.svelte';
+  import { CONFIRM_KEYS } from './lib/confirm-keys';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -59,9 +61,7 @@
   let themeLabel = $state(getThemeMode());
   let promptDialog = $state<{ message: string; resolve: (value: string | null) => void } | null>(null);
   let confirmDialog = $state<{ message: string; confirmLabel: string; key: string; resolve: (value: boolean) => void } | null>(null);
-  const suppressedConfirms = new Set<string>(
-    JSON.parse(localStorage.getItem('suppressedConfirms') ?? '[]')
-  );
+  const confirmSuppression = getConfirmSuppressionStore();
 
   function showPrompt(message: string): Promise<string | null> {
     return new Promise((resolve) => {
@@ -70,7 +70,7 @@
   }
 
   function showConfirm(message: string, key: string, confirmLabel = 'OK'): Promise<boolean> {
-    if (suppressedConfirms.has(key)) return Promise.resolve(true);
+    if (confirmSuppression.isSuppressed(key)) return Promise.resolve(true);
     return new Promise((resolve) => {
       confirmDialog = { message, confirmLabel, key, resolve };
     });
@@ -88,8 +88,7 @@
 
   function handleConfirmOk(dontAskAgain: boolean) {
     if (dontAskAgain && confirmDialog) {
-      suppressedConfirms.add(confirmDialog.key);
-      localStorage.setItem('suppressedConfirms', JSON.stringify([...suppressedConfirms]));
+      confirmSuppression.suppress(confirmDialog.key);
     }
     confirmDialog?.resolve(true);
     confirmDialog = null;
@@ -239,7 +238,7 @@
     if (!notebase.meta) return;
     const label = isDirectory ? 'folder' : 'note';
     const name = relativePath.split('/').pop();
-    const confirmed = await showConfirm(`Delete ${label} "${name}"?`, 'confirm-delete', 'Delete');
+    const confirmed = await showConfirm(`Delete ${label} "${name}"?`, CONFIRM_KEYS.delete, 'Delete');
     if (!confirmed) return;
     if (isDirectory) {
       await api.notebase.deleteFolder(relativePath);
@@ -568,7 +567,7 @@
         if (editor.isPathDirty(p)) {
           const keepDisk = await showConfirm(
             `"${p}" was updated on disk by a link rewrite. Discard your unsaved edits and load the new version?`,
-            'confirm-rewrite-conflict',
+            CONFIRM_KEYS.rewriteConflict,
             'Load disk',
           );
           if (!keepDisk) continue;
@@ -582,7 +581,7 @@
       const msg =
         `The heading "${candidate.oldText}" in ${candidate.relativePath} looks like it was renamed ` +
         `to "${candidate.newText}". Update ${n} incoming link${n === 1 ? '' : 's'}?`;
-      const ok = await showConfirm(msg, 'heading-rename-suggestion', 'Update links');
+      const ok = await showConfirm(msg, CONFIRM_KEYS.headingRenameSuggestion, 'Update links');
       if (!ok) return;
       await api.notebase.renameAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
     });

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -10,6 +10,8 @@
   import { getThemeMode, setThemeMode, type ThemeMode } from '../theme';
   import { api } from '../ipc/client';
   import type { LLMSettings, WebSettings } from '../../../shared/tools/types';
+  import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
+  import { CONFIRM_REGISTRY, confirmRegistryEntry } from '../confirm-keys';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -19,13 +21,30 @@
 
   let { onApplyEditor, onThemeChanged, onClose }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'web' | 'ai';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'web' | 'ai';
   const TABS: { id: TabId; label: string }[] = [
     { id: 'editor', label: 'Editor' },
     { id: 'appearance', label: 'Appearance' },
+    { id: 'behaviors', label: 'Behaviors' },
     { id: 'web', label: 'Web' },
     { id: 'ai', label: 'AI' },
   ];
+
+  const confirmSuppression = getConfirmSuppressionStore();
+  // Derived view: every registered confirm, paired with its current suppressed flag.
+  // Binds to the store's $state so toggling re-enables updates the row live.
+  let confirmRows = $derived(
+    CONFIRM_REGISTRY.map((entry) => ({
+      entry,
+      suppressed: confirmSuppression.suppressed.has(entry.key),
+    }))
+  );
+  // Surface any unknown keys that got into localStorage from older builds so
+  // users can still re-enable them — without pretending they belong here.
+  let orphanSuppressedKeys = $derived(
+    [...confirmSuppression.suppressed].filter((k) => !confirmRegistryEntry(k))
+  );
+  let suppressedCount = $derived(confirmRows.filter((r) => r.suppressed).length);
   let activeTab = $state<TabId>('editor');
 
   // Editor settings
@@ -219,6 +238,55 @@
             </select>
             <p class="hint">
               Applies to the markdown editor and preview. App chrome always uses the system font.
+            </p>
+          </div>
+
+        {:else if activeTab === 'behaviors'}
+          <div class="field">
+            <label>Don't-ask-again confirmations</label>
+            <p class="hint">
+              Dialogs you've muted via "Don't ask again." Re-enable a row to see its
+              prompt next time the action occurs.
+            </p>
+          </div>
+          <ul class="confirm-rows">
+            {#each confirmRows as row}
+              <li class="confirm-row" class:muted={!row.suppressed}>
+                <div class="confirm-text">
+                  <div class="confirm-title">{row.entry.title}</div>
+                  <div class="confirm-desc">{row.entry.description}</div>
+                </div>
+                {#if row.suppressed}
+                  <button
+                    class="btn small"
+                    onclick={() => confirmSuppression.unsuppress(row.entry.key)}
+                  >Re-enable</button>
+                {:else}
+                  <span class="confirm-status">Active</span>
+                {/if}
+              </li>
+            {/each}
+            {#each orphanSuppressedKeys as key}
+              <li class="confirm-row">
+                <div class="confirm-text">
+                  <div class="confirm-title">Unknown confirmation</div>
+                  <div class="confirm-desc mono">{key}</div>
+                </div>
+                <button
+                  class="btn small"
+                  onclick={() => confirmSuppression.unsuppress(key)}
+                >Re-enable</button>
+              </li>
+            {/each}
+          </ul>
+          <div class="field">
+            <button
+              class="btn secondary"
+              disabled={suppressedCount === 0 && orphanSuppressedKeys.length === 0}
+              onclick={() => confirmSuppression.clearAll()}
+            >Show all confirmations again</button>
+            <p class="hint">
+              Clears every muted dialog at once.
             </p>
           </div>
 
@@ -489,6 +557,71 @@
     padding: 0 4px;
     font-size: 10px;
     font-family: ui-monospace, monospace;
+  }
+
+  .confirm-rows {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .confirm-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+  }
+
+  .confirm-row.muted {
+    background: transparent;
+    opacity: 0.7;
+  }
+
+  .confirm-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .confirm-title {
+    font-size: 12px;
+    color: var(--text);
+    font-weight: 500;
+  }
+
+  .confirm-desc {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.4;
+    margin-top: 2px;
+  }
+
+  .confirm-desc.mono {
+    font-family: ui-monospace, monospace;
+  }
+
+  .confirm-status {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--text-muted);
+    align-self: center;
+  }
+
+  .btn.small {
+    padding: 3px 10px;
+    font-size: 11px;
+  }
+
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .api-key-status {

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -1,0 +1,50 @@
+/**
+ * Registry of every \`showConfirm\` key in the app. Each entry gives the
+ * Behaviors settings tab a human-readable row so users can see what
+ * they've muted and re-enable it.
+ *
+ * Call sites reference the CONFIRM_KEYS constants rather than passing
+ * bare strings, so adding a new confirm requires adding its entry here.
+ * A guard test (tests/renderer/confirm-keys.test.ts) checks for drift.
+ */
+
+export const CONFIRM_KEYS = {
+  delete: 'confirm-delete',
+  rewriteConflict: 'confirm-rewrite-conflict',
+  headingRenameSuggestion: 'heading-rename-suggestion',
+} as const;
+
+export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
+
+export interface ConfirmRegistryEntry {
+  key: ConfirmKey;
+  title: string;
+  description: string;
+}
+
+export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
+  {
+    key: CONFIRM_KEYS.delete,
+    title: 'Delete file or folder',
+    description:
+      'Prompt before removing a note, folder, or source from the thoughtbase.',
+  },
+  {
+    key: CONFIRM_KEYS.rewriteConflict,
+    title: 'Reload note rewritten on disk',
+    description:
+      'Prompt when an external link rewrite touches a file you have unsaved changes in.',
+  },
+  {
+    key: CONFIRM_KEYS.headingRenameSuggestion,
+    title: 'Update links after heading rename',
+    description:
+      'Offer to rewrite incoming [[note#heading]] links when a heading edit looks like a rename.',
+  },
+];
+
+const byKey = new Map(CONFIRM_REGISTRY.map((e) => [e.key, e]));
+
+export function confirmRegistryEntry(key: string): ConfirmRegistryEntry | null {
+  return byKey.get(key as ConfirmKey) ?? null;
+}

--- a/src/renderer/lib/stores/confirm-suppression.svelte.ts
+++ b/src/renderer/lib/stores/confirm-suppression.svelte.ts
@@ -1,0 +1,60 @@
+const STORAGE_KEY = 'suppressedConfirms';
+
+function readFromStorage(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr.filter((x) => typeof x === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeToStorage(set: Set<string>): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+}
+
+// Reactive singleton so the Behaviors tab re-renders automatically when the
+// set changes from anywhere — the dialog code, a user confirmation, a clear-
+// all action.
+let suppressed = $state<Set<string>>(readFromStorage());
+
+export function getConfirmSuppressionStore() {
+  function isSuppressed(key: string): boolean {
+    return suppressed.has(key);
+  }
+
+  function suppress(key: string): void {
+    if (suppressed.has(key)) return;
+    suppressed = new Set([...suppressed, key]);
+    writeToStorage(suppressed);
+  }
+
+  function unsuppress(key: string): void {
+    if (!suppressed.has(key)) return;
+    const next = new Set(suppressed);
+    next.delete(key);
+    suppressed = next;
+    writeToStorage(suppressed);
+  }
+
+  function clearAll(): void {
+    if (suppressed.size === 0) return;
+    suppressed = new Set();
+    writeToStorage(suppressed);
+  }
+
+  return {
+    get suppressed() { return suppressed; },
+    isSuppressed,
+    suppress,
+    unsuppress,
+    clearAll,
+  };
+}
+
+// Test-only: reset in-memory state (for unit tests that manipulate localStorage).
+export function __resetSuppressionForTests(): void {
+  suppressed = readFromStorage();
+}

--- a/tests/renderer/confirm-keys.test.ts
+++ b/tests/renderer/confirm-keys.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { CONFIRM_KEYS, CONFIRM_REGISTRY, confirmRegistryEntry } from '../../src/renderer/lib/confirm-keys';
+
+describe('CONFIRM_KEYS / CONFIRM_REGISTRY', () => {
+  it('every constant in CONFIRM_KEYS has a matching registry entry', () => {
+    const registryKeys = new Set(CONFIRM_REGISTRY.map((e) => e.key));
+    const unregistered: string[] = [];
+    for (const [, key] of Object.entries(CONFIRM_KEYS)) {
+      if (!registryKeys.has(key)) unregistered.push(key);
+    }
+    expect(unregistered).toEqual([]);
+  });
+
+  it('every registry entry has a non-empty title and description', () => {
+    for (const entry of CONFIRM_REGISTRY) {
+      expect(entry.title.trim()).not.toBe('');
+      expect(entry.description.trim()).not.toBe('');
+    }
+  });
+
+  it('registry keys are unique', () => {
+    const keys = CONFIRM_REGISTRY.map((e) => e.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('confirmRegistryEntry looks up known keys', () => {
+    expect(confirmRegistryEntry(CONFIRM_KEYS.delete)?.title).toBe('Delete file or folder');
+  });
+
+  it('confirmRegistryEntry returns null for unknown keys', () => {
+    expect(confirmRegistryEntry('does-not-exist')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #149.

## Summary
New **Behaviors** tab in Settings lets users see and undo every confirmation dialog they've muted via "Don't ask again."

- Per-row view of each registered confirm: title, description, current state.
- Re-enable button on muted rows restores the prompt next time.
- \"Show all confirmations again\" button clears the entire suppressed set.
- Orphaned keys left in \`localStorage\` from prior builds get a monospace row so they can still be re-enabled.
- \`localStorage\` key name unchanged — existing user suppressions survive.

## Under the hood
- \`src/renderer/lib/confirm-keys.ts\` — \`CONFIRM_KEYS\` constants + a registry mapping each key to \`{ title, description }\`. All \`showConfirm\` call sites now pass \`CONFIRM_KEYS.delete\`, \`.rewriteConflict\`, \`.headingRenameSuggestion\` instead of bare strings.
- \`src/renderer/lib/stores/confirm-suppression.svelte.ts\` — Svelte 5 reactive singleton fronting the suppressedConfirms localStorage entry. Used by \`showConfirm\` in App.svelte and by the Behaviors tab, so the dialog list updates live as users interact.
- A completeness test (\`tests/renderer/confirm-keys.test.ts\`) asserts every \`CONFIRM_KEYS\` constant has a matching registry entry — new confirmations won't slip in without human-readable copy.

## Future
The tab is also the planned home for:
- Heading-rename auto-apply toggle (\"Always / Ask / Never\" instead of just the current don't-ask-again).
- Rename-prompt thresholds (only prompt when N+ links affected).
- Auto-save delay.
- Inspection severity filters.

None of these land in this PR; the shape is set up for them to arrive cleanly.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 338 pass (+5 for the registry/key lookups)
- [ ] Manual: delete a note, tick Don't-ask-again; open Settings → Behaviors; verify the row is non-muted with a Re-enable button; click Re-enable; delete another note — prompt returns
- [ ] Manual: seed localStorage with a garbage key (\`localStorage.setItem('suppressedConfirms', JSON.stringify(['whatever']))\`), reopen the dialog — garbage row appears with a Re-enable button