### PR TITLE
ipc: SHELL_OPEN_IN_TERMINAL via spawn-with-args, no shell (closes #338)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,7 @@
 import { ipcMain, shell, dialog, BrowserWindow } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { spawn } from 'node:child_process';
 import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
 import { isIndexable } from './notebase/indexable-files';
@@ -601,13 +602,27 @@ export function registerIpcHandlers(): void {
     const dir = relativePath
       ? path.join(rootPath, path.dirname(relativePath))
       : rootPath;
-    const { exec } = require('child_process');
+    // Use spawn with explicit args (no shell) so a filename containing
+    // shell metacharacters can't inject. Detached + unref so closing the
+    // app doesn't kill the user's terminal session.
+    const detached = { stdio: 'ignore' as const, detached: true };
     if (process.platform === 'darwin') {
-      exec(`open -a Terminal "${dir}"`);
+      spawn('open', ['-a', 'Terminal', dir], detached).unref();
     } else if (process.platform === 'win32') {
-      exec(`start cmd /K "cd /d ${dir}"`);
+      // `start` is a cmd.exe builtin; the empty title arg is start's
+      // documented quirk for paths-with-spaces. /D sets the new
+      // window's starting directory — no string interpolation needed.
+      spawn('cmd.exe', ['/c', 'start', '', '/D', dir, 'cmd.exe', '/K'], detached).unref();
     } else {
-      exec(`x-terminal-emulator --working-directory="${dir}" || xterm -e "cd '${dir}' && $SHELL"`);
+      // Try the Debian-style chooser first, fall back to xterm on
+      // spawn-error (binary missing). Both get the directory through
+      // explicit args / cwd, never the shell.
+      const child = spawn('x-terminal-emulator', [`--working-directory=${dir}`], detached);
+      child.once('error', () => {
+        const shellPath = process.env.SHELL ?? '/bin/sh';
+        spawn('xterm', ['-e', shellPath], { ...detached, cwd: dir }).unref();
+      });
+      child.unref();
     }
   });
 


### PR DESCRIPTION
## Summary
`src/main/ipc.ts` had the codebase's only `require('child_process')` and used `exec()` with the project directory interpolated into a shell command string — a note path containing shell metacharacters could inject arguments. Replaced with `spawn` (ESM import) called with an explicit args array per platform:
- macOS: `open -a Terminal <dir>` — args via execvp, no shell.
- Windows: `cmd.exe /c start "" /D <dir> cmd.exe /K` — `/D` sets the new window's starting directory; the empty title is `start`'s documented quirk for paths-with-spaces.
- Linux: `x-terminal-emulator --working-directory=<dir>`; on spawn-error fall back to `xterm -e $SHELL` with `cwd: dir`.

All children spawn detached/unref so closing Minerva doesn't kill the user's terminal session.

Codebase sweep confirms this was the only `require` + `child_process` site.

## Why
Closes #338. P0 security finding from the modernization review — shell-interpolated paths in privileged code is a defense-in-depth issue even if the typical user doesn't have hostile filenames.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1475/1475 passing (no test changes; behavior is fire-and-forget on the OS terminal)
- [ ] **Smoke (manual, per platform)**: right-click a folder/note in the sidebar → "Open in Terminal" → confirm a terminal opens at the expected directory.
- [ ] **Smoke (manual)**: rename a folder so its path contains a space, then "Open in Terminal" → terminal still opens at the right place (regression check for the new arg-array form).

I cannot smoke-test the per-platform flows from here — needs a manual pass before merging. Functional behavior is unchanged on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)