### PR TITLE
Create Learning Journey + Deep Dive on Term (closes #182, #187)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -652,7 +652,7 @@
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
           <span class="submenu-trigger">Learning &#x25B8;</span>
           <div class="submenu">
-            {#each learningTools as tool}
+            {#each learningTools.filter((t) => contextMenu!.hasSelection || !t.requiresSelection) as tool}
               <button onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
             {/each}
           </div>

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -62,6 +62,10 @@
         ...$state.snapshot(panel.context),
         ...(snappedParams ? { parameterValues: snappedParams } : {}),
       };
+      if (tool.requiresSelection && !ctx.selectedText?.trim()) {
+        panel.fail(`${tool.name} needs a text selection. Highlight some text in the editor and try again.`);
+        return;
+      }
       panel.close();
       onOpenConversation?.({ toolId: tool.id, context: ctx });
       return;
@@ -106,6 +110,10 @@
 
     if (tool.outputMode === 'openConversation') {
       const ctx: ToolContext = $state.snapshot(panel.context);
+      if (tool.requiresSelection && !ctx.selectedText?.trim()) {
+        panel.fail(`${tool.name} needs a text selection. Highlight some text in the editor and try again.`);
+        return;
+      }
       panel.close();
       onOpenConversation?.({ toolId: tool.id, context: ctx });
       return;

--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -14,3 +14,5 @@ import './learning/define-terms';
 import './learning/find-prerequisites';
 import './learning/quiz-me';
 import './learning/find-counterexamples';
+import './learning/create-learning-journey';
+import './learning/deep-dive';

--- a/src/shared/tools/definitions/learning/create-learning-journey.ts
+++ b/src/shared/tools/definitions/learning/create-learning-journey.ts
@@ -1,0 +1,39 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are designing an ordered learning path that ends at mastery of the note\u2019s topic.
+
+First, propose a numbered journey of 3\u20138 stops. For each stop:
+- **Name** the stop in 2\u20135 words
+- **What you\u2019ll learn** \u2014 one sentence
+- **Prerequisites** \u2014 note what the previous stop must have established; if none, say so
+- **Why this stop** \u2014 one sentence on how it advances toward the note\u2019s topic
+
+After the first journey, iterate with the user. They may want more stops, fewer, a different starting assumption (e.g. "assume I already know X"), or to skip/merge specific stops.
+
+If the user likes the journey and wants it split into notes \u2014 one parent index plus a child note per stop \u2014 describe that split clearly and say "ready to decompose when you are." The split flow itself is handled by the Decompose Note feature and is not yet wired to this conversation.
+
+Use web search when a stop is a term you need to look up for accuracy.`;
+
+registerTool({
+  id: 'learning.create-learning-journey',
+  name: 'Create Learning Journey',
+  category: 'learning',
+  description: 'Design an ordered learning path ending at mastery',
+  longDescription:
+    'Opens a conversation that proposes an ordered learning path from "where the user is now" to "understanding the note\u2019s topic." ' +
+    'Iterate to shape the journey; follow up with Decompose Note if you want to split it into a parent index plus per-stop sub-notes.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/learning-journey',
+  preferredModel: 'claude-opus-4-7',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    return SYSTEM_PROMPT + noteBlock;
+  },
+  buildFirstMessage: () => 'Build me a learning journey.',
+});

--- a/src/shared/tools/definitions/learning/deep-dive.ts
+++ b/src/shared/tools/definitions/learning/deep-dive.ts
@@ -1,0 +1,64 @@
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const DEPTH_DIRECTIVES: Record<string, string> = {
+  overview: 'Single paragraph. Cover the term\u2019s meaning and its role in the note\u2019s context in under 150 words.',
+  standard: 'Around 500 words. Cover mechanism, brief history, usage today, and one or two common misconceptions. Concrete examples welcome.',
+  exhaustive: 'Multi-section dive suitable for promoting to its own note. Cover mechanism, history, usage, misconceptions, adjacent concepts, and where someone would go to learn more. Cite web sources when an outside fact is load-bearing.',
+};
+
+function depthDirective(value: string | undefined): string {
+  return DEPTH_DIRECTIVES[value ?? 'standard'] ?? DEPTH_DIRECTIVES.standard;
+}
+
+const SYSTEM_PROMPT = `You are deep-diving a term or phrase the user selected in their note.
+
+Use the surrounding note to calibrate depth and angle \u2014 don\u2019t repeat what the note already establishes about the term. Focus on explaining mechanism, history, usage, and common misconceptions. Draw from web search freely; cite when web evidence is load-bearing.
+
+After the first response, iterate with the user \u2014 they may want more depth on one facet, a different angle, or to promote the result to a note.`;
+
+registerTool({
+  id: 'learning.deep-dive',
+  name: 'Deep Dive on Term',
+  category: 'learning',
+  description: 'Expand a selected term into a fuller explanation',
+  longDescription:
+    'Opens a conversation that deep-dives a selected word or phrase, using the surrounding note as secondary context. ' +
+    'Pick a depth \u2014 overview, standard (~500 words), or exhaustive (multi-section). The exhaustive mode is designed to be note-worthy; promote via Create Note from Conversation when ready.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  slashCommand: '/deep-dive',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  requiresSelection: true,
+  parameters: [
+    {
+      id: 'depth',
+      label: 'Depth',
+      type: 'select',
+      options: [
+        { label: 'Overview \u2014 one paragraph', value: 'overview' },
+        { label: 'Standard \u2014 ~500 words', value: 'standard' },
+        { label: 'Exhaustive \u2014 multi-section dive', value: 'exhaustive' },
+      ],
+      defaultValue: 'standard',
+      required: true,
+    },
+  ],
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const selected = ctx.selectedText?.trim();
+    if (!selected) {
+      throw new Error('Deep Dive on Term requires a text selection.');
+    }
+    const noteBlock = ctx.fullNoteContent
+      ? `\n\n## Surrounding note${ctx.fullNoteTitle ? ` \u2014 ${ctx.fullNoteTitle}` : ''}\n\n${ctx.fullNoteContent}`
+      : '';
+    const directive = depthDirective(ctx.parameterValues?.depth);
+    return `${SYSTEM_PROMPT}\n\nTerm to deep-dive: **${selected}**\n\nDepth: ${directive}${noteBlock}`;
+  },
+  buildFirstMessage: (ctx: ToolContext) => {
+    const selected = ctx.selectedText?.trim() ?? '\u2026';
+    return `Explain "${selected}" in depth.`;
+  },
+});

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -64,6 +64,8 @@ export interface ThinkingToolDef {
   preferredModel?: string;
   /** Web-access hint for conversational tools. Global `LLMSettings.web.enabled` still gates. */
   web?: ToolWebHint;
+  /** When true, the tool refuses to run without a non-empty `ctx.selectedText`. The editor right-click hides it, the menu-bar entry fails fast with a clear error. */
+  requiresSelection?: boolean;
 }
 
 /** Serializable subset of ThinkingToolDef sent over IPC (no functions). */
@@ -80,6 +82,7 @@ export interface ThinkingToolInfo {
   slashCommand?: string;
   preferredModel?: string;
   web?: ToolWebHint;
+  requiresSelection?: boolean;
 }
 
 export interface ToolExecutionRequest {

--- a/tests/shared/tools/learning-tools.test.ts
+++ b/tests/shared/tools/learning-tools.test.ts
@@ -11,6 +11,8 @@ const BATCH = [
   'learning.find-prerequisites',
   'learning.quiz-me',
   'learning.find-counterexamples',
+  'learning.create-learning-journey',
+  'learning.deep-dive',
 ];
 
 describe('Learning tools batch (issues #180, #181, #183, #184, #185, #186)', () => {
@@ -21,13 +23,46 @@ describe('Learning tools batch (issues #180, #181, #183, #184, #185, #186)', () 
     }
   });
 
-  it.each(BATCH)('%s is conversational, web-on, Sonnet-preferred', (id) => {
+  it.each(BATCH)('%s is conversational + web-on', (id) => {
     const tool = getTool(id)!;
     expect(tool.outputMode).toBe('openConversation');
     expect(tool.web?.defaultEnabled).toBe(true);
-    expect(tool.preferredModel).toBe('claude-sonnet-4-6');
+    expect(tool.preferredModel).toMatch(/^claude-(sonnet|opus|haiku)-/);
     expect(tool.buildSystemPrompt).toBeDefined();
     expect(tool.buildFirstMessage).toBeDefined();
+  });
+
+  it('create-learning-journey is Opus-preferred (richer planning)', () => {
+    expect(getTool('learning.create-learning-journey')!.preferredModel).toBe('claude-opus-4-7');
+  });
+
+  it('deep-dive is marked requiresSelection', () => {
+    expect(getTool('learning.deep-dive')!.requiresSelection).toBe(true);
+  });
+
+  it('deep-dive threads selected text + depth into system prompt and first message', () => {
+    const tool = getTool('learning.deep-dive')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      {
+        context: {
+          selectedText: 'entropy',
+          fullNoteContent: 'Thermodynamics notes.',
+          parameterValues: { depth: 'exhaustive' },
+        },
+      },
+    );
+    expect(payload.systemPrompt).toContain('entropy');
+    expect(payload.systemPrompt.toLowerCase()).toContain('multi-section');
+    expect(payload.firstMessage).toBe('Explain "entropy" in depth.');
+  });
+
+  it('deep-dive throws without a selection (matches requiresSelection contract)', () => {
+    const tool = getTool('learning.deep-dive')!;
+    expect(() =>
+      buildConversationPayload(tool, {}, { context: { fullNoteContent: 'body' } }),
+    ).toThrow(/requires a text selection/);
   });
 
   it.each(BATCH)('%s has a slash command', (id) => {


### PR DESCRIPTION
## Summary
Finishes the Learning-category tool set. Two new tools plus a small infra addition for selection-required tools.

- **Create Learning Journey** (`#182`) \u2014 Opus-preferred conversational tool that proposes a 3\u20138 stop ordered path to mastery of the note\u2019s topic. Iterate with the user on scope and starting assumptions. *The Decompose-based split-into-notes step is scoped to a follow-up \u2014 `#178` isn\u2019t implemented yet; the system prompt tells the LLM to say "ready to decompose when you are" so users can request Decompose manually once that ticket lands.*
- **Deep Dive on Term** (`#187`) \u2014 takes a selected word or phrase, deep-dives at a chosen depth (overview / standard / exhaustive), using the surrounding note as secondary context.

## New infra: `requiresSelection`
New optional `ThinkingToolDef.requiresSelection` flag. When true:
- The **editor right-click** Learning submenu hides the tool when `contextMenu.hasSelection === false`.
- The **tool panel** fails fast with "\u2026needs a text selection" if invoked (e.g. from the menu bar) without one, instead of handing off to the conversation launcher.
- The tool\u2019s `buildSystemPrompt` also throws as a final backstop.

## Tests
- 8 new tests covering the selection contract, depth parameter, Opus-preferred journey tool, and the expanded registration batch
- Full suite: 448 passing (was 440)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (448 passing)
- [ ] Learning \u2192 Create Learning Journey with a note open; conversation opens with Opus; iterate
- [ ] Right-click the editor with no selection: Deep Dive hidden from Learning submenu
- [ ] Select a word, right-click: Deep Dive visible; invoke with each depth; conversation opens with the selected term
- [ ] Deep Dive via menu bar with no selection: tool panel shows "needs a text selection" error

## Follow-ups
- Wire Create Learning Journey\u2019s "ready to decompose" affordance to #178\u2019s preview/apply flow once Decompose Note lands.
- Placing the upcoming Refactor menu before Learning in the menu bar (per recent user direction).