### PR TITLE
Auto-link 'link to' mode with review dialog (closes #175 partial)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -15,8 +15,14 @@ import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool, prepareConversationTool } from './tools/executor';
 import { runAutoTag } from './llm/auto-tag';
-import { suggestLinksTo, applyAutoLinkToSuggestions } from './llm/auto-link';
+import {
+  suggestLinksTo,
+  applyAutoLinkToSuggestions,
+  suggestLinksInbound,
+  applyInboundSuggestions,
+} from './llm/auto-link';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
+import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
 import * as healthChecks from './graph/health-checks';
 import { getToolBySlashCommand } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
@@ -597,6 +603,40 @@ export function registerIpcHandlers(): void {
       await persistIndexes();
       broadcastRewritten(rootPath, [activeRelPath]);
       return { applied, skipped };
+    },
+  );
+
+  ipcMain.handle(Channels.REFACTOR_AUTO_LINK_INBOUND_SUGGEST, async (e, activeRelPath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return suggestLinksInbound(rootPath, activeRelPath);
+  });
+
+  ipcMain.handle(
+    Channels.REFACTOR_AUTO_LINK_INBOUND_APPLY,
+    async (e, activeRelPath: string, accepted: AutoLinkInboundSuggestion[]) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+
+      const { applied, skipped, touchedPaths, updatedContents } = await applyInboundSuggestions(
+        rootPath,
+        activeRelPath,
+        accepted,
+      );
+
+      // Write each touched source note through the standard index/search/broadcast pipeline.
+      for (const [source, content] of updatedContents) {
+        markPathHandled(source);
+        await notebaseFs.writeFile(rootPath, source, content);
+        await graph.indexNote(source, content);
+        search.indexNote(source, content);
+      }
+      if (touchedPaths.length > 0) {
+        await persistIndexes();
+        broadcastRewritten(rootPath, touchedPaths);
+      }
+
+      return { applied, skipped, touchedPaths };
     },
   );
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -15,6 +15,8 @@ import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool, prepareConversationTool } from './tools/executor';
 import { runAutoTag } from './llm/auto-tag';
+import { suggestLinksTo, applyAutoLinkToSuggestions } from './llm/auto-link';
+import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
 import * as healthChecks from './graph/health-checks';
 import { getToolBySlashCommand } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
@@ -568,6 +570,35 @@ export function registerIpcHandlers(): void {
     broadcastRewritten(rootPath, [relativePath]);
     return { added: plan.added };
   });
+
+  ipcMain.handle(Channels.REFACTOR_AUTO_LINK_SUGGEST, async (e, activeRelPath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return suggestLinksTo(rootPath, activeRelPath);
+  });
+
+  ipcMain.handle(
+    Channels.REFACTOR_AUTO_LINK_APPLY,
+    async (e, activeRelPath: string, accepted: AutoLinkSuggestion[]) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+
+      const { content, applied, skipped } = await applyAutoLinkToSuggestions(
+        rootPath,
+        activeRelPath,
+        accepted,
+      );
+      if (applied.length === 0) return { applied, skipped };
+
+      markPathHandled(activeRelPath);
+      await notebaseFs.writeFile(rootPath, activeRelPath, content);
+      await graph.indexNote(activeRelPath, content);
+      search.indexNote(activeRelPath, content);
+      await persistIndexes();
+      broadcastRewritten(rootPath, [activeRelPath]);
+      return { applied, skipped };
+    },
+  );
 
   // Proposals
   ipcMain.handle(Channels.PROPOSAL_LIST, (_e, status?: string) => approval.listProposals(status));

--- a/src/main/llm/auto-link.ts
+++ b/src/main/llm/auto-link.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from '../notebase/fs';
+import { parseMarkdown } from '../graph/parser';
+import { complete } from './index';
+import { getSettings } from './settings';
+import {
+  buildAutoLinkToPrompt,
+  parseAutoLinkResponse,
+  applyLinkInsertions,
+  extractSummary,
+  type AutoLinkSuggestion,
+  type CandidateNote,
+} from '../../shared/refactor/auto-link';
+
+const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
+const MD_EXT = '.md';
+
+/** Hard cap so a huge thoughtbase doesn\u2019t blow the prompt budget. */
+const MAX_CANDIDATES = 150;
+
+/**
+ * Walks the notebase and returns a compact list of candidate target notes.
+ * The active note is excluded. Candidates are title + short summary, built
+ * from the note\u2019s `dc:description` frontmatter when present, otherwise its
+ * first non-empty paragraph of body.
+ */
+export async function listAutoLinkCandidates(
+  rootPath: string,
+  excludeRelPath: string,
+): Promise<CandidateNote[]> {
+  const notes: string[] = [];
+  await walk(rootPath, '', notes);
+
+  const candidates: CandidateNote[] = [];
+  for (const rel of notes) {
+    if (rel === excludeRelPath) continue;
+    if (candidates.length >= MAX_CANDIDATES) break;
+    try {
+      const raw = await notebaseFs.readFile(rootPath, rel);
+      const parsed = parseMarkdown(raw);
+      const title = parsed.title || rel.replace(/\.md$/i, '').split('/').pop() || rel;
+      const description =
+        typeof parsed.frontmatter.description === 'string'
+          ? parsed.frontmatter.description
+          : undefined;
+      const body = raw.replace(/^---\n[\s\S]*?\n---\n?/, '');
+      candidates.push({
+        relativePath: rel,
+        title,
+        summary: extractSummary(body, description),
+      });
+    } catch { /* unreadable note — skip */ }
+  }
+  return candidates;
+}
+
+async function walk(rootPath: string, relDir: string, out: string[]): Promise<void> {
+  const absDir = path.join(rootPath, relDir);
+  let entries;
+  try {
+    entries = await fs.readdir(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      await walk(rootPath, rel, out);
+    } else if (entry.name.toLowerCase().endsWith(MD_EXT)) {
+      out.push(rel);
+    }
+  }
+}
+
+export interface AutoLinkSuggestResult {
+  suggestions: AutoLinkSuggestion[];
+  candidateCount: number;
+}
+
+/**
+ * "Link to" mode: asks the LLM where in the active note a wiki-link to
+ * one of the thoughtbase\u2019s other notes would fit. Returns suggestions
+ * whose `anchorText` is guaranteed to appear in the active note at an
+ * unlinked position (validated on the renderer\u2019s side when applying).
+ */
+export async function suggestLinksTo(
+  rootPath: string,
+  activeRelPath: string,
+): Promise<AutoLinkSuggestResult> {
+  const activeContent = await notebaseFs.readFile(rootPath, activeRelPath);
+  const parsed = parseMarkdown(activeContent);
+  const activeBody = activeContent.replace(/^---\n[\s\S]*?\n---\n?/, '');
+  const activeTitle = parsed.title || activeRelPath.replace(/\.md$/i, '').split('/').pop() || activeRelPath;
+
+  const candidates = await listAutoLinkCandidates(rootPath, activeRelPath);
+  if (candidates.length === 0) {
+    return { suggestions: [], candidateCount: 0 };
+  }
+
+  const prompt = buildAutoLinkToPrompt({
+    activeTitle,
+    activeBody,
+    candidates,
+  });
+
+  const { model } = await getSettings();
+  const raw = await complete(prompt, { model });
+  const validTargets = new Set(candidates.map((c) => c.relativePath));
+  const suggestions = parseAutoLinkResponse(raw, validTargets);
+
+  // Keep only suggestions whose anchor text actually appears in the active
+  // body — otherwise the apply step would silently drop them anyway.
+  const filtered = suggestions.filter((s) => activeBody.includes(s.anchorText));
+  return { suggestions: filtered, candidateCount: candidates.length };
+}
+
+/** Rewrites the active note with accepted suggestions. Returns the new content + bookkeeping. */
+export async function applyAutoLinkToSuggestions(
+  rootPath: string,
+  activeRelPath: string,
+  accepted: AutoLinkSuggestion[],
+): Promise<{ content: string; applied: AutoLinkSuggestion[]; skipped: AutoLinkSuggestion[] }> {
+  const current = await notebaseFs.readFile(rootPath, activeRelPath);
+  return applyLinkInsertions(current, accepted);
+}

--- a/src/main/llm/auto-link.ts
+++ b/src/main/llm/auto-link.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as notebaseFs from '../notebase/fs';
 import { parseMarkdown } from '../graph/parser';
+import * as graph from '../graph/index';
 import { complete } from './index';
 import { getSettings } from './settings';
 import {
@@ -12,6 +13,13 @@ import {
   type AutoLinkSuggestion,
   type CandidateNote,
 } from '../../shared/refactor/auto-link';
+import {
+  buildAutoLinkInboundPrompt,
+  parseInboundResponse,
+  snippetAround,
+  type AutoLinkInboundSuggestion,
+  type InboundCandidate,
+} from '../../shared/refactor/auto-link-inbound';
 
 const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
 const MD_EXT = '.md';
@@ -125,4 +133,198 @@ export async function applyAutoLinkToSuggestions(
 ): Promise<{ content: string; applied: AutoLinkSuggestion[]; skipped: AutoLinkSuggestion[] }> {
   const current = await notebaseFs.readFile(rootPath, activeRelPath);
   return applyLinkInsertions(current, accepted);
+}
+
+// ── Inbound mode (#175 follow-up) ─────────────────────────────────────────
+
+/** Hard cap on candidate source notes for inbound mode. Full-content passes per note get expensive fast. */
+const INBOUND_CANDIDATE_CAP = 15;
+
+/**
+ * Picks candidate source notes for inbound auto-link:
+ *  1. Notes that share at least one tag with the active note (ranked by shared-tag count).
+ *  2. Most-recently-modified notes as fill-in when tag matches are thin.
+ * Caps at INBOUND_CANDIDATE_CAP.
+ */
+export async function pickInboundCandidates(
+  rootPath: string,
+  activeRelPath: string,
+): Promise<string[]> {
+  // Collect the active note's tags (body #tags + frontmatter tags).
+  const activeContent = await notebaseFs.readFile(rootPath, activeRelPath);
+  const parsed = parseMarkdown(activeContent);
+  const tags = new Set<string>(parsed.tags);
+  if (Array.isArray(parsed.frontmatter.tags)) {
+    for (const t of parsed.frontmatter.tags) {
+      if (typeof t === 'string') tags.add(t);
+    }
+  }
+
+  const scored = new Map<string, number>();
+  for (const tag of tags) {
+    for (const note of graph.notesByTag(tag)) {
+      if (note.relativePath === activeRelPath) continue;
+      scored.set(note.relativePath, (scored.get(note.relativePath) ?? 0) + 1);
+    }
+  }
+
+  // Fill the rest with recent-by-mtime when tag overlap didn't fill the cap.
+  if (scored.size < INBOUND_CANDIDATE_CAP) {
+    const recent = await listRecentNotes(rootPath, INBOUND_CANDIDATE_CAP * 2);
+    for (const rel of recent) {
+      if (rel === activeRelPath) continue;
+      if (scored.has(rel)) continue;
+      scored.set(rel, 0);
+      if (scored.size >= INBOUND_CANDIDATE_CAP) break;
+    }
+  }
+
+  return [...scored.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, INBOUND_CANDIDATE_CAP)
+    .map(([rel]) => rel);
+}
+
+async function listRecentNotes(rootPath: string, limit: number): Promise<string[]> {
+  const notes: string[] = [];
+  await walk(rootPath, '', notes);
+  const withMtime = await Promise.all(
+    notes.map(async (rel) => {
+      try {
+        const stat = await fs.stat(path.join(rootPath, rel));
+        return { rel, mtimeMs: stat.mtimeMs };
+      } catch {
+        return { rel, mtimeMs: 0 };
+      }
+    }),
+  );
+  return withMtime
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, limit)
+    .map((e) => e.rel);
+}
+
+export interface AutoLinkInboundResult {
+  suggestions: AutoLinkInboundSuggestion[];
+  candidateCount: number;
+}
+
+/**
+ * "Link from" / "Auto-link inbound" mode: finds places in *other* notes
+ * where a link pointing at the active note would fit. Single-pass v1:
+ * picks up to 15 candidate source notes (tag overlap + recency), hands
+ * their full content plus the active note's summary to the LLM, and
+ * returns anchor-text based suggestions with pre-computed context
+ * snippets.
+ */
+export async function suggestLinksInbound(
+  rootPath: string,
+  activeRelPath: string,
+): Promise<AutoLinkInboundResult> {
+  const activeContent = await notebaseFs.readFile(rootPath, activeRelPath);
+  const parsedActive = parseMarkdown(activeContent);
+  const activeBody = activeContent.replace(/^---\n[\s\S]*?\n---\n?/, '');
+  const activeTitle = parsedActive.title
+    || activeRelPath.replace(/\.md$/i, '').split('/').pop()
+    || activeRelPath;
+  const activeDescription =
+    typeof parsedActive.frontmatter.description === 'string'
+      ? parsedActive.frontmatter.description
+      : undefined;
+  const activeSummary = extractSummary(activeBody, activeDescription);
+
+  const candidatePaths = await pickInboundCandidates(rootPath, activeRelPath);
+  if (candidatePaths.length === 0) {
+    return { suggestions: [], candidateCount: 0 };
+  }
+
+  const candidates: InboundCandidate[] = [];
+  for (const rel of candidatePaths) {
+    try {
+      const raw = await notebaseFs.readFile(rootPath, rel);
+      const p = parseMarkdown(raw);
+      const body = raw.replace(/^---\n[\s\S]*?\n---\n?/, '');
+      const title = p.title || rel.replace(/\.md$/i, '').split('/').pop() || rel;
+      candidates.push({ relativePath: rel, title, body });
+    } catch { /* unreadable source — skip */ }
+  }
+
+  const prompt = buildAutoLinkInboundPrompt({
+    activeTitle,
+    activePath: activeRelPath,
+    activeSummary,
+    candidates,
+  });
+
+  const { model } = await getSettings();
+  const raw = await complete(prompt, { model });
+  const validSources = new Set(candidates.map((c) => c.relativePath));
+  const suggestions = parseInboundResponse(raw, validSources);
+
+  // Keep only suggestions whose anchor is a verbatim substring of the source
+  // body (LLM paraphrases get dropped), and pre-compute the context snippet.
+  const bodies = new Map(candidates.map((c) => [c.relativePath, c.body]));
+  const filtered: AutoLinkInboundSuggestion[] = [];
+  for (const s of suggestions) {
+    const body = bodies.get(s.source);
+    if (!body) continue;
+    if (!body.includes(s.anchorText)) continue;
+    filtered.push({ ...s, contextSnippet: snippetAround(body, s.anchorText) });
+  }
+
+  return { suggestions: filtered, candidateCount: candidates.length };
+}
+
+export interface ApplyInboundResult {
+  applied: AutoLinkInboundSuggestion[];
+  skipped: AutoLinkInboundSuggestion[];
+  /** Source notes whose content was rewritten (for NOTEBASE_REWRITTEN broadcast). */
+  touchedPaths: string[];
+  /** Updated content per touched source path. Caller writes these. */
+  updatedContents: Map<string, string>;
+}
+
+/**
+ * Groups accepted suggestions by source note, applies link insertions to
+ * each source (linking at the active note), and returns the new contents
+ * to persist. The caller is responsible for the write + reindex + broadcast.
+ */
+export async function applyInboundSuggestions(
+  rootPath: string,
+  activeRelPath: string,
+  accepted: AutoLinkInboundSuggestion[],
+): Promise<ApplyInboundResult> {
+  const bySource = new Map<string, AutoLinkInboundSuggestion[]>();
+  for (const s of accepted) {
+    if (!bySource.has(s.source)) bySource.set(s.source, []);
+    bySource.get(s.source)!.push(s);
+  }
+
+  const applied: AutoLinkInboundSuggestion[] = [];
+  const skipped: AutoLinkInboundSuggestion[] = [];
+  const touchedPaths: string[] = [];
+  const updatedContents = new Map<string, string>();
+
+  for (const [source, items] of bySource) {
+    const current = await notebaseFs.readFile(rootPath, source);
+    const synthetic: AutoLinkSuggestion[] = items.map((s) => ({
+      anchorText: s.anchorText,
+      target: activeRelPath,
+      rationale: s.rationale,
+    }));
+    const res = applyLinkInsertions(current, synthetic);
+    // Map applied/skipped indices back to the original inbound suggestions.
+    const appliedKeys = new Set(res.applied.map((a) => a.anchorText + '\u0001' + a.target));
+    for (const item of items) {
+      const key = item.anchorText + '\u0001' + activeRelPath;
+      if (appliedKeys.has(key)) applied.push(item);
+      else skipped.push(item);
+    }
+    if (res.content !== current) {
+      updatedContents.set(source, res.content);
+      touchedPaths.push(source);
+    }
+  }
+
+  return { applied, skipped, touchedPaths, updatedContents };
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -323,6 +323,7 @@ export function rebuildMenu(): void {
         { label: 'Split by Heading\u2026', click: () => send(Channels.MENU_REFACTOR_SPLIT_BY_HEADING) },
         { type: 'separator' },
         { label: 'Auto-tag', click: () => send(Channels.MENU_REFACTOR_AUTOTAG) },
+        { label: 'Auto-link\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) },
       ],
     },
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -323,7 +323,8 @@ export function rebuildMenu(): void {
         { label: 'Split by Heading\u2026', click: () => send(Channels.MENU_REFACTOR_SPLIT_BY_HEADING) },
         { type: 'separator' },
         { label: 'Auto-tag', click: () => send(Channels.MENU_REFACTOR_AUTOTAG) },
-        { label: 'Auto-link\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) },
+        { label: 'Auto-link outbound\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) },
+        { label: 'Auto-link inbound\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK_INBOUND) },
       ],
     },
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -143,6 +143,10 @@ contextBridge.exposeInMainWorld('api', {
   },
   refactor: {
     autoTag: (relativePath: string) => ipcRenderer.invoke(Channels.REFACTOR_AUTO_TAG, relativePath),
+    autoLinkSuggest: (relativePath: string) =>
+      ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_SUGGEST, relativePath),
+    autoLinkApply: (relativePath: string, accepted: unknown) =>
+      ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_APPLY, relativePath, accepted),
   },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
@@ -259,6 +263,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onRefactorAutoTag: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_AUTOTAG, () => cb());
+    },
+    onRefactorAutoLink: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_AUTOLINK, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -147,6 +147,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_SUGGEST, relativePath),
     autoLinkApply: (relativePath: string, accepted: unknown) =>
       ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_APPLY, relativePath, accepted),
+    autoLinkInboundSuggest: (relativePath: string) =>
+      ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_INBOUND_SUGGEST, relativePath),
+    autoLinkInboundApply: (relativePath: string, accepted: unknown) =>
+      ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_INBOUND_APPLY, relativePath, accepted),
   },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
@@ -266,6 +270,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onRefactorAutoLink: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_AUTOLINK, () => cb());
+    },
+    onRefactorAutoLinkInbound: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_AUTOLINK_INBOUND, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -442,12 +442,27 @@
     await notebase.refresh();
   }
 
+  /**
+   * Runs `fn` with the spinner overlay shown under `label`. Always clears
+   * the overlay before returning — even on error — so that subsequent UI
+   * (e.g. an error dialog) isn't trapped behind it.
+   */
+  async function withBusy<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    busyLabel = label;
+    try {
+      return await fn();
+    } finally {
+      busyLabel = null;
+    }
+  }
+
   async function handleAutoLink(relativePath: string) {
     if (!notebase.meta || autoLinkBusy) return;
     autoLinkBusy = true;
-    busyLabel = 'Auto-linking\u2026';
     try {
-      const { suggestions } = await api.refactor.autoLinkSuggest(relativePath);
+      const { suggestions } = await withBusy('Auto-linking\u2026', () =>
+        api.refactor.autoLinkSuggest(relativePath),
+      );
       if (suggestions.length === 0) {
         await showConfirm(
           'Auto-link found no link candidates in this note.',
@@ -464,7 +479,6 @@
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
     } finally {
-      busyLabel = null;
       autoLinkBusy = false;
     }
   }
@@ -473,12 +487,13 @@
     const review = autoLinkReview;
     if (!review) return;
     autoLinkReview = null;
-    busyLabel = 'Applying links\u2026';
     try {
       // Snapshot the suggestions before IPC — they came out of $state, which
       // wraps them in Svelte 5 proxies that structured-clone can't serialize.
       const plain = $state.snapshot(accepted) as AutoLinkSuggestion[];
-      const { applied, skipped } = await api.refactor.autoLinkApply(review.relativePath, plain);
+      const { applied, skipped } = await withBusy('Applying links\u2026', () =>
+        api.refactor.autoLinkApply(review.relativePath, plain),
+      );
       if (applied.length === 0 && skipped.length > 0) {
         await showConfirm(
           `Auto-link couldn\u2019t apply any suggestions \u2014 the anchor text changed in the note. Try again.`,
@@ -489,16 +504,15 @@
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
-    } finally {
-      busyLabel = null;
     }
   }
 
   async function handleAutoTag(relativePath: string) {
     if (!notebase.meta) return;
-    busyLabel = 'Auto-tagging\u2026';
     try {
-      const result = await api.refactor.autoTag(relativePath);
+      const result = await withBusy('Auto-tagging\u2026', () =>
+        api.refactor.autoTag(relativePath),
+      );
       if (result.added.length === 0) {
         await showConfirm(
           'No new tags suggested. The note may be too short, too generic, or already well tagged.',
@@ -511,8 +525,6 @@
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-tag failed: ${msg}`, CONFIRM_KEYS.autoTagFailed, 'OK');
-    } finally {
-      busyLabel = null;
     }
   }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -469,7 +469,10 @@
     if (!review) return;
     autoLinkReview = null;
     try {
-      const { applied, skipped } = await api.refactor.autoLinkApply(review.relativePath, accepted);
+      // Snapshot the suggestions before IPC — they came out of $state, which
+      // wraps them in Svelte 5 proxies that structured-clone can't serialize.
+      const plain = $state.snapshot(accepted) as AutoLinkSuggestion[];
+      const { applied, skipped } = await api.refactor.autoLinkApply(review.relativePath, plain);
       if (applied.length === 0 && skipped.length > 0) {
         await showConfirm(
           `Auto-link couldn\u2019t apply any suggestions \u2014 the anchor text changed in the note. Try again.`,

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -19,6 +19,7 @@
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationDialog from './lib/components/ConversationDialog.svelte';
   import AutoLinkDialog from './lib/components/AutoLinkDialog.svelte';
+  import BusyOverlay from './lib/components/BusyOverlay.svelte';
   import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
   import SettingsDialog from './lib/components/SettingsDialog.svelte';
   import { api } from './lib/ipc/client';
@@ -65,6 +66,8 @@
   } | null>(null);
   /** Whether the Auto-link suggest request is currently in flight. Keeps the menu from re-triggering. */
   let autoLinkBusy = $state(false);
+  /** When set, renders a modal spinner overlay with this label. */
+  let busyLabel = $state<string | null>(null);
   let inspectionCount = $state(0);
 
   async function refreshInspectionCount() {
@@ -442,6 +445,7 @@
   async function handleAutoLink(relativePath: string) {
     if (!notebase.meta || autoLinkBusy) return;
     autoLinkBusy = true;
+    busyLabel = 'Auto-linking\u2026';
     try {
       const { suggestions } = await api.refactor.autoLinkSuggest(relativePath);
       if (suggestions.length === 0) {
@@ -460,6 +464,7 @@
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
     } finally {
+      busyLabel = null;
       autoLinkBusy = false;
     }
   }
@@ -468,6 +473,7 @@
     const review = autoLinkReview;
     if (!review) return;
     autoLinkReview = null;
+    busyLabel = 'Applying links\u2026';
     try {
       // Snapshot the suggestions before IPC — they came out of $state, which
       // wraps them in Svelte 5 proxies that structured-clone can't serialize.
@@ -483,11 +489,14 @@
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
+    } finally {
+      busyLabel = null;
     }
   }
 
   async function handleAutoTag(relativePath: string) {
     if (!notebase.meta) return;
+    busyLabel = 'Auto-tagging\u2026';
     try {
       const result = await api.refactor.autoTag(relativePath);
       if (result.added.length === 0) {
@@ -502,6 +511,8 @@
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-tag failed: ${msg}`, CONFIRM_KEYS.autoTagFailed, 'OK');
+    } finally {
+      busyLabel = null;
     }
   }
 
@@ -1111,6 +1122,9 @@
       onApply={handleAutoLinkApply}
       onCancel={() => { autoLinkReview = null; }}
     />
+  {/if}
+  {#if busyLabel}
+    <BusyOverlay label={busyLabel} />
   {/if}
   {#if showSettings}
     <SettingsDialog

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -18,6 +18,8 @@
   import GotoNoteDialog from './lib/components/GotoNoteDialog.svelte';
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationDialog from './lib/components/ConversationDialog.svelte';
+  import AutoLinkDialog from './lib/components/AutoLinkDialog.svelte';
+  import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
   import SettingsDialog from './lib/components/SettingsDialog.svelte';
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
@@ -54,6 +56,15 @@
   /** When set, the next ConversationDialog mount auto-fires this message. Cleared after each open. */
   let pendingAutoMessage = $state<string | undefined>(undefined);
   let showSettings = $state(false);
+
+  /** Pending Auto-link suggestions to review. Non-null means the AutoLinkDialog is shown. */
+  let autoLinkReview = $state<{
+    relativePath: string;
+    suggestions: AutoLinkSuggestion[];
+    activeBody: string;
+  } | null>(null);
+  /** Whether the Auto-link suggest request is currently in flight. Keeps the menu from re-triggering. */
+  let autoLinkBusy = $state(false);
   let inspectionCount = $state(0);
 
   async function refreshInspectionCount() {
@@ -428,6 +439,50 @@
     await notebase.refresh();
   }
 
+  async function handleAutoLink(relativePath: string) {
+    if (!notebase.meta || autoLinkBusy) return;
+    autoLinkBusy = true;
+    try {
+      const { suggestions } = await api.refactor.autoLinkSuggest(relativePath);
+      if (suggestions.length === 0) {
+        await showConfirm(
+          'Auto-link found no link candidates in this note.',
+          CONFIRM_KEYS.autoLinkNoSuggestions,
+          'OK',
+        );
+        return;
+      }
+      // Snapshot the current body (sans frontmatter) for context snippets in the dialog.
+      const raw = await api.notebase.readFile(relativePath);
+      const activeBody = raw.replace(/^---\n[\s\S]*?\n---\n?/, '');
+      autoLinkReview = { relativePath, suggestions, activeBody };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
+    } finally {
+      autoLinkBusy = false;
+    }
+  }
+
+  async function handleAutoLinkApply(accepted: AutoLinkSuggestion[]) {
+    const review = autoLinkReview;
+    if (!review) return;
+    autoLinkReview = null;
+    try {
+      const { applied, skipped } = await api.refactor.autoLinkApply(review.relativePath, accepted);
+      if (applied.length === 0 && skipped.length > 0) {
+        await showConfirm(
+          `Auto-link couldn\u2019t apply any suggestions \u2014 the anchor text changed in the note. Try again.`,
+          CONFIRM_KEYS.autoLinkFailed,
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
+    }
+  }
+
   async function handleAutoTag(relativePath: string) {
     if (!notebase.meta) return;
     try {
@@ -751,6 +806,7 @@
     api.menu.onRefactorSplitHere(() => handleSplitHere());
     api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
     api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); });
+    api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); });
 
     // Notebase rename/rewrite notifications from main — keep open tabs
     // consistent with disk so the next auto-save doesn't overwrite a
@@ -911,6 +967,7 @@
                     onRename={() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); }}
                     onMove={() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); }}
                     onAutoTag={() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); }}
+                    onAutoLink={() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;
@@ -1042,6 +1099,14 @@
       confirmLabel={confirmDialog.confirmLabel}
       onConfirm={handleConfirmOk}
       onCancel={handleConfirmCancel}
+    />
+  {/if}
+  {#if autoLinkReview}
+    <AutoLinkDialog
+      suggestions={autoLinkReview.suggestions}
+      activeNoteBody={autoLinkReview.activeBody}
+      onApply={handleAutoLinkApply}
+      onCancel={() => { autoLinkReview = null; }}
     />
   {/if}
   {#if showSettings}

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -19,8 +19,10 @@
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationDialog from './lib/components/ConversationDialog.svelte';
   import AutoLinkDialog from './lib/components/AutoLinkDialog.svelte';
+  import AutoLinkInboundDialog from './lib/components/AutoLinkInboundDialog.svelte';
   import BusyOverlay from './lib/components/BusyOverlay.svelte';
   import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
+  import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
   import SettingsDialog from './lib/components/SettingsDialog.svelte';
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
@@ -68,6 +70,12 @@
   let autoLinkBusy = $state(false);
   /** When set, renders a modal spinner overlay with this label. */
   let busyLabel = $state<string | null>(null);
+
+  /** Pending Auto-link inbound suggestions to review. Non-null = dialog is shown. */
+  let autoLinkInboundReview = $state<{
+    relativePath: string;
+    suggestions: AutoLinkInboundSuggestion[];
+  } | null>(null);
   let inspectionCount = $state(0);
 
   async function refreshInspectionCount() {
@@ -483,6 +491,52 @@
     }
   }
 
+  async function handleAutoLinkInbound(relativePath: string) {
+    if (!notebase.meta || autoLinkBusy) return;
+    autoLinkBusy = true;
+    try {
+      const { suggestions } = await withBusy('Scanning other notes\u2026', () =>
+        api.refactor.autoLinkInboundSuggest(relativePath),
+      );
+      if (suggestions.length === 0) {
+        await showConfirm(
+          'Auto-link inbound found no places in other notes where a link here would fit.',
+          CONFIRM_KEYS.autoLinkNoSuggestions,
+          'OK',
+        );
+        return;
+      }
+      autoLinkInboundReview = { relativePath, suggestions };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
+    } finally {
+      autoLinkBusy = false;
+    }
+  }
+
+  async function handleAutoLinkInboundApply(accepted: AutoLinkInboundSuggestion[]) {
+    const review = autoLinkInboundReview;
+    if (!review) return;
+    autoLinkInboundReview = null;
+    try {
+      const plain = $state.snapshot(accepted) as AutoLinkInboundSuggestion[];
+      const { applied, skipped } = await withBusy('Applying inbound links\u2026', () =>
+        api.refactor.autoLinkInboundApply(review.relativePath, plain),
+      );
+      if (applied.length === 0 && skipped.length > 0) {
+        await showConfirm(
+          `Auto-link couldn\u2019t apply any suggestions \u2014 the anchor text changed in one or more source notes. Try again.`,
+          CONFIRM_KEYS.autoLinkFailed,
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
+    }
+  }
+
   async function handleAutoLinkApply(accepted: AutoLinkSuggestion[]) {
     const review = autoLinkReview;
     if (!review) return;
@@ -833,6 +887,7 @@
     api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
     api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); });
     api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); });
+    api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); });
 
     // Notebase rename/rewrite notifications from main — keep open tabs
     // consistent with disk so the next auto-save doesn't overwrite a
@@ -994,6 +1049,7 @@
                     onMove={() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); }}
                     onAutoTag={() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); }}
                     onAutoLink={() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); }}
+                    onAutoLinkInbound={() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;
@@ -1133,6 +1189,14 @@
       activeNoteBody={autoLinkReview.activeBody}
       onApply={handleAutoLinkApply}
       onCancel={() => { autoLinkReview = null; }}
+    />
+  {/if}
+  {#if autoLinkInboundReview}
+    <AutoLinkInboundDialog
+      suggestions={autoLinkInboundReview.suggestions}
+      activeStem={autoLinkInboundReview.relativePath.replace(/\.md$/i, '')}
+      onApply={handleAutoLinkInboundApply}
+      onCancel={() => { autoLinkInboundReview = null; }}
     />
   {/if}
   {#if busyLabel}

--- a/src/renderer/lib/components/AutoLinkDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkDialog.svelte
@@ -1,0 +1,292 @@
+<script lang="ts">
+  import type { AutoLinkSuggestion } from '../../../shared/refactor/auto-link';
+
+  interface Props {
+    suggestions: AutoLinkSuggestion[];
+    /** Active note body — used to render context snippets around each anchor. */
+    activeNoteBody: string;
+    onApply: (accepted: AutoLinkSuggestion[]) => void;
+    onCancel: () => void;
+  }
+
+  let { suggestions, activeNoteBody, onApply, onCancel }: Props = $props();
+
+  // Each suggestion is selected by default. Track selection by index.
+  let selected = $state<boolean[]>(suggestions.map(() => true));
+
+  const selectedCount = $derived(selected.filter(Boolean).length);
+
+  function toggleAll(value: boolean) {
+    selected = suggestions.map(() => value);
+  }
+
+  function toggle(i: number) {
+    selected[i] = !selected[i];
+  }
+
+  function apply() {
+    const accepted = suggestions.filter((_, i) => selected[i]);
+    onApply(accepted);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+
+  function contextSnippet(anchor: string): string {
+    const idx = activeNoteBody.indexOf(anchor);
+    if (idx < 0) return '';
+    const radius = 50;
+    const start = Math.max(0, idx - radius);
+    const end = Math.min(activeNoteBody.length, idx + anchor.length + radius);
+    const prefix = start > 0 ? '\u2026' : '';
+    const suffix = end < activeNoteBody.length ? '\u2026' : '';
+    return (
+      prefix +
+      activeNoteBody.slice(start, idx) +
+      '\u00BB' + anchor + '\u00AB' +
+      activeNoteBody.slice(idx + anchor.length, end) +
+      suffix
+    ).replace(/\s+/g, ' ');
+  }
+
+  function targetLabel(target: string): string {
+    return target.replace(/\.md$/i, '');
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="overlay"
+  onkeydown={handleKeydown}
+  onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+>
+  <div class="dialog">
+    <header>
+      <h2>Auto-link suggestions</h2>
+      <span class="count">{selectedCount} of {suggestions.length} selected</span>
+    </header>
+
+    {#if suggestions.length === 0}
+      <div class="empty">
+        The LLM didn\u2019t find any link candidates in this note. If the note is short or
+        doesn\u2019t mention concepts covered by other notes, that\u2019s the expected outcome.
+      </div>
+    {:else}
+      <div class="bulk">
+        <button class="link-btn" onclick={() => toggleAll(true)}>Select all</button>
+        <button class="link-btn" onclick={() => toggleAll(false)}>Select none</button>
+      </div>
+      <div class="list">
+        {#each suggestions as s, i (i)}
+          <label class="row">
+            <input type="checkbox" bind:checked={selected[i]} onchange={() => toggle(i)} />
+            <div class="details">
+              <div class="headline">
+                <span class="anchor">{s.anchorText}</span>
+                <span class="arrow">&rarr;</span>
+                <code class="target">[[{targetLabel(s.target)}]]</code>
+              </div>
+              {#if s.rationale}
+                <div class="rationale">{s.rationale}</div>
+              {/if}
+              <div class="context">{contextSnippet(s.anchorText)}</div>
+            </div>
+          </label>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="actions">
+      <button class="btn" onclick={onCancel}>Cancel</button>
+      <button
+        class="btn primary"
+        disabled={selectedCount === 0}
+        onclick={apply}
+      >Apply {selectedCount}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    width: 640px;
+    max-width: 92vw;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .count {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .empty {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    padding: 16px 0;
+  }
+
+  .bulk {
+    display: flex;
+    gap: 8px;
+  }
+
+  .link-btn {
+    background: none;
+    border: none;
+    color: var(--accent);
+    padding: 0;
+    font-size: 11px;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .link-btn:hover {
+    opacity: 0.8;
+  }
+
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-right: 4px;
+  }
+
+  .row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    cursor: pointer;
+  }
+
+  .row:hover {
+    border-color: var(--accent);
+  }
+
+  .row input[type='checkbox'] {
+    margin-top: 2px;
+    flex-shrink: 0;
+  }
+
+  .details {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .headline {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    flex-wrap: wrap;
+  }
+
+  .anchor {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .arrow {
+    color: var(--text-muted);
+  }
+
+  .target {
+    color: var(--accent);
+    font-size: 11px;
+  }
+
+  .rationale {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.4;
+  }
+
+  .context {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    padding: 4px 8px;
+    background: var(--bg-button);
+    border-radius: 4px;
+    word-break: break-word;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 4px;
+  }
+
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .btn:hover:not(:disabled) {
+    background: var(--bg-button-hover);
+  }
+
+  .btn.primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+
+  .btn.primary:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+</style>

--- a/src/renderer/lib/components/AutoLinkDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkDialog.svelte
@@ -20,10 +20,6 @@
     selected = suggestions.map(() => value);
   }
 
-  function toggle(i: number) {
-    selected[i] = !selected[i];
-  }
-
   function apply() {
     const accepted = suggestions.filter((_, i) => selected[i]);
     onApply(accepted);
@@ -80,7 +76,7 @@
       <div class="list">
         {#each suggestions as s, i (i)}
           <label class="row">
-            <input type="checkbox" bind:checked={selected[i]} onchange={() => toggle(i)} />
+            <input type="checkbox" bind:checked={selected[i]} />
             <div class="details">
               <div class="headline">
                 <span class="anchor">{s.anchorText}</span>

--- a/src/renderer/lib/components/AutoLinkInboundDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkInboundDialog.svelte
@@ -1,0 +1,306 @@
+<script lang="ts">
+  import type { AutoLinkInboundSuggestion } from '../../../shared/refactor/auto-link-inbound';
+
+  interface Props {
+    suggestions: AutoLinkInboundSuggestion[];
+    /** Stem (no .md) of the active note, for the link-target label. */
+    activeStem: string;
+    onApply: (accepted: AutoLinkInboundSuggestion[]) => void;
+    onCancel: () => void;
+  }
+
+  let { suggestions, activeStem, onApply, onCancel }: Props = $props();
+
+  let selected = $state<boolean[]>(suggestions.map(() => true));
+
+  const selectedCount = $derived(selected.filter(Boolean).length);
+
+  // Group suggestions by source note for display (keeps each source's
+  // anchors clustered visually). Preserves the original array indices so
+  // we can map checkbox state back.
+  const groups = $derived.by(() => {
+    const bySource = new Map<string, { i: number; s: AutoLinkInboundSuggestion }[]>();
+    suggestions.forEach((s, i) => {
+      if (!bySource.has(s.source)) bySource.set(s.source, []);
+      bySource.get(s.source)!.push({ i, s });
+    });
+    return [...bySource.entries()].map(([source, items]) => ({ source, items }));
+  });
+
+  function toggleAll(value: boolean) {
+    selected = suggestions.map(() => value);
+  }
+
+  function apply() {
+    onApply(suggestions.filter((_, i) => selected[i]));
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+
+  function stemOf(p: string): string {
+    return p.replace(/\.md$/i, '');
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="overlay"
+  onkeydown={handleKeydown}
+  onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+>
+  <div class="dialog">
+    <header>
+      <h2>Auto-link inbound suggestions</h2>
+      <span class="count">{selectedCount} of {suggestions.length} selected</span>
+    </header>
+    <div class="subtitle">
+      Places in other notes where a link to <code>[[{activeStem}]]</code> would fit.
+    </div>
+
+    {#if suggestions.length === 0}
+      <div class="empty">
+        The LLM didn\u2019t find any inbound link candidates across the scanned source notes.
+      </div>
+    {:else}
+      <div class="bulk">
+        <button class="link-btn" onclick={() => toggleAll(true)}>Select all</button>
+        <button class="link-btn" onclick={() => toggleAll(false)}>Select none</button>
+      </div>
+      <div class="list">
+        {#each groups as g (g.source)}
+          <div class="group">
+            <div class="source"><code>{g.source}</code></div>
+            {#each g.items as { i, s } (i)}
+              <label class="row">
+                <input type="checkbox" bind:checked={selected[i]} />
+                <div class="details">
+                  <div class="headline">
+                    <span class="anchor">{s.anchorText}</span>
+                    <span class="arrow">&rarr;</span>
+                    <code class="target">[[{activeStem}]]</code>
+                  </div>
+                  {#if s.rationale}
+                    <div class="rationale">{s.rationale}</div>
+                  {/if}
+                  {#if s.contextSnippet}
+                    <div class="context">{s.contextSnippet}</div>
+                  {/if}
+                </div>
+              </label>
+            {/each}
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="actions">
+      <button class="btn" onclick={onCancel}>Cancel</button>
+      <button class="btn primary" disabled={selectedCount === 0} onclick={apply}>
+        Apply {selectedCount}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    width: 680px;
+    max-width: 92vw;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .count {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .subtitle {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+
+  .subtitle code {
+    color: var(--accent);
+    font-size: 11px;
+  }
+
+  .empty {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    padding: 16px 0;
+  }
+
+  .bulk {
+    display: flex;
+    gap: 8px;
+  }
+
+  .link-btn {
+    background: none;
+    border: none;
+    color: var(--accent);
+    padding: 0;
+    font-size: 11px;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .link-btn:hover { opacity: 0.8; }
+
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-right: 4px;
+  }
+
+  .group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .source {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding-bottom: 2px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .source code {
+    color: var(--text);
+    font-size: 11px;
+  }
+
+  .row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    cursor: pointer;
+  }
+
+  .row:hover { border-color: var(--accent); }
+
+  .row input[type='checkbox'] {
+    margin-top: 2px;
+    flex-shrink: 0;
+  }
+
+  .details {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .headline {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    flex-wrap: wrap;
+  }
+
+  .anchor {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .arrow {
+    color: var(--text-muted);
+  }
+
+  .target {
+    color: var(--accent);
+    font-size: 11px;
+  }
+
+  .rationale {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.4;
+  }
+
+  .context {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    padding: 4px 8px;
+    background: var(--bg-button);
+    border-radius: 4px;
+    word-break: break-word;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 4px;
+  }
+
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .btn:hover:not(:disabled) { background: var(--bg-button-hover); }
+
+  .btn.primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+
+  .btn.primary:hover:not(:disabled) { opacity: 0.9; }
+
+  .btn:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/src/renderer/lib/components/BusyOverlay.svelte
+++ b/src/renderer/lib/components/BusyOverlay.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  interface Props {
+    label: string;
+  }
+
+  let { label }: Props = $props();
+</script>
+
+<div class="overlay">
+  <div class="box">
+    <div class="spinner" aria-hidden="true"></div>
+    <div class="label">{label}</div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 3000;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 18px 22px;
+    min-width: 180px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  .spinner {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent);
+    animation: spin 0.9s linear infinite;
+  }
+
+  .label {
+    font-size: 12px;
+    color: var(--text);
+    text-align: center;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -54,6 +54,7 @@
     onMove?: () => void;
     onAutoTag?: () => void;
     onAutoLink?: () => void;
+    onAutoLinkInbound?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -79,6 +80,7 @@
     onMove,
     onAutoTag,
     onAutoLink,
+    onAutoLinkInbound,
     getNotePaths,
   }: Props = $props();
 
@@ -688,7 +690,7 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag || onAutoLink}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag || onAutoLink || onAutoLinkInbound}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -713,7 +715,7 @@
           {#if onSplitByHeading}
             <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
           {/if}
-          {#if onAutoTag || onAutoLink}
+          {#if onAutoTag || onAutoLink || onAutoLinkInbound}
             {#if onExtractSelection || onSplitHere || onSplitByHeading}
               <div class="separator"></div>
             {/if}
@@ -721,7 +723,10 @@
               <button onclick={() => handleMenuAction(() => onAutoTag?.())}>Auto-tag</button>
             {/if}
             {#if onAutoLink}
-              <button onclick={() => handleMenuAction(() => onAutoLink?.())}>Auto-link&hellip;</button>
+              <button onclick={() => handleMenuAction(() => onAutoLink?.())}>Auto-link outbound&hellip;</button>
+            {/if}
+            {#if onAutoLinkInbound}
+              <button onclick={() => handleMenuAction(() => onAutoLinkInbound?.())}>Auto-link inbound&hellip;</button>
             {/if}
           {/if}
         </div>

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -53,6 +53,7 @@
     onRename?: () => void;
     onMove?: () => void;
     onAutoTag?: () => void;
+    onAutoLink?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -77,6 +78,7 @@
     onRename,
     onMove,
     onAutoTag,
+    onAutoLink,
     getNotePaths,
   }: Props = $props();
 
@@ -686,7 +688,7 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag || onAutoLink}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -711,11 +713,16 @@
           {#if onSplitByHeading}
             <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
           {/if}
-          {#if onAutoTag}
+          {#if onAutoTag || onAutoLink}
             {#if onExtractSelection || onSplitHere || onSplitByHeading}
               <div class="separator"></div>
             {/if}
-            <button onclick={() => handleMenuAction(() => onAutoTag?.())}>Auto-tag</button>
+            {#if onAutoTag}
+              <button onclick={() => handleMenuAction(() => onAutoTag?.())}>Auto-tag</button>
+            {/if}
+            {#if onAutoLink}
+              <button onclick={() => handleMenuAction(() => onAutoLink?.())}>Auto-link&hellip;</button>
+            {/if}
           {/if}
         </div>
       </div>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -15,6 +15,8 @@ export const CONFIRM_KEYS = {
   moveCollision: 'move-collision',
   autoTagNoSuggestions: 'auto-tag-no-suggestions',
   autoTagFailed: 'auto-tag-failed',
+  autoLinkNoSuggestions: 'auto-link-no-suggestions',
+  autoLinkFailed: 'auto-link-failed',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -61,6 +63,18 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Auto-tag failed',
     description:
       'Shown when Auto-tag errors out (network failure, missing API key, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.autoLinkNoSuggestions,
+    title: 'Auto-link returned no suggestions',
+    description:
+      'Shown when the LLM produced no link candidates for the note.',
+  },
+  {
+    key: CONFIRM_KEYS.autoLinkFailed,
+    title: 'Auto-link failed',
+    description:
+      'Shown when Auto-link errors out or can\u2019t apply any accepted suggestions.',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -121,6 +121,17 @@ export interface TabsApi {
 
 export interface RefactorApi {
   autoTag(relativePath: string): Promise<{ added: string[] }>;
+  autoLinkSuggest(relativePath: string): Promise<{
+    suggestions: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[];
+    candidateCount: number;
+  }>;
+  autoLinkApply(
+    relativePath: string,
+    accepted: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[],
+  ): Promise<{
+    applied: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[];
+    skipped: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[];
+  }>;
 }
 
 export interface ToolsApi {
@@ -169,6 +180,7 @@ export interface MenuApi {
   onRefactorSplitHere(cb: () => void): void;
   onRefactorSplitByHeading(cb: () => void): void;
   onRefactorAutoTag(cb: () => void): void;
+  onRefactorAutoLink(cb: () => void): void;
 }
 
 export interface IdeApi {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -132,6 +132,18 @@ export interface RefactorApi {
     applied: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[];
     skipped: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[];
   }>;
+  autoLinkInboundSuggest(relativePath: string): Promise<{
+    suggestions: import('../../../shared/refactor/auto-link-inbound').AutoLinkInboundSuggestion[];
+    candidateCount: number;
+  }>;
+  autoLinkInboundApply(
+    relativePath: string,
+    accepted: import('../../../shared/refactor/auto-link-inbound').AutoLinkInboundSuggestion[],
+  ): Promise<{
+    applied: import('../../../shared/refactor/auto-link-inbound').AutoLinkInboundSuggestion[];
+    skipped: import('../../../shared/refactor/auto-link-inbound').AutoLinkInboundSuggestion[];
+    touchedPaths: string[];
+  }>;
 }
 
 export interface ToolsApi {
@@ -181,6 +193,7 @@ export interface MenuApi {
   onRefactorSplitByHeading(cb: () => void): void;
   onRefactorAutoTag(cb: () => void): void;
   onRefactorAutoLink(cb: () => void): void;
+  onRefactorAutoLinkInbound(cb: () => void): void;
 }
 
 export interface IdeApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -87,6 +87,7 @@ export const Channels = {
   MENU_REFACTOR_SPLIT_BY_HEADING: 'menu:refactor:splitByHeading',
   MENU_REFACTOR_AUTOTAG: 'menu:refactor:autotag',
   MENU_REFACTOR_AUTOLINK: 'menu:refactor:autolink',
+  MENU_REFACTOR_AUTOLINK_INBOUND: 'menu:refactor:autolinkInbound',
 
   /** Renderer-initiated LLM Auto-tag of a note (#174). */
   REFACTOR_AUTO_TAG: 'refactor:autoTag',
@@ -94,6 +95,10 @@ export const Channels = {
   REFACTOR_AUTO_LINK_SUGGEST: 'refactor:autoLinkSuggest',
   /** Apply accepted Auto-link suggestions to the active note. */
   REFACTOR_AUTO_LINK_APPLY: 'refactor:autoLinkApply',
+  /** LLM-suggested inbound wiki-links from other notes to the active note. */
+  REFACTOR_AUTO_LINK_INBOUND_SUGGEST: 'refactor:autoLinkInboundSuggest',
+  /** Apply accepted inbound Auto-link suggestions (writes to multiple source notes). */
+  REFACTOR_AUTO_LINK_INBOUND_APPLY: 'refactor:autoLinkInboundApply',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -86,9 +86,14 @@ export const Channels = {
   MENU_REFACTOR_SPLIT_HERE: 'menu:refactor:splitHere',
   MENU_REFACTOR_SPLIT_BY_HEADING: 'menu:refactor:splitByHeading',
   MENU_REFACTOR_AUTOTAG: 'menu:refactor:autotag',
+  MENU_REFACTOR_AUTOLINK: 'menu:refactor:autolink',
 
   /** Renderer-initiated LLM Auto-tag of a note (#174). */
   REFACTOR_AUTO_TAG: 'refactor:autoTag',
+  /** LLM-suggested outbound wiki-links for a note (#175). */
+  REFACTOR_AUTO_LINK_SUGGEST: 'refactor:autoLinkSuggest',
+  /** Apply accepted Auto-link suggestions to the active note. */
+  REFACTOR_AUTO_LINK_APPLY: 'refactor:autoLinkApply',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',

--- a/src/shared/refactor/auto-link-inbound.ts
+++ b/src/shared/refactor/auto-link-inbound.ts
@@ -1,0 +1,124 @@
+/**
+ * "Auto-link inbound" mode (#175 follow-up): find places in *other* notes
+ * where a link pointing at the active note would fit naturally.
+ */
+
+/** One suggestion for a link pointing to the active note from a specific source note. */
+export interface AutoLinkInboundSuggestion {
+  /** Relative path of the note that should gain the new link. */
+  source: string;
+  /** Verbatim substring of the source note's body that should become the link. */
+  anchorText: string;
+  /** Short reason the LLM gave. */
+  rationale: string;
+  /** Context snippet around the anchor in the source note body, for the review dialog. */
+  contextSnippet?: string;
+}
+
+export interface InboundCandidate {
+  relativePath: string;
+  title: string;
+  /** Full body (frontmatter stripped). */
+  body: string;
+}
+
+export function buildAutoLinkInboundPrompt(args: {
+  activeTitle: string;
+  activePath: string;
+  activeSummary: string;
+  candidates: InboundCandidate[];
+}): string {
+  const sections = args.candidates.map((c) =>
+    `### ${c.title} \u2014 \`${c.relativePath}\`\n\n${c.body.trim() || '(empty)'}`,
+  ).join('\n\n');
+
+  const activeStem = args.activePath.replace(/\.md$/i, '');
+
+  return `You are identifying missing inbound wiki-links across a personal knowledge base. The user is working in a specific "active note", and your job is to find spots in **other notes** where a link pointing at the active note would fit naturally.
+
+## Active note
+Title: ${args.activeTitle || '(untitled)'}
+Path: \`${args.activePath}\`
+
+Summary:
+${args.activeSummary || '(no summary)'}
+
+## Rules
+- Only propose a link where the source note **already discusses the concept covered by the active note**. Don\u2019t invent topics. Don\u2019t link to concepts merely adjacent.
+- The \`anchorText\` must be a **verbatim substring** of the source note\u2019s body. Don\u2019t paraphrase. Preserve capitalisation and punctuation exactly.
+- Prefer short anchor phrases (1\u20134 words) over long ones.
+- Skip anchors that are already inside an existing \`[[\u2026]]\` wiki-link.
+- One anchor per source note per concept \u2014 the most natural first occurrence. The user can manually add more later.
+- Some candidate source notes may genuinely have no good insertion point. **Skip them silently** rather than forcing a suggestion.
+- If nothing fits across any source, return \`[]\`.
+
+## Output format
+A single JSON array, nothing else. No prose, no commentary, no code fences.
+
+\`\`\`
+[
+  { "source": "path/to/source.md", "anchorText": "\u2026", "rationale": "\u2026" }
+]
+\`\`\`
+
+The \`source\` field must be one of the candidate paths below, verbatim. The link itself will be \`[[${activeStem}]]\` \u2014 you do not control the target.
+
+## Candidate source notes
+${sections || '(none)'}
+`;
+}
+
+export function parseInboundResponse(
+  text: string,
+  validSources: Set<string>,
+): AutoLinkInboundSuggestion[] {
+  const json = extractJsonArray(text);
+  if (!json) return [];
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+
+  const out: AutoLinkInboundSuggestion[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const source = typeof e.source === 'string' ? e.source : null;
+    const anchorText = typeof e.anchorText === 'string' ? e.anchorText : null;
+    const rationale = typeof e.rationale === 'string' ? e.rationale : '';
+    if (!source || !anchorText) continue;
+    if (!validSources.has(source)) continue;
+    out.push({ source, anchorText, rationale });
+  }
+  return out;
+}
+
+function extractJsonArray(text: string): string | null {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fence ? fence[1] : text;
+  const start = candidate.indexOf('[');
+  const end = candidate.lastIndexOf(']');
+  if (start < 0 || end <= start) return null;
+  return candidate.slice(start, end + 1);
+}
+
+/** Returns a ~100-char window around the first occurrence of `anchor` in `body`. Empty when not found. */
+export function snippetAround(body: string, anchor: string, radius = 50): string {
+  const idx = body.indexOf(anchor);
+  if (idx < 0) return '';
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(body.length, idx + anchor.length + radius);
+  const prefix = start > 0 ? '\u2026' : '';
+  const suffix = end < body.length ? '\u2026' : '';
+  return (
+    prefix +
+    body.slice(start, idx) +
+    '\u00BB' + anchor + '\u00AB' +
+    body.slice(idx + anchor.length, end) +
+    suffix
+  ).replace(/\s+/g, ' ');
+}

--- a/src/shared/refactor/auto-link.ts
+++ b/src/shared/refactor/auto-link.ts
@@ -1,0 +1,198 @@
+/** One suggestion produced by the Auto-link "link to" mode (#175). */
+export interface AutoLinkSuggestion {
+  /** Verbatim substring of the active note body that should become a link. */
+  anchorText: string;
+  /** Target note's relative path (with .md). The link itself drops the extension. */
+  target: string;
+  /** Short reason the LLM gave for suggesting this link. */
+  rationale: string;
+}
+
+/** Condensed note record sent to the LLM as a candidate target. */
+export interface CandidateNote {
+  relativePath: string;
+  title: string;
+  summary: string;
+}
+
+/** Approximate budget per candidate summary (in characters). Keeps the prompt bounded. */
+const SUMMARY_CHAR_BUDGET = 360;
+
+/**
+ * Pulls a short summary from a note: frontmatter `description` if present,
+ * otherwise the first non-empty paragraph of body content. Falls back to
+ * the first 360 chars of whatever we have when neither is available.
+ */
+export function extractSummary(body: string, frontmatterDescription?: string): string {
+  const d = frontmatterDescription?.trim();
+  if (d) return truncate(d, SUMMARY_CHAR_BUDGET);
+
+  // Strip common non-prose noise: headings, list markers, code fences.
+  const stripped = body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/^#+\s.*$/gm, '')
+    .trim();
+  const firstPara = stripped.split(/\n\s*\n/).find((p) => p.trim().length > 0)?.trim() ?? '';
+  return truncate(firstPara, SUMMARY_CHAR_BUDGET);
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n).trimEnd() + '\u2026';
+}
+
+/**
+ * Builds the "link to" prompt. The LLM sees the active note's body and an
+ * index of candidate notes (path + title + summary). It returns a JSON
+ * array of `{ anchorText, target, rationale }` suggestions.
+ */
+export function buildAutoLinkToPrompt(args: {
+  activeTitle: string;
+  activeBody: string;
+  candidates: CandidateNote[];
+}): string {
+  const index = args.candidates
+    .map((c) => `- \`${c.relativePath}\` \u2014 **${c.title}**\n  ${c.summary || '(no summary)'}`)
+    .join('\n');
+
+  return `You are identifying missing wiki-links in a note the user is working on. Your job is to propose places where a link to one of the candidate notes would fit naturally.
+
+## Rules
+- Only propose links where the active note **already mentions the candidate\u2019s concept** \u2014 don\u2019t invent topics, and don\u2019t link to notes the active note doesn\u2019t actually discuss.
+- The \`anchorText\` must be a **verbatim substring** of the active note body. Don\u2019t paraphrase. Don\u2019t add or drop punctuation. Preserve capitalisation exactly.
+- Prefer short anchor phrases (1\u20134 words) over long ones.
+- Skip anchors that are already inside an existing \`[[\u2026]]\` link.
+- If a concept appears multiple times, propose **one** anchor for it \u2014 the most natural first occurrence. The user can manually add more later.
+- \`target\` must be one of the candidate paths below, verbatim.
+- Keep rationale short \u2014 one short sentence, no fluff.
+- If nothing fits, return \`[]\`.
+
+## Output format
+A single JSON array, nothing else. No prose, no commentary, no code fences.
+
+\`\`\`
+[
+  { "anchorText": "\u2026", "target": "\u2026.md", "rationale": "\u2026" }
+]
+\`\`\`
+
+## Active note
+Title: ${args.activeTitle || '(untitled)'}
+
+${args.activeBody}
+
+## Candidate notes (targets)
+${index || '(none)'}
+`;
+}
+
+/**
+ * Parses the LLM\u2019s JSON array of suggestions. Tolerant of surrounding
+ * prose, code fences, and trailing commas. Skips malformed entries.
+ */
+export function parseAutoLinkResponse(
+  text: string,
+  validTargets: Set<string>,
+): AutoLinkSuggestion[] {
+  const json = extractJsonArray(text);
+  if (!json) return [];
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+
+  const out: AutoLinkSuggestion[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const anchorText = typeof e.anchorText === 'string' ? e.anchorText : null;
+    const target = typeof e.target === 'string' ? e.target : null;
+    const rationale = typeof e.rationale === 'string' ? e.rationale : '';
+    if (!anchorText || !target) continue;
+    if (!validTargets.has(target)) continue;
+    out.push({ anchorText, target, rationale });
+  }
+  return out;
+}
+
+function extractJsonArray(text: string): string | null {
+  // Strip markdown code fences if the model wrapped the JSON in one.
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fence ? fence[1] : text;
+  const start = candidate.indexOf('[');
+  const end = candidate.lastIndexOf(']');
+  if (start < 0 || end <= start) return null;
+  return candidate.slice(start, end + 1);
+}
+
+export interface ApplyResult {
+  /** Rewritten active-note content. Equals the input when nothing applied. */
+  content: string;
+  /** Suggestions that were inserted. */
+  applied: AutoLinkSuggestion[];
+  /** Suggestions whose anchor text wasn\u2019t found (content drifted). */
+  skipped: AutoLinkSuggestion[];
+}
+
+/**
+ * Inserts accepted suggestions into the active note body. Each suggestion
+ * replaces the **first** occurrence of its anchor text with
+ * `[[target-stem|anchorText]]` (or `[[target-stem]]` when the anchor
+ * already matches the target\u2019s stem). Skips anchors already inside a
+ * `[[\u2026]]` link, and anchors that can\u2019t be found.
+ *
+ * Processes suggestions in descending order of anchor length so a longer
+ * phrase isn\u2019t shadowed by a substring of it that already got linked.
+ */
+export function applyLinkInsertions(
+  content: string,
+  suggestions: AutoLinkSuggestion[],
+): ApplyResult {
+  const ordered = [...suggestions].sort((a, b) => b.anchorText.length - a.anchorText.length);
+  const applied: AutoLinkSuggestion[] = [];
+  const skipped: AutoLinkSuggestion[] = [];
+  let current = content;
+
+  for (const s of ordered) {
+    const offset = findUnlinkedOccurrence(current, s.anchorText);
+    if (offset < 0) {
+      skipped.push(s);
+      continue;
+    }
+    const stem = s.target.replace(/\.md$/i, '');
+    const link = stem === s.anchorText ? `[[${stem}]]` : `[[${stem}|${s.anchorText}]]`;
+    current = current.slice(0, offset) + link + current.slice(offset + s.anchorText.length);
+    applied.push(s);
+  }
+
+  return { content: current, applied, skipped };
+}
+
+/**
+ * First occurrence of `needle` in `haystack` that isn\u2019t inside an existing
+ * `[[\u2026]]` wiki-link. Returns -1 when none found.
+ */
+function findUnlinkedOccurrence(haystack: string, needle: string): number {
+  if (!needle) return -1;
+  let from = 0;
+  while (from <= haystack.length - needle.length) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx < 0) return -1;
+    if (!isInsideWikiLink(haystack, idx)) return idx;
+    from = idx + needle.length;
+  }
+  return -1;
+}
+
+function isInsideWikiLink(text: string, offset: number): boolean {
+  // Scan backwards for `[[` without a closing `]]` between it and offset.
+  const before = text.slice(0, offset);
+  const lastOpen = before.lastIndexOf('[[');
+  if (lastOpen < 0) return false;
+  const lastClose = before.lastIndexOf(']]');
+  return lastClose < lastOpen;
+}

--- a/tests/shared/refactor/auto-link-inbound.test.ts
+++ b/tests/shared/refactor/auto-link-inbound.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAutoLinkInboundPrompt,
+  parseInboundResponse,
+  snippetAround,
+} from '../../../src/shared/refactor/auto-link-inbound';
+
+describe('buildAutoLinkInboundPrompt (issue #175 part 2)', () => {
+  it('embeds the active note summary and each candidate\u2019s full body', () => {
+    const prompt = buildAutoLinkInboundPrompt({
+      activeTitle: 'Entropy',
+      activePath: 'physics/entropy.md',
+      activeSummary: 'How disorder scales in closed systems.',
+      candidates: [
+        { relativePath: 'thermo.md', title: 'Thermodynamics', body: 'The second law states that entropy in a closed system never decreases.' },
+      ],
+    });
+    expect(prompt).toContain('Entropy');
+    expect(prompt).toContain('physics/entropy.md');
+    expect(prompt).toContain('disorder scales in closed systems');
+    expect(prompt).toContain('Thermodynamics');
+    expect(prompt).toContain('second law');
+    expect(prompt).toContain('`thermo.md`');
+  });
+
+  it('mentions that the link target will be the active note stem', () => {
+    const prompt = buildAutoLinkInboundPrompt({
+      activeTitle: 'X',
+      activePath: 'notes/x.md',
+      activeSummary: '',
+      candidates: [],
+    });
+    expect(prompt).toContain('[[notes/x]]');
+  });
+
+  it('restates the verbatim-anchor and JSON-output rules', () => {
+    const prompt = buildAutoLinkInboundPrompt({
+      activeTitle: '', activePath: 'a.md', activeSummary: '', candidates: [],
+    });
+    expect(prompt).toMatch(/verbatim substring/i);
+    expect(prompt).toContain('"source"');
+    expect(prompt).toContain('"anchorText"');
+  });
+});
+
+describe('parseInboundResponse', () => {
+  const valid = new Set(['thermo.md', 'stat-mech.md']);
+
+  it('parses a bare JSON array', () => {
+    const raw = '[{"source":"thermo.md","anchorText":"entropy","rationale":"matches active"}]';
+    expect(parseInboundResponse(raw, valid)).toEqual([
+      { source: 'thermo.md', anchorText: 'entropy', rationale: 'matches active' },
+    ]);
+  });
+
+  it('tolerates markdown code fences and prose around the array', () => {
+    const raw = 'Here you go:\n```json\n[{"source":"stat-mech.md","anchorText":"microstates","rationale":""}]\n```\nDone.';
+    expect(parseInboundResponse(raw, valid)).toEqual([
+      { source: 'stat-mech.md', anchorText: 'microstates', rationale: '' },
+    ]);
+  });
+
+  it('drops entries with unknown sources', () => {
+    const raw = '[{"source":"nonexistent.md","anchorText":"x","rationale":""}]';
+    expect(parseInboundResponse(raw, valid)).toEqual([]);
+  });
+
+  it('drops entries missing required fields', () => {
+    const raw = '[{"source":"thermo.md"},{"anchorText":"y"},{"source":"thermo.md","anchorText":"z"}]';
+    expect(parseInboundResponse(raw, valid)).toEqual([
+      { source: 'thermo.md', anchorText: 'z', rationale: '' },
+    ]);
+  });
+
+  it('returns [] for malformed or non-array JSON', () => {
+    expect(parseInboundResponse('not JSON', valid)).toEqual([]);
+    expect(parseInboundResponse('{"source":"thermo.md"}', valid)).toEqual([]);
+  });
+});
+
+describe('snippetAround', () => {
+  it('renders the anchor bracketed by \u00BB / \u00AB with surrounding context', () => {
+    const body = 'In thermodynamics, entropy tends to increase in closed systems over time.';
+    const snippet = snippetAround(body, 'entropy', 20);
+    expect(snippet).toContain('\u00BBentropy\u00AB');
+    expect(snippet.length).toBeLessThanOrEqual(body.length + 4); // ellipsis + markers
+  });
+
+  it('adds leading/trailing ellipsis when context is truncated', () => {
+    const body = 'A'.repeat(200) + ' target ' + 'B'.repeat(200);
+    const s = snippetAround(body, 'target', 20);
+    expect(s.startsWith('\u2026')).toBe(true);
+    expect(s.endsWith('\u2026')).toBe(true);
+  });
+
+  it('returns empty when the anchor is not in the body', () => {
+    expect(snippetAround('hello world', 'missing')).toBe('');
+  });
+
+  it('collapses runs of whitespace into single spaces', () => {
+    const body = 'before\n\n\ttarget\n\nafter';
+    const s = snippetAround(body, 'target');
+    expect(s).not.toMatch(/\s{2,}/);
+  });
+});

--- a/tests/shared/refactor/auto-link.test.ts
+++ b/tests/shared/refactor/auto-link.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractSummary,
+  buildAutoLinkToPrompt,
+  parseAutoLinkResponse,
+  applyLinkInsertions,
+} from '../../../src/shared/refactor/auto-link';
+
+describe('extractSummary (issue #175)', () => {
+  it('prefers the frontmatter description when provided', () => {
+    const s = extractSummary('# Title\n\nBody paragraph.', 'Short description.');
+    expect(s).toBe('Short description.');
+  });
+
+  it('falls back to the first non-empty paragraph of body', () => {
+    const body = '# Title\n\nFirst paragraph.\n\nSecond paragraph.';
+    expect(extractSummary(body)).toBe('First paragraph.');
+  });
+
+  it('strips code fences and headings before finding the paragraph', () => {
+    const body = '# Title\n\n```js\nconst x = 1;\n```\n\nReal paragraph.';
+    expect(extractSummary(body)).toBe('Real paragraph.');
+  });
+
+  it('truncates to the char budget with an ellipsis', () => {
+    const body = 'A'.repeat(500);
+    const s = extractSummary(body);
+    expect(s.length).toBeLessThanOrEqual(361); // budget 360 + ellipsis
+    expect(s.endsWith('\u2026')).toBe(true);
+  });
+
+  it('returns empty when body has no prose', () => {
+    expect(extractSummary('# Only a heading')).toBe('');
+  });
+});
+
+describe('buildAutoLinkToPrompt', () => {
+  it('lists each candidate by path, title, and summary', () => {
+    const prompt = buildAutoLinkToPrompt({
+      activeTitle: 'Active',
+      activeBody: 'Some content.',
+      candidates: [
+        { relativePath: 'ml.md', title: 'Machine Learning', summary: 'ML intro.' },
+        { relativePath: 'bias.md', title: 'Cognitive Bias', summary: 'Bias intro.' },
+      ],
+    });
+    expect(prompt).toContain('`ml.md`');
+    expect(prompt).toContain('**Machine Learning**');
+    expect(prompt).toContain('ML intro.');
+    expect(prompt).toContain('`bias.md`');
+  });
+
+  it('renders "(no summary)" when a candidate has an empty summary', () => {
+    const prompt = buildAutoLinkToPrompt({
+      activeTitle: 'A',
+      activeBody: 'Body.',
+      candidates: [{ relativePath: 'x.md', title: 'X', summary: '' }],
+    });
+    expect(prompt).toContain('(no summary)');
+  });
+
+  it('spells out the verbatim-anchor and return-shape rules', () => {
+    const prompt = buildAutoLinkToPrompt({ activeTitle: '', activeBody: '', candidates: [] });
+    expect(prompt).toMatch(/verbatim substring/i);
+    expect(prompt).toContain('anchorText');
+    expect(prompt).toContain('target');
+  });
+});
+
+describe('parseAutoLinkResponse', () => {
+  const valid = new Set(['ml.md', 'bias.md']);
+
+  it('parses a bare JSON array', () => {
+    const raw = '[{"anchorText":"machine learning","target":"ml.md","rationale":"matches"}]';
+    expect(parseAutoLinkResponse(raw, valid)).toEqual([
+      { anchorText: 'machine learning', target: 'ml.md', rationale: 'matches' },
+    ]);
+  });
+
+  it('strips surrounding prose before the JSON array', () => {
+    const raw = 'Here you go:\n[{"anchorText":"x","target":"ml.md","rationale":""}]\nLet me know.';
+    expect(parseAutoLinkResponse(raw, valid)).toEqual([
+      { anchorText: 'x', target: 'ml.md', rationale: '' },
+    ]);
+  });
+
+  it('strips markdown code fences', () => {
+    const raw = '```json\n[{"anchorText":"x","target":"ml.md","rationale":""}]\n```';
+    expect(parseAutoLinkResponse(raw, valid)).toEqual([
+      { anchorText: 'x', target: 'ml.md', rationale: '' },
+    ]);
+  });
+
+  it('drops entries with unknown targets', () => {
+    const raw = '[{"anchorText":"x","target":"nonexistent.md","rationale":""}]';
+    expect(parseAutoLinkResponse(raw, valid)).toEqual([]);
+  });
+
+  it('drops entries missing required fields', () => {
+    const raw = '[{"anchorText":"x"},{"target":"ml.md"},{"anchorText":"y","target":"ml.md"}]';
+    expect(parseAutoLinkResponse(raw, valid)).toEqual([
+      { anchorText: 'y', target: 'ml.md', rationale: '' },
+    ]);
+  });
+
+  it('returns [] for non-array / malformed JSON', () => {
+    expect(parseAutoLinkResponse('not JSON', valid)).toEqual([]);
+    expect(parseAutoLinkResponse('{"anchorText":"x"}', valid)).toEqual([]);
+  });
+});
+
+describe('applyLinkInsertions', () => {
+  it('replaces anchor text with [[target-stem|anchor]] on first occurrence', () => {
+    const out = applyLinkInsertions(
+      'I care about machine learning and AI.',
+      [{ anchorText: 'machine learning', target: 'ml.md', rationale: '' }],
+    );
+    expect(out.content).toBe('I care about [[ml|machine learning]] and AI.');
+    expect(out.applied).toHaveLength(1);
+    expect(out.skipped).toHaveLength(0);
+  });
+
+  it('uses bare [[stem]] when the anchor already matches the target stem', () => {
+    const out = applyLinkInsertions(
+      'See ml for details.',
+      [{ anchorText: 'ml', target: 'ml.md', rationale: '' }],
+    );
+    expect(out.content).toContain('[[ml]]');
+  });
+
+  it('skips anchor text already inside a [[\u2026]] wiki-link', () => {
+    const out = applyLinkInsertions(
+      '[[existing|machine learning]] and later machine learning again',
+      [{ anchorText: 'machine learning', target: 'ml.md', rationale: '' }],
+    );
+    // Should replace the SECOND occurrence, not the one inside the existing link.
+    expect(out.content).toContain('[[existing|machine learning]]');
+    expect(out.content).toContain('[[ml|machine learning]] again');
+    expect(out.applied).toHaveLength(1);
+  });
+
+  it('reports skipped when the anchor text isn\u2019t found', () => {
+    const out = applyLinkInsertions(
+      'Some unrelated text.',
+      [{ anchorText: 'machine learning', target: 'ml.md', rationale: '' }],
+    );
+    expect(out.content).toBe('Some unrelated text.');
+    expect(out.applied).toHaveLength(0);
+    expect(out.skipped).toHaveLength(1);
+  });
+
+  it('applies longer anchors first so nested overlaps don\u2019t clobber each other', () => {
+    const out = applyLinkInsertions(
+      'The machine learning model improves machine performance.',
+      [
+        { anchorText: 'machine', target: 'machine.md', rationale: '' },
+        { anchorText: 'machine learning', target: 'ml.md', rationale: '' },
+      ],
+    );
+    expect(out.content).toContain('[[ml|machine learning]]');
+    // The second `machine` (standalone) still gets its own link.
+    expect(out.content).toContain('[[machine]] performance');
+    expect(out.applied).toHaveLength(2);
+  });
+
+  it('strips folder paths to just the stem when building the link target', () => {
+    const out = applyLinkInsertions(
+      'Fusion is hot.',
+      [{ anchorText: 'Fusion', target: 'physics/fusion.md', rationale: '' }],
+    );
+    // Stem = "physics/fusion" (no .md extension). Full path preserved; only .md suffix is stripped.
+    expect(out.content).toContain('[[physics/fusion|Fusion]]');
+  });
+});


### PR DESCRIPTION
## Summary
Refactor menu command that suggests places in the active note where a wiki-link to one of the thoughtbase\u2019s other notes would fit. LLM returns anchor-text based suggestions; user reviews them in a dialog; accepted suggestions land as `[[target-stem|anchor]]` on the first unlinked occurrence of each anchor.

Ticket `#175` scoped both "link to" and "link from" directions. This PR ships the **"link to"** direction only. See "Deferred" below.

## Entry points
- **Refactor \u25B8 Auto-link\u2026** in the title-bar Refactor menu
- **Refactor \u25B8 Auto-link\u2026** in the editor right-click submenu

## Flow
1. User invokes \u2192 main walks the thoughtbase, builds compact candidate index (path, title, 1-paragraph summary from `dc:description` or the first non-empty paragraph). Hard cap at 150 candidates to keep the prompt bounded.
2. LLM gets the active note body + candidate index. Returns JSON: `[{ anchorText, target, rationale }]`.
3. Main filters out suggestions whose `anchorText` isn\u2019t a verbatim substring of the active body (LLM paraphrases are dropped).
4. Renderer opens `AutoLinkDialog` \u2014 each row has a checkbox (default on), the anchor text, the proposed target, the rationale, and a context snippet (`\u2026before \u00BB anchor \u00AB after\u2026`). Select all / none shortcuts.
5. Apply \u2192 main replaces the first unlinked occurrence of each accepted anchor with `[[target-stem|anchor]]` (or `[[target-stem]]` when the anchor equals the stem exactly). Longer anchors apply first so nested overlaps don\u2019t clobber each other.
6. Write goes through the standard `NOTEBASE_REWRITTEN` broadcast \u2014 open tabs of the active note reload with the new links.

## Pure pieces (`src/shared/refactor/auto-link.ts`)
- `extractSummary` \u2014 summary builder (description > first paragraph > empty). 360-char budget with ellipsis.
- `buildAutoLinkToPrompt` \u2014 prompt with verbatim-anchor rules + JSON shape.
- `parseAutoLinkResponse` \u2014 tolerant of code fences, surrounding prose; drops unknown targets + malformed entries.
- `applyLinkInsertions` \u2014 first-unlinked-occurrence replacement, longest-anchor-first ordering, avoids anchors inside existing `[[\u2026]]`.

## Tests
- 22 new unit tests covering summary extraction, prompt building, response parsing, and link insertion edge cases.
- 2 new confirm-key registry entries.
- Full suite: **483 passing** (was 463).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (483 passing)
- [ ] Open a note with concepts that exist as other notes \u2192 Refactor \u25B8 Auto-link\u2026 \u2192 suggestions arrive, context snippets show the right spots, Apply inserts links
- [ ] Right-click menu path works identically
- [ ] LLM paraphrasing (slightly off anchor text) gets filtered out
- [ ] Note already contains `[[\u2026]]` around a phrase the LLM picks \u2014 that occurrence is skipped, next unlinked one used
- [ ] Note with no link candidates \u2192 "no suggestions" dialog

## Deferred (follow-up #175 part 2)
- **"Link from" mode** \u2014 suggests links **into** the active note from other notes. Requires either multi-pass LLM calls (candidates by summary, then full content for chosen ones) or much larger prompts with all candidate bodies. Worth its own pass to do well.
- **Pre-invocation checkboxes** \u2014 only meaningful once both directions exist. Added back with "link from".
- Per-tool model override via ThinkingTool registration (same deferral as Auto-tag \u2014 follow-up).