### PR TITLE
fs.assertSafePath: realpath the root for symlinked-tmpdir cases (closes #352)

### DIFF
--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -1,5 +1,6 @@
 import { dialog } from 'electron';
 import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
 import path from 'node:path';
 import type { NoteFile, NotebaseMeta } from '../../shared/types';
 import { INDEXABLE_EXTS } from './indexable-files';
@@ -63,11 +64,35 @@ async function readDirectory(dirPath: string, rootPath: string): Promise<NoteFil
   return files;
 }
 
+/**
+ * Best-effort realpath: returns the canonicalised path when the prefix
+ * exists, falling back to the input when it doesn't (so projects can
+ * still be checked before they're created).
+ */
+function realPathSafe(p: string): string {
+  try {
+    return fsSync.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
 export function assertSafePath(rootPath: string, relativePath: string): string {
-  const resolved = path.resolve(rootPath, relativePath);
-  if (!resolved.startsWith(rootPath + path.sep) && resolved !== rootPath) {
+  // realpath the rootPath so a project rooted on a symlinked path —
+  // notably macOS's /var → /private/var, which is where tmpdir() lives
+  // (#352) — doesn't make a normal in-project relative path look like
+  // a traversal. We resolve `relativePath` *against* the realpath'd
+  // root (rather than realpath'ing each result) because the leaf or
+  // any intermediate dir may not exist yet (write-to-create), and
+  // resolve doesn't follow symlinks anyway, so this canonical-prefix
+  // form is enough to make the startsWith check sound.
+  const realRoot = realPathSafe(rootPath);
+  const resolved = path.resolve(realRoot, relativePath);
+  if (!resolved.startsWith(realRoot + path.sep) && resolved !== realRoot) {
     throw new Error('Path traversal detected');
   }
+  // Return the realpath-anchored resolution: it's always usable by
+  // fs.* and won't drift between symlink endpoints in subsequent ops.
   return resolved;
 }
 

--- a/tests/main/notebase/fs.test.ts
+++ b/tests/main/notebase/fs.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
 import { assertSafePath, listFiles } from '../../../src/main/notebase/fs';
 
 const FIXTURE_DIR = path.resolve(__dirname, '../../fixtures/sample-project');
@@ -20,6 +23,50 @@ describe('assertSafePath', () => {
 
   it('allows path resolving to root itself', () => {
     expect(() => assertSafePath('/root', '')).not.toThrow();
+  });
+});
+
+describe('assertSafePath: symlinked root (#352)', () => {
+  // On macOS, os.tmpdir() returns /var/folders/... which is a symlink
+  // to /private/var/folders/.... Before the fix, the prefix-startsWith
+  // check could fail (or wrongly succeed) when the caller's rootPath
+  // and the resolved subpath disagreed about which side of the
+  // symlink they sat on. realpath both sides → equivalent regardless
+  // of which form the caller hands us.
+  it('treats both ends of a symlinked root as the same project', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'minerva-fs-symlink-test-'));
+    try {
+      const realRoot = fs.realpathSync(root);
+      // The fix only matters when realpath actually changes the
+      // string. On Linux, tmpdir is usually already canonical; in
+      // that case this assertion is just "both forms equal", which
+      // still has to hold.
+      await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+      await fsp.writeFile(path.join(root, 'notes', 'a.md'), '# a', 'utf-8');
+
+      // Either form of the rootPath should accept the same relative path.
+      expect(() => assertSafePath(root, 'notes/a.md')).not.toThrow();
+      expect(() => assertSafePath(realRoot, 'notes/a.md')).not.toThrow();
+
+      // And both should reject a traversal regardless of root form.
+      expect(() => assertSafePath(root, '../escape.md')).toThrow('Path traversal');
+      expect(() => assertSafePath(realRoot, '../escape.md')).toThrow('Path traversal');
+    } finally {
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('allows write-to-create paths whose leaf does not yet exist', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'minerva-fs-create-test-'));
+    try {
+      // The point of `realPathSafe(parent)` (not realpath of leaf) — a
+      // file we're about to create can't be realpath'd, but its parent
+      // exists. Used in every NOTEBASE_CREATE_FILE / WRITE_FILE call.
+      expect(() => assertSafePath(root, 'fresh.md')).not.toThrow();
+      expect(() => assertSafePath(root, 'subdir/fresh.md')).not.toThrow();
+    } finally {
+      await fsp.rm(root, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
`assertSafePath` compared `path.resolve(rootPath, relativePath)` against `rootPath + sep`. On macOS, `/var` is a symlink to `/private/var`, so a project rooted under `tmpdir()` could trip the prefix check when the caller's `rootPath` and the resolved subpath sat on different sides of the symlink.

Fix: realpath the rootPath once with a best-effort `realPathSafe` (falls back to the input on stat failure so projects can be validated before they're created), then resolve `relativePath` against the canonical root. The prefix-startsWith check now stays sound regardless of which endpoint the caller handed us.

`assertSafePath` now returns the realpath-anchored resolution rather than the un-realpath'd form. `fs.*` accepts either, so no caller breaks; the upside is no drift between symlink endpoints in downstream string compares.

## Why
Closes #352. P-low architecture-review finding — narrow edge but the fix is small and the test coverage is worthwhile.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1495/1495 passing (2 new in `tests/main/notebase/fs.test.ts`):
  - both forms of a symlinked root accept the same relative path AND reject the same traversal
  - write-to-create works when neither leaf nor intermediate dirs exist yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)