### PR TITLE
Compute: save output as note with provenance (progress on #244)

### DIFF
--- a/src/main/compute/registry.ts
+++ b/src/main/compute/registry.ts
@@ -11,19 +11,8 @@
  * result the shell surfaces as an error output block.
  */
 
-export type CellResult =
-  | { ok: true; output: CellOutput }
-  | { ok: false; error: string };
-
-/**
- * Executor output. A discriminated union keyed on `type` so the preview
- * renderer can decide how to draw each shape without guessing. New shapes
- * (image, chart, html) extend this union when their executors land.
- */
-export type CellOutput =
-  | { type: 'table'; columns: string[]; rows: Array<Array<string | number | boolean | null>> }
-  | { type: 'text'; value: string }
-  | { type: 'json'; value: unknown };
+export type { CellOutput, CellResult } from '../../shared/compute/types';
+import type { CellResult } from '../../shared/compute/types';
 
 export interface ExecutorContext {
   /** Absolute path to the project root, so executors can read/write files. */

--- a/src/main/compute/save-cell-output.ts
+++ b/src/main/compute/save-cell-output.ts
@@ -1,0 +1,112 @@
+/**
+ * Save the output of a compute cell as a first-class note with
+ * provenance frontmatter (#244).
+ *
+ * Injects a stable `{id=…}` into the source fence (idempotent — reuses
+ * the existing id on re-save) and writes a derived note with a
+ * backlink pointing at `[[source-note#cell-<id>]]`, so the derived
+ * note surfaces on the source's backlinks panel.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from '../notebase/fs';
+import {
+  findRunnableFences,
+  codeOf,
+  type FenceRange,
+} from '../../renderer/lib/editor/output-block';
+import {
+  ensureCellId,
+  rewriteFenceInfo,
+  parseFenceInfo,
+} from '../../shared/compute/cell-id';
+import {
+  buildDerivedNote,
+  defaultDerivedNotePath,
+} from '../../shared/compute/derived-note';
+import type { CellOutput } from '../../shared/compute/types';
+
+export interface SaveCellOutputInput {
+  /** Relative path of the note that owns the source cell. */
+  sourcePath: string;
+  /** Fence language (`sparql`, `sql`, …) — disambiguates the fence in the source. */
+  cellLanguage: string;
+  /** Exact cell body, used to find the matching fence in the current source doc. */
+  cellCode: string;
+  /** The output to serialise. */
+  output: CellOutput;
+  /** Destination relative path. When omitted, a sensible default under `notes/derived/` is chosen. */
+  destPath?: string;
+  /** Optional explicit title; default is `<source-stem> — cell <id>`. */
+  title?: string;
+}
+
+export interface SaveCellOutputResult {
+  /** Relative path where the derived note was written. */
+  derivedPath: string;
+  /** The cell id used (newly generated or pre-existing). */
+  cellId: string;
+  /** True when this save had to inject a new id into the source fence. */
+  injectedId: boolean;
+}
+
+export async function saveCellOutput(
+  rootPath: string,
+  input: SaveCellOutputInput,
+): Promise<SaveCellOutputResult> {
+  // Re-read the source doc to find the fence. Matching by (language, exact
+  // code) is the same heuristic the editor extension uses when applying an
+  // output-block edit after an awaited run.
+  const sourceContent = await notebaseFs.readFile(rootPath, input.sourcePath);
+  const allowed = new Set([input.cellLanguage.toLowerCase()]);
+  const fence = findRunnableFences(sourceContent, allowed).find(
+    (f) => codeOf(sourceContent, f) === input.cellCode,
+  );
+  if (!fence) {
+    throw new Error(
+      `Could not locate the ${input.cellLanguage} cell in ${input.sourcePath}. ` +
+      `The cell body may have changed since the output was produced.`,
+    );
+  }
+
+  // Ensure the fence carries a stable id, rewriting the source doc if we
+  // had to mint one. Re-saves against an already-annotated cell reuse
+  // the existing id.
+  const fenceInfo = extractFenceInfo(sourceContent, fence);
+  const { id: cellId, newInfo, wasNew } = ensureCellId(fenceInfo);
+  if (wasNew) {
+    const rewritten = rewriteFenceInfo(sourceContent, fence.startOffset, newInfo);
+    await notebaseFs.writeFile(rootPath, input.sourcePath, rewritten);
+  }
+
+  const derivedPath = input.destPath ?? defaultDerivedNotePath(input.sourcePath, cellId);
+  const markdown = buildDerivedNote({
+    title: input.title,
+    output: input.output,
+    sourcePath: input.sourcePath,
+    cellId,
+  });
+
+  const destFull = path.join(rootPath, derivedPath);
+  await fs.mkdir(path.dirname(destFull), { recursive: true });
+  await fs.writeFile(destFull, markdown, 'utf-8');
+
+  return { derivedPath, cellId, injectedId: wasNew };
+}
+
+/**
+ * Pull the info string (everything after the opening backticks on the
+ * fence's first line) so we can run it through the cell-id helpers.
+ */
+function extractFenceInfo(doc: string, fence: FenceRange): string {
+  const lineEnd = doc.indexOf('\n', fence.startOffset);
+  const stop = lineEnd < 0 ? doc.length : lineEnd;
+  const line = doc.slice(fence.startOffset, stop);
+  const m = line.match(/^`{3,}(.*)$/);
+  return m ? m[1] : '';
+}
+
+// Re-export for type-checkers that prefer a named symbol over the
+// structural import through `parseFenceInfo`.
+export { parseFenceInfo };

--- a/src/main/graph/frontmatter-predicates.ts
+++ b/src/main/graph/frontmatter-predicates.ts
@@ -10,7 +10,7 @@
  * minor spelling differences.
  */
 
-export type FrontmatterNamespace = 'dc' | 'bibo' | 'schema' | 'thought';
+export type FrontmatterNamespace = 'dc' | 'bibo' | 'schema' | 'thought' | 'prov';
 
 export interface FrontmatterPredicate {
   ns: FrontmatterNamespace;
@@ -21,6 +21,7 @@ const DC = (local: string): FrontmatterPredicate => ({ ns: 'dc', local });
 const BIBO = (local: string): FrontmatterPredicate => ({ ns: 'bibo', local });
 const SCHEMA = (local: string): FrontmatterPredicate => ({ ns: 'schema', local });
 const THOUGHT = (local: string): FrontmatterPredicate => ({ ns: 'thought', local });
+const PROV = (local: string): FrontmatterPredicate => ({ ns: 'prov', local });
 
 const MAP: Record<string, FrontmatterPredicate> = {
   // Dublin Core
@@ -57,6 +58,11 @@ const MAP: Record<string, FrontmatterPredicate> = {
   // thought:* (source-specific bits we define)
   accessedAt: THOUGHT('accessedAt'),
   archivedAt: THOUGHT('archivedAt'),
+
+  // prov:* (provenance — #244 derived notes)
+  derived_from: PROV('wasDerivedFrom'),
+  derived_at: PROV('generatedAtTime'),
+  derived_from_cell: THOUGHT('derivedFromCell'),
 };
 
 export function mapFrontmatterKey(key: string): FrontmatterPredicate | null {

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -57,6 +57,7 @@ const XSD     = $rdf.Namespace('http://www.w3.org/2001/XMLSchema#');
 const CSVW    = $rdf.Namespace('http://www.w3.org/ns/csvw#');
 const BIBO    = $rdf.Namespace('http://purl.org/ontology/bibo/');
 const SCHEMA  = $rdf.Namespace('http://schema.org/');
+const PROV    = $rdf.Namespace('http://www.w3.org/ns/prov#');
 
 let baseUri = '';      // e.g. https://project.minerva.dev/dave/my-notes/
 let store: $rdf.IndexedFormula | null = null;
@@ -211,6 +212,7 @@ function resolveFrontmatterPredicate(key: string) {
     case 'bibo': return BIBO(mapped.local);
     case 'schema': return SCHEMA(mapped.local);
     case 'thought': return THOUGHT(mapped.local);
+    case 'prov': return PROV(mapped.local);
   }
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -36,6 +36,7 @@ import { importBibtex } from './sources/import-bibtex';
 import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
 import { runCell as runComputeCell, registeredLanguages as computeLanguages } from './compute/registry';
+import { saveCellOutput, type SaveCellOutputInput } from './compute/save-cell-output';
 import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
@@ -699,6 +700,12 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(Channels.COMPUTE_LANGUAGES, () => computeLanguages());
+
+  ipcMain.handle(Channels.COMPUTE_SAVE_CELL_OUTPUT, async (e, input: SaveCellOutputInput) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await saveCellOutput(rootPath, input);
+  });
 
   ipcMain.handle(Channels.SOURCES_IMPORT_BIBTEX, async (e) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -113,6 +113,8 @@ contextBridge.exposeInMainWorld('api', {
     runCell: (language: string, code: string, notePath?: string) =>
       ipcRenderer.invoke(Channels.COMPUTE_RUN_CELL, language, code, notePath),
     languages: () => ipcRenderer.invoke(Channels.COMPUTE_LANGUAGES),
+    saveCellOutput: (input: unknown) =>
+      ipcRenderer.invoke(Channels.COMPUTE_SAVE_CELL_OUTPUT, input),
   },
   shell: {
     revealFile: (relativePath?: string) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -771,6 +771,36 @@
     }
   }
 
+  async function handleSaveCellOutput(payload: {
+    cellLanguage: string;
+    cellCode: string;
+    output: import('../shared/compute/types').CellOutput;
+  }): Promise<void> {
+    if (!notebase.meta) return;
+    const sourcePath = editor.activeFilePath;
+    if (!sourcePath) return;
+    const dest = await showPrompt(
+      `Save cell output as note. Path (default: notes/derived/):`,
+    );
+    if (dest === null) return; // user cancelled
+    const trimmed = dest.trim();
+    try {
+      const result = await api.compute.saveCellOutput({
+        sourcePath,
+        cellLanguage: payload.cellLanguage,
+        cellCode: payload.cellCode,
+        output: payload.output,
+        destPath: trimmed.length > 0 ? trimmed : undefined,
+      });
+      // Refresh the file tree so the new note is selectable, then open it.
+      await notebase.refresh();
+      setTimeout(() => handleFileSelect(result.derivedPath), 100);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Save cell output failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
   async function handleIngestPdf() {
     if (!notebase.meta) return;
     try {
@@ -1509,6 +1539,7 @@
                   pendingAnchor={pendingPreviewAnchor}
                   onAnchorResolved={() => { pendingPreviewAnchor = null; }}
                   onTaskToggle={handleTaskToggle}
+                  onSaveCellOutput={handleSaveCellOutput}
                 />
               </div>
             {/if}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -22,9 +22,19 @@
     onAnchorResolved?: () => void;
     /** Fired when a rendered task-list checkbox is toggled. Line is 0-indexed. */
     onTaskToggle?: (lineIndex: number) => void;
+    /**
+     * Save-as-note action on a compute-output block (#244). Receives the
+     * source fence and payload; the caller prompts for a destination path,
+     * invokes `api.compute.saveCellOutput`, and opens the new note.
+     */
+    onSaveCellOutput?: (payload: {
+      cellLanguage: string;
+      cellCode: string;
+      output: import('../../../shared/compute/types').CellOutput;
+    }) => void;
   }
 
-  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved, onTaskToggle }: Props = $props();
+  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved, onTaskToggle, onSaveCellOutput }: Props = $props();
 
   // Query result cache: query text → results (survives re-renders)
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
@@ -233,14 +243,44 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   md.renderer.rules.fence = (tokens, idx, options, env, self) => {
     const tok = tokens[idx];
     if (tok.info.trim() === 'output') {
-      return renderComputeOutput(tok.content);
+      const source = findSourceFenceBefore(tokens as Token[], idx);
+      return renderComputeOutput(tok.content, source);
     }
     return defaultFence
       ? defaultFence(tokens, idx, options, env, self)
       : self.renderToken(tokens, idx, options);
   };
 
-  function renderComputeOutput(content: string): string {
+  /**
+   * Walk backwards from the output fence token to find the executable
+   * fence that produced it. Returns null when anything other than
+   * whitespace sits between the two — a loose sanity check that keeps
+   * us from wiring a Save-as-note action to the wrong source when users
+   * paste an isolated output block.
+   */
+  function findSourceFenceBefore(tokens: Token[], idx: number): { language: string; code: string } | null {
+    const RUNNABLE = new Set(['sparql', 'sql', 'python']);
+    for (let i = idx - 1; i >= 0; i--) {
+      const t = tokens[i];
+      if (t.type === 'fence') {
+        const lang = (t.info ?? '').trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+        if (RUNNABLE.has(lang)) {
+          return { language: lang, code: (t.content ?? '').replace(/\n$/, '') };
+        }
+        return null;
+      }
+      // Any heading / paragraph / blockquote between the two fences means
+      // the output block isn't adjacent to a runnable source — bail.
+      if (t.type === 'paragraph_open' || t.type === 'heading_open' ||
+          t.type === 'blockquote_open' || t.type === 'bullet_list_open' ||
+          t.type === 'ordered_list_open') {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  function renderComputeOutput(content: string, source: { language: string; code: string } | null): string {
     let payload: unknown;
     try {
       payload = JSON.parse(content.trim());
@@ -248,18 +288,19 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       return `<pre class="compute-output compute-output-raw">${escapeHtml(content)}</pre>`;
     }
     const p = payload as { type?: string } & Record<string, unknown>;
+    let inner: string;
+    let saveable = false;
     if (!p || typeof p !== 'object' || typeof p.type !== 'string') {
-      return `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
-    }
-    if (p.type === 'error') {
+      inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+    } else if (p.type === 'error') {
       const message = typeof p.message === 'string' ? p.message : JSON.stringify(p.message);
-      return `<div class="compute-output compute-output-error">${escapeHtml(message)}</div>`;
-    }
-    if (p.type === 'text') {
+      inner = `<div class="compute-output compute-output-error">${escapeHtml(message)}</div>`;
+      // Errors aren't worth saving as notes; skip the overflow menu.
+    } else if (p.type === 'text') {
       const value = typeof p.value === 'string' ? p.value : JSON.stringify(p.value);
-      return `<pre class="compute-output compute-output-text">${escapeHtml(value)}</pre>`;
-    }
-    if (p.type === 'table' && Array.isArray(p.columns) && Array.isArray(p.rows)) {
+      inner = `<pre class="compute-output compute-output-text">${escapeHtml(value)}</pre>`;
+      saveable = true;
+    } else if (p.type === 'table' && Array.isArray(p.columns) && Array.isArray(p.rows)) {
       const columns = p.columns as string[];
       const rows = p.rows as Array<Array<string | number | boolean | null>>;
       const headers = columns.map((c) => `<th>${escapeHtml(c)}</th>`).join('');
@@ -267,13 +308,29 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         const cells = r.map((v) => `<td>${escapeHtml(v == null ? '' : String(v))}</td>`).join('');
         return `<tr>${cells}</tr>`;
       }).join('');
-      return `<table class="compute-output compute-output-table"><thead><tr>${headers}</tr></thead><tbody>${body}</tbody></table>`;
+      inner = `<table class="compute-output compute-output-table"><thead><tr>${headers}</tr></thead><tbody>${body}</tbody></table>`;
+      saveable = true;
+    } else if (p.type === 'json') {
+      inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(p.value, null, 2))}</pre>`;
+      saveable = true;
+    } else {
+      // Unknown type — show the raw JSON so the user can tell what came back.
+      inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
     }
-    if (p.type === 'json') {
-      return `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(p.value, null, 2))}</pre>`;
+
+    // Wrap the rendered output with a ⋯ overflow-menu button when we have
+    // enough context to offer save/copy actions — the output payload
+    // parses cleanly, its type is saveable, and we found the source
+    // fence it came from (so we know what cell to attribute back).
+    if (saveable && source) {
+      const outputB64 = btoa(unescape(encodeURIComponent(JSON.stringify(payload))));
+      const codeB64 = btoa(unescape(encodeURIComponent(source.code)));
+      return `<div class="compute-output-wrap" data-source-language="${escapeAttr(source.language)}" data-source-code-b64="${outputB64.length > 0 ? codeB64 : ''}" data-output-b64="${outputB64}">
+        <button class="compute-output-menu-btn" type="button" title="Output options">⋯</button>
+        ${inner}
+      </div>`;
     }
-    // Unknown type — show the raw JSON so the user can tell what came back.
-    return `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+    return inner;
   }
 
   // Query directive plugin: :::query-list ... :::
@@ -756,7 +813,90 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       e.preventDefault();
       const tag = tagEl.dataset.tag;
       if (tag && onTagSelect) onTagSelect(tag);
+      return;
     }
+
+    // Compute-output overflow menu (#244).
+    const menuBtn = el.closest<HTMLElement>('.compute-output-menu-btn');
+    if (menuBtn) {
+      e.preventDefault();
+      e.stopPropagation();
+      const wrap = menuBtn.closest<HTMLElement>('.compute-output-wrap');
+      if (!wrap) return;
+      openOutputMenu(menuBtn, wrap);
+    }
+  }
+
+  // ── Compute-output overflow menu state (#244) ──────────────────────────────
+
+  let outputMenu = $state<{
+    x: number;
+    y: number;
+    source: { language: string; code: string };
+    output: import('../../../shared/compute/types').CellOutput;
+  } | null>(null);
+
+  function openOutputMenu(btn: HTMLElement, wrap: HTMLElement): void {
+    try {
+      const outputB64 = wrap.dataset.outputB64 ?? '';
+      const codeB64 = wrap.dataset.sourceCodeB64 ?? '';
+      const language = wrap.dataset.sourceLanguage ?? '';
+      if (!outputB64 || !codeB64 || !language) return;
+      const output = JSON.parse(decodeURIComponent(escape(atob(outputB64))));
+      const code = decodeURIComponent(escape(atob(codeB64)));
+      const rect = btn.getBoundingClientRect();
+      outputMenu = {
+        x: rect.left,
+        y: rect.bottom + 2,
+        source: { language, code },
+        output,
+      };
+      const close = (ev: MouseEvent) => {
+        const target = ev.target as HTMLElement | null;
+        if (target?.closest('.compute-output-menu')) return;
+        outputMenu = null;
+        window.removeEventListener('click', close);
+      };
+      setTimeout(() => window.addEventListener('click', close), 0);
+    } catch {
+      outputMenu = null;
+    }
+  }
+
+  function handleSaveAsNote(): void {
+    if (!outputMenu || !onSaveCellOutput) return;
+    onSaveCellOutput({
+      cellLanguage: outputMenu.source.language,
+      cellCode: outputMenu.source.code,
+      output: outputMenu.output,
+    });
+    outputMenu = null;
+  }
+
+  function handleCopyAsMarkdown(): void {
+    if (!outputMenu) return;
+    // Render the output as markdown-table / code-block, matching the
+    // derived-note builder's body format so a user-pasted block looks the
+    // same as a "Save as note" output.
+    const md = outputToMarkdownClipboard(outputMenu.output);
+    navigator.clipboard.writeText(md);
+    outputMenu = null;
+  }
+
+  function outputToMarkdownClipboard(output: import('../../../shared/compute/types').CellOutput): string {
+    if (output.type === 'table') {
+      if (output.columns.length === 0) return '*(empty result)*';
+      const esc = (s: string) => s.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+      const header = `| ${output.columns.map(esc).join(' | ')} |`;
+      const divider = `| ${output.columns.map(() => '---').join(' | ')} |`;
+      const body = output.rows.map((r) =>
+        `| ${r.map((v) => esc(v == null ? '' : String(v))).join(' | ')} |`,
+      );
+      return [header, divider, ...body].join('\n');
+    }
+    if (output.type === 'text') return '```\n' + output.value.replace(/\n$/, '') + '\n```';
+    if (output.type === 'json') return '```json\n' + JSON.stringify(output.value, null, 2) + '\n```';
+    return '```\n' + JSON.stringify(output) + '\n```';
   }
 
   let tooltipVisible = $state(false);
@@ -854,6 +994,15 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     {@html tooltipHtml}
   </div>
 </div>
+
+{#if outputMenu}
+  <div class="compute-output-menu" role="menu" style:left="{outputMenu.x}px" style:top="{outputMenu.y}px">
+    {#if onSaveCellOutput}
+      <button role="menuitem" onclick={handleSaveAsNote}>Save as note…</button>
+    {/if}
+    <button role="menuitem" onclick={handleCopyAsMarkdown}>Copy as markdown</button>
+  </div>
+{/if}
 
 <style>
   .preview {
@@ -1183,5 +1332,60 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     border-radius: 0 4px 4px 0;
     font-family: var(--font-mono, ui-monospace, monospace);
     white-space: pre-wrap;
+  }
+
+  /* Output overflow-menu button — sits in the top-right corner of each
+     saveable compute output, shows ⋯ on hover of the wrapper. */
+  .preview :global(.compute-output-wrap) {
+    position: relative;
+  }
+  .preview :global(.compute-output-menu-btn) {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: var(--bg-button);
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 6px;
+    font-size: 12px;
+    line-height: 16px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+  .preview :global(.compute-output-wrap:hover .compute-output-menu-btn),
+  .preview :global(.compute-output-menu-btn:focus) {
+    opacity: 1;
+  }
+  .preview :global(.compute-output-menu-btn:hover) {
+    color: var(--text);
+  }
+
+  .compute-output-menu {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 160px;
+    display: flex;
+    flex-direction: column;
+  }
+  .compute-output-menu button {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .compute-output-menu button:hover {
+    background: var(--bg-button);
   }
 </style>

--- a/src/renderer/lib/editor/output-block.ts
+++ b/src/renderer/lib/editor/output-block.ts
@@ -154,7 +154,10 @@ export function findRunnableFences(
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
-    const open = line.match(/^```(\w+)\s*$/);
+    // Accept optional post-language info (e.g. `sparql {id=abc}`), but
+    // require *some* language tag — an unlabeled ``` is a plain code
+    // block the compute shell leaves alone.
+    const open = line.match(/^```(\w+)(\s.*)?$/);
     if (!open) { i++; continue; }
     const language = open[1];
     // Find the closing fence.

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -114,20 +114,27 @@ export interface FilesApi {
   dropImport(targetFolder: string, localPaths: string[]): Promise<DropImportResult>;
 }
 
-export type CellOutput =
-  | { type: 'table'; columns: string[]; rows: Array<Array<string | number | boolean | null>> }
-  | { type: 'text'; value: string }
-  | { type: 'json'; value: unknown };
-
-export type CellResult =
-  | { ok: true; output: CellOutput }
-  | { ok: false; error: string };
+export type { CellOutput, CellResult } from '../../../shared/compute/types';
+import type { CellResult } from '../../../shared/compute/types';
 
 export interface ComputeApi {
   /** Dispatch a cell to its language's executor (#238). */
   runCell(language: string, code: string, notePath?: string): Promise<CellResult>;
   /** Every fence language that currently has a registered executor. */
   languages(): Promise<string[]>;
+  /**
+   * Save a cell's output as a first-class note with provenance frontmatter.
+   * Injects a stable `{id=…}` into the source fence when the cell doesn't
+   * already have one, so re-saves land on the same backlink anchor.
+   */
+  saveCellOutput(input: {
+    sourcePath: string;
+    cellLanguage: string;
+    cellCode: string;
+    output: import('../../../shared/compute/types').CellOutput;
+    destPath?: string;
+    title?: string;
+  }): Promise<{ derivedPath: string; cellId: string; injectedId: boolean }>;
 }
 
 export interface ShellApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -216,6 +216,8 @@ export const Channels = {
   COMPUTE_RUN_CELL: 'compute:runCell',
   /** List every fence language that has a registered executor. Drives the editor's gutter. */
   COMPUTE_LANGUAGES: 'compute:languages',
+  /** Save a cell's output as a first-class note with provenance (#244). */
+  COMPUTE_SAVE_CELL_OUTPUT: 'compute:saveCellOutput',
 
   // Renderer → main (for menu-triggered main-process actions)
   EXPORT_CSV: 'export:csv',

--- a/src/shared/compute/cell-id.ts
+++ b/src/shared/compute/cell-id.ts
@@ -1,0 +1,107 @@
+/**
+ * Cell-id infrastructure for notebook fences (#244).
+ *
+ * Executable fences can carry a stable id in their info string, Quarto-style:
+ *
+ *     ```sparql {id=9c8f3e21}
+ *     SELECT …
+ *     ```
+ *
+ * We inject the id lazily — on the first "Save as note" for that cell —
+ * and preserve it thereafter, so re-saving the same cell can find its
+ * previous destination rather than writing a duplicate note each time.
+ * Users never type these ids by hand; they're short (8 hex chars) and
+ * stay out of the way when reading the source.
+ */
+
+/**
+ * Parsed view of a fence info string.
+ *   `sparql`                       → { language: 'sparql', attrs: {} }
+ *   `sparql {id=abc123}`           → { language: 'sparql', attrs: { id: 'abc123' } }
+ *   `python {id=abc} {tag=chart}`  → { language: 'python', attrs: { id: 'abc', tag: 'chart' } }
+ */
+export interface ParsedFenceInfo {
+  language: string;
+  attrs: Record<string, string>;
+}
+
+export function parseFenceInfo(info: string): ParsedFenceInfo {
+  const trimmed = info.trim();
+  if (!trimmed) return { language: '', attrs: {} };
+
+  // Language is the first whitespace-delimited token.
+  const firstSpace = trimmed.search(/\s/);
+  const language = firstSpace < 0 ? trimmed : trimmed.slice(0, firstSpace);
+  const rest = firstSpace < 0 ? '' : trimmed.slice(firstSpace);
+
+  // Attribute tokens come in `{key=value}` braces. Values can hold any
+  // char except `}` and whitespace — simple enough to parse without a
+  // real tokenizer.
+  const attrs: Record<string, string> = {};
+  const attrRe = /\{([a-zA-Z_][a-zA-Z0-9_-]*)=([^\s}]+)\}/g;
+  for (const m of rest.matchAll(attrRe)) {
+    attrs[m[1]] = m[2];
+  }
+  return { language, attrs };
+}
+
+/**
+ * Serialize a parsed fence info back into a fence string. Attribute
+ * order is alphabetical for idempotence — `stringifyFenceInfo(parseFenceInfo(x))`
+ * is a canonical form rather than depending on the input ordering.
+ */
+export function stringifyFenceInfo(parsed: ParsedFenceInfo): string {
+  const keys = Object.keys(parsed.attrs).sort();
+  if (keys.length === 0) return parsed.language;
+  const parts = [parsed.language];
+  for (const k of keys) parts.push(`{${k}=${parsed.attrs[k]}}`);
+  return parts.join(' ');
+}
+
+/** 8-char lowercase-hex id. Collision-free for the scale of a thoughtbase. */
+export function generateCellId(): string {
+  // `crypto.randomUUID` is available in both main (Node ≥ 19) and
+  // renderer (modern Electron). Take the first 8 hex chars of its
+  // body — 32 bits, enough entropy for a library-of-notes scale.
+  const uuid = (globalThis.crypto as Crypto).randomUUID();
+  return uuid.replace(/-/g, '').slice(0, 8);
+}
+
+/**
+ * Ensure a fence info string carries an id. If one's already present,
+ * return it unchanged; otherwise generate a new id and splice it in.
+ * `newInfo` is the value to replace the fence's opening-line info with.
+ */
+export function ensureCellId(
+  info: string,
+  makeId: () => string = generateCellId,
+): { id: string; newInfo: string; wasNew: boolean } {
+  const parsed = parseFenceInfo(info);
+  const existing = parsed.attrs.id;
+  if (existing) {
+    return { id: existing, newInfo: info, wasNew: false };
+  }
+  const id = makeId();
+  const withId: ParsedFenceInfo = {
+    language: parsed.language,
+    attrs: { ...parsed.attrs, id },
+  };
+  return { id, newInfo: stringifyFenceInfo(withId), wasNew: true };
+}
+
+/**
+ * Apply an info-string update to the opening fence line at `startOffset`
+ * in a document. Returns the new doc text. Caller is responsible for
+ * ensuring `startOffset` really points at an opening ``` line.
+ */
+export function rewriteFenceInfo(doc: string, startOffset: number, newInfo: string): string {
+  const lineEnd = doc.indexOf('\n', startOffset);
+  const stop = lineEnd < 0 ? doc.length : lineEnd;
+  const opening = doc.slice(startOffset, stop);
+  // Preserve the opening backticks; replace the info portion.
+  const m = opening.match(/^(`{3,})/);
+  if (!m) return doc; // not a fence, don't mangle
+  const ticks = m[1];
+  const replacement = newInfo.trim() ? `${ticks}${newInfo}` : ticks;
+  return doc.slice(0, startOffset) + replacement + doc.slice(stop);
+}

--- a/src/shared/compute/derived-note.ts
+++ b/src/shared/compute/derived-note.ts
@@ -1,0 +1,142 @@
+/**
+ * Derived-note builder (#244).
+ *
+ * "Save cell output as a note" produces a markdown file that:
+ *
+ *   - Declares its provenance in frontmatter (`derived_from`,
+ *     `derived_from_cell`, `derived_at`) so the graph indexer can emit
+ *     `prov:wasDerivedFrom` triples.
+ *   - Renders the cell output as first-class markdown — a table for
+ *     `type:"table"`, a fenced code block for `text`, pretty JSON for
+ *     `json`.
+ *   - Closes with a prose paragraph that wiki-links back to the
+ *     originating cell — shows up as a backlink on the source note.
+ */
+
+import type { CellOutput } from './types';
+
+export interface BuildDerivedNoteInput {
+  /** Human-readable title. If omitted, derived from the source path. */
+  title?: string;
+  /** The cell output to serialize into the body. */
+  output: CellOutput;
+  /** Relative path of the note that owns the source cell. */
+  sourcePath: string;
+  /** Stable id of the source cell (from its fence info string). */
+  cellId: string;
+  /** Override the timestamp (tests use a fixed clock). */
+  now?: () => Date;
+}
+
+export function buildDerivedNote(input: BuildDerivedNoteInput): string {
+  const now = (input.now ?? (() => new Date()))().toISOString();
+  const title = input.title ?? defaultTitleFrom(input.sourcePath, input.cellId);
+
+  // `derived_from` is emitted as a wiki-link form so the frontmatter
+  // indexer resolves it to the source note's URI — that's what lets
+  // backlinks show the derived note on the source's backlinks panel.
+  // The indexer drops the `.md`, so we do too for canonical form.
+  const sourceTarget = input.sourcePath.replace(/\.md$/i, '');
+  const frontmatter = [
+    '---',
+    `title: ${yamlString(title)}`,
+    `derived_from: ${yamlString(`[[${sourceTarget}]]`)}`,
+    `derived_from_cell: ${yamlString(input.cellId)}`,
+    `derived_at: ${yamlString(now)}`,
+    `derived_tool: minerva-compute`,
+    `tags: [derived]`,
+    '---',
+  ].join('\n');
+
+  const body = renderOutputToMarkdown(input.output);
+
+  // Wiki-link target is the source note's basename (anchors on its
+  // `cell-<id>` slug), matching Minerva's existing `[[path#anchor]]`
+  // linking convention. The graph indexer treats this as a real
+  // incoming link, so backlinks on the source note surface the new
+  // derived note automatically.
+  const backlinkTarget = linkTargetForSource(input.sourcePath);
+  const backlink = `*Derived from [[${backlinkTarget}#cell-${input.cellId}]] on ${now.slice(0, 10)}.*`;
+
+  return `${frontmatter}\n\n# ${escapeHeading(title)}\n\n${body}\n\n${backlink}\n`;
+}
+
+// ── Output → markdown ──────────────────────────────────────────────────────
+
+export function renderOutputToMarkdown(output: CellOutput): string {
+  if (output.type === 'table') {
+    return renderTableToMarkdown(output.columns, output.rows);
+  }
+  if (output.type === 'text') {
+    return '```\n' + output.value.replace(/\n$/, '') + '\n```';
+  }
+  if (output.type === 'json') {
+    return '```json\n' + JSON.stringify(output.value, null, 2) + '\n```';
+  }
+  // Exhaustiveness — current CellOutput union covers the three above.
+  return '```\n' + JSON.stringify(output) + '\n```';
+}
+
+function renderTableToMarkdown(
+  columns: string[],
+  rows: Array<Array<string | number | boolean | null>>,
+): string {
+  if (columns.length === 0) return '*(empty result)*';
+  const header = `| ${columns.map(escapeTableCell).join(' | ')} |`;
+  const divider = `| ${columns.map(() => '---').join(' | ')} |`;
+  const body = rows.map((r) =>
+    `| ${r.map((v) => escapeTableCell(v == null ? '' : String(v))).join(' | ')} |`,
+  );
+  return [header, divider, ...body].join('\n');
+}
+
+function escapeTableCell(s: string): string {
+  // Pipes break the markdown table grammar; escape them. Newlines in
+  // cell values get squashed to spaces so the row stays on one line.
+  return s.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function defaultTitleFrom(sourcePath: string, cellId: string): string {
+  const base = sourcePath.split('/').pop() ?? sourcePath;
+  const stem = base.replace(/\.md$/i, '');
+  return `${stem} — cell ${cellId}`;
+}
+
+/**
+ * Default path for a derived note. `<dir>/<source-stem>-<cellId>.md`
+ * under `notes/derived/` — puts every derived note in one place so
+ * users can browse or prune them as a unit, without burying them in
+ * the original analysis folder.
+ */
+export function defaultDerivedNotePath(sourcePath: string, cellId: string): string {
+  const base = sourcePath.split('/').pop() ?? 'note.md';
+  const stem = base
+    .replace(/\.md$/i, '')
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `notes/derived/${stem}-${cellId}.md`;
+}
+
+/**
+ * The target used inside `[[…]]` — the source note's relative path
+ * with the `.md` dropped. Matches Minerva's wiki-link convention.
+ */
+function linkTargetForSource(sourcePath: string): string {
+  return sourcePath.replace(/\.md$/i, '');
+}
+
+function yamlString(s: string): string {
+  // Always emit a double-quoted YAML string so special chars inside
+  // titles / dates / paths can't break the frontmatter parser.
+  const escaped = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function escapeHeading(s: string): string {
+  // H1 should render as plain text; markdown-it tolerates most content
+  // on a heading line, but backslash-escape special tokens defensively.
+  return s.replace(/#/g, '\\#');
+}

--- a/src/shared/compute/types.ts
+++ b/src/shared/compute/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Compute-shell types shared between main and renderer.
+ *
+ * Both sides duplicated these initially (main in compute/registry, renderer
+ * in ipc/client); centralising here prevents drift and lets shared helpers
+ * (derived-note builder, cell-id) import without reaching into either process.
+ */
+
+export type CellOutput =
+  | { type: 'table'; columns: string[]; rows: Array<Array<string | number | boolean | null>> }
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: unknown };
+
+export type CellResult =
+  | { ok: true; output: CellOutput }
+  | { ok: false; error: string };

--- a/tests/main/compute/save-cell-output.test.ts
+++ b/tests/main/compute/save-cell-output.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { saveCellOutput } from '../../../src/main/compute/save-cell-output';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-save-cell-output-test-'));
+}
+
+const SOURCE_NOTE = `# My analysis
+
+Some prose.
+
+\`\`\`sparql
+SELECT ?n WHERE { ?n a minerva:Note }
+\`\`\`
+
+Trailing prose.
+`;
+
+describe('saveCellOutput (#244)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('writes a derived note + injects a cell id into the source fence', async () => {
+    await fsp.writeFile(path.join(root, 'analysis.md'), SOURCE_NOTE, 'utf-8');
+
+    const result = await saveCellOutput(root, {
+      sourcePath: 'analysis.md',
+      cellLanguage: 'sparql',
+      cellCode: 'SELECT ?n WHERE { ?n a minerva:Note }',
+      output: { type: 'text', value: 'result text' },
+    });
+
+    expect(result.injectedId).toBe(true);
+    expect(result.cellId).toMatch(/^[a-f0-9]{8}$/);
+    expect(result.derivedPath).toMatch(/^notes\/derived\/analysis-[a-f0-9]{8}\.md$/);
+
+    // Source fence now carries `{id=…}`.
+    const source = await fsp.readFile(path.join(root, 'analysis.md'), 'utf-8');
+    expect(source).toContain(`\`\`\`sparql {id=${result.cellId}}`);
+
+    // Derived note lands under notes/derived/ with frontmatter + backlink.
+    const derived = await fsp.readFile(path.join(root, result.derivedPath), 'utf-8');
+    expect(derived).toContain('derived_from: "[[analysis]]"');
+    expect(derived).toContain(`derived_from_cell: "${result.cellId}"`);
+    expect(derived).toMatch(new RegExp(`\\[\\[analysis#cell-${result.cellId}\\]\\]`));
+  });
+
+  it('reuses an existing cell id on re-save instead of minting a new one', async () => {
+    const withId = SOURCE_NOTE.replace('```sparql', '```sparql {id=preexisting}');
+    await fsp.writeFile(path.join(root, 'analysis.md'), withId, 'utf-8');
+
+    const result = await saveCellOutput(root, {
+      sourcePath: 'analysis.md',
+      cellLanguage: 'sparql',
+      cellCode: 'SELECT ?n WHERE { ?n a minerva:Note }',
+      output: { type: 'text', value: 'x' },
+    });
+
+    expect(result.injectedId).toBe(false);
+    expect(result.cellId).toBe('preexisting');
+    // Source unchanged.
+    const source = await fsp.readFile(path.join(root, 'analysis.md'), 'utf-8');
+    expect(source).toBe(withId);
+  });
+
+  it('throws a clear error when the cell can’t be located in the source', async () => {
+    await fsp.writeFile(path.join(root, 'analysis.md'), '# Empty note\n', 'utf-8');
+    await expect(
+      saveCellOutput(root, {
+        sourcePath: 'analysis.md',
+        cellLanguage: 'sparql',
+        cellCode: 'SELECT 1',
+        output: { type: 'text', value: '' },
+      }),
+    ).rejects.toThrow(/could not locate/i);
+  });
+
+  it('graph indexes derived_from frontmatter as prov:wasDerivedFrom pointing at the source note', async () => {
+    await fsp.writeFile(path.join(root, 'analysis.md'), SOURCE_NOTE, 'utf-8');
+    const { derivedPath } = await saveCellOutput(root, {
+      sourcePath: 'analysis.md',
+      cellLanguage: 'sparql',
+      cellCode: 'SELECT ?n WHERE { ?n a minerva:Note }',
+      output: {
+        type: 'table',
+        columns: ['name'],
+        rows: [['alpha'], ['beta']],
+      },
+    });
+
+    // Re-index source + derived notes so their frontmatter + links are in the graph.
+    const sourceContent = await fsp.readFile(path.join(root, 'analysis.md'), 'utf-8');
+    const derivedContent = await fsp.readFile(path.join(root, derivedPath), 'utf-8');
+    await indexNote('analysis.md', sourceContent);
+    await indexNote(derivedPath, derivedContent);
+
+    const { results } = await queryGraph(`
+      SELECT ?source WHERE {
+        ?derived prov:wasDerivedFrom ?source .
+      }
+    `);
+    const sourceIris = results.map((r) => (r as Record<string, string>).source);
+    // The source IRI is the project-scoped note URI ending in `/note/<stem>`
+    // — the indexer drops the .md extension when minting note URIs.
+    expect(sourceIris.length).toBe(1);
+    expect(sourceIris[0]).toMatch(/\/note\/analysis$/);
+  });
+});

--- a/tests/shared/compute/cell-id.test.ts
+++ b/tests/shared/compute/cell-id.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseFenceInfo,
+  stringifyFenceInfo,
+  ensureCellId,
+  rewriteFenceInfo,
+} from '../../../src/shared/compute/cell-id';
+
+describe('parseFenceInfo', () => {
+  it('splits language and attrs', () => {
+    expect(parseFenceInfo('sparql')).toEqual({ language: 'sparql', attrs: {} });
+    expect(parseFenceInfo('sparql {id=abc123}')).toEqual({
+      language: 'sparql',
+      attrs: { id: 'abc123' },
+    });
+    expect(parseFenceInfo('python {id=x} {tag=chart}')).toEqual({
+      language: 'python',
+      attrs: { id: 'x', tag: 'chart' },
+    });
+  });
+
+  it('handles empty info', () => {
+    expect(parseFenceInfo('')).toEqual({ language: '', attrs: {} });
+  });
+});
+
+describe('stringifyFenceInfo', () => {
+  it('is the inverse of parseFenceInfo with alphabetical attr order', () => {
+    const parsed = parseFenceInfo('python {tag=chart} {id=abc}');
+    expect(stringifyFenceInfo(parsed)).toBe('python {id=abc} {tag=chart}');
+  });
+
+  it('returns just the language when attrs is empty', () => {
+    expect(stringifyFenceInfo({ language: 'sql', attrs: {} })).toBe('sql');
+  });
+});
+
+describe('ensureCellId', () => {
+  it('returns the existing id without modifying the info string', () => {
+    const r = ensureCellId('sparql {id=existing}', () => 'NEW');
+    expect(r).toEqual({ id: 'existing', newInfo: 'sparql {id=existing}', wasNew: false });
+  });
+
+  it('injects a new id when none is present', () => {
+    const r = ensureCellId('sparql', () => 'newid');
+    expect(r).toEqual({ id: 'newid', newInfo: 'sparql {id=newid}', wasNew: true });
+  });
+
+  it('preserves other attrs when injecting', () => {
+    const r = ensureCellId('python {tag=chart}', () => 'x');
+    expect(r.id).toBe('x');
+    expect(r.newInfo).toBe('python {id=x} {tag=chart}');
+  });
+});
+
+describe('rewriteFenceInfo', () => {
+  it('rewrites only the opening line at startOffset', () => {
+    const doc = '```sparql\nSELECT 1\n```\n';
+    const next = rewriteFenceInfo(doc, 0, 'sparql {id=abc}');
+    expect(next).toBe('```sparql {id=abc}\nSELECT 1\n```\n');
+  });
+
+  it('preserves the backtick count when the fence uses more than three', () => {
+    const doc = '````sparql\ncode\n````';
+    const next = rewriteFenceInfo(doc, 0, 'sparql {id=x}');
+    expect(next.startsWith('````sparql {id=x}\n')).toBe(true);
+  });
+
+  it('leaves the doc alone when startOffset isn’t at a fence', () => {
+    const doc = 'just prose, not a fence';
+    expect(rewriteFenceInfo(doc, 0, 'sparql {id=x}')).toBe(doc);
+  });
+});

--- a/tests/shared/compute/derived-note.test.ts
+++ b/tests/shared/compute/derived-note.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDerivedNote,
+  renderOutputToMarkdown,
+  defaultDerivedNotePath,
+} from '../../../src/shared/compute/derived-note';
+
+const FROZEN_NOW = () => new Date('2026-04-20T14:22:00.000Z');
+
+describe('buildDerivedNote (#244)', () => {
+  it('produces a well-formed note with frontmatter, title, table body, and backlink', () => {
+    const md = buildDerivedNote({
+      output: {
+        type: 'table',
+        columns: ['station', 'trend'],
+        rows: [['MLO', '2.4'], ['ALT', '2.0']],
+      },
+      sourcePath: 'notes/analysis/co2-analysis.md',
+      cellId: '9c8f3e21',
+      title: 'CO2 Trends by Station',
+      now: FROZEN_NOW,
+    });
+
+    expect(md).toContain('---');
+    expect(md).toContain('title: "CO2 Trends by Station"');
+    // derived_from emitted as a wiki-link so the graph indexer resolves it
+    // to the source's note URI and backlinks surface the derived note.
+    expect(md).toContain('derived_from: "[[notes/analysis/co2-analysis]]"');
+    expect(md).toContain('derived_from_cell: "9c8f3e21"');
+    expect(md).toContain('derived_at: "2026-04-20T14:22:00.000Z"');
+    expect(md).toContain('tags: [derived]');
+    expect(md).toContain('# CO2 Trends by Station');
+    expect(md).toContain('| station | trend |');
+    expect(md).toContain('| MLO | 2.4 |');
+    expect(md).toMatch(/\*Derived from \[\[notes\/analysis\/co2-analysis#cell-9c8f3e21\]\] on 2026-04-20\.\*/);
+  });
+
+  it('falls back to a sensible title when none is provided', () => {
+    const md = buildDerivedNote({
+      output: { type: 'text', value: 'hi' },
+      sourcePath: 'notes/scratch.md',
+      cellId: 'abc',
+      now: FROZEN_NOW,
+    });
+    expect(md).toContain('title: "scratch — cell abc"');
+  });
+});
+
+describe('renderOutputToMarkdown', () => {
+  it('renders a table with columns + rows', () => {
+    const md = renderOutputToMarkdown({
+      type: 'table',
+      columns: ['a', 'b'],
+      rows: [[1, 'two']],
+    });
+    expect(md).toBe('| a | b |\n| --- | --- |\n| 1 | two |');
+  });
+
+  it('emits an empty-result marker for tables with no columns', () => {
+    expect(renderOutputToMarkdown({ type: 'table', columns: [], rows: [] }))
+      .toBe('*(empty result)*');
+  });
+
+  it('escapes pipes inside cells', () => {
+    const md = renderOutputToMarkdown({
+      type: 'table',
+      columns: ['x'],
+      rows: [['a|b']],
+    });
+    expect(md).toContain('| a\\|b |');
+  });
+
+  it('renders text output as a fenced code block', () => {
+    expect(renderOutputToMarkdown({ type: 'text', value: 'hello\nworld' }))
+      .toBe('```\nhello\nworld\n```');
+  });
+
+  it('renders JSON with pretty-printing', () => {
+    const md = renderOutputToMarkdown({ type: 'json', value: { a: 1 } });
+    expect(md).toBe('```json\n{\n  "a": 1\n}\n```');
+  });
+});
+
+describe('defaultDerivedNotePath', () => {
+  it('lands derived notes under notes/derived/ with source-stem + cell-id', () => {
+    expect(defaultDerivedNotePath('notes/analysis/co2.md', 'abc123'))
+      .toBe('notes/derived/co2-abc123.md');
+  });
+
+  it('sanitises awkward characters in the stem', () => {
+    expect(defaultDerivedNotePath('notes/Some File (v2).md', 'x'))
+      .toBe('notes/derived/Some-File-v2-x.md');
+  });
+});


### PR DESCRIPTION
## Summary

Cell output → first-class note with a provenance link back to the cell that produced it. Turns the notebook from a scratchpad into a knowledge tool: once a derived note exists, it's searchable, backlink-visible, graph-queryable, and future rename-rewrites follow it around.

This PR lands the core story. A handful of acceptance items from #244 ride as follow-ups (enumerated below) — this leaves #244 open to track them.

## What's in the box

- **⋯ overflow menu** on every saveable compute-output block in preview. Hover → button appears; click → menu with **Save as note…** and **Copy as markdown**. Error outputs are intentionally not saveable (no value in saving an error block as a note).
- **Save as note** prompts for a path (default: `notes/derived/<source-stem>-<cell-id>.md`), writes a markdown note, and opens it in a new tab.
- **Cell ids** are injected into fence info strings (Quarto-style `{id=…}`) lazily — on the first save for that cell — and reused thereafter. Re-saves land on the same backlink anchor.
- **Derived-note shape:**
  - Frontmatter: `title`, `derived_from` (as a wiki-link to the source), `derived_from_cell`, `derived_at`, `derived_tool`, `tags: [derived]`.
  - Output rendered as markdown (table / code block / pretty JSON depending on output type).
  - Trailing prose paragraph: `*Derived from [[source-note#cell-<id>]] on YYYY-MM-DD.*` — the *real* backlink that surfaces on the source's backlinks panel.
- **Graph indexer** gains the `prov` namespace; `derived_from` / `derived_at` / `derived_from_cell` frontmatter keys emit `prov:wasDerivedFrom`, `prov:generatedAtTime`, `thought:derivedFromCell` triples. The wiki-link form on `derived_from` means the rewrite-on-rename pipeline follows source renames for free.
- **Shared `CellOutput` / `CellResult` types** consolidated into `src/shared/compute/types.ts` — main + renderer + shared helpers now import from one place.

## Design calls worth flagging

- **Backlinks via body wiki-link, not via `prov:wasDerivedFrom`.** The backlinks panel walks `minerva:linksTo` + subproperties; PROV triples sit outside that set. Writing the trailing `*Derived from [[src#cell-id]]*` paragraph gives us a real minerva-typed edge, so the derived note appears on the source's backlinks panel with zero changes to the backlinks query.
- **Cell id is injected lazily, not speculatively.** Every executable fence today doesn't need one; only cells that the user saves output from get an id. Keeps un-saved fences visually clean.
- **Regex widening on the fence-opener.** `findRunnableFences` previously required `^\`\`\`(\w+)\s*$` — rejected `sparql {id=abc}`. Loosened to accept optional post-language info, with a regression-tested edge case.
- **Error outputs aren't saveable.** No overflow menu shows for `{type:"error"}` blocks — saving "the error I got" as a note is rare enough that skipping the affordance is cleaner than cluttering the menu with something users never want.
- **Clipboard "Copy as markdown" ships now; "Copy as CSV" later.** CSV from preview needs the file-save-dialog IPC, which is more plumbing than this PR warrants; deferring to a follow-up.

## Deferred (follow-ups tracked on #244)

- Image-output saving → `.minerva/assets/derived/` (no image output type exists yet; revisits with the Python executor).
- "Pin to notebook" per-cell flag with overwrite-on-resave.
- Overwrite-with-confirm on re-save of a cell that already has a derived note.
- Stock query: "Derived notes missing their source".
- Copy-as-CSV from the preview overflow menu.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 1292/1292 (23 new: cell-id parse/gen/inject, derived-note builder, save-cell-output integration incl. the `prov:wasDerivedFrom` graph round-trip)
- [ ] Manual: run a SPARQL cell → hover output → ⋯ → **Save as note…** → derived note opens in a new tab, source fence now has `{id=…}`
- [ ] Manual: re-run cell → re-save → same derived-path / cell id proposed
- [ ] Manual: source note's backlinks panel shows the derived note
- [ ] Manual: graph query `SELECT ?d ?s WHERE { ?d prov:wasDerivedFrom ?s }` returns the derived → source edge

## Depends on

- #238 (compute shell) — merged
- #239 (SPARQL fence executor) / #240 (SQL fence executor) — merged, produce the outputs this saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)