### PR TITLE
Formatter: footnote rules (closes #159)

### DIFF
--- a/src/shared/formatter/rules/footnote/footnote-after-punctuation.ts
+++ b/src/shared/formatter/rules/footnote/footnote-after-punctuation.ts
@@ -1,0 +1,16 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+registerRule({
+  id: 'footnote-after-punctuation',
+  category: 'footnote',
+  title: 'Footnote reference after punctuation',
+  description:
+    'Move a footnote reference (`[^N]`) that appears before sentence-ending punctuation to after it: `word[^1].` → `word.[^1]`.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(/(\[\^[^\]\s]+\])([.!?,;:])/g, '$2$1'),
+    );
+  },
+});

--- a/src/shared/formatter/rules/footnote/move-footnotes-to-the-bottom.ts
+++ b/src/shared/formatter/rules/footnote/move-footnotes-to-the-bottom.ts
@@ -1,0 +1,83 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+/**
+ * A footnote definition is `[^name]: text` at line start, plus any
+ * subsequent lines that are indented (continuation). An un-indented line
+ * (or a blank line followed by an un-indented line — handled implicitly
+ * since the next non-continuation line terminates the block) ends the
+ * definition block.
+ */
+const DEF_START = /^[ \t]*\[\^[^\]\s]+\]:/;
+const CONTINUATION = /^[ \t]+\S/;
+
+registerRule({
+  id: 'move-footnotes-to-the-bottom',
+  category: 'footnote',
+  title: 'Move footnotes to the bottom',
+  description:
+    'Collect every `[^name]: …` definition (including indented continuation lines) and re-emit them in a block at the very end of the document, in document order.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) => moveFootnotesToEnd(seg));
+  },
+});
+
+function moveFootnotesToEnd(seg: string): string {
+  const lines = splitLinesKeepTerminator(seg);
+  const defs: string[] = [];
+  const kept: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const body = stripTerminator(lines[i]);
+    if (DEF_START.test(body)) {
+      const block: string[] = [lines[i]];
+      let j = i + 1;
+      while (j < lines.length) {
+        const nextBody = stripTerminator(lines[j]);
+        if (CONTINUATION.test(nextBody)) {
+          block.push(lines[j]);
+          j++;
+        } else {
+          break;
+        }
+      }
+      defs.push(block.join(''));
+      i = j;
+      // Consume one trailing blank line so removing a def that was flanked
+      // by blanks doesn't leave two blanks in a row in its place.
+      if (i < lines.length && /^\s*$/.test(stripTerminator(lines[i]))) i++;
+    } else {
+      kept.push(lines[i]);
+      i++;
+    }
+  }
+
+  if (defs.length === 0) return seg;
+
+  const keptJoined = kept.join('');
+  // Trim trailing whitespace from the kept body so we control the
+  // separator explicitly.
+  const keptTrimmed = keptJoined.replace(/\s+$/, '');
+  const defsJoined = defs.map((d) => (d.endsWith('\n') ? d : d + '\n')).join('');
+  if (keptTrimmed.length === 0) return defsJoined;
+  return `${keptTrimmed}\n\n${defsJoined}`;
+}
+
+function splitLinesKeepTerminator(seg: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = seg.length;
+  while (i < n) {
+    let j = i;
+    while (j < n && seg[j] !== '\n') j++;
+    if (j < n) j++;
+    out.push(seg.slice(i, j));
+    i = j;
+  }
+  return out;
+}
+
+function stripTerminator(line: string): string {
+  return line.replace(/\r?\n$/, '');
+}

--- a/src/shared/formatter/rules/footnote/re-index-footnotes.ts
+++ b/src/shared/formatter/rules/footnote/re-index-footnotes.ts
@@ -1,0 +1,47 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+const REF_RE = /(\[\^)([^\]\s]+)(\])(?!:)/g;
+const DEF_RE = /^([ \t]*\[\^)([^\]\s]+)(\]:)/gm;
+
+registerRule({
+  id: 're-index-footnotes',
+  category: 'footnote',
+  title: 'Re-index footnotes',
+  description:
+    'Renumber numeric footnote references and definitions so they read 1, 2, 3, … in document order. Named footnotes (`[^foo]`) are preserved verbatim.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) => reindex(seg));
+  },
+});
+
+function reindex(seg: string): string {
+  // First pass: collect numeric reference names in document order. Only
+  // reference occurrences count — a definition that's never referenced
+  // doesn't get a new number.
+  const order: string[] = [];
+  const seen = new Set<string>();
+  let m;
+  REF_RE.lastIndex = 0;
+  while ((m = REF_RE.exec(seg)) !== null) {
+    const name = m[2];
+    if (/^\d+$/.test(name) && !seen.has(name)) {
+      seen.add(name);
+      order.push(name);
+    }
+  }
+  if (order.length === 0) return seg;
+
+  const mapping = new Map<string, string>();
+  order.forEach((oldName, i) => mapping.set(oldName, String(i + 1)));
+
+  const rewrittenRefs = seg.replace(REF_RE, (match, open, name, close) => {
+    const next = mapping.get(name);
+    return next ? `${open}${next}${close}` : match;
+  });
+  return rewrittenRefs.replace(DEF_RE, (match, open, name, close) => {
+    const next = mapping.get(name);
+    return next ? `${open}${next}${close}` : match;
+  });
+}

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -31,6 +31,13 @@ import './content/unordered-list-marker-style';
 import './content/ordered-list-style';
 import './content/auto-correct-common-misspellings';
 
+// Footnote (#159) — reference placement, definition ordering, renumbering.
+// `move-footnotes-to-the-bottom` runs before `re-index-footnotes` so the
+// latter sees definitions in their final order.
+import './footnote/footnote-after-punctuation';
+import './footnote/move-footnotes-to-the-bottom';
+import './footnote/re-index-footnotes';
+
 // Spacing (#158) — blank-line discipline and inline whitespace normalisation.
 import './spacing/line-break-at-document-end';
 import './spacing/trailing-spaces';

--- a/tests/shared/formatter/rules/footnote/footnote-after-punctuation.test.ts
+++ b/tests/shared/formatter/rules/footnote/footnote-after-punctuation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/footnote/footnote-after-punctuation';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'footnote-after-punctuation': true },
+  configs: {},
+};
+
+describe('footnote-after-punctuation (#159)', () => {
+  it('moves a ref from before a period to after it', () => {
+    expect(formatContent('word[^1].', enabled)).toBe('word.[^1]');
+  });
+
+  it('handles question marks and exclamation points', () => {
+    expect(formatContent('really[^1]?', enabled)).toBe('really?[^1]');
+    expect(formatContent('wow[^1]!', enabled)).toBe('wow![^1]');
+  });
+
+  it('handles commas, semicolons, and colons', () => {
+    expect(formatContent('first[^1], second[^2]; third[^3]:', enabled)).toBe(
+      'first,[^1] second;[^2] third:[^3]',
+    );
+  });
+
+  it('handles named footnotes', () => {
+    expect(formatContent('word[^foo].', enabled)).toBe('word.[^foo]');
+  });
+
+  it('leaves a correctly-placed ref alone', () => {
+    const src = 'word.[^1]';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves a standalone ref (no punctuation after) alone', () => {
+    const src = 'word[^1] continues\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch refs inside a code fence', () => {
+    const src = '```\nword[^1].\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch refs inside inline code', () => {
+    const src = 'see `word[^1].`\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('word[^1].', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/footnote/move-footnotes-to-the-bottom.test.ts
+++ b/tests/shared/formatter/rules/footnote/move-footnotes-to-the-bottom.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/footnote/move-footnotes-to-the-bottom';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'move-footnotes-to-the-bottom': true },
+  configs: {},
+};
+
+describe('move-footnotes-to-the-bottom (#159)', () => {
+  it('collects a single definition and puts it at the bottom', () => {
+    const src = 'body one[^1]\n\n[^1]: note text\n\nbody two\n';
+    expect(formatContent(src, enabled)).toBe(
+      'body one[^1]\n\nbody two\n\n[^1]: note text\n',
+    );
+  });
+
+  it('preserves definition order', () => {
+    const src = 'a[^2] b[^1]\n\n[^2]: second\n[^1]: first\n';
+    expect(formatContent(src, enabled)).toBe(
+      'a[^2] b[^1]\n\n[^2]: second\n[^1]: first\n',
+    );
+  });
+
+  it('handles multi-line (indented) continuation definitions', () => {
+    const src = [
+      'body[^1]',
+      '',
+      '[^1]: first line',
+      '    continuation',
+      '    another',
+      '',
+      'tail',
+      '',
+    ].join('\n');
+    const out = formatContent(src, enabled);
+    expect(out).toContain('[^1]: first line\n    continuation\n    another\n');
+    expect(out.indexOf('[^1]: first line')).toBeGreaterThan(out.indexOf('tail'));
+  });
+
+  it('is a no-op when there are no definitions', () => {
+    const src = 'prose with ref[^1] but no def yet\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves definitions alone when already at the bottom', () => {
+    const src = 'body[^1]\n\n[^1]: note\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch definitions inside a code fence', () => {
+    const src = 'prose\n\n```\n[^1]: not a real def\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const src = 'body one[^1]\n\n[^1]: note text\n\nbody two\n';
+    const once = formatContent(src, enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/footnote/re-index-footnotes.test.ts
+++ b/tests/shared/formatter/rules/footnote/re-index-footnotes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/footnote/re-index-footnotes';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 're-index-footnotes': true }, configs: {} };
+
+describe('re-index-footnotes (#159)', () => {
+  it('renumbers numeric refs 1, 2, 3 in document order', () => {
+    const src = 'a[^5] b[^3] c[^2]\n\n[^2]: two\n[^3]: three\n[^5]: five\n';
+    expect(formatContent(src, enabled)).toBe(
+      'a[^1] b[^2] c[^3]\n\n[^3]: two\n[^2]: three\n[^1]: five\n',
+    );
+  });
+
+  it('keeps repeated refs to the same number', () => {
+    const src = 'a[^7] b[^7] c[^7]\n\n[^7]: note\n';
+    expect(formatContent(src, enabled)).toBe('a[^1] b[^1] c[^1]\n\n[^1]: note\n');
+  });
+
+  it('preserves named footnotes', () => {
+    expect(formatContent('a[^foo] b[^bar] c[^1]\n', enabled)).toBe(
+      'a[^foo] b[^bar] c[^1]\n',
+    );
+  });
+
+  it('handles mixed named and numeric — named stays, numeric gets renumbered', () => {
+    expect(formatContent('a[^3] b[^foo] c[^5]\n', enabled)).toBe(
+      'a[^1] b[^foo] c[^2]\n',
+    );
+  });
+
+  it('is a no-op on a document with already-sequential numbering', () => {
+    const src = 'a[^1] b[^2] c[^3]\n\n[^1]: one\n[^2]: two\n[^3]: three\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not touch refs inside a code fence', () => {
+    const src = '```\n[^99]: keep\n[^99] ref\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const src = 'a[^5] b[^3]\n\n[^3]: x\n[^5]: y\n';
+    const once = formatContent(src, enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the three footnote rules from #159:

- `footnote-after-punctuation` — `word[^1].` → `word.[^1]`. Moves footnote references past `.`, `!`, `?`, `,`, `;`, `:`.
- `move-footnotes-to-the-bottom` — collects every `[^name]: …` block (multi-line continuations included) and re-emits them at the end of the document in document order. One flanking blank line is consumed so removal doesn't leave a visible gap.
- `re-index-footnotes` — renumbers numeric refs 1, 2, 3, … in document order and rewrites matching defs. Named footnotes (`[^foo]`) preserved verbatim per the ticket's mixed-stability rule.

Registered in the barrel so `move-footnotes-to-the-bottom` runs before `re-index-footnotes` — the latter then sees defs in their final positions.

## Test plan

- [x] 23 rule-specific tests; each rule covered for idempotency, code-fence exemption, and its edge cases
- [x] Full suite: 708/708 pass
- [x] `pnpm lint` clean
- [ ] Manual: paste crufty content with mid-sentence footnote refs and out-of-order defs; enable all three rules; confirm output

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)