### PR TITLE
Query panel: SPARQL autocomplete (closes #198)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1038,6 +1038,60 @@ function injectSparqlPrefixes(sparql: string): string {
   return lines.length > 0 ? lines.join('\n') + '\n' + sparql : sparql;
 }
 
+export interface SchemaEntry {
+  iri: string;
+  /** Prefixed form when a known prefix covers the IRI (e.g. "minerva:hasTag"). */
+  prefixed?: string;
+}
+
+export interface GraphSchema {
+  /** Standard prefixes the query path auto-injects. */
+  prefixes: Array<{ prefix: string; iri: string }>;
+  /** Distinct predicate IRIs in the live graph. */
+  predicates: SchemaEntry[];
+  /** Distinct class IRIs (objects of `rdf:type`) in the live graph. */
+  classes: SchemaEntry[];
+}
+
+/**
+ * Snapshot of the live graph\u2019s predicates + classes for autocomplete (#198).
+ * Sorted alphabetically by prefixed form when available, otherwise by full
+ * IRI. Safe to call often \u2014 cheap walk over the store.
+ */
+export function schemaForCompletion(): GraphSchema {
+  const prefixes = STANDARD_PREFIXES.map(([prefix, iri]) => ({ prefix, iri }));
+
+  if (!store) return { prefixes, predicates: [], classes: [] };
+
+  const rdfTypeIri = RDF('type').value;
+  const predicateIris = new Set<string>();
+  const classIris = new Set<string>();
+
+  for (const st of store.statements) {
+    predicateIris.add(st.predicate.value);
+    if (st.predicate.value === rdfTypeIri && st.object.termType === 'NamedNode') {
+      classIris.add(st.object.value);
+    }
+  }
+
+  function toEntry(iri: string): SchemaEntry {
+    for (const { prefix, iri: base } of prefixes) {
+      if (iri.startsWith(base)) {
+        return { iri, prefixed: `${prefix}:${iri.slice(base.length)}` };
+      }
+    }
+    return { iri };
+  }
+
+  const sortKey = (e: SchemaEntry) => (e.prefixed ?? e.iri).toLowerCase();
+
+  return {
+    prefixes,
+    predicates: [...predicateIris].map(toEntry).sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
+    classes: [...classIris].map(toEntry).sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
+  };
+}
+
 export async function queryGraph(sparql: string): Promise<{ results: unknown[] }> {
   if (!store || !engine) return { results: [] };
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -388,6 +388,8 @@ export function registerIpcHandlers(): void {
     return graph.queryGraph(sparql);
   });
 
+  ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, () => graph.schemaForCompletion());
+
   ipcMain.handle(Channels.GRAPH_SOURCE_DETAIL, (_e, sourceId: string) => {
     return graph.getSourceDetail(sourceId);
   });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -83,6 +83,7 @@ contextBridge.exposeInMainWorld('api', {
     export: () => ipcRenderer.invoke(Channels.GRAPH_EXPORT),
     sourceDetail: (sourceId: string) => ipcRenderer.invoke(Channels.GRAPH_SOURCE_DETAIL, sourceId),
     excerptSource: (excerptId: string) => ipcRenderer.invoke(Channels.GRAPH_EXCERPT_SOURCE, excerptId),
+    schemaForCompletion: () => ipcRenderer.invoke(Channels.GRAPH_SCHEMA_FOR_COMPLETION),
   },
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { EditorView, keymap, lineNumbers, placeholder } from '@codemirror/view';
-  import { EditorState, Compartment } from '@codemirror/state';
+  import { EditorState, Compartment, Prec } from '@codemirror/state';
   import { history, historyKeymap, defaultKeymap, indentWithTab } from '@codemirror/commands';
   import {
     bracketMatching,
@@ -143,12 +143,16 @@
           },
           '.cm-scroller': { overflow: 'auto' },
         }),
-        keymap.of([
+        // Prec.highest so our Enter override beats autocompletion's
+        // built-in Enter-accepts binding.
+        Prec.highest(keymap.of([
           { key: 'Mod-Enter', run: () => { onExecute(); return true; } },
           { key: 'Mod-s', run: () => { onSave(); return true; } },
           { key: 'Shift-Alt-f', run: reformat },
           { key: 'Tab', run: acceptCompletion },
           { key: 'Enter', run: acceptAndEatRestOfWord },
+        ])),
+        keymap.of([
           indentWithTab,
           ...defaultKeymap,
           ...historyKeymap,

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -215,15 +215,18 @@
   }
 
   /**
-   * Enter accepts the active completion and swallows any identifier
-   * characters that follow the cursor up to the next whitespace \u2014 useful
-   * when the cursor is mid-word and you want the whole half-typed token
-   * replaced. Tab still accepts without eating, so you can pick between
-   * the two behaviors.
+   * Enter accepts the active completion, then eats any non-whitespace
+   * characters that follow the cursor \u2014 useful when the cursor is
+   * mid-word and you want the whole half-typed token replaced. Tab
+   * still accepts in place (no eating), so you can pick between the two.
    */
   function acceptAndEatRestOfWord(v: EditorView): boolean {
-    const active = selectedCompletion(v.state);
-    if (!active) return false; // let Enter fall through to newline
+    if (!selectedCompletion(v.state)) return false; // let Enter fall through to newline
+    const accepted = acceptCompletion(v);
+    if (!accepted) return false;
+    // Post-accept: cursor sits immediately after the inserted label. Eat
+    // any non-whitespace chars that remain on the line \u2014 that's the tail
+    // of whatever the user had half-typed.
     const head = v.state.selection.main.head;
     const doc = v.state.doc;
     let end = head;
@@ -233,9 +236,9 @@
       end++;
     }
     if (end > head) {
-      v.dispatch({ selection: { anchor: end } });
+      v.dispatch({ changes: { from: head, to: end, insert: '' } });
     }
-    return acceptCompletion(v);
+    return true;
   }
 
   function startDrag(e: MouseEvent) {

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -17,7 +17,7 @@
   import type { QueryTab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
   import { formatSparql } from '../../../shared/sparql-format';
-  import { autocompletion, acceptCompletion, selectedCompletion } from '@codemirror/autocomplete';
+  import { autocompletion, acceptCompletion } from '@codemirror/autocomplete';
   import { createSparqlCompletionSource, type SparqlSchema } from '../editor/sparql-autocomplete';
 
   function toCsv(columns: string[], rows: Record<string, string>[]): string {
@@ -143,14 +143,11 @@
           },
           '.cm-scroller': { overflow: 'auto' },
         }),
-        // Prec.highest so our Enter override beats autocompletion's
-        // built-in Enter-accepts binding.
         Prec.highest(keymap.of([
           { key: 'Mod-Enter', run: () => { onExecute(); return true; } },
           { key: 'Mod-s', run: () => { onSave(); return true; } },
           { key: 'Shift-Alt-f', run: reformat },
           { key: 'Tab', run: acceptCompletion },
-          { key: 'Enter', run: acceptAndEatRestOfWord },
         ])),
         keymap.of([
           indentWithTab,
@@ -214,32 +211,6 @@
     return true;
   }
 
-  /**
-   * Enter accepts the active completion, then eats any non-whitespace
-   * characters that follow the cursor \u2014 useful when the cursor is
-   * mid-word and you want the whole half-typed token replaced. Tab
-   * still accepts in place (no eating), so you can pick between the two.
-   */
-  function acceptAndEatRestOfWord(v: EditorView): boolean {
-    if (!selectedCompletion(v.state)) return false; // let Enter fall through to newline
-    const accepted = acceptCompletion(v);
-    if (!accepted) return false;
-    // Post-accept: cursor sits immediately after the inserted label. Eat
-    // any non-whitespace chars that remain on the line \u2014 that's the tail
-    // of whatever the user had half-typed.
-    const head = v.state.selection.main.head;
-    const doc = v.state.doc;
-    let end = head;
-    while (end < doc.length) {
-      const ch = doc.sliceString(end, end + 1);
-      if (/\s/.test(ch)) break;
-      end++;
-    }
-    if (end > head) {
-      v.dispatch({ changes: { from: head, to: end, insert: '' } });
-    }
-    return true;
-  }
 
   function startDrag(e: MouseEvent) {
     e.preventDefault();

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -17,7 +17,7 @@
   import type { QueryTab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
   import { formatSparql } from '../../../shared/sparql-format';
-  import { autocompletion, acceptCompletion } from '@codemirror/autocomplete';
+  import { autocompletion, acceptCompletion, selectedCompletion } from '@codemirror/autocomplete';
   import { createSparqlCompletionSource, type SparqlSchema } from '../editor/sparql-autocomplete';
 
   function toCsv(columns: string[], rows: Record<string, string>[]): string {
@@ -148,6 +148,7 @@
           { key: 'Mod-s', run: () => { onSave(); return true; } },
           { key: 'Shift-Alt-f', run: reformat },
           { key: 'Tab', run: acceptCompletion },
+          { key: 'Enter', run: acceptAndEatRestOfWord },
           indentWithTab,
           ...defaultKeymap,
           ...historyKeymap,
@@ -207,6 +208,30 @@
       changes: { from: 0, to: view.state.doc.length, insert: formatted },
     });
     return true;
+  }
+
+  /**
+   * Enter accepts the active completion and swallows any identifier
+   * characters that follow the cursor up to the next whitespace \u2014 useful
+   * when the cursor is mid-word and you want the whole half-typed token
+   * replaced. Tab still accepts without eating, so you can pick between
+   * the two behaviors.
+   */
+  function acceptAndEatRestOfWord(v: EditorView): boolean {
+    const active = selectedCompletion(v.state);
+    if (!active) return false; // let Enter fall through to newline
+    const head = v.state.selection.main.head;
+    const doc = v.state.doc;
+    let end = head;
+    while (end < doc.length) {
+      const ch = doc.sliceString(end, end + 1);
+      if (/\s/.test(ch)) break;
+      end++;
+    }
+    if (end > head) {
+      v.dispatch({ selection: { anchor: end } });
+    }
+    return acceptCompletion(v);
   }
 
   function startDrag(e: MouseEvent) {

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -17,6 +17,8 @@
   import type { QueryTab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
   import { formatSparql } from '../../../shared/sparql-format';
+  import { autocompletion, acceptCompletion } from '@codemirror/autocomplete';
+  import { createSparqlCompletionSource, type SparqlSchema } from '../editor/sparql-autocomplete';
 
   function toCsv(columns: string[], rows: Record<string, string>[]): string {
     const escape = (s: string) => {
@@ -44,6 +46,18 @@
   let splitRatio = $state(0.4); // 40% editor, 60% results
   let dragging = $state(false);
   let containerEl = $state<HTMLDivElement>();
+
+  // Lazy-fetched predicates / classes from the live graph for autocomplete.
+  // Null until the first fetch resolves; the completion source treats that
+  // as "standard prefixes only, no schema" so the panel stays usable during
+  // the initial load.
+  let schema: SparqlSchema | null = null;
+
+  async function refreshSchema(): Promise<void> {
+    try {
+      schema = (await api.graph.schemaForCompletion()) as SparqlSchema;
+    } catch { /* graph not ready \u2014 keep schema null, completion falls back */ }
+  }
 
   // Compartments for reconfigurable extensions.
   const themeCompartment = new Compartment();
@@ -118,6 +132,7 @@
         // own mappings in dark mode.
         highlightCompartment.of(cmHighlight()),
         placeholder('SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}'),
+        autocompletion({ override: [createSparqlCompletionSource(() => schema)] }),
         themeCompartment.of(cmTheme()),
         EditorView.theme({
           '&': { height: '100%' },
@@ -132,6 +147,7 @@
           { key: 'Mod-Enter', run: () => { onExecute(); return true; } },
           { key: 'Mod-s', run: () => { onSave(); return true; } },
           { key: 'Shift-Alt-f', run: reformat },
+          { key: 'Tab', run: acceptCompletion },
           indentWithTab,
           ...defaultKeymap,
           ...historyKeymap,
@@ -152,6 +168,10 @@
       parent: editorContainer,
     });
     view.focus();
+    // Kick off an initial schema fetch in the background. If it takes a
+    // while (big graph), completion still works with standard prefixes +
+    // keywords while it\u2019s pending.
+    void refreshSchema();
   });
 
   onDestroy(() => {

--- a/src/renderer/lib/editor/sparql-autocomplete.ts
+++ b/src/renderer/lib/editor/sparql-autocomplete.ts
@@ -1,0 +1,127 @@
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import {
+  detectSparqlPhase,
+  extractQueryVariables,
+  extractUserPrefixes,
+  SPARQL_KEYWORDS,
+  SPARQL_BUILTINS,
+  STANDARD_PREFIXES,
+} from '../../../shared/sparql-completions';
+
+export interface SparqlSchema {
+  prefixes: ReadonlyArray<{ prefix: string; iri: string }>;
+  predicates: ReadonlyArray<{ iri: string; prefixed?: string }>;
+  classes: ReadonlyArray<{ iri: string; prefixed?: string }>;
+}
+
+const EMPTY_SCHEMA: SparqlSchema = { prefixes: STANDARD_PREFIXES, predicates: [], classes: [] };
+
+/**
+ * Build a CodeMirror CompletionSource for SPARQL (#198). `getSchema`
+ * returns the live predicate/class snapshot from the graph \u2014 pulled
+ * lazily so an empty graph or a cold thoughtbase doesn\u2019t block the
+ * panel from opening.
+ */
+export function createSparqlCompletionSource(
+  getSchema: () => SparqlSchema | null,
+) {
+  return function source(ctx: CompletionContext): CompletionResult | null {
+    const before = ctx.state.doc.sliceString(Math.max(0, ctx.pos - 200), ctx.pos);
+    const all = ctx.state.doc.toString();
+
+    const schema = getSchema() ?? EMPTY_SCHEMA;
+    const userPrefixes = extractUserPrefixes(all);
+
+    // Known prefixes = standard + user-declared in buffer. Later entries
+    // override earlier ones (user redecl of a standard prefix wins).
+    const prefixIriByName = new Map<string, string>();
+    for (const { prefix, iri } of schema.prefixes) prefixIriByName.set(prefix, iri);
+    for (const { prefix, iri } of userPrefixes) prefixIriByName.set(prefix, iri);
+    const knownPrefixes = new Set(prefixIriByName.keys());
+
+    const phase = detectSparqlPhase(before, ctx.pos, knownPrefixes);
+
+    if (phase.kind === 'none') return null;
+
+    if (phase.kind === 'variable') {
+      if (!ctx.explicit && phase.prefix.length === 0) return null;
+      const vars = extractQueryVariables(all).map((v) => ({
+        label: v,
+        type: 'variable',
+      } as Completion));
+      return {
+        from: phase.from,
+        options: vars,
+        validFor: /^\w*$/,
+      };
+    }
+
+    if (phase.kind === 'prefixed') {
+      const iri = prefixIriByName.get(phase.prefix);
+      if (!iri) return null;
+      // Local names of predicates + classes whose IRI starts with this prefix.
+      const localsSeen = new Set<string>();
+      const options: Completion[] = [];
+      const pushLocal = (entry: { iri: string }, type: string) => {
+        if (!entry.iri.startsWith(iri)) return;
+        const local = entry.iri.slice(iri.length);
+        if (!local || localsSeen.has(local)) return;
+        localsSeen.add(local);
+        options.push({ label: local, type, detail: entry.iri });
+      };
+      for (const p of schema.predicates) pushLocal(p, 'property');
+      for (const c of schema.classes) pushLocal(c, 'class');
+      return {
+        from: phase.localFrom,
+        options,
+        validFor: /^[\w-]*$/,
+      };
+    }
+
+    // General phase: keywords + built-ins + prefix aliases + prefixed
+    // predicates / classes + current-query variables.
+    if (!ctx.explicit && phase.prefix.length < 2) return null;
+
+    const options: Completion[] = [];
+
+    // Keywords (uppercase) boost higher than everything else so they surface
+    // at the top when the user types `SE`, `PR`, etc.
+    for (const kw of SPARQL_KEYWORDS) {
+      options.push({ label: kw, type: 'keyword', boost: 10 });
+    }
+    for (const fn of SPARQL_BUILTINS) {
+      options.push({ label: fn, type: 'function' });
+    }
+    // Prefix aliases end with `:` so the user keeps typing locally.
+    for (const { prefix } of schema.prefixes) {
+      options.push({ label: `${prefix}:`, type: 'namespace', boost: 5 });
+    }
+    for (const { prefix } of userPrefixes) {
+      options.push({ label: `${prefix}:`, type: 'namespace', boost: 5 });
+    }
+    // Flattened prefixed predicates + classes.
+    const emitted = new Set<string>();
+    for (const p of schema.predicates) {
+      const label = p.prefixed ?? p.iri;
+      if (emitted.has(label)) continue;
+      emitted.add(label);
+      options.push({ label, type: 'property', detail: p.iri });
+    }
+    for (const c of schema.classes) {
+      const label = c.prefixed ?? c.iri;
+      if (emitted.has(label)) continue;
+      emitted.add(label);
+      options.push({ label, type: 'class', detail: c.iri });
+    }
+    // Current-query variables (with sigil included, so they\u2019re inserted whole).
+    for (const v of extractQueryVariables(all)) {
+      options.push({ label: `?${v}`, type: 'variable' });
+    }
+
+    return {
+      from: phase.from,
+      options,
+      validFor: /^[\w:-]*$/,
+    };
+  };
+}

--- a/src/renderer/lib/editor/sparql-autocomplete.ts
+++ b/src/renderer/lib/editor/sparql-autocomplete.ts
@@ -51,8 +51,8 @@ export function createSparqlCompletionSource(
       } as Completion));
       return {
         from: phase.from,
-        options: vars,
-        validFor: /^\w*$/,
+        options: prefixMatchSort(vars, phase.prefix),
+        filter: false,
       };
     }
 
@@ -73,8 +73,8 @@ export function createSparqlCompletionSource(
       for (const c of schema.classes) pushLocal(c, 'class');
       return {
         from: phase.localFrom,
-        options,
-        validFor: /^[\w-]*$/,
+        options: prefixMatchSort(options, phase.local),
+        filter: false,
       };
     }
 
@@ -120,8 +120,34 @@ export function createSparqlCompletionSource(
 
     return {
       from: phase.from,
-      options,
-      validFor: /^[\w:-]*$/,
+      options: prefixMatchSort(options, phase.prefix),
+      filter: false,
     };
   };
+}
+
+/**
+ * Keep only options whose label starts with `input` (case-insensitive),
+ * then sort by label length + explicit boost. Returning these with
+ * `filter: false` on the CompletionResult bypasses CodeMirror\u2019s built-in
+ * fuzzy subsequence matcher \u2014 without this, typing "SEL" surfaces
+ * anything containing s/e/l in order (`csvw:cell`, \u2026), which reads as
+ * spam for a strict-prefix feel.
+ */
+function prefixMatchSort(options: Completion[], input: string): Completion[] {
+  if (input === '') {
+    return [...options].sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0) || a.label.localeCompare(b.label));
+  }
+  const needle = input.toLowerCase();
+  return options
+    .filter((o) => o.label.toLowerCase().startsWith(needle))
+    .sort((a, b) => {
+      // Prefer boosted entries (keywords, prefix aliases) at equal label
+      // length so `SELECT` beats a random predicate starting with `sel…`.
+      const boostDiff = (b.boost ?? 0) - (a.boost ?? 0);
+      if (boostDiff !== 0) return boostDiff;
+      const lenDiff = a.label.length - b.label.length;
+      if (lenDiff !== 0) return lenDiff;
+      return a.label.localeCompare(b.label);
+    });
 }

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -65,6 +65,11 @@ export interface GraphApi {
   export(): Promise<void>;
   sourceDetail(sourceId: string): Promise<SourceDetail | null>;
   excerptSource(excerptId: string): Promise<{ sourceId: string } | null>;
+  schemaForCompletion(): Promise<{
+    prefixes: Array<{ prefix: string; iri: string }>;
+    predicates: Array<{ iri: string; prefixed?: string }>;
+    classes: Array<{ iri: string; prefixed?: string }>;
+  }>;
 }
 
 export interface TagsApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -46,6 +46,8 @@ export const Channels = {
 
   // Graph
   GRAPH_QUERY: 'graph:query',
+  /** Snapshot of the live graph's predicates + classes for SPARQL autocomplete (#198). */
+  GRAPH_SCHEMA_FOR_COMPLETION: 'graph:schemaForCompletion',
   GRAPH_SOURCE_DETAIL: 'graph:sourceDetail',
   GRAPH_EXCERPT_SOURCE: 'graph:excerptSource',
 

--- a/src/shared/sparql-completions.ts
+++ b/src/shared/sparql-completions.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure pieces of SPARQL autocomplete (#198). Cursor-context detection,
+ * keyword tables, buffer-scanners for current-query variables and
+ * user-defined prefixes. The renderer wraps these in a CodeMirror
+ * CompletionSource; tests exercise them directly.
+ */
+
+export const SPARQL_KEYWORDS = [
+  // Query forms + PREFIX / BASE
+  'SELECT', 'CONSTRUCT', 'ASK', 'DESCRIBE', 'WHERE', 'FROM', 'FROM NAMED',
+  'PREFIX', 'BASE',
+  // Modifiers
+  'DISTINCT', 'REDUCED',
+  // Patterns
+  'OPTIONAL', 'FILTER', 'FILTER NOT EXISTS', 'FILTER EXISTS',
+  'UNION', 'MINUS', 'GRAPH', 'SERVICE', 'BIND', 'VALUES',
+  'EXISTS', 'NOT EXISTS',
+  // Solution sequence
+  'ORDER BY', 'GROUP BY', 'HAVING', 'LIMIT', 'OFFSET',
+  'ASC', 'DESC',
+  // Boolean / shorthand
+  'TRUE', 'FALSE', 'UNDEF', 'AS', 'IN', 'NOT IN', 'BY',
+] as const;
+
+export const SPARQL_BUILTINS = [
+  // Term-type predicates
+  'isIRI', 'isURI', 'isBlank', 'isLiteral', 'isNumeric', 'bound', 'sameTerm',
+  // Constructors
+  'IRI', 'URI', 'BNODE', 'STRLANG', 'STRDT',
+  // Strings
+  'STR', 'LANG', 'LANGMATCHES', 'DATATYPE',
+  'CONCAT', 'SUBSTR', 'STRLEN', 'REPLACE', 'UCASE', 'LCASE',
+  'CONTAINS', 'STRSTARTS', 'STRENDS', 'STRBEFORE', 'STRAFTER',
+  'ENCODE_FOR_URI', 'REGEX',
+  // Numerics
+  'ABS', 'CEIL', 'FLOOR', 'ROUND', 'RAND',
+  // Aggregates
+  'COUNT', 'SUM', 'MIN', 'MAX', 'AVG', 'SAMPLE', 'GROUP_CONCAT',
+  // Date/time
+  'YEAR', 'MONTH', 'DAY', 'HOURS', 'MINUTES', 'SECONDS', 'TIMEZONE', 'TZ', 'NOW',
+  // Misc
+  'UUID', 'STRUUID', 'MD5', 'SHA1', 'SHA256', 'SHA384', 'SHA512',
+  'COALESCE', 'IF',
+] as const;
+
+/** Standard prefixes the main-process `injectSparqlPrefixes` auto-adds. */
+export const STANDARD_PREFIXES: ReadonlyArray<{ prefix: string; iri: string }> = [
+  { prefix: 'minerva', iri: 'https://minerva.dev/ontology#' },
+  { prefix: 'thought', iri: 'https://minerva.dev/ontology/thought#' },
+  { prefix: 'dc', iri: 'http://purl.org/dc/terms/' },
+  { prefix: 'rdf', iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' },
+  { prefix: 'rdfs', iri: 'http://www.w3.org/2000/01/rdf-schema#' },
+  { prefix: 'xsd', iri: 'http://www.w3.org/2001/XMLSchema#' },
+  { prefix: 'csvw', iri: 'http://www.w3.org/ns/csvw#' },
+  { prefix: 'prov', iri: 'http://www.w3.org/ns/prov#' },
+  { prefix: 'bibo', iri: 'http://purl.org/ontology/bibo/' },
+  { prefix: 'schema', iri: 'http://schema.org/' },
+];
+
+// ── Phase detection ──────────────────────────────────────────────────────
+
+export type SparqlCompletionPhase =
+  | { kind: 'variable'; from: number; prefix: string }
+  | { kind: 'prefixed'; from: number; prefix: string; local: string; localFrom: number }
+  | { kind: 'general'; from: number; prefix: string }
+  | { kind: 'none' };
+
+/**
+ * Inspect the text before the cursor and decide what phase of completion
+ * we\u2019re in. `pos` is the absolute cursor offset; the returned `from` is
+ * the document position CodeMirror should use as the replacement start.
+ *
+ * Rules:
+ *   1. Immediately after `?` or `$` with word chars \u2192 variable phase.
+ *   2. After `<known-prefix>:<local>` \u2192 prefixed phase.
+ *   3. Otherwise \u2192 general phase, matching the current identifier word.
+ */
+export function detectSparqlPhase(
+  before: string,
+  pos: number,
+  knownPrefixes: ReadonlySet<string>,
+): SparqlCompletionPhase {
+  // Variable: preceded by `?` or `$` and optional word chars.
+  const varM = /([?$])([A-Za-z_]\w*)?$/.exec(before);
+  if (varM) {
+    const prefix = varM[2] ?? '';
+    return { kind: 'variable', from: pos - prefix.length, prefix };
+  }
+
+  // Prefixed name: <prefix>:<local> where prefix is known.
+  const pnM = /([A-Za-z_][\w-]*):([A-Za-z_][\w-]*)?$/.exec(before);
+  if (pnM && knownPrefixes.has(pnM[1])) {
+    const local = pnM[2] ?? '';
+    return {
+      kind: 'prefixed',
+      from: pos - local.length - 1 - pnM[1].length, // back to start of prefix
+      prefix: pnM[1],
+      local,
+      localFrom: pos - local.length,
+    };
+  }
+
+  // Current identifier word. Typing `SEL` should complete `SELECT`,
+  // `minerv` should complete `minerva:`.
+  const wordM = /([A-Za-z_][\w-]*)$/.exec(before);
+  if (wordM) {
+    return { kind: 'general', from: pos - wordM[1].length, prefix: wordM[1] };
+  }
+
+  // Explicit Ctrl+Space on whitespace / punctuation.
+  return { kind: 'general', from: pos, prefix: '' };
+}
+
+// ── Buffer scanners ──────────────────────────────────────────────────────
+
+/**
+ * Distinct variables (`?x`, `$y`) mentioned anywhere in the buffer, sans
+ * the leading sigil. Used to populate variable-phase completions with the
+ * names already in play.
+ */
+export function extractQueryVariables(text: string): string[] {
+  const out = new Set<string>();
+  const re = /[?$]([A-Za-z_]\w*)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) out.add(m[1]);
+  return [...out].sort();
+}
+
+/**
+ * User-defined `PREFIX foo: <iri>` declarations in the current buffer.
+ * Case-insensitive for the `PREFIX` keyword; prefix name is returned
+ * verbatim.
+ */
+export function extractUserPrefixes(text: string): Array<{ prefix: string; iri: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ prefix: string; iri: string }> = [];
+  const re = /PREFIX\s+([A-Za-z_][\w-]*):\s*<([^>]*)>/gi;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (!seen.has(m[1])) {
+      seen.add(m[1]);
+      out.push({ prefix: m[1], iri: m[2] });
+    }
+  }
+  return out;
+}

--- a/src/shared/sparql-format.ts
+++ b/src/shared/sparql-format.ts
@@ -223,13 +223,12 @@ function emit(tokens: Token[]): string {
   let depth = 0;
   /** Set when we\u2019ve emitted the continuation punct (`;` / `,`) and the next token should sit on a fresh indented line. */
   let pendingContinuation = false;
-  /** Tracks what the last non-empty flushed line was, so we can separate the PREFIX block from the query form with a blank line. */
-  let lastFlushedKind: 'prefix' | 'other' | null = null;
+  /** First word of the most recent non-empty flushed line (uppercased). Lets us separate the PREFIX block from the query form with a blank line. */
+  let lastFlushedFirstWord = '';
 
   function flush() {
     if (line.trim() === '') { line = ''; return; }
-    const firstWord = line.trimStart().split(/\s+/, 1)[0]?.toUpperCase() ?? '';
-    lastFlushedKind = firstWord === 'PREFIX' || firstWord === 'BASE' ? 'prefix' : 'other';
+    lastFlushedFirstWord = (line.trimStart().split(/\s+/, 1)[0] ?? '').toUpperCase();
     out += line.trimEnd() + '\n';
     line = '';
   }
@@ -282,11 +281,11 @@ function emit(tokens: Token[]): string {
     if (
       tok.type === 'word'
       && (upper === 'SELECT' || upper === 'CONSTRUCT' || upper === 'ASK' || upper === 'DESCRIBE')
-      && lastFlushedKind === 'prefix'
+      && (lastFlushedFirstWord === 'PREFIX' || lastFlushedFirstWord === 'BASE')
       && line.trim() === ''
     ) {
       out += '\n';
-      lastFlushedKind = 'other';
+      lastFlushedFirstWord = '';
     }
 
     // Block keywords inside a WHERE body begin a new indented line.

--- a/tests/shared/sparql-completions.test.ts
+++ b/tests/shared/sparql-completions.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectSparqlPhase,
+  extractQueryVariables,
+  extractUserPrefixes,
+  STANDARD_PREFIXES,
+} from '../../src/shared/sparql-completions';
+
+const KNOWN = new Set(STANDARD_PREFIXES.map((p) => p.prefix));
+
+function at(src: string): { before: string; pos: number } {
+  // `|` marks the cursor in the test string.
+  const pos = src.indexOf('|');
+  if (pos < 0) throw new Error(`missing cursor marker in test input: ${src}`);
+  return { before: src.slice(0, pos), pos };
+}
+
+describe('detectSparqlPhase (issue #198)', () => {
+  it('variable phase: right after `?`', () => {
+    const { before, pos } = at('SELECT ?|');
+    expect(detectSparqlPhase(before, pos, KNOWN))
+      .toEqual({ kind: 'variable', from: pos, prefix: '' });
+  });
+
+  it('variable phase: partial variable name', () => {
+    const { before, pos } = at('SELECT ?no|');
+    expect(detectSparqlPhase(before, pos, KNOWN))
+      .toEqual({ kind: 'variable', from: pos - 2, prefix: 'no' });
+  });
+
+  it('variable phase: `$y` sigil', () => {
+    const { before, pos } = at('SELECT $yea|');
+    expect(detectSparqlPhase(before, pos, KNOWN))
+      .toEqual({ kind: 'variable', from: pos - 3, prefix: 'yea' });
+  });
+
+  it('prefixed phase: known prefix, empty local', () => {
+    const { before, pos } = at('?x minerva:|');
+    const phase = detectSparqlPhase(before, pos, KNOWN);
+    expect(phase.kind).toBe('prefixed');
+    if (phase.kind === 'prefixed') {
+      expect(phase.prefix).toBe('minerva');
+      expect(phase.local).toBe('');
+      expect(phase.localFrom).toBe(pos);
+    }
+  });
+
+  it('prefixed phase: known prefix with partial local', () => {
+    const { before, pos } = at('?x minerva:ha|');
+    const phase = detectSparqlPhase(before, pos, KNOWN);
+    expect(phase.kind).toBe('prefixed');
+    if (phase.kind === 'prefixed') {
+      expect(phase.prefix).toBe('minerva');
+      expect(phase.local).toBe('ha');
+      expect(phase.localFrom).toBe(pos - 2);
+    }
+  });
+
+  it('general phase: unknown prefix falls through', () => {
+    const { before, pos } = at('?x mystery:|');
+    // `mystery` isn\u2019t in KNOWN, so this is not prefixed-phase; the
+    // current identifier word is "mystery".
+    const phase = detectSparqlPhase(before, pos, KNOWN);
+    expect(phase.kind).toBe('general');
+  });
+
+  it('general phase: mid-keyword', () => {
+    const { before, pos } = at('SEL|');
+    expect(detectSparqlPhase(before, pos, KNOWN))
+      .toEqual({ kind: 'general', from: 0, prefix: 'SEL' });
+  });
+
+  it('general phase: on whitespace (Ctrl+Space invocation)', () => {
+    const { before, pos } = at('SELECT |');
+    expect(detectSparqlPhase(before, pos, KNOWN))
+      .toEqual({ kind: 'general', from: pos, prefix: '' });
+  });
+});
+
+describe('extractQueryVariables', () => {
+  it('returns sorted unique variable names without sigils', () => {
+    const src = 'SELECT ?note ?title WHERE { ?note dc:title ?title . ?note minerva:hasTag $tag }';
+    expect(extractQueryVariables(src)).toEqual(['note', 'tag', 'title']);
+  });
+
+  it('returns [] for a variableless query', () => {
+    expect(extractQueryVariables('ASK { <urn:a> <urn:p> <urn:b> }')).toEqual([]);
+  });
+});
+
+describe('extractUserPrefixes', () => {
+  it('extracts PREFIX declarations in order, deduplicating', () => {
+    const src = `PREFIX a: <urn:a>
+PREFIX b:  <urn:b>
+prefix c: <urn:c>
+PREFIX a: <urn:a-dup>
+SELECT ?x WHERE { ?x a:p ?y }`;
+    expect(extractUserPrefixes(src)).toEqual([
+      { prefix: 'a', iri: 'urn:a' },
+      { prefix: 'b', iri: 'urn:b' },
+      { prefix: 'c', iri: 'urn:c' },
+    ]);
+  });
+
+  it('returns [] when there are no PREFIX lines', () => {
+    expect(extractUserPrefixes('SELECT ?x WHERE { ?x <urn:p> ?y }')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Cursor-context autocomplete in the query editor. Three phases layered by priority:

1. **Variable phase** \u2014 after `?` or `$`, offer variable names already mentioned in the buffer.
2. **Prefixed-name phase** \u2014 after `<known-prefix>:`, offer local names of predicates and classes whose IRI starts with that prefix (standard prefixes + any `PREFIX foo: <\u2026>` declared in the current buffer).
3. **General phase** \u2014 mid-identifier, offer SPARQL keywords + built-in functions + prefix aliases (`minerva:`, `dc:`, \u2026) + all known predicates/classes in their prefixed form + query variables with sigil.

Tab accepts the current suggestion (matches the main editor\u2019s muscle memory).

## Data source
- `api.graph.schemaForCompletion()` \u2014 new IPC. Walks the live graph once per fetch, returns distinct predicates + classes (prefixed-form resolved when a known prefix covers the IRI).
- Fetched lazily on panel mount so a large graph doesn\u2019t block the editor from opening. The completion source treats a pending/empty schema as "standard prefixes only" so the UI stays useful during the fetch.

## Pure pieces (`src/shared/sparql-completions.ts`)
- Keyword + built-in tables.
- `detectSparqlPhase(before, pos, knownPrefixes)` \u2014 identifies which phase the cursor is in.
- `extractQueryVariables(text)` / `extractUserPrefixes(text)` \u2014 buffer scanners.

## Tests
- 12 new unit tests covering phase detection + buffer scanners.
- Full suite: **555 passing** (was 543).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (555 passing)
- [ ] Open a query tab, type `SEL` \u2014 `SELECT` completes
- [ ] Type `minerva:` \u2014 completions are predicates/classes under that prefix with just the local name as label
- [ ] Type `?` \u2014 variables already in the query show up
- [ ] Type `PREFIX foo: <urn:x>` then later `foo:` \u2014 user-defined prefix is honored
- [ ] Tab accepts the active suggestion

## Deferred (per ticket)
- Completion for named-graph URIs in FROM clauses
- Completion inside property path expressions
- Snippet expansions (typing `select` to a template)