### PR TITLE
tooling: add ESLint with type-checked rules (closes #349)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,133 @@
+// ESLint flat config (#349). Adds floating-promise + dead-import + a few
+// other "would have caught a bug" rules on top of the existing tsc +
+// svelte-check pass. Type-checked rules require the TS project, so we
+// hand the parser our tsconfig and let it pick up types per-file.
+//
+// Adoption rule per the issue: don't blow up the dev. We disable any
+// recommended rule that produces a wall of existing warnings and file
+// per-rule cleanup follow-ups instead.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import svelte from 'eslint-plugin-svelte';
+import svelteParser from 'svelte-eslint-parser';
+import globals from 'globals';
+
+export default tseslint.config(
+  {
+    ignores: [
+      '.vite/**',
+      'dist/**',
+      'out/**',
+      'coverage/**',
+      'node_modules/**',
+      '**/*.d.ts',
+      // The fixture project is a hand-authored Minerva thoughtbase, not
+      // app source — linting its bundled TS / JS dust isn't useful.
+      'tests/fixtures/**',
+      // The eslint config itself isn't covered by the TS project, so the
+      // type-aware parser would error trying to load it. Linting our own
+      // config is low value anyway. Same for svelte.config.mjs.
+      'eslint.config.mjs',
+      'svelte.config.mjs',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        // tsconfig.eslint.json widens the main tsconfig to include
+        // tests + vite configs so eslint's project service can type-check
+        // every file we lint.
+        project: './tsconfig.eslint.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+    rules: {
+      // ── Rules we're keeping on ────────────────────────────────────────
+      // Floating promises: the headline ask in #349. Set to `warn`, not
+      // `error`, because the codebase has ~80 existing offenders (mostly
+      // intentional fire-and-forget `api.*()` calls in Svelte event
+      // handlers). Editor + CI will surface them, future code gets
+      // caught, and the cleanup is tracked in its own follow-up.
+      '@typescript-eslint/no-floating-promises': 'warn',
+      // Unused-vars/imports as warnings, with the standard `_`-prefix
+      // escape hatch so tests/handlers can name args they intentionally
+      // ignore.
+      '@typescript-eslint/no-unused-vars': ['warn', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+      'no-unused-vars': 'off', // superseded by the TS variant above
+
+      // ── Rules deferred to follow-up issues ────────────────────────────
+      // Each rule below produces a wall of existing warnings on the
+      // current codebase. Per the issue, ship with them off and track
+      // per-rule cleanup separately — better than stalling adoption on
+      // a hundred-line PR that mixes lint setup with real fixes.
+      // Re-enable each in its own PR after the underlying cleanups land.
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/no-misused-promises': 'off',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/restrict-plus-operands': 'off',
+      '@typescript-eslint/no-redundant-type-constituents': 'off',
+      '@typescript-eslint/no-base-to-string': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/only-throw-error': 'off',
+      '@typescript-eslint/no-empty-object-type': 'off',
+      '@typescript-eslint/await-thenable': 'off',
+      // 30 sites, mostly `(x as Y).foo` in tests. Cosmetic.
+      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+      // 15 sites of `\.` / `\[` / `\-` inside character classes — safe
+      // either way, but touching parsers and editor regexes carries
+      // surface-area risk. Defer to a focused regex audit.
+      'no-useless-escape': 'off',
+    },
+  },
+  {
+    // Tests are looser by design — vitest's expect chains and mocking
+    // patterns intentionally tickle some of the strictness we keep on
+    // for app code.
+    files: ['tests/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'off',
+    },
+  },
+  {
+    // Svelte block. eslint-plugin-svelte handles the .svelte parsing
+    // (which also gives us script-block type info via svelte-eslint-parser).
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parser: svelteParser,
+      parserOptions: {
+        parser: tseslint.parser,
+        project: './tsconfig.eslint.json',
+        tsconfigRootDir: import.meta.dirname,
+        extraFileExtensions: ['.svelte'],
+      },
+    },
+    plugins: { svelte },
+    rules: {
+      // Svelte 5's rune dependency-tracking idiom uses bare expression
+      // statements (`messages;`, `revision;`) to register reactive deps
+      // inside `$effect(() => { ... })`. The TS parser flags those as
+      // unused expressions; they aren't.
+      '@typescript-eslint/no-unused-expressions': 'off',
+      // svelte-check already covers the core a11y + reactivity rules.
+      // Keep eslint-plugin-svelte off here for now and re-enable
+      // selectively as the project standardizes on rules we want.
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "electron-forge start",
     "build": "electron-forge make",
     "package": "electron-forge package",
-    "lint": "tsc --noEmit && svelte-check --threshold error",
+    "lint": "tsc --noEmit && svelte-check --threshold error && eslint .",
+    "lint:eslint": "eslint .",
+    "lint:eslint:fix": "eslint . --fix",
     "test": "vitest"
   },
   "dependencies": {
@@ -57,6 +59,7 @@
     "@electron-forge/maker-dmg": "^7.6.0",
     "@electron-forge/maker-zip": "^7.6.0",
     "@electron-forge/plugin-vite": "^7.6.0",
+    "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/katex": "^0.16.8",
     "@types/markdown-it": "^14.1.2",
@@ -65,12 +68,17 @@
     "@vitest/coverage-v8": "^2.1.9",
     "codemirror": "^6.0.1",
     "electron": "^35.7.5",
+    "eslint": "^10.2.1",
+    "eslint-plugin-svelte": "^3.17.1",
+    "globals": "^17.5.0",
     "happy-dom": "^20.9.0",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.1",
     "svelte": "^5.16.0",
     "svelte-check": "^4.4.6",
+    "svelte-eslint-parser": "^1.6.0",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.59.0",
     "vite": "^6.0.0",
     "vitest": "^2.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@electron-forge/plugin-vite':
         specifier: ^7.6.0
         version: 7.11.1
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.2.1(jiti@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
         version: 5.1.1(svelte@5.55.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
@@ -138,6 +141,15 @@ importers:
       electron:
         specifier: ^35.7.5
         version: 35.7.5
+      eslint:
+        specifier: ^10.2.1
+        version: 10.2.1(jiti@2.6.1)
+      eslint-plugin-svelte:
+        specifier: ^3.17.1
+        version: 3.17.1(eslint@10.2.1(jiti@2.6.1))(svelte@5.55.0)
+      globals:
+        specifier: ^17.5.0
+        version: 17.5.0
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -153,9 +165,15 @@ importers:
       svelte-check:
         specifier: ^4.4.6
         version: 4.4.6(picomatch@4.0.4)(svelte@5.55.0)(typescript@5.9.3)
+      svelte-eslint-parser:
+        specifier: ^1.6.0
+        version: 1.6.0(svelte@5.55.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
@@ -1665,6 +1683,45 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1680,6 +1737,26 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@inquirer/checkbox@3.0.1':
     resolution: {integrity: sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==}
@@ -2193,6 +2270,9 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2295,8 +2375,67 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
+  '@typescript-eslint/eslint-plugin@8.59.0':
+    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.0':
+    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.57.2':
     resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unified-latex/unified-latex-types@1.8.4':
@@ -2432,6 +2571,11 @@ packages:
     peerDependencies:
       acorn: ^8.14.0
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2461,6 +2605,9 @@ packages:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -2842,6 +2989,11 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
@@ -2879,6 +3031,9 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -3041,12 +3196,64 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-svelte@3.17.1:
+    resolution: {integrity: sha512-NyiXHtS3Ni7e532RBwS9OXlMKDIrENg3gY+/+ODjZzQx2xhU3NlJ+nIl1a93iUUQeiJL3lS8KLmY+W8hklzweQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.1 || ^9.0.0 || ^10.0.0
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.2.1:
+    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
 
   esrap@2.2.4:
     resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
@@ -3065,6 +3272,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   event-emitter-promisify@1.1.0:
     resolution: {integrity: sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg==}
@@ -3110,6 +3321,12 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3135,6 +3352,10 @@ packages:
     resolution: {integrity: sha512-+C5x3uOqumCvyqDkwXZ31len8qsNfBERWvL6ngqO4m1PSmfqmut4A+2bBbBln48Ag4qudUrG+9qZjFvzY66ubw==}
     hasBin: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   filename-reserved-regex@2.0.0:
     resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
     engines: {node: '>=4'}
@@ -3154,6 +3375,13 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flora-colossus@2.0.0:
     resolution: {integrity: sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==}
@@ -3250,6 +3478,10 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -3274,6 +3506,14 @@ packages:
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
     engines: {node: '>=10'}
+
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
+
+  globals@17.5.0:
+    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -3389,6 +3629,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   image-size@0.7.5:
@@ -3574,8 +3818,14 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -3626,12 +3876,23 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  known-css-properties@0.37.0:
+    resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
+
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
 
   linkedom@0.18.12:
     resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
@@ -3900,6 +4161,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   nearley@2.20.1:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
@@ -3979,6 +4243,10 @@ packages:
   opencollective-postinstall@2.0.3:
     resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
     hasBin: true
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -4124,6 +4392,34 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-load-config@3.1.4:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-scss@4.0.9:
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4132,6 +4428,10 @@ packages:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
@@ -4596,6 +4896,15 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
+  svelte-eslint-parser@1.6.0:
+    resolution: {integrity: sha512-qoB1ehychT6OxEtQAqc/guSqLS20SlA53Uijl7x375s8nlUT0lb9ol/gzraEEatQwsyPTJo87s2CmKL9Xab+Uw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.30.3}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
   svelte@5.55.0:
     resolution: {integrity: sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==}
     engines: {node: '>=18'}
@@ -4725,12 +5034,22 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   turndown@7.2.4:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
@@ -4747,6 +5066,13 @@ packages:
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.59.0:
+    resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -4823,6 +5149,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   username@5.1.0:
     resolution: {integrity: sha512-PCKbdWw85JsYMvmCv5GH3kXmM66rCd9m1hBEDutPNv94b/pqCMT4NtcKyeWYvLFiE8b+ha1Jdl8XAaUdPn5QTg==}
@@ -5042,6 +5371,10 @@ packages:
     resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -5090,6 +5423,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -8748,12 +9085,62 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 10.2.1(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.5.5':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.6.1))':
+    optionalDependencies:
+      eslint: 10.2.1(jiti@2.6.1)
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@exodus/bytes@1.15.0':
     optional: true
 
   '@frogcat/ttl2jsonld@0.0.10': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@inquirer/checkbox@3.0.1':
     dependencies:
@@ -9320,6 +9707,8 @@ snapshots:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/http-cache-semantics@4.2.0': {}
@@ -9424,7 +9813,98 @@ snapshots:
       '@types/node': 25.5.0
     optional: true
 
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      eslint: 10.2.1(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      eslint: 10.2.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.2.1(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.57.2': {}
+
+  '@typescript-eslint/types@8.59.0': {}
+
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      eslint: 10.2.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      eslint-visitor-keys: 5.0.1
 
   '@unified-latex/unified-latex-types@1.8.4': {}
 
@@ -9620,6 +10100,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@6.0.2:
@@ -9645,6 +10129,13 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       fast-deep-equal: 3.1.3
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@8.18.0:
     dependencies:
@@ -10059,6 +10550,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  cssesc@3.0.0: {}
+
   cssom@0.5.0: {}
 
   data-urls@7.0.0:
@@ -10087,6 +10580,8 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
+
+  deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
 
@@ -10291,15 +10786,103 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
-  escape-string-regexp@4.0.0:
-    optional: true
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-svelte@3.17.1(eslint@10.2.1(jiti@2.6.1))(svelte@5.55.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@jridgewell/sourcemap-codec': 1.5.5
+      eslint: 10.2.1(jiti@2.6.1)
+      esutils: 2.0.3
+      globals: 16.5.0
+      known-css-properties: 0.37.0
+      postcss: 8.5.8
+      postcss-load-config: 3.1.4(postcss@8.5.8)
+      postcss-safe-parser: 7.0.1(postcss@8.5.8)
+      semver: 7.7.4
+      svelte-eslint-parser: 1.6.0(svelte@5.55.0)
+    optionalDependencies:
+      svelte: 5.55.0
+    transitivePeerDependencies:
+      - ts-node
 
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.2.1(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   esm-env@1.2.2: {}
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
 
   esrap@2.2.4:
     dependencies:
@@ -10317,6 +10900,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   event-emitter-promisify@1.1.0: {}
 
@@ -10368,6 +10953,10 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -10399,6 +10988,10 @@ snapshots:
       stream-to-string: 1.2.1
       yargs: 17.7.2
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   filename-reserved-regex@2.0.0: {}
 
   filenamify@4.3.0:
@@ -10419,6 +11012,13 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   flora-colossus@2.0.0:
     dependencies:
@@ -10546,6 +11146,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-to-regexp@0.4.1: {}
 
   glob@10.5.0:
@@ -10587,6 +11191,10 @@ snapshots:
   global-dirs@3.0.1:
     dependencies:
       ini: 2.0.0
+
+  globals@16.5.0: {}
+
+  globals@17.5.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -10730,6 +11338,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   image-size@0.7.5:
     optional: true
@@ -10911,7 +11521,11 @@ snapshots:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -10988,9 +11602,18 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  known-css-properties@0.37.0: {}
+
   kuler@2.0.0: {}
 
   ky@1.14.3: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lilconfig@2.1.0: {}
 
   linkedom@0.18.12:
     dependencies:
@@ -11277,6 +11900,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  natural-compare@1.4.0: {}
+
   nearley@2.20.1:
     dependencies:
       commander: 2.20.3
@@ -11350,6 +11975,15 @@ snapshots:
       mimic-fn: 2.1.0
 
   opencollective-postinstall@2.0.3: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
 
   ora@5.4.1:
     dependencies:
@@ -11469,6 +12103,26 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-load-config@3.1.4(postcss@8.5.8):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.3
+    optionalDependencies:
+      postcss: 8.5.8
+
+  postcss-safe-parser@7.0.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
+  postcss-scss@4.0.9(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -11478,6 +12132,8 @@ snapshots:
   postject@1.0.0-alpha.6:
     dependencies:
       commander: 9.5.0
+
+  prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
 
@@ -11503,8 +12159,7 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  punycode@2.3.1:
-    optional: true
+  punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -12051,6 +12706,18 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
+  svelte-eslint-parser@1.6.0(svelte@5.55.0):
+    dependencies:
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      postcss: 8.5.8
+      postcss-scss: 4.0.9(postcss@8.5.8)
+      postcss-selector-parser: 7.1.1
+      semver: 7.7.4
+    optionalDependencies:
+      svelte: 5.55.0
+
   svelte@5.55.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -12194,11 +12861,19 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   tslib@2.8.1: {}
 
   turndown@7.2.4:
     dependencies:
       '@mixmark-io/domino': 2.2.0
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
 
   type-fest@0.13.1:
     optional: true
@@ -12212,6 +12887,17 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
+
+  typescript-eslint@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.2.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.4.5: {}
 
@@ -12276,6 +12962,10 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   username@5.1.0:
     dependencies:
@@ -12512,6 +13202,8 @@ snapshots:
       triple-beam: 1.4.1
       winston-transport: 4.9.0
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -12547,6 +13239,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@4.0.0: {}
+
+  yaml@1.10.3: {}
 
   yaml@2.8.3: {}
 

--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -105,7 +105,7 @@ async function spawnKernel(rootPath: string): Promise<KernelState> {
       MINERVA_IPC_SOCKET: rpc.socketPath,
       MINERVA_PROJECT_ROOT: rootPath,
     },
-  }) as ChildProcessWithoutNullStreams;
+  });
 
   const pending = new Map<string, PendingCell>();
   let resolveReady: () => void = () => {};
@@ -232,9 +232,9 @@ export async function runPython(
 
   const cellId = randomUUID();
   return new Promise<CellResult>((resolve) => {
-    state!.pending.set(cellId, { resolve, stdout: [], stderr: [] });
+    state.pending.set(cellId, { resolve, stdout: [], stderr: [] });
     const req = JSON.stringify({ op: 'exec', cellId, notebookPath, code });
-    state!.proc.stdin.write(req + '\n');
+    state.proc.stdin.write(req + '\n');
   });
 }
 

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1459,10 +1459,10 @@ export function notesByTag(ctx: ProjectContext, tag: string): TaggedNote[] {
     const subject = st.subject;
     // Sources also carry hasTag edges (body.md tags); filter them out —
     // sourcesByTag handles those.
-    const isNote = store!.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
+    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
     if (!isNote) return [];
-    const titleStmts = store!.statementsMatching(subject, DC('title'), undefined);
-    const pathStmts = store!.statementsMatching(subject, MINERVA('relativePath'), undefined);
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
+    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
     const relativePath = pathStmts[0]?.object.value ?? '';
     if (!relativePath) return [];
     return [{
@@ -1481,10 +1481,10 @@ export function sourcesByTag(ctx: ProjectContext, tag: string): TaggedSource[] {
   const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
   return stmts.flatMap((st) => {
     const subject = st.subject;
-    const idStmts = store!.statementsMatching(subject, MINERVA('sourceId'), undefined);
+    const idStmts = store.statementsMatching(subject, MINERVA('sourceId'), undefined);
     const sourceId = idStmts[0]?.object.value;
     if (!sourceId) return [];
-    const titleStmts = store!.statementsMatching(subject, DC('title'), undefined);
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
     return [{
       sourceId,
       title: titleStmts[0]?.object.value ?? sourceId,
@@ -1683,7 +1683,7 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
   }
 
   const first = (pred: ReturnType<typeof MINERVA>): string | null => {
-    const stmts = store!.statementsMatching(subject, pred, undefined);
+    const stmts = store.statementsMatching(subject, pred, undefined);
     return stmts[0]?.object.value ?? null;
   };
 
@@ -1715,7 +1715,7 @@ function collectExcerptsForSource(state: GraphState, sourceSubject: $rdf.NamedNo
     seen.add(id);
 
     const first = (pred: ReturnType<typeof MINERVA>): string | null => {
-      const s = store!.statementsMatching(ex, pred, undefined);
+      const s = store.statementsMatching(ex, pred, undefined);
       return s[0]?.object.value ?? null;
     };
 
@@ -1742,13 +1742,13 @@ function collectSourceBacklinks(
   const seen = new Set<string>();
 
   const pushBacklink = (noteSubject: $rdf.NamedNode, kind: 'cite' | 'quote', viaExcerptId?: string) => {
-    const pathStmts = store!.statementsMatching(noteSubject, MINERVA('relativePath'), undefined);
+    const pathStmts = store.statementsMatching(noteSubject, MINERVA('relativePath'), undefined);
     const relativePath = pathStmts[0]?.object.value;
     if (!relativePath) return;
     const key = `${kind}::${relativePath}::${viaExcerptId ?? ''}`;
     if (seen.has(key)) return;
     seen.add(key);
-    const titleStmts = store!.statementsMatching(noteSubject, DC('title'), undefined);
+    const titleStmts = store.statementsMatching(noteSubject, DC('title'), undefined);
     results.push({
       relativePath,
       title: titleStmts[0]?.object.value ?? relativePath,

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -78,11 +78,11 @@ export async function complete(
     callbacks = callbacksOrOptions;
     messages = [{ role: 'user', content: prompt }];
   } else if (callbacksOrOptions) {
-    const opts = callbacksOrOptions as CompleteOptions;
+    const opts = callbacksOrOptions;
     system = opts.system;
     callbacks = opts.callbacks;
     modelOverride = opts.model;
-    messages = (opts.messages ?? [{ role: 'user', content: prompt }]) as Anthropic.MessageParam[];
+    messages = (opts.messages ?? [{ role: 'user', content: prompt }]);
   } else {
     messages = [{ role: 'user', content: prompt }];
   }
@@ -107,7 +107,7 @@ export async function complete(
     messages,
   }, { signal: callbacks.signal });
 
-  stream.on('text', (delta) => callbacks!.onChunk(delta));
+  stream.on('text', (delta) => callbacks.onChunk(delta));
   const finalMessage = await stream.finalMessage();
   return extractText(finalMessage.content);
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -431,7 +431,7 @@ export function rebuildMenu(): void {
           toolTip: tool.description,
           click: () => send(Channels.TOOL_INVOKE, tool.id),
         })),
-      } as Electron.MenuItemConstructorOptions)),
+      })),
 
     // Query
     {

--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -28,7 +28,7 @@ export interface RenderedBibliography {
 }
 
 export class CitationRenderer {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   private engine: any;
   private readonly items: Map<string, CslItem>;
   private readonly citedIds = new Set<string>();

--- a/src/main/sources/import-zotero-rdf.ts
+++ b/src/main/sources/import-zotero-rdf.ts
@@ -41,7 +41,7 @@ const NS = {
 };
 
 function sym(iri: string): NamedNode {
-  return $rdf.sym(iri) as NamedNode;
+  return $rdf.sym(iri);
 }
 
 // Known bibliographic item classes. Anything else we see is ignored — a
@@ -104,7 +104,7 @@ export async function importZoteroRdfContent(
   try {
     $rdf.parse(rdfXml, store, PARSE_BASE, 'application/rdf+xml');
   } catch (err) {
-    throw new Error(`Zotero RDF parse failed: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`Zotero RDF parse failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   }
 
   const items = collectBibItems(store);
@@ -325,7 +325,7 @@ function extractPublisher(store: IndexedFormula, subject: NamedNode): string | n
     return st.object.value.trim() || null;
   }
   if (st.object.termType !== 'NamedNode' && st.object.termType !== 'BlankNode') return null;
-  return literalOf(store, st.object as NamedNode, `${NS.foaf}name`);
+  return literalOf(store, st.object, `${NS.foaf}name`);
 }
 
 function extractContainerTitle(store: IndexedFormula, subject: NamedNode): string | null {
@@ -334,7 +334,7 @@ function extractContainerTitle(store: IndexedFormula, subject: NamedNode): strin
   if (!st) return null;
   if (st.object.termType === 'Literal') return st.object.value.trim() || null;
   if (st.object.termType !== 'NamedNode' && st.object.termType !== 'BlankNode') return null;
-  return literalOf(store, st.object as NamedNode, `${NS.dc}title`);
+  return literalOf(store, st.object, `${NS.dc}title`);
 }
 
 export function extractIdentifiers(identifiers: string[]): {

--- a/src/main/sources/ingest-pdf.ts
+++ b/src/main/sources/ingest-pdf.ts
@@ -170,7 +170,7 @@ export interface PdfMeta {
  */
 export async function readPdfMeta(bytes: Uint8Array): Promise<PdfMeta> {
   const { info } = await getMeta(bytes);
-  const rec = info as Record<string, unknown>;
+  const rec = info;
 
   if (rec.EncryptFilterName != null) {
     throw new Error('This PDF is encrypted. Remove the password protection first, then try again.');
@@ -250,9 +250,9 @@ async function extractTextOrFail(
     // pdfjs throws a generic "No password given" for encrypted PDFs it
     // couldn't classify earlier. Translate for clarity.
     if (/password/i.test(msg) || /encrypt/i.test(msg)) {
-      throw new Error('This PDF is encrypted. Remove the password protection first, then try again.');
+      throw new Error('This PDF is encrypted. Remove the password protection first, then try again.', { cause: err });
     }
-    throw new Error(`PDF text extraction failed: ${msg}`);
+    throw new Error(`PDF text extraction failed: ${msg}`, { cause: err });
   }
 }
 

--- a/src/main/sources/ingest.ts
+++ b/src/main/sources/ingest.ts
@@ -57,7 +57,7 @@ export async function ingestUrl(
   Object.defineProperty(document, 'baseURI', { value: normalized, configurable: true });
 
   const urlObj = new URL(normalized);
-  const structured = extractStructured(document as unknown as Parameters<typeof extractStructured>[0], urlObj);
+  const structured = extractStructured(document, urlObj);
 
   const { id: sourceId } = canonicalSourceId({
     doi: structured?.doi ?? undefined,
@@ -80,7 +80,7 @@ export async function ingestUrl(
     // Not found — proceed.
   }
 
-  const extracted = extractReadableFromDoc(document as unknown as Document, normalized);
+  const extracted = extractReadableFromDoc(document, normalized);
 
   await fs.mkdir(sourceDir, { recursive: true });
   await fs.writeFile(path.join(sourceDir, 'original.html'), html, 'utf-8');
@@ -156,7 +156,7 @@ export function extractReadable(html: string, url: string): ExtractedArticle {
   const { document } = parseHTML(html);
   Object.defineProperty(document, 'documentURI', { value: url, configurable: true });
   Object.defineProperty(document, 'baseURI', { value: url, configurable: true });
-  return extractReadableFromDoc(document as unknown as Document, url);
+  return extractReadableFromDoc(document, url);
 }
 
 /**

--- a/src/renderer/lib/editor/commands.ts
+++ b/src/renderer/lib/editor/commands.ts
@@ -249,7 +249,7 @@ export function findSentence(doc: Text, from: number, to: number): { from: numbe
   }
 
   // Find end: scan forward for sentence boundary
-  let sEnd = to;
+  let sEnd: number;
   sentenceEnd.lastIndex = to > from ? to - 1 : from;
   const match = sentenceEnd.exec(text);
   if (match) {

--- a/src/renderer/lib/editor/link-decorations.ts
+++ b/src/renderer/lib/editor/link-decorations.ts
@@ -196,7 +196,7 @@ export function linkDecorations(opts: LinkOptions) {
   function linkElFromEvent(e: MouseEvent): HTMLElement | null {
     const target = e.target as HTMLElement | null;
     if (!target) return null;
-    return target.closest('.cm-clickable-link') as HTMLElement | null;
+    return target.closest('.cm-clickable-link');
   }
 
   const plugin = ViewPlugin.fromClass(

--- a/src/renderer/lib/editor/sparql-autocomplete.ts
+++ b/src/renderer/lib/editor/sparql-autocomplete.ts
@@ -48,7 +48,7 @@ export function createSparqlCompletionSource(
       const vars = extractQueryVariables(all).map((v) => ({
         label: v,
         type: 'variable',
-      } as Completion));
+      }));
       return {
         from: phase.from,
         options: prefixMatchSort(vars, phase.prefix),

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -56,7 +56,7 @@ let queryCounter = 0;
 
 // ── State ───────────────────────────────────────────────────────────────────
 
-let tabs = $state<Tab[]>([]);
+const tabs = $state<Tab[]>([]);
 let activeIndex = $state(-1);
 let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let tabPersistTimer: ReturnType<typeof setTimeout> | null = null;

--- a/src/renderer/lib/stores/navigation.svelte.ts
+++ b/src/renderer/lib/stores/navigation.svelte.ts
@@ -19,8 +19,8 @@ export type NavPosition = NoteNavPosition | QueryNavPosition | SourceNavPosition
 
 const MAX_HISTORY = 100;
 
-let backStack = $state<NavPosition[]>([]);
-let forwardStack = $state<NavPosition[]>([]);
+const backStack = $state<NavPosition[]>([]);
+const forwardStack = $state<NavPosition[]>([]);
 let current = $state<NavPosition | null>(null);
 
 /** True if we're in the middle of a back/forward navigation — suppresses recording */

--- a/src/shared/compute/cell-id.ts
+++ b/src/shared/compute/cell-id.ts
@@ -63,7 +63,7 @@ export function generateCellId(): string {
   // `crypto.randomUUID` is available in both main (Node ≥ 19) and
   // renderer (modern Electron). Take the first 8 hex chars of its
   // body — 32 bits, enough entropy for a library-of-notes scale.
-  const uuid = (globalThis.crypto as Crypto).randomUUID();
+  const uuid = (globalThis.crypto).randomUUID();
   return uuid.replace(/-/g, '').slice(0, 8);
 }
 

--- a/src/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.ts
+++ b/src/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.ts
@@ -57,8 +57,8 @@ registerRule({
 
 function keyString(key: unknown): string | null {
   if (typeof key === 'string') return key;
-  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
-    return String((key as YAML.Scalar).value);
+  if (key && typeof key === 'object' && YAML.isScalar(key)) {
+    return String((key).value);
   }
   return null;
 }

--- a/src/shared/formatter/rules/yaml/format-tags-in-yaml.ts
+++ b/src/shared/formatter/rules/yaml/format-tags-in-yaml.ts
@@ -44,8 +44,8 @@ registerRule<Config>({
 
 function keyString(key: unknown): string | null {
   if (typeof key === 'string') return key;
-  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
-    return String((key as YAML.Scalar).value);
+  if (key && typeof key === 'object' && YAML.isScalar(key)) {
+    return String((key).value);
   }
   return null;
 }

--- a/src/shared/formatter/rules/yaml/format-yaml-array.ts
+++ b/src/shared/formatter/rules/yaml/format-yaml-array.ts
@@ -38,8 +38,8 @@ registerRule<Config>({
 
 function keyString(key: unknown): string | null {
   if (typeof key === 'string') return key;
-  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
-    return String((key as YAML.Scalar).value);
+  if (key && typeof key === 'object' && YAML.isScalar(key)) {
+    return String((key).value);
   }
   return null;
 }

--- a/src/shared/formatter/rules/yaml/insert-yaml-attributes.ts
+++ b/src/shared/formatter/rules/yaml/insert-yaml-attributes.ts
@@ -34,8 +34,8 @@ registerRule<Config>({
 
 function keyString(key: unknown): string | null {
   if (typeof key === 'string') return key;
-  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
-    return String((key as YAML.Scalar).value);
+  if (key && typeof key === 'object' && YAML.isScalar(key)) {
+    return String((key).value);
   }
   return null;
 }

--- a/src/shared/formatter/rules/yaml/remove-yaml-keys.ts
+++ b/src/shared/formatter/rules/yaml/remove-yaml-keys.ts
@@ -28,8 +28,8 @@ registerRule<Config>({
 
 function keyString(key: unknown): string | null {
   if (typeof key === 'string') return key;
-  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
-    return String((key as YAML.Scalar).value);
+  if (key && typeof key === 'object' && YAML.isScalar(key)) {
+    return String((key).value);
   }
   return null;
 }

--- a/src/shared/formatter/rules/yaml/yaml-key-sort.ts
+++ b/src/shared/formatter/rules/yaml/yaml-key-sort.ts
@@ -54,8 +54,8 @@ registerRule<Config>({
 
 function keyString(key: unknown): string | null {
   if (typeof key === 'string') return key;
-  if (key && typeof key === 'object' && YAML.isScalar(key as YAML.Scalar)) {
-    return String((key as YAML.Scalar).value);
+  if (key && typeof key === 'object' && YAML.isScalar(key)) {
+    return String((key).value);
   }
   return null;
 }

--- a/tests/main/compute/rpc-server.test.ts
+++ b/tests/main/compute/rpc-server.test.ts
@@ -127,7 +127,7 @@ describe('rpc server method dispatch (#242)', () => {
   });
 
   it('typed-arg failure surfaces as TypeError', async () => {
-    const r = await dispatchMethod(root, 'sparql', { query: 42 as unknown });
+    const r = await dispatchMethod(root, 'sparql', { query: 42 });
     expect('error' in r).toBe(true);
     if ('error' in r) {
       expect(r.error.code).toBe('TypeError');

--- a/tests/main/llm/conversation-context-iri.test.ts
+++ b/tests/main/llm/conversation-context-iri.test.ts
@@ -61,7 +61,7 @@ describe('Conversation thought:contextNote is a real IRI (#350)', () => {
         ?conv thought:contextNote ?n .
       }
     `);
-    expect((r.results as unknown[]).length).toBe(1);
+    expect((r.results).length).toBe(1);
   });
 
   it('omits contextNote entirely when there is no notePath', async () => {
@@ -72,7 +72,7 @@ describe('Conversation thought:contextNote is a real IRI (#350)', () => {
       PREFIX thought: <https://minerva.dev/ontology/thought#>
       SELECT ?n WHERE { <${expectedIri}> thought:contextNote ?n . }
     `);
-    expect((r.results as unknown[]).length).toBe(0);
+    expect((r.results).length).toBe(0);
   });
 
   it('reindexAllConversations heals historical relative-path-as-IRI dust', async () => {

--- a/tests/main/llm/crystallize-integration.test.ts
+++ b/tests/main/llm/crystallize-integration.test.ts
@@ -94,7 +94,7 @@ describe('crystallize() integration (#342)', () => {
       PREFIX thought: <https://minerva.dev/ontology/thought#>
       SELECT ?label WHERE { <${CLAIM_URI}> thought:label ?label . }
     `);
-    expect((beforeRows.results as unknown[]).length).toBe(0);
+    expect((beforeRows.results).length).toBe(0);
 
     const [pending] = await listProposals(ctx, 'pending');
     const ok = await approveProposal(ctx, pending.uri);
@@ -125,7 +125,7 @@ describe('crystallize() integration (#342)', () => {
       PREFIX thought: <https://minerva.dev/ontology/thought#>
       SELECT ?label WHERE { <${CLAIM_URI}> thought:label ?label . }
     `);
-    expect((rows.results as unknown[]).length).toBe(0);
+    expect((rows.results).length).toBe(0);
 
     // The integrity query stays clean: no LLM-attributed component is
     // sitting in the graph without an approved proposal pointing at it.
@@ -144,7 +144,7 @@ describe('crystallize() integration (#342)', () => {
         }
       }
     `);
-    expect((orphans.results as unknown[]).length).toBe(0);
+    expect((orphans.results).length).toBe(0);
   });
 
   it('skips proposeWrite entirely when the LLM returns nothing', async () => {

--- a/tests/main/llm/trust-guard.test.ts
+++ b/tests/main/llm/trust-guard.test.ts
@@ -238,6 +238,6 @@ describe('crystallize provenance (#331)', () => {
         }
       }
     `);
-    expect((r.results as unknown[]).length).toBe(0);
+    expect((r.results).length).toBe(0);
   });
 });

--- a/tests/main/sources/ingest-identifier.test.ts
+++ b/tests/main/sources/ingest-identifier.test.ts
@@ -119,7 +119,7 @@ describe('ingestIdentifier (#96)', () => {
   afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
 
   function mockFetchForDoi(): typeof fetch {
-    return (async (input: RequestInfo | URL) => {
+    return async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('api.crossref.org/works/')) {
         return new Response(JSON.stringify({
@@ -137,7 +137,7 @@ describe('ingestIdentifier (#96)', () => {
         }), { status: 200, headers: { 'content-type': 'application/json' } });
       }
       return new Response('', { status: 404 });
-    }) as unknown as typeof fetch;
+    };
   }
 
   it('writes meta.ttl and body.md for a DOI ingest', async () => {
@@ -188,7 +188,7 @@ describe('ingestIdentifier (#96)', () => {
   });
 
   it('still creates the source when the advertised PDF fetch fails', async () => {
-    const fetchImpl = (async (input: RequestInfo | URL) => {
+    const fetchImpl = async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('api.crossref.org')) {
         return new Response(JSON.stringify({
@@ -203,7 +203,7 @@ describe('ingestIdentifier (#96)', () => {
       }
       // Simulate a 403 paywall on the PDF endpoint.
       return new Response('', { status: 403, statusText: 'Forbidden' });
-    }) as unknown as typeof fetch;
+    };
 
     const result = await ingestIdentifier(root, '10.1038/pdffail', { fetchImpl });
     expect(result.duplicate).toBe(false);
@@ -216,7 +216,7 @@ describe('ingestIdentifier (#96)', () => {
 
   it('saves the PDF when the fetch succeeds', async () => {
     const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF"
-    const fetchImpl = (async (input: RequestInfo | URL) => {
+    const fetchImpl = async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('api.crossref.org')) {
         return new Response(JSON.stringify({
@@ -230,7 +230,7 @@ describe('ingestIdentifier (#96)', () => {
         }), { status: 200, headers: { 'content-type': 'application/json' } });
       }
       return new Response(pdfBytes, { status: 200, headers: { 'content-type': 'application/pdf' } });
-    }) as unknown as typeof fetch;
+    };
 
     const result = await ingestIdentifier(root, '10.1038/pdfok', { fetchImpl });
     expect(result.pdfSaved).toBe(true);

--- a/tests/main/sources/ingest.test.ts
+++ b/tests/main/sources/ingest.test.ts
@@ -177,12 +177,12 @@ describe('ingestUrl (#93)', () => {
   });
 
   function mockFetch(html: string, opts: { contentType?: string; status?: number } = {}): typeof fetch {
-    return (async () => {
+    return async () => {
       return new Response(html, {
         status: opts.status ?? 200,
         headers: { 'content-type': opts.contentType ?? 'text/html; charset=utf-8' },
       });
-    }) as unknown as typeof fetch;
+    };
   }
 
   it('writes original.html, body.md, and meta.ttl under sources/<id>/', async () => {

--- a/tests/main/sources/site-handlers.test.ts
+++ b/tests/main/sources/site-handlers.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../src/main/sources/site-handlers';
 
 function docFrom(html: string): DocLike {
-  return parseHTML(html).document as unknown as DocLike;
+  return parseHTML(html).document;
 }
 
 describe('citationMetaHandler (#221)', () => {

--- a/tests/shared/formatter/engine.test.ts
+++ b/tests/shared/formatter/engine.test.ts
@@ -21,7 +21,7 @@ function rule(partial: Partial<FormatterRule<unknown>> & {
     description: '',
     defaultConfig: {},
     ...partial,
-  } as FormatterRule<unknown>;
+  };
 }
 
 describe('formatter engine (issue #153)', () => {

--- a/tests/shared/formatter/rules/yaml/dedupe-yaml-array-values.test.ts
+++ b/tests/shared/formatter/rules/yaml/dedupe-yaml-array-values.test.ts
@@ -15,7 +15,7 @@ describe('dedupe-yaml-array-values (#155)', () => {
     expect(out).toContain('- b');
     expect(out).toContain('- c');
     // Three unique tags, so three `- ` lines.
-    expect((out.match(/^  - /gm) || []).length).toBe(3);
+    expect((out.match(/^ {2}- /gm) || []).length).toBe(3);
   });
 
   it('dedupes within flow-style sequences too', () => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "*.config.ts",
+    "*.config.mts",
+    "eslint.config.mjs"
+  ],
+  "exclude": ["node_modules", "dist", ".vite", "out", "coverage", "tests/fixtures"]
+}


### PR DESCRIPTION
## Summary
- Closes #349 — \`pnpm lint\` was \`tsc --noEmit && svelte-check\`, neither of which catches floating promises, dead imports, shadowed vars, or unused params. Adds ESLint 10 (flat config) with typescript-eslint, wired into \`pnpm lint\` so CI fails on lint regressions.
- **Headline rules on**: \`no-floating-promises\` (as \`warn\` — see below), \`no-unused-vars\` (\`warn\`, with the standard \`_\`-prefix escape hatch), \`preserve-caught-error\` (\`error\` — fixed 3 sites in ingest-pdf + import-zotero-rdf), the rest of typescript-eslint's recommended non-typed rules, and the auto-fixable cleanup rules (\`prefer-const\`, \`no-useless-assignment\`).
- **Adoption rule per #349**: don't blow up the dev. Rules with walls of existing warnings ship off, with per-rule cleanup tracked separately in #381 (no-floating-promises) and #382 (no-unsafe-* family + no-unnecessary-type-assertion + no-useless-escape + others). Floating promises ship as \`warn\` rather than \`error\` so the rule surfaces in editors and on CI but the existing ~80 offenders don't fail the build.
- **Auto-fix sweep**: \`eslint --fix\` cleaned up ~45 unnecessary type assertions (mostly \`(x as Y)\` in tests, plus a few non-null \`!\` operators that TS narrowing made redundant) and a handful of \`prefer-const\` cases. \`tsc\` + \`svelte-check\` still pass; all 1587 tests still pass.

## Other config notes
- New \`tsconfig.eslint.json\` widens the main tsconfig to include tests + vite configs so the type-aware parser can resolve every file we lint.
- \`eslint.config.mjs\` + \`svelte.config.mjs\` excluded from linting themselves (not in the TS project; low-value to lint).
- \`@typescript-eslint/no-unused-expressions\` disabled for \`.svelte\` — Svelte 5 runes use bare expression statements for dependency tracking inside \`$effect(() => { ... })\`, which the rule false-positives on.
- Tests are looser by design (vitest \`expect\` chains tickle the strictness we keep on for app code), so \`no-floating-promises\` is off there.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 102 warnings — all in deferred rules)
- [x] \`pnpm test\` — 1587 passed (162 files)
- [x] No production behavior changes; the auto-fixed code is type-equivalent to what was there

## Follow-ups
- #381: clean up the ~80 floating-promise sites and flip the rule to \`error\`
- #382: re-enable typed rules in batches (no-unsafe-*, no-explicit-any, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)