### PR TITLE
Consolidate INDEXABLE_EXTS into a single source of truth

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -9,6 +9,7 @@ import { getLinkType, type LinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
 import { slugify } from '../../shared/slug';
 import { parseCsv } from '../../shared/csv-parse';
+import { isIndexable } from '../notebase/indexable-files';
 import * as uriHelpers from './uri-helpers';
 
 import * as N3 from 'n3';
@@ -957,11 +958,7 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
         const rel = path.relative(root, fullPath);
         ensureFolder(rel);
         await walkAndIndex(fullPath, root);
-      } else if (
-        entry.name.endsWith('.md')
-        || entry.name.endsWith('.ttl')
-        || entry.name.endsWith('.csv')
-      ) {
+      } else if (isIndexable(entry.name)) {
         const relativePath = path.relative(root, fullPath);
         const content = await fs.readFile(fullPath, 'utf-8');
         await indexNote(relativePath, content);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
+import { isIndexable } from './notebase/indexable-files';
 import { renameWithLinkRewrites } from './notebase/rename';
 import { renameAnchor } from './notebase/rename-anchor';
 import { renameSource, renameExcerpt } from './notebase/rename-source-excerpt';
@@ -85,12 +86,6 @@ function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null {
   return getRootPath(win.id);
 }
 
-const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
-
-function isIndexable(relativePath: string): boolean {
-  return INDEXABLE_EXTS.has(path.extname(relativePath));
-}
-
 async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
   if (!isIndexable(relativePath)) return;
   const content = await notebaseFs.readFile(rootPath, relativePath);
@@ -116,7 +111,7 @@ async function listIndexableFiles(rootPath: string, relDir: string): Promise<str
       const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
         results.push(...await listIndexableFiles(rootPath, rel));
-      } else if (INDEXABLE_EXTS.has(path.extname(entry.name))) {
+      } else if (isIndexable(entry.name)) {
         results.push(rel);
       }
     }

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -2,9 +2,9 @@ import { dialog } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { NoteFile, NotebaseMeta } from '../../shared/types';
+import { INDEXABLE_EXTS } from './indexable-files';
 
 const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
-const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
 
 export async function openNotebase(): Promise<NotebaseMeta | null> {
   const result = await dialog.showOpenDialog({

--- a/src/main/notebase/indexable-files.ts
+++ b/src/main/notebase/indexable-files.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+
+/**
+ * Canonical set of file extensions that Minerva indexes + lists as
+ * first-class notebase files. The sidebar filters to this set, the
+ * watcher only re-indexes changes to these, and `graph.indexNote`
+ * dispatches on the extension within it.
+ *
+ * Adding a new extension here is the single change needed to wire it
+ * through sidebar listing, watcher reindex, rename/link-rewrites, and
+ * the bulk index-all-notes walker.
+ */
+export const INDEXABLE_EXTS: ReadonlySet<string> = new Set(['.md', '.ttl', '.csv']);
+
+export function isIndexable(relativePath: string): boolean {
+  return INDEXABLE_EXTS.has(path.extname(relativePath).toLowerCase());
+}

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -3,12 +3,7 @@ import path from 'node:path';
 import * as notebaseFs from './fs';
 import { rewriteWikiLinks, normalizePath as normalizeLinkPath } from './link-rewriting';
 import * as graph from '../graph/index';
-
-const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
-
-function isIndexable(relativePath: string): boolean {
-  return INDEXABLE_EXTS.has(path.extname(relativePath));
-}
+import { isIndexable } from './indexable-files';
 
 async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {
   const results: string[] = [];
@@ -20,7 +15,7 @@ async function listIndexableFiles(rootPath: string, relDir: string): Promise<str
       const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
         results.push(...await listIndexableFiles(rootPath, rel));
-      } else if (INDEXABLE_EXTS.has(path.extname(entry.name))) {
+      } else if (isIndexable(entry.name)) {
         results.push(rel);
       }
     }

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { Channels } from '../../shared/channels';
 
-const INDEXABLE_EXTS = new Set(['.md', '.ttl', '.csv']);
+import { INDEXABLE_EXTS } from './indexable-files';
 
 export interface WatcherCallbacks {
   onFileChanged: (relativePath: string) => void;


### PR DESCRIPTION
## Summary
Four copies of the `{.md, .ttl, .csv}` set (one each in `fs.ts`, `rename.ts`, `watcher.ts`, `ipc.ts`) collapse into `src/main/notebase/indexable-files.ts`. An open-coded `endsWith` chain in `graph/index.ts`\u2019s index-all-notes walker goes with them.

Context: \#199 missed the `fs.ts` copy and the CSV files were invisible in the sidebar until a follow-up commit. With one source of truth, that class of bug goes away \u2014 adding an indexable extension is a single-line change.

## Changes
- **New** `src/main/notebase/indexable-files.ts` exporting `INDEXABLE_EXTS` (ReadonlySet) + `isIndexable(relativePath)`.
- **Deleted** local `INDEXABLE_EXTS` + `isIndexable` definitions from `fs.ts`, `rename.ts`, `watcher.ts`, `ipc.ts`.
- **Replaced** graph/index.ts\u2019s `entry.name.endsWith('.md') || \u2026` chain with the same helper.

Net: `+25 / -21` across 5 touched files + 1 new.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (529 passing, unchanged)
- [ ] Sidebar still lists `.md` / `.ttl` / `.csv` files
- [ ] File watcher still picks up changes to each
- [ ] Rename / move flow still works