### PR TITLE
UI: clamp every custom context menu inside the viewport

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -26,6 +26,7 @@
   import { computeCellsExtension, computeCellsStyles } from '../editor/compute-cells';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
+  import { clampMenuToViewport } from '../utils/menuClamp';
 
   export interface CursorInfo {
     line: number;
@@ -128,6 +129,7 @@
   // content-area menu from growing a gutter-only option that'd only
   // make sense in some click locations.
   let gutterMenu = $state<{ x: number; y: number; lineNumbers: boolean } | null>(null);
+  let gutterMenuEl = $state<HTMLDivElement | undefined>();
   // Snapshot of the selection taken when the context menu opens, so
   // commands from the menu can run against what the user had selected
   // regardless of what the right-click and menu focus do in between.
@@ -700,23 +702,17 @@
   // would otherwise extend past the bottom or right edge.
   $effect(() => {
     if (!contextMenu || !contextMenuEl) return;
-    const rect = contextMenuEl.getBoundingClientRect();
-    const vh = window.innerHeight;
-    const vw = window.innerWidth;
-    const MARGIN = 8;
-
-    let nextX = contextMenu.x;
-    let nextY = contextMenu.y;
-
-    if (rect.bottom > vh - MARGIN) {
-      nextY = Math.max(MARGIN, vh - rect.height - MARGIN);
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
     }
-    if (rect.right > vw - MARGIN) {
-      nextX = Math.max(MARGIN, vw - rect.width - MARGIN);
-    }
+  });
 
-    if (nextX !== contextMenu.x || nextY !== contextMenu.y) {
-      contextMenu = { ...contextMenu, x: nextX, y: nextY };
+  $effect(() => {
+    if (!gutterMenu || !gutterMenuEl) return;
+    const next = clampMenuToViewport(gutterMenu.x, gutterMenu.y, gutterMenuEl);
+    if (next.x !== gutterMenu.x || next.y !== gutterMenu.y) {
+      gutterMenu = { ...gutterMenu, ...next };
     }
   });
 
@@ -752,6 +748,7 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="context-menu gutter-menu"
+    bind:this={gutterMenuEl}
     style:left="{gutterMenu.x}px"
     style:top="{gutterMenu.y}px"
     onmousedown={(e) => e.preventDefault()}

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -2,6 +2,7 @@
   import type { NoteFile } from '../../../shared/types';
   import FileTree from './FileTree.svelte';
   import { api } from '../ipc/client';
+  import { clampMenuToViewport } from '../utils/menuClamp';
 
   interface Props {
     files: NoteFile[];
@@ -25,6 +26,15 @@
 
   let expanded = $state<Record<string, boolean>>({});
   let contextMenu = $state<{ x: number; y: number; dir: string; target?: string; targetIsDir?: boolean } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
   let dropTarget = $state<string | null>(null);
 
   function handleDragStart(e: DragEvent, relativePath: string) {
@@ -136,6 +146,7 @@
 {#if contextMenu}
   <div
     class="context-menu"
+    bind:this={contextMenuEl}
     style:left="{contextMenu.x}px"
     style:top="{contextMenu.y}px"
   >

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -5,6 +5,7 @@
   import TagPanel from './TagPanel.svelte';
   import SourcesPanel from './SourcesPanel.svelte';
   import TablesPanel from './TablesPanel.svelte';
+  import { clampMenuToViewport } from '../utils/menuClamp';
 
   interface Props {
     files: NoteFile[];
@@ -34,6 +35,15 @@
   let sourcesPanel = $state<SourcesPanel>();
   let tablesPanel = $state<TablesPanel>();
   let contextMenu = $state<{ x: number; y: number } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
 
   // Width is user-draggable, persisted to localStorage — matches the
   // right-sidebar pattern. Per-machine UI state, not worth IPC plumbing.
@@ -150,6 +160,7 @@
 {#if contextMenu}
     <div
       class="context-menu"
+      bind:this={contextMenuEl}
       style:left="{contextMenu.x}px"
       style:top="{contextMenu.y}px"
     >

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Tab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
+  import { clampMenuToViewport } from '../utils/menuClamp';
 
   interface Props {
     tabs: Tab[];
@@ -17,6 +18,15 @@
   let { tabs, activeIndex, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark }: Props = $props();
 
   let contextMenu = $state<{ x: number; y: number; index: number } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
 
   function handleContextMenu(e: MouseEvent, index: number) {
     e.preventDefault();
@@ -72,6 +82,7 @@
 {#if contextMenu}
   <div
     class="context-menu"
+    bind:this={contextMenuEl}
     style:left="{contextMenu.x}px"
     style:top="{contextMenu.y}px"
   >

--- a/src/renderer/lib/components/TablesPanel.svelte
+++ b/src/renderer/lib/components/TablesPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { api } from '../ipc/client';
   import type { TableInfo } from '../ipc/client';
+  import { clampMenuToViewport } from '../utils/menuClamp';
 
   interface Props {
     onTableClick: (tableName: string) => void;
@@ -13,6 +14,15 @@
   let filter = $state('');
   let collapsed = $state(false);
   let contextMenu = $state<{ x: number; y: number; table: TableInfo } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
 
   export async function refresh(): Promise<void> {
     tables = await api.tables.list();
@@ -81,6 +91,7 @@
 {#if contextMenu}
   <div
     class="context-menu"
+    bind:this={contextMenuEl}
     style:left="{contextMenu.x}px"
     style:top="{contextMenu.y}px"
   >

--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -2,6 +2,7 @@
   import { getBookmarksStore } from '../../stores/bookmarks.svelte';
   import type { BookmarkNode } from '../../../../shared/types';
   import Ribbon from './Ribbon.svelte';
+  import { clampMenuToViewport } from '../../utils/menuClamp';
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
@@ -14,6 +15,15 @@
   let expanded = $state<Record<string, boolean>>({});
   let search = $state('');
   let contextMenu = $state<{ x: number; y: number; nodeId: string; nodeType: 'bookmark' | 'folder' } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
 
   function collectFolderIds(nodes: BookmarkNode[], out: string[] = []): string[] {
     for (const n of nodes) {
@@ -127,7 +137,7 @@
   {/if}
 
   {#if contextMenu}
-    <div class="context-menu" style:left="{contextMenu.x}px" style:top="{contextMenu.y}px">
+    <div class="context-menu" bind:this={contextMenuEl} style:left="{contextMenu.x}px" style:top="{contextMenu.y}px">
       <button onclick={() => handleRename(contextMenu!.nodeId)}>Rename</button>
       <button onclick={() => { bookmarks.remove(contextMenu!.nodeId); contextMenu = null; }}>Delete</button>
     </div>

--- a/src/renderer/lib/utils/menuClamp.ts
+++ b/src/renderer/lib/utils/menuClamp.ts
@@ -1,0 +1,40 @@
+/**
+ * Keep a floating context menu inside the viewport.
+ *
+ * The Electron title-bar menus are native and the OS handles edge
+ * avoidance. Our in-app menus (sidebar file tree, tab right-click,
+ * tables, bookmarks, editor content + gutter) are custom HTML divs —
+ * so clicking near the bottom-right corner of the window will run them
+ * off-screen unless we nudge them back. Each call site drives a
+ * $effect that measures the menu's bounding box and clamps the
+ * originating pointer coordinates to keep the menu in-bounds with an
+ * 8px margin.
+ *
+ * Usage:
+ *   $effect(() => {
+ *     if (!contextMenu || !menuEl) return;
+ *     const next = clampMenuToViewport(contextMenu.x, contextMenu.y, menuEl);
+ *     if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+ *       contextMenu = { ...contextMenu, ...next };
+ *     }
+ *   });
+ */
+export function clampMenuToViewport(
+  x: number,
+  y: number,
+  el: HTMLElement,
+): { x: number; y: number } {
+  const rect = el.getBoundingClientRect();
+  const vh = window.innerHeight;
+  const vw = window.innerWidth;
+  const MARGIN = 8;
+  let nextX = x;
+  let nextY = y;
+  if (rect.bottom > vh - MARGIN) {
+    nextY = Math.max(MARGIN, vh - rect.height - MARGIN);
+  }
+  if (rect.right > vw - MARGIN) {
+    nextX = Math.max(MARGIN, vw - rect.width - MARGIN);
+  }
+  return { x: nextX, y: nextY };
+}


### PR DESCRIPTION
## Summary
The title-bar menus are native and the OS handles edge avoidance. Our custom HTML context menus, positioned from pointer coordinates, weren't doing that — a right-click near the bottom-right corner ran the menu off-screen. Editor had the fix; nothing else did.

Extracted the clamp logic to \`lib/utils/menuClamp.ts\` and wired it into every custom menu:
- Editor content menu
- Editor gutter menu (new line-numbers toggle)
- Sidebar (file-tree root area)
- FileTree (per-item right-click)
- TabBar (tab right-click)
- Left-sidebar TablesPanel
- Right-sidebar BookmarksPanel

Each call site is a 5-line \`$effect\` that measures the menu's bounding box and nudges \`{x, y}\` if it would overflow with an 8px margin.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [ ] Right-click near each viewport edge for each of the seven menus; menu stays visible, shifted inward

🤖 Generated with [Claude Code](https://claude.com/claude-code)