### PR TITLE
Editor: Copy Block Link context-menu command (closes #138)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -23,6 +23,7 @@
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { linkCompletionSource } from '../editor/link-autocomplete';
+  import { planBlockLink } from '../editor/block-link';
 
   export interface CursorInfo {
     line: number;
@@ -95,7 +96,7 @@
   let editorContainer: HTMLDivElement;
   let view: EditorView;
   let ignoreNextUpdate = false;
-  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean } | null>(null);
+  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean; docPos: number | null } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
   // Snapshot of the selection taken when the context menu opens, so
   // commands from the menu can run against what the user had selected
@@ -218,13 +219,15 @@
     e.preventDefault();
     let link: LinkRange | null = null;
     let hasSelection = false;
+    let docPos: number | null = null;
     if (view) {
       const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+      docPos = pos ?? null;
       if (pos != null) link = findLinkAt(view.state, pos);
       const sel = view.state.selection.main;
       hasSelection = sel.from !== sel.to;
     }
-    contextMenu = { x: e.clientX, y: e.clientY, link, hasSelection };
+    contextMenu = { x: e.clientX, y: e.clientY, link, hasSelection, docPos };
     const close = () => {
       closeMenu();
       window.removeEventListener('click', close);
@@ -283,6 +286,27 @@
   function runCmd(cmd: (v: EditorView) => boolean) {
     restoreSelection();
     if (view) cmd(view);
+    closeMenu();
+  }
+
+  /**
+   * Right-click action: anchor the paragraph under the cursor with a
+   * `^block-id` marker (reusing any existing one) and copy the canonical
+   * `[[note#^block-id]]` link to the clipboard. Blank lines and notes
+   * with no path yet (unsaved buffers) are silently skipped.
+   */
+  async function copyBlockLink(): Promise<void> {
+    if (!view || !contextMenu || contextMenu.docPos == null || !filePath) {
+      closeMenu();
+      return;
+    }
+    const plan = planBlockLink(view.state.doc.toString(), contextMenu.docPos);
+    if (!plan) { closeMenu(); return; }
+    if (plan.edit) {
+      view.dispatch({ changes: { from: plan.edit.at, insert: plan.edit.text } });
+    }
+    const relPath = filePath.replace(/\.md$/, '');
+    await navigator.clipboard.writeText(`[[${relPath}#^${plan.blockId}]]`);
     closeMenu();
   }
 
@@ -618,6 +642,9 @@
     <button onclick={() => execCommand('cut')}>Cut</button>
     <button onclick={() => execCommand('copy')}>Copy</button>
     <button onclick={() => execCommand('paste')}>Paste</button>
+    {#if filePath}
+      <button onclick={() => copyBlockLink()}>Copy Block Link</button>
+    {/if}
     <div class="separator"></div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
       <span class="submenu-trigger">Format &#x25B8;</span>

--- a/src/renderer/lib/editor/block-link.ts
+++ b/src/renderer/lib/editor/block-link.ts
@@ -1,0 +1,82 @@
+/**
+ * Block-link helpers for the editor's "Copy Block Link" right-click action.
+ *
+ * Given a cursor position in the document, figure out which paragraph is
+ * being targeted and decide whether to reuse an existing `^block-id` or
+ * insert a new one. Pure-string implementation so it's testable without
+ * spinning up a CodeMirror state.
+ */
+
+const BLOCK_ID_END_RE = /\s\^([\w-]+)\s*$/;
+
+export interface BlockLinkPlan {
+  /** The id to use in the canonical `[[note#^<id>]]` link. */
+  blockId: string;
+  /**
+   * Non-null when the paragraph doesn't already have an id: insert
+   * `text` at absolute offset `at`. Caller applies the edit.
+   */
+  edit: { at: number; text: string } | null;
+}
+
+/**
+ * Walk out from `pos` to the surrounding paragraph (a run of consecutive
+ * non-blank lines). Returns null when `pos` lands on a blank line — the
+ * caller should treat that as "nothing to anchor here."
+ */
+export function planBlockLink(
+  content: string,
+  pos: number,
+  generateId: () => string = defaultGenerateId,
+): BlockLinkPlan | null {
+  if (pos < 0 || pos > content.length) return null;
+
+  const { lineStart, lineEnd } = lineBoundsAt(content, pos);
+  const lineText = content.slice(lineStart, lineEnd);
+  if (lineText.trim() === '') return null;
+
+  // Walk up while the previous line is non-blank.
+  let fromStart = lineStart;
+  while (fromStart > 0) {
+    const prevEnd = fromStart - 1; // char before start-of-current-line is '\n'
+    if (content[prevEnd] !== '\n') break; // paragraph starts at doc start
+    const prev = lineBoundsAt(content, prevEnd - 1);
+    if (content.slice(prev.lineStart, prev.lineEnd).trim() === '') break;
+    fromStart = prev.lineStart;
+  }
+
+  // Walk down while the next line is non-blank.
+  let toEnd = lineEnd;
+  while (toEnd < content.length) {
+    if (content[toEnd] !== '\n') break;
+    const next = lineBoundsAt(content, toEnd + 1);
+    if (content.slice(next.lineStart, next.lineEnd).trim() === '') break;
+    toEnd = next.lineEnd;
+  }
+
+  const paragraph = content.slice(fromStart, toEnd);
+  const existing = paragraph.match(BLOCK_ID_END_RE);
+  if (existing) return { blockId: existing[1], edit: null };
+
+  const blockId = generateId();
+  const lastLineText = (() => {
+    const last = lineBoundsAt(content, toEnd === fromStart ? toEnd : toEnd - 1);
+    return content.slice(last.lineStart, last.lineEnd);
+  })();
+  const sep = lastLineText.length > 0 && !/\s$/.test(lastLineText) ? ' ' : '';
+  return { blockId, edit: { at: toEnd, text: `${sep}^${blockId}` } };
+}
+
+/** Default id generator — 6 base-36 chars. Collision odds are ~1 in 2 billion. */
+export function defaultGenerateId(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+function lineBoundsAt(content: string, pos: number): { lineStart: number; lineEnd: number } {
+  const clamped = Math.max(0, Math.min(pos, content.length));
+  let lineStart = clamped;
+  while (lineStart > 0 && content[lineStart - 1] !== '\n') lineStart--;
+  let lineEnd = clamped;
+  while (lineEnd < content.length && content[lineEnd] !== '\n') lineEnd++;
+  return { lineStart, lineEnd };
+}

--- a/tests/renderer/editor/block-link.test.ts
+++ b/tests/renderer/editor/block-link.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { planBlockLink } from '../../../src/renderer/lib/editor/block-link';
+
+function fixedId(): string {
+  return 'abc123';
+}
+
+function applyEdit(content: string, edit: { at: number; text: string }): string {
+  return content.slice(0, edit.at) + edit.text + content.slice(edit.at);
+}
+
+describe('planBlockLink (#138)', () => {
+  it('reuses an existing block-id at the paragraph end', () => {
+    const content = 'First paragraph text. ^existing-id\n\nAnother paragraph.\n';
+    // Cursor somewhere in the first paragraph.
+    const plan = planBlockLink(content, 5, fixedId);
+    expect(plan).not.toBeNull();
+    expect(plan!.blockId).toBe('existing-id');
+    expect(plan!.edit).toBeNull();
+  });
+
+  it('proposes inserting a new id when the paragraph has none', () => {
+    const content = 'A paragraph without any marker.\n\nAnother.\n';
+    const plan = planBlockLink(content, 5, fixedId);
+    expect(plan).not.toBeNull();
+    expect(plan!.blockId).toBe('abc123');
+    expect(plan!.edit).not.toBeNull();
+    // The insert should land at the end of the first paragraph's last line.
+    const afterEdit = applyEdit(content, plan!.edit!);
+    expect(afterEdit).toContain('A paragraph without any marker. ^abc123\n');
+  });
+
+  it('expands to the full paragraph even when the click is mid-paragraph', () => {
+    const content = [
+      'Line one of paragraph.',
+      'Line two.',
+      'Line three.',
+      '',
+      'Another paragraph.',
+      '',
+    ].join('\n');
+    // Cursor on "Line two."
+    const pos = content.indexOf('Line two.');
+    const plan = planBlockLink(content, pos, fixedId);
+    expect(plan).not.toBeNull();
+    // Insertion should land at the end of "Line three." — the last line of
+    // the paragraph that contains the click.
+    const afterEdit = applyEdit(content, plan!.edit!);
+    expect(afterEdit).toContain('Line three. ^abc123\n');
+    expect(afterEdit).not.toContain('Line two. ^abc123');
+  });
+
+  it('returns null when the cursor is on a blank line', () => {
+    const content = 'Before.\n\n\nAfter.\n';
+    const blankPos = content.indexOf('\n\n') + 1; // on a blank line
+    expect(planBlockLink(content, blankPos, fixedId)).toBeNull();
+  });
+
+  it('handles a paragraph that ends at doc end (no trailing newline)', () => {
+    const content = 'Just a paragraph.';
+    const plan = planBlockLink(content, 3, fixedId);
+    expect(plan).not.toBeNull();
+    const afterEdit = applyEdit(content, plan!.edit!);
+    expect(afterEdit).toBe('Just a paragraph. ^abc123');
+  });
+
+  it('works at doc start (no preceding content)', () => {
+    const content = 'First paragraph.\n\nSecond.\n';
+    const plan = planBlockLink(content, 0, fixedId);
+    expect(plan).not.toBeNull();
+    const afterEdit = applyEdit(content, plan!.edit!);
+    expect(afterEdit).toContain('First paragraph. ^abc123\n\nSecond.\n');
+  });
+
+  it('does not add a leading space when the paragraph already ends with whitespace', () => {
+    const content = 'Ends with trailing space. ';
+    const plan = planBlockLink(content, 3, fixedId);
+    expect(plan).not.toBeNull();
+    const afterEdit = applyEdit(content, plan!.edit!);
+    expect(afterEdit).toBe('Ends with trailing space. ^abc123');
+  });
+
+  it('preserves line-item paragraphs as one block (no blank line between items)', () => {
+    const content = '- item one\n- item two\n- item three\n\nparagraph\n';
+    const pos = content.indexOf('item two');
+    const plan = planBlockLink(content, pos, fixedId);
+    expect(plan).not.toBeNull();
+    const afterEdit = applyEdit(content, plan!.edit!);
+    // Marker goes at the end of the full list-as-paragraph.
+    expect(afterEdit).toContain('- item three ^abc123\n');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining scope on #138 — the right-click **Copy Block Link** command. Paragraph anchoring, the `^block-id` indexer, and the preview scroll-to-block were already in place from earlier work; this PR adds the user-facing affordance for generating a block link without having to hand-type the marker.

**Behaviour:**
- Right-click in the editor → Copy Block Link.
- The paragraph at the click position is located (runs of non-blank lines, so a bulleted list reads as one block).
- If the paragraph already has a `^block-id` marker at its end, it's reused. Otherwise a new 6-char base-36 id is generated and inserted.
- `[[<path>#^<id>]]` is written to the clipboard (path is the note's relative path with `.md` stripped, matching the indexer's canonical form).
- Button is hidden for unsaved buffers (no valid path for the link).

**Implementation:**
- `src/renderer/lib/editor/block-link.ts`: pure-string `planBlockLink(content, pos, generateId?)`. Returns `{ blockId, edit: { at, text } | null }` or `null` (blank-line click).
- `src/renderer/lib/components/Editor.svelte`: the context menu's state now carries the click's document position, and a new handler calls `planBlockLink`, applies the edit via `view.dispatch`, and writes the clipboard.

## Test plan

- [x] 8 unit tests covering: existing id reused, new id inserted, multi-line paragraph, doc-start / doc-end paragraphs, trailing whitespace, list-as-paragraph, blank-line click returns null
- [x] Full suite: 985/985 pass
- [x] `pnpm lint` clean
- [ ] Manual smoke test (needs an Electron window; can't verify the context-menu UI end-to-end from the harness):
  - Right-click on a paragraph → confirm Copy Block Link appears
  - Click it → confirm a `^block-id` appears at the paragraph end (unless one existed)
  - Paste → confirm the link has the form `[[notes/foo#^abc123]]`
  - Click that link → confirm preview scrolls to the marked paragraph

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)