### PR TITLE
Decompose Note: LLM restructure with preview dialog (closes #178)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -21,6 +21,7 @@ import {
   suggestLinksInbound,
   applyInboundSuggestions,
 } from './llm/auto-link';
+import { suggestDecomposition, type DecomposeHints } from './llm/decompose';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
 import * as healthChecks from './graph/health-checks';
@@ -611,6 +612,15 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     return suggestLinksInbound(rootPath, activeRelPath);
   });
+
+  ipcMain.handle(
+    Channels.REFACTOR_DECOMPOSE_SUGGEST,
+    async (e, activeRelPath: string, hints?: DecomposeHints) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      return suggestDecomposition(rootPath, activeRelPath, hints ?? {});
+    },
+  );
 
   ipcMain.handle(
     Channels.REFACTOR_AUTO_LINK_INBOUND_APPLY,

--- a/src/main/llm/decompose.ts
+++ b/src/main/llm/decompose.ts
@@ -1,0 +1,50 @@
+import * as notebaseFs from '../notebase/fs';
+import { parseMarkdown } from '../graph/parser';
+import { complete } from './index';
+import { getSettings } from './settings';
+import {
+  buildDecomposePrompt,
+  parseDecomposeResponse,
+  type DecomposeProposal,
+} from '../../shared/refactor/decompose';
+
+export interface DecomposeHints {
+  normalizeHeadings?: boolean;
+  transcludeByDefault?: boolean;
+}
+
+export interface SuggestDecompositionResult {
+  proposal: DecomposeProposal | null;
+  /** Short diagnostic when the LLM response couldn\u2019t be parsed. */
+  error?: string;
+}
+
+/**
+ * Runs the Decompose Note LLM call. Uses the user\u2019s global default
+ * model. The ticket specifies Opus-preferred for quality, but we
+ * consistently defer per-tool overrides for direct-mutation flows
+ * (same story as Auto-tag / Auto-link) until ThinkingTool registration
+ * is extended to cover them.
+ */
+export async function suggestDecomposition(
+  rootPath: string,
+  activeRelPath: string,
+  hints: DecomposeHints = {},
+): Promise<SuggestDecompositionResult> {
+  const content = await notebaseFs.readFile(rootPath, activeRelPath);
+  const parsed = parseMarkdown(content);
+  const body = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+  const title = parsed.title
+    || activeRelPath.replace(/\.md$/i, '').split('/').pop()
+    || activeRelPath;
+
+  const prompt = buildDecomposePrompt({
+    sourceTitle: title,
+    sourceBody: body,
+    hints,
+  });
+
+  const { model } = await getSettings();
+  const raw = await complete(prompt, { model });
+  return parseDecomposeResponse(raw);
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -325,6 +325,7 @@ export function rebuildMenu(): void {
         { label: 'Auto-tag', click: () => send(Channels.MENU_REFACTOR_AUTOTAG) },
         { label: 'Auto-link outbound\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) },
         { label: 'Auto-link inbound\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK_INBOUND) },
+        { label: 'Decompose Note\u2026', click: () => send(Channels.MENU_REFACTOR_DECOMPOSE) },
       ],
     },
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -151,6 +151,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_INBOUND_SUGGEST, relativePath),
     autoLinkInboundApply: (relativePath: string, accepted: unknown) =>
       ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_INBOUND_APPLY, relativePath, accepted),
+    decomposeSuggest: (relativePath: string, hints?: unknown) =>
+      ipcRenderer.invoke(Channels.REFACTOR_DECOMPOSE_SUGGEST, relativePath, hints),
   },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
@@ -273,6 +275,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onRefactorAutoLinkInbound: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_AUTOLINK_INBOUND, () => cb());
+    },
+    onRefactorDecompose: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_DECOMPOSE, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -20,9 +20,12 @@
   import ConversationDialog from './lib/components/ConversationDialog.svelte';
   import AutoLinkDialog from './lib/components/AutoLinkDialog.svelte';
   import AutoLinkInboundDialog from './lib/components/AutoLinkInboundDialog.svelte';
+  import DecomposeDialog from './lib/components/DecomposeDialog.svelte';
   import BusyOverlay from './lib/components/BusyOverlay.svelte';
   import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
   import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
+  import type { DecomposeProposal } from '../shared/refactor/decompose';
+  import { planDecompose } from './lib/refactor/decompose-plan';
   import SettingsDialog from './lib/components/SettingsDialog.svelte';
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
@@ -75,6 +78,12 @@
   let autoLinkInboundReview = $state<{
     relativePath: string;
     suggestions: AutoLinkInboundSuggestion[];
+  } | null>(null);
+
+  /** Active Decompose Note preview. Non-null = dialog is shown. */
+  let decomposeReview = $state<{
+    relativePath: string;
+    proposal: DecomposeProposal;
   } | null>(null);
   let inspectionCount = $state(0);
 
@@ -561,6 +570,86 @@
     }
   }
 
+  async function handleDecompose(relativePath: string) {
+    if (!notebase.meta) return;
+    try {
+      const { proposal, error } = await withBusy('Proposing a decomposition\u2026', () =>
+        api.refactor.decomposeSuggest(relativePath),
+      );
+      if (!proposal) {
+        await showConfirm(
+          `The LLM returned an unusable decomposition${error ? ` (${error})` : ''}. Try again, or shorten the note first.`,
+          CONFIRM_KEYS.decomposeBadProposal,
+          'OK',
+        );
+        return;
+      }
+      decomposeReview = { relativePath, proposal };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Decompose failed: ${msg}`, CONFIRM_KEYS.decomposeFailed, 'OK');
+    }
+  }
+
+  async function handleDecomposeRegenerate() {
+    const review = decomposeReview;
+    if (!review) return;
+    try {
+      const { proposal, error } = await withBusy('Regenerating decomposition\u2026', () =>
+        api.refactor.decomposeSuggest(review.relativePath),
+      );
+      if (!proposal) {
+        await showConfirm(
+          `The LLM returned an unusable decomposition${error ? ` (${error})` : ''}. Keeping the previous proposal.`,
+          CONFIRM_KEYS.decomposeBadProposal,
+          'OK',
+        );
+        return;
+      }
+      decomposeReview = { relativePath: review.relativePath, proposal };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Decompose failed: ${msg}`, CONFIRM_KEYS.decomposeFailed, 'OK');
+    }
+  }
+
+  async function handleDecomposeApply(edited: DecomposeProposal, include: boolean[]) {
+    const review = decomposeReview;
+    if (!review) return;
+    const tab = editor.activeNoteTab;
+    if (!tab || tab.relativePath !== review.relativePath) {
+      decomposeReview = null;
+      return;
+    }
+
+    decomposeReview = null;
+    editor.flushAutoSave();
+
+    // Snapshot across the Svelte 5 reactive boundary before use — the edited
+    // proposal / include array came out of $state inside the dialog.
+    const plainProposal = $state.snapshot(edited) as DecomposeProposal;
+    const plainInclude = $state.snapshot(include) as boolean[];
+
+    const plan = planDecompose({
+      sourceRelativePath: tab.relativePath,
+      sourceContent: tab.content,
+      proposal: plainProposal,
+      include: plainInclude,
+      today: todayDateString(),
+      settings: getRefactorSettings(),
+    });
+
+    if (plan.newNotes.length === 0) return;
+
+    for (const note of plan.newNotes) {
+      await api.notebase.writeFile(note.relativePath, note.content);
+    }
+    await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
+    await editor.reloadTabFromDisk(tab.relativePath);
+    await notebase.refresh();
+    sidebar?.refreshTags();
+  }
+
   async function handleAutoTag(relativePath: string) {
     if (!notebase.meta) return;
     try {
@@ -888,6 +977,7 @@
     api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); });
     api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); });
     api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); });
+    api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) handleDecompose(editor.activeFilePath); });
 
     // Notebase rename/rewrite notifications from main — keep open tabs
     // consistent with disk so the next auto-save doesn't overwrite a
@@ -1050,6 +1140,7 @@
                     onAutoTag={() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); }}
                     onAutoLink={() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); }}
                     onAutoLinkInbound={() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); }}
+                    onDecompose={() => { if (editor.activeFilePath) handleDecompose(editor.activeFilePath); }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;
@@ -1197,6 +1288,14 @@
       activeStem={autoLinkInboundReview.relativePath.replace(/\.md$/i, '')}
       onApply={handleAutoLinkInboundApply}
       onCancel={() => { autoLinkInboundReview = null; }}
+    />
+  {/if}
+  {#if decomposeReview}
+    <DecomposeDialog
+      proposal={decomposeReview.proposal}
+      onApply={handleDecomposeApply}
+      onRegenerate={handleDecomposeRegenerate}
+      onCancel={() => { decomposeReview = null; }}
     />
   {/if}
   {#if busyLabel}

--- a/src/renderer/lib/components/DecomposeDialog.svelte
+++ b/src/renderer/lib/components/DecomposeDialog.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+  import type { DecomposeProposal, DecomposeChildProposal } from '../../../shared/refactor/decompose';
+
+  interface Props {
+    proposal: DecomposeProposal;
+    /** Callback invoked with the edited proposal + include mask on Apply. */
+    onApply: (edited: DecomposeProposal, include: boolean[]) => void;
+    /** Callback to request a fresh decomposition from the LLM. */
+    onRegenerate: () => void;
+    onCancel: () => void;
+  }
+
+  let { proposal, onApply, onRegenerate, onCancel }: Props = $props();
+
+  // Editable mirror of the proposal. Rebuilt whenever the incoming proposal
+  // changes (regenerate replaces the whole thing).
+  let parentContent = $state(proposal.parent.content);
+  let editableChildren = $state<DecomposeChildProposal[]>(
+    proposal.children.map((c) => ({ ...c })),
+  );
+  let include = $state<boolean[]>(proposal.children.map(() => true));
+  let expanded = $state<boolean[]>(proposal.children.map((_, i) => i === 0));
+
+  // Rehydrate on regenerate: detect identity change of the proposal prop.
+  let lastSeenProposal = proposal;
+  $effect(() => {
+    if (proposal !== lastSeenProposal) {
+      parentContent = proposal.parent.content;
+      editableChildren = proposal.children.map((c) => ({ ...c }));
+      include = proposal.children.map(() => true);
+      expanded = proposal.children.map((_, i) => i === 0);
+      lastSeenProposal = proposal;
+    }
+  });
+
+  const includedCount = $derived(include.filter(Boolean).length);
+  const canApply = $derived(includedCount >= 2);
+
+  function apply() {
+    if (!canApply) return;
+    const edited: DecomposeProposal = {
+      parent: { content: parentContent },
+      children: editableChildren.map((c) => ({ ...c })),
+    };
+    onApply(edited, [...include]);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="overlay"
+  onkeydown={handleKeydown}
+  onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+>
+  <div class="dialog">
+    <header>
+      <h2>Decompose Note</h2>
+      <span class="count">{includedCount} of {proposal.children.length} children selected</span>
+    </header>
+    <div class="subtitle">
+      Preview the proposed restructure. Edit any content inline, drop children you don\u2019t want,
+      or regenerate for a different cut. Apply writes the parent back to the source and each
+      included child as a new note under a subfolder.
+    </div>
+
+    <div class="scroll">
+      <section class="parent">
+        <div class="section-label">Parent (replaces source body)</div>
+        <textarea
+          class="body"
+          bind:value={parentContent}
+          rows="5"
+          placeholder="Index narrative \u2014 how the children relate"
+        ></textarea>
+        <div class="hint">A <code>## Contents</code> block with links to each included child is appended automatically.</div>
+      </section>
+
+      <div class="children">
+        <div class="section-label">Children ({proposal.children.length} proposed)</div>
+        {#each editableChildren as child, i (i)}
+          <div class="child" class:excluded={!include[i]}>
+            <div class="child-header">
+              <label class="include-toggle">
+                <input type="checkbox" bind:checked={include[i]} />
+                <span class="label-text">Include</span>
+              </label>
+              <input
+                class="title"
+                type="text"
+                bind:value={child.title}
+                placeholder="Child title"
+                disabled={!include[i]}
+              />
+              <button
+                class="expand-btn"
+                onclick={() => { expanded[i] = !expanded[i]; }}
+                disabled={!include[i]}
+                title={expanded[i] ? 'Collapse' : 'Expand'}
+              >{expanded[i] ? '\u25BE' : '\u25B8'}</button>
+            </div>
+            {#if child.rationale}
+              <div class="rationale">{child.rationale}</div>
+            {/if}
+            {#if expanded[i] && include[i]}
+              <textarea
+                class="body"
+                bind:value={child.content}
+                rows="8"
+                placeholder="Child body"
+              ></textarea>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <div class="actions">
+      <button class="btn" onclick={onCancel}>Cancel</button>
+      <button class="btn" onclick={onRegenerate} title="Ask the LLM for a fresh decomposition">
+        Regenerate
+      </button>
+      <button class="btn primary" disabled={!canApply} onclick={apply} title={canApply ? '' : 'Include at least 2 children'}>
+        Apply
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    width: 780px;
+    max-width: 94vw;
+    max-height: 88vh;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .count {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .subtitle {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+
+  .scroll {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding-right: 4px;
+  }
+
+  .section-label {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .parent {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .hint {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .hint code {
+    font-size: 11px;
+    color: var(--accent);
+  }
+
+  .children {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .child {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+  }
+
+  .child.excluded {
+    opacity: 0.5;
+  }
+
+  .child-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .include-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .include-toggle input {
+    cursor: pointer;
+  }
+
+  .label-text {
+    user-select: none;
+  }
+
+  .title {
+    flex: 1;
+    padding: 5px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 600;
+    outline: none;
+  }
+
+  .title:focus {
+    border-color: var(--accent);
+  }
+
+  .title:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .expand-btn {
+    width: 28px;
+    padding: 4px 0;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 11px;
+  }
+
+  .expand-btn:hover:not(:disabled) {
+    background: var(--bg-button-hover);
+  }
+
+  .expand-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .rationale {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding-left: 4px;
+    font-style: italic;
+  }
+
+  .body {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 12px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .body:focus {
+    border-color: var(--accent);
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 4px;
+  }
+
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .btn:hover:not(:disabled) { background: var(--bg-button-hover); }
+
+  .btn.primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+
+  .btn.primary:hover:not(:disabled) { opacity: 0.9; }
+
+  .btn:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -55,6 +55,7 @@
     onAutoTag?: () => void;
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
+    onDecompose?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -81,6 +82,7 @@
     onAutoTag,
     onAutoLink,
     onAutoLinkInbound,
+    onDecompose,
     getNotePaths,
   }: Props = $props();
 
@@ -690,7 +692,7 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag || onAutoLink || onAutoLinkInbound}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -715,7 +717,7 @@
           {#if onSplitByHeading}
             <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
           {/if}
-          {#if onAutoTag || onAutoLink || onAutoLinkInbound}
+          {#if onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose}
             {#if onExtractSelection || onSplitHere || onSplitByHeading}
               <div class="separator"></div>
             {/if}
@@ -727,6 +729,9 @@
             {/if}
             {#if onAutoLinkInbound}
               <button onclick={() => handleMenuAction(() => onAutoLinkInbound?.())}>Auto-link inbound&hellip;</button>
+            {/if}
+            {#if onDecompose}
+              <button onclick={() => handleMenuAction(() => onDecompose?.())}>Decompose Note&hellip;</button>
             {/if}
           {/if}
         </div>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -17,6 +17,8 @@ export const CONFIRM_KEYS = {
   autoTagFailed: 'auto-tag-failed',
   autoLinkNoSuggestions: 'auto-link-no-suggestions',
   autoLinkFailed: 'auto-link-failed',
+  decomposeFailed: 'decompose-failed',
+  decomposeBadProposal: 'decompose-bad-proposal',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -75,6 +77,18 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Auto-link failed',
     description:
       'Shown when Auto-link errors out or can\u2019t apply any accepted suggestions.',
+  },
+  {
+    key: CONFIRM_KEYS.decomposeFailed,
+    title: 'Decompose Note failed',
+    description:
+      'Shown when Decompose Note errors out (network failure, missing API key, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.decomposeBadProposal,
+    title: 'Decompose Note returned an unusable proposal',
+    description:
+      'Shown when the LLM\u2019s response can\u2019t be parsed into a valid parent + children structure.',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -144,6 +144,13 @@ export interface RefactorApi {
     skipped: import('../../../shared/refactor/auto-link-inbound').AutoLinkInboundSuggestion[];
     touchedPaths: string[];
   }>;
+  decomposeSuggest(
+    relativePath: string,
+    hints?: { normalizeHeadings?: boolean; transcludeByDefault?: boolean },
+  ): Promise<{
+    proposal: import('../../../shared/refactor/decompose').DecomposeProposal | null;
+    error?: string;
+  }>;
 }
 
 export interface ToolsApi {
@@ -194,6 +201,7 @@ export interface MenuApi {
   onRefactorAutoTag(cb: () => void): void;
   onRefactorAutoLink(cb: () => void): void;
   onRefactorAutoLinkInbound(cb: () => void): void;
+  onRefactorDecompose(cb: () => void): void;
 }
 
 export interface IdeApi {

--- a/src/renderer/lib/refactor/decompose-plan.ts
+++ b/src/renderer/lib/refactor/decompose-plan.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure planner for Decompose Note (#178). Takes an (edited) LLM proposal
+ * plus the source note and produces the list of files to write. Shape
+ * matches `planSplitByHeading` \u2014 one source-rewrite + N new children
+ * under a subfolder.
+ *
+ * The proposal itself comes from the LLM and may have been user-edited
+ * in the preview dialog; the planner is agnostic about provenance.
+ */
+
+import {
+  sanitizeFilename,
+  resolveDestinationFolder,
+  renderFilenamePrefix,
+  normalizeHeadingLevels,
+  renderLinkBack,
+  renderExtractedBody,
+} from './extract';
+import type { RefactorSettings } from './settings';
+import { DEFAULT_REFACTOR_SETTINGS } from './settings';
+import type { DecomposeProposal, DecomposeChildProposal } from '../../../shared/refactor/decompose';
+
+export interface DecomposePlan {
+  newNotes: Array<{ relativePath: string; content: string }>;
+  /** Rewritten source content: original frontmatter + parent narrative + Contents block. */
+  updatedSourceContent: string;
+}
+
+export interface PlanDecomposeOptions {
+  sourceRelativePath: string;
+  sourceContent: string;
+  proposal: DecomposeProposal;
+  /** Subset selector \u2014 same length as proposal.children; `true` means include. */
+  include: boolean[];
+  today: string;
+  settings?: RefactorSettings;
+  now?: Date;
+}
+
+function extractSourceTitle(relativePath: string, content: string): string {
+  const m = content.match(/^#\s+(.+)$/m);
+  if (m) return m[1].trim();
+  return (relativePath.split('/').pop() ?? relativePath).replace(/\.md$/, '');
+}
+
+function basenameWithoutExt(relativePath: string): string {
+  const file = relativePath.split('/').pop() ?? relativePath;
+  return file.replace(/\.md$/, '');
+}
+
+function yamlQuote(s: string): string {
+  if (!/[:#]/.test(s)) return s;
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+function buildChildFrontmatter(title: string, sourceRelativePath: string, today: string): string {
+  return [
+    '---',
+    `title: ${yamlQuote(title)}`,
+    `created: ${today}`,
+    `source: ${sourceRelativePath}`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+function splitFrontmatter(content: string): { frontmatter: string; body: string } {
+  const m = content.match(/^(---\n[\s\S]*?\n---\n?)/);
+  if (!m) return { frontmatter: '', body: content };
+  return { frontmatter: m[1], body: content.slice(m[1].length) };
+}
+
+/**
+ * Collision-safe stem assignment. Matches planSplitByHeading\u2019s behavior
+ * so two children titled "Details" don\u2019t overwrite each other.
+ */
+function assignStems(children: DecomposeChildProposal[], prefix: string): string[] {
+  const out: string[] = [];
+  const counts = new Map<string, number>();
+  for (const c of children) {
+    const baseStem = sanitizeFilename(c.title) || 'child';
+    const n = counts.get(baseStem) ?? 0;
+    counts.set(baseStem, n + 1);
+    const stem = n === 0 ? baseStem : `${baseStem}-${n + 1}`;
+    out.push(`${prefix}${stem}`);
+  }
+  return out;
+}
+
+export function planDecompose(opts: PlanDecomposeOptions): DecomposePlan {
+  const { sourceRelativePath, sourceContent, proposal, include, today } = opts;
+  const settings = opts.settings ?? DEFAULT_REFACTOR_SETTINGS;
+  const now = opts.now;
+
+  const includedChildren = proposal.children.filter((_, i) => include[i]);
+  if (includedChildren.length === 0) {
+    return { newNotes: [], updatedSourceContent: sourceContent };
+  }
+
+  const { frontmatter } = splitFrontmatter(sourceContent);
+  const parentDir = resolveDestinationFolder(sourceRelativePath, settings, now);
+  const base = basenameWithoutExt(sourceRelativePath);
+  const subfolder = parentDir ? `${parentDir}/${base}` : base;
+  const prefix = renderFilenamePrefix(sourceRelativePath, settings, now);
+  const stems = assignStems(includedChildren, prefix);
+  const sourceTitle = extractSourceTitle(sourceRelativePath, sourceContent);
+
+  const newNotes: Array<{ relativePath: string; content: string }> = [];
+  const links: string[] = [];
+
+  for (let i = 0; i < includedChildren.length; i++) {
+    const child = includedChildren[i];
+    const stem = stems[i];
+    const relativePath = `${subfolder}/${stem}.md`;
+
+    const rawBody = normalizeHeadingLevels(child.content.trimEnd(), settings);
+    const templateCtx = {
+      sourceRelativePath,
+      sourceTitle,
+      newNoteTitle: child.title,
+      now,
+    };
+    const wrappedBody = renderExtractedBody(rawBody, settings, templateCtx);
+    const bodyWithTrailingNewline = wrappedBody + (wrappedBody.endsWith('\n') ? '' : '\n');
+    const content = buildChildFrontmatter(child.title, sourceRelativePath, today) + bodyWithTrailingNewline;
+    newNotes.push({ relativePath, content });
+
+    if (settings.linkTemplate) {
+      links.push(renderLinkBack(relativePath, settings, templateCtx));
+    } else if (settings.transcludeByDefault) {
+      links.push(`- ![[${subfolder}/${stem}]]`);
+    } else {
+      links.push(`- [[${subfolder}/${stem}|${child.title}]]`);
+    }
+  }
+
+  // Build the new source body: LLM's parent narrative + auto-generated Contents list.
+  const narrative = proposal.parent.content.trim();
+  const indexBlock = ['## Contents', '', ...links, ''].join('\n');
+  const newBody = narrative
+    ? `${narrative}\n\n${indexBlock}`
+    : indexBlock;
+
+  return {
+    newNotes,
+    updatedSourceContent: frontmatter + newBody,
+  };
+}

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -88,6 +88,7 @@ export const Channels = {
   MENU_REFACTOR_AUTOTAG: 'menu:refactor:autotag',
   MENU_REFACTOR_AUTOLINK: 'menu:refactor:autolink',
   MENU_REFACTOR_AUTOLINK_INBOUND: 'menu:refactor:autolinkInbound',
+  MENU_REFACTOR_DECOMPOSE: 'menu:refactor:decompose',
 
   /** Renderer-initiated LLM Auto-tag of a note (#174). */
   REFACTOR_AUTO_TAG: 'refactor:autoTag',
@@ -99,6 +100,8 @@ export const Channels = {
   REFACTOR_AUTO_LINK_INBOUND_SUGGEST: 'refactor:autoLinkInboundSuggest',
   /** Apply accepted inbound Auto-link suggestions (writes to multiple source notes). */
   REFACTOR_AUTO_LINK_INBOUND_APPLY: 'refactor:autoLinkInboundApply',
+  /** LLM-driven decomposition of a note into a parent index + children (#178). */
+  REFACTOR_DECOMPOSE_SUGGEST: 'refactor:decomposeSuggest',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',

--- a/src/shared/refactor/decompose.ts
+++ b/src/shared/refactor/decompose.ts
@@ -1,0 +1,138 @@
+/**
+ * "Decompose Note" (#178): LLM-driven restructure of a note into one
+ * parent index + 2\u20137 children. Pure pieces — prompt builder and
+ * response parser. The main-side orchestrator lives in `src/main/llm/`
+ * and the planner that turns an (edited) proposal into actual file
+ * writes lives in `src/renderer/lib/refactor/`.
+ */
+
+export interface DecomposeChildProposal {
+  /** Proposed title for the child note. */
+  title: string;
+  /** Proposed body (no frontmatter; planner handles that). */
+  content: string;
+  /** Short reason the LLM gave for this child existing. */
+  rationale: string;
+}
+
+export interface DecomposeProposal {
+  /** The parent "index" note's body (no frontmatter). The planner appends a Contents block with wiki-links. */
+  parent: { content: string };
+  /** 2\u20137 children. The preview dialog can edit, drop, or regenerate them. */
+  children: DecomposeChildProposal[];
+}
+
+export interface BuildDecomposePromptArgs {
+  sourceTitle: string;
+  sourceBody: string;
+  /** Informational — the LLM adapts tone if the user hints at preferences. Not required. */
+  hints?: {
+    normalizeHeadings?: boolean;
+    transcludeByDefault?: boolean;
+  };
+}
+
+export function buildDecomposePrompt(args: BuildDecomposePromptArgs): string {
+  return `You are restructuring a long note into a **parent index note** plus a handful of focused **child notes**. The goal is semantic coherence: each child should cover one distinct topic or line of thought from the source, and the parent should read as an index / orientation for the whole.
+
+## Rules
+- Produce **2\u20137 children**. Fewer than 2 isn\u2019t decomposition; more than 7 is noise.
+- Each child must stand on its own \u2014 someone reading just that child should get a coherent chunk.
+- Children don\u2019t need to map 1:1 to existing headings. Merge related sections. Split a section that\u2019s actually covering two topics. Invent titles that reflect what the child is really about, not just what the original heading said.
+- **Do not lose content.** Every substantive point from the source should end up somewhere (a child, or the parent narrative).
+- The **parent content** is a short index / orientation: 1\u20133 short paragraphs that frame what the note is about and how the children relate. Don\u2019t duplicate the children\u2019s prose \u2014 point at them.
+- Do **not** include wiki-links in the parent content. The post-processor inserts a \`## Contents\` list with links automatically.
+- Titles: 2\u20136 words, title-case. Stable when re-run on similar content.
+- Preserve the source\u2019s voice in the child bodies; minor tidying is fine, heavy rewriting isn\u2019t.
+
+## Output format
+Return a single JSON object, no prose, no commentary, no code fences:
+
+\`\`\`
+{
+  "parent": { "content": "..." },
+  "children": [
+    { "title": "...", "content": "...", "rationale": "..." },
+    ...
+  ]
+}
+\`\`\`
+
+## Source note
+Title: ${args.sourceTitle || '(untitled)'}
+
+${args.sourceBody}
+`;
+}
+
+export interface ParseDecomposeResult {
+  proposal: DecomposeProposal | null;
+  /** When the JSON parse failed or the shape was wrong, a short diagnostic for logs. */
+  error?: string;
+}
+
+/**
+ * Parses the LLM response into a proposal. Tolerant of code fences and
+ * surrounding prose. Accepts only the strict shape — children with
+ * missing \`title\` / \`content\` are dropped individually; an entirely
+ * malformed response returns null.
+ */
+export function parseDecomposeResponse(text: string): ParseDecomposeResult {
+  const json = extractJsonObject(text);
+  if (!json) return { proposal: null, error: 'no-json' };
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch (e) {
+    return { proposal: null, error: `parse-fail: ${(e as Error).message}` };
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { proposal: null, error: 'not-object' };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const parent = obj.parent;
+  const children = obj.children;
+  if (!parent || typeof parent !== 'object' || Array.isArray(parent)) {
+    return { proposal: null, error: 'missing-parent' };
+  }
+  if (!Array.isArray(children)) {
+    return { proposal: null, error: 'missing-children' };
+  }
+
+  const parentContent = typeof (parent as Record<string, unknown>).content === 'string'
+    ? (parent as { content: string }).content
+    : '';
+
+  const outChildren: DecomposeChildProposal[] = [];
+  for (const c of children) {
+    if (!c || typeof c !== 'object') continue;
+    const rec = c as Record<string, unknown>;
+    const title = typeof rec.title === 'string' ? rec.title.trim() : '';
+    const content = typeof rec.content === 'string' ? rec.content : '';
+    const rationale = typeof rec.rationale === 'string' ? rec.rationale.trim() : '';
+    if (!title || !content) continue;
+    outChildren.push({ title, content, rationale });
+  }
+
+  if (outChildren.length === 0) {
+    return { proposal: null, error: 'no-valid-children' };
+  }
+
+  return {
+    proposal: {
+      parent: { content: parentContent },
+      children: outChildren,
+    },
+  };
+}
+
+function extractJsonObject(text: string): string | null {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fence ? fence[1] : text;
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start < 0 || end <= start) return null;
+  return candidate.slice(start, end + 1);
+}

--- a/tests/renderer/refactor/decompose-plan.test.ts
+++ b/tests/renderer/refactor/decompose-plan.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { planDecompose } from '../../../src/renderer/lib/refactor/decompose-plan';
+import type { DecomposeProposal } from '../../../src/shared/refactor/decompose';
+import type { RefactorSettings } from '../../../src/renderer/lib/refactor/settings';
+import { DEFAULT_REFACTOR_SETTINGS } from '../../../src/renderer/lib/refactor/settings';
+
+function proposal(children: Array<{ title: string; content: string; rationale?: string }>): DecomposeProposal {
+  return {
+    parent: { content: 'Index narrative for the source.' },
+    children: children.map((c) => ({ title: c.title, content: c.content, rationale: c.rationale ?? '' })),
+  };
+}
+
+const today = '2026-04-20';
+const settings: RefactorSettings = { ...DEFAULT_REFACTOR_SETTINGS };
+
+describe('planDecompose (issue #178)', () => {
+  it('writes one child per included proposal under <source-basename>/', () => {
+    const plan = planDecompose({
+      sourceRelativePath: 'notes/big-topic.md',
+      sourceContent: '---\ntitle: Big Topic\n---\n\n# Big Topic\n\nOriginal body.\n',
+      proposal: proposal([
+        { title: 'First Angle', content: 'First child body.' },
+        { title: 'Second Angle', content: 'Second child body.' },
+      ]),
+      include: [true, true],
+      today,
+      settings,
+    });
+    expect(plan.newNotes.map((n) => n.relativePath)).toEqual([
+      'notes/big-topic/first-angle.md',
+      'notes/big-topic/second-angle.md',
+    ]);
+    expect(plan.newNotes[0].content).toContain('---\ntitle: First Angle');
+    expect(plan.newNotes[0].content).toContain('First child body.');
+    expect(plan.newNotes[0].content).toContain('source: notes/big-topic.md');
+  });
+
+  it('skips children whose include flag is false', () => {
+    const plan = planDecompose({
+      sourceRelativePath: 'x.md',
+      sourceContent: 'body',
+      proposal: proposal([
+        { title: 'Keep', content: 'a' },
+        { title: 'Drop', content: 'b' },
+        { title: 'Also Keep', content: 'c' },
+      ]),
+      include: [true, false, true],
+      today,
+      settings,
+    });
+    expect(plan.newNotes).toHaveLength(2);
+    expect(plan.newNotes[0].relativePath).toContain('keep');
+    expect(plan.newNotes[1].relativePath).toContain('also-keep');
+  });
+
+  it('returns no notes + unchanged source when zero children are included', () => {
+    const source = '---\ntitle: X\n---\nbody';
+    const plan = planDecompose({
+      sourceRelativePath: 'x.md',
+      sourceContent: source,
+      proposal: proposal([{ title: 'A', content: 'a' }]),
+      include: [false],
+      today,
+      settings,
+    });
+    expect(plan.newNotes).toEqual([]);
+    expect(plan.updatedSourceContent).toBe(source);
+  });
+
+  it('rewrites the source body as parent narrative + Contents list of wiki-links', () => {
+    const plan = planDecompose({
+      sourceRelativePath: 'idx.md',
+      sourceContent: '---\ntitle: Idx\n---\n\n# Idx\n\nOld body.\n',
+      proposal: proposal([
+        { title: 'Alpha', content: 'a' },
+        { title: 'Beta', content: 'b' },
+      ]),
+      include: [true, true],
+      today,
+      settings,
+    });
+    expect(plan.updatedSourceContent).toContain('---\ntitle: Idx\n---');
+    expect(plan.updatedSourceContent).toContain('Index narrative for the source.');
+    expect(plan.updatedSourceContent).toContain('## Contents');
+    expect(plan.updatedSourceContent).toContain('[[idx/alpha|Alpha]]');
+    expect(plan.updatedSourceContent).toContain('[[idx/beta|Beta]]');
+  });
+
+  it('suffixes stems when two children share the same title', () => {
+    const plan = planDecompose({
+      sourceRelativePath: 'x.md',
+      sourceContent: 'body',
+      proposal: proposal([
+        { title: 'Details', content: 'first details' },
+        { title: 'Details', content: 'second details' },
+      ]),
+      include: [true, true],
+      today,
+      settings,
+    });
+    const paths = plan.newNotes.map((n) => n.relativePath);
+    expect(paths).toEqual(['x/details.md', 'x/details-2.md']);
+  });
+
+  it('honors transcludeByDefault for the Contents links', () => {
+    const plan = planDecompose({
+      sourceRelativePath: 'x.md',
+      sourceContent: 'body',
+      proposal: proposal([{ title: 'Alpha', content: 'a' }]),
+      include: [true],
+      today,
+      settings: { ...settings, transcludeByDefault: true },
+    });
+    expect(plan.updatedSourceContent).toContain('- ![[x/alpha]]');
+  });
+
+  it('applies heading normalization to child bodies', () => {
+    const plan = planDecompose({
+      sourceRelativePath: 'x.md',
+      sourceContent: 'body',
+      proposal: proposal([{ title: 'T', content: '### Deep heading\n\npara\n' }]),
+      include: [true],
+      today,
+      settings: { ...settings, normalizeHeadings: true },
+    });
+    // `### Deep heading` -> `# Deep heading` after normalization (shallowest -> H1).
+    expect(plan.newNotes[0].content).toContain('# Deep heading');
+    expect(plan.newNotes[0].content).not.toContain('### Deep heading');
+  });
+});

--- a/tests/shared/refactor/decompose.test.ts
+++ b/tests/shared/refactor/decompose.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDecomposePrompt,
+  parseDecomposeResponse,
+} from '../../../src/shared/refactor/decompose';
+
+describe('buildDecomposePrompt (issue #178)', () => {
+  it('embeds the source title and body', () => {
+    const p = buildDecomposePrompt({ sourceTitle: 'My Topic', sourceBody: 'Long note body.' });
+    expect(p).toContain('My Topic');
+    expect(p).toContain('Long note body.');
+  });
+
+  it('spells out the 2\u20137 children constraint and JSON shape', () => {
+    const p = buildDecomposePrompt({ sourceTitle: '', sourceBody: '' });
+    expect(p).toMatch(/2\u20137/);
+    expect(p).toContain('"parent"');
+    expect(p).toContain('"children"');
+    expect(p).toContain('"title"');
+    expect(p).toContain('"rationale"');
+  });
+
+  it('tells the LLM not to insert wiki-links in the parent content', () => {
+    const p = buildDecomposePrompt({ sourceTitle: '', sourceBody: '' });
+    expect(p).toMatch(/not.*wiki-links/i);
+  });
+});
+
+describe('parseDecomposeResponse', () => {
+  it('parses a bare JSON object with one parent and multiple children', () => {
+    const raw = JSON.stringify({
+      parent: { content: 'Index narrative.' },
+      children: [
+        { title: 'First', content: 'First body.', rationale: 'opens the topic' },
+        { title: 'Second', content: 'Second body.', rationale: 'drills in' },
+      ],
+    });
+    const { proposal, error } = parseDecomposeResponse(raw);
+    expect(error).toBeUndefined();
+    expect(proposal?.parent.content).toBe('Index narrative.');
+    expect(proposal?.children).toHaveLength(2);
+    expect(proposal?.children[0]).toEqual({
+      title: 'First',
+      content: 'First body.',
+      rationale: 'opens the topic',
+    });
+  });
+
+  it('tolerates markdown code fences and surrounding prose', () => {
+    const inner = JSON.stringify({
+      parent: { content: 'p' },
+      children: [{ title: 'X', content: 'y', rationale: '' }],
+    });
+    const raw = 'Here you go:\n```json\n' + inner + '\n```\nDone.';
+    const { proposal } = parseDecomposeResponse(raw);
+    expect(proposal?.children[0].title).toBe('X');
+  });
+
+  it('drops children missing title or content', () => {
+    const raw = JSON.stringify({
+      parent: { content: 'p' },
+      children: [
+        { title: '', content: 'body' },
+        { title: 'Only Title' },
+        { title: 'Valid', content: 'valid body' },
+      ],
+    });
+    const { proposal } = parseDecomposeResponse(raw);
+    expect(proposal?.children).toHaveLength(1);
+    expect(proposal?.children[0].title).toBe('Valid');
+  });
+
+  it('returns null when no valid children remain', () => {
+    const raw = JSON.stringify({
+      parent: { content: 'p' },
+      children: [{ title: '', content: '' }],
+    });
+    const { proposal, error } = parseDecomposeResponse(raw);
+    expect(proposal).toBeNull();
+    expect(error).toBe('no-valid-children');
+  });
+
+  it('returns null for missing parent / children fields', () => {
+    expect(parseDecomposeResponse('{"children": []}').proposal).toBeNull();
+    expect(parseDecomposeResponse('{"parent": {}}').proposal).toBeNull();
+    expect(parseDecomposeResponse('not JSON').proposal).toBeNull();
+    expect(parseDecomposeResponse('[1, 2, 3]').proposal).toBeNull();
+  });
+
+  it('accepts missing rationale as empty string', () => {
+    const raw = JSON.stringify({
+      parent: { content: 'p' },
+      children: [{ title: 'T', content: 'c' }],
+    });
+    const { proposal } = parseDecomposeResponse(raw);
+    expect(proposal?.children[0].rationale).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Refactor menu command that proposes a restructure of the active note into one parent "index" and 2\u20137 child sub-notes. Mandatory preview dialog with per-child edit + include + **Regenerate**. Apply reuses the existing refactor-helpers pipeline (destination, filename prefix, heading normalization, link templates, transclude) so it composes with the settings users already configured for Extract / Split.

## Entry points
- **Refactor \u25B8 Decompose Note\u2026** in the title-bar Refactor menu
- **Refactor \u25B8 Decompose Note\u2026** in the editor right-click submenu

## Flow
1. User invokes \u2192 main reads the note, builds the prompt, calls `complete()`, parses JSON.
2. Preview dialog (`DecomposeDialog.svelte`) renders the proposal:
   - **Parent** textarea \u2014 editable narrative that replaces the source body.
   - **Children** list \u2014 each with include checkbox, editable title, editable body, collapsible, shows LLM rationale.
   - **Regenerate** button \u2014 fresh LLM call, preserves dialog.
   - Apply requires \u2265 2 included children.
3. Apply \u2192 renderer's `planDecompose` (pure, unit-tested) produces the writes:
   - Children land at `<parent-dir>/<source-basename>/<child-slug>.md`.
   - Parent body = LLM narrative + `## Contents` list of `[[\u2026]]` links (or `![[\u2026]]` when transclude is on).
   - Heading normalization + `refactoredNoteTemplate` apply per child (reusing extract.ts helpers).
   - Collision-safe stems (two children titled "Details" become `details.md` + `details-2.md`).

## Pure pieces
- `src/shared/refactor/decompose.ts` \u2014 prompt + JSON parser (tolerant of code fences, drops malformed children, returns a diagnostic error string when nothing usable came back).
- `src/renderer/lib/refactor/decompose-plan.ts` \u2014 planner.

## Tests
- 9 tests for prompt + parser
- 7 tests for the planner (subfolder layout, include mask, source rewrite, stem collisions, transclude, heading normalization)
- Full suite: **511 passing** (was 495).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (511 passing)
- [ ] Open a long-ish note \u2192 Refactor \u25B8 Decompose Note\u2026 \u2192 preview dialog appears with parent + children
- [ ] Edit a child\u2019s title/body inline, uncheck a child, Apply \u2192 only included children land; titles reflect edits
- [ ] Regenerate \u2192 spinner, fresh proposal replaces the in-dialog state
- [ ] Apply \u2192 source tab reloads to show the new parent body with `## Contents` links; sidebar shows the new child notes

## Deferred
- **Per-tool Opus override via ThinkingTool registration** \u2014 the ticket specified Opus-preferred; consistent with Auto-tag / Auto-link, uses the global default for now. Revisit when the direct-mutation cluster gets uniform per-tool model override.
- Iterative chat-style refinement beyond Regenerate.
- Nested sub-notes (child of child).
- Programmatic revert \u2014 relies on general multi-file undo (#167).

## Dependencies
- #172 (Refactor menu) \u2014 merged
- #120\u2013#125 (refactor settings + helpers) \u2014 merged; reused wholesale