### PR TITLE
Per-tool preferred model + user override table

### DIFF
--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -1,12 +1,33 @@
 import { getTool } from '../../shared/tools/registry';
 import { complete } from '../llm/index';
-import type { ToolExecutionRequest, ToolExecutionResult } from '../../shared/tools/types';
+import { getSettings } from '../llm/settings';
+import type { ToolExecutionRequest, ToolExecutionResult, ThinkingToolDef, LLMSettings } from '../../shared/tools/types';
 
 // Ensure all tool definitions are registered
 import '../../shared/tools/definitions/index';
 
+/**
+ * Resolution order for which model a tool invocation runs on:
+ *   1. Explicit per-invocation override (not wired from any UI yet — reserved
+ *      for a future ad-hoc picker).
+ *   2. User's per-tool override from LLMSettings.toolModelOverrides.
+ *   3. Tool author's preferredModel on the definition.
+ *   4. Global default (LLMSettings.model). Passing undefined here lets
+ *      complete() fall back to it.
+ */
+export function resolveToolModel(
+  tool: Pick<ThinkingToolDef, 'id' | 'preferredModel'>,
+  settings: Pick<LLMSettings, 'toolModelOverrides'>,
+  perInvocation?: string,
+): string | undefined {
+  if (perInvocation) return perInvocation;
+  const userOverride = settings.toolModelOverrides?.[tool.id];
+  if (userOverride) return userOverride;
+  return tool.preferredModel;
+}
+
 export async function executeTool(
-  request: ToolExecutionRequest,
+  request: ToolExecutionRequest & { modelOverride?: string },
   onChunk?: (text: string) => void,
   signal?: AbortSignal,
 ): Promise<ToolExecutionResult> {
@@ -14,8 +35,13 @@ export async function executeTool(
   if (!tool) throw new Error(`Unknown tool: ${request.toolId}`);
 
   const prompt = tool.buildPrompt(request.context);
+  const settings = await getSettings();
+  const model = resolveToolModel(tool, settings, request.modelOverride);
 
-  const output = await complete(prompt, onChunk ? { onChunk, signal } : undefined);
+  const output = await complete(prompt, {
+    ...(onChunk ? { callbacks: { onChunk, signal } } : {}),
+    ...(model ? { model } : {}),
+  });
 
   const noteTitle = request.context.fullNoteTitle ?? 'Untitled';
   return {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -18,7 +18,9 @@
     type DestinationMode,
     type RefactorSettings,
   } from '../refactor/settings';
-  import { MODEL_OPTIONS } from '../../../shared/tools/models';
+  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+  import { getAllToolInfos } from '../tools/tool-registry';
+  import type { ThinkingToolInfo } from '../../../shared/tools/types';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -97,6 +99,8 @@
 
   // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
   let loadedLlm: LLMSettings | null = null;
+  let toolModelOverrides = $state<Record<string, string>>({});
+  const allTools: ThinkingToolInfo[] = getAllToolInfos();
 
   onMount(async () => {
     try {
@@ -108,10 +112,18 @@
       webEnabled = web.enabled;
       allowedDomainsText = web.allowedDomains.join('\n');
       blockedDomainsText = web.blockedDomains.join('\n');
+      toolModelOverrides = { ...(s.toolModelOverrides ?? {}) };
     } catch (e) {
       console.error('[settings] failed to load LLM settings:', e);
     }
   });
+
+  function setToolOverride(toolId: string, value: string) {
+    const next = { ...toolModelOverrides };
+    if (value) next[toolId] = value;
+    else delete next[toolId];
+    toolModelOverrides = next;
+  }
 
   function parseDomains(text: string): string[] {
     return text
@@ -147,6 +159,7 @@
         allowedDomains: parseDomains(allowedDomainsText),
         blockedDomains: parseDomains(blockedDomainsText),
       },
+      ...(Object.keys(toolModelOverrides).length > 0 ? { toolModelOverrides } : {}),
     };
     try {
       await api.tools.setSettings(next);
@@ -502,6 +515,46 @@
               </button>
             {/if}
           </div>
+          <div class="field">
+            <label>Tool model overrides</label>
+            <p class="hint">
+              Each tool's author may suggest a preferred model. You can override that
+              per tool. Empty override → use the tool's preference; no preference →
+              fall back to the default model above.
+            </p>
+            {#if allTools.length === 0}
+              <p class="hint">No tools registered.</p>
+            {:else}
+              <table class="tool-models">
+                <thead>
+                  <tr>
+                    <th>Tool</th>
+                    <th>Tool preference</th>
+                    <th>Your override</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each allTools as t}
+                    <tr>
+                      <td>{t.name}</td>
+                      <td class="muted">{t.preferredModel ? modelLabel(t.preferredModel) : '—'}</td>
+                      <td>
+                        <select
+                          value={toolModelOverrides[t.id] ?? ''}
+                          onchange={(e) => setToolOverride(t.id, (e.currentTarget as HTMLSelectElement).value)}
+                        >
+                          <option value="">Use tool preference</option>
+                          {#each MODEL_OPTIONS as m}
+                            <option value={m.value}>{m.label}</option>
+                          {/each}
+                        </select>
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            {/if}
+          </div>
         {/if}
       </section>
     </div>
@@ -745,6 +798,39 @@
   .btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .tool-models {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+
+  .tool-models th,
+  .tool-models td {
+    text-align: left;
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .tool-models th {
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+
+  .tool-models td.muted {
+    color: var(--text-muted);
+  }
+
+  .tool-models select {
+    padding: 3px 6px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    max-width: 170px;
   }
 
   .api-key-status {

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -45,6 +45,12 @@ export interface ThinkingToolDef {
   outputNotePrefix?: string;
   slashCommand?: string;
   buildPrompt: (ctx: ToolContext) => string;
+  /**
+   * Tool author's hint at the model that suits this tool best. User-level
+   * overrides (LLMSettings.toolModelOverrides) win over this; the global
+   * default takes over when both are absent.
+   */
+  preferredModel?: string;
 }
 
 /** Serializable subset of ThinkingToolDef sent over IPC (no functions). */
@@ -59,6 +65,7 @@ export interface ThinkingToolInfo {
   outputMode: OutputMode;
   outputNotePrefix?: string;
   slashCommand?: string;
+  preferredModel?: string;
 }
 
 export interface ToolExecutionRequest {
@@ -84,6 +91,12 @@ export interface LLMSettings {
   apiKey: string;
   model: string;
   web?: WebSettings;
+  /**
+   * User-level overrides of each tool's preferred model. Keyed by tool id.
+   * Resolution order for a tool invocation:
+   *   request.modelOverride ?? toolModelOverrides[id] ?? tool.preferredModel ?? model
+   */
+  toolModelOverrides?: Record<string, string>;
 }
 
 export const DEFAULT_WEB_SETTINGS: WebSettings = {

--- a/tests/main/tools/resolve-tool-model.test.ts
+++ b/tests/main/tools/resolve-tool-model.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { resolveToolModel } from '../../../src/main/tools/executor';
+
+const tool = (id: string, preferredModel?: string) => ({ id, preferredModel });
+
+describe('resolveToolModel (issue #169)', () => {
+  it('returns undefined when nothing is set (caller falls back to global default)', () => {
+    expect(resolveToolModel(tool('critique'), {})).toBeUndefined();
+  });
+
+  it('uses the tool author preference when no user override', () => {
+    expect(
+      resolveToolModel(tool('critique', 'claude-opus-4-7'), {}),
+    ).toBe('claude-opus-4-7');
+  });
+
+  it('user override beats the tool author preference', () => {
+    expect(
+      resolveToolModel(
+        tool('critique', 'claude-opus-4-7'),
+        { toolModelOverrides: { critique: 'claude-haiku-4-5' } },
+      ),
+    ).toBe('claude-haiku-4-5');
+  });
+
+  it('per-invocation override beats everything', () => {
+    expect(
+      resolveToolModel(
+        tool('critique', 'claude-opus-4-7'),
+        { toolModelOverrides: { critique: 'claude-haiku-4-5' } },
+        'claude-sonnet-4-6',
+      ),
+    ).toBe('claude-sonnet-4-6');
+  });
+
+  it('user override applies even when there is no tool preference', () => {
+    expect(
+      resolveToolModel(
+        tool('summarize'),
+        { toolModelOverrides: { summarize: 'claude-haiku-4-5' } },
+      ),
+    ).toBe('claude-haiku-4-5');
+  });
+
+  it('user override for a different tool is ignored', () => {
+    expect(
+      resolveToolModel(
+        tool('critique', 'claude-opus-4-7'),
+        { toolModelOverrides: { summarize: 'claude-haiku-4-5' } },
+      ),
+    ).toBe('claude-opus-4-7');
+  });
+});


### PR DESCRIPTION
Closes #169. Companion to #168 (per-conversation model).

## Summary
Tools can declare a preferred model; users can override that per tool from Settings. Resolution order at tool-execution time:

\`\`\`
request.modelOverride              (per-invocation — reserved)
?? toolModelOverrides[tool.id]     (user-set in Settings → AI)
?? tool.preferredModel             (tool author declaration)
?? settings.model                  (global default)
\`\`\`

## Surface
- \`ThinkingToolDef\` / \`ThinkingToolInfo\` gain \`preferredModel?: string\`.
- \`LLMSettings\` gains \`toolModelOverrides?: Record<toolId, modelId>\`.
- AI settings tab gets a **Tool model overrides** table: tool name · preference (read-only, shows \"—\" when unset) · user override dropdown with \"Use tool preference\" default.
- \`resolveToolModel()\` in executor.ts is the single source of truth for the precedence rules; exported and unit-tested.

## Out of scope
- Setting \`preferredModel\` on any existing tool. Deliberate — this PR lands the plumbing; tuning which tools want which model is a separate follow-up.
- The \`request.modelOverride\` per-invocation hook is accepted by \`executeTool\` but no UI sets it yet. Future ad-hoc picker work plugs in there.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 406 pass (+6 for resolveToolModel covering every precedence cell)
- [ ] Manual: open Settings → AI, scroll to the tool table. Set a tool's override to Opus. Invoke that tool — conversation / note shows it ran on Opus
- [ ] Manual: leave the override on \"Use tool preference\" and confirm the tool runs on the global default
- [ ] Manual: settings round-trip — close & reopen the dialog, overrides persist