### PR TITLE
Lint: add svelte-check so template/script drift fails CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Minerva is a desktop markdown IDE built with Electron + Svelte 5 + TypeScript. I
 ## Commands
 
 - `pnpm dev` — Start the dev server (electron-forge + Vite HMR)
-- `pnpm lint` — Type check (`tsc --noEmit`). There is a known pre-existing error in `src/main/graph/index.ts` — ignore it.
+- `pnpm lint` — Type check: `tsc --noEmit` for `.ts` files, then `svelte-check --threshold error` for `.svelte` files (script/template drift, undefined references, wrong prop types). Warnings (a11y, state-referenced-locally) are not fatal.
 - `pnpm test` — Run tests (vitest)
 - `pnpm build` — Build distributable (electron-forge make)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "electron-forge start",
     "build": "electron-forge make",
     "package": "electron-forge package",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && svelte-check --threshold error",
     "test": "vitest"
   },
   "dependencies": {
@@ -64,6 +64,7 @@
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.1",
     "svelte": "^5.16.0",
+    "svelte-check": "^4.4.6",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "vitest": "^2.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       svelte:
         specifier: ^5.16.0
         version: 5.55.0
+      svelte-check:
+        specifier: ^4.4.6
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -3747,6 +3750,10 @@ packages:
   moo@0.5.3:
     resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -4208,6 +4215,10 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -4445,6 +4456,14 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svelte-check@4.4.6:
+    resolution: {integrity: sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
 
   svelte@5.55.0:
     resolution: {integrity: sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==}
@@ -10993,6 +11012,8 @@ snapshots:
 
   moo@0.5.3: {}
 
+  mri@1.2.0: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -11509,6 +11530,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -11766,6 +11791,18 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.0)(typescript@5.9.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.55.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - picomatch
 
   svelte@5.55.0:
     dependencies:

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -412,7 +412,7 @@
       await api.notebase.deleteFolder(relativePath);
     } else {
       await api.notebase.deleteFile(relativePath);
-      const tabIdx = editor.tabs.findIndex((t) => t.relativePath === relativePath);
+      const tabIdx = editor.tabs.findIndex((t) => t.type === 'note' && t.relativePath === relativePath);
       if (tabIdx !== -1) editor.closeTab(tabIdx);
     }
     await notebase.refresh();

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -202,18 +202,20 @@
         <div class="kv"><span class="k">Publisher</span><span class="v">{detail.metadata.publisher}</span></div>
       {/if}
       {#if detail.metadata.doi}
+        {@const doiHref = `https://doi.org/${detail.metadata.doi}`}
         <div class="kv">
           <span class="k">DOI</span>
           <span class="v">
-            <a class="external" href={`https://doi.org/${detail.metadata.doi}`} onclick={(e) => { e.preventDefault(); openExternal(`https://doi.org/${detail.metadata.doi}`); }}>{detail.metadata.doi}</a>
+            <a class="external" href={doiHref} onclick={(e) => { e.preventDefault(); openExternal(doiHref); }}>{detail.metadata.doi}</a>
           </span>
         </div>
       {/if}
       {#if detail.metadata.uri}
+        {@const uriHref = detail.metadata.uri}
         <div class="kv">
           <span class="k">URL</span>
           <span class="v">
-            <a class="external" href={detail.metadata.uri} onclick={(e) => { e.preventDefault(); openExternal(detail.metadata.uri!); }}>{detail.metadata.uri}</a>
+            <a class="external" href={uriHref} onclick={(e) => { e.preventDefault(); openExternal(uriHref); }}>{uriHref}</a>
           </span>
         </div>
       {/if}


### PR DESCRIPTION
## Summary
- `tsc --noEmit` doesn't process `.svelte` files, so undefined imports, missing `$state`, and prop mismatches inside templates pass lint and ship. That's how the black-window regression landed in #303.
- Wires `svelte-check --threshold error` after `tsc` in `pnpm lint`. Fast (~1s) and catches the whole class of bug.
- Warnings (a11y, `state-referenced-locally`) are not fatal yet — 28 of them; separate cleanup.

## Baseline fixes to get the tree to 0 errors
- `SourceDetail.svelte`: hoist `detail.metadata.{doi,uri}` into `{@const}` before the onclick closure so the arrow captures a narrowed non-null value.
- `App.svelte` delete-file path: narrow the `Tab` union before reading `.relativePath` (only `NoteTab` has it).

## Test plan
- [x] `pnpm lint` → 0 errors, 28 warnings
- [x] `pnpm test` → 1399/1399 pass
- [ ] Manual: app starts, drag bar present, tabs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)