### PR TITLE
Compute: SQL fence executor (closes #240)

### DIFF
--- a/src/main/compute/executors/index.ts
+++ b/src/main/compute/executors/index.ts
@@ -5,7 +5,9 @@
 
 import { registerExecutor } from '../registry';
 import { executeSparql } from './sparql';
+import { executeSql } from './sql';
 
 export function registerBuiltinExecutors(): void {
   registerExecutor('sparql', executeSparql);
+  registerExecutor('sql', executeSql);
 }

--- a/src/main/compute/executors/sql.ts
+++ b/src/main/compute/executors/sql.ts
@@ -1,0 +1,42 @@
+/**
+ * SQL fence executor (#240) — second concrete language on top of the
+ * compute shell (#238), sibling to #239's SPARQL path. A ```sql fence
+ * runs through the same DuckDB connection the Query Panel uses, so
+ * `SELECT * FROM foo` in a fence and in a query tab return identical
+ * rows.
+ */
+
+import { runQuery } from '../../sources/tables';
+import type { ExecutorFn } from '../registry';
+
+/**
+ * Run a SQL statement against the project's DuckDB. On success, returns
+ * a `type:"table"` cell output with rows normalised into the cell-output
+ * primitive set (`string | number | boolean | null`) so the preview
+ * renderer can draw them without running a JSON type check per cell.
+ * BigInts stringify (DuckDB returns INTEGER columns as BigInt); Dates
+ * become ISO strings; everything else passes through as-is.
+ */
+export const executeSql: ExecutorFn = async (code) => {
+  const response = await runQuery(code);
+  if (!response.ok) return { ok: false, error: response.error };
+  return {
+    ok: true,
+    output: {
+      type: 'table',
+      columns: response.columns,
+      rows: response.rows.map((row) => response.columns.map((c) => normalizeCell(row[c]))),
+    },
+  };
+};
+
+function normalizeCell(v: unknown): string | number | boolean | null {
+  if (v == null) return null;
+  if (typeof v === 'bigint') return v.toString();
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return v;
+  // Arrays / structs / maps — DuckDB nested types don't have a canonical
+  // primitive rendering; stringify as JSON so the table stays legible
+  // rather than showing `[object Object]`.
+  return JSON.stringify(v);
+}

--- a/tests/main/compute/sql-executor.test.ts
+++ b/tests/main/compute/sql-executor.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initTablesDb,
+  closeTablesDb,
+  registerCsv,
+} from '../../../src/main/sources/tables';
+import { executeSql } from '../../../src/main/compute/executors/sql';
+
+const CTX = { rootPath: '/tmp/minerva-sql-exec-test' };
+
+describe('executeSql (#240)', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sql-exec-test-'));
+    await initTablesDb(root);
+    await fsp.writeFile(
+      path.join(root, 'data.csv'),
+      'name,count\nalpha,1\nbeta,2\ngamma,3\n',
+    );
+    await registerCsv(root, 'data.csv');
+  });
+
+  afterAll(async () => {
+    await closeTablesDb();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns a typed table output with columns + row arrays', async () => {
+    const result = await executeSql('SELECT name, count FROM data ORDER BY name', CTX);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.output.type !== 'table') return;
+    expect(result.output.columns).toEqual(['name', 'count']);
+    // DuckDB returns INTEGER as BigInt; normalizeCell stringifies bigints so
+    // the preview can render them without JSON reviver hoops.
+    expect(result.output.rows).toEqual([
+      ['alpha', '1'],
+      ['beta', '2'],
+      ['gamma', '3'],
+    ]);
+  });
+
+  it('surfaces SQL syntax errors as ok:false rather than throwing', async () => {
+    const result = await executeSql('SELEKT * FROM data', CTX);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.length).toBeGreaterThan(0);
+  });
+
+  it('normalises nulls into JSON null rather than empty strings', async () => {
+    const result = await executeSql(`SELECT NULL AS x, 'hi' AS y`, CTX);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.output.type !== 'table') return;
+    expect(result.output.rows).toEqual([[null, 'hi']]);
+  });
+
+  it('normalises DuckDB Date values to ISO strings', async () => {
+    const result = await executeSql(`SELECT DATE '2024-10-15' AS d`, CTX);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.output.type !== 'table') return;
+    const cell = result.output.rows[0][0];
+    // DuckDB + the Node client may surface dates as Date objects OR as
+    // ISO-ish strings depending on type binding — accept either but
+    // require the row dropped us a parseable date-shaped string.
+    expect(typeof cell === 'string' ? cell : '').toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});


### PR DESCRIPTION
## Summary

Second concrete language on top of the compute shell (#238), sibling to #239's SPARQL path. A ```` ```sql ```` fence in any note now runs through the same DuckDB connection the Query Panel uses.

## What's in the box

- **`src/main/compute/executors/sql.ts`** — `executeSql` calls `runQuery` and reshapes rows into the cell-output primitive set (`string | number | boolean | null`) so the preview renderer doesn't have to reason about JSON types cell-by-cell.
- **Registration** — slots into `registerBuiltinExecutors()` next to SPARQL.

## Normalisation rules

| Input | Output |
|---|---|
| `bigint` (DuckDB INTEGER) | decimal string |
| `Date` | ISO string |
| `string` / `number` / `boolean` | passthrough |
| `null` | `null` (not coerced to `""`) |
| array / struct / map | JSON-stringified |

BigInt stringification matters because DuckDB returns INTEGER columns as `BigInt`; without this the preview would render `[object BigInt]` or hit JSON-serialisation errors on the IPC boundary.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1269/1269 (4 new: happy path with INTEGER bigint stringification, syntax error → `ok:false`, NULL preservation, Date normalization)
- [ ] Manual: drop a CSV, write ```` ```sql\nSELECT * FROM <name>\n``` ```` → ▶ renders the table
- [ ] Manual: `SELECT * FROM nonexistent` → output block contains a `{type:"error"}` payload, no crash
- [ ] Manual: re-running the same fence replaces the output block in place

## Depends on

- #238 (compute shell) — merged
- #232, #233 (DuckDB + CSV ingestion) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)