### PR TITLE
Formatter: Minerva-specific rules (closes #161)

### DIFF
--- a/src/main/notebase/link-rewriting.ts
+++ b/src/main/notebase/link-rewriting.ts
@@ -15,44 +15,7 @@
  * like wiki-links at all are left untouched.
  */
 
-const WIKI_LINK_RE = /\[\[([^\]\n]+?)\]\]/g;
-
-interface ParsedWikiLink {
-  /** Type prefix like `supports` or `cite`, or null if untyped. */
-  type: string | null;
-  /** Bare path/id portion (no anchor, no display, no type prefix). */
-  target: string;
-  /** Original anchor including the `#` prefix, or null if absent. */
-  anchor: string | null;
-  /** Display text after `|`, or null if absent. */
-  display: string | null;
-}
-
-function parseWikiInner(inner: string): ParsedWikiLink {
-  // Split off display (|)
-  const pipeIdx = inner.indexOf('|');
-  const head = pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner;
-  const display = pipeIdx >= 0 ? inner.slice(pipeIdx + 1) : null;
-
-  // Split off type::
-  const typeMatch = head.match(/^([a-z][\w-]*)::(.*)$/);
-  const type = typeMatch ? typeMatch[1] : null;
-  const rest = typeMatch ? typeMatch[2] : head;
-
-  // Split off #anchor (everything from # onward, preserving block-id `^`)
-  const hashIdx = rest.indexOf('#');
-  const target = hashIdx >= 0 ? rest.slice(0, hashIdx) : rest;
-  const anchor = hashIdx >= 0 ? rest.slice(hashIdx) : null;
-
-  return { type, target: target.trim(), anchor, display };
-}
-
-function reassembleWikiLink(parsed: ParsedWikiLink, newTarget: string): string {
-  const typeText = parsed.type ? `${parsed.type}::` : '';
-  const anchorText = parsed.anchor ?? '';
-  const displayText = parsed.display !== null ? `|${parsed.display}` : '';
-  return `[[${typeText}${newTarget}${anchorText}${displayText}]]`;
-}
+import { WIKI_LINK_RE, parseWikiInner, reassembleWikiLink } from '../../shared/wiki-link';
 
 /** Strip a trailing `.md` extension so rewrite keys match the indexer's convention. */
 export function normalizePath(p: string): string {

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -48,6 +48,14 @@ import './content/unordered-list-marker-style';
 import './content/ordered-list-style';
 import './content/auto-correct-common-misspellings';
 
+// Minerva-specific (#161) — rules that know about wiki-links, block-ids,
+// anchor slugs, and frontmatter-predicate aliases.
+import './minerva/canonical-wiki-link-extension';
+import './minerva/remove-redundant-wiki-link-display';
+import './minerva/canonicalize-frontmatter-keys';
+import './minerva/unique-block-ids-per-note';
+import './minerva/unique-heading-slugs';
+
 // Footnote (#159) — reference placement, definition ordering, renumbering.
 // `move-footnotes-to-the-bottom` runs before `re-index-footnotes` so the
 // latter sees definitions in their final order.

--- a/src/shared/formatter/rules/minerva/canonical-wiki-link-extension.ts
+++ b/src/shared/formatter/rules/minerva/canonical-wiki-link-extension.ts
@@ -1,0 +1,36 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+import { WIKI_LINK_RE, parseWikiInner, reassembleWikiLink } from '../../../wiki-link';
+
+interface Config {
+  /** `never`: strip `.md` from every wiki-link target. `always`: add it where missing. */
+  extension: 'never' | 'always';
+}
+
+registerRule<Config>({
+  id: 'canonical-wiki-link-extension',
+  category: 'minerva',
+  title: 'Canonical wiki-link extension',
+  description:
+    'Enforce a single style for wiki-link targets — either always with `.md` or always without. Typed links (`[[cite::…]]`, `[[quote::…]]`) are left alone; they target sources/excerpts, not files.',
+  defaultConfig: { extension: 'never' },
+  apply(content, config, cache) {
+    const want = config.extension === 'always' ? 'always' : 'never';
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(WIKI_LINK_RE, (match, inner: string) => {
+        const parsed = parseWikiInner(inner);
+        if (parsed.type !== null) return match; // typed links target ids, not files
+        const target = parsed.target;
+        if (target.length === 0) return match;
+        const hasMd = /\.md$/.test(target);
+        if (want === 'always' && !hasMd) {
+          return reassembleWikiLink(parsed, `${target}.md`);
+        }
+        if (want === 'never' && hasMd) {
+          return reassembleWikiLink(parsed, target.replace(/\.md$/, ''));
+        }
+        return match;
+      }),
+    );
+  },
+});

--- a/src/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.ts
+++ b/src/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.ts
@@ -1,0 +1,64 @@
+import YAML from 'yaml';
+import { registerRule } from '../../registry';
+import { transformFrontmatterDoc } from '../yaml/helpers';
+
+/**
+ * Alias → canonical key. Pulled from Minerva's frontmatter-predicates map
+ * (src/main/graph/frontmatter-predicates.ts) — kept in sync but redefined
+ * here since the main-process module can't be imported from shared code.
+ * The surface is narrow enough that drift is cheap to spot.
+ */
+const ALIAS_TO_CANONICAL: Record<string, string> = {
+  author: 'creator',
+  authors: 'creator',
+  lang: 'language',
+  date: 'issued',
+  year: 'issued',
+  url: 'uri',
+  pageRange: 'pages',
+};
+
+registerRule({
+  id: 'canonicalize-frontmatter-keys',
+  category: 'minerva',
+  title: 'Canonicalise frontmatter keys',
+  description:
+    'Rename well-known alias keys (`author` → `creator`, `date` → `issued`, `url` → `uri`, …) to the canonical form the indexer already maps them to. Unknown keys pass through unchanged.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformFrontmatterDoc(content, cache, (doc) => {
+      if (!YAML.isMap(doc.contents)) return;
+      const existingKeys = new Set<string>();
+      for (const pair of doc.contents.items) {
+        const name = keyString(pair.key);
+        if (name !== null) existingKeys.add(name);
+      }
+      for (const pair of doc.contents.items) {
+        const name = keyString(pair.key);
+        if (name === null) continue;
+        const canonical = ALIAS_TO_CANONICAL[name];
+        if (!canonical) continue;
+        // If both the alias and the canonical form are present, leave
+        // the alias alone — merging two distinct values is out of scope.
+        if (existingKeys.has(canonical)) continue;
+        // Pair keys in parsed documents are always Scalar. The `|| string`
+        // branch of keyString is just a defensive fallback; if we're in the
+        // else-branch here, the source YAML was unusual enough that we'd
+        // rather no-op than risk corrupting it.
+        if (YAML.isScalar(pair.key)) {
+          pair.key.value = canonical;
+          pair.key.type = undefined;
+        }
+        existingKeys.add(canonical);
+      }
+    });
+  },
+});
+
+function keyString(key: unknown): string | null {
+  if (typeof key === 'string') return key;
+  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
+    return String((key as YAML.Scalar).value);
+  }
+  return null;
+}

--- a/src/shared/formatter/rules/minerva/remove-redundant-wiki-link-display.ts
+++ b/src/shared/formatter/rules/minerva/remove-redundant-wiki-link-display.ts
@@ -1,0 +1,26 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+import { WIKI_LINK_RE, parseWikiInner, reassembleWikiLink } from '../../../wiki-link';
+
+registerRule({
+  id: 'remove-redundant-wiki-link-display',
+  category: 'minerva',
+  title: 'Remove redundant wiki-link display',
+  description:
+    'When a wiki-link\'s display alias exactly matches its target (modulo a `.md` extension), drop the pipe: `[[notes/foo|notes/foo]]` → `[[notes/foo]]`.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(WIKI_LINK_RE, (match, inner: string) => {
+        const parsed = parseWikiInner(inner);
+        if (parsed.display === null) return match;
+        const target = parsed.target.replace(/\.md$/, '');
+        const display = parsed.display.trim().replace(/\.md$/, '');
+        if (target !== display) return match;
+        // Drop the display portion; everything else is preserved by
+        // reassembleWikiLink since parsed.display is cleared below.
+        return reassembleWikiLink({ ...parsed, display: null }, parsed.target);
+      }),
+    );
+  },
+});

--- a/src/shared/formatter/rules/minerva/unique-block-ids-per-note.ts
+++ b/src/shared/formatter/rules/minerva/unique-block-ids-per-note.ts
@@ -1,0 +1,40 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+/**
+ * A block-id marker is `^id` appearing near the end of a line after one or
+ * more spaces. See `note-anchors.ts` for the canonical matcher. Here we
+ * only need to locate + rename, not index.
+ */
+const BLOCK_ID_RE = /(\s)\^([\w-]+)(?=\s*(?:\r?\n|$))/g;
+
+registerRule({
+  id: 'unique-block-ids-per-note',
+  category: 'minerva',
+  title: 'Unique block-ids',
+  description:
+    'When two paragraphs in the same note share a `^block-id` marker, suffix the duplicates (`-2`, `-3`, …) so every block-id is unique. Incoming `[[note#^block-id]]` links are NOT updated — if you renamed a duplicate that had incoming links, you\'ll need to fix those by hand.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    return transformUnprotected(content, cache, (seg) => {
+      const seen = new Map<string, number>();
+      return seg.replace(BLOCK_ID_RE, (match, lead: string, id: string) => {
+        const count = seen.get(id) ?? 0;
+        seen.set(id, count + 1);
+        if (count === 0) return match;
+        const suffixed = findUniqueId(id, count + 1, seen);
+        seen.set(suffixed, 1);
+        return `${lead}^${suffixed}`;
+      });
+    });
+  },
+});
+
+function findUniqueId(base: string, startFrom: number, seen: Map<string, number>): string {
+  let n = startFrom;
+  while (true) {
+    const candidate = `${base}-${n}`;
+    if (!seen.has(candidate)) return candidate;
+    n++;
+  }
+}

--- a/src/shared/formatter/rules/minerva/unique-heading-slugs.ts
+++ b/src/shared/formatter/rules/minerva/unique-heading-slugs.ts
@@ -1,0 +1,77 @@
+import { registerRule } from '../../registry';
+import { slugify } from '../../../slug';
+
+const HEADING_RE = /^(#{1,6})([ \t]+)(.+?)([ \t]*#*[ \t]*)$/;
+
+registerRule({
+  id: 'unique-heading-slugs',
+  category: 'minerva',
+  title: 'Unique heading slugs',
+  description:
+    'When two headings in the same note slugify to the same id, suffix the duplicates (`Overview` + `Overview` → `Overview` + `Overview 2`) so every heading anchor is unique. When a heading is renamed, the orchestrator\'s rename cascade rewrites incoming `[[note#old-slug]]` links to match.',
+  defaultConfig: {},
+  apply(content, _cfg, cache) {
+    const lines = splitLinesKeepTerminator(content);
+    const offsets = buildLineOffsets(lines);
+    const seenSlugs = new Map<string, number>();
+    const rewrites: { lineIndex: number; newLine: string }[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const raw = lines[i];
+      if (cache.isProtected(offsets[i])) continue;
+      const body = raw.replace(/\r?\n$/, '');
+      const m = body.match(HEADING_RE);
+      if (!m) continue;
+      const text = m[3].trim();
+      const slug = slugify(text);
+      const count = seenSlugs.get(slug) ?? 0;
+      seenSlugs.set(slug, count + 1);
+      if (count === 0) continue;
+      // Need a unique text; start at `<text> 2`, climb until the slug is free.
+      let n = count + 1;
+      let candidateText: string;
+      let candidateSlug: string;
+      while (true) {
+        candidateText = `${text} ${n}`;
+        candidateSlug = slugify(candidateText);
+        if (!seenSlugs.has(candidateSlug)) break;
+        n++;
+      }
+      seenSlugs.set(candidateSlug, 1);
+      const terminator = raw.slice(body.length);
+      rewrites.push({
+        lineIndex: i,
+        newLine: `${m[1]}${m[2]}${candidateText}${m[4]}${terminator}`,
+      });
+    }
+
+    if (rewrites.length === 0) return content;
+    for (const r of rewrites) lines[r.lineIndex] = r.newLine;
+    return lines.join('');
+  },
+});
+
+function splitLinesKeepTerminator(content: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = content.length;
+  while (i < n) {
+    let j = i;
+    while (j < n && content[j] !== '\n') j++;
+    if (j < n) j++;
+    out.push(content.slice(i, j));
+    i = j;
+  }
+  return out;
+}
+
+function buildLineOffsets(lines: string[]): number[] {
+  const offsets = new Array<number>(lines.length);
+  let pos = 0;
+  for (let i = 0; i < lines.length; i++) {
+    offsets[i] = pos;
+    pos += lines[i].length;
+  }
+  return offsets;
+}
+

--- a/src/shared/wiki-link.ts
+++ b/src/shared/wiki-link.ts
@@ -1,0 +1,44 @@
+/**
+ * Wiki-link parsing primitives shared between the indexer's rewriting code
+ * and the formatter's Minerva-specific rules.
+ *
+ * A wiki-link has four optional parts: `[[type::target#anchor|display]]`.
+ * None of these helpers touch the document around the link; callers slot
+ * the reassembled string back in themselves.
+ */
+
+export const WIKI_LINK_RE = /\[\[([^\]\n]+?)\]\]/g;
+
+export interface ParsedWikiLink {
+  /** Type prefix like `supports` or `cite`, or null if untyped. */
+  type: string | null;
+  /** Bare path/id portion (no anchor, no display, no type prefix). */
+  target: string;
+  /** Original anchor including the `#` prefix, or null if absent. */
+  anchor: string | null;
+  /** Display text after `|`, or null if absent. */
+  display: string | null;
+}
+
+export function parseWikiInner(inner: string): ParsedWikiLink {
+  const pipeIdx = inner.indexOf('|');
+  const head = pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner;
+  const display = pipeIdx >= 0 ? inner.slice(pipeIdx + 1) : null;
+
+  const typeMatch = head.match(/^([a-z][\w-]*)::(.*)$/);
+  const type = typeMatch ? typeMatch[1] : null;
+  const rest = typeMatch ? typeMatch[2] : head;
+
+  const hashIdx = rest.indexOf('#');
+  const target = hashIdx >= 0 ? rest.slice(0, hashIdx) : rest;
+  const anchor = hashIdx >= 0 ? rest.slice(hashIdx) : null;
+
+  return { type, target: target.trim(), anchor, display };
+}
+
+export function reassembleWikiLink(parsed: ParsedWikiLink, newTarget: string): string {
+  const typeText = parsed.type ? `${parsed.type}::` : '';
+  const anchorText = parsed.anchor ?? '';
+  const displayText = parsed.display !== null ? `|${parsed.display}` : '';
+  return `[[${typeText}${newTarget}${anchorText}${displayText}]]`;
+}

--- a/tests/shared/formatter/rules/minerva/canonical-wiki-link-extension.test.ts
+++ b/tests/shared/formatter/rules/minerva/canonical-wiki-link-extension.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/minerva/canonical-wiki-link-extension';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+function run(content: string, extension: 'never' | 'always') {
+  return formatContent(content, {
+    enabled: { 'canonical-wiki-link-extension': true },
+    configs: { 'canonical-wiki-link-extension': { extension } },
+  });
+}
+
+describe('canonical-wiki-link-extension (#161)', () => {
+  describe('extension: never', () => {
+    it('strips `.md` from wiki-link targets', () => {
+      expect(run('[[notes/foo.md]]', 'never')).toBe('[[notes/foo]]');
+    });
+
+    it('preserves type prefixes, anchors, and display aliases', () => {
+      expect(run('[[notes/foo.md#section|Label]]', 'never')).toBe(
+        '[[notes/foo#section|Label]]',
+      );
+    });
+
+    it('leaves links without `.md` alone', () => {
+      const src = '[[notes/foo]]';
+      expect(run(src, 'never')).toBe(src);
+    });
+  });
+
+  describe('extension: always', () => {
+    it('adds `.md` to wiki-link targets', () => {
+      expect(run('[[notes/foo]]', 'always')).toBe('[[notes/foo.md]]');
+    });
+
+    it('leaves links that already have `.md` alone', () => {
+      const src = '[[notes/foo.md]]';
+      expect(run(src, 'always')).toBe(src);
+    });
+  });
+
+  describe('shared', () => {
+    it('does not touch typed links (cite/quote)', () => {
+      const src = '[[cite::some-source]] and [[quote::an-excerpt]]';
+      expect(run(src, 'always')).toBe(src);
+      expect(run(src, 'never')).toBe(src);
+    });
+
+    it('does not touch wiki-links inside a code fence', () => {
+      const src = '```\n[[notes/foo.md]]\n```\n';
+      expect(run(src, 'never')).toBe(src);
+    });
+
+    it('is idempotent', () => {
+      const once = run('[[notes/foo.md]]', 'never');
+      expect(run(once, 'never')).toBe(once);
+    });
+  });
+});

--- a/tests/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.test.ts
+++ b/tests/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/minerva/canonicalize-frontmatter-keys';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'canonicalize-frontmatter-keys': true },
+  configs: {},
+};
+
+describe('canonicalize-frontmatter-keys (#161)', () => {
+  it('renames author → creator', () => {
+    const out = formatContent('---\nauthor: Alice\n---\n', enabled);
+    expect(out).toContain('creator: Alice');
+    expect(out).not.toContain('author:');
+  });
+
+  it('renames date → issued', () => {
+    const out = formatContent('---\ndate: 2025-01-01\n---\n', enabled);
+    expect(out).toContain('issued: 2025-01-01');
+  });
+
+  it('renames url → uri', () => {
+    const out = formatContent('---\nurl: https://example.com\n---\n', enabled);
+    expect(out).toContain('uri: https://example.com');
+  });
+
+  it('leaves canonical keys untouched', () => {
+    const src = '---\ncreator: Alice\nissued: 2025\nuri: https://x\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves unknown keys alone', () => {
+    const src = '---\nstatus: draft\nlocation: office\n---\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not overwrite when both alias and canonical are present', () => {
+    // Merging two values is out of scope; the alias stays.
+    const src = '---\ncreator: Bob\nauthor: Alice\n---\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('creator: Bob');
+    expect(out).toContain('author: Alice');
+  });
+
+  it('is a no-op on files without frontmatter', () => {
+    const src = 'body\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('---\nauthor: Alice\n---\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/minerva/remove-redundant-wiki-link-display.test.ts
+++ b/tests/shared/formatter/rules/minerva/remove-redundant-wiki-link-display.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/minerva/remove-redundant-wiki-link-display';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'remove-redundant-wiki-link-display': true },
+  configs: {},
+};
+
+describe('remove-redundant-wiki-link-display (#161)', () => {
+  it('removes exact duplicate display aliases', () => {
+    expect(formatContent('[[notes/foo|notes/foo]]', enabled)).toBe('[[notes/foo]]');
+  });
+
+  it('removes display aliases that only differ in `.md` extension', () => {
+    expect(formatContent('[[notes/foo.md|notes/foo]]', enabled)).toBe('[[notes/foo.md]]');
+    expect(formatContent('[[notes/foo|notes/foo.md]]', enabled)).toBe('[[notes/foo]]');
+  });
+
+  it('leaves meaningful display aliases alone', () => {
+    const src = '[[notes/foo|Friendly Label]]';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('leaves links without a display alone', () => {
+    const src = '[[notes/foo]]';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('preserves type prefix and anchor when dropping the alias', () => {
+    expect(formatContent('[[notes/foo#section|notes/foo]]', enabled)).toBe(
+      '[[notes/foo#section]]',
+    );
+  });
+
+  it('does not touch links inside a code fence', () => {
+    const src = '```\n[[notes/foo|notes/foo]]\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('[[notes/foo|notes/foo]]', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/minerva/unique-block-ids-per-note.test.ts
+++ b/tests/shared/formatter/rules/minerva/unique-block-ids-per-note.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/minerva/unique-block-ids-per-note';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'unique-block-ids-per-note': true },
+  configs: {},
+};
+
+describe('unique-block-ids-per-note (#161)', () => {
+  it('suffixes a single duplicate', () => {
+    const src = 'First paragraph ^note\n\nSecond paragraph ^note\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain(' ^note\n');
+    expect(out).toContain(' ^note-2\n');
+  });
+
+  it('suffixes multiple duplicates sequentially', () => {
+    const src = 'p1 ^x\n\np2 ^x\n\np3 ^x\n\np4 ^x\n';
+    const out = formatContent(src, enabled);
+    expect(out).toMatch(/p1 \^x\n/);
+    expect(out).toMatch(/p2 \^x-2\n/);
+    expect(out).toMatch(/p3 \^x-3\n/);
+    expect(out).toMatch(/p4 \^x-4\n/);
+  });
+
+  it('leaves unique block-ids alone', () => {
+    const src = 'p1 ^a\n\np2 ^b\n\np3 ^c\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('does not collide with an id that already uses the suffix', () => {
+    const src = 'a ^x\n\nb ^x-2\n\nc ^x\n';
+    const out = formatContent(src, enabled);
+    // The first ^x stays. ^x-2 stays (unique). The second ^x must become
+    // something other than x-2 (already taken) — so x-3.
+    expect(out).toContain(' ^x\n');
+    expect(out).toContain(' ^x-2\n');
+    expect(out).toContain(' ^x-3\n');
+  });
+
+  it('does not rename block-ids inside a code fence', () => {
+    const src = '```\nsome code ^x\n^x again\n```\n\nreal ^x\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('p ^note\n\np ^note\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});

--- a/tests/shared/formatter/rules/minerva/unique-heading-slugs.test.ts
+++ b/tests/shared/formatter/rules/minerva/unique-heading-slugs.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/minerva/unique-heading-slugs';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+
+const enabled = {
+  enabled: { 'unique-heading-slugs': true },
+  configs: {},
+};
+
+describe('unique-heading-slugs (#161)', () => {
+  it('suffixes a duplicate H2', () => {
+    const src = '## Overview\n\nbody\n\n## Overview\n\nmore\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('## Overview\n');
+    expect(out).toContain('## Overview 2\n');
+  });
+
+  it('handles multiple duplicates sequentially', () => {
+    const src = '# Intro\n\n# Intro\n\n# Intro\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('# Intro\n');
+    expect(out).toContain('# Intro 2\n');
+    expect(out).toContain('# Intro 3\n');
+  });
+
+  it('treats case differences as collisions (slug is lowercase)', () => {
+    const src = '## foo\n\n## FOO\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('## foo\n');
+    expect(out).toContain('## FOO 2\n');
+  });
+
+  it('leaves unique headings alone', () => {
+    const src = '# A\n\n## B\n\n### C\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('respects headings across levels as separate (H1 and H2 with same text both collide)', () => {
+    // Slugs are derived from text, not level — so `# Overview` and
+    // `## Overview` clash on the same slug.
+    const src = '# Overview\n\n## Overview\n';
+    const out = formatContent(src, enabled);
+    expect(out).toContain('# Overview\n');
+    expect(out).toContain('## Overview 2\n');
+  });
+
+  it('does not touch `#` inside a code fence', () => {
+    const src = '# Intro\n\n```\n# Intro\n# Intro\n```\n';
+    expect(formatContent(src, enabled)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const once = formatContent('# Intro\n\n# Intro\n', enabled);
+    expect(formatContent(once, enabled)).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Lands 5 of the 9 rules from #161 — the local-scope rules. Four remain as follow-up because they need orchestrator- or inspection-layer extensions that don't fit the pure \`content → content\` rule interface: \`canonical-wiki-link-path-style\`, \`strip-orphaned-block-ids\`, and the two \`warn-unknown-*-targets\` rules.

**Wiki-link canonicalisation:**
- \`canonical-wiki-link-extension\` — directional \`never\` (default, strip \`.md\`) vs \`always\`. Typed links (\`[[cite::…]]\`, \`[[quote::…]]\`) are left alone.
- \`remove-redundant-wiki-link-display\` — drop the pipe alias when it matches the target modulo \`.md\`: \`[[notes/foo|notes/foo]]\` → \`[[notes/foo]]\`. Meaningful aliases preserved.

**Frontmatter alignment:**
- \`canonicalize-frontmatter-keys\` — rename well-known alias keys (\`author\` → \`creator\`, \`date\` → \`issued\`, \`url\` → \`uri\`, …). When both an alias and its canonical form are present the alias is left alone — merging distinct values is out of scope.

**Block-id + heading hygiene:**
- \`unique-block-ids-per-note\` — suffix duplicates with \`-2\`, \`-3\`, skipping any suffix already in use. Does NOT rewrite incoming links.
- \`unique-heading-slugs\` — suffix duplicate headings (\`Overview\` + \`Overview\` → \`Overview\` + \`Overview 2\`). The orchestrator's rename cascade from #156 picks up the slug change and rewrites incoming \`[[note#old-slug]]\` links automatically.

**Refactor:** extracted \`parseWikiInner\` / \`reassembleWikiLink\` / \`WIKI_LINK_RE\` to \`src/shared/wiki-link.ts\` so the formatter rules and the indexer's \`link-rewriting.ts\` share one implementation (rules live under \`shared/\` and can't import from \`main/\`).

## Test plan

- [x] 36 rule-specific tests
- [x] Full suite: 977/977 pass
- [x] \`pnpm lint\` clean
- [ ] Manual: enable \`unique-heading-slugs\` on a note with duplicate headings, confirm the cascade rewrites incoming links in other notes

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)