### PR TITLE
Fix save-cell-output: snapshot $state before IPC + own confirm key

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -797,7 +797,7 @@
       setTimeout(() => handleFileSelect(result.derivedPath), 100);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Save cell output failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+      await showConfirm(`Save cell output failed: ${msg}`, CONFIRM_KEYS.saveCellOutputFailed, 'OK');
     }
   }
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -865,10 +865,13 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
   function handleSaveAsNote(): void {
     if (!outputMenu || !onSaveCellOutput) return;
+    // $state wraps the parsed output in a reactive proxy; Electron's
+    // structured-clone bridge rejects proxies with "An object could not
+    // be cloned", so unwrap before handing it over.
     onSaveCellOutput({
       cellLanguage: outputMenu.source.language,
       cellCode: outputMenu.source.code,
-      output: outputMenu.output,
+      output: $state.snapshot(outputMenu.output),
     });
     outputMenu = null;
   }

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -28,6 +28,7 @@ export const CONFIRM_KEYS = {
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
+  saveCellOutputFailed: 'save-cell-output-failed',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -152,6 +153,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Zotero RDF import complete',
     description:
       'Summary dialog after Import Zotero RDF finishes (counts of imported / duplicate / failed items, and how many PDFs were lifted).',
+  },
+  {
+    key: CONFIRM_KEYS.saveCellOutputFailed,
+    title: 'Save cell output failed',
+    description:
+      'Shown when "Save as note" on a compute-cell output errors out (path collision, write error, etc). Kept separate from ingest-failed so suppressing one doesn\'t mute the other.',
   },
 ];
 


### PR DESCRIPTION
Two bugs on the Save-as-note flow, explaining both the silent first attempt and the structured-clone error on the retry:

1. **$state proxy hits IPC.** The parsed output lives in Preview's \`outputMenu\` \`$state\`, which wraps it in a reactive Proxy. Electron's structured-clone IPC bridge rejects proxies with "An object could not be cloned". Snapshot at the callback-emission boundary with \`\$state.snapshot\`.

2. **Shared \`CONFIRM_KEYS.ingestFailed\` suppression leaked into the error path.** Any user who'd previously "Don't ask again"'d an ingest failure got the save-cell-output error silently swallowed — which is exactly what "nothing happened" on the first attempt looked like. New dedicated \`saveCellOutputFailed\` key keeps past suppressions from muting this error. The confirm-registry drift guard in tests/renderer/confirm-keys.test.ts covers the pairing.

No new tests beyond the drift guard — both fixes are tiny and in code paths already covered by the existing suite.