### PR TITLE
Query panel: Reformat Query (closes #196)

### DIFF
--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -16,6 +16,7 @@
   import { getEffectiveTheme, getThemeMode } from '../theme';
   import type { QueryTab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
+  import { formatSparql } from '../../../shared/sparql-format';
 
   function toCsv(columns: string[], rows: Record<string, string>[]): string {
     const escape = (s: string) => {
@@ -130,6 +131,7 @@
         keymap.of([
           { key: 'Mod-Enter', run: () => { onExecute(); return true; } },
           { key: 'Mod-s', run: () => { onSave(); return true; } },
+          { key: 'Shift-Alt-f', run: reformat },
           indentWithTab,
           ...defaultKeymap,
           ...historyKeymap,
@@ -174,6 +176,17 @@
         highlightCompartment.reconfigure(cmHighlight()),
       ],
     });
+  }
+
+  function reformat(): boolean {
+    if (!view) return false;
+    const current = view.state.doc.toString();
+    const formatted = formatSparql(current);
+    if (formatted === current) return true;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: formatted },
+    });
+    return true;
   }
 
   function startDrag(e: MouseEvent) {
@@ -236,6 +249,11 @@
         onclick={onSave}
         title="Save query"
       >Save</button>
+      <button
+        class="save-query-btn"
+        onclick={reformat}
+        title="Reformat (Shift+Alt+F)"
+      >Format</button>
       {#if tab.executionTime != null}
         <span class="status-text">
           {tab.results ? `${tab.results.length} result${tab.results.length !== 1 ? 's' : ''}` : 'Error'}

--- a/src/shared/sparql-format.ts
+++ b/src/shared/sparql-format.ts
@@ -223,9 +223,13 @@ function emit(tokens: Token[]): string {
   let depth = 0;
   /** Set when we\u2019ve emitted the continuation punct (`;` / `,`) and the next token should sit on a fresh indented line. */
   let pendingContinuation = false;
+  /** Tracks what the last non-empty flushed line was, so we can separate the PREFIX block from the query form with a blank line. */
+  let lastFlushedKind: 'prefix' | 'other' | null = null;
 
   function flush() {
     if (line.trim() === '') { line = ''; return; }
+    const firstWord = line.trimStart().split(/\s+/, 1)[0]?.toUpperCase() ?? '';
+    lastFlushedKind = firstWord === 'PREFIX' || firstWord === 'BASE' ? 'prefix' : 'other';
     out += line.trimEnd() + '\n';
     line = '';
   }
@@ -272,6 +276,17 @@ function emit(tokens: Token[]): string {
     if (tok.type === 'word' && TOP_LEVEL_KW.has(upper) && line.trim() !== '') {
       flush();
       line = '  '.repeat(depth);
+    }
+
+    // Blank line between the PREFIX block and the query form.
+    if (
+      tok.type === 'word'
+      && (upper === 'SELECT' || upper === 'CONSTRUCT' || upper === 'ASK' || upper === 'DESCRIBE')
+      && lastFlushedKind === 'prefix'
+      && line.trim() === ''
+    ) {
+      out += '\n';
+      lastFlushedKind = 'other';
     }
 
     // Block keywords inside a WHERE body begin a new indented line.

--- a/src/shared/sparql-format.ts
+++ b/src/shared/sparql-format.ts
@@ -1,0 +1,377 @@
+/**
+ * Hand-rolled SPARQL pretty-printer (#196). Not a full parser \u2014 just
+ * enough of a tokenizer + emitter to canonicalise the query shapes this
+ * codebase uses. String literals, IRIs in angle brackets, and comments
+ * are preserved verbatim; everything else gets normalised.
+ *
+ * Rules applied:
+ *   - PREFIX / BASE declarations each on their own line, top of query.
+ *   - SELECT / CONSTRUCT / ASK / DESCRIBE and their projections on one
+ *     line, followed by WHERE { on the same line.
+ *   - Triple patterns in WHERE one per line, indented 2 spaces per
+ *     brace-depth.
+ *   - `;` / `,` continuations on their own lines at the current indent.
+ *   - FILTER / OPTIONAL / UNION / MINUS / GRAPH / SERVICE on their own
+ *     lines inside the block.
+ *   - Trailing clauses (ORDER BY, GROUP BY, HAVING, LIMIT, OFFSET,
+ *     VALUES) after the closing brace, each on its own line.
+ *   - Comments stay where they were, on their own line.
+ *
+ * The formatter is intentionally idempotent: `format(format(x)) === format(x)`
+ * for any input it produced.
+ */
+
+type TokenType =
+  | 'word'       // keywords + unprefixed names (SELECT, str, …)
+  | 'pname'      // prefixed names (minerva:Note, dc:title, a)
+  | 'var'        // ?x, $y
+  | 'iri'        // <http://…>
+  | 'string'     // "…", '…', """…"""
+  | 'number'     // 42, 3.14, -1
+  | 'comment'    // # … (newline excluded)
+  | 'punct'      // . ; , ( ) [ ] { }
+  | 'operator';  // * + - < > = ! / & | ^ ? (when not a var leader)
+
+interface Token {
+  type: TokenType;
+  text: string;
+}
+
+// Keywords that should begin their own line at the top level. WHERE is
+// deliberately omitted — it sticks with the preceding SELECT projection
+// (`SELECT ?x WHERE {` on one line) so the common shape reads cleanly.
+const TOP_LEVEL_KW = new Set([
+  'BASE', 'PREFIX', 'SELECT', 'CONSTRUCT', 'ASK', 'DESCRIBE',
+  'FROM',
+  'ORDER', 'GROUP', 'HAVING', 'LIMIT', 'OFFSET', 'VALUES',
+]);
+
+const BLOCK_KW = new Set([
+  'FILTER', 'OPTIONAL', 'UNION', 'MINUS', 'GRAPH', 'SERVICE', 'BIND',
+]);
+
+export function formatSparql(src: string): string {
+  const tokens = tokenize(src);
+  if (tokens.length === 0) return src.trimEnd() + (src.endsWith('\n') ? '\n' : '');
+  return emit(tokens);
+}
+
+// ── Tokenizer ────────────────────────────────────────────────────────────
+
+function tokenize(src: string): Token[] {
+  const out: Token[] = [];
+  let i = 0;
+  const n = src.length;
+
+  while (i < n) {
+    const c = src[i];
+
+    // Whitespace
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { i++; continue; }
+
+    // Comment: `#` through end of line
+    if (c === '#') {
+      const eol = src.indexOf('\n', i);
+      const end = eol < 0 ? n : eol;
+      out.push({ type: 'comment', text: src.slice(i, end).trimEnd() });
+      i = end;
+      continue;
+    }
+
+    // String literal: handle triple-quoted and single-quoted both `"` and `'`.
+    if (c === '"' || c === "'") {
+      const triple = src.slice(i, i + 3) === c + c + c;
+      if (triple) {
+        let j = i + 3;
+        while (j < n && src.slice(j, j + 3) !== c + c + c) j++;
+        j = Math.min(n, j + 3);
+        out.push({ type: 'string', text: src.slice(i, j) });
+        i = j;
+      } else {
+        let j = i + 1;
+        let escaped = false;
+        while (j < n) {
+          const ch = src[j];
+          if (ch === '\\' && !escaped) { escaped = true; j++; continue; }
+          if (ch === c && !escaped) { j++; break; }
+          escaped = false;
+          j++;
+        }
+        out.push({ type: 'string', text: src.slice(i, j) });
+        i = j;
+      }
+      continue;
+    }
+
+    // IRI in angle brackets — distinguish from `<` / `<=` operators by
+    // peeking. An IRI is `<` followed by non-whitespace + closing `>` on
+    // the same line.
+    if (c === '<') {
+      const next = src[i + 1];
+      const looksOp = next === undefined || next === ' ' || next === '\t' || next === '\n' || next === '=';
+      if (!looksOp) {
+        const close = src.indexOf('>', i + 1);
+        const nl = src.indexOf('\n', i + 1);
+        if (close > 0 && (nl < 0 || close < nl)) {
+          out.push({ type: 'iri', text: src.slice(i, close + 1) });
+          i = close + 1;
+          continue;
+        }
+      }
+      // Operator `<` or `<=`
+      if (next === '=') {
+        out.push({ type: 'operator', text: '<=' });
+        i += 2;
+      } else {
+        out.push({ type: 'operator', text: '<' });
+        i++;
+      }
+      continue;
+    }
+
+    // Variable: ?x or $x
+    if (c === '?' || c === '$') {
+      // Standalone `?` (no identifier after) — treat as operator.
+      let j = i + 1;
+      while (j < n && /[A-Za-z0-9_\u00C0-\uFFFD]/.test(src[j])) j++;
+      if (j === i + 1) {
+        out.push({ type: 'operator', text: c });
+        i = j;
+      } else {
+        out.push({ type: 'var', text: src.slice(i, j) });
+        i = j;
+      }
+      continue;
+    }
+
+    // Number: optional sign handled by preceding operator token.
+    if (/[0-9]/.test(c)) {
+      let j = i;
+      while (j < n && /[0-9.eE+-]/.test(src[j])) j++;
+      out.push({ type: 'number', text: src.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    // Single-char punctuation
+    if ('.;,(){}[]'.includes(c)) {
+      out.push({ type: 'punct', text: c });
+      i++;
+      continue;
+    }
+
+    // Operators
+    if ('*+-/=!&|^'.includes(c)) {
+      // Check for `>=`, `!=`, `||`, `&&`
+      const two = src.slice(i, i + 2);
+      if (two === '!=' || two === '>=' || two === '||' || two === '&&') {
+        out.push({ type: 'operator', text: two });
+        i += 2;
+      } else {
+        out.push({ type: 'operator', text: c });
+        i++;
+      }
+      continue;
+    }
+
+    if (c === '>') {
+      const two = src.slice(i, i + 2);
+      if (two === '>=') {
+        out.push({ type: 'operator', text: '>=' });
+        i += 2;
+      } else {
+        out.push({ type: 'operator', text: '>' });
+        i++;
+      }
+      continue;
+    }
+
+    // Word (identifier, keyword, prefixed name). Consume letters/digits/`_`/
+    // `:`/`-`/`.` (dots inside pname-ns or local names).
+    if (/[A-Za-z_:]/.test(c)) {
+      let j = i;
+      while (j < n && /[A-Za-z0-9_:.\-]/.test(src[j])) j++;
+      const text = src.slice(i, j).replace(/\.+$/, (dots) => {
+        // Trailing dots belong to the statement terminator, not the name.
+        return dots === '' ? '' : '';
+      });
+      const realEnd = i + text.length;
+      const type: TokenType = text.includes(':') ? 'pname' : 'word';
+      out.push({ type, text });
+      i = realEnd;
+      continue;
+    }
+
+    // Unknown character — skip defensively so we never infinite-loop.
+    i++;
+  }
+
+  return out;
+}
+
+// ── Emitter ──────────────────────────────────────────────────────────────
+
+function isKeyword(tok: Token, ...names: string[]): boolean {
+  if (tok.type !== 'word') return false;
+  const upper = tok.text.toUpperCase();
+  return names.includes(upper);
+}
+
+function emit(tokens: Token[]): string {
+  let out = '';
+  let line = '';
+  let depth = 0;
+  /** Set when we\u2019ve emitted the continuation punct (`;` / `,`) and the next token should sit on a fresh indented line. */
+  let pendingContinuation = false;
+
+  function flush() {
+    if (line.trim() === '') { line = ''; return; }
+    out += line.trimEnd() + '\n';
+    line = '';
+  }
+
+  function startLine(extraIndent = 0) {
+    flush();
+    line = '  '.repeat(depth + extraIndent);
+  }
+
+  function appendToken(tokText: string, glue: 'space' | 'none' = 'space') {
+    if (line.length > 0 && line.trimEnd() === line && glue === 'space') {
+      line += ' ';
+    }
+    line += tokText;
+  }
+
+  // Top-level loop.
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    const prev = tokens[i - 1];
+    const upper = tok.type === 'word' ? tok.text.toUpperCase() : '';
+
+    // Comments always on their own line, at the current indent.
+    if (tok.type === 'comment') {
+      if (line.trim() !== '') flush();
+      line = '  '.repeat(depth) + tok.text;
+      flush();
+      continue;
+    }
+
+    // `}` closes a block: flush current line, outdent, emit `}` on own line.
+    if (tok.type === 'punct' && tok.text === '}') {
+      flush();
+      depth = Math.max(0, depth - 1);
+      pendingContinuation = false;
+      line = '  '.repeat(depth) + '}';
+      // Trailing clauses (ORDER/GROUP/HAVING/LIMIT/OFFSET/VALUES) after the
+      // closing brace get flushed onto their own new lines below.
+      continue;
+    }
+
+    // Top-level clause keywords always begin a new line (except the very
+    // first line, when the line buffer is still empty).
+    if (tok.type === 'word' && TOP_LEVEL_KW.has(upper) && line.trim() !== '') {
+      flush();
+      line = '  '.repeat(depth);
+    }
+
+    // Block keywords inside a WHERE body begin a new indented line.
+    if (tok.type === 'word' && BLOCK_KW.has(upper) && line.trim() !== '' && depth > 0) {
+      flush();
+      line = '  '.repeat(depth);
+    }
+
+    // After a continuation (`;` / `,`), the next real token starts a fresh
+    // line at the current indent.
+    if (pendingContinuation && !(tok.type === 'punct' && tok.text === '}')) {
+      flush();
+      line = '  '.repeat(depth);
+      pendingContinuation = false;
+    }
+
+    // Trigger a new indented line after `{` opens a block.
+    if (tok.type === 'punct' && tok.text === '{') {
+      if (line.trim() === '') {
+        line = '  '.repeat(depth) + '{';
+      } else {
+        line = line.trimEnd() + ' {';
+      }
+      flush();
+      depth++;
+      line = '  '.repeat(depth);
+      continue;
+    }
+
+    // Statement terminator `.` \u2014 attach to current line, flush, next line.
+    if (tok.type === 'punct' && tok.text === '.') {
+      line = line.trimEnd() + ' .';
+      flush();
+      line = '  '.repeat(depth);
+      continue;
+    }
+
+    // `;` / `,` continuations \u2014 attach to current line, set flag so the
+    // next token opens a fresh indented line.
+    if (tok.type === 'punct' && (tok.text === ';' || tok.text === ',')) {
+      line = line.trimEnd() + ' ' + tok.text;
+      pendingContinuation = true;
+      continue;
+    }
+
+    // `(` / `)` / `[` / `]` \u2014 no space around when adjacent to an
+    // expression boundary.
+    if (tok.type === 'punct' && tok.text === '(') {
+      // Keep tight to prior word (e.g. DESC(?x), COUNT(?y)).
+      if (line.trim() !== '' && prev && (prev.type === 'word' || prev.type === 'pname')) {
+        line += '(';
+      } else if (line.trim() === '') {
+        line = '  '.repeat(depth) + '(';
+      } else {
+        line += ' (';
+      }
+      continue;
+    }
+    if (tok.type === 'punct' && tok.text === ')') {
+      line = line.trimEnd() + ')';
+      continue;
+    }
+    if (tok.type === 'punct' && tok.text === '[') {
+      if (line.trim() === '') line = '  '.repeat(depth) + '[';
+      else line += ' [';
+      continue;
+    }
+    if (tok.type === 'punct' && tok.text === ']') {
+      line = line.trimEnd() + ']';
+      continue;
+    }
+
+    // Default emission: word/pname/var/iri/string/number/operator.
+    const prevText = prev ? prev.text : '';
+    const prevType = prev ? prev.type : null;
+    // Decide whether to add a separating space.
+    let needSpace = line.trim() !== '' && !line.endsWith(' ');
+    // Suppress space after open delimiters.
+    if (prevType === 'punct' && (prevText === '(' || prevText === '[')) needSpace = false;
+    // Suppress space after unary operators that hug their operand.
+    if (prevType === 'operator' && (prevText === '!' || prevText === '-' || prevText === '+')
+        && (tok.type === 'var' || tok.type === 'number' || tok.type === 'pname' || tok.type === 'iri')) {
+      // Only apply unary-hug when operator is clearly unary \u2014 i.e. at the
+      // start of an argument (preceded by `(` or `,` or nothing).
+      const before = i >= 2 ? tokens[i - 2] : null;
+      const beforeText = before ? before.text : '';
+      const beforeType = before ? before.type : null;
+      if (beforeType === 'punct' && (beforeText === '(' || beforeText === ',' || beforeText === '{')) {
+        needSpace = false;
+      }
+    }
+
+    if (line.trim() === '') {
+      line = '  '.repeat(depth) + tok.text;
+    } else {
+      line += (needSpace ? ' ' : '') + tok.text;
+    }
+  }
+
+  flush();
+  // Collapse any triple-blank gaps the state machine may have left.
+  return out.replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}

--- a/tests/shared/sparql-format.test.ts
+++ b/tests/shared/sparql-format.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { formatSparql } from '../../src/shared/sparql-format';
+
+/** Helper: strip a leading newline so test strings can be indented. */
+function q(s: string): string {
+  return s.replace(/^\n/, '');
+}
+
+describe('formatSparql (issue #196)', () => {
+  it('expands a single-line query into WHERE + indented triple patterns', () => {
+    expect(formatSparql('SELECT ?x WHERE { ?x a <urn:Foo> . }')).toBe(q(`
+SELECT ?x WHERE {
+  ?x a <urn:Foo> .
+}
+`));
+  });
+
+  it('puts each PREFIX declaration on its own line', () => {
+    const input = 'PREFIX a: <urn:a> PREFIX b: <urn:b> SELECT ?x WHERE { ?x a:p ?y . }';
+    expect(formatSparql(input)).toBe(q(`
+PREFIX a: <urn:a>
+PREFIX b: <urn:b>
+SELECT ?x WHERE {
+  ?x a:p ?y .
+}
+`));
+  });
+
+  it('puts `;` continuations on their own line at the current indent', () => {
+    const input = 'SELECT ?x WHERE { ?x a <urn:Foo> ; <urn:p> ?y . }';
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x a <urn:Foo> ;
+  <urn:p> ?y .
+}
+`));
+  });
+
+  it('puts FILTER on its own line inside the WHERE body', () => {
+    const input = 'SELECT ?x WHERE { ?x a <urn:Foo> . FILTER(?x > 5) }';
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x a <urn:Foo> .
+  FILTER(?x > 5)
+}
+`));
+  });
+
+  it('indents OPTIONAL block body one deeper than the WHERE body', () => {
+    const input = 'SELECT ?x WHERE { ?x a <urn:Foo> . OPTIONAL { ?x <urn:p> ?y } }';
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x a <urn:Foo> .
+  OPTIONAL {
+    ?x <urn:p> ?y
+  }
+}
+`));
+  });
+
+  it('puts trailing clauses (ORDER BY, LIMIT) after the closing brace on own lines', () => {
+    const input = 'SELECT ?x WHERE { ?x a <urn:Foo> . } ORDER BY DESC(?x) LIMIT 10';
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x a <urn:Foo> .
+}
+ORDER BY DESC(?x)
+LIMIT 10
+`));
+  });
+
+  it('preserves comments on their own line at the current indent', () => {
+    const input = '# Top comment\nSELECT ?x WHERE { ?x a <urn:Foo> . }';
+    expect(formatSparql(input)).toBe(q(`
+# Top comment
+SELECT ?x WHERE {
+  ?x a <urn:Foo> .
+}
+`));
+  });
+
+  it('does not mangle strings that contain { or . or ;', () => {
+    const input = `SELECT ?x WHERE { ?x <urn:p> "contains { and . and ; inside" . }`;
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x <urn:p> "contains { and . and ; inside" .
+}
+`));
+  });
+
+  it('does not mangle IRIs that contain `>` adjacencies', () => {
+    const input = 'SELECT ?x WHERE { ?x <http://foo.example/bar?y=1> ?y . }';
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x <http://foo.example/bar?y=1> ?y .
+}
+`));
+  });
+
+  it('is idempotent on already-formatted output', () => {
+    const input = 'SELECT ?x WHERE { ?x a <urn:Foo> ; <urn:p> ?y . FILTER(?x > 5) } ORDER BY ?x LIMIT 5';
+    const once = formatSparql(input);
+    const twice = formatSparql(once);
+    expect(twice).toBe(once);
+  });
+
+  it('handles SELECT with aggregate + alias', () => {
+    const input = 'SELECT ?x (COUNT(?y) AS ?n) WHERE { ?x <urn:p> ?y . } GROUP BY ?x';
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x (COUNT(?y) AS ?n) WHERE {
+  ?x <urn:p> ?y .
+}
+GROUP BY ?x
+`));
+  });
+
+  it('handles FILTER NOT EXISTS', () => {
+    const input = 'SELECT ?x WHERE { ?x a <urn:Foo> . FILTER NOT EXISTS { ?x <urn:p> ?y } }';
+    // FILTER NOT EXISTS reads as two words plus a block; the formatter
+    // keeps FILTER at current indent and opens the nested block.
+    expect(formatSparql(input)).toBe(q(`
+SELECT ?x WHERE {
+  ?x a <urn:Foo> .
+  FILTER NOT EXISTS {
+    ?x <urn:p> ?y
+  }
+}
+`));
+  });
+
+  it('formats a stock-query-shaped input matching the written style', () => {
+    // Shape matches the stock queries in src/shared/stock-queries.ts:
+    // PREFIX block, SELECT, WHERE body indented, trailing ORDER BY.
+    const input =
+      'PREFIX minerva: <https://minerva.dev/ontology#> ' +
+      'PREFIX dc: <http://purl.org/dc/terms/> ' +
+      'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ' +
+      'SELECT ?title ?tag WHERE { ?note rdf:type minerva:Note . ?note dc:title ?title . ' +
+      '?note minerva:hasTag ?tagNode . ?tagNode minerva:tagName ?tag . } ORDER BY ?title ?tag';
+
+    expect(formatSparql(input)).toBe(q(`
+PREFIX minerva: <https://minerva.dev/ontology#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+SELECT ?title ?tag WHERE {
+  ?note rdf:type minerva:Note .
+  ?note dc:title ?title .
+  ?note minerva:hasTag ?tagNode .
+  ?tagNode minerva:tagName ?tag .
+}
+ORDER BY ?title ?tag
+`));
+  });
+
+  it('returns empty string unchanged (trimmed)', () => {
+    expect(formatSparql('')).toBe('');
+    expect(formatSparql('   \n  ')).toBe('');
+  });
+});

--- a/tests/shared/sparql-format.test.ts
+++ b/tests/shared/sparql-format.test.ts
@@ -15,11 +15,12 @@ SELECT ?x WHERE {
 `));
   });
 
-  it('puts each PREFIX declaration on its own line', () => {
+  it('puts each PREFIX declaration on its own line with a blank line before SELECT', () => {
     const input = 'PREFIX a: <urn:a> PREFIX b: <urn:b> SELECT ?x WHERE { ?x a:p ?y . }';
     expect(formatSparql(input)).toBe(q(`
 PREFIX a: <urn:a>
 PREFIX b: <urn:b>
+
 SELECT ?x WHERE {
   ?x a:p ?y .
 }
@@ -142,6 +143,7 @@ SELECT ?x WHERE {
 PREFIX minerva: <https://minerva.dev/ontology#>
 PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
 SELECT ?title ?tag WHERE {
   ?note rdf:type minerva:Note .
   ?note dc:title ?title .


### PR DESCRIPTION
## Summary
Hand-rolled SPARQL pretty-printer (`src/shared/sparql-format.ts`), a **Format** button in the query toolbar, and a **Shift+Alt+F** keyboard shortcut inside the editor.

Tokenises the query while preserving strings, IRIs, and comments verbatim; then re-emits with canonical layout:

- PREFIX / BASE declarations one per line at the top.
- SELECT / CONSTRUCT / ASK / DESCRIBE projection stays with `WHERE {` on a single line.
- Triple patterns in the WHERE body one per line, 2-space indent per brace-depth.
- `;` and `,` continuations each on their own line at the current indent.
- FILTER / OPTIONAL / UNION / MINUS / GRAPH / SERVICE open their own lines inside the block.
- Trailing clauses (ORDER BY, GROUP BY, HAVING, LIMIT, OFFSET, VALUES) each on their own line after the closing brace.
- Comments preserved on their own line at the current indent.

Idempotent: `format(format(x)) === format(x)`.

## Tests
- 14 new unit tests covering the rules + edge cases (strings containing braces, IRIs with query strings, aggregates with aliases, FILTER NOT EXISTS, stock-query shapes)
- Full suite: **543 passing** (was 529)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (543 passing)
- [ ] Open a query tab, paste `SELECT ?x WHERE { ?x a <urn:Foo> ; <urn:p> ?y . }`, click Format \u2014 gets the expected multiline shape
- [ ] Shift+Alt+F inside the editor triggers the same
- [ ] Open a stock query, click Format \u2014 layout matches what's in `stock-queries.ts`
- [ ] Comments survive the round-trip
- [ ] Format twice in a row \u2014 no change the second time