### PR TITLE
Preview: interactive task-list checkboxes (closes #127)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -47,6 +47,7 @@
   import { planSplitByHeading } from './lib/refactor/split-by-heading';
   import { getRefactorSettings } from './lib/refactor/settings';
   import { getFormatSettings, loadFormatSettings } from './lib/formatter/settings';
+  import { toggleTaskOnLine } from './lib/editor/task-toggle';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos } from './lib/tools/tool-registry';
   import type { ContextBundle } from '../shared/types';
@@ -237,6 +238,12 @@
   function handleTagSelect(tag: string) {
     sidebar?.refreshTags();
     setTimeout(() => sidebar?.selectTag(tag), 50);
+  }
+
+  function handleTaskToggle(lineIndex: number) {
+    const current = editor.content;
+    const next = toggleTaskOnLine(current, lineIndex);
+    if (next !== current) editor.setContent(next);
   }
 
   async function handleSave() {
@@ -1240,6 +1247,7 @@
                   onOpenExcerpt={handleOpenExcerpt}
                   pendingAnchor={pendingPreviewAnchor}
                   onAnchorResolved={() => { pendingPreviewAnchor = null; }}
+                  onTaskToggle={handleTaskToggle}
                 />
               </div>
             {/if}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MarkdownIt from 'markdown-it';
+  import Token from 'markdown-it/lib/token.mjs';
   import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs';
   import hljs from 'highlight.js';
   import 'highlight.js/styles/github-dark.min.css';
@@ -143,9 +144,8 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             }
           }
           // Inject the checkbox as an html_inline prefix on the inline tree.
-          const checkboxHtml = `<input type="checkbox" data-task-line="${line}"${checked ? ' checked' : ''}> `;
-          const cb = new (md as any).Token('html_inline', '', 0);
-          cb.content = checkboxHtml;
+          const cb = new Token('html_inline', '', 0);
+          cb.content = `<input type="checkbox" data-task-line="${line}"${checked ? ' checked' : ''}> `;
           inlineTok.children.unshift(cb);
         }
       }

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -130,7 +130,12 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       const m = inlineTok.content.match(TASK_ITEM_RE);
       if (m) {
         const checked = m[1] === 'x' || m[1] === 'X';
-        const line = tokens[idx].map?.[0] ?? -1;
+        // `map[0]` is 0-indexed within whatever source was passed to
+        // `md.render` — which is the frontmatter-stripped content below.
+        // Add the env-carried offset so the checkbox's data-task-line
+        // points at the line index in the original note.
+        const rawLine = tokens[idx].map?.[0] ?? -1;
+        const line = rawLine >= 0 ? rawLine + ((env as { lineOffset?: number })?.lineOffset ?? 0) : -1;
         tokens[idx].attrSet('data-task-line', String(line));
         tokens[idx].attrJoin('class', 'task-list-item');
         // Strip the `[ ]` prefix from the inline's aggregate content and
@@ -297,7 +302,17 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     return text.replace(/^---\n[\s\S]*?\n---\n?/, '');
   }
 
-  let rendered = $derived(md.render(stripFrontmatter(content)));
+  function countFrontmatterLines(text: string): number {
+    const m = text.match(/^---\n[\s\S]*?\n---\n?/);
+    if (!m) return 0;
+    return (m[0].match(/\n/g) ?? []).length;
+  }
+
+  let rendered = $derived.by(() => {
+    const stripped = stripFrontmatter(content);
+    const lineOffset = countFrontmatterLines(content);
+    return md.render(stripped, { lineOffset });
+  });
   let previewEl = $state<HTMLDivElement>();
   let activeCharts: ChartHandle[] = [];
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -18,9 +18,11 @@
     pendingAnchor?: string | null;
     /** Called when the effect successfully scrolls, so the caller can clear its pending state. */
     onAnchorResolved?: () => void;
+    /** Fired when a rendered task-list checkbox is toggled. Line is 0-indexed. */
+    onTaskToggle?: (lineIndex: number) => void;
   }
 
-  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved }: Props = $props();
+  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved, onTaskToggle }: Props = $props();
 
   // Query result cache: query text → results (survives re-renders)
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
@@ -107,6 +109,49 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     }
     return defaultParagraphOpen
       ? defaultParagraphOpen(tokens, idx, options, env, self)
+      : self.renderToken(tokens, idx, options);
+  };
+
+  // Task-list items: when a list item starts with `[ ]` or `[x]`, render a
+  // live <input type="checkbox"> and stamp `data-task-line` with the source
+  // line (from the list_item_open token's `map`) so the click handler on
+  // the preview root knows which line to flip in the editor store (#127).
+  const TASK_ITEM_RE = /^\[([ xX])\]\s/;
+  const defaultListItemOpen = md.renderer.rules.list_item_open;
+  md.renderer.rules.list_item_open = (tokens, idx, options, env, self) => {
+    // Scan forward to the first inline token inside this list item (typical
+    // structure: list_item_open → paragraph_open → inline). Stop if we hit
+    // the matching close without finding one.
+    let k = idx + 1;
+    while (k < tokens.length && tokens[k].type !== 'inline' && tokens[k].type !== 'list_item_close') k++;
+    const inlineTok = k < tokens.length && tokens[k].type === 'inline' ? tokens[k] : null;
+    if (inlineTok) {
+      const m = inlineTok.content.match(TASK_ITEM_RE);
+      if (m) {
+        const checked = m[1] === 'x' || m[1] === 'X';
+        const line = tokens[idx].map?.[0] ?? -1;
+        tokens[idx].attrSet('data-task-line', String(line));
+        tokens[idx].attrJoin('class', 'task-list-item');
+        // Strip the `[ ]` prefix from the inline's aggregate content and
+        // from its first text child so the rendered output doesn't repeat it.
+        inlineTok.content = inlineTok.content.replace(TASK_ITEM_RE, '');
+        if (inlineTok.children) {
+          for (let i = 0; i < inlineTok.children.length; i++) {
+            if (inlineTok.children[i].type === 'text') {
+              inlineTok.children[i].content = inlineTok.children[i].content.replace(TASK_ITEM_RE, '');
+              break;
+            }
+          }
+          // Inject the checkbox as an html_inline prefix on the inline tree.
+          const checkboxHtml = `<input type="checkbox" data-task-line="${line}"${checked ? ' checked' : ''}> `;
+          const cb = new (md as any).Token('html_inline', '', 0);
+          cb.content = checkboxHtml;
+          inlineTok.children.unshift(cb);
+        }
+      }
+    }
+    return defaultListItemOpen
+      ? defaultListItemOpen(tokens, idx, options, env, self)
       : self.renderToken(tokens, idx, options);
   };
 
@@ -588,6 +633,18 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   function handleClick(e: MouseEvent) {
     const el = e.target as HTMLElement;
 
+    if (
+      el instanceof HTMLInputElement &&
+      el.type === 'checkbox' &&
+      el.dataset.taskLine !== undefined
+    ) {
+      const line = parseInt(el.dataset.taskLine, 10);
+      if (!Number.isNaN(line)) onTaskToggle?.(line);
+      // Don't preventDefault — the native toggle gives an instant flicker-free
+      // response. The content re-render will land the DOM in the same state.
+      return;
+    }
+
     const citeLink = el.closest<HTMLElement>('.cite-link');
     if (citeLink) {
       e.preventDefault();
@@ -799,6 +856,17 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
   .preview :global(p) {
     margin: 0 0 12px;
+  }
+
+  .preview :global(li.task-list-item) {
+    list-style: none;
+    margin-left: -1.2em;
+  }
+
+  .preview :global(li.task-list-item > input[type="checkbox"][data-task-line]) {
+    margin-right: 6px;
+    cursor: pointer;
+    vertical-align: -1px;
   }
 
   .preview :global(a) {

--- a/src/renderer/lib/editor/task-toggle.ts
+++ b/src/renderer/lib/editor/task-toggle.ts
@@ -1,0 +1,19 @@
+/**
+ * Toggle a task-list checkbox (`[ ]` ↔ `[x]`) on a specific line.
+ *
+ * `lineIndex` is 0-indexed, matching markdown-it's token `map` convention
+ * (which is what the preview emits on rendered checkboxes). Returns the
+ * original content unchanged when the line isn't a task-list item —
+ * callers can rely on reference-equality to detect "did anything change."
+ */
+export function toggleTaskOnLine(content: string, lineIndex: number): string {
+  const lines = content.split('\n');
+  if (lineIndex < 0 || lineIndex >= lines.length) return content;
+  const m = lines[lineIndex].match(
+    /^(\s*(?:[-*+]|\d+[.)])\s+)\[([ xX])\](\s[\s\S]*)?$/,
+  );
+  if (!m) return content;
+  const next = m[2] === ' ' ? 'x' : ' ';
+  lines[lineIndex] = `${m[1]}[${next}]${m[3] ?? ''}`;
+  return lines.join('\n');
+}

--- a/tests/renderer/editor/task-toggle.test.ts
+++ b/tests/renderer/editor/task-toggle.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { toggleTaskOnLine } from '../../../src/renderer/lib/editor/task-toggle';
+
+describe('toggleTaskOnLine (#127)', () => {
+  it('flips `[ ]` to `[x]` on the matching line', () => {
+    const src = '- [ ] todo\n- [ ] another\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] todo\n- [ ] another\n');
+  });
+
+  it('flips `[x]` back to `[ ]`', () => {
+    const src = '- [x] done\n- [ ] pending\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [ ] done\n- [ ] pending\n');
+  });
+
+  it('treats uppercase `[X]` as done', () => {
+    const src = '- [X] done\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [ ] done\n');
+  });
+
+  it('preserves leading indentation (nested items)', () => {
+    const src = '- [ ] outer\n  - [ ] inner\n';
+    expect(toggleTaskOnLine(src, 1)).toBe('- [ ] outer\n  - [x] inner\n');
+  });
+
+  it('works with asterisk and plus markers', () => {
+    expect(toggleTaskOnLine('* [ ] foo\n', 0)).toBe('* [x] foo\n');
+    expect(toggleTaskOnLine('+ [ ] foo\n', 0)).toBe('+ [x] foo\n');
+  });
+
+  it('works with ordered list markers', () => {
+    expect(toggleTaskOnLine('1. [ ] numbered\n', 0)).toBe('1. [x] numbered\n');
+  });
+
+  it('leaves lines that are not task items unchanged (by reference)', () => {
+    const src = 'plain paragraph\n- [ ] item\n';
+    expect(toggleTaskOnLine(src, 0)).toBe(src);
+  });
+
+  it('does not match `[ ]` without a list marker', () => {
+    const src = 'just some [ ] text\n';
+    expect(toggleTaskOnLine(src, 0)).toBe(src);
+  });
+
+  it('does not match when no whitespace follows the `]`', () => {
+    const src = '- [ ]foo\n';
+    expect(toggleTaskOnLine(src, 0)).toBe(src);
+  });
+
+  it('handles a task item with empty body', () => {
+    expect(toggleTaskOnLine('- [ ]\n', 0)).toBe('- [x]\n');
+  });
+
+  it('returns content unchanged for out-of-range line index', () => {
+    const src = '- [ ] only line\n';
+    expect(toggleTaskOnLine(src, 99)).toBe(src);
+    expect(toggleTaskOnLine(src, -1)).toBe(src);
+  });
+
+  it('preserves CRLF line endings when line content has \\r', () => {
+    const src = '- [ ] foo\r\n- [ ] bar\r\n';
+    const out = toggleTaskOnLine(src, 0);
+    expect(out).toBe('- [x] foo\r\n- [ ] bar\r\n');
+  });
+});


### PR DESCRIPTION
## Summary

Task-list items in the preview pane render as live checkboxes. Clicking one flips `[ ]` ↔ `[x]` in the underlying markdown via the editor store's existing debounced autosave path. Works in preview-only and split modes (same code path).

**Core logic:** `src/renderer/lib/editor/task-toggle.ts` — pure `toggleTaskOnLine(content, lineIndex)`. 12 unit tests cover nested items, asterisk/plus/ordered markers, uppercase `[X]`, empty body, CRLF endings, and guarded non-matches.

**Rendering:** a `list_item_open` override in `Preview.svelte` detects the `[ ]`/`[x]` prefix on the first inline token, stamps `data-task-line="<line>"` on the rendered `<li>` (from markdown-it's token `map`), strips the prefix from the inline children, and prepends a real `<input type="checkbox">` as an `html_inline` child.

**Click wiring:** Preview's existing root-level click handler checks for `input[type=checkbox][data-task-line]` first and calls the new `onTaskToggle(lineIndex)` prop. App.svelte's handler pipes that through `toggleTaskOnLine` + `editor.setContent`. Rapid clicks coalesce into one save the same way typing does.

**Tight styling:** `li.task-list-item` drops the bullet, indents the checkbox slightly, and sets the checkbox's cursor + vertical alignment.

## Test plan

- [x] 12 unit tests for `toggleTaskOnLine`
- [x] Full suite: 997/997 pass
- [x] `pnpm lint` clean
- [ ] Manual smoke test (needs Electron window):
  - Open a note with a task list, switch to split / preview mode
  - Click a `[ ]` checkbox → it ticks, and the editor now shows `[x]`
  - Click the same one back → reverts to `[ ]`
  - Rapid clicks on several checkboxes coalesce into a single autosave
  - Task items inside code fences render as literal `- [ ]` (no checkbox)
  - Cursor position in the editor survives the content round-trip
  - Nested task items (indented bullets) toggle correctly via their own `map`

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)