### PR TITLE
Auto-tag: LLM-suggested frontmatter tags (closes #174)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -14,6 +14,7 @@ import { clearRecentProjects } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool, prepareConversationTool } from './tools/executor';
+import { runAutoTag } from './llm/auto-tag';
 import * as healthChecks from './graph/health-checks';
 import { getToolBySlashCommand } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
@@ -548,6 +549,25 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(Channels.TOOL_PREPARE_CONVERSATION, (_e, request: ToolExecutionRequest) =>
     prepareConversationTool(request));
+
+  ipcMain.handle(Channels.REFACTOR_AUTO_TAG, async (e, relativePath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+
+    const plan = await runAutoTag(rootPath, relativePath);
+    if (!plan.content) return { added: [] };
+
+    // Route the write through the standard index + search + broadcast path,
+    // so open tabs of the tagged note refresh via NOTEBASE_REWRITTEN (same
+    // conflict handling as a link rewrite).
+    markPathHandled(relativePath);
+    await notebaseFs.writeFile(rootPath, relativePath, plan.content);
+    await graph.indexNote(relativePath, plan.content);
+    search.indexNote(relativePath, plan.content);
+    await persistIndexes();
+    broadcastRewritten(rootPath, [relativePath]);
+    return { added: plan.added };
+  });
 
   // Proposals
   ipcMain.handle(Channels.PROPOSAL_LIST, (_e, status?: string) => approval.listProposals(status));

--- a/src/main/llm/auto-tag.ts
+++ b/src/main/llm/auto-tag.ts
@@ -1,0 +1,58 @@
+import * as notebaseFs from '../notebase/fs';
+import { parseMarkdown } from '../graph/parser';
+import * as graph from '../graph/index';
+import { complete } from './index';
+import { getSettings } from './settings';
+import {
+  buildAutoTagPrompt,
+  parseAutoTagResponse,
+  mergeTagsIntoContent,
+} from '../../shared/refactor/auto-tag';
+
+export interface AutoTagPlan {
+  /** Tags that would be newly added to the note\u2019s frontmatter. Empty when there\u2019s nothing to do. */
+  added: string[];
+  /** Rewritten note content when `added` is non-empty; `null` for the silent no-op case. */
+  content: string | null;
+}
+
+/**
+ * Runs Auto-tag against a single note: asks the LLM for relevant tags
+ * (seeded with the thoughtbase\u2019s existing vocabulary) and returns the
+ * merged frontmatter as a new content string. Does **not** write \u2014 the
+ * caller is responsible for persisting + reindexing so the write flows
+ * through the same broadcast path as a user save (#174).
+ */
+export async function runAutoTag(
+  rootPath: string,
+  relativePath: string,
+): Promise<AutoTagPlan> {
+  const content = await notebaseFs.readFile(rootPath, relativePath);
+  const parsed = parseMarkdown(content);
+
+  const thoughtbaseTags = graph.listTags().map((t) => t.tag);
+  const existingNoteTags: string[] = [];
+  if (Array.isArray(parsed.frontmatter.tags)) {
+    for (const t of parsed.frontmatter.tags) {
+      if (typeof t === 'string') existingNoteTags.push(t);
+    }
+  }
+
+  const noteBody = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+  const prompt = buildAutoTagPrompt({
+    noteTitle: parsed.title ?? '',
+    noteBody,
+    existingNoteTags,
+    thoughtbaseTags,
+  });
+
+  const { model } = await getSettings();
+  const raw = await complete(prompt, { model });
+  const suggested = parseAutoTagResponse(raw);
+  if (suggested.length === 0) return { added: [], content: null };
+
+  const { content: next, addedTags } = mergeTagsIntoContent(content, suggested);
+  if (addedTags.length === 0) return { added: [], content: null };
+
+  return { added: addedTags, content: next };
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -321,6 +321,8 @@ export function rebuildMenu(): void {
         { label: 'Extract Selection to New Note', click: () => send(Channels.MENU_REFACTOR_EXTRACT) },
         { label: 'Split Note Here', click: () => send(Channels.MENU_REFACTOR_SPLIT_HERE) },
         { label: 'Split by Heading\u2026', click: () => send(Channels.MENU_REFACTOR_SPLIT_BY_HEADING) },
+        { type: 'separator' },
+        { label: 'Auto-tag', click: () => send(Channels.MENU_REFACTOR_AUTOTAG) },
       ],
     },
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -141,6 +141,9 @@ contextBridge.exposeInMainWorld('api', {
     save: (session: unknown) => ipcRenderer.invoke(Channels.TABS_SAVE, session),
     load: () => ipcRenderer.invoke(Channels.TABS_LOAD),
   },
+  refactor: {
+    autoTag: (relativePath: string) => ipcRenderer.invoke(Channels.REFACTOR_AUTO_TAG, relativePath),
+  },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
     prepareConversation: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_PREPARE_CONVERSATION, request),
@@ -253,6 +256,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onRefactorSplitByHeading: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_SPLIT_BY_HEADING, () => cb());
+    },
+    onRefactorAutoTag: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_AUTOTAG, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -428,6 +428,25 @@
     await notebase.refresh();
   }
 
+  async function handleAutoTag(relativePath: string) {
+    if (!notebase.meta) return;
+    try {
+      const result = await api.refactor.autoTag(relativePath);
+      if (result.added.length === 0) {
+        await showConfirm(
+          'No new tags suggested. The note may be too short, too generic, or already well tagged.',
+          CONFIRM_KEYS.autoTagNoSuggestions,
+          'OK',
+        );
+      }
+      // On success, the NOTEBASE_REWRITTEN listener reloads the note so the
+      // user sees the new frontmatter tags appear in the editor.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Auto-tag failed: ${msg}`, CONFIRM_KEYS.autoTagFailed, 'OK');
+    }
+  }
+
   async function handleMoveWithPrompt(relativePath: string) {
     if (!notebase.meta) return;
     const fileName = relativePath.split('/').pop()!;
@@ -731,6 +750,7 @@
     api.menu.onRefactorExtract(() => handleExtractSelection());
     api.menu.onRefactorSplitHere(() => handleSplitHere());
     api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
+    api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); });
 
     // Notebase rename/rewrite notifications from main — keep open tabs
     // consistent with disk so the next auto-save doesn't overwrite a
@@ -890,6 +910,7 @@
                     onSplitByHeading={handleSplitByHeading}
                     onRename={() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); }}
                     onMove={() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); }}
+                    onAutoTag={() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -52,6 +52,7 @@
     onSplitByHeading?: () => void;
     onRename?: () => void;
     onMove?: () => void;
+    onAutoTag?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -75,6 +76,7 @@
     onSplitByHeading,
     onRename,
     onMove,
+    onAutoTag,
     getNotePaths,
   }: Props = $props();
 
@@ -684,7 +686,7 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -708,6 +710,12 @@
           {/if}
           {#if onSplitByHeading}
             <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
+          {/if}
+          {#if onAutoTag}
+            {#if onExtractSelection || onSplitHere || onSplitByHeading}
+              <div class="separator"></div>
+            {/if}
+            <button onclick={() => handleMenuAction(() => onAutoTag?.())}>Auto-tag</button>
           {/if}
         </div>
       </div>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -13,6 +13,8 @@ export const CONFIRM_KEYS = {
   rewriteConflict: 'confirm-rewrite-conflict',
   headingRenameSuggestion: 'heading-rename-suggestion',
   moveCollision: 'move-collision',
+  autoTagNoSuggestions: 'auto-tag-no-suggestions',
+  autoTagFailed: 'auto-tag-failed',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -47,6 +49,18 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Move cancelled (destination exists)',
     description:
       'Shown when Move would overwrite an existing file at the chosen destination.',
+  },
+  {
+    key: CONFIRM_KEYS.autoTagNoSuggestions,
+    title: 'Auto-tag returned no new tags',
+    description:
+      'Shown when the LLM produced no tag suggestions for the note (usually because it is too short or already well-tagged).',
+  },
+  {
+    key: CONFIRM_KEYS.autoTagFailed,
+    title: 'Auto-tag failed',
+    description:
+      'Shown when Auto-tag errors out (network failure, missing API key, etc).',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -119,6 +119,10 @@ export interface TabsApi {
   load(): Promise<TabSession | null>;
 }
 
+export interface RefactorApi {
+  autoTag(relativePath: string): Promise<{ added: string[] }>;
+}
+
 export interface ToolsApi {
   execute(request: ToolExecutionRequest): Promise<ToolExecutionResult>;
   prepareConversation(request: ToolExecutionRequest): Promise<ConversationToolPayload>;
@@ -164,6 +168,7 @@ export interface MenuApi {
   onRefactorExtract(cb: () => void): void;
   onRefactorSplitHere(cb: () => void): void;
   onRefactorSplitByHeading(cb: () => void): void;
+  onRefactorAutoTag(cb: () => void): void;
 }
 
 export interface IdeApi {
@@ -181,6 +186,7 @@ export interface IdeApi {
   proposals: ProposalsApi;
   tabs: TabsApi;
   tools: ToolsApi;
+  refactor: RefactorApi;
   menu: MenuApi;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -85,6 +85,10 @@ export const Channels = {
   MENU_REFACTOR_EXTRACT: 'menu:refactor:extract',
   MENU_REFACTOR_SPLIT_HERE: 'menu:refactor:splitHere',
   MENU_REFACTOR_SPLIT_BY_HEADING: 'menu:refactor:splitByHeading',
+  MENU_REFACTOR_AUTOTAG: 'menu:refactor:autotag',
+
+  /** Renderer-initiated LLM Auto-tag of a note (#174). */
+  REFACTOR_AUTO_TAG: 'refactor:autoTag',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',

--- a/src/shared/refactor/auto-tag.ts
+++ b/src/shared/refactor/auto-tag.ts
@@ -1,0 +1,136 @@
+import YAML from 'yaml';
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+const KEBAB_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export interface BuildAutoTagPromptArgs {
+  noteTitle: string;
+  noteBody: string;
+  existingNoteTags: string[];
+  thoughtbaseTags: string[];
+  /** Max tags the LLM is asked to return. Defaults to 5. */
+  cap?: number;
+}
+
+export function buildAutoTagPrompt({
+  noteTitle,
+  noteBody,
+  existingNoteTags,
+  thoughtbaseTags,
+  cap = 5,
+}: BuildAutoTagPromptArgs): string {
+  const existingList = existingNoteTags.length
+    ? existingNoteTags.map((t) => `- ${t}`).join('\n')
+    : '(none yet)';
+
+  const vocab = thoughtbaseTags.length
+    ? thoughtbaseTags.slice(0, 200).map((t) => `- ${t}`).join('\n')
+    : '(the thoughtbase has no tags yet \u2014 feel free to introduce the first ones)';
+
+  return `You are tagging a note in a personal knowledge base.
+
+Produce up to **${cap}** tags that capture what the note is actually about \u2014 the topic, domain, or concept. Prefer specific over generic; skip tags that are so broad they\u2019d apply to half the thoughtbase (e.g. "notes", "thinking", "ideas").
+
+## Rules
+- Reuse existing thoughtbase tags when they fit, rather than inventing near-duplicates.
+- Only coin a new tag when no existing one applies well.
+- Tags must be **kebab-case**: lowercase letters, digits, and hyphens only (e.g. \`machine-learning\`, \`cognitive-bias\`).
+- Do **not** repeat tags the note already has.
+- If the note is too short, generic, or otherwise tag-free, return no tags at all \u2014 an empty list is a valid answer.
+
+## Output format
+Return one tag per line, nothing else. No prose, no numbering, no backticks, no leading hyphens. Just the tags:
+
+machine-learning
+cognitive-bias
+algorithmic-transparency
+
+## Existing tags on this note (do not repeat)
+${existingList}
+
+## Existing thoughtbase vocabulary (reuse when it fits)
+${vocab}
+
+## Note
+Title: ${noteTitle || '(untitled)'}
+
+${noteBody}`;
+}
+
+/**
+ * Extracts kebab-case tags from the LLM response. Tolerates leading hyphens,
+ * leading "#", stray backticks, numbered lists, and commentary lines that
+ * aren\u2019t a valid tag. Deduplicates while preserving first-seen order.
+ */
+export function parseAutoTagResponse(text: string): string[] {
+  const tags: string[] = [];
+  const seen = new Set<string>();
+  for (const rawLine of text.split(/\r?\n/)) {
+    let line = rawLine.trim();
+    if (!line) continue;
+    // Strip common list prefixes / markdown decorations.
+    line = line
+      .replace(/^[-*\u2022\u2013\u2014]\s*/, '')
+      .replace(/^\d+[.)]\s*/, '')
+      .replace(/^#+\s*/, '')
+      .replace(/^`+|`+$/g, '')
+      .trim();
+    if (!line) continue;
+    // Skip obvious commentary lines.
+    if (/\s/.test(line)) continue;
+    const lower = line.toLowerCase();
+    if (!KEBAB_RE.test(lower)) continue;
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    tags.push(lower);
+  }
+  return tags;
+}
+
+export interface MergeResult {
+  /** Updated note content. Equals the input when nothing new to add. */
+  content: string;
+  /** The subset of `newTags` that were actually added (i.e. not already present). */
+  addedTags: string[];
+}
+
+/**
+ * Merges `newTags` into the note\u2019s frontmatter `tags:` array. Skips tags
+ * that are already present (case-insensitive). Creates a frontmatter block
+ * when the note has none.
+ */
+export function mergeTagsIntoContent(content: string, newTags: string[]): MergeResult {
+  const match = content.match(FRONTMATTER_RE);
+  const existing: string[] = [];
+  let fm: Record<string, unknown> = {};
+  if (match) {
+    try {
+      const parsed = YAML.parse(match[1]);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        fm = parsed as Record<string, unknown>;
+      }
+    } catch { /* malformed frontmatter \u2014 overwrite */ }
+    if (Array.isArray(fm.tags)) {
+      for (const t of fm.tags) {
+        if (typeof t === 'string') existing.push(t);
+      }
+    }
+  }
+
+  const existingLower = new Set(existing.map((t) => t.toLowerCase()));
+  const addedTags: string[] = [];
+  for (const t of newTags) {
+    const lower = t.toLowerCase();
+    if (existingLower.has(lower)) continue;
+    existingLower.add(lower);
+    addedTags.push(t);
+  }
+  if (addedTags.length === 0) return { content, addedTags: [] };
+
+  fm.tags = [...existing, ...addedTags];
+  const yamlBlock = YAML.stringify(fm).trimEnd();
+  const rendered = `---\n${yamlBlock}\n---\n`;
+  const body = match ? content.slice(match[0].length) : content;
+  const separator = body.startsWith('\n') || body === '' ? '' : '\n';
+  return { content: rendered + separator + body, addedTags };
+}

--- a/tests/shared/refactor/auto-tag.test.ts
+++ b/tests/shared/refactor/auto-tag.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import YAML from 'yaml';
+import {
+  buildAutoTagPrompt,
+  parseAutoTagResponse,
+  mergeTagsIntoContent,
+} from '../../../src/shared/refactor/auto-tag';
+
+describe('buildAutoTagPrompt (issue #174)', () => {
+  it('includes the existing thoughtbase vocabulary so the LLM can reuse it', () => {
+    const prompt = buildAutoTagPrompt({
+      noteTitle: 'On Fusion',
+      noteBody: 'Fusion reactors use magnetic confinement...',
+      existingNoteTags: [],
+      thoughtbaseTags: ['physics', 'energy', 'plasma'],
+    });
+    expect(prompt).toContain('- physics');
+    expect(prompt).toContain('- energy');
+    expect(prompt).toContain('- plasma');
+  });
+
+  it('lists the note\u2019s current tags under "do not repeat"', () => {
+    const prompt = buildAutoTagPrompt({
+      noteTitle: 'x',
+      noteBody: 'body',
+      existingNoteTags: ['already-here'],
+      thoughtbaseTags: [],
+    });
+    expect(prompt).toMatch(/do not repeat[\s\S]*already-here/i);
+  });
+
+  it('states the requested cap', () => {
+    const prompt = buildAutoTagPrompt({
+      noteTitle: '', noteBody: '', existingNoteTags: [], thoughtbaseTags: [], cap: 3,
+    });
+    expect(prompt).toContain('up to **3**');
+  });
+});
+
+describe('parseAutoTagResponse', () => {
+  it('extracts bare kebab-case tags, one per line', () => {
+    expect(parseAutoTagResponse('machine-learning\ncognitive-bias\nalgorithmic-transparency'))
+      .toEqual(['machine-learning', 'cognitive-bias', 'algorithmic-transparency']);
+  });
+
+  it('tolerates leading hyphens, bullets, numbers, backticks, and stray whitespace', () => {
+    const raw = [
+      '- machine-learning',
+      '* cognitive-bias',
+      '1. algorithmic-transparency',
+      '  `fusion-power` ',
+      '\u2022 nuclear-physics',
+    ].join('\n');
+    expect(parseAutoTagResponse(raw)).toEqual([
+      'machine-learning',
+      'cognitive-bias',
+      'algorithmic-transparency',
+      'fusion-power',
+      'nuclear-physics',
+    ]);
+  });
+
+  it('drops lines that are not valid kebab-case (commentary, spaces, underscores, trailing hyphen)', () => {
+    const raw = [
+      'Here are some tags:',
+      'machine-learning',
+      'this one has spaces',
+      'has_underscore',
+      'ends-with-hyphen-',
+    ].join('\n');
+    expect(parseAutoTagResponse(raw)).toEqual(['machine-learning']);
+  });
+
+  it('lowercases mixed-case input before validating (LLMs occasionally slip)', () => {
+    expect(parseAutoTagResponse('Machine-Learning\nCOGNITIVE-BIAS')).toEqual([
+      'machine-learning',
+      'cognitive-bias',
+    ]);
+  });
+
+  it('deduplicates case-insensitively, preserving first occurrence', () => {
+    expect(parseAutoTagResponse('fusion\nFusion\nfusion')).toEqual(['fusion']);
+  });
+
+  it('returns an empty array when there is nothing to extract', () => {
+    expect(parseAutoTagResponse('(no tags)')).toEqual([]);
+    expect(parseAutoTagResponse('')).toEqual([]);
+  });
+});
+
+describe('mergeTagsIntoContent', () => {
+  it('creates a frontmatter block when the note has none', () => {
+    const out = mergeTagsIntoContent('# Title\n\nbody\n', ['alpha', 'beta']);
+    expect(out.addedTags).toEqual(['alpha', 'beta']);
+    expect(out.content).toMatch(/^---\n[\s\S]*tags:[\s\S]*---\n/);
+    const fm = YAML.parse(out.content.match(/^---\n([\s\S]*?)\n---/)![1]);
+    expect(fm.tags).toEqual(['alpha', 'beta']);
+    expect(out.content).toContain('# Title');
+    expect(out.content).toContain('body');
+  });
+
+  it('appends to an existing tags array without duplicates (case-insensitive)', () => {
+    const content = [
+      '---',
+      'title: Foo',
+      'tags:',
+      '  - physics',
+      '  - Energy',
+      '---',
+      '',
+      'body',
+      '',
+    ].join('\n');
+    const out = mergeTagsIntoContent(content, ['energy', 'plasma']);
+    expect(out.addedTags).toEqual(['plasma']);
+    const fm = YAML.parse(out.content.match(/^---\n([\s\S]*?)\n---/)![1]);
+    expect(fm.tags).toEqual(['physics', 'Energy', 'plasma']);
+  });
+
+  it('preserves other frontmatter keys when merging', () => {
+    const content = [
+      '---',
+      'title: Note',
+      'created: 2026-04-20',
+      'author: me',
+      '---',
+      '',
+      'body',
+    ].join('\n');
+    const out = mergeTagsIntoContent(content, ['tag-one']);
+    const fm = YAML.parse(out.content.match(/^---\n([\s\S]*?)\n---/)![1]);
+    expect(fm.title).toBe('Note');
+    expect(fm.author).toBe('me');
+    expect(fm.tags).toEqual(['tag-one']);
+  });
+
+  it('returns content unchanged when every suggested tag already exists', () => {
+    const content = '---\ntags:\n  - alpha\n  - beta\n---\nbody\n';
+    const out = mergeTagsIntoContent(content, ['alpha', 'BETA']);
+    expect(out.addedTags).toEqual([]);
+    expect(out.content).toBe(content);
+  });
+
+  it('returns content unchanged when no tags are supplied', () => {
+    const content = 'bare body\n';
+    const out = mergeTagsIntoContent(content, []);
+    expect(out.addedTags).toEqual([]);
+    expect(out.content).toBe(content);
+  });
+
+  it('preserves the note body after the frontmatter', () => {
+    const out = mergeTagsIntoContent('# Title\n\nFirst para.\n\nSecond para.\n', ['one']);
+    expect(out.content).toContain('# Title');
+    expect(out.content).toContain('First para.');
+    expect(out.content).toContain('Second para.');
+  });
+});


### PR DESCRIPTION
## Summary
Refactor menu command that hands the active note plus the thoughtbase\u2019s existing tag vocabulary to the LLM, takes a kebab-case list back, and merges it into the note\u2019s frontmatter `tags:`. Direct-write per the design discussion \u2014 the approval pipeline doesn\u2019t apply to low-stakes explicit user operations on their own content.

## Entry points
- **Refactor \u25B8 Auto-tag** in the title-bar Refactor menu
- **Refactor \u25B8 Auto-tag** in the editor right-click submenu

## Implementation
- `src/shared/refactor/auto-tag.ts` \u2014 pure pieces: prompt builder (seeds with thoughtbase vocabulary up to 200 tags), tolerant response parser (strips list prefixes, numbering, backticks, commentary), frontmatter merger (creates block when none, dedupes case-insensitively, preserves other keys).
- `src/main/llm/auto-tag.ts` \u2014 `runAutoTag(rootPath, relativePath)`. Reads note, builds prompt, calls `complete()`, returns the rewritten content (no write here).
- `src/main/ipc.ts` \u2014 new `REFACTOR_AUTO_TAG` handler writes via the standard `notebaseFs.writeFile` + `graph.indexNote` + `search.indexNote` + `persistIndexes` + `NOTEBASE_REWRITTEN` broadcast, so open tabs reload the new frontmatter via the existing conflict path.
- `src/renderer/App.svelte` \u2014 `handleAutoTag(relativePath)`. Silent success (tab reload is the feedback). "No tags suggested" and error cases use suppressible confirm dialogs.

## Model
For v1, uses the user\u2019s global default model. Per-tool override (ThinkingTool registration) is a follow-up \u2014 didn\u2019t want to conflate the direct-mutation flow with the ThinkingTool output-mode machinery on this pass. Easy to layer in when `#169`-style per-tool override becomes desired here.

## Tests
- 15 new unit tests (prompt builder, response parser, content merger)
- 2 new confirm-key registry entries (guard test passes)
- Full suite: 463 passing (was 448)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (463 passing)
- [ ] Open a note, invoke Auto-tag from title-bar menu \u2014 new tags appear in frontmatter
- [ ] Same from editor right-click Refactor \u25B8 Auto-tag
- [ ] Invoke on a short / generic / already-well-tagged note: "No new tags suggested" dialog
- [ ] Existing frontmatter with other keys (title, created, etc.) remains untouched
- [ ] Existing `tags:` array gets new entries appended, no duplicates

## Out of scope
- ThinkingTool registration + per-tool model override (follow-up).
- Bulk auto-tag across a folder.
- Inline `#tag` insertion in the body.
- Surfacing *why* a tag was suggested.