### PR TITLE
Formatter: YAML frontmatter rules (closes #155)

### DIFF
--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -7,6 +7,23 @@
  * application order itself is fixed by CATEGORY_ORDER in registry.ts.
  */
 
+// YAML (#155) — frontmatter normalisation. `compact-yaml` first so later
+// rules work against a tidy block; `add-blank-line-after-yaml` last so it
+// sees the final shape. Timestamp / title rules run mid-category because
+// they mutate values, not structure.
+import './yaml/compact-yaml';
+import './yaml/remove-yaml-keys';
+import './yaml/dedupe-yaml-array-values';
+import './yaml/sort-yaml-array-values';
+import './yaml/format-tags-in-yaml';
+import './yaml/insert-yaml-attributes';
+import './yaml/yaml-timestamp';
+import './yaml/yaml-title';
+import './yaml/yaml-title-alias';
+import './yaml/yaml-key-sort';
+import './yaml/format-yaml-array';
+import './yaml/add-blank-line-after-yaml';
+
 // Heading (#156) — ATX heading structure and text.
 import './heading/header-increment';
 import './heading/remove-trailing-punctuation';

--- a/src/shared/formatter/rules/yaml/add-blank-line-after-yaml.ts
+++ b/src/shared/formatter/rules/yaml/add-blank-line-after-yaml.ts
@@ -1,0 +1,21 @@
+import { registerRule } from '../../registry';
+
+registerRule({
+  id: 'add-blank-line-after-yaml',
+  category: 'yaml',
+  title: 'Blank line after frontmatter',
+  description:
+    'Ensure exactly one blank line between the closing `---` of the frontmatter block and the body.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    const fm = cache.frontmatterRange;
+    if (!fm) return content;
+    // The parse-cache's frontmatter range includes the terminating newline
+    // after the closing `---`. Strip any additional blank lines immediately
+    // after that, then re-insert exactly one.
+    const head = content.slice(0, fm.end);
+    const tail = content.slice(fm.end).replace(/^\n+/, '');
+    if (tail.length === 0) return head;
+    return `${head}\n${tail}`;
+  },
+});

--- a/src/shared/formatter/rules/yaml/compact-yaml.ts
+++ b/src/shared/formatter/rules/yaml/compact-yaml.ts
@@ -1,0 +1,21 @@
+import { registerRule } from '../../registry';
+
+registerRule({
+  id: 'compact-yaml',
+  category: 'yaml',
+  title: 'Compact frontmatter',
+  description:
+    'Strip leading and trailing blank lines inside the YAML frontmatter block.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    const fm = cache.frontmatterRange;
+    if (!fm) return content;
+    const block = content.slice(fm.start, fm.end);
+    const m = block.match(/^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/);
+    if (!m) return content;
+    const [, open, body, close] = m;
+    const compacted = body.replace(/^(?:\s*\n)+/, '').replace(/\n\s*$/, '');
+    if (compacted === body) return content;
+    return content.slice(0, fm.start) + open + compacted + close + content.slice(fm.end);
+  },
+});

--- a/src/shared/formatter/rules/yaml/dedupe-yaml-array-values.ts
+++ b/src/shared/formatter/rules/yaml/dedupe-yaml-array-values.ts
@@ -1,0 +1,32 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+registerRule({
+  id: 'dedupe-yaml-array-values',
+  category: 'yaml',
+  title: 'Dedupe YAML array values',
+  description:
+    'Remove duplicate entries from top-level frontmatter sequences (e.g. `tags: [a, a, b]` → `tags: [a, b]`). First occurrence wins. Non-scalar entries (mappings, nested sequences) are left unchanged.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      for (const pair of doc.contents.items) {
+        if (!YAML.isSeq(pair.value)) continue;
+        dedupeSeq(pair.value);
+      }
+    });
+  },
+});
+
+function dedupeSeq(seq: YAML.YAMLSeq): void {
+  const seen = new Set<string>();
+  seq.items = seq.items.filter((item) => {
+    if (!YAML.isScalar(item)) return true;
+    const key = String(item.value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/src/shared/formatter/rules/yaml/format-tags-in-yaml.ts
+++ b/src/shared/formatter/rules/yaml/format-tags-in-yaml.ts
@@ -1,0 +1,51 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /**
+   * `bare`: `foo` (no prefix). `hash`: `#foo` (Obsidian-style).
+   * Minerva treats them equivalently at index time, so this is purely
+   * cosmetic.
+   */
+  prefix: 'bare' | 'hash';
+  /** Name of the key holding the tag list. */
+  key: string;
+}
+
+registerRule<Config>({
+  id: 'format-tags-in-yaml',
+  category: 'yaml',
+  title: 'Tag prefix style',
+  description:
+    'Normalise each tag in `tags:` to either a bare form (`foo`) or a hash-prefixed form (`#foo`).',
+  defaultConfig: { prefix: 'bare', key: 'tags' },
+  apply(content, config, cache) {
+    const tagKey = config.key || 'tags';
+    const prefix = config.prefix === 'hash' ? 'hash' : 'bare';
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      for (const pair of doc.contents.items) {
+        if (keyString(pair.key) !== tagKey) continue;
+        if (!YAML.isSeq(pair.value)) continue;
+        for (const item of pair.value.items) {
+          if (!YAML.isScalar(item)) continue;
+          const s = String(item.value ?? '');
+          const stripped = s.replace(/^#+/, '');
+          item.value = prefix === 'hash' ? `#${stripped}` : stripped;
+          // Discard any quoting hint the parser retained from the original
+          // `"#foo"` source; yaml v2 will then emit the shortest valid form.
+          item.type = undefined;
+        }
+      }
+    });
+  },
+});
+
+function keyString(key: unknown): string | null {
+  if (typeof key === 'string') return key;
+  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
+    return String((key as YAML.Scalar).value);
+  }
+  return null;
+}

--- a/src/shared/formatter/rules/yaml/format-yaml-array.ts
+++ b/src/shared/formatter/rules/yaml/format-yaml-array.ts
@@ -1,0 +1,45 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /** `block`: one item per line with `-`. `flow`: inline `[a, b, c]`. */
+  style: 'block' | 'flow';
+  /**
+   * When non-empty, only the listed keys are reformatted. An empty list
+   * applies the style to every sequence value.
+   */
+  keys: string[];
+}
+
+registerRule<Config>({
+  id: 'format-yaml-array',
+  category: 'yaml',
+  title: 'Sequence style',
+  description:
+    'Render top-level frontmatter sequences as either block style (`- a` on its own line) or flow style (`[a, b, c]`).',
+  defaultConfig: { style: 'block', keys: [] },
+  apply(content, config, cache) {
+    const targetKeys = new Set(config.keys ?? []);
+    const style = config.style === 'flow' ? 'flow' : 'block';
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      for (const pair of doc.contents.items) {
+        if (!YAML.isSeq(pair.value)) continue;
+        if (targetKeys.size > 0) {
+          const keyName = keyString(pair.key);
+          if (keyName === null || !targetKeys.has(keyName)) continue;
+        }
+        pair.value.flow = style === 'flow';
+      }
+    });
+  },
+});
+
+function keyString(key: unknown): string | null {
+  if (typeof key === 'string') return key;
+  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
+    return String((key as YAML.Scalar).value);
+  }
+  return null;
+}

--- a/src/shared/formatter/rules/yaml/helpers.ts
+++ b/src/shared/formatter/rules/yaml/helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared plumbing for YAML frontmatter rules.
+ *
+ * Rules operate on the frontmatter block identified by the parse cache.
+ * For rules that need structured access, `transformFrontmatterDoc` parses
+ * the YAML body into a yaml v2 `Document`, hands it to the caller's
+ * mutator, and re-serialises — keeping the surrounding `---` fences and
+ * the document terminator newline intact.
+ *
+ * If parsing fails (or the block shape isn't recognised), the helpers
+ * return content unchanged rather than risk corrupting the user's file.
+ */
+
+import YAML from 'yaml';
+import type { ParseCache } from '../../types';
+
+export function transformFrontmatterDoc(
+  content: string,
+  cache: ParseCache,
+  mutate: (doc: YAML.Document.Parsed) => void,
+): string {
+  const fm = cache.frontmatterRange;
+  if (!fm) return content;
+  const block = content.slice(fm.start, fm.end);
+  const m = block.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+  if (!m) return content;
+  const body = m[1];
+  const terminator = m[2];
+  let doc: YAML.Document.Parsed;
+  try {
+    doc = YAML.parseDocument(body);
+    if (doc.errors.length > 0) return content;
+  } catch {
+    return content;
+  }
+
+  mutate(doc);
+
+  let serialised = doc.toString();
+  // yaml v2's `toString` always appends a trailing newline; strip so we
+  // can re-assemble with the exact closing-fence shape the original used.
+  serialised = serialised.replace(/\s+$/, '');
+  if (serialised.length === 0) {
+    // All keys removed — collapse to an empty frontmatter block.
+    return content.slice(0, fm.start) + `---\n---${terminator}` + content.slice(fm.end);
+  }
+  return (
+    content.slice(0, fm.start) +
+    `---\n${serialised}\n---${terminator}` +
+    content.slice(fm.end)
+  );
+}
+
+/**
+ * Read-only variant: returns the parsed value of a specific top-level
+ * frontmatter key, or `undefined` if the key is absent or the frontmatter
+ * is missing/unparseable.
+ */
+export function readFrontmatterKey(
+  content: string,
+  cache: ParseCache,
+  key: string,
+): unknown {
+  const fm = cache.frontmatterRange;
+  if (!fm) return undefined;
+  const block = content.slice(fm.start, fm.end);
+  const m = block.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!m) return undefined;
+  try {
+    const parsed = YAML.parse(m[1]);
+    if (parsed && typeof parsed === 'object') {
+      return (parsed as Record<string, unknown>)[key];
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
+}

--- a/src/shared/formatter/rules/yaml/insert-yaml-attributes.ts
+++ b/src/shared/formatter/rules/yaml/insert-yaml-attributes.ts
@@ -1,0 +1,41 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /** Keys that must be present; missing ones get added with an empty string value. */
+  keys: string[];
+}
+
+registerRule<Config>({
+  id: 'insert-yaml-attributes',
+  category: 'yaml',
+  title: 'Insert missing frontmatter keys',
+  description:
+    'Ensure the listed keys are present in the frontmatter. Missing keys get added with an empty value; existing keys are left alone.',
+  defaultConfig: { keys: [] },
+  apply(content, config, cache) {
+    const required = config.keys ?? [];
+    if (required.length === 0) return content;
+
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      const existing = new Set<string>();
+      for (const pair of doc.contents.items) {
+        const name = keyString(pair.key);
+        if (name !== null) existing.add(name);
+      }
+      for (const key of required) {
+        if (!existing.has(key)) doc.set(key, '');
+      }
+    });
+  },
+});
+
+function keyString(key: unknown): string | null {
+  if (typeof key === 'string') return key;
+  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
+    return String((key as YAML.Scalar).value);
+  }
+  return null;
+}

--- a/src/shared/formatter/rules/yaml/remove-yaml-keys.ts
+++ b/src/shared/formatter/rules/yaml/remove-yaml-keys.ts
@@ -1,0 +1,35 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  keys: string[];
+}
+
+registerRule<Config>({
+  id: 'remove-yaml-keys',
+  category: 'yaml',
+  title: 'Remove frontmatter keys',
+  description:
+    'Delete the listed top-level keys from the frontmatter. Useful for stripping legacy metadata that shouldn\'t travel with a note.',
+  defaultConfig: { keys: [] },
+  apply(content, config, cache) {
+    const toRemove = new Set(config.keys ?? []);
+    if (toRemove.size === 0) return content;
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      doc.contents.items = doc.contents.items.filter((pair) => {
+        const keyName = keyString(pair.key);
+        return keyName === null || !toRemove.has(keyName);
+      });
+    });
+  },
+});
+
+function keyString(key: unknown): string | null {
+  if (typeof key === 'string') return key;
+  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
+    return String((key as YAML.Scalar).value);
+  }
+  return null;
+}

--- a/src/shared/formatter/rules/yaml/sort-yaml-array-values.ts
+++ b/src/shared/formatter/rules/yaml/sort-yaml-array-values.ts
@@ -1,0 +1,42 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /** Keys whose sequence values should be sorted. Others are left alone. Defaults to tags-only. */
+  keys: string[];
+}
+
+registerRule<Config>({
+  id: 'sort-yaml-array-values',
+  category: 'yaml',
+  title: 'Sort YAML array values',
+  description:
+    'Alphabetically sort the entries of named top-level sequences. Off by default for most keys (ordering is often intentional); applied only to keys listed in the config, defaulting to `tags`.',
+  defaultConfig: { keys: ['tags'] },
+  apply(content, config, cache) {
+    const targetKeys = new Set(config.keys ?? []);
+    if (targetKeys.size === 0) return content;
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      for (const pair of doc.contents.items) {
+        if (!YAML.isScalar(pair.key) && typeof pair.key !== 'string') continue;
+        const keyName = YAML.isScalar(pair.key) ? String(pair.key.value) : String(pair.key);
+        if (!targetKeys.has(keyName)) continue;
+        if (!YAML.isSeq(pair.value)) continue;
+        sortSeq(pair.value);
+      }
+    });
+  },
+});
+
+function sortSeq(seq: YAML.YAMLSeq): void {
+  const scalars: YAML.Scalar[] = [];
+  const nonScalars: unknown[] = [];
+  for (const item of seq.items) {
+    if (YAML.isScalar(item)) scalars.push(item);
+    else nonScalars.push(item);
+  }
+  scalars.sort((a, b) => String(a.value).localeCompare(String(b.value)));
+  seq.items = [...scalars, ...nonScalars];
+}

--- a/src/shared/formatter/rules/yaml/yaml-key-sort.ts
+++ b/src/shared/formatter/rules/yaml/yaml-key-sort.ts
@@ -1,0 +1,61 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /** Keys in this array come first, in the listed order. Everything else is sorted alphabetically after. */
+  canonicalOrder: string[];
+}
+
+/**
+ * Default canonical order: identity-ish metadata first, content-describing
+ * metadata next, time-related metadata last. Chosen to match the way a
+ * reader scans: "what is this note, who's it about, when." Everything not
+ * in this list slots in alphabetically after the canonical block.
+ */
+const DEFAULT_ORDER = [
+  'title',
+  'aliases',
+  'creator',
+  'author',
+  'date',
+  'created',
+  'modified',
+  'tags',
+  'description',
+  'status',
+];
+
+registerRule<Config>({
+  id: 'yaml-key-sort',
+  category: 'yaml',
+  title: 'Sort frontmatter keys',
+  description:
+    'Order the top-level frontmatter keys. Listed keys appear first in the given order; unknown keys follow alphabetically.',
+  defaultConfig: { canonicalOrder: DEFAULT_ORDER },
+  apply(content, config, cache) {
+    const order = config.canonicalOrder?.length ? config.canonicalOrder : DEFAULT_ORDER;
+    const orderMap = new Map<string, number>();
+    order.forEach((key, i) => orderMap.set(key, i));
+
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      doc.contents.items.sort((a, b) => {
+        const ka = keyString(a.key);
+        const kb = keyString(b.key);
+        const pa = ka !== null && orderMap.has(ka) ? orderMap.get(ka)! : Infinity;
+        const pb = kb !== null && orderMap.has(kb) ? orderMap.get(kb)! : Infinity;
+        if (pa !== pb) return pa - pb;
+        return String(ka ?? '').localeCompare(String(kb ?? ''));
+      });
+    });
+  },
+});
+
+function keyString(key: unknown): string | null {
+  if (typeof key === 'string') return key;
+  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
+    return String((key as YAML.Scalar).value);
+  }
+  return null;
+}

--- a/src/shared/formatter/rules/yaml/yaml-timestamp.ts
+++ b/src/shared/formatter/rules/yaml/yaml-timestamp.ts
@@ -1,0 +1,55 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /** When true, overwrite `modified:` with today's date each run. */
+  updateModified: boolean;
+  /** When true, add `created:` on first run (never overwrites). */
+  insertCreated: boolean;
+  /**
+   * Date format. `iso-date` is `YYYY-MM-DD`, `iso` is a full ISO-8601
+   * timestamp in UTC. Default `iso-date` — granular enough for human
+   * timelines without triggering a rewrite every time the user hits save.
+   */
+  format: 'iso-date' | 'iso';
+}
+
+registerRule<Config>({
+  id: 'yaml-timestamp',
+  category: 'yaml',
+  title: 'Frontmatter timestamps',
+  description:
+    'Maintain `created:` and `modified:` frontmatter keys. `modified` is overwritten each run (within the same day the value doesn\'t change); `created` is inserted once when missing.',
+  defaultConfig: { updateModified: true, insertCreated: true, format: 'iso-date' },
+  apply(content, config, cache) {
+    if (!config.updateModified && !config.insertCreated) return content;
+    const now = formatNow(config.format);
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      if (config.updateModified) {
+        const existing = readKey(doc, 'modified');
+        if (existing !== now) doc.set('modified', now);
+      }
+      if (config.insertCreated && readKey(doc, 'created') === undefined) {
+        doc.set('created', now);
+      }
+    });
+  },
+});
+
+function formatNow(format: 'iso-date' | 'iso'): string {
+  const d = new Date();
+  if (format === 'iso') return d.toISOString();
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function readKey(doc: YAML.Document.Parsed, key: string): unknown {
+  const node = doc.get(key, true);
+  if (node === undefined || node === null) return undefined;
+  if (YAML.isScalar(node)) return node.value;
+  return node;
+}

--- a/src/shared/formatter/rules/yaml/yaml-title-alias.ts
+++ b/src/shared/formatter/rules/yaml/yaml-title-alias.ts
@@ -1,0 +1,37 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from './helpers';
+
+registerRule({
+  id: 'yaml-title-alias',
+  category: 'yaml',
+  title: 'Mirror title into aliases',
+  description:
+    'Ensure the frontmatter `title` value appears as an entry in `aliases`. Existing alias entries are kept; duplicates are not added.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      const title = readScalarKey(doc, 'title');
+      if (typeof title !== 'string' || title.length === 0) return;
+
+      const aliasesNode = doc.get('aliases', true);
+      if (!aliasesNode) {
+        doc.set('aliases', [title]);
+        return;
+      }
+      if (YAML.isSeq(aliasesNode)) {
+        const present = aliasesNode.items.some(
+          (item) => YAML.isScalar(item) && item.value === title,
+        );
+        if (!present) aliasesNode.add(title);
+      }
+    });
+  },
+});
+
+function readScalarKey(doc: YAML.Document.Parsed, key: string): unknown {
+  const node = doc.get(key, true);
+  if (YAML.isScalar(node)) return node.value;
+  return undefined;
+}

--- a/src/shared/formatter/rules/yaml/yaml-title.ts
+++ b/src/shared/formatter/rules/yaml/yaml-title.ts
@@ -1,0 +1,102 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import type { ParseCache } from '../../types';
+import { transformFrontmatterDoc } from './helpers';
+
+interface Config {
+  /**
+   * `heading-to-yaml`: the note's first H1 populates the frontmatter `title`.
+   * `yaml-to-heading`: the frontmatter `title` populates / replaces the first H1.
+   */
+  direction: 'heading-to-yaml' | 'yaml-to-heading';
+}
+
+const H1_RE = /^#[ \t]+(.+?)(?:[ \t]*#*)?[ \t]*$/;
+
+interface FoundH1 {
+  text: string;
+  lineStart: number;
+  lineEnd: number;
+}
+
+registerRule<Config>({
+  id: 'yaml-title',
+  category: 'yaml',
+  title: 'Sync frontmatter title with H1',
+  description:
+    'Keep the frontmatter `title:` and the note\'s first H1 in sync. Direction is configurable.',
+  defaultConfig: { direction: 'heading-to-yaml' },
+  apply(content, config, cache) {
+    const firstH1 = findFirstH1(content, cache);
+    if (config.direction === 'yaml-to-heading') {
+      return applyYamlToHeading(content, cache, firstH1);
+    }
+    return applyHeadingToYaml(content, cache, firstH1);
+  },
+});
+
+function applyHeadingToYaml(
+  content: string,
+  cache: ParseCache,
+  firstH1: FoundH1 | null,
+): string {
+  if (firstH1 === null) return content;
+  return transformFrontmatterDoc(content, cache, (doc) => {
+    if (!YAML.isMap(doc.contents)) return;
+    const current = readKey(doc, 'title');
+    if (current !== firstH1.text) doc.set('title', firstH1.text);
+  });
+}
+
+function applyYamlToHeading(
+  content: string,
+  cache: ParseCache,
+  firstH1: FoundH1 | null,
+): string {
+  const fm = cache.frontmatterRange;
+  if (!fm) return content;
+  const block = content.slice(fm.start, fm.end);
+  const m = block.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!m) return content;
+  let parsed: unknown;
+  try { parsed = YAML.parse(m[1]); } catch { return content; }
+  if (!parsed || typeof parsed !== 'object') return content;
+  const titleRaw = (parsed as Record<string, unknown>).title;
+  if (typeof titleRaw !== 'string' || titleRaw.length === 0) return content;
+
+  // Insertion of a missing H1 is `file-name-heading`'s job, not this rule's.
+  if (firstH1 === null) return content;
+  if (firstH1.text === titleRaw) return content;
+  return (
+    content.slice(0, firstH1.lineStart) +
+    `# ${titleRaw}` +
+    content.slice(firstH1.lineEnd)
+  );
+}
+
+function findFirstH1(content: string, cache: ParseCache): FoundH1 | null {
+  let lineStart = cache.frontmatterRange ? cache.frontmatterRange.end : 0;
+  while (lineStart <= content.length) {
+    if (cache.isProtected(lineStart)) {
+      const next = content.indexOf('\n', lineStart);
+      if (next === -1) break;
+      lineStart = next + 1;
+      continue;
+    }
+    const newlineIdx = content.indexOf('\n', lineStart);
+    const lineEnd = newlineIdx === -1 ? content.length : newlineIdx;
+    const line = content.slice(lineStart, lineEnd);
+    const m = line.match(H1_RE);
+    if (m) return { text: m[1].trim(), lineStart, lineEnd };
+    if (newlineIdx === -1) break;
+    lineStart = newlineIdx + 1;
+  }
+  return null;
+}
+
+function readKey(doc: YAML.Document.Parsed, key: string): unknown {
+  const node = doc.get(key, true);
+  if (node === undefined || node === null) return undefined;
+  if (YAML.isScalar(node)) return node.value;
+  return node;
+}

--- a/tests/shared/formatter/rules/yaml/add-blank-line-after-yaml.test.ts
+++ b/tests/shared/formatter/rules/yaml/add-blank-line-after-yaml.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/add-blank-line-after-yaml';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'add-blank-line-after-yaml': true }, configs: {} };
+
+describe('add-blank-line-after-yaml (#155)', () => {
+  it('inserts a blank line when body starts immediately after `---`', () => {
+    expect(formatContent('---\ntitle: foo\n---\nbody\n', enabled)).toBe(
+      '---\ntitle: foo\n---\n\nbody\n',
+    );
+  });
+
+  it('leaves a single blank line alone', () => {
+    const src = '---\ntitle: foo\n---\n\nbody\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('collapses multiple blank lines down to one', () => {
+    expect(formatContent('---\ntitle: foo\n---\n\n\n\nbody\n', enabled)).toBe(
+      '---\ntitle: foo\n---\n\nbody\n',
+    );
+  });
+
+  it('is a no-op on files without frontmatter', () => {
+    const src = '# Heading\n\nbody\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('handles frontmatter-only files', () => {
+    const src = '---\ntitle: foo\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('---\ntitle: foo\n---\nbody\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/compact-yaml.test.ts
+++ b/tests/shared/formatter/rules/yaml/compact-yaml.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/compact-yaml';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'compact-yaml': true }, configs: {} };
+
+describe('compact-yaml (#155)', () => {
+  it('strips a leading blank line inside frontmatter', () => {
+    expect(formatContent('---\n\ntitle: foo\n---\n', enabled)).toBe(
+      '---\ntitle: foo\n---\n',
+    );
+  });
+
+  it('strips a trailing blank line inside frontmatter', () => {
+    expect(formatContent('---\ntitle: foo\n\n---\n', enabled)).toBe(
+      '---\ntitle: foo\n---\n',
+    );
+  });
+
+  it('strips both ends', () => {
+    expect(formatContent('---\n\n\ntitle: foo\n\n\n---\n', enabled)).toBe(
+      '---\ntitle: foo\n---\n',
+    );
+  });
+
+  it('leaves a compact frontmatter alone', () => {
+    const src = '---\ntitle: foo\nauthor: Alice\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is a no-op on files without frontmatter', () => {
+    const src = 'plain body\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('---\n\ntitle: foo\n\n---\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/dedupe-yaml-array-values.test.ts
+++ b/tests/shared/formatter/rules/yaml/dedupe-yaml-array-values.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/dedupe-yaml-array-values';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'dedupe-yaml-array-values': true },
+  configs: {},
+};
+
+describe('dedupe-yaml-array-values (#155)', () => {
+  it('drops duplicate tags, first occurrence wins', () => {
+    const src = '---\ntags:\n  - a\n  - b\n  - a\n  - c\n  - b\n---\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('- a');
+    expect(out).toContain('- b');
+    expect(out).toContain('- c');
+    // Three unique tags, so three `- ` lines.
+    expect((out.match(/^  - /gm) || []).length).toBe(3);
+  });
+
+  it('dedupes within flow-style sequences too', () => {
+    const src = '---\ntags: [a, a, b]\n---\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('[ a, b ]');
+  });
+
+  it('is a no-op on already-unique lists', () => {
+    const src = '---\ntags:\n  - a\n  - b\n  - c\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves non-sequence values alone', () => {
+    const src = '---\ntitle: foo\nauthor: Alice\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is a no-op on files without frontmatter', () => {
+    const src = 'body\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const src = '---\ntags:\n  - a\n  - a\n  - b\n---\n';
+    const once = formatContent(src, enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/format-tags-in-yaml.test.ts
+++ b/tests/shared/formatter/rules/yaml/format-tags-in-yaml.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/format-tags-in-yaml';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, prefix: 'bare' | 'hash' = 'bare', key: string = 'tags') {
+  return formatContent(content, {
+    enabled: { 'format-tags-in-yaml': true },
+    configs: { 'format-tags-in-yaml': { prefix, key } },
+  });
+}
+
+describe('format-tags-in-yaml (#155)', () => {
+  it('strips leading `#` from tags in bare mode', () => {
+    const out = run('---\ntags:\n  - "#foo"\n  - bar\n  - "#baz"\n---\n');
+    expect(out).toContain('- foo');
+    expect(out).toContain('- bar');
+    expect(out).toContain('- baz');
+    expect(out).not.toContain('#foo');
+  });
+
+  it('adds leading `#` to bare tags in hash mode', () => {
+    const out = run('---\ntags:\n  - foo\n  - bar\n---\n', 'hash');
+    expect(out).toContain('- "#foo"');
+    expect(out).toContain('- "#bar"');
+  });
+
+  it('leaves already-correct tags alone (bare)', () => {
+    const src = '---\ntags:\n  - foo\n  - bar\n---\n';
+    expect(run(src, 'bare')).toBe(src);
+  });
+
+  it('can target a different tag-list key', () => {
+    const src = '---\nlabels:\n  - "#foo"\n---\n';
+    const out = run(src, 'bare', 'labels');
+    expect(out).toContain('- foo');
+  });
+
+  it('is idempotent', () => {
+    const once = run('---\ntags:\n  - "#foo"\n---\n', 'bare');
+    expect(run(once, 'bare')).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/format-yaml-array.test.ts
+++ b/tests/shared/formatter/rules/yaml/format-yaml-array.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/format-yaml-array';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, style: 'block' | 'flow', keys: string[] = []) {
+  return formatContent(content, {
+    enabled: { 'format-yaml-array': true },
+    configs: { 'format-yaml-array': { style, keys } },
+  });
+}
+
+describe('format-yaml-array (#155)', () => {
+  it('converts a flow sequence to block style (default)', () => {
+    const out = run('---\ntags: [a, b, c]\n---\n', 'block');
+    expect(out).toContain('tags:\n  - a\n  - b\n  - c\n');
+  });
+
+  it('converts a block sequence to flow style', () => {
+    const src = '---\ntags:\n  - a\n  - b\n  - c\n---\n';
+    const out = run(src, 'flow');
+    expect(out).toContain('tags: [ a, b, c ]');
+  });
+
+  it('only touches listed keys when `keys` is non-empty', () => {
+    const src = '---\ntags: [a, b]\nauthors: [x, y]\n---\n';
+    const out = run(src, 'block', ['tags']);
+    expect(out).toContain('tags:\n  - a\n  - b\n');
+    expect(out).toContain('authors: [ x, y ]');
+  });
+
+  it('leaves non-sequence values alone', () => {
+    const src = '---\ntitle: foo\nauthor: Alice\n---\n';
+    expect(run(src, 'block')).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = run('---\ntags: [a, b]\n---\n', 'block');
+    expect(run(once, 'block')).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/insert-yaml-attributes.test.ts
+++ b/tests/shared/formatter/rules/yaml/insert-yaml-attributes.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/insert-yaml-attributes';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, keys: string[]) {
+  return formatContent(content, {
+    enabled: { 'insert-yaml-attributes': true },
+    configs: { 'insert-yaml-attributes': { keys } },
+  });
+}
+
+describe('insert-yaml-attributes (#155)', () => {
+  it('adds a missing key with an empty value', () => {
+    const out = run('---\ntitle: foo\n---\n', ['author']);
+    expect(out).toContain('author:');
+  });
+
+  it('leaves an existing key alone', () => {
+    const src = '---\ntitle: foo\nauthor: Alice\n---\n';
+    const out = run(src, ['author']);
+    expect(out).toContain('author: Alice');
+  });
+
+  it('adds multiple missing keys', () => {
+    const out = run('---\ntitle: foo\n---\n', ['author', 'created']);
+    expect(out).toContain('author:');
+    expect(out).toContain('created:');
+  });
+
+  it('is a no-op when the keys list is empty', () => {
+    const src = '---\ntitle: foo\n---\n';
+    expect(run(src, [])).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = run('---\ntitle: foo\n---\n', ['author']);
+    expect(run(once, ['author'])).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/remove-yaml-keys.test.ts
+++ b/tests/shared/formatter/rules/yaml/remove-yaml-keys.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/remove-yaml-keys';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, keys: string[]) {
+  return formatContent(content, {
+    enabled: { 'remove-yaml-keys': true },
+    configs: { 'remove-yaml-keys': { keys } },
+  });
+}
+
+describe('remove-yaml-keys (#155)', () => {
+  it('removes a single listed key', () => {
+    const out = run('---\ntitle: foo\ndrafted: true\n---\n', ['drafted']);
+    expect(out).toBe('---\ntitle: foo\n---\n');
+  });
+
+  it('removes multiple listed keys', () => {
+    const out = run('---\na: 1\nb: 2\nc: 3\n---\n', ['a', 'c']);
+    expect(out).toBe('---\nb: 2\n---\n');
+  });
+
+  it('leaves other keys untouched', () => {
+    const out = run('---\ntitle: foo\nauthor: Alice\n---\n', ['nonexistent']);
+    expect(out).toBe('---\ntitle: foo\nauthor: Alice\n---\n');
+  });
+
+  it('is a no-op when the keys list is empty', () => {
+    const src = '---\ntitle: foo\n---\n';
+    expect(run(src, [])).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = run('---\ntitle: foo\ndraft: true\n---\n', ['draft']);
+    expect(run(once, ['draft'])).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/sort-yaml-array-values.test.ts
+++ b/tests/shared/formatter/rules/yaml/sort-yaml-array-values.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/sort-yaml-array-values';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, keys?: string[]) {
+  return formatContent(content, {
+    enabled: { 'sort-yaml-array-values': true },
+    configs: keys ? { 'sort-yaml-array-values': { keys } } : {},
+  });
+}
+
+describe('sort-yaml-array-values (#155)', () => {
+  it('sorts the default `tags` key alphabetically', () => {
+    const src = '---\ntags:\n  - zed\n  - apple\n  - middle\n---\n';
+    const out = run(src);
+    expect(out).toMatch(/apple[\s\S]*middle[\s\S]*zed/);
+  });
+
+  it('leaves other keys alone by default', () => {
+    const src = '---\nauthors:\n  - z\n  - a\n---\n';
+    expect(run(src)).toBe(src);
+  });
+
+  it('sorts additional keys when configured', () => {
+    const src = '---\nauthors:\n  - z\n  - a\n---\n';
+    const out = run(src, ['authors']);
+    expect(out).toMatch(/- a[\s\S]*- z/);
+  });
+
+  it('is a no-op when the keys list is empty', () => {
+    const src = '---\ntags:\n  - z\n  - a\n---\n';
+    expect(run(src, [])).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const src = '---\ntags:\n  - z\n  - a\n---\n';
+    const once = run(src);
+    expect(run(once)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/yaml-key-sort.test.ts
+++ b/tests/shared/formatter/rules/yaml/yaml-key-sort.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/yaml-key-sort';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, canonicalOrder?: string[]) {
+  return formatContent(content, {
+    enabled: { 'yaml-key-sort': true },
+    configs: canonicalOrder ? { 'yaml-key-sort': { canonicalOrder } } : {},
+  });
+}
+
+describe('yaml-key-sort (#155)', () => {
+  it('sorts keys into the default canonical order', () => {
+    const src = '---\ntags: [a]\ncreated: 2025-01-01\ntitle: foo\n---\n';
+    const out = run(src);
+    // Order in default: title → created → tags.
+    const lines = out.split('\n').filter((l) => !/^---|^\s*$/.test(l));
+    expect(lines[0]).toMatch(/^title:/);
+    expect(lines[1]).toMatch(/^created:/);
+    expect(lines[2]).toMatch(/^tags:/);
+  });
+
+  it('places unknown keys alphabetically after canonical', () => {
+    const src = '---\nzebra: 1\napple: 2\ntitle: foo\n---\n';
+    const out = run(src);
+    const lines = out.split('\n').filter((l) => !/^---|^\s*$/.test(l));
+    expect(lines[0]).toMatch(/^title:/);
+    expect(lines[1]).toMatch(/^apple:/);
+    expect(lines[2]).toMatch(/^zebra:/);
+  });
+
+  it('respects a user-supplied order', () => {
+    const src = '---\nb: 1\na: 2\n---\n';
+    const out = run(src, ['b', 'a']);
+    const lines = out.split('\n').filter((l) => !/^---|^\s*$/.test(l));
+    expect(lines[0]).toMatch(/^b:/);
+    expect(lines[1]).toMatch(/^a:/);
+  });
+
+  it('is idempotent', () => {
+    const src = '---\ntags: [a]\ntitle: foo\n---\n';
+    const once = run(src);
+    expect(run(once)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/yaml-timestamp.test.ts
+++ b/tests/shared/formatter/rules/yaml/yaml-timestamp.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/yaml-timestamp';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(
+  content: string,
+  config: {
+    updateModified?: boolean;
+    insertCreated?: boolean;
+    format?: 'iso-date' | 'iso';
+  } = {},
+) {
+  return formatContent(content, {
+    enabled: { 'yaml-timestamp': true },
+    configs: { 'yaml-timestamp': { updateModified: true, insertCreated: true, format: 'iso-date', ...config } },
+  });
+}
+
+describe('yaml-timestamp (#155)', () => {
+  beforeEach(() => {
+    // Pin "now" to a stable instant so tests are deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-21T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sets `modified:` to today when updateModified is on', () => {
+    const out = run('---\ntitle: foo\n---\n');
+    expect(out).toContain('modified: 2026-04-21');
+  });
+
+  it('inserts `created:` when missing and insertCreated is on', () => {
+    const out = run('---\ntitle: foo\n---\n');
+    expect(out).toContain('created: 2026-04-21');
+  });
+
+  it('does not overwrite an existing `created:`', () => {
+    const out = run('---\ncreated: 2020-01-01\ntitle: foo\n---\n');
+    expect(out).toContain('created: 2020-01-01');
+    expect(out).not.toContain('created: 2026-04-21');
+  });
+
+  it('is idempotent within the same day', () => {
+    const once = run('---\ntitle: foo\n---\n');
+    expect(run(once)).toBe(once);
+  });
+
+  it('emits full ISO timestamp when format is "iso"', () => {
+    const out = run('---\ntitle: foo\n---\n', { format: 'iso' });
+    expect(out).toContain('modified: 2026-04-21T12:00:00.000Z');
+  });
+
+  it('skips updateModified when the flag is off', () => {
+    const out = run('---\ntitle: foo\n---\n', { updateModified: false });
+    expect(out).not.toContain('modified:');
+  });
+});

--- a/tests/shared/formatter/rules/yaml/yaml-title-alias.test.ts
+++ b/tests/shared/formatter/rules/yaml/yaml-title-alias.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/yaml-title-alias';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = { enabled: { 'yaml-title-alias': true }, configs: {} };
+
+describe('yaml-title-alias (#155)', () => {
+  it('adds an aliases key with the title when aliases is missing', () => {
+    const out = formatContent('---\ntitle: Foo\n---\n', enabled);
+    expect(out).toContain('aliases:');
+    expect(out).toMatch(/aliases:\s*\n?\s*-?\s*Foo/);
+  });
+
+  it('appends the title to an existing aliases list when absent', () => {
+    const src = '---\ntitle: Foo\naliases:\n  - Bar\n---\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('- Bar');
+    expect(out).toContain('- Foo');
+  });
+
+  it('leaves aliases alone if it already contains the title', () => {
+    const src = '---\ntitle: Foo\naliases:\n  - Foo\n  - Bar\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is a no-op when no title key is set', () => {
+    const src = '---\nauthor: Alice\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('---\ntitle: Foo\n---\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/yaml/yaml-title.test.ts
+++ b/tests/shared/formatter/rules/yaml/yaml-title.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/yaml/yaml-title';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, direction: 'heading-to-yaml' | 'yaml-to-heading') {
+  return formatContent(content, {
+    enabled: { 'yaml-title': true },
+    configs: { 'yaml-title': { direction } },
+  });
+}
+
+describe('yaml-title (#155)', () => {
+  describe('direction: heading-to-yaml', () => {
+    it('copies the first H1 text into the frontmatter title', () => {
+      const out = run('---\ntitle: old\n---\n\n# The Real Title\n\nbody\n', 'heading-to-yaml');
+      expect(out).toContain('title: The Real Title');
+    });
+
+    it('inserts the title key when missing', () => {
+      const out = run('---\nauthor: Alice\n---\n\n# Hello\n', 'heading-to-yaml');
+      expect(out).toContain('title: Hello');
+    });
+
+    it('is a no-op when no H1 exists', () => {
+      const src = '---\ntitle: foo\n---\n\n## only h2\n';
+      expect(run(src, 'heading-to-yaml')).toBe(src);
+    });
+
+    it('is a no-op when title already matches H1', () => {
+      const src = '---\ntitle: Same\n---\n\n# Same\n';
+      expect(run(src, 'heading-to-yaml')).toBe(src);
+    });
+  });
+
+  describe('direction: yaml-to-heading', () => {
+    it('rewrites the first H1 to match the frontmatter title', () => {
+      const out = run('---\ntitle: The Right Title\n---\n\n# Wrong Title\n', 'yaml-to-heading');
+      expect(out).toContain('# The Right Title');
+      expect(out).not.toContain('# Wrong Title');
+    });
+
+    it('leaves the H1 alone when no title key exists', () => {
+      const src = '---\nauthor: Alice\n---\n\n# Existing\n';
+      expect(run(src, 'yaml-to-heading')).toBe(src);
+    });
+
+    it('does not insert an H1 when none exists (that is file-name-heading\'s job)', () => {
+      const src = '---\ntitle: Foo\n---\n\nbody\n';
+      expect(run(src, 'yaml-to-heading')).toBe(src);
+    });
+  });
+
+  describe('shared', () => {
+    it('ignores `#` inside a code fence', () => {
+      const src = '---\ntitle: Real\n---\n\n```\n# Not real\n```\n';
+      expect(run(src, 'heading-to-yaml')).toBe(src);
+    });
+
+    it('is idempotent (heading-to-yaml)', () => {
+      const once = run('---\ntitle: old\n---\n\n# New\n', 'heading-to-yaml');
+      expect(run(once, 'heading-to-yaml')).toBe(once);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Lands all 12 YAML frontmatter rules from #155, built on a small `yaml/helpers.ts` that parses via yaml v2's `parseDocument`, hands the doc to the rule's mutator, and re-serialises.

**Block-shape rules** (string-level, no YAML parse):
- `compact-yaml` — strip leading/trailing blanks inside `---` fences.
- `add-blank-line-after-yaml` — exactly one blank line between frontmatter and body.

**Value-level rules** (targeted doc mutation):
- `dedupe-yaml-array-values` — drop duplicate entries (first occurrence wins).
- `sort-yaml-array-values` — alphabetical sort, opt-in per key (defaults to `tags`; ordering is often meaningful for authors/contributors).
- `remove-yaml-keys` — delete configured keys.
- `format-tags-in-yaml` — directional `bare` vs `hash` prefix. Clears the scalar's quote-hint so updated values emit unquoted.
- `insert-yaml-attributes` — add missing keys with empty values.

**Structure rules:**
- `yaml-key-sort` — canonical-order-first, alphabetical tail. Default order: identity metadata → content metadata → timestamps.
- `format-yaml-array` — directional `block` vs `flow`.

**Cross-document rules:**
- `yaml-timestamp` — `modified:` set to today's date per run (no-op within the same day); `created:` inserted if missing, never overwritten.
- `yaml-title` — directional sync between frontmatter title and the first H1.
- `yaml-title-alias` — ensure the title appears in `aliases:`.

**Skipped from the ticket:** `move-tags-to-yaml` (Minerva treats body `#tags` and frontmatter `tags:` as equivalent at index time) and `escape-yaml-special-characters` / `force-yaml-escape` (yaml v2's serialiser handles escaping by construction).

Failures to parse are silently swallowed — rules never corrupt a malformed frontmatter block.

## Test plan

- [x] 67 rule-specific tests (deterministic clock for `yaml-timestamp` via `vi.useFakeTimers`)
- [x] Full suite: 941/941 pass
- [x] `pnpm lint` clean
- [ ] Manual smoke test: enable a handful of rules in a note with messy frontmatter, run Format, confirm output

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)