### PR TITLE
Refactoring settings: destination + filename prefix + heading normalize

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -36,6 +36,7 @@
     todayDateString,
   } from './lib/refactor/extract';
   import { planSplitByHeading } from './lib/refactor/split-by-heading';
+  import { getRefactorSettings } from './lib/refactor/settings';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -245,6 +246,7 @@
       selection,
       title,
       today: todayDateString(),
+      settings: getRefactorSettings(),
     });
 
     await api.notebase.writeFile(plan.newNotePath, plan.newNoteContent);
@@ -274,6 +276,7 @@
       sourceContent: tab.content,
       level: level as 1 | 2 | 3,
       today: todayDateString(),
+      settings: getRefactorSettings(),
     });
 
     if (plan.newNotes.length === 0) return;
@@ -305,6 +308,7 @@
       cursor,
       title,
       today: todayDateString(),
+      settings: getRefactorSettings(),
     });
 
     await api.notebase.writeFile(plan.newNotePath, plan.newNoteContent);

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -12,6 +12,12 @@
   import type { LLMSettings, WebSettings } from '../../../shared/tools/types';
   import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
   import { CONFIRM_REGISTRY, confirmRegistryEntry } from '../confirm-keys';
+  import {
+    getRefactorSettings,
+    setRefactorSettings,
+    type DestinationMode,
+    type RefactorSettings,
+  } from '../refactor/settings';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -21,13 +27,25 @@
 
   let { onApplyEditor, onThemeChanged, onClose }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'behaviors' | 'web' | 'ai';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'web' | 'ai';
   const TABS: { id: TabId; label: string }[] = [
     { id: 'editor', label: 'Editor' },
     { id: 'appearance', label: 'Appearance' },
     { id: 'behaviors', label: 'Behaviors' },
+    { id: 'refactoring', label: 'Refactoring' },
     { id: 'web', label: 'Web' },
     { id: 'ai', label: 'AI' },
+  ];
+
+  let refactor = $state<RefactorSettings>({ ...getRefactorSettings() });
+  function patchRefactor(patch: Partial<RefactorSettings>): void {
+    refactor = { ...refactor, ...patch };
+    setRefactorSettings(patch);
+  }
+  const DESTINATION_OPTIONS: { value: DestinationMode; label: string }[] = [
+    { value: 'same-folder', label: 'Same folder as source note' },
+    { value: 'root', label: 'Thoughtbase root' },
+    { value: 'custom', label: 'Custom folder (template)' },
   ];
 
   const confirmSuppression = getConfirmSuppressionStore();
@@ -287,6 +305,69 @@
             >Show all confirmations again</button>
             <p class="hint">
               Clears every muted dialog at once.
+            </p>
+          </div>
+
+        {:else if activeTab === 'refactoring'}
+          <div class="field">
+            <label for="destination">Destination for new notes</label>
+            <select
+              id="destination"
+              value={refactor.destination}
+              onchange={(e) => patchRefactor({ destination: (e.currentTarget as HTMLSelectElement).value as DestinationMode })}
+            >
+              {#each DESTINATION_OPTIONS as opt}
+                <option value={opt.value}>{opt.label}</option>
+              {/each}
+            </select>
+            <p class="hint">
+              Applies to Extract Selection, Split Here, and Split by Heading.
+            </p>
+          </div>
+          {#if refactor.destination === 'custom'}
+            <div class="field">
+              <label for="destination-template">Custom folder template</label>
+              <input
+                id="destination-template"
+                type="text"
+                value={refactor.destinationTemplate}
+                oninput={(e) => patchRefactor({ destinationTemplate: (e.currentTarget as HTMLInputElement).value })}
+                placeholder="e.g. notes/{{date:YYYY}}/{{date:MM}}"
+              />
+              <p class="hint">
+                Tokens: <code>{'{{date:YYYY}}'}</code>, <code>{'{{date:MM}}'}</code>,
+                <code>{'{{date:DD}}'}</code>, <code>{'{{title}}'}</code>,
+                <code>{'{{source}}'}</code>. Leave blank to use the thoughtbase root.
+              </p>
+            </div>
+          {/if}
+          <div class="field">
+            <label for="filename-prefix">Filename prefix</label>
+            <input
+              id="filename-prefix"
+              type="text"
+              value={refactor.filenamePrefix}
+              oninput={(e) => patchRefactor({ filenamePrefix: (e.currentTarget as HTMLInputElement).value })}
+              placeholder="e.g. {{date:YYYYMMDDHHmm}}-"
+            />
+            <p class="hint">
+              Prepended to every refactored note's filename. Supports the same tokens.
+              Zettelkasten users often set something like <code>{'{{date:YYYYMMDDHHmm}}-'}</code>.
+            </p>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input
+                type="checkbox"
+                checked={refactor.normalizeHeadings}
+                onchange={(e) => patchRefactor({ normalizeHeadings: (e.currentTarget as HTMLInputElement).checked })}
+              />
+              Normalize heading levels in extracted notes
+            </label>
+            <p class="hint">
+              When the extracted body's shallowest heading is H2 or deeper, shift every
+              heading up so it becomes H1. Only affects the new note's body; the source
+              is never touched.
             </p>
           </div>
 

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -332,7 +332,7 @@
                 type="text"
                 value={refactor.destinationTemplate}
                 oninput={(e) => patchRefactor({ destinationTemplate: (e.currentTarget as HTMLInputElement).value })}
-                placeholder="e.g. notes/{{date:YYYY}}/{{date:MM}}"
+                placeholder={'e.g. notes/{{date:YYYY}}/{{date:MM}}'}
               />
               <p class="hint">
                 Tokens: <code>{'{{date:YYYY}}'}</code>, <code>{'{{date:MM}}'}</code>,
@@ -348,7 +348,7 @@
               type="text"
               value={refactor.filenamePrefix}
               oninput={(e) => patchRefactor({ filenamePrefix: (e.currentTarget as HTMLInputElement).value })}
-              placeholder="e.g. {{date:YYYYMMDDHHmm}}-"
+              placeholder={'e.g. {{date:YYYYMMDDHHmm}}-'}
             />
             <p class="hint">
               Prepended to every refactored note's filename. Supports the same tokens.

--- a/src/renderer/lib/refactor/extract.ts
+++ b/src/renderer/lib/refactor/extract.ts
@@ -7,10 +7,18 @@
  * just string transformation so every edge case gets unit tests.
  *
  * Shared conventions match `lib/tools/output.ts`:
- *   - new note lives in the same folder as the source
+ *   - new note lives in the same folder as the source (by default)
  *   - frontmatter carries title, created, source
  *   - source is rewritten to carry a `[[path-without-md]]` wiki-link
+ *
+ * Settings (#123, #125) let users override the destination folder,
+ * prepend a filename prefix, and normalize heading levels in the
+ * extracted body.
  */
+
+import type { RefactorSettings } from './settings';
+import { DEFAULT_REFACTOR_SETTINGS } from './settings';
+import { renderTemplate } from './tokens';
 
 export interface ExtractPlan {
   /** Relative path of the new note, including `.md`. */
@@ -32,6 +40,10 @@ export interface PlanExtractOptions {
   title: string;
   /** `YYYY-MM-DD` — allow tests to pin a deterministic value. */
   today: string;
+  /** Refactoring settings; falls back to defaults when omitted. */
+  settings?: RefactorSettings;
+  /** Pin "now" for tests; defaults to the `today` date at midnight local time. */
+  now?: Date;
 }
 
 export interface PlanSplitHereOptions {
@@ -41,6 +53,8 @@ export interface PlanSplitHereOptions {
   cursor: number;
   title: string;
   today: string;
+  settings?: RefactorSettings;
+  now?: Date;
 }
 
 /**
@@ -87,6 +101,80 @@ function dirOf(relativePath: string): string {
   return idx < 0 ? '' : relativePath.slice(0, idx);
 }
 
+/**
+ * Decide where a new refactored note should go, honoring
+ * destination-mode / folder-template settings. Returns a folder (no
+ * trailing slash) or '' for the thoughtbase root.
+ */
+export function resolveDestinationFolder(
+  sourceRelativePath: string,
+  settings: RefactorSettings,
+  now?: Date,
+): string {
+  switch (settings.destination) {
+    case 'root':
+      return '';
+    case 'custom': {
+      const rendered = renderTemplate(settings.destinationTemplate, {
+        title: basenameTitle(sourceRelativePath),
+        source: sourceRelativePath,
+        now,
+      }).trim();
+      return rendered.replace(/\/+$/, '');
+    }
+    case 'same-folder':
+    default:
+      return dirOf(sourceRelativePath);
+  }
+}
+
+function basenameTitle(relativePath: string): string {
+  const file = relativePath.split('/').pop() ?? relativePath;
+  return file.replace(/\.md$/, '');
+}
+
+/** Render the user-configured filename prefix, returning '' when unset. */
+export function renderFilenamePrefix(
+  sourceRelativePath: string,
+  settings: RefactorSettings,
+  now?: Date,
+): string {
+  if (!settings.filenamePrefix) return '';
+  return renderTemplate(settings.filenamePrefix, {
+    title: basenameTitle(sourceRelativePath),
+    source: sourceRelativePath,
+    now,
+  });
+}
+
+/**
+ * Shift heading levels in `body` so the shallowest-present heading becomes
+ * H1. No-op when settings.normalizeHeadings is off or no headings exist.
+ */
+export function normalizeHeadingLevels(body: string, settings: RefactorSettings): string {
+  if (!settings.normalizeHeadings) return body;
+  const lines = body.split('\n');
+  let inFence = false;
+  let minLevel = Infinity;
+  for (const line of lines) {
+    if (/^```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = line.match(/^(#{1,6})\s+\S/);
+    if (m) minLevel = Math.min(minLevel, m[1].length);
+  }
+  if (!isFinite(minLevel) || minLevel <= 1) return body;
+  const shift = minLevel - 1;
+  inFence = false;
+  return lines.map((line) => {
+    if (/^```/.test(line)) { inFence = !inFence; return line; }
+    if (inFence) return line;
+    const m = line.match(/^(#{1,6})(\s+.+)$/);
+    if (!m) return line;
+    const newLevel = Math.max(1, m[1].length - shift);
+    return '#'.repeat(newLevel) + m[2];
+  }).join('\n');
+}
+
 function yamlQuote(s: string): string {
   if (!/[:#]/.test(s)) return s;
   return `"${s.replace(/"/g, '\\"')}"`;
@@ -124,14 +212,19 @@ function wikiLinkTarget(relativePath: string): string {
  */
 export function planExtract(opts: PlanExtractOptions): ExtractPlan {
   const { sourceRelativePath, sourceContent, selection, title, today } = opts;
+  const settings = opts.settings ?? DEFAULT_REFACTOR_SETTINGS;
+  const now = opts.now;
 
   const selected = sourceContent.slice(selection.from, selection.to);
-  const dir = dirOf(sourceRelativePath);
-  const stem = sanitizeFilename(title) || `note-${Date.now()}`;
+  const body = normalizeHeadingLevels(selected.replace(/^\s+|\s+$/g, ''), settings) + '\n';
+
+  const dir = resolveDestinationFolder(sourceRelativePath, settings, now);
+  const prefix = renderFilenamePrefix(sourceRelativePath, settings, now);
+  const stem = `${prefix}${sanitizeFilename(title) || `note-${Date.now()}`}`;
   const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
 
   const frontmatter = buildFrontmatter(title, sourceRelativePath, today);
-  const newNoteContent = frontmatter + selected.replace(/^\s+|\s+$/g, '') + '\n';
+  const newNoteContent = frontmatter + body;
 
   const linkBack = `[[${wikiLinkTarget(newNotePath)}]]`;
   const updatedSourceContent =
@@ -152,6 +245,8 @@ export function planExtract(opts: PlanExtractOptions): ExtractPlan {
  */
 export function planSplitHere(opts: PlanSplitHereOptions): ExtractPlan {
   const { sourceRelativePath, sourceContent, cursor, title, today } = opts;
+  const settings = opts.settings ?? DEFAULT_REFACTOR_SETTINGS;
+  const now = opts.now;
 
   const { frontmatter } = splitFrontmatter(sourceContent);
   const minOffset = frontmatter ? frontmatter.length : 0;
@@ -163,9 +258,11 @@ export function planSplitHere(opts: PlanSplitHereOptions): ExtractPlan {
     return i;
   })();
 
-  const tail = sourceContent.slice(lineStart).replace(/^\s+/, '');
-  const dir = dirOf(sourceRelativePath);
-  const stem = sanitizeFilename(title) || `note-${Date.now()}`;
+  const tailRaw = sourceContent.slice(lineStart).replace(/^\s+/, '');
+  const tail = normalizeHeadingLevels(tailRaw, settings);
+  const dir = resolveDestinationFolder(sourceRelativePath, settings, now);
+  const prefix = renderFilenamePrefix(sourceRelativePath, settings, now);
+  const stem = `${prefix}${sanitizeFilename(title) || `note-${Date.now()}`}`;
   const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
 
   const newNoteContent = buildFrontmatter(title, sourceRelativePath, today) + tail + (tail.endsWith('\n') ? '' : '\n');

--- a/src/renderer/lib/refactor/settings.ts
+++ b/src/renderer/lib/refactor/settings.ts
@@ -1,0 +1,74 @@
+/**
+ * Settings for the note-refactoring commands (#123, #125).
+ *
+ * Stored in localStorage. Planners read the current snapshot via
+ * getRefactorSettings() — synchronous, returns plain data. The Svelte
+ * SettingsDialog owns the reactive UI state and writes through to this
+ * module on every change.
+ */
+
+export type DestinationMode = 'same-folder' | 'root' | 'custom';
+
+export interface RefactorSettings {
+  /** Where new notes from extract / split / split-by-heading land. */
+  destination: DestinationMode;
+  /**
+   * Used when destination === 'custom'. Supports template tokens
+   * ({{date:YYYY}}, {{title}}, etc.). Rendered at refactor time.
+   * Empty string is treated as the thoughtbase root.
+   */
+  destinationTemplate: string;
+  /**
+   * Prepended to auto-generated filenames. Supports the same tokens.
+   * Empty by default.
+   */
+  filenamePrefix: string;
+  /**
+   * When true, heading levels in an extracted body are shifted so the
+   * shallowest level becomes H1. Doesn't affect the source note (#125).
+   */
+  normalizeHeadings: boolean;
+}
+
+export const DEFAULT_REFACTOR_SETTINGS: RefactorSettings = {
+  destination: 'same-folder',
+  destinationTemplate: '',
+  filenamePrefix: '',
+  normalizeHeadings: false,
+};
+
+const STORAGE_KEY = 'refactorSettings';
+
+function readFromStorage(): RefactorSettings {
+  try {
+    if (typeof localStorage === 'undefined') return { ...DEFAULT_REFACTOR_SETTINGS };
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_REFACTOR_SETTINGS };
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_REFACTOR_SETTINGS };
+    return { ...DEFAULT_REFACTOR_SETTINGS, ...parsed };
+  } catch {
+    return { ...DEFAULT_REFACTOR_SETTINGS };
+  }
+}
+
+let settings: RefactorSettings = readFromStorage();
+
+/** Synchronous snapshot for planners. Always returns the latest persisted values. */
+export function getRefactorSettings(): RefactorSettings {
+  return settings;
+}
+
+/** Write-through update — the SettingsDialog calls this on every change. */
+export function setRefactorSettings(patch: Partial<RefactorSettings>): RefactorSettings {
+  settings = { ...settings, ...patch };
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }
+  return settings;
+}
+
+/** Test-only: re-read from storage / reset to defaults. */
+export function __resetRefactorSettingsForTests(): void {
+  settings = readFromStorage();
+}

--- a/src/renderer/lib/refactor/split-by-heading.ts
+++ b/src/renderer/lib/refactor/split-by-heading.ts
@@ -3,7 +3,14 @@
  * into one new note per heading at the chosen level.
  */
 
-import { sanitizeFilename } from './extract';
+import {
+  sanitizeFilename,
+  resolveDestinationFolder,
+  renderFilenamePrefix,
+  normalizeHeadingLevels,
+} from './extract';
+import type { RefactorSettings } from './settings';
+import { DEFAULT_REFACTOR_SETTINGS } from './settings';
 
 export interface SplitByHeadingPlan {
   /** Files to write (order doesn't matter; caller writes each). */
@@ -18,14 +25,11 @@ export interface PlanSplitByHeadingOptions {
   /** Heading level to split on (1, 2, or 3). */
   level: 1 | 2 | 3;
   today: string;
+  settings?: RefactorSettings;
+  now?: Date;
 }
 
 const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
-
-function dirOf(relativePath: string): string {
-  const idx = relativePath.lastIndexOf('/');
-  return idx < 0 ? '' : relativePath.slice(0, idx);
-}
 
 function basenameWithoutExt(relativePath: string): string {
   const file = relativePath.split('/').pop() ?? relativePath;
@@ -76,20 +80,23 @@ function findHeadings(body: string, level: number): Array<{ lineStart: number; t
  * Assign a unique filename stem per heading, suffixing (-2, -3, …) on
  * collisions so two `## Changes` sections don't overwrite each other.
  */
-function assignStems(headings: Array<{ text: string }>): string[] {
+function assignStems(headings: Array<{ text: string }>, prefix = ''): string[] {
   const out: string[] = [];
   const counts = new Map<string, number>();
   for (const h of headings) {
     const baseStem = sanitizeFilename(h.text) || 'section';
     const n = counts.get(baseStem) ?? 0;
     counts.set(baseStem, n + 1);
-    out.push(n === 0 ? baseStem : `${baseStem}-${n + 1}`);
+    const stem = n === 0 ? baseStem : `${baseStem}-${n + 1}`;
+    out.push(`${prefix}${stem}`);
   }
   return out;
 }
 
 export function planSplitByHeading(opts: PlanSplitByHeadingOptions): SplitByHeadingPlan {
   const { sourceRelativePath, sourceContent, level, today } = opts;
+  const settings = opts.settings ?? DEFAULT_REFACTOR_SETTINGS;
+  const now = opts.now;
 
   const { frontmatter, body } = splitFrontmatter(sourceContent);
   const headings = findHeadings(body, level);
@@ -107,10 +114,11 @@ export function planSplitByHeading(opts: PlanSplitByHeadingOptions): SplitByHead
     sections.push(body.slice(start, end));
   }
 
-  const srcDir = dirOf(sourceRelativePath);
+  const parentDir = resolveDestinationFolder(sourceRelativePath, settings, now);
   const base = basenameWithoutExt(sourceRelativePath);
-  const subfolder = srcDir ? `${srcDir}/${base}` : base;
-  const stems = assignStems(headings);
+  const subfolder = parentDir ? `${parentDir}/${base}` : base;
+  const prefix = renderFilenamePrefix(sourceRelativePath, settings, now);
+  const stems = assignStems(headings, prefix);
 
   const newNotes: Array<{ relativePath: string; content: string }> = [];
   const links: string[] = [];
@@ -119,7 +127,7 @@ export function planSplitByHeading(opts: PlanSplitByHeadingOptions): SplitByHead
     const stem = stems[i];
     const relativePath = `${subfolder}/${stem}.md`;
     const title = headings[i].text;
-    const sectionBody = sections[i].trimEnd() + '\n';
+    const sectionBody = normalizeHeadingLevels(sections[i].trimEnd(), settings) + '\n';
     const content = buildFrontmatter(title, sourceRelativePath, today) + sectionBody;
     newNotes.push({ relativePath, content });
     links.push(`- [[${subfolder}/${stem}|${title}]]`);

--- a/src/renderer/lib/refactor/tokens.ts
+++ b/src/renderer/lib/refactor/tokens.ts
@@ -1,0 +1,61 @@
+/**
+ * Token renderer for refactor templates.
+ *
+ * Supports:
+ *   {{date}}               ISO date (YYYY-MM-DD) in local time
+ *   {{date:FORMAT}}        Custom date format; tokens YYYY, MM, DD, HH, mm, ss
+ *   {{title}}              Source note's title / filename
+ *   {{new_note_title}}     Extracted note's title
+ *   {{new_note_content}}   Extracted note's full body (populated by #124 content templates)
+ *   {{source}}             Source note's relative path
+ *
+ * Unknown tokens render as empty strings so a typo doesn't leak brace
+ * literals into filenames.
+ */
+
+export interface TokenContext {
+  title?: string;
+  new_note_title?: string;
+  new_note_content?: string;
+  source?: string;
+  /** Allow callers to pin the date — tests rely on this. */
+  now?: Date;
+}
+
+const TOKEN_RE = /\{\{([^}]+?)\}\}/g;
+
+export function renderTemplate(template: string, ctx: TokenContext = {}): string {
+  const now = ctx.now ?? new Date();
+  return template.replace(TOKEN_RE, (_, raw: string) => resolveToken(raw.trim(), ctx, now));
+}
+
+function resolveToken(token: string, ctx: TokenContext, now: Date): string {
+  if (token === 'date') return formatDate(now, 'YYYY-MM-DD');
+  if (token.startsWith('date:')) return formatDate(now, token.slice('date:'.length));
+  switch (token) {
+    case 'title': return ctx.title ?? '';
+    case 'new_note_title': return ctx.new_note_title ?? '';
+    case 'new_note_content': return ctx.new_note_content ?? '';
+    case 'source': return ctx.source ?? '';
+  }
+  return '';
+}
+
+function formatDate(d: Date, format: string): string {
+  const pad2 = (n: number) => String(n).padStart(2, '0');
+  const parts: Record<string, string> = {
+    YYYY: String(d.getFullYear()),
+    MM: pad2(d.getMonth() + 1),
+    DD: pad2(d.getDate()),
+    HH: pad2(d.getHours()),
+    mm: pad2(d.getMinutes()),
+    ss: pad2(d.getSeconds()),
+  };
+  // Replace longest keys first so MM doesn't match inside YYYY-MM-DD.
+  const keys = Object.keys(parts).sort((a, b) => b.length - a.length);
+  let out = format;
+  for (const k of keys) {
+    out = out.split(k).join(parts[k]);
+  }
+  return out;
+}

--- a/tests/renderer/refactor/extract-settings.test.ts
+++ b/tests/renderer/refactor/extract-settings.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planExtract,
+  planSplitHere,
+  normalizeHeadingLevels,
+  resolveDestinationFolder,
+  renderFilenamePrefix,
+} from '../../../src/renderer/lib/refactor/extract';
+import { planSplitByHeading } from '../../../src/renderer/lib/refactor/split-by-heading';
+import type { RefactorSettings } from '../../../src/renderer/lib/refactor/settings';
+import { DEFAULT_REFACTOR_SETTINGS } from '../../../src/renderer/lib/refactor/settings';
+
+const today = '2026-04-19';
+const now = new Date('2026-04-19T12:00:00');
+
+function s(patch: Partial<RefactorSettings>): RefactorSettings {
+  return { ...DEFAULT_REFACTOR_SETTINGS, ...patch };
+}
+
+describe('resolveDestinationFolder', () => {
+  it('defaults to same folder as source', () => {
+    expect(resolveDestinationFolder('notes/foo.md', DEFAULT_REFACTOR_SETTINGS)).toBe('notes');
+  });
+
+  it('returns root for destination=root', () => {
+    expect(resolveDestinationFolder('notes/foo.md', s({ destination: 'root' }))).toBe('');
+  });
+
+  it('renders destination=custom with tokens', () => {
+    const folder = resolveDestinationFolder(
+      'notes/foo.md',
+      s({ destination: 'custom', destinationTemplate: 'refactored/{{date:YYYY}}/{{date:MM}}' }),
+      now,
+    );
+    expect(folder).toBe('refactored/2026/04');
+  });
+
+  it('trims trailing slashes from custom templates', () => {
+    const folder = resolveDestinationFolder(
+      'a.md',
+      s({ destination: 'custom', destinationTemplate: 'refactored///' }),
+      now,
+    );
+    expect(folder).toBe('refactored');
+  });
+});
+
+describe('renderFilenamePrefix', () => {
+  it('returns empty by default', () => {
+    expect(renderFilenamePrefix('a.md', DEFAULT_REFACTOR_SETTINGS)).toBe('');
+  });
+
+  it('renders token prefix', () => {
+    const pre = renderFilenamePrefix('a.md', s({ filenamePrefix: '{{date:YYYYMMDD}}-' }), now);
+    expect(pre).toBe('20260419-');
+  });
+});
+
+describe('normalizeHeadingLevels', () => {
+  it('shifts headings so shallowest becomes H1 when enabled', () => {
+    const body = '### Deep\n\nbody\n\n#### Deeper\n';
+    const out = normalizeHeadingLevels(body, s({ normalizeHeadings: true }));
+    expect(out).toContain('# Deep');
+    expect(out).toContain('## Deeper');
+  });
+
+  it('no-ops when disabled', () => {
+    const body = '### Deep\n';
+    expect(normalizeHeadingLevels(body, DEFAULT_REFACTOR_SETTINGS)).toBe(body);
+  });
+
+  it('no-ops when shallowest is already H1', () => {
+    const body = '# Top\n\n## Sub\n';
+    expect(normalizeHeadingLevels(body, s({ normalizeHeadings: true }))).toBe(body);
+  });
+
+  it('ignores headings inside fenced code blocks', () => {
+    const body = '### Real\n\n```\n# not real\n```\n';
+    const out = normalizeHeadingLevels(body, s({ normalizeHeadings: true }));
+    expect(out).toContain('# Real');
+    expect(out).toContain('# not real'); // unchanged because it's in a fence
+  });
+});
+
+describe('planExtract honors settings', () => {
+  const src = '# Overview\n\nSome intro.\n\n### Deep\n\ndeep body\n\n### Other\n';
+  const from = src.indexOf('### Deep');
+  const to = src.indexOf('### Other');
+
+  it('uses custom destination folder', () => {
+    const plan = planExtract({
+      sourceRelativePath: 'notes/overview.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Deep',
+      today,
+      now,
+      settings: s({ destination: 'custom', destinationTemplate: 'refactored/{{date:YYYY}}' }),
+    });
+    expect(plan.newNotePath).toBe('refactored/2026/deep.md');
+  });
+
+  it('prepends filename prefix', () => {
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Deep',
+      today,
+      now,
+      settings: s({ filenamePrefix: '{{date:YYYYMMDD}}-' }),
+    });
+    expect(plan.newNotePath).toBe('20260419-deep.md');
+  });
+
+  it('normalizes heading levels on the extracted body', () => {
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Deep',
+      today,
+      now,
+      settings: s({ normalizeHeadings: true }),
+    });
+    // `### Deep` was the shallowest in the selection; it shifts to `# Deep`.
+    expect(plan.newNoteContent).toContain('# Deep\n');
+    expect(plan.newNoteContent).not.toContain('### Deep');
+  });
+});
+
+describe('planSplitHere honors settings', () => {
+  it('applies destination + prefix + normalize together', () => {
+    const src = '# Note\n\nIntro.\n\n#### Deep Tail\n\ntail body\n';
+    const cursor = src.indexOf('#### Deep Tail');
+    const plan = planSplitHere({
+      sourceRelativePath: 'notes/big.md',
+      sourceContent: src,
+      cursor,
+      title: 'Deep Tail',
+      today,
+      now,
+      settings: s({
+        destination: 'root',
+        filenamePrefix: 'split-',
+        normalizeHeadings: true,
+      }),
+    });
+    expect(plan.newNotePath).toBe('split-deep-tail.md');
+    expect(plan.newNoteContent).toContain('# Deep Tail');
+  });
+});
+
+describe('planSplitByHeading honors settings', () => {
+  it('uses custom destination as the subfolder parent', () => {
+    const src = '## A\nfoo\n\n## B\nbar\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'notes/big.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({ destination: 'custom', destinationTemplate: 'archive/{{date:YYYY}}' }),
+    });
+    expect(plan.newNotes[0].relativePath).toBe('archive/2026/big/a.md');
+  });
+
+  it('prepends filename prefix to each fragment', () => {
+    const src = '## A\nfoo\n\n## B\nbar\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({ filenamePrefix: 'frag-' }),
+    });
+    expect(plan.newNotes.map((n) => n.relativePath)).toEqual([
+      'a/frag-a.md',
+      'a/frag-b.md',
+    ]);
+  });
+
+  it('normalizes headings in each fragment', () => {
+    const src = '## A\n\n### Nested\n\nbody\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({ normalizeHeadings: true }),
+    });
+    // Fragment's shallowest was H2, shifts to H1.
+    expect(plan.newNotes[0].content).toContain('# A');
+    expect(plan.newNotes[0].content).toContain('## Nested');
+  });
+});

--- a/tests/renderer/refactor/tokens.test.ts
+++ b/tests/renderer/refactor/tokens.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { renderTemplate } from '../../../src/renderer/lib/refactor/tokens';
+
+const fixedNow = new Date('2026-04-19T12:34:56');
+
+describe('renderTemplate', () => {
+  it('renders {{date}} as YYYY-MM-DD by default', () => {
+    expect(renderTemplate('{{date}}', { now: fixedNow })).toBe('2026-04-19');
+  });
+
+  it('renders {{date:FORMAT}} using format tokens', () => {
+    expect(renderTemplate('{{date:YYYY}}', { now: fixedNow })).toBe('2026');
+    expect(renderTemplate('{{date:YYYY-MM}}', { now: fixedNow })).toBe('2026-04');
+    expect(renderTemplate('{{date:YYYYMMDDHHmmss}}', { now: fixedNow })).toBe('20260419123456');
+  });
+
+  it('renders context tokens', () => {
+    const out = renderTemplate(
+      '{{title}}/{{new_note_title}}/{{source}}',
+      { title: 'Parent', new_note_title: 'Child', source: 'notes/parent.md', now: fixedNow },
+    );
+    expect(out).toBe('Parent/Child/notes/parent.md');
+  });
+
+  it('renders unknown tokens as empty strings (no brace leaks)', () => {
+    expect(renderTemplate('x-{{mystery}}-y', { now: fixedNow })).toBe('x--y');
+  });
+
+  it('leaves a template without tokens unchanged', () => {
+    expect(renderTemplate('notes/refactor', {})).toBe('notes/refactor');
+  });
+
+  it('handles multiple tokens in a compound template', () => {
+    const out = renderTemplate('notes/{{date:YYYY}}/{{date:MM}}/{{title}}', {
+      title: 'meetings',
+      now: fixedNow,
+    });
+    expect(out).toBe('notes/2026/04/meetings');
+  });
+});


### PR DESCRIPTION
Closes #123 and #125.

New **Refactoring** tab in the Settings dialog. Three controls shape how Extract Selection, Split Here, and Split by Heading behave.

## Destination for new notes (#123)
Dropdown:
- **Same folder as source note** (default)
- **Thoughtbase root**
- **Custom folder (template)** — reveals a text field

Custom template accepts tokens: \`{{date:YYYY}}\`, \`{{date:MM}}\`, \`{{date:DD}}\`, \`{{date:HHmmss}}\`, \`{{title}}\`, \`{{source}}\`. For example \`notes/{{date:YYYY}}/{{date:MM}}\` files refactored notes into year/month folders.

## Filename prefix (#123)
Text field, same token set. Prepended to every auto-generated filename. Typical Zettelkasten use: \`{{date:YYYYMMDDHHmm}}-\` → every new note gets a timestamp ID stem.

## Normalize heading levels (#125)
Checkbox (off by default). When enabled, an extracted body whose shallowest heading is H2+ gets every heading shifted so the shallowest becomes H1. Code-fenced lines are left alone. Source note is never touched.

## New shared modules
- **\`src/renderer/lib/refactor/tokens.ts\`** — pure template renderer. Ready to also serve the link/note templates coming in #124.
- **\`src/renderer/lib/refactor/settings.ts\`** — plain module with \`getRefactorSettings\` / \`setRefactorSettings\`. The SettingsDialog owns the reactive \`\$state\` locally and writes through, which keeps the planners test-friendly (no svelte-specific code needed for unit tests).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 386 pass (+6 token renderer, +17 planner-with-settings variations)
- [ ] Manual: set destination to custom with \`refactored/{{date:YYYY}}\` and extract something — note lands in \`refactored/2026/...\`
- [ ] Manual: set filename prefix to \`{{date:YYYYMMDDHHmm}}-\` and extract — filename gains a timestamp prefix
- [ ] Manual: enable normalize-headings and extract a section whose shallowest heading is \`###\` — new note has \`#\` at the top
- [ ] Manual: settings round-trip through localStorage on app restart

## Out of scope
- #124 link/note templates (next PR, uses the same token renderer).
- Per-project settings overrides (v1 is global per user).