### PR TITLE
Split note by heading level (H1/H2/H3)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -35,6 +35,7 @@
     deriveProposedTitle,
     todayDateString,
   } from './lib/refactor/extract';
+  import { planSplitByHeading } from './lib/refactor/split-by-heading';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -254,6 +255,35 @@
     await editor.reloadTabFromDisk(tab.relativePath);
     await notebase.refresh();
     await editor.openFile(plan.newNotePath);
+    sidebar?.refreshTags();
+  }
+
+  async function handleSplitByHeading() {
+    if (!notebase.meta) return;
+    const tab = editor.activeNoteTab;
+    if (!tab) return;
+
+    const answer = await showPrompt('Heading level to split on (1, 2, or 3):');
+    if (!answer) return;
+    const level = parseInt(answer.trim(), 10);
+    if (level !== 1 && level !== 2 && level !== 3) return;
+
+    editor.flushAutoSave();
+    const plan = planSplitByHeading({
+      sourceRelativePath: tab.relativePath,
+      sourceContent: tab.content,
+      level: level as 1 | 2 | 3,
+      today: todayDateString(),
+    });
+
+    if (plan.newNotes.length === 0) return;
+
+    for (const note of plan.newNotes) {
+      await api.notebase.writeFile(note.relativePath, note.content);
+    }
+    await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
+    await editor.reloadTabFromDisk(tab.relativePath);
+    await notebase.refresh();
     sidebar?.refreshTags();
   }
 
@@ -782,6 +812,7 @@
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
+                    onSplitByHeading={handleSplitByHeading}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -49,6 +49,7 @@
     onNavigate?: (target: string) => void;
     onExtractSelection?: () => void;
     onSplitHere?: () => void;
+    onSplitByHeading?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -69,6 +70,7 @@
     onNavigate,
     onExtractSelection,
     onSplitHere,
+    onSplitByHeading,
     getNotePaths,
   }: Props = $props();
 
@@ -667,7 +669,7 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -679,6 +681,9 @@
           {/if}
           {#if onSplitHere}
             <button onclick={() => handleMenuAction(() => onSplitHere?.())}>Split Note Here</button>
+          {/if}
+          {#if onSplitByHeading}
+            <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading…</button>
           {/if}
         </div>
       </div>

--- a/src/renderer/lib/refactor/split-by-heading.ts
+++ b/src/renderer/lib/refactor/split-by-heading.ts
@@ -1,0 +1,140 @@
+/**
+ * Pure planner for "Split by heading" (#122). Shatters one long note
+ * into one new note per heading at the chosen level.
+ */
+
+import { sanitizeFilename } from './extract';
+
+export interface SplitByHeadingPlan {
+  /** Files to write (order doesn't matter; caller writes each). */
+  newNotes: Array<{ relativePath: string; content: string }>;
+  /** Rewritten source content: preamble + `## Contents` index. */
+  updatedSourceContent: string;
+}
+
+export interface PlanSplitByHeadingOptions {
+  sourceRelativePath: string;
+  sourceContent: string;
+  /** Heading level to split on (1, 2, or 3). */
+  level: 1 | 2 | 3;
+  today: string;
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+
+function dirOf(relativePath: string): string {
+  const idx = relativePath.lastIndexOf('/');
+  return idx < 0 ? '' : relativePath.slice(0, idx);
+}
+
+function basenameWithoutExt(relativePath: string): string {
+  const file = relativePath.split('/').pop() ?? relativePath;
+  return file.replace(/\.md$/, '');
+}
+
+function yamlQuote(s: string): string {
+  if (!/[:#]/.test(s)) return s;
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+function buildFrontmatter(title: string, sourceRelativePath: string, today: string): string {
+  return [
+    '---',
+    `title: ${yamlQuote(title)}`,
+    `created: ${today}`,
+    `source: ${sourceRelativePath}`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+function splitFrontmatter(content: string): { frontmatter: string; body: string; bodyOffset: number } {
+  const m = content.match(/^(---\n[\s\S]*?\n---\n?)/);
+  if (!m) return { frontmatter: '', body: content, bodyOffset: 0 };
+  return { frontmatter: m[1], body: content.slice(m[1].length), bodyOffset: m[1].length };
+}
+
+/** Find every line that looks like an ATX heading of the given level, outside fenced code blocks. */
+function findHeadings(body: string, level: number): Array<{ lineStart: number; text: string; fullLine: string }> {
+  const out: Array<{ lineStart: number; text: string; fullLine: string }> = [];
+  let offset = 0;
+  let inFence = false;
+  for (const line of body.split('\n')) {
+    if (/^```/.test(line)) inFence = !inFence;
+    if (!inFence) {
+      const m = line.match(HEADING_RE);
+      if (m && m[1].length === level) {
+        out.push({ lineStart: offset, text: m[2].trim(), fullLine: line });
+      }
+    }
+    offset += line.length + 1; // account for the \n
+  }
+  return out;
+}
+
+/**
+ * Assign a unique filename stem per heading, suffixing (-2, -3, …) on
+ * collisions so two `## Changes` sections don't overwrite each other.
+ */
+function assignStems(headings: Array<{ text: string }>): string[] {
+  const out: string[] = [];
+  const counts = new Map<string, number>();
+  for (const h of headings) {
+    const baseStem = sanitizeFilename(h.text) || 'section';
+    const n = counts.get(baseStem) ?? 0;
+    counts.set(baseStem, n + 1);
+    out.push(n === 0 ? baseStem : `${baseStem}-${n + 1}`);
+  }
+  return out;
+}
+
+export function planSplitByHeading(opts: PlanSplitByHeadingOptions): SplitByHeadingPlan {
+  const { sourceRelativePath, sourceContent, level, today } = opts;
+
+  const { frontmatter, body } = splitFrontmatter(sourceContent);
+  const headings = findHeadings(body, level);
+  if (headings.length === 0) {
+    return { newNotes: [], updatedSourceContent: sourceContent };
+  }
+
+  // Slice body into [preamble, section_1, section_2, …]. Each section begins
+  // at its heading's line; the preamble is everything before the first.
+  const preamble = body.slice(0, headings[0].lineStart);
+  const sections: string[] = [];
+  for (let i = 0; i < headings.length; i++) {
+    const start = headings[i].lineStart;
+    const end = i + 1 < headings.length ? headings[i + 1].lineStart : body.length;
+    sections.push(body.slice(start, end));
+  }
+
+  const srcDir = dirOf(sourceRelativePath);
+  const base = basenameWithoutExt(sourceRelativePath);
+  const subfolder = srcDir ? `${srcDir}/${base}` : base;
+  const stems = assignStems(headings);
+
+  const newNotes: Array<{ relativePath: string; content: string }> = [];
+  const links: string[] = [];
+
+  for (let i = 0; i < headings.length; i++) {
+    const stem = stems[i];
+    const relativePath = `${subfolder}/${stem}.md`;
+    const title = headings[i].text;
+    const sectionBody = sections[i].trimEnd() + '\n';
+    const content = buildFrontmatter(title, sourceRelativePath, today) + sectionBody;
+    newNotes.push({ relativePath, content });
+    links.push(`- [[${subfolder}/${stem}|${title}]]`);
+  }
+
+  // Rebuild the source: keep the frontmatter, keep any preamble prose, then
+  // replace the shattered sections with a `## Contents` index.
+  const preambleTrimmed = preamble.replace(/\s+$/, '');
+  const indexBlock = ['## Contents', '', ...links, ''].join('\n');
+  const newBody =
+    (preambleTrimmed ? `${preambleTrimmed}\n\n` : '') +
+    indexBlock;
+
+  return {
+    newNotes,
+    updatedSourceContent: frontmatter + newBody,
+  };
+}

--- a/tests/renderer/refactor/split-by-heading.test.ts
+++ b/tests/renderer/refactor/split-by-heading.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { planSplitByHeading } from '../../../src/renderer/lib/refactor/split-by-heading';
+
+const today = '2026-04-19';
+
+function plan(content: string, level: 1 | 2 | 3, sourceRelativePath = 'notes/meetings.md') {
+  return planSplitByHeading({
+    sourceRelativePath,
+    sourceContent: content,
+    level,
+    today,
+  });
+}
+
+describe('planSplitByHeading', () => {
+  it('creates one new note per heading at the target level', () => {
+    const src = '# Meetings\n\n## Feb 14\n\nFoo.\n\n## Feb 21\n\nBar.\n';
+    const p = plan(src, 2);
+    expect(p.newNotes).toHaveLength(2);
+    expect(p.newNotes.map((n) => n.relativePath)).toEqual([
+      'notes/meetings/feb-14.md',
+      'notes/meetings/feb-21.md',
+    ]);
+  });
+
+  it('places each section under its own heading in the new note', () => {
+    const src = '# X\n\n## Feb 14\n\nFoo paragraph.\n\n## Feb 21\n\nBar paragraph.\n';
+    const p = plan(src, 2);
+    expect(p.newNotes[0].content).toContain('## Feb 14');
+    expect(p.newNotes[0].content).toContain('Foo paragraph.');
+    expect(p.newNotes[0].content).not.toContain('Feb 21');
+    expect(p.newNotes[1].content).toContain('## Feb 21');
+    expect(p.newNotes[1].content).toContain('Bar paragraph.');
+  });
+
+  it('writes frontmatter with title, created, and source on each new note', () => {
+    const src = '## Only Heading\n\nBody.\n';
+    const p = plan(src, 2, 'a.md');
+    const fm = p.newNotes[0].content;
+    expect(fm).toContain('---\ntitle: Only Heading');
+    expect(fm).toContain('created: 2026-04-19');
+    expect(fm).toContain('source: a.md');
+  });
+
+  it('rewrites the source as a Contents list of wiki-links', () => {
+    const src = 'Optional preamble.\n\n## A\n\nA body.\n\n## B\n\nB body.\n';
+    const p = plan(src, 2, 'notes/big.md');
+    expect(p.updatedSourceContent).toContain('## Contents');
+    expect(p.updatedSourceContent).toContain('[[notes/big/a|A]]');
+    expect(p.updatedSourceContent).toContain('[[notes/big/b|B]]');
+    expect(p.updatedSourceContent).not.toContain('A body.');
+    expect(p.updatedSourceContent).not.toContain('B body.');
+  });
+
+  it('preserves a preamble before the first matching heading', () => {
+    const src = '# Overview\n\nIntro paragraph.\n\n## A\n\nA body.\n';
+    const p = plan(src, 2);
+    expect(p.updatedSourceContent).toContain('# Overview');
+    expect(p.updatedSourceContent).toContain('Intro paragraph.');
+    expect(p.updatedSourceContent.indexOf('## Contents')).toBeGreaterThan(
+      p.updatedSourceContent.indexOf('Intro paragraph.'),
+    );
+  });
+
+  it('returns empty plan when no headings at the target level exist', () => {
+    const src = '# One H1 only\n\n## Not at requested level\n';
+    const p = plan(src, 1);
+    // One H1 heading — it becomes the only new note, preamble is empty.
+    expect(p.newNotes).toHaveLength(1);
+    expect(p.newNotes[0].relativePath).toBe('notes/meetings/one-h1-only.md');
+  });
+
+  it('returns zero-new-notes plan and leaves source untouched when no match', () => {
+    const src = '# Only H1\n\nNo H2 in sight.\n';
+    const p = plan(src, 2);
+    expect(p.newNotes).toHaveLength(0);
+    expect(p.updatedSourceContent).toBe(src);
+  });
+
+  it('suffixes colliding filenames with -2, -3, …', () => {
+    const src = '## Changes\n\nfirst\n\n## Changes\n\nsecond\n\n## Changes\n\nthird\n';
+    const p = plan(src, 2);
+    expect(p.newNotes.map((n) => n.relativePath)).toEqual([
+      'notes/meetings/changes.md',
+      'notes/meetings/changes-2.md',
+      'notes/meetings/changes-3.md',
+    ]);
+  });
+
+  it('ignores headings inside fenced code blocks', () => {
+    const src = '## Real\n\nbody\n\n```\n## fake\n```\n\n## Real Two\n\nbody two\n';
+    const p = plan(src, 2);
+    expect(p.newNotes).toHaveLength(2);
+    expect(p.newNotes.map((n) => n.relativePath)).toEqual([
+      'notes/meetings/real.md',
+      'notes/meetings/real-two.md',
+    ]);
+    // The fenced fake heading stays inside the first section's content.
+    expect(p.newNotes[0].content).toContain('## fake');
+  });
+
+  it('preserves existing YAML frontmatter on the source', () => {
+    const src = '---\ntitle: Meetings\n---\n\n## A\n\nfoo\n\n## B\n\nbar\n';
+    const p = plan(src, 2);
+    expect(p.updatedSourceContent.startsWith('---\ntitle: Meetings\n---')).toBe(true);
+  });
+
+  it('picks the parent folder for the subfolder, not the project root', () => {
+    const src = '## A\nfoo\n';
+    const p = plan(src, 2, 'research/papers/index.md');
+    expect(p.newNotes[0].relativePath).toBe('research/papers/index/a.md');
+  });
+});


### PR DESCRIPTION
Closes #122.

## Summary
New Refactor submenu entry: **Split by Heading…**. Asks for a heading level (1, 2, or 3), then shatters the source into one new note per heading at that level.

- New notes land in a subfolder named after the source basename. \`notes/meetings.md\` split on H2 → \`notes/meetings/feb-14.md\`, \`notes/meetings/feb-21.md\`, …
- Each new note gets the standard refactor frontmatter (\`title\`, \`created\`, \`source\`).
- Source is rewritten: frontmatter stays, any preamble prose before the first matching heading stays, and the shattered sections are replaced with a \`## Contents\` list of wiki-links.
- Filename collisions (two \`## Changes\` sections) get \`-2\`, \`-3\` suffixes.
- Fenced code blocks are skipped when scanning headings.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 363 pass (+11 planner tests)
- [ ] Manual: open a multi-section note (e.g. \`notes/architecture.md\` in the sample project), right-click → Refactor → Split by Heading… → enter \`2\`. Confirm a subfolder is created, each section becomes a note, the source is now a Contents list of wiki-links
- [ ] Manual: run on a note with duplicate-named headings and confirm \`-2\` / \`-3\` suffixes apply
- [ ] Manual: cancel the prompt or enter something other than 1/2/3 — nothing happens

## Out of scope (follow-up refactor PRs)
- #123: destination-folder + filename-prefix settings (would override the \"subfolder named after source basename\" default).
- #124: link templates + transclusion-by-default.
- #125: heading-level normalization on extracted bodies.