### PR TITLE
SPARQL prefixes: case-insensitive clash detection

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1163,11 +1163,16 @@ const SPARQL_PREFIXES = STANDARD_PREFIXES
   .map(([prefix, iri]) => `PREFIX ${prefix}: <${iri}>`)
   .join('\n') + '\n';
 
-function injectSparqlPrefixes(sparql: string): string {
-  // Only inject prefixes that aren't already declared in the query
+export function injectSparqlPrefixes(sparql: string): string {
+  // Only inject prefixes the user hasn't already declared. SPARQL's
+  // PREFIX keyword is case-insensitive and allows varied whitespace,
+  // so a naive includes("PREFIX x:") test misses `Prefix x:` and
+  // `PREFIX  x :` — both legal, both would produce duplicate-decl
+  // errors from the evaluator if we blindly injected on top.
   const lines: string[] = [];
   for (const [prefix, iri] of STANDARD_PREFIXES) {
-    if (!sparql.includes(`PREFIX ${prefix}:`) && !sparql.includes(`prefix ${prefix}:`)) {
+    const re = new RegExp(`\\bprefix\\s+${prefix}\\s*:`, 'i');
+    if (!re.test(sparql)) {
       lines.push(`PREFIX ${prefix}: <${iri}>`);
     }
   }

--- a/tests/main/graph/sparql-prefix-injection.test.ts
+++ b/tests/main/graph/sparql-prefix-injection.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { injectSparqlPrefixes } from '../../../src/main/graph/index';
+
+describe('injectSparqlPrefixes', () => {
+  it('prepends every standard prefix to a bare query', () => {
+    const out = injectSparqlPrefixes('SELECT ?s WHERE { ?s ?p ?o }');
+    expect(out).toContain('PREFIX minerva: <https://minerva.dev/ontology#>');
+    expect(out).toContain('PREFIX owl: <http://www.w3.org/2002/07/owl#>');
+    expect(out).toContain('PREFIX csvw: <http://www.w3.org/ns/csvw#>');
+    expect(out).toContain('PREFIX bibo: <http://purl.org/ontology/bibo/>');
+    expect(out).toContain('PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>');
+    expect(out).toContain('PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>');
+    expect(out).toContain('PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>');
+  });
+
+  it('does not re-inject a prefix the query already declares (uppercase)', () => {
+    const input = 'PREFIX owl: <http://example.com/other#>\nSELECT ?s WHERE { ?s a owl:X }';
+    const out = injectSparqlPrefixes(input);
+    // One owl: declaration only — the user's, not ours.
+    const matches = out.match(/PREFIX\s+owl:/gi) ?? [];
+    expect(matches.length).toBe(1);
+    expect(out).toContain('http://example.com/other#');
+  });
+
+  it('catches case variants (lowercase, MixedCase) of the PREFIX keyword', () => {
+    const lower = 'prefix owl: <http://example.com/a#>\nSELECT ?s WHERE {}';
+    expect((injectSparqlPrefixes(lower).match(/\bprefix\s+owl\s*:/gi) ?? []).length).toBe(1);
+
+    const mixed = 'Prefix owl: <http://example.com/b#>\nSELECT ?s WHERE {}';
+    expect((injectSparqlPrefixes(mixed).match(/\bprefix\s+owl\s*:/gi) ?? []).length).toBe(1);
+  });
+
+  it('tolerates extra whitespace between keyword and prefix name', () => {
+    const input = 'PREFIX   csvw:   <http://example.com/c#>\nSELECT ?s WHERE {}';
+    const matches = injectSparqlPrefixes(input).match(/PREFIX\s+csvw\s*:/gi) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('still injects the prefixes the user did not declare', () => {
+    const input = 'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nSELECT ?s WHERE {}';
+    const out = injectSparqlPrefixes(input);
+    // user kept their rdf, we added the rest
+    expect(out).toContain('PREFIX owl: <http://www.w3.org/2002/07/owl#>');
+    expect(out).toContain('PREFIX minerva:');
+    expect((out.match(/PREFIX\s+rdf:/gi) ?? []).length).toBe(1);
+  });
+
+  it('leaves a fully-prefixed query unchanged (no duplicate decls)', () => {
+    const input = [
+      'PREFIX minerva: <https://minerva.dev/ontology#>',
+      'PREFIX thought: <https://minerva.dev/ontology/thought#>',
+      'PREFIX dc: <http://purl.org/dc/terms/>',
+      'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>',
+      'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>',
+      'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>',
+      'PREFIX csvw: <http://www.w3.org/ns/csvw#>',
+      'PREFIX owl: <http://www.w3.org/2002/07/owl#>',
+      'PREFIX prov: <http://www.w3.org/ns/prov#>',
+      'PREFIX bibo: <http://purl.org/ontology/bibo/>',
+      'PREFIX schema: <http://schema.org/>',
+      'SELECT ?s WHERE { ?s ?p ?o }',
+    ].join('\n');
+    const out = injectSparqlPrefixes(input);
+    expect(out).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
\`injectSparqlPrefixes\` already auto-prepends the standard set of prefixes (minerva, thought, dc, rdf, rdfs, xsd, csvw, owl, prov, bibo, schema) to every user query via \`queryGraph\`. Previously the "is the user already declaring this prefix?" check used literal substring matches on \`PREFIX \` and \`prefix \` — missed \`Prefix\`, \`PrEfIx\`, and any run of whitespace between the keyword and the prefix name. All legal SPARQL; blindly injecting our copy on top produced a duplicate-declaration error from the Comunica engine.

**Fix:** regex \`\\bprefix\\s+<name>\\s*:\` with the \`i\` flag — catches every case + whitespace variant.

Exported the function and added 6 unit tests covering bare queries, case variants, whitespace tolerance, partial-override, and full-override.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm vitest tests/main/graph/sparql-prefix-injection.test.ts\` → 6 / 6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)