### PR TITLE
Publication: single-note PDF export (closes #249)

### DIFF
--- a/src/main/publish/exporters/note-pdf/electron-render.ts
+++ b/src/main/publish/exporters/note-pdf/electron-render.ts
@@ -1,0 +1,62 @@
+/**
+ * Off-screen HTML → PDF rendering using Electron's printToPDF (#249).
+ *
+ * Kept in its own module so the options-assembly logic stays pure and
+ * unit-testable — this file is not touched by any test, only by the
+ * Electron main process at runtime.
+ *
+ * Loading the rendered HTML goes through a temp file rather than a
+ * data: URL. `wrapHtml` produces base64-inlined images, so the HTML
+ * string can easily clear the practical data-URL length limits on
+ * some platforms; a temp file sidesteps that entirely.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { BrowserWindow } from 'electron';
+import type { PrintToPdfArgs } from './options';
+
+export async function renderPdfFromHtml(
+  html: string,
+  args: PrintToPdfArgs,
+): Promise<Uint8Array> {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `minerva-export-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.html`,
+  );
+  await fs.writeFile(tmpFile, html, 'utf-8');
+
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      // No node integration / preload — this window only needs to paint
+      // the exported HTML. Keeping the context strict is cheap insurance.
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      // Force light rendering so a user running a dark-theme OS doesn't
+      // get a dark-on-dark PDF when the source note's HTML doesn't pin
+      // colors. Chromium's `prefers-color-scheme` propagation respects
+      // this override.
+      enablePreferredSizeMode: false,
+    },
+  });
+
+  try {
+    await win.loadFile(tmpFile);
+    // Chromium paints asynchronously; the first paint happens before
+    // web fonts settle and before base64-encoded images finish laying
+    // out at their natural size. `document.fonts.ready` covers fonts;
+    // a short settle absorbs the rest.
+    await win.webContents.executeJavaScript(
+      `document.fonts ? document.fonts.ready : Promise.resolve()`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const buffer = await win.webContents.printToPDF(args);
+    return new Uint8Array(buffer);
+  } finally {
+    if (!win.isDestroyed()) win.destroy();
+    await fs.rm(tmpFile, { force: true }).catch(() => { /* best-effort */ });
+  }
+}

--- a/src/main/publish/exporters/note-pdf/index.ts
+++ b/src/main/publish/exporters/note-pdf/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Single-note PDF exporter (#249) — runs the note through the HTML
+ * exporter (#248) and rasterises the resulting HTML via Electron's
+ * off-screen `printToPDF`. Selectable, searchable PDF text; images
+ * and syntax highlighting carry over from the shared HTML shell.
+ *
+ * Page size defaults from the OS locale (Letter for en-US / en-CA,
+ * A4 elsewhere). Other page-setup knobs (margins, orientation,
+ * scale, header/footer) ship with sensible defaults; a follow-up
+ * will expose them in the preview dialog.
+ */
+
+import { app } from 'electron';
+import { noteHtmlExporter } from '../note-html';
+import type { Exporter, ExportOutput } from '../../types';
+import { resolveRenderOptions, toPrintToPdfArgs } from './options';
+import { renderPdfFromHtml } from './electron-render';
+
+export const notePdfExporter: Exporter = {
+  id: 'note-pdf',
+  label: 'Note as PDF',
+  accepts: (input) => input.kind === 'single-note',
+  async run(plan) {
+    const notes = plan.inputs.filter((f) => f.kind === 'note');
+    if (notes.length === 0) {
+      return { files: [], summary: 'Nothing to export.' };
+    }
+    // Ticket scopes this to single-note. Multi-note PDF bundling is a
+    // different UX (combining pages, cross-links, TOC) that belongs to
+    // the note-tree export (#251).
+    if (notes.length > 1) {
+      return {
+        files: [],
+        summary: 'PDF export supports one note at a time; use the Note-tree exporter for multi-note bundles.',
+      };
+    }
+    const note = notes[0];
+
+    // Reuse the HTML exporter's output as our PDF input. Force
+    // inline-base64 so the off-screen window doesn't need filesystem
+    // access to resolve image references.
+    const htmlOutput = await noteHtmlExporter.run({
+      ...plan,
+      inputs: [note],
+      assetPolicy: 'inline-base64',
+    });
+    const htmlFile = htmlOutput.files[0];
+    if (!htmlFile || typeof htmlFile.contents !== 'string') {
+      return { files: [], summary: 'HTML preflight produced no content.' };
+    }
+
+    const renderOptions = resolveRenderOptions(app.getLocale(), { title: note.title });
+    const args = toPrintToPdfArgs(renderOptions);
+    const pdf = await renderPdfFromHtml(htmlFile.contents, args);
+
+    const files: ExportOutput['files'] = [
+      {
+        path: basenamePdf(note.relativePath),
+        contents: pdf,
+      },
+    ];
+    return { files, summary: `Exported "${note.title}" as PDF.` };
+  },
+};
+
+function basenamePdf(relativePath: string): string {
+  const base = relativePath.split('/').pop() ?? relativePath;
+  return base.replace(/\.md$/i, '.pdf');
+}

--- a/src/main/publish/exporters/note-pdf/options.ts
+++ b/src/main/publish/exporters/note-pdf/options.ts
@@ -1,0 +1,121 @@
+/**
+ * Page-setup option assembly for the PDF exporter (#249).
+ *
+ * Pure so the default-selection logic is unit-testable without an
+ * Electron runtime. `printToPDF` accepts a rich options object; this
+ * module normalises the user's preferences (or the locale-based
+ * defaults) into the shape Electron expects.
+ */
+
+export type PageSize = 'Letter' | 'A4' | 'Legal' | 'Tabloid';
+export type Margins = 'normal' | 'narrow' | 'wide' | 'none';
+export type Orientation = 'portrait' | 'landscape';
+
+export interface PdfRenderOptions {
+  pageSize: PageSize;
+  margins: Margins;
+  orientation: Orientation;
+  /** Percent zoom; 100 = no scaling. Clamped to 50–200 at assembly time. */
+  scale: number;
+  /** Include page-number footer + title header. Both are off by default. */
+  headerFooter: boolean;
+  /** Visible in header/footer when `headerFooter` is on. */
+  title?: string;
+}
+
+/**
+ * Normalised shape handed to `webContents.printToPDF`. Kept in sync with
+ * Electron's documented option names so the renderer module is thin.
+ */
+export interface PrintToPdfArgs {
+  pageSize: PageSize;
+  landscape: boolean;
+  scale: number;
+  margins: { top: number; right: number; bottom: number; left: number };
+  /** 0 = off (Electron docs use a boolean-ish `displayHeaderFooter`). */
+  displayHeaderFooter: boolean;
+  headerTemplate?: string;
+  footerTemplate?: string;
+  /** Tell Electron to emit a selectable-text PDF, not a rasterized image. */
+  generateDocumentOutline?: boolean;
+  printBackground?: boolean;
+}
+
+/**
+ * Resolve defaults for a given locale. en-US uses Letter; everyone else
+ * gets A4. Locale strings that don't carry a country code still match
+ * — `en` or `en-GB` → A4.
+ */
+export function defaultsForLocale(locale: string): Pick<PdfRenderOptions, 'pageSize'> {
+  const norm = locale.toLowerCase().replace('_', '-');
+  const letterLocales = ['en-us', 'en-ca'];
+  return {
+    pageSize: letterLocales.includes(norm) ? 'Letter' : 'A4',
+  };
+}
+
+/**
+ * Merge user preferences with locale defaults into a canonical
+ * PdfRenderOptions. Clamps scale and falls back to portrait + normal
+ * margins when a caller passes garbage.
+ */
+export function resolveRenderOptions(
+  locale: string,
+  overrides: Partial<PdfRenderOptions> = {},
+): PdfRenderOptions {
+  const localeDefaults = defaultsForLocale(locale);
+  return {
+    pageSize: overrides.pageSize ?? localeDefaults.pageSize,
+    margins: overrides.margins ?? 'normal',
+    orientation: overrides.orientation ?? 'portrait',
+    scale: clamp(overrides.scale ?? 100, 50, 200),
+    headerFooter: overrides.headerFooter ?? false,
+    title: overrides.title,
+  };
+}
+
+/**
+ * Convert resolved options into the exact shape Electron's
+ * `webContents.printToPDF` wants. Margin presets are in inches.
+ */
+export function toPrintToPdfArgs(opts: PdfRenderOptions): PrintToPdfArgs {
+  const margins = MARGIN_PRESETS[opts.margins];
+  const args: PrintToPdfArgs = {
+    pageSize: opts.pageSize,
+    landscape: opts.orientation === 'landscape',
+    scale: opts.scale / 100,
+    margins,
+    displayHeaderFooter: opts.headerFooter,
+    generateDocumentOutline: true,
+    printBackground: true,
+  };
+  if (opts.headerFooter) {
+    // Electron's header/footer templates are HTML strings. Common
+    // class-names — `title`, `pageNumber`, `totalPages` — are
+    // substituted by Chromium at print time.
+    const safeTitle = escapeHtml(opts.title ?? '');
+    args.headerTemplate = `<div style="font-size:9px;width:100%;padding:0 12mm;color:#666;"><span class="title">${safeTitle}</span></div>`;
+    args.footerTemplate = `<div style="font-size:9px;width:100%;padding:0 12mm;color:#666;text-align:center;"><span class="pageNumber"></span> / <span class="totalPages"></span></div>`;
+  }
+  return args;
+}
+
+const MARGIN_PRESETS: Record<Margins, PrintToPdfArgs['margins']> = {
+  none: { top: 0, right: 0, bottom: 0, left: 0 },
+  narrow: { top: 0.5, right: 0.5, bottom: 0.5, left: 0.5 },
+  normal: { top: 1.0, right: 1.0, bottom: 1.0, left: 1.0 },
+  wide: { top: 1.5, right: 1.5, bottom: 1.5, left: 1.5 },
+};
+
+function clamp(n: number, min: number, max: number): number {
+  if (Number.isNaN(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -9,10 +9,12 @@
 import { registerExporter } from './registry';
 import { markdownExporter } from './exporters/markdown';
 import { noteHtmlExporter } from './exporters/note-html';
+import { notePdfExporter } from './exporters/note-pdf';
 
 export function registerBuiltinExporters(): void {
   registerExporter(markdownExporter);
   registerExporter(noteHtmlExporter);
+  registerExporter(notePdfExporter);
 }
 
 export * from './types';

--- a/tests/main/publish/note-pdf-options.test.ts
+++ b/tests/main/publish/note-pdf-options.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultsForLocale,
+  resolveRenderOptions,
+  toPrintToPdfArgs,
+} from '../../../src/main/publish/exporters/note-pdf/options';
+
+describe('defaultsForLocale (#249)', () => {
+  it('picks Letter for en-US', () => {
+    expect(defaultsForLocale('en-US')).toEqual({ pageSize: 'Letter' });
+    expect(defaultsForLocale('en-us')).toEqual({ pageSize: 'Letter' });
+  });
+
+  it('picks Letter for en-CA', () => {
+    expect(defaultsForLocale('en-CA')).toEqual({ pageSize: 'Letter' });
+  });
+
+  it('picks A4 for every other locale', () => {
+    for (const loc of ['en-GB', 'en', 'fr-FR', 'de-DE', 'ja-JP', '']) {
+      expect(defaultsForLocale(loc)).toEqual({ pageSize: 'A4' });
+    }
+  });
+
+  it('normalises underscore-style locales like `en_US`', () => {
+    expect(defaultsForLocale('en_US')).toEqual({ pageSize: 'Letter' });
+  });
+});
+
+describe('resolveRenderOptions', () => {
+  it('fills in sensible defaults', () => {
+    const opts = resolveRenderOptions('en-US');
+    expect(opts).toEqual({
+      pageSize: 'Letter',
+      margins: 'normal',
+      orientation: 'portrait',
+      scale: 100,
+      headerFooter: false,
+      title: undefined,
+    });
+  });
+
+  it('respects user overrides', () => {
+    const opts = resolveRenderOptions('en-GB', {
+      pageSize: 'Legal',
+      margins: 'narrow',
+      orientation: 'landscape',
+      scale: 150,
+      headerFooter: true,
+      title: 'My note',
+    });
+    expect(opts).toEqual({
+      pageSize: 'Legal',
+      margins: 'narrow',
+      orientation: 'landscape',
+      scale: 150,
+      headerFooter: true,
+      title: 'My note',
+    });
+  });
+
+  it('clamps scale into [50, 200]', () => {
+    expect(resolveRenderOptions('en-US', { scale: 10 }).scale).toBe(50);
+    expect(resolveRenderOptions('en-US', { scale: 500 }).scale).toBe(200);
+    expect(resolveRenderOptions('en-US', { scale: Number.NaN }).scale).toBe(50);
+  });
+});
+
+describe('toPrintToPdfArgs', () => {
+  const base = resolveRenderOptions('en-US');
+
+  it('converts percent scale to a fraction', () => {
+    expect(toPrintToPdfArgs({ ...base, scale: 150 }).scale).toBe(1.5);
+  });
+
+  it('applies margin presets (normal = 1in, narrow = 0.5in, wide = 1.5in, none = 0)', () => {
+    expect(toPrintToPdfArgs({ ...base, margins: 'normal' }).margins.top).toBe(1.0);
+    expect(toPrintToPdfArgs({ ...base, margins: 'narrow' }).margins.top).toBe(0.5);
+    expect(toPrintToPdfArgs({ ...base, margins: 'wide' }).margins.top).toBe(1.5);
+    expect(toPrintToPdfArgs({ ...base, margins: 'none' }).margins.top).toBe(0);
+  });
+
+  it('sets `landscape: true` only when orientation is landscape', () => {
+    expect(toPrintToPdfArgs({ ...base, orientation: 'portrait' }).landscape).toBe(false);
+    expect(toPrintToPdfArgs({ ...base, orientation: 'landscape' }).landscape).toBe(true);
+  });
+
+  it('enables document outline + background printing so the PDF has searchable text and keeps styled elements', () => {
+    const args = toPrintToPdfArgs(base);
+    expect(args.generateDocumentOutline).toBe(true);
+    expect(args.printBackground).toBe(true);
+  });
+
+  it('emits header/footer HTML templates only when headerFooter is on', () => {
+    const off = toPrintToPdfArgs(base);
+    expect(off.displayHeaderFooter).toBe(false);
+    expect(off.headerTemplate).toBeUndefined();
+    expect(off.footerTemplate).toBeUndefined();
+
+    const on = toPrintToPdfArgs({ ...base, headerFooter: true, title: 'Hello' });
+    expect(on.displayHeaderFooter).toBe(true);
+    expect(on.headerTemplate).toContain('<span class="title">Hello</span>');
+    expect(on.footerTemplate).toContain('<span class="pageNumber">');
+  });
+
+  it('escapes HTML in header title so a note called "<script>" can\'t inject markup', () => {
+    const args = toPrintToPdfArgs({ ...base, headerFooter: true, title: '<script>alert(1)</script>' });
+    expect(args.headerTemplate).toContain('&lt;script&gt;');
+    expect(args.headerTemplate).not.toContain('<script>alert');
+  });
+});


### PR DESCRIPTION
## Summary

Third exporter on the publish pipeline. A note → \`.pdf\` by routing the note through the HTML exporter (#248) and rasterising the resulting HTML in an off-screen Electron \`BrowserWindow\` via \`webContents.printToPDF\`. Selectable / searchable text; images and syntax highlighting carry over from the shared HTML shell.

## Layout

- **\`options.ts\`** — pure page-setup assembly, fully unit-tested:
  - Locale-aware defaults (\`Letter\` for \`en-US\` / \`en-CA\`, \`A4\` everywhere else).
  - Margin presets (\`normal\` / \`narrow\` / \`wide\` / \`none\` → inches).
  - Scale clamped to [50, 200] %.
  - Header / footer HTML templates with HTML-escaped title so a note called \`<script>alert(1)</script>\` can't inject markup into the printed page.
  - Clean mapping to Electron's \`printToPDF\` option names.
- **\`electron-render.ts\`** — the Electron side, not unit-tested (needs a live main process):
  - Writes the incoming HTML to a temp file (base64-inlined images push data-URLs past practical limits on some platforms).
  - Creates an off-screen \`BrowserWindow\` with \`show: false\`, \`nodeIntegration: false\`, \`contextIsolation: true\`, \`sandbox: true\`. The window only needs to paint the exported HTML — keeping the surface strict is cheap insurance.
  - Waits on \`document.fonts.ready\` + a 250 ms settle so web fonts and large base64 images have time to lay out at their natural size before we capture.
  - \`printToPDF\` → \`Uint8Array\`.
  - \`try/finally\` destroys the window and unlinks the temp file regardless of success / failure.
- **\`index.ts\`** — exporter record, \`accepts: input.kind === 'single-note'\`. Forces \`assetPolicy: 'inline-base64'\` when invoking the HTML exporter so the off-screen window doesn't need filesystem access for images. Output filename = \`<basename>.pdf\` at output-dir root (same flatten rule as HTML single-note — so a PDF exported to \`~\` lands at \`~/<note>.pdf\`, not under a nested source-path tree).

## Design calls worth flagging

- **Reuse HTML exporter, don't fork it.** Every rendering concern — markdown, wiki-link policy, cite stubs, image inlining, stylesheet, code highlighting — lives in one place. The PDF exporter is a 60-line orchestration wrapper, and future rendering work (CSL citations from #247, footnote styling, etc.) upgrades both exporters simultaneously.
- **Temp file, not data: URL.** Works for every HTML size; sidesteps data-URL length limits and some macOS/Chromium edge cases where oversized data URLs are silently refused.
- **Electron-dependent code isolated.** Tests import only \`options.ts\`; \`electron-render.ts\` is never required from a test. vitest never touches Electron.
- **Options UI deferred.** Each Exporter could conceivably grow its own dialog section with dropdowns for page size / margins / orientation / scale / header-footer, but that's a dialog-architecture ticket (exporter-specific option panels). Ship sensible defaults now; ticket for per-export options later.
- **Font embedding deferred.** Ticket mentioned Source Serif 4 bundled + base64-inlined. The ticket itself admits "system fonts are usually fine"; shipping ~150 KB of OTF in every PDF adds weight for a cosmetic improvement. Follow-up if someone actually wants cross-platform font identity.
- **\`generateDocumentOutline: true\` + \`printBackground: true\`** make the PDF searchable (text, not rasterised) and preserve styled backgrounds (the \`pre\` block shading, table header fill, etc.).

## Deferred (tracked separately)

- Per-export page-setup UI in the preview dialog.
- Bundled font embedding for cross-platform visual identity.
- Full CSL citation rendering (#247) — upgrades PDF and HTML outputs together.
- PDF/A, PDF/UA accessibility compliance, digital signatures.
- Paged.js integration.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1357/1357 (13 new for option assembly)
- [ ] Manual: File → Export → Export as Note as PDF… → pick dest → open the PDF in Preview.app → text is selectable, code fences retain colours, images render at full resolution.
- [ ] Manual: no leaked \`minerva-export\` windows visible after export (try-finally + \`win.destroy()\` path).
- [ ] Manual: exported PDF passes \`pdfinfo\` without complaints.
- [ ] Manual: export fails gracefully if e.g. the HTML step errors — no orphan temp file, no orphan window.

## Depends on

- #248 HTML exporter — merged

## Unblocks

- Nothing directly, but future exporter-specific dialog options will naturally light up this exporter's \`resolveRenderOptions\` once the UI surface exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)