### PR TITLE
Ingest PDF: text-layer extraction via unpdf (closes #94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "rdflib": "^2.2.35",
     "sql-formatter": "^15.7.3",
     "turndown": "^7.2.4",
+    "unpdf": "^1.6.0",
     "yaml": "^2.8.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
+      unpdf:
+        specifier: ^1.6.0
+        version: 1.6.0
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -4551,6 +4554,14 @@ packages:
   unorm@1.6.0:
     resolution: {integrity: sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==}
     engines: {node: '>= 0.4.0'}
+
+  unpdf@1.6.0:
+    resolution: {integrity: sha512-DsjbuDe6PDbZzGvAP40QQp0xskrXP3Tm3fd/FLkGObL00Icr7cc28QgrPHYg+6B1lMWydgXwDXauIv5CGyXudA==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -11735,6 +11746,8 @@ snapshots:
 
   unorm@1.6.0:
     optional: true
+
+  unpdf@1.6.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -31,6 +31,7 @@ import {
 import { ingestUrl } from './sources/ingest';
 import * as tables from './sources/tables';
 import { ingestIdentifier } from './sources/ingest-identifier';
+import { ingestPdf } from './sources/ingest-pdf';
 import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
@@ -679,6 +680,20 @@ export function registerIpcHandlers(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     return await ingestIdentifier(rootPath, identifier);
+  });
+
+  ipcMain.handle(Channels.SOURCES_INGEST_PDF, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const win = winFromEvent(e);
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openFile'],
+      filters: [{ name: 'PDF', extensions: ['pdf'] }],
+      title: 'Ingest PDF',
+      buttonLabel: 'Ingest',
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return await ingestPdf(rootPath, result.filePaths[0]);
   });
 
   ipcMain.handle(Channels.SOURCES_LIST_ALL, () => graph.listAllSources());

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -96,6 +96,10 @@ export function rebuildMenu(): void {
           accelerator: 'CmdOrCtrl+Shift+D',
           click: () => send(Channels.MENU_INGEST_IDENTIFIER),
         },
+        {
+          label: 'Ingest PDF…',
+          click: () => send(Channels.MENU_INGEST_PDF),
+        },
         { type: 'separator' },
         {
           label: 'New Window',

--- a/src/main/sources/ingest-pdf.ts
+++ b/src/main/sources/ingest-pdf.ts
@@ -1,0 +1,255 @@
+/**
+ * PDF ingestion (#94).
+ *
+ * Read a local PDF, extract its text layer page-by-page, pull a first pass
+ * of metadata out of the /Info dict, and persist under `.minerva/sources/<id>/`
+ * as:
+ *   - `original.pdf` — the raw PDF bytes
+ *   - `body.md`     — markdown with the title + `<!-- page N -->` markers
+ *   - `meta.ttl`    — a thought:PDFSource with whatever the /Info dict gave us
+ *
+ * Scanned PDFs (no text layer) are out of scope here — they fall through
+ * to the OCR path (#95). Encrypted PDFs are rejected with a clean error.
+ *
+ * Source id: content-hash of the PDF bytes. PDFs rarely embed a DOI that
+ * our canonical-id layer can key on directly, so we take the hash path
+ * and let the user merge-by-hand if the same paper also arrives via a
+ * DOI/arXiv route (#96).
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Buffer } from 'node:buffer';
+import { extractText, getMeta } from 'unpdf';
+import { canonicalSourceId } from './source-id';
+
+export interface PdfIngestResult {
+  sourceId: string;
+  relativePath: string;
+  /** True when the source already existed; no files were overwritten. */
+  duplicate: boolean;
+  title: string;
+  pageCount: number;
+}
+
+export async function ingestPdf(
+  rootPath: string,
+  pdfAbsolutePath: string,
+): Promise<PdfIngestResult> {
+  const buf = await fs.readFile(pdfAbsolutePath);
+  // pdfjs transfers the underlying ArrayBuffer when we hand it a Uint8Array,
+  // so every pdfjs call needs a fresh copy and we compute the content hash
+  // up front from the untouched Node Buffer.
+  const contentSeed = buf.toString('base64');
+  const { id: sourceId } = canonicalSourceId({}, contentSeed);
+  const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
+  const relativePath = `.minerva/sources/${sourceId}/meta.ttl`;
+
+  const meta = await readPdfMeta(freshCopy(buf));
+
+  // Dedupe on the destination meta.ttl — matches the URL / identifier flows.
+  try {
+    await fs.access(path.join(sourceDir, 'meta.ttl'));
+    return {
+      sourceId,
+      relativePath,
+      duplicate: true,
+      title: meta.title ?? path.basename(pdfAbsolutePath),
+      pageCount: 0,
+    };
+  } catch { /* not found — proceed */ }
+
+  const { pages, totalPages } = await extractTextOrFail(freshCopy(buf));
+
+  await fs.mkdir(sourceDir, { recursive: true });
+  await fs.writeFile(path.join(sourceDir, 'original.pdf'), buf);
+  await fs.writeFile(
+    path.join(sourceDir, 'body.md'),
+    buildBodyMarkdown(meta.title ?? path.basename(pdfAbsolutePath), pages),
+    'utf-8',
+  );
+  await fs.writeFile(
+    path.join(sourceDir, 'meta.ttl'),
+    buildMetaTtl(meta, {
+      originalFilename: path.basename(pdfAbsolutePath),
+      pageCount: totalPages,
+    }),
+    'utf-8',
+  );
+
+  return {
+    sourceId,
+    relativePath,
+    duplicate: false,
+    title: meta.title ?? path.basename(pdfAbsolutePath),
+    pageCount: totalPages,
+  };
+}
+
+/**
+ * Copy a Node Buffer into a fresh standalone Uint8Array. pdfjs transfers
+ * (detaches) the underlying ArrayBuffer of whatever we pass it, so every
+ * pdfjs call needs an independent copy — sharing one would zero out our
+ * cached bytes between calls.
+ */
+function freshCopy(buf: Buffer): Uint8Array {
+  const out = new Uint8Array(buf.length);
+  out.set(buf);
+  return out;
+}
+
+// ── PDF parsing ─────────────────────────────────────────────────────────────
+
+export interface PdfMeta {
+  title: string | null;
+  creators: string[];
+  subject: string | null;
+  keywords: string | null;
+  creationDate: string | null;
+  doi: string | null;
+}
+
+/**
+ * Pull the first-pass metadata out of the /Info dict. Rejects encrypted PDFs
+ * here so the caller gets a clean error before we attempt text extraction
+ * (which would throw an opaque pdfjs message).
+ */
+export async function readPdfMeta(bytes: Uint8Array): Promise<PdfMeta> {
+  const { info } = await getMeta(bytes);
+  const rec = info as Record<string, unknown>;
+
+  if (rec.EncryptFilterName != null) {
+    throw new Error('This PDF is encrypted. Remove the password protection first, then try again.');
+  }
+
+  const titleRaw = typeof rec.Title === 'string' ? rec.Title.trim() : '';
+  const authorRaw = typeof rec.Author === 'string' ? rec.Author.trim() : '';
+  const subjectRaw = typeof rec.Subject === 'string' ? rec.Subject.trim() : '';
+  const keywordsRaw = typeof rec.Keywords === 'string' ? rec.Keywords.trim() : '';
+  const createdRaw = typeof rec.CreationDate === 'string' ? rec.CreationDate.trim() : '';
+
+  // PDFs commonly pack multi-author bylines into a single Author string.
+  // `;` is the de-facto separator (arXiv uses it); fall back to `,` where
+  // there's no semicolon but clearly more than one human name.
+  const creators = splitAuthors(authorRaw);
+
+  // DOI sometimes shows up in the Custom dictionary — arXiv and a few
+  // publishers populate it; cross-reference it into meta.ttl when present.
+  const custom = (rec.Custom as Record<string, unknown> | undefined) ?? undefined;
+  const doi = typeof custom?.DOI === 'string' ? normalizeEmbeddedDoi(custom.DOI) : null;
+
+  return {
+    title: titleRaw || null,
+    creators,
+    subject: subjectRaw || null,
+    keywords: keywordsRaw || null,
+    creationDate: parsePdfDate(createdRaw),
+    doi,
+  };
+}
+
+function splitAuthors(raw: string): string[] {
+  if (!raw) return [];
+  const byS = raw.split(';').map((s) => s.trim()).filter(Boolean);
+  if (byS.length > 1) return byS;
+  // A single-string Author that clearly contains multiple commas — e.g.
+  // "Sun, Yang, Ji, Zhiyuan" — isn't split further here; the comma can
+  // also be a "Last, First" separator for a single author, so we'd false-
+  // positive. User can edit meta.ttl.
+  return raw ? [raw] : [];
+}
+
+/**
+ * PDF dates are formatted like `D:20241015123045+00'00'`. Extract the
+ * `YYYY-MM-DD` prefix so meta.ttl gets a usable xsd:date; anything we
+ * can't parse returns null and the field is omitted.
+ */
+export function parsePdfDate(raw: string): string | null {
+  if (!raw) return null;
+  const m = raw.match(/^D?:?(\d{4})(\d{2})?(\d{2})?/);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  if (y && mo && d) return `${y}-${mo}-${d}`;
+  if (y && mo) return `${y}-${mo}`;
+  if (y) return y;
+  return null;
+}
+
+function normalizeEmbeddedDoi(raw: string): string | null {
+  const trimmed = raw.trim();
+  // Accept both the bare DOI and the https://doi.org/ URL form.
+  const stripped = trimmed
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '');
+  return /^10\.\d+\/.+/.test(stripped) ? stripped.toLowerCase() : null;
+}
+
+async function extractTextOrFail(
+  bytes: Uint8Array,
+): Promise<{ pages: string[]; totalPages: number }> {
+  try {
+    const { text, totalPages } = await extractText(bytes);
+    const pages = Array.isArray(text) ? text : [text];
+    return { pages, totalPages };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // pdfjs throws a generic "No password given" for encrypted PDFs it
+    // couldn't classify earlier. Translate for clarity.
+    if (/password/i.test(msg) || /encrypt/i.test(msg)) {
+      throw new Error('This PDF is encrypted. Remove the password protection first, then try again.');
+    }
+    throw new Error(`PDF text extraction failed: ${msg}`);
+  }
+}
+
+// ── Markdown body ───────────────────────────────────────────────────────────
+
+export function buildBodyMarkdown(title: string, pages: string[]): string {
+  const parts: string[] = [`# ${title}`, ''];
+  for (let i = 0; i < pages.length; i++) {
+    parts.push(`<!-- page ${i + 1} -->`);
+    parts.push('');
+    // Trim trailing whitespace per page but preserve internal layout —
+    // pdfjs text extraction is already the best we can do without the
+    // position info. Users clean up post-ingest if they want prose.
+    parts.push(pages[i].trimEnd());
+    parts.push('');
+  }
+  return parts.join('\n');
+}
+
+// ── Turtle meta ─────────────────────────────────────────────────────────────
+
+export function buildMetaTtl(
+  meta: PdfMeta,
+  extras: { originalFilename: string; pageCount: number },
+): string {
+  const lines: string[] = [
+    'this: a thought:PDFSource ;',
+  ];
+  if (meta.title) lines.push(`    dc:title ${ttlString(meta.title)} ;`);
+  for (const c of meta.creators) lines.push(`    dc:creator ${ttlString(c)} ;`);
+  if (meta.creationDate) {
+    const iso = meta.creationDate;
+    if (/^\d{4}$/.test(iso)) lines.push(`    dc:issued ${ttlString(iso)}^^xsd:gYear ;`);
+    else if (/^\d{4}-\d{2}$/.test(iso)) lines.push(`    dc:issued ${ttlString(iso)}^^xsd:gYearMonth ;`);
+    else lines.push(`    dc:issued ${ttlString(iso)}^^xsd:date ;`);
+  }
+  if (meta.subject) lines.push(`    dc:description ${ttlString(meta.subject)} ;`);
+  if (meta.keywords) lines.push(`    dc:subject ${ttlString(meta.keywords)} ;`);
+  if (meta.doi) lines.push(`    bibo:doi ${ttlString(meta.doi)} ;`);
+  lines.push(`    minerva:originalFilename ${ttlString(extras.originalFilename)} ;`);
+  lines.push(`    dc:extent ${ttlString(`${extras.pageCount} pages`)} ;`);
+  lines.push(`    thought:accessedAt ${ttlString(new Date().toISOString())}^^xsd:dateTime .`);
+  return lines.join('\n') + '\n';
+}
+
+function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -166,6 +166,7 @@ contextBridge.exposeInMainWorld('api', {
     ingestUrl: (url: string) => ipcRenderer.invoke(Channels.SOURCES_INGEST_URL, url),
     ingestIdentifier: (identifier: string) =>
       ipcRenderer.invoke(Channels.SOURCES_INGEST_IDENTIFIER, identifier),
+    ingestPdf: () => ipcRenderer.invoke(Channels.SOURCES_INGEST_PDF),
     listAll: () => ipcRenderer.invoke(Channels.SOURCES_LIST_ALL),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
@@ -331,6 +332,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onIngestIdentifier: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_INGEST_IDENTIFIER, () => cb());
+    },
+    onIngestPdf: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_INGEST_PDF, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -675,6 +675,25 @@
     }
   }
 
+  async function handleIngestPdf() {
+    if (!notebase.meta) return;
+    try {
+      const result = await withBusy('Extracting PDF…', () => api.sources.ingestPdf());
+      if (!result) return; // user cancelled the picker
+      setTimeout(() => handleOpenSource(result.sourceId), 150);
+      if (result.duplicate) {
+        await showConfirm(
+          `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
+          CONFIRM_KEYS.ingestDuplicate,
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
   async function handleIngestIdentifier() {
     if (!notebase.meta) return;
     const raw = await showPrompt('DOI, arXiv id, or PubMed id:');
@@ -1140,6 +1159,7 @@
     // Ingest URL (#93)
     api.menu.onIngestUrl(() => handleIngestUrl());
     api.menu.onIngestIdentifier(() => handleIngestIdentifier());
+    api.menu.onIngestPdf(() => handleIngestPdf());
 
     // External file changes (watcher-driven) — refresh the sidebar so files
     // added / deleted in Finder show up without a restart. Debounced because

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -248,6 +248,7 @@ export interface MenuApi {
   onFormatAll(cb: () => void): void;
   onIngestUrl(cb: () => void): void;
   onIngestIdentifier(cb: () => void): void;
+  onIngestPdf(cb: () => void): void;
 }
 
 export interface IdeApi {
@@ -290,6 +291,14 @@ export interface SourcesApi {
     pdfSaved: boolean;
     pdfError: string | null;
   }>;
+  /** Open an OS file picker and ingest the selected PDF (#94). Returns null if cancelled. */
+  ingestPdf(): Promise<{
+    sourceId: string;
+    relativePath: string;
+    duplicate: boolean;
+    title: string;
+    pageCount: number;
+  } | null>;
   /** All indexed sources, sorted by title. */
   listAll(): Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Fires when a source is added, updated, or removed. */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -114,6 +114,8 @@ export const Channels = {
   SOURCES_INGEST_URL: 'sources:ingestUrl',
   /** Ingest a DOI / arXiv id / PubMed id (#96). Hits CrossRef / arXiv / PubMed. */
   SOURCES_INGEST_IDENTIFIER: 'sources:ingestIdentifier',
+  /** Ingest a local PDF (#94). Main opens a file picker and extracts text via unpdf. */
+  SOURCES_INGEST_PDF: 'sources:ingestPdf',
   /** Create an Excerpt (#224) from a highlighted passage in a source body. */
   SOURCES_CREATE_EXCERPT: 'sources:createExcerpt',
   /** Broadcast from main when an excerpt is added/updated/removed so source tabs refresh. */
@@ -122,6 +124,8 @@ export const Channels = {
   MENU_INGEST_URL: 'menu:ingestUrl',
   /** Menu → "Ingest identifier…" — prompts the renderer for a DOI/arXiv/PMID. */
   MENU_INGEST_IDENTIFIER: 'menu:ingestIdentifier',
+  /** Menu → "Ingest PDF…" — opens a file picker in main and extracts the text layer. */
+  MENU_INGEST_PDF: 'menu:ingestPdf',
   /** List every indexed source, for the sidebar Sources panel. */
   SOURCES_LIST_ALL: 'sources:listAll',
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */

--- a/tests/main/sources/ingest-pdf.test.ts
+++ b/tests/main/sources/ingest-pdf.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  ingestPdf,
+  readPdfMeta,
+  buildBodyMarkdown,
+  buildMetaTtl,
+  parsePdfDate,
+} from '../../../src/main/sources/ingest-pdf';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-ingest-pdf-test-'));
+}
+
+// Reuse the arXiv fixture already committed for demo purposes — avoids
+// shipping a separate test fixture PDF.
+const FIXTURE_PDF = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'fixtures',
+  'sample-project',
+  '.minerva',
+  'sources',
+  'arxiv-2604.18522',
+  'original.pdf',
+);
+
+describe('ingestPdf (#94)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkTempProject();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('writes original.pdf + body.md + meta.ttl under a content-hash id', async () => {
+    const result = await ingestPdf(root, FIXTURE_PDF);
+
+    // Content-hash ids start with `sha-` and are 16 chars total (sha- + 12 hex).
+    expect(result.sourceId).toMatch(/^sha-[0-9a-f]{12}$/);
+    expect(result.duplicate).toBe(false);
+    expect(result.pageCount).toBeGreaterThan(0);
+
+    const sourceDir = path.join(root, '.minerva', 'sources', result.sourceId);
+    expect(fs.existsSync(path.join(sourceDir, 'original.pdf'))).toBe(true);
+    expect(fs.existsSync(path.join(sourceDir, 'body.md'))).toBe(true);
+    expect(fs.existsSync(path.join(sourceDir, 'meta.ttl'))).toBe(true);
+
+    const body = await fsp.readFile(path.join(sourceDir, 'body.md'), 'utf-8');
+    // Title line present and at least a couple of page markers.
+    expect(body).toMatch(/^# .+/m);
+    expect(body).toContain('<!-- page 1 -->');
+    expect(body).toContain('<!-- page 2 -->');
+
+    const meta = await fsp.readFile(path.join(sourceDir, 'meta.ttl'), 'utf-8');
+    expect(meta).toContain('thought:PDFSource');
+    expect(meta).toContain('dc:title');
+    expect(meta).toMatch(/dc:extent\s+"\d+\s+pages"/);
+  });
+
+  it('is idempotent: re-ingesting the same bytes returns duplicate=true', async () => {
+    const first = await ingestPdf(root, FIXTURE_PDF);
+    const second = await ingestPdf(root, FIXTURE_PDF);
+
+    expect(first.sourceId).toBe(second.sourceId);
+    expect(second.duplicate).toBe(true);
+  });
+
+  it('surfaces arXiv Custom.DOI as bibo:doi when present', async () => {
+    const result = await ingestPdf(root, FIXTURE_PDF);
+    const meta = await fsp.readFile(
+      path.join(root, '.minerva', 'sources', result.sourceId, 'meta.ttl'),
+      'utf-8',
+    );
+    // The arXiv fixture embeds a DOI in /Custom/DOI — the ingester should
+    // normalize and record it.
+    expect(meta).toMatch(/bibo:doi\s+"10\.48550\/arxiv\.2604\.18522"/);
+  });
+
+  it('splits the semicolon-separated /Author field into dc:creator lines', async () => {
+    const result = await ingestPdf(root, FIXTURE_PDF);
+    const meta = await fsp.readFile(
+      path.join(root, '.minerva', 'sources', result.sourceId, 'meta.ttl'),
+      'utf-8',
+    );
+    // At least a handful of creators for this 14-author paper — no trailing
+    // `;` on any creator line, each on its own line.
+    const creatorLines = meta.match(/^\s+dc:creator\s+".+"/gm) ?? [];
+    expect(creatorLines.length).toBeGreaterThan(5);
+    for (const line of creatorLines) {
+      // Trim + end-of-line checks: creators aren't empty and don't contain
+      // stray semicolons from a failed split.
+      expect(line).not.toContain(';');
+    }
+  });
+});
+
+describe('readPdfMeta', () => {
+  it('reads /Info fields into a normalized shape', async () => {
+    const bytes = new Uint8Array(await fsp.readFile(FIXTURE_PDF));
+    const meta = await readPdfMeta(bytes);
+    expect(meta.title).toBeTruthy();
+    expect(meta.creators.length).toBeGreaterThan(1);
+    expect(meta.doi).toBe('10.48550/arxiv.2604.18522');
+  });
+});
+
+describe('parsePdfDate', () => {
+  it('extracts the YYYY-MM-DD prefix from a PDF date literal', () => {
+    expect(parsePdfDate("D:20241015123045+00'00'")).toBe('2024-10-15');
+  });
+
+  it('falls back to year-month or year when the day is missing', () => {
+    expect(parsePdfDate('D:202410')).toBe('2024-10');
+    expect(parsePdfDate('D:2024')).toBe('2024');
+  });
+
+  it('returns null for unparseable inputs', () => {
+    expect(parsePdfDate('')).toBeNull();
+    expect(parsePdfDate('nonsense')).toBeNull();
+  });
+});
+
+describe('buildBodyMarkdown', () => {
+  it('emits title + per-page markers + page text, in that order', () => {
+    const md = buildBodyMarkdown('Hello World', ['first page', 'second page']);
+    expect(md).toBe(
+      [
+        '# Hello World',
+        '',
+        '<!-- page 1 -->',
+        '',
+        'first page',
+        '',
+        '<!-- page 2 -->',
+        '',
+        'second page',
+        '',
+      ].join('\n'),
+    );
+  });
+});
+
+describe('buildMetaTtl', () => {
+  it('emits a PDFSource with all supplied fields', () => {
+    const ttl = buildMetaTtl(
+      {
+        title: 'Thing',
+        creators: ['A. Author', 'B. Author'],
+        subject: null,
+        keywords: null,
+        creationDate: '2024-10-15',
+        doi: '10.1234/foo',
+      },
+      { originalFilename: 'thing.pdf', pageCount: 5 },
+    );
+    expect(ttl).toContain('this: a thought:PDFSource');
+    expect(ttl).toContain('dc:title "Thing"');
+    expect(ttl).toContain('dc:creator "A. Author"');
+    expect(ttl).toContain('dc:creator "B. Author"');
+    expect(ttl).toContain('dc:issued "2024-10-15"^^xsd:date');
+    expect(ttl).toContain('bibo:doi "10.1234/foo"');
+    expect(ttl).toContain('minerva:originalFilename "thing.pdf"');
+    expect(ttl).toContain('dc:extent "5 pages"');
+  });
+
+  it('omits absent fields cleanly', () => {
+    const ttl = buildMetaTtl(
+      {
+        title: null,
+        creators: [],
+        subject: null,
+        keywords: null,
+        creationDate: null,
+        doi: null,
+      },
+      { originalFilename: 'bare.pdf', pageCount: 1 },
+    );
+    expect(ttl).not.toContain('dc:title');
+    expect(ttl).not.toContain('dc:creator');
+    expect(ttl).not.toContain('dc:issued');
+    expect(ttl).not.toContain('bibo:doi');
+    expect(ttl).toContain('minerva:originalFilename "bare.pdf"');
+  });
+});


### PR DESCRIPTION
## Summary

Drop a PDF through **File → Ingest PDF…** and get a Source. The main process opens an OS file picker, `unpdf` extracts the text layer page-by-page and the /Info metadata, and the result lands under `.minerva/sources/<id>/` with the usual `original.<ext>` / `body.md` / `meta.ttl` triad — same shape as URL (#93) and identifier (#96) ingest.

## Shape

```
.minerva/sources/sha-a1b2c3d4e5f6/
├── original.pdf          # exact bytes
├── body.md               # "# Title\n\n<!-- page 1 -->\n\ntext…"
└── meta.ttl              # thought:PDFSource + dc:* + bibo:doi when present
```

## What's in the box

- **`src/main/sources/ingest-pdf.ts`** — `ingestPdf(rootPath, pdfAbsolutePath)` that reads the PDF once, computes the content hash before handing bytes to pdfjs (see Footgun below), runs `getMeta` + `extractText` via unpdf, and writes the three files.
- **Source id** — content-hash → `sha-<12>` via the existing `canonicalSourceId(..., contentHashSeed)` fallback. Same bytes always land in the same folder; re-ingesting dedupes cleanly without overwriting.
- **Metadata extracted from /Info** — `Title`, `Author` (split on `;` — arXiv's de-facto separator, and the only case where a single-field Author clearly contains multiple humans), `CreationDate` (parsed to `YYYY-MM-DD` or a looser xsd:gYear/gYearMonth where the day/month is absent), `Subject`, `Keywords`. `Custom.DOI` lifts into `bibo:doi` when present (arXiv-stamped PDFs mainly).
- **Encrypted PDFs** rejected with a clean error before any extraction work. Two detection paths: `info.EncryptFilterName` set → throw; pdfjs throws "password required" → translate to the same message.
- **Menu entry** — `File → Ingest PDF…` sends `MENU_INGEST_PDF` to the renderer; renderer's `handleIngestPdf` invokes `api.sources.ingestPdf()`, which runs the file-picker + extraction round-trip in main and returns the result or `null` on cancel.
- **`withBusy('Extracting PDF…', …)`** wrapping matches the URL / identifier flows.

## Footgun: pdfjs transfers the ArrayBuffer

Verified empirically before writing the test:

```
before getMeta, bytes.length: 9299671   buffer.byteLength: 9299671
after  getMeta, bytes.length: 0         buffer.byteLength: 0
```

pdfjs detaches the underlying `ArrayBuffer` when we hand it a `Uint8Array`, so every pdfjs call needs an independent copy and the content hash has to come off the Node Buffer *before* the first pdfjs call. `freshCopy(buf)` allocates a new `Uint8Array` and copies the Buffer bytes into it; cheap relative to the extraction itself. Worth naming this explicitly because the failure mode is silent data loss, not a crash.

## Design calls worth flagging

- **unpdf over raw pdfjs-dist.** unpdf is a thin, maintained wrapper around pdfjs's text layer — the extraction contract we actually need. ~400KB installed vs. pdfjs-dist's ~5MB, TS-first, handles the Node-side pdfjs quirks.
- **Content hash id, no DOI-from-text heuristic.** The user settled on content-hash when we discussed the plan. The `Custom.DOI` lift is a freebie — it only activates when the PDF's own /Info dict embeds the DOI cleanly, never from the text layer.
- **`dc:extent "N pages"` as the page-count slot.** Standard DC, existing parsers handle it. Not adding a new `thought:pageCount` predicate for a single use.
- **Author comma-splitting deferred.** If /Info Author has only commas and no semicolons, we keep it as a single `dc:creator` string — commas double as "Last, First" separators, too easy to false-positive. Users can edit meta.ttl.
- **Scanned PDFs out of scope** — falls through to #95 OCR, as the issue specifies.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1171/1171 (11 new, including the happy path against the committed arXiv fixture so no extra PDF ships with the repo)
- [ ] Manual: File → Ingest PDF… → pick a local PDF → a `sha-…` source appears in the Sources panel and opens
- [ ] Manual: re-ingest the same PDF → "Already ingested" toast
- [ ] Manual: ingest a password-protected PDF → the "encrypted" error message surfaces via the ingestFailed dialog

## Dependencies added

- `unpdf@^1.6.0`

## Related

- Enables #259 (external file drag-drop ingestion) — drop target can call `ingestPdf` directly once the drag-drop surface is wired
- Paired with #95 (OCR for scanned PDFs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)