### PR TITLE
Fix: HTML single-note export buried its file under the source tree

### DIFF
--- a/src/main/publish/exporters/note-html/index.ts
+++ b/src/main/publish/exporters/note-html/index.ts
@@ -19,14 +19,20 @@ export const noteHtmlExporter: Exporter = {
   accepts: () => true,
   async run(plan) {
     const rootPath = plan.rootPath ?? '';
+    const notes = plan.inputs.filter((f) => f.kind === 'note');
+    // Single-note scope: drop the source note's directory structure so
+    // `notes/analysis/foo.md` exported to `~/Desktop` lands as
+    // `~/Desktop/foo.html`, not `~/Desktop/notes/analysis/foo.html`.
+    // Multi-note scope preserves the tree so `follow-to-file` rewrites
+    // keep working as relative links.
+    const flatten = notes.length === 1;
     const files: ExportOutput['files'] = [];
-    for (const f of plan.inputs) {
-      if (f.kind !== 'note') continue;
+    for (const f of notes) {
       const rawBody = renderNoteBody(f, plan);
       const body = await inlineImages(rawBody, f, rootPath, plan.assetPolicy);
       const html = wrapHtml({ title: f.title, body });
       files.push({
-        path: f.relativePath.replace(/\.md$/i, '.html'),
+        path: flatten ? basenameHtml(f.relativePath) : f.relativePath.replace(/\.md$/i, '.html'),
         contents: html,
       });
     }
@@ -36,3 +42,8 @@ export const noteHtmlExporter: Exporter = {
     return { files, summary };
   },
 };
+
+function basenameHtml(relativePath: string): string {
+  const base = relativePath.split('/').pop() ?? relativePath;
+  return base.replace(/\.md$/i, '.html');
+}

--- a/src/main/publish/run-export.ts
+++ b/src/main/publish/run-export.ts
@@ -30,6 +30,12 @@ export interface RunExportResult {
   summary: string;
   /** Absolute path to the directory we wrote into. */
   outputDir: string;
+  /**
+   * Absolute paths of the files the exporter wrote. Surfaced in the
+   * success dialog so a user who exported to their home dir isn't
+   * left wondering which nested folder the file landed in.
+   */
+  writtenPaths: string[];
 }
 
 export async function runExport(
@@ -49,7 +55,7 @@ export async function runExport(
   const absOutputDir = path.resolve(args.outputDir);
   await fs.mkdir(absOutputDir, { recursive: true });
 
-  let filesWritten = 0;
+  const writtenPaths: string[] = [];
   for (const f of output.files) {
     const destAbs = path.resolve(absOutputDir, f.path);
     // Guard against path traversal: every written file must sit under the
@@ -64,10 +70,15 @@ export async function runExport(
     } else {
       await fs.writeFile(destAbs, f.contents);
     }
-    filesWritten++;
+    writtenPaths.push(destAbs);
   }
 
-  return { filesWritten, summary: output.summary, outputDir: absOutputDir };
+  return {
+    filesWritten: writtenPaths.length,
+    summary: output.summary,
+    outputDir: absOutputDir,
+    writtenPaths,
+  };
 }
 
 function isUnder(candidate: string, parent: string): boolean {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1665,8 +1665,12 @@
       onCancel={() => { exportDialogFor = null; }}
       onExported={async (result) => {
         exportDialogFor = null;
+        const pathPreview = result.writtenPaths.slice(0, 5).map((p) => `  • ${p}`).join('\n');
+        const more = result.writtenPaths.length > 5
+          ? `\n  …and ${result.writtenPaths.length - 5} more`
+          : '';
         await showConfirm(
-          `${result.summary}\n\nWrote ${result.filesWritten} file${result.filesWritten === 1 ? '' : 's'} to:\n${result.outputDir}`,
+          `${result.summary}\n\nFiles written:\n${pathPreview}${more}`,
           CONFIRM_KEYS.exportComplete,
           'OK',
         );

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -14,7 +14,7 @@
      * and passes the result up so the caller can show a toast / open
      * the output dir. `null` when the user cancelled the directory picker.
      */
-    onExported: (result: { filesWritten: number; summary: string; outputDir: string }) => void;
+    onExported: (result: { filesWritten: number; summary: string; outputDir: string; writtenPaths: string[] }) => void;
   }
 
   let { exporterId, activeFilePath, onCancel, onExported }: Props = $props();

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -138,6 +138,7 @@ export interface RunExportResult {
   filesWritten: number;
   summary: string;
   outputDir: string;
+  writtenPaths: string[];
 }
 
 export interface PublishApi {

--- a/tests/main/publish/note-html.test.ts
+++ b/tests/main/publish/note-html.test.ts
@@ -53,10 +53,25 @@ describe('noteHtmlExporter (#248)', () => {
     expect(html).not.toMatch(/<script/);
   });
 
-  it('renames output path to .html', async () => {
+  it('single-note scope flattens output to <basename>.html so export-to-home-dir doesn\'t bury the file', async () => {
     const plan = planWithNote({ relativePath: 'notes/nested/thing.md' });
     const output = await noteHtmlExporter.run(plan);
-    expect(output.files[0].path).toBe('notes/nested/thing.html');
+    expect(output.files[0].path).toBe('thing.html');
+  });
+
+  it('multi-note scope preserves the source tree so follow-to-file links resolve', async () => {
+    const plan: ExportPlan = {
+      inputs: [
+        { relativePath: 'notes/a.md', kind: 'note', content: '# A\n', frontmatter: {}, title: 'A' },
+        { relativePath: 'notes/sub/b.md', kind: 'note', content: '# B\n', frontmatter: {}, title: 'B' },
+      ],
+      excluded: [],
+      linkPolicy: 'follow-to-file',
+      assetPolicy: 'keep-relative',
+    };
+    const output = await noteHtmlExporter.run(plan);
+    const paths = output.files.map((f) => f.path).sort();
+    expect(paths).toEqual(['notes/a.html', 'notes/sub/b.html']);
   });
 
   it('strips frontmatter from the rendered body', async () => {


### PR DESCRIPTION
Two bugs compounded into "I don't see the file":

1. **Source-path preservation.** The exporter preserved the note's relative path in the output, so a single-note export of \`notes/analysis/foo.md\` to \`~/Desktop\` landed as \`~/Desktop/notes/analysis/foo.html\`. The user looked at the top of \`~/Desktop\`, found nothing, and reasonably concluded the export failed.

   **Fix**: single-note scope flattens to \`<basename>.html\` at the output-dir root. Multi-note scope still preserves the tree so \`follow-to-file\` relative links resolve.

2. **Uninformative success dialog.** It only showed the chosen root dir, not the actual per-file paths.

   **Fix**: \`RunExportResult\` gains \`writtenPaths: string[]\` (absolute per-file paths); the dialog lists the first five with an "…and N more" footer.

1 new test for the flatten behaviour, 1 new test for multi-note tree preservation.