### PR TITLE
Query panel: SPARQL syntax highlighting (closes #197)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
     "@codemirror/autocomplete": "^6.20.1",
+    "@codemirror/legacy-modes": "^6.5.2",
     "@comunica/query-sparql-rdfjs": "^5.1.3",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@codemirror/autocomplete':
         specifier: ^6.20.1
         version: 6.20.1
+      '@codemirror/legacy-modes':
+        specifier: ^6.5.2
+        version: 6.5.2
       '@comunica/query-sparql-rdfjs':
         specifier: ^5.1.3
         version: 5.1.3(encoding@0.1.13)

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -98,6 +98,7 @@
   let rightSidebar = $state<RightSidebar>();
   let rightSidebarVisible = $state(false);
   let editorComponent = $state<Editor>();
+  let queryPanelComponent = $state<QueryPanel>();
   let toolPanelComponent = $state<ToolPanel>();
   let cursorInfo = $state<CursorInfo>({ line: 1, column: 1, selectionLength: 0, wordCount: 0 });
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
@@ -745,6 +746,7 @@
   function handleCycleTheme() {
     themeLabel = cycleTheme();
     editorComponent?.updateTheme();
+    queryPanelComponent?.updateTheme();
   }
 
   async function handleSwitchTab(index: number) {
@@ -1194,6 +1196,7 @@
           {/if}
         {:else if editor.activeTab?.type === 'query'}
           <QueryPanel
+            bind:this={queryPanelComponent}
             tab={editor.activeQueryTab!}
             onQueryChange={editor.setQueryText}
             onExecute={editor.executeQuery}
@@ -1313,6 +1316,7 @@
       onThemeChanged={() => {
         themeLabel = getThemeMode();
         editorComponent?.updateTheme();
+        queryPanelComponent?.updateTheme();
       }}
       onClose={() => { showSettings = false; }}
     />

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -3,7 +3,13 @@
   import { EditorView, keymap, lineNumbers, placeholder } from '@codemirror/view';
   import { EditorState, Compartment } from '@codemirror/state';
   import { history, historyKeymap, defaultKeymap, indentWithTab } from '@codemirror/commands';
-  import { bracketMatching, indentUnit, StreamLanguage } from '@codemirror/language';
+  import {
+    bracketMatching,
+    indentUnit,
+    StreamLanguage,
+    syntaxHighlighting,
+    defaultHighlightStyle,
+  } from '@codemirror/language';
   import { sparql } from '@codemirror/legacy-modes/mode/sparql';
   import { oneDark } from '@codemirror/theme-one-dark';
   import { getEffectiveTheme, getThemeMode } from '../theme';
@@ -62,6 +68,10 @@
         bracketMatching(),
         indentUnit.of('  '),
         StreamLanguage.define(sparql),
+        // Fallback highlighter for light themes; oneDark brings its own in
+        // dark mode. Without this, the SPARQL parser tokenizes but nothing
+        // paints the tokens.
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         placeholder('SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}'),
         themeCompartment.of(cmTheme()),
         EditorView.theme({

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -8,8 +8,9 @@
     indentUnit,
     StreamLanguage,
     syntaxHighlighting,
-    defaultHighlightStyle,
+    HighlightStyle,
   } from '@codemirror/language';
+  import { tags as t } from '@lezer/highlight';
   import { sparql } from '@codemirror/legacy-modes/mode/sparql';
   import { oneDark } from '@codemirror/theme-one-dark';
   import { getEffectiveTheme, getThemeMode } from '../theme';
@@ -50,6 +51,37 @@
     return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
   }
 
+  // Custom SPARQL palette — Catppuccin Mocha-inspired, with deliberately wide
+  // hue distance so the four things you scan for in a query (keywords, variables,
+  // IRIs/prefixed names, string literals) land on four different points of the
+  // color wheel: purple, yellow, sky, green. Overrides both defaultHighlightStyle
+  // and oneDark's SPARQL-relevant tag bindings.
+  const sparqlHighlight = HighlightStyle.define([
+    // Clause keywords (SELECT, WHERE, PREFIX, FILTER, ORDER BY, …): purple.
+    { tag: t.keyword, color: '#cba6f7', fontWeight: '600' },
+    // Variables (?x, $y): yellow.
+    { tag: [t.variableName, t.labelName], color: '#f9e2af' },
+    // IRIs + prefixed names (<http://…>, minerva:Note) surface as `atom` in
+    // the legacy SPARQL parser; map them to sky blue.
+    { tag: t.atom, color: '#89dceb' },
+    // Built-in functions (str, lang, count, regex, …): a lighter blue to
+    // separate them from the sky-blue IRIs.
+    { tag: [t.standard(t.variableName), t.function(t.variableName)], color: '#89b4fa' },
+    // Quoted literals: green.
+    { tag: t.string, color: '#a6e3a1' },
+    // Numbers: peach (SPARQL mode rarely emits these but included for
+    // completeness in case a number literal shows up).
+    { tag: t.number, color: '#fab387' },
+    // Language tags / directives (@en, @base): teal.
+    { tag: t.meta, color: '#94e2d5' },
+    // Operators (*, +, <, =, !): default text.
+    { tag: t.operator, color: 'inherit' },
+    // Brackets + punctuation: slightly muted so structure recedes.
+    { tag: [t.bracket, t.punctuation], color: '#9399b2' },
+    // Comments: italic grey.
+    { tag: t.comment, color: '#6c7086', fontStyle: 'italic' },
+  ]);
+
   /** Replace the editor contents with `text` without triggering the onQueryChange callback. */
   function setDoc(text: string): void {
     if (!view) return;
@@ -68,10 +100,9 @@
         bracketMatching(),
         indentUnit.of('  '),
         StreamLanguage.define(sparql),
-        // Fallback highlighter for light themes; oneDark brings its own in
-        // dark mode. Without this, the SPARQL parser tokenizes but nothing
-        // paints the tokens.
-        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        // Custom non-fallback highlighter so keywords / variables / IRIs /
+        // strings each get a distinct color regardless of theme.
+        syntaxHighlighting(sparqlHighlight),
         placeholder('SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}'),
         themeCompartment.of(cmTheme()),
         EditorView.theme({

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -1,4 +1,12 @@
 <script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { EditorView, keymap, lineNumbers, placeholder } from '@codemirror/view';
+  import { EditorState, Compartment } from '@codemirror/state';
+  import { history, historyKeymap, defaultKeymap, indentWithTab } from '@codemirror/commands';
+  import { bracketMatching, indentUnit, StreamLanguage } from '@codemirror/language';
+  import { sparql } from '@codemirror/legacy-modes/mode/sparql';
+  import { oneDark } from '@codemirror/theme-one-dark';
+  import { getEffectiveTheme, getThemeMode } from '../theme';
   import type { QueryTab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
 
@@ -23,29 +31,90 @@
 
   let { tab, onQueryChange, onExecute, onSave }: Props = $props();
 
-  let textareaEl = $state<HTMLTextAreaElement>();
+  let editorContainer = $state<HTMLDivElement>();
+  let view: EditorView | null = null;
   let splitRatio = $state(0.4); // 40% editor, 60% results
   let dragging = $state(false);
   let containerEl = $state<HTMLDivElement>();
 
-  function handleKeydown(e: KeyboardEvent) {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-      e.preventDefault();
-      onExecute();
+  // Compartments for reconfigurable extensions.
+  const themeCompartment = new Compartment();
+
+  function cmTheme(): any {
+    return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
+  }
+
+  /** Replace the editor contents with `text` without triggering the onQueryChange callback. */
+  function setDoc(text: string): void {
+    if (!view) return;
+    if (view.state.doc.toString() === text) return;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: text },
+    });
+  }
+
+  function buildState(initial: string): EditorState {
+    return EditorState.create({
+      doc: initial,
+      extensions: [
+        lineNumbers(),
+        history(),
+        bracketMatching(),
+        indentUnit.of('  '),
+        StreamLanguage.define(sparql),
+        placeholder('SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}'),
+        themeCompartment.of(cmTheme()),
+        EditorView.theme({
+          '&': { height: '100%' },
+          '.cm-content': {
+            fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
+            fontSize: '13px',
+            lineHeight: '1.5',
+          },
+          '.cm-scroller': { overflow: 'auto' },
+        }),
+        keymap.of([
+          { key: 'Mod-Enter', run: () => { onExecute(); return true; } },
+          { key: 'Mod-s', run: () => { onSave(); return true; } },
+          indentWithTab,
+          ...defaultKeymap,
+          ...historyKeymap,
+        ]),
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) {
+            onQueryChange(u.state.doc.toString());
+          }
+        }),
+      ],
+    });
+  }
+
+  onMount(() => {
+    if (!editorContainer) return;
+    view = new EditorView({
+      state: buildState(tab.query),
+      parent: editorContainer,
+    });
+    view.focus();
+  });
+
+  onDestroy(() => {
+    view?.destroy();
+    view = null;
+  });
+
+  // Keep the editor in sync when the active tab changes (tab switch, stock
+  // query load, programmatic reset). Skips the round-trip when the user
+  // just typed the change themselves.
+  $effect(() => {
+    const next = tab.query;
+    if (view && view.state.doc.toString() !== next) {
+      setDoc(next);
     }
-    // Tab inserts two spaces in the query editor
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      const ta = textareaEl;
-      if (ta) {
-        const start = ta.selectionStart;
-        const end = ta.selectionEnd;
-        const value = ta.value;
-        ta.value = value.substring(0, start) + '  ' + value.substring(end);
-        ta.selectionStart = ta.selectionEnd = start + 2;
-        onQueryChange(ta.value);
-      }
-    }
+  });
+
+  export function updateTheme(): void {
+    view?.dispatch({ effects: themeCompartment.reconfigure(cmTheme()) });
   }
 
   function startDrag(e: MouseEvent) {
@@ -90,9 +159,6 @@
     });
   });
 
-  $effect(() => {
-    if (textareaEl) textareaEl.focus();
-  });
 </script>
 
 <div class="query-panel" bind:this={containerEl}>
@@ -118,16 +184,7 @@
         </span>
       {/if}
     </div>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <textarea
-      bind:this={textareaEl}
-      class="query-input"
-      value={tab.query}
-      oninput={(e) => onQueryChange((e.target as HTMLTextAreaElement).value)}
-      onkeydown={handleKeydown}
-      placeholder="SELECT ?note ?title WHERE &#123;&#10;  ?note a <https://minerva.dev/ontology#Note> .&#10;  ?note <http://purl.org/dc/terms/title> ?title .&#10;&#125;"
-      spellcheck={false}
-    ></textarea>
+    <div bind:this={editorContainer} class="query-input"></div>
   </div>
 
   <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -266,21 +323,24 @@
   .query-input {
     flex: 1;
     width: 100%;
-    padding: 8px 12px;
-    border: none;
+    min-height: 0;
+    overflow: hidden;
     background: var(--bg);
-    color: var(--text);
-    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-    font-size: 13px;
-    line-height: 1.5;
-    resize: none;
-    outline: none;
-    tab-size: 2;
   }
 
-  .query-input::placeholder {
+  .query-input :global(.cm-editor) {
+    height: 100%;
+    outline: none;
+  }
+
+  .query-input :global(.cm-editor.cm-focused) {
+    outline: none;
+  }
+
+  .query-input :global(.cm-gutters) {
+    background: var(--bg-sidebar);
+    border-right: 1px solid var(--border);
     color: var(--text-muted);
-    opacity: 0.6;
   }
 
   .split-handle {

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -46,41 +46,53 @@
 
   // Compartments for reconfigurable extensions.
   const themeCompartment = new Compartment();
+  const highlightCompartment = new Compartment();
 
-  function cmTheme(): any {
-    return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
+  function isDark(): boolean {
+    return getEffectiveTheme(getThemeMode()) === 'dark';
   }
 
-  // Custom SPARQL palette — Catppuccin Mocha-inspired, with deliberately wide
-  // hue distance so the four things you scan for in a query (keywords, variables,
-  // IRIs/prefixed names, string literals) land on four different points of the
-  // color wheel: purple, yellow, sky, green. Overrides both defaultHighlightStyle
-  // and oneDark's SPARQL-relevant tag bindings.
-  const sparqlHighlight = HighlightStyle.define([
-    // Clause keywords (SELECT, WHERE, PREFIX, FILTER, ORDER BY, …): purple.
-    { tag: t.keyword, color: '#cba6f7', fontWeight: '600' },
-    // Variables (?x, $y): yellow.
-    { tag: [t.variableName, t.labelName], color: '#f9e2af' },
-    // IRIs + prefixed names (<http://…>, minerva:Note) surface as `atom` in
-    // the legacy SPARQL parser; map them to sky blue.
-    { tag: t.atom, color: '#89dceb' },
-    // Built-in functions (str, lang, count, regex, …): a lighter blue to
-    // separate them from the sky-blue IRIs.
-    { tag: [t.standard(t.variableName), t.function(t.variableName)], color: '#89b4fa' },
-    // Quoted literals: green.
-    { tag: t.string, color: '#a6e3a1' },
-    // Numbers: peach (SPARQL mode rarely emits these but included for
-    // completeness in case a number literal shows up).
-    { tag: t.number, color: '#fab387' },
-    // Language tags / directives (@en, @base): teal.
-    { tag: t.meta, color: '#94e2d5' },
-    // Operators (*, +, <, =, !): default text.
+  function cmTheme(): any {
+    return isDark() ? oneDark : [];
+  }
+
+  // Custom SPARQL palette — Catppuccin-inspired, with deliberately wide hue
+  // distance so the four things you scan for in a query (keywords, variables,
+  // IRIs/prefixed names, string literals) land on four different points of
+  // the color wheel. Two variants so contrast holds on both backgrounds.
+
+  // Mocha (dark): saturated pastels that read on a dark editor.
+  const sparqlHighlightDark = HighlightStyle.define([
+    { tag: t.keyword, color: '#cba6f7', fontWeight: '600' },                                  // purple
+    { tag: [t.variableName, t.labelName], color: '#f9e2af' },                                 // yellow
+    { tag: t.atom, color: '#89dceb' },                                                        // sky
+    { tag: [t.standard(t.variableName), t.function(t.variableName)], color: '#89b4fa' },     // blue
+    { tag: t.string, color: '#a6e3a1' },                                                      // green
+    { tag: t.number, color: '#fab387' },                                                      // peach
+    { tag: t.meta, color: '#94e2d5' },                                                        // teal
     { tag: t.operator, color: 'inherit' },
-    // Brackets + punctuation: slightly muted so structure recedes.
     { tag: [t.bracket, t.punctuation], color: '#9399b2' },
-    // Comments: italic grey.
     { tag: t.comment, color: '#6c7086', fontStyle: 'italic' },
   ]);
+
+  // Latte (light): darker, more saturated hues so they read on white. Yellow
+  // is replaced with maroon/red for variables — yellow-on-white is unreadable.
+  const sparqlHighlightLight = HighlightStyle.define([
+    { tag: t.keyword, color: '#8839ef', fontWeight: '600' },                                  // mauve
+    { tag: [t.variableName, t.labelName], color: '#c92f5a' },                                 // deep rose
+    { tag: t.atom, color: '#0370a1' },                                                        // deep sky
+    { tag: [t.standard(t.variableName), t.function(t.variableName)], color: '#1e66f5' },     // blue
+    { tag: t.string, color: '#2d7d1f' },                                                      // deep green
+    { tag: t.number, color: '#d13f00' },                                                      // burnt orange
+    { tag: t.meta, color: '#117276' },                                                        // deep teal
+    { tag: t.operator, color: 'inherit' },
+    { tag: [t.bracket, t.punctuation], color: '#7a7f91' },
+    { tag: t.comment, color: '#6c6f85', fontStyle: 'italic' },
+  ]);
+
+  function cmHighlight(): any {
+    return syntaxHighlighting(isDark() ? sparqlHighlightDark : sparqlHighlightLight);
+  }
 
   /** Replace the editor contents with `text` without triggering the onQueryChange callback. */
   function setDoc(text: string): void {
@@ -100,9 +112,10 @@
         bracketMatching(),
         indentUnit.of('  '),
         StreamLanguage.define(sparql),
-        // Custom non-fallback highlighter so keywords / variables / IRIs /
-        // strings each get a distinct color regardless of theme.
-        syntaxHighlighting(sparqlHighlight),
+        // Custom highlighter \u2014 dark vs light palette swapped via compartment
+        // whenever the theme changes. Non-fallback so it overrides oneDark's
+        // own mappings in dark mode.
+        highlightCompartment.of(cmHighlight()),
         placeholder('SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}'),
         themeCompartment.of(cmTheme()),
         EditorView.theme({
@@ -155,7 +168,12 @@
   });
 
   export function updateTheme(): void {
-    view?.dispatch({ effects: themeCompartment.reconfigure(cmTheme()) });
+    view?.dispatch({
+      effects: [
+        themeCompartment.reconfigure(cmTheme()),
+        highlightCompartment.reconfigure(cmHighlight()),
+      ],
+    });
   }
 
   function startDrag(e: MouseEvent) {


### PR DESCRIPTION
## Summary
Replaces the plain `<textarea>` in QueryPanel with a CodeMirror 6 editor wired to the `sparql` stream-parser language mode from `@codemirror/legacy-modes`. Keywords, variables (`?x` / `$x`), IRIs, prefixed names, literals, and comments all highlight correctly.

Lays the groundwork for #198 (autocomplete) and #196 (reformat) \u2014 both plug into the same CodeMirror instance.

## Bonus wins from the migration
- Line numbers, bracket matching, real undo history.
- Tab indents properly (via `indentWithTab` + `indentUnit("  ")`).
- Cmd+Enter runs, Cmd+S saves \u2014 same shortcuts as before.
- Theme follows the main editor: cycles via `queryPanelComponent.updateTheme()` from `App.svelte` on theme-cycle + settings-theme-change.
- Placeholder via the `@codemirror/view` placeholder helper.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (529 passing, unchanged)
- [ ] Open a query tab \u2014 highlights appear on SELECT, keywords, variables, IRIs
- [ ] Cmd+Enter runs; Cmd+S saves
- [ ] Tab indents by two spaces; Shift+Tab dedents
- [ ] Cycle theme \u2014 query editor flips alongside the main editor
- [ ] Switch query tabs \u2014 editor\u2019s doc swaps to the new tab\u2019s query