### PR TITLE
preview: debounce markdown + KaTeX re-render on keystroke (closes #335)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -421,10 +421,42 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     return (m[0].match(/\n/g) ?? []).length;
   }
 
-  let rendered = $derived.by(() => {
-    const stripped = stripFrontmatter(content);
-    const lineOffset = countFrontmatterLines(content);
+  // Re-rendering markdown + KaTeX + highlight.js + citeproc on every
+  // keystroke felt as typing lag in split-view once notes pass a few
+  // thousand characters (#335). Debounce: render the first frame
+  // synchronously so there's no FOUC, then coalesce subsequent
+  // changes to one render per ~120ms idle window.
+  function renderContent(c: string): string {
+    const stripped = stripFrontmatter(c);
+    const lineOffset = countFrontmatterLines(c);
     return md.render(stripped, { lineOffset });
+  }
+
+  const RENDER_DEBOUNCE_MS = 120;
+  let rendered = $state(renderContent(content));
+  let lastRendered = content;
+  let renderTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    // Track content reactively; bail if nothing actually changed since
+    // the last render commit (avoids re-running for derived state that
+    // happens to share a frame).
+    const c = content;
+    if (c === lastRendered) return;
+
+    if (renderTimer) clearTimeout(renderTimer);
+    renderTimer = setTimeout(() => {
+      rendered = renderContent(c);
+      lastRendered = c;
+      renderTimer = null;
+    }, RENDER_DEBOUNCE_MS);
+
+    return () => {
+      if (renderTimer) {
+        clearTimeout(renderTimer);
+        renderTimer = null;
+      }
+    };
   });
   let previewEl = $state<HTMLDivElement>();
   let activeCharts: ChartHandle[] = [];


### PR DESCRIPTION
## Summary
`Preview.svelte`'s `\$derived.by` re-ran markdown-it + KaTeX + highlight.js + citeproc on every content change — i.e. every keystroke in split-view. Replaced it with a state cell driven by a debounced `\$effect`:
- First frame renders synchronously (no flash of empty preview).
- Subsequent changes coalesce to one render per ~120ms idle window via a clearTimeout/setTimeout pair, with the effect's cleanup cancelling any in-flight timer.

## Why
Closes #335. P0 perf finding from the review — felt as typing lag in split-view once notes pass ~few thousand characters, worse with math/code-fences.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1472/1472 passing (no test changes; behavioral test would have to drive Electron interactively, out of scope here)
- [ ] **Smoke (manual)**: open a long note (>1k lines, ideally with KaTeX + fenced code) in split-view, type a paragraph at the bottom — should feel responsive; preview should commit ~120ms after you stop typing rather than recomputing on every keystroke.
- [ ] **Smoke (manual)**: confirm `query-block` / `cite-link` / `quote-link` post-render hooks still resolve — they're keyed on `rendered` changing, which they still do, just less often.

I cannot drive Electron interactively from here, so the latency improvement is unverified by me — it needs a manual smoke pass before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)