### PR TITLE
approval: updateProposalStatus replaces, does not append (closes #332)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1684,6 +1684,22 @@ export function parseIntoStore(turtle: string): void {
   }
 }
 
+/**
+ * Drop every triple matching `(subject, predicate, *)`. Used by the
+ * approval engine to replace single-cardinality predicates like
+ * `thought:proposalStatus` so a status change doesn't leave the prior
+ * status hanging on the same proposal (#332).
+ *
+ * Subject and predicate are passed as IRIs; both are required to keep
+ * the surface narrow — wholesale subject wipes go through the more
+ * specific `removeNote` / `removeSource` / `removeExcerpt` helpers.
+ */
+export function removeMatchingTriples(subjectIri: string, predicateIri: string): void {
+  if (!store) return;
+  invalidateN3Cache();
+  store.removeMatches($rdf.sym(subjectIri), $rdf.sym(predicateIri), undefined);
+}
+
 export function serializeGraph(): string {
   if (!store) return '';
   // Pass a dummy base that doesn't match any of our URIs,

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -266,25 +266,12 @@ async function writeProposalToGraph(p: Proposal): Promise<void> {
 }
 
 async function updateProposalStatus(uri: string, newStatus: string): Promise<void> {
-  // Remove old status triple and add new one
-  const turtle = `
-    <${uri}> thought:proposalStatus thought:${newStatus} .
-  `;
-  // We need to remove the old status first — use a SPARQL-style approach
-  // Since rdflib doesn't support SPARQL UPDATE, we query then manipulate
-  const results = await graph.queryGraph(`
-    PREFIX thought: <${THOUGHT}>
-    SELECT ?oldStatus WHERE {
-      <${uri}> thought:proposalStatus ?oldStatus .
-    }
-  `);
-  const rows = results.results as Record<string, string>[];
-  if (rows.length > 0) {
-    // Remove old status by re-parsing with the new status
-    // The simplest approach: write a turtle block that sets the new status
-    // The old triple remains but the query will find the latest
-    await applyTurtle(turtle);
-  }
+  // Drop any prior thought:proposalStatus triples on this proposal
+  // before adding the new one — otherwise the proposal accumulates
+  // {pending, approved, ...} markers and history queries return all
+  // historical states (#332).
+  graph.removeMatchingTriples(uri, `${THOUGHT}proposalStatus`);
+  await applyTurtle(`<${uri}> thought:proposalStatus thought:${newStatus} .`);
 }
 
 async function applyTurtle(turtle: string): Promise<void> {

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -1,11 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 import {
   getApprovalTier,
   setPolicy,
   resetPolicy,
+  proposeWrite,
+  approveProposal,
+  rejectProposal,
   type OperationType,
   type ApprovalTier,
 } from '../../../src/main/llm/approval';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
 
 describe('approval policy', () => {
   beforeEach(() => {
@@ -53,6 +61,61 @@ describe('approval policy', () => {
 
   it('falls back to requires_approval for unknown operation types', () => {
     expect(getApprovalTier('unknown_op' as OperationType)).toBe('requires_approval');
+  });
+});
+
+describe('updateProposalStatus replaces, does not append (#332)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-status-'));
+    await initGraph(root);
+    resetPolicy();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function statusesFor(uri: string): Promise<string[]> {
+    const r = await queryGraph(`
+      SELECT ?s WHERE { <${uri}> thought:proposalStatus ?s . }
+    `);
+    return (r.results as Array<{ s: string }>).map((row) => row.s);
+  }
+
+  it('approving a pending proposal leaves only the approved status', async () => {
+    const proposal = await proposeWrite({
+      operationType: 'new_claim',
+      turtleDiff: '<https://ex.example/x> a <https://ex.example/Claim> .',
+      note: 'test',
+      proposedBy: 'unit-test',
+      affectsNodeUri: 'https://ex.example/x',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await statusesFor(proposal!.uri)).toEqual([
+      'https://minerva.dev/ontology/thought#pending',
+    ]);
+
+    expect(await approveProposal(proposal!.uri)).toBe(true);
+    expect(await statusesFor(proposal!.uri)).toEqual([
+      'https://minerva.dev/ontology/thought#approved',
+    ]);
+  });
+
+  it('rejecting a pending proposal leaves only the rejected status', async () => {
+    const proposal = await proposeWrite({
+      operationType: 'new_claim',
+      turtleDiff: '<https://ex.example/y> a <https://ex.example/Claim> .',
+      note: 'test',
+      proposedBy: 'unit-test',
+      affectsNodeUri: 'https://ex.example/y',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await rejectProposal(proposal!.uri)).toBe(true);
+    expect(await statusesFor(proposal!.uri)).toEqual([
+      'https://minerva.dev/ontology/thought#rejected',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
\`updateProposalStatus\` was layering a new \`thought:proposalStatus\` triple on top of any prior one — the comment in the code was honest about it (\"the old triple remains but the query will find the latest\"). It didn't. Queries returning \`?status\` saw all of \`{pending, approved, rejected, expired}\` stack up over a proposal's life.

**Fix:** drop every prior \`thought:proposalStatus\` on the proposal before adding the new one. Exposed a narrow \`graph.removeMatchingTriples(subjectIri, predicateIri)\` helper for this — wholesale subject wipes still go through the existing \`removeNote\` / \`removeSource\` / \`removeExcerpt\` entry points.

## Test plan
- [x] \`pnpm lint\` → 0 errors
- [x] \`pnpm test\` → 1460 / 1460 (2 new in approval.test.ts)
- New tests: approve a fresh pending proposal → exactly one status triple survives. Same for reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)