### PR TITLE
SQL: Copy as List/Table emits language: sql header for SQL tabs

### DIFF
--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -379,7 +379,8 @@
           <button
             class="export-btn"
             onclick={() => {
-              const block = `:::query-list\n${tab.query.trim()}\n:::`;
+              const header = tab.language === 'sql' ? 'language: sql\n---\n' : '';
+              const block = `:::query-list\n${header}${tab.query.trim()}\n:::`;
               navigator.clipboard.writeText(block);
             }}
             title="Copy a :::query-list directive to paste into a note"
@@ -388,8 +389,13 @@
             class="export-btn"
             onclick={() => {
               const cols = tab.columns.join(', ');
-              const linkCol = tab.columns.includes('path') ? 'path' : '';
-              const config = linkCol ? `columns: ${cols}\nlink: ${linkCol}\n---\n` : `columns: ${cols}\n---\n`;
+              // link: is a SPARQL convention (column named 'path' becomes a wiki-link);
+              // skip the auto-detect on SQL results to avoid wrapping arbitrary string
+              // columns that happen to be named 'path'.
+              const linkCol = tab.language === 'sparql' && tab.columns.includes('path') ? 'path' : '';
+              const langLine = tab.language === 'sql' ? 'language: sql\n' : '';
+              const linkLine = linkCol ? `link: ${linkCol}\n` : '';
+              const config = `${langLine}columns: ${cols}\n${linkLine}---\n`;
               const block = `:::query-table\n${config}${tab.query.trim()}\n:::`;
               navigator.clipboard.writeText(block);
             }}


### PR DESCRIPTION
## Summary

Follow-up to #261. The Query Panel's **Copy as List** / **Copy as Table** buttons pasted a bare `:::query-list` / `:::query-table` block into the clipboard regardless of which language the query was authored in — so a SQL query copied out would hit `Preview.svelte` and get executed as SPARQL (producing an error). This PR closes the loop: for SQL query tabs, the pasted block now carries `language: sql` in the config header, matching the format #261 added on the preview side.

## What's in the box

- **Copy as List (SQL)** now emits:
  ````
  :::query-list
  language: sql
  ---
  <query>
  :::
  ````
- **Copy as Table (SQL)** emits the same header + `columns:` (already there), and **drops the `link: path` auto-detect** — that's a SPARQL shortcut where `?path` carries a note path; on SQL results a column named `path` is usually a plain string and shouldn't get wrapped in a wiki-link.
- **SPARQL behavior unchanged.**

## Test plan

- [x] `pnpm lint` clean
- [ ] Manual: in a SQL query tab, click "Copy as Table", paste into a note, switch to preview — renders via DuckDB with no errors
- [ ] Manual: same for SPARQL tab — block has no `language:` line, renders against the graph as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)