### PR TITLE
Editor: persist undo/redo history across tab switches (closes #167)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1284,6 +1284,7 @@
                     bind:this={editorComponent}
                     filePath={editor.activeFilePath!}
                     content={editor.content}
+                    initialHistory={editor.activeNoteTab?.historyJson}
                     searchQuery={pendingSearchQuery}
                     onContentChange={editor.setContent}
                     onSave={handleSave}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -12,6 +12,7 @@
   import { highlightWhitespace } from '@codemirror/view';
   import { search, openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
   import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
+  import { historyField } from '@codemirror/commands';
   import { api } from '../ipc/client';
   import { sortLines, selectionTracker } from '../editor/commands';
   import {
@@ -41,7 +42,19 @@
     onContentChange: (text: string) => void;
     onSave: () => void;
     onSearchQueryConsumed?: () => void;
-    onEditorStateSave?: (filePath: string, cursorOffset: number, scrollTop: number) => void;
+    onEditorStateSave?: (
+      filePath: string,
+      cursorOffset: number,
+      scrollTop: number,
+      historyJson: unknown,
+    ) => void;
+    /**
+     * Snapshot from a prior lifecycle (tab-switch unmount) to restore the
+     * undo/redo stacks into the fresh EditorView. Ignored when the doc
+     * inside the snapshot doesn't match the current `content` — stale
+     * history would let the user undo to a state the file no longer shows.
+     */
+    initialHistory?: unknown;
     onCursorChange?: (info: CursorInfo) => void;
     onToolInvoke?: (toolId: string) => void;
     onOpenConversation?: () => void;
@@ -96,6 +109,7 @@
     onFormatCurrentNote,
     getNotePaths,
     getSources,
+    initialHistory,
   }: Props = $props();
 
   const analysisTools = getToolInfosByCategory('analysis');
@@ -118,6 +132,19 @@
   const wrapCompartment = new Compartment();
   const lineNumbersCompartment = new Compartment();
   const whitespaceCompartment = new Compartment();
+
+  /**
+   * Sanity-check a stored history snapshot before handing it to
+   * `EditorState.fromJSON`. CM's JSON is an opaque blob to us; we just
+   * need `doc` (string) for the drift check. Anything that doesn't match
+   * that minimum shape is treated as "no snapshot, start fresh."
+   */
+  function toHistorySnapshot(raw: unknown): { doc: string } & Record<string, unknown> | null {
+    if (!raw || typeof raw !== 'object') return null;
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.doc !== 'string') return null;
+    return obj as { doc: string } & Record<string, unknown>;
+  }
 
   function cmTheme(): any {
     return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
@@ -565,7 +592,21 @@
 
     const allExtensions = [...extensions, appKeymap, updateListener, completion];
 
-    const state = EditorState.create({ doc: content, extensions: allExtensions });
+    // When the caller passes a history snapshot AND its serialised doc
+    // still matches the current content, restore the undo/redo stacks
+    // into the fresh view. If the content has drifted (file reloaded from
+    // disk, programmatic rewrite, etc.) we fall back to a clean state —
+    // undoing to a document that no longer matches reality is worse than
+    // losing history.
+    const snapshot = toHistorySnapshot(initialHistory);
+    const canRestore = snapshot !== null && snapshot.doc === content;
+    const state = canRestore
+      ? EditorState.fromJSON(
+          snapshot,
+          { extensions: allExtensions },
+          { history: historyField },
+        )
+      : EditorState.create({ doc: content, extensions: allExtensions });
     view = new EditorView({ state, parent: editorContainer });
 
     if (initSettings.alwaysCollapseFrontmatter) {
@@ -581,7 +622,13 @@
     const mountedFilePath = filePath;
     return () => {
       view.scrollDOM.removeEventListener('scroll', onScroll);
-      onEditorStateSave?.(mountedFilePath, view.state.selection.main.head, lastScrollTop);
+      const historySnapshot = view.state.toJSON({ history: historyField });
+      onEditorStateSave?.(
+        mountedFilePath,
+        view.state.selection.main.head,
+        lastScrollTop,
+        historySnapshot,
+      );
       view.destroy();
     };
   });

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -11,6 +11,14 @@ export interface NoteTab {
   savedContent: string;
   cursorOffset?: number;
   scrollTop?: number;
+  /**
+   * Serialised CodeMirror `EditorState` (doc + selection + history
+   * stacks) captured on Editor unmount. Used to restore undo/redo across
+   * tab switches — without this, switching tabs and back would give you
+   * a fresh editor with empty history (#167). Memory-only; not persisted
+   * to disk since session-restore is a separate concern.
+   */
+  historyJson?: unknown;
 }
 
 export interface QueryTab {
@@ -193,11 +201,19 @@ export function getEditorStore() {
     }
   }
 
-  function saveEditorState(relativePath: string, cursorOffset: number, scrollTop: number) {
+  function saveEditorState(
+    relativePath: string,
+    cursorOffset: number,
+    scrollTop: number,
+    historyJson?: unknown,
+  ) {
     const tab = tabs.find((t) => isNote(t) && t.relativePath === relativePath) as NoteTab | undefined;
     if (tab) {
       tab.cursorOffset = cursorOffset;
       tab.scrollTop = scrollTop;
+      // Only record history when the caller provided it — absent arg means
+      // "just updating cursor/scroll" (e.g. position-save on scroll).
+      if (historyJson !== undefined) tab.historyJson = historyJson;
       schedulePersistTabs();
     }
   }


### PR DESCRIPTION
## Summary

Tab switches were silently eating the CodeMirror undo/redo stacks because App.svelte's \`{#key editor.activeFilePath}\` unmounts the whole Editor on every switch and mounts a fresh one. Come back to the tab later and there's nothing to undo.

Fix at the lifecycle boundary:

- **On unmount** → capture \`view.state.toJSON({ history: historyField })\` and pass it through the existing \`onEditorStateSave\` callback (now takes a fourth \`historyJson\` arg).
- **Stored** on \`NoteTab.historyJson\` in the editor store. **Memory-only** — \`persistTabs\` keeps serialising just path + cursor + scroll, so history doesn't follow across window close. Session-restore for history is a separate, much-bigger concern the ticket explicitly scopes out.
- **On mount** → if the tab carries a snapshot AND its serialised \`doc\` matches the current content prop, restore via \`EditorState.fromJSON(…, { extensions }, { history: historyField })\`. When the content has drifted (file reloaded from disk, programmatic rewrite between unmount and remount) we discard the snapshot rather than let the user undo into a document that no longer matches reality.

Scope-limited to \`NoteTab\` per the ticket. Source/Query tabs aren't affected.

## Why now

Every feature that programmatically rewrites a buffer — the formatter, the upcoming LLM edit approvals, the forthcoming auto-fix inspections — depends on undo being a working escape hatch. Patching it once at the lifecycle boundary is cheaper than each of those building its own undo stack.

## Test plan

- [x] Full suite: 1127/1127 pass (no new tests — the logic is lifecycle-glued and hard to unit-test in isolation; the meaningful verification is manual)
- [x] \`pnpm lint\` clean
- [ ] Manual smoke:
  - Open a note, type several edits, switch to another tab, switch back. ⌘Z should walk back through your earlier edits.
  - Run **Format Current Note** on an open buffer. ⌘Z should revert the formatter's rewrite.
  - Make an edit, save, switch tabs, have another window rewrite the file on disk, switch back. History should be discarded (the old undo states no longer correspond to the file) — not restored-and-broken.
  - Close tab, reopen same tab. History gone (memory-only; tab was removed from the tabs array on close) — fresh slate, which is expected per the ticket's \"close-and-reopen\" note.
  - Close the whole window. Reopen. History gone. Same reason.

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)