### PR TITLE
SQL: Sidebar Tables panel — list + click-to-query (progress on #235)

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -159,8 +159,10 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       // it's cheap and hard to fail — keeping it outside the graph+search
       // pipeline means a graph indexing hiccup can't skip table registration.
       if (relativePath.toLowerCase().endsWith('.csv')) {
-        try { await tables.registerCsv(rootPath, relativePath); }
-        catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
+        try {
+          await tables.registerCsv(rootPath, relativePath);
+          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+        } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       }
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
@@ -176,8 +178,10 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     onFileCreated: async (relativePath) => {
       if (wasHandled(relativePath)) return;
       if (relativePath.toLowerCase().endsWith('.csv')) {
-        try { await tables.registerCsv(rootPath, relativePath); }
-        catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
+        try {
+          await tables.registerCsv(rootPath, relativePath);
+          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+        } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       }
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
@@ -191,8 +195,10 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     onFileDeleted: async (relativePath) => {
       if (wasHandled(relativePath)) return;
       if (relativePath.toLowerCase().endsWith('.csv')) {
-        try { await tables.unregisterCsv(relativePath); }
-        catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
+        try {
+          await tables.unregisterCsv(relativePath);
+          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+        } catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
       }
       try {
         search.removeNote(relativePath);
@@ -244,6 +250,9 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     search.indexAllNotes(rootPath),
     tables.registerAllCsvs(rootPath),
   ]);
+  // Tables panel subscribes to this; fires once after the initial scan so the
+  // sidebar populates without the renderer having to poll.
+  if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
   // Run health checks after initial indexing, then periodically
   healthChecks.runAllChecks();
   healthChecks.startPeriodicChecks();

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -88,6 +88,9 @@ contextBridge.exposeInMainWorld('api', {
   tables: {
     query: (sql: string) => ipcRenderer.invoke(Channels.TABLES_QUERY, sql),
     list: () => ipcRenderer.invoke(Channels.TABLES_LIST),
+    onChanged: (cb: () => void) => {
+      ipcRenderer.on(Channels.TABLES_CHANGED, () => cb());
+    },
   },
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -978,6 +978,7 @@
     setTimeout(() => {
       sidebar?.refreshTags();
       sidebar?.refreshSources();
+      sidebar?.refreshTables();
       refreshSourcesCache();
     }, 100);
   };
@@ -988,6 +989,12 @@
   api.sources.onChanged(() => {
     sidebar?.refreshSources();
     refreshSourcesCache();
+  });
+
+  // Main broadcasts after the initial CSV scan and on every register/unregister
+  // from the watcher — keeps the sidebar Tables panel in lockstep.
+  api.tables.onChanged(() => {
+    sidebar?.refreshTables();
   });
 
   function cycleViewMode() {
@@ -1195,6 +1202,7 @@
       await loadFormatSettings();
       sidebar?.refreshTags();
       sidebar?.refreshSources();
+      sidebar?.refreshTables();
       await refreshSourcesCache();
       // Load inspection count after a brief delay to let health checks finish
       setTimeout(refreshInspectionCount, 3000);
@@ -1244,6 +1252,8 @@
           onMove={handleMove}
           onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
           onSourceSelect={(id) => handleOpenSource(id)}
+          onTableClick={(name) => editor.openQuery(`SELECT * FROM ${name}`, 'sql')}
+          onOpenCsv={(rel) => handleFileSelect(rel)}
           canPaste={clipboardItem !== null}
         />
       {/if}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -4,6 +4,7 @@
   import SearchPanel from './SearchPanel.svelte';
   import TagPanel from './TagPanel.svelte';
   import SourcesPanel from './SourcesPanel.svelte';
+  import TablesPanel from './TablesPanel.svelte';
 
   interface Props {
     files: NoteFile[];
@@ -20,14 +21,17 @@
     onMove: (srcPath: string, destDirectory: string) => void;
     onBookmark?: (relativePath: string) => void;
     onSourceSelect?: (sourceId: string) => void;
+    onTableClick?: (tableName: string) => void;
+    onOpenCsv?: (relativePath: string) => void;
     canPaste?: boolean;
   }
 
-  let { files, activeFilePath, onFileSelect, onOpenFolder, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, canPaste = false }: Props = $props();
+  let { files, activeFilePath, onFileSelect, onOpenFolder, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onTableClick, onOpenCsv, canPaste = false }: Props = $props();
   let rootDropHover = $state(false);
   let tagPanel = $state<TagPanel>();
   let searchPanel = $state<SearchPanel>();
   let sourcesPanel = $state<SourcesPanel>();
+  let tablesPanel = $state<TablesPanel>();
   let contextMenu = $state<{ x: number; y: number } | null>(null);
 
   function handleContextMenu(e: MouseEvent) {
@@ -49,6 +53,10 @@
 
   export function refreshSources() {
     sourcesPanel?.refresh();
+  }
+
+  export function refreshTables() {
+    tablesPanel?.refresh();
   }
 
   export function focusSearch() {
@@ -84,6 +92,9 @@
     <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />
     {#if onSourceSelect}
       <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} />
+    {/if}
+    {#if onTableClick && onOpenCsv}
+      <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} />
     {/if}
   {:else}
     <div class="empty" oncontextmenu={handleContextMenu}>

--- a/src/renderer/lib/components/TablesPanel.svelte
+++ b/src/renderer/lib/components/TablesPanel.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+  import { api } from '../ipc/client';
+  import type { TableInfo } from '../ipc/client';
+
+  interface Props {
+    onTableClick: (tableName: string) => void;
+    onOpenCsv: (relativePath: string) => void;
+  }
+
+  let { onTableClick, onOpenCsv }: Props = $props();
+
+  let tables = $state<TableInfo[]>([]);
+  let filter = $state('');
+  let collapsed = $state(false);
+  let contextMenu = $state<{ x: number; y: number; table: TableInfo } | null>(null);
+
+  export async function refresh(): Promise<void> {
+    tables = await api.tables.list();
+  }
+
+  let visible = $derived.by(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return tables;
+    return tables.filter((t) =>
+      t.name.toLowerCase().includes(q) || t.relativePath.toLowerCase().includes(q),
+    );
+  });
+
+  function handleContextMenu(e: MouseEvent, table: TableInfo) {
+    e.preventDefault();
+    e.stopPropagation();
+    contextMenu = { x: e.clientX, y: e.clientY, table };
+    const close = () => {
+      contextMenu = null;
+      window.removeEventListener('click', close);
+    };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+</script>
+
+<div class="tables-panel">
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="panel-header" onclick={() => { collapsed = !collapsed; }}>
+    <span class="chevron" class:collapsed>▾</span>
+    <span>Tables</span>
+    <span class="count">{tables.length}</span>
+  </div>
+
+  {#if !collapsed}
+    {#if tables.length === 0}
+      <div class="empty">No tables yet. Drop a CSV into the thoughtbase.</div>
+    {:else}
+      <div class="filter-row">
+        <input
+          type="text"
+          class="filter-input"
+          placeholder="Filter tables…"
+          bind:value={filter}
+        />
+      </div>
+      <div class="table-list">
+        {#each visible as t (t.name)}
+          <button
+            class="table-item"
+            onclick={() => onTableClick(t.name)}
+            oncontextmenu={(e) => handleContextMenu(e, t)}
+            title={t.relativePath}
+          >
+            <div class="table-name">{t.name}</div>
+            <div class="table-meta">{t.rowCount} {t.rowCount === 1 ? 'row' : 'rows'} · {t.columns.length} {t.columns.length === 1 ? 'col' : 'cols'}</div>
+          </button>
+        {/each}
+        {#if visible.length === 0}
+          <div class="empty">No matches.</div>
+        {/if}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+{#if contextMenu}
+  <div
+    class="context-menu"
+    style:left="{contextMenu.x}px"
+    style:top="{contextMenu.y}px"
+  >
+    <button onclick={() => { onTableClick(contextMenu!.table.name); contextMenu = null; }}>
+      Query (SELECT *)
+    </button>
+    <button onclick={() => { navigator.clipboard.writeText(contextMenu!.table.name); contextMenu = null; }}>
+      Copy Table Name
+    </button>
+    <div class="separator"></div>
+    <button onclick={() => { onOpenCsv(contextMenu!.table.relativePath); contextMenu = null; }}>
+      Open CSV
+    </button>
+    <button onclick={() => { api.shell.revealFile(contextMenu!.table.relativePath); contextMenu = null; }}>
+      Reveal in Finder
+    </button>
+  </div>
+{/if}
+
+<style>
+  .tables-panel {
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+    max-height: 40%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .panel-header {
+    padding: 8px 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .chevron {
+    display: inline-block;
+    transition: transform 0.15s;
+  }
+  .chevron.collapsed {
+    transform: rotate(-90deg);
+  }
+
+  .count {
+    margin-left: auto;
+    font-size: 10px;
+    opacity: 0.7;
+  }
+
+  .empty {
+    padding: 6px 12px 10px;
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+
+  .filter-row {
+    padding: 0 8px 6px;
+  }
+
+  .filter-input {
+    width: 100%;
+    padding: 4px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    font-size: 12px;
+    box-sizing: border-box;
+  }
+  .filter-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .table-list {
+    flex: 1;
+    overflow-y: auto;
+    padding-bottom: 6px;
+  }
+
+  .table-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 4px 12px;
+    background: none;
+    border: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+  }
+  .table-item:hover {
+    background: var(--bg-button);
+    border-left-color: var(--accent);
+  }
+
+  .table-name {
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .table-meta {
+    font-size: 10px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-top: 1px;
+  }
+
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 160px;
+  }
+
+  .context-menu button {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .context-menu button:hover {
+    background: var(--bg-button);
+  }
+
+  .separator {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+  }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -86,6 +86,8 @@ export interface TableInfo {
 export interface TablesApi {
   query(sql: string): Promise<TablesQueryResult>;
   list(): Promise<TableInfo[]>;
+  /** Fires when a CSV is registered/unregistered or the initial scan completes. */
+  onChanged(cb: () => void): void;
 }
 
 export interface TagsApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -131,6 +131,8 @@ export const Channels = {
   TABLES_QUERY: 'tables:query',
   /** List every registered CSV table with its columns + row count (#234, for autocomplete). */
   TABLES_LIST: 'tables:list',
+  /** Broadcast from main when the set of registered DuckDB tables changes (#235). */
+  TABLES_CHANGED: 'tables:changed',
 
   /** Format a single file on disk (#153). Writes through the standard index+broadcast pipeline. */
   FORMATTER_FORMAT_FILE: 'formatter:formatFile',


### PR DESCRIPTION
## Summary

Adds a **Tables** section to the sidebar below Sources that lists every DuckDB-registered CSV. Click opens a new SQL query tab pre-populated with `SELECT * FROM <name>`; right-click offers Query, Copy Name, Open CSV, Reveal in Finder. Filter narrows by substring.

## What's in the box

- **`TablesPanel.svelte`** — new. Mirrors `SourcesPanel` shape exactly (collapsible header, filter input, scrollable list, right-click menu). Name rendered in monospace; meta line shows `N rows · M cols`.
- **`TABLES_CHANGED` broadcast** — new main → renderer channel, emitted from:
  - CSV add / change / delete in the watcher callbacks (`src/main/window-manager.ts`)
  - Once at the end of `openProjectInWindow` after the initial `registerAllCsvs` scan
- **`tables.onChanged(cb)`** — exposed through preload + `TablesApi` in `src/renderer/lib/ipc/client.ts`.
- **`Sidebar.svelte`** — mounts `TablesPanel` under `SourcesPanel`, exports `refreshTables()`, accepts `onTableClick` / `onOpenCsv` props.
- **`App.svelte`** — subscribes to `tables.onChanged`; calls `refreshTables()` in the post-open setTimeout block and in `onProjectOpened` (alongside the existing `refreshSources`). Passes `onTableClick` that calls `editor.openQuery(\`SELECT * FROM ${name}\`, 'sql')` and `onOpenCsv` that routes through the existing `handleFileSelect` (which the `CsvTable` viewer already picks up).

## Known issue — not fixed here

**Live-refresh on external CSV drop doesn't work.** The panel populates correctly on project open (both via the broadcast and via the post-open explicit refresh), and every other acceptance criterion checks out in manual test. But dropping a fresh `.csv` into the open thoughtbase doesn't trigger a panel update — and the file tree doesn't update either, which suggests the chokidar watcher isn't firing `add` for dropped files at all, rather than anything on the broadcast/refresh path we added here. Needs a separate look.

Leaving #235 open for that piece; this PR is the bulk of the ticket.

## Design calls worth flagging

- **Two refresh paths, intentionally.** The subscription handles runtime CSV add/remove (when it's working — see above). The post-open explicit `refreshTables()` handles initial populate, because `TABLES_CHANGED` broadcast fires *before* the renderer's invoke resolves, which is *before* `notebase.meta` is set, which is *before* `Sidebar` mounts. The subscription callback no-ops in that race (`sidebar?.refreshTables()`) and the setTimeout path catches it after mount. Same shape as `refreshSources()`.
- **Unquoted table identifiers in the auto-populated query.** `deriveTableName` produces `[a-zA-Z0-9_]+` identifiers, so `SELECT * FROM foo` parses. If a user overrides `table_name:` to a SQL keyword (e.g. `select`), they'll see a parse error and can fix by editing; felt cleaner than always double-quoting.
- **TABLES_CHANGED not wired into `QueryPanel.refreshSqlSchema`.** #234 explicitly deferred live SQL-autocomplete refresh; this PR stays in scope.
- **`onTableClick` / `onOpenCsv` props are optional** on `Sidebar` — the panel only mounts when both are wired, matching the `onSourceSelect`-gated `SourcesPanel`.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1155/1155
- [x] Manual: open sample project, see Tables panel populated with `newData`
- [x] Manual: click a table → SQL query tab opens with `SELECT * FROM newData` and focus in editor
- [x] Manual: right-click menu — Copy Name / Open CSV / Reveal in Finder all work
- [ ] Manual: drop a new `.csv` and see it appear without reload — **fails** (see Known issue)

## Depends on

- #233 (CSV ingestion — `listTables()`) — merged
- #234 (Query Panel SQL mode — target for click handler) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)