### PR TITLE
graph: conversation contextNote is an IRI, not a path string (closes #350)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -112,6 +112,20 @@ export function disposeProject(ctx: ProjectContext): void {
   states.delete(ctx.rootPath);
 }
 
+/**
+ * The IRI Minerva uses to identify the note at `relativePath` in the
+ * graph for project `ctx`. Exposed so callers outside graph/index.ts
+ * (notably the conversation module, which writes thought:contextNote
+ * triples) can write a real IRI instead of stuffing a relative path
+ * into an angle-bracket slot. Returns null when the project has no
+ * graph state yet — caller should treat that as "no triple to write".
+ */
+export function noteUriFor(ctx: ProjectContext, relativePath: string): string | null {
+  const state = getState(ctx);
+  if (!state) return null;
+  return noteUri(state, relativePath).value;
+}
+
 // ── LLM Write Guard ───────────────────────────────────────────────────────
 // Tracks whether the current call path originates from an LLM operation.
 // Direct graph writes from LLM context that bypass the approval engine

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -13,6 +13,35 @@ export function initConversations(rootPath: string): void {
   activeRootPath = rootPath;
 }
 
+/**
+ * Re-project every persisted conversation into the graph. Called once
+ * during project init: `writeConversationToGraph` clears prior triples
+ * for the subject before re-adding, so historical bad-shape triples
+ * (the #350 relative-path-as-IRI bug) get scrubbed and replaced with
+ * the corrected IRI form. Cheap: small JSON files, in-memory rdflib.
+ */
+export async function reindexAllConversations(): Promise<void> {
+  if (!conversationsDir) return;
+  let files: string[];
+  try {
+    files = await fs.readdir(conversationsDir);
+  } catch { return; /* no conversations yet */ }
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+    try {
+      const data = await fs.readFile(path.join(conversationsDir, file), 'utf-8');
+      const conv = JSON.parse(data) as Conversation;
+      await writeConversationToGraph(conv);
+      if (conv.status !== 'active') {
+        // Mirror the live status so resolve/abandon don't get dropped on reload.
+        await updateConversationInGraph(conv);
+      }
+    } catch (err) {
+      console.warn(`[conversation] reindex skipped ${file}:`, err);
+    }
+  }
+}
+
 function activeCtx(): ProjectContext {
   if (!activeRootPath) throw new Error('Conversations not initialized — no project open');
   return projectContext(activeRootPath);
@@ -173,8 +202,40 @@ function escapeTurtle(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
 }
 
+/** Predicates a conversation subject can hold. Listed so we can drop them
+ *  cleanly before re-projecting (so historical bad-shape triples from
+ *  before #350 don't linger as dust alongside the corrected ones). */
+const CONVERSATION_PREDICATES = [
+  'conversationStatus',
+  'startedAt',
+  'resolvedAt',
+  'trigger',
+  'contextNote',
+  'conversationContent',
+];
+
+function clearConversationTriples(uri: string): void {
+  const ctx = activeCtx();
+  graph.removeMatchingTriples(ctx, uri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+  for (const p of CONVERSATION_PREDICATES) {
+    graph.removeMatchingTriples(ctx, uri, `${THOUGHT}${p}`);
+  }
+  // dc:created lands when a conversation is filed as a source — drop it
+  // for symmetry so re-projection of a resolved conversation produces
+  // exactly one creation timestamp.
+  graph.removeMatchingTriples(ctx, uri, 'http://purl.org/dc/terms/created');
+}
+
 async function writeConversationToGraph(conv: Conversation): Promise<void> {
   const uri = convUri(conv.id);
+  const ctx = activeCtx();
+  // contextNote needs a real IRI, not the raw `notes/foo.md` string —
+  // the prior shape (#350) made downstream joins against
+  // minerva:relativePath silently mismatch.
+  const contextNoteIri = conv.contextBundle.notePath
+    ? graph.noteUriFor(ctx, conv.contextBundle.notePath)
+    : null;
+  clearConversationTriples(uri);
   const turtle = `
     @prefix thought: <${THOUGHT}> .
     @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -183,9 +244,9 @@ async function writeConversationToGraph(conv: Conversation): Promise<void> {
       thought:conversationStatus thought:active ;
       thought:startedAt "${conv.startedAt}"^^xsd:dateTime
       ${conv.triggerNodeUri ? `; thought:trigger <${conv.triggerNodeUri}>` : ''}
-      ${conv.contextBundle.notePath ? `; thought:contextNote <${conv.contextBundle.notePath}>` : ''} .
+      ${contextNoteIri ? `; thought:contextNote <${contextNoteIri}>` : ''} .
   `;
-  graph.parseIntoStore(activeCtx(), turtle);
+  graph.parseIntoStore(ctx, turtle);
 }
 
 async function updateConversationInGraph(conv: Conversation): Promise<void> {

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -58,6 +58,11 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
         search.indexAllNotes(ctx),
         tables.registerAllCsvs(ctx),
       ]);
+      // Re-project conversation JSON into the graph after notes are
+      // indexed (so contextNote IRIs resolve against a populated note
+      // namespace). Also self-heals stale relative-path triples from
+      // before #350.
+      await conversation.reindexAllConversations();
       // Health checks run once at open, then a periodic timer takes over.
       healthChecks.runAllChecks(ctx);
       healthChecks.startPeriodicChecks(ctx);

--- a/tests/main/llm/conversation-context-iri.test.ts
+++ b/tests/main/llm/conversation-context-iri.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #350: thought:contextNote on a Conversation must be a real note IRI,
+ * not the raw `notes/foo.md` relative path. The integration test plants
+ * a note + a conversation, then runs the SPARQL join the bug ticket
+ * called out — "find the conversation triggered from this note via
+ * minerva:relativePath" — and confirms it returns one row.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  queryGraph,
+  parseIntoStore,
+  noteUriFor,
+} from '../../../src/main/graph/index';
+import {
+  initConversations,
+  reindexAllConversations,
+  create as createConversation,
+} from '../../../src/main/llm/conversation';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-conv-iri-test-'));
+}
+
+describe('Conversation thought:contextNote is a real IRI (#350)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    initConversations(root);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('contextNote resolves to a node that joins against minerva:relativePath', async () => {
+    // Plant a note so the join target exists in the graph.
+    await indexNote(ctx, 'notes/foo.md', '# Foo\nContent.\n');
+
+    // Create a conversation whose contextBundle references that note.
+    await createConversation({ notePath: 'notes/foo.md' });
+
+    // The bug ticket's exact query: "what conversation was triggered
+    // from this note?". The join only succeeds if contextNote is the
+    // note's IRI, not its relative-path string.
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?conv WHERE {
+        ?n minerva:relativePath "notes/foo.md" .
+        ?conv thought:contextNote ?n .
+      }
+    `);
+    expect((r.results as unknown[]).length).toBe(1);
+  });
+
+  it('omits contextNote entirely when there is no notePath', async () => {
+    const conv = await createConversation({});
+    const expectedIri = `https://minerva.dev/ontology/thought#conversation/${conv.id}`;
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?n WHERE { <${expectedIri}> thought:contextNote ?n . }
+    `);
+    expect((r.results as unknown[]).length).toBe(0);
+  });
+
+  it('reindexAllConversations heals historical relative-path-as-IRI dust', async () => {
+    // Simulate a graph.ttl from the pre-fix era: a Conversation with a
+    // contextNote pointing at a relative path resolved against an
+    // arbitrary base. parseIntoStore + a hand-rolled turtle stands in
+    // for "the broken triples already on disk".
+    const convId = 'legacy-conv-1';
+    const convIri = `https://minerva.dev/ontology/thought#conversation/${convId}`;
+    parseIntoStore(ctx, `
+      @prefix thought: <https://minerva.dev/ontology/thought#> .
+      <${convIri}> a thought:Conversation ;
+        thought:conversationStatus thought:active ;
+        thought:startedAt "2024-09-01T10:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        thought:contextNote <notes/foo.md> .
+    `);
+
+    // The matching JSON file the user kept on disk — canonical source.
+    await indexNote(ctx, 'notes/foo.md', '# Foo\n');
+    const noteIri = noteUriFor(ctx, 'notes/foo.md')!;
+    const convDir = path.join(root, '.minerva', 'conversations');
+    await fsp.mkdir(convDir, { recursive: true });
+    await fsp.writeFile(path.join(convDir, `${convId}.json`), JSON.stringify({
+      id: convId,
+      contextBundle: { notePath: 'notes/foo.md' },
+      messages: [],
+      status: 'active',
+      startedAt: '2024-09-01T10:00:00Z',
+    }), 'utf-8');
+
+    // Re-project. This is what acquireProject does on each open.
+    await reindexAllConversations();
+
+    // The corrected IRI is now present.
+    const good = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?n WHERE { <${convIri}> thought:contextNote ?n . }
+    `);
+    const ns = (good.results as Array<{ n: string }>).map((r) => r.n);
+    expect(ns).toContain(noteIri);
+    // And the historical relative-path dust is gone — clearConversationTriples
+    // dropped every contextNote on this subject before re-adding.
+    expect(ns.every((u) => u === noteIri)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
`writeConversationToGraph` wrote `<\${conv.contextBundle.notePath}>` — inlining a relative path like `notes/foo.md` into a Turtle angle-bracket slot. The resulting triple's object never matched the IRI `indexNote` uses for the same note, so any SPARQL join through `thought:contextNote ↔ minerva:relativePath` silently mis-matched.

Three changes:
1. **Build a real IRI.** Export `noteUriFor(ctx, relativePath)` from `graph/index.ts`; have `writeConversationToGraph` call it.
2. **Self-heal historical dust.** Add `reindexAllConversations()` in `conversation.ts`; call it from `acquireProject` after notes are indexed. JSON is the canonical source — re-project each conversation through the corrected writer. To make re-projection idempotent, the writer first drops the subject's prior triples for the predicates it owns.
3. **Regression tests** (3): contextNote joins on `minerva:relativePath`; no `notePath` ⇒ no triple; the reindex pass scrubs legacy relative-path triples.

## Why
Closes #350. Architecture-review smaller finding — a quiet correctness bug that broke a stock-query-style join.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1493/1493 passing (3 new in `tests/main/llm/conversation-context-iri.test.ts`)
- [ ] **Smoke (manual)**: open a project that already has conversations, open Query Panel, run:
  `SELECT ?conv ?p WHERE { ?n minerva:relativePath ?p . ?conv thought:contextNote ?n . }` — expect rows for every conversation that was triggered from a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)