### PR TITLE
Formatter settings UI + project-scoped persistence (closes #154)

### DIFF
--- a/src/main/formatter/orchestrator.ts
+++ b/src/main/formatter/orchestrator.ts
@@ -61,7 +61,7 @@ async function runBatch(
     try {
       const result = await formatFile(rootPath, rel, settings);
       if (result.changed) changedPaths.push(rel);
-    } catch { /* unreadable note \u2014 skip */ }
+    } catch { /* unreadable note — skip */ }
   }
   return { changedPaths, totalScanned: paths.length };
 }
@@ -93,6 +93,6 @@ async function writeThrough(
   await graph.indexNote(relativePath, content);
   search.indexNote(relativePath, content);
   // Caller is responsible for the batched persist + NOTEBASE_REWRITTEN
-  // broadcast \u2014 doing it per-file in a folder run would thrash the
+  // broadcast — doing it per-file in a folder run would thrash the
   // editor's open-tab refresh path.
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -631,6 +631,30 @@ export function registerIpcHandlers(): void {
     (_e, content: string, settings: FormatSettings) => formatNoteContent(content, settings),
   );
 
+  // Project-scoped formatter settings (#154). Stored in .minerva/formatter.json
+  // so rule choices travel with the thoughtbase in git.
+  ipcMain.handle(Channels.FORMATTER_LOAD_SETTINGS, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return { enabled: {}, configs: {} };
+    try {
+      const p = path.join(rootPath, '.minerva', 'formatter.json');
+      const data = await fs.readFile(p, 'utf-8');
+      const parsed = JSON.parse(data);
+      return {
+        enabled: (parsed?.enabled && typeof parsed.enabled === 'object') ? parsed.enabled : {},
+        configs: (parsed?.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
+      };
+    } catch { return { enabled: {}, configs: {} }; }
+  });
+
+  ipcMain.handle(Channels.FORMATTER_SAVE_SETTINGS, async (e, settings: FormatSettings) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return;
+    const p = path.join(rootPath, '.minerva', 'formatter.json');
+    await fs.mkdir(path.dirname(p), { recursive: true });
+    await fs.writeFile(p, JSON.stringify(settings, null, 2), 'utf-8');
+  });
+
   ipcMain.handle(
     Channels.FORMATTER_FORMAT_FILE,
     async (e, relativePath: string, settings: FormatSettings) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -162,6 +162,9 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.FORMATTER_FORMAT_FILE, relativePath, settings),
     formatFolder: (relDir: string, settings: unknown) =>
       ipcRenderer.invoke(Channels.FORMATTER_FORMAT_FOLDER, relDir, settings),
+    loadSettings: () => ipcRenderer.invoke(Channels.FORMATTER_LOAD_SETTINGS),
+    saveSettings: (settings: unknown) =>
+      ipcRenderer.invoke(Channels.FORMATTER_SAVE_SETTINGS, settings),
   },
   tools: {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -46,7 +46,7 @@
   } from './lib/refactor/extract';
   import { planSplitByHeading } from './lib/refactor/split-by-heading';
   import { getRefactorSettings } from './lib/refactor/settings';
-  import { getFormatSettings } from './lib/formatter/settings';
+  import { getFormatSettings, loadFormatSettings } from './lib/formatter/settings';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -1093,6 +1093,7 @@
       await notebase.openPath(meta.rootPath);
       await editor.restoreTabs();
       await bookmarkStore.load();
+      await loadFormatSettings();
       sidebar?.refreshTags();
       // Load inspection count after a brief delay to let health checks finish
       setTimeout(refreshInspectionCount, 3000);

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -18,6 +18,17 @@
     type DestinationMode,
     type RefactorSettings,
   } from '../refactor/settings';
+  import {
+    getFormatSettings,
+    setFormatSettings,
+  } from '../formatter/settings';
+  import {
+    listRulesByCategory,
+    CATEGORY_ORDER,
+  } from '../../../shared/formatter/registry';
+  import '../../../shared/formatter/rules/index';
+  import type { FormatterRule } from '../../../shared/formatter/types';
+  import type { FormatSettings } from '../../../shared/formatter/engine';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
   import { getAllToolInfos } from '../tools/tool-registry';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
@@ -30,12 +41,13 @@
 
   let { onApplyEditor, onThemeChanged, onClose }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'web' | 'ai';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'ai';
   const TABS: { id: TabId; label: string }[] = [
     { id: 'editor', label: 'Editor' },
     { id: 'appearance', label: 'Appearance' },
     { id: 'behaviors', label: 'Behaviors' },
     { id: 'refactoring', label: 'Refactoring' },
+    { id: 'formatter', label: 'Formatter' },
     { id: 'web', label: 'Web' },
     { id: 'ai', label: 'AI' },
   ];
@@ -45,6 +57,34 @@
     refactor = { ...refactor, ...patch };
     setRefactorSettings(patch);
   }
+
+  // Formatter settings (#154). Mirror the persisted map into local state so
+  // the Done-close reset path can rehydrate without an IPC round-trip.
+  let formatter = $state<FormatSettings>({
+    enabled: { ...getFormatSettings().enabled },
+    configs: { ...getFormatSettings().configs },
+  });
+  function toggleFormatterRule(id: string, on: boolean): void {
+    formatter = {
+      enabled: { ...formatter.enabled, [id]: on },
+      configs: formatter.configs,
+    };
+    setFormatSettings({ enabled: { [id]: on } });
+  }
+  const FORMATTER_CATEGORY_LABELS: Record<string, string> = {
+    yaml: 'YAML frontmatter',
+    heading: 'Headings',
+    content: 'Content',
+    footnote: 'Footnotes',
+    spacing: 'Spacing',
+    minerva: 'Minerva-specific',
+  };
+  const formatterSections = CATEGORY_ORDER.map((cat) => ({
+    category: cat,
+    label: FORMATTER_CATEGORY_LABELS[cat] ?? cat,
+    rules: listRulesByCategory(cat) as FormatterRule<unknown>[],
+  }));
+  const hasAnyFormatterRules = formatterSections.some((s) => s.rules.length > 0);
   const DESTINATION_OPTIONS: { value: DestinationMode; label: string }[] = [
     { value: 'same-folder', label: 'Same folder as source note' },
     { value: 'root', label: 'Thoughtbase root' },
@@ -425,6 +465,43 @@
               somewhere or the body will be dropped.
             </p>
           </div>
+
+        {:else if activeTab === 'formatter'}
+          <p class="section-intro">
+            Deterministic normalizations applied by the <strong>Refactor \u25B8 Format</strong> commands.
+            Rules are off by default \u2014 turn on the ones whose aesthetics you want
+            enforced. Choices are stored in
+            <code>.minerva/formatter.json</code> so they travel with the thoughtbase.
+          </p>
+
+          {#if !hasAnyFormatterRules}
+            <div class="empty-state">
+              No formatter rules are registered yet. Rule sets land per category
+              in follow-up tickets (#155\u2013#161); once any of those merge, rules
+              appear here as rows you can enable.
+            </div>
+          {/if}
+
+          {#each formatterSections as section}
+            {#if section.rules.length > 0}
+              <h3 class="fm-category">{section.label}</h3>
+              <div class="fm-rules">
+                {#each section.rules as rule (rule.id)}
+                  <div class="field checkbox">
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={!!formatter.enabled[rule.id]}
+                        onchange={(e) => toggleFormatterRule(rule.id, (e.currentTarget as HTMLInputElement).checked)}
+                      />
+                      {rule.title}
+                    </label>
+                    <p class="hint">{rule.description}</p>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          {/each}
 
         {:else if activeTab === 'web'}
           <div class="field checkbox">
@@ -857,6 +934,42 @@
 
   .link-btn:hover {
     color: var(--text);
+  }
+
+  .section-intro {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin: 0 0 16px 0;
+  }
+
+  .section-intro code {
+    font-size: 11px;
+    color: var(--text);
+  }
+
+  .empty-state {
+    padding: 12px;
+    border: 1px dashed var(--border);
+    border-radius: 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .fm-category {
+    margin: 18px 0 8px 0;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .fm-rules {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
 
   footer {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -468,8 +468,8 @@
 
         {:else if activeTab === 'formatter'}
           <p class="section-intro">
-            Deterministic normalizations applied by the <strong>Refactor \u25B8 Format</strong> commands.
-            Rules are off by default \u2014 turn on the ones whose aesthetics you want
+            Deterministic normalizations applied by the <strong>Refactor ▸ Format</strong> commands.
+            Rules are off by default — turn on the ones whose aesthetics you want
             enforced. Choices are stored in
             <code>.minerva/formatter.json</code> so they travel with the thoughtbase.
           </p>
@@ -477,7 +477,7 @@
           {#if !hasAnyFormatterRules}
             <div class="empty-state">
               No formatter rules are registered yet. Rule sets land per category
-              in follow-up tickets (#155\u2013#161); once any of those merge, rules
+              in follow-up tickets (#155–#161); once any of those merge, rules
               appear here as rows you can enable.
             </div>
           {/if}

--- a/src/renderer/lib/formatter/settings.ts
+++ b/src/renderer/lib/formatter/settings.ts
@@ -1,52 +1,57 @@
 /**
- * Renderer-side access to the formatter's per-rule enable + config map (#153).
- * Stored in localStorage, read synchronously before each format run.
- * The settings UI (#154) will write through the same module.
+ * Renderer-side access to the formatter\u2019s per-rule enable + config map (#154).
+ * Persisted project-scoped in `.minerva/formatter.json` via main-side IPC.
+ * The renderer keeps a synchronous snapshot in memory so the engine-facing
+ * code (and the active-note format handler) can pull settings without an
+ * async round-trip on every invocation.
  *
- * No rules are registered yet \u2014 the default settings intentionally leave
- * everything disabled so "Format" is a no-op until the user opts into
- * specific rules as they land.
+ * Flow:
+ *   1. App.svelte calls `loadFormatSettings()` once the project opens.
+ *   2. Synchronous consumers read via `getFormatSettings()`.
+ *   3. The Formatter settings tab writes via `setFormatSettings(patch)`,
+ *      which updates the cache and fires an IPC save (fire-and-forget).
  */
 
+import { api } from '../ipc/client';
 import type { FormatSettings } from '../../../shared/formatter/engine';
 import { DEFAULT_FORMAT_SETTINGS } from '../../../shared/formatter/engine';
 
-const STORAGE_KEY = 'formatSettings';
+let settings: FormatSettings = { ...DEFAULT_FORMAT_SETTINGS };
 
-function readFromStorage(): FormatSettings {
+/** Pull the persisted settings from the main process. Call on project open. */
+export async function loadFormatSettings(): Promise<FormatSettings> {
   try {
-    if (typeof localStorage === 'undefined') return { ...DEFAULT_FORMAT_SETTINGS };
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return { ...DEFAULT_FORMAT_SETTINGS };
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_FORMAT_SETTINGS };
-    return {
-      enabled: (parsed.enabled && typeof parsed.enabled === 'object') ? parsed.enabled : {},
-      configs: (parsed.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
+    const loaded = await api.formatter.loadSettings();
+    settings = {
+      enabled: loaded.enabled ?? {},
+      configs: loaded.configs ?? {},
     };
   } catch {
-    return { ...DEFAULT_FORMAT_SETTINGS };
+    settings = { ...DEFAULT_FORMAT_SETTINGS };
   }
+  return settings;
 }
 
-let settings: FormatSettings = readFromStorage();
-
+/** Synchronous snapshot. Always returns the latest cached values. */
 export function getFormatSettings(): FormatSettings {
   return settings;
 }
 
+/**
+ * Merge `patch` into the cached settings and fire a main-side save. The
+ * save is intentionally not awaited — the UI stays responsive and a
+ * missed write on app-quit is low-stakes (nothing unrecoverable).
+ */
 export function setFormatSettings(patch: Partial<FormatSettings>): FormatSettings {
   settings = {
     enabled: { ...settings.enabled, ...(patch.enabled ?? {}) },
     configs: { ...settings.configs, ...(patch.configs ?? {}) },
   };
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-  }
+  api.formatter.saveSettings(settings).catch(() => { /* swallow \u2014 user will hit it again on next change */ });
   return settings;
 }
 
-/** Test-only: re-read from storage / reset to defaults. */
+/** Test-only: reset the in-memory cache to defaults. */
 export function __resetFormatSettingsForTests(): void {
-  settings = readFromStorage();
+  settings = { ...DEFAULT_FORMAT_SETTINGS };
 }

--- a/src/renderer/lib/formatter/settings.ts
+++ b/src/renderer/lib/formatter/settings.ts
@@ -1,5 +1,5 @@
 /**
- * Renderer-side access to the formatter\u2019s per-rule enable + config map (#154).
+ * Renderer-side access to the formatter’s per-rule enable + config map (#154).
  * Persisted project-scoped in `.minerva/formatter.json` via main-side IPC.
  * The renderer keeps a synchronous snapshot in memory so the engine-facing
  * code (and the active-note format handler) can pull settings without an
@@ -47,7 +47,7 @@ export function setFormatSettings(patch: Partial<FormatSettings>): FormatSetting
     enabled: { ...settings.enabled, ...(patch.enabled ?? {}) },
     configs: { ...settings.configs, ...(patch.configs ?? {}) },
   };
-  api.formatter.saveSettings(settings).catch(() => { /* swallow \u2014 user will hit it again on next change */ });
+  api.formatter.saveSettings(settings).catch(() => { /* swallow — user will hit it again on next change */ });
   return settings;
 }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -171,6 +171,8 @@ export interface FormatterApi {
     relDir: string,
     settings: import('../../../shared/formatter/engine').FormatSettings,
   ): Promise<{ changedPaths: string[]; totalScanned: number }>;
+  loadSettings(): Promise<import('../../../shared/formatter/engine').FormatSettings>;
+  saveSettings(settings: import('../../../shared/formatter/engine').FormatSettings): Promise<void>;
 }
 
 export interface ToolsApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -116,6 +116,10 @@ export const Channels = {
   FORMATTER_FORMAT_FOLDER: 'formatter:formatFolder',
   /** Pure: format a content string and return the result (used for the active note's editor buffer). */
   FORMATTER_FORMAT_CONTENT: 'formatter:formatContent',
+  /** Load per-rule enable + config map from .minerva/formatter.json. */
+  FORMATTER_LOAD_SETTINGS: 'formatter:loadSettings',
+  /** Write per-rule enable + config map to .minerva/formatter.json. */
+  FORMATTER_SAVE_SETTINGS: 'formatter:saveSettings',
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',

--- a/src/shared/formatter/engine.ts
+++ b/src/shared/formatter/engine.ts
@@ -4,7 +4,7 @@
  * deterministic order: category order first (see `CATEGORY_ORDER`), then
  * registration order within each category.
  *
- * The engine does not know about IO \u2014 callers read + write files and wire
+ * The engine does not know about IO — callers read + write files and wire
  * palette commands on top. Pure in / pure out.
  */
 
@@ -15,7 +15,7 @@ import type { EnabledRule, FormatterRule } from './types';
 export interface FormatSettings {
   /** Per-rule enable map. Unlisted rules default to disabled. */
   enabled: Record<string, boolean>;
-  /** Per-rule config override. Unlisted rules use the rule\u2019s defaultConfig. */
+  /** Per-rule config override. Unlisted rules use the rule’s defaultConfig. */
   configs: Record<string, unknown>;
 }
 
@@ -82,7 +82,7 @@ export function formatContentToFixedPoint(
   return current;
 }
 
-/** Alias used by the orchestrator so callers don\u2019t depend on the registry directly. */
+/** Alias used by the orchestrator so callers don’t depend on the registry directly. */
 export function ruleExists(id: string): boolean {
   return getRule(id) !== undefined;
 }

--- a/src/shared/formatter/parse-cache.ts
+++ b/src/shared/formatter/parse-cache.ts
@@ -5,7 +5,7 @@
  *   - top-of-file YAML frontmatter
  *   - fenced code blocks (``` and ~~~ with matching length)
  *   - inline backticked spans
- *   - math blocks (`$$\u2026$$`) and inline math (`$\u2026$`)
+ *   - math blocks (`$$…$$`) and inline math (`$…$`)
  *   - blockquote regions
  *
  * The resulting cache exposes an `isProtected(offset)` helper so rules can

--- a/src/shared/formatter/registry.ts
+++ b/src/shared/formatter/registry.ts
@@ -1,9 +1,9 @@
 /**
- * Rule registry (#153). Category tickets (#155\u2013#161) register their rules
+ * Rule registry (#153). Category tickets (#155–#161) register their rules
  * at import time; the engine consults the registry to find + sort rules
  * for an invocation.
  *
- * Registration order within a category is the apply order \u2014 a rule that
+ * Registration order within a category is the apply order — a rule that
  * depends on another running first just registers later in its module.
  * Categories themselves apply in a fixed order (see CATEGORY_ORDER)
  * chosen so structural passes run before cosmetic ones.
@@ -47,7 +47,7 @@ export const CATEGORY_ORDER: FormatterCategory[] = [
   'content',
   'footnote',
   'spacing',
-  // Minerva-specific rules last \u2014 they need to inspect link shapes that
+  // Minerva-specific rules last — they need to inspect link shapes that
   // earlier passes may have normalised.
   'minerva',
 ];

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Side-effect barrel that registers every formatter rule (#155\u2013#161).
+ * Importing this module causes each rule file to run its `registerRule`
+ * call, populating the shared registry before the engine consults it.
+ *
+ * Empty until the category tickets land \u2014 each sub-issue adds a line here:
+ *
+ *   import './yaml/trailing-spaces';        // #155
+ *   import './heading/heading-increment';   // #156
+ *   \u2026
+ */
+export {};

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -1,12 +1,12 @@
 /**
- * Side-effect barrel that registers every formatter rule (#155\u2013#161).
+ * Side-effect barrel that registers every formatter rule (#155–#161).
  * Importing this module causes each rule file to run its `registerRule`
  * call, populating the shared registry before the engine consults it.
  *
- * Empty until the category tickets land \u2014 each sub-issue adds a line here:
+ * Empty until the category tickets land — each sub-issue adds a line here:
  *
  *   import './yaml/trailing-spaces';        // #155
  *   import './heading/heading-increment';   // #156
- *   \u2026
+ *   …
  */
 export {};

--- a/src/shared/formatter/types.ts
+++ b/src/shared/formatter/types.ts
@@ -21,7 +21,7 @@ export interface Range {
 
 /**
  * Read-only snapshot of the structural regions the formatter should treat
- * as "don\u2019t touch unless a rule explicitly targets this kind of block."
+ * as "don’t touch unless a rule explicitly targets this kind of block."
  * Rules consult `isProtected(offset)` before rewriting at a given position.
  */
 export interface ParseCache {
@@ -31,7 +31,7 @@ export interface ParseCache {
   codeFenceRanges: Range[];
   /** Inline backticked spans — a single rule like "escape YAML special chars" still needs to skip these. */
   inlineCodeRanges: Range[];
-  /** `$$\u2026$$` math blocks and `$\u2026$` inline math. */
+  /** `$$…$$` math blocks and `$…$` inline math. */
   mathRanges: Range[];
   /** Blockquote regions (contiguous lines starting with `>` after optional indent). */
   blockquoteRanges: Range[];


### PR DESCRIPTION
## Summary
New **Formatter** tab in the Settings dialog that reads the rule registry from #153 and renders per-rule enable checkboxes grouped by category. Persistence moves from localStorage to project-scoped `.minerva/formatter.json` so rule choices travel with the thoughtbase in git.

## What landed

### Main-side
- `formatter:loadSettings` / `formatter:saveSettings` IPC reading/writing `.minerva/formatter.json`, matching the bookmarks + tabs pattern.

### Renderer
- `src/renderer/lib/formatter/settings.ts` reworked: sync getter + `loadFormatSettings()` called on project open; writes are fire-and-forget IPC saves that update the in-memory snapshot synchronously.
- **Formatter** tab in SettingsDialog. One section per category (YAML, Heading, Content, Footnote, Spacing, Minerva-specific). Each row: checkbox + title + description. Empty state explains the ticket plan while category PRs are pending.
- `src/shared/formatter/rules/index.ts` barrel \u2014 side-effect import that category tickets add a line to per rule file.

## Expected UX until rules land
The Formatter tab shows the intro paragraph + empty state. No sections render because no rules are registered yet. As #155\u2013#161 land, rows appear automatically.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` (572 passing, unchanged)
- [ ] Open Settings \u2192 Formatter tab is present between Refactoring and Web
- [ ] Empty-state message renders correctly
- [ ] Close + reopen Settings \u2014 any toggles persist (once rules exist to toggle)
- [ ] `.minerva/formatter.json` appears with the expected shape after toggling (once rules exist)

## Next
Pick any of #155\u2013#161 to start populating the rules themselves.