### PR TITLE
compute: minerva.* Python library (closes #242)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ coverage/
 .idea/
 *.log
 .DS_Store
+__pycache__/
+*.pyc
 
 # Demo source/excerpt fixtures in the sample thoughtbase.
 # Everything else under sample-project/.minerva/ (bookmarks.json, tabs.json,

--- a/resources/python/minerva/__init__.py
+++ b/resources/python/minerva/__init__.py
@@ -1,0 +1,111 @@
+"""
+Minerva Python library (#242).
+
+Exposes the project's graph, tables, notes, sources, and excerpts to
+Python cells running inside the Minerva compute kernel. Methods marshal
+calls over a Unix domain socket to the main process — so a SPARQL
+query in a Python cell hits exactly the same code path as the same
+query in the Query Panel, with no separate engine or auth layer.
+
+Public API:
+
+    minerva.sparql(query)             -> pandas.DataFrame
+    minerva.sql(query)                -> pandas.DataFrame
+    minerva.notes.read(rel_path)      -> Note
+    minerva.notes.by_tag(tag)         -> list[TaggedNote]
+    minerva.notes.search(query)       -> list[SearchResult]
+    minerva.sources.get(source_id)    -> SourceDetail
+    minerva.sources.citing(source_id) -> list[Backlink]
+    minerva.excerpts.for_source(id)   -> list[str]
+    minerva.ctx()                     -> {'project_root': str, 'notebook_path': str|None}
+
+Errors are translated into proper Python exceptions:
+    minerva.NotFoundError, minerva.QueryError, minerva.RpcError.
+"""
+
+from . import notes, sources, excerpts
+from ._exceptions import NotFoundError, QueryError, RpcError
+from ._rpc import call as _call
+
+import os as _os
+
+# The kernel sets this before each cell exec via _set_current_notebook.
+_current_notebook = None
+
+
+def _set_current_notebook(path):
+    """Internal — the kernel calls this before executing a cell."""
+    global _current_notebook
+    _current_notebook = path
+
+
+def ctx():
+    """Return the current project + notebook context.
+
+    `notebook_path` is None outside a cell exec — e.g. if the library
+    is imported from an interactive session against the kernel
+    without a containing notebook.
+    """
+    return {
+        'project_root': _os.environ.get('MINERVA_PROJECT_ROOT'),
+        'notebook_path': _current_notebook,
+    }
+
+
+def sparql(query):
+    """Run a SPARQL SELECT and return a pandas DataFrame.
+
+    Empty results return an empty DataFrame (not None). Column order
+    matches the SELECT variable order. Pandas is imported lazily so
+    the rest of the library remains usable in environments without
+    pandas installed.
+    """
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise ImportError(
+            "minerva.sparql() returns a pandas DataFrame; install pandas "
+            "into the Python environment Minerva spawned: pip install pandas"
+        ) from exc
+    res = _call('sparql', query=query)
+    rows = res.get('rows', [])
+    if not rows:
+        return pd.DataFrame()
+    # Preserve key order from the first row — Comunica + the graph
+    # layer return rows in SELECT-projection order, which `dict`
+    # iteration preserves in Python 3.7+.
+    columns = list(rows[0].keys())
+    return pd.DataFrame(rows, columns=columns)
+
+
+def sql(query):
+    """Run a SQL query against the project's DuckDB and return a DataFrame.
+
+    Same lazy-pandas dance as `sparql`.
+    """
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise ImportError(
+            "minerva.sql() returns a pandas DataFrame; install pandas: "
+            "pip install pandas"
+        ) from exc
+    res = _call('sql', query=query)
+    columns = res.get('columns', [])
+    rows = res.get('rows', [])
+    if not rows:
+        return pd.DataFrame(columns=columns)
+    return pd.DataFrame(rows, columns=columns)
+
+
+__all__ = [
+    'sparql',
+    'sql',
+    'notes',
+    'sources',
+    'excerpts',
+    'ctx',
+    'NotFoundError',
+    'QueryError',
+    'RpcError',
+]

--- a/resources/python/minerva/__init__.py
+++ b/resources/python/minerva/__init__.py
@@ -52,6 +52,31 @@ def ctx():
     }
 
 
+def _import_pandas(fn_name):
+    """Lazy pandas import with an actionable error.
+
+    The default `python3` on macOS (Homebrew) is PEP 668-locked, so a
+    naked `pip install pandas` fails. Point users at the venv pattern
+    Minerva supports via $MINERVA_PYTHON.
+    """
+    try:
+        import pandas as pd
+        return pd
+    except ImportError as exc:
+        import sys
+        raise ImportError(
+            f"minerva.{fn_name}() returns a pandas DataFrame, but pandas "
+            f"is not installed in {sys.executable}.\n"
+            "Recommended: create a venv and point Minerva at it.\n"
+            "  python3 -m venv ~/.minerva-venv\n"
+            "  ~/.minerva-venv/bin/pip install pandas\n"
+            "Then relaunch Minerva with:\n"
+            "  MINERVA_PYTHON=~/.minerva-venv/bin/python\n"
+            "(set in your shell or ~/.zshrc before `pnpm dev`; a kernel "
+            "restart alone won't pick up env var changes.)"
+        ) from exc
+
+
 def sparql(query):
     """Run a SPARQL SELECT and return a pandas DataFrame.
 
@@ -60,13 +85,7 @@ def sparql(query):
     the rest of the library remains usable in environments without
     pandas installed.
     """
-    try:
-        import pandas as pd
-    except ImportError as exc:
-        raise ImportError(
-            "minerva.sparql() returns a pandas DataFrame; install pandas "
-            "into the Python environment Minerva spawned: pip install pandas"
-        ) from exc
+    pd = _import_pandas('sparql')
     res = _call('sparql', query=query)
     rows = res.get('rows', [])
     if not rows:
@@ -83,13 +102,7 @@ def sql(query):
 
     Same lazy-pandas dance as `sparql`.
     """
-    try:
-        import pandas as pd
-    except ImportError as exc:
-        raise ImportError(
-            "minerva.sql() returns a pandas DataFrame; install pandas: "
-            "pip install pandas"
-        ) from exc
+    pd = _import_pandas('sql')
     res = _call('sql', query=query)
     columns = res.get('columns', [])
     rows = res.get('rows', [])

--- a/resources/python/minerva/_exceptions.py
+++ b/resources/python/minerva/_exceptions.py
@@ -1,0 +1,51 @@
+"""Python-side exception classes for the Minerva RPC bridge (#242).
+
+The TS RPC server tags each error with a string code; the client maps
+that code onto the matching exception class so user code can catch
+`minerva.NotFoundError` rather than parsing strings.
+"""
+
+
+class RpcError(Exception):
+    """Generic RPC failure — base class for all minerva-* exceptions.
+
+    Catch this if you don't care about the specific failure mode (e.g.
+    the kernel can't reach the main process at all).
+    """
+    def __init__(self, message, code='RpcError'):
+        super().__init__(message)
+        self.code = code
+
+
+class NotFoundError(RpcError):
+    """Requested resource — note, source, excerpt — does not exist."""
+    def __init__(self, message):
+        super().__init__(message, code='NotFoundError')
+
+
+class QueryError(RpcError):
+    """SPARQL parse / runtime error or SQL parse / runtime error.
+
+    Use this for any query that the engine couldn't execute as written;
+    the message carries the engine's diagnostic.
+    """
+    def __init__(self, message):
+        super().__init__(message, code='QueryError')
+
+
+# Map a server-side code string onto a client-side exception class.
+_CODE_TO_EXCEPTION = {
+    'NotFoundError': NotFoundError,
+    'QueryError': QueryError,
+}
+
+
+def from_server_error(error):
+    """Turn an `{code, message}` dict from the server into the right
+    Python exception instance."""
+    code = error.get('code', 'RpcError')
+    message = error.get('message', '<no message>')
+    cls = _CODE_TO_EXCEPTION.get(code, RpcError)
+    if cls is RpcError:
+        return RpcError(message, code=code)
+    return cls(message)

--- a/resources/python/minerva/_rpc.py
+++ b/resources/python/minerva/_rpc.py
@@ -1,0 +1,80 @@
+"""Line-delimited JSON-RPC client over the per-kernel Unix socket (#242).
+
+The kernel adapter spawns the Python child with `MINERVA_IPC_SOCKET`
+pointing at a per-project listening socket. We open a single connection
+per Python process, lazily, on first call — no pool, no reconnect logic
+in v1; if the kernel dies the whole process is going down anyway.
+
+Wire format (one JSON object per line, both directions):
+    request:  {"id": <int>, "method": "...", "params": {...}}
+    response: {"id": <int>, "result": <any>}
+            | {"id": <int>, "error": {"code": "...", "message": "..."}}
+
+This client is synchronous — the goal is to make `minerva.sparql(...)`
+look like a function call. The TS server processes requests sequentially
+per connection, so we don't need request multiplexing.
+"""
+
+import json
+import os
+import socket
+import threading
+import itertools
+
+from ._exceptions import RpcError, from_server_error
+
+
+_lock = threading.Lock()
+_conn = None
+_buf = b''
+_id_seq = itertools.count(1)
+
+
+def _connect():
+    socket_path = os.environ.get('MINERVA_IPC_SOCKET')
+    if not socket_path:
+        raise RpcError(
+            'MINERVA_IPC_SOCKET is not set — this Python process is not '
+            'running inside a Minerva compute kernel.',
+            code='NoTransport',
+        )
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(socket_path)
+    return s
+
+
+def _read_line():
+    """Read until the next \\n. The socket guarantees byte-stream
+    semantics, so we buffer between reads."""
+    global _buf
+    while b'\n' not in _buf:
+        chunk = _conn.recv(8192)
+        if not chunk:
+            raise RpcError('RPC socket closed by main process', code='ConnectionClosed')
+        _buf += chunk
+    line, _, _buf = _buf.partition(b'\n')
+    return line
+
+
+def call(method, **params):
+    """Send a request and block until the matching response arrives.
+
+    The TS server processes requests in arrival order on a connection,
+    so the response we read back is always for the request we sent —
+    no id-matching loop needed.
+    """
+    global _conn
+    with _lock:
+        if _conn is None:
+            _conn = _connect()
+        request_id = next(_id_seq)
+        msg = json.dumps({'id': request_id, 'method': method, 'params': params})
+        _conn.sendall(msg.encode('utf-8') + b'\n')
+        line = _read_line()
+        try:
+            response = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RpcError(f'Malformed RPC reply: {line!r}') from exc
+        if 'error' in response:
+            raise from_server_error(response['error'])
+        return response.get('result')

--- a/resources/python/minerva/excerpts.py
+++ b/resources/python/minerva/excerpts.py
@@ -1,0 +1,15 @@
+"""Excerpt-level operations (#242).
+
+An excerpt is a verbatim quotation lifted from a Source, stored at
+`.minerva/excerpts/<id>.ttl`.
+"""
+
+from ._rpc import call
+
+
+def for_source(source_id):
+    """List the excerpt ids that belong to a given source.
+
+    Returns a list of strings — the excerpt ids — in indexing order.
+    """
+    return call('excerpts.for_source', sourceId=source_id)

--- a/resources/python/minerva/notes.py
+++ b/resources/python/minerva/notes.py
@@ -1,0 +1,41 @@
+"""Note-level operations against the project's notebase (#242).
+
+Mirrors the renderer's API: `read` returns the full content + parsed
+frontmatter + tags + title; `by_tag` returns the same shape the right-
+sidebar uses; `search` is the project's MiniSearch index.
+"""
+
+from ._rpc import call
+
+
+def read(relative_path):
+    """Read a note by its project-relative path.
+
+    Returns a dict::
+
+        {'relativePath': 'notes/x.md',
+         'title': 'X' | None,
+         'frontmatter': {...},
+         'tags': ['a', 'b', ...],
+         'body': '<full markdown source>'}
+
+    Raises `minerva.NotFoundError` if the path doesn't exist.
+    """
+    return call('notes.read', relativePath=relative_path)
+
+
+def by_tag(tag):
+    """Notes carrying `#tag` (in body or frontmatter).
+
+    Returns a list of `{relativePath, title}` dicts in the order the
+    main-side `notesByTag` returns them.
+    """
+    return call('notes.by_tag', tag=tag)
+
+
+def search(query, limit=20):
+    """Full-text search via the project's MiniSearch index.
+
+    Returns a list of `{relativePath, title, snippet, score}` dicts.
+    """
+    return call('notes.search', query=query, limit=limit)

--- a/resources/python/minerva/sources.py
+++ b/resources/python/minerva/sources.py
@@ -1,0 +1,24 @@
+"""Source-level operations (#242).
+
+A source is a citable external work (Article, Book, …). Identified by
+`sourceId` — the directory name under `.minerva/sources/`.
+"""
+
+from ._rpc import call
+
+
+def get(source_id):
+    """Full source metadata + excerpts + backlinks.
+
+    Returns the same `SourceDetail` shape the renderer's source panel
+    uses. Raises `minerva.NotFoundError` if the source isn't indexed.
+    """
+    return call('sources.get', sourceId=source_id)
+
+
+def citing(source_id):
+    """Notes that wiki-link to this source via `[[cite::id]]`.
+
+    Returns a list of `{relativePath, sourceTitle, kind: 'cite'}` dicts.
+    """
+    return call('sources.citing', sourceId=source_id)

--- a/resources/python/minerva_kernel.py
+++ b/resources/python/minerva_kernel.py
@@ -72,11 +72,24 @@ def serialize_value(value):
         return repr(value)
 
 
+def set_current_notebook(notebook_path):
+    """Tell the bundled `minerva` library which notebook the cell is
+    running in (#242). The library reads this for `minerva.ctx()`."""
+    try:
+        import minerva
+        minerva._set_current_notebook(notebook_path)
+    except Exception:
+        # Library not on path / not importable — ignore; user code will
+        # surface a clearer error if they actually try to use it.
+        pass
+
+
 def exec_cell(req):
     cell_id = req.get('cellId')
     code = req.get('code', '')
     notebook = req.get('notebookPath') or '__default__'
     ns = get_ns(notebook)
+    set_current_notebook(notebook)
 
     started = time.monotonic()
     out = io.StringIO()

--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -21,6 +21,7 @@ import readline from 'node:readline';
 import { app } from 'electron';
 import { randomUUID } from 'node:crypto';
 import type { CellResult } from '../../shared/compute/types';
+import { startRpcServer, type RpcServer } from './rpc-server';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 
@@ -46,6 +47,7 @@ interface KernelState {
   proc: ChildProcessWithoutNullStreams;
   ready: Promise<void>;
   pending: Map<string, PendingCell>;
+  rpc: RpcServer;
 }
 
 const kernels = new Map<string, KernelState>();
@@ -64,7 +66,8 @@ function resolvePythonBin(): string {
  * a localhost origin) the repo root is `process.cwd()`; in a packaged
  * build, electron-forge stages `resources/` next to the main bundle.
  */
-function kernelScriptPath(): string {
+/** Root of the bundled Python resources tree. */
+function pythonResourcesRoot(): string {
   // The build-time global is undefined in the test runner — guard so a
   // ReferenceError doesn't kill the import. In dev (or in tests) the
   // repo's `resources/` is reachable from cwd; in a packaged build,
@@ -73,21 +76,35 @@ function kernelScriptPath(): string {
     typeof MAIN_WINDOW_VITE_DEV_SERVER_URL !== 'undefined'
       ? Boolean(MAIN_WINDOW_VITE_DEV_SERVER_URL)
       : !app?.isPackaged;
-  if (isDev) {
-    return path.join(process.cwd(), 'resources', 'python', 'minerva_kernel.py');
-  }
-  return path.join(process.resourcesPath, 'python', 'minerva_kernel.py');
+  return isDev
+    ? path.join(process.cwd(), 'resources', 'python')
+    : path.join(process.resourcesPath, 'python');
 }
 
-function spawnKernel(rootPath: string): KernelState {
+function kernelScriptPath(): string {
+  return path.join(pythonResourcesRoot(), 'minerva_kernel.py');
+}
+
+async function spawnKernel(rootPath: string): Promise<KernelState> {
   const py = resolvePythonBin();
   const script = kernelScriptPath();
+  // RPC server up first so the kernel can connect on first import.
+  const rpc = await startRpcServer(rootPath);
   const proc = spawn(py, [script], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    // PYTHONUNBUFFERED ensures the kernel's stdout writes flush
-    // immediately — without it, Python's buffering would hold each
-    // event line until 4KB accumulated, breaking the line-protocol.
-    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+    env: {
+      ...process.env,
+      // PYTHONUNBUFFERED ensures the kernel's stdout writes flush
+      // immediately — without it, Python's buffering would hold each
+      // event line until 4KB accumulated, breaking the line-protocol.
+      PYTHONUNBUFFERED: '1',
+      // The bundled `minerva` package lives next to the kernel script;
+      // putting its parent on PYTHONPATH lets `import minerva` resolve
+      // without a pip install (#242).
+      PYTHONPATH: pythonResourcesRoot(),
+      MINERVA_IPC_SOCKET: rpc.socketPath,
+      MINERVA_PROJECT_ROOT: rootPath,
+    },
   }) as ChildProcessWithoutNullStreams;
 
   const pending = new Map<string, PendingCell>();
@@ -158,13 +175,17 @@ function spawnKernel(rootPath: string): KernelState {
     if (kernels.get(rootPath)?.proc === proc) {
       kernels.delete(rootPath);
     }
+    // Close the RPC socket on crash too — terminate() handles it on the
+    // graceful path, but a kernel that exits before terminate runs (e.g.
+    // os._exit, segfault) needs the socket cleaned up here.
+    void rpc.close().catch(() => undefined);
   });
 
   proc.on('error', (err) => {
     rejectReady(err);
   });
 
-  return { proc, ready, pending };
+  return { proc, ready, pending, rpc };
 }
 
 function finalizeCell(cell: PendingCell): void {
@@ -197,7 +218,7 @@ export async function runPython(
 ): Promise<CellResult> {
   let state = kernels.get(rootPath);
   if (!state || state.proc.killed || state.proc.exitCode !== null) {
-    state = spawnKernel(rootPath);
+    state = await spawnKernel(rootPath);
     kernels.set(rootPath, state);
   }
   try {
@@ -247,8 +268,8 @@ export async function shutdownAllKernels(): Promise<void> {
   await Promise.all(states.map(terminate));
 }
 
-function terminate(state: KernelState): Promise<void> {
-  return new Promise((resolve) => {
+async function terminate(state: KernelState): Promise<void> {
+  await new Promise<void>((resolve) => {
     if (state.proc.exitCode !== null) {
       resolve();
       return;
@@ -263,6 +284,9 @@ function terminate(state: KernelState): Promise<void> {
       resolve();
     });
   });
+  // Close the RPC socket once the kernel is gone (#242). Best-effort:
+  // a stale .sock inode in /tmp is harmless but unsightly.
+  await state.rpc.close().catch(() => undefined);
 }
 
 /** Test/diagnostic visibility — projects with a live kernel. */

--- a/src/main/compute/rpc-server.ts
+++ b/src/main/compute/rpc-server.ts
@@ -1,0 +1,264 @@
+/**
+ * Minerva Python library RPC server (#242).
+ *
+ * One Unix domain socket per project. The Python kernel for that project
+ * connects with `MINERVA_IPC_SOCKET=<path>`; the bundled `minerva` package
+ * inside the kernel marshals method calls (sparql, sql, notes.read, …) as
+ * line-delimited JSON-RPC over that socket. Main dispatches each method
+ * to the existing service it would have used for the renderer — same
+ * graph queries, same DuckDB session, same fs guards — so a SPARQL
+ * query in a Python cell returns the same rows as the same query in
+ * the Query Panel.
+ *
+ * Wire format (one JSON object per line):
+ *   request:  {"id": <number>, "method": "sparql", "params": {...}}
+ *   response: {"id": <number>, "result": <any>}
+ *           | {"id": <number>, "error": {"code": "...", "message": "..."}}
+ *
+ * Lifecycle: created when a project's Python kernel is spawned, stopped
+ * when the kernel is. One server per project means the socket itself
+ * carries the project identity — no need to re-thread `rootPath` on
+ * every call.
+ */
+
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import readline from 'node:readline';
+import { randomBytes } from 'node:crypto';
+import * as graph from '../graph/index';
+import * as tables from '../sources/tables';
+import * as search from '../search/index';
+import * as notebaseFs from '../notebase/fs';
+import { parseMarkdown } from '../graph/parser';
+import { projectContext } from '../project-context-types';
+
+interface RpcRequest {
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface RpcSuccess {
+  id: number;
+  result: unknown;
+}
+
+interface RpcFailure {
+  id: number;
+  error: { code: string; message: string };
+}
+
+type RpcMethod = (rootPath: string, params: Record<string, unknown>) => Promise<unknown> | unknown;
+
+class RpcError extends Error {
+  constructor(public code: string, message: string) {
+    super(message);
+  }
+}
+
+function notFound(message: string): never {
+  throw new RpcError('NotFoundError', message);
+}
+
+function queryError(message: string): never {
+  throw new RpcError('QueryError', message);
+}
+
+function asString(v: unknown, name: string): string {
+  if (typeof v !== 'string') throw new RpcError('TypeError', `${name} must be a string`);
+  return v;
+}
+
+const methods: Record<string, RpcMethod> = {
+  // ── Graph / SQL ───────────────────────────────────────────────────
+  sparql: async (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const query = asString(params.query, 'query');
+    const r = (await graph.queryGraph(ctx, query)) as { results: unknown[]; error?: string };
+    if (r.error) queryError(r.error);
+    return { rows: r.results };
+  },
+
+  sql: async (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const query = asString(params.query, 'query');
+    const r = await tables.runQuery(ctx, query);
+    if (!r.ok) queryError(r.error);
+    // Strip the discriminant so Python sees a clean { columns, rows }.
+    return { columns: r.columns, rows: serializeForJson(r.rows) };
+  },
+
+  // ── Notes ─────────────────────────────────────────────────────────
+  'notes.read': async (rootPath, params) => {
+    const relativePath = asString(params.relativePath, 'relativePath');
+    let content: string;
+    try {
+      content = await notebaseFs.readFile(rootPath, relativePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') notFound(`Note not found: ${relativePath}`);
+      throw new RpcError('IOError', err instanceof Error ? err.message : String(err));
+    }
+    const parsed = parseMarkdown(content);
+    // parseMarkdown.tags is body-only (#tags inline); merge frontmatter
+    // tags so the Python API's `note['tags']` matches user expectations
+    // ("the tags this note has", not "the tags in the body").
+    const fmTags = parsed.frontmatter.tags;
+    const tags = new Set(parsed.tags);
+    if (Array.isArray(fmTags)) {
+      for (const t of fmTags) {
+        if (typeof t === 'string') tags.add(t);
+      }
+    }
+    return {
+      relativePath,
+      title: parsed.title ?? null,
+      frontmatter: parsed.frontmatter,
+      tags: [...tags],
+      body: content,
+    };
+  },
+
+  'notes.by_tag': (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const tag = asString(params.tag, 'tag');
+    return graph.notesByTag(ctx, tag);
+  },
+
+  'notes.search': (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const query = asString(params.query, 'query');
+    const limit = typeof params.limit === 'number' ? params.limit : 20;
+    return search.search(ctx, query, { limit });
+  },
+
+  // ── Sources ───────────────────────────────────────────────────────
+  'sources.get': (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const sourceId = asString(params.sourceId, 'sourceId');
+    const detail = graph.getSourceDetail(ctx, sourceId);
+    if (!detail) notFound(`Source not found: ${sourceId}`);
+    return detail;
+  },
+
+  'sources.citing': (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const sourceId = asString(params.sourceId, 'sourceId');
+    const detail = graph.getSourceDetail(ctx, sourceId);
+    if (!detail) return [];
+    // SourceDetail.backlinks already mixes cite + quote kinds; filter
+    // to the cite-only set so Python's `sources.citing(id)` matches
+    // its name.
+    return detail.backlinks.filter((b) => b.kind === 'cite');
+  },
+
+  // ── Excerpts ──────────────────────────────────────────────────────
+  'excerpts.for_source': (rootPath, params) => {
+    const ctx = projectContext(rootPath);
+    const sourceId = asString(params.sourceId, 'sourceId');
+    return graph.excerptIdsForSource(ctx, sourceId);
+  },
+};
+
+/** DuckDB returns BigInt for INTEGER columns; JSON.stringify can't
+ *  handle them, so coerce to string here. Mirrors what the SQL
+ *  executor does for the cell-output path. */
+function serializeForJson(rows: Record<string, unknown>[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (typeof v === 'bigint') out[k] = v.toString();
+      else if (v instanceof Date) out[k] = v.toISOString();
+      else out[k] = v;
+    }
+    return out;
+  });
+}
+
+export interface RpcServer {
+  socketPath: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Dispatch a single method by name. Exported for unit tests so they can
+ * exercise the dispatch table without standing up a socket.
+ */
+export async function dispatchMethod(rootPath: string, method: string, params: Record<string, unknown>): Promise<RpcSuccess | RpcFailure> {
+  const fn = methods[method];
+  if (!fn) {
+    return { id: 0, error: { code: 'MethodNotFound', message: `Unknown RPC method: ${method}` } };
+  }
+  try {
+    const result = await fn(rootPath, params);
+    return { id: 0, result };
+  } catch (err) {
+    if (err instanceof RpcError) {
+      return { id: 0, error: { code: err.code, message: err.message } };
+    }
+    return {
+      id: 0,
+      error: { code: 'InternalError', message: err instanceof Error ? err.message : String(err) },
+    };
+  }
+}
+
+/**
+ * Start a listening socket. Returns the path to pass to the kernel
+ * via `MINERVA_IPC_SOCKET` and a close() handle the kernel adapter
+ * calls when the kernel exits.
+ */
+export async function startRpcServer(rootPath: string): Promise<RpcServer> {
+  const socketPath = path.join(
+    os.tmpdir(),
+    `minerva-rpc-${process.pid}-${randomBytes(4).toString('hex')}.sock`,
+  );
+
+  const server = net.createServer((conn) => {
+    const rl = readline.createInterface({ input: conn });
+    rl.on('line', async (line) => {
+      let req: RpcRequest;
+      try {
+        req = JSON.parse(line);
+      } catch {
+        // Malformed line — caller protocol bug. Drop it; the Python
+        // side will time out on its own.
+        return;
+      }
+      const dispatched = await dispatchMethod(rootPath, req.method, req.params ?? {});
+      const reply: RpcSuccess | RpcFailure = 'result' in dispatched
+        ? { id: req.id, result: dispatched.result }
+        : { id: req.id, error: dispatched.error };
+      try {
+        conn.write(JSON.stringify(reply) + '\n');
+      } catch {
+        // Client gone — let the connection close naturally.
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  return {
+    socketPath,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        // The .sock inode hangs around after close on some systems —
+        // best-effort unlink so /tmp doesn't accumulate stragglers.
+        // (Errors ignored: the socket may have already been removed.)
+      }).then(async () => {
+        try {
+          const fs = await import('node:fs/promises');
+          await fs.unlink(socketPath);
+        } catch { /* nothing to do */ }
+      }),
+  };
+}

--- a/tests/main/compute/python-library.test.ts
+++ b/tests/main/compute/python-library.test.ts
@@ -1,0 +1,189 @@
+/**
+ * End-to-end tests for the bundled `minerva` Python library (#242).
+ *
+ * These spawn a real kernel against a real project, run a real
+ * `import minerva` cell, and assert the response shape. The kernel
+ * connects back to the main-side RPC server over a Unix socket, so
+ * a green run here exercises:
+ *   - the kernel adapter spawns with PYTHONPATH + MINERVA_IPC_SOCKET set
+ *   - the RPC server listens, dispatches, replies
+ *   - the Python package's blocking socket client + JSON framing
+ *   - the exception-class translation (server error -> NotFoundError)
+ *
+ * Skips when `python3` isn't on PATH so CI without Python doesn't fail.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { runPython, shutdownAllKernels, stopKernel } from '../../../src/main/compute/python-kernel';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { initSearch, indexNote as searchIndex } from '../../../src/main/search/index';
+import { initTablesDb } from '../../../src/main/sources/tables';
+import { projectContext } from '../../../src/main/project-context-types';
+
+function pythonAvailable(): boolean {
+  const bin = process.env.MINERVA_PYTHON ?? 'python3';
+  try {
+    execSync(`${bin} --version`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const skipIfNoPython = pythonAvailable() ? describe : describe.skip;
+
+skipIfNoPython('minerva.* Python library (#242)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-pylib-test-'));
+  });
+
+  afterAll(async () => {
+    await shutdownAllKernels();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    // Each test gets a fresh project state — but reuse the kernel.
+    // Re-initing graph/search/tables wipes the in-memory store.
+    const ctx = projectContext(root);
+    await initGraph(ctx);
+    await initSearch(ctx);
+    await initTablesDb(ctx);
+  });
+
+  afterEach(async () => {
+    // Wipe Python namespace state too so a leftover `import minerva`
+    // import-cache + sticky `minerva._current_notebook` doesn't leak
+    // between tests. stopKernel + the next runPython respawn is the
+    // simplest reset.
+    await stopKernel(root);
+  });
+
+  it('import minerva succeeds with zero config; ctx() carries the project root', async () => {
+    const r = await runPython(root, 'a.md', `
+import minerva, os
+ctx = minerva.ctx()
+{'project_root': ctx['project_root'], 'notebook_path': ctx['notebook_path']}
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    const value = r.output.value as { project_root: string; notebook_path: string };
+    expect(value.project_root).toBe(root);
+    expect(value.notebook_path).toBe('a.md');
+  });
+
+  it('minerva.notes.read on a missing file raises minerva.NotFoundError', async () => {
+    const r = await runPython(root, 't.md', `
+import minerva
+try:
+    minerva.notes.read('does-not-exist.md')
+    'NO_RAISE'
+except minerva.NotFoundError as e:
+    'NotFoundError: ' + str(e)
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    expect(String(r.output.value)).toMatch(/^NotFoundError:.*does-not-exist\.md/);
+  });
+
+  it('minerva.notes.by_tag round-trips against the graph', async () => {
+    const ctx = projectContext(root);
+    await indexNote(ctx, 'taggedA.md', '# Tagged A\n#myunique\n');
+    await indexNote(ctx, 'taggedB.md', '# Tagged B\nuntagged.\n');
+
+    const r = await runPython(root, 'q.md', `
+import minerva
+sorted(n['relativePath'] for n in minerva.notes.by_tag('myunique'))
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    expect(r.output.value).toEqual(['taggedA.md']);
+  });
+
+  it('minerva.notes.read returns frontmatter + body for an existing note', async () => {
+    await fsp.writeFile(
+      path.join(root, 'real.md'),
+      '---\ntitle: Real Note\ntags: [alpha]\n---\n# Real Note\nHello.\n',
+      'utf-8',
+    );
+    const r = await runPython(root, 'r.md', `
+import minerva
+note = minerva.notes.read('real.md')
+{'title': note['title'], 'tags': note['tags'], 'has_body': 'Hello.' in note['body']}
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    const v = r.output.value as { title: string; tags: string[]; has_body: boolean };
+    expect(v.title).toBe('Real Note');
+    expect(v.tags).toEqual(['alpha']);
+    expect(v.has_body).toBe(true);
+  });
+
+  it('minerva.sparql results round-trip; rows match the same query through queryGraph', async () => {
+    const ctx = projectContext(root);
+    await indexNote(ctx, 'sparkle.md', '# Sparkle\n');
+
+    // Skip this test if pandas isn't installed in the dev env. Use
+    // importlib.util.find_spec — a try/import block is a statement,
+    // not an expression, so it can't be the last value in a cell.
+    const probe = await runPython(root, 'probe.md', `
+import importlib.util
+importlib.util.find_spec('pandas') is not None
+`);
+    if (probe.ok && probe.output.type === 'json' && probe.output.value === false) {
+      // pandas not available — assert minerva.sparql raises a clear ImportError.
+      const r = await runPython(root, 'no-pd.md', `
+import minerva
+try:
+    minerva.sparql('SELECT * WHERE { ?s ?p ?o } LIMIT 1')
+    'NO_RAISE'
+except ImportError as e:
+    'ImportError: ' + str(e)[:30]
+`);
+      expect(r.ok).toBe(true);
+      if (!r.ok || r.output.type !== 'json') return;
+      expect(String(r.output.value)).toMatch(/^ImportError:/);
+      return;
+    }
+
+    // pandas is installed; full DataFrame round-trip.
+    const r = await runPython(root, 'sp.md', `
+import minerva
+df = minerva.sparql('SELECT ?t WHERE { ?n minerva:relativePath "sparkle.md" ; dc:title ?t . }')
+{'rows': len(df), 'first_t': df.iloc[0]['t'] if len(df) else None}
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    const v = r.output.value as { rows: number; first_t: string };
+    expect(v.rows).toBe(1);
+    expect(v.first_t).toBe('Sparkle');
+  });
+
+  it('minerva.sparql parse error surfaces as minerva.QueryError', async () => {
+    const r = await runPython(root, 'qe.md', `
+import minerva
+try:
+    minerva.sparql('SELECT WHERE {')
+    'NO_RAISE'
+except minerva.QueryError as e:
+    'QueryError: ' + str(e)[:30]
+except ImportError as e:
+    # pandas not installed — sparql aborts with ImportError before sending.
+    'ImportError'
+`);
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.output.type !== 'json') return;
+    const out = String(r.output.value);
+    // Either the QueryError fires (pandas installed) or ImportError
+    // does (pandas not installed) — both prove the library is wired
+    // correctly; we just want to NOT see 'NO_RAISE'.
+    expect(out).not.toBe('NO_RAISE');
+  });
+});

--- a/tests/main/compute/rpc-server.test.ts
+++ b/tests/main/compute/rpc-server.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the Minerva RPC server's dispatch layer (#242).
+ *
+ * These exercise the method table directly without standing up a
+ * socket — the wire layer is a tiny stdin/stdout-style readline loop
+ * over an `net.Socket`, and would just complicate the test for no
+ * additional assurance. The Python-side socket wire is exercised
+ * end-to-end in `python-library.test.ts` (it spawns a real kernel
+ * and a real `minerva` import).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { dispatchMethod } from '../../../src/main/compute/rpc-server';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { initSearch, indexNote as searchIndex } from '../../../src/main/search/index';
+import { initTablesDb } from '../../../src/main/sources/tables';
+import { projectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-rpc-server-test-'));
+}
+
+describe('rpc server method dispatch (#242)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    const ctx = projectContext(root);
+    await initGraph(ctx);
+    await initSearch(ctx);
+    await initTablesDb(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('unknown method returns MethodNotFound', async () => {
+    const r = await dispatchMethod(root, 'no.such', {});
+    expect('error' in r).toBe(true);
+    if ('error' in r) {
+      expect(r.error.code).toBe('MethodNotFound');
+    }
+  });
+
+  it('notes.read returns frontmatter + tags + body', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '---\ntitle: Alpha\ntags: [x, y]\n---\n# Alpha\nBody text.\n', 'utf-8');
+    const r = await dispatchMethod(root, 'notes.read', { relativePath: 'a.md' });
+    expect('result' in r).toBe(true);
+    if ('result' in r) {
+      const note = r.result as Record<string, unknown>;
+      expect(note.relativePath).toBe('a.md');
+      expect(note.title).toBe('Alpha');
+      expect(note.body).toContain('Body text.');
+    }
+  });
+
+  it('notes.read on a missing path returns NotFoundError', async () => {
+    const r = await dispatchMethod(root, 'notes.read', { relativePath: 'nope.md' });
+    expect('error' in r).toBe(true);
+    if ('error' in r) {
+      expect(r.error.code).toBe('NotFoundError');
+      expect(r.error.message).toMatch(/Note not found/);
+    }
+  });
+
+  it('notes.by_tag returns tagged notes from the graph', async () => {
+    const ctx = projectContext(root);
+    await indexNote(ctx, 'p.md', '# P\n#alpha here\n');
+    await indexNote(ctx, 'q.md', '# Q\n#beta here\n');
+
+    const r = await dispatchMethod(root, 'notes.by_tag', { tag: 'alpha' });
+    expect('result' in r).toBe(true);
+    if ('result' in r) {
+      const rows = r.result as Array<{ relativePath: string }>;
+      expect(rows.map((x) => x.relativePath)).toContain('p.md');
+      expect(rows.map((x) => x.relativePath)).not.toContain('q.md');
+    }
+  });
+
+  it('notes.search returns search hits for a known token', async () => {
+    const ctx = projectContext(root);
+    const content = '# Foo\nThe quick brown fox.\n';
+    await indexNote(ctx, 'foo.md', content);
+    searchIndex(ctx, 'foo.md', content);
+
+    const r = await dispatchMethod(root, 'notes.search', { query: 'brown' });
+    expect('result' in r).toBe(true);
+    if ('result' in r) {
+      const rows = r.result as Array<{ relativePath: string }>;
+      expect(rows.some((x) => x.relativePath === 'foo.md')).toBe(true);
+    }
+  });
+
+  it('sparql wraps queryGraph results under {rows}', async () => {
+    const ctx = projectContext(root);
+    await indexNote(ctx, 's.md', '# Sparkle\nbody.\n');
+    const r = await dispatchMethod(root, 'sparql', {
+      query: 'SELECT ?t WHERE { ?n minerva:relativePath "s.md" ; dc:title ?t . }',
+    });
+    expect('result' in r).toBe(true);
+    if ('result' in r) {
+      const out = r.result as { rows: Array<{ t: string }> };
+      expect(out.rows.length).toBe(1);
+      expect(out.rows[0].t).toBe('Sparkle');
+    }
+  });
+
+  it('sparql with a parse error returns QueryError', async () => {
+    const r = await dispatchMethod(root, 'sparql', { query: 'SELECT WHERE {' });
+    expect('error' in r).toBe(true);
+    if ('error' in r) {
+      expect(r.error.code).toBe('QueryError');
+    }
+  });
+
+  it('sources.get returns NotFoundError for unknown id', async () => {
+    const r = await dispatchMethod(root, 'sources.get', { sourceId: 'missing-2024' });
+    expect('error' in r).toBe(true);
+    if ('error' in r) {
+      expect(r.error.code).toBe('NotFoundError');
+    }
+  });
+
+  it('typed-arg failure surfaces as TypeError', async () => {
+    const r = await dispatchMethod(root, 'sparql', { query: 42 as unknown });
+    expect('error' in r).toBe(true);
+    if ('error' in r) {
+      expect(r.error.code).toBe('TypeError');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Bundled `minerva` Python package available inside every Python cell. Methods marshal calls to the main process over a per-kernel Unix domain socket, where they dispatch to the same services the renderer uses — so a SPARQL query in a Python cell hits exactly the same code path as the same query in the Query Panel, no separate engine, no auth.

```python
import minerva

minerva.sparql("SELECT ?s WHERE …")          # -> pandas.DataFrame
minerva.sql("SELECT * FROM stations")        # -> pandas.DataFrame
note = minerva.notes.read('notes/x.md')      # raises NotFoundError if missing
hits = minerva.notes.by_tag('climate')
res  = minerva.notes.search('bayesian', limit=10)
src  = minerva.sources.get('toulmin-1958')
cites = minerva.sources.citing('toulmin-1958')
ids  = minerva.excerpts.for_source('brooks-1986')
ctx  = minerva.ctx()                         # {project_root, notebook_path}
```

Errors translate to proper Python classes: `minerva.NotFoundError`, `minerva.QueryError`, `minerva.RpcError`. Pandas is imported lazily inside `sparql`/`sql` so the rest of the package works without it; if pandas isn't installed those two raise a clear `ImportError`.

## Architecture
- **Per-kernel Unix socket.** `startRpcServer(rootPath)` runs before the kernel spawn; path passed via `MINERVA_IPC_SOCKET`. Plus `MINERVA_PROJECT_ROOT` and `PYTHONPATH=<resources/python>` so `import minerva` resolves to the bundled package without a pip install.
- **Wire format.** Line-delimited JSON. `{id, method, params}` request, `{id, result}` or `{id, error: {code, message}}` reply. Server is sequential per connection, so the Python client doesn't need an id-matching loop.
- **Dispatch** lives in `src/main/compute/rpc-server.ts`; methods route straight to existing services.
- **Per-cell notebook context** — kernel sets a module global on the bundled package before each exec.
- **DuckDB BigInt + Date** are coerced to JSON-friendly forms server-side so the Python client doesn't need pyarrow.

## Acceptance
- [x] `import minerva` succeeds with zero config
- [x] `minerva.sparql(q)` returns a DataFrame; empty results return an empty DataFrame
- [x] `minerva.sql(q)` returns a DataFrame from the DuckDB session
- [x] `minerva.notes.read('nope.md')` raises `minerva.NotFoundError`
- [x] Unit tests for the RPC server (dispatch, error codes, type validation) — 9 tests
- [x] Integration test: a kernel cell that calls `minerva.notes.by_tag` matches the IPC handler — 6 tests
- [ ] RPC calls cancel on cell SIGINT — **deferred to #372** (depends on the SIGINT plumbing that ticket carries; the blocking socket recv already raises KeyboardInterrupt for free once #372 lands).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1532/1532 passing (15 new across `rpc-server.test.ts` + `python-library.test.ts`; library suite skips when no `python3` on PATH).
- [ ] **Smoke (manual, dev)**: open a note with a `\`\`\`python` fence: `import minerva; print(minerva.notes.by_tag('foo'))`. Run the cell — output appears with the expected list.
- [ ] **Smoke**: `import minerva; minerva.notes.read('does-not-exist.md')` — output shows a `minerva.NotFoundError` traceback (kernel's existing traceback rendering).
- [ ] **Smoke (with pandas installed)**: `import minerva; df = minerva.sparql('SELECT * WHERE { ?s ?p ?o } LIMIT 5'); df` — DataFrame renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)