### PR TITLE
Menus: drop Planning + Git, rename Graph to Query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ To add a new main-process operation:
 ### Knowledge Graph
 - Stored in `.minerva/graph.ttl` (Turtle format)
 - Auto-indexed on file write
-- Manual rebuild via Graph menu
+- Manual rebuild via Query menu
 - Extracts: titles, tags, wiki-links, frontmatter metadata, embedded Turtle blocks, markdown tables (CSVW)
 - Queryable via SPARQL through `api.graph.query()`
 - Standard prefixes (minerva, thought, dc, rdf, rdfs, xsd, csvw, prov) are auto-injected into all queries

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -383,32 +383,9 @@ export function rebuildMenu(): void {
         })),
       } as Electron.MenuItemConstructorOptions)),
 
-    // Git
+    // Query
     {
-      label: 'Git',
-      submenu: [
-        {
-          label: 'Commit All...',
-          accelerator: 'CmdOrCtrl+Shift+C',
-          click: () => send('git:commitPrompt'),
-        },
-        { type: 'separator' },
-        {
-          label: 'Push',
-          enabled: false,
-          click: () => {},
-        },
-        {
-          label: 'Pull',
-          enabled: false,
-          click: () => {},
-        },
-      ],
-    },
-
-    // Graph
-    {
-      label: 'Graph',
+      label: 'Query',
       submenu: [
         {
           label: 'New Query',

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -116,7 +116,6 @@
   }: Props = $props();
 
   const analysisTools = getToolInfosByCategory('analysis');
-  const planningTools = getToolInfosByCategory('planning');
   const learningTools = getToolInfosByCategory('learning');
 
   let editorContainer: HTMLDivElement;
@@ -779,7 +778,7 @@
         <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
       </div>
     </div>
-    {#if onToolInvoke && (analysisTools.length > 0 || planningTools.length > 0 || learningTools.length > 0)}
+    {#if onToolInvoke && (analysisTools.length > 0 || learningTools.length > 0)}
       <div class="separator"></div>
       {#if learningTools.length > 0}
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
@@ -796,16 +795,6 @@
           <span class="submenu-trigger">Analysis &#x25B8;</span>
           <div class="submenu">
             {#each analysisTools as tool}
-              <button onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
-            {/each}
-          </div>
-        </div>
-      {/if}
-      {#if planningTools.length > 0}
-        <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Planning &#x25B8;</span>
-          <div class="submenu">
-            {#each planningTools as tool}
               <button onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
             {/each}
           </div>

--- a/src/shared/tools/definitions/analysis/murphyjitsu.ts
+++ b/src/shared/tools/definitions/analysis/murphyjitsu.ts
@@ -4,7 +4,7 @@ import type { ToolContext } from '../../types';
 registerTool({
   id: 'planning.murphyjitsu',
   name: 'Murphyjitsu',
-  category: 'planning',
+  category: 'analysis',
   description: 'Pre-mortem failure analysis for plans and decisions',
   longDescription:
     'Treats failure as historical fact and works backward to generate concrete failure narratives. ' +

--- a/src/shared/tools/definitions/analysis/steelman.ts
+++ b/src/shared/tools/definitions/analysis/steelman.ts
@@ -4,7 +4,7 @@ import type { ToolContext } from '../../types';
 registerTool({
   id: 'planning.steelman',
   name: 'Steelman',
-  category: 'planning',
+  category: 'analysis',
   description: 'Construct the strongest version of an opposing argument',
   longDescription:
     'Builds the strongest possible version of a position by assuming intelligent proponents, ' +

--- a/src/shared/tools/definitions/analysis/taboo.ts
+++ b/src/shared/tools/definitions/analysis/taboo.ts
@@ -4,7 +4,7 @@ import type { ToolContext } from '../../types';
 registerTool({
   id: 'planning.taboo',
   name: 'Taboo',
-  category: 'planning',
+  category: 'analysis',
   description: 'Semantic decomposition by banning a contested term',
   longDescription:
     'Forces clarity by banning a word and requiring restatement without it. ' +

--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -1,10 +1,8 @@
 // Analysis tools
 import './analysis/excavate';
-
-// Planning tools
-import './planning/steelman';
-import './planning/taboo';
-import './planning/murphyjitsu';
+import './analysis/steelman';
+import './analysis/taboo';
+import './analysis/murphyjitsu';
 
 // Learning tools
 import './learning/summarize';

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -45,6 +45,5 @@ function toInfo(tool: ThinkingToolDef): ThinkingToolInfo {
 export const CATEGORIES: { id: ToolCategory; label: string }[] = [
   { id: 'learning', label: 'Learning' },
   { id: 'analysis', label: 'Analysis' },
-  { id: 'planning', label: 'Planning' },
   { id: 'research', label: 'Research' },
 ];

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -1,4 +1,4 @@
-export type ToolCategory = 'learning' | 'research' | 'analysis' | 'planning';
+export type ToolCategory = 'learning' | 'research' | 'analysis';
 
 export type ContextRequirement =
   | 'selectedText'


### PR DESCRIPTION
## Summary
- **Planning** category folded into **Analysis**. The three planning tools (steelman, taboo, murphyjitsu) move to \`analysis/\` with \`category: 'analysis'\`. Tool IDs keep their \`planning.\` prefix so any stable references survive.
- **Git menu** removed. Only live entry was Commit All; Push/Pull were disabled placeholders. The underlying \`api.git.commit\` IPC stays put for future re-wiring.
- **Graph menu** renamed to **Query** — matches what it actually is (SPARQL + SQL, stock + saved, rebuild index).

Planning submenu also removed from the editor right-click.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [ ] Title bar: no Planning, no Git, has Query
- [ ] Query menu still lists Stock + Saved queries and the rebuild action
- [ ] Editor right-click: Analysis submenu includes steelman / taboo / murphyjitsu; no Planning submenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)