### PR TITLE
search/tables: per-project state (#333, PR 2 of 3)

### DIFF
--- a/src/main/compute/executors/sql.ts
+++ b/src/main/compute/executors/sql.ts
@@ -7,6 +7,7 @@
  */
 
 import { runQuery } from '../../sources/tables';
+import { projectContext } from '../../project-context-types';
 import type { ExecutorFn } from '../registry';
 
 /**
@@ -17,8 +18,8 @@ import type { ExecutorFn } from '../registry';
  * BigInts stringify (DuckDB returns INTEGER columns as BigInt); Dates
  * become ISO strings; everything else passes through as-is.
  */
-export const executeSql: ExecutorFn = async (code) => {
-  const response = await runQuery(code);
+export const executeSql: ExecutorFn = async (code, ctx) => {
+  const response = await runQuery(projectContext(ctx.rootPath), code);
   if (!response.ok) return { ok: false, error: response.error };
   return {
     ok: true,

--- a/src/main/formatter/orchestrator.ts
+++ b/src/main/formatter/orchestrator.ts
@@ -115,8 +115,9 @@ async function writeThrough(
   content: string,
 ): Promise<void> {
   await notebaseFs.writeFile(rootPath, relativePath, content);
-  await graph.indexNote(projectContext(rootPath), relativePath, content);
-  search.indexNote(relativePath, content);
+  const ctx = projectContext(rootPath);
+  await graph.indexNote(ctx, relativePath, content);
+  search.indexNote(ctx, relativePath, content);
   // Caller is responsible for the batched persist + NOTEBASE_REWRITTEN
   // broadcast — doing it per-file in a folder run would thrash the
   // editor's open-tab refresh path.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -109,16 +109,18 @@ function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null {
 async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
   if (!isIndexable(relativePath)) return;
   const content = await notebaseFs.readFile(rootPath, relativePath);
-  await graph.indexNote(projectContext(rootPath), relativePath, content);
+  const ctx = projectContext(rootPath);
+  await graph.indexNote(ctx, relativePath, content);
   if (relativePath.endsWith('.md')) {
-    search.indexNote(relativePath, content);
+    search.indexNote(ctx, relativePath, content);
   }
 }
 
 function removeFromIndexes(rootPath: string, relativePath: string): void {
   if (!isIndexable(relativePath)) return;
-  search.removeNote(relativePath);
-  graph.removeNote(projectContext(rootPath), relativePath);
+  const ctx = projectContext(rootPath);
+  search.removeNote(ctx, relativePath);
+  graph.removeNote(ctx, relativePath);
 }
 
 async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {
@@ -140,7 +142,8 @@ async function listIndexableFiles(rootPath: string, relDir: string): Promise<str
 }
 
 async function persistIndexes(rootPath: string): Promise<void> {
-  await Promise.all([search.persist(), graph.persistGraph(projectContext(rootPath))]);
+  const ctx = projectContext(rootPath);
+  await Promise.all([search.persist(ctx), graph.persistGraph(ctx)]);
 }
 
 export function registerIpcHandlers(): void {
@@ -260,10 +263,11 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
     await notebaseFs.writeFile(rootPath, relativePath, content);
-    const { headingRenameCandidate } = await graph.indexNote(projectContext(rootPath), relativePath, content);
-    await graph.persistGraph(projectContext(rootPath));
-    search.indexNote(relativePath, content);
-    await search.persist();
+    const ctx = projectContext(rootPath);
+    const { headingRenameCandidate } = await graph.indexNote(ctx, relativePath, content);
+    await graph.persistGraph(ctx);
+    search.indexNote(ctx, relativePath, content);
+    await search.persist(ctx);
     // If a heading edit looks like a rename with affected incoming links,
     // offer to rewrite them. The renderer pops the confirmation; approval
     // routes back through NOTEBASE_RENAME_ANCHOR.
@@ -279,8 +283,9 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
     await notebaseFs.createFile(rootPath, relativePath);
-    await graph.indexNote(projectContext(rootPath), relativePath, '');
-    search.indexNote(relativePath, '');
+    const ctx = projectContext(rootPath);
+    await graph.indexNote(ctx, relativePath, '');
+    search.indexNote(ctx, relativePath, '');
   });
 
   ipcMain.handle(Channels.NOTEBASE_DELETE_FILE, async (e, relativePath: string) => {
@@ -311,12 +316,13 @@ export function registerIpcHandlers(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
 
+    const ctx = projectContext(rootPath);
     const { transitions, rewrittenPaths } = await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
       markPathHandled,
       reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
       },
-      removeHook: (relPath) => search.removeNote(relPath),
+      removeHook: (relPath) => search.removeNote(ctx, relPath),
     });
 
     // Broadcast to every window showing this project so their editor tabs
@@ -343,10 +349,11 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.NOTEBASE_RENAME_SOURCE, async (e, oldId: string, newId: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
+    const ctx = projectContext(rootPath);
     const { rewrittenPaths } = await renameSource(rootPath, oldId, newId, {
       markPathHandled,
       reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
       },
     });
     broadcastRewritten(rootPath, rewrittenPaths);
@@ -357,10 +364,11 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.NOTEBASE_RENAME_EXCERPT, async (e, oldId: string, newId: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
+    const ctx = projectContext(rootPath);
     const { rewrittenPaths } = await renameExcerpt(rootPath, oldId, newId, {
       markPathHandled,
       reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
       },
     });
     broadcastRewritten(rootPath, rewrittenPaths);
@@ -374,10 +382,11 @@ export function registerIpcHandlers(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
 
+      const ctx = projectContext(rootPath);
       const { rewrittenPaths } = await renameAnchor(rootPath, targetRelativePath, oldSlug, newSlug, {
         markPathHandled,
         reindexHook: (relPath, content) => {
-          if (relPath.endsWith('.md')) search.indexNote(relPath, content);
+          if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
         },
       });
 
@@ -473,8 +482,10 @@ export function registerIpcHandlers(): void {
   });
 
   // Search
-  ipcMain.handle(Channels.SEARCH_QUERY, (_e, query: string) => {
-    return search.search(query);
+  ipcMain.handle(Channels.SEARCH_QUERY, (e, query: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return search.search(projectContext(rootPath), query);
   });
 
   // Git
@@ -499,12 +510,16 @@ export function registerIpcHandlers(): void {
   });
 
   // Tables (DuckDB)
-  ipcMain.handle(Channels.TABLES_QUERY, async (_e, sql: string) => {
-    return tables.runQuery(sql);
+  ipcMain.handle(Channels.TABLES_QUERY, async (e, sql: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return { ok: false, error: 'No project open' };
+    return tables.runQuery(projectContext(rootPath), sql);
   });
 
-  ipcMain.handle(Channels.TABLES_LIST, async () => {
-    return tables.listTables();
+  ipcMain.handle(Channels.TABLES_LIST, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return tables.listTables(projectContext(rootPath));
   });
 
   ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, (e) => {
@@ -706,8 +721,9 @@ export function registerIpcHandlers(): void {
     // conflict handling as a link rewrite).
     markPathHandled(relativePath);
     await notebaseFs.writeFile(rootPath, relativePath, plan.content);
-    await graph.indexNote(projectContext(rootPath), relativePath, plan.content);
-    search.indexNote(relativePath, plan.content);
+    const ctx = projectContext(rootPath);
+    await graph.indexNote(ctx, relativePath, plan.content);
+    search.indexNote(ctx, relativePath, plan.content);
     await persistIndexes(rootPath);
     broadcastRewritten(rootPath, [relativePath]);
     return { added: plan.added };
@@ -734,8 +750,9 @@ export function registerIpcHandlers(): void {
 
       markPathHandled(activeRelPath);
       await notebaseFs.writeFile(rootPath, activeRelPath, content);
-      await graph.indexNote(projectContext(rootPath), activeRelPath, content);
-      search.indexNote(activeRelPath, content);
+      const ctx = projectContext(rootPath);
+      await graph.indexNote(ctx, activeRelPath, content);
+      search.indexNote(ctx, activeRelPath, content);
       await persistIndexes(rootPath);
       broadcastRewritten(rootPath, [activeRelPath]);
       return { applied, skipped };
@@ -1033,11 +1050,12 @@ export function registerIpcHandlers(): void {
       );
 
       // Write each touched source note through the standard index/search/broadcast pipeline.
+      const ctx = projectContext(rootPath);
       for (const [source, content] of updatedContents) {
         markPathHandled(source);
         await notebaseFs.writeFile(rootPath, source, content);
-        await graph.indexNote(projectContext(rootPath), source, content);
-        search.indexNote(source, content);
+        await graph.indexNote(ctx, source, content);
+        search.indexNote(ctx, source, content);
       }
       if (touchedPaths.length > 0) {
         await persistIndexes(rootPath);

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -158,7 +158,7 @@ export async function executeNotebaseTool(
   try {
     switch (name) {
       case 'search_notes':
-        return { content: await runSearch(input), isError: false };
+        return { content: await runSearch(ctx, input), isError: false };
       case 'read_note':
         return { content: await runRead(ctx, input), isError: false };
       case 'query_graph':
@@ -174,12 +174,12 @@ export async function executeNotebaseTool(
   }
 }
 
-async function runSearch(input: unknown): Promise<string> {
+async function runSearch(ctx: ToolContext, input: unknown): Promise<string> {
   const { query, limit } = input as { query: string; limit?: number };
   if (typeof query !== 'string' || !query.trim()) {
     throw new Error('query is required');
   }
-  const results = search.search(query, { limit: limit ?? 10 });
+  const results = search.search(projectContext(ctx.rootPath), query, { limit: limit ?? 10 });
   if (results.length === 0) {
     return `No results for "${query}".`;
   }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -215,10 +215,11 @@ export function rebuildMenu(): void {
             if (!win) return;
             const rootPath = getRootPath(win.id);
             if (!rootPath) return;
+            const ctx = projectContext(rootPath);
             await Promise.all([
-              graph.indexAllNotes(projectContext(rootPath)),
-              search.indexAllNotes(rootPath),
-              tables.registerAllCsvs(rootPath),
+              graph.indexAllNotes(ctx),
+              search.indexAllNotes(ctx),
+              tables.registerAllCsvs(ctx),
             ]);
             if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
           },

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -2,26 +2,47 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import type { SearchProvider, SearchResult } from './types';
 import { MiniSearchProvider } from './minisearch-provider';
+import type { ProjectContext } from '../project-context-types';
 
-let provider: SearchProvider = new MiniSearchProvider();
-let currentRootPath: string | null = null;
-
-function indexPath(): string {
-  return path.join(currentRootPath!, '.minerva', 'search-index.json');
+interface SearchState {
+  rootPath: string;
+  provider: SearchProvider;
 }
 
-export async function initSearch(rootPath: string): Promise<void> {
-  currentRootPath = rootPath;
-  await provider.load(indexPath());
+const states = new Map<string, SearchState>();
+
+function getState(ctx: ProjectContext): SearchState | null {
+  return states.get(ctx.rootPath) ?? null;
 }
 
-export async function indexAllNotes(rootPath: string): Promise<number> {
-  currentRootPath = rootPath;
-  provider.clear();
+function indexPath(state: SearchState): string {
+  return path.join(state.rootPath, '.minerva', 'search-index.json');
+}
+
+export async function initSearch(ctx: ProjectContext): Promise<void> {
+  let state = states.get(ctx.rootPath);
+  if (!state) {
+    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider() };
+    states.set(ctx.rootPath, state);
+  }
+  await state.provider.load(indexPath(state));
+}
+
+export async function disposeProject(ctx: ProjectContext): Promise<void> {
+  states.delete(ctx.rootPath);
+}
+
+export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
+  let state = states.get(ctx.rootPath);
+  if (!state) {
+    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider() };
+    states.set(ctx.rootPath, state);
+  }
+  state.provider.clear();
 
   let count = 0;
-  await walk(rootPath, rootPath);
-  await provider.save(indexPath());
+  await walk(state.rootPath, state.rootPath);
+  await state.provider.save(indexPath(state));
 
   async function walk(dirPath: string, root: string) {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
@@ -34,7 +55,7 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
         const relativePath = path.relative(root, fullPath);
         const content = await fs.readFile(fullPath, 'utf-8');
         const title = extractTitle(content) ?? path.basename(relativePath, '.md');
-        provider.index(relativePath, title, content);
+        state!.provider.index(relativePath, title, content);
         count++;
       }
     }
@@ -43,22 +64,29 @@ export async function indexAllNotes(rootPath: string): Promise<number> {
   return count;
 }
 
-export function indexNote(relativePath: string, content: string): void {
+export function indexNote(ctx: ProjectContext, relativePath: string, content: string): void {
+  const state = getState(ctx);
+  if (!state) return;
   const title = extractTitle(content) ?? path.basename(relativePath, '.md');
-  provider.index(relativePath, title, content);
+  state.provider.index(relativePath, title, content);
 }
 
-export function removeNote(relativePath: string): void {
-  provider.remove(relativePath);
+export function removeNote(ctx: ProjectContext, relativePath: string): void {
+  const state = getState(ctx);
+  if (!state) return;
+  state.provider.remove(relativePath);
 }
 
-export function search(query: string, opts?: { limit?: number }): SearchResult[] {
-  return provider.search(query, opts);
+export function search(ctx: ProjectContext, query: string, opts?: { limit?: number }): SearchResult[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  return state.provider.search(query, opts);
 }
 
-export async function persist(): Promise<void> {
-  if (!currentRootPath) return;
-  await provider.save(indexPath());
+export async function persist(ctx: ProjectContext): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  await state.provider.save(indexPath(state));
 }
 
 /** Simple title extraction matching what the graph parser does */

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -3,25 +3,23 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
-import { projectContext } from '../project-context-types';
+import type { ProjectContext } from '../project-context-types';
 
-function activeCtx() {
-  if (!currentRootPath) throw new Error('Tables DB is not initialized — no project open');
-  return projectContext(currentRootPath);
+interface TablesState {
+  rootPath: string;
+  instance: DuckDBInstance;
+  connection: DuckDBConnection;
+  /** relativePath → tableName for the currently-registered CSV views. */
+  pathToTable: Map<string, string>;
+  /** tableName → relativePath, so we can detect + warn on collisions. */
+  tableToPath: Map<string, string>;
 }
 
-// ── Module state ────────────────────────────────────────────────────────────
-// Matches the `graph` module: single live project at a time. If Minerva ever
-// grows true multi-project-per-process, both modules move in lockstep.
+const states = new Map<string, TablesState>();
 
-let instance: DuckDBInstance | null = null;
-let connection: DuckDBConnection | null = null;
-let currentRootPath: string | null = null;
-
-/** relativePath → tableName for the currently-registered CSV views. */
-const pathToTable = new Map<string, string>();
-/** tableName → relativePath, so we can detect + warn on collisions. */
-const tableToPath = new Map<string, string>();
+function getState(ctx: ProjectContext): TablesState | null {
+  return states.get(ctx.rootPath) ?? null;
+}
 
 export type QueryResult =
   | { ok: true; columns: string[]; rows: Record<string, unknown>[] }
@@ -34,23 +32,26 @@ export interface TableInfo {
   rowCount: number;
 }
 
-/** Open an in-memory DuckDB for the given project root. Idempotent per root. */
-export async function initTablesDb(rootPath: string): Promise<void> {
-  if (currentRootPath === rootPath && connection) return;
-  await closeTablesDb();
-  instance = await DuckDBInstance.create(':memory:');
-  connection = await instance.connect();
-  currentRootPath = rootPath;
+/** Open an in-memory DuckDB for the given project. Idempotent per project. */
+export async function initTablesDb(ctx: ProjectContext): Promise<void> {
+  if (states.has(ctx.rootPath)) return;
+  const instance = await DuckDBInstance.create(':memory:');
+  const connection = await instance.connect();
+  states.set(ctx.rootPath, {
+    rootPath: ctx.rootPath,
+    instance,
+    connection,
+    pathToTable: new Map(),
+    tableToPath: new Map(),
+  });
 }
 
-export async function closeTablesDb(): Promise<void> {
-  try { connection?.closeSync(); } catch { /* already closed */ }
-  try { instance?.closeSync(); } catch { /* already closed */ }
-  connection = null;
-  instance = null;
-  currentRootPath = null;
-  pathToTable.clear();
-  tableToPath.clear();
+export async function disposeProject(ctx: ProjectContext): Promise<void> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return;
+  try { state.connection.closeSync(); } catch { /* already closed */ }
+  try { state.instance.closeSync(); } catch { /* already closed */ }
+  states.delete(ctx.rootPath);
 }
 
 /**
@@ -58,10 +59,11 @@ export async function closeTablesDb(): Promise<void> {
  * clone across the IPC boundary. Malformed SQL or runtime errors come back
  * as `{ ok: false, error }` — never thrown.
  */
-export async function runQuery(sql: string): Promise<QueryResult> {
-  if (!connection) return { ok: false, error: 'Tables DB is not initialized' };
+export async function runQuery(ctx: ProjectContext, sql: string): Promise<QueryResult> {
+  const state = getState(ctx);
+  if (!state) return { ok: false, error: 'Tables DB is not initialized' };
   try {
-    const reader = await connection.runAndReadAll(sql);
+    const reader = await state.connection.runAndReadAll(sql);
     const columns = reader.columnNames();
     const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
     return { ok: true, columns, rows };
@@ -129,8 +131,10 @@ async function readCompanionOverride(rootPath: string, relativePath: string): Pr
  * re-registration. Re-register is called when the file is added or when the
  * companion note's `table_name:` may have changed.
  */
-export async function registerCsv(rootPath: string, relativePath: string): Promise<void> {
-  if (!connection) return;
+export async function registerCsv(ctx: ProjectContext, relativePath: string): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  const { rootPath, connection, pathToTable, tableToPath } = state;
   const override = await readCompanionOverride(rootPath, relativePath);
   const tableName = override ?? deriveTableName(relativePath);
 
@@ -154,7 +158,7 @@ export async function registerCsv(rootPath: string, relativePath: string): Promi
       await connection.run(`DROP VIEW IF EXISTS "${previousName}"`);
     } catch { /* tolerate the rare rename race */ }
     tableToPath.delete(previousName);
-    unindexCsvTable(activeCtx(), previousName);
+    unindexCsvTable(ctx, previousName);
   }
 
   const absPath = path.join(rootPath, relativePath);
@@ -168,7 +172,7 @@ export async function registerCsv(rootPath: string, relativePath: string): Promi
     // Reflect the shape into the knowledge graph (CSVW + OWL). This
     // lets SPARQL consumers ask "what tables do I have?", "what columns
     // does X expose?", and reason about column datatypes.
-    await indexCsvTableShape(relativePath, tableName);
+    await indexCsvTableShape(ctx, relativePath, tableName);
   } catch (err) {
     console.warn(
       `[tables] Failed to register '${relativePath}' as '${tableName}': ` +
@@ -183,11 +187,12 @@ export async function registerCsv(rootPath: string, relativePath: string): Promi
  * don't throw — the CSV is still queryable via SQL even if the graph
  * entry didn't land.
  */
-async function indexCsvTableShape(relativePath: string, tableName: string): Promise<void> {
-  if (!connection) return;
+async function indexCsvTableShape(ctx: ProjectContext, relativePath: string, tableName: string): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
   const safeName = tableName.replace(/'/g, "''");
   try {
-    const reader = await connection.runAndReadAll(
+    const reader = await state.connection.runAndReadAll(
       `SELECT column_name, data_type, ordinal_position ` +
       `FROM information_schema.columns ` +
       `WHERE table_name = '${safeName}' AND table_schema = 'main' ` +
@@ -200,7 +205,7 @@ async function indexCsvTableShape(relativePath: string, tableName: string): Prom
       // ordinal_position is 1-based in DuckDB; we publish 0-based.
       index: Number(r.ordinal_position) - 1,
     }));
-    indexCsvTable(activeCtx(), { tableName, relativePath, columns });
+    indexCsvTable(ctx, { tableName, relativePath, columns });
   } catch (err) {
     console.warn(
       `[tables] Failed to index '${tableName}' into graph: ` +
@@ -210,8 +215,10 @@ async function indexCsvTableShape(relativePath: string, tableName: string): Prom
 }
 
 /** Drop the view for a CSV path. No-op if the path was never registered. */
-export async function unregisterCsv(relativePath: string): Promise<void> {
-  if (!connection) return;
+export async function unregisterCsv(ctx: ProjectContext, relativePath: string): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  const { connection, pathToTable, tableToPath } = state;
   const tableName = pathToTable.get(relativePath);
   if (!tableName) return;
   try {
@@ -219,19 +226,21 @@ export async function unregisterCsv(relativePath: string): Promise<void> {
   } catch { /* view may already be gone */ }
   pathToTable.delete(relativePath);
   tableToPath.delete(tableName);
-  unindexCsvTable(activeCtx(), tableName);
+  unindexCsvTable(ctx, tableName);
 }
 
 /**
  * Scan the thoughtbase on project open and register every `.csv` file under
  * the root. Mirrors graph.indexAllNotes's walker shape.
  */
-export async function registerAllCsvs(rootPath: string): Promise<number> {
-  if (!connection) return 0;
+export async function registerAllCsvs(ctx: ProjectContext): Promise<number> {
+  const state = getState(ctx);
+  if (!state) return 0;
+  const { rootPath } = state;
   // Wipe stale CSV-table triples up front so CSVs deleted while the app
   // was closed don't linger in the graph after a full rescan. Each
   // registered CSV writes its own triples as it goes.
-  unindexAllCsvTables(activeCtx());
+  unindexAllCsvTables(ctx);
   let count = 0;
   async function walk(dirPath: string) {
     let entries: import('node:fs').Dirent[];
@@ -247,7 +256,7 @@ export async function registerAllCsvs(rootPath: string): Promise<number> {
         await walk(fullPath);
       } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.csv')) {
         const rel = path.relative(rootPath, fullPath);
-        await registerCsv(rootPath, rel);
+        await registerCsv(ctx, rel);
         count++;
       }
     }
@@ -257,13 +266,14 @@ export async function registerAllCsvs(rootPath: string): Promise<number> {
 }
 
 /** Every registered CSV's table name, relative path, column names, and row count. */
-export async function listTables(): Promise<TableInfo[]> {
-  if (!connection) return [];
+export async function listTables(ctx: ProjectContext): Promise<TableInfo[]> {
+  const state = getState(ctx);
+  if (!state) return [];
   const out: TableInfo[] = [];
-  for (const [relativePath, name] of pathToTable.entries()) {
+  for (const [relativePath, name] of state.pathToTable.entries()) {
     const quoted = `"${name}"`;
-    const countR = await runQuery(`SELECT COUNT(*) AS n FROM ${quoted}`);
-    const colsR = await runQuery(
+    const countR = await runQuery(ctx, `SELECT COUNT(*) AS n FROM ${quoted}`);
+    const colsR = await runQuery(ctx,
       `SELECT column_name FROM information_schema.columns ` +
       `WHERE table_name = '${name.replace(/'/g, "''")}' AND table_schema = 'main' ` +
       `ORDER BY ordinal_position`,
@@ -277,6 +287,6 @@ export async function listTables(): Promise<TableInfo[]> {
 }
 
 /** Exposed for tests. */
-export function _isOpen(): boolean {
-  return connection !== null;
+export function _isOpen(ctx: ProjectContext): boolean {
+  return states.has(ctx.rootPath);
 }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -149,7 +149,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   const debouncedPersist = () => {
     if (indexPersistTimer) clearTimeout(indexPersistTimer);
     indexPersistTimer = setTimeout(async () => {
-      await Promise.all([search.persist(), graph.persistGraph(projectCtx)]);
+      await Promise.all([search.persist(projectCtx), graph.persistGraph(projectCtx)]);
     }, 1000);
   };
 
@@ -162,14 +162,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       // pipeline means a graph indexing hiccup can't skip table registration.
       if (relativePath.toLowerCase().endsWith('.csv')) {
         try {
-          await tables.registerCsv(rootPath, relativePath);
+          await tables.registerCsv(projectCtx, relativePath);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       }
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(projectCtx, relativePath, content);
-        search.indexNote(relativePath, content);
+        search.indexNote(projectCtx, relativePath, content);
         debouncedPersist();
       } catch (err) {
         // Usually a race (file deleted between events), but log so real bugs
@@ -181,14 +181,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (wasHandled(relativePath)) return;
       if (relativePath.toLowerCase().endsWith('.csv')) {
         try {
-          await tables.registerCsv(rootPath, relativePath);
+          await tables.registerCsv(projectCtx, relativePath);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       }
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(projectCtx, relativePath, content);
-        search.indexNote(relativePath, content);
+        search.indexNote(projectCtx, relativePath, content);
         debouncedPersist();
       } catch (err) {
         console.warn(`[watcher] indexing failed for ${relativePath}:`, err);
@@ -198,12 +198,12 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (wasHandled(relativePath)) return;
       if (relativePath.toLowerCase().endsWith('.csv')) {
         try {
-          await tables.unregisterCsv(relativePath);
+          await tables.unregisterCsv(projectCtx, relativePath);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
       }
       try {
-        search.removeNote(relativePath);
+        search.removeNote(projectCtx, relativePath);
         graph.removeNote(projectCtx, relativePath);
       } catch (err) {
         console.warn(`[watcher] removeNote failed for ${relativePath}:`, err);
@@ -245,12 +245,12 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   watchers.set(win.id, rootPath);
 
   await graph.initGraph(projectCtx);
-  await tables.initTablesDb(rootPath);
+  await tables.initTablesDb(projectCtx);
   conversation.initConversations(rootPath);
   await Promise.all([
     graph.indexAllNotes(projectCtx),
-    search.indexAllNotes(rootPath),
-    tables.registerAllCsvs(rootPath),
+    search.indexAllNotes(projectCtx),
+    tables.registerAllCsvs(projectCtx),
   ]);
   // Tables panel subscribes to this; fires once after the initial scan so the
   // sidebar populates without the renderer having to poll.

--- a/tests/main/compute/sql-executor.test.ts
+++ b/tests/main/compute/sql-executor.test.ts
@@ -5,28 +5,31 @@ import path from 'node:path';
 import os from 'node:os';
 import {
   initTablesDb,
-  closeTablesDb,
+  disposeProject,
   registerCsv,
 } from '../../../src/main/sources/tables';
 import { executeSql } from '../../../src/main/compute/executors/sql';
-
-const CTX = { rootPath: '/tmp/minerva-sql-exec-test' };
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 describe('executeSql (#240)', () => {
   let root: string;
+  let ctx: ProjectContext;
+  let CTX: { rootPath: string };
 
   beforeAll(async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sql-exec-test-'));
-    await initTablesDb(root);
+    ctx = projectContext(root);
+    CTX = { rootPath: root };
+    await initTablesDb(ctx);
     await fsp.writeFile(
       path.join(root, 'data.csv'),
       'name,count\nalpha,1\nbeta,2\ngamma,3\n',
     );
-    await registerCsv(root, 'data.csv');
+    await registerCsv(ctx, 'data.csv');
   });
 
   afterAll(async () => {
-    await closeTablesDb();
+    await disposeProject(ctx);
     await fsp.rm(root, { recursive: true, force: true });
   });
 

--- a/tests/main/sources/tables-csv.test.ts
+++ b/tests/main/sources/tables-csv.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import {
   initTablesDb,
-  closeTablesDb,
+  disposeProject,
   runQuery,
   registerCsv,
   unregisterCsv,
@@ -13,6 +13,7 @@ import {
   listTables,
   deriveTableName,
 } from '../../../src/main/sources/tables';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tables-csv-test-'));
@@ -55,14 +56,16 @@ describe('deriveTableName (#233)', () => {
 
 describe('CSV pipeline: register / list / unregister (#233)', () => {
   let root: string;
+  let ctx: ProjectContext;
 
   beforeEach(async () => {
     root = mkTempProject();
-    await initTablesDb(root);
+    ctx = projectContext(root);
+    await initTablesDb(ctx);
   });
 
   afterEach(async () => {
-    await closeTablesDb();
+    await disposeProject(ctx);
     await fsp.rm(root, { recursive: true, force: true });
   });
 
@@ -74,13 +77,13 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
 
   it('registers a CSV and makes it queryable', async () => {
     await writeCsv('stations.csv', 'id,name,lat\n1,Alpha,0.1\n2,Beta,0.2\n3,Gamma,0.3\n');
-    await registerCsv(root, 'stations.csv');
+    await registerCsv(ctx, 'stations.csv');
 
-    const result = await runQuery(`SELECT COUNT(*) AS n FROM stations`);
+    const result = await runQuery(ctx, `SELECT COUNT(*) AS n FROM stations`);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.rows[0]).toEqual({ n: 3n });
 
-    const detail = await runQuery(`SELECT id, name FROM stations ORDER BY id`);
+    const detail = await runQuery(ctx, `SELECT id, name FROM stations ORDER BY id`);
     expect(detail.ok).toBe(true);
     if (detail.ok) {
       // read_csv_auto infers integer columns as BIGINT, so id values are
@@ -95,9 +98,9 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
 
   it('derives nested table names from the relative path', async () => {
     await writeCsv('data/2024-experiment.csv', 'x,y\n1,2\n3,4\n');
-    await registerCsv(root, 'data/2024-experiment.csv');
+    await registerCsv(ctx, 'data/2024-experiment.csv');
 
-    const result = await runQuery(`SELECT SUM(x) AS s FROM data_2024_experiment`);
+    const result = await runQuery(ctx, `SELECT SUM(x) AS s FROM data_2024_experiment`);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.rows[0]).toEqual({ s: 4n });
   });
@@ -110,34 +113,34 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
       '---\ntitle: 2024 readings\ntable_name: experiment_2024\n---\n\n# Notes about the 2024 batch\n',
       'utf-8',
     );
-    await registerCsv(root, 'data/2024-experiment.csv');
+    await registerCsv(ctx, 'data/2024-experiment.csv');
 
-    const hit = await runQuery(`SELECT * FROM experiment_2024`);
+    const hit = await runQuery(ctx, `SELECT * FROM experiment_2024`);
     expect(hit.ok).toBe(true);
     if (hit.ok) expect(hit.rows).toEqual([{ x: 1n, y: 2n }]);
 
     // The derived name should NOT also exist.
-    const derived = await runQuery(`SELECT * FROM data_2024_experiment`);
+    const derived = await runQuery(ctx, `SELECT * FROM data_2024_experiment`);
     expect(derived.ok).toBe(false);
   });
 
   it('unregisterCsv drops the view', async () => {
     await writeCsv('scratch.csv', 'a\n1\n');
-    await registerCsv(root, 'scratch.csv');
-    expect((await runQuery(`SELECT * FROM scratch`)).ok).toBe(true);
+    await registerCsv(ctx, 'scratch.csv');
+    expect((await runQuery(ctx, `SELECT * FROM scratch`)).ok).toBe(true);
 
-    await unregisterCsv('scratch.csv');
-    const gone = await runQuery(`SELECT * FROM scratch`);
+    await unregisterCsv(ctx, 'scratch.csv');
+    const gone = await runQuery(ctx, `SELECT * FROM scratch`);
     expect(gone.ok).toBe(false);
   });
 
   it('listTables returns registered CSVs with row/column counts', async () => {
     await writeCsv('a.csv', 'x,y\n1,2\n3,4\n');
     await writeCsv('nested/b.csv', 'p,q,r\n1,2,3\n');
-    await registerCsv(root, 'a.csv');
-    await registerCsv(root, 'nested/b.csv');
+    await registerCsv(ctx, 'a.csv');
+    await registerCsv(ctx, 'nested/b.csv');
 
-    const tables = await listTables();
+    const tables = await listTables(ctx);
     expect(tables).toHaveLength(2);
 
     const a = tables.find((t) => t.name === 'a');
@@ -153,17 +156,17 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
     // Hidden dir — should be skipped.
     await writeCsv('.minerva/secret.csv', 'x\n1\n');
 
-    const count = await registerAllCsvs(root);
+    const count = await registerAllCsvs(ctx);
     expect(count).toBe(3);
 
-    const tables = await listTables();
+    const tables = await listTables(ctx);
     expect(tables.map((t) => t.name).sort()).toEqual(['sub_deep_bottom', 'sub_mid', 'top']);
   });
 
   it('re-registering after a table_name override swaps the view name', async () => {
     await writeCsv('readings.csv', 'x\n1\n');
-    await registerCsv(root, 'readings.csv');
-    expect((await runQuery(`SELECT * FROM readings`)).ok).toBe(true);
+    await registerCsv(ctx, 'readings.csv');
+    expect((await runQuery(ctx, `SELECT * FROM readings`)).ok).toBe(true);
 
     // Now add a companion note with an override and re-register.
     await fsp.writeFile(
@@ -171,9 +174,9 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
       '---\ntable_name: measurements\n---\n',
       'utf-8',
     );
-    await registerCsv(root, 'readings.csv');
+    await registerCsv(ctx, 'readings.csv');
 
-    expect((await runQuery(`SELECT * FROM measurements`)).ok).toBe(true);
-    expect((await runQuery(`SELECT * FROM readings`)).ok).toBe(false);
+    expect((await runQuery(ctx, `SELECT * FROM measurements`)).ok).toBe(true);
+    expect((await runQuery(ctx, `SELECT * FROM readings`)).ok).toBe(false);
   });
 });

--- a/tests/main/sources/tables.test.ts
+++ b/tests/main/sources/tables.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { initTablesDb, closeTablesDb, runQuery } from '../../../src/main/sources/tables';
+import { initTablesDb, disposeProject, runQuery } from '../../../src/main/sources/tables';
+import { projectContext } from '../../../src/main/project-context-types';
+
+const ctx = projectContext('/tmp/minerva-tables-test');
 
 describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
   beforeAll(async () => {
-    await initTablesDb('/tmp/minerva-tables-test');
+    await initTablesDb(ctx);
   });
 
   afterAll(async () => {
-    await closeTablesDb();
+    await disposeProject(ctx);
   });
 
   it('runs the trivial round-trip query', async () => {
-    const result = await runQuery(`SELECT 'hello' AS greeting`);
+    const result = await runQuery(ctx, `SELECT 'hello' AS greeting`);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.columns).toEqual(['greeting']);
@@ -20,7 +23,7 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
   });
 
   it('returns structured error on malformed SQL instead of throwing', async () => {
-    const result = await runQuery('SELEKT * FROM nothing');
+    const result = await runQuery(ctx, 'SELEKT * FROM nothing');
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toMatch(/syntax|parser|SELEKT/i);
@@ -28,7 +31,7 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
   });
 
   it('returns structured error when a table is missing', async () => {
-    const result = await runQuery('SELECT * FROM no_such_table');
+    const result = await runQuery(ctx, 'SELECT * FROM no_such_table');
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toMatch(/no_such_table|not found|does not exist/i);
@@ -36,7 +39,7 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
   });
 
   it('handles multi-row / multi-column results with typed values', async () => {
-    const result = await runQuery(`
+    const result = await runQuery(ctx, `
       SELECT * FROM (VALUES
         (1, 'alpha', TRUE),
         (2, 'beta', FALSE),
@@ -53,21 +56,27 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
     }
   });
 
-  it('init is idempotent for the same root', async () => {
-    await initTablesDb('/tmp/minerva-tables-test');
-    const result = await runQuery(`SELECT 42 AS answer`);
+  it('init is idempotent for the same project', async () => {
+    await initTablesDb(ctx);
+    const result = await runQuery(ctx, `SELECT 42 AS answer`);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.rows[0]).toEqual({ answer: 42 });
   });
 
-  it('re-init on a different root closes the previous connection', async () => {
-    await runQuery(`CREATE TABLE scratch (x INTEGER)`);
-    await runQuery(`INSERT INTO scratch VALUES (1), (2)`);
-    const before = await runQuery(`SELECT COUNT(*) AS n FROM scratch`);
-    expect(before.ok).toBe(true);
+  it('two projects keep their tables isolated', async () => {
+    const otherCtx = projectContext('/tmp/minerva-tables-test-other');
+    await initTablesDb(otherCtx);
+    try {
+      await runQuery(ctx, `CREATE TABLE scratch (x INTEGER)`);
+      await runQuery(ctx, `INSERT INTO scratch VALUES (1), (2)`);
+      const inFirst = await runQuery(ctx, `SELECT COUNT(*) AS n FROM scratch`);
+      expect(inFirst.ok).toBe(true);
 
-    await initTablesDb('/tmp/minerva-tables-test-other');
-    const after = await runQuery(`SELECT COUNT(*) AS n FROM scratch`);
-    expect(after.ok).toBe(false);
+      // The second project doesn't see the first project's table.
+      const inSecond = await runQuery(otherCtx, `SELECT COUNT(*) AS n FROM scratch`);
+      expect(inSecond.ok).toBe(false);
+    } finally {
+      await disposeProject(otherCtx);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Refactors `src/main/search/index.ts` and `src/main/sources/tables.ts` to key state (MiniSearch provider; DuckDB connection + view maps) by rootPath via a per-project state map, mirroring the shape graph/index.ts already has.
- Public functions take `ctx: ProjectContext` first; the old `closeTablesDb`/single-active-project pattern is replaced with `disposeProject(ctx)`.
- Production callers (window-manager, ipc, menu, formatter, llm/tools, compute/executors/sql) updated in the same change.
- The tables test "re-init on a different root closes the previous connection" was inverted into "two projects keep their tables isolated" — that's the intended invariant under multi-window.

## Why
Second slice of #333. After PR 1 made the RDF graph multi-project-safe, the tables/search modules were the remaining module-level singletons that two windows would silently fight over. With this PR, the only thing left to add is the lifecycle (PR 3): an acquire/release that calls `disposeProject` on the last window-close for a given project.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1460/1460 passing
- [ ] Smoke: open two windows on different projects — confirm SQL/search/tables in each window don't leak into the other
- [ ] Smoke: register a CSV in window A, confirm it isn't visible from window B (different project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)