### PR TITLE
security: CSP + setWindowOpenHandler + will-navigate (closes #339)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7,10 +7,12 @@ import { createWindow, openProjectInWindow } from './window-manager';
 import { loadSession } from './session';
 import { registerBuiltinExecutors } from './compute/executors';
 import { registerBuiltinExporters } from './publish';
+import { installCsp } from './security';
 
 app.setName('Minerva');
 
 app.whenReady().then(async () => {
+  installCsp();
   registerIpcHandlers();
   registerBuiltinExecutors();
   registerBuiltinExporters();

--- a/src/main/security-helpers.ts
+++ b/src/main/security-helpers.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure helpers for security.ts — kept in their own module so tests can
+ * exercise them without pulling in `electron`'s `session`/`shell`/`app`.
+ */
+
+export interface CspOptions {
+  /** When set, dev-mode loosenings (Vite origin + ws) are added. */
+  devServerOrigin?: string;
+}
+
+/** Hosts the renderer is permitted to fetch directly. Main-process API
+ *  adapters (Crossref, arXiv, PubMed, Anthropic) talk to their endpoints
+ *  in main, so renderer connect-src stays narrow. */
+export const RENDERER_FETCH_HOSTS = [
+  // tesseract.js core/wasm + worker glue. Keep both so a tesseract
+  // upgrade that switches CDN doesn't break OCR silently.
+  'https://cdn.jsdelivr.net',
+  'https://unpkg.com',
+];
+
+export function buildCsp(opts: CspOptions = {}): string {
+  const { devServerOrigin } = opts;
+  const dev = Boolean(devServerOrigin);
+  const devWs = devServerOrigin ? devServerOrigin.replace(/^https?:/, 'ws:') : '';
+
+  const directives: Record<string, string[]> = {
+    'default-src': ["'self'"],
+    // 'wasm-unsafe-eval' for tesseract.js's bundled wasm. In dev,
+    // allow the Vite origin so the bootstrap script + HMR client load.
+    'script-src': ["'self'", "'wasm-unsafe-eval'", ...(dev ? [devServerOrigin!] : [])],
+    // Svelte component styles compile to inline-style attributes; KaTeX
+    // also writes inline styles. 'unsafe-inline' for style-src is the
+    // accepted compromise — it doesn't apply to script-src.
+    'style-src': ["'self'", "'unsafe-inline'"],
+    // KaTeX bundles fonts as data URIs.
+    'font-src': ["'self'", 'data:'],
+    // User notes can embed arbitrary <img src> over https/data; allow
+    // those so quoted screenshots / reference images keep rendering.
+    'img-src': ["'self'", 'data:', 'blob:', 'https:'],
+    // Renderer-direct fetches: tesseract.js core, plus Vite HMR ws in dev.
+    'connect-src': [
+      "'self'",
+      ...RENDERER_FETCH_HOSTS,
+      ...(dev ? [devServerOrigin!, devWs] : []),
+    ],
+    // pdf.js + tesseract spawn workers from blob URLs.
+    'worker-src': ["'self'", 'blob:'],
+    // No <object>/<embed>; no <iframe> embed targets either.
+    'object-src': ["'none'"],
+    'frame-src': ["'none'"],
+    // Defense in depth: prevent the renderer from being framed.
+    'frame-ancestors': ["'none'"],
+    // Anchor `<base href="…">` tag injection can't repoint relative URLs.
+    'base-uri': ["'self'"],
+    // Form posts to anywhere are nonsensical inside a desktop app.
+    'form-action': ["'none'"],
+  };
+
+  return Object.entries(directives)
+    .map(([k, vs]) => `${k} ${vs.join(' ')}`)
+    .join('; ');
+}
+
+/** True when `url` is the app's own origin (file:// in prod, the Vite
+ *  dev server in dev). */
+export function isOwnOrigin(url: string, devServerOrigin?: string): boolean {
+  if (url.startsWith('file://')) return true;
+  if (devServerOrigin && url.startsWith(devServerOrigin)) return true;
+  return false;
+}
+
+/** Whether a URL routed through setWindowOpenHandler / will-navigate
+ *  should be deflected to the OS browser. Internal nav stays in the
+ *  app; http(s) externals get shell.openExternal; everything else
+ *  (file:, javascript:, data:, custom schemes) is dropped on the floor. */
+export function externalNavTarget(url: string): { kind: 'external'; url: string } | { kind: 'drop' } {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return { kind: 'external', url };
+  }
+  return { kind: 'drop' };
+}

--- a/src/main/security.ts
+++ b/src/main/security.ts
@@ -1,0 +1,66 @@
+/**
+ * Process-wide web-security hardening (#339).
+ *
+ *  - **CSP** via the session's onHeadersReceived hook so it covers every
+ *    document loaded into a Minerva BrowserWindow. We set it as a header
+ *    rather than a `<meta>` tag because (a) headers apply to all
+ *    subresources including the bootstrap script and (b) a header can't
+ *    be removed by injected HTML. Dev mode loosens the policy enough for
+ *    Vite's HMR + websocket; prod is strict.
+ *
+ *  - **setWindowOpenHandler** wired per-window in window-manager.ts so
+ *    `target="_blank"` and `window.open(...)` can't replace or spawn a
+ *    privileged renderer. http(s) URLs route through `shell.openExternal`;
+ *    every other scheme is denied.
+ *
+ *  - **will-navigate** wired per-window in window-manager.ts so a stray
+ *    `<a href="https://…">` click that escapes the app's click handler
+ *    can't navigate the renderer wholesale. Top-level navigation is
+ *    allowed only to the app's own origin (file:// in prod, the Vite
+ *    dev server in dev); http(s) requests get diverted to the OS browser.
+ *
+ * Pure logic lives in security-helpers.ts so tests can exercise the
+ * CSP string and routing decisions without pulling in `electron`.
+ */
+
+import { session, shell, type WebContents } from 'electron';
+import { buildCsp, externalNavTarget, isOwnOrigin } from './security-helpers';
+
+declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
+
+/** Install the CSP for every response served to the default session. */
+export function installCsp(): void {
+  const csp = buildCsp({ devServerOrigin: MAIN_WINDOW_VITE_DEV_SERVER_URL });
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [csp],
+      },
+    });
+  });
+}
+
+/**
+ * Install the per-WebContents navigation guards. Called once per window
+ * from window-manager.createWindow, after the BrowserWindow is built.
+ */
+export function installNavigationGuards(webContents: WebContents): void {
+  webContents.setWindowOpenHandler(({ url }) => {
+    const route = externalNavTarget(url);
+    if (route.kind === 'external') {
+      // Fire-and-forget; we don't await on a click handler.
+      void shell.openExternal(route.url);
+    }
+    return { action: 'deny' };
+  });
+
+  webContents.on('will-navigate', (event, url) => {
+    if (isOwnOrigin(url, MAIN_WINDOW_VITE_DEV_SERVER_URL)) return;
+    event.preventDefault();
+    const route = externalNavTarget(url);
+    if (route.kind === 'external') {
+      void shell.openExternal(route.url);
+    }
+  });
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -11,6 +11,7 @@ import { addRecentProject } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
 import { acquireProject, releaseProject } from './project-context';
+import { installNavigationGuards } from './security';
 import type { ProjectContext } from './project-context-types';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -71,6 +72,7 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
   });
 
   contexts.set(win.id, { rootPath: null, graphStore: null });
+  installNavigationGuards(win.webContents);
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     win.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);

--- a/tests/main/security-helpers.test.ts
+++ b/tests/main/security-helpers.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure-helper tests for #339. The Electron-bound install* functions are
+ * exercised by smoke testing in dev / packaged builds; here we just lock
+ * down the CSP string and the URL routing decisions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildCsp, isOwnOrigin, externalNavTarget } from '../../src/main/security-helpers';
+
+describe('buildCsp (#339)', () => {
+  it('production CSP: strict default-src self, no external script-src, no inline script', () => {
+    const csp = buildCsp();
+    expect(csp).toMatch(/default-src 'self'/);
+    // 'self' + 'wasm-unsafe-eval' for tesseract; nothing else for scripts.
+    expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval'/);
+    // Crucially, no 'unsafe-inline' for script-src.
+    const scriptSrc = csp.match(/script-src ([^;]+)/)![1];
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    // No external host in script-src in prod.
+    expect(scriptSrc).not.toMatch(/https?:/);
+  });
+
+  it('connect-src allows the renderer-direct hosts but is otherwise tight', () => {
+    const csp = buildCsp();
+    expect(csp).toMatch(/connect-src 'self' https:\/\/cdn\.jsdelivr\.net https:\/\/unpkg\.com/);
+    // No leakage to the main-process API hosts (those are server-side calls).
+    expect(csp).not.toContain('api.crossref.org');
+    expect(csp).not.toContain('api.anthropic.com');
+  });
+
+  it('img-src is permissive (https: + data: + blob:) so user-embedded images render', () => {
+    const csp = buildCsp();
+    const imgSrc = csp.match(/img-src ([^;]+)/)![1];
+    expect(imgSrc).toContain("'self'");
+    expect(imgSrc).toContain('data:');
+    expect(imgSrc).toContain('blob:');
+    expect(imgSrc).toContain('https:');
+  });
+
+  it("style-src 'unsafe-inline' is the documented compromise for Svelte + KaTeX", () => {
+    const csp = buildCsp();
+    expect(csp).toMatch(/style-src 'self' 'unsafe-inline'/);
+  });
+
+  it('worker-src allows blob: for pdf.js + tesseract.js workers', () => {
+    const csp = buildCsp();
+    expect(csp).toMatch(/worker-src 'self' blob:/);
+  });
+
+  it('frame-ancestors / object-src / form-action are locked down', () => {
+    const csp = buildCsp();
+    expect(csp).toMatch(/frame-ancestors 'none'/);
+    expect(csp).toMatch(/object-src 'none'/);
+    expect(csp).toMatch(/form-action 'none'/);
+  });
+
+  it('dev mode adds the Vite origin to script-src and connect-src + ws to connect-src', () => {
+    const csp = buildCsp({ devServerOrigin: 'http://localhost:5173' });
+    expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval' http:\/\/localhost:5173/);
+    const connectSrc = csp.match(/connect-src ([^;]+)/)![1];
+    expect(connectSrc).toContain('http://localhost:5173');
+    expect(connectSrc).toContain('ws://localhost:5173');
+  });
+
+  it('dev mode does NOT relax style-src or object-src', () => {
+    const csp = buildCsp({ devServerOrigin: 'http://localhost:5173' });
+    expect(csp).toMatch(/object-src 'none'/);
+    expect(csp).toMatch(/style-src 'self' 'unsafe-inline'/); // already permissive in prod, unchanged
+  });
+});
+
+describe('isOwnOrigin (#339)', () => {
+  it('treats file:// URLs as own origin (packaged build)', () => {
+    expect(isOwnOrigin('file:///Applications/Minerva.app/Contents/Resources/index.html')).toBe(true);
+  });
+
+  it('treats the Vite dev server as own origin in dev', () => {
+    expect(isOwnOrigin('http://localhost:5173/', 'http://localhost:5173')).toBe(true);
+    expect(isOwnOrigin('http://localhost:5173/foo', 'http://localhost:5173')).toBe(true);
+  });
+
+  it('rejects external https as own origin', () => {
+    expect(isOwnOrigin('https://example.com/')).toBe(false);
+    expect(isOwnOrigin('https://example.com/', 'http://localhost:5173')).toBe(false);
+  });
+
+  it('rejects file:// when dev origin set, file:// stays own (prod-mode reload still works)', () => {
+    expect(isOwnOrigin('file:///x/y.html', 'http://localhost:5173')).toBe(true);
+  });
+});
+
+describe('externalNavTarget (#339)', () => {
+  it('routes http(s) URLs to shell.openExternal', () => {
+    expect(externalNavTarget('https://example.com/')).toEqual({
+      kind: 'external',
+      url: 'https://example.com/',
+    });
+    expect(externalNavTarget('http://example.com/')).toEqual({
+      kind: 'external',
+      url: 'http://example.com/',
+    });
+  });
+
+  it('drops file: URLs (no shell.openExternal — could open arbitrary files)', () => {
+    expect(externalNavTarget('file:///etc/passwd')).toEqual({ kind: 'drop' });
+  });
+
+  it('drops javascript: / data: / custom schemes', () => {
+    expect(externalNavTarget('javascript:alert(1)')).toEqual({ kind: 'drop' });
+    expect(externalNavTarget('data:text/html,<script>')).toEqual({ kind: 'drop' });
+    expect(externalNavTarget('mailto:x@y.z')).toEqual({ kind: 'drop' });
+    expect(externalNavTarget('chrome://settings')).toEqual({ kind: 'drop' });
+  });
+});


### PR DESCRIPTION
## Summary
Three Electron-hardening measures the BrowserWindow setup was missing:

1. **Content-Security-Policy** via the default session's `onHeadersReceived` hook (not `<meta>`). Strict in prod: `default-src 'self'`, no inline/external scripts beyond `'wasm-unsafe-eval'` for tesseract.js. `connect-src` allows the two tesseract CDN hosts; main-process API adapters keep talking to Crossref/arXiv/PubMed/Anthropic from main, so renderer connect-src stays narrow. Dev mode adds the Vite origin + ws for HMR.
2. **setWindowOpenHandler** — per-window: `target="_blank"` / `window.open(...)` are denied; http(s) routes to `shell.openExternal`; other schemes drop.
3. **will-navigate** — per-window: top-level nav allowed only to the app's own origin (file:// in prod, Vite in dev). External http(s) gets diverted to the OS browser.

Pure logic (CSP string + URL routing predicates) lives in `src/main/security-helpers.ts` so tests can exercise it without pulling in `electron`. The Electron-bound `install*` functions are verified by the smoke loop.

## Why
Closes #339. P0 security finding from the modernization review.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1490/1490 passing (15 new in `tests/main/security-helpers.test.ts`)
- [ ] **Smoke (dev)**: `pnpm dev`; confirm renderer loads + HMR works (CSP allowing Vite origin); open devtools console — no CSP violations on load.
- [ ] **Smoke (dev)**: click an `https://…` link in a rendered note → opens in OS browser, not in the Minerva window.
- [ ] **Smoke (dev)**: paste `<a href="https://example.com" target="_blank">x</a>` into a note's preview → click → OS browser, no second Minerva window.
- [ ] **Smoke (dev)**: confirm KaTeX, code-fence highlighting, PDF OCR, and tag/note panels still render (CSP allowances cover them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)