### PR TITLE
Fix Zotero RDF import: namespace import of rdflib

### DIFF
--- a/src/main/sources/import-zotero-rdf.ts
+++ b/src/main/sources/import-zotero-rdf.ts
@@ -21,7 +21,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import $rdf from 'rdflib';
+import * as $rdf from 'rdflib';
 import type { IndexedFormula, NamedNode, Node } from 'rdflib';
 import { canonicalSourceId } from './source-id';
 import { buildMetaTtl } from './ingest-identifier';


### PR DESCRIPTION
## Summary

`import \$rdf from 'rdflib'` worked under vitest (CJS-interop resolver) but broke Vite's main-process ESM bundle at \`pnpm dev\` with:

> "default" is not exported by "node_modules/rdflib/esm/index.js"

Switched to \`import * as \$rdf from 'rdflib'\` — works under both resolvers. No other changes; the 14 Zotero RDF tests still pass.