### PR TITLE
compute: persistent Python kernel per project (closes #241)

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -6,6 +6,10 @@ import { MakerDMG } from '@electron-forge/maker-dmg';
 const config: ForgeConfig = {
   packagerConfig: {
     name: 'Minerva',
+    // Stage `resources/python/minerva_kernel.py` (and anything else
+    // we drop under `resources/`) next to the main bundle in the
+    // packaged app, so process.resourcesPath finds it (#241).
+    extraResource: ['resources'],
   },
   makers: [
     new MakerZIP({}, ['darwin', 'linux', 'win32']),

--- a/resources/python/minerva_kernel.py
+++ b/resources/python/minerva_kernel.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Minerva compute kernel (#241).
+
+Long-running Python subprocess that reads exec requests as JSON-line
+messages on stdin and writes streamed events back on stdout. One process
+per project; per-notebook namespace dicts so cells in the same notebook
+share state but cells in different notebooks don't.
+
+Protocol — request:
+  {"op": "exec", "cellId": "<uuid>", "notebookPath": "notes/x.md", "code": "..."}
+  {"op": "reset", "notebookPath": "notes/x.md"}      # drop one notebook's namespace
+  {"op": "reset"}                                     # drop everything
+
+Protocol — events:
+  {"type": "ready"}                                   # once at startup
+  {"cellId": ..., "type": "stdout",  "payload": "..."}
+  {"cellId": ..., "type": "stderr",  "payload": "..."}
+  {"cellId": ..., "type": "result",  "payload": <json-or-repr>}
+  {"cellId": ..., "type": "error",   "payload": {"ename","evalue","traceback"}}
+  {"cellId": ..., "type": "done",    "executionTimeMs": <int>}
+  {"type": "reset-ack"}
+  {"type": "protocol-error", "message": "..."}        # malformed request
+"""
+
+import sys
+import json
+import io
+import time
+import ast
+import traceback
+
+namespaces = {}
+
+
+def get_ns(notebook_path):
+    if notebook_path not in namespaces:
+        # Fresh module-style globals — __name__ matters for `if __name__ == '__main__'`
+        # (cells running this idiom should behave like __main__).
+        namespaces[notebook_path] = {
+            '__name__': '__main__',
+            '__builtins__': __builtins__,
+        }
+    return namespaces[notebook_path]
+
+
+def emit(event):
+    sys.stdout.write(json.dumps(event) + '\n')
+    sys.stdout.flush()
+
+
+def reset_namespaces(notebook_path):
+    if notebook_path is None:
+        namespaces.clear()
+    else:
+        namespaces.pop(notebook_path, None)
+
+
+def serialize_value(value):
+    """Best-effort: prefer JSON-roundtrippable, fall back to repr.
+
+    The renderer renders 'json' outputs richly and 'text' outputs as
+    monospace. Whatever we send under 'result' goes into the json branch,
+    so unrepresentable types fall back to a string repr to keep the
+    output legible rather than dropping it on the floor.
+    """
+    try:
+        # Round-trip test — JSON.dumps catches most opaque types.
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return repr(value)
+
+
+def exec_cell(req):
+    cell_id = req.get('cellId')
+    code = req.get('code', '')
+    notebook = req.get('notebookPath') or '__default__'
+    ns = get_ns(notebook)
+
+    started = time.monotonic()
+    out = io.StringIO()
+    err = io.StringIO()
+    last_value = None
+    has_last_value = False
+    error_payload = None
+
+    saved_stdout, saved_stderr = sys.stdout, sys.stderr
+    try:
+        sys.stdout = out
+        sys.stderr = err
+        try:
+            tree = ast.parse(code, mode='exec')
+            # Jupyter-style: if the last statement is a bare expression,
+            # exec everything before it then eval the last separately so
+            # we can capture its value as `result`.
+            if tree.body and isinstance(tree.body[-1], ast.Expr):
+                last_expr = tree.body[-1]
+                exec_module = ast.Module(body=tree.body[:-1], type_ignores=[])
+                exec(compile(exec_module, '<cell>', 'exec'), ns)
+                last_value = eval(
+                    compile(ast.Expression(body=last_expr.value), '<cell>', 'eval'),
+                    ns,
+                )
+                # `None` is the typical "no value" sentinel for statements
+                # like `print(...)` whose return is None — skip in that case
+                # to avoid noisy `null` results.
+                if last_value is not None:
+                    has_last_value = True
+            else:
+                exec(compile(tree, '<cell>', 'exec'), ns)
+        except SystemExit:
+            # exit() / sys.exit() — surface as an error rather than killing
+            # the whole kernel.
+            error_payload = {
+                'ename': 'SystemExit',
+                'evalue': 'Cell called sys.exit()',
+                'traceback': traceback.format_exc().splitlines(),
+            }
+        except BaseException as e:
+            error_payload = {
+                'ename': type(e).__name__,
+                'evalue': str(e),
+                'traceback': traceback.format_exc().splitlines(),
+            }
+    finally:
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+
+    if out.getvalue():
+        emit({'cellId': cell_id, 'type': 'stdout', 'payload': out.getvalue()})
+    if err.getvalue():
+        emit({'cellId': cell_id, 'type': 'stderr', 'payload': err.getvalue()})
+    if error_payload:
+        emit({'cellId': cell_id, 'type': 'error', 'payload': error_payload})
+    elif has_last_value:
+        emit({'cellId': cell_id, 'type': 'result', 'payload': serialize_value(last_value)})
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    emit({'cellId': cell_id, 'type': 'done', 'executionTimeMs': elapsed_ms})
+
+
+def main():
+    emit({'type': 'ready'})
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as e:
+            emit({'type': 'protocol-error', 'message': f'JSON parse: {e}'})
+            continue
+        op = req.get('op', 'exec')
+        if op == 'exec':
+            try:
+                exec_cell(req)
+            except Exception as e:
+                # exec_cell catches everything inside the user code path;
+                # this is a kernel-side bug if reached.
+                emit({
+                    'cellId': req.get('cellId'),
+                    'type': 'error',
+                    'payload': {
+                        'ename': 'KernelError',
+                        'evalue': str(e),
+                        'traceback': traceback.format_exc().splitlines(),
+                    },
+                })
+                emit({'cellId': req.get('cellId'), 'type': 'done', 'executionTimeMs': 0})
+        elif op == 'reset':
+            reset_namespaces(req.get('notebookPath'))
+            emit({'type': 'reset-ack'})
+        else:
+            emit({'type': 'protocol-error', 'message': f'Unknown op: {op}'})
+
+
+if __name__ == '__main__':
+    main()

--- a/src/main/compute/executors/index.ts
+++ b/src/main/compute/executors/index.ts
@@ -6,8 +6,14 @@
 import { registerExecutor } from '../registry';
 import { executeSparql } from './sparql';
 import { executeSql } from './sql';
+import { executePython } from './python';
 
 export function registerBuiltinExecutors(): void {
   registerExecutor('sparql', executeSparql);
   registerExecutor('sql', executeSql);
+  registerExecutor('python', executePython);
+  // Common aliases users actually type — markdown-it-fence picks up the
+  // info string verbatim, so register `py` and `python3` too.
+  registerExecutor('py', executePython);
+  registerExecutor('python3', executePython);
 }

--- a/src/main/compute/executors/python.ts
+++ b/src/main/compute/executors/python.ts
@@ -1,0 +1,13 @@
+/**
+ * Python fence executor (#241/#242). Routes a `python` cell through
+ * the persistent per-project kernel rather than spawning fresh per
+ * cell — preserves namespace state across cells in the same notebook.
+ */
+
+import { runPython } from '../python-kernel';
+import type { ExecutorFn } from '../registry';
+
+export const executePython: ExecutorFn = async (code, ctx) => {
+  const notebook = ctx.notePath ?? '__default__';
+  return runPython(ctx.rootPath, notebook, code);
+};

--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -1,0 +1,271 @@
+/**
+ * Persistent Python subprocess per project (#241).
+ *
+ * Spawns a single Python process — the kernel — on first execution for
+ * each project, multiplexes JSON-line requests/events over its stdio,
+ * and tears down on project release / app quit.
+ *
+ * Per-notebook namespaces live inside the kernel itself (kernel keys a
+ * dict on `notebookPath`), so cells in the same notebook share state
+ * and cells in different notebooks don't.
+ *
+ * v1 buffers events per-cell and resolves a single CellResult on `done`,
+ * so the existing executor signature works unchanged. The kernel
+ * already streams events at the protocol level — surfacing them
+ * incrementally to the renderer is a future hook.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import path from 'node:path';
+import readline from 'node:readline';
+import { app } from 'electron';
+import { randomUUID } from 'node:crypto';
+import type { CellResult } from '../../shared/compute/types';
+
+declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
+
+interface PendingCell {
+  resolve: (result: CellResult) => void;
+  stdout: string[];
+  stderr: string[];
+  result?: unknown;
+  error?: { ename: string; evalue: string; traceback: string[] };
+}
+
+interface KernelEvent {
+  cellId?: string;
+  type:
+    | 'ready' | 'stdout' | 'stderr' | 'result' | 'error' | 'done'
+    | 'protocol-error' | 'reset-ack';
+  payload?: unknown;
+  executionTimeMs?: number;
+  message?: string;
+}
+
+interface KernelState {
+  proc: ChildProcessWithoutNullStreams;
+  ready: Promise<void>;
+  pending: Map<string, PendingCell>;
+}
+
+const kernels = new Map<string, KernelState>();
+
+/**
+ * Resolve the Python interpreter to invoke. v1 honours $MINERVA_PYTHON
+ * and falls back to `python3` on PATH. Bundled-Python + a Settings
+ * UI override are tracked in #374.
+ */
+function resolvePythonBin(): string {
+  return process.env.MINERVA_PYTHON ?? 'python3';
+}
+
+/**
+ * Where the kernel script lives. In dev (Vite serves the renderer from
+ * a localhost origin) the repo root is `process.cwd()`; in a packaged
+ * build, electron-forge stages `resources/` next to the main bundle.
+ */
+function kernelScriptPath(): string {
+  // The build-time global is undefined in the test runner — guard so a
+  // ReferenceError doesn't kill the import. In dev (or in tests) the
+  // repo's `resources/` is reachable from cwd; in a packaged build,
+  // process.resourcesPath points at the .app's Resources dir.
+  const isDev =
+    typeof MAIN_WINDOW_VITE_DEV_SERVER_URL !== 'undefined'
+      ? Boolean(MAIN_WINDOW_VITE_DEV_SERVER_URL)
+      : !app?.isPackaged;
+  if (isDev) {
+    return path.join(process.cwd(), 'resources', 'python', 'minerva_kernel.py');
+  }
+  return path.join(process.resourcesPath, 'python', 'minerva_kernel.py');
+}
+
+function spawnKernel(rootPath: string): KernelState {
+  const py = resolvePythonBin();
+  const script = kernelScriptPath();
+  const proc = spawn(py, [script], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    // PYTHONUNBUFFERED ensures the kernel's stdout writes flush
+    // immediately — without it, Python's buffering would hold each
+    // event line until 4KB accumulated, breaking the line-protocol.
+    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+  }) as ChildProcessWithoutNullStreams;
+
+  const pending = new Map<string, PendingCell>();
+  let resolveReady: () => void = () => {};
+  let rejectReady: (err: Error) => void = () => {};
+  const ready = new Promise<void>((res, rej) => {
+    resolveReady = res;
+    rejectReady = rej;
+  });
+
+  const rl = readline.createInterface({ input: proc.stdout });
+  rl.on('line', (line) => {
+    let event: KernelEvent;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      console.warn('[python-kernel] non-JSON event line:', line);
+      return;
+    }
+    if (event.type === 'ready') {
+      resolveReady();
+      return;
+    }
+    if (event.type === 'protocol-error') {
+      console.warn('[python-kernel] protocol error:', event.message);
+      return;
+    }
+    if (!event.cellId) return;
+    const cell = pending.get(event.cellId);
+    if (!cell) return;
+    switch (event.type) {
+      case 'stdout':
+        cell.stdout.push(String(event.payload ?? ''));
+        break;
+      case 'stderr':
+        cell.stderr.push(String(event.payload ?? ''));
+        break;
+      case 'result':
+        cell.result = event.payload;
+        break;
+      case 'error':
+        cell.error = event.payload as PendingCell['error'];
+        break;
+      case 'done':
+        finalizeCell(cell);
+        pending.delete(event.cellId);
+        break;
+    }
+  });
+
+  // Forward kernel stderr (Python tracebacks from kernel-side bugs, not
+  // from user cells — the latter are caught and emitted via `error`
+  // events) to the main-process console so they're not silently lost.
+  const errRl = readline.createInterface({ input: proc.stderr });
+  errRl.on('line', (line) => {
+    if (line.trim()) console.warn('[python-kernel:stderr]', line);
+  });
+
+  proc.on('exit', (code, signal) => {
+    // Any in-flight cells get a synthetic error and the project's
+    // kernel slot clears so the next runPython call respawns.
+    const reason = signal ? `signal ${signal}` : `code ${code}`;
+    for (const cell of pending.values()) {
+      cell.resolve({ ok: false, error: `Python kernel exited (${reason}) before cell finished` });
+    }
+    pending.clear();
+    rejectReady(new Error(`Python kernel exited before ready (${reason})`));
+    if (kernels.get(rootPath)?.proc === proc) {
+      kernels.delete(rootPath);
+    }
+  });
+
+  proc.on('error', (err) => {
+    rejectReady(err);
+  });
+
+  return { proc, ready, pending };
+}
+
+function finalizeCell(cell: PendingCell): void {
+  if (cell.error) {
+    const tb = cell.error.traceback.join('\n');
+    cell.resolve({
+      ok: false,
+      error: tb || `${cell.error.ename}: ${cell.error.evalue}`,
+    });
+    return;
+  }
+  // Output precedence: a `result` payload (last-expression value) wins;
+  // otherwise stdout+stderr concatenated as text.
+  if (cell.result !== undefined) {
+    cell.resolve({ ok: true, output: { type: 'json', value: cell.result } });
+    return;
+  }
+  const text = (cell.stdout.join('') + cell.stderr.join('')).replace(/\n+$/, '');
+  cell.resolve({ ok: true, output: { type: 'text', value: text } });
+}
+
+/**
+ * Run a Python cell. Spawns the project's kernel on first call. A
+ * crashed kernel is detected on the next call and respawned.
+ */
+export async function runPython(
+  rootPath: string,
+  notebookPath: string,
+  code: string,
+): Promise<CellResult> {
+  let state = kernels.get(rootPath);
+  if (!state || state.proc.killed || state.proc.exitCode !== null) {
+    state = spawnKernel(rootPath);
+    kernels.set(rootPath, state);
+  }
+  try {
+    await state.ready;
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Python kernel failed to start: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const cellId = randomUUID();
+  return new Promise<CellResult>((resolve) => {
+    state!.pending.set(cellId, { resolve, stdout: [], stderr: [] });
+    const req = JSON.stringify({ op: 'exec', cellId, notebookPath, code });
+    state!.proc.stdin.write(req + '\n');
+  });
+}
+
+/**
+ * Tear down the kernel for `rootPath`. SIGTERM with a 2s grace before
+ * SIGKILL. Used by `Compute: Restart Python Kernel` and as the per-
+ * project unit of `shutdownAllKernels`.
+ */
+export async function stopKernel(rootPath: string): Promise<void> {
+  const state = kernels.get(rootPath);
+  if (!state) return;
+  kernels.delete(rootPath);
+  await terminate(state);
+}
+
+/**
+ * Restart: kill the current kernel; the next runPython call lazy-spawns
+ * a fresh one. Wipes every notebook's namespace.
+ */
+export async function restartKernel(rootPath: string): Promise<void> {
+  await stopKernel(rootPath);
+}
+
+/**
+ * App-quit hook target. Stops every project's kernel concurrently; the
+ * grace period applies per-kernel.
+ */
+export async function shutdownAllKernels(): Promise<void> {
+  const states = [...kernels.values()];
+  kernels.clear();
+  await Promise.all(states.map(terminate));
+}
+
+function terminate(state: KernelState): Promise<void> {
+  return new Promise((resolve) => {
+    if (state.proc.exitCode !== null) {
+      resolve();
+      return;
+    }
+    state.proc.kill('SIGTERM');
+    const t = setTimeout(() => {
+      try { state.proc.kill('SIGKILL'); } catch { /* already gone */ }
+      resolve();
+    }, 2000);
+    state.proc.once('exit', () => {
+      clearTimeout(t);
+      resolve();
+    });
+  });
+}
+
+/** Test/diagnostic visibility — projects with a live kernel. */
+export function activeKernels(): string[] {
+  return [...kernels.keys()];
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -42,6 +42,7 @@ import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
 import { searchInNotes, replaceInNotes, type SearchOptions, type ReplaceSelection } from './notebase/search-in-notes';
 import { runCell as runComputeCell, registeredLanguages as computeLanguages } from './compute/registry';
+import { restartKernel as restartPythonKernel } from './compute/python-kernel';
 import { saveCellOutput, type SaveCellOutputInput } from './compute/save-cell-output';
 import * as publish from './publish';
 import { createExcerpt } from './sources/create-excerpt';
@@ -854,6 +855,12 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(Channels.COMPUTE_LANGUAGES, () => computeLanguages());
+
+  ipcMain.handle(Channels.COMPUTE_RESTART_PYTHON_KERNEL, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return;
+    await restartPythonKernel(rootPath);
+  });
 
   ipcMain.handle(Channels.COMPUTE_SAVE_CELL_OUTPUT, async (e, input: SaveCellOutputInput) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,6 +9,7 @@ import { registerBuiltinExecutors } from './compute/executors';
 import { registerBuiltinExporters } from './publish';
 import { installCsp } from './security';
 import { flushAllProjects } from './project-context';
+import { shutdownAllKernels } from './compute/python-kernel';
 
 app.setName('Minerva');
 
@@ -62,7 +63,10 @@ app.on('before-quit', (event) => {
   if (isFlushingForQuit) return;
   event.preventDefault();
   isFlushingForQuit = true;
-  flushAllProjects()
-    .catch((err) => console.warn('[quit] project flush failed:', err))
+  Promise.allSettled([
+    flushAllProjects(),
+    shutdownAllKernels(),
+  ])
+    .catch((err) => console.warn('[quit] shutdown failed:', err))
     .finally(() => app.quit());
 });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -9,6 +9,7 @@ import * as search from './search/index';
 import * as tables from './sources/tables';
 import { STOCK_QUERIES } from '../shared/stock-queries';
 import { listSavedQueries } from './saved-queries';
+import { restartKernel as restartPythonKernel } from './compute/python-kernel';
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
 import '../shared/tools/definitions/index';
@@ -222,6 +223,16 @@ export function rebuildMenu(): void {
               tables.registerAllCsvs(ctx),
             ]);
             if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          },
+        }),
+        gate({
+          label: 'Restart Python Kernel',
+          click: async () => {
+            const win = BrowserWindow.getFocusedWindow();
+            if (!win) return;
+            const rootPath = getRootPath(win.id);
+            if (!rootPath) return;
+            await restartPythonKernel(rootPath);
           },
         }),
         { type: 'separator' },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -121,6 +121,7 @@ contextBridge.exposeInMainWorld('api', {
     languages: () => ipcRenderer.invoke(Channels.COMPUTE_LANGUAGES),
     saveCellOutput: (input: unknown) =>
       ipcRenderer.invoke(Channels.COMPUTE_SAVE_CELL_OUTPUT, input),
+    restartPythonKernel: () => ipcRenderer.invoke(Channels.COMPUTE_RESTART_PYTHON_KERNEL),
   },
   publish: {
     listExporters: () => ipcRenderer.invoke(Channels.PUBLISH_LIST_EXPORTERS),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -222,6 +222,9 @@ export interface ComputeApi {
     destPath?: string;
     title?: string;
   }): Promise<{ derivedPath: string; cellId: string; injectedId: boolean }>;
+  /** Wipe and respawn the project's Python kernel — palette command
+   *  "Compute: Restart Python Kernel". Loses every notebook's namespace. */
+  restartPythonKernel(): Promise<void>;
 }
 
 export interface ShellApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -229,6 +229,9 @@ export const Channels = {
 
   /** Notebook compute: dispatch a cell to its language's executor (#238). */
   COMPUTE_RUN_CELL: 'compute:runCell',
+  /** Wipe and respawn the project's Python kernel. Loses every notebook's
+   *  namespace state — palette command "Compute: Restart Python Kernel". */
+  COMPUTE_RESTART_PYTHON_KERNEL: 'compute:restartPythonKernel',
   /** List every fence language that has a registered executor. Drives the editor's gutter. */
   COMPUTE_LANGUAGES: 'compute:languages',
   /** Save a cell's output as a first-class note with provenance (#244). */

--- a/tests/main/compute/python-kernel.test.ts
+++ b/tests/main/compute/python-kernel.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for the Python compute kernel (#241).
+ *
+ * These spawn the real kernel script through `python3` (or whatever
+ * `MINERVA_PYTHON` points at). When neither is available the suite
+ * skips itself rather than fails — kernel work is opt-in for CI that
+ * doesn't have Python on PATH.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import {
+  runPython,
+  stopKernel,
+  restartKernel,
+  shutdownAllKernels,
+  activeKernels,
+} from '../../../src/main/compute/python-kernel';
+
+function pythonAvailable(): boolean {
+  const bin = process.env.MINERVA_PYTHON ?? 'python3';
+  try {
+    execSync(`${bin} --version`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const skipIfNoPython = pythonAvailable() ? describe : describe.skip;
+
+skipIfNoPython('python kernel (#241)', () => {
+  // Use an arbitrary string — the kernel's per-project state is
+  // keyed on it; we don't actually need a real directory.
+  const ROOT = '/tmp/minerva-pyk-test-root';
+
+  afterAll(async () => {
+    await shutdownAllKernels();
+  });
+
+  it('end-to-end: a python fence runs and stdout comes back', async () => {
+    const r = await runPython(ROOT, 'a.md', 'print("hi")');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.output.type).toBe('text');
+    if (r.output.type !== 'text') return;
+    expect(r.output.value).toBe('hi');
+  });
+
+  it('last-expression value comes back as a result (Jupyter-style)', async () => {
+    const r = await runPython(ROOT, 'b.md', '1 + 2');
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    expect(r.output.value).toBe(3);
+  });
+
+  it('namespace persists across cells in the SAME notebook', async () => {
+    const r1 = await runPython(ROOT, 'persist.md', 'x = 41\nx + 1');
+    expect(r1.ok).toBe(true);
+    if (!r1.ok || r1.output.type !== 'json') return;
+    expect(r1.output.value).toBe(42);
+
+    const r2 = await runPython(ROOT, 'persist.md', 'x * 2');
+    expect(r2.ok).toBe(true);
+    if (!r2.ok || r2.output.type !== 'json') return;
+    expect(r2.output.value).toBe(82);
+  });
+
+  it('namespaces are isolated across notebooks', async () => {
+    await runPython(ROOT, 'iso-a.md', 'secret = 7');
+    const inA = await runPython(ROOT, 'iso-a.md', 'secret');
+    expect(inA.ok).toBe(true);
+    if (!inA.ok || inA.output.type !== 'json') return;
+    expect(inA.output.value).toBe(7);
+
+    // Different notebookPath ⇒ different namespace ⇒ NameError.
+    const inB = await runPython(ROOT, 'iso-b.md', 'secret');
+    expect(inB.ok).toBe(false);
+    if (inB.ok) return;
+    expect(inB.error).toMatch(/NameError/);
+  });
+
+  it('syntax error returns a structured error with traceback', async () => {
+    const r = await runPython(ROOT, 'err.md', 'def f(:\n  pass');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toMatch(/SyntaxError/);
+  });
+
+  it('runtime error returns a structured error with traceback', async () => {
+    const r = await runPython(ROOT, 'err2.md', 'raise RuntimeError("nope")');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toMatch(/RuntimeError/);
+    expect(r.error).toMatch(/nope/);
+  });
+
+  it('non-JSON-serialisable result falls back to repr', async () => {
+    // Sets aren't JSON-serialisable; the kernel falls back to repr.
+    const r = await runPython(ROOT, 'repr.md', '{1, 2, 3}');
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    // Set ordering isn't guaranteed; just check it's a stringified set
+    // with the elements somewhere inside.
+    expect(typeof r.output.value).toBe('string');
+    const repr = String(r.output.value);
+    expect(repr.startsWith('{')).toBe(true);
+    expect(repr.endsWith('}')).toBe(true);
+    for (const n of [1, 2, 3]) expect(repr).toContain(String(n));
+  });
+
+  it('restartKernel wipes namespaces and the next call respawns', async () => {
+    await runPython(ROOT, 'restart.md', 'x = 100');
+    const before = await runPython(ROOT, 'restart.md', 'x');
+    expect(before.ok).toBe(true);
+
+    await restartKernel(ROOT);
+    expect(activeKernels()).not.toContain(ROOT);
+
+    // Next call lazy-spawns; the prior `x` is gone.
+    const after = await runPython(ROOT, 'restart.md', 'x');
+    expect(after.ok).toBe(false);
+    if (after.ok) return;
+    expect(after.error).toMatch(/NameError/);
+  });
+
+  it('print without trailing newline still surfaces', async () => {
+    const r = await runPython(ROOT, 'noeol.md', "import sys; sys.stdout.write('no-newline')");
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'text') return;
+    expect(r.output.value).toBe('no-newline');
+  });
+
+  it('multiple statements: only the last expression value comes back as result; preceding stdout still goes', async () => {
+    const r = await runPython(ROOT, 'multi.md', 'print("first")\nprint("second")\n2 + 2');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // result wins over stdout when the last stmt is an expression.
+    expect(r.output.type).toBe('json');
+    if (r.output.type !== 'json') return;
+    expect(r.output.value).toBe(4);
+  });
+
+  it('kernel crash → next cell call auto-respawns', async () => {
+    // Prime: get the kernel running for this project.
+    await runPython(ROOT, 'crash.md', 'x = 1');
+    expect(activeKernels()).toContain(ROOT);
+
+    // os._exit(1) bypasses the kernel's exception handlers and tears
+    // down the Python process — simulates a hard crash.
+    const r = await runPython(ROOT, 'crash.md', 'import os; os._exit(1)');
+    // The cell that triggered the crash gets a synthetic error since
+    // the kernel exited before sending `done`.
+    expect(r.ok).toBe(false);
+
+    // Slot has been cleared by the exit handler; next call respawns.
+    const recovered = await runPython(ROOT, 'crash.md', 'print("alive")');
+    expect(recovered.ok).toBe(true);
+    if (!recovered.ok || recovered.output.type !== 'text') return;
+    expect(recovered.output.value).toBe('alive');
+  });
+
+  it('two projects keep independent kernels', async () => {
+    const ROOT2 = ROOT + '-other';
+    try {
+      await runPython(ROOT, 'sep.md', 'shared = "in-A"');
+      await runPython(ROOT2, 'sep.md', 'shared = "in-B"');
+
+      const inA = await runPython(ROOT, 'sep.md', 'shared');
+      const inB = await runPython(ROOT2, 'sep.md', 'shared');
+      expect(inA.ok && inA.output.type === 'json' ? inA.output.value : null).toBe('in-A');
+      expect(inB.ok && inB.output.type === 'json' ? inB.output.value : null).toBe('in-B');
+    } finally {
+      await stopKernel(ROOT2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
First-class Python compute. Spawns a long-running Python subprocess per project on first cell execution, multiplexes JSON-line requests/events over stdio, keeps per-notebook namespaces so cells in the same notebook share state and cells in different notebooks don't.

### Components
- **`resources/python/minerva_kernel.py`** — single-file kernel. AST-splits each cell so a bare last expression evaluates as a result (Jupyter style). Captures stdout/stderr + tracebacks. Best-effort JSON, falls back to `repr()`. Per-notebook globals dict.
- **`src/main/compute/python-kernel.ts`** — adapter. Per-rootPath singleton, lazy spawn, line-based event reader, finalize-on-`done`. `$MINERVA_PYTHON` → `python3` on PATH. `PYTHONUNBUFFERED=1` so the line-protocol isn't stalled behind 4KB stdio buffering.
- **`src/main/compute/executors/python.ts`** — registers `python`, `py`, `python3` against the compute registry.
- **Lifecycle** — SIGTERM + 2s grace + SIGKILL. `COMPUTE_RESTART_PYTHON_KERNEL` IPC + palette hook. The before-quit shutdown now also awaits `shutdownAllKernels()` so Cmd+Q leaves no orphan Python processes.
- **Crash recovery** — proc-exit handler clears the project's kernel slot; next call lazy-spawns. In-flight cells get a synthetic error.
- **`forge.config.ts`** — `extraResource: ['resources']` so the kernel ships next to the packaged main bundle.

### Acceptance
- [x] python fence executes end-to-end, stdout appears
- [x] var in cell A visible in cell B (same notebook)
- [x] var in notebook A NOT visible in notebook B
- [x] syntax error → traceback rendered
- [x] `Compute: Restart Python Kernel` wipes namespaces + respawns
- [x] crash → next execution auto-respawns
- [ ] `Compute: Interrupt Cell` — **deferred to #372** (cross-platform SIGINT non-trivial)
- [ ] first-run trust dialog — **deferred to #373** (UX gating, kernel works without it)
- [ ] clean shutdown on `app.quit` (ps aux check) — wired via before-quit; needs manual smoke

Bundled-Python + Settings UI override deferred to **#374**.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1516/1516 passing (12 new in `tests/main/compute/python-kernel.test.ts`; suite skips when `python3` isn't on PATH)
- [ ] **Smoke (manual, dev)**: open a note with a `\`\`\`python` fence (\`print('hi'); 1+2\`); run cell — output appears; run a second cell using a variable from the first — same namespace.
- [ ] **Smoke**: run cell, observe `ps aux | grep python` shows one Minerva-spawned Python; quit Minerva; the process is gone.
- [ ] **Smoke**: run a cell that sets `x = 42`; palette → "Compute: Restart Python Kernel"; running `x` returns `NameError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)