### PR TITLE
Source viewer: highlight → excerpt (closes #224)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -30,6 +30,7 @@ import {
 } from './formatter/orchestrator';
 import { ingestUrl } from './sources/ingest';
 import { ingestIdentifier } from './sources/ingest-identifier';
+import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
@@ -671,6 +672,18 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(Channels.SOURCES_LIST_ALL, () => graph.listAllSources());
+
+  ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, async (e, params: {
+    sourceId: string;
+    citedText: string;
+    page?: number | null;
+    pageRange?: string | null;
+    locationText?: string | null;
+  }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await createExcerpt(rootPath, params);
+  });
 
   ipcMain.handle(
     Channels.FORMATTER_FORMAT_FILE,

--- a/src/main/sources/create-excerpt.ts
+++ b/src/main/sources/create-excerpt.ts
@@ -1,0 +1,93 @@
+/**
+ * Create a `thought:Excerpt` from a highlighted passage in a source body (#224).
+ *
+ * Writes `.minerva/excerpts/<excerpt-id>.ttl` with the predicates the
+ * indexer already understands (`thought:fromSource`, `thought:citedText`,
+ * optional `thought:page` / `thought:pageRange` / `thought:locationText`).
+ * The chokidar watcher picks the new file up and reindexes automatically.
+ *
+ * Excerpt id shape: `<sourceId>-<12-hex-short-hash-of-citedText>`. This
+ * clusters excerpts by source in filesystem listings AND makes re-saving
+ * the identical passage idempotent — same text → same id → we either
+ * skip or update in place.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+export interface CreateExcerptParams {
+  sourceId: string;
+  citedText: string;
+  /** Optional page / page-range / location annotations from the UI. */
+  page?: number | null;
+  pageRange?: string | null;
+  locationText?: string | null;
+}
+
+export interface CreateExcerptResult {
+  excerptId: string;
+  relativePath: string;
+  /** True when the file already existed (idempotent re-save). */
+  duplicate: boolean;
+}
+
+export async function createExcerpt(
+  rootPath: string,
+  params: CreateExcerptParams,
+): Promise<CreateExcerptResult> {
+  const cited = params.citedText.trim();
+  if (!cited) throw new Error('Empty selection; nothing to excerpt.');
+  if (!params.sourceId) throw new Error('Missing sourceId.');
+
+  const excerptId = `${params.sourceId}-${shortHash(cited)}`;
+  const relativePath = `.minerva/excerpts/${excerptId}.ttl`;
+  const absPath = path.join(rootPath, relativePath);
+
+  let duplicate = false;
+  try {
+    await fs.access(absPath);
+    duplicate = true;
+  } catch { /* not there yet */ }
+
+  if (!duplicate) {
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, buildExcerptTtl(params), 'utf-8');
+  }
+
+  return { excerptId, relativePath, duplicate };
+}
+
+export function buildExcerptTtl(params: CreateExcerptParams): string {
+  const lines: string[] = [
+    'this: a thought:Excerpt ;',
+    `    thought:fromSource sources:${params.sourceId} ;`,
+    `    thought:citedText ${ttlString(params.citedText.trim())} ;`,
+  ];
+  if (params.page != null) {
+    lines.push(`    thought:page ${params.page} ;`);
+  }
+  if (params.pageRange) {
+    lines.push(`    thought:pageRange ${ttlString(params.pageRange)} ;`);
+  }
+  if (params.locationText) {
+    lines.push(`    thought:locationText ${ttlString(params.locationText)} ;`);
+  }
+  lines.push(`    prov:generatedAtTime ${ttlString(new Date().toISOString())}^^xsd:dateTime .`);
+  return lines.join('\n') + '\n';
+}
+
+function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+/** 12-hex-char sha256 prefix. Same strategy as source-id.ts. */
+function shortHash(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, 12);
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -198,11 +198,13 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         const content = await notebaseFs.readFile(rootPath, relPath);
         graph.indexExcerpt(excerptId, content);
         debouncedPersist();
+        if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
       } catch { /* file may have been deleted between events */ }
     },
     onExcerptDeleted: (excerptId) => {
       graph.removeExcerpt(excerptId);
       debouncedPersist();
+      if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
     },
   });
   watchers.set(win.id, rootPath);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -163,6 +163,16 @@ contextBridge.exposeInMainWorld('api', {
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },
+    createExcerpt: (params: {
+      sourceId: string;
+      citedText: string;
+      page?: number | null;
+      pageRange?: string | null;
+      locationText?: string | null;
+    }) => ipcRenderer.invoke(Channels.SOURCES_CREATE_EXCERPT, params),
+    onExcerptsChanged: (cb: () => void) => {
+      ipcRenderer.on(Channels.EXCERPTS_CHANGED, () => cb());
+    },
   },
   formatter: {
     formatContent: (content: string, settings: unknown, relativePath?: string) =>

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -90,6 +90,59 @@
     }
   }
 
+  // ── Highlight → Excerpt (#224) ──────────────────────────────────────────
+
+  // Right-click inside the rendered body with text selected → show a small
+  // menu with "Save as excerpt". Click invokes the main-process create, then
+  // the file-watcher broadcast refreshes the Excerpts list below.
+  let excerptMenu = $state<{ x: number; y: number; text: string } | null>(null);
+  let excerptError = $state<string | null>(null);
+  let creatingExcerpt = $state(false);
+  let recentExcerpt = $state<{ id: string; duplicate: boolean } | null>(null);
+
+  function handleBodyContextMenu(e: MouseEvent): void {
+    if (editMode) return;
+    const sel = window.getSelection();
+    const text = sel ? sel.toString().trim() : '';
+    if (!text) return; // no selection — let the native context menu show
+    e.preventDefault();
+    excerptMenu = { x: e.clientX, y: e.clientY, text };
+    excerptError = null;
+    const close = () => {
+      excerptMenu = null;
+      window.removeEventListener('click', close);
+    };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  async function saveExcerpt(): Promise<void> {
+    if (!excerptMenu) return;
+    const citedText = excerptMenu.text;
+    creatingExcerpt = true;
+    excerptError = null;
+    try {
+      const result = await api.sources.createExcerpt({ sourceId, citedText });
+      recentExcerpt = { id: result.excerptId, duplicate: result.duplicate };
+      excerptMenu = null;
+      // Reload the source detail so the new excerpt shows up in the list
+      // even before the file-watcher's broadcast arrives.
+      await load(sourceId);
+      // Clear the "just-saved" banner after a moment.
+      setTimeout(() => { recentExcerpt = null; }, 4000);
+    } catch (err) {
+      excerptError = err instanceof Error ? err.message : String(err);
+    } finally {
+      creatingExcerpt = false;
+    }
+  }
+
+  // Reload the source detail when the main process tells us an excerpt
+  // was added/updated/removed (covers cross-window sync and any direct
+  // filesystem edits the user made to excerpt ttls).
+  api.sources.onExcerptsChanged(() => {
+    if (loadedId === sourceId) load(sourceId);
+  });
+
   // After render, if a specific excerpt was highlighted, scroll it into view.
   $effect(() => {
     if (!detail || !highlightExcerptId) return;
@@ -199,11 +252,37 @@
             <button class="btn secondary" disabled={saving} onclick={cancelEdit}>Cancel</button>
           </div>
         {:else if bodyContent !== null}
-          <div class="body-view">
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div class="body-view" oncontextmenu={handleBodyContextMenu}>
             <Preview content={bodyContent} onNavigate={onNavigate} />
           </div>
+          {#if recentExcerpt}
+            <div class="excerpt-banner" class:duplicate={recentExcerpt.duplicate}>
+              {recentExcerpt.duplicate
+                ? 'That passage was already saved as an excerpt.'
+                : 'Saved as excerpt'}
+              <code>{recentExcerpt.id}</code>
+            </div>
+          {/if}
+          {#if excerptError}
+            <div class="save-error">Couldn't save excerpt: {excerptError}</div>
+          {/if}
         {/if}
       </section>
+    {/if}
+
+    {#if excerptMenu}
+      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <div
+        class="excerpt-menu"
+        style:left="{excerptMenu.x}px"
+        style:top="{excerptMenu.y}px"
+        onmousedown={(e) => e.preventDefault()}
+      >
+        <button disabled={creatingExcerpt} onclick={saveExcerpt}>
+          {creatingExcerpt ? 'Saving…' : 'Save as excerpt'}
+        </button>
+      </div>
     {/if}
 
     <section>
@@ -435,6 +514,55 @@
     padding: 8px 12px;
     margin-top: 8px;
     font-size: 12px;
+  }
+
+  .excerpt-menu {
+    position: fixed;
+    z-index: 100;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    padding: 4px;
+    min-width: 160px;
+  }
+  .excerpt-menu button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 6px 12px;
+    background: none;
+    border: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 3px;
+  }
+  .excerpt-menu button:hover:not(:disabled) {
+    background: var(--bg-button);
+  }
+  .excerpt-menu button:disabled {
+    opacity: 0.5;
+    cursor: wait;
+  }
+
+  .excerpt-banner {
+    margin-top: 8px;
+    padding: 6px 10px;
+    border-left: 3px solid var(--accent);
+    background: var(--bg-button);
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .excerpt-banner.duplicate {
+    border-left-color: var(--text-muted);
+  }
+  .excerpt-banner code {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-family: ui-monospace, monospace;
   }
 
   .muted {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -275,6 +275,16 @@ export interface SourcesApi {
   listAll(): Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
+  /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */
+  createExcerpt(params: {
+    sourceId: string;
+    citedText: string;
+    page?: number | null;
+    pageRange?: string | null;
+    locationText?: string | null;
+  }): Promise<{ excerptId: string; relativePath: string; duplicate: boolean }>;
+  /** Fires when an excerpt is added, updated, or removed. */
+  onExcerptsChanged(cb: () => void): void;
 }
 
 declare global {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -114,6 +114,10 @@ export const Channels = {
   SOURCES_INGEST_URL: 'sources:ingestUrl',
   /** Ingest a DOI / arXiv id / PubMed id (#96). Hits CrossRef / arXiv / PubMed. */
   SOURCES_INGEST_IDENTIFIER: 'sources:ingestIdentifier',
+  /** Create an Excerpt (#224) from a highlighted passage in a source body. */
+  SOURCES_CREATE_EXCERPT: 'sources:createExcerpt',
+  /** Broadcast from main when an excerpt is added/updated/removed so source tabs refresh. */
+  EXCERPTS_CHANGED: 'excerpts:changed',
   /** Menu → "Ingest URL…" — prompts the renderer for a URL and calls SOURCES_INGEST_URL. */
   MENU_INGEST_URL: 'menu:ingestUrl',
   /** Menu → "Ingest identifier…" — prompts the renderer for a DOI/arXiv/PMID. */

--- a/tests/main/sources/create-excerpt.test.ts
+++ b/tests/main/sources/create-excerpt.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createExcerpt, buildExcerptTtl } from '../../../src/main/sources/create-excerpt';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-excerpt-test-'));
+}
+
+describe('buildExcerptTtl (#224)', () => {
+  it('emits the required predicates', () => {
+    const ttl = buildExcerptTtl({
+      sourceId: 'toulmin-1958',
+      citedText: 'The essence of a software entity is a construct of interlocking concepts.',
+    });
+    expect(ttl).toContain('this: a thought:Excerpt');
+    expect(ttl).toContain('thought:fromSource sources:toulmin-1958');
+    expect(ttl).toContain('thought:citedText "The essence of a software entity is a construct of interlocking concepts."');
+    expect(ttl).toMatch(/prov:generatedAtTime "[^"]+"\^\^xsd:dateTime \./);
+  });
+
+  it('includes optional page / pageRange / locationText when supplied', () => {
+    const ttl = buildExcerptTtl({
+      sourceId: 's',
+      citedText: 'x',
+      page: 42,
+      pageRange: '97-98',
+      locationText: 'Section: The Essential Difficulties',
+    });
+    expect(ttl).toContain('thought:page 42');
+    expect(ttl).toContain('thought:pageRange "97-98"');
+    expect(ttl).toContain('thought:locationText "Section: The Essential Difficulties"');
+  });
+
+  it('omits optional predicates when absent', () => {
+    const ttl = buildExcerptTtl({ sourceId: 's', citedText: 'x' });
+    expect(ttl).not.toContain('thought:page');
+    expect(ttl).not.toContain('thought:pageRange');
+    expect(ttl).not.toContain('thought:locationText');
+  });
+
+  it('escapes quotes and backslashes in the cited text', () => {
+    const ttl = buildExcerptTtl({
+      sourceId: 's',
+      citedText: 'He said "so" and escaped \\ things.',
+    });
+    expect(ttl).toContain('thought:citedText "He said \\"so\\" and escaped \\\\ things."');
+  });
+
+  it('escapes newlines in multi-line excerpts', () => {
+    const ttl = buildExcerptTtl({ sourceId: 's', citedText: 'line one\nline two' });
+    expect(ttl).toContain('thought:citedText "line one\\nline two"');
+  });
+
+  it('trims leading/trailing whitespace from the cited text', () => {
+    const ttl = buildExcerptTtl({ sourceId: 's', citedText: '   padded on both sides   ' });
+    expect(ttl).toContain('thought:citedText "padded on both sides"');
+  });
+});
+
+describe('createExcerpt (#224)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkTempProject(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  it('writes the ttl under .minerva/excerpts/ with a sourceId-hash id', async () => {
+    const result = await createExcerpt(root, {
+      sourceId: 'toulmin-1958',
+      citedText: 'A quote to cite.',
+    });
+    expect(result.duplicate).toBe(false);
+    expect(result.excerptId).toMatch(/^toulmin-1958-[a-f0-9]{12}$/);
+    expect(result.relativePath).toBe(`.minerva/excerpts/${result.excerptId}.ttl`);
+    expect(fs.existsSync(path.join(root, result.relativePath))).toBe(true);
+  });
+
+  it('is idempotent — same text yields the same id', async () => {
+    const a = await createExcerpt(root, { sourceId: 's', citedText: 'Identical quote.' });
+    const b = await createExcerpt(root, { sourceId: 's', citedText: 'Identical quote.' });
+    expect(a.excerptId).toBe(b.excerptId);
+    expect(b.duplicate).toBe(true);
+  });
+
+  it('produces different ids for different text on the same source', async () => {
+    const a = await createExcerpt(root, { sourceId: 's', citedText: 'First passage.' });
+    const b = await createExcerpt(root, { sourceId: 's', citedText: 'Second passage.' });
+    expect(a.excerptId).not.toBe(b.excerptId);
+  });
+
+  it('produces different ids for the same text on different sources', async () => {
+    const a = await createExcerpt(root, { sourceId: 'alice-2024', citedText: 'shared quote' });
+    const b = await createExcerpt(root, { sourceId: 'bob-2024', citedText: 'shared quote' });
+    expect(a.excerptId).not.toBe(b.excerptId);
+    expect(a.excerptId.startsWith('alice-2024-')).toBe(true);
+    expect(b.excerptId.startsWith('bob-2024-')).toBe(true);
+  });
+
+  it('persists the content so the indexer picks it up', async () => {
+    const result = await createExcerpt(root, {
+      sourceId: 's',
+      citedText: 'Check me.',
+      page: 11,
+      locationText: 'Introduction',
+    });
+    const ttl = await fsp.readFile(path.join(root, result.relativePath), 'utf-8');
+    expect(ttl).toContain('thought:fromSource sources:s');
+    expect(ttl).toContain('thought:page 11');
+    expect(ttl).toContain('thought:locationText "Introduction"');
+  });
+
+  it('does not overwrite an existing file on a duplicate call', async () => {
+    const first = await createExcerpt(root, { sourceId: 's', citedText: 'Same.' });
+    const absPath = path.join(root, first.relativePath);
+    // Hand-edit the file; a duplicate save should preserve the edit.
+    await fsp.writeFile(absPath, 'this: a thought:Excerpt ;\n    thought:citedText "Hand-edited" .\n', 'utf-8');
+    const second = await createExcerpt(root, { sourceId: 's', citedText: 'Same.' });
+    expect(second.duplicate).toBe(true);
+    const content = await fsp.readFile(absPath, 'utf-8');
+    expect(content).toContain('Hand-edited');
+  });
+
+  it('rejects an empty selection', async () => {
+    await expect(
+      createExcerpt(root, { sourceId: 's', citedText: '   \n  ' }),
+    ).rejects.toThrow(/empty/i);
+  });
+
+  it('rejects a missing sourceId', async () => {
+    await expect(
+      createExcerpt(root, { sourceId: '', citedText: 'anything' }),
+    ).rejects.toThrow(/sourceid/i);
+  });
+});


### PR DESCRIPTION
## Summary

Right-click a text selection inside a source's Content section → **Save as excerpt**. Creates \`.minerva/excerpts/<source-id>-<hash>.ttl\` and refreshes the Excerpts list inline, without the user waiting for the watcher round-trip.

Closes the research-library reading loop:
1. Ingest source (#93 / #96)
2. Read body.md in the source viewer (#99 / PR #223)
3. **Highlight → excerpt (this PR)**
4. Cite the source from a note via \`[[cite::id]]\` (#109 / PR #225)
5. Excerpts surface as backlinks on the source (already wired)

## Id shape

\`<sourceId>-<12-hex-sha256-of-text>\` — clusters by source in the filesystem, makes the save idempotent (highlight-the-same-passage-twice gives the same id → file not overwritten → a \"that was already saved\" banner instead of a duplicate), and produces distinct ids across sources even for identical quotes.

## Plumbing

- \`src/main/sources/create-excerpt.ts\` emits TTL using the existing indexer's predicates (\`thought:fromSource\`, \`thought:citedText\`, optional \`thought:page\` / \`thought:pageRange\` / \`thought:locationText\`, \`prov:generatedAtTime\`).
- \`SOURCES_CREATE_EXCERPT\` IPC + \`api.sources.createExcerpt(params)\` client method.
- \`EXCERPTS_CHANGED\` broadcast from \`window-manager\`'s existing excerpt watcher → \`api.sources.onExcerptsChanged\` → SourceDetail reloads. Mirrors how source-meta changes already propagate across windows.
- SourceDetail's body-view div grows an \`oncontextmenu\` handler: on a non-empty selection, \`preventDefault\` and pop a one-item floating menu at the cursor. Click, IPC, local reload, ephemeral \"Saved as excerpt\" banner that fades after 4s.

## Scope decisions

Deferred to follow-ups:

- **Page / location dialog** before save. \`createExcerpt\` already accepts \`page\`/\`pageRange\`/\`locationText\`; only the UI is missing. Users who want those annotations today can hand-edit the resulting \`.ttl\`.
- **Inline highlight overlays** on saved excerpts (coloured highlights in the rendered body showing which passages were clipped). Rendering-layer change of its own scope.

## Test plan

- [x] 14 unit tests covering id stability, cross-source uniqueness, TTL escaping (quotes / backslashes / newlines), optional-predicate handling, duplicate detection, \"don't clobber hand-edited files\"
- [x] Full suite: 1113/1113 pass
- [x] \`pnpm lint\` clean
- [ ] Manual smoke test:
  - Open an ingested source, select a sentence in the body, right-click → \"Save as excerpt\"
  - Confirm a new entry appears in the Excerpts list below, with the selected text in the blockquote
  - Check \`.minerva/excerpts/<id>.ttl\` contains the full passage + \`prov:generatedAtTime\`
  - Select the same passage again, right-click, save → \"already saved\" banner instead of duplicate
  - Select a sentence from a different source → lands in a distinct excerpt
  - Open the same source in a second window → new excerpts from window A show up in window B (via \`EXCERPTS_CHANGED\` broadcast)

Closes #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)