### PR TITLE
graph: dc:modified from disk mtime, not indexer wall clock (closes #336)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -329,6 +329,21 @@ function dateLit(iso: string): $rdf.Literal {
   return $rdf.lit(iso, undefined, XSD('dateTime'));
 }
 
+/**
+ * `dc:modified` should reflect the user's last edit, not the indexer's
+ * last sweep — otherwise checkStaleness sees every note as just-modified
+ * and is always-empty theatre (#336). Read mtime from disk; fall back to
+ * `now` only when the file is gone (mid-rename race) so the triple is
+ * still well-formed.
+ */
+function fileMtimeIso(state: GraphState, relativePath: string): string {
+  try {
+    return fsSync.statSync(path.join(state.rootPath, relativePath)).mtime.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
 const STANDARD_PREFIXES: [string, string][] = [
   ['minerva', 'https://minerva.dev/ontology#'],
   ['thought', 'https://minerva.dev/ontology/thought#'],
@@ -533,8 +548,9 @@ export async function indexNote(
   store.add(subject, MINERVA('filename'), $rdf.lit(path.basename(relativePath)), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
 
-  // Timestamps
-  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  // Timestamps — dc:modified is the user's last edit, sourced from
+  // disk mtime, not the indexer's wall clock (#336).
+  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
 
   // Folder membership
   const dir = path.dirname(relativePath);
@@ -893,7 +909,7 @@ function indexTurtleFile(
   store.add(subject, DC('title'), $rdf.lit(title), graph);
   store.add(subject, MINERVA('filename'), $rdf.lit(path.basename(relativePath)), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
-  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
 
   // Folder membership
   const dir = path.dirname(relativePath);
@@ -936,7 +952,7 @@ function indexCsvFile(
   store.add(subject, DC('title'), $rdf.lit(title), graph);
   store.add(subject, MINERVA('filename'), $rdf.lit(path.basename(relativePath)), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
-  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
 
   const dir = path.dirname(relativePath);
   if (dir && dir !== '.') {
@@ -1016,7 +1032,7 @@ export function indexSource(ctx: ProjectContext, sourceId: string, metaTtl: stri
 
   store.add(subject, MINERVA('sourceId'), $rdf.lit(sourceId), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
-  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
   store.add(projectUri(state), MINERVA('containsSource'), subject, graph);
 
   try {
@@ -1108,7 +1124,7 @@ export function indexExcerpt(ctx: ProjectContext, excerptId: string, metaTtl: st
 
   store.add(subject, MINERVA('excerptId'), $rdf.lit(excerptId), graph);
   store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
-  store.add(subject, DC('modified'), dateLit(new Date().toISOString()), graph);
+  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
   store.add(projectUri(state), MINERVA('containsExcerpt'), subject, graph);
 
   try {

--- a/tests/main/graph/staleness.test.ts
+++ b/tests/main/graph/staleness.test.ts
@@ -1,0 +1,105 @@
+/**
+ * dc:modified comes from disk mtime, not the indexer's wall clock (#336).
+ *
+ * Plant a file with a known-old mtime via fs.utimes, index it, and confirm
+ * the staleness inspection picks it up. Before this fix, every reindex
+ * stamped dc:modified to "now", so checkStaleness was always-empty theatre.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { runAllChecks } from '../../../src/main/graph/health-checks';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-staleness-test-'));
+}
+
+describe('dc:modified is sourced from disk mtime (#336)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('records the file system mtime as dc:modified, not the indexer time', async () => {
+    const oldDate = new Date('2024-01-15T10:30:00Z');
+    const filePath = path.join(root, 'old.md');
+    await fsp.writeFile(filePath, '# Old note\nContent.\n', 'utf-8');
+    await fsp.utimes(filePath, oldDate, oldDate);
+
+    await indexNote(ctx, 'old.md', '# Old note\nContent.\n');
+
+    const r = await queryGraph(ctx, `
+      SELECT ?modified WHERE {
+        ?n minerva:relativePath "old.md" ;
+           dc:modified ?modified .
+      }
+    `);
+    const rows = r.results as Array<{ modified: string }>;
+    expect(rows).toHaveLength(1);
+    // The Date may stringify with millisecond precision; compare on the
+    // calendar-day prefix to avoid filesystem-specific mtime resolution.
+    expect(rows[0].modified.startsWith('2024-01-15')).toBe(true);
+  });
+
+  it('staleness check fires for a note whose mtime is older than the threshold', async () => {
+    const old = new Date(Date.now() - 60 * 86400000); // 60 days ago
+    const fresh = new Date(Date.now() - 5 * 86400000); // 5 days ago
+
+    const oldPath = path.join(root, 'old.md');
+    const freshPath = path.join(root, 'fresh.md');
+    await fsp.writeFile(oldPath, '# Old\nContent.\n', 'utf-8');
+    await fsp.writeFile(freshPath, '# Fresh\nContent.\n', 'utf-8');
+    await fsp.utimes(oldPath, old, old);
+    await fsp.utimes(freshPath, fresh, fresh);
+
+    await indexNote(ctx, 'old.md', '# Old\nContent.\n');
+    await indexNote(ctx, 'fresh.md', '# Fresh\nContent.\n');
+
+    // Default threshold inside checkStaleness is 30 days — old.md should
+    // appear, fresh.md should not.
+    const inspections = await runAllChecks(ctx);
+    const stale = inspections.filter((i) => i.type === 'stale_note');
+    const stalePaths = stale.map((s) => s.nodeLabel);
+    expect(stalePaths).toContain('Old');
+    expect(stalePaths).not.toContain('Fresh');
+  });
+
+  it('re-indexing the same content does not bump dc:modified to now', async () => {
+    const oldDate = new Date('2024-03-01T08:00:00Z');
+    const filePath = path.join(root, 'pinned.md');
+    await fsp.writeFile(filePath, '# Pinned\n', 'utf-8');
+    await fsp.utimes(filePath, oldDate, oldDate);
+
+    // Initial index.
+    await indexNote(ctx, 'pinned.md', '# Pinned\n');
+
+    // A re-index — say from the open-project full scan, or a watcher
+    // re-event — must NOT bump the timestamp to "now". The fs mtime
+    // hasn't changed (we didn't write the file), so dc:modified must
+    // stay anchored to 2024-03-01.
+    await indexNote(ctx, 'pinned.md', '# Pinned\n');
+
+    const r = await queryGraph(ctx, `
+      SELECT ?modified WHERE {
+        ?n minerva:relativePath "pinned.md" ;
+           dc:modified ?modified .
+      }
+    `);
+    const rows = r.results as Array<{ modified: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].modified.startsWith('2024-03-01')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
`dc:modified` was being stamped with `new Date().toISOString()` at five indexer call sites — `indexNote`, `indexTurtleFile`, `indexCsvFile`, `indexSource`, `indexExcerpt`. Every reindex (open-project full scan, watcher re-event, rename rewrite) refreshed the timestamp to "now", which made `checkStaleness` in `health-checks.ts` always-empty theatre.

Replaced each call with a `fileMtimeIso(state, relativePath)` helper that reads `fs.statSync().mtime` from disk; on stat failure (mid-rename race) it falls back to `now` so the triple is still well-formed.

## Why
Closes #336. P0 graph-correctness finding from the perf review — the staleness inspection was a feature people thought existed but never fired.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1475/1475 passing (1472 prior + 3 new in `tests/main/graph/staleness.test.ts`):
  - `dc:modified` equals the on-disk mtime
  - 60-day-old note triggers stale_note inspection; 5-day-old does not
  - Re-indexing same content with unchanged mtime keeps prior `dc:modified` (regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)