### PR TITLE
Per-conversation model override

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -591,6 +591,7 @@ export function registerIpcHandlers(): void {
         system: effectiveSystem,
         messages,
         toolContext: { rootPath },
+        model: conv.model,
         callbacks: {
           onChunk: (chunk: string) => {
             if (!win.isDestroyed()) {
@@ -624,7 +625,12 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(Channels.CONVERSATION_CRYSTALLIZE, async (_e, text: string, conversationId: string) => {
     const convUri = `https://minerva.dev/ontology/thought#conversation/${conversationId}`;
-    return crystallize(text, convUri);
+    const conv = await conversation.load(conversationId);
+    return crystallize(text, convUri, 'llm:crystallization', conv?.model);
+  });
+
+  ipcMain.handle(Channels.CONVERSATION_SET_MODEL, async (_e, convId: string, model: string | undefined) => {
+    return conversation.setModel(convId, model);
   });
 
   // Slash commands in conversations
@@ -652,6 +658,7 @@ export function registerIpcHandlers(): void {
     try {
       const { complete: llmComplete } = await import('./llm/index');
       const output = await llmComplete(prompt, {
+        model: conv.model,
         callbacks: {
           onChunk: (chunk: string) => {
             if (!win.isDestroyed()) {

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -83,6 +83,19 @@ export async function abandon(id: string): Promise<Conversation> {
   return setStatus(id, 'abandoned');
 }
 
+/**
+ * Pin a specific model to this conversation. Pass `undefined` to clear the
+ * override so the conversation again tracks the global default.
+ */
+export async function setModel(id: string, model: string | undefined): Promise<Conversation> {
+  const conv = await load(id);
+  if (!conv) throw new Error(`Conversation not found: ${id}`);
+  if (model) conv.model = model;
+  else delete conv.model;
+  await persist(conv);
+  return conv;
+}
+
 export async function load(id: string): Promise<Conversation | null> {
   try {
     const data = await fs.readFile(convPath(id), 'utf-8');

--- a/src/main/llm/crystallize.ts
+++ b/src/main/llm/crystallize.ts
@@ -41,6 +41,7 @@ export async function crystallize(
   text: string,
   conversationUri: string,
   proposedBy: string = 'llm:crystallization',
+  model?: string,
 ): Promise<CrystallizationResult> {
   const prompt = `${CRYSTALLIZATION_PROMPT}
 
@@ -48,7 +49,7 @@ export async function crystallize(
 
 ${text}`;
 
-  const turtle = await complete(prompt);
+  const turtle = await complete(prompt, model ? { model } : undefined);
   const trimmed = turtle.trim();
 
   if (!trimmed) {

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -22,6 +22,8 @@ export interface CompleteOptions {
   system?: string;
   messages?: ChatMessage[];
   callbacks?: StreamCallbacks;
+  /** Override the global default model for this call only. */
+  model?: string;
 }
 
 export interface CompleteWithToolsOptions {
@@ -31,6 +33,8 @@ export interface CompleteWithToolsOptions {
   callbacks?: StreamCallbacks;
   /** Hard cap on tool-use iterations. Defaults to 10. */
   maxIterations?: number;
+  /** Override the global default model for this call only. */
+  model?: string;
 }
 
 export interface CompleteWithToolsResult {
@@ -65,11 +69,10 @@ export async function complete(
   prompt: string,
   callbacksOrOptions?: StreamCallbacks | CompleteOptions,
 ): Promise<string> {
-  const { client, model } = await getClient();
-
   let system: string | undefined;
   let messages: Anthropic.MessageParam[];
   let callbacks: StreamCallbacks | undefined;
+  let modelOverride: string | undefined;
 
   if (callbacksOrOptions && 'onChunk' in callbacksOrOptions) {
     callbacks = callbacksOrOptions;
@@ -78,10 +81,14 @@ export async function complete(
     const opts = callbacksOrOptions as CompleteOptions;
     system = opts.system;
     callbacks = opts.callbacks;
+    modelOverride = opts.model;
     messages = (opts.messages ?? [{ role: 'user', content: prompt }]) as Anthropic.MessageParam[];
   } else {
     messages = [{ role: 'user', content: prompt }];
   }
+
+  const { client, model: defaultModel } = await getClient();
+  const model = modelOverride ?? defaultModel;
 
   if (!callbacks) {
     const response = await client.messages.create({
@@ -117,7 +124,8 @@ export async function complete(
 export async function completeWithTools(
   options: CompleteWithToolsOptions,
 ): Promise<CompleteWithToolsResult> {
-  const { client, model, web } = await getClient();
+  const { client, model: defaultModel, web } = await getClient();
+  const model = options.model ?? defaultModel;
   const { toolContext, callbacks, maxIterations = 10 } = options;
   const messages: Anthropic.MessageParam[] = [...options.messages];
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -121,6 +121,8 @@ contextBridge.exposeInMainWorld('api', {
     cancel: () => ipcRenderer.invoke(Channels.CONVERSATION_CANCEL),
     crystallize: (text: string, conversationId: string) =>
       ipcRenderer.invoke(Channels.CONVERSATION_CRYSTALLIZE, text, conversationId),
+    setModel: (conversationId: string, model: string | undefined) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_SET_MODEL, conversationId, model),
     slashCommand: (convId: string, slashCmd: string, argText: string) =>
       ipcRenderer.invoke(Channels.CONVERSATION_SLASH_COMMAND, convId, slashCmd, argText),
   },

--- a/src/renderer/lib/components/ConversationDialog.svelte
+++ b/src/renderer/lib/components/ConversationDialog.svelte
@@ -4,6 +4,7 @@
   import { onMount } from 'svelte';
   import { getSlashCommands } from '../tools/tool-registry';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
+  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
 
   interface Props {
     onClose: () => void;
@@ -20,6 +21,19 @@
   let crystallizing = $state(false);
   let crystallizeResult = $state<{ componentCount: number } | null>(null);
   let groundingCache = new Map<string, { grounded: boolean; label?: string; type?: string }>();
+  let defaultModel = $state<string | null>(null);
+
+  onMount(async () => {
+    try {
+      const s = await api.tools.getSettings();
+      defaultModel = s.model ?? null;
+    } catch { /* settings unavailable — picker still works, "Default" just won't show a name */ }
+  });
+
+  async function handleModelChange(e: Event) {
+    const value = (e.currentTarget as HTMLSelectElement).value;
+    await conv.setModel(value || undefined);
+  }
 
   // Parse [[claim: ...]] annotations in assistant output
   function renderAnnotatedContent(text: string): string {
@@ -253,6 +267,17 @@
         <span class="conv-status">{conv.active.status}</span>
       </div>
       <div class="conv-actions">
+        <select
+          class="conv-model"
+          value={conv.active.model ?? ''}
+          onchange={handleModelChange}
+          title="Model used for this conversation"
+        >
+          <option value="">{defaultModel ? `Default (${modelLabel(defaultModel)})` : 'Default'}</option>
+          {#each MODEL_OPTIONS as m}
+            <option value={m.value}>{m.label}</option>
+          {/each}
+        </select>
         <button class="conv-btn" onclick={handleCrystallizeSelection} disabled={crystallizing} title="File selected text as thought components">File Selection</button>
         <button class="conv-btn" onclick={handleResolve} title="Resolve — file results to graph">Resolve</button>
         <button class="conv-btn" onclick={handleAbandon} title="Abandon — close without filing">Abandon</button>
@@ -391,6 +416,18 @@
   .conv-actions {
     display: flex;
     gap: 4px;
+    align-items: center;
+  }
+
+  .conv-model {
+    padding: 2px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 11px;
+    cursor: pointer;
+    max-width: 180px;
   }
 
   .conv-btn {

--- a/src/renderer/lib/components/ConversationDialog.svelte
+++ b/src/renderer/lib/components/ConversationDialog.svelte
@@ -274,7 +274,7 @@
           title="Model used for this conversation"
         >
           <option value="">{defaultModel ? `Default (${modelLabel(defaultModel)})` : 'Default'}</option>
-          {#each MODEL_OPTIONS as m}
+          {#each MODEL_OPTIONS.filter((m) => m.value !== defaultModel) as m}
             <option value={m.value}>{m.label}</option>
           {/each}
         </select>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -18,6 +18,7 @@
     type DestinationMode,
     type RefactorSettings,
   } from '../refactor/settings';
+  import { MODEL_OPTIONS } from '../../../shared/tools/models';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -93,13 +94,6 @@
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');
   let clearApiKey = $state(false);
-
-  const MODEL_OPTIONS = [
-    { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
-    { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
-    { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-    { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
-  ];
 
   // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
   let loadedLlm: LLMSettings | null = null;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -103,6 +103,7 @@ export interface ConversationsApi {
   cancel(): Promise<void>;
   crystallize(text: string, conversationId: string): Promise<{ turtle: string; componentCount: number }>;
   slashCommand(convId: string, slashCmd: string, argText: string): Promise<Conversation>;
+  setModel(conversationId: string, model: string | undefined): Promise<Conversation>;
 }
 
 export interface ProposalsApi {

--- a/src/renderer/lib/stores/conversation.svelte.ts
+++ b/src/renderer/lib/stores/conversation.svelte.ts
@@ -55,6 +55,12 @@ export function getConversationStore() {
     activeConversation = null;
   }
 
+  async function setModel(model: string | undefined): Promise<Conversation | null> {
+    if (!activeConversation) return null;
+    activeConversation = await api.conversations.setModel(activeConversation.id, model);
+    return activeConversation;
+  }
+
   return {
     get active() { return activeConversation; },
     get messages() { return activeConversation?.messages ?? []; },
@@ -68,5 +74,6 @@ export function getConversationStore() {
     resumeConversation,
     refreshList,
     close,
+    setModel,
   };
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -112,6 +112,7 @@ export const Channels = {
   CONVERSATION_CANCEL: 'conversation:cancel',
   CONVERSATION_CRYSTALLIZE: 'conversation:crystallize',
   CONVERSATION_SLASH_COMMAND: 'conversation:slashCommand',
+  CONVERSATION_SET_MODEL: 'conversation:setModel',
   GRAPH_GROUND_CHECK: 'graph:groundCheck',
   INSPECTIONS_LIST: 'inspections:list',
   INSPECTIONS_RUN: 'inspections:run',

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical list of Anthropic models surfaced in the UI.
+ *
+ * Kept in `shared/` so both the Settings dialog and the per-conversation
+ * picker read from the same source of truth. Callers that need the
+ * current default read it from LLMSettings.model, which is validated
+ * against this list.
+ */
+
+export interface ModelOption {
+  value: string;
+  label: string;
+}
+
+export const MODEL_OPTIONS: ModelOption[] = [
+  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+  { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+  { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+];
+
+export function modelLabel(value: string): string {
+  return MODEL_OPTIONS.find((m) => m.value === value)?.label ?? value;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -178,4 +178,10 @@ export interface Conversation {
   status: ConversationStatus;
   startedAt: string;
   resolvedAt?: string;
+  /**
+   * Model used for LLM calls in this conversation. `undefined` means the
+   * global default from LLMSettings — the conversation then tracks the
+   * default if the user changes it later. Once set explicitly, it sticks.
+   */
+  model?: string;
 }

--- a/tests/main/llm/conversation-model.test.ts
+++ b/tests/main/llm/conversation-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph } from '../../../src/main/graph/index';
+import {
+  initConversations,
+  create,
+  setModel,
+  load,
+} from '../../../src/main/llm/conversation';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-conv-model-test-'));
+}
+
+describe('conversation.setModel (issue #168)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+    initConversations(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('new conversations have no model override (undefined = track global default)', async () => {
+    const conv = await create({ notePath: 'x.md' });
+    expect(conv.model).toBeUndefined();
+    const reloaded = await load(conv.id);
+    expect(reloaded?.model).toBeUndefined();
+  });
+
+  it('pins a model and persists it', async () => {
+    const conv = await create({ notePath: 'x.md' });
+    await setModel(conv.id, 'claude-opus-4-7');
+    const reloaded = await load(conv.id);
+    expect(reloaded?.model).toBe('claude-opus-4-7');
+  });
+
+  it('clears the override when passed undefined', async () => {
+    const conv = await create({ notePath: 'x.md' });
+    await setModel(conv.id, 'claude-opus-4-7');
+    await setModel(conv.id, undefined);
+    const reloaded = await load(conv.id);
+    expect(reloaded?.model).toBeUndefined();
+  });
+
+  it('each conversation carries its own model independently', async () => {
+    const a = await create({ notePath: 'a.md' });
+    const b = await create({ notePath: 'b.md' });
+    await setModel(a.id, 'claude-opus-4-7');
+    await setModel(b.id, 'claude-haiku-4-5');
+
+    const reloadedA = await load(a.id);
+    const reloadedB = await load(b.id);
+    expect(reloadedA?.model).toBe('claude-opus-4-7');
+    expect(reloadedB?.model).toBe('claude-haiku-4-5');
+  });
+
+  it('throws on an unknown conversation id', async () => {
+    await expect(setModel('nope', 'claude-opus-4-7')).rejects.toThrow(/not found/i);
+  });
+});


### PR DESCRIPTION
Closes #168.

## Summary
Conversations now carry an optional model that overrides the global default. Picker lives in the ConversationDialog header; the choice persists on the \`Conversation\` JSON alongside messages; subsequent sends, slash commands, and crystallize calls honor it.

## Flow
- Default selection is \"Default (<current global model>)\", so an un-overridden conversation visibly tracks whatever the user has set in Settings.
- Picking a specific model pins it — subsequent global-default changes don't move it.
- Picking \"Default\" clears the override.

## Plumbing
- \`complete()\` and \`completeWithTools()\` accept an optional \`model\`. \`getClient()\` still reads apiKey / web from settings; only the model becomes per-call.
- \`crystallize()\` forwards a model through from the caller.
- Three IPC handlers (\`CONVERSATION_SEND\`, \`CONVERSATION_SLASH_COMMAND\`, \`CONVERSATION_CRYSTALLIZE\`) load the conversation and pass \`conv.model\` to the LLM entry points.
- New channel \`CONVERSATION_SET_MODEL\` + \`conversation.setModel()\` for the picker. Pass \`undefined\` to revert to default.

## Data shape
- \`Conversation.model?: string\` — optional. Old persisted conversations without the field keep working (undefined = follow the current global default).
- \`MODEL_OPTIONS\` lifted to \`src/shared/tools/models.ts\` so SettingsDialog and ConversationDialog share the same list.

## Fallback
Not wired explicitly — if the API rejects an unknown model the error already surfaces through the existing conversation error path. Per the issue, no auto-downgrade.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 400 pass (+5 for conversation.setModel persistence: round-trip, clearing, independence across conversations, unknown-id error)
- [ ] Manual: open a conversation, verify the picker shows \"Default (Claude Sonnet 4.6)\" or similar
- [ ] Manual: switch to Opus, send a message — assistant reply comes from Opus
- [ ] Manual: close and reopen the same conversation — picker still shows Opus
- [ ] Manual: change the global default in Settings → AI — the unpinned default-badge conversation tracks it; the Opus-pinned conversation doesn't move

## Out of scope
- #169 per-tool preferred model (follow-up, builds on this plumbing).