### PR TITLE
Six Learning tools (closes #180, #181, #183, #184, #185, #186)

### DIFF
--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -8,3 +8,9 @@ import './planning/murphyjitsu';
 
 // Learning tools
 import './learning/summarize';
+import './learning/explain-like-im';
+import './learning/give-examples';
+import './learning/define-terms';
+import './learning/find-prerequisites';
+import './learning/quiz-me';
+import './learning/find-counterexamples';

--- a/src/shared/tools/definitions/learning/define-terms.ts
+++ b/src/shared/tools/definitions/learning/define-terms.ts
@@ -1,0 +1,34 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are building a glossary for the note the user is working in.
+
+Extract jargon, proper nouns, and technical terms that would genuinely puzzle someone new to the topic. Skip terms the note already defines inline. For each:
+- the term
+- a one-sentence working definition
+- (if useful) a "not to be confused with" disambiguation
+
+Use web lookup when you need a canonical definition. After the first glossary, iterate \u2014 the user may want more or fewer entries, deeper definitions, or clarification on specific terms.`;
+
+registerTool({
+  id: 'learning.define-terms',
+  name: 'Define Terms',
+  category: 'learning',
+  description: 'Extract and define jargon from the note',
+  longDescription:
+    'Opens a conversation that extracts jargon, proper nouns, and technical terms from the active note and defines each. ' +
+    'Skips terms defined inline in the note. Iterate if definitions are off or terms are missing.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/define-terms',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    return SYSTEM_PROMPT + noteBlock;
+  },
+  buildFirstMessage: () => 'Define the terms in this note.',
+});

--- a/src/shared/tools/definitions/learning/explain-like-im.ts
+++ b/src/shared/tools/definitions/learning/explain-like-im.ts
@@ -1,0 +1,59 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const AUDIENCE_PHRASES: Record<string, string> = {
+  child: 'a curious 8-year-old',
+  highschool: 'a bright high schooler',
+  undergrad: 'a motivated undergrad new to the topic',
+  expert: 'an expert in an adjacent field',
+};
+
+function audiencePhrase(value: string | undefined): string {
+  return AUDIENCE_PHRASES[value ?? 'undergrad'] ?? AUDIENCE_PHRASES.undergrad;
+}
+
+const SYSTEM_PROMPT = `You are a tutor re-explaining a note the user is working in.
+
+Tune your explanation to the audience level the user specified. Keep it accurate — simplify without falsifying. Use analogies, narrative, or concrete examples as the audience demands. You have web tools available; use them when a canonical example or external framing would help.
+
+After the first explanation, iterate with the user — different angle, different slice, a specific point in more depth.`;
+
+registerTool({
+  id: 'learning.explain-like-im',
+  name: 'Explain Like I\u2019m\u2026',
+  category: 'learning',
+  description: 'Re-explain the note at a chosen audience level',
+  longDescription:
+    'Opens a conversation that re-explains the active note tuned to an audience level — child, high schooler, undergrad, or expert in an adjacent field. ' +
+    'The first response is the re-explanation; from there you can iterate on angle, depth, or specific confusing points.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/eli',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  parameters: [
+    {
+      id: 'audience',
+      label: 'Audience level',
+      type: 'select',
+      options: [
+        { label: 'Child \u2014 a curious 8-year-old', value: 'child' },
+        { label: 'High schooler', value: 'highschool' },
+        { label: 'Undergrad new to the topic', value: 'undergrad' },
+        { label: 'Expert in an adjacent field', value: 'expert' },
+      ],
+      defaultValue: 'undergrad',
+      required: true,
+    },
+  ],
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    const phrase = audiencePhrase(ctx.parameterValues?.audience);
+    return `${SYSTEM_PROMPT}\n\nAudience: ${phrase}.${noteBlock}`;
+  },
+  buildFirstMessage: (ctx: ToolContext) =>
+    `Explain this like I\u2019m ${audiencePhrase(ctx.parameterValues?.audience)}.`,
+});

--- a/src/shared/tools/definitions/learning/find-counterexamples.ts
+++ b/src/shared/tools/definitions/learning/find-counterexamples.ts
@@ -1,0 +1,33 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are finding where the note\u2019s claims break down.
+
+Identify edge cases, failure modes, historical exceptions, or scenarios where reasonable readers should disagree. For each:
+- state the counterexample crisply
+- give one sentence on why the claim falters there
+
+Draw from web search when a real-world case would strengthen the counterexample. Rank from most damaging to most marginal. After the first list, iterate with the user \u2014 they may want to dig into one counterexample, generate more in a particular category, or steelman the original claim back against the counterexamples.`;
+
+registerTool({
+  id: 'learning.find-counterexamples',
+  name: 'Find Counterexamples',
+  category: 'learning',
+  description: 'Where does this note\u2019s argument break down?',
+  longDescription:
+    'Opens a conversation that generates edge cases, failure modes, and situations where the note\u2019s claims break down. ' +
+    'Ordered from most damaging to most marginal, each with a brief reason.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/counterexamples',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    return SYSTEM_PROMPT + noteBlock;
+  },
+  buildFirstMessage: () => 'Where does this break down?',
+});

--- a/src/shared/tools/definitions/learning/find-prerequisites.ts
+++ b/src/shared/tools/definitions/learning/find-prerequisites.ts
@@ -1,0 +1,31 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are mapping what a reader needs to know before the note below will make sense.
+
+Identify the concepts, facts, or skills a reader needs in hand. Order from most fundamental to closest-adjacent. For each, give one sentence on why it\u2019s prerequisite \u2014 what the note assumes the reader already has.
+
+Use web search when a prerequisite is itself a technical term you need to look up. After the first list, iterate with the user \u2014 they may want a shorter curriculum, more depth on one prerequisite, or pointers to resources for learning it.`;
+
+registerTool({
+  id: 'learning.find-prerequisites',
+  name: 'Find Prerequisites',
+  category: 'learning',
+  description: 'List concepts to understand before tackling this note',
+  longDescription:
+    'Opens a conversation that lists the concepts, facts, or skills a reader should understand before tackling the active note. ' +
+    'Ordered from most fundamental to closest-adjacent, with a one-sentence rationale per item.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/prerequisites',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    return SYSTEM_PROMPT + noteBlock;
+  },
+  buildFirstMessage: () => 'What should I know before reading this?',
+});

--- a/src/shared/tools/definitions/learning/give-examples.ts
+++ b/src/shared/tools/definitions/learning/give-examples.ts
@@ -1,0 +1,31 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are illustrating the claims or concepts in a note with concrete examples.
+
+Produce 3\u20135 varied examples. Prefer real-world cases. Span multiple domains when the note\u2019s claim is general enough to warrant it. Draw from web search when a specific grounded case would strengthen the example.
+
+Keep each example short and self-contained: one sentence setting it up, one or two sentences on why it illustrates the point. After the first set, iterate with the user \u2014 different domains, more extreme cases, a single example in more depth, etc.`;
+
+registerTool({
+  id: 'learning.give-examples',
+  name: 'Give Examples',
+  category: 'learning',
+  description: 'Generate concrete examples illustrating the note',
+  longDescription:
+    'Opens a conversation that produces 3\u20135 concrete, varied examples of the claims or concepts in the active note. ' +
+    'Iterate if the examples miss the point or if you want them from a different domain.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/examples',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    return SYSTEM_PROMPT + noteBlock;
+  },
+  buildFirstMessage: () => 'Give me examples.',
+});

--- a/src/shared/tools/definitions/learning/quiz-me.ts
+++ b/src/shared/tools/definitions/learning/quiz-me.ts
@@ -1,0 +1,56 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const DIFFICULTY_DIRECTIVES: Record<string, string> = {
+  recall: 'Focus on factual recall \u2014 terms, definitions, direct statements from the note.',
+  apply: 'Focus on application and inference \u2014 ask the user to apply the note\u2019s claims to new cases, draw out implications, or identify which claim explains a given situation.',
+  synthesis: 'Focus on cross-topic synthesis and stress cases \u2014 ask the user to connect the note\u2019s ideas to other domains, find tensions between claims, or defend the claims against a counterexample you supply.',
+};
+
+function difficultyDirective(value: string | undefined): string {
+  return DIFFICULTY_DIRECTIVES[value ?? 'apply'] ?? DIFFICULTY_DIRECTIVES.apply;
+}
+
+const SYSTEM_PROMPT = `You are a quiz master testing the user\u2019s understanding of a note they wrote.
+
+Ask one question at a time. When the user answers, grade honestly (**correct**, **partial**, or **incorrect**), explain the full answer, then ask the next question. Adapt difficulty to their performance \u2014 go harder if they\u2019re breezing through, back off if they\u2019re struggling. Aim for 5\u201310 questions unless the user stops earlier.
+
+End with a one-paragraph assessment of which areas they\u2019ve mastered and which need more work.`;
+
+registerTool({
+  id: 'learning.quiz-me',
+  name: 'Quiz Me',
+  category: 'learning',
+  description: 'Test your understanding of the note with graded questions',
+  longDescription:
+    'Opens a conversation where an LLM quizzes you on the active note. Ask a question, grade your answer, explain, repeat. ' +
+    'Adjusts difficulty to your performance and wraps with an assessment of strong and weak areas.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/quiz',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  parameters: [
+    {
+      id: 'difficulty',
+      label: 'Difficulty',
+      type: 'select',
+      options: [
+        { label: 'Recall \u2014 facts and definitions', value: 'recall' },
+        { label: 'Apply \u2014 application and inference', value: 'apply' },
+        { label: 'Synthesis \u2014 cross-topic and stress cases', value: 'synthesis' },
+      ],
+      defaultValue: 'apply',
+      required: true,
+    },
+  ],
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    const directive = difficultyDirective(ctx.parameterValues?.difficulty);
+    return `${SYSTEM_PROMPT}\n\nDifficulty focus: ${directive}${noteBlock}`;
+  },
+  buildFirstMessage: () => 'Quiz me.',
+});

--- a/tests/shared/tools/learning-tools.test.ts
+++ b/tests/shared/tools/learning-tools.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import '../../../src/shared/tools/definitions/index';
+import { getTool, getToolInfosByCategory } from '../../../src/shared/tools/registry';
+import { buildConversationPayload } from '../../../src/main/tools/executor';
+
+const BATCH = [
+  'learning.summarize',
+  'learning.explain-like-im',
+  'learning.give-examples',
+  'learning.define-terms',
+  'learning.find-prerequisites',
+  'learning.quiz-me',
+  'learning.find-counterexamples',
+];
+
+describe('Learning tools batch (issues #180, #181, #183, #184, #185, #186)', () => {
+  it('all tools are registered under the learning category', () => {
+    const ids = getToolInfosByCategory('learning').map((t) => t.id);
+    for (const id of BATCH) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it.each(BATCH)('%s is conversational, web-on, Sonnet-preferred', (id) => {
+    const tool = getTool(id)!;
+    expect(tool.outputMode).toBe('openConversation');
+    expect(tool.web?.defaultEnabled).toBe(true);
+    expect(tool.preferredModel).toBe('claude-sonnet-4-6');
+    expect(tool.buildSystemPrompt).toBeDefined();
+    expect(tool.buildFirstMessage).toBeDefined();
+  });
+
+  it.each(BATCH)('%s has a slash command', (id) => {
+    const tool = getTool(id)!;
+    expect(tool.slashCommand).toMatch(/^\//);
+  });
+
+  it('explain-like-im threads audience into system + first message', () => {
+    const tool = getTool('learning.explain-like-im')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      { context: { fullNoteContent: 'Body.', parameterValues: { audience: 'child' } } },
+    );
+    expect(payload.systemPrompt).toContain('8-year-old');
+    expect(payload.firstMessage).toContain('8-year-old');
+  });
+
+  it('explain-like-im defaults to undergrad when audience is unset', () => {
+    const tool = getTool('learning.explain-like-im')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      { context: { fullNoteContent: 'Body.' } },
+    );
+    expect(payload.systemPrompt).toContain('undergrad');
+    expect(payload.firstMessage).toContain('undergrad');
+  });
+
+  it('quiz-me threads difficulty into the system prompt', () => {
+    const tool = getTool('learning.quiz-me')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      { context: { fullNoteContent: 'Body.', parameterValues: { difficulty: 'synthesis' } } },
+    );
+    expect(payload.systemPrompt).toMatch(/cross-topic synthesis|stress cases/i);
+    expect(payload.firstMessage).toBe('Quiz me.');
+  });
+
+  it('give-examples, define-terms, find-prerequisites, find-counterexamples embed note content', () => {
+    for (const id of ['learning.give-examples', 'learning.define-terms', 'learning.find-prerequisites', 'learning.find-counterexamples']) {
+      const tool = getTool(id)!;
+      const payload = buildConversationPayload(
+        tool,
+        {},
+        { context: { fullNoteContent: 'distinctive-body-token', fullNoteTitle: 'Important Note' } },
+      );
+      expect(payload.systemPrompt).toContain('distinctive-body-token');
+      expect(payload.systemPrompt).toContain('Important Note');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Six new Learning-category tools, all thin registrations on the conversational-tool infrastructure from #179.
- Each opens a ConversationDialog pre-seeded with the note + a tool-specific system prompt, auto-fires a first user message, and iterates from there.

| Tool | Slash | Notes |
|------|-------|-------|
| Explain Like I\u2019m\u2026 | `/eli` | Audience select (child / highschool / undergrad / expert) threaded into system + first message |
| Give Examples | `/examples` | 3\u20135 concrete examples from multiple domains |
| Define Terms | `/define-terms` | Glossary of jargon, skipping terms defined inline |
| Find Prerequisites | `/prerequisites` | Ordered most-fundamental to closest-adjacent |
| Quiz Me | `/quiz` | Difficulty select (recall / apply / synthesis), one question at a time with grading |
| Find Counterexamples | `/counterexamples` | Ranked most-damaging to most-marginal |

All: Sonnet-preferred, web on by default.

## Tests
- 19 new registration + parameter-substitution tests
- Full suite: 438 passing (was 419)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (438 passing)
- [ ] Manual UX: each tool from **Learning** menu (title bar + editor right-click), Explain-Like-I\u2019m and Quiz-Me in both the parameter-configure path and the post-run behavior
- [ ] Slash commands inside an existing conversation still work (`/eli`, `/examples`, etc.)

## Out of scope / follow-ups
- **#182 Create Learning Journey** \u2014 depends on #178 Decompose; needs a separate ticket-by-ticket sequence.
- **#187 Deep Dive on Term** \u2014 requires a text selection; needs menu enablement + UI nudge for selection-required tools.