### PR TITLE
SQL: CSV ingestion — watcher picks up .csv, auto-registers as DuckDB views (closes #233)

### DIFF
--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 
 // ── Module state ────────────────────────────────────────────────────────────
@@ -8,9 +11,21 @@ let instance: DuckDBInstance | null = null;
 let connection: DuckDBConnection | null = null;
 let currentRootPath: string | null = null;
 
+/** relativePath → tableName for the currently-registered CSV views. */
+const pathToTable = new Map<string, string>();
+/** tableName → relativePath, so we can detect + warn on collisions. */
+const tableToPath = new Map<string, string>();
+
 export type QueryResult =
   | { ok: true; columns: string[]; rows: Record<string, unknown>[] }
   | { ok: false; error: string };
+
+export interface TableInfo {
+  name: string;
+  relativePath: string;
+  columnCount: number;
+  rowCount: number;
+}
 
 /** Open an in-memory DuckDB for the given project root. Idempotent per root. */
 export async function initTablesDb(rootPath: string): Promise<void> {
@@ -27,6 +42,8 @@ export async function closeTablesDb(): Promise<void> {
   connection = null;
   instance = null;
   currentRootPath = null;
+  pathToTable.clear();
+  tableToPath.clear();
 }
 
 /**
@@ -46,13 +63,167 @@ export async function runQuery(sql: string): Promise<QueryResult> {
   }
 }
 
+// ── CSV pipeline (#233) ─────────────────────────────────────────────────────
+
 /**
- * Register a CSV file as a queryable view. Full implementation lands in the
- * CSV ingestion ticket (#233); this is a stub so IPC + lifecycle can be wired
- * against the final signature.
+ * Derive a DuckDB-safe table name from a CSV's relative path.
+ * `notes/data/2024-experiment.csv` → `notes_data_2024_experiment`.
+ * Identifiers that would start with a digit get a `t_` prefix.
  */
-export async function registerCsv(_relativePath: string, _tableName: string): Promise<void> {
-  throw new Error('registerCsv not yet implemented (see issue #233)');
+export function deriveTableName(relativePath: string): string {
+  const withoutExt = relativePath.replace(/\.csv$/i, '');
+  // Separator-ish characters collapse to a single underscore; anything else
+  // non-alphanumeric just drops out.
+  let name = withoutExt
+    .replace(/[\/\\.\-\s]+/g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!name) name = 'table';
+  if (/^[0-9]/.test(name)) name = 't_' + name;
+  return name;
+}
+
+/**
+ * Read a companion markdown note alongside the CSV (same dir, matching stem).
+ * If the frontmatter declares `table_name:`, return it as the SQL identifier.
+ * Returns null if no companion exists, no frontmatter, or no override.
+ */
+async function readCompanionOverride(rootPath: string, relativePath: string): Promise<string | null> {
+  const dir = path.dirname(relativePath);
+  const stem = path.basename(relativePath, path.extname(relativePath));
+  const companionRel = dir === '.' ? `${stem}.md` : `${dir}/${stem}.md`;
+  const companionAbs = path.join(rootPath, companionRel);
+  let content: string;
+  try {
+    content = await fs.readFile(companionAbs, 'utf-8');
+  } catch {
+    return null;
+  }
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  try {
+    const fm = YAML.parse(m[1]) as Record<string, unknown> | null;
+    const raw = fm?.table_name;
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      // Run the user-supplied override through the same sanitizer so a
+      // whitespace-happy YAML value can't produce an invalid identifier.
+      return deriveTableName(raw);
+    }
+  } catch {
+    /* malformed YAML — ignore, fall back to the derived name */
+  }
+  return null;
+}
+
+/**
+ * Register (or re-register) a CSV file as a DuckDB view. The view is lazy —
+ * DuckDB re-reads the file on every query — so content changes don't require
+ * re-registration. Re-register is called when the file is added or when the
+ * companion note's `table_name:` may have changed.
+ */
+export async function registerCsv(rootPath: string, relativePath: string): Promise<void> {
+  if (!connection) return;
+  const override = await readCompanionOverride(rootPath, relativePath);
+  const tableName = override ?? deriveTableName(relativePath);
+
+  // If another path already claimed this table name, warn and skip rather
+  // than silently clobbering whichever one loaded first.
+  const existingPath = tableToPath.get(tableName);
+  if (existingPath && existingPath !== relativePath) {
+    console.warn(
+      `[tables] Table name collision: '${tableName}' would be used by both ` +
+      `'${existingPath}' and '${relativePath}'. Skipping the second. Use ` +
+      `'table_name:' in a companion .md to disambiguate.`,
+    );
+    return;
+  }
+
+  // If this path was previously registered under a different name (e.g. the
+  // companion override was just added or changed), drop the old view first.
+  const previousName = pathToTable.get(relativePath);
+  if (previousName && previousName !== tableName) {
+    try {
+      await connection.run(`DROP VIEW IF EXISTS "${previousName}"`);
+    } catch { /* tolerate the rare rename race */ }
+    tableToPath.delete(previousName);
+  }
+
+  const absPath = path.join(rootPath, relativePath);
+  const escapedPath = absPath.replace(/'/g, "''");
+  try {
+    await connection.run(
+      `CREATE OR REPLACE VIEW "${tableName}" AS SELECT * FROM read_csv_auto('${escapedPath}')`,
+    );
+    pathToTable.set(relativePath, tableName);
+    tableToPath.set(tableName, relativePath);
+  } catch (err) {
+    console.warn(
+      `[tables] Failed to register '${relativePath}' as '${tableName}': ` +
+      (err instanceof Error ? err.message : String(err)),
+    );
+  }
+}
+
+/** Drop the view for a CSV path. No-op if the path was never registered. */
+export async function unregisterCsv(relativePath: string): Promise<void> {
+  if (!connection) return;
+  const tableName = pathToTable.get(relativePath);
+  if (!tableName) return;
+  try {
+    await connection.run(`DROP VIEW IF EXISTS "${tableName}"`);
+  } catch { /* view may already be gone */ }
+  pathToTable.delete(relativePath);
+  tableToPath.delete(tableName);
+}
+
+/**
+ * Scan the thoughtbase on project open and register every `.csv` file under
+ * the root. Mirrors graph.indexAllNotes's walker shape.
+ */
+export async function registerAllCsvs(rootPath: string): Promise<number> {
+  if (!connection) return 0;
+  let count = 0;
+  async function walk(dirPath: string) {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.csv')) {
+        const rel = path.relative(rootPath, fullPath);
+        await registerCsv(rootPath, rel);
+        count++;
+      }
+    }
+  }
+  await walk(rootPath);
+  return count;
+}
+
+/** Every registered CSV's table name, relative path, and row/column counts. */
+export async function listTables(): Promise<TableInfo[]> {
+  if (!connection) return [];
+  const out: TableInfo[] = [];
+  for (const [relativePath, name] of pathToTable.entries()) {
+    const quoted = `"${name}"`;
+    const countR = await runQuery(`SELECT COUNT(*) AS n FROM ${quoted}`);
+    const colsR = await runQuery(
+      `SELECT column_name FROM information_schema.columns ` +
+      `WHERE table_name = '${name.replace(/'/g, "''")}' AND table_schema = 'main'`,
+    );
+    const rowCount = countR.ok ? Number(countR.rows[0]?.n ?? 0) : 0;
+    const columnCount = colsR.ok ? colsR.rows.length : 0;
+    out.push({ name, relativePath, columnCount, rowCount });
+  }
+  out.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return out;
 }
 
 /** Exposed for tests. */

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -158,6 +158,9 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(relativePath, content);
         search.indexNote(relativePath, content);
+        if (relativePath.toLowerCase().endsWith('.csv')) {
+          await tables.registerCsv(rootPath, relativePath);
+        }
         debouncedPersist();
       } catch { /* file may have been deleted between events */ }
     },
@@ -167,13 +170,19 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(relativePath, content);
         search.indexNote(relativePath, content);
+        if (relativePath.toLowerCase().endsWith('.csv')) {
+          await tables.registerCsv(rootPath, relativePath);
+        }
         debouncedPersist();
       } catch { /* race condition */ }
     },
-    onFileDeleted: (relativePath) => {
+    onFileDeleted: async (relativePath) => {
       if (wasHandled(relativePath)) return;
       search.removeNote(relativePath);
       graph.removeNote(relativePath);
+      if (relativePath.toLowerCase().endsWith('.csv')) {
+        await tables.unregisterCsv(relativePath);
+      }
       debouncedPersist();
     },
     onSourceMetaChanged: async (sourceId) => {
@@ -216,6 +225,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   await Promise.all([
     graph.indexAllNotes(rootPath),
     search.indexAllNotes(rootPath),
+    tables.registerAllCsvs(rootPath),
   ]);
   // Run health checks after initial indexing, then periodically
   healthChecks.runAllChecks();

--- a/tests/main/sources/tables-csv.test.ts
+++ b/tests/main/sources/tables-csv.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initTablesDb,
+  closeTablesDb,
+  runQuery,
+  registerCsv,
+  unregisterCsv,
+  registerAllCsvs,
+  listTables,
+  deriveTableName,
+} from '../../../src/main/sources/tables';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tables-csv-test-'));
+}
+
+describe('deriveTableName (#233)', () => {
+  it('converts slashes and dots to underscores', () => {
+    expect(deriveTableName('notes/data/2024-experiment.csv'))
+      .toBe('notes_data_2024_experiment');
+  });
+
+  it('drops the .csv extension', () => {
+    expect(deriveTableName('foo.csv')).toBe('foo');
+  });
+
+  it('handles uppercase extensions', () => {
+    expect(deriveTableName('Foo.CSV')).toBe('Foo');
+  });
+
+  it('prefixes t_ when the name would start with a digit', () => {
+    expect(deriveTableName('2024-readings.csv')).toBe('t_2024_readings');
+  });
+
+  it('strips non-identifier characters', () => {
+    expect(deriveTableName('my (weird) file!.csv')).toBe('my_weird_file');
+  });
+
+  it('collapses runs of separators', () => {
+    expect(deriveTableName('a///b...c.csv')).toBe('a_b_c');
+  });
+
+  it('falls back to `table` for a pathological empty input', () => {
+    expect(deriveTableName('.csv')).toBe('table');
+  });
+
+  it('preserves underscores and case', () => {
+    expect(deriveTableName('My_Data.csv')).toBe('My_Data');
+  });
+});
+
+describe('CSV pipeline: register / list / unregister (#233)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initTablesDb(root);
+  });
+
+  afterEach(async () => {
+    await closeTablesDb();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function writeCsv(relativePath: string, content: string): Promise<void> {
+    const abs = path.join(root, relativePath);
+    await fsp.mkdir(path.dirname(abs), { recursive: true });
+    await fsp.writeFile(abs, content, 'utf-8');
+  }
+
+  it('registers a CSV and makes it queryable', async () => {
+    await writeCsv('stations.csv', 'id,name,lat\n1,Alpha,0.1\n2,Beta,0.2\n3,Gamma,0.3\n');
+    await registerCsv(root, 'stations.csv');
+
+    const result = await runQuery(`SELECT COUNT(*) AS n FROM stations`);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.rows[0]).toEqual({ n: 3n });
+
+    const detail = await runQuery(`SELECT id, name FROM stations ORDER BY id`);
+    expect(detail.ok).toBe(true);
+    if (detail.ok) {
+      // read_csv_auto infers integer columns as BIGINT, so id values are
+      // bigints — faithful reflection of DuckDB's inference, not a bug.
+      expect(detail.rows).toEqual([
+        { id: 1n, name: 'Alpha' },
+        { id: 2n, name: 'Beta' },
+        { id: 3n, name: 'Gamma' },
+      ]);
+    }
+  });
+
+  it('derives nested table names from the relative path', async () => {
+    await writeCsv('data/2024-experiment.csv', 'x,y\n1,2\n3,4\n');
+    await registerCsv(root, 'data/2024-experiment.csv');
+
+    const result = await runQuery(`SELECT SUM(x) AS s FROM data_2024_experiment`);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.rows[0]).toEqual({ s: 4n });
+  });
+
+  it('honours a companion .md `table_name:` override', async () => {
+    await writeCsv('data/2024-experiment.csv', 'x,y\n1,2\n');
+    await fsp.mkdir(path.join(root, 'data'), { recursive: true });
+    await fsp.writeFile(
+      path.join(root, 'data', '2024-experiment.md'),
+      '---\ntitle: 2024 readings\ntable_name: experiment_2024\n---\n\n# Notes about the 2024 batch\n',
+      'utf-8',
+    );
+    await registerCsv(root, 'data/2024-experiment.csv');
+
+    const hit = await runQuery(`SELECT * FROM experiment_2024`);
+    expect(hit.ok).toBe(true);
+    if (hit.ok) expect(hit.rows).toEqual([{ x: 1n, y: 2n }]);
+
+    // The derived name should NOT also exist.
+    const derived = await runQuery(`SELECT * FROM data_2024_experiment`);
+    expect(derived.ok).toBe(false);
+  });
+
+  it('unregisterCsv drops the view', async () => {
+    await writeCsv('scratch.csv', 'a\n1\n');
+    await registerCsv(root, 'scratch.csv');
+    expect((await runQuery(`SELECT * FROM scratch`)).ok).toBe(true);
+
+    await unregisterCsv('scratch.csv');
+    const gone = await runQuery(`SELECT * FROM scratch`);
+    expect(gone.ok).toBe(false);
+  });
+
+  it('listTables returns registered CSVs with row/column counts', async () => {
+    await writeCsv('a.csv', 'x,y\n1,2\n3,4\n');
+    await writeCsv('nested/b.csv', 'p,q,r\n1,2,3\n');
+    await registerCsv(root, 'a.csv');
+    await registerCsv(root, 'nested/b.csv');
+
+    const tables = await listTables();
+    expect(tables).toHaveLength(2);
+
+    const a = tables.find((t) => t.name === 'a');
+    const b = tables.find((t) => t.name === 'nested_b');
+    expect(a).toEqual({ name: 'a', relativePath: 'a.csv', columnCount: 2, rowCount: 2 });
+    expect(b).toEqual({ name: 'nested_b', relativePath: 'nested/b.csv', columnCount: 3, rowCount: 1 });
+  });
+
+  it('registerAllCsvs picks up existing CSVs on project open', async () => {
+    await writeCsv('top.csv', 'n\n1\n2\n');
+    await writeCsv('sub/mid.csv', 'm\nx\n');
+    await writeCsv('sub/deep/bottom.csv', 'k\na\nb\nc\n');
+    // Hidden dir — should be skipped.
+    await writeCsv('.minerva/secret.csv', 'x\n1\n');
+
+    const count = await registerAllCsvs(root);
+    expect(count).toBe(3);
+
+    const tables = await listTables();
+    expect(tables.map((t) => t.name).sort()).toEqual(['sub_deep_bottom', 'sub_mid', 'top']);
+  });
+
+  it('re-registering after a table_name override swaps the view name', async () => {
+    await writeCsv('readings.csv', 'x\n1\n');
+    await registerCsv(root, 'readings.csv');
+    expect((await runQuery(`SELECT * FROM readings`)).ok).toBe(true);
+
+    // Now add a companion note with an override and re-register.
+    await fsp.writeFile(
+      path.join(root, 'readings.md'),
+      '---\ntable_name: measurements\n---\n',
+      'utf-8',
+    );
+    await registerCsv(root, 'readings.csv');
+
+    expect((await runQuery(`SELECT * FROM measurements`)).ok).toBe(true);
+    expect((await runQuery(`SELECT * FROM readings`)).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Second ticket of the SQL stream. Drop a `.csv` anywhere in the thoughtbase and it's queryable immediately — no import step, no schema declaration. Builds directly on #232's in-memory DuckDB.

- **`deriveTableName`** — `notes/data/2024-experiment.csv` → `notes_data_2024_experiment`. Collapses slashes / dots / hyphens to underscores, strips non-identifier chars, escapes digit-prefixes with `t_`.
- **`registerCsv(rootPath, relativePath)`** — `CREATE OR REPLACE VIEW` over `read_csv_auto`. Companion `.md` frontmatter `table_name:` wins over the derived name.
- **`unregisterCsv`** — `DROP VIEW` on file delete, map state cleaned up.
- **`registerAllCsvs`** — project-open scanner parallel to `graph.indexAllNotes`; skips hidden dirs + `node_modules`.
- **`listTables`** — returns `{ name, relativePath, columnCount, rowCount }[]` (populated from the internal path↔name map + `information_schema.columns` + a per-view `COUNT(*)`).
- **`window-manager.ts`** wires `.csv` create / change / delete into the pipeline and calls `registerAllCsvs` alongside `graph` + `search` index-all.

## Design calls worth flagging

- **Views, not tables.** `CREATE OR REPLACE VIEW … FROM read_csv_auto(path)` is lazy, so content edits to the CSV file flow through without re-registration. Re-registration happens only when a companion `.md`'s `table_name:` changes, or when `registerAllCsvs` reruns on project open.
- **`read_csv_auto` infers integers as BIGINT.** The test expectations use `1n`/`2n`/etc. for integer columns — faithful reflection of DuckDB's behaviour, not a bug. If the renderer-side Query Panel (#234) needs to down-convert for display, that's a concern there.
- **Table-name collision = warn + skip second.** If two CSVs derive the same name, we log and skip rather than silently clobbering. The `table_name:` frontmatter is the documented escape hatch.
- **Companion `.md` change doesn't auto-re-register.** If a user adds `table_name:` to an existing companion note, the CSV keeps its old view until the next project open or CSV touch. Deliberate v1 scope call — a future ticket can watch companion-note changes if this bites.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1148/1148 pass, including 15 new tests across `tests/main/sources/tables-csv.test.ts`:
  - 8 `deriveTableName` edge cases
  - end-to-end register → query → count
  - nested path → nested table name
  - frontmatter `table_name:` override honoured
  - `unregisterCsv` drops the view
  - `listTables` row + column counts
  - `registerAllCsvs` picks up nested CSVs, skips `.minerva/`
  - re-register after override change swaps the view name
- [ ] Manual smoke: open a project, drop a `.csv` in, then in DevTools: `await window.api.tables.query(\"SELECT * FROM my_csv LIMIT 5\")`

## Out of scope (per ticket)

- UI sidebar for the table list — #235
- Schema pinning (column types, date formats, encoding) — separate follow-up
- Parquet / Arrow / JSON ingestion — follow-ups
- Embedded CSV-in-note fences — probably never

🤖 Generated with [Claude Code](https://claude.com/claude-code)