### PR TITLE
SQL: DuckDB integration — main-process lifecycle + TABLES_QUERY IPC (closes #232)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/legacy-modes": "^6.5.2",
     "@comunica/query-sparql-rdfjs": "^5.1.3",
+    "@duckdb/node-api": "1.5.2-r.1",
     "@mozilla/readability": "^0.6.0",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@comunica/query-sparql-rdfjs':
         specifier: ^5.1.3
         version: 5.1.3(encoding@0.1.13)
+      '@duckdb/node-api':
+        specifier: 1.5.2-r.1
+        version: 1.5.2-r.1
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1177,6 +1180,42 @@ packages:
   '@digitalbazaar/http-client@4.3.0':
     resolution: {integrity: sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==}
     engines: {node: '>=18.0'}
+
+  '@duckdb/node-api@1.5.2-r.1':
+    resolution: {integrity: sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.2-r.1':
+    resolution: {integrity: sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-darwin-x64@1.5.2-r.1':
+    resolution: {integrity: sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-linux-arm64@1.5.2-r.1':
+    resolution: {integrity: sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-x64@1.5.2-r.1':
+    resolution: {integrity: sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@duckdb/node-bindings-win32-arm64@1.5.2-r.1':
+    resolution: {integrity: sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.5.2-r.1':
+    resolution: {integrity: sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@duckdb/node-bindings@1.5.2-r.1':
+    resolution: {integrity: sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==}
 
   '@electron-forge/cli@7.11.1':
     resolution: {integrity: sha512-pk8AoLsr7t7LBAt0cFD06XFA6uxtPdvtLx06xeal7O9o7GHGCbj29WGwFoJ8Br/ENM0Ho868S3PrAn1PtBXt5g==}
@@ -7850,6 +7889,37 @@ snapshots:
     dependencies:
       ky: 1.14.3
       undici: 6.24.1
+
+  '@duckdb/node-api@1.5.2-r.1':
+    dependencies:
+      '@duckdb/node-bindings': 1.5.2-r.1
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-darwin-x64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-arm64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.2-r.1':
+    optionalDependencies:
+      '@duckdb/node-bindings-darwin-arm64': 1.5.2-r.1
+      '@duckdb/node-bindings-darwin-x64': 1.5.2-r.1
+      '@duckdb/node-bindings-linux-arm64': 1.5.2-r.1
+      '@duckdb/node-bindings-linux-x64': 1.5.2-r.1
+      '@duckdb/node-bindings-win32-arm64': 1.5.2-r.1
+      '@duckdb/node-bindings-win32-x64': 1.5.2-r.1
 
   '@electron-forge/cli@7.11.1(encoding@0.1.13)':
     dependencies:

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -29,6 +29,7 @@ import {
   formatFolder as formatFolderOnDisk,
 } from './formatter/orchestrator';
 import { ingestUrl } from './sources/ingest';
+import * as tables from './sources/tables';
 import { ingestIdentifier } from './sources/ingest-identifier';
 import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
@@ -395,6 +396,11 @@ export function registerIpcHandlers(): void {
   // Graph
   ipcMain.handle(Channels.GRAPH_QUERY, async (_e, sparql: string) => {
     return graph.queryGraph(sparql);
+  });
+
+  // Tables (DuckDB)
+  ipcMain.handle(Channels.TABLES_QUERY, async (_e, sql: string) => {
+    return tables.runQuery(sql);
   });
 
   ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, () => graph.schemaForCompletion());

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -1,0 +1,61 @@
+import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
+
+// ── Module state ────────────────────────────────────────────────────────────
+// Matches the `graph` module: single live project at a time. If Minerva ever
+// grows true multi-project-per-process, both modules move in lockstep.
+
+let instance: DuckDBInstance | null = null;
+let connection: DuckDBConnection | null = null;
+let currentRootPath: string | null = null;
+
+export type QueryResult =
+  | { ok: true; columns: string[]; rows: Record<string, unknown>[] }
+  | { ok: false; error: string };
+
+/** Open an in-memory DuckDB for the given project root. Idempotent per root. */
+export async function initTablesDb(rootPath: string): Promise<void> {
+  if (currentRootPath === rootPath && connection) return;
+  await closeTablesDb();
+  instance = await DuckDBInstance.create(':memory:');
+  connection = await instance.connect();
+  currentRootPath = rootPath;
+}
+
+export async function closeTablesDb(): Promise<void> {
+  try { connection?.closeSync(); } catch { /* already closed */ }
+  try { instance?.closeSync(); } catch { /* already closed */ }
+  connection = null;
+  instance = null;
+  currentRootPath = null;
+}
+
+/**
+ * Execute `sql` and return rows as plain JS objects suitable for structured
+ * clone across the IPC boundary. Malformed SQL or runtime errors come back
+ * as `{ ok: false, error }` — never thrown.
+ */
+export async function runQuery(sql: string): Promise<QueryResult> {
+  if (!connection) return { ok: false, error: 'Tables DB is not initialized' };
+  try {
+    const reader = await connection.runAndReadAll(sql);
+    const columns = reader.columnNames();
+    const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
+    return { ok: true, columns, rows };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Register a CSV file as a queryable view. Full implementation lands in the
+ * CSV ingestion ticket (#233); this is a stub so IPC + lifecycle can be wired
+ * against the final signature.
+ */
+export async function registerCsv(_relativePath: string, _tableName: string): Promise<void> {
+  throw new Error('registerCsv not yet implemented (see issue #233)');
+}
+
+/** Exposed for tests. */
+export function _isOpen(): boolean {
+  return connection !== null;
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -8,6 +8,7 @@ import * as search from './search/index';
 import * as notebaseFs from './notebase/fs';
 import * as conversation from './llm/conversation';
 import * as healthChecks from './graph/health-checks';
+import * as tables from './sources/tables';
 import { addRecentProject } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
@@ -210,6 +211,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   watchers.set(win.id, rootPath);
 
   await graph.initGraph(rootPath);
+  await tables.initTablesDb(rootPath);
   conversation.initConversations(rootPath);
   await Promise.all([
     graph.indexAllNotes(rootPath),

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -85,6 +85,9 @@ contextBridge.exposeInMainWorld('api', {
     excerptSource: (excerptId: string) => ipcRenderer.invoke(Channels.GRAPH_EXCERPT_SOURCE, excerptId),
     schemaForCompletion: () => ipcRenderer.invoke(Channels.GRAPH_SCHEMA_FOR_COMPLETION),
   },
+  tables: {
+    query: (sql: string) => ipcRenderer.invoke(Channels.TABLES_QUERY, sql),
+  },
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),
     notesByTag: (tag: string) => ipcRenderer.invoke(Channels.TAGS_NOTES_BY_TAG, tag),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -72,6 +72,14 @@ export interface GraphApi {
   }>;
 }
 
+export type TablesQueryResult =
+  | { ok: true; columns: string[]; rows: Record<string, unknown>[] }
+  | { ok: false; error: string };
+
+export interface TablesApi {
+  query(sql: string): Promise<TablesQueryResult>;
+}
+
 export interface TagsApi {
   list(): Promise<TagInfo[]>;
   notesByTag(tag: string): Promise<TaggedNote[]>;
@@ -239,6 +247,7 @@ export interface IdeApi {
   search: SearchApi;
   git: GitApi;
   graph: GraphApi;
+  tables: TablesApi;
   tags: TagsApi;
   export: ExportApi;
   shell: ShellApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -127,6 +127,9 @@ export const Channels = {
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */
   SOURCES_CHANGED: 'sources:changed',
 
+  /** Run a SQL query against the project's DuckDB (#232). */
+  TABLES_QUERY: 'tables:query',
+
   /** Format a single file on disk (#153). Writes through the standard index+broadcast pipeline. */
   FORMATTER_FORMAT_FILE: 'formatter:formatFile',
   /** Format every .md under a relative folder (empty string = whole thoughtbase). */

--- a/tests/main/sources/tables.test.ts
+++ b/tests/main/sources/tables.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { initTablesDb, closeTablesDb, runQuery } from '../../../src/main/sources/tables';
+
+describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
+  beforeAll(async () => {
+    await initTablesDb('/tmp/minerva-tables-test');
+  });
+
+  afterAll(async () => {
+    await closeTablesDb();
+  });
+
+  it('runs the trivial round-trip query', async () => {
+    const result = await runQuery(`SELECT 'hello' AS greeting`);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.columns).toEqual(['greeting']);
+      expect(result.rows).toEqual([{ greeting: 'hello' }]);
+    }
+  });
+
+  it('returns structured error on malformed SQL instead of throwing', async () => {
+    const result = await runQuery('SELEKT * FROM nothing');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/syntax|parser|SELEKT/i);
+    }
+  });
+
+  it('returns structured error when a table is missing', async () => {
+    const result = await runQuery('SELECT * FROM no_such_table');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/no_such_table|not found|does not exist/i);
+    }
+  });
+
+  it('handles multi-row / multi-column results with typed values', async () => {
+    const result = await runQuery(`
+      SELECT * FROM (VALUES
+        (1, 'alpha', TRUE),
+        (2, 'beta', FALSE),
+        (3, 'gamma', TRUE)
+      ) AS t(n, label, flag)
+      ORDER BY n
+    `);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.columns).toEqual(['n', 'label', 'flag']);
+      expect(result.rows).toHaveLength(3);
+      expect(result.rows[0]).toEqual({ n: 1, label: 'alpha', flag: true });
+      expect(result.rows[2]).toEqual({ n: 3, label: 'gamma', flag: true });
+    }
+  });
+
+  it('init is idempotent for the same root', async () => {
+    await initTablesDb('/tmp/minerva-tables-test');
+    const result = await runQuery(`SELECT 42 AS answer`);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.rows[0]).toEqual({ answer: 42 });
+  });
+
+  it('re-init on a different root closes the previous connection', async () => {
+    await runQuery(`CREATE TABLE scratch (x INTEGER)`);
+    await runQuery(`INSERT INTO scratch VALUES (1), (2)`);
+    const before = await runQuery(`SELECT COUNT(*) AS n FROM scratch`);
+    expect(before.ok).toBe(true);
+
+    await initTablesDb('/tmp/minerva-tables-test-other');
+    const after = await runQuery(`SELECT COUNT(*) AS n FROM scratch`);
+    expect(after.ok).toBe(false);
+  });
+});

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -15,7 +15,15 @@ export default defineConfig({
       // the unresolvable `canvas` and the app crashes at load. Mark
       // `canvas` external so the `require` stays runtime and the
       // fallback branch actually runs.
-      external: ['canvas'],
+      //
+      // DuckDB ships a platform-specific `.node` binary per arch via
+      // `require('@duckdb/node-bindings-<platform>-<arch>/duckdb.node')`.
+      // Rollup can't resolve `.node` files — keep the whole bindings
+      // family external so the require stays runtime.
+      external: [
+        'canvas',
+        /^@duckdb\/node-bindings/,
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary

First ticket of the SQL stream (see `docs/vision/sql.md`). Adds an in-memory DuckDB connection per open project, parallel to the graph module's lifecycle, plus the IPC surface every later SQL ticket will plug into.

- `@duckdb/node-api` (Neo binding — N-API, prebuilt per-platform, ABI-stable for Electron)
- `src/main/sources/tables.ts`: `initTablesDb` / `closeTablesDb` / `runQuery` / `registerCsv` stub. `QueryResult` is a discriminated union so malformed SQL comes back as `{ ok: false, error }` rather than throwing
- Wired into `openProjectInWindow` alongside `initGraph` — project-open opens a fresh in-memory DB, re-init on a new root closes the previous
- `TABLES_QUERY` channel + handler + preload bridge + client types → renderer calls `window.api.tables.query(sql)`
- `vite.main.config.ts` externalizes `@duckdb/node-bindings*` so the per-platform `.node` binary stays a runtime `require` (same shape as the linkedom/canvas fix)

## Why this shape

- **Neo over legacy `duckdb`**: Neo uses N-API, so no node-gyp rebuild against Electron's ABI; the legacy binding has repeatedly been painful in Electron apps.
- **Module-level singleton**: mirrors the graph module. One project per window in Minerva today; both modules move in lockstep if that changes.
- **In-memory only**: per the ticket, persistence is a nice-to-have deferred until re-ingest perf bites. Falls out of scope here cleanly.
- **Structured errors**: every downstream consumer (Query Panel, LLM compute proposals) will want to surface SQL errors in-UI. Throwing across IPC loses structure.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1133/1133 pass, including new `tests/main/sources/tables.test.ts` (6 tests)
- [x] Direct Node import smoke: `DuckDBInstance.create(':memory:')` + `runAndReadAll` round-trips
- [x] Electron boots past the native import without the `node:sqlite`-style regression the ticket called out
- [ ] Manual smoke: open DevTools in the running app, run `await window.api.tables.query(\"SELECT 'hello' AS greeting\")` — expect `{ ok: true, columns: ['greeting'], rows: [{ greeting: 'hello' }] }`

## Out of scope (per ticket)

- CSV ingestion — stub only; body lands in #233
- Renderer-side query UX — Query Panel SQL extension comes in #234
- Persistence on disk — in-memory until proven insufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)