### PR TITLE
SQL: note-preview query directives accept language: sql (closes #261)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -7,6 +7,7 @@
   import { getLinkType } from '../../../shared/link-types';
   import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
+  import { normalizeSqlRows } from '../editor/sql-result';
   import { renderChart, type ChartHandle, type ChartConfig, type ChartSeries } from '../charts';
 
   interface Props {
@@ -503,8 +504,12 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     let config: Record<string, string> = {};
     try { config = JSON.parse(el.dataset.config ?? '{}'); } catch { /* ignore */ }
 
-    // Check cache first
-    const cached = queryCache.get(query);
+    const language = config.language === 'sql' ? 'sql' : 'sparql';
+    // Cache key pairs (language, query) so a SQL query and a SPARQL query that
+    // happen to share the same string don't collide.
+    const cacheKey = `${language}::${query}`;
+
+    const cached = queryCache.get(cacheKey);
     if (cached) {
       renderQueryResults(el, type ?? 'list', config, cached.results, cached.error);
       return;
@@ -513,14 +518,24 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     el.innerHTML = '<span class="query-loading">Loading...</span>';
 
     try {
-      const prefixed = QUERY_PREFIXES + query;
-      const response = await api.graph.query(prefixed);
-      const results = response.results;
-      queryCache.set(query, { results });
+      let results: Record<string, string>[];
+      if (language === 'sql') {
+        const response = await api.tables.query(query);
+        if (!response.ok) {
+          queryCache.set(cacheKey, { results: [], error: response.error });
+          renderQueryResults(el, type ?? 'list', config, [], response.error);
+          return;
+        }
+        results = normalizeSqlRows(response.columns, response.rows);
+      } else {
+        const response = await api.graph.query(QUERY_PREFIXES + query);
+        results = response.results as Record<string, string>[];
+      }
+      queryCache.set(cacheKey, { results });
       renderQueryResults(el, type ?? 'list', config, results);
     } catch (e) {
       const error = e instanceof Error ? e.message : String(e);
-      queryCache.set(query, { results: [], error });
+      queryCache.set(cacheKey, { results: [], error });
       renderQueryResults(el, type ?? 'list', config, [], error);
     }
   }


### PR DESCRIPTION
## Summary

The note-preview `:::query-list` / `:::query-table` / `:::query-timeseries` directives now accept `language: sql` as a config key, so embedded results in notes can pull from DuckDB tables the same way they pull from the RDF graph today.

## Shape

````markdown
:::query-table
language: sql
title: Rows per CSV
---
SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'
:::
````

Default stays `sparql` — every existing note renders unchanged.

## What's in the box

- **`executeQueryBlock` branches on `config.language`** — `sparql` still goes through `api.graph.query(QUERY_PREFIXES + query)`; `sql` goes through `api.tables.query(query)` + `normalizeSqlRows` (same helper the Query Panel uses, shipped in #234).
- **Cache key is now `(language, query)`** — a SQL query and a SPARQL query that happen to share text don't collide.
- **Error surface unchanged** — SQL parser errors (`{ ok: false, error }` from `api.tables.query`) land in the same `.query-error` slot as SPARQL errors. Thrown exceptions still reach the outer `catch`.
- **Renderers unchanged** — `renderAsList` / `renderAsTable` / `renderAsTimeseries` already operate on `Record<string,string>[]`; `normalizeSqlRows` puts SQL results in that shape, so bigints, nulls, and `TIMESTAMP` values all render right without touching the renderers.

## Design calls worth flagging

- **`language: sql` config vs. new `:::sql-table` directive.** Went with the config key per the ticket's preferred option (B). Symmetric, non-breaking, and keeps the renderer code single-path.
- **Timeseries + SQL.** The `SUMMARIZE` / `date_trunc` stock queries from #236 return `TIMESTAMP` columns that `normalizeSqlRows` ISO-stringifies. The timeseries renderer treats the x-axis as an opaque label and `parseFloat`s the y-values, so rows-per-month style charts work without any timeseries-renderer change. Verified mentally, not yet clicked through.
- **No live refresh on CSV add.** Same deferred behavior the Query Panel has (#234 called this out). Cache is per-render; a full note re-render invalidates it.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1155/1155
- [ ] Manual: create a note with a `:::query-table` + `language: sql` + `SELECT * FROM newData` and verify results render
- [ ] Manual: omit `language:` in an existing SPARQL directive in the sample project — still renders identically
- [ ] Manual: bad SQL in the directive shows an inline `.query-error`, doesn't crash the preview

## Out of scope

- Cross-language blocks (SPARQL + SQL in one directive). Federation is the Compute epic's story (#240, #242).
- Autocomplete inside the directive body. The Query Panel is the authoring surface.

## Depends on

- #234 (Query Panel SQL mode, `normalizeSqlRows`, `api.tables.query`) — merged
- #233 (CSV registration) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)