### PR TITLE
CSV files: index + display (closes #199, #200)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -8,6 +8,7 @@ import { parseMarkdown, type ParsedTable, type FrontmatterValue } from './parser
 import { getLinkType, type LinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
 import { slugify } from '../../shared/slug';
+import { parseCsv } from '../../shared/csv-parse';
 import * as uriHelpers from './uri-helpers';
 
 import * as N3 from 'n3';
@@ -433,6 +434,11 @@ export async function indexNote(
     return {};
   }
 
+  if (relativePath.endsWith('.csv')) {
+    indexCsvFile(relativePath, content, subject, graph);
+    return {};
+  }
+
   // Diff headings against the previous snapshot BEFORE overwriting it so we
   // can offer to rewrite `[[note#oldSlug]]` links when a single heading
   // gets renamed. Initial index (no prior snapshot) never flags a rename.
@@ -680,6 +686,73 @@ function indexTurtleFile(
   }
 }
 
+/**
+ * Index a standalone `.csv` file (#199). Mirrors indexTurtleFile\u2019s
+ * note-metadata setup, then parses the file as CSV and emits CSVW
+ * triples. The file\u2019s subject IS the Table (`rdf:type csvw:Table`),
+ * with `csvw:inFile <relativePath>` for symmetry with the markdown-
+ * table indexer\u2019s `csvw:inNote`.
+ */
+function indexCsvFile(
+  relativePath: string,
+  content: string,
+  subject: $rdf.NamedNode,
+  graph: $rdf.NamedNode,
+): void {
+  if (!store) return;
+
+  // Note-style metadata so the file shows up in listings / tag queries / etc.
+  store.add(subject, RDF('type'), MINERVA('Note'), graph);
+  const title = path.basename(relativePath, '.csv');
+  store.add(subject, DC('title'), $rdf.lit(title), graph);
+  store.add(subject, MINERVA('filename'), $rdf.lit(path.basename(relativePath)), graph);
+  store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
+  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+
+  const dir = path.dirname(relativePath);
+  if (dir && dir !== '.') {
+    store.add(subject, MINERVA('inFolder'), folderUri(dir), graph);
+    ensureFolder(dir);
+  }
+  store.add(projectUri(), MINERVA('containsNote'), subject, graph);
+
+  // CSVW: the file IS the Table. One file \u2192 one table.
+  store.add(subject, RDF('type'), CSVW('Table'), graph);
+  store.add(subject, CSVW('inFile'), $rdf.lit(relativePath), graph);
+
+  const parsed = parseCsv(content);
+  if (parsed.headers.length === 0) return;
+
+  // Columns
+  const colNodes: $rdf.NamedNode[] = [];
+  for (let ci = 0; ci < parsed.headers.length; ci++) {
+    const colName = parsed.headers[ci];
+    const colUri = $rdf.sym(`${subject.value}/column/${encodeURIComponent(colName)}`);
+    colNodes.push(colUri);
+    store.add(colUri, RDF('type'), CSVW('Column'), graph);
+    store.add(colUri, CSVW('name'), $rdf.lit(colName), graph);
+    store.add(colUri, CSVW('columnIndex'), $rdf.lit(String(ci), undefined, XSD('integer')), graph);
+    store.add(subject, CSVW('column'), colUri, graph);
+  }
+
+  // Rows + cells
+  for (let ri = 0; ri < parsed.rows.length; ri++) {
+    const rowUri = $rdf.sym(`${subject.value}/row/${ri}`);
+    store.add(rowUri, RDF('type'), CSVW('Row'), graph);
+    store.add(rowUri, CSVW('rowIndex'), $rdf.lit(String(ri), undefined, XSD('integer')), graph);
+    store.add(subject, CSVW('row'), rowUri, graph);
+
+    for (let ci = 0; ci < parsed.headers.length; ci++) {
+      const value = parsed.rows[ri][ci] ?? '';
+      const cellUri = $rdf.sym(`${rowUri.value}/cell/${encodeURIComponent(parsed.headers[ci])}`);
+      store.add(cellUri, RDF('type'), CSVW('Cell'), graph);
+      store.add(cellUri, CSVW('column'), colNodes[ci], graph);
+      store.add(cellUri, RDF('value'), $rdf.lit(value), graph);
+      store.add(rowUri, CSVW('cell'), cellUri, graph);
+    }
+  }
+}
+
 export function removeNote(relativePath: string): void {
   if (!store) return;
   const subject = noteUri(relativePath);
@@ -884,7 +957,11 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
         const rel = path.relative(root, fullPath);
         ensureFolder(rel);
         await walkAndIndex(fullPath, root);
-      } else if (entry.name.endsWith('.md') || entry.name.endsWith('.ttl')) {
+      } else if (
+        entry.name.endsWith('.md')
+        || entry.name.endsWith('.ttl')
+        || entry.name.endsWith('.csv')
+      ) {
         const relativePath = path.relative(root, fullPath);
         const content = await fs.readFile(fullPath, 'utf-8');
         await indexNote(relativePath, content);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -85,7 +85,7 @@ function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null {
   return getRootPath(win.id);
 }
 
-const INDEXABLE_EXTS = new Set(['.md', '.ttl']);
+const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
 
 function isIndexable(relativePath: string): boolean {
   return INDEXABLE_EXTS.has(path.extname(relativePath));

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { NoteFile, NotebaseMeta } from '../../shared/types';
 
 const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
-const INDEXABLE_EXTS = new Set(['.md', '.ttl']);
+const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
 
 export async function openNotebase(): Promise<NotebaseMeta | null> {
   const result = await dialog.showOpenDialog({

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -4,7 +4,7 @@ import * as notebaseFs from './fs';
 import { rewriteWikiLinks, normalizePath as normalizeLinkPath } from './link-rewriting';
 import * as graph from '../graph/index';
 
-const INDEXABLE_EXTS = new Set(['.md', '.ttl']);
+const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
 
 function isIndexable(relativePath: string): boolean {
   return INDEXABLE_EXTS.has(path.extname(relativePath));

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { Channels } from '../../shared/channels';
 
-const INDEXABLE_EXTS = new Set(['.md', '.ttl']);
+const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
 
 export interface WatcherCallbacks {
   onFileChanged: (relativePath: string) => void;

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -22,6 +22,7 @@
   import AutoLinkInboundDialog from './lib/components/AutoLinkInboundDialog.svelte';
   import DecomposeDialog from './lib/components/DecomposeDialog.svelte';
   import BusyOverlay from './lib/components/BusyOverlay.svelte';
+  import CsvTable from './lib/components/CsvTable.svelte';
   import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
   import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
   import type { DecomposeProposal } from '../shared/refactor/decompose';
@@ -224,7 +225,7 @@
     const walk = (xs: import('../shared/types').NoteFile[]) => {
       for (const f of xs) {
         if (f.isDirectory) walk(f.children ?? []);
-        else if (/\.(md|ttl)$/.test(f.relativePath)) out.push(f.relativePath);
+        else if (/\.(md|ttl|csv)$/.test(f.relativePath)) out.push(f.relativePath);
       }
     };
     walk(files);
@@ -1068,7 +1069,7 @@
           onCopy={handleCopy}
           onPaste={handlePaste}
           onMove={handleMove}
-          onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl)$/, '') ?? path, path)}
+          onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
           onSourceSelect={(id) => handleOpenSource(id)}
           canPaste={clipboardItem !== null}
         />
@@ -1084,10 +1085,15 @@
             onCloseAll={editor.closeAll}
             onReveal={handleRevealInSidebar}
             onOpenConversation={openConversation}
-            onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl)$/, '') ?? path, path)}
+            onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
           />
         {/if}
-        {#if editor.activeTab?.type === 'note'}
+        {#if editor.activeTab?.type === 'note' && editor.activeTab.relativePath.endsWith('.csv')}
+          <CsvTable
+            relativePath={editor.activeTab.relativePath}
+            content={editor.activeTab.content}
+          />
+        {:else if editor.activeTab?.type === 'note'}
           <div class="toolbar">
             <div class="view-toggle">
               <button
@@ -1131,7 +1137,7 @@
                     onOpenConversation={openConversation}
                     onNavigate={handleNavigate}
                     getNotePaths={() => flattenNotePaths(notebase.files)}
-                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
+                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
                     onSplitByHeading={handleSplitByHeading}

--- a/src/renderer/lib/components/CsvTable.svelte
+++ b/src/renderer/lib/components/CsvTable.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import { parseCsv } from '../../../shared/csv-parse';
+
+  interface Props {
+    relativePath: string;
+    content: string;
+  }
+
+  let { relativePath, content }: Props = $props();
+
+  // Keep the render cost bounded; the rest stays indexed and queryable.
+  const ROW_LIMIT = 10000;
+
+  const parsed = $derived(parseCsv(content));
+  const totalRows = $derived(parsed.rows.length);
+  const visibleRows = $derived(totalRows > ROW_LIMIT ? parsed.rows.slice(0, ROW_LIMIT) : parsed.rows);
+  const truncated = $derived(totalRows > ROW_LIMIT);
+</script>
+
+<div class="csv-container">
+  <div class="meta">
+    <span class="path">{relativePath}</span>
+    <span class="counts">
+      {totalRows.toLocaleString()} row{totalRows === 1 ? '' : 's'}
+      &times;
+      {parsed.headers.length} column{parsed.headers.length === 1 ? '' : 's'}
+    </span>
+  </div>
+
+  {#if parsed.headers.length === 0}
+    <div class="empty">Empty CSV.</div>
+  {:else}
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            {#each parsed.headers as header (header)}
+              <th>{header}</th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each visibleRows as row, ri (ri)}
+            <tr>
+              {#each row as cell, ci (ci)}
+                <td class:empty-cell={!cell}>
+                  {#if cell}{cell}{:else}\u2014{/if}
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+    {#if truncated}
+      <div class="truncation-note">
+        Showing first {ROW_LIMIT.toLocaleString()} of {totalRows.toLocaleString()} rows. The full file remains indexed and SPARQL-queryable.
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .csv-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 6px 12px;
+    background: var(--bg-titlebar);
+    border-bottom: 1px solid var(--border);
+    font-size: 11px;
+    color: var(--titlebar-text-muted);
+    flex-shrink: 0;
+  }
+
+  .path {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    color: var(--titlebar-text);
+  }
+
+  .table-scroll {
+    flex: 1;
+    overflow: auto;
+    min-height: 0;
+  }
+
+  table {
+    border-collapse: collapse;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 12px;
+    min-width: 100%;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg-button);
+    color: var(--text);
+    text-align: left;
+    font-weight: 600;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
+  tbody td {
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+    color: var(--text);
+    white-space: nowrap;
+    vertical-align: top;
+  }
+
+  tbody tr:nth-child(even) td {
+    background: var(--bg-sidebar);
+  }
+
+  .empty-cell {
+    color: var(--text-muted);
+  }
+
+  .empty {
+    padding: 24px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .truncation-note {
+    padding: 6px 12px;
+    background: var(--bg-titlebar);
+    border-top: 1px solid var(--border);
+    font-size: 11px;
+    color: var(--text-muted);
+    text-align: center;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -114,7 +114,7 @@
           ondragstart={(e) => handleDragStart(e, file.relativePath)}
         >
           <span class="icon">📄</span>
-          {file.name.replace(/\.(md|ttl)$/, '')}
+          {file.name.replace(/\.(md|ttl|csv)$/, '')}
         </button>
       {/if}
     </li>

--- a/src/shared/csv-parse.ts
+++ b/src/shared/csv-parse.ts
@@ -1,0 +1,137 @@
+/**
+ * Small RFC 4180-ish CSV parser used by both the main-process graph
+ * indexer and the renderer\u2019s table-view component. Kept pure + tiny so
+ * it\u2019s easy to unit-test and cheap to ship in both bundles.
+ *
+ * Handles: quoted fields, embedded commas, embedded newlines,
+ * doubled-quote escapes (`""` \u2192 `"`), trailing newlines, BOM.
+ *
+ * Does **not** try to detect delimiters (comma only), decode non-UTF-8
+ * encodings, infer column datatypes, or reshape jagged rows \u2014 rows get
+ * padded/trimmed to the first row\u2019s width.
+ */
+
+export interface ParsedCsv {
+  headers: string[];
+  rows: string[][];
+  /**
+   * True when the first row was treated as the header row. False when
+   * the first row looked like data and we synthesized `col_1`, `col_2`, \u2026
+   */
+  hadHeaderRow: boolean;
+}
+
+export function parseCsv(text: string): ParsedCsv {
+  // Strip BOM if the file starts with one.
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+
+  const records = splitRecords(text);
+  if (records.length === 0) {
+    return { headers: [], rows: [], hadHeaderRow: false };
+  }
+
+  const first = records[0];
+  const headerish = looksLikeHeader(first);
+  const width = first.length;
+
+  if (headerish) {
+    return {
+      headers: first.slice(),
+      rows: records.slice(1).map((r) => normalizeWidth(r, width)),
+      hadHeaderRow: true,
+    };
+  }
+
+  const headers = Array.from({ length: width }, (_, i) => `col_${i + 1}`);
+  return {
+    headers,
+    rows: records.map((r) => normalizeWidth(r, width)),
+    hadHeaderRow: false,
+  };
+}
+
+function splitRecords(text: string): string[][] {
+  const out: string[][] = [];
+  let cur: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const c = text[i];
+
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      field += c;
+      i++;
+      continue;
+    }
+
+    if (c === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+
+    if (c === ',') {
+      cur.push(field);
+      field = '';
+      i++;
+      continue;
+    }
+
+    if (c === '\r') {
+      // Swallow CR. LF on the next iteration closes the record.
+      i++;
+      continue;
+    }
+
+    if (c === '\n') {
+      cur.push(field);
+      out.push(cur);
+      cur = [];
+      field = '';
+      i++;
+      continue;
+    }
+
+    field += c;
+    i++;
+  }
+
+  // Flush the tail unless it\u2019s a purely empty trailing newline.
+  if (field !== '' || cur.length > 0) {
+    cur.push(field);
+    out.push(cur);
+  }
+
+  // Drop fully-empty records (common with trailing \\n at EOF).
+  return out.filter((r) => !(r.length === 1 && r[0] === ''));
+}
+
+function looksLikeHeader(row: string[]): boolean {
+  if (row.length === 0) return false;
+  for (const cell of row) {
+    const s = cell.trim();
+    if (!s) return false;                 // empty / whitespace-only cell \u2192 not a header
+    if (!isNaN(Number(s))) return false;  // any numeric-looking cell \u2192 not a header
+  }
+  return true;
+}
+
+function normalizeWidth(row: string[], width: number): string[] {
+  if (row.length === width) return row;
+  if (row.length > width) return row.slice(0, width);
+  const out = row.slice();
+  while (out.length < width) out.push('');
+  return out;
+}

--- a/tests/main/graph/csv-indexing.test.ts
+++ b/tests/main/graph/csv-indexing.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csv-index-test-'));
+}
+
+describe('CSV file indexing (issue #199)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('emits the file as both a minerva:Note and a csvw:Table', async () => {
+    await indexNote('data/metrics.csv', 'name,count\nalice,3\nbob,5\n');
+
+    const { results } = await queryGraph(`
+      SELECT ?path ?type WHERE {
+        ?t minerva:relativePath "data/metrics.csv" ;
+           minerva:relativePath ?path ;
+           a ?type .
+      }
+    `);
+    const types = (results as Array<{ type: string }>).map((r) => r.type);
+    expect(types).toContain('https://minerva.dev/ontology#Note');
+    expect(types).toContain('http://www.w3.org/ns/csvw#Table');
+  });
+
+  it('records csvw:inFile with the relative path as a literal', async () => {
+    await indexNote('data/m.csv', 'a,b\n1,2\n');
+    const { results } = await queryGraph(`
+      SELECT ?p WHERE {
+        ?t minerva:relativePath "data/m.csv" ;
+           csvw:inFile ?p .
+      }
+    `);
+    expect((results as Array<{ p: string }>)[0].p).toBe('data/m.csv');
+  });
+
+  it('emits one csvw:Column per header with its name + zero-based index', async () => {
+    await indexNote('data/m.csv', 'name,count,tag\nalice,3,red\n');
+    const { results } = await queryGraph(`
+      SELECT ?name ?idx WHERE {
+        ?t minerva:relativePath "data/m.csv" ;
+           csvw:column ?c .
+        ?c csvw:name ?name ;
+           csvw:columnIndex ?idx .
+      } ORDER BY ?idx
+    `);
+    const rows = results as Array<{ name: string; idx: string }>;
+    expect(rows).toEqual([
+      { name: 'name', idx: '0' },
+      { name: 'count', idx: '1' },
+      { name: 'tag', idx: '2' },
+    ]);
+  });
+
+  it('emits one csvw:Row per data row with cells keyed to columns', async () => {
+    await indexNote('data/m.csv', 'name,count\nalice,3\nbob,5\n');
+    const { results } = await queryGraph(`
+      SELECT ?name ?count WHERE {
+        ?t minerva:relativePath "data/m.csv" ;
+           csvw:row ?r .
+        ?r csvw:cell ?cellName, ?cellCount .
+        ?cellName  csvw:column ?colName  . ?colName  csvw:name "name"  . ?cellName  rdf:value ?name  .
+        ?cellCount csvw:column ?colCount . ?colCount csvw:name "count" . ?cellCount rdf:value ?count .
+      } ORDER BY ?name
+    `);
+    expect(results).toEqual([
+      { name: 'alice', count: '3' },
+      { name: 'bob', count: '5' },
+    ]);
+  });
+
+  it('re-indexing a CSV replaces the old triples (no stale rows)', async () => {
+    await indexNote('data/m.csv', 'name,count\nalice,3\nbob,5\n');
+    await indexNote('data/m.csv', 'name,count\ncarol,7\n');
+
+    const { results } = await queryGraph(`
+      SELECT ?name WHERE {
+        ?t minerva:relativePath "data/m.csv" ;
+           csvw:row ?r .
+        ?r csvw:cell ?c .
+        ?c csvw:column ?col . ?col csvw:name "name" . ?c rdf:value ?name .
+      }
+    `);
+    const names = (results as Array<{ name: string }>).map((r) => r.name);
+    expect(names).toEqual(['carol']);
+  });
+
+  it('uses the filename stem as dc:title', async () => {
+    await indexNote('data/metrics.csv', 'a,b\n1,2\n');
+    const { results } = await queryGraph(`
+      SELECT ?title WHERE {
+        ?t minerva:relativePath "data/metrics.csv" ;
+           dc:title ?title .
+      }
+    `);
+    expect((results as Array<{ title: string }>)[0].title).toBe('metrics');
+  });
+});

--- a/tests/shared/csv-parse.test.ts
+++ b/tests/shared/csv-parse.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { parseCsv } from '../../src/shared/csv-parse';
+
+describe('parseCsv (issue #199)', () => {
+  it('parses a simple header + rows', () => {
+    const r = parseCsv('name,count\nalice,3\nbob,5');
+    expect(r.hadHeaderRow).toBe(true);
+    expect(r.headers).toEqual(['name', 'count']);
+    expect(r.rows).toEqual([['alice', '3'], ['bob', '5']]);
+  });
+
+  it('tolerates a trailing newline', () => {
+    const r = parseCsv('a,b\n1,2\n');
+    expect(r.rows).toEqual([['1', '2']]);
+  });
+
+  it('handles quoted fields with embedded commas', () => {
+    const r = parseCsv('name,desc\nalice,"hello, world"\n');
+    expect(r.rows).toEqual([['alice', 'hello, world']]);
+  });
+
+  it('handles quoted fields with embedded newlines', () => {
+    const r = parseCsv('name,note\nalice,"line 1\nline 2"\n');
+    expect(r.rows).toEqual([['alice', 'line 1\nline 2']]);
+  });
+
+  it('decodes doubled quotes as a single literal quote', () => {
+    const r = parseCsv('name,quote\nbob,"she said ""hi"""');
+    expect(r.rows).toEqual([['bob', 'she said "hi"']]);
+  });
+
+  it('treats CRLF and LF equivalently as record separators', () => {
+    const r = parseCsv('a,b\r\n1,2\r\n3,4');
+    expect(r.rows).toEqual([['1', '2'], ['3', '4']]);
+  });
+
+  it('strips a leading BOM', () => {
+    const r = parseCsv('\uFEFFname,count\nalice,3');
+    expect(r.headers).toEqual(['name', 'count']);
+  });
+
+  it('synthesizes col_N headers when the first row looks numeric', () => {
+    const r = parseCsv('1,2,3\n4,5,6');
+    expect(r.hadHeaderRow).toBe(false);
+    expect(r.headers).toEqual(['col_1', 'col_2', 'col_3']);
+    expect(r.rows).toEqual([['1', '2', '3'], ['4', '5', '6']]);
+  });
+
+  it('synthesizes col_N headers when the first row contains an empty cell', () => {
+    const r = parseCsv('name,,value\nalice,foo,3');
+    expect(r.hadHeaderRow).toBe(false);
+    expect(r.headers).toEqual(['col_1', 'col_2', 'col_3']);
+    expect(r.rows[0]).toEqual(['name', '', 'value']);
+  });
+
+  it('pads short rows and trims long rows to the header width', () => {
+    const r = parseCsv('a,b,c\n1,2\n4,5,6,7');
+    expect(r.rows).toEqual([
+      ['1', '2', ''],
+      ['4', '5', '6'],
+    ]);
+  });
+
+  it('returns empty headers + rows for an empty file', () => {
+    expect(parseCsv('')).toEqual({ headers: [], rows: [], hadHeaderRow: false });
+    expect(parseCsv('\n\n\n')).toEqual({ headers: [], rows: [], hadHeaderRow: false });
+  });
+
+  it('preserves whitespace inside fields verbatim', () => {
+    const r = parseCsv('a,b\n  spaced  ,  also  ');
+    expect(r.rows).toEqual([['  spaced  ', '  also  ']]);
+  });
+});


### PR DESCRIPTION
## Summary
CSV files become first-class citizens of the notebase, parallel to `.ttl`. Dropping a `data.csv` next to your notes now means it shows up in the sidebar, gets indexed into the graph as CSVW, is SPARQL-queryable, and renders as a proper table when opened.

## What landed

### Indexing (`#199`)
- `.csv` added to `INDEXABLE_EXTS` in `ipc.ts`, `rename.ts`, and `watcher.ts` \u2014 same path `.md` / `.ttl` already take.
- New `indexCsvFile` branch in `graph.indexNote`: sets up the note metadata (type, title from filename-stem, filename, relativePath, modified, folder, project membership) and emits CSVW:
  - The file\u2019s subject IS the `csvw:Table` (one file, one table).
  - `csvw:inFile <relativePath>` literal, parallel to `csvw:inNote` for markdown-sourced tables.
  - `csvw:Column` per header with `csvw:name` + `csvw:columnIndex`.
  - `csvw:Row` per data row; `csvw:cell` links row\u2194column with the string value on `rdf:value`.
- RFC 4180 parser (`src/shared/csv-parse.ts`): quoted fields, embedded commas/newlines, `""` escapes, BOM, CRLF. Synthesizes `col_1, col_2, \u2026` headers when the first row looks like data (numeric or has empty cells).

### Display (`#200`)
- Opening a `.csv` tab routes to a new `CsvTable.svelte` component instead of the markdown editor.
- Sticky header row, monospace cells, zebra striping, per-cell borders, horizontal scroll; empty cells rendered as `\u2014`.
- Header bar shows path + `N rows \u00D7 M columns`.
- Soft cap at 10,000 rendered rows with a "showing first N of M" footer \u2014 indexed data is unaffected.
- Read-only for v1 (per the ticket).

### Consistency
- FileTree label, bookmark default name, getNotePaths autocomplete source, and the graph walker now all treat `.csv` the same way as `.md` / `.ttl`.

## Tests
- 12 parser tests (`src/shared/csv-parse.ts`)
- 6 indexer tests (CSVW triples, re-index replaces, dc:title, inFile predicate)
- Full suite: **529 passing** (was 511)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (529 passing)
- [ ] Drop a `data.csv` into the notebase folder. Sidebar shows it without `.csv` suffix.
- [ ] Click it. A table renders; row/col counts match the file.
- [ ] In a `.sparql` tab: `SELECT ?name WHERE { ?t csvw:inFile "data.csv" ; csvw:row ?r . ?r csvw:cell ?c . ?c csvw:column ?col . ?col csvw:name "name" . ?c rdf:value ?name . }` \u2014 returns the name column.
- [ ] Edit the CSV externally \u2014 watcher re-indexes; repeating the query reflects the new data.
- [ ] Rename `data.csv` \u2014 watcher + graph handle it like any other note rename.

## Out of scope
- In-app CSV editing (spreadsheet UI / cell edits) \u2014 use an external editor for now.
- Column datatype inference (everything indexes as a string literal).
- TSV / PSV or user-configured delimiters.
- Virtualized rendering for very large files (10,000-row soft cap for now).