### PR TITLE
preview: drop runtime markdown-it/lib/token deep import (#347)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import MarkdownIt from 'markdown-it';
-  import Token from 'markdown-it/lib/token.mjs';
+  // The Token *value* (used below for `new Token(...)` to inject a
+  // task-list checkbox) is now recovered from `inlineTok.constructor`
+  // (#347) so we no longer need a runtime import of
+  // `markdown-it/lib/token.mjs`. The remaining `import type` paths
+  // stay deep — `MarkdownIt.Token` / `MarkdownIt.StateBlock` namespace
+  // lookups don't resolve through `@types/markdown-it`'s `export = X`
+  // shape under isolatedModules — but type-only imports don't ship to
+  // the bundler and only fail loudly at typecheck if the typings move.
+  import type Token from 'markdown-it/lib/token.mjs';
   import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs';
   import hljs from 'highlight.js';
   import 'highlight.js/styles/github-dark.min.css';
@@ -163,7 +171,12 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             }
           }
           // Inject the checkbox as an html_inline prefix on the inline tree.
-          const cb = new Token('html_inline', '', 0);
+          // Recover the Token constructor from the inline token itself so we
+          // don't have to deep-import `markdown-it/lib/token.mjs` (#347).
+          const TokenCtor = inlineTok.constructor as new (
+            type: string, tag: string, nesting: -1 | 0 | 1,
+          ) => Token;
+          const cb = new TokenCtor('html_inline', '', 0);
           cb.content = `<input type="checkbox" data-task-line="${line}"${checked ? ' checked' : ''}> `;
           inlineTok.children.unshift(cb);
         }

--- a/src/renderer/lib/markdown/math-plugin.ts
+++ b/src/renderer/lib/markdown/math-plugin.ts
@@ -14,6 +14,12 @@
  */
 
 import type MarkdownIt from 'markdown-it';
+// Type-only deep imports for parser-state classes — `MarkdownIt.StateBlock`
+// namespace lookups don't resolve through `@types/markdown-it`'s
+// `export = X` shape under isolatedModules. Keeping these as
+// `import type` means they don't ship to the bundler; if a future
+// markdown-it version moves the file the failure surfaces as a loud
+// typecheck error rather than a silent runtime miss (#347).
 import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs';
 import katex from 'katex';


### PR DESCRIPTION
## Summary
`Preview.svelte` was importing `Token` from `markdown-it/lib/token.mjs` as both a **value** (`new Token('html_inline', ...)` once, to inject the task-list checkbox) and a type. Recover the constructor from `inlineTok.constructor` at the call site instead — same runtime behaviour, no deep-import dependency for the value.

**Honest scope reduction:** the `import type` deep imports for `Token` / `StateBlock` (Preview.svelte) and `StateInline` / `StateBlock` (math-plugin.ts) remain. The ticket suggested swapping them for `MarkdownIt.Token` / `MarkdownIt.StateBlock` namespace lookups, but under `isolatedModules`, `@types/markdown-it`'s `export = X` + `declare namespace X` pattern doesn't surface the namespace through a default-imported value — multiple idioms all hit `TS2702: 'MarkdownIt' only refers to a type, but is being used as a namespace`. Type-only imports are the practical compromise: they don't ship to the bundler, so the runtime stability concern is gone. If a future markdown-it ever moves the path, failure is a loud typecheck error rather than a silent runtime miss.

## Why
Closes #347. The substantive risk in the ticket was the *runtime* deep import (a layout change ⇒ runtime crash). That's gone. The type-only paths stay until either `@types/markdown-it` exposes named exports or TS gains a path to namespace-resolve `export = X` shapes under isolatedModules.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1500/1500 passing
- [ ] **Smoke (manual)**: render a note with a task list (`- [ ] item`) in preview — checkbox still injects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)