### PR TITLE
Extract selection + split-here refactor commands

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -29,6 +29,12 @@
   import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
   import { getConfirmSuppressionStore } from './lib/stores/confirm-suppression.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
+  import {
+    planExtract,
+    planSplitHere,
+    deriveProposedTitle,
+    todayDateString,
+  } from './lib/refactor/extract';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -211,6 +217,67 @@
     if (!name) return;
     await api.queries.save('project', name, '', tab.query);
     tab.title = name;
+  }
+
+  // ── Note refactoring: extract / split ──────────────────────────────────
+
+  async function resolveTitle(body: string): Promise<string | null> {
+    const derived = deriveProposedTitle(body);
+    if (derived) return derived;
+    return showPrompt('New note name:');
+  }
+
+  async function handleExtractSelection() {
+    if (!notebase.meta) return;
+    const tab = editor.activeNoteTab;
+    if (!tab) return;
+    const selection = editorComponent?.getSelectionRange();
+    if (!selection) return;
+    const selectedText = tab.content.slice(selection.from, selection.to);
+    const title = await resolveTitle(selectedText);
+    if (!title) return;
+
+    editor.flushAutoSave();
+    const plan = planExtract({
+      sourceRelativePath: tab.relativePath,
+      sourceContent: tab.content,
+      selection,
+      title,
+      today: todayDateString(),
+    });
+
+    await api.notebase.writeFile(plan.newNotePath, plan.newNoteContent);
+    await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
+    await notebase.refresh();
+    await editor.openFile(plan.newNotePath);
+    sidebar?.refreshTags();
+  }
+
+  async function handleSplitHere() {
+    if (!notebase.meta) return;
+    const tab = editor.activeNoteTab;
+    if (!tab) return;
+    const cursor = editorComponent?.getOffset() ?? 0;
+    if (cursor >= tab.content.length) return;
+
+    const tail = tab.content.slice(cursor);
+    const title = await resolveTitle(tail);
+    if (!title) return;
+
+    editor.flushAutoSave();
+    const plan = planSplitHere({
+      sourceRelativePath: tab.relativePath,
+      sourceContent: tab.content,
+      cursor,
+      title,
+      today: todayDateString(),
+    });
+
+    await api.notebase.writeFile(plan.newNotePath, plan.newNoteContent);
+    await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
+    await notebase.refresh();
+    await editor.openFile(plan.newNotePath);
+    sidebar?.refreshTags();
   }
 
   async function handleNewNote(directory: string = '') {
@@ -708,6 +775,8 @@
                     onNavigate={handleNavigate}
                     getNotePaths={() => flattenNotePaths(notebase.files)}
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
+                    onExtractSelection={handleExtractSelection}
+                    onSplitHere={handleSplitHere}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -248,6 +248,10 @@
 
     await api.notebase.writeFile(plan.newNotePath, plan.newNoteContent);
     await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
+    // The active tab still holds the pre-extract content in memory; reload
+    // it from disk so the user sees the wiki-link and so the next auto-save
+    // doesn't overwrite our rewrite.
+    await editor.reloadTabFromDisk(tab.relativePath);
     await notebase.refresh();
     await editor.openFile(plan.newNotePath);
     sidebar?.refreshTags();
@@ -275,6 +279,7 @@
 
     await api.notebase.writeFile(plan.newNotePath, plan.newNoteContent);
     await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
+    await editor.reloadTabFromDisk(tab.relativePath);
     await notebase.refresh();
     await editor.openFile(plan.newNotePath);
     sidebar?.refreshTags();

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -47,6 +47,8 @@
     onBookmark?: () => void;
     onInsertQueryList?: () => void;
     onNavigate?: (target: string) => void;
+    onExtractSelection?: () => void;
+    onSplitHere?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -65,6 +67,8 @@
     onBookmark,
     onInsertQueryList,
     onNavigate,
+    onExtractSelection,
+    onSplitHere,
     getNotePaths,
   }: Props = $props();
 
@@ -74,7 +78,7 @@
   let editorContainer: HTMLDivElement;
   let view: EditorView;
   let ignoreNextUpdate = false;
-  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null } | null>(null);
+  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
   // Snapshot of the selection taken when the context menu opens, so
   // commands from the menu can run against what the user had selected
@@ -196,11 +200,14 @@
   function showContextMenu(e: MouseEvent) {
     e.preventDefault();
     let link: LinkRange | null = null;
+    let hasSelection = false;
     if (view) {
       const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
       if (pos != null) link = findLinkAt(view.state, pos);
+      const sel = view.state.selection.main;
+      hasSelection = sel.from !== sel.to;
     }
-    contextMenu = { x: e.clientX, y: e.clientY, link };
+    contextMenu = { x: e.clientX, y: e.clientY, link, hasSelection };
     const close = () => {
       closeMenu();
       window.removeEventListener('click', close);
@@ -406,6 +413,13 @@
 
   export function getView(): EditorView | undefined {
     return view;
+  }
+
+  export function getSelectionRange(): { from: number; to: number } | null {
+    if (!view) return null;
+    const main = view.state.selection.main;
+    if (main.from === main.to) return null;
+    return { from: main.from, to: main.to };
   }
 
   export function gotoOffset(offset: number) {
@@ -653,6 +667,23 @@
       {/if}
     {/if}
     <div class="separator"></div>
+    {#if onExtractSelection || onSplitHere}
+      <div class="submenu-item" onmouseenter={adjustSubmenu}>
+        <span class="submenu-trigger">Refactor &#x25B8;</span>
+        <div class="submenu">
+          {#if onExtractSelection}
+            <button
+              onclick={() => handleMenuAction(() => onExtractSelection?.())}
+              disabled={!contextMenu.hasSelection}
+            >Extract Selection to New Note</button>
+          {/if}
+          {#if onSplitHere}
+            <button onclick={() => handleMenuAction(() => onSplitHere?.())}>Split Note Here</button>
+          {/if}
+        </div>
+      </div>
+      <div class="separator"></div>
+    {/if}
     <button onclick={() => handleMenuAction(() => onOpenConversation?.())}>Ask About This...</button>
     <button onclick={() => handleMenuAction(() => onBookmark?.())}>Bookmark This Note</button>
     <div class="separator"></div>

--- a/src/renderer/lib/refactor/extract.ts
+++ b/src/renderer/lib/refactor/extract.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure planning functions for note-refactoring commands (#120, #121).
+ *
+ * Each planner takes the source note's content + the user's selection /
+ * cursor + a proposed title and returns everything the caller needs to
+ * (a) write the new note and (b) rewrite the source note. No IO, no IPC —
+ * just string transformation so every edge case gets unit tests.
+ *
+ * Shared conventions match `lib/tools/output.ts`:
+ *   - new note lives in the same folder as the source
+ *   - frontmatter carries title, created, source
+ *   - source is rewritten to carry a `[[path-without-md]]` wiki-link
+ */
+
+export interface ExtractPlan {
+  /** Relative path of the new note, including `.md`. */
+  newNotePath: string;
+  /** Full content of the new note (frontmatter + body). */
+  newNoteContent: string;
+  /** Full content of the source note after the extraction. */
+  updatedSourceContent: string;
+  /** The wiki-link that was inserted into the source (for tests / logging). */
+  linkBack: string;
+}
+
+export interface PlanExtractOptions {
+  sourceRelativePath: string;
+  sourceContent: string;
+  /** Character offsets into sourceContent. from ≤ to; both must be in range. */
+  selection: { from: number; to: number };
+  /** Title for the new note. Callers typically feed this through deriveProposedTitle first. */
+  title: string;
+  /** `YYYY-MM-DD` — allow tests to pin a deterministic value. */
+  today: string;
+}
+
+export interface PlanSplitHereOptions {
+  sourceRelativePath: string;
+  sourceContent: string;
+  /** Character offset; everything from here to EOF becomes the new note. */
+  cursor: number;
+  title: string;
+  today: string;
+}
+
+/**
+ * Look at `body` and decide what the new note should be called.
+ * - If the first non-blank line is an ATX heading (`# …`), use the heading text.
+ * - Else if the first non-blank line is short (≤ 60 chars), use it.
+ * - Else return null — caller should prompt.
+ */
+export function deriveProposedTitle(body: string): string | null {
+  for (const raw of body.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const heading = line.match(/^#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (heading) return heading[1].trim();
+    if (line.length <= 60) return line;
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Sanitize a title into a safe filename stem (no extension).
+ * - Strips path separators and other illegal chars
+ * - Collapses whitespace into single dashes
+ * - Lowercases
+ * - Trims leading/trailing dashes
+ *
+ * Returns an empty string if nothing usable remains — callers should
+ * fall back to a timestamp name in that case.
+ */
+export function sanitizeFilename(title: string): string {
+  return title
+    .replace(/[\\/:*?"<>|]/g, ' ')  // illegal on some OSes
+    .replace(/[^\w\s\-.]/g, ' ')    // everything else: keep word, space, hyphen, dot
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '');
+}
+
+function dirOf(relativePath: string): string {
+  const idx = relativePath.lastIndexOf('/');
+  return idx < 0 ? '' : relativePath.slice(0, idx);
+}
+
+function yamlQuote(s: string): string {
+  if (!/[:#]/.test(s)) return s;
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+function buildFrontmatter(title: string, sourceRelativePath: string, today: string): string {
+  return [
+    '---',
+    `title: ${yamlQuote(title)}`,
+    `created: ${today}`,
+    `source: ${sourceRelativePath}`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+/** Strip a frontmatter block from the top of content. Returns `null` if none. */
+function splitFrontmatter(content: string): { frontmatter: string | null; body: string } {
+  const m = content.match(/^(---\n[\s\S]*?\n---\n?)/);
+  if (!m) return { frontmatter: null, body: content };
+  return { frontmatter: m[1], body: content.slice(m[1].length) };
+}
+
+/**
+ * Turn a relative-path into the wiki-link target form (no `.md`).
+ * `notes/foo.md` → `notes/foo`.
+ */
+function wikiLinkTarget(relativePath: string): string {
+  return relativePath.replace(/\.md$/, '');
+}
+
+/**
+ * Plan an extract-selection operation. Returns the new note's full text and
+ * the rewritten source text; the caller writes both and navigates.
+ */
+export function planExtract(opts: PlanExtractOptions): ExtractPlan {
+  const { sourceRelativePath, sourceContent, selection, title, today } = opts;
+
+  const selected = sourceContent.slice(selection.from, selection.to);
+  const dir = dirOf(sourceRelativePath);
+  const stem = sanitizeFilename(title) || `note-${Date.now()}`;
+  const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
+
+  const frontmatter = buildFrontmatter(title, sourceRelativePath, today);
+  const newNoteContent = frontmatter + selected.replace(/^\s+|\s+$/g, '') + '\n';
+
+  const linkBack = `[[${wikiLinkTarget(newNotePath)}]]`;
+  const updatedSourceContent =
+    sourceContent.slice(0, selection.from) +
+    linkBack +
+    sourceContent.slice(selection.to);
+
+  return { newNotePath, newNoteContent, updatedSourceContent, linkBack };
+}
+
+/**
+ * Plan a split-here operation: everything from `cursor` to EOF becomes the
+ * new note; the source is truncated and gets a trailing link-back.
+ *
+ * If the cursor falls inside the frontmatter block, we treat the split as
+ * "just after the frontmatter" — splitting frontmatter produces two
+ * malformed notes.
+ */
+export function planSplitHere(opts: PlanSplitHereOptions): ExtractPlan {
+  const { sourceRelativePath, sourceContent, cursor, title, today } = opts;
+
+  const { frontmatter } = splitFrontmatter(sourceContent);
+  const minOffset = frontmatter ? frontmatter.length : 0;
+  // Snap to the start of the containing line so the split lands on a
+  // paragraph boundary instead of mid-word.
+  const lineStart = (() => {
+    let i = Math.max(cursor, minOffset);
+    while (i > minOffset && sourceContent[i - 1] !== '\n') i--;
+    return i;
+  })();
+
+  const tail = sourceContent.slice(lineStart).replace(/^\s+/, '');
+  const dir = dirOf(sourceRelativePath);
+  const stem = sanitizeFilename(title) || `note-${Date.now()}`;
+  const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
+
+  const newNoteContent = buildFrontmatter(title, sourceRelativePath, today) + tail + (tail.endsWith('\n') ? '' : '\n');
+
+  const linkBack = `[[${wikiLinkTarget(newNotePath)}]]`;
+  // Keep one trailing newline before the link, none after.
+  const head = sourceContent.slice(0, lineStart).replace(/\s*$/, '');
+  const updatedSourceContent = head + (head ? '\n\n' : '') + linkBack + '\n';
+
+  return { newNotePath, newNoteContent, updatedSourceContent, linkBack };
+}
+
+/** ISO `YYYY-MM-DD` for today, in the local timezone. */
+export function todayDateString(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/tests/renderer/refactor/extract.test.ts
+++ b/tests/renderer/refactor/extract.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveProposedTitle,
+  sanitizeFilename,
+  planExtract,
+  planSplitHere,
+} from '../../../src/renderer/lib/refactor/extract';
+
+describe('deriveProposedTitle', () => {
+  it('uses the first ATX heading when the body starts with one', () => {
+    expect(deriveProposedTitle('# My Heading\n\nbody')).toBe('My Heading');
+    expect(deriveProposedTitle('\n\n## Second Level Heading')).toBe('Second Level Heading');
+  });
+
+  it('uses a short first line when no heading is present', () => {
+    expect(deriveProposedTitle('A short line\nthen body')).toBe('A short line');
+  });
+
+  it('returns null when the first non-blank line is long', () => {
+    const long = 'Here is a long first line that exceeds the short-line threshold intentionally so we fall through';
+    expect(deriveProposedTitle(long)).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(deriveProposedTitle('')).toBeNull();
+    expect(deriveProposedTitle('\n\n\n')).toBeNull();
+  });
+});
+
+describe('sanitizeFilename', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(sanitizeFilename('My Heading')).toBe('my-heading');
+  });
+
+  it('strips illegal path chars', () => {
+    expect(sanitizeFilename('x/y\\z:*?')).toBe('x-y-z');
+  });
+
+  it('collapses repeated hyphens and trims edges', () => {
+    expect(sanitizeFilename('  foo -- bar  ')).toBe('foo-bar');
+  });
+
+  it('returns empty string for pure junk (caller falls back)', () => {
+    expect(sanitizeFilename('///')).toBe('');
+  });
+});
+
+describe('planExtract', () => {
+  const today = '2026-04-19';
+
+  it('builds a new note in the source folder with frontmatter + selected content', () => {
+    const source = '# Overview\n\nIntro.\n\n## Details\n\nRelevant detail paragraph that should move.\n\n## Other';
+    const from = source.indexOf('## Details');
+    const to = source.indexOf('## Other');
+    const plan = planExtract({
+      sourceRelativePath: 'notes/overview.md',
+      sourceContent: source,
+      selection: { from, to },
+      title: 'Details',
+      today,
+    });
+
+    expect(plan.newNotePath).toBe('notes/details.md');
+    expect(plan.newNoteContent).toContain('---\ntitle: Details');
+    expect(plan.newNoteContent).toContain('created: 2026-04-19');
+    expect(plan.newNoteContent).toContain('source: notes/overview.md');
+    expect(plan.newNoteContent).toContain('## Details');
+    expect(plan.newNoteContent).toContain('Relevant detail paragraph');
+    expect(plan.newNoteContent).not.toContain('## Other');
+  });
+
+  it('replaces the selection in the source with a wiki-link (no .md)', () => {
+    const source = 'Before [SELECT] after.';
+    const from = source.indexOf('[SELECT]');
+    const to = from + '[SELECT]'.length;
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: source,
+      selection: { from, to },
+      title: 'Pulled Out',
+      today,
+    });
+
+    expect(plan.linkBack).toBe('[[pulled-out]]');
+    expect(plan.updatedSourceContent).toBe('Before [[pulled-out]] after.');
+    expect(plan.newNotePath).toBe('pulled-out.md');
+  });
+
+  it('uses a timestamp fallback when the title sanitizes to empty', () => {
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: 'foo',
+      selection: { from: 0, to: 3 },
+      title: '///',
+      today,
+    });
+    expect(plan.newNotePath).toMatch(/^note-\d+\.md$/);
+  });
+});
+
+describe('planSplitHere', () => {
+  const today = '2026-04-19';
+
+  it('splits cursor-to-EOF into a new note, truncates source, appends link', () => {
+    const source = '# Note\n\nIntro.\n\n## Tail section\n\nTail text.\n';
+    const cursor = source.indexOf('## Tail section');
+    const plan = planSplitHere({
+      sourceRelativePath: 'notes/big.md',
+      sourceContent: source,
+      cursor,
+      title: 'Tail section',
+      today,
+    });
+
+    expect(plan.newNotePath).toBe('notes/tail-section.md');
+    expect(plan.newNoteContent).toContain('## Tail section');
+    expect(plan.newNoteContent).toContain('Tail text.');
+    expect(plan.updatedSourceContent).toContain('Intro.');
+    expect(plan.updatedSourceContent).not.toContain('Tail text.');
+    expect(plan.updatedSourceContent.trim().endsWith('[[notes/tail-section]]')).toBe(true);
+  });
+
+  it('snaps to line start so the split never lands mid-word', () => {
+    const source = '# Note\n\nIntro paragraph here.\n\nTail line.\n';
+    // cursor mid-line inside "Intro" — "paragraph" starts after "Intro "
+    const cursor = source.indexOf('paragraph');
+    const plan = planSplitHere({
+      sourceRelativePath: 'a.md',
+      sourceContent: source,
+      cursor,
+      title: 'Split',
+      today,
+    });
+    // The new note keeps the full "Intro paragraph here." line intact
+    // because the split snapped to the start of that line.
+    expect(plan.newNoteContent).toContain('Intro paragraph here.');
+    expect(plan.updatedSourceContent).not.toContain('Intro');
+  });
+
+  it('refuses to split inside frontmatter — snaps past it', () => {
+    const source = '---\ntitle: X\n---\n\nBody text.\nMore.\n';
+    // Cursor inside the frontmatter block
+    const plan = planSplitHere({
+      sourceRelativePath: 'a.md',
+      sourceContent: source,
+      cursor: source.indexOf('title:'),
+      title: 'Split',
+      today,
+    });
+    // Source keeps its frontmatter; new note has the body only.
+    expect(plan.updatedSourceContent.startsWith('---\ntitle: X\n---')).toBe(true);
+    expect(plan.newNoteContent).toContain('Body text.');
+    expect(plan.newNoteContent).not.toContain('title: X');
+  });
+});


### PR DESCRIPTION
Closes #120 and #121.

Two commands on the editor's right-click menu under a new **Refactor ▸** submenu. They share so much plumbing — filename resolution, frontmatter template, link-back pattern, source rewrite — that splitting the PR would have been artificial.

## Extract Selection to New Note
- Enabled when there's a selection.
- Pulls the selected passage into a new note in the same folder.
- Source's selection is replaced with \`[[path/to/new-note]]\`.
- New note's frontmatter: \`title\`, \`created\`, \`source\` — matching \`lib/tools/output.ts\`.

## Split Note Here
- Takes cursor-to-EOF and moves it into a new note.
- Source truncates; a \`[[new-note]]\` link lands where the content was.
- Snaps to the start of the cursor's line so a mid-word cursor doesn't slice text.
- Refuses to split inside YAML frontmatter — snaps past it instead.

## Filename resolution
1. First ATX heading in the extracted content wins (\`## Components\` → \`components.md\`).
2. Else a short (≤ 60 char) first line.
3. Else \`showPrompt\`.
4. If the resulting sanitized stem is empty, fall back to \`note-\<timestamp\>.md\`.

## Code layout
- \`src/renderer/lib/refactor/extract.ts\` — pure planners (\`planExtract\`, \`planSplitHere\`), plus helpers \`deriveProposedTitle\` and \`sanitizeFilename\`. Deterministic — takes strings, returns strings — so every edge case gets unit tests.
- \`Editor.svelte\` — new \`getSelectionRange()\` method and two callback props.
- \`App.svelte\` — \`handleExtractSelection\` and \`handleSplitHere\` wire prompt → planner → writeFile → navigate; reuses the #145 tab-refresh pipeline automatically.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 352 pass (+14 for planners: heading detection, short-line fallback, sanitization edge cases, selection replacement, frontmatter presence, cursor snapping, frontmatter protection)
- [ ] Manual: select a \`## Section\` and its body; right-click → Refactor → Extract. New note opens with frontmatter; original now has \`[[section]]\` where the content was
- [ ] Manual: place cursor on a heading line deep in a note; Refactor → Split Note Here. Tail moves to a new sibling note, original ends in \`[[new-note]]\`
- [ ] Manual: verify the wiki-link-back appears correctly in both directions (backlinks panel on the new note points at the source)

## Out of scope (future refactor PRs)
- Split-by-heading fan-out (#122).
- Destination folder / filename prefix settings (#123).
- Link templates + transclusion default (#124).
- Heading-level normalization on the extracted body (#125).