### PR TITLE
Formatter: content rules (closes #157)

### DIFF
--- a/src/shared/formatter/rules/content/auto-correct-common-misspellings.ts
+++ b/src/shared/formatter/rules/content/auto-correct-common-misspellings.ts
@@ -1,0 +1,98 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+interface Config {
+  /**
+   * Extra entries merged on top of the default starter dictionary.
+   * Keys are the lowercase misspelling; values are the correct form.
+   * User entries override defaults with the same key.
+   */
+  extraCorrections: Record<string, string>;
+}
+
+/**
+ * A small starter dictionary of very common English misspellings. Intentionally
+ * conservative — this rule defaults to off and the expectation is that users
+ * extend it via `extraCorrections` rather than hope the formatter catches
+ * everything. Expanding this list to match platers/obsidian-linter's full
+ * corpus is follow-up work.
+ */
+const DEFAULT_CORRECTIONS: Record<string, string> = {
+  teh: 'the',
+  adn: 'and',
+  alot: 'a lot',
+  alright: 'all right',
+  beleive: 'believe',
+  calender: 'calendar',
+  cemetary: 'cemetery',
+  concious: 'conscious',
+  definately: 'definitely',
+  dissapear: 'disappear',
+  embarass: 'embarrass',
+  existance: 'existence',
+  experiance: 'experience',
+  goverment: 'government',
+  happend: 'happened',
+  harrass: 'harass',
+  independant: 'independent',
+  mispell: 'misspell',
+  neccessary: 'necessary',
+  noticable: 'noticeable',
+  occured: 'occurred',
+  occurence: 'occurrence',
+  occuring: 'occurring',
+  preceeding: 'preceding',
+  priviledge: 'privilege',
+  publically: 'publicly',
+  recieve: 'receive',
+  recieved: 'received',
+  refered: 'referred',
+  refering: 'referring',
+  resistence: 'resistance',
+  seperate: 'separate',
+  seperated: 'separated',
+  succesful: 'successful',
+  succesfully: 'successfully',
+  tommorrow: 'tomorrow',
+  truely: 'truly',
+  untill: 'until',
+  wierd: 'weird',
+  writen: 'written',
+};
+
+registerRule<Config>({
+  id: 'auto-correct-common-misspellings',
+  category: 'content',
+  title: 'Auto-correct common misspellings',
+  description:
+    'Replace common English misspellings with their correct forms. Case of the first letter is preserved (e.g. `Teh` → `The`). Off by default; extend via `extraCorrections` in the rule config.',
+  defaultConfig: { extraCorrections: {} },
+  apply(content, config, cache) {
+    const merged: Record<string, string> = {
+      ...DEFAULT_CORRECTIONS,
+      ...(config.extraCorrections ?? {}),
+    };
+    const keys = Object.keys(merged);
+    if (keys.length === 0) return content;
+
+    // Escape regex metachars just in case a user adds something exotic.
+    const pattern = new RegExp(
+      `\\b(${keys.map(escapeRegex).join('|')})\\b`,
+      'gi',
+    );
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(pattern, (match) => {
+        const lower = match.toLowerCase();
+        const replacement = merged[lower];
+        if (!replacement) return match;
+        return match[0] === match[0].toUpperCase()
+          ? replacement[0].toUpperCase() + replacement.slice(1)
+          : replacement;
+      }),
+    );
+  },
+});
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/shared/formatter/rules/content/blockquote-style.ts
+++ b/src/shared/formatter/rules/content/blockquote-style.ts
@@ -1,0 +1,16 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'blockquote-style',
+  category: 'content',
+  title: 'Blockquote style',
+  description:
+    'Ensure a single space after every `>` marker on a blockquote line. Lines that are already `> `, or that are empty quote lines (`>` alone), are left alone.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(/^([ \t]{0,3})(>+)(?=\S)/gm, '$1$2 '),
+    );
+  },
+});

--- a/src/shared/formatter/rules/content/default-language-for-code-fences.ts
+++ b/src/shared/formatter/rules/content/default-language-for-code-fences.ts
@@ -1,0 +1,37 @@
+import { registerRule } from '../../registry';
+
+interface Config {
+  defaultLanguage: string;
+}
+
+registerRule<Config>({
+  id: 'default-language-for-code-fences',
+  category: 'content',
+  title: 'Default language for code fences',
+  description:
+    'Tag un-languaged code fences (`\\`\\`\\`` with no language) with a configurable default (default `text`).',
+  defaultConfig: { defaultLanguage: 'text' },
+  apply(content, config, cache) {
+    const lang = String(config.defaultLanguage ?? '').trim();
+    if (!lang) return content;
+
+    const insertions: { offset: number; text: string }[] = [];
+    for (const r of cache.codeFenceRanges) {
+      const firstNewline = content.indexOf('\n', r.start);
+      if (firstNewline === -1 || firstNewline >= r.end) continue;
+      const openingLine = content.slice(r.start, firstNewline);
+      // Only match bare fences — if an info string is already present, leave it.
+      if (/^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*$/.test(openingLine)) {
+        insertions.push({ offset: firstNewline, text: lang });
+      }
+    }
+    if (insertions.length === 0) return content;
+
+    insertions.sort((a, b) => b.offset - a.offset);
+    let out = content;
+    for (const ins of insertions) {
+      out = out.slice(0, ins.offset) + ins.text + out.slice(ins.offset);
+    }
+    return out;
+  },
+});

--- a/src/shared/formatter/rules/content/emphasis-style.ts
+++ b/src/shared/formatter/rules/content/emphasis-style.ts
@@ -1,0 +1,27 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+interface Config {
+  style: 'asterisk' | 'underscore';
+}
+
+registerRule<Config>({
+  id: 'emphasis-style',
+  category: 'content',
+  title: 'Emphasis style',
+  description:
+    'Enforce a single style for italic emphasis: either `*word*` or `_word_`.',
+  defaultConfig: { style: 'asterisk' },
+  apply(content, config, cache) {
+    return transformUnprotected(content, cache, (seg) => {
+      if (config.style === 'asterisk') {
+        return seg.replace(/(?<![_\w])_([^_\n]+?)_(?![_\w])/g, (m, inner: string) =>
+          inner.trim() ? `*${inner}*` : m,
+        );
+      }
+      return seg.replace(/(?<![*\w])\*([^*\n]+?)\*(?![*\w])/g, (m, inner: string) =>
+        inner.trim() ? `_${inner}_` : m,
+      );
+    });
+  },
+});

--- a/src/shared/formatter/rules/content/no-bare-urls.ts
+++ b/src/shared/formatter/rules/content/no-bare-urls.ts
@@ -1,0 +1,22 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'no-bare-urls',
+  category: 'content',
+  title: 'Wrap bare URLs',
+  description:
+    'Wrap a URL that sits alone on a line in autolink angle brackets (`<https://…>`) so every markdown parser treats it uniformly.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(
+        /^([ \t]*)((?:https?|ftp):\/\/\S+?)([ \t]*)$/gm,
+        (_m, indent: string, url: string, trail: string) => {
+          if (url.startsWith('<') && url.endsWith('>')) return _m;
+          return `${indent}<${url}>${trail}`;
+        },
+      ),
+    );
+  },
+});

--- a/src/shared/formatter/rules/content/ordered-list-style.ts
+++ b/src/shared/formatter/rules/content/ordered-list-style.ts
@@ -1,0 +1,70 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+interface Config {
+  style: 'increment' | 'same';
+}
+
+registerRule<Config>({
+  id: 'ordered-list-style',
+  category: 'content',
+  title: 'Ordered list numbering',
+  description:
+    'Normalise ordered-list numbering. `increment` renumbers 1, 2, 3, … per list; `same` writes every item as `1.` (markdown renumbers at render time).',
+  defaultConfig: { style: 'increment' },
+  apply(content, config, cache) {
+    return transformUnprotected(content, cache, (seg) => {
+      if (config.style === 'same') {
+        return seg.replace(/^([ \t]*)\d+([.)])([ \t]+)/gm, '$11$2$3');
+      }
+      return renumberIncrementally(seg);
+    });
+  },
+});
+
+function renumberIncrementally(seg: string): string {
+  const lines = splitLinesKeepTerminator(seg);
+  const counters = new Map<number, number>(); // indent → next counter value
+  const LIST = /^([ \t]*)(\d+)([.)])([ \t]+)/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const body = raw.replace(/\r?\n$/, '');
+    const m = LIST.exec(body);
+
+    if (m) {
+      const indent = m[1];
+      const indentLen = indent.length;
+      // Any deeper-indented lists are done — drop their counters.
+      for (const k of [...counters.keys()]) {
+        if (k > indentLen) counters.delete(k);
+      }
+      const next = (counters.get(indentLen) ?? 0) + 1;
+      counters.set(indentLen, next);
+      const punct = m[3];
+      const sep = m[4];
+      const terminator = raw.slice(body.length);
+      const tail = body.slice(m[0].length);
+      lines[i] = `${indent}${next}${punct}${sep}${tail}${terminator}`;
+      continue;
+    }
+
+    if (/^\s*$/.test(body)) continue; // blank line — preserve state (list may continue)
+    counters.clear(); // any non-list, non-blank line ends every open list
+  }
+  return lines.join('');
+}
+
+function splitLinesKeepTerminator(content: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = content.length;
+  while (i < n) {
+    let j = i;
+    while (j < n && content[j] !== '\n') j++;
+    if (j < n) j++;
+    out.push(content.slice(i, j));
+    i = j;
+  }
+  return out;
+}

--- a/src/shared/formatter/rules/content/proper-ellipsis.ts
+++ b/src/shared/formatter/rules/content/proper-ellipsis.ts
@@ -1,0 +1,13 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'proper-ellipsis',
+  category: 'content',
+  title: 'Proper ellipsis',
+  description: 'Collapse three consecutive dots (`...`) into a single `…` character.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) => seg.replace(/\.{3}/g, '…'));
+  },
+});

--- a/src/shared/formatter/rules/content/quote-style.ts
+++ b/src/shared/formatter/rules/content/quote-style.ts
@@ -1,0 +1,37 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+interface Config {
+  style: 'straight' | 'curly';
+}
+
+const L_DOUBLE = '“';
+const R_DOUBLE = '”';
+const L_SINGLE = '‘';
+const R_SINGLE = '’';
+
+registerRule<Config>({
+  id: 'quote-style',
+  category: 'content',
+  title: 'Quote style',
+  description:
+    'Normalise quotation marks to either straight (`"` `\'`) or curly (`“” ‘’`). Apostrophes that aren’t clearly paired (e.g. `don’t`) are only flipped in `straight` mode.',
+  defaultConfig: { style: 'straight' },
+  apply(content, config, cache) {
+    return transformUnprotected(content, cache, (seg) => {
+      if (config.style === 'straight') {
+        return seg
+          .replace(new RegExp(`[${L_DOUBLE}${R_DOUBLE}]`, 'g'), '"')
+          .replace(new RegExp(`[${L_SINGLE}${R_SINGLE}]`, 'g'), "'");
+      }
+      // Curly: pair-match straight quotes, word-boundary-guarded so in-word
+      // apostrophes (don't, it's) aren't mis-split.
+      let out = seg.replace(/"([^"\n]*)"/g, `${L_DOUBLE}$1${R_DOUBLE}`);
+      out = out.replace(
+        /(^|[\s(\[{])'([^'\n]+?)'(?=[\s.,!?;:)\]}]|$)/gm,
+        `$1${L_SINGLE}$2${R_SINGLE}`,
+      );
+      return out;
+    });
+  },
+});

--- a/src/shared/formatter/rules/content/remove-consecutive-list-markers.ts
+++ b/src/shared/formatter/rules/content/remove-consecutive-list-markers.ts
@@ -1,0 +1,26 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+const HR_RE = /^([-*_])(?:[ \t]*\1){2,}$/;
+
+registerRule({
+  id: 'remove-consecutive-list-markers',
+  category: 'content',
+  title: 'Collapse consecutive list markers',
+  description:
+    'A line like `- - item` becomes `- item`. Only the first marker is kept.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(
+        /^([ \t]*)([-*+])(?:[ \t]+[-*+])+[ \t]+(\S.*)$/gm,
+        (match, indent: string, marker: string, rest: string) => {
+          // An HR-shaped line (e.g. `* * *`, `- - -`) would match the regex
+          // by backtracking on the marker-repetition count; detect and skip.
+          if (HR_RE.test(match.trim())) return match;
+          return `${indent}${marker} ${rest}`;
+        },
+      ),
+    );
+  },
+});

--- a/src/shared/formatter/rules/content/remove-empty-list-markers.ts
+++ b/src/shared/formatter/rules/content/remove-empty-list-markers.ts
@@ -1,0 +1,18 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'remove-empty-list-markers',
+  category: 'content',
+  title: 'Remove empty list markers',
+  description:
+    'Blank out lines that contain only a list marker (`-`, `*`, `+`, `1.`, `1)`) with no content. The line is kept but emptied, leaving `consecutive-blank-lines` to handle further tidy-up.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg
+        .replace(/^[ \t]*[-*+][ \t]*$/gm, '')
+        .replace(/^[ \t]*\d+[.)][ \t]*$/gm, ''),
+    );
+  },
+});

--- a/src/shared/formatter/rules/content/remove-hyphenated-line-breaks.ts
+++ b/src/shared/formatter/rules/content/remove-hyphenated-line-breaks.ts
@@ -1,0 +1,16 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'remove-hyphenated-line-breaks',
+  category: 'content',
+  title: 'Remove PDF-style hyphenated line breaks',
+  description:
+    'Rejoin words that were broken across a line with a trailing `-` (typical of text copied out of a PDF). Only fires when a letter precedes the hyphen and a lowercase letter follows on the next line.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(/([A-Za-z])-\r?\n([a-z])/g, '$1$2'),
+    );
+  },
+});

--- a/src/shared/formatter/rules/content/remove-multiple-spaces.ts
+++ b/src/shared/formatter/rules/content/remove-multiple-spaces.ts
@@ -1,0 +1,16 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'remove-multiple-spaces',
+  category: 'content',
+  title: 'Collapse multiple spaces',
+  description:
+    'Collapse runs of multiple spaces inside a line to a single space. Leading indentation and trailing whitespace are left for other rules to handle.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(/(\S) {2,}(?=\S)/g, '$1 '),
+    );
+  },
+});

--- a/src/shared/formatter/rules/content/strong-style.ts
+++ b/src/shared/formatter/rules/content/strong-style.ts
@@ -1,0 +1,27 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+interface Config {
+  style: 'asterisk' | 'underscore';
+}
+
+registerRule<Config>({
+  id: 'strong-style',
+  category: 'content',
+  title: 'Strong emphasis style',
+  description:
+    'Enforce a single style for bold emphasis: either `**word**` or `__word__`.',
+  defaultConfig: { style: 'asterisk' },
+  apply(content, config, cache) {
+    return transformUnprotected(content, cache, (seg) => {
+      if (config.style === 'asterisk') {
+        return seg.replace(/(?<!\w)__([^_\n]+?)__(?!\w)/g, (m, inner: string) =>
+          inner.trim() ? `**${inner}**` : m,
+        );
+      }
+      return seg.replace(/(?<!\w)\*\*([^*\n]+?)\*\*(?!\w)/g, (m, inner: string) =>
+        inner.trim() ? `__${inner}__` : m,
+      );
+    });
+  },
+});

--- a/src/shared/formatter/rules/content/unordered-list-marker-style.ts
+++ b/src/shared/formatter/rules/content/unordered-list-marker-style.ts
@@ -1,0 +1,32 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+interface Config {
+  marker: '-' | '*' | '+';
+}
+
+const HR_RE = /^([-*_])(?:[ \t]*\1){2,}$/;
+
+registerRule<Config>({
+  id: 'unordered-list-marker-style',
+  category: 'content',
+  title: 'Unordered list marker',
+  description: 'Enforce a single style (`-`, `*`, or `+`) for unordered list markers.',
+  defaultConfig: { marker: '-' },
+  apply(content, config, cache) {
+    const target = config.marker;
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(
+        /^([ \t]*)([-*+])([ \t]+\S.*)$/gm,
+        (match, indent: string, _curr, rest: string) => {
+          // Skip lines that are HRs (e.g. `* * *`) both before and after rewrite.
+          const orig = (indent + match.slice(indent.length)).trim();
+          if (HR_RE.test(orig)) return match;
+          const rewritten = `${indent}${target}${rest}`;
+          if (HR_RE.test(rewritten.trim())) return match;
+          return rewritten;
+        },
+      ),
+    );
+  },
+});

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -7,6 +7,14 @@
  * application order itself is fixed by CATEGORY_ORDER in registry.ts.
  */
 
+// Content (#157) — in-line text normalisations.
+import './content/proper-ellipsis';
+import './content/remove-multiple-spaces';
+import './content/remove-hyphenated-line-breaks';
+import './content/no-bare-urls';
+import './content/default-language-for-code-fences';
+import './content/quote-style';
+
 // Spacing (#158) — blank-line discipline and inline whitespace normalisation.
 import './spacing/line-break-at-document-end';
 import './spacing/trailing-spaces';

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -17,6 +17,12 @@ import './content/quote-style';
 import './content/emphasis-style';
 import './content/strong-style';
 import './content/blockquote-style';
+// List normalisation — empty/consecutive cleanups run before the style rules
+// so renumbering sees a tidy list.
+import './content/remove-empty-list-markers';
+import './content/remove-consecutive-list-markers';
+import './content/unordered-list-marker-style';
+import './content/ordered-list-style';
 
 // Spacing (#158) — blank-line discipline and inline whitespace normalisation.
 import './spacing/line-break-at-document-end';

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -23,6 +23,7 @@ import './content/remove-empty-list-markers';
 import './content/remove-consecutive-list-markers';
 import './content/unordered-list-marker-style';
 import './content/ordered-list-style';
+import './content/auto-correct-common-misspellings';
 
 // Spacing (#158) — blank-line discipline and inline whitespace normalisation.
 import './spacing/line-break-at-document-end';

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -14,6 +14,9 @@ import './content/remove-hyphenated-line-breaks';
 import './content/no-bare-urls';
 import './content/default-language-for-code-fences';
 import './content/quote-style';
+import './content/emphasis-style';
+import './content/strong-style';
+import './content/blockquote-style';
 
 // Spacing (#158) — blank-line discipline and inline whitespace normalisation.
 import './spacing/line-break-at-document-end';

--- a/tests/shared/formatter/rules/content/auto-correct-common-misspellings.test.ts
+++ b/tests/shared/formatter/rules/content/auto-correct-common-misspellings.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/auto-correct-common-misspellings';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, extraCorrections?: Record<string, string>) {
+  return formatContent(content, {
+    enabled: { 'auto-correct-common-misspellings': true },
+    configs: extraCorrections
+      ? { 'auto-correct-common-misspellings': { extraCorrections } }
+      : {},
+  });
+}
+
+describe('auto-correct-common-misspellings (#157)', () => {
+  it('corrects a simple misspelling from the default dictionary', () => {
+    expect(run('teh cat\n')).toBe('the cat\n');
+  });
+
+  it('preserves sentence-start capitalisation', () => {
+    expect(run('Teh cat\n')).toBe('The cat\n');
+  });
+
+  it('leaves correctly-spelled text alone', () => {
+    const src = 'The cat is here.\n';
+    expect(run(src)).toBe(src);
+  });
+
+  it('handles multiple corrections in one sentence', () => {
+    expect(run('I recieve the package on tommorrow')).toBe(
+      'I receive the package on tomorrow',
+    );
+  });
+
+  it('accepts a user-supplied correction that augments the default dictionary', () => {
+    expect(run('myWord here\n', { myword: 'my_word' })).toBe('my_word here\n');
+  });
+
+  it('lets a user override a default correction', () => {
+    expect(run('teh cat\n', { teh: 'TEH!' })).toBe('TEH! cat\n');
+  });
+
+  it('does not touch misspellings inside code fences', () => {
+    const src = '```\nteh code\n```\n';
+    expect(run(src)).toBe(src);
+  });
+
+  it('does not touch misspellings inside inline code', () => {
+    const src = 'see `teh function`\n';
+    expect(run(src)).toBe(src);
+  });
+
+  it('respects word boundaries (does not correct inside a longer token)', () => {
+    const src = 'otheh\n';
+    expect(run(src)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = run('teh recieve\n');
+    expect(run(once)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/blockquote-style.test.ts
+++ b/tests/shared/formatter/rules/content/blockquote-style.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/blockquote-style';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'blockquote-style': true }, configs: {} };
+
+describe('blockquote-style (#157)', () => {
+  it('inserts a space after `>` when followed by non-space content', () => {
+    expect(formatContent('>hello\n', enabled)).toBe('> hello\n');
+  });
+
+  it('leaves `> hello` alone', () => {
+    const src = '> hello\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves a bare `>` continuation line alone', () => {
+    const src = '> first\n>\n> third\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('handles nested `>>` markers', () => {
+    expect(formatContent('>>deeply\n', enabled)).toBe('>> deeply\n');
+  });
+
+  it('does not touch `>` characters in regular prose', () => {
+    const src = '5 > 3 and foo > bar\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch `>` inside a code fence', () => {
+    const src = '```\n>not a quote\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('normalises every line in a multi-line blockquote', () => {
+    expect(formatContent('>one\n>two\n>three\n', enabled)).toBe(
+      '> one\n> two\n> three\n',
+    );
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('>hello\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/default-language-for-code-fences.test.ts
+++ b/tests/shared/formatter/rules/content/default-language-for-code-fences.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/default-language-for-code-fences';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, defaultLanguage?: string) {
+  return formatContent(content, {
+    enabled: { 'default-language-for-code-fences': true },
+    configs:
+      defaultLanguage !== undefined
+        ? { 'default-language-for-code-fences': { defaultLanguage } }
+        : {},
+  });
+}
+
+describe('default-language-for-code-fences (#157)', () => {
+  it('tags a bare ``` fence with the default language (`text`)', () => {
+    expect(run('```\nfoo\n```\n')).toBe('```text\nfoo\n```\n');
+  });
+
+  it('leaves a fence with an existing info string alone', () => {
+    const src = '```js\nconst x = 1;\n```\n';
+    expect(run(src)).toBe(src);
+  });
+
+  it('honours a non-default language', () => {
+    expect(run('```\nfoo\n```\n', 'plaintext')).toBe('```plaintext\nfoo\n```\n');
+  });
+
+  it('works with tilde fences', () => {
+    expect(run('~~~\nfoo\n~~~\n')).toBe('~~~text\nfoo\n~~~\n');
+  });
+
+  it('no-op when configured language is empty', () => {
+    const src = '```\nfoo\n```\n';
+    expect(run(src, '')).toBe(src);
+  });
+
+  it('handles multiple bare fences in the same document', () => {
+    const src = '```\na\n```\n\n```\nb\n```\n';
+    expect(run(src)).toBe('```text\na\n```\n\n```text\nb\n```\n');
+  });
+
+  it('is idempotent', () => {
+    const once = run('```\nfoo\n```\n');
+    expect(run(once)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/emphasis-style.test.ts
+++ b/tests/shared/formatter/rules/content/emphasis-style.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/emphasis-style';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, style: 'asterisk' | 'underscore' = 'asterisk') {
+  return formatContent(content, {
+    enabled: { 'emphasis-style': true },
+    configs: { 'emphasis-style': { style } },
+  });
+}
+
+describe('emphasis-style (#157)', () => {
+  describe('style: asterisk (default)', () => {
+    it('converts `_word_` to `*word*`', () => {
+      expect(run('_hello_')).toBe('*hello*');
+    });
+
+    it('leaves `*word*` alone', () => {
+      expect(run('*hello*')).toBe('*hello*');
+    });
+
+    it('does not touch `__strong__` double underscores', () => {
+      expect(run('__bold__')).toBe('__bold__');
+    });
+
+    it('does not touch in-word underscores (snake_case)', () => {
+      expect(run('snake_case_ident')).toBe('snake_case_ident');
+    });
+
+    it('handles multiple spans on one line', () => {
+      expect(run('_one_ and _two_')).toBe('*one* and *two*');
+    });
+  });
+
+  describe('style: underscore', () => {
+    it('converts `*word*` to `_word_`', () => {
+      expect(run('*hello*', 'underscore')).toBe('_hello_');
+    });
+
+    it('leaves `_word_` alone', () => {
+      expect(run('_hello_', 'underscore')).toBe('_hello_');
+    });
+
+    it('does not touch `**strong**` double asterisks', () => {
+      expect(run('**bold**', 'underscore')).toBe('**bold**');
+    });
+
+    it('does not touch an unordered-list `*` marker', () => {
+      expect(run('* item one\n* item two\n', 'underscore')).toBe(
+        '* item one\n* item two\n',
+      );
+    });
+  });
+
+  describe('shared', () => {
+    it('does not touch emphasis inside code fences', () => {
+      const src = '```\n_code_\n```\n';
+      expect(run(src)).toBe(src);
+    });
+
+    it('is idempotent (asterisk)', () => {
+      const once = run('_hello_');
+      expect(run(once)).toBe(once);
+    });
+
+    it('is idempotent (underscore)', () => {
+      const once = run('*hello*', 'underscore');
+      expect(run(once, 'underscore')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/content/no-bare-urls.test.ts
+++ b/tests/shared/formatter/rules/content/no-bare-urls.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/no-bare-urls';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'no-bare-urls': true }, configs: {} };
+
+describe('no-bare-urls (#157)', () => {
+  it('wraps a standalone URL in angle brackets', () => {
+    expect(formatContent('https://example.com\n', enabled)).toBe(
+      '<https://example.com>\n',
+    );
+  });
+
+  it('wraps URLs with leading indentation', () => {
+    expect(formatContent('  https://example.com\n', enabled)).toBe(
+      '  <https://example.com>\n',
+    );
+  });
+
+  it('wraps http and ftp as well as https', () => {
+    expect(formatContent('http://example.com\n', enabled)).toBe('<http://example.com>\n');
+    expect(formatContent('ftp://example.com\n', enabled)).toBe('<ftp://example.com>\n');
+  });
+
+  it('leaves an already-bracketed URL alone', () => {
+    const src = '<https://example.com>\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch URLs that share a line with other text', () => {
+    const src = 'see https://example.com for details\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch URLs in markdown link syntax', () => {
+    const src = '[text](https://example.com)\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch URLs inside a code fence', () => {
+    const src = '```\nhttps://example.com\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('https://example.com\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/ordered-list-style.test.ts
+++ b/tests/shared/formatter/rules/content/ordered-list-style.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/ordered-list-style';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, style: 'increment' | 'same' = 'increment') {
+  return formatContent(content, {
+    enabled: { 'ordered-list-style': true },
+    configs: { 'ordered-list-style': { style } },
+  });
+}
+
+describe('ordered-list-style (#157)', () => {
+  describe('style: increment', () => {
+    it('renumbers a list that starts with wrong numbers', () => {
+      expect(run('3. a\n4. b\n7. c\n')).toBe('1. a\n2. b\n3. c\n');
+    });
+
+    it('handles `1.` that should stay `1.`', () => {
+      const src = '1. a\n2. b\n';
+      expect(run(src)).toBe(src);
+    });
+
+    it('keeps blank lines as part of the same list', () => {
+      expect(run('1. a\n2. b\n\n3. c\n')).toBe('1. a\n2. b\n\n3. c\n');
+    });
+
+    it('resets numbering after a non-list, non-blank line', () => {
+      expect(run('5. a\n6. b\n\nparagraph\n\n1. c\n')).toBe(
+        '1. a\n2. b\n\nparagraph\n\n1. c\n',
+      );
+    });
+
+    it('tracks nested lists separately per indent', () => {
+      expect(run('1. a\n   3. nested a\n   5. nested b\n1. b\n')).toBe(
+        '1. a\n   1. nested a\n   2. nested b\n2. b\n',
+      );
+    });
+
+    it('handles `)` punctuation as well as `.`', () => {
+      expect(run('2) a\n3) b\n')).toBe('1) a\n2) b\n');
+    });
+  });
+
+  describe('style: same', () => {
+    it('rewrites every item as `1.`', () => {
+      expect(run('1. a\n2. b\n3. c\n', 'same')).toBe('1. a\n1. b\n1. c\n');
+    });
+
+    it('handles nested lists', () => {
+      expect(run('1. a\n   2. nested\n3. b\n', 'same')).toBe(
+        '1. a\n   1. nested\n1. b\n',
+      );
+    });
+  });
+
+  describe('shared', () => {
+    it('does not touch ordered lists inside a code fence', () => {
+      const src = '```\n1. a\n5. b\n```\n';
+      expect(run(src)).toBe(src);
+    });
+
+    it('is idempotent (increment)', () => {
+      const once = run('3. a\n4. b\n');
+      expect(run(once)).toBe(once);
+    });
+
+    it('is idempotent (same)', () => {
+      const once = run('1. a\n2. b\n', 'same');
+      expect(run(once, 'same')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/content/proper-ellipsis.test.ts
+++ b/tests/shared/formatter/rules/content/proper-ellipsis.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/proper-ellipsis';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'proper-ellipsis': true }, configs: {} };
+
+describe('proper-ellipsis (#157)', () => {
+  it('collapses `...` into `…`', () => {
+    expect(formatContent('Wait...\n', enabled)).toBe('Wait…\n');
+  });
+
+  it('ignores a single or double dot', () => {
+    expect(formatContent('End. And.. more\n', enabled)).toBe('End. And.. more\n');
+  });
+
+  it('reduces four dots to `….` (three get replaced, fourth left as-is)', () => {
+    expect(formatContent('oh....\n', enabled)).toBe('oh….\n');
+  });
+
+  it('does not touch `...` inside a code fence', () => {
+    const src = '```\nif (...) {}\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch `...` inside inline code', () => {
+    const src = 'see `foo...bar`\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('Wait...\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/quote-style.test.ts
+++ b/tests/shared/formatter/rules/content/quote-style.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/quote-style';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, style?: 'straight' | 'curly') {
+  return formatContent(content, {
+    enabled: { 'quote-style': true },
+    configs: style ? { 'quote-style': { style } } : {},
+  });
+}
+
+describe('quote-style (#157)', () => {
+  describe('style: straight (default)', () => {
+    it('converts curly double quotes to straight', () => {
+      expect(run('“hello”')).toBe('"hello"');
+    });
+
+    it('converts curly single quotes to straight', () => {
+      expect(run('‘hi’ and don’t')).toBe("'hi' and don't");
+    });
+
+    it('leaves already-straight quotes alone', () => {
+      const src = '"hello" and \'hi\'\n';
+      expect(run(src)).toBe(src);
+    });
+
+    it('does not touch quotes inside a code fence', () => {
+      const src = '```\n“keep”\n```\n';
+      expect(run(src)).toBe(src);
+    });
+  });
+
+  describe('style: curly', () => {
+    it('converts paired double quotes', () => {
+      expect(run('"hello"', 'curly')).toBe('“hello”');
+    });
+
+    it('converts paired single quotes surrounded by word boundaries', () => {
+      expect(run("say 'hi' now", 'curly')).toBe('say ‘hi’ now');
+    });
+
+    it('leaves a lone in-word apostrophe alone', () => {
+      const src = "don't do it\n";
+      expect(run(src, 'curly')).toBe(src);
+    });
+
+    it('leaves unpaired straight quotes alone', () => {
+      const src = 'she said "maybe\n';
+      expect(run(src, 'curly')).toBe(src);
+    });
+
+    it('does not touch quotes inside inline code', () => {
+      const src = 'see `"foo"` below\n';
+      expect(run(src, 'curly')).toBe(src);
+    });
+  });
+
+  describe('shared', () => {
+    it('is idempotent (straight)', () => {
+      const once = run('“hello”');
+      expect(run(once)).toBe(once);
+    });
+
+    it('is idempotent (curly)', () => {
+      const once = run('"hello"', 'curly');
+      expect(run(once, 'curly')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/content/remove-consecutive-list-markers.test.ts
+++ b/tests/shared/formatter/rules/content/remove-consecutive-list-markers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/remove-consecutive-list-markers';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'remove-consecutive-list-markers': true },
+  configs: {},
+};
+
+describe('remove-consecutive-list-markers (#157)', () => {
+  it('collapses `- - item` to `- item`', () => {
+    expect(formatContent('- - item\n', enabled)).toBe('- item\n');
+  });
+
+  it('collapses three consecutive markers', () => {
+    expect(formatContent('- - - item\n', enabled)).toBe('- item\n');
+  });
+
+  it('works on asterisk and plus', () => {
+    expect(formatContent('* * item\n', enabled)).toBe('* item\n');
+    expect(formatContent('+ + item\n', enabled)).toBe('+ item\n');
+  });
+
+  it('preserves leading indentation', () => {
+    expect(formatContent('  - - nested\n', enabled)).toBe('  - nested\n');
+  });
+
+  it('leaves a single-marker item alone', () => {
+    const src = '- item\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch an HR made of spaced markers', () => {
+    const src = '* * *\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch consecutive markers inside a code fence', () => {
+    const src = '```\n- - item\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('- - - item\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/remove-empty-list-markers.test.ts
+++ b/tests/shared/formatter/rules/content/remove-empty-list-markers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/remove-empty-list-markers';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'remove-empty-list-markers': true }, configs: {} };
+
+describe('remove-empty-list-markers (#157)', () => {
+  it('blanks a line containing only a dash', () => {
+    expect(formatContent('a\n-\nb\n', enabled)).toBe('a\n\nb\n');
+  });
+
+  it('blanks a line containing only an asterisk or plus', () => {
+    expect(formatContent('*\n', enabled)).toBe('\n');
+    expect(formatContent('+\n', enabled)).toBe('\n');
+  });
+
+  it('blanks an empty ordered list marker', () => {
+    expect(formatContent('1.\n', enabled)).toBe('\n');
+    expect(formatContent('42)\n', enabled)).toBe('\n');
+  });
+
+  it('blanks markers with trailing whitespace', () => {
+    expect(formatContent('-   \n', enabled)).toBe('\n');
+  });
+
+  it('leaves populated list items alone', () => {
+    const src = '- one\n- two\n1. three\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not blank markers inside a code fence', () => {
+    const src = '```\n-\n1.\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('a\n-\nb\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/remove-hyphenated-line-breaks.test.ts
+++ b/tests/shared/formatter/rules/content/remove-hyphenated-line-breaks.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/remove-hyphenated-line-breaks';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'remove-hyphenated-line-breaks': true },
+  configs: {},
+};
+
+describe('remove-hyphenated-line-breaks (#157)', () => {
+  it('rejoins a letter-hyphen-newline-letter break', () => {
+    expect(formatContent('some-\nthing\n', enabled)).toBe('something\n');
+  });
+
+  it('preserves legitimate hyphenated compounds (no newline after the hyphen)', () => {
+    expect(formatContent('state-of-the-art\n', enabled)).toBe('state-of-the-art\n');
+  });
+
+  it('leaves a hyphen followed by an uppercase letter alone (probably a name or start-of-sentence)', () => {
+    const src = 'sub-\nHeading\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves a hyphen followed by a non-letter alone', () => {
+    const src = 'first-\n1. item\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('handles CRLF line endings', () => {
+    expect(formatContent('some-\r\nthing\n', enabled)).toBe('something\n');
+  });
+
+  it('does not touch breaks inside a code fence', () => {
+    const src = '```\nsome-\nthing\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('some-\nthing\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/remove-multiple-spaces.test.ts
+++ b/tests/shared/formatter/rules/content/remove-multiple-spaces.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/remove-multiple-spaces';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'remove-multiple-spaces': true }, configs: {} };
+
+describe('remove-multiple-spaces (#157)', () => {
+  it('collapses double spaces between words', () => {
+    expect(formatContent('hello  world\n', enabled)).toBe('hello world\n');
+  });
+
+  it('collapses long runs to a single space', () => {
+    expect(formatContent('hello     world\n', enabled)).toBe('hello world\n');
+  });
+
+  it('leaves single spaces alone', () => {
+    expect(formatContent('hello world\n', enabled)).toBe('hello world\n');
+  });
+
+  it('does not collapse leading indentation', () => {
+    expect(formatContent('    indented\n', enabled)).toBe('    indented\n');
+  });
+
+  it('does not collapse trailing spaces (left for trailing-spaces rule)', () => {
+    expect(formatContent('hello  \n', enabled)).toBe('hello  \n');
+  });
+
+  it('does not touch runs inside a code fence', () => {
+    const src = '```\nhello  world\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('hello  world\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/content/strong-style.test.ts
+++ b/tests/shared/formatter/rules/content/strong-style.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/strong-style';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, style: 'asterisk' | 'underscore' = 'asterisk') {
+  return formatContent(content, {
+    enabled: { 'strong-style': true },
+    configs: { 'strong-style': { style } },
+  });
+}
+
+describe('strong-style (#157)', () => {
+  describe('style: asterisk (default)', () => {
+    it('converts `__word__` to `**word**`', () => {
+      expect(run('__hello__')).toBe('**hello**');
+    });
+
+    it('leaves `**word**` alone', () => {
+      expect(run('**hello**')).toBe('**hello**');
+    });
+
+    it('does not touch single `_word_` emphasis', () => {
+      expect(run('_italic_')).toBe('_italic_');
+    });
+  });
+
+  describe('style: underscore', () => {
+    it('converts `**word**` to `__word__`', () => {
+      expect(run('**hello**', 'underscore')).toBe('__hello__');
+    });
+
+    it('leaves `__word__` alone', () => {
+      expect(run('__hello__', 'underscore')).toBe('__hello__');
+    });
+
+    it('does not touch single `*word*` emphasis', () => {
+      expect(run('*italic*', 'underscore')).toBe('*italic*');
+    });
+  });
+
+  describe('shared', () => {
+    it('does not touch strong emphasis inside code fences', () => {
+      const src = '```\n__bold__\n```\n';
+      expect(run(src)).toBe(src);
+    });
+
+    it('handles multiple spans on one line', () => {
+      expect(run('__a__ and __b__')).toBe('**a** and **b**');
+    });
+
+    it('is idempotent (asterisk)', () => {
+      const once = run('__hello__');
+      expect(run(once)).toBe(once);
+    });
+
+    it('is idempotent (underscore)', () => {
+      const once = run('**hello**', 'underscore');
+      expect(run(once, 'underscore')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/content/unordered-list-marker-style.test.ts
+++ b/tests/shared/formatter/rules/content/unordered-list-marker-style.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/content/unordered-list-marker-style';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, marker: '-' | '*' | '+' = '-') {
+  return formatContent(content, {
+    enabled: { 'unordered-list-marker-style': true },
+    configs: { 'unordered-list-marker-style': { marker } },
+  });
+}
+
+describe('unordered-list-marker-style (#157)', () => {
+  it('converts `*` items to the target marker', () => {
+    expect(run('* one\n* two\n', '-')).toBe('- one\n- two\n');
+  });
+
+  it('converts `+` items to the target marker', () => {
+    expect(run('+ one\n+ two\n', '-')).toBe('- one\n- two\n');
+  });
+
+  it('leaves items matching the target marker alone', () => {
+    const src = '- one\n- two\n';
+    expect(run(src, '-')).toBe(src);
+  });
+
+  it('preserves indentation for nested items', () => {
+    expect(run('- one\n  * nested\n- two\n', '-')).toBe(
+      '- one\n  - nested\n- two\n',
+    );
+  });
+
+  it('does not touch `* * *` horizontal rules', () => {
+    const src = '* * *\n';
+    expect(run(src, '-')).toBe(src);
+  });
+
+  it('does not rewrite a line that would become an HR', () => {
+    const src = '- - -\n';
+    expect(run(src, '*')).toBe(src);
+  });
+
+  it('does not touch items inside a code fence', () => {
+    const src = '```\n* item\n```\n';
+    expect(run(src, '-')).toBe(src);
+  });
+
+  it('converts to `+` when configured', () => {
+    expect(run('- one\n', '+')).toBe('+ one\n');
+  });
+
+  it('is idempotent', () => {
+    const once = run('* one\n* two\n', '-');
+    expect(run(once, '-')).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the full content category (#157) — 14 rules for in-line markdown normalisation.

**Text hygiene:**
- `proper-ellipsis` — `...` → `…`
- `remove-multiple-spaces` — collapse double-spaces between words (indent and trailing whitespace left to other rules)
- `remove-hyphenated-line-breaks` — rejoin PDF-extraction artefacts like `some-\nthing`, guarded against legitimate compound hyphens and sentence starts
- `no-bare-urls` — wrap standalone-on-a-line URLs in `<autolink>` form
- `default-language-for-code-fences` — tag bare \`\`\`/~~~ fences with a default (default `text`)
- `quote-style` — directional `{ style: 'straight' | 'curly' }`, with word-boundary guards so in-word apostrophes don't get misidentified

**Emphasis style:**
- `emphasis-style` — directional `*word*` ↔ `_word_`
- `strong-style` — directional `**word**` ↔ `__word__`
- `blockquote-style` — single space after every `>`, bare `>` continuation lines left alone

**List normalisation:**
- `remove-empty-list-markers` — blank out lines with just `-` / `1.` / etc.
- `remove-consecutive-list-markers` — `- - item` → `- item`; HR-shaped lines detected and left alone
- `unordered-list-marker-style` — directional `{ marker: '-' | '*' | '+' }`, with both pre-match and post-rewrite HR guards
- `ordered-list-style` — `{ style: 'increment' | 'same' }`; `increment` tracks counters per indent-level, clears on non-list/non-blank lines, preserves across blank lines within a list

**Auto-correct:**
- `auto-correct-common-misspellings` — ~40-entry starter dictionary (`teh`→`the`, `recieve`→`receive`, …) plus user-extendable `extraCorrections` config. Preserves sentence-start capitalisation.

**Out of scope:** `two-spaces-between-lines-with-content` (semantic-newline conflict), per the ticket.

**Follow-up work** mentioned in the misspellings rule: expand the default dictionary to match platers/obsidian-linter's full corpus.

## Test plan

- [x] 121 rule-specific tests pass
- [x] Full suite: 806/806 pass
- [x] `pnpm lint` clean
- [ ] Manual smoke test: enable a handful of content rules in the Formatter tab, paste some crufty markdown, run Format, confirm output

Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)