### PR TITLE
Publication: note-tree HTML bundle (progress on #251)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -711,7 +711,14 @@ export function registerIpcHandlers(): void {
   // ── Publication (#282) ─────────────────────────────────────────────────────
 
   ipcMain.handle(Channels.PUBLISH_LIST_EXPORTERS, () =>
-    publish.listExporters().map((e) => ({ id: e.id, label: e.label })),
+    publish.listExporters().map((e) => ({
+      id: e.id,
+      label: e.label,
+      // Default to the non-tree kinds when the exporter didn't declare —
+      // tree is opt-in (only exporters that know how to walk wiki-link
+      // closures should expose it as a scope in the dialog).
+      acceptedKinds: e.acceptedKinds ?? ['single-note', 'folder', 'project'],
+    })),
   );
 
   ipcMain.handle(Channels.PUBLISH_RESOLVE_PLAN, async (e, input: publish.ExportInput, opts?: {

--- a/src/main/publish/exporters/markdown.ts
+++ b/src/main/publish/exporters/markdown.ts
@@ -21,7 +21,8 @@ import type { Exporter } from '../types';
 export const markdownExporter: Exporter = {
   id: 'markdown',
   label: 'Markdown (passthrough)',
-  accepts: () => true,
+  accepts: (input) => input.kind !== 'tree',
+  acceptedKinds: ['single-note', 'folder', 'project'],
   async run(plan) {
     const ctx = buildLinkResolverContext(plan);
     const files = plan.inputs

--- a/src/main/publish/exporters/note-html/index.ts
+++ b/src/main/publish/exporters/note-html/index.ts
@@ -14,9 +14,11 @@ import type { Exporter, ExportOutput } from '../../types';
 export const noteHtmlExporter: Exporter = {
   id: 'note-html',
   label: 'Note as HTML',
-  // Accepts every scope; the per-note rendering is identical, and
-  // `follow-to-file` works best when there's more than one note.
-  accepts: () => true,
+  // Single-note HTML is the canonical use; folder / project scopes also
+  // work (emits one file per note) but the tree scope belongs to the
+  // dedicated tree-html exporter which handles the bundle shape.
+  accepts: (input) => input.kind !== 'tree',
+  acceptedKinds: ['single-note', 'folder', 'project'],
   async run(plan) {
     const rootPath = plan.rootPath ?? '';
     const notes = plan.inputs.filter((f) => f.kind === 'note');

--- a/src/main/publish/exporters/note-pdf/index.ts
+++ b/src/main/publish/exporters/note-pdf/index.ts
@@ -20,6 +20,7 @@ export const notePdfExporter: Exporter = {
   id: 'note-pdf',
   label: 'Note as PDF',
   accepts: (input) => input.kind === 'single-note',
+  acceptedKinds: ['single-note'],
   async run(plan) {
     const notes = plan.inputs.filter((f) => f.kind === 'note');
     if (notes.length === 0) {

--- a/src/main/publish/exporters/tree-html/index.ts
+++ b/src/main/publish/exporters/tree-html/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Note-tree HTML bundle exporter (#251).
+ *
+ * Given the ExportPlan of a tree-mode resolve — root note + its
+ * transitive wiki-link closure — render every note as HTML using the
+ * same pipeline as #248's note-html exporter, but with link resolution
+ * forced to `follow-to-file` and the root renamed to `index.html`.
+ * Cross-links inside the bundle resolve relative to each page.
+ *
+ * Deferred to follow-up tickets: shared external stylesheet, sidebar
+ * navigation, consolidated bibliography (needs #247), manual
+ * deselection of notes in the preview dialog.
+ */
+
+import { renderNoteBody, inlineImages } from '../note-html/render';
+import { wrapHtml } from '../note-html/shell';
+import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../../types';
+
+export const treeHtmlExporter: Exporter = {
+  id: 'tree-html',
+  label: 'Note Tree as HTML Bundle',
+  // Only the tree scope — walking wiki-link closures is the whole point.
+  accepts: (input) => input.kind === 'tree',
+  acceptedKinds: ['tree'],
+  async run(plan) {
+    // The root is the first entry of the resolver's BFS order.
+    const rootPath = plan.rootPath ?? '';
+    const notes = plan.inputs.filter((f) => f.kind === 'note');
+    if (notes.length === 0) {
+      return { files: [], summary: 'Nothing to export in this tree.' };
+    }
+    const rootNote = notes[0];
+
+    // Force follow-to-file even when the plan's linkPolicy is
+    // inline-title — within a bundle the user clearly wants cross-links
+    // to work, and inline-title is the wrong default here.
+    const bundlePlan: ExportPlan = { ...plan, linkPolicy: 'follow-to-file' };
+
+    const files: ExportOutput['files'] = [];
+    for (const note of notes) {
+      const rawBody = renderNoteBody(note, bundlePlan);
+      const body = await inlineImages(rawBody, note, rootPath, bundlePlan.assetPolicy);
+      const html = wrapHtml({ title: note.title, body });
+      files.push({
+        path: outputPathFor(note, rootNote),
+        contents: html,
+      });
+    }
+
+    const excluded = plan.excluded.length;
+    const summary = excluded > 0
+      ? `Bundle of ${files.length} note${files.length === 1 ? '' : 's'} (${excluded} excluded).`
+      : `Bundle of ${files.length} note${files.length === 1 ? '' : 's'}.`;
+    return { files, summary };
+  },
+};
+
+/**
+ * Root note → `index.html` at the bundle root.
+ * Other notes keep their source-relative path with `.md` → `.html`.
+ * This pairs with note-html's `follow-to-file` rewriter, which turns
+ * `[[other]]` into `<a href="other.html">` — the same shape relative
+ * to the emitting file, regardless of depth.
+ */
+function outputPathFor(note: ExportPlanFile, rootNote: ExportPlanFile): string {
+  if (note.relativePath === rootNote.relativePath) return 'index.html';
+  return note.relativePath.replace(/\.md$/i, '.html');
+}

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -10,11 +10,13 @@ import { registerExporter } from './registry';
 import { markdownExporter } from './exporters/markdown';
 import { noteHtmlExporter } from './exporters/note-html';
 import { notePdfExporter } from './exporters/note-pdf';
+import { treeHtmlExporter } from './exporters/tree-html';
 
 export function registerBuiltinExporters(): void {
   registerExporter(markdownExporter);
   registerExporter(noteHtmlExporter);
   registerExporter(notePdfExporter);
+  registerExporter(treeHtmlExporter);
 }
 
 export * from './types';

--- a/src/main/publish/pipeline.ts
+++ b/src/main/publish/pipeline.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import YAML from 'yaml';
 import { checkExclusion } from './exclusion';
+import { resolveTree, extractWikiLinkTargets } from './tree-resolver';
 import type {
   ExportInput,
   ExportPlan,
@@ -40,6 +41,67 @@ export async function resolvePlan(
   input: ExportInput,
   opts: ResolvePlanOptions = {},
 ): Promise<ExportPlan> {
+  const { inputs, excluded } = input.kind === 'tree'
+    ? await collectTreeEntries(rootPath, input)
+    : await collectFilesystemEntries(rootPath, input);
+
+  return {
+    inputs,
+    excluded,
+    linkPolicy: opts.linkPolicy ?? 'inline-title',
+    assetPolicy: opts.assetPolicy ?? 'keep-relative',
+    citationStyle: opts.citationStyle,
+    outputDir: opts.outputDir,
+    rootPath,
+  };
+}
+
+// ── Tree-mode resolution ────────────────────────────────────────────────────
+
+async function collectTreeEntries(
+  rootPath: string,
+  input: ExportInput,
+): Promise<{ inputs: ExportPlanFile[]; excluded: ExportPlanExclusion[] }> {
+  if (!input.relativePath) {
+    throw new Error('Tree export requires a root note (input.relativePath).');
+  }
+  const tree = await resolveTree({
+    rootNote: input.relativePath,
+    maxDepth: input.maxDepth ?? 3,
+    extractLinks: extractWikiLinkTargets,
+    async readFile(rel: string) {
+      try {
+        return await fs.readFile(path.join(rootPath, rel), 'utf-8');
+      } catch {
+        return null;
+      }
+    },
+    isExcluded: (rel: string, content: string) => checkExclusion(rel, content),
+  });
+
+  const inputs: ExportPlanFile[] = tree.included.map((entry) => {
+    const { frontmatter, title } = parseHeader(entry.relativePath, entry.content);
+    return {
+      relativePath: entry.relativePath,
+      kind: 'note',
+      content: entry.content,
+      frontmatter,
+      title,
+    };
+  });
+  const excluded: ExportPlanExclusion[] = tree.excluded.map((e) => ({
+    relativePath: e.relativePath,
+    reason: e.reason,
+  }));
+  return { inputs, excluded };
+}
+
+// ── Filesystem-walk resolution (single-note / folder / project) ─────────────
+
+async function collectFilesystemEntries(
+  rootPath: string,
+  input: ExportInput,
+): Promise<{ inputs: ExportPlanFile[]; excluded: ExportPlanExclusion[] }> {
   const candidatePaths = await collectCandidatePaths(rootPath, input);
 
   const inputs: ExportPlanFile[] = [];
@@ -72,16 +134,7 @@ export async function resolvePlan(
   // Sort for deterministic ordering across exporter runs.
   inputs.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
   excluded.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
-
-  return {
-    inputs,
-    excluded,
-    linkPolicy: opts.linkPolicy ?? 'inline-title',
-    assetPolicy: opts.assetPolicy ?? 'keep-relative',
-    citationStyle: opts.citationStyle,
-    outputDir: opts.outputDir,
-    rootPath,
-  };
+  return { inputs, excluded };
 }
 
 export async function runExporter(

--- a/src/main/publish/tree-resolver.ts
+++ b/src/main/publish/tree-resolver.ts
@@ -1,0 +1,158 @@
+/**
+ * Note-tree resolver for bundle exports (#251).
+ *
+ * BFS from a root note through outbound wiki-links, bounded by depth,
+ * de-duplicating cycles, and respecting the private-by-default exclusion
+ * rules from #246. Returns the ordered manifest the tree exporter feeds
+ * into the per-note renderer, plus an audit of what got excluded and
+ * which links couldn't be resolved.
+ *
+ * Pure — accepts pluggable `readFile`, `extractLinks`, and `isExcluded`
+ * functions so tests exercise the algorithm without the filesystem and
+ * the production flow wires in real implementations.
+ */
+
+export interface TreeResolveOptions {
+  /** Relative path to the root note the user selected. */
+  rootNote: string;
+  /** 0 = root only; default 3 everywhere else this module is called. */
+  maxDepth: number;
+  /** Pull every plain wiki-link target out of a note's content. `cite::` / `quote::` should be omitted. */
+  extractLinks: (content: string) => string[];
+  /**
+   * Read a note's raw content by relative path (as-written in the
+   * source's wiki-links). Returns null when the path doesn't resolve
+   * to a real file — the resolver records it as unresolved rather
+   * than throwing.
+   */
+  readFile: (relativePath: string) => Promise<string | null>;
+  /** Exclusion check — private-folder / frontmatter / tag rules from #246. */
+  isExcluded: (relativePath: string, content: string) => { excluded: boolean; reason?: string };
+}
+
+export interface ResolvedTreeEntry {
+  relativePath: string;
+  depth: number;
+  content: string;
+}
+
+export interface ResolvedTreeExclusion {
+  relativePath: string;
+  reason: string;
+  depth: number;
+}
+
+export interface ResolvedTree {
+  /** Root first, then BFS order. One entry per unique relative path. */
+  included: ResolvedTreeEntry[];
+  /** Notes reached but dropped by the exclusion rules. Depth-annotated for the audit. */
+  excluded: ResolvedTreeExclusion[];
+  /**
+   * Wiki-link targets that didn't resolve to a real file. Common on
+   * stub-linked notes ("[[future-work]]") — listed but non-fatal.
+   */
+  unresolved: string[];
+}
+
+/**
+ * Run the BFS. Works over abstract string paths; see `normalizeTarget`
+ * for the convention used to turn wiki-link targets ("notes/foo",
+ * "foo.md") into the canonical form the filesystem sees ("notes/foo.md").
+ */
+export async function resolveTree(opts: TreeResolveOptions): Promise<ResolvedTree> {
+  const visited = new Set<string>();
+  const included: ResolvedTreeEntry[] = [];
+  const excluded: ResolvedTreeExclusion[] = [];
+  const unresolved: string[] = [];
+
+  interface QueueEntry { path: string; depth: number }
+  const queue: QueueEntry[] = [{ path: normalizeTarget(opts.rootNote), depth: 0 }];
+
+  while (queue.length > 0) {
+    const entry = queue.shift();
+    if (!entry) break;
+    if (visited.has(entry.path)) continue;
+    visited.add(entry.path);
+
+    const content = await opts.readFile(entry.path);
+    if (content == null) {
+      // The root not existing is fatal; downstream paths are just missing links.
+      if (entry.depth === 0) {
+        throw new Error(`Tree root "${opts.rootNote}" not found.`);
+      }
+      unresolved.push(entry.path);
+      continue;
+    }
+
+    const check = opts.isExcluded(entry.path, content);
+    if (check.excluded) {
+      excluded.push({
+        relativePath: entry.path,
+        reason: check.reason ?? 'excluded',
+        depth: entry.depth,
+      });
+      continue;
+    }
+
+    included.push({ relativePath: entry.path, depth: entry.depth, content });
+
+    if (entry.depth >= opts.maxDepth) continue;
+
+    const links = opts.extractLinks(content);
+    for (const raw of links) {
+      const target = normalizeTarget(raw);
+      if (!target) continue;
+      if (visited.has(target)) continue;
+      // Queueing a path we've already enqueued but not yet visited
+      // is harmless — the `visited` check at dequeue time filters it.
+      queue.push({ path: target, depth: entry.depth + 1 });
+    }
+  }
+
+  return { included, excluded, unresolved };
+}
+
+/**
+ * Turn a wiki-link target into the canonical relative path we use
+ * throughout the pipeline: `.md`-suffixed, forward-slashed, no
+ * leading `./`. Anchor and display fragments are stripped by the
+ * caller's `extractLinks`; we tolerate stragglers anyway.
+ */
+export function normalizeTarget(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  // Drop any anchor the caller didn't strip.
+  const hashIdx = trimmed.indexOf('#');
+  const noAnchor = hashIdx >= 0 ? trimmed.slice(0, hashIdx) : trimmed;
+  // Normalise slashes + ensure `.md` suffix.
+  const unified = noAnchor.replace(/\\/g, '/').replace(/^\.?\//, '');
+  if (!unified) return '';
+  return unified.toLowerCase().endsWith('.md') ? unified : `${unified}.md`;
+}
+
+/**
+ * Wiki-link extractor tuned for the tree resolver's needs: returns only
+ * the *target* portion of every `[[…]]` match that isn't a `cite::` or
+ * `quote::` reference. Typed prefixes (`references::foo`) are stripped.
+ * Anchors (`#section`) dropped. Display text (`|label`) dropped.
+ *
+ * Lives here (not in the resolver itself) so it's reusable by the
+ * exporter's dry-run path and by the dialog's preview.
+ */
+export function extractWikiLinkTargets(content: string): string[] {
+  const out: string[] = [];
+  // Strip frontmatter so `derived_from: "[[…]]"` in a note's YAML
+  // still contributes the link — we include frontmatter wiki-links
+  // deliberately, because that's how derived notes trace back.
+  const WIKI_RE = /\[\[([^\]|\n]+?)(?:\|[^\]\n]+)?\]\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = WIKI_RE.exec(content)) !== null) {
+    const inner = m[1].trim();
+    if (/^(cite|quote)::/i.test(inner)) continue;
+    const untyped = inner.replace(/^[a-z][a-z0-9_]*::/i, '');
+    const hashIdx = untyped.indexOf('#');
+    const target = (hashIdx >= 0 ? untyped.slice(0, hashIdx) : untyped).trim();
+    if (target) out.push(target);
+  }
+  return out;
+}

--- a/src/main/publish/types.ts
+++ b/src/main/publish/types.ts
@@ -13,13 +13,20 @@
 
 /** What the caller asked to export. The pipeline resolves this into a plan. */
 export interface ExportInput {
-  kind: 'single-note' | 'folder' | 'project';
+  kind: 'single-note' | 'folder' | 'project' | 'tree';
   /**
    * For `single-note`: the note's relative path.
    * For `folder`: the folder's relative path (empty = project root).
    * For `project`: ignored; always the whole project.
+   * For `tree`: the root note whose reachable wiki-link closure we bundle.
    */
   relativePath?: string;
+  /**
+   * Only meaningful for `kind === 'tree'`. Max BFS depth from the root.
+   * `0` = just the root. Unbounded trees are expensive — the default of
+   * 3 balances "include everything plausible" against runaway bundles.
+   */
+  maxDepth?: number;
 }
 
 /**
@@ -106,6 +113,13 @@ export interface Exporter {
   label: string;
   /** Whether the exporter can handle this input kind. Falsy = hidden in the menu. */
   accepts(input: ExportInput): boolean;
+  /**
+   * Optional hint for the preview dialog — which input kinds to offer
+   * as scope options. When omitted the dialog offers every kind except
+   * `tree` (which requires explicit opt-in since not every exporter
+   * knows how to walk wiki-link closures).
+   */
+  acceptedKinds?: ExportInput['kind'][];
   /** Transform plan → output. Exporters never write files directly; that's the pipeline's job. */
   run(plan: ExportPlan): Promise<ExportOutput>;
 }

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -19,7 +19,7 @@
 
   let { exporterId, activeFilePath, onCancel, onExported }: Props = $props();
 
-  type Scope = 'project' | 'folder' | 'single-note';
+  type Scope = 'project' | 'folder' | 'single-note' | 'tree';
   type LinkPolicy = 'drop' | 'inline-title' | 'follow-to-file';
 
   let scope = $state<Scope>('project');
@@ -28,6 +28,8 @@
   let loading = $state(false);
   let exporting = $state(false);
   let error = $state<string | null>(null);
+  let acceptedKinds = $state<readonly Scope[]>(['single-note', 'folder', 'project']);
+  let acceptedLoaded = $state(false);
 
   const activeFolder = $derived.by(() => {
     if (!activeFilePath) return '';
@@ -39,10 +41,15 @@
   // when no file is open) get disabled rather than hidden — keeps the
   // radio layout stable.
   const canScopeNote = $derived(activeFilePath != null);
+  const canScopeTree = $derived(activeFilePath != null && acceptedKinds.includes('tree'));
+  const canScopeProject = $derived(acceptedKinds.includes('project'));
+  const canScopeFolder = $derived(acceptedKinds.includes('folder'));
+  const canScopeSingleNote = $derived(acceptedKinds.includes('single-note'));
 
-  function scopeInput(): { kind: Scope; relativePath?: string } {
+  function scopeInput(): { kind: Scope; relativePath?: string; maxDepth?: number } {
     if (scope === 'single-note') return { kind: 'single-note', relativePath: activeFilePath ?? '' };
     if (scope === 'folder') return { kind: 'folder', relativePath: activeFolder };
+    if (scope === 'tree') return { kind: 'tree', relativePath: activeFilePath ?? '', maxDepth: 3 };
     return { kind: 'project' };
   }
 
@@ -59,6 +66,28 @@
     }
   }
 
+  // On mount, fetch acceptedKinds so the scope radios can disable
+  // kinds the exporter doesn't support, and pick a sensible initial
+  // scope (tree when only tree is accepted; else project).
+  $effect(() => {
+    void (async () => {
+      const list = await api.publish.listExporters();
+      const entry = list.find((e) => e.id === exporterId);
+      if (entry) {
+        acceptedKinds = entry.acceptedKinds as Scope[];
+        // Pick the best default scope given what the exporter accepts
+        // AND what the context supports.
+        if (!acceptedKinds.includes(scope)) {
+          if (acceptedKinds.includes('tree') && activeFilePath) scope = 'tree';
+          else if (acceptedKinds.includes('project')) scope = 'project';
+          else if (acceptedKinds.includes('single-note') && activeFilePath) scope = 'single-note';
+          else scope = acceptedKinds[0] ?? 'project';
+        }
+      }
+      acceptedLoaded = true;
+    })();
+  });
+
   // Re-resolve whenever the scope or link policy changes. `$effect`
   // re-runs on any tracked read, so wrapping refreshPlan() in here
   // subscribes to scope, linkPolicy, activeFilePath, and activeFolder.
@@ -66,6 +95,7 @@
     void scope;
     void linkPolicy;
     void activeFilePath;
+    if (!acceptedLoaded) return;
     void refreshPlan();
   });
 
@@ -105,18 +135,30 @@
     <div class="option-row">
       <label>Scope</label>
       <div class="radio-group">
-        <label>
-          <input type="radio" name="scope" value="project" bind:group={scope} />
-          Entire project
-        </label>
-        <label>
-          <input type="radio" name="scope" value="folder" bind:group={scope} disabled={!activeFilePath} />
-          Current folder{activeFolder ? ` (${activeFolder || 'root'})` : ''}
-        </label>
-        <label>
-          <input type="radio" name="scope" value="single-note" bind:group={scope} disabled={!canScopeNote} />
-          Current note{activeFilePath ? ` (${activeFilePath})` : ''}
-        </label>
+        {#if canScopeProject}
+          <label>
+            <input type="radio" name="scope" value="project" bind:group={scope} />
+            Entire project
+          </label>
+        {/if}
+        {#if canScopeFolder}
+          <label>
+            <input type="radio" name="scope" value="folder" bind:group={scope} disabled={!activeFilePath} />
+            Current folder{activeFolder ? ` (${activeFolder || 'root'})` : ''}
+          </label>
+        {/if}
+        {#if canScopeSingleNote}
+          <label>
+            <input type="radio" name="scope" value="single-note" bind:group={scope} disabled={!canScopeNote} />
+            Current note{activeFilePath ? ` (${activeFilePath})` : ''}
+          </label>
+        {/if}
+        {#if acceptedKinds.includes('tree')}
+          <label>
+            <input type="radio" name="scope" value="tree" bind:group={scope} disabled={!canScopeTree} />
+            Note tree from current note (depth 3)
+          </label>
+        {/if}
       </div>
     </div>
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -124,11 +124,14 @@ export interface ExportPreviewPlan {
   excluded: Array<{ relativePath: string; reason: string }>;
 }
 
+export type ExportInputKind = 'single-note' | 'folder' | 'project' | 'tree';
+
 export interface RunExportInput {
   exporterId: string;
   input: {
-    kind: 'single-note' | 'folder' | 'project';
+    kind: ExportInputKind;
     relativePath?: string;
+    maxDepth?: number;
   };
   outputDir: string;
   linkPolicy?: 'drop' | 'inline-title' | 'follow-to-file';
@@ -143,7 +146,7 @@ export interface RunExportResult {
 
 export interface PublishApi {
   /** Every registered exporter, for menu + dialog population. */
-  listExporters(): Promise<Array<{ id: string; label: string }>>;
+  listExporters(): Promise<Array<{ id: string; label: string; acceptedKinds: ExportInputKind[] }>>;
   /** Resolve an ExportPlan without running it — for the preview dialog. */
   resolvePlan(
     input: RunExportInput['input'],

--- a/tests/main/publish/tree-html.test.ts
+++ b/tests/main/publish/tree-html.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
+import { treeHtmlExporter } from '../../../src/main/publish/exporters/tree-html';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tree-html-test-'));
+}
+
+describe('tree-html exporter (#251) — through the pipeline', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkTempProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('bundles the root and its wiki-link closure, root → index.html, others keep tree paths', async () => {
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/root.md'),
+      '---\ntitle: The Thesis\n---\n\n# The Thesis\n\nLinked to [[notes/ch1]] and [[notes/ch2]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'notes/ch1.md'),
+      '---\ntitle: Chapter One\n---\n\n# Chapter One\n\nSee [[notes/ch2]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'notes/ch2.md'),
+      '---\ntitle: Chapter Two\n---\n\n# Chapter Two\n', 'utf-8');
+    // A floating note outside the reachable closure — must not appear.
+    await fsp.writeFile(path.join(root, 'notes/unreachable.md'), '# nope\n', 'utf-8');
+
+    const plan = await resolvePlan(root, {
+      kind: 'tree',
+      relativePath: 'notes/root.md',
+      maxDepth: 3,
+    }, { linkPolicy: 'follow-to-file' });
+    const output = await runExporter(treeHtmlExporter, plan);
+
+    const paths = output.files.map((f) => f.path).sort();
+    expect(paths).toEqual(['index.html', 'notes/ch1.html', 'notes/ch2.html']);
+
+    const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    expect(indexHtml).toContain('<title>The Thesis</title>');
+    // Cross-links use relative .html paths so the bundle browses as-is.
+    expect(indexHtml).toContain('href="notes/ch1.html"');
+    expect(indexHtml).toContain('href="notes/ch2.html"');
+  });
+
+  it('respects maxDepth — a note at depth > limit is excluded from the bundle', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '[[b]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '[[c]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'c.md'), '[[d]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'd.md'), 'deep\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 2 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    const paths = output.files.map((f) => f.path).sort();
+    expect(paths).toEqual(['b.html', 'c.html', 'index.html']);
+    expect(paths).not.toContain('d.html');
+  });
+
+  it('excludes private notes from the bundle and records them in the plan', async () => {
+    await fsp.mkdir(path.join(root, 'private'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'root.md'), '[[public]] [[private/secret]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'public.md'), 'hello\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'private/secret.md'), 'shh\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 3 });
+    expect(plan.excluded.map((e) => e.relativePath)).toEqual(['private/secret.md']);
+    const output = await runExporter(treeHtmlExporter, plan);
+    const paths = output.files.map((f) => f.path).sort();
+    expect(paths).toEqual(['index.html', 'public.html']);
+  });
+
+  it('cycles in the link graph do not cause infinite loops', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '[[b]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '[[a]]\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 10 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    expect(output.files.map((f) => f.path).sort()).toEqual(['b.html', 'index.html']);
+  });
+
+  it('forces follow-to-file even when the plan arrived with inline-title', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '[[b]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '# B\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'a.md', maxDepth: 3 },
+      { linkPolicy: 'inline-title' },
+    );
+    const output = await runExporter(treeHtmlExporter, plan);
+    const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    expect(indexHtml).toContain('href="b.html"');
+  });
+});

--- a/tests/main/publish/tree-resolver.test.ts
+++ b/tests/main/publish/tree-resolver.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveTree,
+  extractWikiLinkTargets,
+  normalizeTarget,
+} from '../../../src/main/publish/tree-resolver';
+
+/** Minimal file system — Map<relativePath, content>. */
+function mkFs(entries: Record<string, string>) {
+  return async (p: string) => (p in entries ? entries[p] : null);
+}
+
+describe('extractWikiLinkTargets', () => {
+  it('returns targets of plain and display-text wiki-links', () => {
+    expect(extractWikiLinkTargets('See [[notes/foo]] and [[notes/bar|the other]].')).toEqual([
+      'notes/foo',
+      'notes/bar',
+    ]);
+  });
+
+  it('strips typed-link prefixes (references::, supports::, …)', () => {
+    expect(extractWikiLinkTargets('[[references::notes/baz]]')).toEqual(['notes/baz']);
+  });
+
+  it('omits cite / quote refs — those resolve via the citations path', () => {
+    expect(extractWikiLinkTargets('As [[cite::smith-2023]] notes, [[quote::p42]] says…')).toEqual([]);
+  });
+
+  it('strips anchors from the target', () => {
+    expect(extractWikiLinkTargets('Jump to [[notes/foo#section-2]].')).toEqual(['notes/foo']);
+  });
+});
+
+describe('normalizeTarget', () => {
+  it('adds .md when missing', () => {
+    expect(normalizeTarget('notes/foo')).toBe('notes/foo.md');
+  });
+  it('leaves .md alone when present', () => {
+    expect(normalizeTarget('notes/foo.md')).toBe('notes/foo.md');
+  });
+  it('strips leading ./ and normalizes backslashes', () => {
+    expect(normalizeTarget('./notes/foo')).toBe('notes/foo.md');
+    expect(normalizeTarget('notes\\foo')).toBe('notes/foo.md');
+  });
+  it('returns empty string for empty input', () => {
+    expect(normalizeTarget('')).toBe('');
+    expect(normalizeTarget('  ')).toBe('');
+  });
+});
+
+describe('resolveTree (#251)', () => {
+  const notExcluded = () => ({ excluded: false as const });
+
+  it('walks a small linear tree from the root', async () => {
+    const fs = {
+      'root.md': 'Root → [[a]]',
+      'a.md': 'A → [[b]]',
+      'b.md': 'B leaf.',
+    };
+    const tree = await resolveTree({
+      rootNote: 'root.md',
+      maxDepth: 3,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: notExcluded,
+    });
+    expect(tree.included.map((e) => e.relativePath)).toEqual(['root.md', 'a.md', 'b.md']);
+    expect(tree.included.map((e) => e.depth)).toEqual([0, 1, 2]);
+    expect(tree.excluded).toEqual([]);
+    expect(tree.unresolved).toEqual([]);
+  });
+
+  it('respects maxDepth — a note at depth 4 is not included when maxDepth is 3', async () => {
+    const fs = {
+      'root.md': '[[d1]]',
+      'd1.md': '[[d2]]',
+      'd2.md': '[[d3]]',
+      'd3.md': '[[d4]]',
+      'd4.md': 'leaf',
+    };
+    const tree = await resolveTree({
+      rootNote: 'root.md',
+      maxDepth: 3,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: notExcluded,
+    });
+    expect(tree.included.map((e) => e.relativePath)).toEqual(['root.md', 'd1.md', 'd2.md', 'd3.md']);
+    expect(tree.included.some((e) => e.relativePath === 'd4.md')).toBe(false);
+  });
+
+  it('handles cycles without looping', async () => {
+    const fs = {
+      'a.md': '[[b]]',
+      'b.md': '[[c]]',
+      'c.md': '[[a]] and [[b]]',
+    };
+    const tree = await resolveTree({
+      rootNote: 'a.md',
+      maxDepth: 10,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: notExcluded,
+    });
+    expect(tree.included.map((e) => e.relativePath)).toEqual(['a.md', 'b.md', 'c.md']);
+  });
+
+  it('visits each note once even when multiple paths reach it', async () => {
+    // Diamond: root → a, root → b, a → c, b → c
+    const fs = {
+      'root.md': '[[a]] [[b]]',
+      'a.md': '[[c]]',
+      'b.md': '[[c]]',
+      'c.md': 'shared leaf',
+    };
+    const tree = await resolveTree({
+      rootNote: 'root.md',
+      maxDepth: 5,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: notExcluded,
+    });
+    const paths = tree.included.map((e) => e.relativePath);
+    expect(paths).toEqual(['root.md', 'a.md', 'b.md', 'c.md']);
+    // c appears at depth 2 (shorter of the two reachings is the BFS-first).
+    expect(tree.included.find((e) => e.relativePath === 'c.md')?.depth).toBe(2);
+  });
+
+  it('excludes private notes with the reason surfaced in the audit', async () => {
+    const fs = {
+      'root.md': '[[public]] [[private/secret]]',
+      'public.md': 'ok',
+      'private/secret.md': 'secret',
+    };
+    const tree = await resolveTree({
+      rootNote: 'root.md',
+      maxDepth: 3,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: (p) => p.startsWith('private/')
+        ? { excluded: true, reason: 'under private/' }
+        : { excluded: false },
+    });
+    expect(tree.included.map((e) => e.relativePath)).toEqual(['root.md', 'public.md']);
+    expect(tree.excluded).toEqual([
+      { relativePath: 'private/secret.md', reason: 'under private/', depth: 1 },
+    ]);
+  });
+
+  it('records unresolved links without aborting', async () => {
+    const fs = {
+      'root.md': '[[real]] [[nonexistent]]',
+      'real.md': 'ok',
+    };
+    const tree = await resolveTree({
+      rootNote: 'root.md',
+      maxDepth: 3,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: notExcluded,
+    });
+    expect(tree.included.map((e) => e.relativePath)).toEqual(['root.md', 'real.md']);
+    expect(tree.unresolved).toEqual(['nonexistent.md']);
+  });
+
+  it('throws when the root itself is missing', async () => {
+    await expect(
+      resolveTree({
+        rootNote: 'absent.md',
+        maxDepth: 3,
+        readFile: mkFs({}),
+        extractLinks: extractWikiLinkTargets,
+        isExcluded: notExcluded,
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('maxDepth 0 includes only the root', async () => {
+    const fs = { 'root.md': '[[child]]', 'child.md': 'leaf' };
+    const tree = await resolveTree({
+      rootNote: 'root.md',
+      maxDepth: 0,
+      readFile: mkFs(fs),
+      extractLinks: extractWikiLinkTargets,
+      isExcluded: notExcluded,
+    });
+    expect(tree.included.map((e) => e.relativePath)).toEqual(['root.md']);
+  });
+});


### PR DESCRIPTION
## Summary

Fourth exporter. Given a root note, walks its transitive wiki-link closure and emits one HTML file per reachable note, cross-linked relative inside the bundle. Root → \`index.html\`; other notes keep their source-relative paths with \`.md → .html\`.

Scope was cut to the tree-html variant so the resolver foundation can be validated in isolation; follow-ups for the PDF / markdown-zip variants and the polish layers are filed alongside (#290, #291, #292, #293).

## What's in the box

- **Tree resolver** (\`src/main/publish/tree-resolver.ts\`) — pure BFS from a root with depth limit (default 3), cycle protection, private-by-default exclusion pass-through, unresolved-link audit. Pluggable \`readFile\` / \`extractLinks\` / \`isExcluded\` so tests exercise the algorithm without touching the filesystem and the production flow wires in real implementations.
- **\`ExportInput\` gains \`'tree'\` kind + optional \`maxDepth\`**. \`resolvePlan\` branches on kind: filesystem walk for single-note / folder / project, BFS for tree.
- **\`treeHtmlExporter\`** reuses \`note-html\`'s \`renderNoteBody\` + \`inlineImages\` + \`wrapHtml\` as-is. Forces \`linkPolicy: 'follow-to-file'\` so cross-links work inside the bundle even when the plan arrived with \`inline-title\`.
- **\`Exporter\` gains optional \`acceptedKinds\`**; surfaced via \`listExporters\` IPC so the preview dialog can filter scope radios per-exporter. Every existing exporter tagged with its scope set.
- **\`ExportDialog\`** reads \`acceptedKinds\` on mount, disables scope radios the exporter doesn't support, picks a sensible default scope given the exporter + context, and offers "Note tree from current note (depth 3)" when tree is accepted.

## Design calls worth flagging

- **Tree is opt-in at the \`acceptedKinds\` level.** Tree resolution is a different shape of input (walks the graph, not the filesystem), and most exporters shouldn't expose it. Defaulting \`acceptedKinds\` to \`['single-note', 'folder', 'project']\` keeps existing exporters backward-compatible and requires tree-aware exporters to opt in explicitly.
- **Reuse, don't fork, the HTML renderer.** \`treeHtmlExporter\` imports \`renderNoteBody\` / \`inlineImages\` / \`wrapHtml\` directly from \`note-html\`. Every rendering concern stays in one place; when CSL (#247) lands, both single-note and bundled-tree HTML pick up proper citations simultaneously.
- **Force \`follow-to-file\` inside the bundle.** The plan might arrive with \`inline-title\` as the user's dialog choice, but a bundle needs working cross-links or it's pointless. Honoring the dialog's link-policy over this intrinsic bundle need would be surprising; exporter-level override is the right call.
- **Root → \`index.html\`, other notes keep structure.** A tree rooted at \`notes/thesis.md\` produces \`index.html\` + \`notes/ch1.html\` + \`notes/ch2.html\`, and \`follow-to-file\` rewrites turn \`[[notes/ch1]]\` → \`<a href="notes/ch1.html">\`. Same relative shape the renderer already emits; no bespoke path handling.
- **Depth 3 is the default.** Unbounded BFS in a thoughtbase that's a dense cross-reference graph pulls in far more than the user expects. The ticket calls out 3 as a reasonable default; exposed as \`maxDepth\` on \`ExportInput\` for future UI control.
- **Inline styles still, not a shared \`style.css\` at the bundle root.** Separate polish ticket (#292). The practical cost of duplicated inline styles across 10 bundle pages is negligible.

## Deferred (tracked separately)

- #290 — \`tree-pdf\` concatenated single-PDF with TOC + chapter breaks
- #291 — \`tree-markdown\` zip variant
- #292 — shared \`style.css\` + sidebar nav for tree-html bundles
- #293 — manual per-note deselection in the preview dialog
- Consolidated bibliography (unlocks when #247 CSL ships)

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1378/1378 (21 new)
- [x] Resolver unit tests: linear walk, depth limit clamp, cycle handling, diamond graph (single visit), private-note exclusion, unresolved-link audit, missing root error, maxDepth=0 root-only.
- [x] Integration: end-to-end tree output root → index.html, depth enforcement, private exclusion through the pipeline, cycle handling, link-policy override.
- [ ] Manual: select a root note, File → Export → Export as Note Tree as HTML Bundle → pick dest → bundle lands with \`index.html\` + linked children, cross-links click through.

## Depends on

- #246 export foundation (merged)
- #248 HTML exporter (merged)
- #282 export menu + dialog (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)