### PR TITLE
Sources: delete with cascading excerpt removal

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1019,6 +1019,24 @@ export function removeExcerpt(excerptId: string): void {
   store.removeMatches(subject, undefined, undefined);
 }
 
+/**
+ * Every excerpt-id with thought:fromSource pointing at the given source.
+ * Used by the source-delete path to cascade-remove orphaned excerpts.
+ */
+export function excerptIdsForSource(sourceId: string): string[] {
+  if (!store) return [];
+  const subject = sourceUri(sourceId);
+  const stmts = store.statementsMatching(undefined, THOUGHT('fromSource'), subject);
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const st of stmts) {
+    const idStmts = store.statementsMatching(st.subject, MINERVA('excerptId'), undefined);
+    const id = idStmts[0]?.object.value;
+    if (id && !seen.has(id)) { seen.add(id); ids.push(id); }
+  }
+  return ids;
+}
+
 /** Parse `<id>` out of `.minerva/excerpts/<id>.ttl`. Returns null for other paths. */
 export function parseExcerptIdFromPath(relativePath: string): string | null {
   const normalized = relativePath.replace(/\\/g, '/');

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -32,6 +32,7 @@ import { ingestUrl } from './sources/ingest';
 import * as tables from './sources/tables';
 import { ingestIdentifier } from './sources/ingest-identifier';
 import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
+import { deleteSource } from './sources/delete-source';
 import { importBibtex } from './sources/import-bibtex';
 import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
@@ -922,6 +923,19 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(Channels.SOURCES_LIST_ALL, () => graph.listAllSources());
+
+  ipcMain.handle(Channels.SOURCES_DELETE, async (e, sourceId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const result = await deleteSource(rootPath, sourceId);
+    await persistIndexes();
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) {
+      win.webContents.send(Channels.SOURCES_CHANGED);
+      win.webContents.send(Channels.EXCERPTS_CHANGED);
+    }
+    return result;
+  });
 
   ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, async (e, params: {
     sourceId: string;

--- a/src/main/sources/delete-source.ts
+++ b/src/main/sources/delete-source.ts
@@ -1,0 +1,46 @@
+/**
+ * Delete a Source and its excerpts.
+ *
+ * Cascades by design: a Source's excerpts have no meaning without the
+ * Source, so we remove them first. Wiki-links / cite-links pointing at
+ * the deleted source become dead links — same UX story as deleting a
+ * note, and users have git for recovery.
+ *
+ * Order of operations matters for the graph + disk: we remove graph
+ * entries first (so the watcher doesn't re-add them when it sees the
+ * file disappear), then delete the files.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as graph from '../graph/index';
+
+export interface DeleteSourceResult {
+  sourceId: string;
+  /** Number of excerpts removed alongside the source. */
+  excerptsRemoved: number;
+}
+
+export async function deleteSource(
+  rootPath: string,
+  sourceId: string,
+): Promise<DeleteSourceResult> {
+  const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
+
+  // Snapshot excerpt ids before we wipe the graph — once the graph
+  // entries are gone, we can't list them anymore.
+  const excerptIds = graph.excerptIdsForSource(sourceId);
+
+  for (const id of excerptIds) {
+    graph.removeExcerpt(id);
+    const excerptFile = path.join(rootPath, '.minerva', 'excerpts', `${id}.ttl`);
+    try { await fs.unlink(excerptFile); } catch { /* already gone */ }
+  }
+
+  graph.removeSource(sourceId);
+  try {
+    await fs.rm(sourceDir, { recursive: true, force: true });
+  } catch { /* already gone */ }
+
+  return { sourceId, excerptsRemoved: excerptIds.length };
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -205,6 +205,7 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.on(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, (_e, progress) => cb(progress));
     },
     listAll: () => ipcRenderer.invoke(Channels.SOURCES_LIST_ALL),
+    delete: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_DELETE, sourceId),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -235,6 +235,13 @@
     return null;
   }
 
+  function handleSourceDeleted(sourceId: string) {
+    // Close any open tab for this source so the user isn't staring at
+    // a ghost viewer after delete.
+    const idx = editor.tabs.findIndex((t) => t.type === 'source' && t.sourceId === sourceId);
+    if (idx !== -1) editor.closeTab(idx);
+  }
+
   function handleOpenSource(sourceId: string, highlightExcerptId?: string) {
     recordCurrentPosition();
     editor.openSource(sourceId, { highlightExcerptId });
@@ -1560,6 +1567,8 @@
           onMove={handleMove}
           onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
           onSourceSelect={(id) => handleOpenSource(id)}
+          onSourceDeleted={handleSourceDeleted}
+          onShowConfirm={showConfirm}
           onTableClick={(name) => editor.openQuery(`SELECT * FROM ${name}`, 'sql')}
           onOpenCsv={(rel) => handleFileSelect(rel)}
           onExternalDrop={handleExternalDrop}
@@ -1735,6 +1744,8 @@
               sourceId={editor.activeTab.sourceId}
               highlightExcerptId={editor.activeTab.highlightExcerptId}
               onNavigate={handleNavigate}
+              onShowConfirm={showConfirm}
+              onDeleted={handleSourceDeleted}
             />
           {/key}
         {:else}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -20,13 +20,15 @@
     onMove: (srcPath: string, destDirectory: string) => void;
     onBookmark?: (relativePath: string) => void;
     onSourceSelect?: (sourceId: string) => void;
+    onSourceDeleted?: (sourceId: string) => void;
+    onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
     onTableClick?: (tableName: string) => void;
     onOpenCsv?: (relativePath: string) => void;
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
     canPaste?: boolean;
   }
 
-  let { files, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let rootDropHover = $state(false);
   let tagPanel = $state<TagPanel>();
   let sourcesPanel = $state<SourcesPanel>();
@@ -132,8 +134,8 @@
       <FileTree {files} {activeFilePath} {canPaste} {onFileSelect} {onNewNote} {onNewFolder} {onDelete} {onRename} {onCut} {onCopy} {onPaste} {onMove} {onBookmark} {onExternalDrop} />
     </div>
     <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />
-    {#if onSourceSelect}
-      <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} />
+    {#if onSourceSelect && onShowConfirm}
+      <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} />
     {/if}
     {#if onTableClick && onOpenCsv}
       <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} />

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -8,9 +8,24 @@
     sourceId: string;
     highlightExcerptId?: string;
     onNavigate: (target: string) => void;
+    onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
+    onDeleted?: (sourceId: string) => void;
   }
 
-  let { sourceId, highlightExcerptId, onNavigate }: Props = $props();
+  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted }: Props = $props();
+
+  async function handleDelete() {
+    if (!detail) return;
+    const label = detail.metadata.title ?? sourceId;
+    const confirmed = await onShowConfirm(
+      `Delete source "${label}"? Any excerpts from this source will also be removed.`,
+      'delete-source',
+      'Delete',
+    );
+    if (!confirmed) return;
+    await api.sources.delete(sourceId);
+    onDeleted?.(sourceId);
+  }
 
   let detail = $state<SourceDetail | null>(null);
   let loading = $state(true);
@@ -221,6 +236,9 @@
         </div>
       {/if}
       <div class="kv"><span class="k">Source id</span><span class="v mono">{detail.metadata.sourceId}</span></div>
+      <div class="actions">
+        <button class="action-btn" onclick={handleDelete}>Delete source</button>
+      </div>
     </section>
 
     {#if detail.metadata.abstract}
@@ -404,6 +422,22 @@
   }
 
   .kv { display: contents; }
+  .actions {
+    grid-column: 1 / -1;
+    margin-top: 8px;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .action-btn {
+    padding: 4px 12px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .action-btn:hover { background: var(--bg-button-hover); }
   .k {
     color: var(--text-muted);
     font-size: 13px;

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1,16 +1,51 @@
 <script lang="ts">
   import { api } from '../ipc/client';
   import type { SourceMetadata } from '../../../shared/types';
+  import { clampMenuToViewport } from '../utils/menuClamp';
 
   interface Props {
     onSourceSelect: (sourceId: string) => void;
+    onSourceDeleted?: (sourceId: string) => void;
+    onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
   }
 
-  let { onSourceSelect }: Props = $props();
+  let { onSourceSelect, onSourceDeleted, onShowConfirm }: Props = $props();
 
   let sources = $state<SourceMetadata[]>([]);
   let filter = $state('');
   let collapsed = $state(false);
+  let contextMenu = $state<{ x: number; y: number; source: SourceMetadata } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
+
+  function handleContextMenu(e: MouseEvent, source: SourceMetadata) {
+    e.preventDefault();
+    e.stopPropagation();
+    contextMenu = { x: e.clientX, y: e.clientY, source };
+    const close = () => { contextMenu = null; window.removeEventListener('click', close); };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  async function handleDelete(source: SourceMetadata) {
+    contextMenu = null;
+    const label = source.title ?? source.sourceId;
+    const confirmed = await onShowConfirm(
+      `Delete source "${label}"? Any excerpts from this source will also be removed.`,
+      'delete-source',
+      'Delete',
+    );
+    if (!confirmed) return;
+    await api.sources.delete(source.sourceId);
+    onSourceDeleted?.(source.sourceId);
+    await refresh();
+  }
 
   export async function refresh(): Promise<void> {
     sources = await api.sources.listAll();
@@ -62,6 +97,7 @@
           <button
             class="source-item"
             onclick={() => onSourceSelect(s.sourceId)}
+            oncontextmenu={(e) => handleContextMenu(e, s)}
             title={s.sourceId}
           >
             <div class="source-title">{s.title ?? s.sourceId}</div>
@@ -76,9 +112,42 @@
       </div>
     {/if}
   {/if}
+
+  {#if contextMenu}
+    <div
+      class="context-menu"
+      bind:this={contextMenuEl}
+      style:left="{contextMenu.x}px"
+      style:top="{contextMenu.y}px"
+    >
+      <button onclick={() => handleDelete(contextMenu!.source)}>Delete Source</button>
+    </div>
+  {/if}
 </div>
 
 <style>
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 160px;
+  }
+  .context-menu button {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .context-menu button:hover { background: var(--bg-button); }
   .sources-panel {
     border-top: 1px solid var(--border);
     flex-shrink: 0;

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -10,6 +10,7 @@
 
 export const CONFIRM_KEYS = {
   delete: 'confirm-delete',
+  deleteSource: 'delete-source',
   rewriteConflict: 'confirm-rewrite-conflict',
   headingRenameSuggestion: 'heading-rename-suggestion',
   moveCollision: 'move-collision',
@@ -47,6 +48,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Delete file or folder',
     description:
       'Prompt before removing a note, folder, or source from the thoughtbase.',
+  },
+  {
+    key: CONFIRM_KEYS.deleteSource,
+    title: 'Delete source',
+    description:
+      'Prompt before removing a Source (and its excerpts) from the thoughtbase.',
   },
   {
     key: CONFIRM_KEYS.rewriteConflict,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -456,6 +456,8 @@ export interface SourcesApi {
   onImportZoteroRdfProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): void;
   /** All indexed sources, sorted by title. */
   listAll(): Promise<import('../../../shared/types').SourceMetadata[]>;
+  /** Delete a source + cascade-delete its excerpts. */
+  delete(sourceId: string): Promise<{ sourceId: string; excerptsRemoved: number }>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -150,6 +150,8 @@ export const Channels = {
   MENU_IMPORT_ZOTERO_RDF: 'menu:importZoteroRdf',
   /** List every indexed source, for the sidebar Sources panel. */
   SOURCES_LIST_ALL: 'sources:listAll',
+  /** Delete a source + cascade-delete its excerpts. */
+  SOURCES_DELETE: 'sources:delete',
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */
   SOURCES_CHANGED: 'sources:changed',
 

--- a/tests/main/sources/delete-source.test.ts
+++ b/tests/main/sources/delete-source.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexSource, indexExcerpt, listAllSources, excerptIdsForSource } from '../../../src/main/graph/index';
+import { deleteSource } from '../../../src/main/sources/delete-source';
+
+function mkTemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-delete-source-'));
+}
+
+describe('deleteSource', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTemp();
+    await initGraph(root);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('removes the source directory, all excerpts, and their graph entries', async () => {
+    const sourceId = 'sha-abc123';
+    const sourceDir = path.join(root, '.minerva', 'sources', sourceId);
+    await fsp.mkdir(sourceDir, { recursive: true });
+    await fsp.writeFile(path.join(sourceDir, 'meta.ttl'),
+      'this: a thought:PDFSource ; dc:title "Test" .\n');
+    await fsp.writeFile(path.join(sourceDir, 'body.md'), '# Test\n');
+    await fsp.writeFile(path.join(sourceDir, 'original.pdf'), new Uint8Array([0x25, 0x50, 0x44, 0x46]));
+
+    indexSource(sourceId,
+      'this: a thought:PDFSource ; dc:title "Test" .\n',
+      '# Test\n',
+    );
+
+    const excerptsDir = path.join(root, '.minerva', 'excerpts');
+    await fsp.mkdir(excerptsDir, { recursive: true });
+    for (const exId of ['ex-1', 'ex-2']) {
+      const ttl = `this: a thought:Excerpt ;\n  thought:fromSource sources:${sourceId} ;\n  thought:citedText "..." .\n`;
+      await fsp.writeFile(path.join(excerptsDir, `${exId}.ttl`), ttl);
+      indexExcerpt(exId, ttl);
+    }
+
+    // Sanity: the source + excerpts are in the graph before deletion.
+    expect(listAllSources().some((s) => s.sourceId === sourceId)).toBe(true);
+    expect(excerptIdsForSource(sourceId).sort()).toEqual(['ex-1', 'ex-2']);
+
+    const result = await deleteSource(root, sourceId);
+
+    expect(result.sourceId).toBe(sourceId);
+    expect(result.excerptsRemoved).toBe(2);
+    expect(fs.existsSync(sourceDir)).toBe(false);
+    expect(fs.existsSync(path.join(excerptsDir, 'ex-1.ttl'))).toBe(false);
+    expect(fs.existsSync(path.join(excerptsDir, 'ex-2.ttl'))).toBe(false);
+    expect(listAllSources().some((s) => s.sourceId === sourceId)).toBe(false);
+    expect(excerptIdsForSource(sourceId)).toEqual([]);
+  });
+
+  it('is a no-op on an already-deleted source', async () => {
+    const result = await deleteSource(root, 'sha-nonexistent');
+    expect(result.excerptsRemoved).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Sources could be ingested but never deleted from the UI. The \`.minerva/sources/<id>/\` directory is hidden from the file tree, and the Sources panel had no affordance. Fixed.

### Pipeline (main)
\`deleteSource(root, id)\`:
1. Graph query: every excerpt with \`thought:fromSource <source>\`.
2. Remove each excerpt's \`.ttl\` file and its graph entries.
3. Strip the source's graph entries.
4. \`rm -rf\` the source directory.

New helper \`graph.excerptIdsForSource\` surfaces the excerpt list cleanly for the cascade.

### Surfaces (renderer)
- **SourcesPanel right-click** → *Delete Source*
- **SourceDetail header** → *Delete source* button beside the metadata grid

Both route through a suppressible \`delete-source\` confirm (\"Delete source X? Its excerpts will also be removed.\"), call \`api.sources.delete\`, and close any open tab for the deleted source.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm test\` → full suite green; 2 new tests for cascade + no-op-on-missing
- [ ] Manual: right-click a source in the left sidebar → Delete → confirm → source + any excerpts disappear
- [ ] Manual: open a source viewer → Delete source → confirm → tab closes, source gone from panel
- [ ] Manual: notes that cited the deleted source still open (dead cite-links are the expected outcome, same as deleted notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)