### PR TITLE
Publication: export foundation + markdown passthrough (closes #246)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,12 +6,14 @@ import { buildMenu } from './menu';
 import { createWindow, openProjectInWindow } from './window-manager';
 import { loadSession } from './session';
 import { registerBuiltinExecutors } from './compute/executors';
+import { registerBuiltinExporters } from './publish';
 
 app.setName('Minerva');
 
 app.whenReady().then(async () => {
   registerIpcHandlers();
   registerBuiltinExecutors();
+  registerBuiltinExporters();
 
   const session = loadSession().filter((s) => {
     try { return fs.statSync(s.rootPath).isDirectory(); } catch { return false; }

--- a/src/main/publish/exclusion.ts
+++ b/src/main/publish/exclusion.ts
@@ -1,0 +1,135 @@
+/**
+ * Private-by-default exclusion rules (#246).
+ *
+ * Minerva holds personal thinking, half-formed arguments, and reading
+ * notes. Accidentally publishing those is a reputation-damaging failure
+ * mode, so the export pipeline drops anything that matches a private
+ * signal unless the user explicitly overrides in the preview dialog
+ * (that override lives on #283).
+ *
+ * The three signals, in order:
+ *   1. Path under any `private/` or `.private/` folder.
+ *   2. Frontmatter `private: true`.
+ *   3. Tag `#private` (frontmatter `tags: [..., private, ...]` or an
+ *      inline `#private` in the body).
+ *
+ * Each match returns a human-readable reason that lands in the preview's
+ * "excluded" audit — no silent drops.
+ */
+
+/** Result of checking a single note against the exclusion rules. */
+export interface ExclusionCheck {
+  excluded: boolean;
+  /** Populated only when `excluded` is true. */
+  reason?: string;
+}
+
+/**
+ * Check a note against every rule. The path check is cheap and runs
+ * first so we can short-circuit without parsing frontmatter for anything
+ * under `private/`.
+ */
+export function checkExclusion(
+  relativePath: string,
+  content: string,
+): ExclusionCheck {
+  if (isUnderPrivateFolder(relativePath)) {
+    return { excluded: true, reason: `under ${privateFolderMatch(relativePath)}` };
+  }
+  const frontmatter = extractFrontmatterRaw(content);
+  if (frontmatter) {
+    if (isPrivateTrue(frontmatter)) {
+      return { excluded: true, reason: 'frontmatter `private: true`' };
+    }
+    if (hasPrivateTag(frontmatter)) {
+      return { excluded: true, reason: 'tagged #private' };
+    }
+  }
+  if (hasInlinePrivateTag(content)) {
+    return { excluded: true, reason: 'tagged #private' };
+  }
+  return { excluded: false };
+}
+
+// ── Path-based check ───────────────────────────────────────────────────────
+
+/**
+ * True when any segment of the relative path is `private` or `.private`.
+ * Matches both `private/secret.md` and `notes/private/secret.md`.
+ */
+export function isUnderPrivateFolder(relativePath: string): boolean {
+  const segments = relativePath.split('/');
+  return segments.some((s) => s === 'private' || s === '.private');
+}
+
+function privateFolderMatch(relativePath: string): string {
+  const segments = relativePath.split('/');
+  for (const s of segments) {
+    if (s === 'private' || s === '.private') return `${s}/`;
+  }
+  return 'private/';
+}
+
+// ── Frontmatter inspection ─────────────────────────────────────────────────
+
+/**
+ * Pull the raw frontmatter block without running YAML — we only need to
+ * string-match two specific patterns. Avoids depending on the `yaml`
+ * library from this pure-logic module and keeps the check robust to
+ * malformed YAML elsewhere in the frontmatter.
+ */
+function extractFrontmatterRaw(content: string): string | null {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return m ? m[1] : null;
+}
+
+/** Match `private: true` (any whitespace, case-insensitive on `true`). */
+function isPrivateTrue(frontmatter: string): boolean {
+  return /^\s*private\s*:\s*true\s*$/im.test(frontmatter);
+}
+
+/**
+ * Match a `private` tag in any of the common YAML shapes:
+ *     tags: private
+ *     tags: [private]
+ *     tags: [draft, private, todo]
+ *     tags:
+ *       - private
+ *       - draft
+ */
+function hasPrivateTag(frontmatter: string): boolean {
+  // Horizontal-whitespace-only after the colon so `\s*` doesn't gobble
+  // a newline and pull in the first block-list item as a false positive.
+  const tagsMatch = frontmatter.match(/^tags[ \t]*:[ \t]*(.*)$/im);
+  if (!tagsMatch) return false;
+  const rest = tagsMatch[1].trim();
+  // Inline scalar or inline list.
+  if (/^\[[^\]]*\]$/.test(rest) || /^[^\s[]/.test(rest)) {
+    return /(^|[[,\s])private([,\s\]]|$)/.test(rest);
+  }
+  // Block list: scan subsequent lines until a key change.
+  const lines = frontmatter.split(/\r?\n/);
+  const tagsIdx = lines.findIndex((l) => /^tags\s*:/i.test(l));
+  if (tagsIdx < 0) return false;
+  for (let i = tagsIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*-\s*private\s*$/i.test(line)) return true;
+    if (/^\S/.test(line)) break; // next top-level key
+  }
+  return false;
+}
+
+// ── Body inspection ────────────────────────────────────────────────────────
+
+/**
+ * An inline `#private` tag anywhere in the note body counts. Uses the
+ * same delimiter regex the indexer already applies: `#tag` preceded by a
+ * whitespace / newline / start-of-line so it doesn't match `##heading`
+ * or URL fragments.
+ */
+export function hasInlinePrivateTag(content: string): boolean {
+  // Strip frontmatter before scanning the body to avoid matching inside
+  // commented-out YAML examples.
+  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+  return /(^|[\s(])#private(\b|$)/m.test(body);
+}

--- a/src/main/publish/exporters/markdown.ts
+++ b/src/main/publish/exporters/markdown.ts
@@ -1,0 +1,39 @@
+/**
+ * Markdown passthrough exporter (#246).
+ *
+ * The minimal end-to-end exporter — proves the pipeline works. Emits
+ * every included note as its own `.md` file under the output dir, with
+ * wiki-links rewritten according to the plan's `linkPolicy`. Frontmatter
+ * passes through verbatim so downstream tools see the same YAML the
+ * user authored.
+ *
+ * HTML / PDF / tree / site exporters will follow the same shape: take a
+ * plan, run `rewriteWikiLinksInContent`, transform the body further if
+ * needed, emit files. This one is the template.
+ */
+
+import {
+  buildLinkResolverContext,
+  rewriteWikiLinksInContent,
+} from '../link-resolver';
+import type { Exporter } from '../types';
+
+export const markdownExporter: Exporter = {
+  id: 'markdown',
+  label: 'Markdown (passthrough)',
+  accepts: () => true,
+  async run(plan) {
+    const ctx = buildLinkResolverContext(plan);
+    const files = plan.inputs
+      .filter((f) => f.kind === 'note')
+      .map((f) => ({
+        path: f.relativePath,
+        contents: rewriteWikiLinksInContent(f.content, ctx),
+      }));
+    const dropped = plan.excluded.length;
+    const summary = dropped > 0
+      ? `${files.length} note${files.length === 1 ? '' : 's'} exported (${dropped} excluded).`
+      : `${files.length} note${files.length === 1 ? '' : 's'} exported.`;
+    return { files, summary };
+  },
+};

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Publish-module entry point (#246).
+ *
+ * `registerBuiltinExporters()` slots every bundled exporter into the
+ * registry. Called once at app-ready from `main.ts`, right after
+ * `registerBuiltinExecutors()`.
+ */
+
+import { registerExporter } from './registry';
+import { markdownExporter } from './exporters/markdown';
+
+export function registerBuiltinExporters(): void {
+  registerExporter(markdownExporter);
+}
+
+export * from './types';
+export { resolvePlan, runExporter } from './pipeline';
+export { listExporters, exportersFor, getExporter } from './registry';

--- a/src/main/publish/link-resolver.ts
+++ b/src/main/publish/link-resolver.ts
@@ -1,0 +1,111 @@
+/**
+ * Wiki-link resolution for exports (#246).
+ *
+ * Every exporter handles the same link grammar — `[[target]]`,
+ * `[[target|display]]`, `[[target#anchor]]`, typed links like
+ * `[[references::target]]` — so the resolution logic lives here once and
+ * every exporter gets it consistently.
+ *
+ * Out of the resolver's scope: `[[cite::…]]` and `[[quote::…]]`. Those
+ * point at sources / excerpts whose output rendering is its own problem
+ * (a citations ticket), so we leave them untouched and let the consumer
+ * decide.
+ */
+
+import type { ExportPlan, LinkPolicy } from './types';
+
+export interface LinkResolverContext {
+  /**
+   * Lookup from a wiki-link target (path without `.md`) to the title
+   * we should surface in `inline-title` / `follow-to-file` rendering.
+   */
+  titleByTarget: Map<string, string>;
+  /**
+   * The set of note paths that are part of the export (e.g. `notes/foo.md`).
+   * `follow-to-file` emits relative links only to members of this set.
+   */
+  includedPaths: Set<string>;
+  linkPolicy: LinkPolicy;
+}
+
+/** Build a resolver context from a resolved export plan. */
+export function buildLinkResolverContext(plan: ExportPlan): LinkResolverContext {
+  const titleByTarget = new Map<string, string>();
+  const includedPaths = new Set<string>();
+  for (const f of plan.inputs) {
+    if (f.kind !== 'note') continue;
+    const stem = stripMdExt(f.relativePath);
+    includedPaths.add(f.relativePath);
+    titleByTarget.set(f.relativePath, f.title);
+    titleByTarget.set(stem, f.title);
+  }
+  return { titleByTarget, includedPaths, linkPolicy: plan.linkPolicy };
+}
+
+/**
+ * Resolve a single wiki-link reference into its rendered form. Returns a
+ * markdown string — a plain run of text for `drop` / `inline-title`, or
+ * a `[label](href)` link for `follow-to-file` when the target is in the
+ * plan.
+ */
+export function resolveWikiLink(
+  target: string,
+  anchor: string | null,
+  display: string | null,
+  ctx: LinkResolverContext,
+): string {
+  const title = titleFor(target, ctx);
+  switch (ctx.linkPolicy) {
+    case 'drop':
+      return display ?? title ?? target;
+    case 'inline-title':
+      return title ?? display ?? target;
+    case 'follow-to-file': {
+      const asMd = target.endsWith('.md') ? target : `${target}.md`;
+      if (ctx.includedPaths.has(asMd)) {
+        const label = display ?? title ?? target;
+        const href = anchor ? `${asMd}#${anchor}` : asMd;
+        return `[${label}](${href})`;
+      }
+      return title ?? display ?? target;
+    }
+  }
+}
+
+/**
+ * Rewrite every wiki-link in `content` using the given resolver context.
+ * `[[cite::…]]` and `[[quote::…]]` pass through verbatim — those are
+ * source references, resolved by a separate mechanism.
+ */
+export function rewriteWikiLinksInContent(content: string, ctx: LinkResolverContext): string {
+  // [[target]], [[target|display]], [[type::target]], [[type::target|display]]
+  // with optional #anchor inside the target. Lazy target/display captures
+  // to keep away from nested brackets in link text.
+  const WIKI_LINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
+  return content.replace(WIKI_LINK_RE, (full, rawTarget: string, display?: string) => {
+    // Preserve cite / quote — those resolve through the citations path.
+    if (/^(cite|quote)::/.test(rawTarget)) return full;
+    // Strip a typed prefix (`references::`, `supports::`, …) from the
+    // target for exporter purposes; we don't annotate link types in v1.
+    const untyped = rawTarget.replace(/^[a-z][a-z0-9_]*::/, '');
+    // Split anchor.
+    const hashIdx = untyped.indexOf('#');
+    const target = hashIdx >= 0 ? untyped.slice(0, hashIdx).trim() : untyped.trim();
+    const anchor = hashIdx >= 0 ? untyped.slice(hashIdx + 1).trim() : null;
+    if (!target) return full;
+    return resolveWikiLink(target, anchor, display ? display.trim() : null, ctx);
+  });
+}
+
+function titleFor(target: string, ctx: LinkResolverContext): string | null {
+  return (
+    ctx.titleByTarget.get(target) ??
+    ctx.titleByTarget.get(stripMdExt(target)) ??
+    ctx.titleByTarget.get(`${target}.md`) ??
+    null
+  );
+}
+
+function stripMdExt(p: string): string {
+  return p.replace(/\.md$/i, '');
+}

--- a/src/main/publish/pipeline.ts
+++ b/src/main/publish/pipeline.ts
@@ -1,0 +1,158 @@
+/**
+ * Export pipeline (#246).
+ *
+ * `resolvePlan(rootPath, input, opts)` walks the thoughtbase, loads the
+ * notes the input specifies, and filters them through the private-by-
+ * default exclusion rules. The result — an `ExportPlan` — names exactly
+ * what's in the export (and why each dropped file got dropped), for the
+ * exporter to transform and the preview dialog to audit.
+ *
+ * `runExporter(plan, exporter)` is a thin pass-through; the pipeline
+ * doesn't write files itself — the exporter's output lists what to
+ * write, and the caller (the save-dialog IPC from the UX ticket #282)
+ * decides how.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import YAML from 'yaml';
+import { checkExclusion } from './exclusion';
+import type {
+  ExportInput,
+  ExportPlan,
+  ExportPlanFile,
+  ExportPlanExclusion,
+  Exporter,
+  ExportOutput,
+  LinkPolicy,
+  AssetPolicy,
+} from './types';
+
+export interface ResolvePlanOptions {
+  linkPolicy?: LinkPolicy;
+  assetPolicy?: AssetPolicy;
+  citationStyle?: string;
+  outputDir?: string;
+}
+
+export async function resolvePlan(
+  rootPath: string,
+  input: ExportInput,
+  opts: ResolvePlanOptions = {},
+): Promise<ExportPlan> {
+  const candidatePaths = await collectCandidatePaths(rootPath, input);
+
+  const inputs: ExportPlanFile[] = [];
+  const excluded: ExportPlanExclusion[] = [];
+
+  for (const rel of candidatePaths) {
+    let content: string;
+    try {
+      content = await fs.readFile(path.join(rootPath, rel), 'utf-8');
+    } catch {
+      // File disappeared between the walk and the read — ignore.
+      continue;
+    }
+
+    const check = checkExclusion(rel, content);
+    if (check.excluded) {
+      excluded.push({ relativePath: rel, reason: check.reason ?? 'excluded' });
+      continue;
+    }
+    const { frontmatter, title } = parseHeader(rel, content);
+    inputs.push({
+      relativePath: rel,
+      kind: 'note',
+      content,
+      frontmatter,
+      title,
+    });
+  }
+
+  // Sort for deterministic ordering across exporter runs.
+  inputs.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  excluded.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+  return {
+    inputs,
+    excluded,
+    linkPolicy: opts.linkPolicy ?? 'inline-title',
+    assetPolicy: opts.assetPolicy ?? 'keep-relative',
+    citationStyle: opts.citationStyle,
+    outputDir: opts.outputDir,
+  };
+}
+
+export async function runExporter(
+  exporter: Exporter,
+  plan: ExportPlan,
+): Promise<ExportOutput> {
+  return exporter.run(plan);
+}
+
+// ── Candidate-path collection ───────────────────────────────────────────────
+
+async function collectCandidatePaths(rootPath: string, input: ExportInput): Promise<string[]> {
+  if (input.kind === 'single-note') {
+    if (!input.relativePath) return [];
+    return [input.relativePath];
+  }
+  const subdir = input.kind === 'folder' ? (input.relativePath ?? '') : '';
+  const walkRoot = path.join(rootPath, subdir);
+  const paths: string[] = [];
+  await walkMarkdown(walkRoot, rootPath, paths);
+  return paths;
+}
+
+/**
+ * Walk a directory and collect every `.md` file relative to `rootPath`.
+ * Skips hidden directories (`.git`, `.minerva`, `.obsidian`, …) and
+ * `node_modules` — same set the sidebar filters out — so exports match
+ * the user's mental model of what's "in" their thoughtbase.
+ */
+async function walkMarkdown(dir: string, rootPath: string, out: string[]): Promise<void> {
+  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    if (entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walkMarkdown(full, rootPath, out);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      out.push(path.relative(rootPath, full));
+    }
+  }
+}
+
+// ── Header parsing ─────────────────────────────────────────────────────────
+
+function parseHeader(relativePath: string, content: string): {
+  frontmatter: Record<string, unknown>;
+  title: string;
+} {
+  const fm = extractFrontmatter(content);
+  const titleFromFm = typeof fm.title === 'string' ? fm.title.trim() : '';
+  if (titleFromFm) return { frontmatter: fm, title: titleFromFm };
+  // Fall back to the first H1, then the filename stem.
+  const bodyAfterFm = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+  const h1 = bodyAfterFm.match(/^\s*#\s+(.+?)\s*$/m);
+  if (h1) return { frontmatter: fm, title: h1[1] };
+  const stem = (relativePath.split('/').pop() ?? relativePath).replace(/\.md$/i, '');
+  return { frontmatter: fm, title: stem };
+}
+
+function extractFrontmatter(content: string): Record<string, unknown> {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return {};
+  try {
+    const parsed = YAML.parse(m[1]);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/main/publish/registry.ts
+++ b/src/main/publish/registry.ts
@@ -1,0 +1,36 @@
+/**
+ * Exporter registry (#246).
+ *
+ * Each exporter registers once at startup with a stable id. The pipeline
+ * looks up by id when `runExporter` is called; the export-menu UI (#282)
+ * reads the registry to populate menu items, filtering by the
+ * `accepts(input)` check so exporters that can't handle a given input
+ * shape don't appear.
+ */
+
+import type { Exporter, ExportInput } from './types';
+
+const exporters = new Map<string, Exporter>();
+
+export function registerExporter(exporter: Exporter): void {
+  exporters.set(exporter.id, exporter);
+}
+
+export function getExporter(id: string): Exporter | null {
+  return exporters.get(id) ?? null;
+}
+
+/** Every registered exporter, in insertion order — useful for menu population. */
+export function listExporters(): Exporter[] {
+  return [...exporters.values()];
+}
+
+/** Only the exporters that can handle this input — drives the menu's dynamic contents. */
+export function exportersFor(input: ExportInput): Exporter[] {
+  return listExporters().filter((e) => e.accepts(input));
+}
+
+/** Exposed for tests to reset state between cases. */
+export function _clearRegistry(): void {
+  exporters.clear();
+}

--- a/src/main/publish/types.ts
+++ b/src/main/publish/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Export-pipeline types (#246).
+ *
+ * Every publication target (markdown, HTML, PDF, static site, annotated
+ * reading, …) routes through the same foundation: an `ExportInput` names
+ * what the user asked for, `resolvePlan` loads the relevant notes and
+ * filters out private ones, an `Exporter` turns the plan into files, and
+ * the resulting `ExportOutput` lists what to write (and where).
+ *
+ * Shared so the pipeline, the link resolver, the UI, and every
+ * individual exporter all agree on the vocabulary.
+ */
+
+/** What the caller asked to export. The pipeline resolves this into a plan. */
+export interface ExportInput {
+  kind: 'single-note' | 'folder' | 'project';
+  /**
+   * For `single-note`: the note's relative path.
+   * For `folder`: the folder's relative path (empty = project root).
+   * For `project`: ignored; always the whole project.
+   */
+  relativePath?: string;
+}
+
+/**
+ * How wiki-links render in the exported output.
+ *
+ *   - `drop`           — link goes away; display text (or target) remains
+ *     as plain text. Useful for single-note exports where link targets
+ *     aren't in the export set.
+ *   - `inline-title`   — link replaced with the target note's title (from
+ *     frontmatter or H1). Content-style exports where the reader has no
+ *     way to follow the link anyway.
+ *   - `follow-to-file` — rewrite to a relative file-link when the target
+ *     is part of the export, else fall through to `inline-title`. The
+ *     shape for folder / tree exports where the output is readable as a
+ *     set of inter-linked files.
+ *
+ * A `site-relative` policy is planned for the eventual static-site
+ * exporter but held back until that ticket lands; its presence here
+ * would be speculative.
+ */
+export type LinkPolicy = 'drop' | 'inline-title' | 'follow-to-file';
+
+/**
+ * How media referenced from notes gets handled. Markdown passthrough only
+ * needs `keep-relative`; HTML and PDF tickets introduce the others.
+ */
+export type AssetPolicy = 'keep-relative' | 'copy-to-dir' | 'inline-base64';
+
+/** A note (or source / excerpt) that made it through exclusion and into the plan. */
+export interface ExportPlanFile {
+  relativePath: string;
+  kind: 'note' | 'source' | 'excerpt';
+  /** Raw file content as loaded. Exporters transform this. */
+  content: string;
+  /** Parsed frontmatter; empty object when the file has none. */
+  frontmatter: Record<string, unknown>;
+  /** Title for link-resolver display — frontmatter.title, H1, or filename stem. */
+  title: string;
+}
+
+export interface ExportPlanExclusion {
+  relativePath: string;
+  /** Human-readable reason for exclusion, surfaced in the preview dialog. */
+  reason: string;
+}
+
+export interface ExportPlan {
+  inputs: ExportPlanFile[];
+  excluded: ExportPlanExclusion[];
+  linkPolicy: LinkPolicy;
+  assetPolicy: AssetPolicy;
+  /** CSL style id; exporters ignore when not set. Populated by a later citations ticket. */
+  citationStyle?: string;
+  /** Absolute destination directory for exporters that write multiple files. */
+  outputDir?: string;
+}
+
+/**
+ * One file an exporter wants written. Path is relative to the plan's
+ * `outputDir`. Binary formats pass `Uint8Array`; everything else strings.
+ */
+export interface ExportOutputFile {
+  path: string;
+  contents: string | Uint8Array;
+}
+
+export interface ExportOutput {
+  files: ExportOutputFile[];
+  /** One-line summary the caller can surface in the preview or a toast. */
+  summary: string;
+}
+
+export interface Exporter {
+  /** Stable id — used by the menu registry and IPC. */
+  id: string;
+  /** Human-readable label for the menu / palette. */
+  label: string;
+  /** Whether the exporter can handle this input kind. Falsy = hidden in the menu. */
+  accepts(input: ExportInput): boolean;
+  /** Transform plan → output. Exporters never write files directly; that's the pipeline's job. */
+  run(plan: ExportPlan): Promise<ExportOutput>;
+}

--- a/tests/main/publish/exclusion.test.ts
+++ b/tests/main/publish/exclusion.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { checkExclusion, isUnderPrivateFolder, hasInlinePrivateTag } from '../../../src/main/publish/exclusion';
+
+describe('isUnderPrivateFolder', () => {
+  it('matches a top-level private/ path', () => {
+    expect(isUnderPrivateFolder('private/secret.md')).toBe(true);
+    expect(isUnderPrivateFolder('.private/secret.md')).toBe(true);
+  });
+
+  it('matches nested private/ paths', () => {
+    expect(isUnderPrivateFolder('notes/private/secret.md')).toBe(true);
+    expect(isUnderPrivateFolder('a/b/.private/c/d.md')).toBe(true);
+  });
+
+  it('does not match paths that just contain the word "private"', () => {
+    expect(isUnderPrivateFolder('notes/privateish.md')).toBe(false);
+    expect(isUnderPrivateFolder('research/privacy-law.md')).toBe(false);
+  });
+});
+
+describe('hasInlinePrivateTag', () => {
+  it('matches #private at word boundaries in the body', () => {
+    expect(hasInlinePrivateTag('# A note\n\nThis is #private\n')).toBe(true);
+    expect(hasInlinePrivateTag('(#private)')).toBe(true);
+  });
+
+  it('ignores #private inside a YAML frontmatter block', () => {
+    const content = '---\nexample: "#private"\n---\n\nPlain body.\n';
+    expect(hasInlinePrivateTag(content)).toBe(false);
+  });
+
+  it('ignores #privateish substrings', () => {
+    expect(hasInlinePrivateTag('Tags: #privateish\n')).toBe(false);
+  });
+});
+
+describe('checkExclusion (#246)', () => {
+  it('passes a normal public note', () => {
+    const content = '---\ntitle: Public\n---\n\n# Public\nBody.\n';
+    expect(checkExclusion('notes/public.md', content)).toEqual({ excluded: false });
+  });
+
+  it('excludes anything under private/', () => {
+    const out = checkExclusion('private/secret.md', '# Secret\n');
+    expect(out.excluded).toBe(true);
+    expect(out.reason).toMatch(/under private\//);
+  });
+
+  it('excludes frontmatter `private: true`', () => {
+    const content = '---\nprivate: true\n---\n\n# Whatever\n';
+    expect(checkExclusion('notes/x.md', content))
+      .toEqual({ excluded: true, reason: 'frontmatter `private: true`' });
+  });
+
+  it('does NOT exclude `private: false`', () => {
+    const content = '---\nprivate: false\n---\n\n# Whatever\n';
+    expect(checkExclusion('notes/x.md', content)).toEqual({ excluded: false });
+  });
+
+  it('excludes frontmatter tags list that contains `private`', () => {
+    const content = '---\ntags: [draft, private, todo]\n---\n\nbody\n';
+    expect(checkExclusion('notes/x.md', content))
+      .toEqual({ excluded: true, reason: 'tagged #private' });
+  });
+
+  it('excludes block-list frontmatter tags with `- private`', () => {
+    const content = '---\ntags:\n  - draft\n  - private\n  - todo\n---\n\nbody\n';
+    expect(checkExclusion('notes/x.md', content))
+      .toEqual({ excluded: true, reason: 'tagged #private' });
+  });
+
+  it('excludes an inline #private body tag when no frontmatter flags match', () => {
+    const content = '# Some note\n\nAnd a #private sidebar.\n';
+    expect(checkExclusion('notes/x.md', content))
+      .toEqual({ excluded: true, reason: 'tagged #private' });
+  });
+
+  it('returns the first-matching reason when several apply', () => {
+    // Path check wins: short-circuits before frontmatter is read.
+    const content = '---\nprivate: true\ntags: [private]\n---\n#private\n';
+    expect(checkExclusion('private/x.md', content).reason).toMatch(/under private\//);
+  });
+});

--- a/tests/main/publish/link-resolver.test.ts
+++ b/tests/main/publish/link-resolver.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLinkResolverContext,
+  resolveWikiLink,
+  rewriteWikiLinksInContent,
+} from '../../../src/main/publish/link-resolver';
+import type { ExportPlan, LinkPolicy } from '../../../src/main/publish/types';
+
+function mkPlan(linkPolicy: LinkPolicy): ExportPlan {
+  return {
+    inputs: [
+      {
+        relativePath: 'notes/foo.md',
+        kind: 'note',
+        content: '',
+        frontmatter: {},
+        title: 'Foo Title',
+      },
+      {
+        relativePath: 'notes/bar.md',
+        kind: 'note',
+        content: '',
+        frontmatter: {},
+        title: 'Bar Title',
+      },
+    ],
+    excluded: [],
+    linkPolicy,
+    assetPolicy: 'keep-relative',
+  };
+}
+
+describe('resolveWikiLink — per linkPolicy', () => {
+  it('drop: collapses to the display text, or title, or raw target', () => {
+    const ctx = buildLinkResolverContext(mkPlan('drop'));
+    expect(resolveWikiLink('notes/foo', null, 'custom display', ctx)).toBe('custom display');
+    expect(resolveWikiLink('notes/foo', null, null, ctx)).toBe('Foo Title');
+    expect(resolveWikiLink('notes/never-heard-of', null, null, ctx)).toBe('notes/never-heard-of');
+  });
+
+  it('inline-title: replaces with the target title, even when display text is provided', () => {
+    const ctx = buildLinkResolverContext(mkPlan('inline-title'));
+    expect(resolveWikiLink('notes/foo', null, 'display', ctx)).toBe('Foo Title');
+  });
+
+  it('follow-to-file: rewrites to a relative md link when the target is in the plan', () => {
+    const ctx = buildLinkResolverContext(mkPlan('follow-to-file'));
+    expect(resolveWikiLink('notes/foo', null, null, ctx)).toBe('[Foo Title](notes/foo.md)');
+    expect(resolveWikiLink('notes/foo', 'main', 'display', ctx)).toBe('[display](notes/foo.md#main)');
+  });
+
+  it('follow-to-file: falls through to inline-title when the target isn’t in the plan', () => {
+    const ctx = buildLinkResolverContext(mkPlan('follow-to-file'));
+    expect(resolveWikiLink('notes/missing', null, 'display', ctx)).toBe('display');
+  });
+});
+
+describe('rewriteWikiLinksInContent', () => {
+  const ctx = buildLinkResolverContext(mkPlan('follow-to-file'));
+
+  it('rewrites plain, display-text, and typed links', () => {
+    const out = rewriteWikiLinksInContent(
+      'See [[notes/foo]] and [[notes/bar|over here]] and [[references::notes/foo]].',
+      ctx,
+    );
+    expect(out).toBe(
+      'See [Foo Title](notes/foo.md) and [over here](notes/bar.md) and [Foo Title](notes/foo.md).',
+    );
+  });
+
+  it('preserves anchors in follow-to-file rewrites', () => {
+    const out = rewriteWikiLinksInContent('Jump to [[notes/foo#section]].', ctx);
+    expect(out).toBe('Jump to [Foo Title](notes/foo.md#section).');
+  });
+
+  it('leaves [[cite::…]] and [[quote::…]] untouched', () => {
+    const input = 'See [[cite::smith-2023]] and [[quote::p42]].';
+    expect(rewriteWikiLinksInContent(input, ctx)).toBe(input);
+  });
+
+  it('drops the link but preserves the display text when the target is missing and policy is follow-to-file', () => {
+    const out = rewriteWikiLinksInContent('See [[notes/deleted|the old one]].', ctx);
+    expect(out).toBe('See the old one.');
+  });
+});

--- a/tests/main/publish/pipeline.test.ts
+++ b/tests/main/publish/pipeline.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
+import { markdownExporter } from '../../../src/main/publish/exporters/markdown';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-publish-test-'));
+}
+
+describe('resolvePlan (#246)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('walks the project and loads every non-private .md into the plan', async () => {
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/foo.md'), '---\ntitle: Foo\n---\n\n# Foo\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'notes/bar.md'), '# Bar\n\nbody.\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    expect(plan.inputs.map((f) => f.relativePath).sort()).toEqual(['notes/bar.md', 'notes/foo.md']);
+    expect(plan.excluded).toEqual([]);
+  });
+
+  it('excludes private/secret.md but keeps notes/public.md', async () => {
+    await fsp.mkdir(path.join(root, 'private'), { recursive: true });
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'private/secret.md'), '# Secret\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'notes/public.md'), '# Public\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    expect(plan.inputs.map((f) => f.relativePath)).toEqual(['notes/public.md']);
+    expect(plan.excluded).toEqual([
+      { relativePath: 'private/secret.md', reason: 'under private/' },
+    ]);
+  });
+
+  it('picks up frontmatter-title, H1, or filename stem as the title (in that order)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '---\ntitle: "A from FM"\n---\n\n# Different H1\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '# H1 for B\n\nbody\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'c-from-stem.md'), 'No header at all.\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const titleByPath = new Map(plan.inputs.map((f) => [f.relativePath, f.title]));
+    expect(titleByPath.get('a.md')).toBe('A from FM');
+    expect(titleByPath.get('b.md')).toBe('H1 for B');
+    expect(titleByPath.get('c-from-stem.md')).toBe('c-from-stem');
+  });
+
+  it('ignores hidden and node_modules directories', async () => {
+    await fsp.mkdir(path.join(root, '.obsidian'), { recursive: true });
+    await fsp.mkdir(path.join(root, 'node_modules/sub'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.obsidian/x.md'), '# x\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'node_modules/sub/y.md'), '# y\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'visible.md'), '# v\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    expect(plan.inputs.map((f) => f.relativePath)).toEqual(['visible.md']);
+  });
+
+  it('single-note input loads exactly that file', async () => {
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/one.md'), '# One\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'notes/two.md'), '# Two\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'notes/one.md' });
+    expect(plan.inputs.map((f) => f.relativePath)).toEqual(['notes/one.md']);
+  });
+
+  it('default link + asset policies are inline-title + keep-relative', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    expect(plan.linkPolicy).toBe('inline-title');
+    expect(plan.assetPolicy).toBe('keep-relative');
+  });
+});
+
+describe('markdownExporter end-to-end (#246)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('writes one file per included note, excluding private/*.md, with links rewritten', async () => {
+    await fsp.mkdir(path.join(root, 'private'), { recursive: true });
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(
+      path.join(root, 'private/secret.md'),
+      '---\ntitle: Top secret\n---\n\nDo not publish.\n',
+      'utf-8',
+    );
+    await fsp.writeFile(
+      path.join(root, 'notes/public.md'),
+      '---\ntitle: Public\n---\n\n# Public\n\nSee [[notes/other]] for details.\n',
+      'utf-8',
+    );
+    await fsp.writeFile(
+      path.join(root, 'notes/other.md'),
+      '---\ntitle: Other\n---\n\n# Other\n\nbody\n',
+      'utf-8',
+    );
+
+    const plan = await resolvePlan(root, { kind: 'project' }, { linkPolicy: 'follow-to-file' });
+    const output = await runExporter(markdownExporter, plan);
+
+    // Integration acceptance: private/secret.md is NOT in the output,
+    // but IS recorded in the plan's excluded list.
+    expect(output.files.map((f) => f.path).sort()).toEqual(['notes/other.md', 'notes/public.md']);
+    expect(plan.excluded.map((e) => e.relativePath)).toEqual(['private/secret.md']);
+
+    const publicOut = output.files.find((f) => f.path === 'notes/public.md')!;
+    expect(publicOut.contents).toContain('See [Other](notes/other.md) for details.');
+    expect(publicOut.contents).toContain('---');
+    expect(publicOut.contents).toContain('title: Public');
+  });
+
+  it('summary string reflects included + excluded counts', async () => {
+    await fsp.mkdir(path.join(root, 'private'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'private/b.md'), '# B\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(markdownExporter, plan);
+    expect(output.summary).toBe('1 note exported (1 excluded).');
+  });
+});

--- a/tests/main/publish/registry.test.ts
+++ b/tests/main/publish/registry.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerExporter,
+  listExporters,
+  exportersFor,
+  getExporter,
+  _clearRegistry,
+} from '../../../src/main/publish/registry';
+import type { Exporter } from '../../../src/main/publish/types';
+
+function mkExporter(id: string, accepts = true): Exporter {
+  return {
+    id,
+    label: id,
+    accepts: () => accepts,
+    async run() { return { files: [], summary: '' }; },
+  };
+}
+
+describe('publish registry (#246)', () => {
+  beforeEach(() => _clearRegistry());
+
+  it('registers and looks up by id', () => {
+    const e = mkExporter('markdown');
+    registerExporter(e);
+    expect(getExporter('markdown')).toBe(e);
+    expect(getExporter('unknown')).toBeNull();
+  });
+
+  it('listExporters returns them in insertion order', () => {
+    registerExporter(mkExporter('a'));
+    registerExporter(mkExporter('b'));
+    registerExporter(mkExporter('c'));
+    expect(listExporters().map((x) => x.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('exportersFor filters out exporters whose accepts() returns false', () => {
+    registerExporter(mkExporter('yes', true));
+    registerExporter(mkExporter('no', false));
+    const list = exportersFor({ kind: 'project' });
+    expect(list.map((x) => x.id)).toEqual(['yes']);
+  });
+});


### PR DESCRIPTION
## Summary

Stands up \`src/main/publish/\` as a pluggable export pipeline with private-by-default semantics baked in. Every future exporter (HTML, PDF, tree, static-site, annotated reading) registers with one registry and inherits: exclusion rules, shared wiki-link resolution, a common \`ExportPlan\` shape. First end-to-end exporter — markdown passthrough — proves the pipeline in isolation.

Scope was split out of the original #246 so UX / polish / CSV migration don't block the foundation from landing. See #246's comment thread for the split; follow-ups are #282 / #283 / #284.

## What's in the box

- **Types** (\`types.ts\`) — \`ExportInput\` | \`ExportPlan\` | \`Exporter\` | \`ExportOutput\`, plus \`LinkPolicy\` (\`drop\` | \`inline-title\` | \`follow-to-file\`) and \`AssetPolicy\` (\`keep-relative\` for now).
- **Registry** (\`registry.ts\`) — \`registerExporter\`, \`getExporter(id)\`, \`listExporters()\`, \`exportersFor(input)\`. The UX ticket will read \`exportersFor\` to populate the Export menu at runtime.
- **Exclusion** (\`exclusion.ts\`) — three private-by-default signals with human-readable reasons:
  - Path segment matches \`private\` or \`.private\`
  - Frontmatter \`private: true\`
  - \`#private\` tag (frontmatter list — inline, block, or scalar — or inline in the body)
- **Link resolver** (\`link-resolver.ts\`) — rewrites \`[[target]]\`, \`[[target|display]]\`, \`[[target#anchor]]\`, and typed links (\`[[references::target]]\`) per the plan's policy. \`[[cite::…]]\` and \`[[quote::…]]\` pass through untouched so the upcoming citations path can handle them.
- **Pipeline** (\`pipeline.ts\`) — \`resolvePlan(rootPath, input, opts)\` walks the project (skipping hidden dirs + node_modules, matching the sidebar's filter), partitions via exclusion, and returns a plan whose \`inputs\` are pre-loaded with content, frontmatter, and a resolved title (frontmatter.title > first H1 > filename stem). \`runExporter(exporter, plan)\` is a thin pass-through; exporters never write files themselves — the caller (save-dialog IPC from the UX ticket) does.
- **Markdown passthrough** (\`exporters/markdown.ts\`) — emits one file per included note with wiki-links rewritten per policy. Summary string reports include + exclude counts.

## Design calls worth flagging

- **Link policy scoped to three values.** Shipping \`site-relative\` here would be speculative: the policy has no consumer until the static-site exporter lands. Adding it later is a one-case addition to the resolver — no consumer lock-in.
- **Frontmatter parsing in exclusion is string-based, not YAML-based.** The frontmatter-for-exclusion check only looks for two specific patterns (\`private: true\`, a \`private\` tag), and we don't want a malformed YAML block in the *rest* of the frontmatter to tank the exclusion decision. Same-shape regex logic covers every common YAML expression for each pattern.
- **Horizontal-whitespace-only after \`tags:\`.** A greedy \`\\s*\` across newlines pulled in the first block-list item (\`- draft\`) as the "inline value" and skipped the block-list walk — the regression test for block-form tags caught this.
- **Title resolution falls through frontmatter.title → H1 → filename stem.** Matches how users write notes: frontmatter if they're disciplined, H1 if they're not, and the filename will always be there.
- **Hidden dirs and \`node_modules\` skipped in the walk.** Matches the sidebar's filter — exports match the user's mental model of what's "in" their thoughtbase.
- **Exporters don't write files.** The pipeline only transforms; writing is the caller's job (the save-dialog IPC from #282). Keeps exporters pure and testable, and lets the UX decide what "write" means (prompt once, prompt per-file, etc.).

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1325/1325 (33 new across exclusion, link-resolver, pipeline, registry)
- [x] Integration acceptance from #246: a project with \`private/secret.md\` + \`notes/public.md\` exports only \`public.md\` and lists \`secret.md\` in the plan's excluded audit.
- [ ] Manual: none — the UX lands on #282. Foundation is headless by design; all behavior is unit-tested.

## Depends on

- None (foundation ticket).

## Unblocks

- #282 (Export menu + preview dialog UX) — the front-end on top of this pipeline.
- Every other publication-epic ticket (HTML, PDF, tree, site, annotated reading, git-push destination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)