### PR TITLE
Formatter: heading rules + rename cascade (closes #156)

### DIFF
--- a/src/main/formatter/orchestrator.ts
+++ b/src/main/formatter/orchestrator.ts
@@ -5,6 +5,8 @@ import * as graph from '../graph/index';
 import * as search from '../search/index';
 import { formatContent, type FormatSettings } from '../../shared/formatter/engine';
 import type { FormatFileResult } from '../../shared/formatter/types';
+import { slugify } from '../../shared/slug';
+import { renameAnchor } from '../notebase/rename-anchor';
 // Side-effect import: populates the rule registry on the main-process side.
 // The renderer has its own import in SettingsDialog for the UI listing.
 import '../../shared/formatter/rules/index';
@@ -13,16 +15,24 @@ const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
 
 export interface FormatRunSummary {
   changedPaths: string[];
+  cascadedPaths: string[];
   totalScanned: number;
 }
 
 /**
- * Format a single note's content string. Pure — caller decides whether to
- * write the result back. Used by the "format current note" palette command,
- * which wants to diff against the editor buffer without touching disk.
+ * Format a single note's content string. When `relativePath` is supplied, the
+ * filename is injected into the `file-name-heading` rule's config so that rule
+ * has something to sync against. No filesystem writes; no link cascade.
  */
-export function formatNoteContent(content: string, settings: FormatSettings): string {
-  return formatContent(content, settings);
+export function formatNoteContent(
+  content: string,
+  settings: FormatSettings,
+  relativePath?: string,
+): string {
+  const settingsWithCtx = relativePath
+    ? injectFileContext(settings, relativePath)
+    : settings;
+  return formatContent(content, settingsWithCtx);
 }
 
 /** Format a single `.md` file on disk + route the write through the standard broadcast pipeline. */
@@ -32,12 +42,14 @@ export async function formatFile(
   settings: FormatSettings,
 ): Promise<FormatFileResult> {
   const before = await notebaseFs.readFile(rootPath, relativePath);
-  const after = formatContent(before, settings);
+  const settingsWithCtx = injectFileContext(settings, relativePath);
+  const after = formatContent(before, settingsWithCtx);
   if (after === before) {
-    return { relativePath, changed: false, before, after };
+    return { relativePath, changed: false, before, after, cascadedPaths: [] };
   }
+  const cascadedPaths = await cascadeHeadingRenames(rootPath, relativePath, before, after);
   await writeThrough(rootPath, relativePath, after);
-  return { relativePath, changed: true, before, after };
+  return { relativePath, changed: true, before, after, cascadedPaths };
 }
 
 /**
@@ -60,13 +72,22 @@ async function runBatch(
   settings: FormatSettings,
 ): Promise<FormatRunSummary> {
   const changedPaths: string[] = [];
+  const cascadedPaths = new Set<string>();
   for (const rel of paths) {
     try {
       const result = await formatFile(rootPath, rel, settings);
       if (result.changed) changedPaths.push(rel);
+      for (const p of result.cascadedPaths) cascadedPaths.add(p);
     } catch { /* unreadable note — skip */ }
   }
-  return { changedPaths, totalScanned: paths.length };
+  // Drop any cascaded paths that were themselves formatted — they're already
+  // in changedPaths and the broadcast layer shouldn't list them twice.
+  for (const p of changedPaths) cascadedPaths.delete(p);
+  return {
+    changedPaths,
+    cascadedPaths: [...cascadedPaths],
+    totalScanned: paths.length,
+  };
 }
 
 async function walk(rootPath: string, relDir: string, out: string[]): Promise<void> {
@@ -98,4 +119,70 @@ async function writeThrough(
   // Caller is responsible for the batched persist + NOTEBASE_REWRITTEN
   // broadcast — doing it per-file in a folder run would thrash the
   // editor's open-tab refresh path.
+}
+
+/**
+ * When a heading's text rewrite changes its slug, the in-file anchor changes
+ * too, and any `[[file#old-slug]]` link in the thoughtbase points at a dead
+ * anchor unless we chase it. Diff the ordered list of heading slugs before
+ * vs after; for each mismatched pair, call `renameAnchor` to rewrite incoming
+ * links. Returns the set of other notes that were rewritten so the caller
+ * can broadcast their paths.
+ *
+ * If the heading count changed (rule removed or added a heading) we can't
+ * safely attribute renames by position, so we bail on the cascade.
+ */
+async function cascadeHeadingRenames(
+  rootPath: string,
+  relativePath: string,
+  before: string,
+  after: string,
+): Promise<string[]> {
+  const oldH = extractHeadingSlugsInOrder(before);
+  const newH = extractHeadingSlugsInOrder(after);
+  if (oldH.length !== newH.length || oldH.length === 0) return [];
+  const rewritten = new Set<string>();
+  for (let i = 0; i < oldH.length; i++) {
+    const oldSlug = oldH[i];
+    const newSlug = newH[i];
+    if (oldSlug === newSlug || newSlug.length === 0) continue;
+    try {
+      const result = await renameAnchor(rootPath, relativePath, oldSlug, newSlug);
+      for (const p of result.rewrittenPaths) rewritten.add(p);
+    } catch (err) {
+      console.error(
+        `[formatter] heading-rename cascade failed (${relativePath} ${oldSlug} → ${newSlug}):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+  return [...rewritten];
+}
+
+function extractHeadingSlugsInOrder(content: string): string[] {
+  const out: string[] = [];
+  let inFence = false;
+  for (const line of content.split('\n')) {
+    if (/^[ \t]{0,3}(?:`{3,}|~{3,})/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = line.match(/^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$/);
+    if (m) out.push(slugify(m[2].trim()));
+  }
+  return out;
+}
+
+function injectFileContext(settings: FormatSettings, relativePath: string): FormatSettings {
+  const filename = path.basename(relativePath, path.extname(relativePath));
+  const existingConfig =
+    (settings.configs?.['file-name-heading'] as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...settings,
+    configs: {
+      ...settings.configs,
+      'file-name-heading': { ...existingConfig, filename },
+    },
+  };
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -628,7 +628,8 @@ export function registerIpcHandlers(): void {
   // Formatter (issue #153)
   ipcMain.handle(
     Channels.FORMATTER_FORMAT_CONTENT,
-    (_e, content: string, settings: FormatSettings) => formatNoteContent(content, settings),
+    (_e, content: string, settings: FormatSettings, relativePath?: string) =>
+      formatNoteContent(content, settings, relativePath),
   );
 
   // Project-scoped formatter settings (#154). Stored in .minerva/formatter.json
@@ -661,10 +662,13 @@ export function registerIpcHandlers(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
       const result = await formatFileOnDisk(rootPath, relativePath, settings);
-      if (result.changed) {
-        markPathHandled(relativePath);
+      const touched = result.changed
+        ? [relativePath, ...result.cascadedPaths]
+        : result.cascadedPaths;
+      if (touched.length > 0) {
+        for (const p of touched) markPathHandled(p);
         await persistIndexes();
-        broadcastRewritten(rootPath, [relativePath]);
+        broadcastRewritten(rootPath, touched);
       }
       return result;
     },
@@ -676,10 +680,11 @@ export function registerIpcHandlers(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
       const summary = await formatFolderOnDisk(rootPath, relDir ?? '', settings);
-      if (summary.changedPaths.length > 0) {
-        for (const p of summary.changedPaths) markPathHandled(p);
+      const touched = [...summary.changedPaths, ...summary.cascadedPaths];
+      if (touched.length > 0) {
+        for (const p of touched) markPathHandled(p);
         await persistIndexes();
-        broadcastRewritten(rootPath, summary.changedPaths);
+        broadcastRewritten(rootPath, touched);
       }
       return summary;
     },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -156,8 +156,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.REFACTOR_DECOMPOSE_SUGGEST, relativePath, hints),
   },
   formatter: {
-    formatContent: (content: string, settings: unknown) =>
-      ipcRenderer.invoke(Channels.FORMATTER_FORMAT_CONTENT, content, settings),
+    formatContent: (content: string, settings: unknown, relativePath?: string) =>
+      ipcRenderer.invoke(Channels.FORMATTER_FORMAT_CONTENT, content, settings, relativePath),
     formatFile: (relativePath: string, settings: unknown) =>
       ipcRenderer.invoke(Channels.FORMATTER_FORMAT_FILE, relativePath, settings),
     formatFolder: (relDir: string, settings: unknown) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -580,7 +580,7 @@
     const settings = getFormatSettings();
     try {
       const result = await withBusy('Formatting\u2026', () =>
-        api.formatter.formatContent(tab.content, settings),
+        api.formatter.formatContent(tab.content, settings, tab.relativePath),
       );
       if (result !== tab.content) {
         editor.setContent(result);

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -162,6 +162,7 @@ export interface FormatterApi {
   formatContent(
     content: string,
     settings: import('../../../shared/formatter/engine').FormatSettings,
+    relativePath?: string,
   ): Promise<string>;
   formatFile(
     relativePath: string,
@@ -170,7 +171,7 @@ export interface FormatterApi {
   formatFolder(
     relDir: string,
     settings: import('../../../shared/formatter/engine').FormatSettings,
-  ): Promise<{ changedPaths: string[]; totalScanned: number }>;
+  ): Promise<{ changedPaths: string[]; cascadedPaths: string[]; totalScanned: number }>;
   loadSettings(): Promise<import('../../../shared/formatter/engine').FormatSettings>;
   saveSettings(settings: import('../../../shared/formatter/engine').FormatSettings): Promise<void>;
 }

--- a/src/shared/formatter/rules/heading/capitalize-headings.ts
+++ b/src/shared/formatter/rules/heading/capitalize-headings.ts
@@ -1,0 +1,92 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+type Style = 'title-case' | 'sentence-case' | 'lowercase' | 'off';
+
+interface Config {
+  style: Style;
+  /**
+   * Words that should be preserved in their canonical case regardless of the
+   * style (e.g. `['JavaScript', 'Minerva']`). Case-insensitive match on the
+   * token; the supplied casing is written back verbatim.
+   */
+  properNouns: string[];
+}
+
+const TITLE_SHORT_WORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'nor', 'of', 'in', 'on', 'at',
+  'to', 'for', 'by', 'with', 'as', 'from', 'up', 'so', 'yet', 'if', 'vs',
+]);
+
+registerRule<Config>({
+  id: 'capitalize-headings',
+  category: 'heading',
+  title: 'Capitalize headings',
+  description:
+    'Normalise heading case. `title-case` capitalises each major word (short words stay lowercase unless first or last); `sentence-case` only capitalises the first word; `lowercase` lowercases everything. User-supplied `properNouns` preserve their canonical casing.',
+  defaultConfig: { style: 'off', properNouns: [] },
+  apply(content, config, cache) {
+    if (config.style === 'off') return content;
+    const nounMap = buildNounMap(config.properNouns ?? []);
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(
+        /^(#{1,6}[ \t]+)(.+?)([ \t]*#*[ \t]*)$/gm,
+        (_m, prefix: string, text: string, suffix: string) =>
+          `${prefix}${recase(text, config.style, nounMap)}${suffix}`,
+      ),
+    );
+  },
+});
+
+function recase(text: string, style: Style, nounMap: Map<string, string>): string {
+  if (style === 'lowercase') {
+    return rewriteWords(text, (w) => nounMap.get(w.toLowerCase()) ?? w.toLowerCase());
+  }
+  if (style === 'sentence-case') {
+    return rewriteWords(text, (w, i) => {
+      const override = nounMap.get(w.toLowerCase());
+      if (override) return override;
+      return i === 0 ? capitalizeFirst(w) : w.toLowerCase();
+    });
+  }
+  if (style === 'title-case') {
+    return rewriteWords(text, (w, i, n) => {
+      const override = nounMap.get(w.toLowerCase());
+      if (override) return override;
+      const isBoundary = i === 0 || i === n - 1;
+      if (isBoundary) return capitalizeFirst(w);
+      if (TITLE_SHORT_WORDS.has(w.toLowerCase())) return w.toLowerCase();
+      return capitalizeFirst(w);
+    });
+  }
+  return text;
+}
+
+function rewriteWords(
+  text: string,
+  rewriter: (word: string, index: number, total: number) => string,
+): string {
+  const tokens = text.split(/(\s+)/);
+  const wordPositions: number[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (!/^\s*$/.test(tokens[i]) && tokens[i].length > 0) wordPositions.push(i);
+  }
+  const total = wordPositions.length;
+  wordPositions.forEach((pos, idx) => {
+    tokens[pos] = rewriter(tokens[pos], idx, total);
+  });
+  return tokens.join('');
+}
+
+function capitalizeFirst(word: string): string {
+  if (word.length === 0) return word;
+  return word[0].toUpperCase() + word.slice(1).toLowerCase();
+}
+
+function buildNounMap(nouns: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const noun of nouns) {
+    if (noun.length > 0) map.set(noun.toLowerCase(), noun);
+  }
+  return map;
+}

--- a/src/shared/formatter/rules/heading/file-name-heading.ts
+++ b/src/shared/formatter/rules/heading/file-name-heading.ts
@@ -1,0 +1,74 @@
+import { registerRule } from '../../registry';
+
+type Mode = 'off' | 'insert-if-missing' | 'replace-h1';
+
+interface Config {
+  mode: Mode;
+  /**
+   * Injected by the orchestrator per call — the file's basename without the
+   * `.md` extension. Pure buffer-format calls without a known file leave
+   * this undefined, in which case the rule is a no-op.
+   */
+  filename?: string;
+}
+
+const ATX_H1 = /^#[ \t]+.+?(?:[ \t]*#*)?[ \t]*$/;
+
+registerRule<Config>({
+  id: 'file-name-heading',
+  category: 'heading',
+  title: 'File-name heading',
+  description:
+    'Keep the note\'s first H1 in sync with its filename. `insert-if-missing` prepends `# <filename>` when no H1 is present; `replace-h1` overwrites the first H1\'s text. Needs a file on disk — the palette\'s "Format current note" works on unsaved tabs and injects the filename automatically; unsaved new notes are skipped.',
+  defaultConfig: { mode: 'off' },
+  apply(content, config) {
+    const mode: Mode = config.mode ?? 'off';
+    const filename = config.filename;
+    if (mode === 'off' || !filename) return content;
+
+    const firstH1 = findFirstH1(content);
+    if (firstH1 === null) {
+      if (mode !== 'insert-if-missing') return content;
+      const fmEnd = findFrontmatterEnd(content);
+      const head = content.slice(0, fmEnd);
+      const body = content.slice(fmEnd).replace(/^\n+/, '');
+      const heading = `# ${filename}`;
+      if (head.length === 0) {
+        return body.length > 0 ? `${heading}\n\n${body}` : `${heading}\n`;
+      }
+      return body.length > 0 ? `${head}\n${heading}\n\n${body}` : `${head}\n${heading}\n`;
+    }
+
+    if (mode !== 'replace-h1') return content;
+    // Replace the text between the `# ` and the optional trailing `#` run.
+    const { lineStart, lineEnd } = firstH1;
+    return (
+      content.slice(0, lineStart) +
+      `# ${filename}` +
+      content.slice(lineEnd)
+    );
+  },
+});
+
+function findFirstH1(content: string): { lineStart: number; lineEnd: number } | null {
+  let inFence = false;
+  let lineStart = 0;
+  while (lineStart <= content.length) {
+    const newlineIdx = content.indexOf('\n', lineStart);
+    const lineEnd = newlineIdx === -1 ? content.length : newlineIdx;
+    const line = content.slice(lineStart, lineEnd);
+    if (/^[ \t]{0,3}(?:`{3,}|~{3,})/.test(line)) {
+      inFence = !inFence;
+    } else if (!inFence && /^#[ \t]/.test(line) && ATX_H1.test(line)) {
+      return { lineStart, lineEnd };
+    }
+    if (newlineIdx === -1) break;
+    lineStart = newlineIdx + 1;
+  }
+  return null;
+}
+
+function findFrontmatterEnd(content: string): number {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---(\r?\n|$)/);
+  return match ? match[0].length : 0;
+}

--- a/src/shared/formatter/rules/heading/header-increment.ts
+++ b/src/shared/formatter/rules/heading/header-increment.ts
@@ -1,0 +1,28 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'header-increment',
+  category: 'heading',
+  title: 'Heading increment',
+  description:
+    'Heading levels may only step by one at a time. An out-of-order level (e.g. H1 straight to H3) is clamped down to the previous level + 1. The first heading in the document is accepted as-is.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) => {
+      let lastLevel: number | null = null;
+      const parts = seg.split(/(\r?\n)/);
+      for (let i = 0; i < parts.length; i += 2) {
+        const m = parts[i].match(/^(#{1,6})(?=[ \t]|$)/);
+        if (!m) continue;
+        const level = m[1].length;
+        const allowed: number = lastLevel === null ? level : Math.min(level, lastLevel + 1);
+        if (allowed !== level) {
+          parts[i] = '#'.repeat(allowed) + parts[i].slice(level);
+        }
+        lastLevel = allowed;
+      }
+      return parts.join('');
+    });
+  },
+});

--- a/src/shared/formatter/rules/heading/remove-trailing-punctuation.ts
+++ b/src/shared/formatter/rules/heading/remove-trailing-punctuation.ts
@@ -1,0 +1,16 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'remove-trailing-punctuation-in-heading',
+  category: 'heading',
+  title: 'Remove trailing punctuation in headings',
+  description:
+    'Strip trailing `.`, `,`, `:`, or `;` from ATX headings. `?` and `!` are kept.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(/^(#{1,6}[ \t]+.*?)[.,:;]+([ \t]*)$/gm, '$1$2'),
+    );
+  },
+});

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -11,6 +11,7 @@
 import './heading/header-increment';
 import './heading/remove-trailing-punctuation';
 import './heading/capitalize-headings';
+import './heading/file-name-heading';
 
 // Content (#157) — in-line text normalisations.
 import './content/proper-ellipsis';

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -7,6 +7,11 @@
  * application order itself is fixed by CATEGORY_ORDER in registry.ts.
  */
 
+// Heading (#156) — ATX heading structure and text.
+import './heading/header-increment';
+import './heading/remove-trailing-punctuation';
+import './heading/capitalize-headings';
+
 // Content (#157) — in-line text normalisations.
 import './content/proper-ellipsis';
 import './content/remove-multiple-spaces';

--- a/src/shared/formatter/types.ts
+++ b/src/shared/formatter/types.ts
@@ -64,4 +64,6 @@ export interface FormatFileResult {
   before: string;
   /** Rewritten content. Equals `before` when no rule matched. */
   after: string;
+  /** Other notes whose incoming `[[file#slug]]` links were rewritten when a heading slug changed. */
+  cascadedPaths: string[];
 }

--- a/tests/main/formatter/orchestrator-cascade.test.ts
+++ b/tests/main/formatter/orchestrator-cascade.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { formatFile } from '../../../src/main/formatter/orchestrator';
+// Rule side-effects — the orchestrator already imports the barrel, but we
+// repeat here so the test file is explicit about what it's exercising.
+import '../../../src/shared/formatter/rules/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fmt-cascade-test-'));
+}
+
+function writeNote(root: string, rel: string, content: string): void {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+function readNote(root: string, rel: string): string {
+  return fs.readFileSync(path.join(root, rel), 'utf-8');
+}
+
+describe('formatter orchestrator heading-rename cascade (#156)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('rewrites incoming anchor links when `file-name-heading` (replace-h1) changes an H1', async () => {
+    // Target note has `# Old Title`; slug: `old-title`.
+    writeNote(root, 'notes/my-note.md', '# Old Title\n\nbody\n');
+    writeNote(root, 'notes/other.md', 'See [[notes/my-note#old-title]] for context.\n');
+
+    await indexNote('notes/my-note.md', readNote(root, 'notes/my-note.md'));
+    await indexNote('notes/other.md', readNote(root, 'notes/other.md'));
+
+    const result = await formatFile(root, 'notes/my-note.md', {
+      enabled: { 'file-name-heading': true },
+      configs: { 'file-name-heading': { mode: 'replace-h1' } },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.after).toBe('# my-note\n\nbody\n');
+    expect(result.cascadedPaths).toEqual(['notes/other.md']);
+    expect(readNote(root, 'notes/other.md')).toBe(
+      'See [[notes/my-note#my-note]] for context.\n',
+    );
+  });
+
+  it('does not cascade when a rule preserves the slug (case-only change)', async () => {
+    writeNote(root, 'notes/foo.md', '# hello world\n\nbody\n');
+    writeNote(root, 'notes/other.md', 'See [[notes/foo#hello-world]].\n');
+
+    await indexNote('notes/foo.md', readNote(root, 'notes/foo.md'));
+    await indexNote('notes/other.md', readNote(root, 'notes/other.md'));
+
+    const result = await formatFile(root, 'notes/foo.md', {
+      enabled: { 'capitalize-headings': true },
+      configs: { 'capitalize-headings': { style: 'title-case', properNouns: [] } },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.after).toContain('# Hello World');
+    expect(result.cascadedPaths).toEqual([]);
+    // Other note is untouched since the slug `hello-world` survives.
+    expect(readNote(root, 'notes/other.md')).toBe(
+      'See [[notes/foo#hello-world]].\n',
+    );
+  });
+
+  it('no cascade when the heading count changes (safety bail-out)', async () => {
+    // Simulate a scenario where a heading is effectively removed — the
+    // cascade should refuse rather than mis-attribute by position.
+    // We don't ship a rule that removes headings, so this is constructed:
+    // format a file that already has no H1 using `file-name-heading` +
+    // `insert-if-missing`, and verify cascade remains empty because no
+    // rename was detected (no change to existing headings, just an insert).
+    writeNote(root, 'notes/foo.md', 'no heading yet\n');
+
+    await indexNote('notes/foo.md', readNote(root, 'notes/foo.md'));
+
+    const result = await formatFile(root, 'notes/foo.md', {
+      enabled: { 'file-name-heading': true },
+      configs: { 'file-name-heading': { mode: 'insert-if-missing' } },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.after).toBe('# foo\n\nno heading yet\n');
+    // 0 → 1 headings: count changed, cascade bails.
+    expect(result.cascadedPaths).toEqual([]);
+  });
+});

--- a/tests/shared/formatter/rules/heading/capitalize-headings.test.ts
+++ b/tests/shared/formatter/rules/heading/capitalize-headings.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/heading/capitalize-headings';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(
+  content: string,
+  style: 'title-case' | 'sentence-case' | 'lowercase' | 'off',
+  properNouns: string[] = [],
+) {
+  return formatContent(content, {
+    enabled: { 'capitalize-headings': true },
+    configs: { 'capitalize-headings': { style, properNouns } },
+  });
+}
+
+describe('capitalize-headings (#156)', () => {
+  describe('style: title-case', () => {
+    it('capitalises each major word', () => {
+      expect(run('## the quick brown fox\n', 'title-case')).toBe(
+        '## The Quick Brown Fox\n',
+      );
+    });
+
+    it('leaves short words (a, an, the, …) lowercase unless at a boundary', () => {
+      expect(run('## a brief history of time\n', 'title-case')).toBe(
+        '## A Brief History of Time\n',
+      );
+    });
+
+    it('preserves proper nouns', () => {
+      expect(run('## learning javascript with minerva\n', 'title-case', ['JavaScript', 'Minerva'])).toBe(
+        '## Learning JavaScript with Minerva\n',
+      );
+    });
+  });
+
+  describe('style: sentence-case', () => {
+    it('capitalises only the first word', () => {
+      expect(run('## THE QUICK BROWN FOX\n', 'sentence-case')).toBe(
+        '## The quick brown fox\n',
+      );
+    });
+
+    it('preserves proper nouns mid-sentence', () => {
+      expect(run('## learning about JavaScript\n', 'sentence-case', ['JavaScript'])).toBe(
+        '## Learning about JavaScript\n',
+      );
+    });
+  });
+
+  describe('style: lowercase', () => {
+    it('lowercases everything', () => {
+      expect(run('## Hello World\n', 'lowercase')).toBe('## hello world\n');
+    });
+
+    it('still preserves proper nouns', () => {
+      expect(run('## Hello JavaScript\n', 'lowercase', ['JavaScript'])).toBe(
+        '## hello JavaScript\n',
+      );
+    });
+  });
+
+  describe('style: off', () => {
+    it('is a no-op', () => {
+      const src = '## Some RaNdOm CaSe\n';
+      expect(run(src, 'off')).toBe(src);
+    });
+  });
+
+  describe('shared', () => {
+    it('does not touch headings inside a code fence', () => {
+      const src = '```\n## keep this\n```\n';
+      expect(run(src, 'title-case')).toBe(src);
+    });
+
+    it('is idempotent (title-case)', () => {
+      const once = run('## the quick brown fox\n', 'title-case');
+      expect(run(once, 'title-case')).toBe(once);
+    });
+
+    it('is idempotent (sentence-case)', () => {
+      const once = run('## THE QUICK BROWN FOX\n', 'sentence-case');
+      expect(run(once, 'sentence-case')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/heading/file-name-heading.test.ts
+++ b/tests/shared/formatter/rules/heading/file-name-heading.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/heading/file-name-heading';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(
+  content: string,
+  mode: 'off' | 'insert-if-missing' | 'replace-h1',
+  filename: string = 'my-note',
+) {
+  return formatContent(content, {
+    enabled: { 'file-name-heading': true },
+    configs: { 'file-name-heading': { mode, filename } },
+  });
+}
+
+describe('file-name-heading (#156)', () => {
+  describe('mode: off', () => {
+    it('is a no-op even with a mismatched H1', () => {
+      const src = '# Wrong\n\nbody\n';
+      expect(run(src, 'off')).toBe(src);
+    });
+  });
+
+  describe('mode: insert-if-missing', () => {
+    it('prepends `# <filename>` when no H1 is present', () => {
+      expect(run('body\n', 'insert-if-missing', 'my-note')).toBe(
+        '# my-note\n\nbody\n',
+      );
+    });
+
+    it('leaves an existing H1 alone', () => {
+      const src = '# Existing\n\nbody\n';
+      expect(run(src, 'insert-if-missing', 'my-note')).toBe(src);
+    });
+
+    it('leaves an H2 alone when no H1 is present (only cares about H1)', () => {
+      expect(run('## only an h2\n', 'insert-if-missing', 'my-note')).toBe(
+        '# my-note\n\n## only an h2\n',
+      );
+    });
+
+    it('inserts after YAML frontmatter when present', () => {
+      expect(
+        run('---\ntitle: foo\n---\n\nbody\n', 'insert-if-missing', 'my-note'),
+      ).toBe('---\ntitle: foo\n---\n\n# my-note\n\nbody\n');
+    });
+
+    it('handles empty document', () => {
+      expect(run('', 'insert-if-missing', 'my-note')).toBe('# my-note\n');
+    });
+  });
+
+  describe('mode: replace-h1', () => {
+    it('replaces the first H1 text with the filename', () => {
+      expect(run('# Something else\n\nbody\n', 'replace-h1', 'my-note')).toBe(
+        '# my-note\n\nbody\n',
+      );
+    });
+
+    it('does not insert an H1 when none exists', () => {
+      const src = 'body without a heading\n';
+      expect(run(src, 'replace-h1', 'my-note')).toBe(src);
+    });
+
+    it('only touches the first H1, leaving later ones alone', () => {
+      expect(run('# Old\n\n## sub\n\n# Another\n', 'replace-h1', 'my-note')).toBe(
+        '# my-note\n\n## sub\n\n# Another\n',
+      );
+    });
+
+    it('strips a trailing `#` closing run from the original H1', () => {
+      expect(run('# Old title ##\n', 'replace-h1', 'my-note')).toBe(
+        '# my-note\n',
+      );
+    });
+  });
+
+  describe('no filename injected', () => {
+    // Orchestrator injects the filename; palette calls without a known
+    // file (unusual) leave it empty. The rule should treat an empty
+    // filename as "no file context available" and do nothing.
+    it('is a no-op regardless of mode', () => {
+      const src = '# Old\n\nbody\n';
+      expect(run(src, 'replace-h1', '')).toBe(src);
+      expect(run('body\n', 'insert-if-missing', '')).toBe('body\n');
+    });
+  });
+
+  describe('shared', () => {
+    it('does not treat `#` inside a code fence as H1', () => {
+      expect(run('```\n# Fake\n```\n\nbody\n', 'insert-if-missing', 'my-note')).toBe(
+        '# my-note\n\n```\n# Fake\n```\n\nbody\n',
+      );
+    });
+
+    it('is idempotent (insert-if-missing)', () => {
+      const once = run('body\n', 'insert-if-missing', 'my-note');
+      expect(run(once, 'insert-if-missing', 'my-note')).toBe(once);
+    });
+
+    it('is idempotent (replace-h1)', () => {
+      const once = run('# Old\n\nbody\n', 'replace-h1', 'my-note');
+      expect(run(once, 'replace-h1', 'my-note')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/heading/header-increment.test.ts
+++ b/tests/shared/formatter/rules/heading/header-increment.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/heading/header-increment';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'header-increment': true }, configs: {} };
+
+describe('header-increment (#156)', () => {
+  it('bumps H1 → H3 down to H1 → H2', () => {
+    expect(formatContent('# A\n### B\n', enabled)).toBe('# A\n## B\n');
+  });
+
+  it('accepts the first heading at any level', () => {
+    expect(formatContent('### start here\n', enabled)).toBe('### start here\n');
+  });
+
+  it('leaves monotonically-stepping headings alone', () => {
+    const src = '# A\n## B\n### C\n#### D\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('allows jumps back up (H3 → H1)', () => {
+    const src = '# A\n## B\n### C\n# next section\n## sub\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('clamps after a shallow-then-deep jump over multiple levels', () => {
+    expect(formatContent('# A\n#### B\n', enabled)).toBe('# A\n## B\n');
+  });
+
+  it('accepts H3 as the first heading and then enforces stepping from there', () => {
+    expect(formatContent('### A\n##### B\n', enabled)).toBe('### A\n#### B\n');
+  });
+
+  it('does not touch `#` inside a code fence', () => {
+    const src = '# A\n```\n### not a heading\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not treat `#hashtag` as a heading', () => {
+    expect(formatContent('# A\n#hashtag\n### C\n', enabled)).toBe(
+      '# A\n#hashtag\n## C\n',
+    );
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('# A\n### B\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/heading/remove-trailing-punctuation.test.ts
+++ b/tests/shared/formatter/rules/heading/remove-trailing-punctuation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/heading/remove-trailing-punctuation';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'remove-trailing-punctuation-in-heading': true },
+  configs: {},
+};
+
+describe('remove-trailing-punctuation-in-heading (#156)', () => {
+  it('strips a trailing period', () => {
+    expect(formatContent('## Heading.\n', enabled)).toBe('## Heading\n');
+  });
+
+  it('strips a trailing comma, colon, and semicolon', () => {
+    expect(formatContent('# A,\n## B:\n### C;\n', enabled)).toBe(
+      '# A\n## B\n### C\n',
+    );
+  });
+
+  it('strips a run of mixed trailing punctuation', () => {
+    expect(formatContent('## Hello.,;:\n', enabled)).toBe('## Hello\n');
+  });
+
+  it('keeps `?` and `!` trailing punctuation', () => {
+    expect(formatContent('## Is this a question?\n## Yes!\n', enabled)).toBe(
+      '## Is this a question?\n## Yes!\n',
+    );
+  });
+
+  it('does not strip internal punctuation', () => {
+    expect(formatContent('## A, B, and C\n', enabled)).toBe('## A, B, and C\n');
+  });
+
+  it('preserves trailing whitespace (trailing-spaces rule cleans it up)', () => {
+    expect(formatContent('## Heading.   \n', enabled)).toBe('## Heading   \n');
+  });
+
+  it('does not touch headings inside a code fence', () => {
+    const src = '```\n## Heading.\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('## Heading.\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the heading category (#156) — 4 rules plus orchestrator infrastructure so heading-rewriting rules safely update incoming `[[file#slug]]` links.

**Rules:**
- `header-increment` — clamp any heading whose level jumps more than one from the previous heading. First heading accepted as-is. No text change, no cascade.
- `remove-trailing-punctuation-in-heading` — strip trailing `.,:;` from ATX headings; keep `?!`.
- `capitalize-headings` — directional `{ style: 'title-case' | 'sentence-case' | 'lowercase' | 'off', properNouns }` with a conservative title-case short-word set.
- `file-name-heading` — `{ mode: 'off' | 'insert-if-missing' | 'replace-h1' }`. Syncs the first H1 with the note's filename. Filename is injected by the orchestrator, not configured by the user.

**Skipped from the ticket:** `headings-start-line` — ambiguous / duplicative of #158's `heading-blank-lines`. The only alternative reading (detect inline `text## heading` and split) would risk breaking code and prose.

**Infrastructure (`main/formatter/orchestrator.ts`):**
- `injectFileContext`: before running `formatContent`, the file's basename is injected into `file-name-heading`'s config. Applies to both `formatFile`/`formatFolder` (filename known from path) and buffer formatting via IPC (`api.formatter.formatContent` gained an optional `relativePath` arg so the palette's "Format current note" can pass it through).
- `cascadeHeadingRenames`: after formatting a file, extract the ordered list of heading slugs before and after. For each mismatched position, call `renameAnchor` to rewrite every `[[file#old-slug]]` in the thoughtbase. Rewritten paths are surfaced in `FormatFileResult.cascadedPaths` / `FormatRunSummary.cascadedPaths` so the IPC layer includes them in the `NOTEBASE_REWRITTEN` broadcast.
- Position-based attribution: if the heading count changed (rule removed/added a heading), cascade bails. No rule in this PR changes heading count on existing headings, so this is safe.
- Buffer-mode formatting injects the filename but does NOT cascade (writing to other files when this file hasn't been saved would leave the thoughtbase inconsistent).

## Test plan

- [x] 42 rule-specific tests + 3 end-to-end orchestrator-cascade integration tests
- [x] Full suite: 730/730 pass
- [x] `pnpm lint` clean
- [ ] Manual: open a note with a mismatched H1, enable `file-name-heading: replace-h1`, run Format; confirm the H1 updates and incoming links from other notes get rewritten

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)