### PR TITLE
Conversational ThinkingTool infra + Summarize (closes #179, #176)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,7 +13,7 @@ import * as savedQueries from './saved-queries';
 import { clearRecentProjects } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
-import { executeTool } from './tools/executor';
+import { executeTool, prepareConversationTool } from './tools/executor';
 import * as healthChecks from './graph/health-checks';
 import { getToolBySlashCommand } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
@@ -546,6 +546,9 @@ export function registerIpcHandlers(): void {
     }
   });
 
+  ipcMain.handle(Channels.TOOL_PREPARE_CONVERSATION, (_e, request: ToolExecutionRequest) =>
+    prepareConversationTool(request));
+
   // Proposals
   ipcMain.handle(Channels.PROPOSAL_LIST, (_e, status?: string) => approval.listProposals(status));
   ipcMain.handle(Channels.PROPOSAL_DETAIL, (_e, uri: string) => approval.getProposal(uri));
@@ -554,8 +557,8 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.PROPOSAL_EXPIRE, () => approval.expireProposals());
 
   // Conversations
-  ipcMain.handle(Channels.CONVERSATION_CREATE, (_e, contextBundle: ContextBundle, triggerNodeUri?: string, systemMessage?: string) =>
-    conversation.create(contextBundle, triggerNodeUri, systemMessage));
+  ipcMain.handle(Channels.CONVERSATION_CREATE, (_e, contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) =>
+    conversation.create(contextBundle, triggerNodeUri, options));
   ipcMain.handle(Channels.CONVERSATION_APPEND, (_e, id: string, role: ConversationMessage['role'], content: string) =>
     conversation.appendMessage(id, role, content));
   ipcMain.handle(Channels.CONVERSATION_RESOLVE, (_e, id: string) => conversation.resolve(id));
@@ -581,7 +584,10 @@ export function registerIpcHandlers(): void {
         .filter(m => m.role !== 'system')
         .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }));
 
-      const effectiveSystem = buildConversationSystemPrompt(systemPrompt, conv.contextBundle);
+      const effectiveSystem = buildConversationSystemPrompt(
+        systemPrompt ?? conv.systemPrompt,
+        conv.contextBundle,
+      );
 
       if (!rootPath) {
         throw new Error('No thoughtbase is open — cannot send conversation message.');

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -28,7 +28,7 @@ function generateId(): string {
 export async function create(
   contextBundle: ContextBundle,
   triggerNodeUri?: string,
-  initialSystemMessage?: string,
+  options?: { systemPrompt?: string; model?: string },
 ): Promise<Conversation> {
   const dir = ensureDir();
   await fs.mkdir(dir, { recursive: true });
@@ -42,10 +42,8 @@ export async function create(
     status: 'active',
     startedAt: now,
   };
-
-  if (initialSystemMessage) {
-    conv.messages.push({ role: 'system', content: initialSystemMessage, timestamp: now });
-  }
+  if (options?.systemPrompt) conv.systemPrompt = options.systemPrompt;
+  if (options?.model) conv.model = options.model;
 
   await persist(conv);
   await writeConversationToGraph(conv);

--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -1,7 +1,7 @@
 import { getTool } from '../../shared/tools/registry';
 import { complete } from '../llm/index';
 import { getSettings } from '../llm/settings';
-import type { ToolExecutionRequest, ToolExecutionResult, ThinkingToolDef, LLMSettings } from '../../shared/tools/types';
+import type { ToolExecutionRequest, ToolExecutionResult, ThinkingToolDef, LLMSettings, ConversationToolPayload } from '../../shared/tools/types';
 
 // Ensure all tool definitions are registered
 import '../../shared/tools/definitions/index';
@@ -33,6 +33,9 @@ export async function executeTool(
 ): Promise<ToolExecutionResult> {
   const tool = getTool(request.toolId);
   if (!tool) throw new Error(`Unknown tool: ${request.toolId}`);
+  if (tool.outputMode === 'openConversation') {
+    throw new Error(`Tool ${request.toolId} is conversational — use prepareConversationTool instead of executeTool.`);
+  }
 
   const prompt = tool.buildPrompt(request.context);
   const settings = await getSettings();
@@ -50,4 +53,47 @@ export async function executeTool(
     suggestedTitle: `${tool.name}: ${noteTitle}`,
     suggestedFilename: `${tool.outputNotePrefix ?? tool.id.replace('.', '-')}-${noteTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '')}.md`,
   };
+}
+
+/**
+ * Pure payload builder. Extracted so tests don't need to mock `getSettings()`.
+ * `prepareConversationTool` is the real entry point that looks up the tool
+ * and threads settings in.
+ */
+export function buildConversationPayload(
+  tool: ThinkingToolDef,
+  settings: Pick<LLMSettings, 'toolModelOverrides'>,
+  request: Pick<ToolExecutionRequest, 'context'> & { modelOverride?: string },
+): ConversationToolPayload {
+  if (tool.outputMode !== 'openConversation') {
+    throw new Error(`Tool ${tool.id} is not conversational (outputMode=${tool.outputMode}).`);
+  }
+  if (!tool.buildSystemPrompt) {
+    throw new Error(`Conversational tool ${tool.id} must define buildSystemPrompt.`);
+  }
+
+  const model = resolveToolModel(tool, settings, request.modelOverride);
+
+  return {
+    toolId: tool.id,
+    systemPrompt: tool.buildSystemPrompt(request.context),
+    firstMessage: tool.buildFirstMessage ? tool.buildFirstMessage(request.context) : '',
+    ...(model ? { model } : {}),
+    webEnabled: tool.web?.defaultEnabled ?? false,
+  };
+}
+
+/**
+ * Resolves everything needed to launch a conversation for a tool with
+ * `outputMode: 'openConversation'`: the pinned system prompt, the optional
+ * auto-first-message, the effective model, and the web hint. Does not open
+ * the conversation itself — that's the renderer's job (create, pin, show).
+ */
+export async function prepareConversationTool(
+  request: ToolExecutionRequest & { modelOverride?: string },
+): Promise<ConversationToolPayload> {
+  const tool = getTool(request.toolId);
+  if (!tool) throw new Error(`Unknown tool: ${request.toolId}`);
+  const settings = await getSettings();
+  return buildConversationPayload(tool, settings, request);
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -104,8 +104,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SHELL_OPEN_EXTERNAL, url),
   },
   conversations: {
-    create: (contextBundle: unknown, triggerNodeUri?: string, systemMessage?: string) =>
-      ipcRenderer.invoke(Channels.CONVERSATION_CREATE, contextBundle, triggerNodeUri, systemMessage),
+    create: (contextBundle: unknown, triggerNodeUri?: string, options?: unknown) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_CREATE, contextBundle, triggerNodeUri, options),
     append: (id: string, role: string, content: string) =>
       ipcRenderer.invoke(Channels.CONVERSATION_APPEND, id, role, content),
     resolve: (id: string) => ipcRenderer.invoke(Channels.CONVERSATION_RESOLVE, id),
@@ -143,6 +143,7 @@ contextBridge.exposeInMainWorld('api', {
   },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
+    prepareConversation: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_PREPARE_CONVERSATION, request),
     cancel: () => ipcRenderer.invoke(Channels.TOOL_CANCEL),
     onStream: (cb: (chunk: string) => void) => {
       ipcRenderer.on(Channels.TOOL_STREAM, (_e, chunk) => cb(chunk));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -40,6 +40,7 @@
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
+  import type { ToolContext } from '../shared/tools/types';
 
   type ViewMode = 'source' | 'preview' | 'split';
 
@@ -50,6 +51,8 @@
   const convStore = getConversationStore();
   const bookmarkStore = getBookmarksStore();
   let showConversation = $state(false);
+  /** When set, the next ConversationDialog mount auto-fires this message. Cleared after each open. */
+  let pendingAutoMessage = $state<string | undefined>(undefined);
   let showSettings = $state(false);
   let inspectionCount = $state(0);
 
@@ -511,7 +514,41 @@
         label: editor.activeFileName || editor.activeFilePath,
       } : undefined,
     };
-    await convStore.start(bundle, undefined, undefined);
+    pendingAutoMessage = undefined;
+    await convStore.start(bundle);
+    showConversation = true;
+  }
+
+  async function handleOpenConversationFromTool(invocation: { toolId: string; context: ToolContext }) {
+    let prep;
+    try {
+      prep = await api.tools.prepareConversation({
+        toolId: invocation.toolId,
+        context: invocation.context,
+      });
+    } catch (err) {
+      console.error('[tool] prepareConversation failed:', err);
+      return;
+    }
+
+    const ctx = invocation.context;
+    const notePath = ctx.fullNotePath ?? editor.activeFilePath ?? undefined;
+    const bundle: ContextBundle = {
+      notePath,
+      noteContent: ctx.fullNoteContent ?? (editor.content || undefined),
+      triggerNode: notePath ? {
+        uri: notePath,
+        type: 'minerva:Note',
+        label: ctx.fullNoteTitle ?? editor.activeFileName ?? notePath,
+      } : undefined,
+    };
+
+    await convStore.start(bundle, undefined, {
+      systemPrompt: prep.systemPrompt,
+      ...(prep.model ? { model: prep.model } : {}),
+    });
+
+    pendingAutoMessage = prep.firstMessage || undefined;
     showConversation = true;
   }
 
@@ -853,11 +890,13 @@
           <ToolPanel
             bind:this={toolPanelComponent}
             onNoteCreated={() => { notebase.refresh(); sidebar?.refreshTags(); }}
+            onOpenConversation={handleOpenConversationFromTool}
           />
           {#if showConversation}
             <ConversationDialog
               onClose={() => { showConversation = false; }}
               onNavigate={handleNavigate}
+              initialAutoMessage={pendingAutoMessage}
             />
           {/if}
         {:else if editor.activeTab?.type === 'query'}
@@ -871,6 +910,7 @@
             <ConversationDialog
               onClose={() => { showConversation = false; }}
               onNavigate={handleNavigate}
+              initialAutoMessage={pendingAutoMessage}
             />
           {/if}
         {:else if editor.activeTab?.type === 'source'}

--- a/src/renderer/lib/components/ConversationDialog.svelte
+++ b/src/renderer/lib/components/ConversationDialog.svelte
@@ -9,9 +9,11 @@
   interface Props {
     onClose: () => void;
     onNavigate?: (target: string) => void;
+    /** Auto-fired user message when the dialog mounts. Used by conversational tools. Consumed once. */
+    initialAutoMessage?: string;
   }
 
-  let { onClose, onNavigate }: Props = $props();
+  let { onClose, onNavigate, initialAutoMessage }: Props = $props();
 
   const conv = getConversationStore();
   let input = $state('');
@@ -121,6 +123,10 @@
       streamedChunks += chunk;
       scrollToBottom();
     });
+    if (initialAutoMessage && initialAutoMessage.trim()) {
+      input = initialAutoMessage;
+      requestAnimationFrame(() => { handleSend(); });
+    }
   });
 
   // Run grounding checks on claim annotations after messages render
@@ -170,7 +176,14 @@
 
     try {
       const ctx = conv.active.contextBundle;
-      let system = 'You are a thoughtful epistemic partner helping the user analyze and develop ideas in their knowledge base. When you make a substantive claim, assertion, or finding, wrap it in [[claim: your claim here]] notation so it can be checked against the knowledge base.';
+      let system: string;
+      if (conv.active.systemPrompt) {
+        // Tool-spawned conversation — use the pinned tool prompt and skip the
+        // default [[claim:]] epistemic-partner framing (the tool is in charge).
+        system = conv.active.systemPrompt;
+      } else {
+        system = 'You are a thoughtful epistemic partner helping the user analyze and develop ideas in their knowledge base. When you make a substantive claim, assertion, or finding, wrap it in [[claim: your claim here]] notation so it can be checked against the knowledge base.';
+      }
       if (ctx.noteContent) {
         system += `\n\nCurrent note content:\n${ctx.noteContent}`;
       }

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -76,6 +76,7 @@
 
   const analysisTools = getToolInfosByCategory('analysis');
   const planningTools = getToolInfosByCategory('planning');
+  const learningTools = getToolInfosByCategory('learning');
 
   let editorContainer: HTMLDivElement;
   let view: EditorView;
@@ -645,8 +646,18 @@
         <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
       </div>
     </div>
-    {#if onToolInvoke && (analysisTools.length > 0 || planningTools.length > 0)}
+    {#if onToolInvoke && (analysisTools.length > 0 || planningTools.length > 0 || learningTools.length > 0)}
       <div class="separator"></div>
+      {#if learningTools.length > 0}
+        <div class="submenu-item" onmouseenter={adjustSubmenu}>
+          <span class="submenu-trigger">Learning &#x25B8;</span>
+          <div class="submenu">
+            {#each learningTools as tool}
+              <button onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
+            {/each}
+          </div>
+        </div>
+      {/if}
       {#if analysisTools.length > 0}
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
           <span class="submenu-trigger">Analysis &#x25B8;</span>

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -2,12 +2,15 @@
   import { getToolPanelStore } from '../stores/tool-panel.svelte';
   import { handleToolOutput } from '../tools/output';
   import { api } from '../ipc/client';
+  import type { ToolContext } from '../../../shared/tools/types';
 
   interface Props {
     onNoteCreated?: () => void;
+    /** Called when the user invokes a tool whose outputMode is `openConversation`. */
+    onOpenConversation?: (invocation: { toolId: string; context: ToolContext }) => void;
   }
 
-  let { onNoteCreated }: Props = $props();
+  let { onNoteCreated, onOpenConversation }: Props = $props();
 
   const panel = getToolPanelStore();
   let paramValues = $state<Record<string, string>>({});
@@ -45,8 +48,27 @@
   }
 
   function handleRunWithParams() {
-    if (Object.keys(paramValues).length > 0) {
-      panel.startRunning($state.snapshot(paramValues));
+    const tool = panel.activeTool;
+    if (!tool) return;
+
+    const snappedParams = Object.keys(paramValues).length > 0
+      ? $state.snapshot(paramValues)
+      : undefined;
+
+    if (tool.outputMode === 'openConversation') {
+      // Fold parameter values into the context and hand off to the
+      // conversation launcher. No in-panel execution or review.
+      const ctx: ToolContext = {
+        ...$state.snapshot(panel.context),
+        ...(snappedParams ? { parameterValues: snappedParams } : {}),
+      };
+      panel.close();
+      onOpenConversation?.({ toolId: tool.id, context: ctx });
+      return;
+    }
+
+    if (snappedParams) {
+      panel.startRunning(snappedParams);
     } else {
       panel.startRunning();
     }
@@ -79,6 +101,16 @@
 
   // Called externally when panel opens in 'running' state (no params)
   export function startExecution() {
+    const tool = panel.activeTool;
+    if (!tool) return;
+
+    if (tool.outputMode === 'openConversation') {
+      const ctx: ToolContext = $state.snapshot(panel.context);
+      panel.close();
+      onOpenConversation?.({ toolId: tool.id, context: ctx });
+      return;
+    }
+
     panel.startRunning();
     executeToolRun();
   }

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,5 +1,5 @@
 import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
-import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings } from '../../../shared/tools/types';
+import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings, ConversationToolPayload } from '../../../shared/tools/types';
 
 export interface NotebaseApi {
   open(): Promise<NotebaseMeta | null>;
@@ -91,7 +91,7 @@ export interface BookmarksApi {
 }
 
 export interface ConversationsApi {
-  create(contextBundle: ContextBundle, triggerNodeUri?: string, systemMessage?: string): Promise<Conversation>;
+  create(contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }): Promise<Conversation>;
   append(id: string, role: ConversationMessage['role'], content: string): Promise<Conversation>;
   resolve(id: string): Promise<Conversation>;
   abandon(id: string): Promise<Conversation>;
@@ -121,6 +121,7 @@ export interface TabsApi {
 
 export interface ToolsApi {
   execute(request: ToolExecutionRequest): Promise<ToolExecutionResult>;
+  prepareConversation(request: ToolExecutionRequest): Promise<ConversationToolPayload>;
   cancel(): Promise<void>;
   onStream(cb: (chunk: string) => void): void;
   getSettings(): Promise<LLMSettings>;

--- a/src/renderer/lib/stores/conversation.svelte.ts
+++ b/src/renderer/lib/stores/conversation.svelte.ts
@@ -5,8 +5,12 @@ let activeConversation = $state<Conversation | null>(null);
 let allConversations = $state<Conversation[]>([]);
 
 export function getConversationStore() {
-  async function start(contextBundle: ContextBundle, triggerNodeUri?: string, systemMessage?: string): Promise<Conversation> {
-    const conv = await api.conversations.create(contextBundle, triggerNodeUri, systemMessage);
+  async function start(
+    contextBundle: ContextBundle,
+    triggerNodeUri?: string,
+    options?: { systemPrompt?: string; model?: string },
+  ): Promise<Conversation> {
+    const conv = await api.conversations.create(contextBundle, triggerNodeUri, options);
     activeConversation = conv;
     return conv;
   }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -91,6 +91,8 @@ export const Channels = {
   TOOL_CANCEL: 'tool:cancel',
   TOOL_GET_SETTINGS: 'tool:getSettings',
   TOOL_SET_SETTINGS: 'tool:setSettings',
+  /** Prepare the system prompt + first message + model for a conversational tool. */
+  TOOL_PREPARE_CONVERSATION: 'tool:prepareConversation',
 
   // Proposals
   PROPOSAL_LIST: 'proposal:list',

--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -5,3 +5,6 @@ import './analysis/excavate';
 import './planning/steelman';
 import './planning/taboo';
 import './planning/murphyjitsu';
+
+// Learning tools
+import './learning/summarize';

--- a/src/shared/tools/definitions/learning/summarize.ts
+++ b/src/shared/tools/definitions/learning/summarize.ts
@@ -1,0 +1,34 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are a summarization assistant for a note-taking thinking tool.
+
+First, produce a crisp summary of the note the user is working in. Lead with one sentence that captures the core idea, then give 3–6 bullets covering the substantive moves (claims, arguments, decisions, open questions — whatever matters). Stay concrete. Don't pad.
+
+After the first summary, stand ready to iterate. The user may ask for a different angle (bullets vs prose, shorter, longer, aimed at a specific audience), a different slice (just the arguments, just the open questions), or follow-up questions about the note's content.
+
+You have web tools available — use them when iterating if an external fact, date, or reference would ground the summary better.`;
+
+registerTool({
+  id: 'learning.summarize',
+  name: 'Summarize',
+  category: 'learning',
+  description: 'Open a conversation that summarizes the active note',
+  longDescription:
+    'Opens a conversation pre-seeded with the current note and a summarization system prompt. ' +
+    'The first response is a crisp summary; from there you can iterate (different angle, length, audience), ' +
+    'crystallize excerpts as thought components, or promote the summary into a new note.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/summarize',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note to summarize${ctx.fullNoteTitle ? ` — ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    return SYSTEM_PROMPT + noteBlock;
+  },
+  buildFirstMessage: () => 'Summarize.',
+});

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -11,7 +11,8 @@ export type OutputMode =
   | 'appendToNote'
   | 'replaceSelection'
   | 'insertAtCursor'
-  | 'multipleNotes';
+  | 'multipleNotes'
+  | 'openConversation';
 
 export interface ToolParameter {
   id: string;
@@ -33,6 +34,11 @@ export interface ToolContext {
   parameterValues?: Record<string, string>;
 }
 
+export interface ToolWebHint {
+  /** Whether the tool expects web access on by default when invoked. */
+  defaultEnabled: boolean;
+}
+
 export interface ThinkingToolDef {
   id: string;
   name: string;
@@ -44,13 +50,20 @@ export interface ThinkingToolDef {
   outputMode: OutputMode;
   outputNotePrefix?: string;
   slashCommand?: string;
+  /** Used for one-shot tools. Conversational tools use buildSystemPrompt + buildFirstMessage. */
   buildPrompt: (ctx: ToolContext) => string;
+  /** Tool-specific system prompt for `outputMode: 'openConversation'`. Stays active across all sends in the conversation. */
+  buildSystemPrompt?: (ctx: ToolContext) => string;
+  /** User message auto-fired when the conversation opens. Optional — omit to let the user type the first thing. */
+  buildFirstMessage?: (ctx: ToolContext) => string;
   /**
    * Tool author's hint at the model that suits this tool best. User-level
    * overrides (LLMSettings.toolModelOverrides) win over this; the global
    * default takes over when both are absent.
    */
   preferredModel?: string;
+  /** Web-access hint for conversational tools. Global `LLMSettings.web.enabled` still gates. */
+  web?: ToolWebHint;
 }
 
 /** Serializable subset of ThinkingToolDef sent over IPC (no functions). */
@@ -66,6 +79,7 @@ export interface ThinkingToolInfo {
   outputNotePrefix?: string;
   slashCommand?: string;
   preferredModel?: string;
+  web?: ToolWebHint;
 }
 
 export interface ToolExecutionRequest {
@@ -79,6 +93,17 @@ export interface ToolExecutionResult {
   suggestedTitle?: string;
   suggestedFilename?: string;
   sections?: { title: string; content: string }[];
+}
+
+/** Payload returned by the `prepareConversationTool` path for `outputMode: 'openConversation'`. */
+export interface ConversationToolPayload {
+  toolId: string;
+  systemPrompt: string;
+  firstMessage: string;
+  /** Model to pin on the created conversation. Undefined means track the global default. */
+  model?: string;
+  /** Whether the tool wants web access on. Actual effect also depends on global `LLMSettings.web.enabled`. */
+  webEnabled: boolean;
 }
 
 export interface WebSettings {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,4 +184,11 @@ export interface Conversation {
    * default if the user changes it later. Once set explicitly, it sticks.
    */
   model?: string;
+  /**
+   * Tool-specific system prompt pinned on the conversation. When set, every
+   * `send` uses this as the tool/user-supplied system (on top of the
+   * default tool-using system prompt built on the main side). Set when the
+   * conversation was launched from a `outputMode: 'openConversation'` tool.
+   */
+  systemPrompt?: string;
 }

--- a/tests/main/tools/build-conversation-payload.test.ts
+++ b/tests/main/tools/build-conversation-payload.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { buildConversationPayload } from '../../../src/main/tools/executor';
+import type { ThinkingToolDef, ToolContext } from '../../../src/shared/tools/types';
+
+function makeTool(partial: Partial<ThinkingToolDef> = {}): ThinkingToolDef {
+  return {
+    id: 'learning.summarize',
+    name: 'Summarize',
+    category: 'learning',
+    description: '',
+    longDescription: '',
+    context: ['fullNote'],
+    outputMode: 'openConversation',
+    buildPrompt: () => '',
+    buildSystemPrompt: () => 'System prompt.',
+    buildFirstMessage: () => 'Summarize.',
+    ...partial,
+  };
+}
+
+describe('buildConversationPayload (issue #179)', () => {
+  it('returns system prompt + first message + tool id', () => {
+    const payload = buildConversationPayload(makeTool(), {}, { context: {} });
+    expect(payload.toolId).toBe('learning.summarize');
+    expect(payload.systemPrompt).toBe('System prompt.');
+    expect(payload.firstMessage).toBe('Summarize.');
+  });
+
+  it('threads tool context through buildSystemPrompt and buildFirstMessage', () => {
+    const tool = makeTool({
+      buildSystemPrompt: (ctx: ToolContext) => `Note body: ${ctx.fullNoteContent ?? ''}`,
+      buildFirstMessage: (ctx: ToolContext) => `Summarize ${ctx.fullNoteTitle ?? ''}.`,
+    });
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      { context: { fullNoteContent: 'Hello', fullNoteTitle: 'My Note' } },
+    );
+    expect(payload.systemPrompt).toBe('Note body: Hello');
+    expect(payload.firstMessage).toBe('Summarize My Note.');
+  });
+
+  it('omits firstMessage when buildFirstMessage is undefined', () => {
+    const tool = makeTool({ buildFirstMessage: undefined });
+    const payload = buildConversationPayload(tool, {}, { context: {} });
+    expect(payload.firstMessage).toBe('');
+  });
+
+  it('carries preferredModel into the payload when no user override', () => {
+    const tool = makeTool({ preferredModel: 'claude-opus-4-7' });
+    const payload = buildConversationPayload(tool, {}, { context: {} });
+    expect(payload.model).toBe('claude-opus-4-7');
+  });
+
+  it('user override beats preferredModel (matches resolveToolModel precedence)', () => {
+    const tool = makeTool({ preferredModel: 'claude-opus-4-7' });
+    const payload = buildConversationPayload(
+      tool,
+      { toolModelOverrides: { 'learning.summarize': 'claude-haiku-4-5' } },
+      { context: {} },
+    );
+    expect(payload.model).toBe('claude-haiku-4-5');
+  });
+
+  it('omits model entirely when nothing is set (caller falls back to global default)', () => {
+    const payload = buildConversationPayload(makeTool(), {}, { context: {} });
+    expect(payload.model).toBeUndefined();
+  });
+
+  it('surfaces the tool author web hint (defaults to false)', () => {
+    expect(buildConversationPayload(makeTool(), {}, { context: {} }).webEnabled).toBe(false);
+    expect(
+      buildConversationPayload(
+        makeTool({ web: { defaultEnabled: true } }),
+        {},
+        { context: {} },
+      ).webEnabled,
+    ).toBe(true);
+  });
+
+  it('throws for non-conversational tools', () => {
+    expect(() =>
+      buildConversationPayload(makeTool({ outputMode: 'newNote' }), {}, { context: {} }),
+    ).toThrow(/not conversational/);
+  });
+
+  it('throws when buildSystemPrompt is missing', () => {
+    expect(() =>
+      buildConversationPayload(makeTool({ buildSystemPrompt: undefined }), {}, { context: {} }),
+    ).toThrow(/buildSystemPrompt/);
+  });
+});

--- a/tests/shared/tools/summarize.test.ts
+++ b/tests/shared/tools/summarize.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import '../../../src/shared/tools/definitions/index';
+import { getTool, getToolInfosByCategory } from '../../../src/shared/tools/registry';
+import { buildConversationPayload } from '../../../src/main/tools/executor';
+
+describe('learning.summarize (issue #176)', () => {
+  it('is registered under the learning category', () => {
+    const learningTools = getToolInfosByCategory('learning');
+    expect(learningTools.find((t) => t.id === 'learning.summarize')).toBeDefined();
+  });
+
+  it('is a conversational tool with web on by default', () => {
+    const tool = getTool('learning.summarize')!;
+    expect(tool.outputMode).toBe('openConversation');
+    expect(tool.web?.defaultEnabled).toBe(true);
+    expect(tool.preferredModel).toBe('claude-sonnet-4-6');
+  });
+
+  it('system prompt embeds the note content when present', () => {
+    const tool = getTool('learning.summarize')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      { context: { fullNoteContent: '# Nuclear Fusion\nFusion is when...', fullNoteTitle: 'Nuclear Fusion' } },
+    );
+    expect(payload.systemPrompt).toContain('Nuclear Fusion');
+    expect(payload.systemPrompt).toContain('Fusion is when...');
+    expect(payload.firstMessage).toBe('Summarize.');
+  });
+
+  it('system prompt still works when note content is absent', () => {
+    const tool = getTool('learning.summarize')!;
+    const payload = buildConversationPayload(tool, {}, { context: {} });
+    expect(payload.systemPrompt).toMatch(/summariz/i);
+    expect(payload.firstMessage).toBe('Summarize.');
+  });
+});


### PR DESCRIPTION
## Summary
- New `outputMode: 'openConversation'` on `ThinkingToolDef` — tools can launch a pre-seeded ConversationDialog instead of running one-shot. Closes #179.
- Summarize lands as the first **Learning**-category tool, exercising the new path end-to-end. Closes #176.
- Learning submenu wired into the editor's right-click menu (menu bar already auto-generates from tool categories).

## What lands

**#179 (infrastructure)**
- `ThinkingToolDef` additions: `buildSystemPrompt`, `buildFirstMessage`, `web.defaultEnabled`.
- `Conversation.systemPrompt` — persisted pin so every send uses the tool's system prompt (vs rebuilding the default epistemic-partner one).
- Executor: `prepareConversationTool()` returns `{ systemPrompt, firstMessage, model, webEnabled }`. Pure `buildConversationPayload()` helper extracted for unit testing (bypasses electron `app.getPath`).
- New IPC channel `TOOL_PREPARE_CONVERSATION`.
- `CONVERSATION_SEND` now falls back to `conv.systemPrompt` when the caller doesn't pass one.
- `ConversationDialog` reads `conv.active.systemPrompt` when present, and accepts a new `initialAutoMessage` prop that fires on mount — how tool-spawned conversations kick off.
- `ToolPanel` branches on `outputMode === 'openConversation'` and hands off via a new `onOpenConversation` prop; `App.svelte` wires the handler (`prepareConversation` → `convStore.start` with systemPrompt + model → show dialog with pending auto-message).

**#176 (Summarize)**
- `learning.summarize`: Sonnet-preferred, web on by default, slash command `/summarize`, auto-first-message `Summarize.`
- Category rewritten: moved out of Refactor, into Learning (per the ticket revision earlier in the cluster).

## Tests
- `buildConversationPayload` — 9 tests (precedence, omissions, errors).
- Summarize registration + payload composition — 4 tests.
- Full suite: 419 tests passing (was 406).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (419 passing)
- [x] `pnpm dev` compiles + bundles Vite/main/preload without error
- [ ] **Manual UX (verified by author):** Learning → Summarize opens ConversationDialog pre-seeded with note content; auto-fires "Summarize."; streamed summary arrives; iteration works; slash `/summarize` also works.

## Follow-ups (stacked behind this)
- #180–#187 — the remaining Learning tools; each a thin registration on top of this infrastructure.