### PR TITLE
graph: per-project ProjectContext (#333, PR 1 of 3)

### DIFF
--- a/src/main/compute/executors/sparql.ts
+++ b/src/main/compute/executors/sparql.ts
@@ -6,6 +6,7 @@
  */
 
 import { queryGraph } from '../../graph';
+import { projectContext } from '../../project-context-types';
 import type { ExecutorFn } from '../registry';
 
 /**
@@ -15,8 +16,8 @@ import type { ExecutorFn } from '../registry';
  * objects from the graph layer — we flatten them into row-major order
  * using the first binding's keys as the column list.
  */
-export const executeSparql: ExecutorFn = async (code) => {
-  const response = await queryGraph(code);
+export const executeSparql: ExecutorFn = async (code, ctx) => {
+  const response = await queryGraph(projectContext(ctx.rootPath), code);
   // `queryGraph` returns `{ results: [], error }` on parse / runtime
   // failure — surface that as a cell-level error rather than a thrown
   // exception, so the shell writes a readable output block.

--- a/src/main/formatter/orchestrator.ts
+++ b/src/main/formatter/orchestrator.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as notebaseFs from '../notebase/fs';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
 import { formatContent, type FormatSettings } from '../../shared/formatter/engine';
 import type { FormatFileResult } from '../../shared/formatter/types';
@@ -114,7 +115,7 @@ async function writeThrough(
   content: string,
 ): Promise<void> {
   await notebaseFs.writeFile(rootPath, relativePath, content);
-  await graph.indexNote(relativePath, content);
+  await graph.indexNote(projectContext(rootPath), relativePath, content);
   search.indexNote(relativePath, content);
   // Caller is responsible for the batched persist + NOTEBASE_REWRITTEN
   // broadcast — doing it per-file in a folder run would thrash the

--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -1,4 +1,5 @@
 import { queryGraph } from './index';
+import type { ProjectContext } from '../project-context-types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -14,11 +15,11 @@ export interface Inspection {
   suggestedAction?: string;
 }
 
-let lastResults: Inspection[] = [];
+const lastResultsByProject = new Map<string, Inspection[]>();
 let running = false;
 
-export function getInspections(): Inspection[] {
-  return lastResults;
+export function getInspections(ctx: ProjectContext): Inspection[] {
+  return lastResultsByProject.get(ctx.rootPath) ?? [];
 }
 
 export function isRunning(): boolean {
@@ -27,19 +28,20 @@ export function isRunning(): boolean {
 
 // ── Run All Checks ─────────────────────────────────────────────────────────
 
-export async function runAllChecks(): Promise<Inspection[]> {
-  if (running) return lastResults;
+export async function runAllChecks(ctx: ProjectContext): Promise<Inspection[]> {
+  if (running) return lastResultsByProject.get(ctx.rootPath) ?? [];
   running = true;
 
   try {
     const results = await Promise.all([
-      checkUnsupportedClaims(),
-      checkStaleness(30), // 30 days
-      checkEvidenceGaps(),
-      checkContradictions(),
+      checkUnsupportedClaims(ctx),
+      checkStaleness(ctx, 30), // 30 days
+      checkEvidenceGaps(ctx),
+      checkContradictions(ctx),
     ]);
-    lastResults = results.flat();
-    return lastResults;
+    const flat = results.flat();
+    lastResultsByProject.set(ctx.rootPath, flat);
+    return flat;
   } finally {
     running = false;
   }
@@ -47,8 +49,8 @@ export async function runAllChecks(): Promise<Inspection[]> {
 
 // ── Individual Checks ──────────────────────────────────────────────────────
 
-async function checkUnsupportedClaims(): Promise<Inspection[]> {
-  const results = await queryGraph(`
+async function checkUnsupportedClaims(ctx: ProjectContext): Promise<Inspection[]> {
+  const results = await queryGraph(ctx, `
     PREFIX thought: <https://minerva.dev/ontology/thought#>
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     SELECT ?claim ?label WHERE {
@@ -69,10 +71,10 @@ async function checkUnsupportedClaims(): Promise<Inspection[]> {
   }));
 }
 
-async function checkStaleness(thresholdDays: number): Promise<Inspection[]> {
+async function checkStaleness(ctx: ProjectContext, thresholdDays: number): Promise<Inspection[]> {
   const cutoff = new Date(Date.now() - thresholdDays * 86400000).toISOString();
 
-  const results = await queryGraph(`
+  const results = await queryGraph(ctx, `
     PREFIX dc: <http://purl.org/dc/terms/>
     PREFIX minerva: <https://minerva.dev/ontology#>
     SELECT ?note ?title ?modified WHERE {
@@ -96,11 +98,11 @@ async function checkStaleness(thresholdDays: number): Promise<Inspection[]> {
   }));
 }
 
-async function checkEvidenceGaps(): Promise<Inspection[]> {
+async function checkEvidenceGaps(ctx: ProjectContext): Promise<Inspection[]> {
   const inspections: Inspection[] = [];
 
   // Claims with grounds but no warrant
-  const noWarrant = await queryGraph(`
+  const noWarrant = await queryGraph(ctx, `
     PREFIX thought: <https://minerva.dev/ontology/thought#>
     SELECT ?claim ?label WHERE {
       ?claim a thought:Claim .
@@ -127,7 +129,7 @@ async function checkEvidenceGaps(): Promise<Inspection[]> {
   }
 
   // Warrants with no backing
-  const noBacking = await queryGraph(`
+  const noBacking = await queryGraph(ctx, `
     PREFIX thought: <https://minerva.dev/ontology/thought#>
     SELECT ?warrant ?label WHERE {
       ?warrant a thought:Warrant .
@@ -154,8 +156,8 @@ async function checkEvidenceGaps(): Promise<Inspection[]> {
   return inspections;
 }
 
-async function checkContradictions(): Promise<Inspection[]> {
-  const results = await queryGraph(`
+async function checkContradictions(ctx: ProjectContext): Promise<Inspection[]> {
+  const results = await queryGraph(ctx, `
     PREFIX thought: <https://minerva.dev/ontology/thought#>
     SELECT ?a ?aLabel ?b ?bLabel WHERE {
       ?a thought:contradicts ?b .
@@ -179,16 +181,18 @@ async function checkContradictions(): Promise<Inspection[]> {
 
 // ── Timer ──────────────────────────────────────────────────────────────────
 
-let timer: ReturnType<typeof setInterval> | null = null;
+const timersByProject = new Map<string, ReturnType<typeof setInterval>>();
 
-export function startPeriodicChecks(intervalMs: number = 5 * 60 * 1000): void {
-  stopPeriodicChecks();
-  timer = setInterval(() => { runAllChecks(); }, intervalMs);
+export function startPeriodicChecks(ctx: ProjectContext, intervalMs: number = 5 * 60 * 1000): void {
+  stopPeriodicChecks(ctx);
+  const timer = setInterval(() => { runAllChecks(ctx); }, intervalMs);
+  timersByProject.set(ctx.rootPath, timer);
 }
 
-export function stopPeriodicChecks(): void {
-  if (timer) {
-    clearInterval(timer);
-    timer = null;
+export function stopPeriodicChecks(ctx: ProjectContext): void {
+  const t = timersByProject.get(ctx.rootPath);
+  if (t) {
+    clearInterval(t);
+    timersByProject.delete(ctx.rootPath);
   }
 }

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -16,21 +16,8 @@ import * as N3 from 'n3';
 
 let engine: QueryEngine | null = null;
 
-/**
- * Cached N3 mirror of the rdflib store, keyed implicitly by store identity
- * + cumulative mutations. Cleared by `invalidateN3Cache()` at every public
- * mutator boundary; rebuilt on demand by `queryGraph`.
- *
- * Why this exists: every SPARQL query used to walk every rdflib statement
- * and copy it into a fresh N3.Store before handing to Comunica. On medium
- * graphs (10k+ triples) that O(N) copy dominated panel-refresh latency in
- * the renderer.
- */
-let n3StoreCache: N3.Store | null = null;
-
-function invalidateN3Cache(): void {
-  n3StoreCache = null;
-}
+// N3 cache + invalidation now live on GraphState (per-project) — see
+// `state.n3Cache` and the `invalidate(state)` helper above.
 
 /** Build an N3.Store from rdflib's IndexedFormula for Comunica to query */
 function buildN3Store(s: $rdf.IndexedFormula): N3.Store {
@@ -77,9 +64,53 @@ const BIBO    = $rdf.Namespace('http://purl.org/ontology/bibo/');
 const SCHEMA  = $rdf.Namespace('http://schema.org/');
 const PROV    = $rdf.Namespace('http://www.w3.org/ns/prov#');
 
-let baseUri = '';      // e.g. https://project.minerva.dev/dave/my-notes/
-let store: $rdf.IndexedFormula | null = null;
-let currentRootPath: string | null = null;
+// ── Per-project state (#333) ────────────────────────────────────────────────
+//
+// Each open thoughtbase has one GraphState regardless of how many windows
+// show it. Lookup is keyed by ctx.rootPath. Internal helpers take a
+// `state` parameter where they need any of the project-scoped fields;
+// public exports take `ctx: ProjectContext` and resolve state from it.
+
+import type { ProjectContext } from '../project-context-types';
+
+interface HeadingSnapshot {
+  slug: string;
+  text: string;
+  level: number;
+}
+
+interface GraphState {
+  rootPath: string;
+  baseUri: string;
+  store: $rdf.IndexedFormula;
+  /** N3.Store mirror cached for Comunica; rebuilt on demand by queryGraph. */
+  n3Cache: N3.Store | null;
+  /** Cached parsed ontology triples; reloaded fresh on init, stripped before persist. */
+  ontologyStatements: $rdf.Statement[];
+  /** Heading snapshot per note for the rename-detection heuristic. */
+  headingsPerNote: Map<string, HeadingSnapshot[]>;
+}
+
+const states = new Map<string, GraphState>();
+
+function getState(ctx: ProjectContext): GraphState | null {
+  return states.get(ctx.rootPath) ?? null;
+}
+
+function requireState(ctx: ProjectContext): GraphState {
+  const s = states.get(ctx.rootPath);
+  if (!s) throw new Error(`graph: no state for project "${ctx.rootPath}"`);
+  return s;
+}
+
+function invalidate(state: GraphState): void {
+  state.n3Cache = null;
+}
+
+/** Tear down a project's graph state. Called by ProjectContext on last release. */
+export function disposeProject(ctx: ProjectContext): void {
+  states.delete(ctx.rootPath);
+}
 
 // ── LLM Write Guard ───────────────────────────────────────────────────────
 // Tracks whether the current call path originates from an LLM operation.
@@ -107,21 +138,9 @@ export function isInLLMContext(): boolean {
  * Add a triple to the store with write-guard checking.
  * In LLM context, logs a warning unless the write is to a Proposal node.
  */
-function guardedAdd(
-  s: $rdf.NamedNode,
-  p: $rdf.NamedNode,
-  o: $rdf.Node,
-  graph?: $rdf.NamedNode,
-): void {
-  if (!store) return;
-  if (llmContextDepth > 0) {
-    const isProposal = s.value.includes('/proposal/') || o.value?.includes?.('Proposal');
-    if (!isProposal) {
-      console.warn(`[minerva:trust] Direct graph write from LLM context: ${s.value} ${p.value} — should go through approval engine`);
-    }
-  }
-  store.add(s, p, o, graph);
-}
+// `guardedAdd` removed — unused since landing. The trust-principle
+// enforcement work in #331 will reintroduce a similar check at the
+// approval-engine boundary, not as an opt-in store wrapper.
 
 // ── Project config (persisted in .minerva/config.json) ─────────────────────
 
@@ -153,38 +172,38 @@ function resolveBaseUri(rootPath: string): string {
 
 // ── URI helpers (delegate to uri-helpers module) ────────────────────────────
 
-function noteUri(relativePath: string): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.noteUri(baseUri, relativePath));
+function noteUri(state: GraphState, relativePath: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.noteUri(state.baseUri, relativePath));
 }
 
-function tagUri(tagName: string): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.tagUri(baseUri, tagName));
+function tagUri(state: GraphState, tagName: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.tagUri(state.baseUri, tagName));
 }
 
-function folderUri(relativePath: string): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.folderUri(baseUri, relativePath));
+function folderUri(state: GraphState, relativePath: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.folderUri(state.baseUri, relativePath));
 }
 
-function sourceUri(sourceId: string): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.sourceUri(baseUri, sourceId));
+function sourceUri(state: GraphState, sourceId: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.sourceUri(state.baseUri, sourceId));
 }
 
-function excerptUri(excerptId: string): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.excerptUri(baseUri, excerptId));
+function excerptUri(state: GraphState, excerptId: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.excerptUri(state.baseUri, excerptId));
 }
 
-function tableUri(tableName: string): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.tableUri(baseUri, tableName));
+function tableUri(state: GraphState, tableName: string): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.tableUri(state.baseUri, tableName));
 }
 
 function linkPredicate(lt: LinkType) {
   return lt.predicateNamespace === 'thought' ? THOUGHT(lt.predicate) : MINERVA(lt.predicate);
 }
 
-function resolveLinkTarget(lt: LinkType, target: string, anchor?: string) {
-  if (lt.targetKind === 'source') return sourceUri(target);
-  if (lt.targetKind === 'excerpt') return excerptUri(target);
-  const base = noteUri(target.endsWith('.md') ? target : `${target}.md`);
+function resolveLinkTarget(state: GraphState, lt: LinkType, target: string, anchor?: string) {
+  if (lt.targetKind === 'source') return sourceUri(state, target);
+  if (lt.targetKind === 'excerpt') return excerptUri(state, target);
+  const base = noteUri(state, target.endsWith('.md') ? target : `${target}.md`);
   // Anchors append as an IRI fragment: headings become `#slug`, block-ids
   // stay as `#^raw-id` (we don't slugify the `^` prefix or its payload so
   // ids survive edits on the referenced block).
@@ -281,8 +300,8 @@ function frontmatterValueToTerm(value: Exclude<FrontmatterValue, null | Frontmat
   return $rdf.lit(value);
 }
 
-function projectUri(): $rdf.NamedNode {
-  return $rdf.sym(uriHelpers.projectUri(baseUri));
+function projectUri(state: GraphState): $rdf.NamedNode {
+  return $rdf.sym(uriHelpers.projectUri(state.baseUri));
 }
 
 function dateLit(iso: string): $rdf.Literal {
@@ -303,7 +322,7 @@ const STANDARD_PREFIXES: [string, string][] = [
   ['schema', 'http://schema.org/'],
 ];
 
-function injectPrefixes(turtle: string, noteIri: string): string {
+function injectPrefixes(state: GraphState, turtle: string, noteIri: string): string {
   const lines: string[] = [];
   for (const [prefix, iri] of STANDARD_PREFIXES) {
     if (!turtle.includes(`@prefix ${prefix}:`)) {
@@ -312,12 +331,12 @@ function injectPrefixes(turtle: string, noteIri: string): string {
   }
   // Project-scoped shortcuts for referring to other sources/excerpts in
   // this thoughtbase by bare id: `sources:smith-2023`, `excerpts:p42`.
-  if (baseUri) {
+  if (state.baseUri) {
     if (!turtle.includes('@prefix sources:')) {
-      lines.push(`@prefix sources: <${baseUri}source/> .`);
+      lines.push(`@prefix sources: <${state.baseUri}source/> .`);
     }
     if (!turtle.includes('@prefix excerpts:')) {
-      lines.push(`@prefix excerpts: <${baseUri}excerpt/> .`);
+      lines.push(`@prefix excerpts: <${state.baseUri}excerpt/> .`);
     }
   }
   if (!turtle.includes('@prefix this:')) {
@@ -328,19 +347,11 @@ function injectPrefixes(turtle: string, noteIri: string): string {
 }
 
 // ── Heading snapshots ──────────────────────────────────────────────────────
-// Per-note record of which headings are currently in a note, keyed by slug.
-// Used by indexNote to spot the case where a single heading was renamed so
-// we can offer to rewrite `[[note#oldSlug]]` links across the thoughtbase.
-// Cleared on initGraph so a reindex from empty doesn't surface phantom
-// renames for every note.
-
-interface HeadingSnapshot {
-  slug: string;
-  text: string;
-  level: number;
-}
-
-const headingsPerNote = new Map<string, HeadingSnapshot[]>();
+// HeadingSnapshot moved up into per-project state (#333). Snapshots live
+// on `state.headingsPerNote` — used by indexNote to spot the case where
+// a single heading was renamed so we can offer to rewrite
+// `[[note#oldSlug]]` links across the thoughtbase. Cleared on initGraph
+// so a reindex from empty doesn't surface phantom renames for every note.
 
 /** ATX-style headings only (`# …` — `###### …`). Setext headings are ignored in v1. */
 const HEADING_LINE_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
@@ -373,8 +384,9 @@ export interface HeadingRenameCandidate {
 }
 
 /** Return headings present in the last indexNote call for `relativePath`, or []. */
-export function headingsFor(relativePath: string): HeadingSnapshot[] {
-  return headingsPerNote.get(relativePath) ?? [];
+export function headingsFor(ctx: ProjectContext, relativePath: string): HeadingSnapshot[] {
+  const state = getState(ctx);
+  return state?.headingsPerNote.get(relativePath) ?? [];
 }
 
 // ── Ontology bootstrap ──────────────────────────────────────────────────────
@@ -388,10 +400,8 @@ const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
 // to .minerva/graph.ttl. Holding the parsed statements lets us (1) self-heal
 // old graph.ttl files that included the ontology by removing any matching
 // triples, and (2) strip them before writing on persistGraph().
-let ontologyStatements: $rdf.Statement[] = [];
 
-function addOntologyToStore(): void {
-  if (!store) return;
+function addOntologyToStore(state: GraphState): void {
   const tempStore = $rdf.graph();
   try {
     $rdf.parse(ONTOLOGY_TTL, tempStore, MINERVA('').value, 'text/turtle');
@@ -399,37 +409,39 @@ function addOntologyToStore(): void {
   try {
     $rdf.parse(THOUGHT_ONTOLOGY_TTL, tempStore, THOUGHT('').value, 'text/turtle');
   } catch { /* thought ontology parse failure is non-fatal */ }
-  ontologyStatements = tempStore.statements.slice();
-  for (const st of ontologyStatements) {
-    store.removeMatches(st.subject, st.predicate, st.object);
+  state.ontologyStatements = tempStore.statements.slice();
+  for (const st of state.ontologyStatements) {
+    state.store.removeMatches(st.subject, st.predicate, st.object);
   }
-  for (const st of ontologyStatements) {
-    store.add(st.subject, st.predicate, st.object, st.graph);
+  for (const st of state.ontologyStatements) {
+    state.store.add(st.subject, st.predicate, st.object, st.graph);
   }
 }
 
 // ── Init ────────────────────────────────────────────────────────────────────
 
-export async function initGraph(rootPath: string): Promise<void> {
-  store = $rdf.graph();
-  invalidateN3Cache();
-  currentRootPath = rootPath;
-  headingsPerNote.clear();
-
+export async function initGraph(ctx: ProjectContext): Promise<void> {
+  const { rootPath } = ctx;
   const metaDir = path.join(rootPath, '.minerva');
   await fs.mkdir(metaDir, { recursive: true });
 
-  // Resolve (or coin) the stable base URI for this project
-  baseUri = resolveBaseUri(rootPath);
-
-  // Initialize Comunica engine
+  // Initialize Comunica engine (process-wide; stateless across projects)
   if (!engine) engine = new QueryEngine();
+
+  const state: GraphState = {
+    rootPath,
+    baseUri: resolveBaseUri(rootPath),
+    store: $rdf.graph(),
+    n3Cache: null,
+    ontologyStatements: [],
+    headingsPerNote: new Map(),
+  };
 
   // Load persisted graph if it exists
   const graphPath = path.join(metaDir, 'graph.ttl');
   try {
     const turtle = await fs.readFile(graphPath, 'utf-8');
-    $rdf.parse(turtle, store, 'urn:x-minerva:void', 'text/turtle');
+    $rdf.parse(turtle, state.store, 'urn:x-minerva:void', 'text/turtle');
   } catch {
     // No persisted graph yet, start fresh
   }
@@ -437,22 +449,27 @@ export async function initGraph(rootPath: string): Promise<void> {
   // Load ontology last: addOntologyToStore() strips any matching triples
   // before re-adding, which self-heals graph.ttl files written by older
   // versions that persisted the ontology alongside the user's data.
-  addOntologyToStore();
+  addOntologyToStore(state);
+
+  states.set(rootPath, state);
 }
 
 // ── Indexing ────────────────────────────────────────────────────────────────
 
 export async function indexNote(
+  ctx: ProjectContext,
   relativePath: string,
   content: string,
 ): Promise<{ headingRenameCandidate?: HeadingRenameCandidate }> {
-  if (!store) return {};
+  const state = getState(ctx);
+  if (!state) return {};
   // Any successful exit through this function has mutated the rdflib
   // store; flag the N3 mirror as stale once, at the boundary, instead
   // of after every internal store.add.
-  invalidateN3Cache();
+  invalidate(state);
+  const { store, baseUri, headingsPerNote } = state;
 
-  const subject = noteUri(relativePath);
+  const subject = noteUri(state, relativePath);
   const graph = subject; // named graph = note URI, for clean removal on re-index
 
   // Remove ALL triples from this note's graph (handles arbitrary turtle subjects)
@@ -461,12 +478,12 @@ export async function indexNote(
   store.removeMatches(subject, undefined, undefined);
 
   if (relativePath.endsWith('.ttl')) {
-    indexTurtleFile(relativePath, content, subject, graph);
+    indexTurtleFile(state, relativePath, content, subject, graph);
     return {};
   }
 
   if (relativePath.endsWith('.csv')) {
-    indexCsvFile(relativePath, content, subject, graph);
+    indexCsvFile(state, relativePath, content, subject, graph);
     return {};
   }
 
@@ -476,7 +493,7 @@ export async function indexNote(
   const prevHeadings = headingsPerNote.get(relativePath);
   const newHeadings = extractHeadingsFromContent(content);
   const headingRenameCandidate = prevHeadings
-    ? detectHeadingRename(relativePath, prevHeadings, newHeadings)
+    ? detectHeadingRename(state, relativePath, prevHeadings, newHeadings)
     : undefined;
   headingsPerNote.set(relativePath, newHeadings);
 
@@ -500,12 +517,12 @@ export async function indexNote(
   // Folder membership
   const dir = path.dirname(relativePath);
   if (dir && dir !== '.') {
-    store.add(subject, MINERVA('inFolder'), folderUri(dir), graph);
-    ensureFolder(dir);
+    store.add(subject, MINERVA('inFolder'), folderUri(state, dir), graph);
+    ensureFolder(state, dir);
   }
 
   // Project membership
-  store.add(projectUri(), MINERVA('containsNote'), subject, graph);
+  store.add(projectUri(state), MINERVA('containsNote'), subject, graph);
 
   // Tags — modeled as resources. Body tags (#foo) are already in parsed.tags;
   // add frontmatter `tags: [foo, bar]` on top (they're not added to parsed.tags
@@ -518,8 +535,8 @@ export async function indexNote(
     }
   }
   for (const tag of bodyTags) {
-    const tagNode = tagUri(tag);
-    ensureTag(tagNode, tag);
+    const tagNode = tagUri(state, tag);
+    ensureTag(state, tagNode, tag);
     store.add(subject, MINERVA('hasTag'), tagNode, graph);
   }
 
@@ -527,7 +544,7 @@ export async function indexNote(
   for (const link of parsed.links) {
     const linkType = getLinkType(link.type);
     const predicate = linkPredicate(linkType);
-    const targetNode = resolveLinkTarget(linkType, link.target, link.anchor);
+    const targetNode = resolveLinkTarget(state, linkType, link.target, link.anchor);
     store.add(subject, predicate, targetNode, graph);
   }
 
@@ -545,7 +562,7 @@ export async function indexNote(
   // Embedded turtle blocks — parse into the note's named graph
   for (const block of parsed.turtleBlocks) {
     try {
-      const prefixed = injectPrefixes(block, subject.value);
+      const prefixed = injectPrefixes(state, block, subject.value);
       $rdf.parse(prefixed, store, graph.value, 'text/turtle');
     } catch (e) {
       console.error(`[minerva] Failed to parse turtle block in ${relativePath}:`, e instanceof Error ? e.message : e);
@@ -554,7 +571,7 @@ export async function indexNote(
 
   // Markdown tables — CSVW triples
   for (let ti = 0; ti < parsed.tables.length; ti++) {
-    indexTable(parsed.tables[ti], ti, subject, graph);
+    indexTable(state, parsed.tables[ti], ti, subject, graph);
   }
 
   return headingRenameCandidate ? { headingRenameCandidate } : {};
@@ -567,6 +584,7 @@ export async function indexNote(
  * removals, pure deletion, additions without removals) → no prompt.
  */
 function detectHeadingRename(
+  state: GraphState,
   relativePath: string,
   prev: HeadingSnapshot[],
   next: HeadingSnapshot[],
@@ -579,7 +597,7 @@ function detectHeadingRename(
 
   const old = removed[0];
   const fresh = added[0];
-  const incoming = findNotesLinkingToAnchor(relativePath, old.slug).length;
+  const incoming = findNotesLinkingToAnchorImpl(state, relativePath, old.slug).length;
   if (incoming === 0) return undefined;
 
   return {
@@ -593,24 +611,27 @@ function detectHeadingRename(
 }
 
 /** Notes with a `thought:cites` edge to the given source URI. */
-export function findNotesCitingSource(sourceId: string): string[] {
-  if (!store) return [];
-  const target = sourceUri(sourceId);
-  return collectNotePathsWithPredicate(THOUGHT('cites'), target);
+export function findNotesCitingSource(ctx: ProjectContext, sourceId: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const target = sourceUri(state, sourceId);
+  return collectNotePathsWithPredicate(state, THOUGHT('cites'), target);
 }
 
 /** Notes with a `thought:quotes` edge to the given excerpt URI. */
-export function findNotesQuotingExcerpt(excerptId: string): string[] {
-  if (!store) return [];
-  const target = excerptUri(excerptId);
-  return collectNotePathsWithPredicate(THOUGHT('quotes'), target);
+export function findNotesQuotingExcerpt(ctx: ProjectContext, excerptId: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const target = excerptUri(state, excerptId);
+  return collectNotePathsWithPredicate(state, THOUGHT('quotes'), target);
 }
 
 function collectNotePathsWithPredicate(
+  state: GraphState,
   predicate: ReturnType<typeof MINERVA>,
   target: $rdf.NamedNode,
 ): string[] {
-  if (!store) return [];
+  const { store } = state;
   const stmts = store.statementsMatching(undefined, predicate, target);
   const seen = new Set<string>();
   for (const st of stmts) {
@@ -622,9 +643,23 @@ function collectNotePathsWithPredicate(
 }
 
 /** Like findNotesLinkingTo, but scoped to links whose anchor is exactly `slug`. */
-export function findNotesLinkingToAnchor(targetRelativePath: string, slug: string): string[] {
-  if (!store) return [];
-  const exactTarget = `${noteUri(targetRelativePath).value}#${slug}`;
+export function findNotesLinkingToAnchor(
+  ctx: ProjectContext,
+  targetRelativePath: string,
+  slug: string,
+): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  return findNotesLinkingToAnchorImpl(state, targetRelativePath, slug);
+}
+
+function findNotesLinkingToAnchorImpl(
+  state: GraphState,
+  targetRelativePath: string,
+  slug: string,
+): string[] {
+  const { store } = state;
+  const exactTarget = `${noteUri(state, targetRelativePath).value}#${slug}`;
   const seen = new Set<string>();
   for (const lt of LINK_TYPES) {
     if (lt.targetKind && lt.targetKind !== 'note') continue;
@@ -641,12 +676,13 @@ export function findNotesLinkingToAnchor(targetRelativePath: string, slug: strin
 }
 
 function indexTable(
+  state: GraphState,
   table: ParsedTable,
   tableIndex: number,
   noteNode: $rdf.NamedNode,
   graph: $rdf.NamedNode,
 ): void {
-  if (!store) return;
+  const { store } = state;
 
   const tableUri = $rdf.sym(`${noteNode.value}/table/${tableIndex}`);
   store.add(tableUri, RDF('type'), CSVW('Table'), graph);
@@ -741,10 +777,12 @@ function xsdForDuckDbType(duckdbType: string) {
  *   `owl:DatatypeProperty` (rdfs:domain = table, rdfs:range = xsd type)
  *   so SPARQL queries can reason about columns-as-predicates.
  */
-export function indexCsvTable(shape: CsvTableShape): void {
-  if (!store) return;
-  invalidateN3Cache();
-  const table = tableUri(shape.tableName);
+export function indexCsvTable(ctx: ProjectContext, shape: CsvTableShape): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
+  const table = tableUri(state, shape.tableName);
   const graph = table;
   const schema = $rdf.sym(`${table.value}/schema`);
 
@@ -761,7 +799,7 @@ export function indexCsvTable(shape: CsvTableShape): void {
   // Join-back link to the CSV file's own note-URI, so SPARQL can pivot
   // between the file-level view (row data, written by indexCsvFile)
   // and this SQL-centric view (named table, typed columns, OWL class).
-  store.add(table, MINERVA('fromFile'), noteUri(shape.relativePath), graph);
+  store.add(table, MINERVA('fromFile'), noteUri(state, shape.relativePath), graph);
 
   store.add(schema, RDF('type'), CSVW('Schema'), graph);
 
@@ -781,11 +819,12 @@ export function indexCsvTable(shape: CsvTableShape): void {
 }
 
 /** Remove all triples for a CSV table (entire named graph). */
-export function unindexCsvTable(tableName: string): void {
-  if (!store) return;
-  invalidateN3Cache();
-  const graph = tableUri(tableName);
-  store.removeMatches(undefined, undefined, undefined, graph);
+export function unindexCsvTable(ctx: ProjectContext, tableName: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const graph = tableUri(state, tableName);
+  state.store.removeMatches(undefined, undefined, undefined, graph);
 }
 
 /**
@@ -794,9 +833,11 @@ export function unindexCsvTable(tableName: string): void {
  * don't persist. Identifies them via `minerva:tableName`, which
  * markdown-embedded csvw:Table nodes don't carry — those stay.
  */
-export function unindexAllCsvTables(): void {
-  if (!store) return;
-  invalidateN3Cache();
+export function unindexAllCsvTables(ctx: ProjectContext): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
   // Snapshot subjects before removing — rdflib's statementsMatching
   // returns a live reference into the store, so removing triples while
   // iterating drops subsequent matches.
@@ -813,12 +854,13 @@ export function unindexAllCsvTables(): void {
 }
 
 function indexTurtleFile(
+  state: GraphState,
   relativePath: string,
   content: string,
   subject: $rdf.NamedNode,
   graph: $rdf.NamedNode,
 ): void {
-  if (!store) return;
+  const { store } = state;
 
   // Basic file metadata
   store.add(subject, RDF('type'), MINERVA('Note'), graph);
@@ -831,16 +873,16 @@ function indexTurtleFile(
   // Folder membership
   const dir = path.dirname(relativePath);
   if (dir && dir !== '.') {
-    store.add(subject, MINERVA('inFolder'), folderUri(dir), graph);
-    ensureFolder(dir);
+    store.add(subject, MINERVA('inFolder'), folderUri(state, dir), graph);
+    ensureFolder(state, dir);
   }
 
   // Project membership
-  store.add(projectUri(), MINERVA('containsNote'), subject, graph);
+  store.add(projectUri(state), MINERVA('containsNote'), subject, graph);
 
   // Parse the entire file as Turtle into the note's named graph
   try {
-    const prefixed = injectPrefixes(content, subject.value);
+    const prefixed = injectPrefixes(state, content, subject.value);
     $rdf.parse(prefixed, store, graph.value, 'text/turtle');
   } catch (e) {
     console.error(`[minerva] Failed to parse turtle file ${relativePath}:`, e instanceof Error ? e.message : e);
@@ -855,12 +897,13 @@ function indexTurtleFile(
  * table indexer\u2019s `csvw:inNote`.
  */
 function indexCsvFile(
+  state: GraphState,
   relativePath: string,
   content: string,
   subject: $rdf.NamedNode,
   graph: $rdf.NamedNode,
 ): void {
-  if (!store) return;
+  const { store } = state;
 
   // Note-style metadata so the file shows up in listings / tag queries / etc.
   store.add(subject, RDF('type'), MINERVA('Note'), graph);
@@ -872,10 +915,10 @@ function indexCsvFile(
 
   const dir = path.dirname(relativePath);
   if (dir && dir !== '.') {
-    store.add(subject, MINERVA('inFolder'), folderUri(dir), graph);
-    ensureFolder(dir);
+    store.add(subject, MINERVA('inFolder'), folderUri(state, dir), graph);
+    ensureFolder(state, dir);
   }
-  store.add(projectUri(), MINERVA('containsNote'), subject, graph);
+  store.add(projectUri(state), MINERVA('containsNote'), subject, graph);
 
   // CSVW: the file IS the Table. One file \u2192 one table.
   store.add(subject, RDF('type'), CSVW('Table'), graph);
@@ -914,14 +957,15 @@ function indexCsvFile(
   }
 }
 
-export function removeNote(relativePath: string): void {
-  if (!store) return;
-  invalidateN3Cache();
-  const subject = noteUri(relativePath);
+export function removeNote(ctx: ProjectContext, relativePath: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const subject = noteUri(state, relativePath);
   // Remove all triples in this note's named graph
-  store.removeMatches(undefined, undefined, undefined, subject);
+  state.store.removeMatches(undefined, undefined, undefined, subject);
   // Also remove any legacy triples with no graph
-  store.removeMatches(subject, undefined, undefined);
+  state.store.removeMatches(subject, undefined, undefined);
 }
 
 // ── Source indexing ─────────────────────────────────────────────────────────
@@ -930,11 +974,13 @@ export function removeNote(relativePath: string): void {
 // node's URI is `${baseUri}source/<id>`; inside meta.ttl, `this:` resolves
 // to that URI so users can write `this: a thought:Article ; dc:title ...`.
 
-export function indexSource(sourceId: string, metaTtl: string, bodyMd?: string): void {
-  if (!store) return;
-  invalidateN3Cache();
+export function indexSource(ctx: ProjectContext, sourceId: string, metaTtl: string, bodyMd?: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
 
-  const subject = sourceUri(sourceId);
+  const subject = sourceUri(state, sourceId);
   const graph = subject;
   const relativePath = `${uriHelpers.SOURCES_DIR}/${sourceId}/meta.ttl`;
 
@@ -944,26 +990,27 @@ export function indexSource(sourceId: string, metaTtl: string, bodyMd?: string):
   store.add(subject, MINERVA('sourceId'), $rdf.lit(sourceId), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
   store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
-  store.add(projectUri(), MINERVA('containsSource'), subject, graph);
+  store.add(projectUri(state), MINERVA('containsSource'), subject, graph);
 
   try {
-    const prefixed = injectPrefixes(metaTtl, subject.value);
+    const prefixed = injectPrefixes(state, metaTtl, subject.value);
     $rdf.parse(prefixed, store, graph.value, 'text/turtle');
   } catch (e) {
     console.error(`[minerva] Failed to parse source meta.ttl for ${sourceId}:`, e instanceof Error ? e.message : e);
   }
 
-  if (bodyMd) indexSourceBody(sourceId, bodyMd, subject, graph);
+  if (bodyMd) indexSourceBody(state, sourceId, bodyMd, subject, graph);
 }
 
 /** Parse body.md for a source — tags and wiki-links attach to the source URI. */
 function indexSourceBody(
+  state: GraphState,
   _sourceId: string,
   bodyMd: string,
   subject: $rdf.NamedNode,
   graph: $rdf.NamedNode,
 ): void {
-  if (!store) return;
+  const { store } = state;
   const parsed = parseMarkdown(bodyMd);
 
   // Body tags → hasTag edges on the source.
@@ -973,8 +1020,8 @@ function indexSourceBody(
     for (const t of flattenFrontmatterStrings(fmTags)) if (t) tags.add(t);
   }
   for (const tag of tags) {
-    const tagNode = tagUri(tag);
-    ensureTag(tagNode, tag);
+    const tagNode = tagUri(state, tag);
+    ensureTag(state, tagNode, tag);
     store.add(subject, MINERVA('hasTag'), tagNode, graph);
   }
 
@@ -982,17 +1029,18 @@ function indexSourceBody(
   for (const link of parsed.links) {
     const linkType = getLinkType(link.type);
     const predicate = linkPredicate(linkType);
-    const targetNode = resolveLinkTarget(linkType, link.target, link.anchor);
+    const targetNode = resolveLinkTarget(state, linkType, link.target, link.anchor);
     store.add(subject, predicate, targetNode, graph);
   }
 }
 
-export function removeSource(sourceId: string): void {
-  if (!store) return;
-  invalidateN3Cache();
-  const subject = sourceUri(sourceId);
-  store.removeMatches(undefined, undefined, undefined, subject);
-  store.removeMatches(subject, undefined, undefined);
+export function removeSource(ctx: ProjectContext, sourceId: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const subject = sourceUri(state, sourceId);
+  state.store.removeMatches(undefined, undefined, undefined, subject);
+  state.store.removeMatches(subject, undefined, undefined);
 }
 
 /** Parse `<id>` out of `.minerva/sources/<id>/meta.ttl`. Returns null for other paths. */
@@ -1016,11 +1064,13 @@ export function parseSourceIdFromPath(relativePath: string): string | null {
 //       thought:citedText "..." ;
 //       thought:page 42 .
 
-export function indexExcerpt(excerptId: string, metaTtl: string): void {
-  if (!store) return;
-  invalidateN3Cache();
+export function indexExcerpt(ctx: ProjectContext, excerptId: string, metaTtl: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
 
-  const subject = excerptUri(excerptId);
+  const subject = excerptUri(state, excerptId);
   const graph = subject;
   const relativePath = `${uriHelpers.EXCERPTS_DIR}/${excerptId}.ttl`;
 
@@ -1030,20 +1080,22 @@ export function indexExcerpt(excerptId: string, metaTtl: string): void {
   store.add(subject, MINERVA('excerptId'), $rdf.lit(excerptId), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
   store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
-  store.add(projectUri(), MINERVA('containsExcerpt'), subject, graph);
+  store.add(projectUri(state), MINERVA('containsExcerpt'), subject, graph);
 
   try {
-    const prefixed = injectPrefixes(metaTtl, subject.value);
+    const prefixed = injectPrefixes(state, metaTtl, subject.value);
     $rdf.parse(prefixed, store, graph.value, 'text/turtle');
   } catch (e) {
     console.error(`[minerva] Failed to parse excerpt ttl for ${excerptId}:`, e instanceof Error ? e.message : e);
   }
 }
 
-export function removeExcerpt(excerptId: string): void {
-  if (!store) return;
-  invalidateN3Cache();
-  const subject = excerptUri(excerptId);
+export function removeExcerpt(ctx: ProjectContext, excerptId: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
+  const subject = excerptUri(state, excerptId);
   store.removeMatches(undefined, undefined, undefined, subject);
   store.removeMatches(subject, undefined, undefined);
 }
@@ -1052,9 +1104,11 @@ export function removeExcerpt(excerptId: string): void {
  * Every excerpt-id with thought:fromSource pointing at the given source.
  * Used by the source-delete path to cascade-remove orphaned excerpts.
  */
-export function excerptIdsForSource(sourceId: string): string[] {
-  if (!store) return [];
-  const subject = sourceUri(sourceId);
+export function excerptIdsForSource(ctx: ProjectContext, sourceId: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+  const subject = sourceUri(state, sourceId);
   const stmts = store.statementsMatching(undefined, THOUGHT('fromSource'), subject);
   const ids: string[] = [];
   const seen = new Set<string>();
@@ -1077,8 +1131,8 @@ export function parseExcerptIdFromPath(relativePath: string): string | null {
   return id;
 }
 
-function ensureTag(tagNode: $rdf.NamedNode, tagName: string): void {
-  if (!store) return;
+function ensureTag(state: GraphState, tagNode: $rdf.NamedNode, tagName: string): void {
+  const { store } = state;
   const existing = store.statementsMatching(tagNode, RDF('type'), MINERVA('Tag'));
   if (existing.length === 0) {
     store.add(tagNode, RDF('type'), MINERVA('Tag'));
@@ -1086,52 +1140,52 @@ function ensureTag(tagNode: $rdf.NamedNode, tagName: string): void {
   }
 }
 
-function ensureFolder(relativePath: string): void {
-  if (!store) return;
-  const folder = folderUri(relativePath);
+function ensureFolder(state: GraphState, relativePath: string): void {
+  const { store } = state;
+  const folder = folderUri(state, relativePath);
   const existing = store.statementsMatching(folder, RDF('type'), MINERVA('Folder'));
   if (existing.length === 0) {
     store.add(folder, RDF('type'), MINERVA('Folder'));
     store.add(folder, MINERVA('relativePath'), $rdf.lit(relativePath));
     store.add(folder, DC('title'), $rdf.lit(path.basename(relativePath)));
-    store.add(projectUri(), MINERVA('containsFolder'), folder);
+    store.add(projectUri(state), MINERVA('containsFolder'), folder);
 
     // Nest under parent folder if applicable
     const parent = path.dirname(relativePath);
     if (parent && parent !== '.') {
-      store.add(folder, MINERVA('inFolder'), folderUri(parent));
-      ensureFolder(parent);
+      store.add(folder, MINERVA('inFolder'), folderUri(state, parent));
+      ensureFolder(state, parent);
     }
   }
 }
 
-function ensureProject(): void {
-  if (!store) return;
-  const proj = projectUri();
+function ensureProject(state: GraphState): void {
+  const { store, rootPath } = state;
+  const proj = projectUri(state);
   const existing = store.statementsMatching(proj, RDF('type'), MINERVA('Project'));
   if (existing.length === 0) {
     store.add(proj, RDF('type'), MINERVA('Project'));
-    if (currentRootPath) {
-      store.add(proj, DC('title'), $rdf.lit(path.basename(currentRootPath)));
-    }
+    store.add(proj, DC('title'), $rdf.lit(path.basename(rootPath)));
   }
 }
 
-export async function indexAllNotes(rootPath: string): Promise<number> {
-  if (!store) return 0;
+export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
+  const state = getState(ctx);
+  if (!state) return 0;
+  const { rootPath } = state;
 
   // Reset and rebuild from scratch with ontology
-  store = $rdf.graph();
-  invalidateN3Cache();
-  addOntologyToStore();
+  state.store = $rdf.graph();
+  invalidate(state);
+  addOntologyToStore(state);
 
-  ensureProject();
+  ensureProject(state);
 
   let count = 0;
   await walkAndIndex(rootPath, rootPath);
-  count += await walkAndIndexSources(rootPath);
-  count += await walkAndIndexExcerpts(rootPath);
-  await persistGraph();
+  count += await walkAndIndexSources(ctx, rootPath);
+  count += await walkAndIndexExcerpts(ctx, rootPath);
+  await persistGraph(ctx);
 
   async function walkAndIndex(dirPath: string, root: string) {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
@@ -1140,12 +1194,12 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
       const fullPath = path.join(dirPath, entry.name);
       if (entry.isDirectory()) {
         const rel = path.relative(root, fullPath);
-        ensureFolder(rel);
+        ensureFolder(state!, rel);
         await walkAndIndex(fullPath, root);
       } else if (isIndexable(entry.name)) {
         const relativePath = path.relative(root, fullPath);
         const content = await fs.readFile(fullPath, 'utf-8');
-        await indexNote(relativePath, content);
+        await indexNote(ctx, relativePath, content);
         count++;
       }
     }
@@ -1154,7 +1208,7 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
   return count;
 }
 
-async function walkAndIndexSources(rootPath: string): Promise<number> {
+async function walkAndIndexSources(ctx: ProjectContext, rootPath: string): Promise<number> {
   const sourcesRoot = path.join(rootPath, uriHelpers.SOURCES_DIR);
   let count = 0;
   let entries: import('node:fs').Dirent[];
@@ -1172,7 +1226,7 @@ async function walkAndIndexSources(rootPath: string): Promise<number> {
       const metaContent = await fs.readFile(metaPath, 'utf-8');
       let bodyContent: string | undefined;
       try { bodyContent = await fs.readFile(bodyPath, 'utf-8'); } catch { /* body optional */ }
-      indexSource(sourceId, metaContent, bodyContent);
+      indexSource(ctx, sourceId, metaContent, bodyContent);
       count++;
     } catch {
       // No meta.ttl in this directory — skip
@@ -1181,7 +1235,7 @@ async function walkAndIndexSources(rootPath: string): Promise<number> {
   return count;
 }
 
-async function walkAndIndexExcerpts(rootPath: string): Promise<number> {
+async function walkAndIndexExcerpts(ctx: ProjectContext, rootPath: string): Promise<number> {
   const excerptsRoot = path.join(rootPath, uriHelpers.EXCERPTS_DIR);
   let count = 0;
   let entries: import('node:fs').Dirent[];
@@ -1196,7 +1250,7 @@ async function walkAndIndexExcerpts(rootPath: string): Promise<number> {
     const filePath = path.join(excerptsRoot, entry.name);
     try {
       const content = await fs.readFile(filePath, 'utf-8');
-      indexExcerpt(excerptId, content);
+      indexExcerpt(ctx, excerptId, content);
       count++;
     } catch {
       // Couldn't read — skip
@@ -1247,10 +1301,11 @@ export interface GraphSchema {
  * Sorted alphabetically by prefixed form when available, otherwise by full
  * IRI. Safe to call often \u2014 cheap walk over the store.
  */
-export function schemaForCompletion(): GraphSchema {
+export function schemaForCompletion(ctx: ProjectContext): GraphSchema {
   const prefixes = STANDARD_PREFIXES.map(([prefix, iri]) => ({ prefix, iri }));
-
-  if (!store) return { prefixes, predicates: [], classes: [] };
+  const state = getState(ctx);
+  if (!state) return { prefixes, predicates: [], classes: [] };
+  const { store } = state;
 
   const rdfTypeIri = RDF('type').value;
   const predicateIris = new Set<string>();
@@ -1281,12 +1336,14 @@ export function schemaForCompletion(): GraphSchema {
   };
 }
 
-export async function queryGraph(sparql: string): Promise<{ results: unknown[] }> {
-  if (!store || !engine) return { results: [] };
+export async function queryGraph(ctx: ProjectContext, sparql: string): Promise<{ results: unknown[] }> {
+  const state = getState(ctx);
+  if (!state || !engine) return { results: [] };
+  const { store } = state;
 
   try {
-    if (!n3StoreCache) n3StoreCache = buildN3Store(store);
-    const n3Store = n3StoreCache;
+    if (!state.n3Cache) state.n3Cache = buildN3Store(store);
+    const n3Store = state.n3Cache;
     const prefixed = injectSparqlPrefixes(sparql);
     const bindingsStream = await engine.queryBindings(prefixed, {
       sources: [n3Store],
@@ -1311,8 +1368,10 @@ export async function queryGraph(sparql: string): Promise<{ results: unknown[] }
 
 import type { TagInfo, TaggedNote, TaggedSource } from '../../shared/types';
 
-export function listTags(): TagInfo[] {
-  if (!store) return [];
+export function listTags(ctx: ProjectContext): TagInfo[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
 
   const tagCounts = new Map<string, number>();
   const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
@@ -1328,10 +1387,12 @@ export function listTags(): TagInfo[] {
     .sort((a, b) => a.tag.localeCompare(b.tag));
 }
 
-export function notesByTag(tag: string): TaggedNote[] {
-  if (!store) return [];
+export function notesByTag(ctx: ProjectContext, tag: string): TaggedNote[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
 
-  const tagNode = tagUri(tag);
+  const tagNode = tagUri(state, tag);
   const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
   return stmts.flatMap((st) => {
     const subject = st.subject;
@@ -1350,10 +1411,12 @@ export function notesByTag(tag: string): TaggedNote[] {
   });
 }
 
-export function sourcesByTag(tag: string): TaggedSource[] {
-  if (!store) return [];
+export function sourcesByTag(ctx: ProjectContext, tag: string): TaggedSource[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
 
-  const tagNode = tagUri(tag);
+  const tagNode = tagUri(state, tag);
   const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
   return stmts.flatMap((st) => {
     const subject = st.subject;
@@ -1372,8 +1435,10 @@ export function sourcesByTag(tag: string): TaggedSource[] {
  * List every indexed source with its display metadata, sorted by title.
  * Used by the sidebar's Sources panel for navigation.
  */
-export function listAllSources(): SourceMetadata[] {
-  if (!store) return [];
+export function listAllSources(ctx: ProjectContext): SourceMetadata[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
   const entries: SourceMetadata[] = [];
   const seen = new Set<string>();
   const idStmts = store.statementsMatching(undefined, MINERVA('sourceId'), undefined);
@@ -1381,7 +1446,7 @@ export function listAllSources(): SourceMetadata[] {
     const sourceId = st.object.value;
     if (seen.has(sourceId)) continue;
     seen.add(sourceId);
-    entries.push(collectSourceMetadata(sourceId, st.subject as $rdf.NamedNode));
+    entries.push(collectSourceMetadata(state, sourceId, st.subject as $rdf.NamedNode));
   }
   entries.sort((a, b) => {
     const ta = (a.title ?? a.sourceId).toLowerCase();
@@ -1391,8 +1456,10 @@ export function listAllSources(): SourceMetadata[] {
   return entries;
 }
 
-export function allTags(): string[] {
-  if (!store) return [];
+export function allTags(ctx: ProjectContext): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
   const tags = new Set<string>();
   const stmts = store.statementsMatching(undefined, RDF('type'), MINERVA('Tag'));
   for (const st of stmts) {
@@ -1409,10 +1476,12 @@ export function allTags(): string[] {
 import type { OutgoingLink, Backlink } from '../../shared/types';
 import { LINK_TYPES } from '../../shared/link-types';
 
-export function outgoingLinks(relativePath: string): OutgoingLink[] {
-  if (!store) return [];
+export function outgoingLinks(ctx: ProjectContext, relativePath: string): OutgoingLink[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
 
-  const subject = noteUri(relativePath);
+  const subject = noteUri(state, relativePath);
   const results: OutgoingLink[] = [];
 
   for (const lt of LINK_TYPES) {
@@ -1454,9 +1523,11 @@ export function outgoingLinks(relativePath: string): OutgoingLink[] {
  * Only note-targeted link types are considered — cite/quote links point at
  * sources/excerpts and are handled by a separate rename path.
  */
-export function findNotesLinkingTo(targetRelativePath: string): string[] {
-  if (!store) return [];
-  const targetBase = noteUri(targetRelativePath).value;
+export function findNotesLinkingTo(ctx: ProjectContext, targetRelativePath: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+  const targetBase = noteUri(state, targetRelativePath).value;
   const seen = new Set<string>();
   for (const lt of LINK_TYPES) {
     if (lt.targetKind && lt.targetKind !== 'note') continue;
@@ -1474,10 +1545,12 @@ export function findNotesLinkingTo(targetRelativePath: string): string[] {
   return [...seen];
 }
 
-export function backlinks(relativePath: string): Backlink[] {
-  if (!store) return [];
+export function backlinks(ctx: ProjectContext, relativePath: string): Backlink[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
 
-  const targetBase = noteUri(relativePath).value;
+  const targetBase = noteUri(state, relativePath).value;
   const results: Backlink[] = [];
 
   for (const lt of LINK_TYPES) {
@@ -1510,28 +1583,25 @@ export function backlinks(relativePath: string): Backlink[] {
 
 import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink } from '../../shared/types';
 
-export function getSourceDetail(sourceId: string): SourceDetail | null {
-  if (!store) return null;
+export function getSourceDetail(ctx: ProjectContext, sourceId: string): SourceDetail | null {
+  const state = getState(ctx);
+  if (!state) return null;
+  const { store } = state;
 
-  const subject = sourceUri(sourceId);
+  const subject = sourceUri(state, sourceId);
   // Probe for existence via sourceId triple (which indexSource always writes).
   const exists = store.statementsMatching(subject, MINERVA('sourceId'), undefined).length > 0;
   if (!exists) return null;
 
-  const metadata = collectSourceMetadata(sourceId, subject);
-  const excerpts = collectExcerptsForSource(subject);
-  const backlinks = collectSourceBacklinks(subject, excerpts);
+  const metadata = collectSourceMetadata(state, sourceId, subject);
+  const excerpts = collectExcerptsForSource(state, subject);
+  const backlinks = collectSourceBacklinks(state, subject, excerpts);
 
   return { metadata, excerpts, backlinks };
 }
 
-function collectSourceMetadata(sourceId: string, subject: $rdf.NamedNode): SourceMetadata {
-  if (!store) {
-    return {
-      sourceId, subtype: null, title: null, creators: [], year: null,
-      publisher: null, doi: null, uri: null, abstract: null,
-    };
-  }
+function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rdf.NamedNode): SourceMetadata {
+  const { store } = state;
 
   // Pick the most specific thought:* type we recognize (not the generic Source).
   let subtype: string | null = null;
@@ -1570,8 +1640,8 @@ function collectSourceMetadata(sourceId: string, subject: $rdf.NamedNode): Sourc
   };
 }
 
-function collectExcerptsForSource(sourceSubject: $rdf.NamedNode): SourceExcerpt[] {
-  if (!store) return [];
+function collectExcerptsForSource(state: GraphState, sourceSubject: $rdf.NamedNode): SourceExcerpt[] {
+  const { store } = state;
 
   const excerpts: SourceExcerpt[] = [];
   const seen = new Set<string>();
@@ -1601,10 +1671,11 @@ function collectExcerptsForSource(sourceSubject: $rdf.NamedNode): SourceExcerpt[
 }
 
 function collectSourceBacklinks(
+  state: GraphState,
   sourceSubject: $rdf.NamedNode,
   excerpts: SourceExcerpt[],
 ): SourceBacklink[] {
-  if (!store) return [];
+  const { store } = state;
 
   const results: SourceBacklink[] = [];
   const seen = new Set<string>();
@@ -1632,7 +1703,7 @@ function collectSourceBacklinks(
 
   // Quotes of excerpts that belong to this source
   for (const ex of excerpts) {
-    const exNode = excerptUri(ex.excerptId);
+    const exNode = excerptUri(state, ex.excerptId);
     for (const st of store.statementsMatching(undefined, THOUGHT('quotes'), exNode)) {
       pushBacklink(st.subject as $rdf.NamedNode, 'quote', ex.excerptId);
     }
@@ -1643,9 +1714,11 @@ function collectSourceBacklinks(
 }
 
 /** Resolve an excerpt-id to the sourceId of its fromSource, or null if not found. */
-export function getExcerptSource(excerptId: string): { sourceId: string } | null {
-  if (!store) return null;
-  const ex = excerptUri(excerptId);
+export function getExcerptSource(ctx: ProjectContext, excerptId: string): { sourceId: string } | null {
+  const state = getState(ctx);
+  if (!state) return null;
+  const { store } = state;
+  const ex = excerptUri(state, excerptId);
   const stmts = store.statementsMatching(ex, THOUGHT('fromSource'), undefined);
   const sourceNode = stmts[0]?.object as $rdf.NamedNode | undefined;
   if (!sourceNode) return null;
@@ -1656,17 +1729,19 @@ export function getExcerptSource(excerptId: string): { sourceId: string } | null
 
 // ── Persistence & Export ────────────────────────────────────────────────────
 
-export async function persistGraph(): Promise<void> {
-  if (!store || !currentRootPath) return;
+export async function persistGraph(ctx: ProjectContext): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  const { store, rootPath, ontologyStatements } = state;
 
-  const graphPath = path.join(currentRootPath, '.minerva', 'graph.ttl');
+  const graphPath = path.join(rootPath, '.minerva', 'graph.ttl');
   // Strip ontology triples before serializing — they're re-loaded fresh
   // from the embedded resource on startup, so persisting them would
   // cause duplication on the next load.
   for (const st of ontologyStatements) {
     store.removeMatches(st.subject, st.predicate, st.object);
   }
-  const turtle = serializeGraph();
+  const turtle = serializeGraph(ctx);
   for (const st of ontologyStatements) {
     store.add(st.subject, st.predicate, st.object, st.graph);
   }
@@ -1674,11 +1749,12 @@ export async function persistGraph(): Promise<void> {
 }
 
 /** Parse a Turtle string and add its triples to the store. Used by the approval engine. */
-export function parseIntoStore(turtle: string): void {
-  if (!store) return;
-  invalidateN3Cache();
+export function parseIntoStore(ctx: ProjectContext, turtle: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
   try {
-    $rdf.parse(turtle, store, 'urn:x-minerva:void', 'text/turtle');
+    $rdf.parse(turtle, state.store, 'urn:x-minerva:void', 'text/turtle');
   } catch (e) {
     console.error('[minerva] Failed to parse turtle into store:', e instanceof Error ? e.message : e);
   }
@@ -1689,27 +1765,30 @@ export function parseIntoStore(turtle: string): void {
  * approval engine to replace single-cardinality predicates like
  * `thought:proposalStatus` so a status change doesn't leave the prior
  * status hanging on the same proposal (#332).
- *
- * Subject and predicate are passed as IRIs; both are required to keep
- * the surface narrow — wholesale subject wipes go through the more
- * specific `removeNote` / `removeSource` / `removeExcerpt` helpers.
  */
-export function removeMatchingTriples(subjectIri: string, predicateIri: string): void {
-  if (!store) return;
-  invalidateN3Cache();
-  store.removeMatches($rdf.sym(subjectIri), $rdf.sym(predicateIri), undefined);
+export function removeMatchingTriples(
+  ctx: ProjectContext,
+  subjectIri: string,
+  predicateIri: string,
+): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  state.store.removeMatches($rdf.sym(subjectIri), $rdf.sym(predicateIri), undefined);
 }
 
-export function serializeGraph(): string {
-  if (!store) return '';
+export function serializeGraph(ctx: ProjectContext): string {
+  const state = getState(ctx);
+  if (!state) return '';
   // Pass a dummy base that doesn't match any of our URIs,
   // forcing the serializer to emit all IRIs as absolute.
-  return $rdf.serialize(null, store, 'urn:x-minerva:void', 'text/turtle') ?? '';
+  return $rdf.serialize(null, state.store, 'urn:x-minerva:void', 'text/turtle') ?? '';
 }
 
-export async function exportGraph(destPath: string): Promise<void> {
-  if (!store) return;
-  await persistGraph();
-  const turtle = serializeGraph();
+export async function exportGraph(ctx: ProjectContext, destPath: string): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  await persistGraph(ctx);
+  const turtle = serializeGraph(ctx);
   await fs.writeFile(destPath, turtle, 'utf-8');
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,7 @@ import { renameAnchor } from './notebase/rename-anchor';
 import { renameSource, renameExcerpt } from './notebase/rename-source-excerpt';
 import * as gitOps from './git/index';
 import * as graph from './graph/index';
+import { projectContext } from './project-context-types';
 import * as search from './search/index';
 import * as savedQueries from './saved-queries';
 import { clearRecentProjects } from './recent-projects';
@@ -108,16 +109,16 @@ function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null {
 async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
   if (!isIndexable(relativePath)) return;
   const content = await notebaseFs.readFile(rootPath, relativePath);
-  await graph.indexNote(relativePath, content);
+  await graph.indexNote(projectContext(rootPath), relativePath, content);
   if (relativePath.endsWith('.md')) {
     search.indexNote(relativePath, content);
   }
 }
 
-function removeFromIndexes(relativePath: string): void {
+function removeFromIndexes(rootPath: string, relativePath: string): void {
   if (!isIndexable(relativePath)) return;
   search.removeNote(relativePath);
-  graph.removeNote(relativePath);
+  graph.removeNote(projectContext(rootPath), relativePath);
 }
 
 async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {
@@ -138,8 +139,8 @@ async function listIndexableFiles(rootPath: string, relDir: string): Promise<str
   return results;
 }
 
-async function persistIndexes(): Promise<void> {
-  await Promise.all([search.persist(), graph.persistGraph()]);
+async function persistIndexes(rootPath: string): Promise<void> {
+  await Promise.all([search.persist(), graph.persistGraph(projectContext(rootPath))]);
 }
 
 export function registerIpcHandlers(): void {
@@ -259,8 +260,8 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
     await notebaseFs.writeFile(rootPath, relativePath, content);
-    const { headingRenameCandidate } = await graph.indexNote(relativePath, content);
-    await graph.persistGraph();
+    const { headingRenameCandidate } = await graph.indexNote(projectContext(rootPath), relativePath, content);
+    await graph.persistGraph(projectContext(rootPath));
     search.indexNote(relativePath, content);
     await search.persist();
     // If a heading edit looks like a rename with affected incoming links,
@@ -278,7 +279,7 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
     await notebaseFs.createFile(rootPath, relativePath);
-    await graph.indexNote(relativePath, '');
+    await graph.indexNote(projectContext(rootPath), relativePath, '');
     search.indexNote(relativePath, '');
   });
 
@@ -287,8 +288,8 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
     await notebaseFs.deleteFile(rootPath, relativePath);
-    removeFromIndexes(relativePath);
-    await persistIndexes();
+    removeFromIndexes(rootPath, relativePath);
+    await persistIndexes(rootPath);
   });
 
   ipcMain.handle(Channels.NOTEBASE_CREATE_FOLDER, async (e, relativePath: string) => {
@@ -302,8 +303,8 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     const files = await listIndexableFiles(rootPath, relativePath);
     await notebaseFs.deleteFolder(rootPath, relativePath);
-    for (const f of files) removeFromIndexes(f);
-    await persistIndexes();
+    for (const f of files) removeFromIndexes(rootPath, f);
+    await persistIndexes(rootPath);
   });
 
   ipcMain.handle(Channels.NOTEBASE_RENAME, async (e, oldRelPath: string, newRelPath: string) => {
@@ -329,7 +330,7 @@ export function registerIpcHandlers(): void {
       }
     }
 
-    await persistIndexes();
+    await persistIndexes(rootPath);
   });
 
   const broadcastRewritten = (rootPath: string, paths: string[]) => {
@@ -349,7 +350,7 @@ export function registerIpcHandlers(): void {
       },
     });
     broadcastRewritten(rootPath, rewrittenPaths);
-    await persistIndexes();
+    await persistIndexes(rootPath);
     return { rewrittenPaths };
   });
 
@@ -363,7 +364,7 @@ export function registerIpcHandlers(): void {
       },
     });
     broadcastRewritten(rootPath, rewrittenPaths);
-    await persistIndexes();
+    await persistIndexes(rootPath);
     return { rewrittenPaths };
   });
 
@@ -388,7 +389,7 @@ export function registerIpcHandlers(): void {
         }
       }
 
-      await persistIndexes();
+      await persistIndexes(rootPath);
       return { rewrittenPaths };
     },
   );
@@ -404,7 +405,7 @@ export function registerIpcHandlers(): void {
     } else {
       await reindexFile(rootPath, destRelPath);
     }
-    await persistIndexes();
+    await persistIndexes(rootPath);
   });
 
   ipcMain.handle(Channels.NOTEBASE_SEARCH_IN_NOTES, async (e, opts: SearchOptions) => {
@@ -421,19 +422,23 @@ export function registerIpcHandlers(): void {
       // Re-index each rewritten file so the graph + search index stay in
       // sync, then tell open editor tabs to reload from disk.
       for (const rel of result.changedPaths) await reindexFile(rootPath, rel);
-      await persistIndexes();
+      await persistIndexes(rootPath);
       broadcastRewritten(rootPath, result.changedPaths);
     }
     return result;
   });
 
   // Links
-  ipcMain.handle(Channels.LINKS_OUTGOING, (_e, relativePath: string) => {
-    return graph.outgoingLinks(relativePath);
+  ipcMain.handle(Channels.LINKS_OUTGOING, (e, relativePath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.outgoingLinks(projectContext(rootPath), relativePath);
   });
 
-  ipcMain.handle(Channels.LINKS_BACKLINKS, (_e, relativePath: string) => {
-    return graph.backlinks(relativePath);
+  ipcMain.handle(Channels.LINKS_BACKLINKS, (e, relativePath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.backlinks(projectContext(rootPath), relativePath);
   });
 
   // Saved queries
@@ -487,8 +492,10 @@ export function registerIpcHandlers(): void {
   });
 
   // Graph
-  ipcMain.handle(Channels.GRAPH_QUERY, async (_e, sparql: string) => {
-    return graph.queryGraph(sparql);
+  ipcMain.handle(Channels.GRAPH_QUERY, async (e, sparql: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return graph.queryGraph(projectContext(rootPath), sparql);
   });
 
   // Tables (DuckDB)
@@ -500,31 +507,47 @@ export function registerIpcHandlers(): void {
     return tables.listTables();
   });
 
-  ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, () => graph.schemaForCompletion());
-
-  ipcMain.handle(Channels.GRAPH_SOURCE_DETAIL, (_e, sourceId: string) => {
-    return graph.getSourceDetail(sourceId);
+  ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return null;
+    return graph.schemaForCompletion(projectContext(rootPath));
   });
 
-  ipcMain.handle(Channels.GRAPH_EXCERPT_SOURCE, (_e, excerptId: string) => {
-    return graph.getExcerptSource(excerptId);
+  ipcMain.handle(Channels.GRAPH_SOURCE_DETAIL, (e, sourceId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return null;
+    return graph.getSourceDetail(projectContext(rootPath), sourceId);
+  });
+
+  ipcMain.handle(Channels.GRAPH_EXCERPT_SOURCE, (e, excerptId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return null;
+    return graph.getExcerptSource(projectContext(rootPath), excerptId);
   });
 
   // Tags
-  ipcMain.handle(Channels.TAGS_LIST, () => {
-    return graph.listTags();
+  ipcMain.handle(Channels.TAGS_LIST, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.listTags(projectContext(rootPath));
   });
 
-  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG, (_e, tag: string) => {
-    return graph.notesByTag(tag);
+  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG, (e, tag: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.notesByTag(projectContext(rootPath), tag);
   });
 
-  ipcMain.handle(Channels.TAGS_SOURCES_BY_TAG, (_e, tag: string) => {
-    return graph.sourcesByTag(tag);
+  ipcMain.handle(Channels.TAGS_SOURCES_BY_TAG, (e, tag: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.sourcesByTag(projectContext(rootPath), tag);
   });
 
-  ipcMain.handle(Channels.TAGS_ALL_NAMES, () => {
-    return graph.allTags();
+  ipcMain.handle(Channels.TAGS_ALL_NAMES, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.allTags(projectContext(rootPath));
   });
 
   // Export
@@ -588,13 +611,23 @@ export function registerIpcHandlers(): void {
   });
 
   // Inspections
-  ipcMain.handle(Channels.INSPECTIONS_LIST, () => healthChecks.getInspections());
-  ipcMain.handle(Channels.INSPECTIONS_RUN, () => healthChecks.runAllChecks());
+  ipcMain.handle(Channels.INSPECTIONS_LIST, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return healthChecks.getInspections(projectContext(rootPath));
+  });
+  ipcMain.handle(Channels.INSPECTIONS_RUN, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return healthChecks.runAllChecks(projectContext(rootPath));
+  });
 
   // Grounding check — fuzzy match a claim against graph labels
-  ipcMain.handle(Channels.GRAPH_GROUND_CHECK, async (_e, claimText: string) => {
+  ipcMain.handle(Channels.GRAPH_GROUND_CHECK, async (e, claimText: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
     const escaped = claimText.replace(/"/g, '\\"').replace(/\n/g, ' ');
-    const results = await graph.queryGraph(`
+    const results = await graph.queryGraph(projectContext(rootPath), `
       PREFIX dc: <http://purl.org/dc/terms/>
       PREFIX thought: <https://minerva.dev/ontology/thought#>
       PREFIX minerva: <https://minerva.dev/ontology#>
@@ -618,7 +651,7 @@ export function registerIpcHandlers(): void {
       filters: [{ name: 'Turtle', extensions: ['ttl'] }],
     });
     if (!result.canceled && result.filePath) {
-      await graph.persistGraph();
+      await graph.persistGraph(projectContext(rootPath));
       const fs = await import('node:fs/promises');
       const srcPath = path.join(rootPath, '.minerva', 'graph.ttl');
       await fs.copyFile(srcPath, result.filePath);
@@ -673,9 +706,9 @@ export function registerIpcHandlers(): void {
     // conflict handling as a link rewrite).
     markPathHandled(relativePath);
     await notebaseFs.writeFile(rootPath, relativePath, plan.content);
-    await graph.indexNote(relativePath, plan.content);
+    await graph.indexNote(projectContext(rootPath), relativePath, plan.content);
     search.indexNote(relativePath, plan.content);
-    await persistIndexes();
+    await persistIndexes(rootPath);
     broadcastRewritten(rootPath, [relativePath]);
     return { added: plan.added };
   });
@@ -701,9 +734,9 @@ export function registerIpcHandlers(): void {
 
       markPathHandled(activeRelPath);
       await notebaseFs.writeFile(rootPath, activeRelPath, content);
-      await graph.indexNote(activeRelPath, content);
+      await graph.indexNote(projectContext(rootPath), activeRelPath, content);
       search.indexNote(activeRelPath, content);
-      await persistIndexes();
+      await persistIndexes(rootPath);
       broadcastRewritten(rootPath, [activeRelPath]);
       return { applied, skipped };
     },
@@ -897,7 +930,7 @@ export function registerIpcHandlers(): void {
     const ingested = await ingestPdf(rootPath, result.filePaths[0]);
     // Re-index the new source so it shows up in the sidebar + graph.
     await reindexFile(rootPath, `.minerva/sources/${ingested.sourceId}/meta.ttl`);
-    await persistIndexes();
+    await persistIndexes(rootPath);
     return ingested;
   });
 
@@ -917,18 +950,22 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     await finishPdfOcrIngest(rootPath, sourceId, pages);
     await reindexFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
-    await persistIndexes();
+    await persistIndexes(rootPath);
     const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
   });
 
-  ipcMain.handle(Channels.SOURCES_LIST_ALL, () => graph.listAllSources());
+  ipcMain.handle(Channels.SOURCES_LIST_ALL, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.listAllSources(projectContext(rootPath));
+  });
 
   ipcMain.handle(Channels.SOURCES_DELETE, async (e, sourceId: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     const result = await deleteSource(rootPath, sourceId);
-    await persistIndexes();
+    await persistIndexes(rootPath);
     const win = winFromEvent(e);
     if (!win.isDestroyed()) {
       win.webContents.send(Channels.SOURCES_CHANGED);
@@ -960,7 +997,7 @@ export function registerIpcHandlers(): void {
         : result.cascadedPaths;
       if (touched.length > 0) {
         for (const p of touched) markPathHandled(p);
-        await persistIndexes();
+        await persistIndexes(rootPath);
         broadcastRewritten(rootPath, touched);
       }
       return result;
@@ -976,7 +1013,7 @@ export function registerIpcHandlers(): void {
       const touched = [...summary.changedPaths, ...summary.cascadedPaths];
       if (touched.length > 0) {
         for (const p of touched) markPathHandled(p);
-        await persistIndexes();
+        await persistIndexes(rootPath);
         broadcastRewritten(rootPath, touched);
       }
       return summary;
@@ -999,11 +1036,11 @@ export function registerIpcHandlers(): void {
       for (const [source, content] of updatedContents) {
         markPathHandled(source);
         await notebaseFs.writeFile(rootPath, source, content);
-        await graph.indexNote(source, content);
+        await graph.indexNote(projectContext(rootPath), source, content);
         search.indexNote(source, content);
       }
       if (touchedPaths.length > 0) {
-        await persistIndexes();
+        await persistIndexes(rootPath);
         broadcastRewritten(rootPath, touchedPaths);
       }
 
@@ -1012,11 +1049,31 @@ export function registerIpcHandlers(): void {
   );
 
   // Proposals
-  ipcMain.handle(Channels.PROPOSAL_LIST, (_e, status?: string) => approval.listProposals(status));
-  ipcMain.handle(Channels.PROPOSAL_DETAIL, (_e, uri: string) => approval.getProposal(uri));
-  ipcMain.handle(Channels.PROPOSAL_APPROVE, (_e, uri: string) => approval.approveProposal(uri));
-  ipcMain.handle(Channels.PROPOSAL_REJECT, (_e, uri: string) => approval.rejectProposal(uri));
-  ipcMain.handle(Channels.PROPOSAL_EXPIRE, () => approval.expireProposals());
+  ipcMain.handle(Channels.PROPOSAL_LIST, (e, status?: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return approval.listProposals(projectContext(rootPath), status);
+  });
+  ipcMain.handle(Channels.PROPOSAL_DETAIL, (e, uri: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return null;
+    return approval.getProposal(projectContext(rootPath), uri);
+  });
+  ipcMain.handle(Channels.PROPOSAL_APPROVE, (e, uri: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return false;
+    return approval.approveProposal(projectContext(rootPath), uri);
+  });
+  ipcMain.handle(Channels.PROPOSAL_REJECT, (e, uri: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return false;
+    return approval.rejectProposal(projectContext(rootPath), uri);
+  });
+  ipcMain.handle(Channels.PROPOSAL_EXPIRE, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return 0;
+    return approval.expireProposals(projectContext(rootPath));
+  });
 
   // Conversations
   ipcMain.handle(Channels.CONVERSATION_CREATE, (_e, contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) =>
@@ -1091,10 +1148,12 @@ export function registerIpcHandlers(): void {
     }
   });
 
-  ipcMain.handle(Channels.CONVERSATION_CRYSTALLIZE, async (_e, text: string, conversationId: string) => {
+  ipcMain.handle(Channels.CONVERSATION_CRYSTALLIZE, async (e, text: string, conversationId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
     const convUri = `https://minerva.dev/ontology/thought#conversation/${conversationId}`;
     const conv = await conversation.load(conversationId);
-    return crystallize(text, convUri, 'llm:crystallization', conv?.model);
+    return crystallize(projectContext(rootPath), text, convUri, 'llm:crystallization', conv?.model);
   });
 
   ipcMain.handle(Channels.CONVERSATION_SET_MODEL, async (_e, convId: string, model: string | undefined) => {

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -1,4 +1,5 @@
 import * as graph from '../graph/index';
+import type { ProjectContext } from '../project-context-types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -83,14 +84,14 @@ function proposalUri(): string {
  * - notify_only: applies the write immediately, creates an approved Proposal for audit
  * - autonomous: applies the write immediately, no proposal record
  */
-export async function proposeWrite(write: ProposedWrite): Promise<Proposal | null> {
+export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal | null> {
   const tier = getApprovalTier(write.operationType);
   const now = new Date().toISOString();
   const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * 86400000).toISOString();
 
   if (tier === 'autonomous') {
     // Apply immediately, no record
-    await applyTurtle(write.turtleDiff);
+    await applyTurtle(ctx, write.turtleDiff);
     return null;
   }
 
@@ -109,11 +110,11 @@ export async function proposeWrite(write: ProposedWrite): Promise<Proposal | nul
   };
 
   // Write proposal metadata to graph
-  await writeProposalToGraph(proposal);
+  await writeProposalToGraph(ctx, proposal);
 
   // For notify_only, also apply the mutation immediately
   if (tier === 'notify_only') {
-    await applyTurtle(write.turtleDiff);
+    await applyTurtle(ctx, write.turtleDiff);
   }
 
   return proposal;
@@ -122,31 +123,31 @@ export async function proposeWrite(write: ProposedWrite): Promise<Proposal | nul
 /**
  * Approve a pending proposal: apply its turtle diff and update status.
  */
-export async function approveProposal(uri: string): Promise<boolean> {
-  const proposal = await getProposal(uri);
+export async function approveProposal(ctx: ProjectContext, uri: string): Promise<boolean> {
+  const proposal = await getProposal(ctx, uri);
   if (!proposal || proposal.status !== 'pending') return false;
 
-  await applyTurtle(proposal.turtleDiff);
-  await updateProposalStatus(uri, 'approved');
+  await applyTurtle(ctx, proposal.turtleDiff);
+  await updateProposalStatus(ctx, uri, 'approved');
   return true;
 }
 
 /**
  * Reject a pending proposal: update status without applying.
  */
-export async function rejectProposal(uri: string): Promise<boolean> {
-  const proposal = await getProposal(uri);
+export async function rejectProposal(ctx: ProjectContext, uri: string): Promise<boolean> {
+  const proposal = await getProposal(ctx, uri);
   if (!proposal || proposal.status !== 'pending') return false;
 
-  await updateProposalStatus(uri, 'rejected');
+  await updateProposalStatus(ctx, uri, 'rejected');
   return true;
 }
 
 /**
  * Expire proposals past their autoExpires date.
  */
-export async function expireProposals(): Promise<number> {
-  const results = await graph.queryGraph(`
+export async function expireProposals(ctx: ProjectContext): Promise<number> {
+  const results = await graph.queryGraph(ctx, `
     PREFIX thought: <${THOUGHT}>
     SELECT ?proposal ?expires WHERE {
       ?proposal a thought:Proposal .
@@ -160,7 +161,7 @@ export async function expireProposals(): Promise<number> {
   for (const row of results.results as Record<string, string>[]) {
     const expires = new Date(row.expires);
     if (expires <= now) {
-      await updateProposalStatus(row.proposal, 'expired');
+      await updateProposalStatus(ctx, row.proposal, 'expired');
       count++;
     }
   }
@@ -170,12 +171,12 @@ export async function expireProposals(): Promise<number> {
 /**
  * List proposals, optionally filtered by status.
  */
-export async function listProposals(status?: string): Promise<Proposal[]> {
+export async function listProposals(ctx: ProjectContext, status?: string): Promise<Proposal[]> {
   const statusFilter = status
     ? `?proposal thought:proposalStatus thought:${status} .`
     : '';
 
-  const results = await graph.queryGraph(`
+  const results = await graph.queryGraph(ctx, `
     PREFIX thought: <${THOUGHT}>
     SELECT ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff ?affectsNode ?conversation WHERE {
       ?proposal a thought:Proposal .
@@ -211,8 +212,8 @@ export async function listProposals(status?: string): Promise<Proposal[]> {
 /**
  * Get a single proposal by URI.
  */
-export async function getProposal(uri: string): Promise<Proposal | null> {
-  const results = await graph.queryGraph(`
+export async function getProposal(ctx: ProjectContext, uri: string): Promise<Proposal | null> {
+  const results = await graph.queryGraph(ctx, `
     PREFIX thought: <${THOUGHT}>
     SELECT ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff ?affectsNode ?conversation WHERE {
       <${uri}> a thought:Proposal .
@@ -249,7 +250,7 @@ export async function getProposal(uri: string): Promise<Proposal | null> {
 
 // ── Internal Helpers ───────────────────────────────────────────────────────
 
-async function writeProposalToGraph(p: Proposal): Promise<void> {
+async function writeProposalToGraph(ctx: ProjectContext, p: Proposal): Promise<void> {
   const turtle = `
     <${p.uri}> a thought:Proposal ;
       thought:proposalStatus thought:${p.status} ;
@@ -262,19 +263,19 @@ async function writeProposalToGraph(p: Proposal): Promise<void> {
       ${p.affectsNodeUri ? `; thought:affectsNode <${p.affectsNodeUri}>` : ''}
       ${p.conversationUri ? `; thought:conversationRef <${p.conversationUri}>` : ''} .
   `;
-  await applyTurtle(turtle);
+  await applyTurtle(ctx, turtle);
 }
 
-async function updateProposalStatus(uri: string, newStatus: string): Promise<void> {
+async function updateProposalStatus(ctx: ProjectContext, uri: string, newStatus: string): Promise<void> {
   // Drop any prior thought:proposalStatus triples on this proposal
   // before adding the new one — otherwise the proposal accumulates
   // {pending, approved, ...} markers and history queries return all
   // historical states (#332).
-  graph.removeMatchingTriples(uri, `${THOUGHT}proposalStatus`);
-  await applyTurtle(`<${uri}> thought:proposalStatus thought:${newStatus} .`);
+  graph.removeMatchingTriples(ctx, uri, `${THOUGHT}proposalStatus`);
+  await applyTurtle(ctx, `<${uri}> thought:proposalStatus thought:${newStatus} .`);
 }
 
-async function applyTurtle(turtle: string): Promise<void> {
+async function applyTurtle(ctx: ProjectContext, turtle: string): Promise<void> {
   // Use the graph module's parse infrastructure with standard prefixes
   const prefixed = `
     @prefix thought: <${THOUGHT}> .
@@ -286,8 +287,8 @@ async function applyTurtle(turtle: string): Promise<void> {
     @prefix prov: <http://www.w3.org/ns/prov#> .
     ${turtle}
   `;
-  graph.parseIntoStore(prefixed);
-  await graph.persistGraph();
+  graph.parseIntoStore(ctx, prefixed);
+  await graph.persistGraph(ctx);
 }
 
 function escapeTurtle(s: string): string {

--- a/src/main/llm/auto-link.ts
+++ b/src/main/llm/auto-link.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import * as notebaseFs from '../notebase/fs';
 import { parseMarkdown } from '../graph/parser';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 import { complete } from './index';
 import { getSettings } from './settings';
 import {
@@ -162,7 +163,7 @@ export async function pickInboundCandidates(
 
   const scored = new Map<string, number>();
   for (const tag of tags) {
-    for (const note of graph.notesByTag(tag)) {
+    for (const note of graph.notesByTag(projectContext(rootPath), tag)) {
       if (note.relativePath === activeRelPath) continue;
       scored.set(note.relativePath, (scored.get(note.relativePath) ?? 0) + 1);
     }

--- a/src/main/llm/auto-tag.ts
+++ b/src/main/llm/auto-tag.ts
@@ -1,6 +1,7 @@
 import * as notebaseFs from '../notebase/fs';
 import { parseMarkdown } from '../graph/parser';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 import { complete } from './index';
 import { getSettings } from './settings';
 import {
@@ -30,7 +31,7 @@ export async function runAutoTag(
   const content = await notebaseFs.readFile(rootPath, relativePath);
   const parsed = parseMarkdown(content);
 
-  const thoughtbaseTags = graph.listTags().map((t) => t.tag);
+  const thoughtbaseTags = graph.listTags(projectContext(rootPath)).map((t) => t.tag);
   const existingNoteTags: string[] = [];
   if (Array.isArray(parsed.frontmatter.tags)) {
     for (const t of parsed.frontmatter.tags) {

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -1,13 +1,21 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as graph from '../graph/index';
+import { projectContext, type ProjectContext } from '../project-context-types';
 import type { Conversation, ConversationMessage, ContextBundle, ConversationStatus } from '../../shared/types';
 
 const THOUGHT = 'https://minerva.dev/ontology/thought#';
 let conversationsDir: string | null = null;
+let activeRootPath: string | null = null;
 
 export function initConversations(rootPath: string): void {
   conversationsDir = path.join(rootPath, '.minerva', 'conversations');
+  activeRootPath = rootPath;
+}
+
+function activeCtx(): ProjectContext {
+  if (!activeRootPath) throw new Error('Conversations not initialized — no project open');
+  return projectContext(activeRootPath);
 }
 
 function ensureDir(): string {
@@ -177,7 +185,7 @@ async function writeConversationToGraph(conv: Conversation): Promise<void> {
       ${conv.triggerNodeUri ? `; thought:trigger <${conv.triggerNodeUri}>` : ''}
       ${conv.contextBundle.notePath ? `; thought:contextNote <${conv.contextBundle.notePath}>` : ''} .
   `;
-  graph.parseIntoStore(turtle);
+  graph.parseIntoStore(activeCtx(), turtle);
 }
 
 async function updateConversationInGraph(conv: Conversation): Promise<void> {
@@ -194,7 +202,7 @@ async function updateConversationInGraph(conv: Conversation): Promise<void> {
     <${uri}> thought:conversationStatus thought:${statusMap[conv.status]}
       ${conv.resolvedAt ? `; thought:resolvedAt "${conv.resolvedAt}"^^xsd:dateTime` : ''} .
   `;
-  graph.parseIntoStore(turtle);
+  graph.parseIntoStore(activeCtx(), turtle);
 }
 
 async function fileAsSource(conv: Conversation): Promise<void> {
@@ -212,6 +220,7 @@ async function fileAsSource(conv: Conversation): Promise<void> {
       thought:conversationContent "${escapeTurtle(transcript)}" ;
       dc:created "${conv.startedAt}"^^xsd:dateTime .
   `;
-  graph.parseIntoStore(turtle);
-  await graph.persistGraph();
+  const ctx = activeCtx();
+  graph.parseIntoStore(ctx, turtle);
+  await graph.persistGraph(ctx);
 }

--- a/src/main/llm/crystallize.ts
+++ b/src/main/llm/crystallize.ts
@@ -1,5 +1,6 @@
 import { complete } from './index';
 import { proposeWrite } from './approval';
+import type { ProjectContext } from '../project-context-types';
 
 const CRYSTALLIZATION_PROMPT = `You are an epistemic analyst. Given the following conversation excerpt, extract structured thought components using the Minerva thought ontology.
 
@@ -38,6 +39,7 @@ export interface CrystallizationResult {
 }
 
 export async function crystallize(
+  ctx: ProjectContext,
   text: string,
   conversationUri: string,
   proposedBy: string = 'llm:crystallization',
@@ -63,7 +65,7 @@ ${text}`;
   const groundedTurtle = `${trimmed}`;
 
   // Route through approval engine as component_creation
-  await proposeWrite({
+  await proposeWrite(ctx, {
     operationType: 'component_creation',
     turtleDiff: groundedTurtle,
     note: `Crystallized ${componentCount} thought component${componentCount !== 1 ? 's' : ''} from conversation`,

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -1,6 +1,7 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import * as fs from '../notebase/fs';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
 import ONTOLOGY_TTL from '../../shared/ontology.ttl?raw';
 import THOUGHT_ONTOLOGY_TTL from '../../shared/ontology-thought.ttl?raw';
@@ -161,7 +162,7 @@ export async function executeNotebaseTool(
       case 'read_note':
         return { content: await runRead(ctx, input), isError: false };
       case 'query_graph':
-        return runQuery(input);
+        return runQuery(ctx, input);
       case 'describe_graph_schema':
         return { content: runDescribeSchema(), isError: false };
       default:
@@ -198,12 +199,12 @@ async function runRead(ctx: ToolContext, input: unknown): Promise<string> {
   return fs.readFile(ctx.rootPath, relative_path);
 }
 
-async function runQuery(input: unknown): Promise<{ content: string; isError: boolean }> {
+async function runQuery(ctx: ToolContext, input: unknown): Promise<{ content: string; isError: boolean }> {
   const { sparql } = input as { sparql: string };
   if (typeof sparql !== 'string' || !sparql.trim()) {
     throw new Error('sparql is required');
   }
-  const response = await graph.queryGraph(sparql) as { results: unknown[]; error?: string };
+  const response = await graph.queryGraph(projectContext(ctx.rootPath), sparql) as { results: unknown[]; error?: string };
   if (response.error) {
     return {
       content: `SPARQL error: ${response.error}\n\nCall describe_graph_schema to see available classes and predicates.`,

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,6 +4,7 @@ import { Channels } from '../shared/channels';
 import { getRecentProjects } from './recent-projects';
 import { createWindow, openProjectInWindow, getRootPath } from './window-manager';
 import * as graph from './graph/index';
+import { projectContext } from './project-context-types';
 import * as search from './search/index';
 import * as tables from './sources/tables';
 import { STOCK_QUERIES } from '../shared/stock-queries';
@@ -215,7 +216,7 @@ export function rebuildMenu(): void {
             const rootPath = getRootPath(win.id);
             if (!rootPath) return;
             await Promise.all([
-              graph.indexAllNotes(rootPath),
+              graph.indexAllNotes(projectContext(rootPath)),
               search.indexAllNotes(rootPath),
               tables.registerAllCsvs(rootPath),
             ]);
@@ -518,7 +519,7 @@ export function rebuildMenu(): void {
               filters: [{ name: 'Turtle', extensions: ['ttl'] }],
             });
             if (!result.canceled && result.filePath) {
-              await graph.exportGraph(result.filePath);
+              await graph.exportGraph(projectContext(rootPath), result.filePath);
             }
           },
         }));

--- a/src/main/notebase/rename-anchor.ts
+++ b/src/main/notebase/rename-anchor.ts
@@ -1,6 +1,7 @@
 import * as notebaseFs from './fs';
 import { rewriteAnchorInLinks } from './link-rewriting';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 
 export interface RenameAnchorOptions {
   markPathHandled?: (relativePath: string) => void;
@@ -25,8 +26,9 @@ export async function renameAnchor(
   opts: RenameAnchorOptions = {},
 ): Promise<RenameAnchorResult> {
   const { markPathHandled, reindexHook } = opts;
+  const ctx = projectContext(rootPath);
 
-  const referringNotes = graph.findNotesLinkingToAnchor(targetRelativePath, oldSlug);
+  const referringNotes = graph.findNotesLinkingToAnchor(ctx, targetRelativePath, oldSlug);
   const rewrittenPaths: string[] = [];
 
   for (const notePath of referringNotes) {
@@ -36,7 +38,7 @@ export async function renameAnchor(
       if (rewritten === content) continue;
       markPathHandled?.(notePath);
       await notebaseFs.writeFile(rootPath, notePath, rewritten);
-      await graph.indexNote(notePath, rewritten);
+      await graph.indexNote(ctx, notePath, rewritten);
       reindexHook?.(notePath, rewritten);
       rewrittenPaths.push(notePath);
     } catch (err) {

--- a/src/main/notebase/rename-source-excerpt.ts
+++ b/src/main/notebase/rename-source-excerpt.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import * as notebaseFs from './fs';
 import { rewriteTypedIdLinks } from './link-rewriting';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 
 export interface RenameIdOptions {
   markPathHandled?: (relativePath: string) => void;
@@ -26,26 +27,27 @@ export async function renameSource(
 ): Promise<RenameIdResult> {
   if (oldId === newId) return { rewrittenPaths: [] };
   const { markPathHandled, reindexHook } = opts;
+  const ctx = projectContext(rootPath);
 
   const oldDir = path.join(rootPath, '.minerva', 'sources', oldId);
   const newDir = path.join(rootPath, '.minerva', 'sources', newId);
 
   // Collect referring notes BEFORE the graph changes — query the old id.
-  const referringNotes = graph.findNotesCitingSource(oldId);
+  const referringNotes = graph.findNotesCitingSource(ctx, oldId);
 
   // Rename on disk.
   await fs.mkdir(path.dirname(newDir), { recursive: true });
   await fs.rename(oldDir, newDir);
 
   // Swap graph: remove old, index new.
-  graph.removeSource(oldId);
+  graph.removeSource(ctx, oldId);
   try {
     const metaContent = await fs.readFile(path.join(newDir, 'meta.ttl'), 'utf-8');
     let bodyContent: string | undefined;
     try {
       bodyContent = await fs.readFile(path.join(newDir, 'body.md'), 'utf-8');
     } catch { /* body optional */ }
-    graph.indexSource(newId, metaContent, bodyContent);
+    graph.indexSource(ctx, newId, metaContent, bodyContent);
   } catch {
     // meta.ttl missing — source is effectively removed as far as the graph is concerned.
   }
@@ -73,19 +75,20 @@ export async function renameExcerpt(
 ): Promise<RenameIdResult> {
   if (oldId === newId) return { rewrittenPaths: [] };
   const { markPathHandled, reindexHook } = opts;
+  const ctx = projectContext(rootPath);
 
   const oldPath = path.join(rootPath, '.minerva', 'excerpts', `${oldId}.ttl`);
   const newPath = path.join(rootPath, '.minerva', 'excerpts', `${newId}.ttl`);
 
-  const referringNotes = graph.findNotesQuotingExcerpt(oldId);
+  const referringNotes = graph.findNotesQuotingExcerpt(ctx, oldId);
 
   await fs.mkdir(path.dirname(newPath), { recursive: true });
   await fs.rename(oldPath, newPath);
 
-  graph.removeExcerpt(oldId);
+  graph.removeExcerpt(ctx, oldId);
   try {
     const content = await fs.readFile(newPath, 'utf-8');
-    graph.indexExcerpt(newId, content);
+    graph.indexExcerpt(ctx, newId, content);
   } catch {
     // ttl missing — excerpt removed.
   }
@@ -116,7 +119,7 @@ async function rewriteReferringNotes(
       if (rewritten === content) continue;
       markPathHandled?.(notePath);
       await notebaseFs.writeFile(rootPath, notePath, rewritten);
-      await graph.indexNote(notePath, rewritten);
+      await graph.indexNote(projectContext(rootPath), notePath, rewritten);
       reindexHook?.(notePath, rewritten);
       rewrittenPaths.push(notePath);
     } catch (err) {

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import * as notebaseFs from './fs';
 import { rewriteWikiLinks, normalizePath as normalizeLinkPath } from './link-rewriting';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 import { isIndexable } from './indexable-files';
 
 async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {
@@ -57,6 +58,7 @@ export async function renameWithLinkRewrites(
   opts: RenameWithLinksOptions = {},
 ): Promise<RenameResult> {
   const { markPathHandled, reindexHook, removeHook } = opts;
+  const ctx = projectContext(rootPath);
 
   // Determine whether this is a directory rename BEFORE the fs.rename call
   // so we can enumerate descendants at the old location.
@@ -78,7 +80,7 @@ export async function renameWithLinkRewrites(
   // Compute referring notes BEFORE renaming (querying pre-rename graph state).
   const referringNotes = new Set<string>();
   for (const oldPath of rewrites.keys()) {
-    for (const p of graph.findNotesLinkingTo(`${oldPath}.md`)) {
+    for (const p of graph.findNotesLinkingTo(ctx, `${oldPath}.md`)) {
       referringNotes.add(p);
     }
   }
@@ -94,21 +96,21 @@ export async function renameWithLinkRewrites(
     for (const f of newFiles) {
       const oldEquivalent = oldRelPath + f.slice(newRelPath.length);
       if (isIndexable(oldEquivalent)) {
-        graph.removeNote(oldEquivalent);
+        graph.removeNote(ctx, oldEquivalent);
         removeHook?.(oldEquivalent);
       }
       if (isIndexable(f)) {
         const content = await notebaseFs.readFile(rootPath, f);
-        await graph.indexNote(f, content);
+        await graph.indexNote(ctx, f, content);
         reindexHook?.(f, content);
         transitions.push({ old: oldEquivalent, new: f });
       }
     }
   } else if (isIndexable(oldRelPath)) {
-    graph.removeNote(oldRelPath);
+    graph.removeNote(ctx, oldRelPath);
     removeHook?.(oldRelPath);
     const content = await notebaseFs.readFile(rootPath, newRelPath);
-    await graph.indexNote(newRelPath, content);
+    await graph.indexNote(ctx, newRelPath, content);
     reindexHook?.(newRelPath, content);
     transitions.push({ old: oldRelPath, new: newRelPath });
   }
@@ -126,7 +128,7 @@ export async function renameWithLinkRewrites(
       if (rewritten !== content) {
         markPathHandled?.(actualPath);
         await notebaseFs.writeFile(rootPath, actualPath, rewritten);
-        await graph.indexNote(actualPath, rewritten);
+        await graph.indexNote(ctx, actualPath, rewritten);
         reindexHook?.(actualPath, rewritten);
         rewrittenPaths.push(actualPath);
       }

--- a/src/main/project-context-types.ts
+++ b/src/main/project-context-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared type for ProjectContext (#333). The runtime registry +
+ * acquire/release lifecycle will land in `./project-context.ts` once
+ * graph/tables/search are all ctx-aware. This file exists to hold the
+ * type so it can be imported by every module without circular deps.
+ */
+
+export interface ProjectContext {
+  readonly rootPath: string;
+  /** Phantom field to keep raw strings from being passed where a ctx is wanted. */
+  readonly _brand: 'ProjectContext';
+}
+
+/** Helper for tests + boundary code that has only a string. */
+export function projectContext(rootPath: string): ProjectContext {
+  return { rootPath, _brand: 'ProjectContext' as const };
+}

--- a/src/main/sources/delete-source.ts
+++ b/src/main/sources/delete-source.ts
@@ -14,6 +14,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
 
 export interface DeleteSourceResult {
   sourceId: string;
@@ -26,18 +27,19 @@ export async function deleteSource(
   sourceId: string,
 ): Promise<DeleteSourceResult> {
   const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
+  const ctx = projectContext(rootPath);
 
   // Snapshot excerpt ids before we wipe the graph — once the graph
   // entries are gone, we can't list them anymore.
-  const excerptIds = graph.excerptIdsForSource(sourceId);
+  const excerptIds = graph.excerptIdsForSource(ctx, sourceId);
 
   for (const id of excerptIds) {
-    graph.removeExcerpt(id);
+    graph.removeExcerpt(ctx, id);
     const excerptFile = path.join(rootPath, '.minerva', 'excerpts', `${id}.ttl`);
     try { await fs.unlink(excerptFile); } catch { /* already gone */ }
   }
 
-  graph.removeSource(sourceId);
+  graph.removeSource(ctx, sourceId);
   try {
     await fs.rm(sourceDir, { recursive: true, force: true });
   } catch { /* already gone */ }

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -3,6 +3,12 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
+import { projectContext } from '../project-context-types';
+
+function activeCtx() {
+  if (!currentRootPath) throw new Error('Tables DB is not initialized — no project open');
+  return projectContext(currentRootPath);
+}
 
 // ── Module state ────────────────────────────────────────────────────────────
 // Matches the `graph` module: single live project at a time. If Minerva ever
@@ -148,7 +154,7 @@ export async function registerCsv(rootPath: string, relativePath: string): Promi
       await connection.run(`DROP VIEW IF EXISTS "${previousName}"`);
     } catch { /* tolerate the rare rename race */ }
     tableToPath.delete(previousName);
-    unindexCsvTable(previousName);
+    unindexCsvTable(activeCtx(), previousName);
   }
 
   const absPath = path.join(rootPath, relativePath);
@@ -194,7 +200,7 @@ async function indexCsvTableShape(relativePath: string, tableName: string): Prom
       // ordinal_position is 1-based in DuckDB; we publish 0-based.
       index: Number(r.ordinal_position) - 1,
     }));
-    indexCsvTable({ tableName, relativePath, columns });
+    indexCsvTable(activeCtx(), { tableName, relativePath, columns });
   } catch (err) {
     console.warn(
       `[tables] Failed to index '${tableName}' into graph: ` +
@@ -213,7 +219,7 @@ export async function unregisterCsv(relativePath: string): Promise<void> {
   } catch { /* view may already be gone */ }
   pathToTable.delete(relativePath);
   tableToPath.delete(tableName);
-  unindexCsvTable(tableName);
+  unindexCsvTable(activeCtx(), tableName);
 }
 
 /**
@@ -225,7 +231,7 @@ export async function registerAllCsvs(rootPath: string): Promise<number> {
   // Wipe stale CSV-table triples up front so CSVs deleted while the app
   // was closed don't linger in the graph after a full rescan. Each
   // registered CSV writes its own triples as it goes.
-  unindexAllCsvTables();
+  unindexAllCsvTables(activeCtx());
   let count = 0;
   async function walk(dirPath: string) {
     let entries: import('node:fs').Dirent[];

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -12,6 +12,7 @@ import * as tables from './sources/tables';
 import { addRecentProject } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
+import { projectContext, type ProjectContext } from './project-context-types';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -133,6 +134,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   }
 
   ctx.rootPath = rootPath;
+  const projectCtx: ProjectContext = projectContext(rootPath);
   addRecentProject(rootPath);
   rebuildMenu();
 
@@ -147,7 +149,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   const debouncedPersist = () => {
     if (indexPersistTimer) clearTimeout(indexPersistTimer);
     indexPersistTimer = setTimeout(async () => {
-      await Promise.all([search.persist(), graph.persistGraph()]);
+      await Promise.all([search.persist(), graph.persistGraph(projectCtx)]);
     }, 1000);
   };
 
@@ -166,7 +168,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       }
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
-        await graph.indexNote(relativePath, content);
+        await graph.indexNote(projectCtx, relativePath, content);
         search.indexNote(relativePath, content);
         debouncedPersist();
       } catch (err) {
@@ -185,7 +187,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       }
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
-        await graph.indexNote(relativePath, content);
+        await graph.indexNote(projectCtx, relativePath, content);
         search.indexNote(relativePath, content);
         debouncedPersist();
       } catch (err) {
@@ -202,7 +204,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       }
       try {
         search.removeNote(relativePath);
-        graph.removeNote(relativePath);
+        graph.removeNote(projectCtx, relativePath);
       } catch (err) {
         console.warn(`[watcher] removeNote failed for ${relativePath}:`, err);
       }
@@ -215,13 +217,13 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         try {
           bodyContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/body.md`);
         } catch { /* body optional */ }
-        graph.indexSource(sourceId, metaContent, bodyContent);
+        graph.indexSource(projectCtx, sourceId, metaContent, bodyContent);
         debouncedPersist();
         if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
       } catch { /* meta.ttl may have been deleted between events */ }
     },
     onSourceMetaDeleted: (sourceId) => {
-      graph.removeSource(sourceId);
+      graph.removeSource(projectCtx, sourceId);
       debouncedPersist();
       if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
     },
@@ -229,24 +231,24 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       try {
         const relPath = `.minerva/excerpts/${excerptId}.ttl`;
         const content = await notebaseFs.readFile(rootPath, relPath);
-        graph.indexExcerpt(excerptId, content);
+        graph.indexExcerpt(projectCtx, excerptId, content);
         debouncedPersist();
         if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
       } catch { /* file may have been deleted between events */ }
     },
     onExcerptDeleted: (excerptId) => {
-      graph.removeExcerpt(excerptId);
+      graph.removeExcerpt(projectCtx, excerptId);
       debouncedPersist();
       if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
     },
   });
   watchers.set(win.id, rootPath);
 
-  await graph.initGraph(rootPath);
+  await graph.initGraph(projectCtx);
   await tables.initTablesDb(rootPath);
   conversation.initConversations(rootPath);
   await Promise.all([
-    graph.indexAllNotes(rootPath),
+    graph.indexAllNotes(projectCtx),
     search.indexAllNotes(rootPath),
     tables.registerAllCsvs(rootPath),
   ]);
@@ -254,8 +256,8 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   // sidebar populates without the renderer having to poll.
   if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
   // Run health checks after initial indexing, then periodically
-  healthChecks.runAllChecks();
-  healthChecks.startPeriodicChecks();
+  healthChecks.runAllChecks(projectCtx);
+  healthChecks.startPeriodicChecks(projectCtx);
   persistSession();
 }
 

--- a/tests/main/compute/save-cell-output.test.ts
+++ b/tests/main/compute/save-cell-output.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { saveCellOutput } from '../../../src/main/compute/save-cell-output';
 import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-save-cell-output-test-'));
@@ -23,10 +24,12 @@ Trailing prose.
 
 describe('saveCellOutput (#244)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(async () => {
@@ -104,10 +107,10 @@ describe('saveCellOutput (#244)', () => {
     // Re-index source + derived notes so their frontmatter + links are in the graph.
     const sourceContent = await fsp.readFile(path.join(root, 'analysis.md'), 'utf-8');
     const derivedContent = await fsp.readFile(path.join(root, derivedPath), 'utf-8');
-    await indexNote('analysis.md', sourceContent);
-    await indexNote(derivedPath, derivedContent);
+    await indexNote(ctx, 'analysis.md', sourceContent);
+    await indexNote(ctx, derivedPath, derivedContent);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?source WHERE {
         ?derived prov:wasDerivedFrom ?source .
       }

--- a/tests/main/compute/sparql-executor.test.ts
+++ b/tests/main/compute/sparql-executor.test.ts
@@ -3,20 +3,21 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import { executeSparql } from '../../../src/main/compute/executors/sparql';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sparql-exec-test-'));
 }
 
-const CTX = { rootPath: '/tmp/ignored' };
-
 describe('executeSparql (#239)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -24,12 +25,12 @@ describe('executeSparql (#239)', () => {
   });
 
   it('returns a typed table output with columns taken from the first binding', async () => {
-    await indexNote('foo.md', '---\ntitle: "Foo"\n---\n\nhi');
-    await indexNote('bar.md', '---\ntitle: "Bar"\n---\n\nhi');
+    await indexNote(ctx, 'foo.md', '---\ntitle: "Foo"\n---\n\nhi');
+    await indexNote(ctx, 'bar.md', '---\ntitle: "Bar"\n---\n\nhi');
 
     const result = await executeSparql(
       'SELECT ?title ?path WHERE { ?n a minerva:Note . ?n dc:title ?title . ?n minerva:relativePath ?path } ORDER BY ?title',
-      CTX,
+      { rootPath: root },
     );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -45,7 +46,7 @@ describe('executeSparql (#239)', () => {
   it('returns an empty table (no columns, no rows) when the query matches nothing', async () => {
     const result = await executeSparql(
       'SELECT ?x WHERE { ?x minerva:definitelyDoesNotExist "nope" }',
-      CTX,
+      { rootPath: root },
     );
     expect(result).toEqual({
       ok: true,
@@ -56,7 +57,7 @@ describe('executeSparql (#239)', () => {
   it('surfaces SPARQL syntax errors as ok:false rather than throwing', async () => {
     // Unclosed WHERE clause — the parser bails; queryGraph surfaces the
     // error through its response envelope rather than throwing.
-    const result = await executeSparql('SELECT ?x WHERE { ?x ?p', CTX);
+    const result = await executeSparql('SELECT ?x WHERE { ?x ?p', { rootPath: root });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toMatch(/parse/i);

--- a/tests/main/formatter/orchestrator-cascade.test.ts
+++ b/tests/main/formatter/orchestrator-cascade.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import { formatFile } from '../../../src/main/formatter/orchestrator';
 // Rule side-effects — the orchestrator already imports the barrel, but we
 // repeat here so the test file is explicit about what it's exercising.
@@ -24,10 +25,12 @@ function readNote(root: string, rel: string): string {
 
 describe('formatter orchestrator heading-rename cascade (#156)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -39,8 +42,8 @@ describe('formatter orchestrator heading-rename cascade (#156)', () => {
     writeNote(root, 'notes/my-note.md', '# Old Title\n\nbody\n');
     writeNote(root, 'notes/other.md', 'See [[notes/my-note#old-title]] for context.\n');
 
-    await indexNote('notes/my-note.md', readNote(root, 'notes/my-note.md'));
-    await indexNote('notes/other.md', readNote(root, 'notes/other.md'));
+    await indexNote(ctx, 'notes/my-note.md', readNote(root, 'notes/my-note.md'));
+    await indexNote(ctx, 'notes/other.md', readNote(root, 'notes/other.md'));
 
     const result = await formatFile(root, 'notes/my-note.md', {
       enabled: { 'file-name-heading': true },
@@ -59,8 +62,8 @@ describe('formatter orchestrator heading-rename cascade (#156)', () => {
     writeNote(root, 'notes/foo.md', '# hello world\n\nbody\n');
     writeNote(root, 'notes/other.md', 'See [[notes/foo#hello-world]].\n');
 
-    await indexNote('notes/foo.md', readNote(root, 'notes/foo.md'));
-    await indexNote('notes/other.md', readNote(root, 'notes/other.md'));
+    await indexNote(ctx, 'notes/foo.md', readNote(root, 'notes/foo.md'));
+    await indexNote(ctx, 'notes/other.md', readNote(root, 'notes/other.md'));
 
     const result = await formatFile(root, 'notes/foo.md', {
       enabled: { 'capitalize-headings': true },
@@ -85,7 +88,7 @@ describe('formatter orchestrator heading-rename cascade (#156)', () => {
     // rename was detected (no change to existing headings, just an insert).
     writeNote(root, 'notes/foo.md', 'no heading yet\n');
 
-    await indexNote('notes/foo.md', readNote(root, 'notes/foo.md'));
+    await indexNote(ctx, 'notes/foo.md', readNote(root, 'notes/foo.md'));
 
     const result = await formatFile(root, 'notes/foo.md', {
       enabled: { 'file-name-heading': true },

--- a/tests/main/graph/anchor-links.test.ts
+++ b/tests/main/graph/anchor-links.test.ts
@@ -10,6 +10,7 @@ import {
   outgoingLinks,
   backlinks,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-anchor-test-'));
@@ -17,10 +18,12 @@ function mkTempProject(): string {
 
 describe('anchor links (issue #137)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -28,10 +31,10 @@ describe('anchor links (issue #137)', () => {
   });
 
   it('indexes heading anchors as an IRI fragment (slug)', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n## Components');
-    await indexNote('notes/a.md', 'See [[notes/foo#Components]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Components');
+    await indexNote(ctx, 'notes/a.md', 'See [[notes/foo#Components]].');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?target WHERE {
         ?src minerva:relativePath "notes/a.md" .
         ?src minerva:references ?target .
@@ -42,9 +45,9 @@ describe('anchor links (issue #137)', () => {
   });
 
   it('preserves block-id anchors verbatim (with ^ prefix, no slugification)', async () => {
-    await indexNote('notes/a.md', 'See [[notes/foo#^para-3]].');
+    await indexNote(ctx, 'notes/a.md', 'See [[notes/foo#^para-3]].');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?target WHERE {
         ?src minerva:relativePath "notes/a.md" ;
              minerva:references ?target .
@@ -55,28 +58,28 @@ describe('anchor links (issue #137)', () => {
   });
 
   it('findNotesLinkingTo tolerates anchored links to the same note', async () => {
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/a.md', 'See [[notes/foo]].');
-    await indexNote('notes/b.md', 'See [[notes/foo#components]].');
-    await indexNote('notes/c.md', 'See [[notes/foo#^block-1]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/a.md', 'See [[notes/foo]].');
+    await indexNote(ctx, 'notes/b.md', 'See [[notes/foo#components]].');
+    await indexNote(ctx, 'notes/c.md', 'See [[notes/foo#^block-1]].');
 
-    const linkers = findNotesLinkingTo('notes/foo.md').sort();
+    const linkers = findNotesLinkingTo(ctx, 'notes/foo.md').sort();
     expect(linkers).toEqual(['notes/a.md', 'notes/b.md', 'notes/c.md']);
   });
 
   it('backlinks reports anchored links as backlinks to the bare note', async () => {
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/a.md', 'See [[notes/foo#section]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/a.md', 'See [[notes/foo#section]].');
 
-    const bl = backlinks('notes/foo.md');
+    const bl = backlinks(ctx, 'notes/foo.md');
     expect(bl.map((b) => b.source)).toEqual(['notes/a.md']);
   });
 
   it('outgoingLinks resolves anchored targets to the bare note metadata', async () => {
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/a.md', 'See [[notes/foo#section]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/a.md', 'See [[notes/foo#section]].');
 
-    const out = outgoingLinks('notes/a.md');
+    const out = outgoingLinks(ctx, 'notes/a.md');
     expect(out).toHaveLength(1);
     expect(out[0].target).toBe('notes/foo.md');
     expect(out[0].exists).toBe(true);

--- a/tests/main/graph/cite-indexing.test.ts
+++ b/tests/main/graph/cite-indexing.test.ts
@@ -9,6 +9,7 @@ import {
   queryGraph,
   outgoingLinks,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cite-test-'));
@@ -29,10 +30,12 @@ this: a thought:Article ;
 
 describe('[[cite::source-id]] link (issue #91)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -41,12 +44,12 @@ describe('[[cite::source-id]] link (issue #91)', () => {
 
   it('writes a thought:cites edge from the note to the source URI', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     const noteContent = '# My thoughts\n\nAs [[cite::smith-2023]] argues, knowledge graphs…';
-    await indexNote('thoughts.md', noteContent);
+    await indexNote(ctx, 'thoughts.md', noteContent);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?src WHERE {
         ?note minerva:relativePath "thoughts.md" .
         ?note thought:cites ?src .
@@ -57,9 +60,9 @@ describe('[[cite::source-id]] link (issue #91)', () => {
   });
 
   it('does not route cite targets through the note URI namespace', async () => {
-    await indexNote('thoughts.md', 'See [[cite::smith-2023]].');
+    await indexNote(ctx, 'thoughts.md', 'See [[cite::smith-2023]].');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?path WHERE {
         ?note minerva:relativePath "thoughts.md" .
         ?note thought:cites ?src .
@@ -72,9 +75,9 @@ describe('[[cite::source-id]] link (issue #91)', () => {
   });
 
   it('uses thought:cites (not minerva:cites)', async () => {
-    await indexNote('thoughts.md', 'See [[cite::smith-2023]].');
+    await indexNote(ctx, 'thoughts.md', 'See [[cite::smith-2023]].');
 
-    const { results: withThought } = await queryGraph(`
+    const { results: withThought } = await queryGraph(ctx, `
       SELECT ?src WHERE {
         ?note minerva:relativePath "thoughts.md" .
         ?note thought:cites ?src .
@@ -82,7 +85,7 @@ describe('[[cite::source-id]] link (issue #91)', () => {
     `);
     expect(withThought).toHaveLength(1);
 
-    const { results: withMinerva } = await queryGraph(`
+    const { results: withMinerva } = await queryGraph(ctx, `
       SELECT ?src WHERE {
         ?note minerva:relativePath "thoughts.md" .
         ?note minerva:cites ?src .
@@ -93,20 +96,20 @@ describe('[[cite::source-id]] link (issue #91)', () => {
 
   it('reports cite links via outgoingLinks with linkType "cite"', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
-    await indexNote('thoughts.md', 'See [[cite::smith-2023]].');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'thoughts.md', 'See [[cite::smith-2023]].');
 
-    const links = outgoingLinks('thoughts.md');
+    const links = outgoingLinks(ctx, 'thoughts.md');
     const cite = links.find(l => l.linkType === 'cite');
     expect(cite).toBeDefined();
     expect(cite!.exists).toBe(true);
   });
 
   it('existing note-typed links (supports, references, …) still work', async () => {
-    await indexNote('a.md', '# A\n\nClaim A.');
-    await indexNote('b.md', '# B\n\n[[supports::a]] is the ground.');
+    await indexNote(ctx, 'a.md', '# A\n\nClaim A.');
+    await indexNote(ctx, 'b.md', '# B\n\n[[supports::a]] is the ground.');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?target WHERE {
         ?note minerva:relativePath "b.md" .
         ?note minerva:supports ?target .

--- a/tests/main/graph/csv-indexing.test.ts
+++ b/tests/main/graph/csv-indexing.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csv-index-test-'));
@@ -10,10 +11,12 @@ function mkTempProject(): string {
 
 describe('CSV file indexing (issue #199)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -21,9 +24,9 @@ describe('CSV file indexing (issue #199)', () => {
   });
 
   it('emits the file as both a minerva:Note and a csvw:Table', async () => {
-    await indexNote('data/metrics.csv', 'name,count\nalice,3\nbob,5\n');
+    await indexNote(ctx, 'data/metrics.csv', 'name,count\nalice,3\nbob,5\n');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?path ?type WHERE {
         ?t minerva:relativePath "data/metrics.csv" ;
            minerva:relativePath ?path ;
@@ -36,8 +39,8 @@ describe('CSV file indexing (issue #199)', () => {
   });
 
   it('records csvw:inFile with the relative path as a literal', async () => {
-    await indexNote('data/m.csv', 'a,b\n1,2\n');
-    const { results } = await queryGraph(`
+    await indexNote(ctx, 'data/m.csv', 'a,b\n1,2\n');
+    const { results } = await queryGraph(ctx, `
       SELECT ?p WHERE {
         ?t minerva:relativePath "data/m.csv" ;
            csvw:inFile ?p .
@@ -47,8 +50,8 @@ describe('CSV file indexing (issue #199)', () => {
   });
 
   it('emits one csvw:Column per header with its name + zero-based index', async () => {
-    await indexNote('data/m.csv', 'name,count,tag\nalice,3,red\n');
-    const { results } = await queryGraph(`
+    await indexNote(ctx, 'data/m.csv', 'name,count,tag\nalice,3,red\n');
+    const { results } = await queryGraph(ctx, `
       SELECT ?name ?idx WHERE {
         ?t minerva:relativePath "data/m.csv" ;
            csvw:column ?c .
@@ -65,8 +68,8 @@ describe('CSV file indexing (issue #199)', () => {
   });
 
   it('emits one csvw:Row per data row with cells keyed to columns', async () => {
-    await indexNote('data/m.csv', 'name,count\nalice,3\nbob,5\n');
-    const { results } = await queryGraph(`
+    await indexNote(ctx, 'data/m.csv', 'name,count\nalice,3\nbob,5\n');
+    const { results } = await queryGraph(ctx, `
       SELECT ?name ?count WHERE {
         ?t minerva:relativePath "data/m.csv" ;
            csvw:row ?r .
@@ -82,10 +85,10 @@ describe('CSV file indexing (issue #199)', () => {
   });
 
   it('re-indexing a CSV replaces the old triples (no stale rows)', async () => {
-    await indexNote('data/m.csv', 'name,count\nalice,3\nbob,5\n');
-    await indexNote('data/m.csv', 'name,count\ncarol,7\n');
+    await indexNote(ctx, 'data/m.csv', 'name,count\nalice,3\nbob,5\n');
+    await indexNote(ctx, 'data/m.csv', 'name,count\ncarol,7\n');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?name WHERE {
         ?t minerva:relativePath "data/m.csv" ;
            csvw:row ?r .
@@ -98,8 +101,8 @@ describe('CSV file indexing (issue #199)', () => {
   });
 
   it('uses the filename stem as dc:title', async () => {
-    await indexNote('data/metrics.csv', 'a,b\n1,2\n');
-    const { results } = await queryGraph(`
+    await indexNote(ctx, 'data/metrics.csv', 'a,b\n1,2\n');
+    const { results } = await queryGraph(ctx, `
       SELECT ?title WHERE {
         ?t minerva:relativePath "data/metrics.csv" ;
            dc:title ?title .

--- a/tests/main/graph/csv-table-indexing.test.ts
+++ b/tests/main/graph/csv-table-indexing.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexCsvTable, unindexCsvTable, unindexAllCsvTables, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csv-table-test-'));
@@ -10,10 +11,12 @@ function mkTempProject(): string {
 
 describe('indexCsvTable — DuckDB table shape in the graph', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -21,7 +24,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
   });
 
   it('emits the table as csvw:Table and owl:Class', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 'experiments',
       relativePath: 'data/experiments.csv',
       columns: [
@@ -29,7 +32,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
         { name: 'name', duckdbType: 'VARCHAR', index: 1 },
       ],
     });
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?type WHERE {
         ?t minerva:tableName "experiments" ;
            a ?type .
@@ -41,7 +44,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
   });
 
   it('exposes each column as csvw:Column + owl:DatatypeProperty with domain and xsd range', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 'experiments',
       relativePath: 'data/experiments.csv',
       columns: [
@@ -49,7 +52,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
         { name: 'value', duckdbType: 'DOUBLE', index: 1 },
       ],
     });
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?name ?range ?domain WHERE {
         ?t minerva:tableName "experiments" ;
            csvw:tableSchema ?s .
@@ -72,7 +75,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
   });
 
   it('maps TIMESTAMP and BOOLEAN columns to xsd:dateTime and xsd:boolean', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 'events',
       relativePath: 'events.csv',
       columns: [
@@ -80,7 +83,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
         { name: 'ok', duckdbType: 'BOOLEAN', index: 1 },
       ],
     });
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?name ?range WHERE {
         ?t minerva:tableName "events" ;
            csvw:tableSchema ?s .
@@ -96,7 +99,7 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
   });
 
   it('re-indexing the same table replaces the old triples (no stale columns)', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 't',
       relativePath: 't.csv',
       columns: [
@@ -104,14 +107,14 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
         { name: 'b', duckdbType: 'INTEGER', index: 1 },
       ],
     });
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 't',
       relativePath: 't.csv',
       columns: [
         { name: 'c', duckdbType: 'VARCHAR', index: 0 },
       ],
     });
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?name WHERE {
         ?t minerva:tableName "t" ;
            csvw:tableSchema ?s .
@@ -124,43 +127,43 @@ describe('indexCsvTable — DuckDB table shape in the graph', () => {
   });
 
   it('unindexCsvTable drops every triple for that table', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 't',
       relativePath: 't.csv',
       columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
     });
-    unindexCsvTable('t');
-    const { results } = await queryGraph(`
+    unindexCsvTable(ctx, 't');
+    const { results } = await queryGraph(ctx, `
       SELECT ?s WHERE { ?s minerva:tableName "t" . }
     `);
     expect(results).toEqual([]);
   });
 
   it('unindexAllCsvTables drops only CSV-registered tables, not markdown csvw:Tables', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 'x',
       relativePath: 'x.csv',
       columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
     });
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 'y',
       relativePath: 'y.csv',
       columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
     });
-    unindexAllCsvTables();
-    const { results } = await queryGraph(`
+    unindexAllCsvTables(ctx);
+    const { results } = await queryGraph(ctx, `
       SELECT ?s WHERE { ?s minerva:tableName ?n . }
     `);
     expect(results).toEqual([]);
   });
 
   it('links the SQL-table view back to the CSV file via minerva:fromFile', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 'experiments',
       relativePath: 'data/experiments.csv',
       columns: [{ name: 'id', duckdbType: 'INTEGER', index: 0 }],
     });
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?file WHERE {
         ?t minerva:tableName "experiments" ;
            minerva:fromFile ?file .

--- a/tests/main/graph/excerpt-index.test.ts
+++ b/tests/main/graph/excerpt-index.test.ts
@@ -12,6 +12,7 @@ import {
   outgoingLinks,
   parseExcerptIdFromPath,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-excerpt-test-'));
@@ -47,10 +48,12 @@ this: a thought:Excerpt ;
 
 describe('excerpt indexing (issue #92)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -60,9 +63,9 @@ describe('excerpt indexing (issue #92)', () => {
   it('indexAllNotes picks up hand-placed excerpts under .minerva/excerpts/', async () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?id WHERE { ?ex minerva:excerptId ?id . }
     `);
     const ids = (results as Array<{ id: string }>).map(r => r.id);
@@ -72,9 +75,9 @@ describe('excerpt indexing (issue #92)', () => {
   it('resolves sources: prefix so thought:fromSource points at the Source URI', async () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?title WHERE {
         ?ex minerva:excerptId "smith-2023-p42" ;
             thought:fromSource ?src .
@@ -88,9 +91,9 @@ describe('excerpt indexing (issue #92)', () => {
 
   it('stores structured location predicates on the excerpt', async () => {
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?page ?charStart ?charEnd ?text WHERE {
         ?ex minerva:excerptId "smith-2023-p42" ;
             thought:page ?page ;
@@ -108,23 +111,23 @@ describe('excerpt indexing (issue #92)', () => {
 
   it('removeExcerpt drops the excerpt triples', async () => {
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    removeExcerpt('smith-2023-p42');
-    const { results } = await queryGraph(`SELECT ?id WHERE { ?ex minerva:excerptId ?id . }`);
+    removeExcerpt(ctx, 'smith-2023-p42');
+    const { results } = await queryGraph(ctx, `SELECT ?id WHERE { ?ex minerva:excerptId ?id . }`);
     expect(results).toHaveLength(0);
   });
 
   it('re-indexing an excerpt replaces its triples', async () => {
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    indexExcerpt('smith-2023-p42', `
+    indexExcerpt(ctx, 'smith-2023-p42', `
       this: a thought:Excerpt ;
           thought:citedText "Revised quotation." .
     `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?text WHERE { ?ex minerva:excerptId "smith-2023-p42" ; thought:citedText ?text . }
     `);
     const texts = (results as Array<{ text: string }>).map(r => r.text);
@@ -141,10 +144,12 @@ describe('excerpt indexing (issue #92)', () => {
 
 describe('[[quote::excerpt-id]] link and graph walk', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -153,11 +158,11 @@ describe('[[quote::excerpt-id]] link and graph walk', () => {
 
   it('writes a thought:quotes edge from the note to the excerpt URI', async () => {
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    await indexNote('argument.md', '# Argument\n\nAs [[quote::smith-2023-p42]] shows...');
+    await indexNote(ctx, 'argument.md', '# Argument\n\nAs [[quote::smith-2023-p42]] shows...');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?ex WHERE {
         ?note minerva:relativePath "argument.md" .
         ?note thought:quotes ?ex .
@@ -170,10 +175,10 @@ describe('[[quote::excerpt-id]] link and graph walk', () => {
   it('walks claim → thought:quotes → excerpt → thought:fromSource → source', async () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
-    await indexNote('argument.md', '# Argument\n\n[[quote::smith-2023-p42]]');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'argument.md', '# Argument\n\n[[quote::smith-2023-p42]]');
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?sourceTitle ?citedText WHERE {
         ?note minerva:relativePath "argument.md" .
         ?note thought:quotes ?ex .
@@ -189,10 +194,10 @@ describe('[[quote::excerpt-id]] link and graph walk', () => {
 
   it('outgoingLinks reports the quote edge with linkType "quote"', async () => {
     writeExcerpt(root, 'smith-2023-p42', EXCERPT_TTL);
-    await indexAllNotes(root);
-    await indexNote('argument.md', '[[quote::smith-2023-p42]]');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'argument.md', '[[quote::smith-2023-p42]]');
 
-    const links = outgoingLinks('argument.md');
+    const links = outgoingLinks(ctx, 'argument.md');
     const quote = links.find(l => l.linkType === 'quote');
     expect(quote).toBeDefined();
     expect(quote!.exists).toBe(true);

--- a/tests/main/graph/frontmatter-indexing.test.ts
+++ b/tests/main/graph/frontmatter-indexing.test.ts
@@ -7,6 +7,7 @@ import {
   indexNote,
   queryGraph,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fm-test-'));
@@ -14,10 +15,12 @@ function mkTempProject(): string {
 
 describe('frontmatter → graph indexing (issue #126)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -25,7 +28,7 @@ describe('frontmatter → graph indexing (issue #126)', () => {
   });
 
   it('maps known keys to canonical predicates (author → dc:creator, doi → bibo:doi, year → dc:issued)', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 title: My Paper
 author: Ada Lovelace
 doi: 10.1234/abc
@@ -34,7 +37,7 @@ year: 1843
 # My Paper
 `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       PREFIX bibo: <http://purl.org/ontology/bibo/>
       SELECT ?creator ?doi ?issued WHERE {
         ?note minerva:relativePath "paper.md" .
@@ -50,7 +53,7 @@ year: 1843
   });
 
   it('emits one triple per YAML list element', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 authors:
   - Alice Smith
   - Bob Jones
@@ -58,7 +61,7 @@ authors:
 # Paper
 `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?creator WHERE {
         ?note minerva:relativePath "paper.md" ; dc:creator ?creator .
       }
@@ -68,13 +71,13 @@ authors:
   });
 
   it('frontmatter tags become minerva:hasTag edges', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 tags: [research, epistemology]
 ---
 # Paper
 `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?tagName WHERE {
         ?note minerva:relativePath "paper.md" ;
               minerva:hasTag ?tag .
@@ -86,7 +89,7 @@ tags: [research, epistemology]
   });
 
   it('coerces integers, decimals, booleans to typed literals', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 pages: 42
 ratio: 3.14
 draft: true
@@ -94,7 +97,7 @@ draft: true
 # Paper
 `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       PREFIX bibo: <http://purl.org/ontology/bibo/>
       SELECT ?pages ?ratio ?draft WHERE {
         ?note minerva:relativePath "paper.md" .
@@ -110,13 +113,13 @@ draft: true
   });
 
   it('ISO dates become xsd:date / xsd:dateTime literals on dc:issued', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 date: 2023-07-15
 ---
 # Paper
 `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?issued WHERE {
         ?note minerva:relativePath "paper.md" ; dc:issued ?issued .
       }
@@ -127,14 +130,14 @@ date: 2023-07-15
   });
 
   it('resolves wiki-links in frontmatter values to note URIs (backlink-ready)', async () => {
-    await indexNote('a.md', '# A');
-    await indexNote('b.md', `---
+    await indexNote(ctx, 'a.md', '# A');
+    await indexNote(ctx, 'b.md', `---
 related: "[[a]]"
 ---
 # B
 `);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?target ?targetPath WHERE {
         ?note minerva:relativePath "b.md" ;
               minerva:meta-related ?target .
@@ -147,24 +150,24 @@ related: "[[a]]"
   });
 
   it('unknown keys still fall through to minerva:meta-<key>', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 weirdField: some value
 ---
 # Paper
 `);
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?v WHERE { ?note minerva:relativePath "paper.md" ; minerva:meta-weirdField ?v . }
     `);
     expect((results as Array<{ v: string }>)[0].v).toBe('some value');
   });
 
   it('frontmatter title still suppressed (H1/filename title wins the dc:title slot)', async () => {
-    await indexNote('paper.md', `---
+    await indexNote(ctx, 'paper.md', `---
 title: Frontmatter Title
 ---
 # H1 Heading
 `);
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?title WHERE { ?note minerva:relativePath "paper.md" ; dc:title ?title . }
     `);
     const titles = (results as Array<{ title: string }>).map(r => r.title);

--- a/tests/main/graph/heading-rename.test.ts
+++ b/tests/main/graph/heading-rename.test.ts
@@ -8,6 +8,7 @@ import {
   findNotesLinkingToAnchor,
   headingsFor,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import { renameAnchor } from '../../../src/main/notebase/rename-anchor';
 import { rewriteAnchorInLinks } from '../../../src/main/notebase/link-rewriting';
 
@@ -27,10 +28,12 @@ function readNote(root: string, relPath: string): string {
 
 describe('heading snapshots (issue #139)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -38,22 +41,22 @@ describe('heading snapshots (issue #139)', () => {
   });
 
   it('records headings after indexNote', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n## Overview\n\n## Components');
-    const headings = headingsFor('notes/foo.md');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Overview\n\n## Components');
+    const headings = headingsFor(ctx, 'notes/foo.md');
     expect(headings.map((h) => h.slug).sort()).toEqual(['components', 'foo', 'overview']);
   });
 
   it('does not flag a rename on the first indexNote call (initial index)', async () => {
     // Pre-seed some incoming links, then first-index the target — should not prompt.
-    await indexNote('other.md', 'See [[notes/foo#overview]].');
-    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## Overview');
+    await indexNote(ctx, 'other.md', 'See [[notes/foo#overview]].');
+    const { headingRenameCandidate } = await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Overview');
     expect(headingRenameCandidate).toBeUndefined();
   });
 
   it('flags a single heading rename with >0 incoming anchored links', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n## Overview');
-    await indexNote('other.md', 'See [[notes/foo#overview]].');
-    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## Summary');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Overview');
+    await indexNote(ctx, 'other.md', 'See [[notes/foo#overview]].');
+    const { headingRenameCandidate } = await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Summary');
     expect(headingRenameCandidate).toBeDefined();
     expect(headingRenameCandidate!.oldSlug).toBe('overview');
     expect(headingRenameCandidate!.newSlug).toBe('summary');
@@ -61,29 +64,29 @@ describe('heading snapshots (issue #139)', () => {
   });
 
   it('does not flag when there are no incoming links to the old slug', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n## Overview');
-    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## Summary');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Overview');
+    const { headingRenameCandidate } = await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Summary');
     expect(headingRenameCandidate).toBeUndefined();
   });
 
   it('does not flag ambiguous cases (multiple removals or additions)', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n## A\n\n## B');
-    await indexNote('other.md', '[[notes/foo#a]] [[notes/foo#b]]');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## A\n\n## B');
+    await indexNote(ctx, 'other.md', '[[notes/foo#a]] [[notes/foo#b]]');
     // Rename A→X and B→Y in the same edit — ambiguous, skip.
-    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo\n\n## X\n\n## Y');
+    const { headingRenameCandidate } = await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## X\n\n## Y');
     expect(headingRenameCandidate).toBeUndefined();
   });
 
   it('does not flag a pure deletion (one removal, no addition)', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n## Overview');
-    await indexNote('other.md', '[[notes/foo#overview]]');
-    const { headingRenameCandidate } = await indexNote('notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Overview');
+    await indexNote(ctx, 'other.md', '[[notes/foo#overview]]');
+    const { headingRenameCandidate } = await indexNote(ctx, 'notes/foo.md', '# Foo');
     expect(headingRenameCandidate).toBeUndefined();
   });
 
   it('ignores headings inside fenced code blocks', async () => {
-    await indexNote('notes/foo.md', '# Foo\n\n```\n## Not a heading\n```\n\n## Real');
-    const slugs = headingsFor('notes/foo.md').map((h) => h.slug);
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n```\n## Not a heading\n```\n\n## Real');
+    const slugs = headingsFor(ctx, 'notes/foo.md').map((h) => h.slug);
     expect(slugs).toContain('real');
     expect(slugs).not.toContain('not-a-heading');
   });
@@ -91,10 +94,12 @@ describe('heading snapshots (issue #139)', () => {
 
 describe('findNotesLinkingToAnchor (issue #139)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -102,22 +107,24 @@ describe('findNotesLinkingToAnchor (issue #139)', () => {
   });
 
   it('returns only notes with the exact anchor', async () => {
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('a.md', '[[notes/foo#overview]]');
-    await indexNote('b.md', '[[notes/foo#other]]');
-    await indexNote('c.md', '[[notes/foo]]');  // no anchor
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'a.md', '[[notes/foo#overview]]');
+    await indexNote(ctx, 'b.md', '[[notes/foo#other]]');
+    await indexNote(ctx, 'c.md', '[[notes/foo]]');  // no anchor
 
-    expect(findNotesLinkingToAnchor('notes/foo.md', 'overview').sort()).toEqual(['a.md']);
-    expect(findNotesLinkingToAnchor('notes/foo.md', 'other').sort()).toEqual(['b.md']);
+    expect(findNotesLinkingToAnchor(ctx, 'notes/foo.md', 'overview').sort()).toEqual(['a.md']);
+    expect(findNotesLinkingToAnchor(ctx, 'notes/foo.md', 'other').sort()).toEqual(['b.md']);
   });
 });
 
 describe('renameAnchor integration (issue #139)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -129,10 +136,10 @@ describe('renameAnchor integration (issue #139)', () => {
     writeNote(root, 'a.md', 'See [[notes/foo#overview]].');
     writeNote(root, 'b.md', '[[supports::notes/foo#overview|rationale]]');
     writeNote(root, 'c.md', '[[notes/foo#unrelated]]');
-    await indexNote('notes/foo.md', '# Foo\n\n## Summary');
-    await indexNote('a.md', 'See [[notes/foo#overview]].');
-    await indexNote('b.md', '[[supports::notes/foo#overview|rationale]]');
-    await indexNote('c.md', '[[notes/foo#unrelated]]');
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Summary');
+    await indexNote(ctx, 'a.md', 'See [[notes/foo#overview]].');
+    await indexNote(ctx, 'b.md', '[[supports::notes/foo#overview|rationale]]');
+    await indexNote(ctx, 'c.md', '[[notes/foo#unrelated]]');
 
     const { rewrittenPaths } = await renameAnchor(root, 'notes/foo.md', 'overview', 'summary');
 

--- a/tests/main/graph/n3-cache.bench.ts
+++ b/tests/main/graph/n3-cache.bench.ts
@@ -13,26 +13,29 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 describe.skip('N3 cache benchmark', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeAll(async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3bench-'));
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
     // Plant 500 synthetic notes — roughly the inflection point where
     // the un-cached cost becomes user-visible in panel refreshes.
     for (let i = 0; i < 500; i++) {
       const body = `# Note ${i}\n\n${'lorem ipsum '.repeat(50)}\n\n#tag-${i % 10}\n`;
-      await indexNote(`note-${i}.md`, body);
+      await indexNote(ctx, `note-${i}.md`, body);
     }
   });
 
   bench('queryGraph: simple SELECT (cache hit after first call)', async () => {
-    await queryGraph('SELECT ?n WHERE { ?n a minerva:Note } LIMIT 50');
+    await queryGraph(ctx, 'SELECT ?n WHERE { ?n a minerva:Note } LIMIT 50');
   });
 
   bench('queryGraph: tag filter (cache hit after first call)', async () => {
-    await queryGraph(`SELECT ?n WHERE { ?n minerva:hasTag ?t . ?t minerva:tagName "tag-3" }`);
+    await queryGraph(ctx, `SELECT ?n WHERE { ?n minerva:hasTag ?t . ?t minerva:tagName "tag-3" }`);
   });
 });

--- a/tests/main/graph/n3-cache.test.ts
+++ b/tests/main/graph/n3-cache.test.ts
@@ -8,6 +8,7 @@ import {
   indexExcerpt, removeExcerpt, indexCsvTable, unindexCsvTable,
   unindexAllCsvTables, parseIntoStore, queryGraph,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTemp(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3cache-'));
@@ -15,10 +16,12 @@ function mkTemp(): string {
 
 describe('queryGraph N3 store cache (#334)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTemp();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(async () => {
@@ -31,106 +34,106 @@ describe('queryGraph N3 store cache (#334)', () => {
   // a stale snapshot.
 
   it('indexNote → query reflects the note', async () => {
-    await indexNote('a.md', '# Alpha\n');
-    const r1 = await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    const r1 = await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
     expect((r1.results as Array<{ t: string }>)[0].t).toBe('Alpha');
   });
 
   it('two queries in a row reuse the same cache (no error)', async () => {
-    await indexNote('a.md', '# Alpha\n');
-    const r1 = await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
-    const r2 = await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    const r1 = await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
+    const r2 = await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
     expect(r1.results).toEqual(r2.results);
   });
 
   it('indexNote after a query reflects the new note (cache invalidated)', async () => {
-    await indexNote('a.md', '# Alpha\n');
-    await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
-    await indexNote('b.md', '# Beta\n');
-    const r = await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "b.md" ; dc:title ?t . }`);
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
+    await indexNote(ctx, 'b.md', '# Beta\n');
+    const r = await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "b.md" ; dc:title ?t . }`);
     expect((r.results as Array<{ t: string }>)[0].t).toBe('Beta');
   });
 
   it('removeNote after a query removes from results', async () => {
-    await indexNote('a.md', '# Alpha\n');
-    await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
-    removeNote('a.md');
-    const r = await queryGraph(`SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
+    removeNote(ctx, 'a.md');
+    const r = await queryGraph(ctx, `SELECT ?t WHERE { ?n minerva:relativePath "a.md" ; dc:title ?t . }`);
     expect(r.results).toEqual([]);
   });
 
   it('indexSource after a query reflects the source', async () => {
-    await queryGraph('SELECT ?s WHERE { ?s a minerva:Note }'); // warm the cache
-    indexSource('foo', 'this: a thought:Source ; dc:title "T" .\n');
-    const r = await queryGraph(`SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a minerva:Note }'); // warm the cache
+    indexSource(ctx, 'foo', 'this: a thought:Source ; dc:title "T" .\n');
+    const r = await queryGraph(ctx, `SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
     const ids = (r.results as Array<{ id: string }>).map((x) => x.id);
     expect(ids).toContain('foo');
   });
 
   it('removeSource invalidates the cache', async () => {
-    indexSource('foo', 'this: a thought:Source ; dc:title "T" .\n');
-    await queryGraph(`SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
-    removeSource('foo');
-    const r = await queryGraph(`SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
+    indexSource(ctx, 'foo', 'this: a thought:Source ; dc:title "T" .\n');
+    await queryGraph(ctx, `SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
+    removeSource(ctx, 'foo');
+    const r = await queryGraph(ctx, `SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
     expect(r.results).toEqual([]);
   });
 
   it('indexExcerpt invalidates the cache', async () => {
-    indexSource('foo', 'this: a thought:Source ; dc:title "T" .\n');
-    await queryGraph(`SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
-    indexExcerpt('ex-1', 'this: a thought:Excerpt ; thought:fromSource sources:foo .\n');
-    const r = await queryGraph(`SELECT ?eid WHERE { ?e minerva:excerptId ?eid . }`);
+    indexSource(ctx, 'foo', 'this: a thought:Source ; dc:title "T" .\n');
+    await queryGraph(ctx, `SELECT ?id WHERE { ?s minerva:sourceId ?id . }`);
+    indexExcerpt(ctx, 'ex-1', 'this: a thought:Excerpt ; thought:fromSource sources:foo .\n');
+    const r = await queryGraph(ctx, `SELECT ?eid WHERE { ?e minerva:excerptId ?eid . }`);
     const ids = (r.results as Array<{ eid: string }>).map((x) => x.eid);
     expect(ids).toContain('ex-1');
   });
 
   it('removeExcerpt invalidates the cache', async () => {
-    indexExcerpt('ex-1', 'this: a thought:Excerpt .\n');
-    await queryGraph(`SELECT ?eid WHERE { ?e minerva:excerptId ?eid . }`);
-    removeExcerpt('ex-1');
-    const r = await queryGraph(`SELECT ?eid WHERE { ?e minerva:excerptId ?eid . }`);
+    indexExcerpt(ctx, 'ex-1', 'this: a thought:Excerpt .\n');
+    await queryGraph(ctx, `SELECT ?eid WHERE { ?e minerva:excerptId ?eid . }`);
+    removeExcerpt(ctx, 'ex-1');
+    const r = await queryGraph(ctx, `SELECT ?eid WHERE { ?e minerva:excerptId ?eid . }`);
     expect(r.results).toEqual([]);
   });
 
   it('indexCsvTable invalidates the cache', async () => {
-    await queryGraph('SELECT ?s WHERE { ?s a csvw:Table }'); // warm
-    indexCsvTable({
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a csvw:Table }'); // warm
+    indexCsvTable(ctx, {
       tableName: 't',
       relativePath: 't.csv',
       columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
     });
-    const r = await queryGraph(`SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
+    const r = await queryGraph(ctx, `SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
     const names = (r.results as Array<{ n: string }>).map((x) => x.n);
     expect(names).toContain('t');
   });
 
   it('unindexCsvTable invalidates the cache', async () => {
-    indexCsvTable({
+    indexCsvTable(ctx, {
       tableName: 't',
       relativePath: 't.csv',
       columns: [{ name: 'a', duckdbType: 'VARCHAR', index: 0 }],
     });
-    await queryGraph(`SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
-    unindexCsvTable('t');
-    const r = await queryGraph(`SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
+    await queryGraph(ctx, `SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
+    unindexCsvTable(ctx, 't');
+    const r = await queryGraph(ctx, `SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
     expect(r.results).toEqual([]);
   });
 
   it('unindexAllCsvTables invalidates the cache', async () => {
-    indexCsvTable({ tableName: 'x', relativePath: 'x.csv', columns: [] });
-    indexCsvTable({ tableName: 'y', relativePath: 'y.csv', columns: [] });
-    await queryGraph(`SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
-    unindexAllCsvTables();
-    const r = await queryGraph(`SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
+    indexCsvTable(ctx, { tableName: 'x', relativePath: 'x.csv', columns: [] });
+    indexCsvTable(ctx, { tableName: 'y', relativePath: 'y.csv', columns: [] });
+    await queryGraph(ctx, `SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
+    unindexAllCsvTables(ctx);
+    const r = await queryGraph(ctx, `SELECT ?n WHERE { ?t minerva:tableName ?n . }`);
     expect(r.results).toEqual([]);
   });
 
   it('parseIntoStore invalidates the cache', async () => {
-    await queryGraph('SELECT ?s WHERE { ?s a thought:Proposal }'); // warm
-    parseIntoStore(`@prefix thought: <https://minerva.dev/ontology/thought#> .
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a thought:Proposal }'); // warm
+    parseIntoStore(ctx, `@prefix thought: <https://minerva.dev/ontology/thought#> .
 @prefix ex: <https://example.com/> .
 ex:p1 a thought:Proposal ; thought:hasStatus thought:pending .`);
-    const r = await queryGraph(`SELECT ?p WHERE { ?p a thought:Proposal . }`);
+    const r = await queryGraph(ctx, `SELECT ?p WHERE { ?p a thought:Proposal . }`);
     expect(r.results.length).toBeGreaterThan(0);
   });
 });

--- a/tests/main/graph/source-detail.test.ts
+++ b/tests/main/graph/source-detail.test.ts
@@ -9,6 +9,7 @@ import {
   getSourceDetail,
   getExcerptSource,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-source-detail-test-'));
@@ -46,10 +47,12 @@ this: a thought:Excerpt ;
 
 describe('getSourceDetail', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -57,15 +60,15 @@ describe('getSourceDetail', () => {
   });
 
   it('returns null for an unknown source id', async () => {
-    await indexAllNotes(root);
-    expect(getSourceDetail('nope')).toBeNull();
+    await indexAllNotes(ctx);
+    expect(getSourceDetail(ctx, 'nope')).toBeNull();
   });
 
   it('returns structured metadata including subtype, creators, DOI', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const detail = getSourceDetail('smith-2023');
+    const detail = getSourceDetail(ctx, 'smith-2023');
     expect(detail).not.toBeNull();
     expect(detail!.metadata.sourceId).toBe('smith-2023');
     expect(detail!.metadata.subtype).toBe('Article');
@@ -81,9 +84,9 @@ describe('getSourceDetail', () => {
   it('lists excerpts that belong to the source', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
     writeExcerpt(root, 'p42-graphs', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const detail = getSourceDetail('smith-2023');
+    const detail = getSourceDetail(ctx, 'smith-2023');
     expect(detail!.excerpts).toHaveLength(1);
     expect(detail!.excerpts[0].excerptId).toBe('p42-graphs');
     expect(detail!.excerpts[0].citedText).toBe('Graphs are relational.');
@@ -92,11 +95,11 @@ describe('getSourceDetail', () => {
 
   it('returns cite backlinks from notes with [[cite::id]]', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
-    await indexNote('a.md', '# A\n\nAs [[cite::smith-2023]] shows...');
-    await indexNote('b.md', '# B\n\nSee also [[cite::smith-2023]].');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'a.md', '# A\n\nAs [[cite::smith-2023]] shows...');
+    await indexNote(ctx, 'b.md', '# B\n\nSee also [[cite::smith-2023]].');
 
-    const detail = getSourceDetail('smith-2023');
+    const detail = getSourceDetail(ctx, 'smith-2023');
     const cites = detail!.backlinks.filter(b => b.kind === 'cite');
     expect(cites.map(b => b.relativePath).sort()).toEqual(['a.md', 'b.md']);
   });
@@ -104,10 +107,10 @@ describe('getSourceDetail', () => {
   it('returns quote backlinks via excerpts, carrying the excerpt id', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
     writeExcerpt(root, 'p42-graphs', EXCERPT_TTL);
-    await indexAllNotes(root);
-    await indexNote('c.md', '# C\n\n[[quote::p42-graphs]]');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'c.md', '# C\n\n[[quote::p42-graphs]]');
 
-    const detail = getSourceDetail('smith-2023');
+    const detail = getSourceDetail(ctx, 'smith-2023');
     const quotes = detail!.backlinks.filter(b => b.kind === 'quote');
     expect(quotes).toHaveLength(1);
     expect(quotes[0].relativePath).toBe('c.md');
@@ -117,10 +120,12 @@ describe('getSourceDetail', () => {
 
 describe('getExcerptSource', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -130,13 +135,13 @@ describe('getExcerptSource', () => {
   it('resolves an excerpt to its source id via thought:fromSource', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
     writeExcerpt(root, 'p42-graphs', EXCERPT_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    expect(getExcerptSource('p42-graphs')).toEqual({ sourceId: 'smith-2023' });
+    expect(getExcerptSource(ctx, 'p42-graphs')).toEqual({ sourceId: 'smith-2023' });
   });
 
   it('returns null for an unknown excerpt', async () => {
-    await indexAllNotes(root);
-    expect(getExcerptSource('nope')).toBeNull();
+    await indexAllNotes(ctx);
+    expect(getExcerptSource(ctx, 'nope')).toBeNull();
   });
 });

--- a/tests/main/graph/source-tags.test.ts
+++ b/tests/main/graph/source-tags.test.ts
@@ -11,6 +11,7 @@ import {
   sourcesByTag,
   indexNote,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-source-tags-test-'));
@@ -36,10 +37,12 @@ this: a thought:Article ;
 
 describe('Source participation in tag system (issue #118)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -49,64 +52,64 @@ describe('Source participation in tag system (issue #118)', () => {
   it('picks up body #tags on the source URI during indexAllNotes', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     writeSourceBody(root, 'smith-2023', '# Notes\n\nThis is great #research stuff #epistemology.');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const sources = sourcesByTag('research');
+    const sources = sourcesByTag(ctx, 'research');
     expect(sources).toHaveLength(1);
     expect(sources[0].sourceId).toBe('smith-2023');
     expect(sources[0].title).toBe('Example paper');
 
-    const epistemology = sourcesByTag('epistemology');
+    const epistemology = sourcesByTag(ctx, 'epistemology');
     expect(epistemology.map(s => s.sourceId)).toEqual(['smith-2023']);
   });
 
   it('picks up frontmatter tags: [...] on the source URI', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     writeSourceBody(root, 'smith-2023', '---\ntags: [research, epistemology]\n---\n# Notes\n');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const sources = sourcesByTag('research');
+    const sources = sourcesByTag(ctx, 'research');
     expect(sources.map(s => s.sourceId)).toEqual(['smith-2023']);
   });
 
   it('listTags counts both notes and sources that share a tag', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     writeSourceBody(root, 'smith-2023', '# x\n\n#research');
-    await indexAllNotes(root);
-    await indexNote('notes/overview.md', '# Overview\n\n#research');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'notes/overview.md', '# Overview\n\n#research');
 
-    const info = listTags().find(t => t.tag === 'research');
+    const info = listTags(ctx).find(t => t.tag === 'research');
     expect(info?.count).toBe(2);
   });
 
   it('notesByTag excludes sources (no misleading relativePath)', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     writeSourceBody(root, 'smith-2023', '# x\n\n#research');
-    await indexAllNotes(root);
-    await indexNote('notes/overview.md', '# Overview\n\n#research');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'notes/overview.md', '# Overview\n\n#research');
 
-    const notes = notesByTag('research');
+    const notes = notesByTag(ctx, 'research');
     expect(notes.map(n => n.relativePath)).toEqual(['notes/overview.md']);
   });
 
   it('sourcesByTag returns empty when no sources are tagged', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     // No body.md at all
-    await indexAllNotes(root);
-    await indexNote('notes/overview.md', '# x\n\n#research');
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'notes/overview.md', '# x\n\n#research');
 
-    expect(sourcesByTag('research')).toEqual([]);
+    expect(sourcesByTag(ctx, 'research')).toEqual([]);
   });
 
   it('re-indexing replaces the source tags (no stale triples)', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     writeSourceBody(root, 'smith-2023', '# x\n\n#research');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     // Simulate body edit: drop #research, add #methodology
-    indexSource('smith-2023', META, '# x\n\n#methodology');
+    indexSource(ctx, 'smith-2023', META, '# x\n\n#methodology');
 
-    expect(sourcesByTag('research')).toEqual([]);
-    expect(sourcesByTag('methodology').map(s => s.sourceId)).toEqual(['smith-2023']);
+    expect(sourcesByTag(ctx, 'research')).toEqual([]);
+    expect(sourcesByTag(ctx, 'methodology').map(s => s.sourceId)).toEqual(['smith-2023']);
   });
 });

--- a/tests/main/graph/sources-index.test.ts
+++ b/tests/main/graph/sources-index.test.ts
@@ -10,6 +10,7 @@ import {
   queryGraph,
   parseSourceIdFromPath,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sources-test-'));
@@ -38,10 +39,12 @@ this: a thought:WebPage ;
 
 describe('source indexing (issue #89)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -51,9 +54,9 @@ describe('source indexing (issue #89)', () => {
   it('indexAllNotes picks up hand-placed sources under .minerva/sources/', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
     writeSourceMeta(root, 'example-page', WEBPAGE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?id ?title WHERE {
         ?src minerva:sourceId ?id ; dc:title ?title .
       } ORDER BY ?id
@@ -65,9 +68,9 @@ describe('source indexing (issue #89)', () => {
 
   it('stores the source subtype from meta.ttl', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?type WHERE {
         ?src minerva:sourceId "smith-2023" ; a ?type .
         FILTER(STRSTARTS(STR(?type), "https://minerva.dev/ontology/thought#"))
@@ -79,9 +82,9 @@ describe('source indexing (issue #89)', () => {
 
   it('exposes source metadata (title, creator, doi) on the source node', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       PREFIX bibo: <http://purl.org/ontology/bibo/>
       SELECT ?title ?creator ?doi WHERE {
         ?src minerva:sourceId "smith-2023" .
@@ -98,9 +101,9 @@ describe('source indexing (issue #89)', () => {
 
   it('records relativePath pointing at .minerva/sources/<id>/meta.ttl', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?path WHERE { ?src minerva:sourceId "smith-2023" ; minerva:relativePath ?path . }
     `);
     const row = (results as Array<{ path: string }>)[0];
@@ -109,10 +112,10 @@ describe('source indexing (issue #89)', () => {
 
   it('removeSource drops the source from the graph', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
-    removeSource('smith-2023');
-    const { results } = await queryGraph(`
+    removeSource(ctx, 'smith-2023');
+    const { results } = await queryGraph(ctx, `
       SELECT ?id WHERE { ?src minerva:sourceId ?id . }
     `);
     expect(results).toHaveLength(0);
@@ -120,16 +123,16 @@ describe('source indexing (issue #89)', () => {
 
   it('re-indexing a source replaces its triples (no duplication)', async () => {
     writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     const updated = `
       this: a thought:Article ;
           dc:title "A revised title" ;
           dc:creator "Alice Smith" .
     `;
-    indexSource('smith-2023', updated);
+    indexSource(ctx, 'smith-2023', updated);
 
-    const { results } = await queryGraph(`
+    const { results } = await queryGraph(ctx, `
       SELECT ?title WHERE { ?src minerva:sourceId "smith-2023" ; dc:title ?title . }
     `);
     const titles = (results as Array<{ title: string }>).map(r => r.title);

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -14,6 +14,7 @@ import {
   type ApprovalTier,
 } from '../../../src/main/llm/approval';
 import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 describe('approval policy', () => {
   beforeEach(() => {
@@ -66,10 +67,12 @@ describe('approval policy', () => {
 
 describe('updateProposalStatus replaces, does not append (#332)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-status-'));
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
     resetPolicy();
   });
 
@@ -78,14 +81,14 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
   });
 
   async function statusesFor(uri: string): Promise<string[]> {
-    const r = await queryGraph(`
+    const r = await queryGraph(ctx, `
       SELECT ?s WHERE { <${uri}> thought:proposalStatus ?s . }
     `);
     return (r.results as Array<{ s: string }>).map((row) => row.s);
   }
 
   it('approving a pending proposal leaves only the approved status', async () => {
-    const proposal = await proposeWrite({
+    const proposal = await proposeWrite(ctx, {
       operationType: 'new_claim',
       turtleDiff: '<https://ex.example/x> a <https://ex.example/Claim> .',
       note: 'test',
@@ -97,14 +100,14 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
       'https://minerva.dev/ontology/thought#pending',
     ]);
 
-    expect(await approveProposal(proposal!.uri)).toBe(true);
+    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
     expect(await statusesFor(proposal!.uri)).toEqual([
       'https://minerva.dev/ontology/thought#approved',
     ]);
   });
 
   it('rejecting a pending proposal leaves only the rejected status', async () => {
-    const proposal = await proposeWrite({
+    const proposal = await proposeWrite(ctx, {
       operationType: 'new_claim',
       turtleDiff: '<https://ex.example/y> a <https://ex.example/Claim> .',
       note: 'test',
@@ -112,7 +115,7 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
       affectsNodeUri: 'https://ex.example/y',
     });
     expect(proposal).not.toBeNull();
-    expect(await rejectProposal(proposal!.uri)).toBe(true);
+    expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);
     expect(await statusesFor(proposal!.uri)).toEqual([
       'https://minerva.dev/ontology/thought#rejected',
     ]);

--- a/tests/main/llm/conversation-model.test.ts
+++ b/tests/main/llm/conversation-model.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import {
   initConversations,
   create,
@@ -16,10 +17,12 @@ function mkTempProject(): string {
 
 describe('conversation.setModel (issue #168)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
     initConversations(root);
   });
 

--- a/tests/main/notebase/rename-source-excerpt.test.ts
+++ b/tests/main/notebase/rename-source-excerpt.test.ts
@@ -9,6 +9,7 @@ import {
   findNotesCitingSource,
   findNotesQuotingExcerpt,
 } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import { renameSource, renameExcerpt } from '../../../src/main/notebase/rename-source-excerpt';
 import { rewriteTypedIdLinks } from '../../../src/main/notebase/link-rewriting';
 
@@ -53,10 +54,12 @@ this: a thought:Excerpt ;
 
 describe('renameSource (issue #141)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -67,7 +70,7 @@ describe('renameSource (issue #141)', () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
     writeNote(root, 'a.md', 'As [[cite::smith-2023]] argues...');
     writeNote(root, 'b.md', '[[cite::smith-2023|see the paper]] and [[cite::other-2020]]');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     const { rewrittenPaths } = await renameSource(root, 'smith-2023', 'lovelace-2023');
 
@@ -83,17 +86,17 @@ describe('renameSource (issue #141)', () => {
   it('shifts the graph so new id is citable and old id isn\'t', async () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
     writeNote(root, 'a.md', 'As [[cite::smith-2023]] argues...');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     await renameSource(root, 'smith-2023', 'lovelace-2023');
 
-    expect(findNotesCitingSource('smith-2023')).toEqual([]);
-    expect(findNotesCitingSource('lovelace-2023')).toEqual(['a.md']);
+    expect(findNotesCitingSource(ctx, 'smith-2023')).toEqual([]);
+    expect(findNotesCitingSource(ctx, 'lovelace-2023')).toEqual(['a.md']);
   });
 
   it('no-ops when oldId equals newId', async () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
     const { rewrittenPaths } = await renameSource(root, 'smith-2023', 'smith-2023');
     expect(rewrittenPaths).toEqual([]);
   });
@@ -101,10 +104,12 @@ describe('renameSource (issue #141)', () => {
 
 describe('renameExcerpt (issue #141)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -116,7 +121,7 @@ describe('renameExcerpt (issue #141)', () => {
     writeExcerpt(root, 'p42', EXCERPT_TTL);
     writeNote(root, 'a.md', '[[quote::p42]]');
     writeNote(root, 'b.md', '[[quote::p42|on page 42]] and [[quote::other]]');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     const { rewrittenPaths } = await renameExcerpt(root, 'p42', 'graphs-relational');
 
@@ -133,12 +138,12 @@ describe('renameExcerpt (issue #141)', () => {
     writeSourceMeta(root, 'smith-2023', SOURCE_TTL);
     writeExcerpt(root, 'p42', EXCERPT_TTL);
     writeNote(root, 'a.md', '[[quote::p42]]');
-    await indexAllNotes(root);
+    await indexAllNotes(ctx);
 
     await renameExcerpt(root, 'p42', 'graphs-relational');
 
-    expect(findNotesQuotingExcerpt('p42')).toEqual([]);
-    expect(findNotesQuotingExcerpt('graphs-relational')).toEqual(['a.md']);
+    expect(findNotesQuotingExcerpt(ctx, 'p42')).toEqual([]);
+    expect(findNotesQuotingExcerpt(ctx, 'graphs-relational')).toEqual(['a.md']);
   });
 });
 

--- a/tests/main/notebase/rename.test.ts
+++ b/tests/main/notebase/rename.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote, findNotesLinkingTo } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import { renameWithLinkRewrites } from '../../../src/main/notebase/rename';
 
 function mkTempProject(): string {
@@ -21,10 +22,12 @@ function readNote(root: string, relPath: string): string {
 
 describe('renameWithLinkRewrites — file rename (issue #136)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -34,8 +37,8 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
   it('renames the file and rewrites a simple incoming link', async () => {
     writeNote(root, 'notes/foo.md', '# Foo');
     writeNote(root, 'notes/overview.md', '# Overview\n\nSee [[notes/foo]].');
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/overview.md', '# Overview\n\nSee [[notes/foo]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/overview.md', '# Overview\n\nSee [[notes/foo]].');
 
     const { rewrittenPaths, transitions } = await renameWithLinkRewrites(
       root, 'notes/foo.md', 'archive/foo.md',
@@ -52,9 +55,9 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
     writeNote(root, 'notes/a.md', '# A');
     writeNote(root, 'notes/b.md', '# B');
     writeNote(root, 'other/overview.md', 'See [[notes/a]].');
-    await indexNote('notes/a.md', '# A');
-    await indexNote('notes/b.md', '# B');
-    await indexNote('other/overview.md', 'See [[notes/a]].');
+    await indexNote(ctx, 'notes/a.md', '# A');
+    await indexNote(ctx, 'notes/b.md', '# B');
+    await indexNote(ctx, 'other/overview.md', 'See [[notes/a]].');
 
     const { transitions } = await renameWithLinkRewrites(root, 'notes', 'archive');
 
@@ -77,8 +80,8 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
       'All    [[rebuts::notes/foo#section|see this]].',
     ].join('\n');
     writeNote(root, 'notes/overview.md', body);
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/overview.md', body);
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/overview.md', body);
 
     await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md');
 
@@ -94,20 +97,20 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
   it('updates the graph so findNotesLinkingTo now reports the NEW path', async () => {
     writeNote(root, 'notes/foo.md', '# Foo');
     writeNote(root, 'notes/overview.md', 'See [[notes/foo]].');
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/overview.md', 'See [[notes/foo]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/overview.md', 'See [[notes/foo]].');
 
     await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md');
 
-    expect(findNotesLinkingTo('notes/foo.md')).toEqual([]);
-    expect(findNotesLinkingTo('archive/foo.md')).toEqual(['notes/overview.md']);
+    expect(findNotesLinkingTo(ctx, 'notes/foo.md')).toEqual([]);
+    expect(findNotesLinkingTo(ctx, 'archive/foo.md')).toEqual(['notes/overview.md']);
   });
 
   it('leaves unrelated notes untouched', async () => {
     writeNote(root, 'notes/foo.md', '# Foo');
     writeNote(root, 'notes/bar.md', '# Bar\n\nNothing to do with foo.');
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/bar.md', '# Bar\n\nNothing to do with foo.');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/bar.md', '# Bar\n\nNothing to do with foo.');
 
     const before = readNote(root, 'notes/bar.md');
     await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md');
@@ -117,8 +120,8 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
   it('invokes reindexHook for the rewritten referrer so downstream indexes stay consistent', async () => {
     writeNote(root, 'notes/foo.md', '# Foo');
     writeNote(root, 'notes/overview.md', 'See [[notes/foo]].');
-    await indexNote('notes/foo.md', '# Foo');
-    await indexNote('notes/overview.md', 'See [[notes/foo]].');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/overview.md', 'See [[notes/foo]].');
 
     const reindexed: string[] = [];
     await renameWithLinkRewrites(root, 'notes/foo.md', 'archive/foo.md', {
@@ -132,10 +135,12 @@ describe('renameWithLinkRewrites — file rename (issue #136)', () => {
 
 describe('renameWithLinkRewrites — folder rename (issue #136)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(() => {
@@ -146,9 +151,9 @@ describe('renameWithLinkRewrites — folder rename (issue #136)', () => {
     writeNote(root, 'notes/a.md', '# A');
     writeNote(root, 'notes/b.md', '# B');
     writeNote(root, 'other/overview.md', 'Links: [[notes/a]] and [[notes/b]].');
-    await indexNote('notes/a.md', '# A');
-    await indexNote('notes/b.md', '# B');
-    await indexNote('other/overview.md', 'Links: [[notes/a]] and [[notes/b]].');
+    await indexNote(ctx, 'notes/a.md', '# A');
+    await indexNote(ctx, 'notes/b.md', '# B');
+    await indexNote(ctx, 'other/overview.md', 'Links: [[notes/a]] and [[notes/b]].');
 
     await renameWithLinkRewrites(root, 'notes', 'archive');
 
@@ -162,8 +167,8 @@ describe('renameWithLinkRewrites — folder rename (issue #136)', () => {
   it('rewrites links inside the renamed folder too (same-folder self-reference)', async () => {
     writeNote(root, 'notes/a.md', '# A');
     writeNote(root, 'notes/overview.md', 'See [[notes/a]].');
-    await indexNote('notes/a.md', '# A');
-    await indexNote('notes/overview.md', 'See [[notes/a]].');
+    await indexNote(ctx, 'notes/a.md', '# A');
+    await indexNote(ctx, 'notes/overview.md', 'See [[notes/a]].');
 
     await renameWithLinkRewrites(root, 'notes', 'archive');
 

--- a/tests/main/sources/delete-source.test.ts
+++ b/tests/main/sources/delete-source.test.ts
@@ -4,6 +4,7 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexSource, indexExcerpt, listAllSources, excerptIdsForSource } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import { deleteSource } from '../../../src/main/sources/delete-source';
 
 function mkTemp(): string {
@@ -12,10 +13,12 @@ function mkTemp(): string {
 
 describe('deleteSource', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTemp();
-    await initGraph(root);
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
   afterEach(async () => {
@@ -31,7 +34,7 @@ describe('deleteSource', () => {
     await fsp.writeFile(path.join(sourceDir, 'body.md'), '# Test\n');
     await fsp.writeFile(path.join(sourceDir, 'original.pdf'), new Uint8Array([0x25, 0x50, 0x44, 0x46]));
 
-    indexSource(sourceId,
+    indexSource(ctx, sourceId,
       'this: a thought:PDFSource ; dc:title "Test" .\n',
       '# Test\n',
     );
@@ -41,12 +44,12 @@ describe('deleteSource', () => {
     for (const exId of ['ex-1', 'ex-2']) {
       const ttl = `this: a thought:Excerpt ;\n  thought:fromSource sources:${sourceId} ;\n  thought:citedText "..." .\n`;
       await fsp.writeFile(path.join(excerptsDir, `${exId}.ttl`), ttl);
-      indexExcerpt(exId, ttl);
+      indexExcerpt(ctx, exId, ttl);
     }
 
     // Sanity: the source + excerpts are in the graph before deletion.
-    expect(listAllSources().some((s) => s.sourceId === sourceId)).toBe(true);
-    expect(excerptIdsForSource(sourceId).sort()).toEqual(['ex-1', 'ex-2']);
+    expect(listAllSources(ctx).some((s) => s.sourceId === sourceId)).toBe(true);
+    expect(excerptIdsForSource(ctx, sourceId).sort()).toEqual(['ex-1', 'ex-2']);
 
     const result = await deleteSource(root, sourceId);
 
@@ -55,8 +58,8 @@ describe('deleteSource', () => {
     expect(fs.existsSync(sourceDir)).toBe(false);
     expect(fs.existsSync(path.join(excerptsDir, 'ex-1.ttl'))).toBe(false);
     expect(fs.existsSync(path.join(excerptsDir, 'ex-2.ttl'))).toBe(false);
-    expect(listAllSources().some((s) => s.sourceId === sourceId)).toBe(false);
-    expect(excerptIdsForSource(sourceId)).toEqual([]);
+    expect(listAllSources(ctx).some((s) => s.sourceId === sourceId)).toBe(false);
+    expect(excerptIdsForSource(ctx, sourceId)).toEqual([]);
   });
 
   it('is a no-op on an already-deleted source', async () => {


### PR DESCRIPTION
## Summary
- Introduces `ProjectContext` (branded type in `src/main/project-context-types.ts`) and refactors `graph/index.ts` to key all state by `rootPath` via a per-project `GraphState` map, instead of module-level singletons.
- Threads `ctx: ProjectContext` as the first argument through every public graph operation (init, index, query, persist, etc.).
- Updates every production caller in lockstep — window-manager, ipc, menu, approval engine, conversation/auto-tag/auto-link/crystallize/tools, formatter, rename pipelines, delete-source, sparql executor, health-checks (per-project results + per-project timer), and tables.ts (graph calls only).
- Updates the 20 affected test files to construct a `ctx` per project.

## Why
First slice of #333 (multi-window project isolation). Today, opening two windows on different projects has them quietly stomping each other's RDF store. This PR removes the module-level state from graph/index.ts so a second project can co-exist; subsequent PRs give the same treatment to `tables.ts` and `search/index.ts`, then add the acquire/release lifecycle that disposes per-project state when the last window for a project closes.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1460/1460 passing
- [ ] Smoke: open a project, edit notes, run a SPARQL query — confirm no behavior change for the single-window case
- [ ] Smoke: open two windows on the same project — confirm graph operations still work in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)