### PR TITLE
Compute: SPARQL fence executor (closes #239)

### DIFF
--- a/src/main/compute/executors/index.ts
+++ b/src/main/compute/executors/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Compute-shell builtin executor registrations. Called once at
+ * app-ready; concrete executor modules slot in here.
+ */
+
+import { registerExecutor } from '../registry';
+import { executeSparql } from './sparql';
+
+export function registerBuiltinExecutors(): void {
+  registerExecutor('sparql', executeSparql);
+}

--- a/src/main/compute/executors/sparql.ts
+++ b/src/main/compute/executors/sparql.ts
@@ -1,0 +1,46 @@
+/**
+ * SPARQL fence executor (#239) — first concrete language on top of the
+ * compute shell (#238). Dispatches through the same `queryGraph` path
+ * the Query Panel already uses, so a fence in a note and a query tab
+ * with identical SPARQL produce identical rows.
+ */
+
+import { queryGraph } from '../../graph';
+import type { ExecutorFn } from '../registry';
+
+/**
+ * Run a SPARQL SELECT against the project's graph. Returns a
+ * `type: "table"` output on success, or a structured error on syntax /
+ * runtime failure. Bindings come back as `Record<variable, value>`
+ * objects from the graph layer — we flatten them into row-major order
+ * using the first binding's keys as the column list.
+ */
+export const executeSparql: ExecutorFn = async (code) => {
+  const response = await queryGraph(code);
+  // `queryGraph` returns `{ results: [], error }` on parse / runtime
+  // failure — surface that as a cell-level error rather than a thrown
+  // exception, so the shell writes a readable output block.
+  const err = (response as { error?: string }).error;
+  if (err) return { ok: false, error: err };
+
+  const rows = response.results as Array<Record<string, string>>;
+  if (rows.length === 0) {
+    return { ok: true, output: { type: 'table', columns: [], rows: [] } };
+  }
+  // Union the keys across all bindings — some engines produce row-shape
+  // variance when OPTIONAL clauses leave variables unbound in some rows.
+  // Falling back to the first row's keys would drop those columns.
+  const columnSet = new Set<string>();
+  for (const r of rows) {
+    for (const k of Object.keys(r)) columnSet.add(k);
+  }
+  const columns = [...columnSet];
+  // A solution binding with no variables (ASK-like edge case or a bare
+  // `SELECT *` against zero triples) comes through as `[{}]` — an empty
+  // columns list with a one-row carrier. Render it as empty.
+  if (columns.length === 0) {
+    return { ok: true, output: { type: 'table', columns: [], rows: [] } };
+  }
+  const tableRows = rows.map((r) => columns.map((c) => r[c] ?? ''));
+  return { ok: true, output: { type: 'table', columns, rows: tableRows } };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,11 +5,13 @@ import { registerIpcHandlers } from './ipc';
 import { buildMenu } from './menu';
 import { createWindow, openProjectInWindow } from './window-manager';
 import { loadSession } from './session';
+import { registerBuiltinExecutors } from './compute/executors';
 
 app.setName('Minerva');
 
 app.whenReady().then(async () => {
   registerIpcHandlers();
+  registerBuiltinExecutors();
 
   const session = loadSession().filter((s) => {
     try { return fs.statSync(s.rootPath).isDirectory(); } catch { return false; }

--- a/tests/main/compute/sparql-executor.test.ts
+++ b/tests/main/compute/sparql-executor.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { executeSparql } from '../../../src/main/compute/executors/sparql';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sparql-exec-test-'));
+}
+
+const CTX = { rootPath: '/tmp/ignored' };
+
+describe('executeSparql (#239)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns a typed table output with columns taken from the first binding', async () => {
+    await indexNote('foo.md', '---\ntitle: "Foo"\n---\n\nhi');
+    await indexNote('bar.md', '---\ntitle: "Bar"\n---\n\nhi');
+
+    const result = await executeSparql(
+      'SELECT ?title ?path WHERE { ?n a minerva:Note . ?n dc:title ?title . ?n minerva:relativePath ?path } ORDER BY ?title',
+      CTX,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.output.type).toBe('table');
+    if (result.output.type !== 'table') return;
+    expect(result.output.columns).toEqual(['title', 'path']);
+    expect(result.output.rows).toEqual([
+      ['Bar', 'bar.md'],
+      ['Foo', 'foo.md'],
+    ]);
+  });
+
+  it('returns an empty table (no columns, no rows) when the query matches nothing', async () => {
+    const result = await executeSparql(
+      'SELECT ?x WHERE { ?x minerva:definitelyDoesNotExist "nope" }',
+      CTX,
+    );
+    expect(result).toEqual({
+      ok: true,
+      output: { type: 'table', columns: [], rows: [] },
+    });
+  });
+
+  it('surfaces SPARQL syntax errors as ok:false rather than throwing', async () => {
+    // Unclosed WHERE clause — the parser bails; queryGraph surfaces the
+    // error through its response envelope rather than throwing.
+    const result = await executeSparql('SELECT ?x WHERE { ?x ?p', CTX);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/parse/i);
+  });
+});


### PR DESCRIPTION
## Summary

First concrete language on top of the compute shell (#238). A ```` ```sparql ```` fence in any note is now runnable — click the ▶ in the editor gutter or hit `Cmd+Shift+Enter` inside the fence, and the companion ```` ```output ```` block below fills with a `{type:"table", columns, rows}` payload that the preview renders as an HTML table.

Dispatches through the same `queryGraph` path the Query Panel already uses, so identical SPARQL in a fence and in a query tab produces identical rows.

## What's in the box

- **`src/main/compute/executors/sparql.ts`** — `executeSparql` calls `queryGraph`, reshapes bindings into the `type:"table"` cell output.
- **`src/main/compute/executors/index.ts`** — `registerBuiltinExecutors()` wires every bundled executor into the registry. Called once from `main.ts` after `registerIpcHandlers()`. This is where #240 SQL and #242 Python slot in when their executors land.
- **`src/main/main.ts`** — call site for the registration.

## Result-shape notes worth flagging

- **Column union across all bindings**, not just the first row's keys. SPARQL `OPTIONAL` clauses leave variables unbound in some rows; keying off the first would drop those columns for every other row that does have them.
- **`{"results":[{}]}` — the empty-binding edge case** that Comunica emits for `SELECT *` over zero matching triples — surfaces as an empty-rows table rather than a one-row no-column artefact the preview would render as a ghost.
- **Parser errors come back through `queryGraph`'s `{error}` envelope**, not as thrown exceptions. We unwrap the envelope into a cell-level `ok: false` so the output block shows the parser message rather than the cell crashing.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1263/1263 (3 new: multi-column ordered result, empty result, parse error)
- [ ] Manual: paste ```` ```sparql\nSELECT ?t WHERE { ?n a minerva:Note . ?n dc:title ?t }\n``` ```` into a note, click ▶ → table of note titles appears below
- [ ] Manual: a bad query (unclosed brace) → output block contains a `{type:"error"}` payload rendered as a red-accented panel
- [ ] Manual: re-running the same fence replaces the existing `output` block rather than appending a new one

## Depends on

- #238 (notebook execution shell) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)