### PR TITLE
Refactor menu + Move command (closes #172, #173)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -311,6 +311,19 @@ export function rebuildMenu(): void {
       ],
     },
 
+    // Refactor — single surface for every refactor-style command (issue #172).
+    {
+      label: 'Refactor',
+      submenu: [
+        { label: 'Rename\u2026', click: () => send(Channels.MENU_REFACTOR_RENAME) },
+        { label: 'Move\u2026', click: () => send(Channels.MENU_REFACTOR_MOVE) },
+        { type: 'separator' },
+        { label: 'Extract Selection to New Note', click: () => send(Channels.MENU_REFACTOR_EXTRACT) },
+        { label: 'Split Note Here', click: () => send(Channels.MENU_REFACTOR_SPLIT_HERE) },
+        { label: 'Split by Heading\u2026', click: () => send(Channels.MENU_REFACTOR_SPLIT_BY_HEADING) },
+      ],
+    },
+
     // Tools for Thought — dynamic menus from tool registry
     ...CATEGORIES
       .filter(cat => getToolsByCategory(cat.id).length > 0)

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -239,6 +239,21 @@ contextBridge.exposeInMainWorld('api', {
     onOpenInTerminal: (cb: () => void) => {
       ipcRenderer.on('menu:openInTerminal', () => cb());
     },
+    onRefactorRename: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_RENAME, () => cb());
+    },
+    onRefactorMove: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_MOVE, () => cb());
+    },
+    onRefactorExtract: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_EXTRACT, () => cb());
+    },
+    onRefactorSplitHere: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_SPLIT_HERE, () => cb());
+    },
+    onRefactorSplitByHeading: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_SPLIT_BY_HEADING, () => cb());
+    },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -428,6 +428,33 @@
     await notebase.refresh();
   }
 
+  async function handleMoveWithPrompt(relativePath: string) {
+    if (!notebase.meta) return;
+    const fileName = relativePath.split('/').pop()!;
+    const currentDir = relativePath.includes('/') ? relativePath.substring(0, relativePath.lastIndexOf('/')) : '';
+    const raw = await showPrompt(`Move "${fileName}" to folder (leave empty for root):`);
+    if (raw === null) return;
+    const destDir = raw.trim().replace(/^\/+|\/+$/g, '');
+    if (destDir === currentDir) return;
+    const newPath = destDir ? `${destDir}/${fileName}` : fileName;
+
+    let collision = false;
+    try {
+      await api.notebase.readFile(newPath);
+      collision = true;
+    } catch { /* expected: dest doesn't exist */ }
+    if (collision) {
+      await showConfirm(
+        `A file already exists at "${newPath}". Move cancelled.`,
+        CONFIRM_KEYS.moveCollision,
+        'OK',
+      );
+      return;
+    }
+
+    await handleMove(relativePath, destDir);
+  }
+
   function recordCurrentPosition() {
     const activeTab = editor.activeTab;
     if (!activeTab) return;
@@ -698,6 +725,13 @@
     api.menu.onOpenInTerminal(() => { api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
     api.menu.onOpenSettings(() => { showSettings = true; });
 
+    // Refactor menu (issue #172)
+    api.menu.onRefactorRename(() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); });
+    api.menu.onRefactorMove(() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); });
+    api.menu.onRefactorExtract(() => handleExtractSelection());
+    api.menu.onRefactorSplitHere(() => handleSplitHere());
+    api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
+
     // Notebase rename/rewrite notifications from main — keep open tabs
     // consistent with disk so the next auto-save doesn't overwrite a
     // link rewrite silently.
@@ -854,6 +888,8 @@
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
                     onSplitByHeading={handleSplitByHeading}
+                    onRename={() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); }}
+                    onMove={() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -50,6 +50,8 @@
     onExtractSelection?: () => void;
     onSplitHere?: () => void;
     onSplitByHeading?: () => void;
+    onRename?: () => void;
+    onMove?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -71,6 +73,8 @@
     onExtractSelection,
     onSplitHere,
     onSplitByHeading,
+    onRename,
+    onMove,
     getNotePaths,
   }: Props = $props();
 
@@ -680,10 +684,19 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
+          {#if onRename}
+            <button onclick={() => handleMenuAction(() => onRename?.())}>Rename&hellip;</button>
+          {/if}
+          {#if onMove}
+            <button onclick={() => handleMenuAction(() => onMove?.())}>Move&hellip;</button>
+          {/if}
+          {#if onRename || onMove}
+            <div class="separator"></div>
+          {/if}
           {#if onExtractSelection}
             <button
               onclick={() => handleMenuAction(() => onExtractSelection?.())}
@@ -694,7 +707,7 @@
             <button onclick={() => handleMenuAction(() => onSplitHere?.())}>Split Note Here</button>
           {/if}
           {#if onSplitByHeading}
-            <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading…</button>
+            <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
           {/if}
         </div>
       </div>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -12,6 +12,7 @@ export const CONFIRM_KEYS = {
   delete: 'confirm-delete',
   rewriteConflict: 'confirm-rewrite-conflict',
   headingRenameSuggestion: 'heading-rename-suggestion',
+  moveCollision: 'move-collision',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -40,6 +41,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Update links after heading rename',
     description:
       'Offer to rewrite incoming [[note#heading]] links when a heading edit looks like a rename.',
+  },
+  {
+    key: CONFIRM_KEYS.moveCollision,
+    title: 'Move cancelled (destination exists)',
+    description:
+      'Shown when Move would overwrite an existing file at the chosen destination.',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -159,6 +159,11 @@ export interface MenuApi {
   onCloseProject(cb: () => void): void;
   onClearRecent(cb: () => void): void;
   onProjectOpened(cb: (meta: { rootPath: string; name: string }) => void): void;
+  onRefactorRename(cb: () => void): void;
+  onRefactorMove(cb: () => void): void;
+  onRefactorExtract(cb: () => void): void;
+  onRefactorSplitHere(cb: () => void): void;
+  onRefactorSplitByHeading(cb: () => void): void;
 }
 
 export interface IdeApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -79,6 +79,13 @@ export const Channels = {
   MENU_SORT_LINES: 'menu:sortLines',
   MENU_OPEN_SETTINGS: 'menu:openSettings',
 
+  // Refactor menu (issue #172) — title-bar menu commands dispatched to the renderer.
+  MENU_REFACTOR_RENAME: 'menu:refactor:rename',
+  MENU_REFACTOR_MOVE: 'menu:refactor:move',
+  MENU_REFACTOR_EXTRACT: 'menu:refactor:extract',
+  MENU_REFACTOR_SPLIT_HERE: 'menu:refactor:splitHere',
+  MENU_REFACTOR_SPLIT_BY_HEADING: 'menu:refactor:splitByHeading',
+
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',
   MENU_SAVE_QUERY: 'menu:saveQuery',


### PR DESCRIPTION
## Summary
Single surface for every refactor-style command. Title-bar **Refactor** menu sits between Navigate and the tool categories (Learning, Analysis, Planning\u2026) and the editor right-click Refactor submenu picks up the same items.

| Item | Source |
|---|---|
| Rename\u2026 | Existing `handleRename` flow |
| Move\u2026 | **New** (#173) \u2014 folder-only prompt |
| Extract Selection to New Note | Existing `handleExtractSelection` |
| Split Note Here | Existing `handleSplitHere` |
| Split by Heading\u2026 | Existing `handleSplitByHeading` |

## Move behavior (#173)
- Prompts for a destination folder (leave empty for root). Filename stays the same.
- If the destination folder doesn\u2019t exist, it\u2019s created by the underlying `fs.rename` (parent `mkdir` already in place).
- If a file with the same name already exists there, Move aborts with an OK-style dialog \u2014 no silent overwrite.
- Delegates to the existing sidebar-drop `handleMove(src, destDir)` for the actual rename + tab update, so incoming links rewrite, bookmarks update, and open tabs refresh automatically (reuses #136, #142, #145).

## Deferred
- **Auto-tag** (#174) and **Auto-link** (#175) \u2014 LLM-backed Refactor items; their PRs slot them into this menu.
- **Summarize** has already moved to the Learning category (#176) and isn\u2019t a Refactor item anymore.
- **Title-bar menu enablement** (disable items when no note active) \u2014 the main process doesn\u2019t track renderer state yet; handlers no-op gracefully in the meantime. Right-click menu already enables/disables correctly (`Extract` requires selection).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (448 passing)
- [ ] Menu bar shows Refactor before Learning
- [ ] Rename via title-bar Refactor > Rename\u2026 and via editor right-click > Refactor > Rename\u2026 both work
- [ ] Move prompts for folder; creates missing folder; aborts on collision
- [ ] Extract / Split Here / Split by Heading still work via both entry points