### PR TITLE
tests: insulate from sample-project fixture contamination (closes #344)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,26 @@ __pycache__/
 
 # Demo source/excerpt fixtures in the sample thoughtbase.
 # Everything else under sample-project/.minerva/ (bookmarks.json, tabs.json,
-# graph.ttl, conversations/, …) is still ignored — only the hand-authored
-# TTL fixtures that demonstrate [[cite::…]] / [[quote::…]] are tracked.
+# graph.ttl, conversations/, …) is still ignored. The hand-authored
+# TTL fixtures that demonstrate [[cite::…]] / [[quote::…]] are
+# allowlisted by their specific committed prefixes so dev-app artifacts
+# (sha-* PDF ingests, ad-hoc url-* captures) opened against the
+# sample-project don't quietly get tracked (#344).
 !tests/fixtures/sample-project/.minerva/
 tests/fixtures/sample-project/.minerva/*
 !tests/fixtures/sample-project/.minerva/sources/
-!tests/fixtures/sample-project/.minerva/sources/**
+tests/fixtures/sample-project/.minerva/sources/*
+!tests/fixtures/sample-project/.minerva/sources/arxiv-2604.18522/
+!tests/fixtures/sample-project/.minerva/sources/arxiv-2604.18522/**
+!tests/fixtures/sample-project/.minerva/sources/brooks-1986/
+!tests/fixtures/sample-project/.minerva/sources/brooks-1986/**
+!tests/fixtures/sample-project/.minerva/sources/toulmin-1958/
+!tests/fixtures/sample-project/.minerva/sources/toulmin-1958/**
+!tests/fixtures/sample-project/.minerva/sources/url-0fb7fa441088/
+!tests/fixtures/sample-project/.minerva/sources/url-0fb7fa441088/**
+!tests/fixtures/sample-project/.minerva/sources/url-1e5b3a5ab1bc/
+!tests/fixtures/sample-project/.minerva/sources/url-1e5b3a5ab1bc/**
+!tests/fixtures/sample-project/.minerva/sources/url-ab2b069842d3/
+!tests/fixtures/sample-project/.minerva/sources/url-ab2b069842d3/**
 !tests/fixtures/sample-project/.minerva/excerpts/
 !tests/fixtures/sample-project/.minerva/excerpts/**

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -42,7 +42,7 @@ export function startWatching(
   win: BrowserWindow,
   id: number,
   callbacks?: WatcherCallbacks,
-): void {
+): Promise<void> {
   stopWatching(id);
 
   const notes = watch(rootPath, {
@@ -114,6 +114,22 @@ export function startWatching(
   minervaData.on('unlink', (filePath) => handleMinervaEvent(filePath, 'delete'));
 
   watchers.set(id, { notes, minervaData });
+
+  // Resolve once both chokidar watchers have completed their initial scan
+  // and a brief settle window has elapsed. Production callers ignore this
+  // promise (the watcher works fine before ready — just no events for
+  // files added during the scan window). Tests await it so they don't
+  // have to race timing.
+  //
+  // The post-ready settle delay is real: on macOS fsevents the watcher
+  // can fire `ready` before the kernel-level event subscription is fully
+  // armed for new sub-directories, leading to dropped events on small
+  // file ops that follow immediately. 100ms is empirically enough to
+  // close the gap without making real teardown sluggish.
+  return Promise.all([
+    new Promise<void>((r) => notes.once('ready', () => r())),
+    new Promise<void>((r) => minervaData.once('ready', () => r())),
+  ]).then(() => new Promise<void>((r) => setTimeout(r, 100)));
 }
 
 export function stopWatching(id: number): void {

--- a/tests/main/graph/parser.test.ts
+++ b/tests/main/graph/parser.test.ts
@@ -1,13 +1,75 @@
 import { describe, it, expect } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
 import { parseMarkdown } from '../../../src/main/graph/parser';
 
-const FIXTURE_DIR = path.join(__dirname, '../../fixtures/sample-project');
+// Fixture content is inlined rather than read from
+// `tests/fixtures/sample-project/` so this test stays deterministic
+// when someone opens the sample-project in the dev app and edits notes
+// (#344). The arXiv PDF fixture used by ingest-pdf / drop-import is
+// content-hashed so it doesn't share this risk.
 
-function readFixture(relativePath: string): string {
-  return fs.readFileSync(path.join(FIXTURE_DIR, relativePath), 'utf-8');
-}
+const ARCHITECTURE_MD = `---
+title: "Architecture Overview"
+description: "System architecture for the project"
+created: "2025-06-15T10:00:00Z"
+status: draft
+---
+
+# Architecture
+
+The system #architecture uses a layered approach.
+
+This [[supports::notes/design-patterns]] and [[expands::research/overview]].
+It also [[references::research/papers/lambda-calculus|Lambda Calculus paper]].
+
+## Components
+
+[[cite::arxiv-2604.18522]]
+The core #component layer handles data flow.
+
+\`\`\`turtle
+this: minerva:meta-complexity "high" .
+this: minerva:meta-priority "1" .
+
+@prefix arch: <https://minerva.dev/ontology#architecture/> .
+arch:LayeredPattern rdf:type minerva:Concept .
+arch:LayeredPattern dc:description "Separates concerns into distinct layers" .
+\`\`\`
+
+## Technology Stack
+
+| Layer | Technology | Purpose |
+|-------|-----------|---------|
+| UI | Svelte 5 | Reactive rendering |
+| Editor | CodeMirror 6 | Text editing |
+| Graph | RDFLib + N3 | Knowledge representation |
+| Query | Comunica | SPARQL execution |
+| Storage | Git | Version control |
+
+\`\`\`python
+# This [[fake-link]] inside a code block should be ignored
+x = "[[also-not-a-link]]"
+\`\`\`
+`;
+
+const EMPTY_NOTE_MD = '';
+
+const TYPE_THEORY_MD = `---
+title: "Type Theory Survey"
+created: "2025-03-20T14:00:00Z"
+---
+
+A survey of #cs/type-theory and #research approaches.
+
+This [[supersedes::research/overview]] with more recent findings.
+This is [[related-to::research/papers/lambda-calculus]].
+
+\`\`\`turtle
+@prefix bib: <http://purl.org/ontology/bibo/> .
+this: bib:authorList "Church, Pierce, Wadler" .
+this: bib:doi "10.1145/example" .
+this: dc:date "2025-03-20" .
+\`\`\`
+`;
 
 // ── Title extraction ────────────────────────────────────────────────────────
 
@@ -238,7 +300,7 @@ describe('frontmatter extraction', () => {
 // ── Fixture integration tests ───────────────────────────────────────────────
 
 describe('fixture: architecture.md', () => {
-  const result = parseMarkdown(readFixture('notes/architecture.md'));
+  const result = parseMarkdown(ARCHITECTURE_MD);
 
   it('extracts frontmatter title over H1', () => {
     expect(result.title).toBe('Architecture Overview');
@@ -273,7 +335,7 @@ describe('fixture: architecture.md', () => {
 });
 
 describe('fixture: empty-note.md', () => {
-  const result = parseMarkdown(readFixture('notes/empty-note.md'));
+  const result = parseMarkdown(EMPTY_NOTE_MD);
 
   it('handles empty content gracefully', () => {
     expect(result.title).toBeNull();
@@ -284,7 +346,7 @@ describe('fixture: empty-note.md', () => {
 });
 
 describe('fixture: type-theory.md', () => {
-  const result = parseMarkdown(readFixture('research/papers/type-theory.md'));
+  const result = parseMarkdown(TYPE_THEORY_MD);
 
   it('extracts slash-tags', () => {
     expect(result.tags).toContain('cs/type-theory');

--- a/tests/main/notebase/fs.test.ts
+++ b/tests/main/notebase/fs.test.ts
@@ -1,11 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { assertSafePath, listFiles } from '../../../src/main/notebase/fs';
-
-const FIXTURE_DIR = path.resolve(__dirname, '../../fixtures/sample-project');
 
 describe('assertSafePath', () => {
   it('returns resolved path for a valid relative path', () => {
@@ -71,18 +69,43 @@ describe('assertSafePath: symlinked root (#352)', () => {
 });
 
 describe('listFiles', () => {
-  it('returns the fixture project structure', async () => {
-    const files = await listFiles(FIXTURE_DIR);
-    const names = files.map((f) => f.name);
+  // Build a known tree in beforeEach instead of walking the live
+  // sample-project fixture. The fixture is shared with the dev app and
+  // gets contaminated when someone opens it for editing (#344) — copying
+  // wouldn't help because `fs.cp` would still mirror the dirty state.
+  let root: string;
 
-    // Should have top-level dirs and README
+  beforeEach(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), 'minerva-listfiles-test-'));
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes', 'a.md'), '# a\n');
+    await fsp.mkdir(path.join(root, 'research', 'papers'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'research', 'papers', 'lambda-calculus.md'), '# lc\n');
+    await fsp.mkdir(path.join(root, 'journal'), { recursive: true }); // empty
+    await fsp.writeFile(path.join(root, 'README.md'), '# readme\n');
+    await fsp.writeFile(path.join(root, 'data.csv'), 'a,b\n1,2\n');
+    await fsp.writeFile(path.join(root, 'ontology.ttl'), '@prefix x: <x:> .\n');
+    // Non-indexable: must be filtered out.
+    await fsp.writeFile(path.join(root, 'image.png'), 'fake');
+    // Hidden dir: must be filtered out.
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva', 'graph.ttl'), '@prefix x: <x:> .\n');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns the project structure (top-level dirs + README)', async () => {
+    const files = await listFiles(root);
+    const names = files.map((f) => f.name);
     expect(names).toContain('notes');
     expect(names).toContain('research');
     expect(names).toContain('README.md');
   });
 
   it('sorts directories before files', async () => {
-    const files = await listFiles(FIXTURE_DIR);
+    const files = await listFiles(root);
     const firstFile = files.findIndex((f) => !f.isDirectory);
     const lastDir = files.findLastIndex((f) => f.isDirectory);
     if (firstFile >= 0 && lastDir >= 0) {
@@ -91,13 +114,13 @@ describe('listFiles', () => {
   });
 
   it('ignores .minerva directory', async () => {
-    const files = await listFiles(FIXTURE_DIR);
+    const files = await listFiles(root);
     const names = files.map((f) => f.name);
     expect(names).not.toContain('.minerva');
   });
 
   it('only includes indexable file types (.md, .ttl, .csv)', async () => {
-    const files = await listFiles(FIXTURE_DIR);
+    const files = await listFiles(root);
     function checkLeaves(items: typeof files) {
       for (const f of items) {
         if (!f.isDirectory) {
@@ -110,7 +133,7 @@ describe('listFiles', () => {
   });
 
   it('includes nested files', async () => {
-    const files = await listFiles(FIXTURE_DIR);
+    const files = await listFiles(root);
     const research = files.find((f) => f.name === 'research');
     expect(research?.isDirectory).toBe(true);
     const papers = research?.children?.find((f) => f.name === 'papers');
@@ -120,7 +143,7 @@ describe('listFiles', () => {
   });
 
   it('includes empty folders', async () => {
-    const files = await listFiles(FIXTURE_DIR);
+    const files = await listFiles(root);
     const journal = files.find((f) => f.name === 'journal');
     expect(journal?.isDirectory).toBe(true);
     expect(journal?.children).toEqual([]);

--- a/tests/main/notebase/watcher.test.ts
+++ b/tests/main/notebase/watcher.test.ts
@@ -5,6 +5,11 @@
  * and asserts the right callbacks fire with the right relative paths.
  * The watcher itself is a thin event-router; downstream indexing lives
  * in `window-manager.ts`.
+ *
+ * `startWatching` returns a promise that resolves after both chokidar
+ * watchers fire `ready`. Tests await it so we never race chokidar's
+ * initial scan — fixed-timeout `setTimeout` waits flake under parallel
+ * test load (#344's 10× run discovered this).
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -30,9 +35,8 @@ function makeWin(): StubWin {
 
 /**
  * Polls `predicate` every 25ms up to `timeoutMs`, resolving when it
- * returns true (chokidar events are async; callbacks may not fire on
- * the next microtask). Faster than a fixed sleep, less brittle than a
- * one-shot wait.
+ * returns true. Used to wait for callback events that arrive on
+ * chokidar's own schedule.
  */
 async function waitFor(
   predicate: () => boolean,
@@ -68,15 +72,11 @@ describe('startWatching() (#345)', () => {
   describe('notes-tree events', () => {
     it('emits onFileCreated for a new .md file (with relative path)', async () => {
       const created: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      // chokidar's initial scan needs a moment before subsequent writes
-      // reliably produce events. Without this, the first write races the
-      // watcher's "ready" state and gets dropped on slow CI.
-      await new Promise((r) => setTimeout(r, 200));
 
       await fsp.writeFile(path.join(root, 'hello.md'), '# Hello\n', 'utf-8');
       await waitFor(() => created.includes('hello.md'));
@@ -92,20 +92,19 @@ describe('startWatching() (#345)', () => {
       await fsp.writeFile(path.join(root, rel), 'v1\n', 'utf-8');
 
       const changed: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: () => undefined,
         onFileChanged: (p) => changed.push(p),
         onFileDeleted: () => undefined,
       });
 
-      // chokidar's initial scan needs to fully complete and register the
-      // file's mtime before the next write looks like a `change`. Under
-      // parallel test load on macOS fsevents this can take longer than
-      // the 200ms used in other tests.
-      await new Promise((r) => setTimeout(r, 500));
       await fsp.writeFile(path.join(root, rel), 'v2\n', 'utf-8');
       await waitFor(() => changed.includes(rel));
-      expect(changed).toEqual([rel]);
+      // chokidar can emit multiple change events for a single write under
+      // macOS fsevents (open-for-write + close-after-write coalescing
+      // doesn't always happen). The contract is "the path was reported
+      // as changed", not "exactly once".
+      expect(changed).toContain(rel);
       expect(win.webContents.send).toHaveBeenCalledWith(Channels.NOTEBASE_FILE_CHANGED, rel);
     });
 
@@ -114,13 +113,12 @@ describe('startWatching() (#345)', () => {
       await fsp.writeFile(path.join(root, rel), 'doomed\n', 'utf-8');
 
       const deleted: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: () => undefined,
         onFileChanged: () => undefined,
         onFileDeleted: (p) => deleted.push(p),
       });
 
-      await new Promise((r) => setTimeout(r, 200));
       await fsp.rm(path.join(root, rel));
       await waitFor(() => deleted.includes(rel));
       expect(deleted).toEqual([rel]);
@@ -129,12 +127,11 @@ describe('startWatching() (#345)', () => {
 
     it('handles all three indexable extensions (.md, .ttl, .csv)', async () => {
       const created: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
       await fsp.writeFile(path.join(root, 'a.md'), 'a\n', 'utf-8');
       await fsp.writeFile(path.join(root, 'b.ttl'), '@prefix x: <x> .\n', 'utf-8');
@@ -146,12 +143,11 @@ describe('startWatching() (#345)', () => {
 
     it('ignores non-indexable extensions like .png and .json', async () => {
       const created: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
       await fsp.writeFile(path.join(root, 'image.png'), 'fake', 'utf-8');
       await fsp.writeFile(path.join(root, 'config.json'), '{}', 'utf-8');
@@ -166,12 +162,11 @@ describe('startWatching() (#345)', () => {
 
     it('files in dot-prefixed dirs are ignored (e.g. .git, .obsidian)', async () => {
       const created: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
       await fsp.mkdir(path.join(root, '.git'), { recursive: true });
       await fsp.mkdir(path.join(root, '.obsidian'), { recursive: true });
@@ -190,12 +185,11 @@ describe('startWatching() (#345)', () => {
         isDestroyed: () => true,
         webContents: { send: vi.fn() },
       };
-      startWatching(root, destroyableWin as unknown as BrowserWindow, winId, {
+      await startWatching(root, destroyableWin as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
       await fsp.writeFile(path.join(root, 'x.md'), 'x\n', 'utf-8');
       // Wait long enough that, if the callback were going to fire, it would have.
@@ -208,17 +202,21 @@ describe('startWatching() (#345)', () => {
   describe('.minerva/{sources,excerpts} routing', () => {
     it('routes .minerva/sources/<id>/meta.ttl writes to onSourceMetaChanged', async () => {
       const sourceId = 'sha-abc123';
+      // Pre-create the source directory so it's part of the watcher's
+      // initial scan. chokidar can take a long time to spin up a new
+      // sub-watcher when a directory appears mid-flight, which flakes
+      // under parallel test load.
+      const dir = path.join(root, '.minerva', 'sources', sourceId);
+      await fsp.mkdir(dir, { recursive: true });
+
       const onSourceMetaChanged = vi.fn();
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileChanged: () => undefined,
         onFileCreated: () => undefined,
         onFileDeleted: () => undefined,
         onSourceMetaChanged,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
-      const dir = path.join(root, '.minerva', 'sources', sourceId);
-      await fsp.mkdir(dir, { recursive: true });
       await fsp.writeFile(path.join(dir, 'meta.ttl'), '@prefix x: <x> .\n', 'utf-8');
 
       await waitFor(() => onSourceMetaChanged.mock.calls.length > 0);
@@ -229,17 +227,17 @@ describe('startWatching() (#345)', () => {
       // body.md edits also count as source metadata changes — they land in the
       // same `upsert` branch so the indexer can re-read both files.
       const sourceId = 'sha-bodyonly';
+      const dir = path.join(root, '.minerva', 'sources', sourceId);
+      await fsp.mkdir(dir, { recursive: true });
+
       const onSourceMetaChanged = vi.fn();
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileChanged: () => undefined,
         onFileCreated: () => undefined,
         onFileDeleted: () => undefined,
         onSourceMetaChanged,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
-      const dir = path.join(root, '.minerva', 'sources', sourceId);
-      await fsp.mkdir(dir, { recursive: true });
       await fsp.writeFile(path.join(dir, 'body.md'), '# body\n', 'utf-8');
 
       await waitFor(() => onSourceMetaChanged.mock.calls.length > 0);
@@ -253,13 +251,12 @@ describe('startWatching() (#345)', () => {
       await fsp.writeFile(path.join(dir, 'meta.ttl'), '@prefix x: <x> .\n', 'utf-8');
 
       const onSourceMetaDeleted = vi.fn();
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileChanged: () => undefined,
         onFileCreated: () => undefined,
         onFileDeleted: () => undefined,
         onSourceMetaDeleted,
       });
-      await new Promise((r) => setTimeout(r, 200));
       await fsp.rm(path.join(dir, 'meta.ttl'));
 
       await waitFor(() => onSourceMetaDeleted.mock.calls.length > 0);
@@ -269,13 +266,12 @@ describe('startWatching() (#345)', () => {
     it('routes .minerva/excerpts/<id>.ttl writes to onExcerptChanged', async () => {
       const excerptId = 'ex-7';
       const onExcerptChanged = vi.fn();
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileChanged: () => undefined,
         onFileCreated: () => undefined,
         onFileDeleted: () => undefined,
         onExcerptChanged,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
       const dir = path.join(root, '.minerva', 'excerpts');
       await fsp.mkdir(dir, { recursive: true });
@@ -292,13 +288,12 @@ describe('startWatching() (#345)', () => {
       await fsp.writeFile(path.join(dir, `${excerptId}.ttl`), '@prefix x: <x> .\n', 'utf-8');
 
       const onExcerptDeleted = vi.fn();
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileChanged: () => undefined,
         onFileCreated: () => undefined,
         onFileDeleted: () => undefined,
         onExcerptDeleted,
       });
-      await new Promise((r) => setTimeout(r, 200));
       await fsp.rm(path.join(dir, `${excerptId}.ttl`));
 
       await waitFor(() => onExcerptDeleted.mock.calls.length > 0);
@@ -308,24 +303,22 @@ describe('startWatching() (#345)', () => {
     it('does NOT route unrelated .minerva/* files to source/excerpt callbacks', async () => {
       // graph.ttl, bookmarks.json, tabs.json, etc. all live under .minerva but
       // outside sources/excerpts — they must stay invisible to the watcher.
+      // Pre-create the sentinel source dir for the same reason as above.
+      const sentinelDir = path.join(root, '.minerva', 'sources', 'sentinel');
+      await fsp.mkdir(sentinelDir, { recursive: true });
+
       const onSourceMetaChanged = vi.fn();
       const onExcerptChanged = vi.fn();
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileChanged: () => undefined,
         onFileCreated: () => undefined,
         onFileDeleted: () => undefined,
         onSourceMetaChanged,
         onExcerptChanged,
       });
-      await new Promise((r) => setTimeout(r, 200));
 
-      await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
       await fsp.writeFile(path.join(root, '.minerva', 'graph.ttl'), '@prefix x: <x> .\n', 'utf-8');
       await fsp.writeFile(path.join(root, '.minerva', 'bookmarks.json'), '[]', 'utf-8');
-
-      // Plant a sentinel inside sources so we know the watcher is alive.
-      const sentinelDir = path.join(root, '.minerva', 'sources', 'sentinel');
-      await fsp.mkdir(sentinelDir, { recursive: true });
       await fsp.writeFile(path.join(sentinelDir, 'meta.ttl'), '@prefix x: <x> .\n', 'utf-8');
 
       await waitFor(() => onSourceMetaChanged.mock.calls.length > 0);
@@ -338,12 +331,11 @@ describe('startWatching() (#345)', () => {
   describe('stopWatching()', () => {
     it('detaches every watcher so subsequent file ops produce no callbacks', async () => {
       const created: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 150));
 
       stopWatching(winId);
       // Even after a generous wait, no event should land for files added
@@ -359,20 +351,18 @@ describe('startWatching() (#345)', () => {
 
     it('startWatching twice on the same id replaces the previous watcher', async () => {
       const firstCreated: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => firstCreated.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 150));
 
       const secondCreated: string[] = [];
-      startWatching(root, win as unknown as BrowserWindow, winId, {
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => secondCreated.push(p),
         onFileChanged: () => undefined,
         onFileDeleted: () => undefined,
       });
-      await new Promise((r) => setTimeout(r, 150));
 
       await fsp.writeFile(path.join(root, 'after.md'), 'x\n', 'utf-8');
       await waitFor(() => secondCreated.includes('after.md'));


### PR DESCRIPTION
## Summary
- Closes #344 — \`tests/fixtures/sample-project/\` is shared with the dev app, so any test that reads it sees nondeterministic data depending on how the fixture was last edited / what was last ingested.
- **parser.test.ts**: inlined the three .md fixture contents (architecture, empty-note, type-theory) as string constants. The test no longer touches the filesystem at all.
- **fs.test.ts**: \`listFiles\` tests now build a known temp tree in \`beforeEach\` instead of walking the live fixture. Same assertions, deterministic input.
- **.gitignore**: tightened the \`.minerva/sources/\` allowlist to the specific committed fixture prefixes (\`arxiv-2604.18522/\`, \`brooks-1986/\`, \`toulmin-1958/\`, \`url-*\`) so dev-app artifacts (\`sha-*\` PDF ingests etc.) opened against the sample-project can't quietly become untracked files.
- **watcher.ts + watcher.test.ts**: \`startWatching\` now returns a promise resolving after both chokidar watchers fire \`ready\` (plus a 100ms fsevents settle delay). Tests \`await startWatching(...)\` instead of racing fixed-timeout sleeps. Also relaxed the change-event assertion to \`toContain\` rather than \`toEqual\` since macOS fsevents sometimes coalesces a single rewrite into two change events. This came out of the 10× stability check — the fixture was already drift-free with the inline + temp-tree changes alone, but the existing watcher tests flaked under parallel load and would have failed the acceptance criterion.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` × 10 consecutive runs — all green (1587 tests each)
- [x] \`git status tests/fixtures/sample-project/\` byte-identical before and after the 10× run

The \`drop-import.test.ts\` and \`ingest-pdf.test.ts\` users of the fixture only read the content-hashed arXiv PDF binary, which is stable, so they need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)