### PR TITLE
SQL: stock queries for DuckDB tables (closes #236)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -396,11 +396,24 @@ export function rebuildMenu(): void {
         { type: 'separator' },
         {
           label: 'Stock Queries',
-          submenu: STOCK_QUERIES.map((sq) => ({
-            label: sq.name,
-            sublabel: sq.description,
-            click: () => send(Channels.MENU_OPEN_STOCK_QUERY, sq.query),
-          })),
+          submenu: [
+            {
+              label: 'SPARQL',
+              submenu: STOCK_QUERIES.filter((sq) => sq.language === 'sparql').map((sq) => ({
+                label: sq.name,
+                sublabel: sq.description,
+                click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: sq.query, language: sq.language }),
+              })),
+            },
+            {
+              label: 'SQL',
+              submenu: STOCK_QUERIES.filter((sq) => sq.language === 'sql').map((sq) => ({
+                label: sq.name,
+                sublabel: sq.description,
+                click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: sq.query, language: sq.language }),
+              })),
+            },
+          ],
         },
         {
           label: 'Saved Queries',
@@ -419,7 +432,7 @@ export function rebuildMenu(): void {
               for (const q of project) {
                 items.push({
                   label: q.name,
-                  click: () => send(Channels.MENU_OPEN_STOCK_QUERY, q.query),
+                  click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: 'sparql' }),
                 });
               }
             }
@@ -429,7 +442,7 @@ export function rebuildMenu(): void {
               for (const q of global) {
                 items.push({
                   label: q.name,
-                  click: () => send(Channels.MENU_OPEN_STOCK_QUERY, q.query),
+                  click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: 'sparql' }),
                 });
               }
             }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -257,8 +257,8 @@ contextBridge.exposeInMainWorld('api', {
     onSaveQuery: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SAVE_QUERY, () => cb());
     },
-    onOpenStockQuery: (cb: (query: string) => void) => {
-      ipcRenderer.on(Channels.MENU_OPEN_STOCK_QUERY, (_e, q) => cb(q));
+    onOpenStockQuery: (cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void) => {
+      ipcRenderer.on(Channels.MENU_OPEN_STOCK_QUERY, (_e, payload) => cb(payload));
     },
     onSortLines: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SORT_LINES, () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1114,7 +1114,7 @@
     api.menu.onQuickOpen(() => { showGotoNote = true; });
     api.menu.onNewQuery(() => editor.openQuery());
     api.menu.onSaveQuery(() => handleSaveQuery());
-    api.menu.onOpenStockQuery((q) => editor.openQuery(q));
+    api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
     api.menu.onSortLines(() => editorComponent?.runSortLines());
     api.menu.onPrint(() => window.print());
     api.menu.onOpenInDefault(() => { if (editor.activeFilePath) api.shell.openInDefault(editor.activeFilePath); });

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -222,7 +222,7 @@ export interface MenuApi {
   onFindReplace(cb: () => void): void;
   onNewQuery(cb: () => void): void;
   onSaveQuery(cb: () => void): void;
-  onOpenStockQuery(cb: (query: string) => void): void;
+  onOpenStockQuery(cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void): void;
   onSortLines(cb: () => void): void;
   onOpenSettings(cb: () => void): void;
   onPrint(cb: () => void): void;

--- a/src/shared/stock-queries.ts
+++ b/src/shared/stock-queries.ts
@@ -1,6 +1,9 @@
+export type StockQueryLanguage = 'sparql' | 'sql';
+
 export interface StockQuery {
   name: string;
   description: string;
+  language: StockQueryLanguage;
   query: string;
 }
 
@@ -14,6 +17,7 @@ export const STOCK_QUERIES: StockQuery[] = [
   {
     name: 'All notes with tags',
     description: 'Lists every note and its associated tags',
+    language: 'sparql',
     query: `${PREFIXES}
 SELECT ?title ?tag WHERE {
   ?note rdf:type minerva:Note .
@@ -26,6 +30,7 @@ ORDER BY ?title ?tag`,
   {
     name: 'Backlinks to note',
     description: 'Notes that link to a specific note (edit the target path)',
+    language: 'sparql',
     query: `${PREFIXES}
 # Edit the target note path below
 SELECT ?title ?path WHERE {
@@ -40,6 +45,7 @@ ORDER BY ?title`,
   {
     name: 'Orphan notes',
     description: 'Notes with no incoming or outgoing wiki-links',
+    language: 'sparql',
     query: `${PREFIXES}
 SELECT ?title ?path WHERE {
   ?note rdf:type minerva:Note .
@@ -53,6 +59,7 @@ ORDER BY ?title`,
   {
     name: 'Most-linked notes',
     description: 'Notes ranked by number of incoming links',
+    language: 'sparql',
     query: `${PREFIXES}
 SELECT ?title ?path (COUNT(?source) AS ?incomingLinks) WHERE {
   ?note rdf:type minerva:Note .
@@ -66,6 +73,7 @@ ORDER BY DESC(?incomingLinks)`,
   {
     name: 'Recently modified',
     description: 'Notes ordered by last modification date',
+    language: 'sparql',
     query: `${PREFIXES}
 SELECT ?title ?path ?modified WHERE {
   ?note rdf:type minerva:Note .
@@ -78,6 +86,7 @@ ORDER BY DESC(?modified)`,
   {
     name: 'All tags with counts',
     description: 'Tag names with the number of notes using each',
+    language: 'sparql',
     query: `${PREFIXES}
 SELECT ?tag (COUNT(?note) AS ?count) WHERE {
   ?tagNode rdf:type minerva:Tag .
@@ -90,6 +99,7 @@ ORDER BY DESC(?count)`,
   {
     name: 'Notes in folder',
     description: 'Notes within a specific folder (edit the folder path)',
+    language: 'sparql',
     query: `${PREFIXES}
 # Edit the folder path below
 SELECT ?title ?path WHERE {
@@ -104,6 +114,7 @@ ORDER BY ?title`,
   {
     name: 'Typed outgoing links',
     description: 'All typed links from each note (supports, rebuts, expands, etc.)',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
@@ -121,6 +132,7 @@ ORDER BY ?sourceTitle ?linkType`,
   {
     name: 'Typed backlinks',
     description: 'All typed links pointing to each note (who supports/rebuts/expands this note)',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
@@ -138,6 +150,7 @@ ORDER BY ?targetTitle ?linkType`,
   {
     name: 'Sources: all with authors and year',
     description: 'Every indexed Source with its title, first author, and year',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -152,6 +165,7 @@ ORDER BY ?sourceId`,
   {
     name: 'Sources: most-cited',
     description: 'Sources ranked by the number of distinct notes citing or quoting them',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -171,6 +185,7 @@ ORDER BY DESC(?citations)`,
   {
     name: 'Sources: cited by N or more notes',
     description: 'Sources that cross a citation threshold (edit MIN_COUNT)',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -192,6 +207,7 @@ ORDER BY DESC(?citations)`,
   {
     name: 'Sources: most-quoted',
     description: 'Sources ranked by the number of linked Excerpts',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -206,6 +222,7 @@ ORDER BY DESC(?excerptCount)`,
   {
     name: 'Sources: missing metadata',
     description: 'Sources that are missing a title, an author, or both (stub records)',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -220,6 +237,7 @@ ORDER BY ?sourceId`,
   {
     name: 'Trust: Unreviewed LLM writes',
     description: 'Components attributed to an LLM without a corresponding approved proposal (trust principle violations)',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -239,6 +257,7 @@ ORDER BY ?component`,
   {
     name: 'Pending proposals',
     description: 'All proposals awaiting human review',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -255,6 +274,7 @@ ORDER BY ?proposedAt`,
   {
     name: 'Conversation history',
     description: 'All recorded conversations with their status and trigger',
+    language: 'sparql',
     query: `${PREFIXES}
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 
@@ -269,5 +289,63 @@ SELECT ?conversation ?status ?startedAt ?triggerTitle WHERE {
   }
 }
 ORDER BY DESC(?startedAt)`,
+  },
+
+  // ── SQL (DuckDB) ──────────────────────────────────────────────────────────
+
+  {
+    name: 'All tables',
+    description: 'Every CSV registered as a DuckDB view in this thoughtbase',
+    language: 'sql',
+    query: `SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'main'
+ORDER BY table_name;`,
+  },
+  {
+    name: 'Describe schema',
+    description: 'Column names and types for one table (edit the table name)',
+    language: 'sql',
+    query: `-- Replace YOUR_TABLE with a name from the Tables panel.
+DESCRIBE YOUR_TABLE;`,
+  },
+  {
+    name: 'Summarize (per-column stats)',
+    description: 'Row count, null rate, distinct count, min/max/mean/stddev for every column',
+    language: 'sql',
+    query: `-- Replace YOUR_TABLE with a name from the Tables panel.
+SUMMARIZE YOUR_TABLE;`,
+  },
+  {
+    name: 'Null rate per column',
+    description: 'Columns ranked by how often the value is NULL',
+    language: 'sql',
+    query: `-- Replace YOUR_TABLE with a name from the Tables panel.
+SELECT column_name, null_percentage
+FROM (SUMMARIZE YOUR_TABLE)
+ORDER BY null_percentage DESC;`,
+  },
+  {
+    name: 'Top values for a column',
+    description: 'Top-20 most frequent values of one column (edit table + column)',
+    language: 'sql',
+    query: `-- Replace YOUR_TABLE and YOUR_COLUMN.
+SELECT YOUR_COLUMN, COUNT(*) AS n
+FROM YOUR_TABLE
+GROUP BY YOUR_COLUMN
+ORDER BY n DESC
+LIMIT 20;`,
+  },
+  {
+    name: 'Rows per month',
+    description: 'Row counts bucketed by month over a date column (edit table + date column)',
+    language: 'sql',
+    query: `-- Replace YOUR_TABLE and YOUR_DATE_COLUMN.
+SELECT
+  date_trunc('month', YOUR_DATE_COLUMN) AS month,
+  COUNT(*) AS rows
+FROM YOUR_TABLE
+GROUP BY month
+ORDER BY month;`,
   },
 ];


### PR DESCRIPTION
## Summary

Adds a SQL section to the stock-queries menu so common table-shape questions are one click away. The existing flat submenu splits into **SPARQL** and **SQL** groupings; picking an entry from either opens a fresh query tab in the matching language.

## What's in the box

- **`StockQuery.language: 'sparql' | 'sql'`** — new required field. All 17 existing entries tagged `sparql`.
- **Six new SQL entries**:
  - **All tables** — `SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'`
  - **Describe schema** — `DESCRIBE YOUR_TABLE` (template)
  - **Summarize (per-column stats)** — `SUMMARIZE YOUR_TABLE` — DuckDB's built-in per-column min/max/mean/null_percentage/distinct_count table
  - **Null rate per column** — `SELECT column_name, null_percentage FROM (SUMMARIZE YOUR_TABLE) ORDER BY null_percentage DESC`
  - **Top values for a column** — top-20 `GROUP BY … COUNT(*)` (template)
  - **Rows per month** — `date_trunc('month', …)` bucketed row counts (template)
- **Menu restructure** — `Graph → Stock Queries` now has two sub-submenus (SPARQL, SQL). Each entry's sublabel still carries the description on hover.
- **IPC payload change** — `MENU_OPEN_STOCK_QUERY` now carries `{ query, language }` instead of a bare query string. `api.menu.onOpenStockQuery` callback signature changes accordingly; App.svelte's handler destructures and passes language through to `editor.openQuery(query, language)`. Saved Queries default `language: 'sparql'` — unchanged behavior.

## Design calls worth flagging

- **Templates for anything table-specific.** DuckDB has no clean way to pivot across all registered views in a single query (views don't carry row-count stats, and `GENERATE_SERIES` over `information_schema.tables` would need EXECUTE IMMEDIATE per row). Templates with `YOUR_TABLE` placeholders are the pragmatic shape; matches how "Backlinks to note" and "Notes in folder" already work on the SPARQL side.
- **Leaned on `SUMMARIZE`.** DuckDB ships this built-in and it gives min/max/mean/null_percentage/distinct_count per column for free. The "Null rate" entry is a thin wrapper over it for the specific use case.
- **Sub-submenus vs flat separator.** 17 SPARQL + 6 SQL in one flat list felt noisy; the sub-submenu grouping stays discoverable without scroll-hunting. The Saved Queries submenu still uses its disabled-label section style because it's user-controlled and short.
- **PostgreSQL dialect assumption.** Matches #234's CodeMirror choice. DuckDB-exclusive syntax like `SUMMARIZE`, `PIVOT`, `date_trunc` (which works but isn't strictly standard) will under-highlight; all of these execute fine.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1155/1155
- [ ] Manual: Graph → Stock Queries → SPARQL → "All notes with tags" still works (no regression)
- [ ] Manual: Graph → Stock Queries → SQL → "All tables" opens in a SQL tab and runs
- [ ] Manual: "Summarize" template → replace `YOUR_TABLE` with `newData` → runs and returns column stats

## Out of scope

- Parameterised queries / actual prompt-for-table UX — templates stay template.
- Cross-table JOIN templates — depends too much on schema.
- Saved Queries language awareness — `.rq` convention today; separate ticket if needed.

## Depends on

- #234 (Query Panel SQL mode) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)