### PR TITLE
Bulk import: Zotero RDF export with PDF lifting (closes #270, closes #98)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -33,6 +33,7 @@ import * as tables from './sources/tables';
 import { ingestIdentifier } from './sources/ingest-identifier';
 import { ingestPdf } from './sources/ingest-pdf';
 import { importBibtex } from './sources/import-bibtex';
+import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
 import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
@@ -705,6 +706,26 @@ export function registerIpcHandlers(): void {
       onProgress: (progress) => {
         if (!win.isDestroyed()) {
           win.webContents.send(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, progress);
+        }
+      },
+    });
+  });
+
+  ipcMain.handle(Channels.SOURCES_IMPORT_ZOTERO_RDF, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const win = winFromEvent(e);
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openFile'],
+      filters: [{ name: 'Zotero RDF', extensions: ['rdf', 'xml'] }],
+      title: 'Import Zotero RDF',
+      buttonLabel: 'Import',
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return await importZoteroRdf(rootPath, result.filePaths[0], {
+      onProgress: (progress) => {
+        if (!win.isDestroyed()) {
+          win.webContents.send(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, progress);
         }
       },
     });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -104,6 +104,10 @@ export function rebuildMenu(): void {
           label: 'Import BibTeX…',
           click: () => send(Channels.MENU_IMPORT_BIBTEX),
         },
+        {
+          label: 'Import Zotero RDF…',
+          click: () => send(Channels.MENU_IMPORT_ZOTERO_RDF),
+        },
         { type: 'separator' },
         {
           label: 'New Window',

--- a/src/main/sources/import-zotero-rdf.ts
+++ b/src/main/sources/import-zotero-rdf.ts
@@ -1,0 +1,448 @@
+/**
+ * Bulk import from a Zotero RDF export (#270 / tail of #98).
+ *
+ * Zotero's "Zotero RDF" export produces an `.rdf` (RDF/XML) file plus a
+ * sibling `files/` directory that holds attached PDFs. This module parses
+ * the RDF, maps every bibliographic item onto the shared `ArticleMetadata`
+ * shape (same one the BibTeX + identifier-ingest pipelines use), writes
+ * a `meta.ttl` under `.minerva/sources/<id>/`, and — when the item has a
+ * linked PDF attachment that actually exists on disk — copies it in as
+ * `original.pdf`.
+ *
+ * Canonical id and dedupe semantics match every other ingest path:
+ * DOI > arXiv > ISBN > URL > content-hash fallback.
+ *
+ * The parser is deliberately lenient. Zotero's RDF dialect is under-
+ * specified in the wild (different Zotero versions, BetterBibTeX plugins,
+ * hand-edited exports); we extract what we can and fall through silently
+ * on anything non-fatal rather than rejecting a whole 5000-entry library
+ * over a missing predicate in one item.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import $rdf from 'rdflib';
+import type { IndexedFormula, NamedNode, Node } from 'rdflib';
+import { canonicalSourceId } from './source-id';
+import { buildMetaTtl } from './ingest-identifier';
+import type { ArticleMetadata } from './api-adapters/types';
+
+// ── Namespaces ──────────────────────────────────────────────────────────────
+
+const NS = {
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  dc: 'http://purl.org/dc/elements/1.1/',
+  dcterms: 'http://purl.org/dc/terms/',
+  bib: 'http://purl.org/net/biblio#',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  z: 'http://www.zotero.org/namespaces/export#',
+  link: 'http://purl.org/rss/1.0/modules/link/',
+  prism: 'http://prismstandard.org/namespaces/1.2/basic/',
+};
+
+function sym(iri: string): NamedNode {
+  return $rdf.sym(iri) as NamedNode;
+}
+
+// Known bibliographic item classes. Anything else we see is ignored — a
+// Zotero export also contains journal/publisher/person resources that we
+// only dereference when a bib item points at them.
+const BIB_CLASSES: Record<string, ArticleMetadata['subtype']> = {
+  [`${NS.bib}Article`]: 'Article',
+  [`${NS.bib}Book`]: 'Book',
+  [`${NS.bib}BookSection`]: 'Book',
+  [`${NS.bib}Thesis`]: 'Source',
+  [`${NS.bib}Memo`]: 'Source',
+  [`${NS.bib}Letter`]: 'Source',
+  [`${NS.bib}Document`]: 'Source',
+  [`${NS.bib}Report`]: 'Report',
+  [`${NS.bib}Manuscript`]: 'Source',
+};
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export interface ZoteroImportProgress {
+  done: number;
+  total: number;
+  currentTitle: string;
+}
+
+export interface ZoteroImportResult {
+  imported: Array<{ sourceId: string; title: string; pdfAttached: boolean }>;
+  duplicate: Array<{ sourceId: string; title: string }>;
+  failed: Array<{ subject: string; reason: string }>;
+  /** Count of bibliographic items the parser emitted. */
+  totalItems: number;
+}
+
+export interface ZoteroImportOptions {
+  onProgress?: (p: ZoteroImportProgress) => void;
+}
+
+export async function importZoteroRdf(
+  rootPath: string,
+  rdfAbsolutePath: string,
+  options: ZoteroImportOptions = {},
+): Promise<ZoteroImportResult> {
+  const content = await fs.readFile(rdfAbsolutePath, 'utf-8');
+  // Files are referenced relative to the .rdf's parent directory.
+  const baseDir = path.dirname(rdfAbsolutePath);
+  return importZoteroRdfContent(rootPath, content, baseDir, options);
+}
+
+/** Base URI we hand rdflib when parsing; relative attribute values resolve
+ *  against this, and we strip it back off when recovering file paths. */
+const PARSE_BASE = 'http://zotero.local/';
+
+export async function importZoteroRdfContent(
+  rootPath: string,
+  rdfXml: string,
+  attachmentBaseDir: string,
+  options: ZoteroImportOptions = {},
+): Promise<ZoteroImportResult> {
+  const store = $rdf.graph();
+  try {
+    $rdf.parse(rdfXml, store, PARSE_BASE, 'application/rdf+xml');
+  } catch (err) {
+    throw new Error(`Zotero RDF parse failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const items = collectBibItems(store);
+  const result: ZoteroImportResult = {
+    imported: [],
+    duplicate: [],
+    failed: [],
+    totalItems: items.length,
+  };
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    let titleForProgress = item.value;
+    try {
+      const { metadata, attachmentRelPath } = extractItem(store, item);
+      titleForProgress = metadata.title;
+
+      const { id: sourceId } = canonicalSourceId(
+        {
+          doi: metadata.doi ?? undefined,
+          arxiv: metadata.arxiv ?? undefined,
+          pubmed: metadata.pubmed ?? undefined,
+          isbn: metadata.isbn ?? undefined,
+          url: metadata.uri ?? undefined,
+        },
+        // Hash fallback: the item's URI + its title gives a stable key
+        // even for items Zotero exported without any identifier.
+        `zotero:${item.value}:${metadata.title}`,
+      );
+
+      const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
+      const metaPath = path.join(sourceDir, 'meta.ttl');
+
+      try {
+        await fs.access(metaPath);
+        result.duplicate.push({ sourceId, title: metadata.title });
+        continue;
+      } catch { /* not found — proceed */ }
+
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(metaPath, buildMetaTtl(metadata), 'utf-8');
+
+      let pdfAttached = false;
+      if (attachmentRelPath) {
+        pdfAttached = await copyAttachmentIfPresent(
+          attachmentBaseDir,
+          attachmentRelPath,
+          path.join(sourceDir, 'original.pdf'),
+        );
+      }
+      result.imported.push({ sourceId, title: metadata.title, pdfAttached });
+    } catch (err) {
+      result.failed.push({
+        subject: item.value,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      options.onProgress?.({
+        done: i + 1,
+        total: items.length,
+        currentTitle: titleForProgress,
+      });
+    }
+  }
+
+  return result;
+}
+
+// ── Item collection ─────────────────────────────────────────────────────────
+
+function collectBibItems(store: IndexedFormula): NamedNode[] {
+  const rdfType = sym(`${NS.rdf}type`);
+  const seen = new Set<string>();
+  const items: NamedNode[] = [];
+  for (const classIri of Object.keys(BIB_CLASSES)) {
+    const klass = sym(classIri);
+    for (const st of store.statementsMatching(null, rdfType, klass)) {
+      const subj = st.subject;
+      if (subj.termType !== 'NamedNode' && subj.termType !== 'BlankNode') continue;
+      if (seen.has(subj.value)) continue;
+      seen.add(subj.value);
+      items.push(subj as NamedNode);
+    }
+  }
+  return items;
+}
+
+// ── Per-item extraction ─────────────────────────────────────────────────────
+
+export interface ExtractedItem {
+  metadata: ArticleMetadata;
+  /** Relative path into the sibling `files/` directory; null if no PDF linked. */
+  attachmentRelPath: string | null;
+}
+
+export function extractItem(store: IndexedFormula, subject: NamedNode): ExtractedItem {
+  const subtype = subtypeOf(store, subject);
+  const title = literalOf(store, subject, `${NS.dc}title`) ?? '(untitled)';
+  const abstract = literalOf(store, subject, `${NS.dcterms}abstract`);
+  const dateRaw = literalOf(store, subject, `${NS.dc}date`);
+  const issued = normalizeIssuedDate(dateRaw);
+  const creators = extractPersonList(store, subject, `${NS.bib}authors`);
+  const publisher = extractPublisher(store, subject);
+  const containerTitle = extractContainerTitle(store, subject);
+
+  // Identifiers live in `dc:identifier` as prefix-tagged strings
+  // ("DOI 10.1234/...", "ISBN 978-..."). A Zotero item commonly has
+  // multiple dc:identifier values.
+  const identifiers = literalsOf(store, subject, `${NS.dc}identifier`);
+  const { doi, isbn, issn: _issn, url: urlFromIdentifier } = extractIdentifiers(identifiers);
+
+  // The item's own URI — when it's an HTTP(S) URL NOT pointing at our
+  // synthetic parse base — is a fine source URI. `http://zotero.local/#…`
+  // URIs are just rdflib's relative-resolution artifact and shouldn't
+  // drive the canonical id or land in meta.ttl.
+  const uriFromSubject =
+    subject.termType === 'NamedNode' &&
+    /^https?:/i.test(subject.value) &&
+    !subject.value.startsWith(PARSE_BASE)
+      ? subject.value
+      : null;
+
+  const attachmentRelPath = extractAttachmentPath(store, subject);
+
+  const metadata: ArticleMetadata = {
+    subtype,
+    title,
+    creators,
+    abstract: abstract ?? null,
+    issued: issued ?? null,
+    publisher: publisher ?? null,
+    containerTitle: containerTitle ?? null,
+    doi: doi ?? null,
+    isbn: isbn ?? null,
+    arxiv: null,
+    pubmed: null,
+    uri: urlFromIdentifier ?? uriFromSubject,
+    pdfUrl: null,
+    category: null,
+  };
+
+  return { metadata, attachmentRelPath };
+}
+
+function subtypeOf(store: IndexedFormula, subject: NamedNode): ArticleMetadata['subtype'] {
+  const rdfType = sym(`${NS.rdf}type`);
+  for (const st of store.statementsMatching(subject, rdfType, null)) {
+    const mapped = BIB_CLASSES[st.object.value];
+    if (mapped) return mapped;
+  }
+  return 'Source';
+}
+
+function literalOf(store: IndexedFormula, subject: Node, predicate: string): string | null {
+  const st = store.statementsMatching(subject as NamedNode, sym(predicate), null)[0];
+  if (!st) return null;
+  const v = st.object.value;
+  return v.trim().length > 0 ? v.trim() : null;
+}
+
+function literalsOf(store: IndexedFormula, subject: Node, predicate: string): string[] {
+  return store
+    .statementsMatching(subject as NamedNode, sym(predicate), null)
+    .map((st) => st.object.value)
+    .filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+}
+
+/**
+ * Resolve `bib:authors` (or `bib:editors`) into ordered "First Last"
+ * strings. The predicate points at an `rdf:Seq` whose `rdf:_1`, `rdf:_2`,
+ * … slots (or `rdf:li` in list-ish form) are `foaf:Person` nodes.
+ */
+function extractPersonList(
+  store: IndexedFormula,
+  subject: NamedNode,
+  predicate: string,
+): string[] {
+  const container = store.statementsMatching(subject, sym(predicate), null)[0]?.object;
+  if (!container) return [];
+  const members = orderedContainerMembers(store, container as NamedNode);
+  const names: string[] = [];
+  for (const m of members) {
+    const name = personName(store, m);
+    if (name) names.push(name);
+  }
+  return names;
+}
+
+function orderedContainerMembers(store: IndexedFormula, container: NamedNode): NamedNode[] {
+  // rdf:Seq with rdf:_1..rdf:_N predicates — read the triples and sort by
+  // the numeric suffix so authors come out in authored order.
+  const entries: Array<{ n: number; node: NamedNode }> = [];
+  for (const st of store.statementsMatching(container, null, null)) {
+    const m = st.predicate.value.match(/_(\d+)$/);
+    if (!m) continue;
+    if (st.object.termType !== 'NamedNode' && st.object.termType !== 'BlankNode') continue;
+    entries.push({ n: parseInt(m[1], 10), node: st.object as NamedNode });
+  }
+  entries.sort((a, b) => a.n - b.n);
+  return entries.map((e) => e.node);
+}
+
+function personName(store: IndexedFormula, person: NamedNode): string | null {
+  const given = literalOf(store, person, `${NS.foaf}givenname`);
+  const surname = literalOf(store, person, `${NS.foaf}surname`);
+  if (given || surname) {
+    return [given, surname].filter(Boolean).join(' ').trim();
+  }
+  // Some Zotero exports use `foaf:name` for institutional authors.
+  return literalOf(store, person, `${NS.foaf}name`);
+}
+
+function extractPublisher(store: IndexedFormula, subject: NamedNode): string | null {
+  // dc:publisher points at a foaf:Organization with foaf:name, or a literal.
+  const st = store.statementsMatching(subject, sym(`${NS.dc}publisher`), null)[0];
+  if (!st) return null;
+  if (st.object.termType === 'Literal') {
+    return st.object.value.trim() || null;
+  }
+  if (st.object.termType !== 'NamedNode' && st.object.termType !== 'BlankNode') return null;
+  return literalOf(store, st.object as NamedNode, `${NS.foaf}name`);
+}
+
+function extractContainerTitle(store: IndexedFormula, subject: NamedNode): string | null {
+  // dcterms:isPartOf → a bib:Journal / bib:Book with dc:title.
+  const st = store.statementsMatching(subject, sym(`${NS.dcterms}isPartOf`), null)[0];
+  if (!st) return null;
+  if (st.object.termType === 'Literal') return st.object.value.trim() || null;
+  if (st.object.termType !== 'NamedNode' && st.object.termType !== 'BlankNode') return null;
+  return literalOf(store, st.object as NamedNode, `${NS.dc}title`);
+}
+
+export function extractIdentifiers(identifiers: string[]): {
+  doi: string | null;
+  isbn: string | null;
+  issn: string | null;
+  url: string | null;
+} {
+  let doi: string | null = null;
+  let isbn: string | null = null;
+  let issn: string | null = null;
+  let url: string | null = null;
+  for (const raw of identifiers) {
+    const s = raw.trim();
+    let m: RegExpMatchArray | null;
+    // Order matters: doi.org URLs masquerade as plain http URLs, so they
+    // get the DOI lane before the general URL lane picks them up.
+    if ((m = s.match(/^\s*DOI[\s:]+(.+)$/i))) doi = normalizeDoiLiteral(m[1]);
+    else if (/^https?:\/\/(?:dx\.)?doi\.org\//i.test(s)) doi = normalizeDoiLiteral(s);
+    else if ((m = s.match(/^\s*ISBN[\s:]+(.+)$/i))) isbn = m[1].replace(/[\s-]/g, '');
+    else if ((m = s.match(/^\s*ISSN[\s:]+(.+)$/i))) issn = m[1].replace(/\s/g, '');
+    else if (/^https?:\/\//i.test(s)) url = s;
+    else if (/^10\.\d+\//.test(s)) doi = normalizeDoiLiteral(s);
+  }
+  return { doi, isbn, issn, url };
+}
+
+function normalizeDoiLiteral(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '')
+    .toLowerCase();
+}
+
+export function normalizeIssuedDate(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  // Already ISO-shaped: YYYY, YYYY-MM, YYYY-MM-DD — passed through.
+  if (/^\d{4}(-\d{2}(-\d{2})?)?$/.test(trimmed)) return trimmed;
+  // Zotero often stores "October 15, 2024" or "2024-10-15".
+  const m = trimmed.match(/(\d{4})/);
+  return m ? m[1] : null;
+}
+
+// ── Attachments ─────────────────────────────────────────────────────────────
+
+/**
+ * Walk `link:link` from the item to find an attachment, then pull the
+ * local file path out of the attachment node. Zotero's RDF puts the path
+ * in a quirky `<rdf:resource rdf:resource="files/…"/>` element (the
+ * attachment → file path predicate is `rdf:resource`), and some exports
+ * put it on the attachment's own `rdf:about` URI.
+ */
+export function extractAttachmentPath(store: IndexedFormula, subject: NamedNode): string | null {
+  for (const linkSt of store.statementsMatching(subject, sym(`${NS.link}link`), null)) {
+    const attachment = linkSt.object;
+    if (attachment.termType !== 'NamedNode' && attachment.termType !== 'BlankNode') continue;
+
+    // Only consider PDF-typed attachments when the export tagged them.
+    const linkType = literalOf(store, attachment, `${NS.link}type`);
+    if (linkType && !linkType.toLowerCase().includes('pdf')) continue;
+
+    // Preferred: the attachment has a `rdf:resource` predicate (note: this
+    // is Zotero's quirk of treating it as a predicate rather than an
+    // attribute; rdflib reifies it into a triple).
+    const pathFromResource = literalOf(store, attachment, `${NS.rdf}resource`);
+    if (pathFromResource) return relativeifyPath(pathFromResource);
+
+    // Fallback: when the attachment's own URI looks like a file path.
+    if (attachment.termType === 'NamedNode' && /^files\//.test(attachment.value)) {
+      return relativeifyPath(attachment.value);
+    }
+  }
+  return null;
+}
+
+function relativeifyPath(raw: string): string | null {
+  // rdflib resolves `rdf:resource` attributes against the parse base URI,
+  // so a raw `files/1/foo.pdf` comes back as `http://zotero.local/files/1/foo.pdf`.
+  // Strip the base back off before treating it as a filesystem path.
+  let stripped = raw.startsWith(PARSE_BASE) ? raw.slice(PARSE_BASE.length) : raw;
+  stripped = stripped.replace(/^file:\/\//, '').replace(/^\/+/, '');
+  // Reject absolute paths and anything with `..` — they could escape the
+  // attachment base dir, and Zotero's own export always uses `files/…`.
+  if (path.isAbsolute(stripped)) return null;
+  if (stripped.split('/').includes('..')) return null;
+  return stripped;
+}
+
+async function copyAttachmentIfPresent(
+  baseDir: string,
+  relativePath: string,
+  destAbsolute: string,
+): Promise<boolean> {
+  const src = path.join(baseDir, relativePath);
+  try {
+    await fs.access(src);
+  } catch {
+    // File advertised but not on disk — common when a user ships only the
+    // .rdf without the `files/` tree. Silent skip; the meta.ttl still
+    // records the source.
+    return false;
+  }
+  try {
+    await fs.copyFile(src, destAbsolute);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -179,6 +179,10 @@ contextBridge.exposeInMainWorld('api', {
     onImportBibtexProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) => {
       ipcRenderer.on(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, (_e, progress) => cb(progress));
     },
+    importZoteroRdf: () => ipcRenderer.invoke(Channels.SOURCES_IMPORT_ZOTERO_RDF),
+    onImportZoteroRdfProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) => {
+      ipcRenderer.on(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, (_e, progress) => cb(progress));
+    },
     listAll: () => ipcRenderer.invoke(Channels.SOURCES_LIST_ALL),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
@@ -350,6 +354,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onImportBibtex: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_IMPORT_BIBTEX, () => cb());
+    },
+    onImportZoteroRdf: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_IMPORT_ZOTERO_RDF, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
       ipcRenderer.on('project:opened', (_e, meta) => cb(meta));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -742,6 +742,35 @@
     }
   }
 
+  async function handleImportZoteroRdf() {
+    if (!notebase.meta) return;
+    try {
+      const result = await withBusy('Importing Zotero RDF…', () => api.sources.importZoteroRdf());
+      if (!result) return;
+      sidebar?.refreshSources();
+      await refreshSourcesCache();
+      const pdfsLifted = result.imported.filter((i) => i.pdfAttached).length;
+      const parts: string[] = [
+        `Imported: ${result.imported.length}` + (pdfsLifted > 0 ? ` (${pdfsLifted} with PDF)` : ''),
+        `Duplicate (skipped): ${result.duplicate.length}`,
+      ];
+      if (result.failed.length > 0) parts.push(`Failed: ${result.failed.length}`);
+      let message = `Zotero RDF import complete.\n\n${parts.join('\n')}`;
+      if (result.failed.length > 0) {
+        const preview = result.failed
+          .slice(0, 5)
+          .map((f) => `  • ${f.subject}: ${f.reason}`)
+          .join('\n');
+        const more = result.failed.length > 5 ? `\n  …and ${result.failed.length - 5} more` : '';
+        message += `\n\nFirst failures:\n${preview}${more}`;
+      }
+      await showConfirm(message, CONFIRM_KEYS.zoteroRdfImportComplete, 'OK');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Zotero RDF import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
   async function handleIngestPdf() {
     if (!notebase.meta) return;
     try {
@@ -1228,15 +1257,20 @@
     api.menu.onIngestIdentifier(() => handleIngestIdentifier());
     api.menu.onIngestPdf(() => handleIngestPdf());
     api.menu.onImportBibtex(() => handleImportBibtex());
+    api.menu.onImportZoteroRdf(() => handleImportZoteroRdf());
 
-    // Progress updates during a BibTeX import — rewrites the busy-overlay
+    // Progress updates during a bulk import — rewrites the busy-overlay
     // label in place so the user sees running counts on large imports.
-    api.sources.onImportBibtexProgress(({ done, total, currentTitle }) => {
+    // One handler per stream; both funnel into the same busyLabel so the
+    // user doesn't care which import is running.
+    const progressToBusyLabel = ({ done, total, currentTitle }: { done: number; total: number; currentTitle: string }) => {
       if (busyLabel) {
         const short = currentTitle.length > 60 ? currentTitle.slice(0, 57) + '…' : currentTitle;
         busyLabel = `Importing ${done}/${total}: ${short}`;
       }
-    });
+    };
+    api.sources.onImportBibtexProgress(progressToBusyLabel);
+    api.sources.onImportZoteroRdfProgress(progressToBusyLabel);
 
     // External file changes (watcher-driven) — refresh the sidebar so files
     // added / deleted in Finder show up without a restart. Debounced because

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -27,6 +27,7 @@ export const CONFIRM_KEYS = {
   ingestPdfFailed: 'ingest-pdf-failed',
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
+  zoteroRdfImportComplete: 'zotero-rdf-import-complete',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -145,6 +146,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'BibTeX import complete',
     description:
       'Summary dialog after Import BibTeX finishes (counts of imported / duplicate / failed entries).',
+  },
+  {
+    key: CONFIRM_KEYS.zoteroRdfImportComplete,
+    title: 'Zotero RDF import complete',
+    description:
+      'Summary dialog after Import Zotero RDF finishes (counts of imported / duplicate / failed items, and how many PDFs were lifted).',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -263,6 +263,7 @@ export interface MenuApi {
   onIngestIdentifier(cb: () => void): void;
   onIngestPdf(cb: () => void): void;
   onImportBibtex(cb: () => void): void;
+  onImportZoteroRdf(cb: () => void): void;
 }
 
 export interface IdeApi {
@@ -324,6 +325,15 @@ export interface SourcesApi {
   } | null>;
   /** Stream progress while a BibTeX import runs. */
   onImportBibtexProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): void;
+  /** Open a .rdf picker and import a Zotero RDF export (#270). Returns null if cancelled. */
+  importZoteroRdf(): Promise<{
+    imported: Array<{ sourceId: string; title: string; pdfAttached: boolean }>;
+    duplicate: Array<{ sourceId: string; title: string }>;
+    failed: Array<{ subject: string; reason: string }>;
+    totalItems: number;
+  } | null>;
+  /** Stream progress while a Zotero RDF import runs. */
+  onImportZoteroRdfProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): void;
   /** All indexed sources, sorted by title. */
   listAll(): Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Fires when a source is added, updated, or removed. */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -120,6 +120,10 @@ export const Channels = {
   SOURCES_IMPORT_BIBTEX: 'sources:importBibtex',
   /** Progress events during a BibTeX import — { done, total, currentTitle }. */
   SOURCES_IMPORT_BIBTEX_PROGRESS: 'sources:importBibtexProgress',
+  /** Bulk import from a Zotero RDF export (#270). Main picks the .rdf and lifts attached PDFs. */
+  SOURCES_IMPORT_ZOTERO_RDF: 'sources:importZoteroRdf',
+  /** Progress events during a Zotero RDF import. */
+  SOURCES_IMPORT_ZOTERO_RDF_PROGRESS: 'sources:importZoteroRdfProgress',
   /** Create an Excerpt (#224) from a highlighted passage in a source body. */
   SOURCES_CREATE_EXCERPT: 'sources:createExcerpt',
   /** Broadcast from main when an excerpt is added/updated/removed so source tabs refresh. */
@@ -132,6 +136,8 @@ export const Channels = {
   MENU_INGEST_PDF: 'menu:ingestPdf',
   /** Menu → "Import BibTeX…" — opens a .bib picker and imports each entry as a Source. */
   MENU_IMPORT_BIBTEX: 'menu:importBibtex',
+  /** Menu → "Import Zotero RDF…" — opens a .rdf picker; lifts attached PDFs when present. */
+  MENU_IMPORT_ZOTERO_RDF: 'menu:importZoteroRdf',
   /** List every indexed source, for the sidebar Sources panel. */
   SOURCES_LIST_ALL: 'sources:listAll',
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */

--- a/tests/main/sources/import-zotero-rdf.test.ts
+++ b/tests/main/sources/import-zotero-rdf.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  importZoteroRdfContent,
+  extractIdentifiers,
+  normalizeIssuedDate,
+} from '../../../src/main/sources/import-zotero-rdf';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-zotero-rdf-test-'));
+}
+
+/**
+ * Synthetic Zotero-style RDF covering a journal article with DOI + PDF
+ * attachment, a book with ISBN, and a no-id @misc that should fall to
+ * the content-hash fallback.
+ */
+const SAMPLE_RDF = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:dcterms="http://purl.org/dc/terms/"
+ xmlns:bib="http://purl.org/net/biblio#"
+ xmlns:foaf="http://xmlns.com/foaf/0.1/"
+ xmlns:z="http://www.zotero.org/namespaces/export#"
+ xmlns:link="http://purl.org/rss/1.0/modules/link/">
+
+  <bib:Article rdf:about="#item_1">
+    <z:itemType>journalArticle</z:itemType>
+    <dc:title>Neural ISM Survey</dc:title>
+    <dcterms:abstract>We present a survey of neutral ISM.</dcterms:abstract>
+    <dc:date>2024-10-15</dc:date>
+    <dc:identifier>DOI 10.1234/foo.bar</dc:identifier>
+    <bib:authors>
+      <rdf:Seq>
+        <rdf:li>
+          <foaf:Person>
+            <foaf:surname>Sun</foaf:surname>
+            <foaf:givenname>Yang</foaf:givenname>
+          </foaf:Person>
+        </rdf:li>
+        <rdf:li>
+          <foaf:Person>
+            <foaf:surname>Ji</foaf:surname>
+            <foaf:givenname>Zhiyuan</foaf:givenname>
+          </foaf:Person>
+        </rdf:li>
+      </rdf:Seq>
+    </bib:authors>
+    <dcterms:isPartOf rdf:resource="#journal_1"/>
+    <link:link rdf:resource="#item_1_attachment_1"/>
+  </bib:Article>
+
+  <bib:Journal rdf:about="#journal_1">
+    <dc:title>Astrophysical Journal</dc:title>
+  </bib:Journal>
+
+  <z:Attachment rdf:about="#item_1_attachment_1">
+    <z:itemType>attachment</z:itemType>
+    <dc:title>Full Text PDF</dc:title>
+    <link:type>application/pdf</link:type>
+    <rdf:resource rdf:resource="files/1/paper.pdf"/>
+  </z:Attachment>
+
+  <bib:Book rdf:about="#item_2">
+    <z:itemType>book</z:itemType>
+    <dc:title>The Pragmatic Programmer</dc:title>
+    <dc:date>2020</dc:date>
+    <dc:identifier>ISBN 978-0-13-468599-1</dc:identifier>
+    <bib:authors>
+      <rdf:Seq>
+        <rdf:li>
+          <foaf:Person>
+            <foaf:surname>Smith</foaf:surname>
+            <foaf:givenname>John</foaf:givenname>
+          </foaf:Person>
+        </rdf:li>
+      </rdf:Seq>
+    </bib:authors>
+    <dc:publisher>
+      <foaf:Organization>
+        <foaf:name>Addison-Wesley</foaf:name>
+      </foaf:Organization>
+    </dc:publisher>
+  </bib:Book>
+
+  <bib:Document rdf:about="#item_3">
+    <dc:title>Loose Memo Without Identifiers</dc:title>
+    <dc:date>January 2023</dc:date>
+  </bib:Document>
+</rdf:RDF>
+`;
+
+describe('importZoteroRdfContent (#270)', () => {
+  let root: string;
+  let attachmentBase: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    attachmentBase = mkTempProject();
+    // Create the attachment file referenced in SAMPLE_RDF. The dir layout
+    // mirrors what Zotero's `.rdf + files/` export looks like on disk.
+    await fsp.mkdir(path.join(attachmentBase, 'files', '1'), { recursive: true });
+    await fsp.writeFile(
+      path.join(attachmentBase, 'files', '1', 'paper.pdf'),
+      'fake-pdf-bytes',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+    await fsp.rm(attachmentBase, { recursive: true, force: true });
+  });
+
+  it('imports one source per bib:* item and picks up DOI / ISBN identifiers', async () => {
+    const result = await importZoteroRdfContent(root, SAMPLE_RDF, attachmentBase);
+    expect(result.totalItems).toBe(3);
+    expect(result.imported).toHaveLength(3);
+    expect(result.failed).toEqual([]);
+
+    const ids = result.imported.map((i) => i.sourceId);
+    expect(ids).toContain('doi-10.1234_foo.bar');
+    expect(ids).toContain('isbn-9780134685991');
+    // The no-identifier document falls through to the content-hash fallback.
+    expect(ids.some((id) => id.startsWith('sha-'))).toBe(true);
+  });
+
+  it('writes a meta.ttl with the expected shape', async () => {
+    await importZoteroRdfContent(root, SAMPLE_RDF, attachmentBase);
+    const ttl = await fsp.readFile(
+      path.join(root, '.minerva/sources/doi-10.1234_foo.bar/meta.ttl'),
+      'utf-8',
+    );
+    expect(ttl).toContain('this: a thought:Article');
+    expect(ttl).toContain('dc:title "Neural ISM Survey"');
+    // Authors preserved in order.
+    expect(ttl).toMatch(/dc:creator "Yang Sun"[\s\S]*dc:creator "Zhiyuan Ji"/);
+    expect(ttl).toContain('dc:issued "2024-10-15"^^xsd:date');
+    expect(ttl).toContain('schema:inContainer "Astrophysical Journal"');
+    expect(ttl).toContain('bibo:doi "10.1234/foo.bar"');
+  });
+
+  it('copies an attached PDF into the source folder as original.pdf', async () => {
+    const result = await importZoteroRdfContent(root, SAMPLE_RDF, attachmentBase);
+    const article = result.imported.find((i) => i.sourceId === 'doi-10.1234_foo.bar');
+    expect(article?.pdfAttached).toBe(true);
+    const pdfPath = path.join(root, '.minerva/sources/doi-10.1234_foo.bar/original.pdf');
+    expect(fs.existsSync(pdfPath)).toBe(true);
+    expect(await fsp.readFile(pdfPath, 'utf-8')).toBe('fake-pdf-bytes');
+  });
+
+  it('silently skips missing attachments (the PDF is advertised but not on disk)', async () => {
+    // Delete the file the RDF points at.
+    await fsp.rm(path.join(attachmentBase, 'files', '1', 'paper.pdf'));
+    const result = await importZoteroRdfContent(root, SAMPLE_RDF, attachmentBase);
+    const article = result.imported.find((i) => i.sourceId === 'doi-10.1234_foo.bar');
+    expect(article?.pdfAttached).toBe(false);
+    // meta.ttl still written.
+    expect(
+      fs.existsSync(path.join(root, '.minerva/sources/doi-10.1234_foo.bar/meta.ttl')),
+    ).toBe(true);
+  });
+
+  it('is idempotent: re-importing the same RDF dedupes on canonical id', async () => {
+    await importZoteroRdfContent(root, SAMPLE_RDF, attachmentBase);
+    const second = await importZoteroRdfContent(root, SAMPLE_RDF, attachmentBase);
+    expect(second.imported).toHaveLength(0);
+    expect(second.duplicate).toHaveLength(3);
+  });
+
+  it('surfaces parse failures as a thrown error, not a silent empty result', async () => {
+    await expect(
+      importZoteroRdfContent(root, '<not valid xml at all', attachmentBase),
+    ).rejects.toThrow(/parse failed/i);
+  });
+});
+
+describe('extractIdentifiers', () => {
+  it('extracts DOI from the "DOI …" literal form', () => {
+    expect(extractIdentifiers(['DOI 10.1234/foo']).doi).toBe('10.1234/foo');
+  });
+
+  it('normalises a DOI-URL-form identifier', () => {
+    expect(extractIdentifiers(['https://doi.org/10.1234/Foo']).doi).toBe('10.1234/foo');
+  });
+
+  it('strips whitespace and hyphens from ISBN', () => {
+    expect(extractIdentifiers(['ISBN 978-0-13-468599-1']).isbn).toBe('9780134685991');
+  });
+
+  it('picks up ISSN', () => {
+    expect(extractIdentifiers(['ISSN 1234-5678']).issn).toBe('1234-5678');
+  });
+
+  it('collects a plain http URL from the identifier list', () => {
+    expect(extractIdentifiers(['https://example.org/paper']).url).toBe('https://example.org/paper');
+  });
+});
+
+describe('normalizeIssuedDate', () => {
+  it('passes ISO-shaped dates through', () => {
+    expect(normalizeIssuedDate('2024-10-15')).toBe('2024-10-15');
+    expect(normalizeIssuedDate('2024-10')).toBe('2024-10');
+    expect(normalizeIssuedDate('2024')).toBe('2024');
+  });
+
+  it('extracts the year from a prose date', () => {
+    expect(normalizeIssuedDate('October 15, 2024')).toBe('2024');
+    expect(normalizeIssuedDate('Jan 2023')).toBe('2023');
+  });
+
+  it('returns null for inputs with no year-shaped run', () => {
+    expect(normalizeIssuedDate('')).toBeNull();
+    expect(normalizeIssuedDate('no year here')).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary

**File → Import Zotero RDF…** reads a Zotero RDF/XML export, maps every bibliographic item onto the shared `ArticleMetadata` shape (same one BibTeX + identifier ingest use), dedupes via `canonicalSourceId`, writes `meta.ttl` through the existing `buildMetaTtl`, and copies linked PDFs out of the sibling `files/` tree into each source's `original.pdf` — the Zotero-specific half of #98 the BibTeX PR deliberately deferred.

Closes #270 and finishes #98.

## What's in the box

- **`src/main/sources/import-zotero-rdf.ts`** — `importZoteroRdf(rootPath, rdfAbsolutePath, { onProgress })`. RDF/XML parsed with `rdflib` (already a dep).
- **Subtype mapping** — `bib:Article` / `BookSection` / `Thesis` / `Memo` / `Letter` / `Document` / `Report` / `Manuscript` → `thought:*` subtype.
- **Authors** — `bib:authors` → `rdf:Seq` → ordered `foaf:Person` list, stringified as `"First Last"`; `foaf:name` fallback for institutional / anonymous authors.
- **Container** — `dcterms:isPartOf` → referenced journal/book's `dc:title`.
- **Publisher** — literal or `foaf:Organization/foaf:name`.
- **Identifiers** — `dc:identifier` strings come in as `"DOI …"`, `"ISBN …"`, `"ISSN …"`, plain http URL, or bare `10.xxxx/…`. DOI takes priority over the general URL lane so `doi.org` URLs don't get misclassified as plain URLs.
- **Attachments** — `link:link` → `z:Attachment`; file path read off the attachment's own `rdf:resource` predicate (Zotero writes it as an *element* with an `rdf:resource` attribute, which rdflib reifies into a triple rather than parsing as an attribute — see Footgun below), resolved relative to the `.rdf` file's directory, copied if present. Silent skip when advertised but missing on disk — users shipping only the `.rdf` without the `files/` tree still get the meta records.
- **Menu + IPC + preload + client + renderer handler + summary dialog** — all plumbed, parallel to the BibTeX flow. Progress stream shares the busy-overlay label handler so the UX is identical across both bulk imports.

## Footgun: parse-base URI resolution

`rdflib.parse(xml, store, base, 'application/rdf+xml')` resolves every relative `rdf:resource` attribute against `base`. If we hand it no base, relative refs fail; if we hand it `http://zotero.local/`, a raw `files/1/foo.pdf` comes back as `http://zotero.local/files/1/foo.pdf`. Documented in the module's `PARSE_BASE` constant — `relativeifyPath` strips it back off before the filesystem lookup, and path-traversal guards still reject anything with `..` or absolute paths after stripping. The item's own `rdf:about` is treated as a real source URL only when it's a real http(s) URL *not* pointing at `PARSE_BASE` — otherwise the no-identifier items would get a `url-<hash>` id from the synthetic base rather than the intended content-hash fallback.

## Design calls worth flagging

- **Reuses `buildMetaTtl` from `ingest-identifier.ts`** — third importer sharing the same TTL emitter. Single canonical shape for every Source, regardless of origin.
- **Content-hash seed is `zotero:${subject.value}:${title}`.** Stable across re-imports; doesn't collide with BibTeX's `entry.input` hash even for items with the same title.
- **No `readStatus` yet.** Same reasoning as the BibTeX PR — no UI consumer.
- **rdflib, not a hand-rolled XML parser.** Zotero's RDF dialect is under-specified in the wild; structured matching on predicates is much more robust than DOM-walking.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1213/1213 (14 new: canonical id assignment, meta.ttl shape, PDF copy, dedupe, parse failure, identifier parsing, date normalization)
- [ ] Manual: export a real Zotero library (RDF + files), Import Zotero RDF… → Sources panel populates, attached PDFs open in the source viewer
- [ ] Manual: re-import → summary dialog shows 0 imported / N duplicate
- [ ] Manual: ship only the `.rdf` without `files/` → meta records land, pdfAttached=false in summary

## Dependencies

No new runtime deps — uses `rdflib` which was already installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)