### PR TITLE
Formatter engine: rule interface + parse cache + palette commands (closes #153)

### DIFF
--- a/src/main/formatter/orchestrator.ts
+++ b/src/main/formatter/orchestrator.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from '../notebase/fs';
+import * as graph from '../graph/index';
+import * as search from '../search/index';
+import { formatContent, type FormatSettings } from '../../shared/formatter/engine';
+import type { FormatFileResult } from '../../shared/formatter/types';
+
+const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
+
+export interface FormatRunSummary {
+  changedPaths: string[];
+  totalScanned: number;
+}
+
+/**
+ * Format a single note's content string. Pure — caller decides whether to
+ * write the result back. Used by the "format current note" palette command,
+ * which wants to diff against the editor buffer without touching disk.
+ */
+export function formatNoteContent(content: string, settings: FormatSettings): string {
+  return formatContent(content, settings);
+}
+
+/** Format a single `.md` file on disk + route the write through the standard broadcast pipeline. */
+export async function formatFile(
+  rootPath: string,
+  relativePath: string,
+  settings: FormatSettings,
+): Promise<FormatFileResult> {
+  const before = await notebaseFs.readFile(rootPath, relativePath);
+  const after = formatContent(before, settings);
+  if (after === before) {
+    return { relativePath, changed: false, before, after };
+  }
+  await writeThrough(rootPath, relativePath, after);
+  return { relativePath, changed: true, before, after };
+}
+
+/**
+ * Format every `.md` under `relDir` (inclusive, recursive). When `relDir`
+ * is empty, walks the whole thoughtbase.
+ */
+export async function formatFolder(
+  rootPath: string,
+  relDir: string,
+  settings: FormatSettings,
+): Promise<FormatRunSummary> {
+  const paths: string[] = [];
+  await walk(rootPath, relDir, paths);
+  return runBatch(rootPath, paths, settings);
+}
+
+async function runBatch(
+  rootPath: string,
+  paths: string[],
+  settings: FormatSettings,
+): Promise<FormatRunSummary> {
+  const changedPaths: string[] = [];
+  for (const rel of paths) {
+    try {
+      const result = await formatFile(rootPath, rel, settings);
+      if (result.changed) changedPaths.push(rel);
+    } catch { /* unreadable note \u2014 skip */ }
+  }
+  return { changedPaths, totalScanned: paths.length };
+}
+
+async function walk(rootPath: string, relDir: string, out: string[]): Promise<void> {
+  const absDir = path.join(rootPath, relDir);
+  let entries;
+  try {
+    entries = await fs.readdir(absDir, { withFileTypes: true });
+  } catch { return; }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      await walk(rootPath, rel, out);
+    } else if (entry.name.endsWith('.md')) {
+      out.push(rel);
+    }
+  }
+}
+
+async function writeThrough(
+  rootPath: string,
+  relativePath: string,
+  content: string,
+): Promise<void> {
+  await notebaseFs.writeFile(rootPath, relativePath, content);
+  await graph.indexNote(relativePath, content);
+  search.indexNote(relativePath, content);
+  // Caller is responsible for the batched persist + NOTEBASE_REWRITTEN
+  // broadcast \u2014 doing it per-file in a folder run would thrash the
+  // editor's open-tab refresh path.
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,6 +23,12 @@ import {
   applyInboundSuggestions,
 } from './llm/auto-link';
 import { suggestDecomposition, type DecomposeHints } from './llm/decompose';
+import {
+  formatNoteContent,
+  formatFile as formatFileOnDisk,
+  formatFolder as formatFolderOnDisk,
+} from './formatter/orchestrator';
+import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
 import * as healthChecks from './graph/health-checks';
@@ -616,6 +622,42 @@ export function registerIpcHandlers(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
       return suggestDecomposition(rootPath, activeRelPath, hints ?? {});
+    },
+  );
+
+  // Formatter (issue #153)
+  ipcMain.handle(
+    Channels.FORMATTER_FORMAT_CONTENT,
+    (_e, content: string, settings: FormatSettings) => formatNoteContent(content, settings),
+  );
+
+  ipcMain.handle(
+    Channels.FORMATTER_FORMAT_FILE,
+    async (e, relativePath: string, settings: FormatSettings) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      const result = await formatFileOnDisk(rootPath, relativePath, settings);
+      if (result.changed) {
+        markPathHandled(relativePath);
+        await persistIndexes();
+        broadcastRewritten(rootPath, [relativePath]);
+      }
+      return result;
+    },
+  );
+
+  ipcMain.handle(
+    Channels.FORMATTER_FORMAT_FOLDER,
+    async (e, relDir: string, settings: FormatSettings) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      const summary = await formatFolderOnDisk(rootPath, relDir ?? '', settings);
+      if (summary.changedPaths.length > 0) {
+        for (const p of summary.changedPaths) markPathHandled(p);
+        await persistIndexes();
+        broadcastRewritten(rootPath, summary.changedPaths);
+      }
+      return summary;
     },
   );
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -326,13 +326,9 @@ export function rebuildMenu(): void {
         { label: 'Auto-link outbound\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) },
         { label: 'Auto-link inbound\u2026', click: () => send(Channels.MENU_REFACTOR_AUTOLINK_INBOUND) },
         { label: 'Decompose Note\u2026', click: () => send(Channels.MENU_REFACTOR_DECOMPOSE) },
-      ],
-    },
-
-    // Format — deterministic markdown normalizations (issue #152 epic).
-    {
-      label: 'Format',
-      submenu: [
+        { type: 'separator' },
+        // Deterministic markdown normalisation (issue #152 epic). Nested
+        // under Refactor so the title bar stays lean.
         { label: 'Format Current Note', click: () => send(Channels.MENU_FORMAT_CURRENT_NOTE) },
         { label: 'Format Folder\u2026', click: () => send(Channels.MENU_FORMAT_FOLDER) },
         { label: 'Format All Notes', click: () => send(Channels.MENU_FORMAT_ALL) },

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -329,6 +329,16 @@ export function rebuildMenu(): void {
       ],
     },
 
+    // Format — deterministic markdown normalizations (issue #152 epic).
+    {
+      label: 'Format',
+      submenu: [
+        { label: 'Format Current Note', click: () => send(Channels.MENU_FORMAT_CURRENT_NOTE) },
+        { label: 'Format Folder\u2026', click: () => send(Channels.MENU_FORMAT_FOLDER) },
+        { label: 'Format All Notes', click: () => send(Channels.MENU_FORMAT_ALL) },
+      ],
+    },
+
     // Tools for Thought — dynamic menus from tool registry
     ...CATEGORIES
       .filter(cat => getToolsByCategory(cat.id).length > 0)

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -155,6 +155,14 @@ contextBridge.exposeInMainWorld('api', {
     decomposeSuggest: (relativePath: string, hints?: unknown) =>
       ipcRenderer.invoke(Channels.REFACTOR_DECOMPOSE_SUGGEST, relativePath, hints),
   },
+  formatter: {
+    formatContent: (content: string, settings: unknown) =>
+      ipcRenderer.invoke(Channels.FORMATTER_FORMAT_CONTENT, content, settings),
+    formatFile: (relativePath: string, settings: unknown) =>
+      ipcRenderer.invoke(Channels.FORMATTER_FORMAT_FILE, relativePath, settings),
+    formatFolder: (relDir: string, settings: unknown) =>
+      ipcRenderer.invoke(Channels.FORMATTER_FORMAT_FOLDER, relDir, settings),
+  },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
     prepareConversation: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_PREPARE_CONVERSATION, request),
@@ -279,6 +287,15 @@ contextBridge.exposeInMainWorld('api', {
     },
     onRefactorDecompose: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_DECOMPOSE, () => cb());
+    },
+    onFormatCurrentNote: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_FORMAT_CURRENT_NOTE, () => cb());
+    },
+    onFormatFolder: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_FORMAT_FOLDER, () => cb());
+    },
+    onFormatAll: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_FORMAT_ALL, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -46,6 +46,7 @@
   } from './lib/refactor/extract';
   import { planSplitByHeading } from './lib/refactor/split-by-heading';
   import { getRefactorSettings } from './lib/refactor/settings';
+  import { getFormatSettings } from './lib/formatter/settings';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -572,6 +573,69 @@
     }
   }
 
+  async function handleFormatCurrentNote() {
+    if (!notebase.meta) return;
+    const tab = editor.activeNoteTab;
+    if (!tab) return;
+    const settings = getFormatSettings();
+    try {
+      const result = await withBusy('Formatting\u2026', () =>
+        api.formatter.formatContent(tab.content, settings),
+      );
+      if (result !== tab.content) {
+        editor.setContent(result);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Formatting failed: ${msg}`, CONFIRM_KEYS.formatFailed, 'OK');
+    }
+  }
+
+  async function handleFormatFolder() {
+    if (!notebase.meta) return;
+    const raw = await showPrompt('Format every .md under folder (leave empty for root):');
+    if (raw === null) return;
+    const relDir = raw.trim().replace(/^\/+|\/+$/g, '');
+    const settings = getFormatSettings();
+    try {
+      const summary = await withBusy('Formatting folder\u2026', () =>
+        api.formatter.formatFolder(relDir, settings),
+      );
+      await showConfirm(
+        `Formatting complete. Changed ${summary.changedPaths.length} of ${summary.totalScanned} file${summary.totalScanned === 1 ? '' : 's'}.`,
+        CONFIRM_KEYS.formatComplete,
+        'OK',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Formatting failed: ${msg}`, CONFIRM_KEYS.formatFailed, 'OK');
+    }
+  }
+
+  async function handleFormatAll() {
+    if (!notebase.meta) return;
+    const ok = await showConfirm(
+      'Format every note in the thoughtbase? Rewrites are applied in-place through the standard write pipeline.',
+      CONFIRM_KEYS.formatAllConfirm,
+      'Format all',
+    );
+    if (!ok) return;
+    const settings = getFormatSettings();
+    try {
+      const summary = await withBusy('Formatting all notes\u2026', () =>
+        api.formatter.formatFolder('', settings),
+      );
+      await showConfirm(
+        `Formatting complete. Changed ${summary.changedPaths.length} of ${summary.totalScanned} file${summary.totalScanned === 1 ? '' : 's'}.`,
+        CONFIRM_KEYS.formatComplete,
+        'OK',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Formatting failed: ${msg}`, CONFIRM_KEYS.formatFailed, 'OK');
+    }
+  }
+
   async function handleDecompose(relativePath: string) {
     if (!notebase.meta) return;
     try {
@@ -981,6 +1045,11 @@
     api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); });
     api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); });
     api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) handleDecompose(editor.activeFilePath); });
+
+    // Format menu (issue #153)
+    api.menu.onFormatCurrentNote(() => handleFormatCurrentNote());
+    api.menu.onFormatFolder(() => handleFormatFolder());
+    api.menu.onFormatAll(() => handleFormatAll());
 
     // Notebase rename/rewrite notifications from main — keep open tabs
     // consistent with disk so the next auto-save doesn't overwrite a

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1218,6 +1218,7 @@
                     onAutoLink={() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); }}
                     onAutoLinkInbound={() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); }}
                     onDecompose={() => { if (editor.activeFilePath) handleDecompose(editor.activeFilePath); }}
+                    onFormatCurrentNote={() => handleFormatCurrentNote()}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -56,6 +56,7 @@
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
     onDecompose?: () => void;
+    onFormatCurrentNote?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
   }
@@ -83,6 +84,7 @@
     onAutoLink,
     onAutoLinkInbound,
     onDecompose,
+    onFormatCurrentNote,
     getNotePaths,
   }: Props = $props();
 
@@ -733,6 +735,10 @@
             {#if onDecompose}
               <button onclick={() => handleMenuAction(() => onDecompose?.())}>Decompose Note&hellip;</button>
             {/if}
+          {/if}
+          {#if onFormatCurrentNote}
+            <div class="separator"></div>
+            <button onclick={() => handleMenuAction(() => onFormatCurrentNote?.())}>Format Note</button>
           {/if}
         </div>
       </div>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -19,6 +19,9 @@ export const CONFIRM_KEYS = {
   autoLinkFailed: 'auto-link-failed',
   decomposeFailed: 'decompose-failed',
   decomposeBadProposal: 'decompose-bad-proposal',
+  formatFailed: 'format-failed',
+  formatComplete: 'format-complete',
+  formatAllConfirm: 'format-all-confirm',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -89,6 +92,24 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Decompose Note returned an unusable proposal',
     description:
       'Shown when the LLM\u2019s response can\u2019t be parsed into a valid parent + children structure.',
+  },
+  {
+    key: CONFIRM_KEYS.formatFailed,
+    title: 'Format failed',
+    description:
+      'Shown when the formatter errors out during a Format command.',
+  },
+  {
+    key: CONFIRM_KEYS.formatComplete,
+    title: 'Format batch complete',
+    description:
+      'Summary dialog after Format Folder / Format All Notes finishes (counts changed + scanned files).',
+  },
+  {
+    key: CONFIRM_KEYS.formatAllConfirm,
+    title: 'Confirm Format All Notes',
+    description:
+      'Prompt before running the formatter across the whole thoughtbase.',
   },
 ];
 

--- a/src/renderer/lib/formatter/settings.ts
+++ b/src/renderer/lib/formatter/settings.ts
@@ -1,0 +1,52 @@
+/**
+ * Renderer-side access to the formatter's per-rule enable + config map (#153).
+ * Stored in localStorage, read synchronously before each format run.
+ * The settings UI (#154) will write through the same module.
+ *
+ * No rules are registered yet \u2014 the default settings intentionally leave
+ * everything disabled so "Format" is a no-op until the user opts into
+ * specific rules as they land.
+ */
+
+import type { FormatSettings } from '../../../shared/formatter/engine';
+import { DEFAULT_FORMAT_SETTINGS } from '../../../shared/formatter/engine';
+
+const STORAGE_KEY = 'formatSettings';
+
+function readFromStorage(): FormatSettings {
+  try {
+    if (typeof localStorage === 'undefined') return { ...DEFAULT_FORMAT_SETTINGS };
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_FORMAT_SETTINGS };
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_FORMAT_SETTINGS };
+    return {
+      enabled: (parsed.enabled && typeof parsed.enabled === 'object') ? parsed.enabled : {},
+      configs: (parsed.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
+    };
+  } catch {
+    return { ...DEFAULT_FORMAT_SETTINGS };
+  }
+}
+
+let settings: FormatSettings = readFromStorage();
+
+export function getFormatSettings(): FormatSettings {
+  return settings;
+}
+
+export function setFormatSettings(patch: Partial<FormatSettings>): FormatSettings {
+  settings = {
+    enabled: { ...settings.enabled, ...(patch.enabled ?? {}) },
+    configs: { ...settings.configs, ...(patch.configs ?? {}) },
+  };
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }
+  return settings;
+}
+
+/** Test-only: re-read from storage / reset to defaults. */
+export function __resetFormatSettingsForTests(): void {
+  settings = readFromStorage();
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -158,6 +158,21 @@ export interface RefactorApi {
   }>;
 }
 
+export interface FormatterApi {
+  formatContent(
+    content: string,
+    settings: import('../../../shared/formatter/engine').FormatSettings,
+  ): Promise<string>;
+  formatFile(
+    relativePath: string,
+    settings: import('../../../shared/formatter/engine').FormatSettings,
+  ): Promise<import('../../../shared/formatter/types').FormatFileResult>;
+  formatFolder(
+    relDir: string,
+    settings: import('../../../shared/formatter/engine').FormatSettings,
+  ): Promise<{ changedPaths: string[]; totalScanned: number }>;
+}
+
 export interface ToolsApi {
   execute(request: ToolExecutionRequest): Promise<ToolExecutionResult>;
   prepareConversation(request: ToolExecutionRequest): Promise<ConversationToolPayload>;
@@ -207,6 +222,9 @@ export interface MenuApi {
   onRefactorAutoLink(cb: () => void): void;
   onRefactorAutoLinkInbound(cb: () => void): void;
   onRefactorDecompose(cb: () => void): void;
+  onFormatCurrentNote(cb: () => void): void;
+  onFormatFolder(cb: () => void): void;
+  onFormatAll(cb: () => void): void;
 }
 
 export interface IdeApi {
@@ -225,6 +243,7 @@ export interface IdeApi {
   tabs: TabsApi;
   tools: ToolsApi;
   refactor: RefactorApi;
+  formatter: FormatterApi;
   menu: MenuApi;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -92,6 +92,11 @@ export const Channels = {
   MENU_REFACTOR_AUTOLINK_INBOUND: 'menu:refactor:autolinkInbound',
   MENU_REFACTOR_DECOMPOSE: 'menu:refactor:decompose',
 
+  // Formatter menu (issue #153)
+  MENU_FORMAT_CURRENT_NOTE: 'menu:format:currentNote',
+  MENU_FORMAT_FOLDER: 'menu:format:folder',
+  MENU_FORMAT_ALL: 'menu:format:all',
+
   /** Renderer-initiated LLM Auto-tag of a note (#174). */
   REFACTOR_AUTO_TAG: 'refactor:autoTag',
   /** LLM-suggested outbound wiki-links for a note (#175). */
@@ -104,6 +109,13 @@ export const Channels = {
   REFACTOR_AUTO_LINK_INBOUND_APPLY: 'refactor:autoLinkInboundApply',
   /** LLM-driven decomposition of a note into a parent index + children (#178). */
   REFACTOR_DECOMPOSE_SUGGEST: 'refactor:decomposeSuggest',
+
+  /** Format a single file on disk (#153). Writes through the standard index+broadcast pipeline. */
+  FORMATTER_FORMAT_FILE: 'formatter:formatFile',
+  /** Format every .md under a relative folder (empty string = whole thoughtbase). */
+  FORMATTER_FORMAT_FOLDER: 'formatter:formatFolder',
+  /** Pure: format a content string and return the result (used for the active note's editor buffer). */
+  FORMATTER_FORMAT_CONTENT: 'formatter:formatContent',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',

--- a/src/shared/formatter/engine.ts
+++ b/src/shared/formatter/engine.ts
@@ -1,0 +1,88 @@
+/**
+ * Formatter engine (#153). Applies a set of enabled rules to note content,
+ * parsing the cache once and passing it to every rule. Runs rules in a
+ * deterministic order: category order first (see `CATEGORY_ORDER`), then
+ * registration order within each category.
+ *
+ * The engine does not know about IO \u2014 callers read + write files and wire
+ * palette commands on top. Pure in / pure out.
+ */
+
+import { buildParseCache } from './parse-cache';
+import { CATEGORY_ORDER, getRule, listAllRules } from './registry';
+import type { EnabledRule, FormatterRule } from './types';
+
+export interface FormatSettings {
+  /** Per-rule enable map. Unlisted rules default to disabled. */
+  enabled: Record<string, boolean>;
+  /** Per-rule config override. Unlisted rules use the rule\u2019s defaultConfig. */
+  configs: Record<string, unknown>;
+}
+
+export const DEFAULT_FORMAT_SETTINGS: FormatSettings = {
+  enabled: {},
+  configs: {},
+};
+
+/**
+ * Apply enabled rules to `content`. Returns the rewritten string; equal to
+ * `content` when no enabled rule matched.
+ */
+export function formatContent(content: string, settings: FormatSettings): string {
+  const enabledRules = resolveEnabled(settings);
+  if (enabledRules.length === 0) return content;
+
+  let current = content;
+  for (const { rule, config } of enabledRules) {
+    const cache = buildParseCache(current);
+    const next = rule.apply(current, config, cache);
+    if (next !== current) current = next;
+  }
+  return current;
+}
+
+/** Expose which rules would run, in order. Useful for the settings UI + tests. */
+export function resolveEnabled(settings: FormatSettings): EnabledRule[] {
+  const all = listAllRules();
+  const byCategory = new Map<string, FormatterRule<any>[]>();
+  for (const r of all) {
+    if (!byCategory.has(r.category)) byCategory.set(r.category, []);
+    byCategory.get(r.category)!.push(r);
+  }
+
+  const ordered: FormatterRule<any>[] = [];
+  for (const cat of CATEGORY_ORDER) {
+    const group = byCategory.get(cat);
+    if (group) ordered.push(...group);
+  }
+
+  const out: EnabledRule[] = [];
+  for (const rule of ordered) {
+    if (!settings.enabled[rule.id]) continue;
+    const config = rule.id in settings.configs
+      ? settings.configs[rule.id]
+      : rule.defaultConfig;
+    out.push({ rule, config });
+  }
+  return out;
+}
+
+/** Re-apply formatting until output stabilises or we hit the pass cap. */
+export function formatContentToFixedPoint(
+  content: string,
+  settings: FormatSettings,
+  maxPasses = 3,
+): string {
+  let current = content;
+  for (let i = 0; i < maxPasses; i++) {
+    const next = formatContent(current, settings);
+    if (next === current) return current;
+    current = next;
+  }
+  return current;
+}
+
+/** Alias used by the orchestrator so callers don\u2019t depend on the registry directly. */
+export function ruleExists(id: string): boolean {
+  return getRule(id) !== undefined;
+}

--- a/src/shared/formatter/parse-cache.ts
+++ b/src/shared/formatter/parse-cache.ts
@@ -1,0 +1,209 @@
+/**
+ * Builds the ParseCache (#153) for a note in a single pass.
+ *
+ * Identifies:
+ *   - top-of-file YAML frontmatter
+ *   - fenced code blocks (``` and ~~~ with matching length)
+ *   - inline backticked spans
+ *   - math blocks (`$$\u2026$$`) and inline math (`$\u2026$`)
+ *   - blockquote regions
+ *
+ * The resulting cache exposes an `isProtected(offset)` helper so rules can
+ * cheaply skip content inside any "don't touch" region.
+ */
+
+import type { ParseCache, Range } from './types';
+
+export function buildParseCache(content: string): ParseCache {
+  const frontmatterRange = findFrontmatter(content);
+
+  // Find fenced-code-block ranges first so we can mask them from the other
+  // scanners — inline-math `$...$` inside a JS code block shouldn't count.
+  const codeFenceRanges = findFencedCodeBlocks(content);
+  const masked = maskRanges(content, [
+    ...codeFenceRanges,
+    ...(frontmatterRange ? [frontmatterRange] : []),
+  ]);
+
+  const inlineCodeRanges = findInlineCode(masked).map((r) => absoluteRange(r));
+  const mathRanges = findMath(masked).map((r) => absoluteRange(r));
+  const blockquoteRanges = findBlockquotes(content);
+
+  const allProtected = [
+    ...(frontmatterRange ? [frontmatterRange] : []),
+    ...codeFenceRanges,
+    ...inlineCodeRanges,
+    ...mathRanges,
+  ];
+
+  function isProtected(offset: number): boolean {
+    for (const r of allProtected) {
+      if (offset >= r.start && offset < r.end) return true;
+    }
+    return false;
+  }
+
+  return {
+    frontmatterRange,
+    codeFenceRanges,
+    inlineCodeRanges,
+    mathRanges,
+    blockquoteRanges,
+    isProtected,
+  };
+}
+
+// ── Frontmatter ──────────────────────────────────────────────────────────
+
+function findFrontmatter(content: string): Range | null {
+  const m = content.match(/^---\r?\n[\s\S]*?\r?\n---(\r?\n|$)/);
+  if (!m || m.index !== 0) return null;
+  return { start: 0, end: m[0].length };
+}
+
+// ── Fenced code blocks ───────────────────────────────────────────────────
+
+function findFencedCodeBlocks(content: string): Range[] {
+  const out: Range[] = [];
+  const lines = splitLines(content);
+  let i = 0;
+  let offset = 0;
+  const lineOffsets: number[] = [];
+  // Pre-compute line start offsets for range math.
+  {
+    let pos = 0;
+    for (const l of lines) {
+      lineOffsets.push(pos);
+      pos += l.length;
+    }
+    lineOffsets.push(pos);
+  }
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const fenceMatch = /^[ \t]{0,3}(`{3,}|~{3,})/.exec(line);
+    if (!fenceMatch) {
+      offset += line.length;
+      i++;
+      continue;
+    }
+    const fenceChar = fenceMatch[1][0];
+    const fenceLen = fenceMatch[1].length;
+    const blockStart = lineOffsets[i];
+    let j = i + 1;
+    while (j < lines.length) {
+      const candidate = lines[j];
+      const closeMatch = new RegExp(`^[ \\t]{0,3}(${fenceChar}{${fenceLen},})[ \\t]*(\\r?\\n|$)`).exec(candidate);
+      if (closeMatch) { j++; break; }
+      j++;
+    }
+    const blockEnd = j < lines.length ? lineOffsets[j] : lineOffsets[lines.length];
+    out.push({ start: blockStart, end: blockEnd });
+    i = j;
+    offset = lineOffsets[j] ?? content.length;
+  }
+  return out;
+}
+
+/**
+ * Split content into lines preserving their terminators. `lines.join('')`
+ * reconstructs the original content exactly.
+ */
+function splitLines(content: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = content.length;
+  while (i < n) {
+    let j = i;
+    while (j < n && content[j] !== '\n') j++;
+    if (j < n) j++; // include the '\n'
+    out.push(content.slice(i, j));
+    i = j;
+  }
+  return out;
+}
+
+// ── Inline code ──────────────────────────────────────────────────────────
+
+function findInlineCode(content: string): Range[] {
+  // Match the longest-possible backtick run as delimiter to mirror CommonMark:
+  //   `code`, ``code with ` inside``, etc.
+  const out: Range[] = [];
+  const re = /(`+)(?:[^`]|(?!\1)`)*\1/g;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    // Avoid zero-length infinite loops on empty matches.
+    if (m[0].length === 0) { re.lastIndex++; continue; }
+    out.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return out;
+}
+
+// ── Math ─────────────────────────────────────────────────────────────────
+
+function findMath(content: string): Range[] {
+  const out: Range[] = [];
+  // Block math first: $$...$$ possibly spanning newlines.
+  const blockRe = /\$\$[\s\S]*?\$\$/g;
+  let m;
+  while ((m = blockRe.exec(content)) !== null) {
+    out.push({ start: m.index, end: m.index + m[0].length });
+  }
+  // Inline math: single `$...$`. Skip anything already inside a block match.
+  const inlineRe = /\$[^\n$]+?\$/g;
+  while ((m = inlineRe.exec(content)) !== null) {
+    const inside = out.some((r) => m!.index >= r.start && m!.index < r.end);
+    if (inside) continue;
+    out.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return out;
+}
+
+// ── Blockquotes ──────────────────────────────────────────────────────────
+
+function findBlockquotes(content: string): Range[] {
+  const out: Range[] = [];
+  const lines = splitLines(content);
+  const lineOffsets: number[] = [];
+  {
+    let pos = 0;
+    for (const l of lines) { lineOffsets.push(pos); pos += l.length; }
+    lineOffsets.push(pos);
+  }
+  let i = 0;
+  while (i < lines.length) {
+    if (/^[ \t]{0,3}>/.test(lines[i])) {
+      const start = lineOffsets[i];
+      let j = i + 1;
+      while (j < lines.length && /^[ \t]{0,3}>/.test(lines[j])) j++;
+      out.push({ start, end: lineOffsets[j] });
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  return out;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Produce a content string with characters inside `ranges` replaced by
+ * spaces (preserving newlines and offsets). Used to prevent scanners like
+ * inline-code from matching text inside code fences.
+ */
+function maskRanges(content: string, ranges: Range[]): string {
+  if (ranges.length === 0) return content;
+  const chars = content.split('');
+  for (const r of ranges) {
+    for (let i = r.start; i < r.end && i < chars.length; i++) {
+      if (chars[i] !== '\n' && chars[i] !== '\r') chars[i] = ' ';
+    }
+  }
+  return chars.join('');
+}
+
+/** After masking, the absolute offsets still line up with the original. Identity passthrough kept for clarity at call sites. */
+function absoluteRange(r: Range): Range {
+  return r;
+}

--- a/src/shared/formatter/registry.ts
+++ b/src/shared/formatter/registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Rule registry (#153). Category tickets (#155\u2013#161) register their rules
+ * at import time; the engine consults the registry to find + sort rules
+ * for an invocation.
+ *
+ * Registration order within a category is the apply order \u2014 a rule that
+ * depends on another running first just registers later in its module.
+ * Categories themselves apply in a fixed order (see CATEGORY_ORDER)
+ * chosen so structural passes run before cosmetic ones.
+ */
+
+import type { FormatterCategory, FormatterRule } from './types';
+
+const rules = new Map<string, FormatterRule<any>>();
+const order: string[] = [];
+
+export function registerRule<Config>(rule: FormatterRule<Config>): void {
+  if (rules.has(rule.id)) {
+    throw new Error(`Formatter rule "${rule.id}" is already registered.`);
+  }
+  rules.set(rule.id, rule as FormatterRule<any>);
+  order.push(rule.id);
+}
+
+export function getRule(id: string): FormatterRule<any> | undefined {
+  return rules.get(id);
+}
+
+export function listAllRules(): FormatterRule<any>[] {
+  return order.map((id) => rules.get(id)!).filter(Boolean);
+}
+
+export function listRulesByCategory(category: FormatterCategory): FormatterRule<any>[] {
+  return listAllRules().filter((r) => r.category === category);
+}
+
+/** Test-only: drop every registration. */
+export function __resetRuleRegistryForTests(): void {
+  rules.clear();
+  order.length = 0;
+}
+
+export const CATEGORY_ORDER: FormatterCategory[] = [
+  // Structural passes first so later rules see a normalised document shape.
+  'yaml',
+  'heading',
+  'content',
+  'footnote',
+  'spacing',
+  // Minerva-specific rules last \u2014 they need to inspect link shapes that
+  // earlier passes may have normalised.
+  'minerva',
+];

--- a/src/shared/formatter/types.ts
+++ b/src/shared/formatter/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Formatter engine types (#153). Each rule is a pure function that takes
+ * note content plus a config blob and returns transformed content. Rules
+ * share a parse-once cache so identifying code fences, frontmatter, math
+ * blocks, etc. happens one time per invocation rather than per rule.
+ */
+
+export type FormatterCategory =
+  | 'yaml'
+  | 'heading'
+  | 'content'
+  | 'spacing'
+  | 'footnote'
+  | 'minerva';
+
+/** Half-open character offset range `[start, end)` into the note content. */
+export interface Range {
+  start: number;
+  end: number;
+}
+
+/**
+ * Read-only snapshot of the structural regions the formatter should treat
+ * as "don\u2019t touch unless a rule explicitly targets this kind of block."
+ * Rules consult `isProtected(offset)` before rewriting at a given position.
+ */
+export interface ParseCache {
+  /** Top-of-file YAML frontmatter block, or null if none. Offsets cover the surrounding `---` fences. */
+  frontmatterRange: Range | null;
+  /** Fenced code blocks (``` or ~~~). Offsets cover the fences plus the body. */
+  codeFenceRanges: Range[];
+  /** Inline backticked spans — a single rule like "escape YAML special chars" still needs to skip these. */
+  inlineCodeRanges: Range[];
+  /** `$$\u2026$$` math blocks and `$\u2026$` inline math. */
+  mathRanges: Range[];
+  /** Blockquote regions (contiguous lines starting with `>` after optional indent). */
+  blockquoteRanges: Range[];
+  /** Convenience: true when the offset lies inside any of the above ranges. */
+  isProtected(offset: number): boolean;
+}
+
+export interface FormatterRule<Config = unknown> {
+  id: string;
+  category: FormatterCategory;
+  title: string;
+  description: string;
+  defaultConfig: Config;
+  /** Pure, idempotent. Must not perform IO or mutate shared state. */
+  apply(content: string, config: Config, cache: ParseCache): string;
+}
+
+/** A rule bound to its user-configured state for a single invocation. */
+export interface EnabledRule<Config = unknown> {
+  rule: FormatterRule<Config>;
+  config: Config;
+}
+
+/** Per-file outcome of a batch format run. */
+export interface FormatFileResult {
+  relativePath: string;
+  /** True when the content differs from disk after applying enabled rules. */
+  changed: boolean;
+  /** Original content (for callers that want to show a diff later). */
+  before: string;
+  /** Rewritten content. Equals `before` when no rule matched. */
+  after: string;
+}

--- a/tests/shared/formatter/engine.test.ts
+++ b/tests/shared/formatter/engine.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  formatContent,
+  formatContentToFixedPoint,
+  resolveEnabled,
+  DEFAULT_FORMAT_SETTINGS,
+} from '../../../src/shared/formatter/engine';
+import {
+  registerRule,
+  __resetRuleRegistryForTests,
+} from '../../../src/shared/formatter/registry';
+import type { FormatterRule } from '../../../src/shared/formatter/types';
+
+function rule(partial: Partial<FormatterRule<unknown>> & {
+  id: string;
+  apply: FormatterRule<unknown>['apply'];
+}): FormatterRule<unknown> {
+  return {
+    category: 'content',
+    title: partial.id,
+    description: '',
+    defaultConfig: {},
+    ...partial,
+  } as FormatterRule<unknown>;
+}
+
+describe('formatter engine (issue #153)', () => {
+  beforeEach(() => {
+    __resetRuleRegistryForTests();
+  });
+
+  it('no-ops when no rules are enabled', () => {
+    registerRule(rule({ id: 'to-upper', apply: (c) => c.toUpperCase() }));
+    const out = formatContent('hello\nworld', DEFAULT_FORMAT_SETTINGS);
+    expect(out).toBe('hello\nworld');
+  });
+
+  it('applies an enabled rule', () => {
+    registerRule(rule({ id: 'trim-trailing', apply: (c) => c.replace(/ +$/gm, '') }));
+    const out = formatContent('hello   \nworld  ', {
+      enabled: { 'trim-trailing': true },
+      configs: {},
+    });
+    expect(out).toBe('hello\nworld');
+  });
+
+  it('applies rules in category order then registration order', () => {
+    registerRule(rule({ id: 'content-a', category: 'content', apply: (c) => c + '[A]' }));
+    registerRule(rule({ id: 'yaml-first', category: 'yaml', apply: (c) => c + '[Y]' }));
+    registerRule(rule({ id: 'content-b', category: 'content', apply: (c) => c + '[B]' }));
+    const out = formatContent('start', {
+      enabled: { 'content-a': true, 'yaml-first': true, 'content-b': true },
+      configs: {},
+    });
+    // yaml runs before content (CATEGORY_ORDER), content-a before content-b (registration).
+    expect(out).toBe('start[Y][A][B]');
+  });
+
+  it('respects per-rule config overrides', () => {
+    registerRule(rule({
+      id: 'append',
+      apply: (c, cfg: { suffix: string }) => c + cfg.suffix,
+      defaultConfig: { suffix: '!' },
+    }));
+    const outDefault = formatContent('x', {
+      enabled: { append: true },
+      configs: {},
+    });
+    expect(outDefault).toBe('x!');
+    const outOverride = formatContent('x', {
+      enabled: { append: true },
+      configs: { append: { suffix: '?' } },
+    });
+    expect(outOverride).toBe('x?');
+  });
+
+  it('resolveEnabled returns only enabled rules in run order', () => {
+    registerRule(rule({ id: 'r1', apply: (c) => c }));
+    registerRule(rule({ id: 'r2', apply: (c) => c }));
+    registerRule(rule({ id: 'r3', apply: (c) => c }));
+    const enabled = resolveEnabled({
+      enabled: { r1: true, r3: true },
+      configs: {},
+    });
+    expect(enabled.map((e) => e.rule.id)).toEqual(['r1', 'r3']);
+  });
+
+  it('passes a ParseCache to each rule so they can skip code fences', () => {
+    registerRule(rule({
+      id: 'h2-to-h3',
+      apply: (content, _cfg, cache) => {
+        // Rewrite `## ` to `### ` except inside protected regions.
+        let out = '';
+        for (let i = 0; i < content.length; i++) {
+          if (!cache.isProtected(i) && content.slice(i, i + 3) === '## ') {
+            out += '### ';
+            i += 2;
+          } else {
+            out += content[i];
+          }
+        }
+        return out;
+      },
+    }));
+    const input = '## outside\n\n```\n## inside\n```\n';
+    const out = formatContent(input, { enabled: { 'h2-to-h3': true }, configs: {} });
+    expect(out).toContain('### outside');
+    expect(out).toContain('## inside');
+  });
+
+  it('formatContentToFixedPoint settles when rules converge', () => {
+    registerRule(rule({
+      id: 'max-blank-lines',
+      apply: (c) => c.replace(/\n{3,}/g, '\n\n'),
+    }));
+    const input = 'a\n\n\n\n\nb';
+    const out = formatContentToFixedPoint(input, {
+      enabled: { 'max-blank-lines': true },
+      configs: {},
+    });
+    expect(out).toBe('a\n\nb');
+  });
+});

--- a/tests/shared/formatter/parse-cache.test.ts
+++ b/tests/shared/formatter/parse-cache.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { buildParseCache } from '../../../src/shared/formatter/parse-cache';
+
+describe('buildParseCache (issue #153)', () => {
+  it('detects a top-of-file YAML frontmatter block', () => {
+    const src = '---\ntitle: Foo\ntags: [a, b]\n---\n\n# Heading\n';
+    const cache = buildParseCache(src);
+    expect(cache.frontmatterRange).not.toBeNull();
+    expect(cache.frontmatterRange!.start).toBe(0);
+    // `---\ntitle: Foo\ntags: [a, b]\n---\n` ends at col 36 \u00B1 a few.
+    expect(cache.frontmatterRange!.end).toBeGreaterThan(25);
+    expect(cache.isProtected(5)).toBe(true);   // inside frontmatter
+    expect(cache.isProtected(50)).toBe(false); // in the body
+  });
+
+  it('ignores a `---` line that isn\u2019t at the top of the file', () => {
+    const src = '# Title\n\nSome body\n\n---\nnot: frontmatter\n---\n';
+    const cache = buildParseCache(src);
+    expect(cache.frontmatterRange).toBeNull();
+  });
+
+  it('finds fenced code blocks (triple backticks)', () => {
+    const src = '# Heading\n\n```js\nconst x = 1;\n```\n\nplain\n';
+    const cache = buildParseCache(src);
+    expect(cache.codeFenceRanges).toHaveLength(1);
+    const range = cache.codeFenceRanges[0];
+    expect(src.slice(range.start, range.end)).toContain('```js');
+    expect(src.slice(range.start, range.end)).toContain('const x = 1;');
+  });
+
+  it('finds fenced code blocks with tildes', () => {
+    const src = '~~~~\ncode\n~~~~\n';
+    const cache = buildParseCache(src);
+    expect(cache.codeFenceRanges).toHaveLength(1);
+  });
+
+  it('masks inline-backtick matches inside fenced code blocks', () => {
+    const src = '```\n`inside fence`\n```\n\n`real inline`\n';
+    const cache = buildParseCache(src);
+    // Only the after-fence `real inline` should register as inline code.
+    expect(cache.inlineCodeRanges).toHaveLength(1);
+    const r = cache.inlineCodeRanges[0];
+    expect(src.slice(r.start, r.end)).toBe('`real inline`');
+  });
+
+  it('finds inline math `$\u2026$` and block math `$$\u2026$$`', () => {
+    const src = 'inline $a+b$ math and block\n$$\nx = 1\n$$\ndone\n';
+    const cache = buildParseCache(src);
+    expect(cache.mathRanges.length).toBeGreaterThanOrEqual(2);
+    const texts = cache.mathRanges.map((r) => src.slice(r.start, r.end));
+    expect(texts).toContain('$a+b$');
+    expect(texts.some((t) => t.includes('x = 1'))).toBe(true);
+  });
+
+  it('does not match inline math inside code fences', () => {
+    const src = '```\n$ not math $\n```\n\nreal $x$ math\n';
+    const cache = buildParseCache(src);
+    expect(cache.mathRanges).toHaveLength(1);
+    const r = cache.mathRanges[0];
+    expect(src.slice(r.start, r.end)).toBe('$x$');
+  });
+
+  it('detects contiguous blockquote regions', () => {
+    const src = [
+      'prose',
+      '',
+      '> first quote line',
+      '> second quote line',
+      '',
+      'not a quote',
+      '',
+      '> another quote',
+      'not a quote',
+      '',
+    ].join('\n');
+    const cache = buildParseCache(src);
+    expect(cache.blockquoteRanges).toHaveLength(2);
+  });
+
+  it('isProtected returns true for offsets inside any protected range', () => {
+    const src = '---\nt: x\n---\n\n```\ncode\n```\n\n`inline`\n$m$\n';
+    const cache = buildParseCache(src);
+    // Pick an offset inside each protected kind.
+    const fmIdx = 5;
+    const codeIdx = src.indexOf('code');
+    const inlineIdx = src.indexOf('`inline`') + 1;
+    const mathIdx = src.indexOf('$m$') + 1;
+    expect(cache.isProtected(fmIdx)).toBe(true);
+    expect(cache.isProtected(codeIdx)).toBe(true);
+    expect(cache.isProtected(inlineIdx)).toBe(true);
+    expect(cache.isProtected(mathIdx)).toBe(true);
+    // A position on a plain blank line should not be protected.
+    const blankIdx = src.indexOf('\n\n') + 1;
+    expect(cache.isProtected(blankIdx)).toBe(false);
+  });
+
+  it('returns empty ranges on an empty document', () => {
+    const cache = buildParseCache('');
+    expect(cache.frontmatterRange).toBeNull();
+    expect(cache.codeFenceRanges).toEqual([]);
+    expect(cache.inlineCodeRanges).toEqual([]);
+    expect(cache.mathRanges).toEqual([]);
+    expect(cache.blockquoteRanges).toEqual([]);
+    expect(cache.isProtected(0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Foundation for the markdown formatter epic (#152). Lands the rule interface, the parse-once cache, the registry, the engine, the main-side orchestrator, and the three palette commands. **No rules yet** \u2014 those arrive in the category sub-issues (#155\u2013#161). Until then, "Format Current Note / Format Folder / Format All Notes" are no-ops, by design.

## What landed

### Types + engine (`src/shared/formatter/`)
- `FormatterRule` interface \u2014 pure `(content, config, cache) \u2192 content`, with `id`, `category`, `defaultConfig`, and must-be-idempotent invariant.
- `ParseCache` \u2014 identifies top-of-file YAML frontmatter, fenced code blocks (``` and ~~~ with matching length), inline backtick spans, block + inline math (`$$` / `$`), and blockquote regions. Exposes `isProtected(offset)` so rules can cheaply skip "don't touch" regions.
- `CATEGORY_ORDER` (yaml \u2192 heading \u2192 content \u2192 footnote \u2192 spacing \u2192 minerva) so later rules see a normalised document shape.
- `formatContent` + `formatContentToFixedPoint` (re-applies until stable, capped).

### Main-side orchestrator (`src/main/formatter/orchestrator.ts`)
- `formatFile` \u2014 format one file on disk, route the write through the standard index + search + `NOTEBASE_REWRITTEN` broadcast.
- `formatFolder` \u2014 walk recursively, apply, batched persist + broadcast at the end.

### UI
- New **Format** menu in the title bar between Refactor and Learning with: Format Current Note / Format Folder\u2026 / Format All Notes.
- Renderer handlers: busy overlay while running, summary dialog for batch runs, confirm-before-all-notes guard, per-rule settings read from localStorage (same pattern as refactor settings).

## Tests
- 10 parse-cache tests (frontmatter, fences, inline code, math, blockquotes, `isProtected`, masking inside fences, empty doc).
- 7 engine tests (no-op when disabled, single rule, category + registration ordering, per-rule config override, `resolveEnabled`, `ParseCache` pass-through, fixed-point convergence).
- Full suite: **572 passing** (was 555).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (572 passing)
- [ ] Menu bar shows **Format** between Refactor and Learning
- [ ] Format Current Note: no-op until a category rule PR lands + user enables a rule
- [ ] Format Folder\u2026 / Format All Notes: summary dialog reports `0 of N changed`
- [ ] Confirm dialog before "Format All Notes" honors "don't ask again"

## Follow-ups
- **#154** settings UI (per-rule enable + config)
- **#155 YAML**, **#156 heading**, **#157 content**, **#158 spacing**, **#159 footnote**, **#161 Minerva-specific** rule sets
- **#160** paste-event rules (separate event interceptor)