### PR TITLE
lint: enable no-explicit-any (progress on #382)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,7 +74,7 @@ export default tseslint.config(
       // a hundred-line PR that mixes lint setup with real fixes.
       // Re-enable each in its own PR after the underlying cleanups land.
       // Still off — sites > 0; tracked in #382, batched separately.
-      '@typescript-eslint/no-explicit-any': 'off',                  // 35 sites
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unsafe-assignment': 'off',             // 77 sites
       '@typescript-eslint/no-unsafe-member-access': 'off',          // 108 sites
       '@typescript-eslint/no-unsafe-call': 'off',                   // 99 sites

--- a/src/main/compute/rpc-server.ts
+++ b/src/main/compute/rpc-server.ts
@@ -75,7 +75,7 @@ const methods: Record<string, RpcMethod> = {
   sparql: async (rootPath, params) => {
     const ctx = projectContext(rootPath);
     const query = asString(params.query, 'query');
-    const r = (await graph.queryGraph(ctx, query)) as { results: unknown[]; error?: string };
+    const r = await graph.queryGraph(ctx, query);
     if (r.error) queryError(r.error);
     return { rows: r.results };
   },

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -30,7 +30,10 @@ function buildN3Store(s: $rdf.IndexedFormula): N3.Store {
       const predicate = convertTerm(st.predicate, df) as N3.NamedNode;
       const object = convertTerm(st.object, df);
       if (subject && predicate && object) {
-        n3Store.addQuad(subject as any, predicate, object as any, df.defaultGraph());
+        // n3.addQuad's overloads insist on (Quad_Subject, Quad_Predicate,
+        // Quad_Object, ...) but our convertTerm produces N3.Term —
+        // structurally compatible for the runtime check it does.
+        n3Store.addQuad(subject as N3.Quad_Subject, predicate, object as N3.Quad_Object, df.defaultGraph());
       }
     } catch { /* skip malformed triples */ }
   }
@@ -38,8 +41,17 @@ function buildN3Store(s: $rdf.IndexedFormula): N3.Store {
   return n3Store;
 }
 
-function convertTerm(term: any, df: typeof N3.DataFactory): N3.Term | null {
-  if (!term || !term.termType) return null;
+// rdflib's term shape isn't fully typed at this boundary — accept anything
+// shaped like { termType, value, datatype? } and translate to N3.
+interface RdflibTermLike {
+  termType?: string;
+  value?: string;
+  datatype?: { value: string };
+  language?: string;
+}
+
+function convertTerm(term: RdflibTermLike | null | undefined, df: typeof N3.DataFactory): N3.Term | null {
+  if (!term || !term.termType || term.value == null) return null;
   switch (term.termType) {
     case 'NamedNode': return df.namedNode(term.value);
     case 'BlankNode': return df.blankNode(term.value);
@@ -1397,7 +1409,7 @@ export function schemaForCompletion(ctx: ProjectContext): GraphSchema {
   };
 }
 
-export async function queryGraph(ctx: ProjectContext, sparql: string): Promise<{ results: unknown[] }> {
+export async function queryGraph(ctx: ProjectContext, sparql: string): Promise<{ results: unknown[]; error?: string }> {
   const state = getState(ctx);
   if (!state || !engine) return { results: [] };
   const { store } = state;
@@ -1421,7 +1433,7 @@ export async function queryGraph(ctx: ProjectContext, sparql: string): Promise<{
 
     return { results };
   } catch (e) {
-    return { results: [], error: String(e) } as any;
+    return { results: [], error: String(e) };
   }
 }
 

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -204,7 +204,7 @@ async function runQuery(ctx: ToolContext, input: unknown): Promise<{ content: st
   if (typeof sparql !== 'string' || !sparql.trim()) {
     throw new Error('sparql is required');
   }
-  const response = await graph.queryGraph(projectContext(ctx.rootPath), sparql) as { results: unknown[]; error?: string };
+  const response = await graph.queryGraph(projectContext(ctx.rootPath), sparql);
   if (response.error) {
     return {
       content: `SPARQL error: ${response.error}\n\nCall describe_graph_schema to see available classes and predicates.`,

--- a/src/main/publish/csl/citeproc.d.ts
+++ b/src/main/publish/csl/citeproc.d.ts
@@ -21,8 +21,8 @@ declare module 'citeproc' {
       citationsPre: unknown[],
       citationsPost: unknown[],
     ): [Record<string, unknown>, Array<[number, string, string]>];
-    // Engine exposes more — we treat it as `unknown` on the wrapper side.
-    cslXml?: unknown;
+    // Engine exposes more — we surface only the bits the wrapper reads.
+    cslXml?: { dataObj?: { attrs?: { class?: string } } };
   }
 
   const _default: {

--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -13,7 +13,7 @@
  * exporters don't have to learn it.
  */
 
-import CSL from 'citeproc';
+import CSL, { Engine as CslEngine } from 'citeproc';
 import type { CslItem } from './source-to-csl';
 
 export interface RenderedBibliography {
@@ -28,8 +28,7 @@ export interface RenderedBibliography {
 }
 
 export class CitationRenderer {
-   
-  private engine: any;
+  private engine: CslEngine;
   private readonly items: Map<string, CslItem>;
   private readonly citedIds = new Set<string>();
   /** Ids we've been asked to render but couldn't find in `items`. */
@@ -79,7 +78,7 @@ export class CitationRenderer {
         [],
       );
       // citeproc returns [updateInfo, [[index, text, id], ...]]
-      const pairs = result[1] as Array<[number, string, string]>;
+      const pairs = result[1];
       return pairs.length > 0 ? pairs[0][1] : '';
     } catch (err) {
       return `<span class="csl-error" title="${escapeHtml(String(err))}">[citation error: ${escapeHtml(id)}]</span>`;

--- a/src/main/search/minisearch-provider.ts
+++ b/src/main/search/minisearch-provider.ts
@@ -53,7 +53,7 @@ export class MiniSearchProvider implements SearchProvider {
       const snippet = doc ? extractSnippet(doc.content, query) : '';
       return {
         relativePath: hit.id as string,
-        title: (hit as any).title ?? doc?.title ?? hit.id,
+        title: (hit as { title?: string }).title ?? doc?.title ?? hit.id,
         snippet,
         score: hit.score,
       };

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -454,9 +454,11 @@
     // Update open tab if the moved file was open
     const tabIdx = editor.tabs.findIndex((t) => t.type === 'note' && t.relativePath === srcPath);
     if (tabIdx !== -1) {
-      const tab = editor.tabs[tabIdx] as any;
-      tab.relativePath = destPath;
-      tab.fileName = srcName;
+      const tab = editor.tabs[tabIdx];
+      if (tab.type === 'note') {
+        tab.relativePath = destPath;
+        tab.fileName = srcName;
+      }
     }
     await notebase.refresh();
   }
@@ -471,9 +473,11 @@
       // If the moved file was open, update the tab
       const tabIdx = editor.tabs.findIndex((t) => t.type === 'note' && t.relativePath === clipboardItem!.relativePath);
       if (tabIdx !== -1) {
-        const tab = editor.tabs[tabIdx] as any;
-        tab.relativePath = destPath;
-        tab.fileName = srcName;
+        const tab = editor.tabs[tabIdx];
+        if (tab.type === 'note') {
+          tab.relativePath = destPath;
+          tab.fileName = srcName;
+        }
       }
       clipboardItem = null;
     } else {
@@ -1183,16 +1187,16 @@
     recordCurrentPosition();
 
     const targetTab = editor.tabs[index];
-    const savedOffset = targetTab?.type === 'note' ? (targetTab as any).cursorOffset : undefined;
-    const savedScroll = targetTab?.type === 'note' ? (targetTab as any).scrollTop : undefined;
+    const savedOffset = targetTab?.type === 'note' ? targetTab.cursorOffset : undefined;
+    const savedScroll = targetTab?.type === 'note' ? targetTab.scrollTop : undefined;
     if (targetTab?.type === 'note') {
-      await editor.openFile((targetTab as any).relativePath);
+      await editor.openFile(targetTab.relativePath);
       if (savedOffset != null) {
         requestAnimationFrame(() => {
           editorComponent?.restorePosition(savedOffset, savedScroll);
         });
       }
-      nav.record({ type: 'note', relativePath: (targetTab as any).relativePath, offset: savedOffset ?? 0 });
+      nav.record({ type: 'note', relativePath: targetTab.relativePath, offset: savedOffset ?? 0 });
     } else if (targetTab?.type === 'query') {
       editor.switchTab(index);
       nav.record({ type: 'query', tabId: targetTab.id });

--- a/src/renderer/lib/components/ConversationDialog.svelte
+++ b/src/renderer/lib/components/ConversationDialog.svelte
@@ -57,7 +57,7 @@
 
     try {
       const results = await api.graph.groundCheck(claim);
-      const match = (results as any[])?.[0];
+      const match = (results as Array<{ label: string; type: string }>)?.[0];
       const state = match
         ? { grounded: true, label: match.label, type: match.type }
         : { grounded: false };

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -4,7 +4,7 @@
   import { basicSetup } from 'codemirror';
   import { markdown } from '@codemirror/lang-markdown';
   import { languages } from '@codemirror/language-data';
-  import { EditorState, Prec, Compartment } from '@codemirror/state';
+  import { EditorState, Prec, Compartment, type Extension } from '@codemirror/state';
   import { oneDark } from '@codemirror/theme-one-dark';
   import { getEffectiveTheme, getThemeMode } from '../theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
@@ -155,7 +155,7 @@
     return obj as { doc: string } & Record<string, unknown>;
   }
 
-  function cmTheme(): any {
+  function cmTheme(): Extension {
     return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
   }
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -409,9 +409,9 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     return true;
   });
 
-  md.renderer.rules.query_directive = (tokens: any[], idx: number) => {
+  md.renderer.rules.query_directive = (tokens: Token[], idx: number) => {
     const query = tokens[idx].content;
-    const { type, config } = tokens[idx].meta;
+    const { type, config } = tokens[idx].meta as { type: string; config: Record<string, unknown> };
     const configJson = Object.keys(config).length > 0 ? escapeAttr(JSON.stringify(config)) : '';
     return `<div class="query-block" data-type="${escapeAttr(type)}" data-query="${escapeAttr(query)}"${configJson ? ` data-config="${configJson}"` : ''}><span class="query-loading">Loading...</span></div>`;
   };

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { EditorView, keymap, lineNumbers, placeholder } from '@codemirror/view';
-  import { EditorState, Compartment, Prec } from '@codemirror/state';
+  import { EditorState, Compartment, Prec, type Extension } from '@codemirror/state';
   import { history, historyKeymap, defaultKeymap, indentWithTab } from '@codemirror/commands';
   import {
     bracketMatching,
@@ -138,7 +138,7 @@
     } catch { /* tables DB not ready — autocomplete just falls back to keywords */ }
   }
 
-  function languageExt(lang: QueryLanguage): any {
+  function languageExt(lang: QueryLanguage): Extension {
     if (lang === 'sql') {
       return sql({
         dialect: PostgreSQL,
@@ -155,7 +155,7 @@
       : 'SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}';
   }
 
-  function completionFor(lang: QueryLanguage): any {
+  function completionFor(lang: QueryLanguage): Extension {
     // lang-sql bundles its own completion source via the `schema` option;
     // we only need to override for SPARQL.
     if (lang === 'sql') return autocompletion();
@@ -166,7 +166,7 @@
     return getEffectiveTheme(getThemeMode()) === 'dark';
   }
 
-  function cmTheme(): any {
+  function cmTheme(): Extension {
     return isDark() ? oneDark : [];
   }
 
@@ -204,7 +204,7 @@
     { tag: t.comment, color: '#6c6f85', fontStyle: 'italic' },
   ]);
 
-  function cmHighlight(): any {
+  function cmHighlight(): Extension {
     return syntaxHighlighting(isDark() ? sparqlHighlightDark : sparqlHighlightLight);
   }
 

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -82,7 +82,7 @@
   const formatterSections = CATEGORY_ORDER.map((cat) => ({
     category: cat,
     label: FORMATTER_CATEGORY_LABELS[cat] ?? cat,
-    rules: listRulesByCategory(cat) as FormatterRule<unknown>[],
+    rules: listRulesByCategory(cat),
   }));
   const hasAnyFormatterRules = formatterSections.some((s) => s.rules.length > 0);
   const DESTINATION_OPTIONS: { value: DestinationMode; label: string }[] = [

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -103,7 +103,7 @@ export interface GitApi {
 }
 
 export interface GraphApi {
-  query(sparql: string): Promise<{ results: unknown[] }>;
+  query(sparql: string): Promise<{ results: unknown[]; error?: string }>;
   groundCheck(claimText: string): Promise<{ node: string; label: string; type: string }[]>;
   inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
   runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -369,8 +369,8 @@ export function getEditorStore() {
       } else {
         const response = await api.graph.query(tab.query);
         tab.executionTime = Math.round(performance.now() - start);
-        if ((response as any).error) {
-          tab.error = (response as any).error;
+        if (response.error) {
+          tab.error = response.error;
         } else if (response.results.length > 0) {
           tab.columns = Object.keys(response.results[0] as Record<string, string>);
           tab.results = response.results as Record<string, string>[];

--- a/src/shared/formatter/engine.ts
+++ b/src/shared/formatter/engine.ts
@@ -44,13 +44,13 @@ export function formatContent(content: string, settings: FormatSettings): string
 /** Expose which rules would run, in order. Useful for the settings UI + tests. */
 export function resolveEnabled(settings: FormatSettings): EnabledRule[] {
   const all = listAllRules();
-  const byCategory = new Map<string, FormatterRule<any>[]>();
+  const byCategory = new Map<string, FormatterRule[]>();
   for (const r of all) {
     if (!byCategory.has(r.category)) byCategory.set(r.category, []);
     byCategory.get(r.category)!.push(r);
   }
 
-  const ordered: FormatterRule<any>[] = [];
+  const ordered: FormatterRule[] = [];
   for (const cat of CATEGORY_ORDER) {
     const group = byCategory.get(cat);
     if (group) ordered.push(...group);

--- a/src/shared/formatter/registry.ts
+++ b/src/shared/formatter/registry.ts
@@ -11,26 +11,26 @@
 
 import type { FormatterCategory, FormatterRule } from './types';
 
-const rules = new Map<string, FormatterRule<any>>();
+const rules = new Map<string, FormatterRule>();
 const order: string[] = [];
 
 export function registerRule<Config>(rule: FormatterRule<Config>): void {
   if (rules.has(rule.id)) {
     throw new Error(`Formatter rule "${rule.id}" is already registered.`);
   }
-  rules.set(rule.id, rule as FormatterRule<any>);
+  rules.set(rule.id, rule);
   order.push(rule.id);
 }
 
-export function getRule(id: string): FormatterRule<any> | undefined {
+export function getRule(id: string): FormatterRule | undefined {
   return rules.get(id);
 }
 
-export function listAllRules(): FormatterRule<any>[] {
+export function listAllRules(): FormatterRule[] {
   return order.map((id) => rules.get(id)!).filter(Boolean);
 }
 
-export function listRulesByCategory(category: FormatterCategory): FormatterRule<any>[] {
+export function listRulesByCategory(category: FormatterCategory): FormatterRule[] {
   return listAllRules().filter((r) => r.category === category);
 }
 

--- a/tests/shared/bookmark-transitions.test.ts
+++ b/tests/shared/bookmark-transitions.test.ts
@@ -14,14 +14,14 @@ describe('applyBookmarkPathTransitions', () => {
   it('returns false on empty transitions and leaves tree untouched', () => {
     const tree = [bm('a', 'notes/a.md')];
     expect(applyBookmarkPathTransitions(tree, [])).toBe(false);
-    expect((tree[0] as any).relativePath).toBe('notes/a.md');
+    expect((tree[0] as { relativePath: string }).relativePath).toBe('notes/a.md');
   });
 
   it('rewrites an exact path match', () => {
     const tree = [bm('a', 'notes/a.md')];
     const changed = applyBookmarkPathTransitions(tree, [{ old: 'notes/a.md', new: 'archive/a.md' }]);
     expect(changed).toBe(true);
-    expect((tree[0] as any).relativePath).toBe('archive/a.md');
+    expect((tree[0] as { relativePath: string }).relativePath).toBe('archive/a.md');
   });
 
   it('rewrites bookmarks inside a renamed folder (prefix match)', () => {
@@ -35,15 +35,15 @@ describe('applyBookmarkPathTransitions', () => {
       { old: 'notes/sub/y.md', new: 'archive/sub/y.md' },
     ]);
     expect(changed).toBe(true);
-    expect((tree[0] as any).relativePath).toBe('archive/sub/x.md');
-    expect((tree[1] as any).relativePath).toBe('archive/sub/y.md');
-    expect((tree[2] as any).relativePath).toBe('other/z.md'); // untouched
+    expect((tree[0] as { relativePath: string }).relativePath).toBe('archive/sub/x.md');
+    expect((tree[1] as { relativePath: string }).relativePath).toBe('archive/sub/y.md');
+    expect((tree[2] as { relativePath: string }).relativePath).toBe('other/z.md'); // untouched
   });
 
   it('recurses into folders', () => {
     const tree = [folder('research', [bm('a', 'notes/a.md')])];
     applyBookmarkPathTransitions(tree, [{ old: 'notes/a.md', new: 'archive/a.md' }]);
-    expect((tree[0] as any).children[0].relativePath).toBe('archive/a.md');
+    expect((tree[0] as { children: Array<{ relativePath: string }> }).children[0].relativePath).toBe('archive/a.md');
   });
 
   it('stops at the first matching transition (longer prefixes win)', () => {
@@ -54,7 +54,7 @@ describe('applyBookmarkPathTransitions', () => {
       { old: 'notes', new: 'archive' },
       { old: 'notes/sub/x.md', new: 'archive/sub/new-x.md' },
     ]);
-    expect((tree[0] as any).relativePath).toBe('archive/sub/new-x.md');
+    expect((tree[0] as { relativePath: string }).relativePath).toBe('archive/sub/new-x.md');
   });
 
   it('returns false when no bookmark matches any transition', () => {


### PR DESCRIPTION
## Summary
Closes the no-explicit-any line on #382 (35 sites). The rule now fails the build on any new \`any\` use.

## Highlights by area
- **graph/index.ts**: extracted \`RdflibTermLike\` for the rdflib→n3 term boundary; added \`error?: string\` to \`queryGraph\`'s return type so callers don't need \`as any\` to read it.
- **publish/csl/**: typed the citeproc \`Engine\` field properly (using the existing \`.d.ts\` shim) and tightened \`cslXml\` to surface the \`dataObj.attrs.class\` slice the wrapper reads.
- **llm/tools.ts + compute/rpc-server.ts**: dropped redundant \`as { results, error? }\` casts now that \`queryGraph\`'s return type carries the error field.
- **search/minisearch-provider.ts**: replaced \`(hit as any).title\` with a narrow \`{ title?: string }\` cast.
- **App.svelte**: dropped \`(tab as any)\` accesses by type-narrowing on \`tab.type === 'note'\` first.
- **Editor.svelte + QueryPanel.svelte**: typed CodeMirror compartment factories as \`Extension\` from \`@codemirror/state\`.
- **Preview.svelte**: typed query_directive renderer args as \`Token[]\` from markdown-it.
- **ConversationDialog.svelte**: tightened \`(results as any[])\` to \`Array<{ label, type }>\`.
- **editor.svelte.ts**: dropped \`(response as any).error\` reads now that GraphApi.query carries the field.
- **formatter/{engine,registry}.ts**: dropped \`FormatterRule<any>\` for the default-generic form.
- **bookmark-transitions.test.ts**: replaced \`as any\` reads with narrow structural casts.

Side-effect: tightening the type shims surfaced 5 stale \`no-unnecessary-type-assertion\` sites that immediately preceded the new narrower types — fixed in the same pass.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 22 warnings — all unused-vars, unrelated)
- [x] \`pnpm test\` — 1587 passed
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)