### PR TITLE
Editor: citation autocomplete for [[cite:: (closes #109)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -103,6 +103,13 @@
   let queryPanelComponent = $state<QueryPanel>();
   let toolPanelComponent = $state<ToolPanel>();
   let cursorInfo = $state<CursorInfo>({ line: 1, column: 1, selectionLength: 0, wordCount: 0 });
+  // Cache of every indexed source, refreshed on `sources:changed` and on
+  // project open. Feeds the Editor's `[[cite::…]]` autocomplete so typing
+  // in the editor doesn't have to await an IPC round-trip per keystroke.
+  let sourcesCache = $state<import('../shared/types').SourceMetadata[]>([]);
+  async function refreshSourcesCache(): Promise<void> {
+    try { sourcesCache = await api.sources.listAll(); } catch { /* ignore */ }
+  }
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
   let promptDialog = $state<{ message: string; resolve: (value: string | null) => void } | null>(null);
@@ -943,14 +950,16 @@
     setTimeout(() => {
       sidebar?.refreshTags();
       sidebar?.refreshSources();
+      refreshSourcesCache();
     }, 100);
   };
 
   // Main broadcasts when the sources watcher reindexes or removes a source.
-  // Refresh the sidebar Sources panel so newly-ingested sources appear
-  // without a manual reload.
+  // Refresh the sidebar Sources panel AND the editor autocomplete cache so
+  // newly-ingested sources become reachable without a manual reload.
   api.sources.onChanged(() => {
     sidebar?.refreshSources();
+    refreshSourcesCache();
   });
 
   function cycleViewMode() {
@@ -1141,6 +1150,7 @@
       await loadFormatSettings();
       sidebar?.refreshTags();
       sidebar?.refreshSources();
+      await refreshSourcesCache();
       // Load inspection count after a brief delay to let health checks finish
       setTimeout(refreshInspectionCount, 3000);
       // Refresh periodically
@@ -1255,6 +1265,7 @@
                     onOpenConversation={openConversation}
                     onNavigate={handleNavigate}
                     getNotePaths={() => flattenNotePaths(notebase.files)}
+                    getSources={() => sourcesCache}
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -60,6 +60,8 @@
     onFormatCurrentNote?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
+    /** Live list of Sources for `[[cite::…]]` autocomplete. */
+    getSources?: () => readonly import('../../../shared/types').SourceMetadata[];
   }
 
   let {
@@ -87,6 +89,7 @@
     onDecompose,
     onFormatCurrentNote,
     getNotePaths,
+    getSources,
   }: Props = $props();
 
   const analysisTools = getToolInfosByCategory('analysis');
@@ -532,6 +535,7 @@
 
     const linkCompletion = linkCompletionSource({
       getNotePaths: () => getNotePaths?.() ?? [],
+      getSources: () => getSources?.() ?? [],
       readNote: (p) => api.notebase.readFile(p),
     });
 

--- a/src/renderer/lib/editor/link-autocomplete.ts
+++ b/src/renderer/lib/editor/link-autocomplete.ts
@@ -1,5 +1,6 @@
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { LINK_TYPES } from '../../../shared/link-types';
+import type { SourceMetadata } from '../../../shared/types';
 import { extractAnchors } from './note-anchors';
 
 // ── Phase detection (pure) ─────────────────────────────────────────────────
@@ -107,6 +108,28 @@ function notePathOptions(paths: string[]): Completion[] {
   });
 }
 
+export function sourceOptions(sources: readonly SourceMetadata[]): Completion[] {
+  return sources.map((s) => {
+    const title = s.title ?? s.sourceId;
+    const creators = s.creators.length > 0
+      ? (s.creators.length === 1 ? s.creators[0]
+        : s.creators.length === 2 ? `${s.creators[0]} and ${s.creators[1]}`
+        : `${s.creators[0]} et al.`)
+      : '';
+    const byline = creators && s.year ? `${creators} · ${s.year}`
+      : creators || s.year || '';
+    // Put the source id into the label string (tail) so fuzzy-matching picks
+    // up both title searches ("toulmin", "uses of argument") and direct id
+    // searches ("toulmin-1958"). `apply` inserts only the id.
+    return {
+      label: `${title} — ${s.sourceId}`,
+      apply: s.sourceId,
+      detail: byline || undefined,
+      type: 'class',
+    };
+  });
+}
+
 function headingOptions(anchors: { slug: string; text: string; level: number }[]): Completion[] {
   return anchors.map((a) => ({
     label: a.slug,
@@ -124,6 +147,8 @@ function blockIdOptions(ids: string[]): Completion[] {
 export interface LinkAutocompleteOptions {
   /** Returns the current list of note-file relativePaths in the thoughtbase. */
   getNotePaths: () => string[];
+  /** Returns the current list of indexed Sources (for `[[cite::…]]`). */
+  getSources: () => readonly SourceMetadata[];
   /** Fetch raw markdown for a note so we can scan its headings + block-ids. */
   readNote: (relativePath: string) => Promise<string>;
 }
@@ -173,6 +198,19 @@ export function linkCompletionSource(opts: LinkAutocompleteOptions) {
     }
 
     if (phase.kind === 'path') {
+      // Typed-link paths pick from a different universe depending on the
+      // prefix: `[[cite::…]]` completes against Sources (title / creator /
+      // source id all searchable), everything else stays on notes.
+      if (phase.typePrefix === 'cite') {
+        return {
+          from: phase.innerStart,
+          options: sourceOptions(opts.getSources()),
+          // Source ids are lowercase alphanumerics + `.`, `_`, `-`; titles
+          // additionally carry spaces and punctuation which the default
+          // matcher can chew on.
+          validFor: /^[a-z0-9_\-\. ]*$/i,
+        };
+      }
       return {
         from: phase.innerStart,
         options: notePathOptions(paths),

--- a/tests/renderer/editor/link-autocomplete.test.ts
+++ b/tests/renderer/editor/link-autocomplete.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { detectCompletionPhase } from '../../../src/renderer/lib/editor/link-autocomplete';
+import { detectCompletionPhase, sourceOptions } from '../../../src/renderer/lib/editor/link-autocomplete';
+import type { SourceMetadata } from '../../../src/shared/types';
+
+function source(partial: Partial<SourceMetadata> & { sourceId: string }): SourceMetadata {
+  return {
+    sourceId: partial.sourceId,
+    subtype: null,
+    title: null,
+    creators: [],
+    year: null,
+    publisher: null,
+    doi: null,
+    uri: null,
+    abstract: null,
+    ...partial,
+  };
+}
 
 /**
  * Helper: simulate a cursor at the end of `before`. The absolute position
@@ -78,5 +94,74 @@ describe('detectCompletionPhase', () => {
 
   it('returns none when inner contains a newline', () => {
     expect(phase('[[first line\nsecond').kind).toBe('none');
+  });
+
+  it('surfaces the `cite` typePrefix so the source picker can kick in', () => {
+    const p = phase('[[cite::toul');
+    expect(p.kind).toBe('path');
+    if (p.kind === 'path') {
+      expect(p.typePrefix).toBe('cite');
+      expect(p.prefix).toBe('toul');
+      expect(p.innerStart).toBe('[[cite::'.length);
+    }
+  });
+});
+
+describe('sourceOptions (#109)', () => {
+  it('inserts the source id when picked, not the title', () => {
+    const [opt] = sourceOptions([source({
+      sourceId: 'toulmin-1958',
+      title: 'The Uses of Argument',
+      creators: ['Stephen E. Toulmin'],
+      year: '1958',
+    })]);
+    expect(opt.apply).toBe('toulmin-1958');
+  });
+
+  it('combines title and id in the match label so either text searches work', () => {
+    const [opt] = sourceOptions([source({
+      sourceId: 'toulmin-1958',
+      title: 'The Uses of Argument',
+      creators: ['Stephen E. Toulmin'],
+      year: '1958',
+    })]);
+    expect(opt.label).toContain('The Uses of Argument');
+    expect(opt.label).toContain('toulmin-1958');
+  });
+
+  it('formats the detail as `Creator · Year`', () => {
+    const [opt] = sourceOptions([source({
+      sourceId: 'x',
+      creators: ['Alice Smith'],
+      year: '2020',
+    })]);
+    expect(opt.detail).toBe('Alice Smith · 2020');
+  });
+
+  it('collapses multi-author bylines like the metadata header does', () => {
+    const two = sourceOptions([source({
+      sourceId: 'x',
+      creators: ['Alice', 'Bob'],
+      year: '2020',
+    })])[0];
+    expect(two.detail).toBe('Alice and Bob · 2020');
+
+    const many = sourceOptions([source({
+      sourceId: 'y',
+      creators: ['Alice', 'Bob', 'Carol'],
+      year: '2021',
+    })])[0];
+    expect(many.detail).toBe('Alice et al. · 2021');
+  });
+
+  it('falls back to the source id when title is missing', () => {
+    const [opt] = sourceOptions([source({ sourceId: 'url-abcdef' })]);
+    expect(opt.label).toContain('url-abcdef');
+    expect(opt.apply).toBe('url-abcdef');
+  });
+
+  it('omits detail entirely when there is no byline and no year', () => {
+    const [opt] = sourceOptions([source({ sourceId: 'plain' })]);
+    expect(opt.detail).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Typing \`[[cite::\` in the editor now opens a source picker. Shows every indexed source by title with a \"Creator · Year\" byline subtitle, matches fuzzy against both the title and the source id (so \`toul\` finds Toulmin by id, and \`uses of argument\` finds it by title), and inserts just the canonical source id on selection — exactly what \`[[cite::…]]\` expects.

## Plumbing

- \`linkCompletionSource\` learns to dispatch on the existing phase detector's \`typePrefix === 'cite'\` branch; everything else (note paths, headings, block ids) is untouched.
- \`App.svelte\` caches the sources list in \`sourcesCache\`, refreshes it on project-open and on every \`sources:changed\` broadcast from main. Editor reads it synchronously so keystrokes don't eat an IPC round-trip.

## Test plan

- [x] 7 new unit tests covering the \`sourceOptions\` mapping — label-includes-both-title-and-id, apply-inserts-id-only, byline formatting (solo / duo / et al. / empty), title-fallback to source id, detail-omitted-when-empty.
- [x] Full suite: 1062/1062 pass
- [x] \`pnpm lint\` clean
- [ ] Manual smoke:
  - In a note, type \`[[cite::\` → picker appears with all your sources
  - Type part of a title (\"uses\") → filters to Toulmin
  - Type part of a source id (\"toul\") → filters to Toulmin
  - Enter → inserts \`[[cite::toulmin-1958]]\`
  - Ingest a new URL → go back to the editor, the new source is already in the picker (no restart needed)

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)