### PR TITLE
tests: renderer-side OCR pipeline coverage (closes #343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@vitest/coverage-v8": "^2.1.9",
     "codemirror": "^6.0.1",
     "electron": "^35.7.5",
+    "happy-dom": "^20.9.0",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.1",
     "svelte": "^5.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,13 +131,16 @@ importers:
         version: 5.0.6
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0)(jsdom@29.0.2)(terser@5.46.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1))
       codemirror:
         specifier: ^6.0.1
         version: 6.0.2
       electron:
         specifier: ^35.7.5
         version: 35.7.5
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -158,7 +161,7 @@ importers:
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@25.5.0)(jsdom@29.0.2)(terser@5.46.1)
+        version: 2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1)
 
 packages:
 
@@ -2274,8 +2277,14 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3288,6 +3297,10 @@ packages:
   graphql@15.10.2:
     resolution: {integrity: sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==}
     engines: {node: '>= 10.x'}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4981,6 +4994,10 @@ packages:
       webpack-cli:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -5039,6 +5056,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -9376,7 +9405,13 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/wrap-ansi@3.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.5.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9433,7 +9468,7 @@ snapshots:
       '@unified-latex/unified-latex-types': 1.8.4
       '@unified-latex/unified-latex-util-match': 1.8.4
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.5.0)(jsdom@29.0.2)(terser@5.46.1))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -9447,7 +9482,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@25.5.0)(jsdom@29.0.2)(terser@5.46.1)
+      vitest: 2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10588,6 +10623,18 @@ snapshots:
       rdf-data-factory: 2.0.2
 
   graphql@15.10.2: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.5.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -12305,7 +12352,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
-  vitest@2.1.9(@types/node@25.5.0)(jsdom@29.0.2)(terser@5.46.1):
+  vitest@2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.5.0)(terser@5.46.1))
@@ -12329,6 +12376,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
+      happy-dom: 20.9.0
       jsdom: 29.0.2
     transitivePeerDependencies:
       - less
@@ -12397,6 +12445,8 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@5.0.0:
     optional: true
@@ -12481,6 +12531,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0:
     optional: true

--- a/tests/main/notebase/watcher.test.ts
+++ b/tests/main/notebase/watcher.test.ts
@@ -98,9 +98,11 @@ describe('startWatching() (#345)', () => {
         onFileDeleted: () => undefined,
       });
 
-      // chokidar's initial scan needs a moment to register the file, otherwise
-      // the next write looks like an `add`.
-      await new Promise((r) => setTimeout(r, 200));
+      // chokidar's initial scan needs to fully complete and register the
+      // file's mtime before the next write looks like a `change`. Under
+      // parallel test load on macOS fsevents this can take longer than
+      // the 200ms used in other tests.
+      await new Promise((r) => setTimeout(r, 500));
       await fsp.writeFile(path.join(root, rel), 'v2\n', 'utf-8');
       await waitFor(() => changed.includes(rel));
       expect(changed).toEqual([rel]);

--- a/tests/renderer/ocr/run-ocr.test.ts
+++ b/tests/renderer/ocr/run-ocr.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Coverage for the renderer-side OCR pipeline (#343).
+ *
+ * `runOcr` orchestrates pdfjs-dist + tesseract.js across N pages, fires
+ * a progress callback at three points per page, and respects an
+ * AbortSignal. The whole pipeline was untested — a tesseract / pdfjs
+ * dep bump that drifted the worker API would ship broken silently.
+ *
+ * Both deps are mocked at module scope so the test never touches the
+ * real WASM/Tesseract worker; happy-dom provides a `document` that's
+ * just rich enough for `document.createElement('canvas')` (we stub
+ * `getContext('2d')` because happy-dom returns null for it).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { getDocumentMock, createWorkerMock, recognizeMock, terminateMock } = vi.hoisted(() => ({
+  getDocumentMock: vi.fn(),
+  createWorkerMock: vi.fn(),
+  recognizeMock: vi.fn(),
+  terminateMock: vi.fn(),
+}));
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: getDocumentMock,
+}));
+
+vi.mock('pdfjs-dist/build/pdf.worker.min.mjs?url', () => ({ default: 'stub-worker-url' }));
+vi.mock('../../../src/renderer/assets/ocr/eng.traineddata?url', () => ({
+  default: 'stub://lang/eng.traineddata',
+}));
+
+vi.mock('tesseract.js', () => ({
+  createWorker: createWorkerMock,
+}));
+
+import { runOcr, type OcrProgress } from '../../../src/renderer/lib/ocr/run-ocr';
+
+/**
+ * Build a stub PDFDocumentProxy that hands back N stub pages. Each page's
+ * `render({...}).promise` resolves immediately so the test doesn't depend
+ * on a real canvas backend.
+ */
+function stubPdf(numPages: number, opts: { onPageRender?: (n: number) => void } = {}) {
+  const pageCleanup = vi.fn();
+  const docCleanup = vi.fn();
+  const docDestroy = vi.fn();
+  const getPage = vi.fn(async (n: number) => ({
+    getViewport: () => ({ width: 100, height: 200 }),
+    render: () => ({
+      promise: (async () => {
+        opts.onPageRender?.(n);
+      })(),
+    }),
+    cleanup: pageCleanup,
+  }));
+  return {
+    doc: { numPages, getPage, cleanup: docCleanup, destroy: docDestroy },
+    getPage,
+    pageCleanup,
+    docCleanup,
+    docDestroy,
+  };
+}
+
+beforeEach(() => {
+  getDocumentMock.mockReset();
+  createWorkerMock.mockReset();
+  recognizeMock.mockReset();
+  terminateMock.mockReset();
+
+  // happy-dom doesn't implement canvas; stub getContext so renderPageToCanvas
+  // doesn't trip its "2D canvas context unavailable" guard.
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as unknown as CanvasRenderingContext2D);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runOcr() (#343)', () => {
+  it('returns one extracted text per page in order', async () => {
+    const { doc } = stubPdf(3);
+    getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+    recognizeMock
+      .mockResolvedValueOnce({ data: { text: 'page-1-text' } })
+      .mockResolvedValueOnce({ data: { text: 'page-2-text' } })
+      .mockResolvedValueOnce({ data: { text: 'page-3-text' } });
+    createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
+
+    const pages = await runOcr(new Uint8Array(), () => undefined);
+    expect(pages).toEqual(['page-1-text', 'page-2-text', 'page-3-text']);
+  });
+
+  it('fires onProgress at start, mid, and end of each page in order', async () => {
+    const { doc } = stubPdf(3);
+    getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+    recognizeMock.mockResolvedValue({ data: { text: 'x' } });
+    createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
+
+    const events: OcrProgress[] = [];
+    await runOcr(new Uint8Array(), (p) => events.push({ ...p }));
+
+    expect(events).toEqual([
+      { page: 1, totalPages: 3, pageProgress: 0 },
+      { page: 1, totalPages: 3, pageProgress: 0.5 },
+      { page: 1, totalPages: 3, pageProgress: 1 },
+      { page: 2, totalPages: 3, pageProgress: 0 },
+      { page: 2, totalPages: 3, pageProgress: 0.5 },
+      { page: 2, totalPages: 3, pageProgress: 1 },
+      { page: 3, totalPages: 3, pageProgress: 0 },
+      { page: 3, totalPages: 3, pageProgress: 0.5 },
+      { page: 3, totalPages: 3, pageProgress: 1 },
+    ]);
+  });
+
+  it('always tears down the worker and the doc, even on error', async () => {
+    const { doc, docCleanup, docDestroy } = stubPdf(1);
+    getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+    recognizeMock.mockRejectedValueOnce(new Error('tesseract bombed'));
+    createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
+
+    await expect(runOcr(new Uint8Array(), () => undefined)).rejects.toThrow('tesseract bombed');
+    expect(terminateMock).toHaveBeenCalledTimes(1);
+    expect(docCleanup).toHaveBeenCalledTimes(1);
+    expect(docDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  describe('AbortSignal', () => {
+    it('rejects with AbortError when aborted before the first page', async () => {
+      const { doc, getPage } = stubPdf(3);
+      getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+      recognizeMock.mockResolvedValue({ data: { text: 'x' } });
+      createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
+
+      const ctrl = new AbortController();
+      ctrl.abort();
+      const err = await runOcr(new Uint8Array(), () => undefined, ctrl.signal)
+        .then(() => null)
+        .catch((e) => e);
+
+      expect(err).toBeInstanceOf(DOMException);
+      expect((err as DOMException).name).toBe('AbortError');
+      expect(getPage).not.toHaveBeenCalled();
+      expect(recognizeMock).not.toHaveBeenCalled();
+      expect(terminateMock).toHaveBeenCalledTimes(1); // worker still cleaned up
+    });
+
+    it('mid-run abort skips remaining pages and still tears down', async () => {
+      // Abort after page 2 finishes — page 3 must never be processed.
+      const ctrl = new AbortController();
+      const { doc, getPage, docDestroy } = stubPdf(3);
+      getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+      recognizeMock.mockImplementation(async () => {
+        // Trigger abort once page 2's recognize resolves; the loop will
+        // see the signal at the top of iteration 3.
+        if (recognizeMock.mock.calls.length === 2) ctrl.abort();
+        return { data: { text: 'x' } };
+      });
+      createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
+
+      const err = await runOcr(new Uint8Array(), () => undefined, ctrl.signal)
+        .then(() => null)
+        .catch((e) => e);
+
+      expect(err).toBeInstanceOf(DOMException);
+      expect((err as DOMException).name).toBe('AbortError');
+      expect(getPage).toHaveBeenCalledTimes(2);
+      expect(recognizeMock).toHaveBeenCalledTimes(2);
+      expect(terminateMock).toHaveBeenCalledTimes(1);
+      expect(docDestroy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #343 — \`src/renderer/lib/ocr/run-ocr.ts\` is ~100 LOC of pdfjs + tesseract.js orchestration with no tests; a worker-API drift in either dep would ship broken silently.
- Adds \`happy-dom\` as a devDep and configures the renderer test via the per-file pragma \`/** @vitest-environment happy-dom */\` so other tests stay on the default node env. Pulls in only the DOM cost where it's needed; this also unblocks future Svelte component tests called out in the ticket (\`OcrProgressDialog.svelte\`, \`Editor.svelte\`).
- New \`tests/renderer/ocr/run-ocr.test.ts\` mocks pdfjs-dist + tesseract.js + the \`?url\` asset imports, drives a 3-page stub PDF, and asserts text-in-order, the per-page progress sequence \`{0, 0.5, 1}\`, teardown on error, and both AbortSignal paths (pre-loop abort and mid-run abort).
- Bumps a pre-write delay in the watcher change-event test from 200ms to 500ms — under parallel test load on macOS fsevents the prior value sometimes lost the race and chokidar reported \`add\` instead of \`change\`.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1587 passed (162 files), including 5 new OCR tests
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)