### PR TITLE
Saved Queries: menu refresh, Edit dialog, empty-state guards

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -422,11 +422,20 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(Channels.QUERIES_SAVE, (e, scope: string, name: string, description: string, query: string) => {
     const rootPath = rootPathFromEvent(e);
-    return savedQueries.saveQuery(rootPath, scope as 'project' | 'global', name, description, query);
+    const result = savedQueries.saveQuery(rootPath, scope as 'project' | 'global', name, description, query);
+    rebuildMenu();
+    return result;
   });
 
   ipcMain.handle(Channels.QUERIES_DELETE, (_e, filePath: string) => {
     savedQueries.deleteQuery(filePath);
+    rebuildMenu();
+  });
+
+  ipcMain.handle(Channels.QUERIES_RENAME, (_e, filePath: string, newName: string) => {
+    const newPath = savedQueries.renameQuery(filePath, newName);
+    rebuildMenu();
+    return newPath;
   });
 
   // Search

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -7,7 +7,7 @@ import * as graph from './graph/index';
 import * as search from './search/index';
 import * as tables from './sources/tables';
 import { STOCK_QUERIES } from '../shared/stock-queries';
-import { listSavedQueries, deleteQuery } from './saved-queries';
+import { listSavedQueries } from './saved-queries';
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
@@ -440,28 +440,28 @@ export function rebuildMenu(): void {
             if (saved.length === 0) {
               return [{ label: 'No Saved Queries', enabled: false }];
             }
-            const items: Electron.MenuItemConstructorOptions[] = [];
             const project = saved.filter((q) => q.scope === 'project');
             const global = saved.filter((q) => q.scope === 'global');
-            if (project.length > 0) {
-              items.push({ label: 'Thoughtbase', enabled: false });
-              for (const q of project) {
-                items.push({
-                  label: q.name,
-                  click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: 'sparql' }),
-                });
-              }
+            const mkEntry = (q: typeof saved[number]) => ({
+              label: q.name,
+              click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: 'sparql' }),
+            });
+            const items: Electron.MenuItemConstructorOptions[] = [];
+            // When both scopes are populated, nest under Thoughtbase ▸ /
+            // Global ▸ submenus (mirrors the Stock Queries pattern).
+            // When only one scope has entries, list flat — a one-branch
+            // tree is noise.
+            if (project.length > 0 && global.length > 0) {
+              items.push({ label: 'Thoughtbase', submenu: project.map(mkEntry) });
+              items.push({ label: 'Global', submenu: global.map(mkEntry) });
+            } else {
+              items.push(...(project.length > 0 ? project : global).map(mkEntry));
             }
-            if (global.length > 0) {
-              if (items.length > 0) items.push({ type: 'separator' });
-              items.push({ label: 'Global', enabled: false });
-              for (const q of global) {
-                items.push({
-                  label: q.name,
-                  click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: 'sparql' }),
-                });
-              }
-            }
+            items.push({ type: 'separator' });
+            items.push({
+              label: 'Edit Saved Queries…',
+              click: () => send(Channels.MENU_EDIT_SAVED_QUERIES),
+            });
             return items;
           })(),
         },

--- a/src/main/saved-queries.ts
+++ b/src/main/saved-queries.ts
@@ -102,3 +102,23 @@ export function deleteQuery(filePath: string): void {
     fs.unlinkSync(filePath);
   } catch { /* already gone */ }
 }
+
+export function renameQuery(filePath: string, newName: string): string {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const id = path.basename(filePath, '.rq');
+  // We need the description + query body but a fresh name — reuse the parser
+  // rather than hand-rolling header edits that miss edge cases like a missing
+  // description line.
+  const scope: 'project' | 'global' = filePath.includes(`${path.sep}.minerva${path.sep}queries${path.sep}`)
+    ? 'project'
+    : 'global';
+  const parsed = parseQueryContent(content, id, scope);
+  const newFilename = sanitizeFilename(newName) + '.rq';
+  const newPath = path.join(path.dirname(filePath), newFilename);
+  const rewritten = serializeQuery(newName, parsed.description, parsed.query);
+  fs.writeFileSync(newPath, rewritten, 'utf-8');
+  if (newPath !== filePath) {
+    try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+  }
+  return newPath;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -69,6 +69,7 @@ contextBridge.exposeInMainWorld('api', {
     save: (scope: string, name: string, description: string, query: string) =>
       ipcRenderer.invoke(Channels.QUERIES_SAVE, scope, name, description, query),
     delete: (filePath: string) => ipcRenderer.invoke(Channels.QUERIES_DELETE, filePath),
+    rename: (filePath: string, newName: string) => ipcRenderer.invoke(Channels.QUERIES_RENAME, filePath, newName),
   },
   search: {
     query: (query: string) => ipcRenderer.invoke(Channels.SEARCH_QUERY, query),
@@ -288,6 +289,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onOpenStockQuery: (cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void) => {
       ipcRenderer.on(Channels.MENU_OPEN_STOCK_QUERY, (_e, payload) => cb(payload));
+    },
+    onEditSavedQueries: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_EDIT_SAVED_QUERIES, () => cb());
     },
     onSortLines: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SORT_LINES, () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -17,6 +17,7 @@
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import OpenTargetDialog from './lib/components/OpenTargetDialog.svelte';
   import GotoLineDialog from './lib/components/GotoLineDialog.svelte';
+  import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
   import GotoNoteDialog from './lib/components/GotoNoteDialog.svelte';
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationDialog from './lib/components/ConversationDialog.svelte';
@@ -166,6 +167,7 @@
   let pendingSearchQuery = $state<string | null>(null);
   let showGotoLine = $state(false);
   let showGotoNote = $state(false);
+  let showEditSavedQueries = $state(false);
 
   async function handleFileSelect(relativePath: string, searchQuery?: string) {
     recordCurrentPosition();
@@ -1358,6 +1360,7 @@
     api.menu.onQuickOpen(() => { showGotoNote = true; });
     api.menu.onNewQuery(() => editor.openQuery());
     api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
+    api.menu.onEditSavedQueries(() => { showEditSavedQueries = true; });
     api.menu.onSortLines(() => editorComponent?.runSortLines());
     api.menu.onFind(() => editorComponent?.openFind());
     api.menu.onFindReplace(() => editorComponent?.openFindReplace());
@@ -1742,6 +1745,9 @@
       }}
       onCancel={() => { showGotoLine = false; }}
     />
+  {/if}
+  {#if showEditSavedQueries}
+    <EditSavedQueriesDialog onClose={() => { showEditSavedQueries = false; }} />
   {/if}
   {#if promptDialog}
     <PromptDialog

--- a/src/renderer/lib/components/EditSavedQueriesDialog.svelte
+++ b/src/renderer/lib/components/EditSavedQueriesDialog.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { SavedQuery } from '../../../shared/types';
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  let { onClose }: Props = $props();
+
+  let queries = $state<SavedQuery[]>([]);
+  let renamingPath = $state<string | null>(null);
+  let renameValue = $state('');
+  let renameInput = $state<HTMLInputElement>();
+
+  async function load() {
+    queries = await window.api.queries.list();
+  }
+
+  onMount(() => { load(); });
+
+  const projectQueries = $derived(queries.filter((q) => q.scope === 'project'));
+  const globalQueries = $derived(queries.filter((q) => q.scope === 'global'));
+  // Same rule as the title-bar menu: show scope labels only when both
+  // scopes are populated, else the label is dead weight over the one
+  // group that exists.
+  const showScopeLabels = $derived(projectQueries.length > 0 && globalQueries.length > 0);
+
+  function startRename(q: SavedQuery) {
+    renamingPath = q.filePath;
+    renameValue = q.name;
+    queueMicrotask(() => { renameInput?.focus(); renameInput?.select(); });
+  }
+
+  async function commitRename(q: SavedQuery) {
+    const next = renameValue.trim();
+    renamingPath = null;
+    if (!next || next === q.name) return;
+    await window.api.queries.rename(q.filePath, next);
+    await load();
+  }
+
+  function cancelRename() {
+    renamingPath = null;
+  }
+
+  async function deleteQ(q: SavedQuery) {
+    await window.api.queries.delete(q.filePath);
+    await load();
+  }
+
+  function overlayKey(e: KeyboardEvent) {
+    if (e.key === 'Escape' && renamingPath === null) onClose();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={overlayKey} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+  <div class="dialog">
+    <h3 class="title">Saved Queries</h3>
+
+    {#if queries.length === 0}
+      <p class="empty">No saved queries yet.</p>
+    {:else}
+      {#if projectQueries.length > 0}
+        {#if showScopeLabels}<div class="section-label">Thoughtbase</div>{/if}
+        <ul class="list">
+          {#each projectQueries as q (q.filePath)}
+            <li class="row">
+              {#if renamingPath === q.filePath}
+                <input
+                  bind:this={renameInput}
+                  bind:value={renameValue}
+                  class="name-input"
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); commitRename(q); }
+                    else if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
+                  }}
+                  onblur={() => commitRename(q)}
+                />
+              {:else}
+                <span class="name">{q.name}</span>
+                <button class="row-btn" onclick={() => startRename(q)}>Rename</button>
+                <button class="row-btn" onclick={() => deleteQ(q)}>Delete</button>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+
+      {#if globalQueries.length > 0}
+        {#if showScopeLabels}<div class="section-label">Global</div>{/if}
+        <ul class="list">
+          {#each globalQueries as q (q.filePath)}
+            <li class="row">
+              {#if renamingPath === q.filePath}
+                <input
+                  bind:this={renameInput}
+                  bind:value={renameValue}
+                  class="name-input"
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); commitRename(q); }
+                    else if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
+                  }}
+                  onblur={() => commitRename(q)}
+                />
+              {:else}
+                <span class="name">{q.name}</span>
+                <button class="row-btn" onclick={() => startRename(q)}>Rename</button>
+                <button class="row-btn" onclick={() => deleteQ(q)}>Delete</button>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    {/if}
+
+    <div class="actions">
+      <button class="btn" onclick={onClose}>Close</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    min-width: 420px;
+    max-width: 560px;
+    max-height: 70vh;
+    overflow-y: auto;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .title {
+    margin: 0 0 4px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .empty {
+    color: var(--text-muted);
+    font-size: 13px;
+    margin: 8px 0;
+  }
+  .section-label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    padding: 6px 0 4px 0;
+    border-bottom: 1px solid var(--border);
+    margin-top: 8px;
+  }
+  .list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 4px;
+  }
+  .row:hover { background: var(--bg-button); }
+  .name {
+    flex: 1;
+    color: var(--text);
+    font-size: 13px;
+  }
+  .name-input {
+    flex: 1;
+    padding: 2px 6px;
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+  }
+  .row-btn {
+    padding: 3px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .row-btn:hover { background: var(--bg-button-hover); }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .btn:hover { opacity: 0.9; }
+</style>

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -44,6 +44,8 @@
 
   let { tab, onQueryChange, onLanguageChange, onExecute, onSave }: Props = $props();
 
+  const isEmpty = $derived(tab.query.trim().length === 0);
+
   let editorContainer = $state<HTMLDivElement>();
   let view: EditorView | null = null;
   let splitRatio = $state(0.4); // 40% editor, 60% results
@@ -241,9 +243,9 @@
           '.cm-scroller': { overflow: 'auto' },
         }),
         Prec.highest(keymap.of([
-          { key: 'Mod-Enter', run: () => { onExecute(); return true; } },
-          { key: 'Mod-s', run: () => { onSave(); return true; } },
-          { key: 'Shift-Alt-f', run: reformat },
+          { key: 'Mod-Enter', run: () => { if (!isEmpty) onExecute(); return true; } },
+          { key: 'Mod-s', run: () => { if (!isEmpty) onSave(); return true; } },
+          { key: 'Shift-Alt-f', run: () => { if (isEmpty) return true; return reformat(); } },
           { key: 'Tab', run: acceptCompletion },
         ])),
         keymap.of([
@@ -382,7 +384,7 @@
       <button
         class="run-btn"
         onclick={onExecute}
-        disabled={tab.executing}
+        disabled={tab.executing || isEmpty}
         title="Run query (Cmd+Enter)"
       >
         {tab.executing ? 'Running...' : 'Run'}
@@ -399,11 +401,13 @@
       <button
         class="save-query-btn"
         onclick={onSave}
+        disabled={isEmpty}
         title="Save query"
       >Save</button>
       <button
         class="save-query-btn"
         onclick={reformat}
+        disabled={isEmpty}
         title="Reformat (Shift+Alt+F)"
       >Format</button>
       {#if tab.executionTime != null}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -51,6 +51,7 @@ export interface QueriesApi {
   list(): Promise<SavedQuery[]>;
   save(scope: string, name: string, description: string, query: string): Promise<SavedQuery>;
   delete(filePath: string): Promise<void>;
+  rename(filePath: string, newName: string): Promise<string>;
 }
 
 export interface SearchApi {
@@ -305,6 +306,7 @@ export interface MenuApi {
   onFindReplace(cb: () => void): void;
   onNewQuery(cb: () => void): void;
   onOpenStockQuery(cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void): void;
+  onEditSavedQueries(cb: () => void): void;
   onSortLines(cb: () => void): void;
   onOpenSettings(cb: () => void): void;
   onPrint(cb: () => void): void;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -36,6 +36,7 @@ export const Channels = {
   QUERIES_LIST: 'queries:list',
   QUERIES_SAVE: 'queries:save',
   QUERIES_DELETE: 'queries:delete',
+  QUERIES_RENAME: 'queries:rename',
 
   // Search
   SEARCH_QUERY: 'search:query',
@@ -165,6 +166,7 @@ export const Channels = {
   // Graph
   MENU_NEW_QUERY: 'menu:newQuery',
   MENU_OPEN_STOCK_QUERY: 'menu:openStockQuery',
+  MENU_EDIT_SAVED_QUERIES: 'menu:editSavedQueries',
 
   // Tools for Thought
   TOOL_INVOKE: 'tool:invoke',


### PR DESCRIPTION
## Summary
- **Menu refresh bug** — \`QUERIES_SAVE\` / \`QUERIES_DELETE\` (and the new rename) didn't call \`rebuildMenu()\`, so the title-bar submenu went stale until app restart. Fixed.
- **Edit Saved Queries dialog** — click-to-rename (Enter / Escape / blur) and per-row Delete. Reached via a new \`Edit Saved Queries…\` entry at the bottom of the Saved Queries submenu.
- **Better scope separation in menu** — when both Thoughtbase and Global scopes have queries, split into two submenus (mirrors Stock Queries). When only one scope has entries, list flat. No more greyed-out \"Thoughtbase\" label that reads like a disabled query.
- **Empty-state hide** — \`Edit Saved Queries…\` is absent when there are no saved queries.
- **Query pane empty guards** — Run / Save / Format (buttons + Cmd+Enter / Cmd+S / Shift-Alt-F) disabled when the editor is empty. Saving an empty query would write a zero-body \`.rq\`.

## Follow-ups (already tracked)
- #313 scope picker on save
- #314 promote/demote between scopes
- #315 grouping + ordering

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [x] Manual smoke test (user-confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)