### PR TITLE
lint: enable no-floating-promises as error (closes #381)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,12 +50,13 @@ export default tseslint.config(
     },
     rules: {
       // ── Rules we're keeping on ────────────────────────────────────────
-      // Floating promises: the headline ask in #349. Set to `warn`, not
-      // `error`, because the codebase has ~80 existing offenders (mostly
-      // intentional fire-and-forget `api.*()` calls in Svelte event
-      // handlers). Editor + CI will surface them, future code gets
-      // caught, and the cleanup is tracked in its own follow-up.
-      '@typescript-eslint/no-floating-promises': 'warn',
+      // Floating promises: was warn during #349 adoption while the
+      // existing ~80 offenders got cleaned up; promoted to `error` after
+      // #381 audited every site (most became `void api.*()` for
+      // intentional fire-and-forget UI handlers, with main-process
+      // sites individually reviewed). New floating promises now fail
+      // the build.
+      '@typescript-eslint/no-floating-promises': 'error',
       // Unused-vars/imports as warnings, with the standard `_`-prefix
       // escape hatch so tests/handlers can name args they intentionally
       // ignore.

--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -185,7 +185,7 @@ const timersByProject = new Map<string, ReturnType<typeof setInterval>>();
 
 export function startPeriodicChecks(ctx: ProjectContext, intervalMs: number = 5 * 60 * 1000): void {
   stopPeriodicChecks(ctx);
-  const timer = setInterval(() => { runAllChecks(ctx); }, intervalMs);
+  const timer = setInterval(() => { void runAllChecks(ctx); }, intervalMs);
   timersByProject.set(ctx.rootPath, timer);
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -614,7 +614,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.SHELL_OPEN_IN_DEFAULT, (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return;
-    shell.openPath(path.join(rootPath, relativePath));
+    void shell.openPath(path.join(rootPath, relativePath));
   });
 
   ipcMain.handle(Channels.SHELL_OPEN_IN_TERMINAL, (e, relativePath?: string) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,7 +13,7 @@ import { shutdownAllKernels } from './compute/python-kernel';
 
 app.setName('Minerva');
 
-app.whenReady().then(async () => {
+void app.whenReady().then(async () => {
   installCsp();
   registerIpcHandlers();
   registerBuiltinExecutors();

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -585,7 +585,7 @@ export function rebuildMenu(): void {
         {
           label: 'Report Issue',
           click: () => {
-            shell.openExternal('https://github.com/dgriffith/minerva/issues');
+            void shell.openExternal('https://github.com/dgriffith/minerva/issues');
           },
         },
       ],

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -135,8 +135,11 @@ export function startWatching(
 export function stopWatching(id: number): void {
   const pair = watchers.get(id);
   if (pair) {
-    pair.notes.close();
-    pair.minervaData.close();
+    // chokidar's close() returns a Promise that resolves when handles
+    // are released. We don't block on it: callers (window-manager
+    // teardown, test cleanup) just want the watcher detached now.
+    void pair.notes.close();
+    void pair.minervaData.close();
     watchers.delete(id);
   }
 }

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -64,7 +64,8 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
       // before #350.
       await conversation.reindexAllConversations();
       // Health checks run once at open, then a periodic timer takes over.
-      healthChecks.runAllChecks(ctx);
+      // Fire-and-forget — no need to block project init on the result.
+      void healthChecks.runAllChecks(ctx);
       healthChecks.startPeriodicChecks(ctx);
     })();
     rec = { ctx, rootPath, acquirers: new Set(), initPromise };

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -75,9 +75,9 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
   installNavigationGuards(win.webContents);
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    win.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
+    void win.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
   } else {
-    win.loadFile(
+    void win.loadFile(
       path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`)
     );
   }
@@ -165,7 +165,9 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     }, 1000);
   };
 
-  startWatching(rootPath, win, win.id, {
+  // startWatching returns a ready-promise (#345); we don't await here
+  // because the watcher works fine before its initial scan completes.
+  void startWatching(rootPath, win, win.id, {
     onFileChanged: async (relativePath) => {
       if (wasHandled(relativePath)) return;
       // CSVs route to DuckDB first in an independent try. registerCsv doesn't

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1267,7 +1267,7 @@
   }
 
   function handleRevealInSidebar(relativePath: string) {
-    api.shell.revealFile(relativePath);
+    void api.shell.revealFile(relativePath);
   }
 
   // Refresh tags when notebase opens
@@ -1278,7 +1278,7 @@
       sidebar?.refreshTags();
       sidebar?.refreshSources();
       sidebar?.refreshTables();
-      refreshSourcesCache();
+      void refreshSourcesCache();
     }, 100);
   };
 
@@ -1287,7 +1287,7 @@
   // newly-ingested sources become reachable without a manual reload.
   api.sources.onChanged(() => {
     sidebar?.refreshSources();
-    refreshSourcesCache();
+    void refreshSourcesCache();
   });
 
   // Main broadcasts after the initial CSV scan and on every register/unregister
@@ -1305,11 +1305,11 @@
   function handleKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key === '[') {
       e.preventDefault();
-      handleNavBack();
+      void handleNavBack();
     }
     if ((e.metaKey || e.ctrlKey) && e.key === ']') {
       e.preventDefault();
-      handleNavForward();
+      void handleNavForward();
     }
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'p') {
       e.preventDefault();
@@ -1325,7 +1325,7 @@
     }
     if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
       e.preventDefault();
-      handleNewNote();
+      void handleNewNote();
     }
     if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'w') {
       if (editor.activeIndex >= 0) {
@@ -1356,7 +1356,7 @@
       if (showConversation) {
         showConversation = false;
       } else {
-        openConversation();
+        void openConversation();
       }
     }
   }
@@ -1415,21 +1415,21 @@
     api.menu.onFindInNotes(() => { findInNotesMode = 'find'; });
     api.menu.onReplaceInNotes(() => { findInNotesMode = 'replace'; });
     api.menu.onPrint(() => window.print());
-    api.menu.onOpenInDefault(() => { if (editor.activeFilePath) api.shell.openInDefault(editor.activeFilePath); });
-    api.menu.onOpenInTerminal(() => { api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
+    api.menu.onOpenInDefault(() => { if (editor.activeFilePath) void api.shell.openInDefault(editor.activeFilePath); });
+    api.menu.onOpenInTerminal(() => { void api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
     api.menu.onOpenSettings(() => { showSettings = true; });
 
     // Refactor menu (issue #172)
-    api.menu.onRefactorRename(() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); });
-    api.menu.onRefactorMove(() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); });
-    api.menu.onRefactorCopy(() => { if (editor.activeFilePath) handleCopyWithPrompt(editor.activeFilePath); });
+    api.menu.onRefactorRename(() => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); });
+    api.menu.onRefactorMove(() => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); });
+    api.menu.onRefactorCopy(() => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); });
     api.menu.onRefactorExtract(() => handleExtractSelection());
     api.menu.onRefactorSplitHere(() => handleSplitHere());
     api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
-    api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); });
-    api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); });
-    api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); });
-    api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) handleDecompose(editor.activeFilePath); });
+    api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); });
+    api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); });
+    api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); });
+    api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); });
 
     // Format menu (issue #153)
     api.menu.onFormatCurrentNote(() => handleFormatCurrentNote());
@@ -1594,7 +1594,7 @@
           const activePath = editor.activeFilePath ?? '';
           const slash = activePath.lastIndexOf('/');
           const destDir = slash >= 0 ? activePath.slice(0, slash) : '';
-          handleExternalDrop(destDir, files);
+          void handleExternalDrop(destDir, files);
         }}
       >
         {#if editor.tabs.length > 0}
@@ -1667,13 +1667,13 @@
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
                     onSplitByHeading={handleSplitByHeading}
-                    onRename={() => { if (editor.activeFilePath) handleRename(editor.activeFilePath); }}
-                    onMove={() => { if (editor.activeFilePath) handleMoveWithPrompt(editor.activeFilePath); }}
-                    onCopyFile={() => { if (editor.activeFilePath) handleCopyWithPrompt(editor.activeFilePath); }}
-                    onAutoTag={() => { if (editor.activeFilePath) handleAutoTag(editor.activeFilePath); }}
-                    onAutoLink={() => { if (editor.activeFilePath) handleAutoLink(editor.activeFilePath); }}
-                    onAutoLinkInbound={() => { if (editor.activeFilePath) handleAutoLinkInbound(editor.activeFilePath); }}
-                    onDecompose={() => { if (editor.activeFilePath) handleDecompose(editor.activeFilePath); }}
+                    onRename={() => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); }}
+                    onMove={() => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); }}
+                    onCopyFile={() => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); }}
+                    onAutoTag={() => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); }}
+                    onAutoLink={() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); }}
+                    onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
+                    onDecompose={() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); }}
                     onFormatCurrentNote={() => handleFormatCurrentNote()}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
@@ -1712,7 +1712,7 @@
           />
           <ToolPanel
             bind:this={toolPanelComponent}
-            onNoteCreated={() => { notebase.refresh(); sidebar?.refreshTags(); }}
+            onNoteCreated={() => { void notebase.refresh(); sidebar?.refreshTags(); }}
             onOpenConversation={handleOpenConversationFromTool}
           />
           {#if showConversation}
@@ -1762,7 +1762,7 @@
           onFileSelect={handleFileSelect}
           onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
           onShowPrompt={showPrompt}
-          onOpenConversation={(msg) => { openConversationWithMessage(msg); }}
+          onOpenConversation={(msg) => { void openConversationWithMessage(msg); }}
           onOpenQuery={(sql) => editor.openQuery(sql, 'sql')}
           onOpenSource={handleOpenSource}
           onOpenExcerpt={handleOpenExcerpt}
@@ -1780,7 +1780,7 @@
   {#if showGotoNote}
     <GotoNoteDialog
       files={notebase.files}
-      onSelect={(path) => { showGotoNote = false; handleFileSelect(path); }}
+      onSelect={(path) => { showGotoNote = false; void handleFileSelect(path); }}
       onCancel={() => { showGotoNote = false; }}
     />
   {/if}

--- a/src/renderer/lib/components/ConversationDialog.svelte
+++ b/src/renderer/lib/components/ConversationDialog.svelte
@@ -125,7 +125,7 @@
     });
     if (initialAutoMessage && initialAutoMessage.trim()) {
       input = initialAutoMessage;
-      requestAnimationFrame(() => { handleSend(); });
+      requestAnimationFrame(() => { void handleSend(); });
     }
   });
 
@@ -258,7 +258,7 @@
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleSend();
+      void handleSend();
     }
     if (e.key === 'Escape') {
       onClose();
@@ -337,7 +337,7 @@
               </ol>
             {/if}
             <div class="msg-actions">
-              <button class="msg-action-btn" onclick={() => { input = 'Tell me more about this.'; handleSend(); }} title="Continue exploring this topic">Explore Further</button>
+              <button class="msg-action-btn" onclick={() => { input = 'Tell me more about this.'; void handleSend(); }} title="Continue exploring this topic">Explore Further</button>
               <button class="msg-action-btn" onclick={() => handleCrystallize(msg.content)} disabled={crystallizing} title="Extract thought components">{crystallizing ? 'Filing...' : 'File This'}</button>
               <button class="msg-action-btn" onclick={() => handleCrystallize(msg.content)} disabled={crystallizing} title="Flag for later review">Flag for Later</button>
             </div>

--- a/src/renderer/lib/components/EditSavedQueriesDialog.svelte
+++ b/src/renderer/lib/components/EditSavedQueriesDialog.svelte
@@ -17,7 +17,7 @@
     queries = await window.api.queries.list();
   }
 
-  onMount(() => { load(); });
+  onMount(() => { void load(); });
 
   const projectQueries = $derived(queries.filter((q) => q.scope === 'project'));
   const globalQueries = $derived(queries.filter((q) => q.scope === 'global'));
@@ -73,7 +73,7 @@
                   bind:value={renameValue}
                   class="name-input"
                   onkeydown={(e) => {
-                    if (e.key === 'Enter') { e.preventDefault(); commitRename(q); }
+                    if (e.key === 'Enter') { e.preventDefault(); void commitRename(q); }
                     else if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
                   }}
                   onblur={() => commitRename(q)}
@@ -99,7 +99,7 @@
                   bind:value={renameValue}
                   class="name-input"
                   onkeydown={(e) => {
-                    if (e.key === 'Enter') { e.preventDefault(); commitRename(q); }
+                    if (e.key === 'Enter') { e.preventDefault(); void commitRename(q); }
                     else if (e.key === 'Escape') { e.preventDefault(); cancelRename(); }
                   }}
                   onblur={() => commitRename(q)}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -330,7 +330,7 @@
         onNavigate?.(link.href);
       }
     } else {
-      api.shell.openExternal(link.href);
+      void api.shell.openExternal(link.href);
     }
     closeMenu();
   }
@@ -449,7 +449,7 @@
         if (onOpenExcerpt) onOpenExcerpt(excerptId);
       },
       onOpenExternal: (url: string) => {
-        api.shell.openExternal(url);
+        void api.shell.openExternal(url);
       },
     }),
     computeCellsExtension({
@@ -905,9 +905,9 @@
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
       <span class="submenu-trigger">Open In &#x25B8;</span>
       <div class="submenu">
-        <button onclick={() => { api.shell.revealFile(filePath); closeMenu(); }}>Reveal in Finder</button>
-        <button onclick={() => { api.shell.openInDefault(filePath); closeMenu(); }}>Open in Default App</button>
-        <button onclick={() => { api.shell.openInTerminal(filePath); closeMenu(); }}>Open in Terminal</button>
+        <button onclick={() => { void api.shell.revealFile(filePath); closeMenu(); }}>Reveal in Finder</button>
+        <button onclick={() => { void api.shell.openInDefault(filePath); closeMenu(); }}>Open in Default App</button>
+        <button onclick={() => { void api.shell.openInTerminal(filePath); closeMenu(); }}>Open in Terminal</button>
       </div>
     </div>
     <div class="separator"></div>

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -177,7 +177,7 @@
       <button onclick={() => { onRename(contextMenu!.target!); contextMenu = null; }}>
         Rename
       </button>
-      <button onclick={() => { navigator.clipboard.writeText(contextMenu!.target!); contextMenu = null; }}>
+      <button onclick={() => { void navigator.clipboard.writeText(contextMenu!.target!); contextMenu = null; }}>
         Copy Path
       </button>
       {#if !contextMenu.targetIsDir}
@@ -186,9 +186,9 @@
       <div class="submenu-item">
         <span class="submenu-trigger">Open In &#x25B8;</span>
         <div class="submenu">
-          <button onclick={() => { api.shell.revealFile(contextMenu!.target!); contextMenu = null; }}>Reveal in Finder</button>
-          <button onclick={() => { api.shell.openInDefault(contextMenu!.target!); contextMenu = null; }}>Open in Default App</button>
-          <button onclick={() => { api.shell.openInTerminal(contextMenu!.target!); contextMenu = null; }}>Open in Terminal</button>
+          <button onclick={() => { void api.shell.revealFile(contextMenu!.target!); contextMenu = null; }}>Reveal in Finder</button>
+          <button onclick={() => { void api.shell.openInDefault(contextMenu!.target!); contextMenu = null; }}>Open in Default App</button>
+          <button onclick={() => { void api.shell.openInTerminal(contextMenu!.target!); contextMenu = null; }}>Open in Terminal</button>
         </div>
       </div>
       <div class="separator"></div>

--- a/src/renderer/lib/components/OcrProgressDialog.svelte
+++ b/src/renderer/lib/components/OcrProgressDialog.svelte
@@ -60,7 +60,7 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') { e.preventDefault(); cancel(); }
-    if (e.key === 'Enter' && stage === 'confirm') { e.preventDefault(); start(); }
+    if (e.key === 'Enter' && stage === 'confirm') { e.preventDefault(); void start(); }
   }
 
   const pct = $derived(

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -930,7 +930,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     // derived-note builder's body format so a user-pasted block looks the
     // same as a "Save as note" output.
     const md = outputToMarkdownClipboard(outputMenu.output);
-    navigator.clipboard.writeText(md);
+    void navigator.clipboard.writeText(md);
     outputMenu = null;
   }
 

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -61,7 +61,7 @@
   function copyAsList(): void {
     const header = tab.language === 'sql' ? 'language: sql\n---\n' : '';
     const block = `:::query-list\n${header}${tab.query.trim()}\n:::`;
-    navigator.clipboard.writeText(block);
+    void navigator.clipboard.writeText(block);
     copyMenuOpen = false;
   }
 
@@ -75,14 +75,14 @@
     const linkLine = linkCol ? `link: ${linkCol}\n` : '';
     const config = `${langLine}columns: ${cols}\n${linkLine}---\n`;
     const block = `:::query-table\n${config}${tab.query.trim()}\n:::`;
-    navigator.clipboard.writeText(block);
+    void navigator.clipboard.writeText(block);
     copyMenuOpen = false;
   }
 
   /** Paste-into-note as an executable fence (#238 shell picks it up). */
   function copyAsExecutableBlock(): void {
     const block = `\`\`\`${tab.language}\n${tab.query.trim()}\n\`\`\``;
-    navigator.clipboard.writeText(block);
+    void navigator.clipboard.writeText(block);
     copyMenuOpen = false;
   }
 

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -70,13 +70,13 @@
 
   $effect(() => {
     if (sourceId !== loadedId) {
-      load(sourceId);
+      void load(sourceId);
     }
   });
 
   $effect(() => {
     if (sourceId !== bodyLoadedFor) {
-      loadBody(sourceId);
+      void loadBody(sourceId);
     }
   });
 
@@ -156,7 +156,7 @@
   // was added/updated/removed (covers cross-window sync and any direct
   // filesystem edits the user made to excerpt ttls).
   api.sources.onExcerptsChanged(() => {
-    if (loadedId === sourceId) load(sourceId);
+    if (loadedId === sourceId) void load(sourceId);
   });
 
   // After render, if a specific excerpt was highlighted, scroll it into view.
@@ -178,7 +178,7 @@
   }
 
   function openExternal(url: string) {
-    api.shell.openExternal(url);
+    void api.shell.openExternal(url);
   }
 
   function excerptLocation(e: SourceExcerpt): string {

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -97,9 +97,9 @@
       <div class="submenu-item">
         <span class="submenu-trigger">Open In &#x25B8;</span>
         <div class="submenu">
-          <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') api.shell.revealFile(t.relativePath); contextMenu = null; }}>Reveal in Finder</button>
-          <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') api.shell.openInDefault(t.relativePath); contextMenu = null; }}>Open in Default App</button>
-          <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') api.shell.openInTerminal(t.relativePath); contextMenu = null; }}>Open in Terminal</button>
+          <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') void api.shell.revealFile(t.relativePath); contextMenu = null; }}>Reveal in Finder</button>
+          <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') void api.shell.openInDefault(t.relativePath); contextMenu = null; }}>Open in Default App</button>
+          <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') void api.shell.openInTerminal(t.relativePath); contextMenu = null; }}>Open in Terminal</button>
         </div>
       </div>
     {/if}

--- a/src/renderer/lib/components/TablesPanel.svelte
+++ b/src/renderer/lib/components/TablesPanel.svelte
@@ -98,14 +98,14 @@
     <button onclick={() => { onTableClick(contextMenu!.table.name); contextMenu = null; }}>
       Query (SELECT *)
     </button>
-    <button onclick={() => { navigator.clipboard.writeText(contextMenu!.table.name); contextMenu = null; }}>
+    <button onclick={() => { void navigator.clipboard.writeText(contextMenu!.table.name); contextMenu = null; }}>
       Copy Table Name
     </button>
     <div class="separator"></div>
     <button onclick={() => { onOpenCsv(contextMenu!.table.relativePath); contextMenu = null; }}>
       Open CSV
     </button>
-    <button onclick={() => { api.shell.revealFile(contextMenu!.table.relativePath); contextMenu = null; }}>
+    <button onclick={() => { void api.shell.revealFile(contextMenu!.table.relativePath); contextMenu = null; }}>
       Reveal in Finder
     </button>
   </div>

--- a/src/renderer/lib/components/TagPanel.svelte
+++ b/src/renderer/lib/components/TagPanel.svelte
@@ -21,7 +21,7 @@
   }
 
   export function selectTag(tag: string) {
-    showNotesForTag(tag);
+    void showNotesForTag(tag);
   }
 
   async function showNotesForTag(tag: string) {

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -76,7 +76,7 @@
     } else {
       panel.startRunning();
     }
-    executeToolRun();
+    void executeToolRun();
   }
 
   async function handleCancel() {
@@ -100,7 +100,7 @@
 
   function handleCopyToClipboard() {
     const text = panel.result?.output ?? panel.streamedOutput;
-    if (text) navigator.clipboard.writeText(text);
+    if (text) void navigator.clipboard.writeText(text);
   }
 
   // Called externally when panel opens in 'running' state (no params)
@@ -120,7 +120,7 @@
     }
 
     panel.startRunning();
-    executeToolRun();
+    void executeToolRun();
   }
 </script>
 

--- a/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
@@ -19,7 +19,7 @@
   $effect(() => {
     if (activeFilePath) {
       // Coalesced fetch (#351) — siblings on the same tab switch share one IPC.
-      getLinkBundle(activeFilePath, revision).then((b) => { links = b.backlinks; });
+      void getLinkBundle(activeFilePath, revision).then((b) => { links = b.backlinks; });
     } else {
       links = [];
     }

--- a/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
@@ -37,9 +37,9 @@
     loading = false;
   }
 
-  onMount(() => { refresh(); });
+  onMount(() => { void refresh(); });
 
-  $effect(() => { revision; refresh(); });
+  $effect(() => { revision; void refresh(); });
 
   const filtered = $derived(() => {
     const q = search.trim().toLowerCase();

--- a/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
@@ -20,7 +20,7 @@
     if (activeFilePath) {
       // Coalesced fetch (#351) — the sibling BacklinksPanel reads the
       // same bundle, so siblings on a tab switch share one IPC.
-      getLinkBundle(activeFilePath, revision).then((b) => { links = b.outgoing; });
+      void getLinkBundle(activeFilePath, revision).then((b) => { links = b.outgoing; });
     } else {
       links = [];
     }

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -47,11 +47,11 @@
     proposals = result as Proposal[];
   }
 
-  onMount(() => { refresh(); });
+  onMount(() => { void refresh(); });
 
   $effect(() => {
     revision;
-    refresh();
+    void refresh();
   });
 
   async function handleApprove(uri: string) {
@@ -72,8 +72,8 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (!selectedUri) return;
-    if (e.key === 'y') { e.preventDefault(); handleApprove(selectedUri); }
-    if (e.key === 'n') { e.preventDefault(); handleReject(selectedUri); }
+    if (e.key === 'y') { e.preventDefault(); void handleApprove(selectedUri); }
+    if (e.key === 'n') { e.preventDefault(); void handleReject(selectedUri); }
     if (e.key === 's' || e.key === 'Escape') { e.preventDefault(); selectedUri = null; }
   }
 </script>

--- a/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
@@ -30,7 +30,7 @@
     } catch { /* tables db not ready — keep empty set */ }
   }
 
-  $effect(() => { refreshTables(); });
+  $effect(() => { void refreshTables(); });
 
   // Pull out SQL fences first so we don't false-positive on "FROM" in
   // prose. Matches both ```sql and the query-directive fences that

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -13,7 +13,7 @@ function schedulePersist() {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = setTimeout(() => {
     persistTimer = null;
-    api.bookmarks.save($state.snapshot(tree));
+    void api.bookmarks.save($state.snapshot(tree));
   }, 500);
 }
 

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -201,7 +201,7 @@ export function getEditorStore() {
     if (autoSaveTimer) {
       clearTimeout(autoSaveTimer);
       autoSaveTimer = null;
-      save();
+      void save();
     }
   }
 
@@ -243,7 +243,7 @@ export function getEditorStore() {
       }
     });
     const session: TabSession = { activeIndex, tabs: savedTabs };
-    api.tabs.save(session);
+    void api.tabs.save(session);
   }
 
   async function restoreTabs() {

--- a/src/renderer/lib/stores/notebase.svelte.ts
+++ b/src/renderer/lib/stores/notebase.svelte.ts
@@ -28,7 +28,7 @@ export function getNotebaseStore() {
   }
 
   function close() {
-    api.notebase.close();
+    void api.notebase.close();
     meta = null;
     files = [];
   }


### PR DESCRIPTION
## Summary
- Closes #381 — audited every floating-promise site flagged during #349 adoption (~83 sites across 28 files) and promoted the rule from \`warn\` to \`error\`.
- The vast majority were intentional fire-and-forget UI handlers (\`api.shell.revealFile\`, \`navigator.clipboard.writeText\`, async \`refresh()\` calls inside \`$effect\` and \`onMount\`, async helpers triggered from \`api.menu.on*\` callbacks). These got \`void\` prefixes — explicit "yes, I know, fire and forget".
- Main-process sites (10) got individual review:
  - \`health-checks.ts\` setInterval, \`project-context.ts\` open-time check — fire-and-forget by design.
  - \`shell.openPath\` / \`shell.openExternal\` — UX is fire-and-forget.
  - \`app.whenReady().then(...)\` lifecycle entry, \`win.loadURL\` / \`loadFile\` (\`createWindow\` returns the window object synchronously) — \`void\` matches existing semantics.
  - \`watcher.ts\` chokidar \`close()\` inside synchronous \`stopWatching\` — voided with a comment.
- Rule now fails the build on new violations.

## Test plan
- [x] \`pnpm lint\` clean (0 errors; 19 warnings, all unrelated unused-vars from #349)
- [x] \`pnpm test\` — 1587 passed
- [x] No behavior change — every \`void\` keeps semantically-equivalent fire-and-forget behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)