### PR TITLE
Link templates + transclusion-by-default

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -370,6 +370,54 @@
               is never touched.
             </p>
           </div>
+          <div class="field checkbox">
+            <label>
+              <input
+                type="checkbox"
+                checked={refactor.transcludeByDefault}
+                onchange={(e) => patchRefactor({ transcludeByDefault: (e.currentTarget as HTMLInputElement).checked })}
+                disabled={!!refactor.linkTemplate}
+              />
+              Transclude by default
+            </label>
+            <p class="hint">
+              Refactor commands emit <code>![[new-note]]</code> in the source so the
+              preview inlines the extracted content. Overridden when a link template
+              is set below.
+            </p>
+          </div>
+          <div class="field">
+            <label for="link-template">Link template</label>
+            <textarea
+              id="link-template"
+              rows="3"
+              value={refactor.linkTemplate}
+              oninput={(e) => patchRefactor({ linkTemplate: (e.currentTarget as HTMLTextAreaElement).value })}
+              placeholder={'e.g. > See [[{{new_note_title}}]] — split from {{title}} on {{date}}'}
+            ></textarea>
+            <p class="hint">
+              What to put in the source note in place of the extracted content. When
+              blank, Minerva uses a plain wiki-link (or <code>![[…]]</code> if
+              transclude is enabled). Tokens: <code>{'{{new_note_title}}'}</code>,
+              <code>{'{{title}}'}</code>, <code>{'{{source}}'}</code>,
+              <code>{'{{date}}'}</code>.
+            </p>
+          </div>
+          <div class="field">
+            <label for="refactored-note-template">Refactored note template</label>
+            <textarea
+              id="refactored-note-template"
+              rows="4"
+              value={refactor.refactoredNoteTemplate}
+              oninput={(e) => patchRefactor({ refactoredNoteTemplate: (e.currentTarget as HTMLTextAreaElement).value })}
+              placeholder={'e.g. > Extracted from [[{{source}}]] on {{date}}\n\n{{new_note_content}}'}
+            ></textarea>
+            <p class="hint">
+              Wraps each extracted note's body. Leave blank to use the raw extracted
+              content unchanged. Must reference <code>{'{{new_note_content}}'}</code>
+              somewhere or the body will be dropped.
+            </p>
+          </div>
 
         {:else if activeTab === 'web'}
           <div class="field checkbox">

--- a/src/renderer/lib/refactor/extract.ts
+++ b/src/renderer/lib/refactor/extract.ts
@@ -207,6 +207,57 @@ function wikiLinkTarget(relativePath: string): string {
 }
 
 /**
+ * Produce the source-side link-back given the settings precedence:
+ * explicit linkTemplate > transcludeByDefault > plain `[[…]]`.
+ * The rendered template is used as-is; plain and transclude forms
+ * generate the link from the new note's path.
+ */
+export function renderLinkBack(
+  newNotePath: string,
+  settings: RefactorSettings,
+  ctx: { sourceRelativePath: string; sourceTitle: string; newNoteTitle: string; now?: Date },
+): string {
+  const target = wikiLinkTarget(newNotePath);
+  if (settings.linkTemplate) {
+    return renderTemplate(settings.linkTemplate, {
+      title: ctx.sourceTitle,
+      new_note_title: ctx.newNoteTitle,
+      source: ctx.sourceRelativePath,
+      now: ctx.now,
+    });
+  }
+  return settings.transcludeByDefault ? `![[${target}]]` : `[[${target}]]`;
+}
+
+/**
+ * Produce the extracted note's body. If `refactoredNoteTemplate` is
+ * empty (default), returns `rawBody` with normalization already applied.
+ * Otherwise renders the template with {{new_note_content}} bound to the
+ * raw body — lets users wrap it in a callout, prepend metadata, etc.
+ */
+export function renderExtractedBody(
+  rawBody: string,
+  settings: RefactorSettings,
+  ctx: { sourceRelativePath: string; sourceTitle: string; newNoteTitle: string; now?: Date },
+): string {
+  if (!settings.refactoredNoteTemplate) return rawBody;
+  return renderTemplate(settings.refactoredNoteTemplate, {
+    title: ctx.sourceTitle,
+    new_note_title: ctx.newNoteTitle,
+    new_note_content: rawBody,
+    source: ctx.sourceRelativePath,
+    now: ctx.now,
+  });
+}
+
+/** Source note's title for template contexts — the H1 or the filename stem. */
+function sourceTitleFor(relativePath: string, content: string): string {
+  const match = content.match(/^#\s+(.+)$/m);
+  if (match) return match[1].trim();
+  return (relativePath.split('/').pop() ?? relativePath).replace(/\.md$/, '');
+}
+
+/**
  * Plan an extract-selection operation. Returns the new note's full text and
  * the rewritten source text; the caller writes both and navigates.
  */
@@ -216,17 +267,25 @@ export function planExtract(opts: PlanExtractOptions): ExtractPlan {
   const now = opts.now;
 
   const selected = sourceContent.slice(selection.from, selection.to);
-  const body = normalizeHeadingLevels(selected.replace(/^\s+|\s+$/g, ''), settings) + '\n';
+  const rawBody = normalizeHeadingLevels(selected.replace(/^\s+|\s+$/g, ''), settings);
 
   const dir = resolveDestinationFolder(sourceRelativePath, settings, now);
   const prefix = renderFilenamePrefix(sourceRelativePath, settings, now);
   const stem = `${prefix}${sanitizeFilename(title) || `note-${Date.now()}`}`;
   const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
 
-  const frontmatter = buildFrontmatter(title, sourceRelativePath, today);
-  const newNoteContent = frontmatter + body;
+  const templateCtx = {
+    sourceRelativePath,
+    sourceTitle: sourceTitleFor(sourceRelativePath, sourceContent),
+    newNoteTitle: title,
+    now,
+  };
 
-  const linkBack = `[[${wikiLinkTarget(newNotePath)}]]`;
+  const frontmatter = buildFrontmatter(title, sourceRelativePath, today);
+  const wrappedBody = renderExtractedBody(rawBody, settings, templateCtx);
+  const newNoteContent = frontmatter + wrappedBody + (wrappedBody.endsWith('\n') ? '' : '\n');
+
+  const linkBack = renderLinkBack(newNotePath, settings, templateCtx);
   const updatedSourceContent =
     sourceContent.slice(0, selection.from) +
     linkBack +
@@ -259,15 +318,23 @@ export function planSplitHere(opts: PlanSplitHereOptions): ExtractPlan {
   })();
 
   const tailRaw = sourceContent.slice(lineStart).replace(/^\s+/, '');
-  const tail = normalizeHeadingLevels(tailRaw, settings);
+  const rawBody = normalizeHeadingLevels(tailRaw, settings);
   const dir = resolveDestinationFolder(sourceRelativePath, settings, now);
   const prefix = renderFilenamePrefix(sourceRelativePath, settings, now);
   const stem = `${prefix}${sanitizeFilename(title) || `note-${Date.now()}`}`;
   const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
 
-  const newNoteContent = buildFrontmatter(title, sourceRelativePath, today) + tail + (tail.endsWith('\n') ? '' : '\n');
+  const templateCtx = {
+    sourceRelativePath,
+    sourceTitle: sourceTitleFor(sourceRelativePath, sourceContent),
+    newNoteTitle: title,
+    now,
+  };
 
-  const linkBack = `[[${wikiLinkTarget(newNotePath)}]]`;
+  const wrappedBody = renderExtractedBody(rawBody, settings, templateCtx);
+  const newNoteContent = buildFrontmatter(title, sourceRelativePath, today) + wrappedBody + (wrappedBody.endsWith('\n') ? '' : '\n');
+
+  const linkBack = renderLinkBack(newNotePath, settings, templateCtx);
   // Keep one trailing newline before the link, none after.
   const head = sourceContent.slice(0, lineStart).replace(/\s*$/, '');
   const updatedSourceContent = head + (head ? '\n\n' : '') + linkBack + '\n';

--- a/src/renderer/lib/refactor/settings.ts
+++ b/src/renderer/lib/refactor/settings.ts
@@ -28,6 +28,25 @@ export interface RefactorSettings {
    * shallowest level becomes H1. Doesn't affect the source note (#125).
    */
   normalizeHeadings: boolean;
+  /**
+   * When true (and linkTemplate is empty), extract/split commands emit
+   * `![[new-note]]` instead of `[[new-note]]` so the source transcludes
+   * the extracted content in preview (#124).
+   */
+  transcludeByDefault: boolean;
+  /**
+   * Multiline template used in place of the default `[[new-note]]` link
+   * when the source is rewritten. Empty disables. Tokens: {{title}},
+   * {{new_note_title}}, {{date}}, {{source}}. When set, overrides the
+   * transclude toggle.
+   */
+  linkTemplate: string;
+  /**
+   * Multiline template wrapping the extracted note's body. Empty disables.
+   * Tokens: {{new_note_title}}, {{new_note_content}}, {{title}}, {{source}},
+   * {{date}}.
+   */
+  refactoredNoteTemplate: string;
 }
 
 export const DEFAULT_REFACTOR_SETTINGS: RefactorSettings = {
@@ -35,6 +54,9 @@ export const DEFAULT_REFACTOR_SETTINGS: RefactorSettings = {
   destinationTemplate: '',
   filenamePrefix: '',
   normalizeHeadings: false,
+  transcludeByDefault: false,
+  linkTemplate: '',
+  refactoredNoteTemplate: '',
 };
 
 const STORAGE_KEY = 'refactorSettings';

--- a/src/renderer/lib/refactor/split-by-heading.ts
+++ b/src/renderer/lib/refactor/split-by-heading.ts
@@ -8,6 +8,8 @@ import {
   resolveDestinationFolder,
   renderFilenamePrefix,
   normalizeHeadingLevels,
+  renderLinkBack,
+  renderExtractedBody,
 } from './extract';
 import type { RefactorSettings } from './settings';
 import { DEFAULT_REFACTOR_SETTINGS } from './settings';
@@ -30,6 +32,12 @@ export interface PlanSplitByHeadingOptions {
 }
 
 const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+
+function extractSourceTitle(relativePath: string, content: string): string {
+  const m = content.match(/^#\s+(.+)$/m);
+  if (m) return m[1].trim();
+  return (relativePath.split('/').pop() ?? relativePath).replace(/\.md$/, '');
+}
 
 function basenameWithoutExt(relativePath: string): string {
   const file = relativePath.split('/').pop() ?? relativePath;
@@ -123,14 +131,33 @@ export function planSplitByHeading(opts: PlanSplitByHeadingOptions): SplitByHead
   const newNotes: Array<{ relativePath: string; content: string }> = [];
   const links: string[] = [];
 
+  const sourceTitle = extractSourceTitle(sourceRelativePath, sourceContent);
+
   for (let i = 0; i < headings.length; i++) {
     const stem = stems[i];
     const relativePath = `${subfolder}/${stem}.md`;
     const title = headings[i].text;
-    const sectionBody = normalizeHeadingLevels(sections[i].trimEnd(), settings) + '\n';
-    const content = buildFrontmatter(title, sourceRelativePath, today) + sectionBody;
+    const rawBody = normalizeHeadingLevels(sections[i].trimEnd(), settings);
+    const templateCtx = {
+      sourceRelativePath,
+      sourceTitle,
+      newNoteTitle: title,
+      now,
+    };
+    const wrappedBody = renderExtractedBody(rawBody, settings, templateCtx);
+    const bodyWithTrailingNewline = wrappedBody + (wrappedBody.endsWith('\n') ? '' : '\n');
+    const content = buildFrontmatter(title, sourceRelativePath, today) + bodyWithTrailingNewline;
     newNotes.push({ relativePath, content });
-    links.push(`- [[${subfolder}/${stem}|${title}]]`);
+
+    // Contents-list entry: respect linkTemplate / transcludeByDefault, fall
+    // back to a bulleted `- [[path|title]]` line.
+    if (settings.linkTemplate) {
+      links.push(renderLinkBack(relativePath, settings, templateCtx));
+    } else if (settings.transcludeByDefault) {
+      links.push(`- ![[${subfolder}/${stem}]]`);
+    } else {
+      links.push(`- [[${subfolder}/${stem}|${title}]]`);
+    }
   }
 
   // Rebuild the source: keep the frontmatter, keep any preamble prose, then

--- a/tests/renderer/refactor/link-templates.test.ts
+++ b/tests/renderer/refactor/link-templates.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { planExtract, planSplitHere } from '../../../src/renderer/lib/refactor/extract';
+import { planSplitByHeading } from '../../../src/renderer/lib/refactor/split-by-heading';
+import type { RefactorSettings } from '../../../src/renderer/lib/refactor/settings';
+import { DEFAULT_REFACTOR_SETTINGS } from '../../../src/renderer/lib/refactor/settings';
+
+const today = '2026-04-19';
+const now = new Date('2026-04-19T12:00:00');
+
+function s(patch: Partial<RefactorSettings>): RefactorSettings {
+  return { ...DEFAULT_REFACTOR_SETTINGS, ...patch };
+}
+
+describe('transcludeByDefault', () => {
+  it('uses ![[…]] for extract when enabled', () => {
+    const src = 'before [pulled] after.';
+    const from = src.indexOf('[pulled]');
+    const to = from + '[pulled]'.length;
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Pulled',
+      today,
+      now,
+      settings: s({ transcludeByDefault: true }),
+    });
+    expect(plan.updatedSourceContent).toContain('![[pulled]]');
+    // No un-prefixed `[[pulled]]` — the preceding char must be `!`.
+    expect(plan.updatedSourceContent).not.toMatch(/(^|[^!])\[\[pulled\]\]/);
+  });
+
+  it('uses ![[…]] for split-here when enabled', () => {
+    const src = '# Note\n\nIntro.\n\n## Tail\n\nTail body.\n';
+    const plan = planSplitHere({
+      sourceRelativePath: 'notes/big.md',
+      sourceContent: src,
+      cursor: src.indexOf('## Tail'),
+      title: 'Tail',
+      today,
+      now,
+      settings: s({ transcludeByDefault: true }),
+    });
+    expect(plan.updatedSourceContent).toContain('![[notes/tail]]');
+  });
+
+  it('uses `- ![[…]]` for split-by-heading Contents entries when enabled', () => {
+    const src = '## A\nfoo\n\n## B\nbar\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({ transcludeByDefault: true }),
+    });
+    expect(plan.updatedSourceContent).toContain('- ![[a/a]]');
+    expect(plan.updatedSourceContent).toContain('- ![[a/b]]');
+  });
+});
+
+describe('linkTemplate', () => {
+  it('overrides the default link-back for extract', () => {
+    const src = 'before [pulled] after.';
+    const from = src.indexOf('[pulled]');
+    const to = from + '[pulled]'.length;
+    const plan = planExtract({
+      sourceRelativePath: 'notes/a.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Pulled Out',
+      today,
+      now,
+      settings: s({ linkTemplate: '[[{{new_note_title}}]] — see also {{source}}' }),
+    });
+    expect(plan.updatedSourceContent).toContain('[[Pulled Out]] — see also notes/a.md');
+    // The explicit template overrides the transclude setting entirely:
+    expect(plan.updatedSourceContent).not.toContain('![[');
+  });
+
+  it('wins over transcludeByDefault when both are set', () => {
+    const src = 'x [pulled] y';
+    const from = src.indexOf('[pulled]');
+    const to = from + '[pulled]'.length;
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Pulled',
+      today,
+      now,
+      settings: s({ transcludeByDefault: true, linkTemplate: 'LINK:{{new_note_title}}' }),
+    });
+    expect(plan.updatedSourceContent).toBe('x LINK:Pulled y');
+  });
+
+  it('overrides every Contents entry for split-by-heading', () => {
+    const src = '## A\nfoo\n\n## B\nbar\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({ linkTemplate: '* {{new_note_title}}' }),
+    });
+    expect(plan.updatedSourceContent).toContain('* A');
+    expect(plan.updatedSourceContent).toContain('* B');
+    // No default bulleted link form remains:
+    expect(plan.updatedSourceContent).not.toContain('- [[a/a|A]]');
+  });
+});
+
+describe('refactoredNoteTemplate', () => {
+  it('wraps the extracted body with {{new_note_content}} token', () => {
+    const src = 'before [core content] after.';
+    const from = src.indexOf('[core content]');
+    const to = from + '[core content]'.length;
+    const plan = planExtract({
+      sourceRelativePath: 'a.md',
+      sourceContent: src,
+      selection: { from, to },
+      title: 'Core',
+      today,
+      now,
+      settings: s({
+        refactoredNoteTemplate: '> Extracted from [[{{source}}]] on {{date}}\n\n{{new_note_content}}',
+      }),
+    });
+    expect(plan.newNoteContent).toContain('> Extracted from [[a.md]] on 2026-04-19');
+    expect(plan.newNoteContent).toContain('[core content]');
+  });
+
+  it('applies to split-by-heading fragments', () => {
+    const src = '## A\n\nalpha body\n\n## B\n\nbravo body\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'notes/deck.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({
+        refactoredNoteTemplate: 'FROM {{title}}: {{new_note_content}}',
+      }),
+    });
+    // With no H1 in source, {{title}} falls back to the filename stem.
+    expect(plan.newNotes[0].content).toContain('FROM deck: ');
+    expect(plan.newNotes[0].content).toContain('alpha body');
+    expect(plan.newNotes[1].content).toContain('FROM deck: ');
+    expect(plan.newNotes[1].content).toContain('bravo body');
+  });
+
+  it('uses H1 as {{title}} when present', () => {
+    const src = '# My Source Note\n\nprelude\n\n## A\n\na body\n';
+    const plan = planSplitByHeading({
+      sourceRelativePath: 'deep/note.md',
+      sourceContent: src,
+      level: 2,
+      today,
+      now,
+      settings: s({
+        refactoredNoteTemplate: 'parent: {{title}}\n\n{{new_note_content}}',
+      }),
+    });
+    expect(plan.newNotes[0].content).toContain('parent: My Source Note');
+  });
+});


### PR DESCRIPTION
Closes #124. Closes out the note-refactoring cluster (#120–#125).

## Three controls
**Transclude by default** — extract / split commands emit \`![[new-note]]\` in the source so the preview inlines the extracted content. The new note is still a standalone file on disk.

**Link template** (multi-line) — replaces the default link-back entirely. Tokens: \`{{new_note_title}}\`, \`{{title}}\` (source H1 or filename), \`{{source}}\`, \`{{date}}\` (with \`{{date:FORMAT}}\` variants). Overrides the transclude toggle.

**Refactored note template** (multi-line) — wraps the extracted body. \`{{new_note_content}}\` expands to the raw text; users wrap it in a callout, prepend metadata, etc.

## Settings precedence
For the source-side link-back:
- \`linkTemplate\` set → render template verbatim.
- Else if \`transcludeByDefault\` → \`![[path]]\`.
- Else → plain \`[[path]]\`.

For split-by-heading's Contents list, each item follows the same rule: default is \`- [[path|title]]\`; transclude gives \`- ![[path]]\`; template replaces the line entirely.

## Implementation
Two new helpers in \`extract.ts\` — \`renderLinkBack\` and \`renderExtractedBody\` — consolidate the precedence logic. The three planners now all route through them, so adding a fourth command later only needs to call these helpers.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 395 pass (+11 for template precedence across all three commands)
- [ ] Manual: toggle Transclude by default, extract a selection, confirm preview inlines the content via \`![[…]]\`
- [ ] Manual: set link template to \`> see [[{{new_note_title}}]] — extracted from {{title}} on {{date}}\`, extract — source gets the rendered line
- [ ] Manual: set refactored note template to \`> Extracted from [[{{source}}]] on {{date}}\n\n{{new_note_content}}\`, extract — new note's body is wrapped

## Epic status
With this merged, the note-refactoring cluster from #120–#125 is complete:
- #120 extract selection — shipped
- #121 split here — shipped
- #122 split by heading — shipped
- #123 destination + filename prefix settings — shipped
- #125 heading-level normalize — shipped
- #124 link & note templates — this PR