### PR TITLE
tests: chokidar watcher + IPC dedup coverage (closes #345)

### DIFF
--- a/src/main/notebase/path-dedup.ts
+++ b/src/main/notebase/path-dedup.ts
@@ -1,0 +1,42 @@
+/**
+ * Path-level dedup window between IPC writes and watcher events.
+ *
+ * The watcher and the IPC handlers can both react to the same write —
+ * IPC because it just performed the write, watcher because chokidar
+ * picked up the resulting fs event. Without dedup, the file is indexed
+ * twice (and broadcast twice). The IPC path marks each path it just
+ * touched; the watcher consults the mark before re-running the same
+ * pipeline.
+ *
+ * The window is short-lived so a real subsequent edit (the user typing
+ * after a save lands) still triggers the watcher pipeline normally.
+ */
+
+const DEDUP_WINDOW_MS = 2000;
+
+const recentlyHandledPaths = new Map<string, number>();
+
+/** Stamp `relativePath` as just-written-by-IPC. */
+export function markPathHandled(relativePath: string): void {
+  recentlyHandledPaths.set(relativePath, Date.now());
+}
+
+/**
+ * True when a write to `relativePath` was marked within the dedup window.
+ * Lazily evicts expired entries so the map can't grow unbounded under a
+ * write-heavy workload.
+ */
+export function wasHandled(relativePath: string): boolean {
+  const ts = recentlyHandledPaths.get(relativePath);
+  if (!ts) return false;
+  if (Date.now() - ts > DEDUP_WINDOW_MS) {
+    recentlyHandledPaths.delete(relativePath);
+    return false;
+  }
+  return true;
+}
+
+/** Test-only reset. */
+export function _resetForTests(): void {
+  recentlyHandledPaths.clear();
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { startWatching, stopWatching } from './notebase/watcher';
+import { markPathHandled as markPathHandledImpl, wasHandled } from './notebase/path-dedup';
 import * as graph from './graph/index';
 import * as search from './search/index';
 import * as notebaseFs from './notebase/fs';
@@ -24,11 +25,10 @@ interface WindowContext {
 
 const contexts = new Map<number, WindowContext>();
 const watchers = new Map<number, string>();
-const recentlyHandledPaths = new Map<string, number>();
 
 /** Mark a path as recently handled by IPC to avoid duplicate watcher re-indexing */
 export function markPathHandled(relativePath: string): void {
-  recentlyHandledPaths.set(relativePath, Date.now());
+  markPathHandledImpl(relativePath);
 }
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -152,12 +152,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   rebuildMenu();
 
   // Deduplication: IPC handlers mark paths they've already indexed
-  const wasHandled = (p: string) => {
-    const ts = recentlyHandledPaths.get(p);
-    if (!ts || Date.now() - ts > 2000) { recentlyHandledPaths.delete(p); return false; }
-    return true;
-  };
-
+  // (see `notebase/path-dedup.ts`).
   let indexPersistTimer: ReturnType<typeof setTimeout> | null = null;
   const debouncedPersist = () => {
     if (indexPersistTimer) clearTimeout(indexPersistTimer);

--- a/tests/main/notebase/path-dedup.test.ts
+++ b/tests/main/notebase/path-dedup.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the IPC↔watcher dedup window (#345).
+ *
+ * The dedup logic used to live as a closure inside `openProjectInWindow`
+ * and a module-scoped Map in `window-manager.ts`, neither testable in
+ * isolation. It now lives in `notebase/path-dedup.ts`; these tests pin
+ * the 2s-window contract that the watcher relies on to avoid double
+ * indexing IPC-originated writes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  markPathHandled,
+  wasHandled,
+  _resetForTests,
+} from '../../../src/main/notebase/path-dedup';
+
+describe('path-dedup (#345)', () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-25T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('an unmarked path is never considered handled', () => {
+    expect(wasHandled('notes/x.md')).toBe(false);
+  });
+
+  it('immediately after markPathHandled, the path is handled', () => {
+    markPathHandled('notes/x.md');
+    expect(wasHandled('notes/x.md')).toBe(true);
+  });
+
+  it('marks are scoped to the exact path string (no prefix matching)', () => {
+    markPathHandled('notes/x.md');
+    expect(wasHandled('notes/y.md')).toBe(false);
+    expect(wasHandled('notes/x')).toBe(false);
+    expect(wasHandled('x.md')).toBe(false);
+  });
+
+  it('a mark stays valid for the full 2s window', () => {
+    markPathHandled('notes/x.md');
+    vi.advanceTimersByTime(1999);
+    expect(wasHandled('notes/x.md')).toBe(true);
+  });
+
+  it('a mark expires after 2s (>2000ms is stale)', () => {
+    markPathHandled('notes/x.md');
+    vi.advanceTimersByTime(2001);
+    expect(wasHandled('notes/x.md')).toBe(false);
+  });
+
+  it('reading an expired mark evicts it (the map cannot grow unbounded)', () => {
+    markPathHandled('notes/x.md');
+    vi.advanceTimersByTime(2001);
+    // First read returns false AND drops the entry. A second read on the
+    // same path must still return false — i.e. the entry's truly gone, not
+    // just temporarily masked.
+    expect(wasHandled('notes/x.md')).toBe(false);
+    // Any later mark on a different path doesn't resurrect the first one.
+    markPathHandled('notes/y.md');
+    expect(wasHandled('notes/x.md')).toBe(false);
+  });
+
+  it('re-marking a path refreshes its window', () => {
+    markPathHandled('notes/x.md');
+    vi.advanceTimersByTime(1500);
+    markPathHandled('notes/x.md'); // re-stamp
+    vi.advanceTimersByTime(1500);  // 3000ms since first mark, 1500ms since re-stamp
+    expect(wasHandled('notes/x.md')).toBe(true);
+  });
+
+  it('different paths track independent windows', () => {
+    markPathHandled('notes/a.md');
+    vi.advanceTimersByTime(1000);
+    markPathHandled('notes/b.md');
+    vi.advanceTimersByTime(1500); // a is now 2500ms old, b is 1500ms old
+    expect(wasHandled('notes/a.md')).toBe(false); // expired
+    expect(wasHandled('notes/b.md')).toBe(true);  // still fresh
+  });
+});

--- a/tests/main/notebase/watcher.test.ts
+++ b/tests/main/notebase/watcher.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Integration coverage for the chokidar-based notebase watcher (#345).
+ *
+ * Wires up real chokidar against a temp dir, plants/edits/deletes files,
+ * and asserts the right callbacks fire with the right relative paths.
+ * The watcher itself is a thin event-router; downstream indexing lives
+ * in `window-manager.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type { BrowserWindow } from 'electron';
+import { startWatching, stopWatching } from '../../../src/main/notebase/watcher';
+import { Channels } from '../../../src/main/../shared/channels';
+
+interface StubWin {
+  isDestroyed: () => boolean;
+  webContents: { send: ReturnType<typeof vi.fn> };
+}
+
+function makeWin(): StubWin {
+  return {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn() },
+  };
+}
+
+/**
+ * Polls `predicate` every 25ms up to `timeoutMs`, resolving when it
+ * returns true (chokidar events are async; callbacks may not fire on
+ * the next microtask). Faster than a fixed sleep, less brittle than a
+ * one-shot wait.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 4000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+describe('startWatching() (#345)', () => {
+  let root: string;
+  let win: StubWin;
+  let winId: number;
+  let nextWinId = 9000;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-watcher-test-'));
+    win = makeWin();
+    winId = nextWinId++;
+  });
+
+  afterEach(async () => {
+    stopWatching(winId);
+    // Give chokidar a beat to release its handles before we yank the dir.
+    await new Promise((r) => setTimeout(r, 50));
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  describe('notes-tree events', () => {
+    it('emits onFileCreated for a new .md file (with relative path)', async () => {
+      const created: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      // chokidar's initial scan needs a moment before subsequent writes
+      // reliably produce events. Without this, the first write races the
+      // watcher's "ready" state and gets dropped on slow CI.
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.writeFile(path.join(root, 'hello.md'), '# Hello\n', 'utf-8');
+      await waitFor(() => created.includes('hello.md'));
+      expect(created).toEqual(['hello.md']);
+      expect(win.webContents.send).toHaveBeenCalledWith(Channels.NOTEBASE_FILE_CREATED, 'hello.md');
+    });
+
+    it('emits onFileChanged when a watched .md file is rewritten', async () => {
+      // Plant the file BEFORE startWatching so the create event doesn't fire
+      // (ignoreInitial: true). We need a stable starting state to test change.
+      const rel = 'notes/topic.md';
+      await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+      await fsp.writeFile(path.join(root, rel), 'v1\n', 'utf-8');
+
+      const changed: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: () => undefined,
+        onFileChanged: (p) => changed.push(p),
+        onFileDeleted: () => undefined,
+      });
+
+      // chokidar's initial scan needs a moment to register the file, otherwise
+      // the next write looks like an `add`.
+      await new Promise((r) => setTimeout(r, 200));
+      await fsp.writeFile(path.join(root, rel), 'v2\n', 'utf-8');
+      await waitFor(() => changed.includes(rel));
+      expect(changed).toEqual([rel]);
+      expect(win.webContents.send).toHaveBeenCalledWith(Channels.NOTEBASE_FILE_CHANGED, rel);
+    });
+
+    it('emits onFileDeleted when a watched .md file is removed', async () => {
+      const rel = 'gone.md';
+      await fsp.writeFile(path.join(root, rel), 'doomed\n', 'utf-8');
+
+      const deleted: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: () => undefined,
+        onFileChanged: () => undefined,
+        onFileDeleted: (p) => deleted.push(p),
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+      await fsp.rm(path.join(root, rel));
+      await waitFor(() => deleted.includes(rel));
+      expect(deleted).toEqual([rel]);
+      expect(win.webContents.send).toHaveBeenCalledWith(Channels.NOTEBASE_FILE_DELETED, rel);
+    });
+
+    it('handles all three indexable extensions (.md, .ttl, .csv)', async () => {
+      const created: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.writeFile(path.join(root, 'a.md'), 'a\n', 'utf-8');
+      await fsp.writeFile(path.join(root, 'b.ttl'), '@prefix x: <x> .\n', 'utf-8');
+      await fsp.writeFile(path.join(root, 'c.csv'), 'col\n1\n', 'utf-8');
+
+      await waitFor(() => created.length >= 3);
+      expect(created.sort()).toEqual(['a.md', 'b.ttl', 'c.csv']);
+    });
+
+    it('ignores non-indexable extensions like .png and .json', async () => {
+      const created: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.writeFile(path.join(root, 'image.png'), 'fake', 'utf-8');
+      await fsp.writeFile(path.join(root, 'config.json'), '{}', 'utf-8');
+      // Plant something we DO care about so we know the watcher is alive.
+      await fsp.writeFile(path.join(root, 'real.md'), '# r\n', 'utf-8');
+
+      await waitFor(() => created.includes('real.md'));
+      // .png / .json must not have invoked the callback, even though they
+      // landed in the watched tree.
+      expect(created).toEqual(['real.md']);
+    });
+
+    it('files in dot-prefixed dirs are ignored (e.g. .git, .obsidian)', async () => {
+      const created: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.mkdir(path.join(root, '.git'), { recursive: true });
+      await fsp.mkdir(path.join(root, '.obsidian'), { recursive: true });
+      await fsp.writeFile(path.join(root, '.git', 'HEAD.md'), 'x\n', 'utf-8');
+      await fsp.writeFile(path.join(root, '.obsidian', 'config.md'), 'x\n', 'utf-8');
+      // sentinel
+      await fsp.writeFile(path.join(root, 'sentinel.md'), '# s\n', 'utf-8');
+
+      await waitFor(() => created.includes('sentinel.md'));
+      expect(created).toEqual(['sentinel.md']);
+    });
+
+    it('does not call back after the window has been destroyed', async () => {
+      const created: string[] = [];
+      const destroyableWin: StubWin = {
+        isDestroyed: () => true,
+        webContents: { send: vi.fn() },
+      };
+      startWatching(root, destroyableWin as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.writeFile(path.join(root, 'x.md'), 'x\n', 'utf-8');
+      // Wait long enough that, if the callback were going to fire, it would have.
+      await new Promise((r) => setTimeout(r, 400));
+      expect(created).toEqual([]);
+      expect(destroyableWin.webContents.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('.minerva/{sources,excerpts} routing', () => {
+    it('routes .minerva/sources/<id>/meta.ttl writes to onSourceMetaChanged', async () => {
+      const sourceId = 'sha-abc123';
+      const onSourceMetaChanged = vi.fn();
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileChanged: () => undefined,
+        onFileCreated: () => undefined,
+        onFileDeleted: () => undefined,
+        onSourceMetaChanged,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      const dir = path.join(root, '.minerva', 'sources', sourceId);
+      await fsp.mkdir(dir, { recursive: true });
+      await fsp.writeFile(path.join(dir, 'meta.ttl'), '@prefix x: <x> .\n', 'utf-8');
+
+      await waitFor(() => onSourceMetaChanged.mock.calls.length > 0);
+      expect(onSourceMetaChanged).toHaveBeenCalledWith(sourceId);
+    });
+
+    it('routes .minerva/sources/<id>/body.md writes to onSourceMetaChanged too', async () => {
+      // body.md edits also count as source metadata changes — they land in the
+      // same `upsert` branch so the indexer can re-read both files.
+      const sourceId = 'sha-bodyonly';
+      const onSourceMetaChanged = vi.fn();
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileChanged: () => undefined,
+        onFileCreated: () => undefined,
+        onFileDeleted: () => undefined,
+        onSourceMetaChanged,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      const dir = path.join(root, '.minerva', 'sources', sourceId);
+      await fsp.mkdir(dir, { recursive: true });
+      await fsp.writeFile(path.join(dir, 'body.md'), '# body\n', 'utf-8');
+
+      await waitFor(() => onSourceMetaChanged.mock.calls.length > 0);
+      expect(onSourceMetaChanged).toHaveBeenCalledWith(sourceId);
+    });
+
+    it('routes meta.ttl deletion to onSourceMetaDeleted', async () => {
+      const sourceId = 'sha-doomed';
+      const dir = path.join(root, '.minerva', 'sources', sourceId);
+      await fsp.mkdir(dir, { recursive: true });
+      await fsp.writeFile(path.join(dir, 'meta.ttl'), '@prefix x: <x> .\n', 'utf-8');
+
+      const onSourceMetaDeleted = vi.fn();
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileChanged: () => undefined,
+        onFileCreated: () => undefined,
+        onFileDeleted: () => undefined,
+        onSourceMetaDeleted,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+      await fsp.rm(path.join(dir, 'meta.ttl'));
+
+      await waitFor(() => onSourceMetaDeleted.mock.calls.length > 0);
+      expect(onSourceMetaDeleted).toHaveBeenCalledWith(sourceId);
+    });
+
+    it('routes .minerva/excerpts/<id>.ttl writes to onExcerptChanged', async () => {
+      const excerptId = 'ex-7';
+      const onExcerptChanged = vi.fn();
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileChanged: () => undefined,
+        onFileCreated: () => undefined,
+        onFileDeleted: () => undefined,
+        onExcerptChanged,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      const dir = path.join(root, '.minerva', 'excerpts');
+      await fsp.mkdir(dir, { recursive: true });
+      await fsp.writeFile(path.join(dir, `${excerptId}.ttl`), '@prefix x: <x> .\n', 'utf-8');
+
+      await waitFor(() => onExcerptChanged.mock.calls.length > 0);
+      expect(onExcerptChanged).toHaveBeenCalledWith(excerptId);
+    });
+
+    it('routes excerpt deletion to onExcerptDeleted', async () => {
+      const excerptId = 'ex-doomed';
+      const dir = path.join(root, '.minerva', 'excerpts');
+      await fsp.mkdir(dir, { recursive: true });
+      await fsp.writeFile(path.join(dir, `${excerptId}.ttl`), '@prefix x: <x> .\n', 'utf-8');
+
+      const onExcerptDeleted = vi.fn();
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileChanged: () => undefined,
+        onFileCreated: () => undefined,
+        onFileDeleted: () => undefined,
+        onExcerptDeleted,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+      await fsp.rm(path.join(dir, `${excerptId}.ttl`));
+
+      await waitFor(() => onExcerptDeleted.mock.calls.length > 0);
+      expect(onExcerptDeleted).toHaveBeenCalledWith(excerptId);
+    });
+
+    it('does NOT route unrelated .minerva/* files to source/excerpt callbacks', async () => {
+      // graph.ttl, bookmarks.json, tabs.json, etc. all live under .minerva but
+      // outside sources/excerpts — they must stay invisible to the watcher.
+      const onSourceMetaChanged = vi.fn();
+      const onExcerptChanged = vi.fn();
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileChanged: () => undefined,
+        onFileCreated: () => undefined,
+        onFileDeleted: () => undefined,
+        onSourceMetaChanged,
+        onExcerptChanged,
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+      await fsp.writeFile(path.join(root, '.minerva', 'graph.ttl'), '@prefix x: <x> .\n', 'utf-8');
+      await fsp.writeFile(path.join(root, '.minerva', 'bookmarks.json'), '[]', 'utf-8');
+
+      // Plant a sentinel inside sources so we know the watcher is alive.
+      const sentinelDir = path.join(root, '.minerva', 'sources', 'sentinel');
+      await fsp.mkdir(sentinelDir, { recursive: true });
+      await fsp.writeFile(path.join(sentinelDir, 'meta.ttl'), '@prefix x: <x> .\n', 'utf-8');
+
+      await waitFor(() => onSourceMetaChanged.mock.calls.length > 0);
+      const calls = onSourceMetaChanged.mock.calls.map((c) => c[0]);
+      expect(calls).toEqual(['sentinel']);
+      expect(onExcerptChanged).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('stopWatching()', () => {
+    it('detaches every watcher so subsequent file ops produce no callbacks', async () => {
+      const created: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 150));
+
+      stopWatching(winId);
+      // Even after a generous wait, no event should land for files added
+      // after the watcher closed.
+      await fsp.writeFile(path.join(root, 'after-stop.md'), 'x\n', 'utf-8');
+      await new Promise((r) => setTimeout(r, 400));
+      expect(created).toEqual([]);
+    });
+
+    it('stopWatching on an unknown id is a no-op (no throw)', () => {
+      expect(() => stopWatching(98765)).not.toThrow();
+    });
+
+    it('startWatching twice on the same id replaces the previous watcher', async () => {
+      const firstCreated: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => firstCreated.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 150));
+
+      const secondCreated: string[] = [];
+      startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => secondCreated.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+      await new Promise((r) => setTimeout(r, 150));
+
+      await fsp.writeFile(path.join(root, 'after.md'), 'x\n', 'utf-8');
+      await waitFor(() => secondCreated.includes('after.md'));
+      expect(secondCreated).toEqual(['after.md']);
+      expect(firstCreated).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #345 — `src/main/notebase/watcher.ts` had zero tests despite being a primary actuation surface (add/change/unlink → graph reindex, DuckDB CSV registration, search index updates, renderer broadcasts).
- Adds 16-test `tests/main/notebase/watcher.test.ts` exercising real chokidar against a temp dir: every indexable extension (`.md`/`.ttl`/`.csv`), filtered non-indexables, dot-prefixed dirs ignored, `isDestroyed` short-circuit, `.minerva/sources/<id>/{meta.ttl,body.md}` and `.minerva/excerpts/<id>.ttl` routing, unrelated `.minerva/*` files staying invisible, `stopWatching` teardown, and re-`startWatching` replacing the prior pair.
- Extracts the IPC↔watcher dedup window (`recentlyHandledPaths` Map + `wasHandled` closure that lived in `window-manager.ts`) into a focused `notebase/path-dedup.ts` module, then adds 8-test coverage of the 2s-window contract: marks expire correctly, expired reads evict (so the map can't grow unbounded), re-marking refreshes, paths track independently.
- `markPathHandled` continues to be re-exported from `window-manager.ts` so callers (`ipc.ts`, `write-pipeline.ts`, rename helpers) need no changes.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1582 passed (161 files), including 24 new tests
- [x] No behavior change for the watcher or window manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)