### PR TITLE
Graph: CSVW + OWL view of DuckDB-registered CSV tables

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -53,8 +53,10 @@ function convertTerm(term: any, df: typeof N3.DataFactory): N3.Term | null {
 const MINERVA = $rdf.Namespace('https://minerva.dev/ontology#');
 const DC      = $rdf.Namespace('http://purl.org/dc/terms/');
 const RDF     = $rdf.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+const RDFS    = $rdf.Namespace('http://www.w3.org/2000/01/rdf-schema#');
 const XSD     = $rdf.Namespace('http://www.w3.org/2001/XMLSchema#');
 const CSVW    = $rdf.Namespace('http://www.w3.org/ns/csvw#');
+const OWL     = $rdf.Namespace('http://www.w3.org/2002/07/owl#');
 const BIBO    = $rdf.Namespace('http://purl.org/ontology/bibo/');
 const SCHEMA  = $rdf.Namespace('http://schema.org/');
 const PROV    = $rdf.Namespace('http://www.w3.org/ns/prov#');
@@ -153,6 +155,10 @@ function sourceUri(sourceId: string): $rdf.NamedNode {
 
 function excerptUri(excerptId: string): $rdf.NamedNode {
   return $rdf.sym(uriHelpers.excerptUri(baseUri, excerptId));
+}
+
+function tableUri(tableName: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.tableUri(baseUri, tableName));
 }
 
 function linkPredicate(lt: LinkType) {
@@ -275,6 +281,7 @@ const STANDARD_PREFIXES: [string, string][] = [
   ['rdfs', 'http://www.w3.org/2000/01/rdf-schema#'],
   ['xsd', 'http://www.w3.org/2001/XMLSchema#'],
   ['csvw', 'http://www.w3.org/ns/csvw#'],
+  ['owl', 'http://www.w3.org/2002/07/owl#'],
   ['prov', 'http://www.w3.org/ns/prov#'],
   ['bibo', 'http://purl.org/ontology/bibo/'],
   ['schema', 'http://schema.org/'],
@@ -651,6 +658,133 @@ function indexTable(
       store.add(cellUri, RDF('value'), $rdf.lit(value), graph);
       store.add(rowUri, CSVW('cell'), cellUri, graph);
     }
+  }
+}
+
+// ── CSV-as-DuckDB table indexing ────────────────────────────────────────────
+
+/**
+ * Shape of a registered CSV table column, passed in from the DuckDB side.
+ * `duckdbType` comes from `information_schema.columns` (VARCHAR, INTEGER,
+ * DOUBLE, TIMESTAMP, …). We map it to an xsd datatype so SPARQL consumers
+ * can reason about ranges.
+ */
+export interface CsvTableColumn {
+  name: string;
+  duckdbType: string;
+  index: number;
+}
+
+export interface CsvTableShape {
+  tableName: string;
+  relativePath: string;
+  columns: CsvTableColumn[];
+}
+
+/**
+ * Crude DuckDB type → XSD datatype mapping. DuckDB's type vocabulary is
+ * richer than xsd's — e.g. HUGEINT, UUID, INTERVAL — so we keep the map
+ * conservative and fall back to xsd:string when nothing else fits. The
+ * goal is "a SPARQL consumer can filter by range", not "round-trip every
+ * DuckDB value losslessly".
+ */
+function xsdForDuckDbType(duckdbType: string) {
+  const t = duckdbType.toUpperCase();
+  if (t === 'BOOLEAN') return XSD('boolean');
+  if (t === 'DATE') return XSD('date');
+  if (t === 'TIME') return XSD('time');
+  if (t.startsWith('TIMESTAMP')) return XSD('dateTime');
+  if (t === 'FLOAT' || t === 'REAL') return XSD('float');
+  if (t === 'DOUBLE') return XSD('double');
+  if (t.startsWith('DECIMAL') || t === 'NUMERIC') return XSD('decimal');
+  if (t === 'TINYINT' || t === 'SMALLINT' || t === 'INTEGER' || t === 'BIGINT' || t === 'HUGEINT') {
+    return XSD('integer');
+  }
+  if (t === 'UTINYINT' || t === 'USMALLINT' || t === 'UINTEGER' || t === 'UBIGINT') {
+    return XSD('nonNegativeInteger');
+  }
+  // VARCHAR / TEXT / BLOB / UUID / INTERVAL / LIST / STRUCT / … all fall
+  // through to string. Users who need finer typing can refine via a
+  // companion note's frontmatter in a later pass.
+  return XSD('string');
+}
+
+/**
+ * Write CSVW + OWL triples describing a registered CSV table. The named
+ * graph equals the table URI so re-indexing is a clean wipe-and-replace,
+ * same pattern as notes.
+ *
+ * - `csvw:Table` + `owl:Class` on the table (rows are its instances).
+ * - `csvw:Schema` with ordered `csvw:column` references.
+ * - Each column is both a `csvw:Column` (index, name, datatype) and an
+ *   `owl:DatatypeProperty` (rdfs:domain = table, rdfs:range = xsd type)
+ *   so SPARQL queries can reason about columns-as-predicates.
+ */
+export function indexCsvTable(shape: CsvTableShape): void {
+  if (!store) return;
+  const table = tableUri(shape.tableName);
+  const graph = table;
+  const schema = $rdf.sym(`${table.value}/schema`);
+
+  // Clean slate for this table's triples.
+  store.removeMatches(undefined, undefined, undefined, graph);
+
+  store.add(table, RDF('type'), CSVW('Table'), graph);
+  store.add(table, RDF('type'), OWL('Class'), graph);
+  store.add(table, RDFS('label'), $rdf.lit(shape.tableName), graph);
+  store.add(table, CSVW('url'), $rdf.lit(shape.relativePath), graph);
+  store.add(table, CSVW('tableSchema'), schema, graph);
+  store.add(table, MINERVA('tableName'), $rdf.lit(shape.tableName), graph);
+  store.add(table, MINERVA('relativePath'), $rdf.lit(shape.relativePath), graph);
+  // Join-back link to the CSV file's own note-URI, so SPARQL can pivot
+  // between the file-level view (row data, written by indexCsvFile)
+  // and this SQL-centric view (named table, typed columns, OWL class).
+  store.add(table, MINERVA('fromFile'), noteUri(shape.relativePath), graph);
+
+  store.add(schema, RDF('type'), CSVW('Schema'), graph);
+
+  for (const col of shape.columns) {
+    const colUri = $rdf.sym(`${table.value}/column/${encodeURIComponent(col.name)}`);
+    const xsdType = xsdForDuckDbType(col.duckdbType);
+    store.add(schema, CSVW('column'), colUri, graph);
+    store.add(colUri, RDF('type'), CSVW('Column'), graph);
+    store.add(colUri, RDF('type'), OWL('DatatypeProperty'), graph);
+    store.add(colUri, CSVW('name'), $rdf.lit(col.name), graph);
+    store.add(colUri, CSVW('columnIndex'), $rdf.lit(String(col.index), undefined, XSD('integer')), graph);
+    store.add(colUri, CSVW('datatype'), xsdType, graph);
+    store.add(colUri, RDFS('label'), $rdf.lit(col.name), graph);
+    store.add(colUri, RDFS('domain'), table, graph);
+    store.add(colUri, RDFS('range'), xsdType, graph);
+  }
+}
+
+/** Remove all triples for a CSV table (entire named graph). */
+export function unindexCsvTable(tableName: string): void {
+  if (!store) return;
+  const graph = tableUri(tableName);
+  store.removeMatches(undefined, undefined, undefined, graph);
+}
+
+/**
+ * Drop every CSV-registered table's triples. Used at the start of a
+ * full rescan so triples for CSVs deleted while the app was closed
+ * don't persist. Identifies them via `minerva:tableName`, which
+ * markdown-embedded csvw:Table nodes don't carry — those stay.
+ */
+export function unindexAllCsvTables(): void {
+  if (!store) return;
+  // Snapshot subjects before removing — rdflib's statementsMatching
+  // returns a live reference into the store, so removing triples while
+  // iterating drops subsequent matches.
+  const subjects: $rdf.NamedNode[] = [];
+  const seen = new Set<string>();
+  for (const st of store.statementsMatching(undefined, MINERVA('tableName'), undefined)) {
+    if (seen.has(st.subject.value)) continue;
+    seen.add(st.subject.value);
+    subjects.push(st.subject as $rdf.NamedNode);
+  }
+  for (const s of subjects) {
+    store.removeMatches(undefined, undefined, undefined, s);
   }
 }
 

--- a/src/main/graph/uri-helpers.ts
+++ b/src/main/graph/uri-helpers.ts
@@ -29,6 +29,10 @@ export function excerptUri(baseUri: string, excerptId: string): string {
   return `${baseUri}excerpt/${encodeURIComponent(excerptId)}`;
 }
 
+export function tableUri(baseUri: string, tableName: string): string {
+  return `${baseUri}table/${encodeURIComponent(tableName)}`;
+}
+
 export const SOURCES_DIR = '.minerva/sources';
 export const EXCERPTS_DIR = '.minerva/excerpts';
 

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
+import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
 
 // ── Module state ────────────────────────────────────────────────────────────
 // Matches the `graph` module: single live project at a time. If Minerva ever
@@ -147,6 +148,7 @@ export async function registerCsv(rootPath: string, relativePath: string): Promi
       await connection.run(`DROP VIEW IF EXISTS "${previousName}"`);
     } catch { /* tolerate the rare rename race */ }
     tableToPath.delete(previousName);
+    unindexCsvTable(previousName);
   }
 
   const absPath = path.join(rootPath, relativePath);
@@ -157,9 +159,45 @@ export async function registerCsv(rootPath: string, relativePath: string): Promi
     );
     pathToTable.set(relativePath, tableName);
     tableToPath.set(tableName, relativePath);
+    // Reflect the shape into the knowledge graph (CSVW + OWL). This
+    // lets SPARQL consumers ask "what tables do I have?", "what columns
+    // does X expose?", and reason about column datatypes.
+    await indexCsvTableShape(relativePath, tableName);
   } catch (err) {
     console.warn(
       `[tables] Failed to register '${relativePath}' as '${tableName}': ` +
+      (err instanceof Error ? err.message : String(err)),
+    );
+  }
+}
+
+/**
+ * Fetch column names + DuckDB types from information_schema and write
+ * the corresponding CSVW/OWL triples to the graph. Failures here log but
+ * don't throw — the CSV is still queryable via SQL even if the graph
+ * entry didn't land.
+ */
+async function indexCsvTableShape(relativePath: string, tableName: string): Promise<void> {
+  if (!connection) return;
+  const safeName = tableName.replace(/'/g, "''");
+  try {
+    const reader = await connection.runAndReadAll(
+      `SELECT column_name, data_type, ordinal_position ` +
+      `FROM information_schema.columns ` +
+      `WHERE table_name = '${safeName}' AND table_schema = 'main' ` +
+      `ORDER BY ordinal_position`,
+    );
+    const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
+    const columns: CsvTableColumn[] = rows.map((r) => ({
+      name: String(r.column_name),
+      duckdbType: String(r.data_type),
+      // ordinal_position is 1-based in DuckDB; we publish 0-based.
+      index: Number(r.ordinal_position) - 1,
+    }));
+    indexCsvTable({ tableName, relativePath, columns });
+  } catch (err) {
+    console.warn(
+      `[tables] Failed to index '${tableName}' into graph: ` +
       (err instanceof Error ? err.message : String(err)),
     );
   }
@@ -175,6 +213,7 @@ export async function unregisterCsv(relativePath: string): Promise<void> {
   } catch { /* view may already be gone */ }
   pathToTable.delete(relativePath);
   tableToPath.delete(tableName);
+  unindexCsvTable(tableName);
 }
 
 /**
@@ -183,6 +222,10 @@ export async function unregisterCsv(relativePath: string): Promise<void> {
  */
 export async function registerAllCsvs(rootPath: string): Promise<number> {
   if (!connection) return 0;
+  // Wipe stale CSV-table triples up front so CSVs deleted while the app
+  // was closed don't linger in the graph after a full rescan. Each
+  // registered CSV writes its own triples as it goes.
+  unindexAllCsvTables();
   let count = 0;
   async function walk(dirPath: string) {
     let entries: import('node:fs').Dirent[];

--- a/src/shared/sparql-completions.ts
+++ b/src/shared/sparql-completions.ts
@@ -52,6 +52,7 @@ export const STANDARD_PREFIXES: ReadonlyArray<{ prefix: string; iri: string }> =
   { prefix: 'rdfs', iri: 'http://www.w3.org/2000/01/rdf-schema#' },
   { prefix: 'xsd', iri: 'http://www.w3.org/2001/XMLSchema#' },
   { prefix: 'csvw', iri: 'http://www.w3.org/ns/csvw#' },
+  { prefix: 'owl', iri: 'http://www.w3.org/2002/07/owl#' },
   { prefix: 'prov', iri: 'http://www.w3.org/ns/prov#' },
   { prefix: 'bibo', iri: 'http://purl.org/ontology/bibo/' },
   { prefix: 'schema', iri: 'http://schema.org/' },

--- a/tests/main/graph/csv-table-indexing.test.ts
+++ b/tests/main/graph/csv-table-indexing.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexCsvTable, unindexCsvTable, unindexAllCsvTables, queryGraph } from '../../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csv-table-test-'));
+}
+
+describe('indexCsvTable — DuckDB table shape in the graph', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initGraph(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('emits the table as csvw:Table and owl:Class', async () => {
+    indexCsvTable({
+      tableName: 'experiments',
+      relativePath: 'data/experiments.csv',
+      columns: [
+        { name: 'id', duckdbType: 'INTEGER', index: 0 },
+        { name: 'name', duckdbType: 'VARCHAR', index: 1 },
+      ],
+    });
+    const { results } = await queryGraph(`
+      SELECT ?type WHERE {
+        ?t minerva:tableName "experiments" ;
+           a ?type .
+      }
+    `);
+    const types = (results as Array<{ type: string }>).map((r) => r.type);
+    expect(types).toContain('http://www.w3.org/ns/csvw#Table');
+    expect(types).toContain('http://www.w3.org/2002/07/owl#Class');
+  });
+
+  it('exposes each column as csvw:Column + owl:DatatypeProperty with domain and xsd range', async () => {
+    indexCsvTable({
+      tableName: 'experiments',
+      relativePath: 'data/experiments.csv',
+      columns: [
+        { name: 'id', duckdbType: 'INTEGER', index: 0 },
+        { name: 'value', duckdbType: 'DOUBLE', index: 1 },
+      ],
+    });
+    const { results } = await queryGraph(`
+      SELECT ?name ?range ?domain WHERE {
+        ?t minerva:tableName "experiments" ;
+           csvw:tableSchema ?s .
+        ?s csvw:column ?c .
+        ?c a owl:DatatypeProperty ;
+           csvw:name ?name ;
+           rdfs:range ?range ;
+           rdfs:domain ?domain .
+      } ORDER BY ?name
+    `);
+    const rows = results as Array<{ name: string; range: string; domain: string }>;
+    expect(rows.length).toBe(2);
+    const id = rows.find((r) => r.name === 'id')!;
+    const value = rows.find((r) => r.name === 'value')!;
+    expect(id.range).toBe('http://www.w3.org/2001/XMLSchema#integer');
+    expect(value.range).toBe('http://www.w3.org/2001/XMLSchema#double');
+    // domain points at the table subject
+    expect(id.domain).toBe(value.domain);
+    expect(id.domain).toContain('/table/experiments');
+  });
+
+  it('maps TIMESTAMP and BOOLEAN columns to xsd:dateTime and xsd:boolean', async () => {
+    indexCsvTable({
+      tableName: 'events',
+      relativePath: 'events.csv',
+      columns: [
+        { name: 'at', duckdbType: 'TIMESTAMP', index: 0 },
+        { name: 'ok', duckdbType: 'BOOLEAN', index: 1 },
+      ],
+    });
+    const { results } = await queryGraph(`
+      SELECT ?name ?range WHERE {
+        ?t minerva:tableName "events" ;
+           csvw:tableSchema ?s .
+        ?s csvw:column ?c .
+        ?c csvw:name ?name ; rdfs:range ?range .
+      } ORDER BY ?name
+    `);
+    const rows = results as Array<{ name: string; range: string }>;
+    const at = rows.find((r) => r.name === 'at')!;
+    const ok = rows.find((r) => r.name === 'ok')!;
+    expect(at.range).toBe('http://www.w3.org/2001/XMLSchema#dateTime');
+    expect(ok.range).toBe('http://www.w3.org/2001/XMLSchema#boolean');
+  });
+
+  it('re-indexing the same table replaces the old triples (no stale columns)', async () => {
+    indexCsvTable({
+      tableName: 't',
+      relativePath: 't.csv',
+      columns: [
+        { name: 'a', duckdbType: 'INTEGER', index: 0 },
+        { name: 'b', duckdbType: 'INTEGER', index: 1 },
+      ],
+    });
+    indexCsvTable({
+      tableName: 't',
+      relativePath: 't.csv',
+      columns: [
+        { name: 'c', duckdbType: 'VARCHAR', index: 0 },
+      ],
+    });
+    const { results } = await queryGraph(`
+      SELECT ?name WHERE {
+        ?t minerva:tableName "t" ;
+           csvw:tableSchema ?s .
+        ?s csvw:column ?c .
+        ?c csvw:name ?name .
+      }
+    `);
+    const names = (results as Array<{ name: string }>).map((r) => r.name);
+    expect(names).toEqual(['c']);
+  });
+
+  it('unindexCsvTable drops every triple for that table', async () => {
+    indexCsvTable({
+      tableName: 't',
+      relativePath: 't.csv',
+      columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
+    });
+    unindexCsvTable('t');
+    const { results } = await queryGraph(`
+      SELECT ?s WHERE { ?s minerva:tableName "t" . }
+    `);
+    expect(results).toEqual([]);
+  });
+
+  it('unindexAllCsvTables drops only CSV-registered tables, not markdown csvw:Tables', async () => {
+    indexCsvTable({
+      tableName: 'x',
+      relativePath: 'x.csv',
+      columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
+    });
+    indexCsvTable({
+      tableName: 'y',
+      relativePath: 'y.csv',
+      columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
+    });
+    unindexAllCsvTables();
+    const { results } = await queryGraph(`
+      SELECT ?s WHERE { ?s minerva:tableName ?n . }
+    `);
+    expect(results).toEqual([]);
+  });
+
+  it('links the SQL-table view back to the CSV file via minerva:fromFile', async () => {
+    indexCsvTable({
+      tableName: 'experiments',
+      relativePath: 'data/experiments.csv',
+      columns: [{ name: 'id', duckdbType: 'INTEGER', index: 0 }],
+    });
+    const { results } = await queryGraph(`
+      SELECT ?file WHERE {
+        ?t minerva:tableName "experiments" ;
+           minerva:fromFile ?file .
+      }
+    `);
+    const rows = results as Array<{ file: string }>;
+    expect(rows.length).toBe(1);
+    expect(rows[0].file).toContain('/note/data/experiments.csv');
+  });
+});


### PR DESCRIPTION
## Summary
The CSV watcher registers tables with DuckDB but previously wrote nothing about them to the knowledge graph. Now it does, using CSVW for table shape and OWL for class / predicate semantics:

\`\`\`turtle
<…/table/experiments> a csvw:Table, owl:Class ;
  rdfs:label "experiments" ;
  csvw:url "data/experiments.csv" ;
  csvw:tableSchema <…/schema> ;
  minerva:tableName "experiments" ;
  minerva:fromFile <…/note/data/experiments.csv> .

<…/schema> a csvw:Schema ; csvw:column <…/col/id>, <…/col/value> .

<…/col/id> a csvw:Column, owl:DatatypeProperty ;
  csvw:name "id" ; csvw:columnIndex 0 ;
  csvw:datatype xsd:integer ; rdfs:range xsd:integer ;
  rdfs:domain <…/table/experiments> ; rdfs:label "id" .
\`\`\`

- **Table** = \`csvw:Table\` ∩ \`owl:Class\` (rows are instances).
- **Column** = \`csvw:Column\` ∩ \`owl:DatatypeProperty\` with rdfs:domain = table, rdfs:range = xsd datatype.
- **DuckDB → xsd mapping**: BOOLEAN / INTEGER / BIGINT / FLOAT / DOUBLE / DECIMAL / DATE / TIMESTAMP / TIME; VARCHAR / UUID / LIST / STRUCT / INTERVAL → xsd:string fallback.
- **Named graph per table**: re-registration is a clean wipe-and-replace.
- **\`minerva:fromFile\`** links the SQL-centric view back to the existing \`indexCsvFile\` structural view so SPARQL can pivot between them.
- **Lifecycle**: \`registerAllCsvs\` wipes stale CSV-table triples up front; \`unregisterCsv\` drops just that table's graph; rename path drops the old name's graph.
- Standard SPARQL prefix list gains \`owl:\`.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm test\` → 1407 / 1407 pass (7 new)
- [ ] Manual: drop a CSV in the project, \`ASK { ?t a csvw:Table ; minerva:tableName "x" }\` returns true; columns show with xsd types

🤖 Generated with [Claude Code](https://claude.com/claude-code)