### PR TITLE
Refactor menu: add Copy parallel to Rename and Move

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -352,6 +352,7 @@ export function rebuildMenu(): void {
       submenu: [
         { label: 'Rename\u2026', click: () => send(Channels.MENU_REFACTOR_RENAME) },
         { label: 'Move\u2026', click: () => send(Channels.MENU_REFACTOR_MOVE) },
+        { label: 'Copy\u2026', click: () => send(Channels.MENU_REFACTOR_COPY) },
         { type: 'separator' },
         { label: 'Extract Selection to New Note', click: () => send(Channels.MENU_REFACTOR_EXTRACT) },
         { label: 'Split Note Here', click: () => send(Channels.MENU_REFACTOR_SPLIT_HERE) },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -329,6 +329,9 @@ contextBridge.exposeInMainWorld('api', {
     onRefactorMove: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_MOVE, () => cb());
     },
+    onRefactorCopy: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_REFACTOR_COPY, () => cb());
+    },
     onRefactorExtract: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_EXTRACT, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1008,6 +1008,46 @@
     }
   }
 
+  async function handleCopyWithPrompt(relativePath: string) {
+    if (!notebase.meta) return;
+    const oldName = relativePath.split('/').pop()!;
+    const dir = relativePath.includes('/') ? relativePath.substring(0, relativePath.lastIndexOf('/')) : '';
+    const rawNewName = await showPrompt('Copy to (new name, or dir/name):');
+    if (!rawNewName) return;
+    const oldDotIdx = oldName.lastIndexOf('.');
+    const oldExt = oldDotIdx > 0 ? oldName.slice(oldDotIdx) : '';
+    // Preserve extension when the user didn't type one — mirror handleRename
+    // so a copy doesn't silently fall out of the indexed set.
+    const trimmed = rawNewName.trim().replace(/^\/+/, '');
+    const lastSeg = trimmed.split('/').pop()!;
+    const needsExt = !lastSeg.includes('.') && oldExt;
+    const finalLast = needsExt ? `${lastSeg}${oldExt}` : lastSeg;
+    const segs = trimmed.split('/');
+    segs[segs.length - 1] = finalLast;
+    const userPath = segs.join('/');
+    // If the user typed a path-like value (contains `/`), treat it as
+    // project-root relative; otherwise keep it in the source directory.
+    const destPath = trimmed.includes('/') ? userPath : (dir ? `${dir}/${userPath}` : userPath);
+    if (destPath === relativePath) return;
+
+    let collision = false;
+    try {
+      await api.notebase.readFile(destPath);
+      collision = true;
+    } catch { /* expected: dest doesn't exist */ }
+    if (collision) {
+      await showConfirm(
+        `A file already exists at "${destPath}". Copy cancelled.`,
+        CONFIRM_KEYS.copyCollision,
+        'OK',
+      );
+      return;
+    }
+
+    await api.notebase.copy(relativePath, destPath);
+    await notebase.refresh();
+  }
+
   async function handleMoveWithPrompt(relativePath: string) {
     if (!notebase.meta) return;
     const fileName = relativePath.split('/').pop()!;
@@ -1330,6 +1370,7 @@
     // Refactor menu (issue #172)
     api.menu.onRefactorRename(() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); });
     api.menu.onRefactorMove(() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); });
+    api.menu.onRefactorCopy(() => { if (editor.activeFilePath) handleCopyWithPrompt(editor.activeFilePath); });
     api.menu.onRefactorExtract(() => handleExtractSelection());
     api.menu.onRefactorSplitHere(() => handleSplitHere());
     api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
@@ -1575,6 +1616,7 @@
                     onSplitByHeading={handleSplitByHeading}
                     onRename={() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); }}
                     onMove={() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); }}
+                    onCopyFile={() => { if (editor.activeFilePath) handleCopyWithPrompt(editor.activeFilePath); }}
                     onAutoTag={() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); }}
                     onAutoLink={() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); }}
                     onAutoLinkInbound={() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); }}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -71,6 +71,7 @@
     onSplitByHeading?: () => void;
     onRename?: () => void;
     onMove?: () => void;
+    onCopyFile?: () => void;
     onAutoTag?: () => void;
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
@@ -103,6 +104,7 @@
     onSplitByHeading,
     onRename,
     onMove,
+    onCopyFile,
     onAutoTag,
     onAutoLink,
     onAutoLinkInbound,
@@ -811,7 +813,7 @@
       {/if}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -821,7 +823,10 @@
           {#if onMove}
             <button onclick={() => handleMenuAction(() => onMove?.())}>Move&hellip;</button>
           {/if}
-          {#if onRename || onMove}
+          {#if onCopyFile}
+            <button onclick={() => handleMenuAction(() => onCopyFile?.())}>Copy&hellip;</button>
+          {/if}
+          {#if onRename || onMove || onCopyFile}
             <div class="separator"></div>
           {/if}
           {#if onExtractSelection}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -13,6 +13,7 @@ export const CONFIRM_KEYS = {
   rewriteConflict: 'confirm-rewrite-conflict',
   headingRenameSuggestion: 'heading-rename-suggestion',
   moveCollision: 'move-collision',
+  copyCollision: 'copy-collision',
   autoTagNoSuggestions: 'auto-tag-no-suggestions',
   autoTagFailed: 'auto-tag-failed',
   autoLinkNoSuggestions: 'auto-link-no-suggestions',
@@ -64,6 +65,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Move cancelled (destination exists)',
     description:
       'Shown when Move would overwrite an existing file at the chosen destination.',
+  },
+  {
+    key: CONFIRM_KEYS.copyCollision,
+    title: 'Copy cancelled (destination exists)',
+    description:
+      'Shown when Copy would overwrite an existing file at the chosen destination.',
   },
   {
     key: CONFIRM_KEYS.autoTagNoSuggestions,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -320,6 +320,7 @@ export interface MenuApi {
   onProjectOpened(cb: (meta: { rootPath: string; name: string }) => void): void;
   onRefactorRename(cb: () => void): void;
   onRefactorMove(cb: () => void): void;
+  onRefactorCopy(cb: () => void): void;
   onRefactorExtract(cb: () => void): void;
   onRefactorSplitHere(cb: () => void): void;
   onRefactorSplitByHeading(cb: () => void): void;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -84,6 +84,7 @@ export const Channels = {
   // Refactor menu (issue #172) — title-bar menu commands dispatched to the renderer.
   MENU_REFACTOR_RENAME: 'menu:refactor:rename',
   MENU_REFACTOR_MOVE: 'menu:refactor:move',
+  MENU_REFACTOR_COPY: 'menu:refactor:copy',
   MENU_REFACTOR_EXTRACT: 'menu:refactor:extract',
   MENU_REFACTOR_SPLIT_HERE: 'menu:refactor:splitHere',
   MENU_REFACTOR_SPLIT_BY_HEADING: 'menu:refactor:splitByHeading',


### PR DESCRIPTION
## Summary
- Adds \`Refactor > Copy…\` mirroring the existing Rename / Move pair.
- Prompts for a new name (or \`dir/name\`). No slash → same folder; slash → project-root-relative.
- Preserves the original extension if the user didn't type one (matches Rename's indexed-set safeguard).
- Suppressible collision dialog if the destination already exists.

Wired in both surfaces:
- Title-bar Refactor menu (Rename / Move / Copy)
- Editor right-click → Refactor submenu (same three)

Uses the existing \`api.notebase.copy\` IPC, which copies files/folders and re-indexes the graph.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [ ] Manual: Refactor > Copy with same-folder name → duplicates in place
- [ ] Manual: Refactor > Copy with \`subdir/name\` → copies across folders
- [ ] Manual: Copy to an existing path → collision dialog, no file written
- [ ] Manual: Editor right-click → Refactor → Copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)