### PR TITLE
docs: vision statements for SQL, Compute, Publication

### DIFF
--- a/docs/vision/compute.md
+++ b/docs/vision/compute.md
@@ -1,0 +1,67 @@
+# Vision: Compute — Executing Code Over Your Library
+
+## Position
+
+Once the thoughtbase contains both the graph (via Turtle) and tables (via CSV / SQL), the next question is the obvious one: _can I run code over it?_ Most knowledge tools would answer "export your data, run the code elsewhere, paste the result back as text." Minerva's answer is: **notebooks live inside the library, and the library is their primary data source.**
+
+A Minerva note with executable code fences is a notebook. The fence language (`sparql`, `sql`, `python`) picks the interpreter; the output renders inline; derived outputs — plots, tables, summaries — persist as their own notes with a provenance link back to the computation that produced them. The same editor, formatter, linker, and preview pipeline that serves normal notes serves notebooks unchanged.
+
+## Differentiator
+
+General-purpose notebook environments (Jupyter, Marimo, Observable) treat the library as something you import _into_ the notebook. Minerva inverts the relationship. A one-liner like `minerva.notes(tag="stats-methodology", since="2023")` returns a collection of Note objects — title, body, tags, backlinks, all the metadata the graph indexer has already extracted. A two-liner cross-joins that with a CSV table of publications you care about. A three-liner plots the intersection and saves the plot as a note with `[[derivedFrom::<notebook-id>]]` linking back to the computation that produced it.
+
+The thoughtbase isn't data you have to pull _into_ the notebook; it's already there, shaped the way the notebook expects.
+
+## Capability surface
+
+**Markdown-native notebooks.** No separate `.ipynb` JSON format. An executable notebook is just a regular `.md` note with code fences in the right languages. Git-friendly by construction. Every other Minerva feature (formatter, search, wiki-links, backlinks) works unchanged.
+
+**Three fence languages, same execution model:**
+
+- `sparql` — runs against the existing rdflib store. Zero subprocess; purely in-process. Already the easiest land.
+- `sql` — runs against DuckDB (see SQL vision). Also in-process; zero subprocess.
+- `python` — runs against a Python subprocess per open notebook. The "full" compute story; the heaviest implementation work.
+
+**Native library API** (available in all Python cells):
+
+- `minerva.sparql(query: str) → DataFrame`
+- `minerva.sql(query: str) → DataFrame`
+- `minerva.notes(tag=…, since=…, …) → Collection[Note]`
+- `minerva.source(id: str) → Source`  (metadata + body + excerpts)
+- `minerva.excerpts(source=…, tag=…) → Collection[Excerpt]`
+- `minerva.table(name: str) → DataFrame`  (convenience for full-table reads)
+
+**Inline output rendering** for the standard shapes: tables, charts (via the existing Chart.js integration), images, HTML fragments. SQL and SPARQL results render as `CsvTable`-style tables immediately.
+
+**Provenance by construction.** Saving a computed output as a note emits `[[derivedFrom::<notebook-id>]]` in the resulting file. Conversely, citations written inside a code cell index as real `[[cite::…]]` links — a notebook that quotes a source becomes discoverable from that source's backlinks.
+
+**Assistant integration.** The LLM can propose a computation in whichever language fits the question ("histogram of excerpts by source year" → SPARQL + matplotlib, "monthly reading rate" → SQL over a table), emit the code, and offer to save the output. All through the existing approval gate; the assistant never silently executes code or writes files.
+
+**Phased delivery.** Shipping this end-to-end in one chunk is too big. The natural phases:
+
+1. **SPARQL fences** become executable in regular notes. Zero new infra — the rdflib store is already there. Smallest meaningful ship.
+2. **SQL fences** become executable. Adds DuckDB and CSV ingest (see SQL vision).
+3. **Python cells** with the `minerva.*` library. Real engineering: subprocess lifecycle, output protocol, interrupt handling.
+4. **Provenance + assistant integration** on top.
+
+## Scope discipline
+
+- **Not a general-purpose scientific computing environment.** If you need multi-kernel management, package-manager UIs, distributed compute, or GPU access, use Jupyter / Colab / a real IDE. Minerva's notebooks compute _over the user's library_; the library is the boundary.
+- **Not a spreadsheet.** No inline-formula cells, no cell dependencies other than Python's normal flow.
+- **Not an authoring tool for computational reports.** Quarto, RStudio, Observable Framework already own that ground. Minerva's notebooks are for answering questions; the polished-manuscript path goes through the Publication pillar, not here.
+- **Not inventing a notebook format.** Markdown-with-executable-fences is well-worn prior art (Quarto, Myst-NB, Observable Framework). Minerva implements the pattern for its own data model — it doesn't wrap an existing executor.
+- **Not a heavy Python runtime wrapper.** We spawn the user's Python, inject a local `minerva` package, execute code through stdin / stdout JSON protocol. No bundled kernel, no isolated envs, no package resolution.
+
+## Open decisions
+
+- **Python runtime discovery.** Find the user's Python via `python3` on PATH? Let them configure it in settings? Bundle a minimal `uv`-managed runtime? Start with "use what's on PATH, settings override," punt a bundled runtime to the "polish" phase.
+- **Cell execution protocol.** Line-based stdin with a cell-separator sentinel? A small socket-per-notebook? The simplest shape that gets us "run one cell, capture output" is line-based stdin; upgrade when interrupt and partial-output streaming demand more.
+- **Rich output rendering.** Plots are Chart.js — we can emit JSON `{type: 'chart', config: {…}}` from Python via a `minerva.chart(…)` helper. Images (matplotlib `plt.savefig` to PNG, return as base64)? HTML fragments (Pandas `.to_html()`)? All trivially supported via a small display protocol.
+- **Save-output-as-note UX.** Right-click a rendered output → "Save as note"? A `minerva.save(…)` call inside Python? Both, probably.
+- **Long-running / interruptible cells.** `Ctrl-C` equivalent? Kill-and-restart the subprocess? Phase 1 is probably "no interrupt, kill-notebook-kills-subprocess." Interrupt is a real feature but non-trivial.
+- **Dependency declaration.** A notebook-level `# /// script` pragma that declares `requires` (like `uv run`'s inline deps)? Users without it fall back to their global Python env. Later concern.
+
+## Depends on / enables
+
+- **Depends on**: SQL vision (for the `sql` fence and the `minerva.sql` / `minerva.table` APIs). SPARQL support can ship independently.
+- **Enables**: the "LLM proposes a computation" pathway, which is the next step of conversational research assistance once the compute substrate exists.

--- a/docs/vision/publication.md
+++ b/docs/vision/publication.md
@@ -1,0 +1,57 @@
+# Vision: Publication — Knowledge That Can Leave the App
+
+## Position
+
+A library that only you can read isn't really yours; it's hostage to the tool. The moment your library becomes useful to someone else — a reader, a collaborator, a future you on a different machine — is the moment the library earns its keep. Minerva treats **export-to-readable-artifact as a core capability**, not a plugin or a third-party hand-off. Publication discipline is what turns a personal knowledge base into shareable work.
+
+"Publication" in Minerva covers the full range of external artifacts the library can produce: a single note exported as HTML, a note tree exported as a navigable PDF, a curated subset of the thoughtbase rendered as a static site, an annotated reading bundle ("here's what I learned from this paper") shared with a collaborator. All of them resolve citations, strip private metadata, and preserve the structure the reader actually needs.
+
+## Differentiator
+
+Most knowledge tools either lock you in (Notion, Roam) or export badly — Obsidian's markdown-to-PDF is workable but citations are on their own, Logseq's sharing is basic, Notion's export has notorious gaps. The Minerva edge is **citations that survive the trip out**. The thoughtbase is RDF-backed, so `[[cite::smith-2023]]` in a note is already a structured reference. Turning it into APA, MLA, Chicago, or any CSL style on export is a rendering problem, not a data-recovery problem. Annotated-reading artifacts (a source plus its excerpts plus your notes about it) become a publishable format with almost no additional work, because all three shapes are already first-class objects in the graph.
+
+## Capability surface
+
+**Single-note export:**
+- HTML — self-contained, citations inlined, optional bibliography footer, anchor-linked headings preserved, wiki-links translated to hyperlinks or footnotes depending on whether the target is in the export set.
+- PDF — same shape, driven off the HTML pipeline (Electron's `webContents.printToPDF` already exists here).
+- Clean markdown — frontmatter stripped of internal-only fields, wiki-links translated, code fences normalized.
+
+**Note-tree export.** A folder, or a note + its transclusions + its cited sources, bundles into a navigable HTML site or a linked PDF. Minerva is a knowledge _environment_; if a subset of it is worth reading, a subset of it should be publishable as one coherent artifact.
+
+**Static-site generation.** Any subset of the thoughtbase — a folder, a tag, a SPARQL query result — renders as a browsable static site with internal navigation preserved, backlinks rendered as related-notes sections, tag pages, and a full-text search index. The gwern.net / digital-garden model, with citation support the gardens usually lack.
+
+**Citation style rendering via CSL** (Citation Style Language — the stack Zotero and Pandoc use). Author-year, numeric, inline, footnote, full styles from citationstyles.org. The source's `meta.ttl` drives the bibliography; Minerva's job is to hand CSL a clean record.
+
+**Annotated-reading as a first-class export format.** One command produces "everything I read in this source + what I pulled out of it + what I've written about it." The graph already knows all three shapes; the format is a templating exercise, not a data-assembly one.
+
+**Preview before publish.** Side-by-side with the source note, see exactly what the external reader sees — resolved citations, stripped metadata, wiki-links rendered as whatever the target needs. Same pattern as the existing Source / Preview split.
+
+**Publish destinations:**
+- **File export** first (write to a user-chosen folder).
+- **Git-push-to-repo** second (static site to GitHub Pages, Netlify, etc.).
+- **Minerva-hosted public library** eventually, for users who want a single-command share without running their own infra. Out of scope for initial ticket rounds.
+
+**Private-by-default semantics.** The export pipeline includes only notes that _opt in_ — via a frontmatter flag, a tag, or their location in a designated subtree. Fail-safe on the side of "accidentally private" rather than "accidentally public," because the alternative is a user accidentally posting their personal notes to the internet. Any single export run gets a summary preview ("this export will publish 47 notes and 12 sources; click to review") before the write fires.
+
+## Scope discipline
+
+- **Not WYSIWYG authoring.** You write markdown; publication renders markdown. Google Docs already exists.
+- **Not collaborative editing.** A separate, much bigger problem (CRDT, real-time presence, permissions). Publication is one-way out; collaboration is a two-way problem that warrants its own design pass.
+- **Not feature-for-feature parity with Obsidian Publish.** That product picked a specific hosting story and a specific rendering style. Minerva's publication should be output-neutral — produce the artifact, let the user host it wherever.
+- **Not a CMS.** No comments, no dashboards, no view analytics. Published output is static content the reader consumes; what they do with it is their business.
+- **Not solving long-form manuscript authoring.** Books, thesis chapters, journal articles with complex layout requirements are still Quarto/RStudio/LaTeX territory. Minerva exports research artifacts; it doesn't replace typesetting.
+
+## Open decisions
+
+- **CSL engine.** `citeproc-js` is the obvious pick (what Zotero and Pandoc use under the hood). In-renderer or via a Pandoc sidecar? `citeproc-js` is pure JS, small bundle; probably in-renderer.
+- **Static-site generator.** Bolt onto an existing one (Eleventy, Astro) or emit a minimal bespoke one? The "no Node toolchain in user's distribution" instinct argues for bespoke, but the feature surface is large and SSG is a mature space — standing on someone else's work is probably right.
+- **Draft state.** When a note has half-finished thoughts you haven't cleaned up, does the export include them, warn you, or silently skip them? Probably a `status: draft` frontmatter convention with opt-in "include drafts" at export time.
+- **Internal links to non-exported notes.** When a published note's wiki-links resolve to notes _not_ in the export set, do we render them as plain text, 404-ing anchors, or silently drop them? Default: plain text, with an option in the export config to turn them into tooltips or footnotes.
+- **Transclusion-aware export.** `![[other-note]]` in a published note — inline the transcluded content, link to it if it's in the export set, or treat it as a reference? Likely: inline by default, with an opt-out.
+- **Computed outputs from the Compute pillar.** A note generated from a notebook cell carries a `[[derivedFrom::…]]` link. On public export, strip the provenance trail (readers don't care about the internal notebook that produced the chart). On collaborator export, keep it (they might want to re-run the computation). Configurable per-export.
+
+## Depends on / enables
+
+- **Depends on**: the graph's citation infrastructure (already there), the existing Preview pipeline (already there), the source-viewer ingestion work (already there). The groundwork is laid.
+- **Enables**: Minerva-as-research-output-pipeline — a path from reading through annotation through analysis through publication that never leaves the environment.

--- a/docs/vision/sql.md
+++ b/docs/vision/sql.md
@@ -1,0 +1,43 @@
+# Vision: SQL — Tabular Data as a Library Citizen
+
+## Position
+
+A thoughtbase should hold more than prose. Research generates tables — experiment runs, survey results, spreadsheet exports, scraped datasets, reading lists with structured metadata — and those tables are part of what the user knows. Minerva treats them as first-class library members: you drop a CSV into the thoughtbase and it becomes a queryable table, indexed alongside notes and the graph, reachable by the same tools.
+
+The graph already handles one axis of structured data: Turtle blocks in notes and standalone `.ttl` files populate an RDF store that SPARQL queries. The SQL vision is the parallel on the tabular axis: CSV files populate a DuckDB-backed store that SQL queries. Users pick the query language closest to the shape of the question — SPARQL for relationships and types, SQL for aggregations and joins over rows.
+
+## Differentiator
+
+Most knowledge tools treat tabular data as foreign — something you link to ("see the attached spreadsheet"), embed verbatim, or bounce out to a separate tool to query. Minerva's edge is that **the same library holds both shapes of data**, and both are queryable from inside the environment. The existing graph panel becomes a _data_ panel with language-tagged query cells; CSVs in the thoughtbase appear in the Sources panel (or its sibling) and can be opened, inspected, and cross-joined with the graph.
+
+SQL is load-bearing here for a reason: it's the query language everyone already knows. SPARQL is powerful but niche; the barrier to "I can answer a question about my library" drops substantially when the user has SQL as a fallback. The LLM assistant benefits too — its SQL generation is approximately 1000× more reliable than its SPARQL generation because of training-data ratios.
+
+## Capability surface
+
+- **CSV ingestion as a first-class library operation.** Any `.csv` in the thoughtbase gets registered as a DuckDB table on the same watcher pipeline that picks up Turtle files and sources. Table naming follows a predictable convention (relative path → identifier, with a frontmatter-declared override).
+- **Schema inference by default, declaration when needed.** DuckDB auto-detects column types; a sidecar frontmatter or `.schema.yaml` pins them explicitly for users who care about date handling, categoricals, or non-UTF-8 encodings.
+- **Query language parity in the existing panel.** The current Query Panel (SPARQL) extends to accept `sql` as a second fence language in the query UI. Switching between SPARQL and SQL is a dropdown or a fence-tag change.
+- **Stock queries for common shapes.** The stock-queries menu grows a SQL section: "rows per table," "schema of X," "null rates per column," etc.
+- **CSV viewer integration.** The existing `CsvTable` component renders a CSV file's contents; the "Query this" affordance opens the panel pre-populated with `SELECT * FROM <table>`.
+- **Cross-axis joins through Python (phase 2, see Compute).** Federation across SPARQL and SQL in a single query is out of scope for v1 — users sequence the two through a Python cell or intermediate results.
+- **Engine choice: DuckDB via the Node native binding**, main-process. Rationale documented separately; primary driver is `read_csv_auto`'s frictionless zero-ETL story.
+
+## Scope discipline
+
+- **Not a data warehouse.** Personal-KM scale. Thousands-to-millions of rows is the sweet spot; gigabytes of ETL workload is not the use case.
+- **Not a spreadsheet editor.** Users edit CSVs with whatever tool they prefer (VS Code, Excel, etc.); Minerva queries them.
+- **Not a replacement for the graph.** Tabular data and RDF serve different shapes of question. Adding SQL doesn't deprecate SPARQL — both axes coexist.
+- **Not inventing new file formats.** CSV stays CSV on disk. Any Minerva-specific metadata (table name overrides, column type pins) lives in sidecar files that the user can delete without losing data.
+
+## Open decisions
+
+- **Table naming convention.** `notes/data/2024-experiment.csv` → table name `notes_data_2024_experiment`? Or the stem `experiment_2024`? Likely: both, with a frontmatter-declared `table_name` winning when present.
+- **DuckDB embedding shape.** Native Node binding (main-process) vs DuckDB-wasm (either side). Native gets us tighter file-system integration and slightly better perf; WASM gets us bundle-size flexibility. Start native, keep the WASM path open.
+- **Schema declaration format.** Frontmatter on a companion note? Sidecar `.schema.yaml`? JSON Schema subset? Picking a format is a small but load-bearing choice — users will grow attached.
+- **Also-ingest Parquet / Arrow / JSON?** DuckDB reads all three natively. Do we surface them now or CSV-only and add others on demand? Probably CSV-only at launch; the rest are a one-line extension when users ask.
+- **What about embedded CSV blocks inside notes (via a ````csv` fence)?** Tempting symmetry with Turtle blocks, but note files would bloat fast and diffing CSV-in-markdown is awkward. Probably out of scope.
+
+## Depends on / enables
+
+- **Depends on**: the existing Turtle-ingest watcher model (`.minerva/sources/` has a parallel story; `.csv` files anywhere in the tree are the trigger).
+- **Enables**: the SQL fence language in the Compute notebook work. Users can run SQL in a note without needing Python installed.


### PR DESCRIPTION
Three vision docs under \`docs/vision/\` capturing the new pillars of the Integrated Knowledge Environment framing. Each follows a consistent structure so the capability sections map cleanly onto tickets.

- **\`sql.md\`** — tabular data as a library citizen. CSV files become queryable via DuckDB; the query panel extends to accept both SPARQL and SQL.
- **\`compute.md\`** — markdown-native notebooks whose library is the thoughtbase. Three fence languages (\`sparql\`, \`sql\`, \`python\`) and a \`minerva.*\` API exposing the graph and tables as first-class data. Phased delivery: SPARQL fences → SQL fences → Python + library API.
- **\`publication.md\`** — export as a core capability. Single-note / tree / static-site exports with CSL-rendered citations; annotated-reading as a first-class artifact format; private-by-default opt-in semantics.

Ordering across the three:
- **SQL first** — foundation for Compute phase 2 and for Publication's computed-output provenance.
- **Compute second**, phased. SPARQL-as-executable-fences is nearly free; SQL-as-fences rides SQL's coattails; Python cells + library API is the real engineering.
- **Publication in parallel** — its prerequisites (citation infra, preview pipeline) already exist.

Next up after merge: turn the capability-surface sections into concrete tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)