### PR TITLE
tests: integration coverage for LLM orchestrators (closes #342)

### DIFF
--- a/tests/main/llm/auto-link-integration.test.ts
+++ b/tests/main/llm/auto-link-integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration coverage for the Auto-link orchestrator (#342).
+ *
+ * Drives the full suggest → apply pipeline for both modes:
+ *  - "Link to": the active note picks up wiki-links to other notes.
+ *  - "Link inbound": *other* notes pick up wiki-links pointing at the
+ *    active note.
+ * The LLM call is mocked; everything else (file reads, candidate listing,
+ * insertion-point math, applied/skipped accounting) runs for real.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const { completeMock, getSettingsMock } = vi.hoisted(() => ({
+  completeMock: vi.fn(),
+  getSettingsMock: vi.fn(),
+}));
+
+vi.mock('../../../src/main/llm/index', () => ({ complete: completeMock }));
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: getSettingsMock }));
+
+import {
+  suggestLinksTo,
+  applyAutoLinkToSuggestions,
+  suggestLinksInbound,
+  applyInboundSuggestions,
+} from '../../../src/main/llm/auto-link';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('Auto-link integration (#342)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-autolink-int-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    completeMock.mockReset();
+    getSettingsMock.mockReset();
+    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', apiKey: 'fake' });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function plant(rel: string, content: string): Promise<void> {
+    const full = path.join(root, rel);
+    await fsp.mkdir(path.dirname(full), { recursive: true });
+    await fsp.writeFile(full, content, 'utf-8');
+    await indexNote(ctx, rel, content);
+  }
+
+  describe('"Link to" mode', () => {
+    it('returns suggestions whose anchor text is a verbatim substring of the active body', async () => {
+      await plant('notes/active.md', '# Active\n\nThis discusses cognitive bias and decision making.\n');
+      await plant('notes/cognitive-bias.md', '# Cognitive Bias\n\nWhen judgement deviates from rationality.\n');
+
+      completeMock.mockResolvedValueOnce(JSON.stringify([
+        { anchorText: 'cognitive bias', target: 'notes/cognitive-bias.md', rationale: 'matches.' },
+        { anchorText: 'NOT IN BODY', target: 'notes/cognitive-bias.md', rationale: 'paraphrase.' },
+      ]));
+
+      const result = await suggestLinksTo(root, 'notes/active.md');
+      expect(result.candidateCount).toBe(1);
+      expect(result.suggestions).toHaveLength(1);
+      expect(result.suggestions[0].anchorText).toBe('cognitive bias');
+      expect(result.suggestions[0].target).toBe('notes/cognitive-bias.md');
+    });
+
+    it('drops suggestions whose target is not in the candidate set', async () => {
+      await plant('notes/active.md', '# Active\n\nMentions cognitive bias.\n');
+      await plant('notes/cognitive-bias.md', '# CB\nBody.\n');
+
+      completeMock.mockResolvedValueOnce(JSON.stringify([
+        { anchorText: 'cognitive bias', target: 'notes/does-not-exist.md', rationale: 'oops.' },
+      ]));
+
+      const result = await suggestLinksTo(root, 'notes/active.md');
+      expect(result.suggestions).toHaveLength(0);
+    });
+
+    it('apply path rewrites file content with the wiki-link', async () => {
+      const original = '# Active\n\nThis discusses cognitive bias and decision making.\n';
+      await plant('notes/active.md', original);
+      await plant('notes/cognitive-bias.md', '# CB\nBody.\n');
+
+      const accepted = [
+        { anchorText: 'cognitive bias', target: 'notes/cognitive-bias.md', rationale: 'r.' },
+      ];
+      const result = await applyAutoLinkToSuggestions(root, 'notes/active.md', accepted);
+
+      expect(result.applied).toHaveLength(1);
+      expect(result.skipped).toHaveLength(0);
+      expect(result.content).toContain('[[notes/cognitive-bias|cognitive bias]]');
+      // The orchestrator does NOT write — it returns the new content for
+      // the caller to persist + reindex (#174). Confirm the file on disk
+      // is untouched.
+      const onDisk = await fsp.readFile(path.join(root, 'notes/active.md'), 'utf-8');
+      expect(onDisk).toBe(original);
+    });
+
+    it('apply path skips suggestions whose anchor has drifted out of the file', async () => {
+      await plant('notes/active.md', '# Active\n\nDifferent words now.\n');
+      await plant('notes/cognitive-bias.md', '# CB\n');
+
+      const accepted = [
+        { anchorText: 'cognitive bias', target: 'notes/cognitive-bias.md', rationale: 'r.' },
+      ];
+      const result = await applyAutoLinkToSuggestions(root, 'notes/active.md', accepted);
+      expect(result.applied).toHaveLength(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.content).toBe('# Active\n\nDifferent words now.\n');
+    });
+  });
+
+  describe('"Link inbound" mode', () => {
+    it('suggests inbound links into other notes that mention the active concept', async () => {
+      await plant('notes/active.md', '---\ntags:\n  - epistemics\n---\n# Trust Principle\nLLM proposes, human confirms.\n');
+      await plant('notes/source-a.md', '---\ntags:\n  - epistemics\n---\n# A\nWe rely on the trust principle here.\n');
+      await plant('notes/source-b.md', '---\ntags:\n  - epistemics\n---\n# B\nNo mention of that idea here.\n');
+
+      completeMock.mockResolvedValueOnce(JSON.stringify([
+        { source: 'notes/source-a.md', anchorText: 'trust principle', rationale: 'r.' },
+        // This anchor doesn't appear in source-b — orchestrator should drop it.
+        { source: 'notes/source-b.md', anchorText: 'trust principle', rationale: 'r.' },
+      ]));
+
+      const result = await suggestLinksInbound(root, 'notes/active.md');
+      expect(result.candidateCount).toBeGreaterThanOrEqual(2);
+      expect(result.suggestions).toHaveLength(1);
+      expect(result.suggestions[0].source).toBe('notes/source-a.md');
+      expect(result.suggestions[0].contextSnippet).toContain('trust principle');
+    });
+
+    it('apply path rewrites every touched source and tracks them in touchedPaths', async () => {
+      const aOrig = '---\ntags:\n  - x\n---\n# A\nThe trust principle matters.\n';
+      const bOrig = '---\ntags:\n  - x\n---\n# B\nAnother mention of trust principle here.\n';
+      await plant('notes/active.md', '---\ntags:\n  - x\n---\n# Trust Principle\nBody.\n');
+      await plant('notes/source-a.md', aOrig);
+      await plant('notes/source-b.md', bOrig);
+
+      const accepted = [
+        { source: 'notes/source-a.md', anchorText: 'trust principle', rationale: 'r.', contextSnippet: '' },
+        { source: 'notes/source-b.md', anchorText: 'trust principle', rationale: 'r.', contextSnippet: '' },
+      ];
+      const result = await applyInboundSuggestions(root, 'notes/active.md', accepted);
+
+      expect(result.applied).toHaveLength(2);
+      expect(result.skipped).toHaveLength(0);
+      expect(result.touchedPaths.sort()).toEqual(['notes/source-a.md', 'notes/source-b.md']);
+      const newA = result.updatedContents.get('notes/source-a.md')!;
+      const newB = result.updatedContents.get('notes/source-b.md')!;
+      expect(newA).toContain('[[notes/active|trust principle]]');
+      expect(newB).toContain('[[notes/active|trust principle]]');
+
+      // Disks are untouched — caller writes (#174).
+      expect(await fsp.readFile(path.join(root, 'notes/source-a.md'), 'utf-8')).toBe(aOrig);
+      expect(await fsp.readFile(path.join(root, 'notes/source-b.md'), 'utf-8')).toBe(bOrig);
+    });
+
+    it('apply path returns no touched paths when every accepted suggestion drifts', async () => {
+      await plant('notes/active.md', '# Active\n');
+      await plant('notes/source.md', '# S\nNothing relevant.\n');
+
+      const accepted = [
+        { source: 'notes/source.md', anchorText: 'missing phrase', rationale: 'r.', contextSnippet: '' },
+      ];
+      const result = await applyInboundSuggestions(root, 'notes/active.md', accepted);
+      expect(result.applied).toHaveLength(0);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.touchedPaths).toEqual([]);
+      expect(result.updatedContents.size).toBe(0);
+    });
+  });
+});

--- a/tests/main/llm/auto-tag-integration.test.ts
+++ b/tests/main/llm/auto-tag-integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration coverage for the Auto-tag orchestrator (#342).
+ *
+ * Drives `runAutoTag()` end-to-end: a real notebase file on disk, a real
+ * graph projection (so `listTags` returns real vocabulary), and a mocked
+ * LLM response. Asserts the merged frontmatter the orchestrator returns
+ * matches what the apply step will eventually persist.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const { completeMock, getSettingsMock } = vi.hoisted(() => ({
+  completeMock: vi.fn(),
+  getSettingsMock: vi.fn(),
+}));
+
+vi.mock('../../../src/main/llm/index', () => ({ complete: completeMock }));
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: getSettingsMock }));
+
+import { runAutoTag } from '../../../src/main/llm/auto-tag';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('runAutoTag() integration (#342)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-autotag-int-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    completeMock.mockReset();
+    getSettingsMock.mockReset();
+    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', apiKey: 'fake' });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function plant(rel: string, content: string): Promise<void> {
+    const full = path.join(root, rel);
+    await fsp.mkdir(path.dirname(full), { recursive: true });
+    await fsp.writeFile(full, content, 'utf-8');
+    await indexNote(ctx, rel, content);
+  }
+
+  it('merges new tags into a note with no frontmatter', async () => {
+    await plant('notes/llm-trust.md', '# LLM Trust\n\nSome thoughts on trust.\n');
+    completeMock.mockResolvedValueOnce('llm-trust\nepistemics\n');
+
+    const plan = await runAutoTag(root, 'notes/llm-trust.md');
+    expect(plan.added.sort()).toEqual(['epistemics', 'llm-trust']);
+    expect(plan.content).not.toBeNull();
+    expect(plan.content!.startsWith('---\n')).toBe(true);
+    expect(plan.content).toContain('llm-trust');
+    expect(plan.content).toContain('epistemics');
+    expect(plan.content!.endsWith('# LLM Trust\n\nSome thoughts on trust.\n')).toBe(true);
+  });
+
+  it('skips tags the note already has (case-insensitive)', async () => {
+    const existing = '---\ntags:\n  - LLM-Trust\n---\n# LLM Trust\n\nBody.\n';
+    await plant('notes/llm-trust.md', existing);
+    completeMock.mockResolvedValueOnce('llm-trust\nnew-thing\n');
+
+    const plan = await runAutoTag(root, 'notes/llm-trust.md');
+    expect(plan.added).toEqual(['new-thing']);
+    expect(plan.content).toContain('LLM-Trust');
+    expect(plan.content).toContain('new-thing');
+  });
+
+  it('returns the no-op shape when the LLM proposes nothing new', async () => {
+    await plant('notes/x.md', '---\ntags:\n  - already-here\n---\n# X\nBody.\n');
+    completeMock.mockResolvedValueOnce('already-here\n');
+
+    const plan = await runAutoTag(root, 'notes/x.md');
+    expect(plan.added).toEqual([]);
+    expect(plan.content).toBeNull();
+  });
+
+  it('returns the no-op shape when the LLM returns an empty list', async () => {
+    await plant('notes/x.md', '# X\nShort.\n');
+    completeMock.mockResolvedValueOnce('');
+
+    const plan = await runAutoTag(root, 'notes/x.md');
+    expect(plan.added).toEqual([]);
+    expect(plan.content).toBeNull();
+  });
+
+  it('seeds the prompt with the thoughtbase’s existing tag vocabulary', async () => {
+    await plant('notes/a.md', '---\ntags:\n  - shared-tag\n---\n# A\n');
+    await plant('notes/b.md', '---\ntags:\n  - other-tag\n---\n# B\n');
+    completeMock.mockResolvedValueOnce('');
+
+    await runAutoTag(root, 'notes/a.md');
+    expect(completeMock).toHaveBeenCalledTimes(1);
+    const prompt = completeMock.mock.calls[0][0] as string;
+    // Vocabulary section must include tags from sibling notes; the active
+    // note's own tag is also listed (under both sections — the orchestrator
+    // doesn't dedupe across them, and that's fine for the prompt).
+    expect(prompt).toContain('other-tag');
+    expect(prompt).toContain('shared-tag');
+  });
+});

--- a/tests/main/llm/conversation-tool-dispatch.test.ts
+++ b/tests/main/llm/conversation-tool-dispatch.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Integration coverage for the conversation tool-dispatch loop (#342).
+ *
+ * Targets `completeWithTools()` in `src/main/llm/index.ts`. Mocks the
+ * Anthropic SDK at the client boundary so the orchestrator's loop —
+ * stream → finalMessage → handle tool_use → executeNotebaseTool →
+ * append tool_result → re-stream — runs for real against a real
+ * notebase. The unit tests in `tests/main/tools/` only cover the
+ * payload builder; the dispatch loop itself was previously uncovered.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type Anthropic from '@anthropic-ai/sdk';
+
+const { streamMock, getSettingsMock } = vi.hoisted(() => ({
+  streamMock: vi.fn(),
+  getSettingsMock: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      messages: { stream: streamMock },
+    })),
+  };
+});
+
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: getSettingsMock }));
+
+import { completeWithTools } from '../../../src/main/llm/index';
+
+/** Mint a stream-shaped object that resolves to `message` on finalMessage(). */
+function streamReturning(message: Anthropic.Message): unknown {
+  return {
+    on: () => undefined,
+    finalMessage: async () => message,
+  };
+}
+
+/**
+ * Captures a deep snapshot of each stream() invocation's messages array.
+ * The orchestrator pushes onto its `messages` reference between calls, so
+ * `streamMock.mock.calls` would otherwise show the *final* state of the
+ * array on every entry.
+ */
+function setupStreamWith(responses: Anthropic.Message[]): Anthropic.MessageParam[][] {
+  const snapshots: Anthropic.MessageParam[][] = [];
+  let i = 0;
+  streamMock.mockImplementation((args: { messages: Anthropic.MessageParam[] }) => {
+    snapshots.push(JSON.parse(JSON.stringify(args.messages)));
+    const response = responses[Math.min(i, responses.length - 1)];
+    i++;
+    return streamReturning(response);
+  });
+  return snapshots;
+}
+
+function textMessage(text: string): Anthropic.Message {
+  return {
+    id: 'msg-text',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-sonnet-4-6',
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 1 } as unknown as Anthropic.Usage,
+    content: [{ type: 'text', text, citations: null }],
+  } as unknown as Anthropic.Message;
+}
+
+function toolUseMessage(name: string, input: unknown, id: string): Anthropic.Message {
+  return {
+    id: 'msg-tool',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-sonnet-4-6',
+    stop_reason: 'tool_use',
+    stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 1 } as unknown as Anthropic.Usage,
+    content: [
+      { type: 'tool_use', id, name, input },
+    ],
+  } as unknown as Anthropic.Message;
+}
+
+describe('completeWithTools() dispatch loop (#342)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-conv-dispatch-'));
+    streamMock.mockReset();
+    getSettingsMock.mockReset();
+    getSettingsMock.mockResolvedValue({
+      apiKey: 'fake',
+      model: 'claude-sonnet-4-6',
+      web: { enabled: false, allowedDomains: [], blockedDomains: [] },
+    });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('runs a real notebase tool and feeds the result into the next iteration', async () => {
+    // Plant a note for read_note to actually read.
+    const notePath = 'notes/hello.md';
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, notePath), '# Hello\nFile body.\n', 'utf-8');
+
+    const snapshots = setupStreamWith([
+      toolUseMessage('read_note', { relative_path: notePath }, 'tu-1'),
+      textMessage('Final answer.'),
+    ]);
+
+    const result = await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'read it' }],
+      toolContext: { rootPath: root },
+    });
+
+    expect(result.text).toBe('Final answer.');
+    expect(streamMock).toHaveBeenCalledTimes(2);
+
+    // Iteration 2 must include the assistant's tool_use turn AND the
+    // user-role tool_result with the actual file body the notebase produced.
+    const secondMessages = snapshots[1];
+    expect(secondMessages).toHaveLength(3); // user → assistant(tool_use) → user(tool_result)
+    const last = secondMessages[2];
+    expect(last.role).toBe('user');
+    const blocks = last.content as Anthropic.ToolResultBlockParam[];
+    expect(blocks[0].type).toBe('tool_result');
+    expect(blocks[0].tool_use_id).toBe('tu-1');
+    expect(blocks[0].content).toContain('# Hello');
+    expect(blocks[0].is_error).toBeUndefined();
+  });
+
+  it('marks tool errors with is_error so the model can recover', async () => {
+    const snapshots = setupStreamWith([
+      toolUseMessage('read_note', { relative_path: 'does/not/exist.md' }, 'tu-err'),
+      textMessage('Sorry.'),
+    ]);
+
+    await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'read missing' }],
+      toolContext: { rootPath: root },
+    });
+
+    const secondMessages = snapshots[1];
+    const last = secondMessages[2];
+    const blocks = last.content as Anthropic.ToolResultBlockParam[];
+    expect(blocks[0].is_error).toBe(true);
+    expect(String(blocks[0].content)).toMatch(/failed|not found|exist/i);
+  });
+
+  it('breaks the loop on non-tool_use stop_reason without a third call', async () => {
+    streamMock.mockReturnValueOnce(streamReturning(textMessage('Just text, no tools.')));
+
+    const result = await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'hi' }],
+      toolContext: { rootPath: root },
+    });
+    expect(result.text).toBe('Just text, no tools.');
+    expect(streamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects the model override over the global default', async () => {
+    streamMock.mockReturnValueOnce(streamReturning(textMessage('done')));
+
+    await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'go' }],
+      toolContext: { rootPath: root },
+      model: 'claude-opus-4-7',
+    });
+    const args = streamMock.mock.calls[0][0] as { model: string };
+    expect(args.model).toBe('claude-opus-4-7');
+  });
+
+  it('honours maxIterations as a hard cap on tool-use cycles', async () => {
+    // Always return tool_use — the loop should break at maxIterations
+    // without ever emitting a final text response.
+    streamMock.mockImplementation(() =>
+      streamReturning(toolUseMessage('read_note', { relative_path: 'x.md' }, 'tu')),
+    );
+
+    const result = await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'go' }],
+      toolContext: { rootPath: root },
+      maxIterations: 3,
+    });
+    expect(streamMock).toHaveBeenCalledTimes(3);
+    expect(result.text).toBe('');
+  });
+});

--- a/tests/main/llm/crystallize-integration.test.ts
+++ b/tests/main/llm/crystallize-integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration coverage for the crystallize orchestrator (#342).
+ *
+ * The trust-guard tests (#331) exercise proposeWrite directly with a
+ * hand-crafted Turtle diff. These tests drive `crystallize()` end-to-end
+ * with a mocked LLM response so the wiring — prompt → LLM call → Turtle
+ * → proposeWrite → graph proposal → optional approve — is exercised as
+ * a single path. That path was previously uncovered (P0 #2 in
+ * `reports/quality-review-entire-project-2026-04-24-1.md`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const { completeMock } = vi.hoisted(() => ({ completeMock: vi.fn() }));
+vi.mock('../../../src/main/llm/index', () => ({
+  complete: completeMock,
+}));
+
+import { crystallize } from '../../../src/main/llm/crystallize';
+import {
+  approveProposal,
+  rejectProposal,
+  getProposal,
+  listProposals,
+  resetPolicy,
+} from '../../../src/main/llm/approval';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const CLAIM_URI = 'https://minerva.dev/c/claim-water-boils';
+const GROUNDS_URI = 'https://minerva.dev/c/grounds-1atm';
+const CONV_URI = 'https://minerva.dev/ontology/thought#conversation/conv-test';
+
+const CRYSTALLIZED_TURTLE = `
+@prefix thought: <https://minerva.dev/ontology/thought#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<${CLAIM_URI}> rdf:type thought:Claim ;
+  thought:label "Water boils at 100C at 1atm." ;
+  thought:extractedBy "llm:crystallization" ;
+  thought:hasStatus thought:proposed .
+
+<${GROUNDS_URI}> rdf:type thought:Grounds ;
+  thought:label "Standard physics reference." ;
+  thought:supports <${CLAIM_URI}> ;
+  thought:extractedBy "llm:crystallization" ;
+  thought:hasStatus thought:proposed .
+`;
+
+describe('crystallize() integration (#342)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-crystallize-int-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+    completeMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('produces a pending Proposal whose shape matches the contract', async () => {
+    completeMock.mockResolvedValueOnce(CRYSTALLIZED_TURTLE);
+
+    const result = await crystallize(ctx, 'Water boils...', CONV_URI, 'llm:test');
+    expect(result.componentCount).toBe(2);
+
+    const proposals = await listProposals(ctx, 'pending');
+    expect(proposals).toHaveLength(1);
+    const p = proposals[0];
+
+    expect(p.status).toBe('pending');
+    expect(p.operationType).toBe('component_creation');
+    expect(p.proposedBy).toBe('llm:test');
+    expect(p.conversationUri).toBe(CONV_URI);
+    expect(p.affectsNodeUris.sort()).toEqual([CLAIM_URI, GROUNDS_URI].sort());
+    expect(p.turtleDiff).toContain(CLAIM_URI);
+  });
+
+  it('approving the proposal applies the component triples to the graph', async () => {
+    completeMock.mockResolvedValueOnce(CRYSTALLIZED_TURTLE);
+    await crystallize(ctx, 'text', CONV_URI);
+
+    // Pre-approval: components must NOT be in the queryable graph yet.
+    const beforeRows = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?label WHERE { <${CLAIM_URI}> thought:label ?label . }
+    `);
+    expect((beforeRows.results as unknown[]).length).toBe(0);
+
+    const [pending] = await listProposals(ctx, 'pending');
+    const ok = await approveProposal(ctx, pending.uri);
+    expect(ok).toBe(true);
+
+    // Post-approval: the component is reachable.
+    const afterRows = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?label WHERE { <${CLAIM_URI}> thought:label ?label . }
+    `);
+    expect((afterRows.results as Array<{ label: string }>).map(r => r.label))
+      .toContain('Water boils at 100C at 1atm.');
+
+    // And the proposal itself flips to approved (not duplicated — see #332).
+    const refreshed = await getProposal(ctx, pending.uri);
+    expect(refreshed?.status).toBe('approved');
+  });
+
+  it('rejecting (skipping approval) leaves component triples out of the graph', async () => {
+    completeMock.mockResolvedValueOnce(CRYSTALLIZED_TURTLE);
+    await crystallize(ctx, 'text', CONV_URI);
+
+    const [pending] = await listProposals(ctx, 'pending');
+    const ok = await rejectProposal(ctx, pending.uri);
+    expect(ok).toBe(true);
+
+    const rows = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?label WHERE { <${CLAIM_URI}> thought:label ?label . }
+    `);
+    expect((rows.results as unknown[]).length).toBe(0);
+
+    // The integrity query stays clean: no LLM-attributed component is
+    // sitting in the graph without an approved proposal pointing at it.
+    const orphans = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?component WHERE {
+        ?component rdf:type/rdfs:subClassOf* thought:Component .
+        ?component thought:extractedBy ?extractedBy .
+        FILTER(CONTAINS(LCASE(?extractedBy), "llm"))
+        FILTER NOT EXISTS {
+          ?proposal rdf:type thought:Proposal .
+          ?proposal thought:affectsNode ?component .
+          ?proposal thought:proposalStatus thought:approved .
+        }
+      }
+    `);
+    expect((orphans.results as unknown[]).length).toBe(0);
+  });
+
+  it('skips proposeWrite entirely when the LLM returns nothing', async () => {
+    completeMock.mockResolvedValueOnce('   \n  ');
+
+    const result = await crystallize(ctx, 'unhelpful', CONV_URI);
+    expect(result.componentCount).toBe(0);
+    expect(result.turtle).toBe('');
+
+    const proposals = await listProposals(ctx);
+    expect(proposals).toHaveLength(0);
+  });
+
+  it('threads the model override into the underlying complete() call', async () => {
+    completeMock.mockResolvedValueOnce(CRYSTALLIZED_TURTLE);
+    await crystallize(ctx, 'text', CONV_URI, 'llm:test', 'claude-opus-4-7');
+
+    expect(completeMock).toHaveBeenCalledTimes(1);
+    const opts = completeMock.mock.calls[0][1];
+    expect(opts).toEqual({ model: 'claude-opus-4-7' });
+  });
+});

--- a/tests/main/llm/decompose-integration.test.ts
+++ b/tests/main/llm/decompose-integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration coverage for the Decompose orchestrator (#342).
+ *
+ * `suggestDecomposition()` is a thin wrapper: read the source note, build
+ * a prompt, call the LLM, parse the response. The unit tests in
+ * `tests/shared/refactor/decompose.test.ts` already cover the parser; the
+ * gap was end-to-end wiring (file I/O + LLM call + parse) plus the LLM
+ * write-guard scope. These tests close that.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const { completeMock, getSettingsMock } = vi.hoisted(() => ({
+  completeMock: vi.fn(),
+  getSettingsMock: vi.fn(),
+}));
+
+vi.mock('../../../src/main/llm/index', () => ({ complete: completeMock }));
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: getSettingsMock }));
+
+import { suggestDecomposition } from '../../../src/main/llm/decompose';
+import {
+  initGraph,
+  indexNote,
+  enterLLMContext,
+  exitLLMContext,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('suggestDecomposition() integration (#342)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-decompose-int-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    completeMock.mockReset();
+    getSettingsMock.mockReset();
+    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', apiKey: 'fake' });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function plant(rel: string, content: string): Promise<void> {
+    const full = path.join(root, rel);
+    await fsp.mkdir(path.dirname(full), { recursive: true });
+    await fsp.writeFile(full, content, 'utf-8');
+    await indexNote(ctx, rel, content);
+  }
+
+  it('parses a well-formed LLM response into a proposal', async () => {
+    await plant('notes/big.md',
+      '# Big Note\n\n## Section A\nFirst topic.\n\n## Section B\nSecond topic.\n');
+    completeMock.mockResolvedValueOnce(JSON.stringify({
+      parent: { content: 'Index of two topics.' },
+      children: [
+        { title: 'Topic A', content: 'First topic.', rationale: 'split a.' },
+        { title: 'Topic B', content: 'Second topic.', rationale: 'split b.' },
+      ],
+    }));
+
+    const result = await suggestDecomposition(root, 'notes/big.md');
+    expect(result.error).toBeUndefined();
+    expect(result.proposal).not.toBeNull();
+    expect(result.proposal!.parent.content).toBe('Index of two topics.');
+    expect(result.proposal!.children).toHaveLength(2);
+    expect(result.proposal!.children[0].title).toBe('Topic A');
+  });
+
+  it('feeds the source title and body into the prompt', async () => {
+    await plant('notes/big.md', '# My Title\n\nUnique body marker xyz.\n');
+    completeMock.mockResolvedValueOnce('{"parent":{"content":"x"},"children":[{"title":"T","content":"c","rationale":"r"}]}');
+
+    await suggestDecomposition(root, 'notes/big.md');
+    const prompt = completeMock.mock.calls[0][0] as string;
+    expect(prompt).toContain('My Title');
+    expect(prompt).toContain('Unique body marker xyz.');
+    // The frontmatter-stripped body is what gets fed in; nothing else.
+  });
+
+  it('returns null proposal with a diagnostic when the LLM response is unparseable', async () => {
+    await plant('notes/big.md', '# Big\nBody.\n');
+    completeMock.mockResolvedValueOnce('not-json-at-all');
+
+    const result = await suggestDecomposition(root, 'notes/big.md');
+    expect(result.proposal).toBeNull();
+    expect(result.error).toBeTruthy();
+  });
+
+  it('exits the LLM-context guard even when the LLM call throws', async () => {
+    await plant('notes/big.md', '# Big\nBody.\n');
+    completeMock.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(suggestDecomposition(root, 'notes/big.md'))
+      .rejects.toThrow('network down');
+
+    // If exitLLMContext didn't run, a follow-up enter→exit would unbalance
+    // the depth counter. Guard the assertion by entering+exiting once and
+    // confirming a subsequent indexNote (outside LLM context) doesn't warn.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    enterLLMContext();
+    exitLLMContext();
+    await indexNote(ctx, 'notes/quiet.md', '# Q\n');
+    const calls = warnSpy.mock.calls.flat().map(String);
+    expect(calls.some(m => m.includes('[trust-guard]'))).toBe(false);
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #342 — `src/main/llm/` orchestrators previously had no integration coverage; only the prompt builders and parse helpers were tested.
- Adds five integration test files exercising the wiring end-to-end against real notebases and a real graph, with the Anthropic SDK / local `complete()` wrapper mocked at the boundary.
- Covers: `crystallize` (proposal shape + approve/reject paths), `runAutoTag`, `suggestLinksTo` + `applyAutoLinkToSuggestions`, `suggestLinksInbound` + `applyInboundSuggestions`, `suggestDecomposition`, and the `completeWithTools` tool-dispatch loop (real `read_note` runs through `executeNotebaseTool`, errors carry `is_error: true`, `maxIterations` caps runaway cycles).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1558 passed (159 files), including 26 new tests
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)