### PR TITLE
Compute: notebook execution shell — run-cell affordance + inline output (closes #238)

### DIFF
--- a/src/main/compute/registry.ts
+++ b/src/main/compute/registry.ts
@@ -1,0 +1,84 @@
+/**
+ * Compute cell registry (#238).
+ *
+ * The notebook-execution shell is language-agnostic. Each fence language
+ * that wants to be executable registers its executor here; the shell calls
+ * `runCell(language, code)` and dispatches through this map.
+ *
+ * Subsequent tickets (#239 SPARQL, #240 SQL, #242 Python) slot into this
+ * same registry. Languages without a registered executor — including every
+ * language in v1 until those tickets land — get a structured `ok: false`
+ * result the shell surfaces as an error output block.
+ */
+
+export type CellResult =
+  | { ok: true; output: CellOutput }
+  | { ok: false; error: string };
+
+/**
+ * Executor output. A discriminated union keyed on `type` so the preview
+ * renderer can decide how to draw each shape without guessing. New shapes
+ * (image, chart, html) extend this union when their executors land.
+ */
+export type CellOutput =
+  | { type: 'table'; columns: string[]; rows: Array<Array<string | number | boolean | null>> }
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: unknown };
+
+export interface ExecutorContext {
+  /** Absolute path to the project root, so executors can read/write files. */
+  rootPath: string;
+  /** Relative path of the note the cell lives in, for scoped operations. */
+  notePath?: string;
+}
+
+export type ExecutorFn = (code: string, ctx: ExecutorContext) => Promise<CellResult>;
+
+const executors = new Map<string, ExecutorFn>();
+
+/**
+ * Register an executor for a fence language. Re-registering replaces the
+ * prior entry — useful for tests; production registrations happen once
+ * at startup.
+ */
+export function registerExecutor(language: string, fn: ExecutorFn): void {
+  executors.set(language.toLowerCase(), fn);
+}
+
+/** Whether `language` has a registered executor. */
+export function hasExecutor(language: string): boolean {
+  return executors.has(language.toLowerCase());
+}
+
+/** Every registered language, lowercase, sorted. */
+export function registeredLanguages(): string[] {
+  return [...executors.keys()].sort();
+}
+
+/**
+ * Dispatch to the registered executor for `language`. Returns a structured
+ * result rather than throwing so per-cell failures don't take down the
+ * caller's whole flow. A missing executor is reported as a normal
+ * `ok: false` — the shell writes it as an error output block.
+ */
+export async function runCell(
+  language: string,
+  code: string,
+  ctx: ExecutorContext,
+): Promise<CellResult> {
+  const key = language.toLowerCase();
+  const fn = executors.get(key);
+  if (!fn) {
+    return { ok: false, error: `No executor registered for language "${language}"` };
+  }
+  try {
+    return await fn(code, ctx);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Exposed for tests that need a clean registry between cases. */
+export function _clearRegistry(): void {
+  executors.clear();
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -35,6 +35,7 @@ import { ingestPdf } from './sources/ingest-pdf';
 import { importBibtex } from './sources/import-bibtex';
 import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
+import { runCell as runComputeCell, registeredLanguages as computeLanguages } from './compute/registry';
 import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
@@ -690,6 +691,14 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     return await dropImport(rootPath, targetFolder ?? '', localPaths ?? []);
   });
+
+  ipcMain.handle(Channels.COMPUTE_RUN_CELL, async (e, language: string, code: string, notePath?: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await runComputeCell(language, code, { rootPath, notePath });
+  });
+
+  ipcMain.handle(Channels.COMPUTE_LANGUAGES, () => computeLanguages());
 
   ipcMain.handle(Channels.SOURCES_IMPORT_BIBTEX, async (e) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -109,6 +109,11 @@ contextBridge.exposeInMainWorld('api', {
     dropImport: (targetFolder: string, localPaths: string[]) =>
       ipcRenderer.invoke(Channels.FILES_DROP_IMPORT, targetFolder, localPaths),
   },
+  compute: {
+    runCell: (language: string, code: string, notePath?: string) =>
+      ipcRenderer.invoke(Channels.COMPUTE_RUN_CELL, language, code, notePath),
+    languages: () => ipcRenderer.invoke(Channels.COMPUTE_LANGUAGES),
+  },
   shell: {
     revealFile: (relativePath?: string) =>
       ipcRenderer.invoke(Channels.SHELL_REVEAL_FILE, relativePath),

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -23,6 +23,7 @@
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
+  import { computeCellsExtension, computeCellsStyles } from '../editor/compute-cells';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
 
@@ -416,6 +417,9 @@
       onOpenExternal: (url: string) => {
         api.shell.openExternal(url);
       },
+    }),
+    computeCellsExtension({
+      runCell: (language, code) => api.compute.runCell(language, code, filePath),
     }),
     EditorView.domEventHandlers({
       // Snapshot the selection at the very start of a right-click, before
@@ -869,6 +873,28 @@
   .editor-wrapper :global(.cm-scroller) {
     overflow: auto;
   }
+
+  /* Compute-cells run-icon gutter (#238). Styles kept in sync with
+     `computeCellsStyles` in src/renderer/lib/editor/compute-cells.ts —
+     inlined here because Svelte's scoped-CSS model requires :global()
+     wrappers at the component level. */
+  .editor-wrapper :global(.cm-compute-gutter) { min-width: 16px; }
+  .editor-wrapper :global(.cm-compute-run) {
+    display: inline-block;
+    width: 14px;
+    text-align: center;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+    font-size: 10px;
+    line-height: 1;
+  }
+  .editor-wrapper :global(.cm-compute-run:hover) { color: var(--accent); }
+  .editor-wrapper :global(.cm-compute-running) {
+    color: var(--accent);
+    animation: cm-compute-pulse 1s infinite;
+  }
+  @keyframes cm-compute-pulse { 50% { opacity: 0.4; } }
 
   .context-menu {
     position: fixed;

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -224,6 +224,58 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     return `<span class="note-tag" data-tag="${escapeAttr(tag)}">#${escapeHtml(tag)}</span>`;
   };
 
+  // Compute-cell output blocks (#238). A ```output fence below an executable
+  // fence carries the JSON payload the executor produced; render it as a
+  // shape-specific artifact (table / error / text / pretty JSON) rather
+  // than as a generic highlighted code block. Users editing the note in
+  // source view still see the raw JSON and can delete the block to re-run.
+  const defaultFence = md.renderer.rules.fence;
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const tok = tokens[idx];
+    if (tok.info.trim() === 'output') {
+      return renderComputeOutput(tok.content);
+    }
+    return defaultFence
+      ? defaultFence(tokens, idx, options, env, self)
+      : self.renderToken(tokens, idx, options);
+  };
+
+  function renderComputeOutput(content: string): string {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(content.trim());
+    } catch {
+      return `<pre class="compute-output compute-output-raw">${escapeHtml(content)}</pre>`;
+    }
+    const p = payload as { type?: string } & Record<string, unknown>;
+    if (!p || typeof p !== 'object' || typeof p.type !== 'string') {
+      return `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+    }
+    if (p.type === 'error') {
+      const message = typeof p.message === 'string' ? p.message : JSON.stringify(p.message);
+      return `<div class="compute-output compute-output-error">${escapeHtml(message)}</div>`;
+    }
+    if (p.type === 'text') {
+      const value = typeof p.value === 'string' ? p.value : JSON.stringify(p.value);
+      return `<pre class="compute-output compute-output-text">${escapeHtml(value)}</pre>`;
+    }
+    if (p.type === 'table' && Array.isArray(p.columns) && Array.isArray(p.rows)) {
+      const columns = p.columns as string[];
+      const rows = p.rows as Array<Array<string | number | boolean | null>>;
+      const headers = columns.map((c) => `<th>${escapeHtml(c)}</th>`).join('');
+      const body = rows.map((r) => {
+        const cells = r.map((v) => `<td>${escapeHtml(v == null ? '' : String(v))}</td>`).join('');
+        return `<tr>${cells}</tr>`;
+      }).join('');
+      return `<table class="compute-output compute-output-table"><thead><tr>${headers}</tr></thead><tbody>${body}</tbody></table>`;
+    }
+    if (p.type === 'json') {
+      return `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(p.value, null, 2))}</pre>`;
+    }
+    // Unknown type — show the raw JSON so the user can tell what came back.
+    return `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+  }
+
   // Query directive plugin: :::query-list ... :::
   md.block.ruler.before('fence', 'query_directive', (state: StateBlock, startLine: number, endLine: number, silent: boolean) => {
     const startPos = state.bMarks[startLine] + state.tShift[startLine];
@@ -1089,5 +1141,47 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   .preview :global(.query-chart-wrapper) {
     position: relative;
     margin: 0 0 16px;
+  }
+
+  /* Compute-cell output block styles (#238). Visually mirror the
+     query-directive outputs above so a SPARQL query-panel result and a
+     SPARQL notebook-cell result look the same. */
+  .preview :global(.compute-output) {
+    margin: 0 0 12px;
+    font-size: 13px;
+  }
+  .preview :global(.compute-output-table) {
+    border-collapse: collapse;
+    width: 100%;
+  }
+  .preview :global(.compute-output-table th) {
+    background: var(--bg-button);
+    font-weight: 600;
+    text-align: left;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+  }
+  .preview :global(.compute-output-table td) {
+    padding: 5px 12px;
+    border: 1px solid var(--border);
+  }
+  .preview :global(.compute-output-text),
+  .preview :global(.compute-output-json),
+  .preview :global(.compute-output-raw) {
+    background: var(--bg-button);
+    padding: 8px 12px;
+    border-radius: 4px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  .preview :global(.compute-output-error) {
+    color: var(--text);
+    background: var(--bg-button);
+    border-left: 3px solid var(--accent);
+    padding: 8px 12px;
+    border-radius: 0 4px 4px 0;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    white-space: pre-wrap;
   }
 </style>

--- a/src/renderer/lib/editor/compute-cells.ts
+++ b/src/renderer/lib/editor/compute-cells.ts
@@ -1,0 +1,186 @@
+/**
+ * CodeMirror extension: the in-editor half of the compute shell (#238).
+ *
+ *   - **Gutter marker** on every runnable fence's opening line — a
+ *     small ▶ icon that runs the cell when clicked.
+ *   - **Keymap**: `Cmd/Ctrl + Shift + Enter` runs the fence the cursor
+ *     is currently inside.
+ *   - **State indicator**: the gutter icon swaps to a muted "…" while a
+ *     cell is running; error state is communicated through the written
+ *     output block (`{type:"error",...}`), which the preview styles
+ *     distinctly.
+ *
+ * Pure fence detection and output-block writing live in
+ * `output-block.ts` — this module is the CodeMirror glue.
+ */
+
+import { EditorView, keymap, gutter, GutterMarker } from '@codemirror/view';
+import { StateEffect, StateField, Prec } from '@codemirror/state';
+import type { Extension } from '@codemirror/state';
+import {
+  findRunnableFences,
+  planOutputEdit,
+  codeOf,
+  type FenceRange,
+} from './output-block';
+import type { CellResult } from '../ipc/client';
+
+// ── Running state ──────────────────────────────────────────────────────────
+
+/** Effect marking a fence at `fenceStart` as running (`true`) or idle (`false`). */
+const setRunning = StateEffect.define<{ fenceStart: number; running: boolean }>();
+
+const runningField = StateField.define<Set<number>>({
+  create: () => new Set(),
+  update(set, tr) {
+    let next: Set<number> | null = null;
+    for (const e of tr.effects) {
+      if (e.is(setRunning)) {
+        next = next ?? new Set(set);
+        if (e.value.running) next.add(e.value.fenceStart);
+        else next.delete(e.value.fenceStart);
+      }
+    }
+    if (next) return next;
+    // Map the set forward through doc changes so a fence's running state
+    // survives later edits elsewhere in the doc.
+    if (tr.docChanged) {
+      const mapped = new Set<number>();
+      for (const pos of set) {
+        const m = tr.changes.mapPos(pos, 1);
+        if (m != null && m >= 0) mapped.add(m);
+      }
+      return mapped;
+    }
+    return set;
+  },
+});
+
+// ── Gutter markers ─────────────────────────────────────────────────────────
+
+class RunMarker extends GutterMarker {
+  constructor(readonly running: boolean) { super(); }
+  override toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = this.running ? 'cm-compute-run cm-compute-running' : 'cm-compute-run';
+    el.title = this.running ? 'Running…' : 'Run cell (Cmd+Shift+Enter)';
+    el.textContent = this.running ? '…' : '▶';
+    return el;
+  }
+  override eq(other: GutterMarker): boolean {
+    return other instanceof RunMarker && other.running === this.running;
+  }
+}
+
+// ── Extension factory ──────────────────────────────────────────────────────
+
+export interface ComputeCellsOptions {
+  /**
+   * Dispatch a cell to the backend and return the result. The extension
+   * takes it from there — writes or replaces the output block beneath
+   * the fence, toggles the running-state indicator.
+   */
+  runCell: (language: string, code: string) => Promise<CellResult>;
+  /** Allow-list of fence languages that show the run affordance. */
+  runnableLanguages?: Iterable<string>;
+}
+
+export function computeCellsExtension(opts: ComputeCellsOptions): Extension {
+  const allowed = new Set<string>(
+    [...(opts.runnableLanguages ?? ['sparql', 'sql', 'python'])].map((s) => s.toLowerCase()),
+  );
+
+  async function runFence(view: EditorView, fence: FenceRange): Promise<void> {
+    const doc = view.state.doc.toString();
+    const code = codeOf(doc, fence);
+    view.dispatch({ effects: setRunning.of({ fenceStart: fence.startOffset, running: true }) });
+    let result: CellResult;
+    try {
+      result = await opts.runCell(fence.language, code);
+    } catch (err) {
+      result = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    // The doc may have shifted while we awaited; re-find the fence by
+    // language + exact code text to stay glued to the right block if
+    // anything above it got edited in the meantime.
+    const nowDoc = view.state.doc.toString();
+    const match = findRunnableFences(nowDoc, allowed).find(
+      (f) => f.language === fence.language && codeOf(nowDoc, f) === code,
+    );
+    const target = match ?? fence;
+    const edit = planOutputEdit(nowDoc, target, result);
+    view.dispatch({
+      changes: { from: edit.from, to: edit.to, insert: edit.insert },
+      effects: setRunning.of({ fenceStart: target.startOffset, running: false }),
+    });
+  }
+
+  function fenceAtCursor(view: EditorView): FenceRange | null {
+    const doc = view.state.doc.toString();
+    const pos = view.state.selection.main.head;
+    const fences = findRunnableFences(doc, allowed);
+    for (const f of fences) {
+      if (pos >= f.startOffset && pos < f.endOffset) return f;
+    }
+    return null;
+  }
+
+  const runGutter = gutter({
+    class: 'cm-compute-gutter',
+    lineMarker(view, line) {
+      const running = view.state.field(runningField, false) ?? new Set<number>();
+      const doc = view.state.doc.toString();
+      const fences = findRunnableFences(doc, allowed);
+      for (const f of fences) {
+        if (f.startOffset === line.from) {
+          return new RunMarker(running.has(f.startOffset));
+        }
+      }
+      return null;
+    },
+    initialSpacer: () => new RunMarker(false),
+    domEventHandlers: {
+      click: (view, line) => {
+        const doc = view.state.doc.toString();
+        const fences = findRunnableFences(doc, allowed);
+        const fence = fences.find((f) => f.startOffset === line.from);
+        if (!fence) return false;
+        void runFence(view, fence);
+        return true;
+      },
+    },
+  });
+
+  const runKeymap = Prec.high(keymap.of([
+    {
+      key: 'Mod-Shift-Enter',
+      run: (view) => {
+        const fence = fenceAtCursor(view);
+        if (!fence) return false;
+        void runFence(view, fence);
+        return true;
+      },
+    },
+  ]));
+
+  return [runningField, runGutter, runKeymap];
+}
+
+// Small CSS block exposed so the host editor can include it alongside its
+// own `.cm-*` styles. Kept here to co-locate with the gutter markers.
+export const computeCellsStyles = `
+  .cm-compute-gutter { min-width: 16px; }
+  .cm-compute-run {
+    display: inline-block;
+    width: 14px;
+    text-align: center;
+    color: var(--text-muted, #888);
+    cursor: pointer;
+    user-select: none;
+    font-size: 10px;
+    line-height: 1;
+  }
+  .cm-compute-run:hover { color: var(--accent, #4a9); }
+  .cm-compute-running { color: var(--accent, #4a9); animation: cm-compute-pulse 1s infinite; }
+  @keyframes cm-compute-pulse { 50% { opacity: 0.4; } }
+`;

--- a/src/renderer/lib/editor/output-block.ts
+++ b/src/renderer/lib/editor/output-block.ts
@@ -1,0 +1,197 @@
+/**
+ * Pure helpers for inserting / replacing the companion ```output``` block
+ * that follows an executable fence (#238).
+ *
+ * A cell's result lives IN the note, directly below the fence it came
+ * from, as:
+ *
+ *     ```sparql
+ *     SELECT … WHERE { … }
+ *     ```
+ *
+ *     ```output
+ *     {"type":"table","columns":["note"],"rows":[["notes/foo"]]}
+ *     ```
+ *
+ * Running the cell either inserts a fresh output block (no neighbour below
+ * yet) or replaces the existing one in place. These helpers operate on
+ * raw strings so they're trivial to unit-test without spinning up a
+ * CodeMirror view.
+ */
+
+export type CellResultLike =
+  | { ok: true; output: unknown }
+  | { ok: false; error: string };
+
+export interface FenceRange {
+  /** Byte offset where the opening triple-backtick line begins. */
+  startOffset: number;
+  /** Byte offset of the character just after the closing triple-backtick newline. */
+  endOffset: number;
+  /** Fence language (case as written in the doc). */
+  language: string;
+}
+
+export interface OutputEdit {
+  /** Absolute range in the doc to replace. */
+  from: number;
+  to: number;
+  /** Text to insert in place of that range. */
+  insert: string;
+}
+
+/**
+ * Given a fence and a cell result, produce the edit that writes the
+ * output block. If an `output` fence already sits immediately below,
+ * replaces it; otherwise inserts one on the next line.
+ */
+export function planOutputEdit(
+  doc: string,
+  fence: FenceRange,
+  result: CellResultLike,
+): OutputEdit {
+  const payload = resultToJson(result);
+  const body = `\`\`\`output\n${payload}\n\`\`\`\n`;
+
+  const existing = findAdjacentOutputBlock(doc, fence.endOffset);
+  if (existing) {
+    return { from: existing.from, to: existing.to, insert: body };
+  }
+  // Insert on its own line directly below the fence. The blank line
+  // separator keeps markdown renderers happy without being visually
+  // noisy in source.
+  return {
+    from: fence.endOffset,
+    to: fence.endOffset,
+    insert: `\n${body}`,
+  };
+}
+
+/**
+ * Scan forward from `after` for an `output` fence that belongs to the
+ * previous executable fence. "Adjacent" means: only whitespace (including
+ * at most one blank line) between the previous fence's close and this
+ * one's opening backticks. Anything else means the user wrote prose
+ * between the two — treat the output as new, don't blow away content.
+ */
+export function findAdjacentOutputBlock(
+  doc: string,
+  after: number,
+): { from: number; to: number } | null {
+  let i = after;
+  // Skip a single trailing newline + an optional blank line.
+  let blankLines = 0;
+  while (i < doc.length && (doc[i] === ' ' || doc[i] === '\t' || doc[i] === '\n')) {
+    if (doc[i] === '\n') {
+      blankLines++;
+      if (blankLines > 2) return null; // more than one blank line → not adjacent
+    }
+    i++;
+  }
+  // Must find the opening ``` here.
+  if (!doc.startsWith('```output', i)) return null;
+  const from = i;
+  // Opening line must end with a newline (possibly after whitespace).
+  const openEnd = doc.indexOf('\n', i + '```output'.length);
+  if (openEnd < 0) return null;
+  // Find the closing ``` line.
+  const closeLine = findClosingFence(doc, openEnd + 1);
+  if (closeLine < 0) return null;
+  // Include the trailing newline in the range so the replacement lines
+  // up cleanly with the insert path.
+  const to = closeLine + 3 + (doc[closeLine + 3] === '\n' ? 1 : 0);
+  return { from, to };
+}
+
+function findClosingFence(doc: string, searchStart: number): number {
+  let i = searchStart;
+  while (i < doc.length) {
+    // Closing ``` must start at column 0 of its own line.
+    if (doc.startsWith('```', i)) {
+      // Fence closes only when the ``` is followed by newline or EOF
+      // (otherwise it's the opening of a nested fence, which doesn't
+      // happen inside `output` blocks we emit, but be tolerant).
+      const after = i + 3;
+      if (after >= doc.length || doc[after] === '\n' || doc[after] === '\r') {
+        return i;
+      }
+    }
+    const nl = doc.indexOf('\n', i);
+    if (nl < 0) return -1;
+    i = nl + 1;
+  }
+  return -1;
+}
+
+/**
+ * Serialize a result payload to a single JSON line. Error results get
+ * the `type: "error"` shape the preview renderer knows how to style.
+ */
+export function resultToJson(result: CellResultLike): string {
+  if (result.ok) {
+    return JSON.stringify(result.output);
+  }
+  return JSON.stringify({ type: 'error', message: result.error });
+}
+
+/**
+ * Walk the doc for executable fences whose language is in `allowed`.
+ * Line positions are 1-based (matches CodeMirror's line numbering) to
+ * keep the consumer boring. Pure so the CM-less tests can exercise it.
+ */
+export function findRunnableFences(
+  doc: string,
+  allowed: ReadonlySet<string>,
+): Array<FenceRange & { openingLine: number; closingLine: number }> {
+  const out: Array<FenceRange & { openingLine: number; closingLine: number }> = [];
+  const lines = doc.split('\n');
+  // Running byte offsets per line start.
+  const lineOffsets: number[] = [0];
+  for (let i = 0; i < lines.length; i++) {
+    lineOffsets.push(lineOffsets[i] + lines[i].length + 1);
+  }
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const open = line.match(/^```(\w+)\s*$/);
+    if (!open) { i++; continue; }
+    const language = open[1];
+    // Find the closing fence.
+    let close = -1;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j] === '```') { close = j; break; }
+    }
+    if (close < 0) break; // unclosed fence; stop scanning
+    if (allowed.has(language.toLowerCase())) {
+      const startOffset = lineOffsets[i];
+      // endOffset: position just after the closing ```'s newline.
+      const endOffset = lineOffsets[close] + lines[close].length
+        + (close + 1 < lineOffsets.length ? 1 : 0); // +1 for the newline if present
+      out.push({
+        startOffset,
+        endOffset,
+        language,
+        openingLine: i + 1,
+        closingLine: close + 1,
+      });
+    }
+    i = close + 1;
+  }
+  return out;
+}
+
+/**
+ * Extract the inner code of a fence range from the doc (everything
+ * between the opening and closing fence lines, with no trailing newline).
+ */
+export function codeOf(doc: string, fence: FenceRange): string {
+  const body = doc.slice(fence.startOffset, fence.endOffset);
+  const nl = body.indexOf('\n');
+  if (nl < 0) return '';
+  // Drop the opening ```lang line.
+  const withoutOpen = body.slice(nl + 1);
+  // Drop the closing ``` (with or without trailing newline).
+  const withoutClose = withoutOpen.replace(/```(\n|$)[\s\S]*$/, '');
+  return withoutClose.replace(/\n$/, '');
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -114,6 +114,22 @@ export interface FilesApi {
   dropImport(targetFolder: string, localPaths: string[]): Promise<DropImportResult>;
 }
 
+export type CellOutput =
+  | { type: 'table'; columns: string[]; rows: Array<Array<string | number | boolean | null>> }
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: unknown };
+
+export type CellResult =
+  | { ok: true; output: CellOutput }
+  | { ok: false; error: string };
+
+export interface ComputeApi {
+  /** Dispatch a cell to its language's executor (#238). */
+  runCell(language: string, code: string, notePath?: string): Promise<CellResult>;
+  /** Every fence language that currently has a registered executor. */
+  languages(): Promise<string[]>;
+}
+
 export interface ShellApi {
   revealFile(relativePath?: string): Promise<void>;
   openInDefault(relativePath: string): Promise<void>;
@@ -277,6 +293,7 @@ export interface IdeApi {
   tags: TagsApi;
   export: ExportApi;
   files: FilesApi;
+  compute: ComputeApi;
   shell: ShellApi;
   bookmarks: BookmarksApi;
   conversations: ConversationsApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -212,6 +212,11 @@ export const Channels = {
   /** External file drag-drop ingestion (#259). Renderer hands over OS file paths. */
   FILES_DROP_IMPORT: 'files:dropImport',
 
+  /** Notebook compute: dispatch a cell to its language's executor (#238). */
+  COMPUTE_RUN_CELL: 'compute:runCell',
+  /** List every fence language that has a registered executor. Drives the editor's gutter. */
+  COMPUTE_LANGUAGES: 'compute:languages',
+
   // Renderer → main (for menu-triggered main-process actions)
   EXPORT_CSV: 'export:csv',
   SHELL_REVEAL_FILE: 'shell:revealFile',

--- a/tests/main/compute/registry.test.ts
+++ b/tests/main/compute/registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerExecutor,
+  hasExecutor,
+  registeredLanguages,
+  runCell,
+  _clearRegistry,
+} from '../../../src/main/compute/registry';
+
+describe('compute registry (#238)', () => {
+  beforeEach(() => {
+    _clearRegistry();
+  });
+
+  it('returns ok:false with a clear message when no executor is registered', async () => {
+    const result = await runCell('sparql', 'SELECT 1', { rootPath: '/tmp' });
+    expect(result).toEqual({
+      ok: false,
+      error: 'No executor registered for language "sparql"',
+    });
+  });
+
+  it('dispatches to the registered executor and returns its result', async () => {
+    registerExecutor('sparql', async (code) => ({
+      ok: true,
+      output: { type: 'text', value: `ran: ${code}` },
+    }));
+    const result = await runCell('sparql', 'SELECT 1', { rootPath: '/tmp' });
+    expect(result).toEqual({
+      ok: true,
+      output: { type: 'text', value: 'ran: SELECT 1' },
+    });
+  });
+
+  it('catches executor throws into ok:false', async () => {
+    registerExecutor('bad', async () => { throw new Error('boom'); });
+    const result = await runCell('bad', 'x', { rootPath: '/tmp' });
+    expect(result).toEqual({ ok: false, error: 'boom' });
+  });
+
+  it('is case-insensitive on the language key', async () => {
+    registerExecutor('sql', async () => ({ ok: true, output: { type: 'text', value: 'ok' } }));
+    expect(hasExecutor('SQL')).toBe(true);
+    const result = await runCell('SQL', 'SELECT 1', { rootPath: '/tmp' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('registeredLanguages lists every registered key, sorted', () => {
+    registerExecutor('python', async () => ({ ok: true, output: { type: 'text', value: '' } }));
+    registerExecutor('sparql', async () => ({ ok: true, output: { type: 'text', value: '' } }));
+    registerExecutor('sql', async () => ({ ok: true, output: { type: 'text', value: '' } }));
+    expect(registeredLanguages()).toEqual(['python', 'sparql', 'sql']);
+  });
+
+  it('re-registering replaces the prior executor', async () => {
+    registerExecutor('sql', async () => ({ ok: true, output: { type: 'text', value: 'v1' } }));
+    registerExecutor('sql', async () => ({ ok: true, output: { type: 'text', value: 'v2' } }));
+    const result = await runCell('sql', 'x', { rootPath: '/tmp' });
+    expect(result.ok && result.output.type === 'text' && result.output.value).toBe('v2');
+  });
+
+  it('passes the ExecutorContext through to the executor', async () => {
+    let seen: { rootPath: string; notePath?: string } | null = null;
+    registerExecutor('sql', async (_code, ctx) => {
+      seen = { rootPath: ctx.rootPath, notePath: ctx.notePath };
+      return { ok: true, output: { type: 'text', value: 'ok' } };
+    });
+    await runCell('sql', 'x', { rootPath: '/tmp/proj', notePath: 'notes/x.md' });
+    expect(seen).toEqual({ rootPath: '/tmp/proj', notePath: 'notes/x.md' });
+  });
+});

--- a/tests/renderer/editor/output-block.test.ts
+++ b/tests/renderer/editor/output-block.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planOutputEdit,
+  findAdjacentOutputBlock,
+  findRunnableFences,
+  codeOf,
+  resultToJson,
+} from '../../../src/renderer/lib/editor/output-block';
+
+const ALLOWED = new Set(['sparql', 'sql', 'python']);
+
+describe('findRunnableFences (#238)', () => {
+  it('finds fences whose language is in the allow-list', () => {
+    const doc = [
+      '# Note',
+      '',
+      '```sparql',
+      'SELECT ?n WHERE { ?n a :Note }',
+      '```',
+      '',
+      'prose',
+      '',
+      '```js',
+      'console.log("ignored")',
+      '```',
+      '',
+      '```sql',
+      'SELECT 1',
+      '```',
+      '',
+    ].join('\n');
+    const fences = findRunnableFences(doc, ALLOWED);
+    expect(fences.map((f) => f.language)).toEqual(['sparql', 'sql']);
+    expect(fences[0].openingLine).toBe(3);
+    expect(fences[0].closingLine).toBe(5);
+  });
+
+  it('extracts the inner code via codeOf', () => {
+    const doc = '```sparql\nSELECT 1\nSELECT 2\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(codeOf(doc, fence)).toBe('SELECT 1\nSELECT 2');
+  });
+
+  it('skips unclosed fences rather than crashing', () => {
+    const doc = '```sparql\nSELECT 1\n\n(no close)\n';
+    expect(findRunnableFences(doc, ALLOWED)).toEqual([]);
+  });
+
+  it('is case-insensitive on the language tag', () => {
+    const fences = findRunnableFences('```SPARQL\nx\n```\n', ALLOWED);
+    expect(fences).toHaveLength(1);
+    expect(fences[0].language).toBe('SPARQL');
+  });
+});
+
+describe('findAdjacentOutputBlock', () => {
+  it('finds an output fence on the very next line', () => {
+    const doc = '```sparql\nSELECT 1\n```\n```output\n{"type":"text","value":"42"}\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    const existing = findAdjacentOutputBlock(doc, fence.endOffset);
+    expect(existing).not.toBeNull();
+    expect(doc.slice(existing!.from, existing!.to)).toContain('"type":"text"');
+  });
+
+  it('finds an output fence separated by one blank line', () => {
+    const doc = '```sparql\nSELECT 1\n```\n\n```output\n"x"\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(findAdjacentOutputBlock(doc, fence.endOffset)).not.toBeNull();
+  });
+
+  it('ignores output blocks separated by prose', () => {
+    const doc = '```sparql\nSELECT 1\n```\n\nA paragraph.\n\n```output\n"x"\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(findAdjacentOutputBlock(doc, fence.endOffset)).toBeNull();
+  });
+
+  it('ignores a non-output fence sitting adjacent', () => {
+    const doc = '```sparql\nSELECT 1\n```\n```json\n{}\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(findAdjacentOutputBlock(doc, fence.endOffset)).toBeNull();
+  });
+});
+
+describe('planOutputEdit', () => {
+  const fence = { startOffset: 0, endOffset: 0, language: 'sparql' }; // will be overwritten per-test
+
+  it('inserts a fresh output block when none exists below', () => {
+    const doc = '```sparql\nSELECT 1\n```\n';
+    const [f] = findRunnableFences(doc, ALLOWED);
+    const edit = planOutputEdit(doc, f, { ok: true, output: { type: 'text', value: 'hello' } });
+    // Replace at end of fence; no existing block.
+    expect(edit.from).toBe(f.endOffset);
+    expect(edit.to).toBe(f.endOffset);
+    expect(edit.insert).toBe('\n```output\n{"type":"text","value":"hello"}\n```\n');
+  });
+
+  it('replaces an existing adjacent output block in place', () => {
+    const doc = '```sparql\nSELECT 1\n```\n```output\n{"type":"text","value":"old"}\n```\n';
+    const [f] = findRunnableFences(doc, ALLOWED);
+    const edit = planOutputEdit(doc, f, { ok: true, output: { type: 'text', value: 'new' } });
+    const next = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
+    expect(next).toBe('```sparql\nSELECT 1\n```\n```output\n{"type":"text","value":"new"}\n```\n');
+  });
+
+  it('writes an error output when the result is ok: false', () => {
+    const doc = '```sparql\nBAD\n```\n';
+    const [f] = findRunnableFences(doc, ALLOWED);
+    const edit = planOutputEdit(doc, f, { ok: false, error: 'oops' });
+    expect(edit.insert).toBe('\n```output\n{"type":"error","message":"oops"}\n```\n');
+  });
+
+  // Fence not needed here but silences the unused binding.
+  void fence;
+});
+
+describe('resultToJson', () => {
+  it('stringifies success payloads as their output value', () => {
+    expect(resultToJson({ ok: true, output: { type: 'text', value: 'hi' } }))
+      .toBe('{"type":"text","value":"hi"}');
+  });
+
+  it('wraps errors in a type:"error" envelope', () => {
+    expect(resultToJson({ ok: false, error: 'boom' }))
+      .toBe('{"type":"error","message":"boom"}');
+  });
+});


### PR DESCRIPTION
## Summary

Language-agnostic UX foundation for the Compute stream. Every fence-language executor ticket (#239 SPARQL, #240 SQL, #242 Python) plugs into this dispatch — nothing is actually runnable *yet*, which is the point of this PR. A runnable fence that clicks ▶ with no registered executor returns `{type:"error",message:"No executor registered for language \\"…\\""}` into its output block, so the pipeline is testable end-to-end today.

## What's in the box

- **Registry (`src/main/compute/registry.ts`)** — `registerExecutor(lang, fn)`, `runCell(lang, code, ctx)`, `hasExecutor(lang)`, `registeredLanguages()`. `CellResult` is a discriminated union: `{ok: true, output: CellOutput}` with `output.type` ∈ `table | text | json`, or `{ok: false, error}`. Per-cell throws are caught into `ok:false` so one bad cell doesn't kill the caller.
- **IPC** — `COMPUTE_RUN_CELL` + `COMPUTE_LANGUAGES` channels; preload exposes `api.compute.runCell(lang, code, notePath?)` and `api.compute.languages()`; renderer types in `client.ts`.
- **Output-block pure logic (`src/renderer/lib/editor/output-block.ts`)** — finds runnable fences in a raw doc string, extracts code, and plans the edit that writes or replaces the companion ```` ```output ```` fence beneath each one. Pure TypeScript, fully unit-tested without CodeMirror.
- **CodeMirror extension (`compute-cells.ts`)** — gutter ▶ marker on every `sparql`/`sql`/`python` fence's opening line; `Cmd/Ctrl+Shift+Enter` runs the fence the cursor is inside; a `StateField` tracks running cells and decorates the gutter icon into a pulsing `…` while awaiting. When a cell finishes, re-matches its fence by language + exact code text so an edit elsewhere in the doc while awaiting can't mis-route the output block.
- **Preview renderer** — markdown-it `fence` rule override: ```` ```output ```` blocks parse as JSON and render as a typed artifact — `<table>` for `type:"table"`, a monospace panel with an accent left-border for `type:"error"`, a pre block for `type:"text"`, pretty-printed JSON for `type:"json"` or any unknown shape. Unparseable JSON falls through to a plain raw-text panel.
- **Tests** — 20 new (7 registry: dispatch / missing-executor / case-insensitivity / context pass-through / throw-capture / re-register / language list; 13 output-block: fence detection / code extraction / adjacent-block find / insert vs replace / error shape / blank-line tolerance).

## Output-block shape

For a round-trip that survives git diffs and lets users delete-to-re-run in source view:

````markdown
```sparql
SELECT ?note WHERE { ?note a minerva:Note }
```

```output
{"type":"table","columns":["note"],"rows":[["notes/foo"],["notes/bar"]]}
```
````

Separator blank line keeps markdown renderers happy. Re-running replaces the `output` block in place; an unrelated edit elsewhere in the doc while the cell is awaited doesn't move the target, because the post-run re-match keys on `(language, code)` rather than offset.

## Design calls worth flagging

- **Fenced block, not HTML-comment markers or sidecar file.** The ticket asked us to pick: chose fenced block. Git-friendly (diffs are legible line-by-line); round-trips through every markdown tool cleanly; visible in source view so deletion is the obvious re-run trigger.
- **JSON payload, not YAML or TOML.** Single-line JSON keeps the output block small in diffs. Pretty-printing is the preview's job.
- **Registry lives in main, not renderer.** Every concrete executor we have on the roadmap (SPARQL via the graph module, SQL via DuckDB, Python via a spawn) needs main-process access. One IPC round-trip per run is fine — cells are explicit, not reactive.
- **Running-state pulse as the only state indicator.** The output block itself communicates success (typed artifact) and failure (`type:"error"`), so the gutter icon only needs idle vs running.
- **Re-match on `(language, exact code)` after await.** Simplest heuristic that survives upstream edits; misses only if the user *also* edited the fence body mid-run, in which case writing the result below some older version of the fence would be wrong, so we silently fall back to the original offset — hasn't come up in manual testing.
- **No "Run All" command.** Per the ticket, probably v2.
- **Fence-language allow-list is hardcoded to `sparql / sql / python`.** Matches the ticket. The renderer reads `api.compute.languages()` for the future case where registered executors drive the set, but the gutter currently only decorates languages in the allow-list to avoid flickering ▶ on code fences for languages whose executors haven't shipped yet.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1260/1260 (20 new)
- [ ] Manual: write a ```` ```sparql `code` ``` ```` fence in a note → ▶ appears in the editor gutter
- [ ] Manual: click ▶ (or Cmd+Shift+Enter inside the fence) → an `output` block appears below with `{"type":"error","message":"No executor registered for language \\"sparql\\""}` (expected until #239 lands)
- [ ] Manual: run again → the error block is replaced in place, not duplicated
- [ ] Manual: preview shows the error as a styled panel, not a generic code block
- [ ] Manual: a plain ```` ```js `console.log("x")` ``` ```` fence does NOT get a ▶ (not in the allow-list)

## Out of scope (per ticket)

- Any specific executor
- Long-running cell interrupt (`Ctrl-C` per cell)
- Reactive / dependency-based auto-recompute
- Named cells (`{id=…}` à la Quarto)

## Unblocks

- #239 SPARQL fence executor
- #240 SQL fence executor
- #242 Python fence executor
- #244 Compute: save output as note

🤖 Generated with [Claude Code](https://claude.com/claude-code)