### PR TITLE
Menus: drop Run Health Checks, move Rebuild to File as Rebuild All Indexes

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -571,13 +571,6 @@ export function registerIpcHandlers(): void {
   });
 
   // Graph management
-  ipcMain.handle(Channels.GRAPH_REBUILD, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { count: 0 };
-    const count = await graph.indexAllNotes(rootPath);
-    return { count };
-  });
-
   ipcMain.handle(Channels.GRAPH_EXPORT, async (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return;

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,12 +4,13 @@ import { Channels } from '../shared/channels';
 import { getRecentProjects } from './recent-projects';
 import { createWindow, openProjectInWindow, getRootPath } from './window-manager';
 import * as graph from './graph/index';
+import * as search from './search/index';
+import * as tables from './sources/tables';
 import { STOCK_QUERIES } from '../shared/stock-queries';
 import { listSavedQueries, deleteQuery } from './saved-queries';
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
-import * as healthChecks from './graph/health-checks';
 
 function send(channel: string, ...args: unknown[]) {
   const win = BrowserWindow.getFocusedWindow();
@@ -194,6 +195,22 @@ export function rebuildMenu(): void {
               click: () => send('menu:openInTerminal'),
             },
           ],
+        },
+        { type: 'separator' },
+        {
+          label: 'Rebuild All Indexes',
+          click: async () => {
+            const win = BrowserWindow.getFocusedWindow();
+            if (!win) return;
+            const rootPath = getRootPath(win.id);
+            if (!rootPath) return;
+            await Promise.all([
+              graph.indexAllNotes(rootPath),
+              search.indexAllNotes(rootPath),
+              tables.registerAllCsvs(rootPath),
+            ]);
+            if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          },
         },
         { type: 'separator' },
         isMac ? { role: 'close' } : { role: 'quit' },
@@ -453,22 +470,6 @@ export function rebuildMenu(): void {
           })(),
         },
         { type: 'separator' },
-        {
-          label: 'Run Health Checks',
-          click: async () => {
-            await healthChecks.runAllChecks();
-          },
-        },
-        {
-          label: 'Rebuild Index',
-          click: async () => {
-            const win = BrowserWindow.getFocusedWindow();
-            if (!win) return;
-            const rootPath = getRootPath(win.id);
-            if (!rootPath) return;
-            await graph.indexAllNotes(rootPath);
-          },
-        },
         {
           label: 'Export as Turtle',
           click: async () => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -79,7 +79,6 @@ contextBridge.exposeInMainWorld('api', {
   },
   graph: {
     query: (sparql: string) => ipcRenderer.invoke(Channels.GRAPH_QUERY, sparql),
-    rebuild: () => ipcRenderer.invoke(Channels.GRAPH_REBUILD),
     groundCheck: (claimText: string) => ipcRenderer.invoke(Channels.GRAPH_GROUND_CHECK, claimText),
     inspections: () => ipcRenderer.invoke(Channels.INSPECTIONS_LIST),
     runInspections: () => ipcRenderer.invoke(Channels.INSPECTIONS_RUN),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -64,7 +64,6 @@ export interface GitApi {
 
 export interface GraphApi {
   query(sparql: string): Promise<{ results: unknown[] }>;
-  rebuild(): Promise<{ count: number }>;
   groundCheck(claimText: string): Promise<{ node: string; label: string; type: string }[]>;
   inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
   runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -235,6 +235,5 @@ export const Channels = {
   SHELL_OPEN_IN_DEFAULT: 'shell:openInDefault',
   SHELL_OPEN_IN_TERMINAL: 'shell:openInTerminal',
   SHELL_OPEN_EXTERNAL: 'shell:openExternal',
-  GRAPH_REBUILD: 'graph:rebuild',
   GRAPH_EXPORT: 'graph:export',
 } as const;


### PR DESCRIPTION
## Summary
- **Run Health Checks** (Query menu) — deleted. The Inspections right-sidebar panel has its own Run button and a 5-minute periodic runner fires in the background. No one was reaching this menu item.
- **Rebuild Index** (Query menu) — deleted. It was the only UI trigger for a forced re-scan, but only covered the RDF graph — left minisearch and DuckDB CSV registrations stale. Replaced with a complete version.
- **Rebuild All Indexes** (File menu, above Close/Quit) — new. Rebuilds graph + minisearch + CSV registrations in parallel and emits TABLES_CHANGED so the sidebar refreshes. Mirrors project-open behavior in window-manager.
- Removed the dead \`GRAPH_REBUILD\` channel / IPC / preload / client entry — nothing in the renderer ever called it.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [ ] Query menu: no Run Health Checks, no Rebuild Index
- [ ] File menu: Rebuild All Indexes appears near the bottom, runs without error, tables sidebar refreshes
- [ ] Inspections panel still works (its own Run button, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)