### PR TITLE
project-context: acquire/release lifecycle (closes #333, PR 3 of 3)

### DIFF
--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -1,0 +1,102 @@
+/**
+ * Runtime registry for ProjectContext (#333).
+ *
+ * Tracks which BrowserWindows have a given project open, so per-project
+ * subsystem state (graph, tables, search, conversation, health-checks)
+ * can be initialized once when the first window opens the project and
+ * disposed when the last window closes it.
+ *
+ * Window-manager is the only caller. It acquires on `openProjectInWindow`
+ * and releases on close.
+ */
+
+import * as graph from './graph/index';
+import * as search from './search/index';
+import * as tables from './sources/tables';
+import * as healthChecks from './graph/health-checks';
+import * as conversation from './llm/conversation';
+import { projectContext, type ProjectContext } from './project-context-types';
+
+interface ProjectRecord {
+  ctx: ProjectContext;
+  rootPath: string;
+  /** winIds currently holding this project open. */
+  acquirers: Set<number>;
+  /** First-acquire init: shared between concurrent acquirers so they all
+   * await the same initialisation before continuing. */
+  initPromise: Promise<void>;
+}
+
+const projects = new Map<string, ProjectRecord>();
+
+/** Test/diagnostic visibility — number of windows holding `rootPath` open. */
+export function refCountFor(rootPath: string): number {
+  return projects.get(rootPath)?.acquirers.size ?? 0;
+}
+
+/** Test/diagnostic visibility — every project currently held open. */
+export function activeProjects(): string[] {
+  return [...projects.keys()];
+}
+
+/**
+ * Acquire a project for a window. First acquirer triggers full init
+ * (graph + tables + search + conversation + health-checks). Subsequent
+ * acquirers reuse the in-flight or completed init promise — they wait
+ * for it but don't re-run it.
+ */
+export async function acquireProject(rootPath: string, winId: number): Promise<ProjectContext> {
+  let rec = projects.get(rootPath);
+  if (!rec) {
+    const ctx = projectContext(rootPath);
+    const initPromise = (async () => {
+      await graph.initGraph(ctx);
+      await tables.initTablesDb(ctx);
+      conversation.initConversations(rootPath);
+      await Promise.all([
+        graph.indexAllNotes(ctx),
+        search.indexAllNotes(ctx),
+        tables.registerAllCsvs(ctx),
+      ]);
+      // Health checks run once at open, then a periodic timer takes over.
+      healthChecks.runAllChecks(ctx);
+      healthChecks.startPeriodicChecks(ctx);
+    })();
+    rec = { ctx, rootPath, acquirers: new Set(), initPromise };
+    projects.set(rootPath, rec);
+  }
+  rec.acquirers.add(winId);
+  await rec.initPromise;
+  return rec.ctx;
+}
+
+/**
+ * Release a project from a window. When the last acquirer drops, persist
+ * once and dispose every per-project state map.
+ */
+export async function releaseProject(rootPath: string, winId: number): Promise<void> {
+  const rec = projects.get(rootPath);
+  if (!rec) return;
+  rec.acquirers.delete(winId);
+  if (rec.acquirers.size > 0) return;
+
+  // Last window closed for this project — dispose.
+  healthChecks.stopPeriodicChecks(rec.ctx);
+  // Best-effort final persist before tearing down state. A failure here
+  // shouldn't block disposal — the on-disk graph is already up to date
+  // through the debounced persist that runs while the window is open.
+  try {
+    await Promise.all([search.persist(rec.ctx), graph.persistGraph(rec.ctx)]);
+  } catch (err) {
+    console.warn(`[project-context] final persist failed for ${rootPath}:`, err);
+  }
+  await tables.disposeProject(rec.ctx);
+  await search.disposeProject(rec.ctx);
+  graph.disposeProject(rec.ctx);
+  projects.delete(rootPath);
+}
+
+/** Resolve the live ProjectContext for a rootPath, if currently held. */
+export function getProjectContext(rootPath: string): ProjectContext | null {
+  return projects.get(rootPath)?.ctx ?? null;
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -6,13 +6,12 @@ import { startWatching, stopWatching } from './notebase/watcher';
 import * as graph from './graph/index';
 import * as search from './search/index';
 import * as notebaseFs from './notebase/fs';
-import * as conversation from './llm/conversation';
-import * as healthChecks from './graph/health-checks';
 import * as tables from './sources/tables';
 import { addRecentProject } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
-import { projectContext, type ProjectContext } from './project-context-types';
+import { acquireProject, releaseProject } from './project-context';
+import type { ProjectContext } from './project-context-types';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -87,7 +86,13 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
       stopWatching(win.id);
       watchers.delete(win.id);
     }
+    const heldRoot = contexts.get(win.id)?.rootPath ?? null;
     contexts.delete(win.id);
+    if (heldRoot) {
+      // Fire-and-forget: window's already gone; the release just disposes
+      // shared state if this was the last acquirer.
+      void releaseProject(heldRoot, win.id);
+    }
     persistSession();
   });
 
@@ -127,14 +132,20 @@ export function windowsForProject(rootPath: string): BrowserWindow[] {
 export async function openProjectInWindow(win: BrowserWindow, rootPath: string): Promise<void> {
   const ctx = getContext(win.id);
 
-  // Tear down previous
+  // Tear down previous: stop the watcher, and if the window already held a
+  // (different) project, release that project's reference. If the window
+  // was on the same project, no-op — we're effectively reloading.
   if (watchers.has(win.id)) {
     stopWatching(win.id);
     watchers.delete(win.id);
   }
+  const previousRoot = ctx.rootPath;
+  if (previousRoot && previousRoot !== rootPath) {
+    await releaseProject(previousRoot, win.id);
+  }
 
   ctx.rootPath = rootPath;
-  const projectCtx: ProjectContext = projectContext(rootPath);
+  const projectCtx: ProjectContext = await acquireProject(rootPath, win.id);
   addRecentProject(rootPath);
   rebuildMenu();
 
@@ -244,20 +255,11 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   });
   watchers.set(win.id, rootPath);
 
-  await graph.initGraph(projectCtx);
-  await tables.initTablesDb(projectCtx);
-  conversation.initConversations(rootPath);
-  await Promise.all([
-    graph.indexAllNotes(projectCtx),
-    search.indexAllNotes(projectCtx),
-    tables.registerAllCsvs(projectCtx),
-  ]);
-  // Tables panel subscribes to this; fires once after the initial scan so the
-  // sidebar populates without the renderer having to poll.
+  // Tables panel subscribes to this; fires once after the project's initial
+  // scan so this window's sidebar populates without the renderer having to
+  // poll. (For the second+ window on a project, the data is already
+  // registered, but the renderer still needs a kick to load it.)
   if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
-  // Run health checks after initial indexing, then periodically
-  healthChecks.runAllChecks(projectCtx);
-  healthChecks.startPeriodicChecks(projectCtx);
   persistSession();
 }
 
@@ -268,7 +270,11 @@ export function closeProjectInWindow(winId: number): void {
       stopWatching(winId);
       watchers.delete(winId);
     }
+    const previousRoot = ctx.rootPath;
     ctx.rootPath = null;
+    if (previousRoot) {
+      void releaseProject(previousRoot, winId);
+    }
   }
   rebuildMenu();
   persistSession();

--- a/tests/main/project-context.test.ts
+++ b/tests/main/project-context.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  acquireProject,
+  releaseProject,
+  refCountFor,
+  activeProjects,
+  getProjectContext,
+} from '../../src/main/project-context';
+import { queryGraph } from '../../src/main/graph/index';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-project-context-test-'));
+}
+
+describe('project-context lifecycle (#333)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkTempProject();
+  });
+
+  afterEach(async () => {
+    // Belt and suspenders: drain the registry so the next test starts clean.
+    // Iterate `activeProjects()` and release every winId we used during the
+    // test. The test set keeps to a small range of synthetic ids.
+    for (const r of [...activeProjects()]) {
+      for (const id of [1, 2, 3, 999]) await releaseProject(r, id);
+    }
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('first acquire initialises the project, second acquire reuses it', async () => {
+    const ctxA = await acquireProject(root, 1);
+    expect(refCountFor(root)).toBe(1);
+
+    const ctxB = await acquireProject(root, 2);
+    // Second acquirer gets the *same* ProjectContext instance — identity
+    // matters because it's used as a Map key in subsystem state.
+    expect(ctxB).toBe(ctxA);
+    expect(refCountFor(root)).toBe(2);
+  });
+
+  it('releasing all acquirers disposes the graph state', async () => {
+    await acquireProject(root, 1);
+    await acquireProject(root, 2);
+
+    // Sanity: querying the graph works while held.
+    const ctx = getProjectContext(root)!;
+    const live = await queryGraph(ctx, 'SELECT * WHERE { ?s ?p ?o } LIMIT 1');
+    expect(live.error).toBeUndefined();
+
+    await releaseProject(root, 1);
+    expect(refCountFor(root)).toBe(1);
+    expect(getProjectContext(root)).not.toBeNull();
+
+    await releaseProject(root, 2);
+    expect(refCountFor(root)).toBe(0);
+    expect(getProjectContext(root)).toBeNull();
+
+    // After full release, queryGraph against a no-state ctx returns the
+    // empty-binding sentinel rather than throwing.
+    const after = await queryGraph(ctx, 'SELECT * WHERE { ?s ?p ?o }');
+    expect(after.results).toEqual([]);
+  });
+
+  it('two projects open simultaneously stay isolated', async () => {
+    const root2 = mkTempProject();
+    try {
+      const ctxA = await acquireProject(root, 1);
+      const ctxB = await acquireProject(root2, 2);
+      expect(ctxA).not.toBe(ctxB);
+      expect(activeProjects().sort()).toEqual([root, root2].sort());
+      await releaseProject(root, 1);
+      expect(activeProjects()).toEqual([root2]);
+    } finally {
+      await releaseProject(root2, 2);
+      await fsp.rm(root2, { recursive: true, force: true });
+    }
+  });
+
+  it('release on a winId that never acquired is a no-op', async () => {
+    await acquireProject(root, 1);
+    await releaseProject(root, 999);
+    expect(refCountFor(root)).toBe(1);
+    await releaseProject(root, 1);
+    expect(refCountFor(root)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/main/project-context.ts` — runtime registry that maintains a refcount of windows per rootPath. First acquirer runs full project init (graph, tables, search, conversation, health-checks); subsequent acquirers reuse the in-flight or completed init promise.
- Last release disposes graph/search/tables per-project state and stops the periodic health-check timer (best-effort final persist on the way out).
- `window-manager.openProjectInWindow` now `await acquireProject(...)` — the inline init/index/health-check calls move into `acquireProject`, so opening a second window on the same project skips re-indexing. Window close + `closeProjectInWindow` both release.
- 4 new lifecycle tests cover refcounting, isolation between two projects, and full disposal on last release.

## Why
Closes #333. PR 1 and PR 2 made graph/search/tables per-project; this PR adds the lifecycle that disposes them. Together: Minerva can now hold multiple projects open concurrently across windows without state collisions.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1464/1464 passing (1460 existing + 4 new lifecycle tests)
- [ ] Smoke: open project A in window 1, open project B in window 2 — confirm graph/search/tables in each window stay isolated
- [ ] Smoke: open project A in two windows; close one — the other should still work; close the second — disposal should run cleanly
- [ ] Smoke: switch a window from project A to project B — A's state disposes if no other window held it

🤖 Generated with [Claude Code](https://claude.com/claude-code)