### PR TITLE
External file drag-drop ingestion (closes #259)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -32,6 +32,7 @@ import { ingestUrl } from './sources/ingest';
 import * as tables from './sources/tables';
 import { ingestIdentifier } from './sources/ingest-identifier';
 import { ingestPdf } from './sources/ingest-pdf';
+import { dropImport } from './notebase/drop-import';
 import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
@@ -680,6 +681,12 @@ export function registerIpcHandlers(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     return await ingestIdentifier(rootPath, identifier);
+  });
+
+  ipcMain.handle(Channels.FILES_DROP_IMPORT, async (e, targetFolder: string, localPaths: string[]) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await dropImport(rootPath, targetFolder ?? '', localPaths ?? []);
   });
 
   ipcMain.handle(Channels.SOURCES_INGEST_PDF, async (e) => {

--- a/src/main/notebase/drop-import.ts
+++ b/src/main/notebase/drop-import.ts
@@ -1,0 +1,140 @@
+/**
+ * External file drag-drop ingestion (#259).
+ *
+ * Accepts absolute paths the renderer resolved from a DataTransfer file
+ * list (via Electron's `webUtils.getPathForFile`) and routes each through
+ * the right pipeline:
+ *
+ *   - `.md` / `.ttl` / `.csv` → copy into the thoughtbase with a
+ *     collision-rename (`foo.md`, `foo-2.md`, `foo-3.md`, …). The watcher
+ *     picks the copy up and runs the usual index / CSV-register passes.
+ *
+ *   - `.pdf` → run through #94's `ingestPdf`, producing a Source under
+ *     `.minerva/sources/<id>/`. The target folder is ignored for PDFs —
+ *     Sources live in the sources library, not the file tree.
+ *
+ *   - Anything else → rejected with a short reason; the caller surfaces
+ *     the rejections in a single toast.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { assertSafePath } from './fs';
+import { ingestPdf } from '../sources/ingest-pdf';
+
+/** Extensions we copy into the thoughtbase's note tree. */
+const COPY_EXTS = new Set(['.md', '.ttl', '.csv']);
+
+export interface CopiedFile {
+  localPath: string;
+  relativePath: string;
+}
+
+export interface IngestedPdf {
+  localPath: string;
+  sourceId: string;
+  duplicate: boolean;
+  title: string;
+}
+
+export interface RejectedFile {
+  localPath: string;
+  reason: string;
+}
+
+export interface DropImportResult {
+  copied: CopiedFile[];
+  ingestedPdfs: IngestedPdf[];
+  rejected: RejectedFile[];
+}
+
+/**
+ * Import each local path into the thoughtbase. Failures are captured
+ * per-file in `rejected` rather than thrown — one bad file in a multi-
+ * drop shouldn't cancel the other imports.
+ */
+export async function dropImport(
+  rootPath: string,
+  targetFolder: string,
+  localPaths: string[],
+): Promise<DropImportResult> {
+  const copied: CopiedFile[] = [];
+  const ingestedPdfs: IngestedPdf[] = [];
+  const rejected: RejectedFile[] = [];
+
+  // Normalise the folder argument: '' (root) or a relative subdir.
+  const relDir = targetFolder.replace(/^\/+|\/+$/g, '');
+
+  for (const localPath of localPaths) {
+    try {
+      const ext = path.extname(localPath).toLowerCase();
+      if (!ext) {
+        rejected.push({ localPath, reason: 'Unknown file type (no extension)' });
+        continue;
+      }
+
+      if (ext === '.pdf') {
+        const result = await ingestPdf(rootPath, localPath);
+        ingestedPdfs.push({
+          localPath,
+          sourceId: result.sourceId,
+          duplicate: result.duplicate,
+          title: result.title,
+        });
+        continue;
+      }
+
+      if (!COPY_EXTS.has(ext)) {
+        rejected.push({
+          localPath,
+          reason: `Minerva doesn't ingest *${ext} files yet`,
+        });
+        continue;
+      }
+
+      const relativePath = await resolveDropName(
+        rootPath,
+        relDir,
+        path.basename(localPath),
+      );
+      const destFull = assertSafePath(rootPath, relativePath);
+      await fs.mkdir(path.dirname(destFull), { recursive: true });
+      await fs.copyFile(localPath, destFull);
+      copied.push({ localPath, relativePath });
+    } catch (err) {
+      rejected.push({
+        localPath,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { copied, ingestedPdfs, rejected };
+}
+
+/**
+ * Pick a non-colliding destination filename under `relDir` for `baseName`.
+ * `foo.md` → `foo.md` if free, else `foo-2.md`, `foo-3.md`, … until a
+ * free slot is found. Capped at 1000 attempts to avoid an infinite loop
+ * when something pathological is happening to the filesystem.
+ */
+export async function resolveDropName(
+  rootPath: string,
+  relDir: string,
+  baseName: string,
+): Promise<string> {
+  const ext = path.extname(baseName);
+  const stem = ext ? baseName.slice(0, -ext.length) : baseName;
+  for (let i = 1; i <= 1000; i++) {
+    const candidateName = i === 1 ? baseName : `${stem}-${i}${ext}`;
+    const candidateRel = relDir ? `${relDir}/${candidateName}` : candidateName;
+    const candidateFull = assertSafePath(rootPath, candidateRel);
+    try {
+      await fs.access(candidateFull);
+      // Exists — try the next index.
+    } catch {
+      return candidateRel;
+    }
+  }
+  throw new Error(`Could not find a free filename for '${baseName}' after 1000 attempts`);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { Channels } from '../shared/channels';
 
 contextBridge.exposeInMainWorld('api', {
@@ -100,6 +100,14 @@ contextBridge.exposeInMainWorld('api', {
   },
   export: {
     csv: (csv: string) => ipcRenderer.invoke(Channels.EXPORT_CSV, csv),
+  },
+  files: {
+    // Resolve a DataTransfer File to its absolute disk path. Electron ≥ 32:
+    // `File.path` was deprecated and removed in 34; webUtils is the forward-
+    // compatible accessor and works in preload where `electron` is in scope.
+    getPathForFile: (file: File) => webUtils.getPathForFile(file),
+    dropImport: (targetFolder: string, localPaths: string[]) =>
+      ipcRenderer.invoke(Channels.FILES_DROP_IMPORT, targetFolder, localPaths),
   },
   shell: {
     revealFile: (relativePath?: string) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -675,6 +675,43 @@
     }
   }
 
+  async function handleExternalDrop(destFolder: string, files: FileList) {
+    if (!notebase.meta) return;
+    const localPaths: string[] = [];
+    for (const f of files) {
+      // Electron 32+: `webUtils.getPathForFile` is the supported accessor;
+      // `File.path` was deprecated and is removed in Electron 34.
+      const p = api.files.getPathForFile(f);
+      if (p) localPaths.push(p);
+    }
+    if (localPaths.length === 0) return;
+    try {
+      const result = await withBusy('Importing…', () =>
+        api.files.dropImport(destFolder, localPaths),
+      );
+      // Open the first newly-ingested PDF source tab, matching the menu-
+      // triggered Ingest PDF flow. setTimeout waits for the watcher to
+      // finish reindexing the source so the detail panel has data.
+      const openablePdf = result.ingestedPdfs.find((p) => !p.duplicate) ?? result.ingestedPdfs[0];
+      if (openablePdf) {
+        setTimeout(() => handleOpenSource(openablePdf.sourceId), 150);
+      }
+      if (result.rejected.length > 0) {
+        const lines = result.rejected
+          .map((r) => `• ${r.localPath.split('/').pop()} — ${r.reason}`)
+          .join('\n');
+        await showConfirm(
+          `Some files were skipped:\n${lines}`,
+          CONFIRM_KEYS.dropImportRejected,
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
   async function handleIngestPdf() {
     if (!notebase.meta) return;
     try {
@@ -1274,10 +1311,32 @@
           onSourceSelect={(id) => handleOpenSource(id)}
           onTableClick={(name) => editor.openQuery(`SELECT * FROM ${name}`, 'sql')}
           onOpenCsv={(rel) => handleFileSelect(rel)}
+          onExternalDrop={handleExternalDrop}
           canPaste={clipboardItem !== null}
         />
       {/if}
-      <div class="editor-pane">
+      <div
+        class="editor-pane"
+        ondragover={(e) => {
+          // Only react when the drag carries real files (Finder, Explorer, etc),
+          // not when the user is dragging within Minerva (e.g. a FileTree row).
+          if (e.dataTransfer?.types?.includes('Files')) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'copy';
+          }
+        }}
+        ondrop={(e) => {
+          const files = e.dataTransfer?.files;
+          if (!files || files.length === 0) return;
+          e.preventDefault();
+          // Land the drop in the folder of the active note; fall back to
+          // project root when no note is open (or the note is at root).
+          const activePath = editor.activeFilePath ?? '';
+          const slash = activePath.lastIndexOf('/');
+          const destDir = slash >= 0 ? activePath.slice(0, slash) : '';
+          handleExternalDrop(destDir, files);
+        }}
+      >
         {#if editor.tabs.length > 0}
           <TabBar
             tabs={editor.tabs}

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -18,9 +18,10 @@
     onPaste: (destDirectory: string) => void;
     onMove: (srcPath: string, destDirectory: string) => void;
     onBookmark?: (relativePath: string) => void;
+    onExternalDrop?: (destDirectory: string, files: FileList) => void;
   }
 
-  let { files, activeFilePath, depth = 0, canPaste = false, onFileSelect, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark }: Props = $props();
+  let { files, activeFilePath, depth = 0, canPaste = false, onFileSelect, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onExternalDrop }: Props = $props();
 
   let expanded = $state<Record<string, boolean>>({});
   let contextMenu = $state<{ x: number; y: number; dir: string; target?: string; targetIsDir?: boolean } | null>(null);
@@ -44,6 +45,15 @@
   function handleDrop(e: DragEvent, destDir: string) {
     e.preventDefault();
     dropTarget = null;
+    // External file drops (from Finder, Explorer, another app) arrive with a
+    // populated `files` list; the internal-move drag sets `text/plain`
+    // instead. Check files first so an OS drop never falls through to the
+    // internal-move path.
+    const files = e.dataTransfer?.files;
+    if (files && files.length > 0) {
+      onExternalDrop?.(destDir, files);
+      return;
+    }
     const srcPath = e.dataTransfer!.getData('text/plain');
     if (srcPath && srcPath !== destDir) {
       onMove(srcPath, destDir);
@@ -101,6 +111,8 @@
             {onCopy}
             {onPaste}
             {onMove}
+            {onBookmark}
+            {onExternalDrop}
           />
         {/if}
       {:else}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -23,10 +23,11 @@
     onSourceSelect?: (sourceId: string) => void;
     onTableClick?: (tableName: string) => void;
     onOpenCsv?: (relativePath: string) => void;
+    onExternalDrop?: (destDirectory: string, files: FileList) => void;
     canPaste?: boolean;
   }
 
-  let { files, activeFilePath, onFileSelect, onOpenFolder, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onTableClick, onOpenCsv, canPaste = false }: Props = $props();
+  let { files, activeFilePath, onFileSelect, onOpenFolder, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let rootDropHover = $state(false);
   let tagPanel = $state<TagPanel>();
   let searchPanel = $state<SearchPanel>();
@@ -85,9 +86,19 @@
       oncontextmenu={handleContextMenu}
       ondragover={(e) => { e.preventDefault(); e.dataTransfer!.dropEffect = 'move'; rootDropHover = true; }}
       ondragleave={(e) => { if (e.currentTarget === e.target) rootDropHover = false; }}
-      ondrop={(e) => { e.preventDefault(); rootDropHover = false; const src = e.dataTransfer!.getData('text/plain'); if (src) onMove(src, ''); }}
+      ondrop={(e) => {
+        e.preventDefault();
+        rootDropHover = false;
+        const files = e.dataTransfer?.files;
+        if (files && files.length > 0) {
+          onExternalDrop?.('', files);
+          return;
+        }
+        const src = e.dataTransfer!.getData('text/plain');
+        if (src) onMove(src, '');
+      }}
     >
-      <FileTree {files} {activeFilePath} {canPaste} {onFileSelect} {onNewNote} {onNewFolder} {onDelete} {onRename} {onCut} {onCopy} {onPaste} {onMove} {onBookmark} />
+      <FileTree {files} {activeFilePath} {canPaste} {onFileSelect} {onNewNote} {onNewFolder} {onDelete} {onRename} {onCut} {onCopy} {onPaste} {onMove} {onBookmark} {onExternalDrop} />
     </div>
     <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />
     {#if onSourceSelect}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -25,6 +25,7 @@ export const CONFIRM_KEYS = {
   ingestDuplicate: 'ingest-duplicate',
   ingestFailed: 'ingest-failed',
   ingestPdfFailed: 'ingest-pdf-failed',
+  dropImportRejected: 'drop-import-rejected',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -131,6 +132,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Ingest identifier: PDF fetch failed',
     description:
       'Shown when identifier ingest succeeds on metadata but the advertised open-access PDF cannot be fetched (paywall, 403, network error). The source lands without the PDF.',
+  },
+  {
+    key: CONFIRM_KEYS.dropImportRejected,
+    title: 'Drag-drop ingestion: some files skipped',
+    description:
+      'Shown after a multi-file drag-drop when one or more files were rejected (unsupported extension, read error, etc). Supported files still land.',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -101,6 +101,19 @@ export interface ExportApi {
   csv(csv: string): Promise<void>;
 }
 
+export interface DropImportResult {
+  copied: Array<{ localPath: string; relativePath: string }>;
+  ingestedPdfs: Array<{ localPath: string; sourceId: string; duplicate: boolean; title: string }>;
+  rejected: Array<{ localPath: string; reason: string }>;
+}
+
+export interface FilesApi {
+  /** Get the absolute OS path for a `File` object from a drag-drop `DataTransfer`. */
+  getPathForFile(file: File): string;
+  /** Import a batch of external files into the thoughtbase (#259). */
+  dropImport(targetFolder: string, localPaths: string[]): Promise<DropImportResult>;
+}
+
 export interface ShellApi {
   revealFile(relativePath?: string): Promise<void>;
   openInDefault(relativePath: string): Promise<void>;
@@ -261,6 +274,7 @@ export interface IdeApi {
   tables: TablesApi;
   tags: TagsApi;
   export: ExportApi;
+  files: FilesApi;
   shell: ShellApi;
   bookmarks: BookmarksApi;
   conversations: ConversationsApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -197,6 +197,9 @@ export const Channels = {
   TABS_SAVE: 'tabs:save',
   TABS_LOAD: 'tabs:load',
 
+  /** External file drag-drop ingestion (#259). Renderer hands over OS file paths. */
+  FILES_DROP_IMPORT: 'files:dropImport',
+
   // Renderer → main (for menu-triggered main-process actions)
   EXPORT_CSV: 'export:csv',
   SHELL_REVEAL_FILE: 'shell:revealFile',

--- a/tests/main/notebase/drop-import.test.ts
+++ b/tests/main/notebase/drop-import.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  dropImport,
+  resolveDropName,
+} from '../../../src/main/notebase/drop-import';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-drop-import-test-'));
+}
+
+async function writeLocalFile(dir: string, name: string, content: string): Promise<string> {
+  const p = path.join(dir, name);
+  await fsp.writeFile(p, content, 'utf-8');
+  return p;
+}
+
+const ARXIV_FIXTURE = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'fixtures',
+  'sample-project',
+  '.minerva',
+  'sources',
+  'arxiv-2604.18522',
+  'original.pdf',
+);
+
+describe('dropImport (#259)', () => {
+  let root: string;
+  let staging: string;
+
+  beforeEach(() => {
+    root = mkTempProject();
+    staging = mkTempProject();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+    await fsp.rm(staging, { recursive: true, force: true });
+  });
+
+  it('copies a .md into the target folder, preserving the basename', async () => {
+    const src = await writeLocalFile(staging, 'note.md', '# Hello\n');
+    const result = await dropImport(root, 'notes', [src]);
+    expect(result.copied).toEqual([
+      { localPath: src, relativePath: 'notes/note.md' },
+    ]);
+    expect(result.ingestedPdfs).toEqual([]);
+    expect(result.rejected).toEqual([]);
+    const landed = await fsp.readFile(path.join(root, 'notes/note.md'), 'utf-8');
+    expect(landed).toBe('# Hello\n');
+  });
+
+  it('creates a missing target folder on the fly', async () => {
+    const src = await writeLocalFile(staging, 'note.md', 'x');
+    await dropImport(root, 'a/b/c', [src]);
+    expect(fs.existsSync(path.join(root, 'a/b/c/note.md'))).toBe(true);
+  });
+
+  it('drops into the project root when targetFolder is empty', async () => {
+    const src = await writeLocalFile(staging, 'root-note.md', 'r');
+    const result = await dropImport(root, '', [src]);
+    expect(result.copied[0]?.relativePath).toBe('root-note.md');
+  });
+
+  it('auto-renames on collision: foo.md → foo-2.md → foo-3.md', async () => {
+    // Pre-populate the target folder with `foo.md` and `foo-2.md`.
+    await fsp.writeFile(path.join(root, 'foo.md'), 'existing', 'utf-8');
+    await fsp.writeFile(path.join(root, 'foo-2.md'), 'existing', 'utf-8');
+    const src = await writeLocalFile(staging, 'foo.md', 'new');
+    const result = await dropImport(root, '', [src]);
+    expect(result.copied[0]?.relativePath).toBe('foo-3.md');
+    const content = await fsp.readFile(path.join(root, 'foo-3.md'), 'utf-8');
+    expect(content).toBe('new');
+  });
+
+  it('accepts .md / .ttl / .csv; rejects unknown extensions', async () => {
+    const md = await writeLocalFile(staging, 'n.md', '# n');
+    const ttl = await writeLocalFile(staging, 's.ttl', '@prefix ex: <ex:> .');
+    const csv = await writeLocalFile(staging, 't.csv', 'a,b\n1,2');
+    const exe = await writeLocalFile(staging, 'bad.exe', 'NOT ALLOWED');
+    const noext = await writeLocalFile(staging, 'noext', 'x');
+    const result = await dropImport(root, '', [md, ttl, csv, exe, noext]);
+    expect(result.copied.map((c) => c.relativePath).sort()).toEqual(
+      ['n.md', 's.ttl', 't.csv'].sort(),
+    );
+    expect(result.rejected.map((r) => r.localPath).sort()).toEqual([exe, noext].sort());
+    expect(result.rejected.find((r) => r.localPath === exe)?.reason).toMatch(/\.exe/);
+    expect(result.rejected.find((r) => r.localPath === noext)?.reason).toMatch(/no extension/i);
+  });
+
+  it('ingests .pdf through ingestPdf — does NOT copy into the target folder', async () => {
+    const result = await dropImport(root, 'anywhere', [ARXIV_FIXTURE]);
+    expect(result.ingestedPdfs).toHaveLength(1);
+    expect(result.ingestedPdfs[0].sourceId).toMatch(/^sha-[0-9a-f]{12}$/);
+    expect(result.copied).toEqual([]);
+    // Target folder should not have received a copy of the PDF.
+    expect(fs.existsSync(path.join(root, 'anywhere'))).toBe(false);
+    // The Source lives under .minerva/sources/…
+    expect(
+      fs.existsSync(path.join(root, '.minerva/sources', result.ingestedPdfs[0].sourceId, 'original.pdf')),
+    ).toBe(true);
+  });
+
+  it('captures a per-file failure in `rejected` without short-circuiting the others', async () => {
+    const good = await writeLocalFile(staging, 'good.md', '# good');
+    const missing = path.join(staging, 'never-existed.md');
+    const result = await dropImport(root, '', [missing, good]);
+    expect(result.copied.map((c) => c.relativePath)).toEqual(['good.md']);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].localPath).toBe(missing);
+  });
+});
+
+describe('resolveDropName', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkTempProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('returns the input name when the slot is free', async () => {
+    expect(await resolveDropName(root, '', 'foo.md')).toBe('foo.md');
+    expect(await resolveDropName(root, 'notes', 'foo.md')).toBe('notes/foo.md');
+  });
+
+  it('increments the suffix past every existing collision', async () => {
+    await fsp.writeFile(path.join(root, 'foo.md'), 'x');
+    await fsp.writeFile(path.join(root, 'foo-2.md'), 'x');
+    await fsp.writeFile(path.join(root, 'foo-3.md'), 'x');
+    expect(await resolveDropName(root, '', 'foo.md')).toBe('foo-4.md');
+  });
+
+  it('preserves the extension when stemming the basename', async () => {
+    await fsp.writeFile(path.join(root, 'data.csv'), 'x');
+    expect(await resolveDropName(root, '', 'data.csv')).toBe('data-2.csv');
+  });
+});


### PR DESCRIPTION
## Summary

Drop files from Finder / Explorer / any other app onto the file tree, sidebar root, or the main editor area and they flow through the right ingestion pipeline. Internal drags (file-row → folder-row) still work — the external-files branch sits ahead of the existing `text/plain` move path, so no regression.

## Routing

| Extension | Pipeline | Land in |
|-----------|----------|---------|
| `.md` / `.ttl` / `.csv` | `fs.copyFile` + collision-rename | The drop target's folder |
| `.pdf` | `ingestPdf` (from #94) | `.minerva/sources/<id>/`; the new Source tab auto-opens |
| anything else | rejected, per-file reason | — |

Collision rename: `foo.md` → `foo-2.md` → `foo-3.md`, …, capped at 1000 attempts.

## Drop targets

- **Each file-tree folder row** — the existing internal-move drop zone. External-files branch sits ahead of the `text/plain` path.
- **Sidebar root area** (`.file-list` outside any folder).
- **Editor pane** — lands in the folder of the active note, or project root when no note is open. Only reacts when `e.dataTransfer.types` includes `'Files'`, so in-app drags don't steal the drop.

## IPC

- **Preload** exposes `api.files.getPathForFile(File)` — a thin wrapper around `webUtils.getPathForFile`. `File.path` was deprecated in Electron 32 and removed in 34; this is the forward-compatible accessor and has to live in preload because `electron` isn't importable from the renderer under context isolation.
- **`api.files.dropImport(targetFolder, localPaths)`** returns three parallel streams:
  - `copied: { localPath, relativePath }[]`
  - `ingestedPdfs: { localPath, sourceId, duplicate, title }[]`
  - `rejected: { localPath, reason }[]`

The watcher handles indexing for copied files — no explicit reindex or `markPathHandled` needed. Same convention as the internal Copy/Paste flow.

## Design calls worth flagging

- **PDFs don't go to the target folder.** The user is adding the PDF to their library; ingesting as a Source is the useful behavior. The drop target's folder is ignored for `.pdf` and the result surfaces through the Sources flow (panel entry + new tab).
- **Images deferred.** The issue listed `.png/.jpg/.gif/.webp` as accepted; I left them out. The watcher only indexes `.md/.ttl/.csv` and the sidebar filters to that set, so a dropped image would land on disk but be invisible. That's worse than rejecting with a clear reason — follow-up ticket territory when an image-reference UX gets designed.
- **No toast on success.** The file / source appearing in the sidebar is the feedback. Matches how the Ingest URL flow already works.
- **One rejection dialog, not N.** Multi-file drops with a mix of good/bad produce one dismissable `showConfirm` listing every rejection. Uses a new `CONFIRM_KEYS.dropImportRejected` entry (drift-guard test keeps the registry in sync).
- **No markPathHandled.** Would match the spec's suggestion but means duplicating index work in main. Letting the watcher do its one-and-only pass matches the existing internal-copy flow and is simpler.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1181/1181 (10 new: copy, collision rename, folder-autocreate, PDF routing, per-file failure isolation, `resolveDropName` edge cases)
- [ ] Manual: drag `.md` from Finder onto a folder row → file appears, clickable in tree
- [ ] Manual: drag `.csv` onto the root → Tables panel picks it up (via the existing CSV watcher path from #233)
- [ ] Manual: drag `.pdf` onto the editor pane → Source ingests and opens as a tab
- [ ] Manual: drag `.exe` → rejection dialog with clear reason, no file copied
- [ ] Manual: mix good/bad → good files land, single dialog lists the rejected ones
- [ ] Manual: internal drag (file row → folder row) still moves; doesn't fall into the external-drop branch
- [ ] Manual: collision — drop `foo.md` when `foo.md` + `foo-2.md` exist → lands as `foo-3.md`

## Out of scope

- URL drops (drag a link from a browser tab → ingestUrl) — mentioned in the issue's out-of-scope list.
- Folder-tree drops — separate ticket; recursion + conflict resolution deserves its own design.
- Image file drops — see design note above; deferred until there's an image-reference UX.
- Per-file destination picker after drop — v1 uses the drop target's folder implicitly.

## Depends on

- #233 (CSV watcher) — merged
- #94 (ingestPdf) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)