### PR TITLE
Menu order + model-picker default for conversational tools

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -311,6 +311,18 @@ export function rebuildMenu(): void {
       ],
     },
 
+    // Tools for Thought — dynamic menus from tool registry
+    ...CATEGORIES
+      .filter(cat => getToolsByCategory(cat.id).length > 0)
+      .map(cat => ({
+        label: cat.label,
+        submenu: getToolsByCategory(cat.id).map(tool => ({
+          label: tool.name,
+          sublabel: tool.description,
+          click: () => send(Channels.TOOL_INVOKE, tool.id),
+        })),
+      } as Electron.MenuItemConstructorOptions)),
+
     // Git
     {
       label: 'Git',
@@ -426,18 +438,6 @@ export function rebuildMenu(): void {
         },
       ],
     },
-
-    // Tools for Thought — dynamic menus from tool registry
-    ...CATEGORIES
-      .filter(cat => getToolsByCategory(cat.id).length > 0)
-      .map(cat => ({
-        label: cat.label,
-        submenu: getToolsByCategory(cat.id).map(tool => ({
-          label: tool.name,
-          sublabel: tool.description,
-          click: () => send(Channels.TOOL_INVOKE, tool.id),
-        })),
-      } as Electron.MenuItemConstructorOptions)),
 
     // Window (macOS)
     ...(isMac

--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -59,10 +59,16 @@ export async function executeTool(
  * Pure payload builder. Extracted so tests don't need to mock `getSettings()`.
  * `prepareConversationTool` is the real entry point that looks up the tool
  * and threads settings in.
+ *
+ * If the resolved model equals the global default, the payload omits `model`
+ * entirely — the conversation tracks the default instead of pinning a
+ * redundant value. Without this, the ConversationDialog model picker
+ * renders blank (its filter already drops the default option to avoid a
+ * duplicate, so the pinned-but-same-as-default value matches no option).
  */
 export function buildConversationPayload(
   tool: ThinkingToolDef,
-  settings: Pick<LLMSettings, 'toolModelOverrides'>,
+  settings: Pick<LLMSettings, 'toolModelOverrides' | 'model'>,
   request: Pick<ToolExecutionRequest, 'context'> & { modelOverride?: string },
 ): ConversationToolPayload {
   if (tool.outputMode !== 'openConversation') {
@@ -72,7 +78,8 @@ export function buildConversationPayload(
     throw new Error(`Conversational tool ${tool.id} must define buildSystemPrompt.`);
   }
 
-  const model = resolveToolModel(tool, settings, request.modelOverride);
+  const resolved = resolveToolModel(tool, settings, request.modelOverride);
+  const model = resolved && resolved !== settings.model ? resolved : undefined;
 
   return {
     toolId: tool.id,

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -43,8 +43,8 @@ function toInfo(tool: ThinkingToolDef): ThinkingToolInfo {
 }
 
 export const CATEGORIES: { id: ToolCategory; label: string }[] = [
+  { id: 'learning', label: 'Learning' },
   { id: 'analysis', label: 'Analysis' },
   { id: 'planning', label: 'Planning' },
-  { id: 'learning', label: 'Learning' },
   { id: 'research', label: 'Research' },
 ];

--- a/tests/main/tools/build-conversation-payload.test.ts
+++ b/tests/main/tools/build-conversation-payload.test.ts
@@ -67,6 +67,26 @@ describe('buildConversationPayload (issue #179)', () => {
     expect(payload.model).toBeUndefined();
   });
 
+  it('omits model when the resolved pin equals the global default (avoids duplicate picker option)', () => {
+    const tool = makeTool({ preferredModel: 'claude-sonnet-4-6' });
+    const payload = buildConversationPayload(
+      tool,
+      { model: 'claude-sonnet-4-6' },
+      { context: {} },
+    );
+    expect(payload.model).toBeUndefined();
+  });
+
+  it('keeps the pin when the resolved model differs from the global default', () => {
+    const tool = makeTool({ preferredModel: 'claude-opus-4-7' });
+    const payload = buildConversationPayload(
+      tool,
+      { model: 'claude-sonnet-4-6' },
+      { context: {} },
+    );
+    expect(payload.model).toBe('claude-opus-4-7');
+  });
+
   it('surfaces the tool author web hint (defaults to false)', () => {
     expect(buildConversationPayload(makeTool(), {}, { context: {} }).webEnabled).toBe(false);
     expect(


### PR DESCRIPTION
## Summary
Two small fixes surfaced while smoke-testing the Learning-tools batch.

- **Menu order**: Learning now sits before Analysis; Git and Graph moved to after the tool categories (Learning, Analysis, Planning, Research).
- **Model picker default was blank**: `buildConversationPayload` now drops the model pin when it equals the global default. The ConversationDialog picker filters out the default option (to avoid a duplicate), so a tool whose `preferredModel` equaled the user's default pinned a value that matched no remaining `<option>`.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` \u2014 440 passing (2 new tests for the default-equality behavior)
- [ ] Menu bar shows: \u2026 Navigate, Learning, Analysis, Planning, Git, Graph, \u2026
- [ ] Launch a Learning tool; model picker shows "Default (Sonnet 4.6)" selected (not blank)