### PR TITLE
Edit menu: wire Find and Find and Replace

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1320,6 +1320,8 @@
     api.menu.onSaveQuery(() => handleSaveQuery());
     api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
     api.menu.onSortLines(() => editorComponent?.runSortLines());
+    api.menu.onFind(() => editorComponent?.openFind());
+    api.menu.onFindReplace(() => editorComponent?.openFindReplace());
     api.menu.onPrint(() => window.print());
     api.menu.onOpenInDefault(() => { if (editor.activeFilePath) api.shell.openInDefault(editor.activeFilePath); });
     api.menu.onOpenInTerminal(() => { api.shell.openInTerminal(editor.activeFilePath ?? undefined); });

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -476,6 +476,23 @@
     if (view) sortLines(view);
   }
 
+  export function openFind() {
+    if (!view) return;
+    openSearchPanel(view);
+  }
+
+  export function openFindReplace() {
+    if (!view) return;
+    openSearchPanel(view);
+    // The panel renders synchronously but focus lands on the search input —
+    // hop to the replace field so Cmd+H lands where the user expects.
+    requestAnimationFrame(() => {
+      const replaceInput = view?.dom.querySelector<HTMLInputElement>('.cm-search input[name="replace"]');
+      replaceInput?.focus();
+      replaceInput?.select();
+    });
+  }
+
   export function gotoLineColumn(line: number, col: number) {
     if (!view) return;
     const maxLine = view.state.doc.lines;


### PR DESCRIPTION
## Summary
- Edit > Find and Edit > Find and Replace fired IPCs that nothing subscribed to — the menu items silently did nothing.
- CodeMirror's search extension was already configured; just needed a trigger. Added two exports on Editor.svelte (`openFind`, `openFindReplace`) and wired them in App.svelte.
- Find and Replace focuses the replace input after the panel mounts so Cmd+H lands where the user expects.

## Test plan
- [x] `pnpm lint` → 0 errors
- [ ] Manual: Edit > Find (Cmd+F) opens search panel with search input focused
- [ ] Manual: Edit > Find and Replace (Cmd+H) opens search panel with replace input focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)