### PR TITLE
trust: wire enterLLMContext + crystallize affectsNode (closes #331)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -115,9 +115,12 @@ export function disposeProject(ctx: ProjectContext): void {
 // ── LLM Write Guard ───────────────────────────────────────────────────────
 // Tracks whether the current call path originates from an LLM operation.
 // Direct graph writes from LLM context that bypass the approval engine
-// are logged as warnings during development.
+// are logged as warnings during development. Approval engine wraps its
+// own writes in the *trusted* counter so its in-LLM-context writes don't
+// trigger the warning.
 
 let llmContextDepth = 0;
+let trustedContextDepth = 0;
 
 /** Mark the start of an LLM-originated operation. Nest-safe. */
 export function enterLLMContext(): void {
@@ -135,12 +138,30 @@ export function isInLLMContext(): boolean {
 }
 
 /**
- * Add a triple to the store with write-guard checking.
- * In LLM context, logs a warning unless the write is to a Proposal node.
+ * Mark the start of a trusted graph mutation — i.e. one going through the
+ * approval engine. Used by approval.ts to wrap its own parseIntoStore /
+ * removeMatchingTriples calls so the write guard doesn't flag them.
  */
-// `guardedAdd` removed — unused since landing. The trust-principle
-// enforcement work in #331 will reintroduce a similar check at the
-// approval-engine boundary, not as an opt-in store wrapper.
+export function enterTrustedContext(): void {
+  trustedContextDepth++;
+}
+
+export function exitTrustedContext(): void {
+  if (trustedContextDepth > 0) trustedContextDepth--;
+}
+
+/** Dev-time guard. Logs once per offending call when an LLM-originated
+ *  call path mutates the graph without going through the approval engine.
+ *  No-op in trusted context (proposeWrite / approveProposal / approval-only
+ *  mutators) and outside LLM context. */
+function checkLLMWriteGuard(operation: string): void {
+  if (!isInLLMContext()) return;
+  if (trustedContextDepth > 0) return;
+  console.warn(
+    `[trust-guard] ${operation} called from LLM context outside the approval engine. ` +
+    `LLM-originated writes must go through proposeWrite()/approveProposal().`,
+  );
+}
 
 // ── Project config (persisted in .minerva/config.json) ─────────────────────
 
@@ -461,6 +482,7 @@ export async function indexNote(
   relativePath: string,
   content: string,
 ): Promise<{ headingRenameCandidate?: HeadingRenameCandidate }> {
+  checkLLMWriteGuard('indexNote');
   const state = getState(ctx);
   if (!state) return {};
   // Any successful exit through this function has mutated the rdflib
@@ -778,6 +800,7 @@ function xsdForDuckDbType(duckdbType: string) {
  *   so SPARQL queries can reason about columns-as-predicates.
  */
 export function indexCsvTable(ctx: ProjectContext, shape: CsvTableShape): void {
+  checkLLMWriteGuard('indexCsvTable');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -820,6 +843,7 @@ export function indexCsvTable(ctx: ProjectContext, shape: CsvTableShape): void {
 
 /** Remove all triples for a CSV table (entire named graph). */
 export function unindexCsvTable(ctx: ProjectContext, tableName: string): void {
+  checkLLMWriteGuard('unindexCsvTable');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -834,6 +858,7 @@ export function unindexCsvTable(ctx: ProjectContext, tableName: string): void {
  * markdown-embedded csvw:Table nodes don't carry — those stay.
  */
 export function unindexAllCsvTables(ctx: ProjectContext): void {
+  checkLLMWriteGuard('unindexAllCsvTables');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -958,6 +983,7 @@ function indexCsvFile(
 }
 
 export function removeNote(ctx: ProjectContext, relativePath: string): void {
+  checkLLMWriteGuard('removeNote');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -975,6 +1001,7 @@ export function removeNote(ctx: ProjectContext, relativePath: string): void {
 // to that URI so users can write `this: a thought:Article ; dc:title ...`.
 
 export function indexSource(ctx: ProjectContext, sourceId: string, metaTtl: string, bodyMd?: string): void {
+  checkLLMWriteGuard('indexSource');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -1035,6 +1062,7 @@ function indexSourceBody(
 }
 
 export function removeSource(ctx: ProjectContext, sourceId: string): void {
+  checkLLMWriteGuard('removeSource');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -1065,6 +1093,7 @@ export function parseSourceIdFromPath(relativePath: string): string | null {
 //       thought:page 42 .
 
 export function indexExcerpt(ctx: ProjectContext, excerptId: string, metaTtl: string): void {
+  checkLLMWriteGuard('indexExcerpt');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -1091,6 +1120,7 @@ export function indexExcerpt(ctx: ProjectContext, excerptId: string, metaTtl: st
 }
 
 export function removeExcerpt(ctx: ProjectContext, excerptId: string): void {
+  checkLLMWriteGuard('removeExcerpt');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -1750,6 +1780,7 @@ export async function persistGraph(ctx: ProjectContext): Promise<void> {
 
 /** Parse a Turtle string and add its triples to the store. Used by the approval engine. */
 export function parseIntoStore(ctx: ProjectContext, turtle: string): void {
+  checkLLMWriteGuard('parseIntoStore');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
@@ -1771,6 +1802,7 @@ export function removeMatchingTriples(
   subjectIri: string,
   predicateIri: string,
 ): void {
+  checkLLMWriteGuard('removeMatchingTriples');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1113,6 +1113,7 @@ export function registerIpcHandlers(): void {
     const controller = new AbortController();
     convAbortControllers.set(win.id, controller);
 
+    graph.enterLLMContext();
     try {
       const conv = await conversation.appendMessage(convId, 'user', userMessage);
 
@@ -1154,6 +1155,7 @@ export function registerIpcHandlers(): void {
       return updated;
     } finally {
       convAbortControllers.delete(win.id);
+      graph.exitLLMContext();
     }
   });
 

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -21,8 +21,13 @@ export interface ProposedWrite {
   turtleDiff: string;
   /** Human-readable description */
   note: string;
-  /** URI of the node being created or modified */
-  affectsNodeUri?: string;
+  /**
+   * URIs of the nodes being created or modified by this proposal. The
+   * "Trust: Unreviewed LLM writes" stock query joins on
+   * `thought:affectsNode`, so every component the proposal mutates must
+   * appear here for the integrity check to find the proposal.
+   */
+  affectsNodeUris?: string[];
   /** URI of the conversation that produced this proposal */
   conversationUri?: string;
   /** Agent identifier */
@@ -37,7 +42,7 @@ export interface Proposal {
   operationType: string;
   turtleDiff: string;
   note: string;
-  affectsNodeUri?: string;
+  affectsNodeUris: string[];
   conversationUri?: string;
   proposedBy: string;
   proposedAt: string;
@@ -102,7 +107,7 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
     operationType: write.operationType,
     turtleDiff: write.turtleDiff,
     note: write.note,
-    affectsNodeUri: write.affectsNodeUri,
+    affectsNodeUris: write.affectsNodeUris ?? [],
     conversationUri: write.conversationUri,
     proposedBy: write.proposedBy,
     proposedAt: now,
@@ -178,7 +183,9 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
 
   const results = await graph.queryGraph(ctx, `
     PREFIX thought: <${THOUGHT}>
-    SELECT ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff ?affectsNode ?conversation WHERE {
+    SELECT ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff
+           (GROUP_CONCAT(DISTINCT ?affectsNode; separator="\\u001f") AS ?affectsNodes)
+           ?conversation WHERE {
       ?proposal a thought:Proposal .
       ?proposal thought:proposalStatus ?statusNode .
       BIND(REPLACE(STR(?statusNode), "${THOUGHT}", "") AS ?status)
@@ -192,6 +199,7 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
       OPTIONAL { ?proposal thought:affectsNode ?affectsNode }
       OPTIONAL { ?proposal thought:conversationRef ?conversation }
     }
+    GROUP BY ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff ?conversation
     ORDER BY DESC(?proposedAt)
   `);
 
@@ -201,7 +209,7 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
     operationType: r.operationType,
     turtleDiff: r.turtleDiff,
     note: r.note,
-    affectsNodeUri: r.affectsNode,
+    affectsNodeUris: splitAffectsNodes(r.affectsNodes),
     conversationUri: r.conversation,
     proposedBy: r.proposedBy,
     proposedAt: r.proposedAt,
@@ -234,13 +242,18 @@ export async function getProposal(ctx: ProjectContext, uri: string): Promise<Pro
   if (rows.length === 0) return null;
 
   const r = rows[0];
+  // Multiple affectsNode rows show up as multiple result rows (one per URI).
+  // Collect them all rather than just the first.
+  const affectsNodeUris = Array.from(
+    new Set(rows.map(row => row.affectsNode).filter((u): u is string => Boolean(u)))
+  );
   return {
     uri,
     status: r.status as Proposal['status'],
     operationType: r.operationType,
     turtleDiff: r.turtleDiff,
     note: r.note,
-    affectsNodeUri: r.affectsNode,
+    affectsNodeUris,
     conversationUri: r.conversation,
     proposedBy: r.proposedBy,
     proposedAt: r.proposedAt,
@@ -248,9 +261,18 @@ export async function getProposal(ctx: ProjectContext, uri: string): Promise<Pro
   };
 }
 
+/** Split the GROUP_CONCAT result for affectsNode URIs back into a list. */
+function splitAffectsNodes(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split('').filter(Boolean);
+}
+
 // ── Internal Helpers ───────────────────────────────────────────────────────
 
 async function writeProposalToGraph(ctx: ProjectContext, p: Proposal): Promise<void> {
+  const affectsNodeTriples = p.affectsNodeUris
+    .map(u => `; thought:affectsNode <${u}>`)
+    .join('\n      ');
   const turtle = `
     <${p.uri}> a thought:Proposal ;
       thought:proposalStatus thought:${p.status} ;
@@ -260,7 +282,7 @@ async function writeProposalToGraph(ctx: ProjectContext, p: Proposal): Promise<v
       thought:proposedAt "${p.proposedAt}"^^xsd:dateTime ;
       thought:autoExpires "${p.autoExpires}"^^xsd:dateTime ;
       thought:proposalDiff "${escapeTurtle(p.turtleDiff)}"
-      ${p.affectsNodeUri ? `; thought:affectsNode <${p.affectsNodeUri}>` : ''}
+      ${affectsNodeTriples}
       ${p.conversationUri ? `; thought:conversationRef <${p.conversationUri}>` : ''} .
   `;
   await applyTurtle(ctx, turtle);
@@ -271,7 +293,12 @@ async function updateProposalStatus(ctx: ProjectContext, uri: string, newStatus:
   // before adding the new one — otherwise the proposal accumulates
   // {pending, approved, ...} markers and history queries return all
   // historical states (#332).
-  graph.removeMatchingTriples(ctx, uri, `${THOUGHT}proposalStatus`);
+  graph.enterTrustedContext();
+  try {
+    graph.removeMatchingTriples(ctx, uri, `${THOUGHT}proposalStatus`);
+  } finally {
+    graph.exitTrustedContext();
+  }
   await applyTurtle(ctx, `<${uri}> thought:proposalStatus thought:${newStatus} .`);
 }
 
@@ -287,7 +314,15 @@ async function applyTurtle(ctx: ProjectContext, turtle: string): Promise<void> {
     @prefix prov: <http://www.w3.org/ns/prov#> .
     ${turtle}
   `;
-  graph.parseIntoStore(ctx, prefixed);
+  // Approval engine writes are the *only* in-LLM-context writes that
+  // shouldn't trip the trust guard. Everything else flowing through
+  // parseIntoStore from an LLM call site is a bug we want to know about.
+  graph.enterTrustedContext();
+  try {
+    graph.parseIntoStore(ctx, prefixed);
+  } finally {
+    graph.exitTrustedContext();
+  }
   await graph.persistGraph(ctx);
 }
 

--- a/src/main/llm/auto-link.ts
+++ b/src/main/llm/auto-link.ts
@@ -99,31 +99,36 @@ export async function suggestLinksTo(
   rootPath: string,
   activeRelPath: string,
 ): Promise<AutoLinkSuggestResult> {
-  const activeContent = await notebaseFs.readFile(rootPath, activeRelPath);
-  const parsed = parseMarkdown(activeContent);
-  const activeBody = activeContent.replace(/^---\n[\s\S]*?\n---\n?/, '');
-  const activeTitle = parsed.title || activeRelPath.replace(/\.md$/i, '').split('/').pop() || activeRelPath;
+  graph.enterLLMContext();
+  try {
+    const activeContent = await notebaseFs.readFile(rootPath, activeRelPath);
+    const parsed = parseMarkdown(activeContent);
+    const activeBody = activeContent.replace(/^---\n[\s\S]*?\n---\n?/, '');
+    const activeTitle = parsed.title || activeRelPath.replace(/\.md$/i, '').split('/').pop() || activeRelPath;
 
-  const candidates = await listAutoLinkCandidates(rootPath, activeRelPath);
-  if (candidates.length === 0) {
-    return { suggestions: [], candidateCount: 0 };
+    const candidates = await listAutoLinkCandidates(rootPath, activeRelPath);
+    if (candidates.length === 0) {
+      return { suggestions: [], candidateCount: 0 };
+    }
+
+    const prompt = buildAutoLinkToPrompt({
+      activeTitle,
+      activeBody,
+      candidates,
+    });
+
+    const { model } = await getSettings();
+    const raw = await complete(prompt, { model });
+    const validTargets = new Set(candidates.map((c) => c.relativePath));
+    const suggestions = parseAutoLinkResponse(raw, validTargets);
+
+    // Keep only suggestions whose anchor text actually appears in the active
+    // body — otherwise the apply step would silently drop them anyway.
+    const filtered = suggestions.filter((s) => activeBody.includes(s.anchorText));
+    return { suggestions: filtered, candidateCount: candidates.length };
+  } finally {
+    graph.exitLLMContext();
   }
-
-  const prompt = buildAutoLinkToPrompt({
-    activeTitle,
-    activeBody,
-    candidates,
-  });
-
-  const { model } = await getSettings();
-  const raw = await complete(prompt, { model });
-  const validTargets = new Set(candidates.map((c) => c.relativePath));
-  const suggestions = parseAutoLinkResponse(raw, validTargets);
-
-  // Keep only suggestions whose anchor text actually appears in the active
-  // body — otherwise the apply step would silently drop them anyway.
-  const filtered = suggestions.filter((s) => activeBody.includes(s.anchorText));
-  return { suggestions: filtered, candidateCount: candidates.length };
 }
 
 /** Rewrites the active note with accepted suggestions. Returns the new content + bookkeeping. */
@@ -132,8 +137,13 @@ export async function applyAutoLinkToSuggestions(
   activeRelPath: string,
   accepted: AutoLinkSuggestion[],
 ): Promise<{ content: string; applied: AutoLinkSuggestion[]; skipped: AutoLinkSuggestion[] }> {
-  const current = await notebaseFs.readFile(rootPath, activeRelPath);
-  return applyLinkInsertions(current, accepted);
+  graph.enterLLMContext();
+  try {
+    const current = await notebaseFs.readFile(rootPath, activeRelPath);
+    return applyLinkInsertions(current, accepted);
+  } finally {
+    graph.exitLLMContext();
+  }
 }
 
 // ── Inbound mode (#175 follow-up) ─────────────────────────────────────────
@@ -222,6 +232,18 @@ export async function suggestLinksInbound(
   rootPath: string,
   activeRelPath: string,
 ): Promise<AutoLinkInboundResult> {
+  graph.enterLLMContext();
+  try {
+    return await suggestLinksInboundInner(rootPath, activeRelPath);
+  } finally {
+    graph.exitLLMContext();
+  }
+}
+
+async function suggestLinksInboundInner(
+  rootPath: string,
+  activeRelPath: string,
+): Promise<AutoLinkInboundResult> {
   const activeContent = await notebaseFs.readFile(rootPath, activeRelPath);
   const parsedActive = parseMarkdown(activeContent);
   const activeBody = activeContent.replace(/^---\n[\s\S]*?\n---\n?/, '');
@@ -291,6 +313,19 @@ export interface ApplyInboundResult {
  * to persist. The caller is responsible for the write + reindex + broadcast.
  */
 export async function applyInboundSuggestions(
+  rootPath: string,
+  activeRelPath: string,
+  accepted: AutoLinkInboundSuggestion[],
+): Promise<ApplyInboundResult> {
+  graph.enterLLMContext();
+  try {
+    return await applyInboundSuggestionsInner(rootPath, activeRelPath, accepted);
+  } finally {
+    graph.exitLLMContext();
+  }
+}
+
+async function applyInboundSuggestionsInner(
   rootPath: string,
   activeRelPath: string,
   accepted: AutoLinkInboundSuggestion[],

--- a/src/main/llm/auto-tag.ts
+++ b/src/main/llm/auto-tag.ts
@@ -28,32 +28,37 @@ export async function runAutoTag(
   rootPath: string,
   relativePath: string,
 ): Promise<AutoTagPlan> {
-  const content = await notebaseFs.readFile(rootPath, relativePath);
-  const parsed = parseMarkdown(content);
+  graph.enterLLMContext();
+  try {
+    const content = await notebaseFs.readFile(rootPath, relativePath);
+    const parsed = parseMarkdown(content);
 
-  const thoughtbaseTags = graph.listTags(projectContext(rootPath)).map((t) => t.tag);
-  const existingNoteTags: string[] = [];
-  if (Array.isArray(parsed.frontmatter.tags)) {
-    for (const t of parsed.frontmatter.tags) {
-      if (typeof t === 'string') existingNoteTags.push(t);
+    const thoughtbaseTags = graph.listTags(projectContext(rootPath)).map((t) => t.tag);
+    const existingNoteTags: string[] = [];
+    if (Array.isArray(parsed.frontmatter.tags)) {
+      for (const t of parsed.frontmatter.tags) {
+        if (typeof t === 'string') existingNoteTags.push(t);
+      }
     }
+
+    const noteBody = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+    const prompt = buildAutoTagPrompt({
+      noteTitle: parsed.title ?? '',
+      noteBody,
+      existingNoteTags,
+      thoughtbaseTags,
+    });
+
+    const { model } = await getSettings();
+    const raw = await complete(prompt, { model });
+    const suggested = parseAutoTagResponse(raw);
+    if (suggested.length === 0) return { added: [], content: null };
+
+    const { content: next, addedTags } = mergeTagsIntoContent(content, suggested);
+    if (addedTags.length === 0) return { added: [], content: null };
+
+    return { added: addedTags, content: next };
+  } finally {
+    graph.exitLLMContext();
   }
-
-  const noteBody = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
-  const prompt = buildAutoTagPrompt({
-    noteTitle: parsed.title ?? '',
-    noteBody,
-    existingNoteTags,
-    thoughtbaseTags,
-  });
-
-  const { model } = await getSettings();
-  const raw = await complete(prompt, { model });
-  const suggested = parseAutoTagResponse(raw);
-  if (suggested.length === 0) return { added: [], content: null };
-
-  const { content: next, addedTags } = mergeTagsIntoContent(content, suggested);
-  if (addedTags.length === 0) return { added: [], content: null };
-
-  return { added: addedTags, content: next };
 }

--- a/src/main/llm/crystallize.ts
+++ b/src/main/llm/crystallize.ts
@@ -1,5 +1,6 @@
 import { complete } from './index';
 import { proposeWrite } from './approval';
+import * as graph from '../graph/index';
 import type { ProjectContext } from '../project-context-types';
 
 const CRYSTALLIZATION_PROMPT = `You are an epistemic analyst. Given the following conversation excerpt, extract structured thought components using the Minerva thought ontology.
@@ -45,33 +46,74 @@ export async function crystallize(
   proposedBy: string = 'llm:crystallization',
   model?: string,
 ): Promise<CrystallizationResult> {
-  const prompt = `${CRYSTALLIZATION_PROMPT}
+  graph.enterLLMContext();
+  try {
+    const prompt = `${CRYSTALLIZATION_PROMPT}
 
 ## Conversation Excerpt
 
 ${text}`;
 
-  const turtle = await complete(prompt, model ? { model } : undefined);
-  const trimmed = turtle.trim();
+    const turtle = await complete(prompt, model ? { model } : undefined);
+    const trimmed = turtle.trim();
 
-  if (!trimmed) {
-    return { turtle: '', componentCount: 0 };
+    if (!trimmed) {
+      return { turtle: '', componentCount: 0 };
+    }
+
+    // Count rough number of components (rdf:type declarations)
+    const componentCount = (trimmed.match(/rdf:type\s+thought:/g) || []).length;
+
+    // Add grounding to the conversation
+    const groundedTurtle = `${trimmed}`;
+
+    // Pull every absolute IRI subject out of the LLM's Turtle so the
+    // resulting Proposal carries thought:affectsNode for every component
+    // it creates. The "Trust: Unreviewed LLM writes" stock query joins
+    // proposals to components on this predicate — without it, every
+    // crystallized component is a false-positive trust violation.
+    const affectsNodeUris = extractSubjectIris(groundedTurtle);
+
+    await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      turtleDiff: groundedTurtle,
+      note: `Crystallized ${componentCount} thought component${componentCount !== 1 ? 's' : ''} from conversation`,
+      conversationUri,
+      proposedBy,
+      affectsNodeUris,
+    });
+
+    return { turtle: groundedTurtle, componentCount };
+  } finally {
+    graph.exitLLMContext();
   }
+}
 
-  // Count rough number of components (rdf:type declarations)
-  const componentCount = (trimmed.match(/rdf:type\s+thought:/g) || []).length;
-
-  // Add grounding to the conversation
-  const groundedTurtle = `${trimmed}`;
-
-  // Route through approval engine as component_creation
-  await proposeWrite(ctx, {
-    operationType: 'component_creation',
-    turtleDiff: groundedTurtle,
-    note: `Crystallized ${componentCount} thought component${componentCount !== 1 ? 's' : ''} from conversation`,
-    conversationUri,
-    proposedBy,
-  });
-
-  return { turtle: groundedTurtle, componentCount };
+/**
+ * Extract every absolute-IRI subject from a Turtle blob. Used by
+ * crystallize to enumerate the components a proposal will create so the
+ * proposal's thought:affectsNode triples cover all of them.
+ *
+ * Best-effort: a regex over the unparsed string. Misses subjects expressed
+ * as prefixed names (no full IRI to point at), and misses blank nodes
+ * (those have no stable URI to record). For a stricter parse, switch to
+ * the rdflib parser — but we want to record the URI before approval
+ * applies the diff, so we read the LLM's text, not the parsed store.
+ */
+export function extractSubjectIris(turtle: string): string[] {
+  const out = new Set<string>();
+  // Match `<http://...>` or `<https://...>` at the start of a triple.
+  // A "start" means after a `;`-or-`.` predicate-list terminator, after
+  // a `}` graph close, or at the beginning of the document — but the
+  // simplest practical heuristic is "an IRI followed by whitespace then
+  // anything that isn't `,`" since predicate-position IRIs follow a
+  // predicate keyword and are surrounded differently. We approximate
+  // by matching IRIs that appear at the start of a non-empty line
+  // (after optional indentation).
+  const lineHead = /^[ \t]*<((?:https?|urn):[^>\s]+)>/gm;
+  let m: RegExpExecArray | null;
+  while ((m = lineHead.exec(turtle)) !== null) {
+    out.add(m[1]);
+  }
+  return [...out];
 }

--- a/src/main/llm/decompose.ts
+++ b/src/main/llm/decompose.ts
@@ -1,5 +1,6 @@
 import * as notebaseFs from '../notebase/fs';
 import { parseMarkdown } from '../graph/parser';
+import * as graph from '../graph/index';
 import { complete } from './index';
 import { getSettings } from './settings';
 import {
@@ -31,20 +32,25 @@ export async function suggestDecomposition(
   activeRelPath: string,
   hints: DecomposeHints = {},
 ): Promise<SuggestDecompositionResult> {
-  const content = await notebaseFs.readFile(rootPath, activeRelPath);
-  const parsed = parseMarkdown(content);
-  const body = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
-  const title = parsed.title
-    || activeRelPath.replace(/\.md$/i, '').split('/').pop()
-    || activeRelPath;
+  graph.enterLLMContext();
+  try {
+    const content = await notebaseFs.readFile(rootPath, activeRelPath);
+    const parsed = parseMarkdown(content);
+    const body = content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+    const title = parsed.title
+      || activeRelPath.replace(/\.md$/i, '').split('/').pop()
+      || activeRelPath;
 
-  const prompt = buildDecomposePrompt({
-    sourceTitle: title,
-    sourceBody: body,
-    hints,
-  });
+    const prompt = buildDecomposePrompt({
+      sourceTitle: title,
+      sourceBody: body,
+      hints,
+    });
 
-  const { model } = await getSettings();
-  const raw = await complete(prompt, { model });
-  return parseDecomposeResponse(raw);
+    const { model } = await getSettings();
+    const raw = await complete(prompt, { model });
+    return parseDecomposeResponse(raw);
+  } finally {
+    graph.exitLLMContext();
+  }
 }

--- a/tests/main/llm/trust-guard.test.ts
+++ b/tests/main/llm/trust-guard.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Trust-principle wiring tests (#331).
+ *
+ * Three things this exercises:
+ *  1. The LLM-context guard fires console.warn when an LLM-originated path
+ *     mutates the graph without going through the approval engine.
+ *  2. The approval engine's writes (proposeWrite / approveProposal) do
+ *     NOT trip the guard, because they wrap their parseIntoStore calls
+ *     in trustedContext.
+ *  3. crystallize's resulting Proposal carries thought:affectsNode for
+ *     every component subject in its turtleDiff — so the
+ *     "Trust: Unreviewed LLM writes" stock query stays clean after a
+ *     normal crystallize → approve flow.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  enterLLMContext,
+  exitLLMContext,
+  enterTrustedContext,
+  exitTrustedContext,
+  parseIntoStore,
+  queryGraph,
+} from '../../../src/main/graph/index';
+import {
+  proposeWrite,
+  approveProposal,
+  resetPolicy,
+  setPolicy,
+  getProposal,
+} from '../../../src/main/llm/approval';
+import { extractSubjectIris } from '../../../src/main/llm/crystallize';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-trust-guard-test-'));
+}
+
+describe('LLM write guard (#331)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('outside LLM context: mutators are silent', async () => {
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('in LLM context: a direct indexNote (bypass) triggers a warn', async () => {
+    enterLLMContext();
+    try {
+      await indexNote(ctx, 'a.md', '# Alpha\n');
+    } finally {
+      exitLLMContext();
+    }
+    const calls = warnSpy.mock.calls.flat().map(String);
+    expect(calls.some((m) => m.includes('[trust-guard]') && m.includes('indexNote'))).toBe(true);
+  });
+
+  it('in LLM context: approval-engine writes do NOT trigger a warn', async () => {
+    // Use a tier that applies the diff immediately — any path that does so
+    // exercises the approval engine's parseIntoStore call.
+    enterLLMContext();
+    try {
+      await proposeWrite(ctx, {
+        operationType: 'tag_addition',
+        turtleDiff: '<https://ex/a> a <https://ex/T> .',
+        note: 'autonomous tier — applied directly',
+        proposedBy: 'unit-test',
+      });
+    } finally {
+      exitLLMContext();
+    }
+    // Important: NO trust-guard warning. (Other warnings, e.g. from rdflib,
+    // could in principle leak through; assert specifically on the prefix.)
+    const calls = warnSpy.mock.calls.flat().map(String);
+    expect(calls.some((m) => m.includes('[trust-guard]'))).toBe(false);
+  });
+
+  it('approveProposal of a pending proposal: no trust-guard warn', async () => {
+    enterLLMContext();
+    let proposalUri: string;
+    try {
+      const p = await proposeWrite(ctx, {
+        operationType: 'new_claim',
+        turtleDiff: '<https://ex/x> a <https://ex/Claim> .',
+        note: 'pending',
+        proposedBy: 'unit-test',
+      });
+      proposalUri = p!.uri;
+    } finally {
+      exitLLMContext();
+    }
+    // Approval can happen out-of-LLM-context (the user clicks approve), but
+    // the assertion we want is "even *if* it ran in LLM context, it stays
+    // quiet". So enter again and approve.
+    enterLLMContext();
+    try {
+      const ok = await approveProposal(ctx, proposalUri);
+      expect(ok).toBe(true);
+    } finally {
+      exitLLMContext();
+    }
+    const calls = warnSpy.mock.calls.flat().map(String);
+    expect(calls.some((m) => m.includes('[trust-guard]'))).toBe(false);
+  });
+
+  it('manually-nested trustedContext suppresses the guard', () => {
+    enterLLMContext();
+    enterTrustedContext();
+    try {
+      parseIntoStore(ctx, '<https://ex/y> a <https://ex/T> .');
+    } finally {
+      exitTrustedContext();
+      exitLLMContext();
+    }
+    const calls = warnSpy.mock.calls.flat().map(String);
+    expect(calls.some((m) => m.includes('[trust-guard]'))).toBe(false);
+  });
+});
+
+describe('crystallize provenance (#331)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('extractSubjectIris pulls every absolute-IRI subject from a Turtle blob', () => {
+    const ttl = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+
+      <https://minerva.dev/c/claim-1>
+        a thought:Claim ;
+        thought:label "Subjects matter." .
+
+      <https://minerva.dev/c/grounds-1>
+        a thought:Grounds ;
+        thought:supports <https://minerva.dev/c/claim-1> .
+    `;
+    const subs = extractSubjectIris(ttl);
+    expect(subs.sort()).toEqual([
+      'https://minerva.dev/c/claim-1',
+      'https://minerva.dev/c/grounds-1',
+    ]);
+  });
+
+  it('a proposal carries thought:affectsNode for every URI in affectsNodeUris', async () => {
+    const aUri = 'https://minerva.dev/c/alpha';
+    const bUri = 'https://minerva.dev/c/beta';
+    setPolicy('component_creation', 'requires_approval');
+    const p = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      turtleDiff: `<${aUri}> a <https://ex/T> .\n<${bUri}> a <https://ex/T> .`,
+      note: 'two components',
+      proposedBy: 'unit-test',
+      affectsNodeUris: [aUri, bUri],
+    });
+    expect(p).not.toBeNull();
+
+    const back = await getProposal(ctx, p!.uri);
+    expect(back).not.toBeNull();
+    expect(back!.affectsNodeUris.sort()).toEqual([aUri, bUri]);
+
+    // And the SPARQL view used by the integrity query: each URI is reachable
+    // from the proposal via thought:affectsNode.
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?n WHERE { <${p!.uri}> thought:affectsNode ?n . }
+    `);
+    const found = (r.results as Array<{ n: string }>).map((row) => row.n).sort();
+    expect(found).toEqual([aUri, bUri]);
+  });
+
+  it('the "Unreviewed LLM writes" integrity query stays clean after approve', async () => {
+    setPolicy('component_creation', 'requires_approval');
+    const componentUri = 'https://minerva.dev/c/c1';
+    // Mimic a crystallize-shaped proposal: LLM-attributed component +
+    // matching affectsNodeUris.
+    const turtleDiff = `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      <${componentUri}> rdf:type thought:Claim ;
+        thought:label "test" ;
+        thought:extractedBy "llm:crystallization" .
+    `;
+    const p = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      turtleDiff,
+      note: 'test',
+      proposedBy: 'unit-test',
+      affectsNodeUris: [componentUri],
+    });
+    expect(p).not.toBeNull();
+    expect(await approveProposal(ctx, p!.uri)).toBe(true);
+
+    // Same shape as the stock query "Trust: Unreviewed LLM writes":
+    // an LLM-attributed component without an approved proposal pointing
+    // at it via thought:affectsNode.
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?component WHERE {
+        ?component rdf:type/rdfs:subClassOf* thought:Component .
+        ?component thought:extractedBy ?extractedBy .
+        FILTER(CONTAINS(LCASE(?extractedBy), "llm"))
+        FILTER NOT EXISTS {
+          ?proposal rdf:type thought:Proposal .
+          ?proposal thought:affectsNode ?component .
+          ?proposal thought:proposalStatus thought:approved .
+        }
+      }
+    `);
+    expect((r.results as unknown[]).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Three changes that turn the CLAUDE.md trust principle ("LLM proposes, human confirms") into something the code actually enforces:

1. **Wire `enterLLMContext()`/`exitLLMContext()` at LLM call sites** — `auto-tag`, `auto-link` (suggest+apply, both directions), `decompose`, `crystallize`, and `ipc.ts:CONVERSATION_SEND`. Try/finally so errors don't leak the depth counter.
2. **Reintroduce the dev-time write guard.** Add a sibling `enterTrustedContext`/`exitTrustedContext` counter and have `graph/index.ts` mutators (`indexNote`, `removeNote`, `indexSource`, `removeSource`, `indexExcerpt`, `removeExcerpt`, `indexCsvTable`, `unindexCsvTable`, `unindexAllCsvTables`, `parseIntoStore`, `removeMatchingTriples`) `console.warn` when LLM context is active and trusted context is not. Approval engine wraps its own `parseIntoStore`/`removeMatchingTriples` calls in trusted context so the normal `proposeWrite`/`approveProposal` flow stays quiet.
3. **Fix crystallize provenance.** `ProposedWrite.affectsNodeUri: string` → `affectsNodeUris: string[]`; the proposal carries one `thought:affectsNode` triple per URI; crystallize parses its own Turtle blob to extract every component subject and passes the full list. Without this fix the "Trust: Unreviewed LLM writes" stock query produced false positives for every crystallized component.

## Why
Closes #331. The architecture review flagged the guardrail as cosmetic — the plumbing existed but no production code called it, and the integrity query couldn't reach crystallize-created components. Now the guardrail trips loudly during development and the integrity query is meaningful.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1472/1472 passing (1464 prior + 8 new in `trust-guard.test.ts`)
- [ ] Smoke: trigger Auto-tag in dev — should run quietly (proposeWrite path is trusted).
- [ ] Smoke: trigger Crystallize in dev — proposal should appear with `thought:affectsNode` for each component; running the "Trust: Unreviewed LLM writes" stock query after approving should return zero rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)