### PR TITLE
Menus: drop Save Current Query, move Export as Turtle to Export menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -409,10 +409,6 @@ export function rebuildMenu(): void {
           accelerator: 'CmdOrCtrl+Shift+Q',
           click: () => send(Channels.MENU_NEW_QUERY),
         },
-        {
-          label: 'Save Current Query',
-          click: () => send(Channels.MENU_SAVE_QUERY),
-        },
         { type: 'separator' },
         {
           label: 'Stock Queries',
@@ -469,16 +465,35 @@ export function rebuildMenu(): void {
             return items;
           })(),
         },
-        { type: 'separator' },
-        {
-          label: 'Export as Turtle',
+      ],
+    },
+
+    // Export (#282) — dynamically populated from the publish registry.
+    // Empty submenu is a placeholder that surfaces a disabled item when
+    // no exporter is registered; in practice #246's markdown passthrough
+    // always registers at app-ready. The knowledge-graph dump is a
+    // separate hard-coded entry — the note-export pipeline's ExportPlan
+    // shape doesn't fit an RDF dump, so it stays outside the registry.
+    {
+      label: 'Export',
+      submenu: (() => {
+        const exporters = publish.listExporters();
+        const items: Electron.MenuItemConstructorOptions[] = exporters.length === 0
+          ? [{ label: 'No exporters registered', enabled: false }]
+          : exporters.map((e) => ({
+              label: `Export as ${e.label}…`,
+              click: () => send(Channels.MENU_EXPORT, e.id),
+            }));
+        items.push({ type: 'separator' });
+        items.push({
+          label: 'Export Knowledge Graph…',
           click: async () => {
             const win = BrowserWindow.getFocusedWindow();
             if (!win) return;
             const rootPath = getRootPath(win.id);
             if (!rootPath) return;
             const result = await dialog.showSaveDialog(win, {
-              title: 'Export Graph',
+              title: 'Export Knowledge Graph',
               defaultPath: `${path.basename(rootPath)}.ttl`,
               filters: [{ name: 'Turtle', extensions: ['ttl'] }],
             });
@@ -486,25 +501,8 @@ export function rebuildMenu(): void {
               await graph.exportGraph(result.filePath);
             }
           },
-        },
-      ],
-    },
-
-    // Export (#282) — dynamically populated from the publish registry.
-    // Empty submenu is a placeholder that surfaces a disabled item when
-    // no exporter is registered; in practice #246's markdown passthrough
-    // always registers at app-ready.
-    {
-      label: 'Export',
-      submenu: (() => {
-        const exporters = publish.listExporters();
-        if (exporters.length === 0) {
-          return [{ label: 'No exporters registered', enabled: false }];
-        }
-        return exporters.map((e) => ({
-          label: `Export as ${e.label}…`,
-          click: () => send(Channels.MENU_EXPORT, e.id),
-        }));
+        });
+        return items;
       })(),
     },
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -286,9 +286,6 @@ contextBridge.exposeInMainWorld('api', {
     onNewQuery: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_NEW_QUERY, () => cb());
     },
-    onSaveQuery: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SAVE_QUERY, () => cb());
-    },
     onOpenStockQuery: (cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void) => {
       ipcRenderer.on(Channels.MENU_OPEN_STOCK_QUERY, (_e, payload) => cb(payload));
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1357,7 +1357,6 @@
     api.menu.onGotoLine(() => { if (editor.activeTab) showGotoLine = true; });
     api.menu.onQuickOpen(() => { showGotoNote = true; });
     api.menu.onNewQuery(() => editor.openQuery());
-    api.menu.onSaveQuery(() => handleSaveQuery());
     api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
     api.menu.onSortLines(() => editorComponent?.runSortLines());
     api.menu.onFind(() => editorComponent?.openFind());

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -304,7 +304,6 @@ export interface MenuApi {
   onFind(cb: () => void): void;
   onFindReplace(cb: () => void): void;
   onNewQuery(cb: () => void): void;
-  onSaveQuery(cb: () => void): void;
   onOpenStockQuery(cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void): void;
   onSortLines(cb: () => void): void;
   onOpenSettings(cb: () => void): void;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -164,7 +164,6 @@ export const Channels = {
 
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',
-  MENU_SAVE_QUERY: 'menu:saveQuery',
   MENU_OPEN_STOCK_QUERY: 'menu:openStockQuery',
 
   // Tools for Thought


### PR DESCRIPTION
## Summary
- **Save Current Query** (Query menu) — removed. The query pane already has a Save button and a Cmd+S binding, both calling the same handler. Menu item was a third surface duplicating what was already right next to the query. Also removed the dead channel / preload / client-interface entry / App.svelte subscription.
- **Export as Turtle** (Query menu) — moved to **Export > Export Knowledge Graph…**, low-ish below the dynamic note exporters. Hard-coded rather than registered in the publish pipeline: the \`ExportPlan\` shape (notes + link policy + asset policy) doesn't describe an RDF dump, and forcing it through that pipeline would be a square peg / round hole.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [ ] Query menu: New Query + separator + Stock / Saved Queries only. No Save, no Export as Turtle.
- [ ] Query pane Save button + Cmd+S still persist the query.
- [ ] Export menu: Export Knowledge Graph… appears under the dynamic note exporters, writes a .ttl file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)