### PR TITLE
Ingest URL: site-specific extractors for structured sources (closes #221)

### DIFF
--- a/src/main/sources/ingest.ts
+++ b/src/main/sources/ingest.ts
@@ -21,6 +21,8 @@ import { parseHTML } from 'linkedom';
 import { Readability } from '@mozilla/readability';
 import TurndownService from 'turndown';
 import { canonicalSourceId, normalizeUrl } from './source-id';
+import { extractStructured, structuredToArticleMetadata } from './site-handlers';
+import { buildMetaTtl as buildArticleMetaTtl } from './ingest-identifier';
 
 export interface IngestResult {
   sourceId: string;
@@ -44,7 +46,26 @@ export async function ingestUrl(
   const normalized = normalizeUrl(rawUrl);
   if (!normalized) throw new Error(`Not a valid URL: ${rawUrl}`);
 
-  const { id: sourceId } = canonicalSourceId({ url: normalized });
+  // Structured-metadata extraction (#221) needs the DOM, so we have to
+  // fetch before we can decide on a canonical id. That means dedupe has
+  // to happen after fetch, not before — an extra network round-trip in
+  // the duplicate case, but scholarly sites dedupe straight to their
+  // identifier-based folder (arxiv-<id>, doi-<id>) which is what we want.
+  const html = await fetchHtml(normalized, opts.fetchImpl ?? globalThis.fetch);
+  const { document } = parseHTML(html);
+  Object.defineProperty(document, 'documentURI', { value: normalized, configurable: true });
+  Object.defineProperty(document, 'baseURI', { value: normalized, configurable: true });
+
+  const urlObj = new URL(normalized);
+  const structured = extractStructured(document as unknown as Parameters<typeof extractStructured>[0], urlObj);
+
+  const { id: sourceId } = canonicalSourceId({
+    doi: structured?.doi ?? undefined,
+    arxiv: structured?.arxiv ?? undefined,
+    pubmed: structured?.pubmed ?? undefined,
+    isbn: structured?.isbn ?? undefined,
+    url: normalized,
+  });
   const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
   const relativePath = `.minerva/sources/${sourceId}/meta.ttl`;
 
@@ -59,15 +80,36 @@ export async function ingestUrl(
     // Not found — proceed.
   }
 
-  const html = await fetchHtml(normalized, opts.fetchImpl ?? globalThis.fetch);
-  const extracted = extractReadable(html, normalized);
+  const extracted = extractReadableFromDoc(document as unknown as Document, normalized);
 
   await fs.mkdir(sourceDir, { recursive: true });
   await fs.writeFile(path.join(sourceDir, 'original.html'), html, 'utf-8');
   await fs.writeFile(path.join(sourceDir, 'body.md'), buildBodyMarkdown(extracted), 'utf-8');
-  await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildMetaTtl(extracted, normalized), 'utf-8');
 
-  return { sourceId, relativePath, duplicate: false, title: extracted.title };
+  let title: string;
+  if (structured) {
+    // Handler-enriched path: emit the richer thought:Article / thought:Preprint
+    // / thought:Book meta.ttl, with one dc:creator per author and bibo:doi /
+    // arXiv-id / PubMed-id when present. Readability fills in whatever the
+    // handler left null.
+    const metadata = structuredToArticleMetadata(structured, {
+      title: extracted.title,
+      byline: extracted.byline,
+      abstract: extracted.excerpt,
+      issued: extracted.publishedTime,
+      publisher: extracted.siteName,
+      uri: normalized,
+    });
+    await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildArticleMetaTtl(metadata), 'utf-8');
+    title = metadata.title;
+  } else {
+    // No site handler matched — Readability-only fallback writes a
+    // thought:WebPage meta.ttl with a single byline.
+    await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildMetaTtl(extracted, normalized), 'utf-8');
+    title = extracted.title;
+  }
+
+  return { sourceId, relativePath, duplicate: false, title };
 }
 
 // ── HTML fetch ──────────────────────────────────────────────────────────
@@ -114,11 +156,20 @@ export function extractReadable(html: string, url: string): ExtractedArticle {
   const { document } = parseHTML(html);
   Object.defineProperty(document, 'documentURI', { value: url, configurable: true });
   Object.defineProperty(document, 'baseURI', { value: url, configurable: true });
-  const reader = new Readability(document as unknown as Document);
+  return extractReadableFromDoc(document as unknown as Document, url);
+}
+
+/**
+ * Same contract as `extractReadable` but takes an already-parsed linkedom
+ * document so `ingestUrl` can run site handlers on the DOM without
+ * parsing the HTML twice. The `documentURI` / `baseURI` setup is the
+ * caller's responsibility.
+ */
+export function extractReadableFromDoc(document: Document, _url: string): ExtractedArticle {
+  const reader = new Readability(document);
   const article = reader.parse();
   if (!article) throw new Error('Readability could not extract content from this page');
 
-  // Readability's result types are loose; normalise missing bits to nulls.
   const byline = article.byline?.trim() || null;
   const siteName = article.siteName?.trim() || null;
   const excerpt = article.excerpt?.trim() || null;

--- a/src/main/sources/site-handlers.ts
+++ b/src/main/sources/site-handlers.ts
@@ -1,0 +1,320 @@
+/**
+ * Site-specific structured-metadata extraction (#221).
+ *
+ * Before we fall back to Readability's heuristic extraction, pages that
+ * expose structured bibliographic metadata (arXiv, PubMed, Semantic
+ * Scholar, most publisher pages) let us pull authors, DOI / arXiv id,
+ * publication date, journal title straight out of the page. That fixes
+ * the classic Readability-byline-is-wrong symptom on arXiv
+ * (`dc:creator "[Submitted on 20 Apr 2026]"`) and upgrades the canonical
+ * id from `url-<hash>` to `arxiv-<id>` / `doi-<id>` when identifiers are
+ * available.
+ *
+ * The Google-Scholar-era `<meta name="citation_*">` convention is the
+ * dominant source format in the wild — most scholarly publishers
+ * implement it, and a generic handler captures them all in one pass.
+ * Per-site handlers stack on top for URL-pattern fallbacks (the arXiv
+ * abs / pdf URL structure tells us the arXiv id even when a PDF
+ * response doesn't carry the meta tags).
+ */
+
+import type { ArticleMetadata } from './api-adapters/types';
+
+/**
+ * Partial metadata derived from site-handler inspection. The ingest
+ * orchestrator merges this with Readability's body extraction — handler
+ * fields win for structured bibliographic data; Readability fills body
+ * text, excerpt, and whatever the handler left null.
+ */
+export interface StructuredExtraction {
+  title?: string | null;
+  creators?: string[];
+  abstract?: string | null;
+  issued?: string | null;
+  publisher?: string | null;
+  containerTitle?: string | null;
+  doi?: string | null;
+  arxiv?: string | null;
+  pubmed?: string | null;
+  isbn?: string | null;
+  pdfUrl?: string | null;
+  /** The site-handler's subtype inference (Article / Preprint / Book …). */
+  subtype?: ArticleMetadata['subtype'];
+}
+
+/**
+ * DOM contract that matches both linkedom and the native Document type,
+ * so the module is testable without importing either into a test that
+ * already has a jsdom-ish environment.
+ */
+export interface DocLike {
+  querySelectorAll(selector: string): ArrayLike<MetaLike>;
+  querySelector(selector: string): MetaLike | null;
+}
+interface MetaLike {
+  getAttribute(name: string): string | null;
+}
+
+/**
+ * Run every known site handler against a DOM and a URL. Merges their
+ * outputs with later handlers filling in gaps left by earlier ones.
+ * Returns null when no handler contributed anything.
+ */
+export function extractStructured(doc: DocLike, url: URL): StructuredExtraction | null {
+  const handlers = [citationMetaHandler, arxivUrlHandler, pubmedUrlHandler];
+  let out: StructuredExtraction | null = null;
+  for (const handler of handlers) {
+    const result = handler(doc, url);
+    if (!result) continue;
+    out = out ? mergeExtractions(out, result) : result;
+  }
+  return out;
+}
+
+/**
+ * Merge two extractions with the first argument taking priority — it's
+ * the accumulator, so later handlers can only fill in gaps rather than
+ * override a high-confidence earlier extraction.
+ */
+function mergeExtractions(a: StructuredExtraction, b: StructuredExtraction): StructuredExtraction {
+  return {
+    title: a.title ?? b.title,
+    creators: a.creators && a.creators.length > 0 ? a.creators : b.creators,
+    abstract: a.abstract ?? b.abstract,
+    issued: a.issued ?? b.issued,
+    publisher: a.publisher ?? b.publisher,
+    containerTitle: a.containerTitle ?? b.containerTitle,
+    doi: a.doi ?? b.doi,
+    arxiv: a.arxiv ?? b.arxiv,
+    pubmed: a.pubmed ?? b.pubmed,
+    isbn: a.isbn ?? b.isbn,
+    pdfUrl: a.pdfUrl ?? b.pdfUrl,
+    subtype: a.subtype ?? b.subtype,
+  };
+}
+
+// ── Citation meta handler (Google Scholar convention) ──────────────────────
+
+/**
+ * The `<meta name="citation_*">` convention that Google Scholar indexes
+ * on. Most publisher pages populate at least title + author + DOI /
+ * journal. arXiv, PubMed, Semantic Scholar, IEEE Xplore, ACM DL, SSRN,
+ * Nature, Cell, Elsevier journals — all of them. The handler activates
+ * whenever `citation_title` is present, regardless of host.
+ */
+export function citationMetaHandler(doc: DocLike, _url: URL): StructuredExtraction | null {
+  const title = metaContent(doc, 'citation_title');
+  if (!title) return null;
+
+  const creators = metaContentsAll(doc, 'citation_author');
+  const doiRaw = metaContent(doc, 'citation_doi');
+  const arxivRaw = metaContent(doc, 'citation_arxiv_id');
+  const pubmedRaw = metaContent(doc, 'citation_pmid')
+    ?? metaContent(doc, 'citation_pubmed_id');
+  const isbnRaw = metaContent(doc, 'citation_isbn');
+  const dateRaw = metaContent(doc, 'citation_publication_date')
+    ?? metaContent(doc, 'citation_date');
+  const journal = metaContent(doc, 'citation_journal_title')
+    ?? metaContent(doc, 'citation_conference_title');
+  const publisher = metaContent(doc, 'citation_publisher');
+  const abstractRaw = metaContent(doc, 'citation_abstract')
+    ?? metaContent(doc, 'description');
+  const pdfUrl = metaContent(doc, 'citation_pdf_url');
+
+  // Authors sometimes come as a single `citation_author` value with
+  // semicolons (older Elsevier pages). Split if that looks like what
+  // we got instead of one meta tag per author.
+  const resolvedCreators = creators.length > 1
+    ? creators
+    : creators.length === 1 && creators[0].includes(';')
+      ? creators[0].split(';').map((c) => c.trim()).filter(Boolean)
+      : creators;
+
+  const subtype: ArticleMetadata['subtype'] | undefined =
+    arxivRaw ? 'Preprint' :
+    journal ? 'Article' :
+    isbnRaw ? 'Book' :
+    undefined;
+
+  return {
+    title,
+    creators: resolvedCreators.length > 0 ? resolvedCreators : undefined,
+    abstract: abstractRaw ?? null,
+    issued: normalizeCitationDate(dateRaw),
+    publisher: publisher ?? null,
+    containerTitle: journal ?? null,
+    doi: normalizeDoi(doiRaw),
+    arxiv: normalizeArxivId(arxivRaw),
+    pubmed: normalizePubmed(pubmedRaw),
+    isbn: normalizeIsbn(isbnRaw),
+    pdfUrl: pdfUrl ?? null,
+    subtype,
+  };
+}
+
+/**
+ * arXiv URL fallback — some pages (PDF responses, old abs-page variants)
+ * don't include the citation_arxiv_id tag, but the URL itself carries
+ * the id. Only fires on the arxiv.org host so we don't misread random
+ * other URLs.
+ */
+export function arxivUrlHandler(_doc: DocLike, url: URL): StructuredExtraction | null {
+  if (!/(^|\.)arxiv\.org$/i.test(url.hostname)) return null;
+  // /abs/2604.18561, /abs/2604.18561v2, /pdf/2604.18561(.pdf)?
+  const m = url.pathname.match(/\/(?:abs|pdf)\/([a-z-]+(?:\.[a-z-]+)?\/\d{7}|\d{4}\.\d{4,5})(?:v\d+)?(?:\.pdf)?$/i);
+  if (!m) return null;
+  return { arxiv: m[1], subtype: 'Preprint' };
+}
+
+/**
+ * PubMed URL fallback — the numeric PMID is typically the last path
+ * segment. Gives us a non-hash canonical id even when the landing
+ * page's meta tags are sparse.
+ */
+export function pubmedUrlHandler(_doc: DocLike, url: URL): StructuredExtraction | null {
+  if (!/ncbi\.nlm\.nih\.gov$/i.test(url.hostname) && !/pubmed\.ncbi\.nlm\.nih\.gov$/i.test(url.hostname)) {
+    return null;
+  }
+  const m = url.pathname.match(/\/(?:pubmed|pmc)\/(\d+)/i) ?? url.pathname.match(/\/(\d{4,})\/?$/);
+  if (!m) return null;
+  return { pubmed: m[1] };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function metaContent(doc: DocLike, name: string): string | null {
+  // Some publishers use `name=`; rarer `property=` (OpenGraph-ish). Try
+  // both — cheap, and covers a long tail of publisher variations.
+  const nameMatch = doc.querySelector(`meta[name="${name}"]`);
+  if (nameMatch) {
+    const v = nameMatch.getAttribute('content');
+    if (v && v.trim()) return v.trim();
+  }
+  const propertyMatch = doc.querySelector(`meta[property="${name}"]`);
+  if (propertyMatch) {
+    const v = propertyMatch.getAttribute('content');
+    if (v && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+function metaContentsAll(doc: DocLike, name: string): string[] {
+  const out: string[] = [];
+  const nodes = doc.querySelectorAll(`meta[name="${name}"]`);
+  for (let i = 0; i < nodes.length; i++) {
+    const v = nodes[i].getAttribute('content');
+    if (v && v.trim()) out.push(v.trim());
+  }
+  if (out.length === 0) {
+    const propNodes = doc.querySelectorAll(`meta[property="${name}"]`);
+    for (let i = 0; i < propNodes.length; i++) {
+      const v = propNodes[i].getAttribute('content');
+      if (v && v.trim()) out.push(v.trim());
+    }
+  }
+  return out;
+}
+
+export function normalizeCitationDate(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  // Already ISO-shaped: YYYY, YYYY-MM, YYYY-MM-DD.
+  if (/^\d{4}(-\d{2}(-\d{2})?)?$/.test(trimmed)) return trimmed;
+  // Google Scholar also accepts `YYYY/MM/DD`, which some older publishers emit.
+  const slash = trimmed.match(/^(\d{4})\/(\d{1,2})(?:\/(\d{1,2}))?$/);
+  if (slash) {
+    const [, y, m, d] = slash;
+    if (d) return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+    return `${y}-${m.padStart(2, '0')}`;
+  }
+  // Last resort: pull the first 4-digit run.
+  const year = trimmed.match(/(\d{4})/);
+  return year ? year[1] : null;
+}
+
+function normalizeDoi(raw: string | null): string | null {
+  if (!raw) return null;
+  const stripped = raw.trim()
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '')
+    .toLowerCase();
+  return /^10\.\d+\/.+/.test(stripped) ? stripped : null;
+}
+
+function normalizeArxivId(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim().replace(/^arxiv:\s*/i, '').replace(/v\d+$/i, '');
+  // New style
+  if (/^\d{4}\.\d{4,5}$/.test(trimmed)) return trimmed;
+  // Old style
+  if (/^[a-z-]+(?:\.[a-z-]+)?\/\d{7}$/i.test(trimmed)) return trimmed.toLowerCase();
+  return null;
+}
+
+function normalizePubmed(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim().replace(/^pmid:\s*/i, '');
+  return /^\d+$/.test(trimmed) ? trimmed : null;
+}
+
+function normalizeIsbn(raw: string | null): string | null {
+  if (!raw) return null;
+  const stripped = raw.replace(/[\s-]/g, '');
+  return stripped.length >= 10 ? stripped : null;
+}
+
+// ── Translation to ArticleMetadata ──────────────────────────────────────────
+
+/**
+ * Convert a `StructuredExtraction` (enriched with Readability fall-backs
+ * by the caller) into the `ArticleMetadata` shape the rest of the ingest
+ * pipeline consumes. Readability is the fallback for anything the
+ * handler didn't fill in — title and abstract especially, since some
+ * handlers return just identifiers.
+ */
+export function structuredToArticleMetadata(
+  structured: StructuredExtraction,
+  fallback: {
+    title: string;
+    byline?: string | null;
+    abstract?: string | null;
+    issued?: string | null;
+    publisher?: string | null;
+    uri?: string | null;
+  },
+): ArticleMetadata {
+  const title = structured.title ?? fallback.title;
+  const creators = structured.creators && structured.creators.length > 0
+    ? structured.creators
+    : fallback.byline ? [fallback.byline] : [];
+  const abstract = structured.abstract ?? fallback.abstract ?? null;
+  const issued = structured.issued ?? fallback.issued ?? null;
+  const publisher = structured.publisher ?? fallback.publisher ?? null;
+
+  const subtype: ArticleMetadata['subtype'] = structured.subtype ?? inferSubtype(structured);
+
+  return {
+    subtype,
+    title,
+    creators,
+    abstract,
+    issued,
+    publisher,
+    containerTitle: structured.containerTitle ?? null,
+    doi: structured.doi ?? null,
+    isbn: structured.isbn ?? null,
+    arxiv: structured.arxiv ?? null,
+    pubmed: structured.pubmed ?? null,
+    uri: fallback.uri ?? null,
+    pdfUrl: structured.pdfUrl ?? null,
+    category: null,
+  };
+}
+
+function inferSubtype(s: StructuredExtraction): ArticleMetadata['subtype'] {
+  if (s.arxiv) return 'Preprint';
+  if (s.isbn) return 'Book';
+  if (s.containerTitle) return 'Article';
+  if (s.doi || s.pubmed) return 'Article';
+  return 'Source';
+}

--- a/tests/main/sources/ingest.test.ts
+++ b/tests/main/sources/ingest.test.ts
@@ -253,4 +253,69 @@ describe('ingestUrl (#93)', () => {
       }),
     ).rejects.toThrow(/unsupported content-type/i);
   });
+
+  it('uses the arXiv URL pattern to upgrade the canonical id past url-<hash> (#221)', async () => {
+    const arxivHtml = samplePageHtml({
+      title: 'On the Growth Rate of Trees',
+      body: '<p>We prove a bound on tree growth rates. This paragraph is long enough for Readability to latch onto it as the article body, which needs a bit of prose to clear the heuristic bar.</p><p>A second paragraph keeps the word count comfortable.</p><p>And a third for safety.</p>',
+    });
+    const result = await ingestUrl(root, 'https://arxiv.org/abs/2604.18561', {
+      fetchImpl: mockFetch(arxivHtml),
+    });
+    // The site handler picked up the arXiv id from the URL and routed the
+    // source through the arxiv-<id> folder instead of url-<hash>.
+    expect(result.sourceId).toBe('arxiv-2604.18561');
+    const meta = await fsp.readFile(
+      path.join(root, '.minerva/sources/arxiv-2604.18561/meta.ttl'),
+      'utf-8',
+    );
+    expect(meta).toContain('thought:Preprint');
+  });
+
+  it('reads citation_* meta tags into multi-author meta.ttl (#221)', async () => {
+    const html = `<!doctype html><html><head>
+      <title>Publisher-generated page title</title>
+      <meta name="citation_title" content="A Census of Na D-traced Neutral ISM">
+      <meta name="citation_author" content="Sun, Yang">
+      <meta name="citation_author" content="Ji, Zhiyuan">
+      <meta name="citation_doi" content="10.1234/foo.bar">
+      <meta name="citation_journal_title" content="Astrophysical Journal">
+      <meta name="citation_publication_date" content="2024-10-15">
+    </head><body>
+      <article><h1>A Census of Na D-traced Neutral ISM</h1>
+      <p>We present a large-scale survey of neutral interstellar medium (ISM) properties across galaxies at intermediate redshift. The dataset spans hundreds of targets observed with modern integral-field spectrographs, and the analysis recovers outflow velocities for a substantial fraction of the sample.</p>
+      <p>This provides the first statistical census of ISM-traced outflows in this redshift range, with implications for feedback modelling in galaxy-formation simulations.</p>
+      <p>We release the reduced data and a public catalogue of line measurements.</p>
+      </article>
+    </body></html>`;
+    const result = await ingestUrl(root, 'https://example-journal.org/articles/foo', {
+      fetchImpl: mockFetch(html),
+    });
+    // Upgraded to a DOI-based canonical id, with an Article-typed meta.ttl
+    // carrying one dc:creator per author rather than a byline guess.
+    expect(result.sourceId).toBe('doi-10.1234_foo.bar');
+    const meta = await fsp.readFile(
+      path.join(root, '.minerva/sources/doi-10.1234_foo.bar/meta.ttl'),
+      'utf-8',
+    );
+    expect(meta).toContain('thought:Article');
+    expect(meta).toContain('dc:title "A Census of Na D-traced Neutral ISM"');
+    expect(meta).toContain('dc:creator "Sun, Yang"');
+    expect(meta).toContain('dc:creator "Ji, Zhiyuan"');
+    expect(meta).toContain('bibo:doi "10.1234/foo.bar"');
+    expect(meta).toContain('schema:inContainer "Astrophysical Journal"');
+    expect(meta).toContain('dc:issued "2024-10-15"^^xsd:date');
+  });
+
+  it('falls back to the Readability + WebPage flow when no site handler matches', async () => {
+    const result = await ingestUrl(root, 'https://random-blog.example/post', {
+      fetchImpl: mockFetch(samplePageHtml()),
+    });
+    expect(result.sourceId).toMatch(/^url-[a-f0-9]{12}$/);
+    const meta = await fsp.readFile(
+      path.join(root, '.minerva/sources', result.sourceId, 'meta.ttl'),
+      'utf-8',
+    );
+    expect(meta).toContain('thought:WebPage');
+  });
 });

--- a/tests/main/sources/site-handlers.test.ts
+++ b/tests/main/sources/site-handlers.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import { parseHTML } from 'linkedom';
+import {
+  extractStructured,
+  citationMetaHandler,
+  arxivUrlHandler,
+  pubmedUrlHandler,
+  structuredToArticleMetadata,
+  normalizeCitationDate,
+  type DocLike,
+} from '../../../src/main/sources/site-handlers';
+
+function docFrom(html: string): DocLike {
+  return parseHTML(html).document as unknown as DocLike;
+}
+
+describe('citationMetaHandler (#221)', () => {
+  it('pulls title, authors, DOI, arXiv id, journal, and date from Scholar-style meta tags', () => {
+    const doc = docFrom(`<html><head>
+      <meta name="citation_title" content="A Census of Na D-traced Neutral ISM">
+      <meta name="citation_author" content="Sun, Yang">
+      <meta name="citation_author" content="Ji, Zhiyuan">
+      <meta name="citation_author" content="D'Eugenio, Francesco">
+      <meta name="citation_doi" content="10.1234/foo.bar">
+      <meta name="citation_arxiv_id" content="2604.18561">
+      <meta name="citation_journal_title" content="Astrophysical Journal">
+      <meta name="citation_publication_date" content="2024/10/15">
+      <meta name="citation_publisher" content="IEEE">
+      <meta name="citation_pdf_url" content="https://example.org/paper.pdf">
+    </head></html>`);
+    const out = citationMetaHandler(doc, new URL('https://example.org/paper'));
+    expect(out).not.toBeNull();
+    expect(out!.title).toBe('A Census of Na D-traced Neutral ISM');
+    expect(out!.creators).toEqual(['Sun, Yang', 'Ji, Zhiyuan', "D'Eugenio, Francesco"]);
+    expect(out!.doi).toBe('10.1234/foo.bar');
+    expect(out!.arxiv).toBe('2604.18561');
+    expect(out!.containerTitle).toBe('Astrophysical Journal');
+    expect(out!.issued).toBe('2024-10-15');
+    expect(out!.publisher).toBe('IEEE');
+    expect(out!.pdfUrl).toBe('https://example.org/paper.pdf');
+    expect(out!.subtype).toBe('Preprint'); // arxiv wins over journal for subtype
+  });
+
+  it('splits a single semicolon-joined citation_author field', () => {
+    const doc = docFrom(`<html><head>
+      <meta name="citation_title" content="X">
+      <meta name="citation_author" content="Smith, J; Jones, A; Brown, B">
+    </head></html>`);
+    const out = citationMetaHandler(doc, new URL('https://ex.org/'));
+    expect(out!.creators).toEqual(['Smith, J', 'Jones, A', 'Brown, B']);
+  });
+
+  it('returns null when no citation_title is present', () => {
+    const doc = docFrom('<html><head><meta name="description" content="hi"></head></html>');
+    expect(citationMetaHandler(doc, new URL('https://ex.org/'))).toBeNull();
+  });
+
+  it('infers Article subtype from a journal tag (no arXiv id)', () => {
+    const doc = docFrom(`<html><head>
+      <meta name="citation_title" content="T">
+      <meta name="citation_author" content="A B">
+      <meta name="citation_journal_title" content="J">
+    </head></html>`);
+    expect(citationMetaHandler(doc, new URL('https://ex.org/'))!.subtype).toBe('Article');
+  });
+
+  it('strips DOI URL prefix and lowercases', () => {
+    const doc = docFrom(`<html><head>
+      <meta name="citation_title" content="T">
+      <meta name="citation_doi" content="https://doi.org/10.1109/MC.1987.1663532">
+    </head></html>`);
+    expect(citationMetaHandler(doc, new URL('https://ex.org/'))!.doi).toBe('10.1109/mc.1987.1663532');
+  });
+
+  it('strips `arXiv:` prefix and version suffix on arxiv ids', () => {
+    const doc = docFrom(`<html><head>
+      <meta name="citation_title" content="T">
+      <meta name="citation_arxiv_id" content="arXiv:2604.18561v2">
+    </head></html>`);
+    expect(citationMetaHandler(doc, new URL('https://ex.org/'))!.arxiv).toBe('2604.18561');
+  });
+});
+
+describe('arxivUrlHandler', () => {
+  it('extracts the new-style id from /abs/ URLs', () => {
+    expect(arxivUrlHandler(docFrom(''), new URL('https://arxiv.org/abs/2604.18561'))!.arxiv)
+      .toBe('2604.18561');
+  });
+
+  it('extracts past a version suffix', () => {
+    expect(arxivUrlHandler(docFrom(''), new URL('https://arxiv.org/abs/2604.18561v3'))!.arxiv)
+      .toBe('2604.18561');
+  });
+
+  it('extracts from /pdf/ URLs with or without .pdf', () => {
+    expect(arxivUrlHandler(docFrom(''), new URL('https://arxiv.org/pdf/2604.18561.pdf'))!.arxiv)
+      .toBe('2604.18561');
+    expect(arxivUrlHandler(docFrom(''), new URL('https://arxiv.org/pdf/2604.18561'))!.arxiv)
+      .toBe('2604.18561');
+  });
+
+  it('returns null for non-arxiv hosts', () => {
+    expect(arxivUrlHandler(docFrom(''), new URL('https://example.org/abs/2604.18561'))).toBeNull();
+  });
+
+  it('returns null when the URL doesn’t match the /abs/ or /pdf/ pattern', () => {
+    expect(arxivUrlHandler(docFrom(''), new URL('https://arxiv.org/help/find'))).toBeNull();
+  });
+});
+
+describe('pubmedUrlHandler', () => {
+  it('extracts the PMID from pubmed URLs', () => {
+    expect(pubmedUrlHandler(docFrom(''), new URL('https://pubmed.ncbi.nlm.nih.gov/12345678/'))!.pubmed)
+      .toBe('12345678');
+  });
+
+  it('returns null for non-pubmed hosts', () => {
+    expect(pubmedUrlHandler(docFrom(''), new URL('https://example.org/pubmed/12345'))).toBeNull();
+  });
+});
+
+describe('extractStructured', () => {
+  it('merges handler outputs — meta tags win but URL fallback fills gaps', () => {
+    // Only an arxiv id is recoverable from the URL, but the page also
+    // has meta-tag title and authors; merged result should have all three.
+    const doc = docFrom(`<html><head>
+      <meta name="citation_title" content="Paper">
+      <meta name="citation_author" content="Author One">
+    </head></html>`);
+    const out = extractStructured(doc, new URL('https://arxiv.org/abs/2604.18561'));
+    expect(out).not.toBeNull();
+    expect(out!.title).toBe('Paper');
+    expect(out!.creators).toEqual(['Author One']);
+    expect(out!.arxiv).toBe('2604.18561'); // from URL handler, citation meta had none
+    expect(out!.subtype).toBe('Preprint');
+  });
+
+  it('returns null when no handler found anything', () => {
+    const doc = docFrom('<html><head><title>Plain page</title></head></html>');
+    expect(extractStructured(doc, new URL('https://example.org/blog/post'))).toBeNull();
+  });
+});
+
+describe('structuredToArticleMetadata', () => {
+  it('uses handler fields with Readability fallbacks for the rest', () => {
+    const meta = structuredToArticleMetadata(
+      {
+        title: 'Real Title',
+        creators: ['Alice Smith'],
+        doi: '10.1234/foo',
+        subtype: 'Article',
+      },
+      {
+        title: 'Readability Title',
+        byline: 'Wrong Byline',
+        abstract: 'Summary',
+        issued: '2024',
+        publisher: 'Publisher Inc',
+        uri: 'https://example.org/paper',
+      },
+    );
+    expect(meta.title).toBe('Real Title');
+    expect(meta.creators).toEqual(['Alice Smith']); // not the byline
+    expect(meta.doi).toBe('10.1234/foo');
+    expect(meta.abstract).toBe('Summary'); // fallback filled this
+    expect(meta.issued).toBe('2024');
+    expect(meta.publisher).toBe('Publisher Inc');
+    expect(meta.uri).toBe('https://example.org/paper');
+    expect(meta.subtype).toBe('Article');
+  });
+
+  it('falls back to the Readability byline when the handler has no creators', () => {
+    const meta = structuredToArticleMetadata(
+      { doi: '10.1234/foo' },
+      { title: 'T', byline: 'Bob B', uri: 'https://ex.org/' },
+    );
+    expect(meta.creators).toEqual(['Bob B']);
+  });
+
+  it('infers Preprint subtype from an arxiv id when handler didn’t set one', () => {
+    const meta = structuredToArticleMetadata(
+      { arxiv: '2604.18561' },
+      { title: 'T', uri: 'https://arxiv.org/abs/2604.18561' },
+    );
+    expect(meta.subtype).toBe('Preprint');
+  });
+
+  it('infers Article when only a journal / DOI is known', () => {
+    expect(structuredToArticleMetadata(
+      { doi: '10.1/f', containerTitle: 'J' },
+      { title: 'T', uri: 'u' },
+    ).subtype).toBe('Article');
+  });
+
+  it('defaults to Source when nothing else is informative', () => {
+    expect(structuredToArticleMetadata({}, { title: 'T', uri: 'u' }).subtype).toBe('Source');
+  });
+});
+
+describe('normalizeCitationDate', () => {
+  it('passes ISO shapes through', () => {
+    expect(normalizeCitationDate('2024-10-15')).toBe('2024-10-15');
+    expect(normalizeCitationDate('2024-10')).toBe('2024-10');
+    expect(normalizeCitationDate('2024')).toBe('2024');
+  });
+
+  it('converts Google-Scholar-style slashes', () => {
+    expect(normalizeCitationDate('2024/10/15')).toBe('2024-10-15');
+    expect(normalizeCitationDate('2024/10')).toBe('2024-10');
+    expect(normalizeCitationDate('2024/1/5')).toBe('2024-01-05');
+  });
+
+  it('falls back to the first 4-digit run', () => {
+    expect(normalizeCitationDate('October 15, 2024')).toBe('2024');
+  });
+
+  it('returns null for unparseable inputs', () => {
+    expect(normalizeCitationDate('')).toBeNull();
+    expect(normalizeCitationDate('no year')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Before Readability runs, the URL ingest pipeline now consults a pluggable **site-handler** layer that pulls structured bibliographic metadata out of Google-Scholar-style `<meta name="citation_*">` tags and, where useful, out of the URL itself. The arXiv-ingest-of-the-submission-date-as-the-byline problem the ticket called out is gone.

## Before / after

**Before** (ingesting `https://arxiv.org/abs/2604.18561`):
```turtle
this: a thought:WebPage ;
    dc:title "A Census of Na D-traced…" ;
    dc:creator "[Submitted on 20 Apr 2026]" ;  # Readability guess
    ...
```
Folder: `.minerva/sources/url-a1b2c3d4e5f6/`

**After**:
```turtle
this: a thought:Preprint ;
    dc:title "A Census of Na D-traced Neutral ISM" ;
    dc:creator "Sun, Yang" ;
    dc:creator "Ji, Zhiyuan" ;
    dc:creator "D'Eugenio, Francesco" ;
    dc:issued "2024-10-15"^^xsd:date ;
    bibo:doi "10.1234/foo.bar" ;
    schema:inContainer "Astrophysical Journal" ;
    ...
```
Folder: `.minerva/sources/arxiv-2604.18561/` — dedupes cleanly with an identifier-ingest of the same paper (#96).

## Handlers (merge-in-order, earlier wins)

- **`citationMetaHandler`** — reads every `citation_*` meta tag the Google Scholar convention defines (title, author, doi, arxiv_id, pmid, isbn, journal_title, publisher, publication_date, abstract, pdf_url). Splits a semicolon-joined `citation_author` fallback, normalises DOI URL prefix + `arXiv:…v2` suffixes, infers subtype (`Preprint` > `Article` > `Book` > `Source`) from the strongest signal. Activates whenever `citation_title` is present — covers arXiv, Semantic Scholar, IEEE, ACM, SSRN, PubMed, most publisher pages in one handler.
- **`arxivUrlHandler`** — URL-based arXiv id fallback for `/abs/`, `/pdf/`, `+vN` suffix, and old-style `archive/yymmNNN` ids. Fires only on `arxiv.org` to avoid false positives on anything else that happens to have a `/abs/<id>`-shaped path.
- **`pubmedUrlHandler`** — PMID extraction from PubMed URLs.

Falls back cleanly to the existing Readability + `thought:WebPage` flow when no handler matches (blogs, docs sites, news articles).

## Design calls worth flagging

- **Generic `citation_*` first, per-site bolted on.** The Google Scholar tag convention is dominant across scholarly publishers. One handler gets most of the value; per-site handlers fill URL-pattern gaps and survive publishers who only populate a subset of tags. The `SiteHandler` shape from the ticket is effectively `(doc, url) => StructuredExtraction | null`; the registry in `extractStructured` calls each in order and merges outputs.
- **Reuse `buildMetaTtl` from `ingest-identifier.ts`.** Same TTL emitter URL-via-handler and identifier-ingest now share — so `arxiv-2604.18561/meta.ttl` has the same shape regardless of whether the user typed the arXiv id or dropped the abs URL.
- **Fetch before id computation.** The ticket's diff lands naturally because structured extraction needs the DOM. One extra round trip on the duplicate case, but dedupe now hits the correct arxiv-`/doi-` folder rather than `url-<hash>`.
- **No per-site HTML scraping.** Everything comes from meta tags or URL patterns. Keeps the handlers under ~30 lines each and immune to publisher page-layout changes.
- **Subtype inference.** arXiv id → `Preprint`; journal title → `Article`; ISBN → `Book`; DOI or PMID alone → `Article`; else `Source`. The handler's explicit `subtype` wins over the inference when set.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1240/1240 (27 new: 24 handler unit tests, 3 ingestUrl integration tests covering arXiv URL upgrade, citation-meta multi-author round-trip, WebPage fallback)
- [ ] Manual: ingest a real arXiv `/abs/…` URL → `.minerva/sources/arxiv-<id>/` with correct authors
- [ ] Manual: ingest a Semantic Scholar paper URL → `doi-<slug>` folder, one dc:creator per author
- [ ] Manual: ingest a plain blog post → `url-<hash>` folder, `thought:WebPage`

## Out of scope (per the ticket)

- PDF-URL ingestion (a `.pdf` response is a separate code path)
- Splitting `dc:creator` strings into `thought:contributor` person nodes

## Related

- Enables identifier-ingest dedupe across the URL + identifier paths — re-ingesting the same arXiv paper through either flow now lands in the same folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)