### PR TITLE
Fix: ▶ did nothing when the fence was the last thing in the doc

### DIFF
--- a/src/renderer/lib/editor/output-block.ts
+++ b/src/renderer/lib/editor/output-block.ts
@@ -165,9 +165,17 @@ export function findRunnableFences(
     if (close < 0) break; // unclosed fence; stop scanning
     if (allowed.has(language.toLowerCase())) {
       const startOffset = lineOffsets[i];
-      // endOffset: position just after the closing ```'s newline.
-      const endOffset = lineOffsets[close] + lines[close].length
-        + (close + 1 < lineOffsets.length ? 1 : 0); // +1 for the newline if present
+      // endOffset: position just after the closing ```. When the closing
+      // line is followed by more content (`close < lines.length - 1`),
+      // a `\n` sits between the closing ``` and the next line, so we
+      // skip past it. When the fence is the last thing in the doc —
+      // no trailing newline — endOffset stops at doc.length. Without
+      // this the offset ran one past the end, which made subsequent
+      // `view.dispatch({ changes: { from: endOffset } })` calls silently
+      // no-op in CodeMirror, breaking output-block writes for any note
+      // that ended with an executable fence.
+      const hasTrailingNewline = close < lines.length - 1;
+      const endOffset = lineOffsets[close] + lines[close].length + (hasTrailingNewline ? 1 : 0);
       out.push({
         startOffset,
         endOffset,

--- a/tests/renderer/editor/output-block.test.ts
+++ b/tests/renderer/editor/output-block.test.ts
@@ -51,6 +51,21 @@ describe('findRunnableFences (#238)', () => {
     expect(fences).toHaveLength(1);
     expect(fences[0].language).toBe('SPARQL');
   });
+
+  it('endOffset stops at doc.length when the fence is the last line (no trailing newline)', () => {
+    // Regression: running a fence that ended with no trailing \n set
+    // endOffset past the doc end, and view.dispatch silently no-op'd.
+    const doc = '# Title\n\n```sparql\nSELECT 1\n```';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(fence.endOffset).toBe(doc.length);
+  });
+
+  it('endOffset includes the trailing newline when one is present', () => {
+    const doc = '```sparql\nSELECT 1\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(fence.endOffset).toBe(doc.length);
+    expect(doc[fence.endOffset - 1]).toBe('\n');
+  });
 });
 
 describe('findAdjacentOutputBlock', () => {


### PR DESCRIPTION
Root cause: \`findRunnableFences\` treated the closing \`\`\`\` line as always followed by a \`\\n\`. For a fence at EOF without a trailing newline, \`endOffset\` ran one past \`doc.length\`, and every downstream \`view.dispatch({ changes: { from: endOffset } })\` silently no-op'd — the ▶ icon rendered, the click fired, the SPARQL executor ran, but the output block never landed because CodeMirror rejected the out-of-range edit.

Two new regression tests (one EOF, one trailing-newline) so this can't come back.