### PR TITLE
Fix compute-cells ▶ gutter hidden when line numbers are off

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -202,7 +202,7 @@
         ]),
         wrapCompartment.reconfigure(settings.wordWrap ? EditorView.lineWrapping : []),
         lineNumbersCompartment.reconfigure(settings.lineNumbers ? [] : EditorView.theme({
-          '.cm-gutters': { display: 'none' },
+          '.cm-gutter.cm-lineNumbers': { display: 'none' },
         })),
         whitespaceCompartment.reconfigure(settings.showWhitespace ? highlightWhitespace() : []),
       ],
@@ -401,7 +401,7 @@
     ]),
     wrapCompartment.of(initSettings.wordWrap ? EditorView.lineWrapping : []),
     lineNumbersCompartment.of(initSettings.lineNumbers ? [] : EditorView.theme({
-      '.cm-gutters': { display: 'none' },
+      '.cm-gutter.cm-lineNumbers': { display: 'none' },
     })),
     whitespaceCompartment.of(initSettings.showWhitespace ? highlightWhitespace() : []),
     linkDecorations({


### PR DESCRIPTION
## Summary

The line-numbers toggle worked by hiding the whole \`.cm-gutters\` container via a theme rule. Fine when there was only one gutter, but #238 added a second — the compute-cells ▶ run button — so turning line numbers off silently broke cell execution. The gutter stopped rendering, which meant the click handler never fired, which looked exactly like "nothing happens when I click ▶."

Scoping the rule to the line-numbers-specific child gutter (\`.cm-gutter.cm-lineNumbers\`) keeps the container visible for sibling gutters. Same fix on both the initial-mount path and the settings-reconfigure path.

No test (CSS-driven visibility isn't covered by the existing suite).