### PR TITLE
graph: graph.ttl as cold snapshot, not write-through (closes #348)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1245,7 +1245,8 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
   await walkAndIndex(rootPath, rootPath);
   count += await walkAndIndexSources(ctx, rootPath);
   count += await walkAndIndexExcerpts(ctx, rootPath);
-  await persistGraph(ctx);
+  // graph.ttl is a cold snapshot now (#348). The release / quit path
+  // writes the snapshot; an in-app rebuild only mutates the live store.
 
   async function walkAndIndex(dirPath: string, root: string) {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -144,7 +144,10 @@ async function listIndexableFiles(rootPath: string, relDir: string): Promise<str
 
 async function persistIndexes(rootPath: string): Promise<void> {
   const ctx = projectContext(rootPath);
-  await Promise.all([search.persist(ctx), graph.persistGraph(ctx)]);
+  // graph.ttl is a cold snapshot (#348). Persist only the search
+  // index here; the graph flushes on project release / app-quit.
+  void ctx;
+  await search.persist(ctx);
 }
 
 export function registerIpcHandlers(): void {
@@ -266,7 +269,7 @@ export function registerIpcHandlers(): void {
     await notebaseFs.writeFile(rootPath, relativePath, content);
     const ctx = projectContext(rootPath);
     const { headingRenameCandidate } = await graph.indexNote(ctx, relativePath, content);
-    await graph.persistGraph(ctx);
+    // graph.ttl is a cold snapshot (#348); flushes on release / quit.
     search.indexNote(ctx, relativePath, content);
     await search.persist(ctx);
     // If a heading edit looks like a rename with affected incoming links,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,7 @@ import { loadSession } from './session';
 import { registerBuiltinExecutors } from './compute/executors';
 import { registerBuiltinExporters } from './publish';
 import { installCsp } from './security';
+import { flushAllProjects } from './project-context';
 
 app.setName('Minerva');
 
@@ -49,4 +50,19 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+// graph.ttl is a cold snapshot (#348). releaseProject persists per-project
+// when a window closes; this catches Cmd+Q where windows close concurrently
+// and we want the snapshot on disk before the process exits. Re-emits the
+// before-quit event after the flush so Electron's normal teardown still
+// runs.
+let isFlushingForQuit = false;
+app.on('before-quit', (event) => {
+  if (isFlushingForQuit) return;
+  event.preventDefault();
+  isFlushingForQuit = true;
+  flushAllProjects()
+    .catch((err) => console.warn('[quit] project flush failed:', err))
+    .finally(() => app.quit());
 });

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -105,3 +105,21 @@ export async function releaseProject(rootPath: string, winId: number): Promise<v
 export function getProjectContext(rootPath: string): ProjectContext | null {
   return projects.get(rootPath)?.ctx ?? null;
 }
+
+/**
+ * Flush every currently-held project's persistent state to disk —
+ * called from app-quit so the cold-snapshot graph.ttl (#348) gets the
+ * latest before the process exits. Doesn't dispose state; an active
+ * project stays acquired until its last window closes.
+ */
+export async function flushAllProjects(): Promise<void> {
+  await Promise.all(
+    [...projects.values()].map(async (rec) => {
+      try {
+        await Promise.all([search.persist(rec.ctx), graph.persistGraph(rec.ctx)]);
+      } catch (err) {
+        console.warn(`[project-context] flush failed for ${rec.rootPath}:`, err);
+      }
+    }),
+  );
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -162,7 +162,11 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   const debouncedPersist = () => {
     if (indexPersistTimer) clearTimeout(indexPersistTimer);
     indexPersistTimer = setTimeout(async () => {
-      await Promise.all([search.persist(projectCtx), graph.persistGraph(projectCtx)]);
+      // graph.ttl is a cold snapshot now (#348) — fully reconstructible
+      // from notes/sources/excerpts/CSVs/conversations/proposals, so we
+      // skip per-write serialization. Search index isn't reconstructed
+      // automatically, so it still gets the live persist.
+      await search.persist(projectCtx);
     }, 1000);
   };
 

--- a/tests/main/graph/cold-snapshot.test.ts
+++ b/tests/main/graph/cold-snapshot.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #348: graph.ttl is a cold snapshot.
+ *
+ *  - indexNote does NOT trip per-write serialization (we used to debounce
+ *    persistGraph on every keystroke; now the in-memory store is the
+ *    source of truth and graph.ttl is only refreshed on
+ *    persistGraph(ctx) — i.e. release / quit).
+ *  - The graph rebuilds correctly from sources when graph.ttl is absent
+ *    (initGraph + indexAllNotes is the cold-start path).
+ *  - persistGraph still works on demand (release path) and writes the
+ *    live store to graph.ttl.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexNote,
+  queryGraph,
+  persistGraph,
+  indexAllNotes,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cold-snapshot-test-'));
+}
+
+describe('graph.ttl cold-snapshot semantics (#348)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('indexNote does not write graph.ttl', async () => {
+    const graphPath = path.join(root, '.minerva', 'graph.ttl');
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    expect(fs.existsSync(graphPath)).toBe(false);
+  });
+
+  it('many indexNote calls do not write graph.ttl', async () => {
+    const graphPath = path.join(root, '.minerva', 'graph.ttl');
+    for (let i = 0; i < 20; i++) {
+      await indexNote(ctx, `n${i}.md`, `# n${i}\nbody\n`);
+    }
+    expect(fs.existsSync(graphPath)).toBe(false);
+  });
+
+  it('persistGraph writes graph.ttl with the current store contents', async () => {
+    await indexNote(ctx, 'a.md', '# Alpha\n');
+    await persistGraph(ctx);
+    const graphPath = path.join(root, '.minerva', 'graph.ttl');
+    const ttl = await fsp.readFile(graphPath, 'utf-8');
+    // Snapshot should contain the indexed note's title literal.
+    expect(ttl).toContain('Alpha');
+  });
+
+  it('rebuilds the in-memory graph from sources when graph.ttl is absent', async () => {
+    // Plant a note on disk so indexAllNotes has something to find.
+    await fsp.writeFile(path.join(root, 'a.md'), '# Alpha\n', 'utf-8');
+    expect(fs.existsSync(path.join(root, '.minerva', 'graph.ttl'))).toBe(false);
+
+    // Cold start: no persisted graph, but indexAllNotes rebuilds.
+    const count = await indexAllNotes(ctx);
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    const r = await queryGraph(ctx, `
+      SELECT ?t WHERE {
+        ?n minerva:relativePath "a.md" ;
+           dc:title ?t .
+      }
+    `);
+    expect((r.results as Array<{ t: string }>)[0].t).toBe('Alpha');
+
+    // And it STILL didn't write graph.ttl on its own — that's release-only now.
+    expect(fs.existsSync(path.join(root, '.minerva', 'graph.ttl'))).toBe(false);
+  });
+
+  it('snapshot survives between sessions: write, init from disk, query reads from snapshot', async () => {
+    // Session 1: index a note + persist explicitly.
+    await indexNote(ctx, 'persisted.md', '# Persisted\n');
+    await persistGraph(ctx);
+
+    // Session 2: a fresh ctx (different rootPath would normally apply,
+    // but the same path is fine — we're emulating "app reopens project").
+    // Drop the in-memory state so the next initGraph reads from disk.
+    const ctx2 = projectContext(root);
+    await initGraph(ctx2); // re-reads .minerva/graph.ttl
+
+    // The persisted note's metadata is in the store BEFORE indexAllNotes
+    // runs — that's the whole point of having a snapshot.
+    const r = await queryGraph(ctx2, `
+      SELECT ?t WHERE {
+        ?n minerva:relativePath "persisted.md" ;
+           dc:title ?t .
+      }
+    `);
+    expect((r.results as Array<{ t: string }>)[0]?.t).toBe('Persisted');
+  });
+});


### PR DESCRIPTION
## Summary
The watcher's debounced persist + per-write paths in `ipc.ts` were running `rdflib.serialize` on every 1s edit window — walks every statement, scales linearly with graph size. That was the P1 perf wall.

But `graph.ttl` is fully reconstructible: notes / sources / excerpts / CSVs are walked by `indexAllNotes`; conversation triples re-project from JSON on init (#350); Proposal triples flush on release. So treat `graph.ttl` as a cold snapshot:
- **Removed** `persistGraph` from the watcher debounce, `persistIndexes`, the `NOTEBASE_WRITE_FILE` handler, and the end of `indexAllNotes`. The in-memory rdflib store is the source of truth during a session.
- **Kept** `persistGraph` at the cold-write moments — project release (last window-close) and the GRAPH_EXPORT menu action.
- **Added** `flushAllProjects()` and a `before-quit` hook so Cmd+Q also flushes (releaseProject is fire-and-forget on window-close and races process exit).

`search.persist` still runs on the debounce — the search index isn't auto-reconstructed from sources.

Crash safety: SIGKILL between writes and graceful close → next open does a full rebuild via `indexAllNotes`. Same end state, slightly slower one-time startup.

## Why
Closes #348. P1 performance — the review flagged this as the structural move that buys runway before rdflib's serialize hits its ceiling. The P0 N3-cache fix (#334) was the orthogonal first step; this is the second.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1500/1500 passing (5 new in `tests/main/graph/cold-snapshot.test.ts`):
  - indexNote does not write `graph.ttl`
  - 20 indexNotes do not write `graph.ttl`
  - persistGraph still works on demand and writes the current store
  - cold start (no `graph.ttl`) rebuilds correctly via indexAllNotes
  - snapshot round-trips between sessions
- [ ] **Smoke (manual)**: edit a note in a project; observe that `.minerva/graph.ttl` mtime does NOT update on every keystroke. Close the window — mtime updates once, on close.
- [ ] **Smoke (manual)**: `Cmd+Q` while a project is open and dirty → app exits cleanly; reopen → graph state matches the last write.
- [ ] **Smoke (manual)**: `File > Rebuild All Indexes` still works (already explicit; no change there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)