### PR TITLE
Saved Queries: preserve language (SPARQL vs SQL) through save / load

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -420,9 +420,16 @@ export function registerIpcHandlers(): void {
     return savedQueries.listSavedQueries(rootPath);
   });
 
-  ipcMain.handle(Channels.QUERIES_SAVE, (e, scope: string, name: string, description: string, query: string) => {
+  ipcMain.handle(Channels.QUERIES_SAVE, (e, scope: string, name: string, description: string, query: string, language: string) => {
     const rootPath = rootPathFromEvent(e);
-    const result = savedQueries.saveQuery(rootPath, scope as 'project' | 'global', name, description, query);
+    const result = savedQueries.saveQuery(
+      rootPath,
+      scope as 'project' | 'global',
+      name,
+      description,
+      query,
+      language === 'sql' ? 'sql' : 'sparql',
+    );
     rebuildMenu();
     return result;
   });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -444,7 +444,7 @@ export function rebuildMenu(): void {
             const global = saved.filter((q) => q.scope === 'global');
             const mkEntry = (q: typeof saved[number]) => ({
               label: q.name,
-              click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: 'sparql' }),
+              click: () => send(Channels.MENU_OPEN_STOCK_QUERY, { query: q.query, language: q.language }),
             });
             const items: Electron.MenuItemConstructorOptions[] = [];
             // When both scopes are populated, nest under Thoughtbase ▸ /

--- a/src/main/saved-queries.ts
+++ b/src/main/saved-queries.ts
@@ -2,11 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
 
+export type QueryLanguage = 'sparql' | 'sql';
+
 export interface SavedQuery {
   id: string;       // filename without extension
   name: string;
   description: string;
   query: string;
+  language: QueryLanguage;
   scope: 'project' | 'global';
   filePath: string;  // absolute path for deletion
 }
@@ -23,8 +26,27 @@ function ensureDir(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
 }
 
+/**
+ * Extension is the language signal: `.rq` is the W3C-standard SPARQL
+ * extension, `.sql` the de-facto SQL one. Embedding the language in a
+ * header comment would be redundant and lets file-manager previews /
+ * syntax highlighting work for free.
+ */
+function extensionFor(language: QueryLanguage): '.rq' | '.sql' {
+  return language === 'sql' ? '.sql' : '.rq';
+}
+
+function languageFromPath(filePath: string): QueryLanguage {
+  return filePath.endsWith('.sql') ? 'sql' : 'sparql';
+}
+
 /** Parse query content string into metadata + body (pure, no I/O) */
-export function parseQueryContent(content: string, id: string, scope: 'project' | 'global'): Omit<SavedQuery, 'filePath'> {
+export function parseQueryContent(
+  content: string,
+  id: string,
+  scope: 'project' | 'global',
+  language: QueryLanguage,
+): Omit<SavedQuery, 'filePath'> {
   let name = id;
   let description = '';
 
@@ -39,13 +61,14 @@ export function parseQueryContent(content: string, id: string, scope: 'project' 
     .join('\n')
     .trim();
 
-  return { id, name, description, query, scope };
+  return { id, name, description, query, language, scope };
 }
 
 function parseQueryFile(filePath: string, scope: 'project' | 'global'): SavedQuery {
   const content = fs.readFileSync(filePath, 'utf-8');
-  const id = path.basename(filePath, '.rq');
-  return { ...parseQueryContent(content, id, scope), filePath };
+  const ext = path.extname(filePath);
+  const id = path.basename(filePath, ext);
+  return { ...parseQueryContent(content, id, scope, languageFromPath(filePath)), filePath };
 }
 
 export function serializeQuery(name: string, description: string, query: string): string {
@@ -62,7 +85,7 @@ export function sanitizeFilename(name: string): string {
 function listDir(dir: string, scope: 'project' | 'global'): SavedQuery[] {
   try {
     return fs.readdirSync(dir)
-      .filter((f) => f.endsWith('.rq'))
+      .filter((f) => f.endsWith('.rq') || f.endsWith('.sql'))
       .map((f) => parseQueryFile(path.join(dir, f), scope))
       .sort((a, b) => a.name.localeCompare(b.name));
   } catch {
@@ -84,17 +107,18 @@ export function saveQuery(
   name: string,
   description: string,
   query: string,
+  language: QueryLanguage,
 ): SavedQuery {
   const dir = scope === 'project' && rootPath
     ? projectQueriesDir(rootPath)
     : globalQueriesDir();
 
   ensureDir(dir);
-  const filename = sanitizeFilename(name) + '.rq';
+  const filename = sanitizeFilename(name) + extensionFor(language);
   const filePath = path.join(dir, filename);
   fs.writeFileSync(filePath, serializeQuery(name, description, query), 'utf-8');
 
-  return { id: sanitizeFilename(name), name, description, query, scope, filePath };
+  return { id: sanitizeFilename(name), name, description, query, language, scope, filePath };
 }
 
 export function deleteQuery(filePath: string): void {
@@ -105,15 +129,17 @@ export function deleteQuery(filePath: string): void {
 
 export function renameQuery(filePath: string, newName: string): string {
   const content = fs.readFileSync(filePath, 'utf-8');
-  const id = path.basename(filePath, '.rq');
+  const ext = path.extname(filePath);
+  const id = path.basename(filePath, ext);
   // We need the description + query body but a fresh name — reuse the parser
   // rather than hand-rolling header edits that miss edge cases like a missing
   // description line.
   const scope: 'project' | 'global' = filePath.includes(`${path.sep}.minerva${path.sep}queries${path.sep}`)
     ? 'project'
     : 'global';
-  const parsed = parseQueryContent(content, id, scope);
-  const newFilename = sanitizeFilename(newName) + '.rq';
+  const parsed = parseQueryContent(content, id, scope, languageFromPath(filePath));
+  // Preserve the original extension — language doesn't change on rename.
+  const newFilename = sanitizeFilename(newName) + ext;
   const newPath = path.join(path.dirname(filePath), newFilename);
   const rewritten = serializeQuery(newName, parsed.description, parsed.query);
   fs.writeFileSync(newPath, rewritten, 'utf-8');

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -66,8 +66,8 @@ contextBridge.exposeInMainWorld('api', {
   },
   queries: {
     list: () => ipcRenderer.invoke(Channels.QUERIES_LIST),
-    save: (scope: string, name: string, description: string, query: string) =>
-      ipcRenderer.invoke(Channels.QUERIES_SAVE, scope, name, description, query),
+    save: (scope: string, name: string, description: string, query: string, language: string) =>
+      ipcRenderer.invoke(Channels.QUERIES_SAVE, scope, name, description, query, language),
     delete: (filePath: string) => ipcRenderer.invoke(Channels.QUERIES_DELETE, filePath),
     rename: (filePath: string, newName: string) => ipcRenderer.invoke(Channels.QUERIES_RENAME, filePath, newName),
   },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -281,7 +281,7 @@
     if (!tab) return;
     const name = await showPrompt('Query name:');
     if (!name) return;
-    await api.queries.save('project', name, '', tab.query);
+    await api.queries.save('project', name, '', tab.query, tab.language);
     tab.title = name;
   }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -49,7 +49,7 @@ export interface LinksApi {
 
 export interface QueriesApi {
   list(): Promise<SavedQuery[]>;
-  save(scope: string, name: string, description: string, query: string): Promise<SavedQuery>;
+  save(scope: string, name: string, description: string, query: string, language: 'sparql' | 'sql'): Promise<SavedQuery>;
   delete(filePath: string): Promise<void>;
   rename(filePath: string, newName: string): Promise<string>;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,6 +30,7 @@ export interface SavedQuery {
   name: string;
   description: string;
   query: string;
+  language: 'sparql' | 'sql';
   scope: 'project' | 'global';
   filePath: string;
 }

--- a/tests/main/saved-queries.test.ts
+++ b/tests/main/saved-queries.test.ts
@@ -23,32 +23,37 @@ describe('sanitizeFilename', () => {
 describe('parseQueryContent', () => {
   it('extracts @name from comment header', () => {
     const content = '# @name My Query\nSELECT * WHERE {}';
-    const result = parseQueryContent(content, 'fallback-id', 'project');
+    const result = parseQueryContent(content, 'fallback-id', 'project', 'sparql');
     expect(result.name).toBe('My Query');
   });
 
   it('extracts @description', () => {
     const content = '# @name Test\n# @description A test query\nSELECT ?x WHERE {}';
-    const result = parseQueryContent(content, 'id', 'project');
+    const result = parseQueryContent(content, 'id', 'project', 'sparql');
     expect(result.description).toBe('A test query');
   });
 
   it('uses id as name when @name is missing', () => {
     const content = 'SELECT * WHERE {}';
-    const result = parseQueryContent(content, 'my-fallback', 'global');
+    const result = parseQueryContent(content, 'my-fallback', 'global', 'sparql');
     expect(result.name).toBe('my-fallback');
   });
 
   it('strips metadata comments from query body', () => {
     const content = '# @name Test\n# @description Desc\nSELECT ?x WHERE {}';
-    const result = parseQueryContent(content, 'id', 'project');
+    const result = parseQueryContent(content, 'id', 'project', 'sparql');
     expect(result.query).toBe('SELECT ?x WHERE {}');
     expect(result.query).not.toContain('@name');
   });
 
   it('preserves scope', () => {
-    const result = parseQueryContent('query', 'id', 'global');
+    const result = parseQueryContent('query', 'id', 'global', 'sparql');
     expect(result.scope).toBe('global');
+  });
+
+  it('captures language passed in by caller (derived from extension)', () => {
+    const result = parseQueryContent('SELECT 1', 'id', 'project', 'sql');
+    expect(result.language).toBe('sql');
   });
 });
 
@@ -70,9 +75,10 @@ describe('serializeQuery', () => {
 
   it('round-trips with parseQueryContent', () => {
     const serialized = serializeQuery('My Query', 'Desc', 'SELECT ?x WHERE { ?x a ?y }');
-    const parsed = parseQueryContent(serialized, 'id', 'project');
+    const parsed = parseQueryContent(serialized, 'id', 'project', 'sparql');
     expect(parsed.name).toBe('My Query');
     expect(parsed.description).toBe('Desc');
     expect(parsed.query).toBe('SELECT ?x WHERE { ?x a ?y }');
+    expect(parsed.language).toBe('sparql');
   });
 });


### PR DESCRIPTION
## Summary
Saving a SQL query and reopening it from Saved Queries used to drop the language — the menu click hardcoded \`language: 'sparql'\`, and the \`.rq\` file format had no language field anyway. Reopened SQL queries therefore ran through the SPARQL engine and parse-errored.

Fix: **file extension is the language signal.**
- \`.rq\` — SPARQL (W3C standard extension)
- \`.sql\` — SQL (de-facto standard)

No \`@language\` header — the extension is stable, survives external edits, and doubles as a hint to file-manager previews and editor syntax highlighting.

### What changed
- \`saveQuery(..., language)\` writes \`.rq\` or \`.sql\` accordingly.
- \`listDir\` reads both extensions.
- \`renameQuery\` preserves the source file's extension.
- Menu click passes through the SavedQuery's language instead of hardcoded SPARQL.
- Existing \`.rq\` files parse unchanged as SPARQL — no migration.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm vitest tests/main/saved-queries.test.ts\` → 14/14 pass (including a new language-round-trip case)
- [ ] Manual: save a SQL query, reopen from Saved Queries, click Run — executes against DuckDB, not SPARQL engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)