### PR TITLE
lint: enable require-await (progress on #382)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,7 +80,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-call': 'off',                   // 99 sites
       '@typescript-eslint/no-unsafe-argument': 'off',               // 79 sites
       '@typescript-eslint/no-unsafe-return': 'off',                 // 23 sites
-      '@typescript-eslint/require-await': 'off',                    // 37 sites
+      '@typescript-eslint/require-await': 'error',
       '@typescript-eslint/no-misused-promises': 'off',              // 45 sites
       // Re-enabled (#382) — small-count rules cleaned up site-by-site
       // and now catch new offenders.
@@ -103,6 +103,10 @@ export default tseslint.config(
     files: ['tests/**/*.ts'],
     rules: {
       '@typescript-eslint/no-floating-promises': 'off',
+      // Test mocks routinely satisfy Promise-returning interfaces with
+      // `async () => stub` bodies that have nothing to await. That's the
+      // whole point of the mock — the production interface IS async.
+      '@typescript-eslint/require-await': 'off',
     },
   },
   {

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -518,6 +518,11 @@ export async function initGraph(ctx: ProjectContext): Promise<void> {
 
 // ── Indexing ────────────────────────────────────────────────────────────────
 
+// indexNote is an async-by-contract public API: callers `await` it across
+// the project (ipc, write-pipeline, watchers, rename), and we want the
+// freedom to add real async work later without rippling out a signature
+// change. The current body happens to be sync.
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function indexNote(
   ctx: ProjectContext,
   relativePath: string,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -208,7 +208,7 @@ export function registerIpcHandlers(): void {
     return null;
   });
 
-  ipcMain.handle('notebase:newWindow', async (_e, rootPath?: string) => {
+  ipcMain.handle('notebase:newWindow', (_e, rootPath?: string) => {
     const win = createWindow();
     if (rootPath) {
       // Wait for window to be ready before opening project
@@ -258,7 +258,7 @@ export function registerIpcHandlers(): void {
     return { rootPath, name: path.basename(rootPath) };
   });
 
-  ipcMain.handle('notebase:openPathInNewWindow', async (_e, rootPath: string) => {
+  ipcMain.handle('notebase:openPathInNewWindow', (_e, rootPath: string) => {
     const freshWin = createWindow();
     freshWin.webContents.once('did-finish-load', async () => {
       await openProjectInWindow(freshWin, rootPath);

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -31,10 +31,10 @@ export async function reindexAllConversations(): Promise<void> {
     try {
       const data = await fs.readFile(path.join(conversationsDir, file), 'utf-8');
       const conv = JSON.parse(data) as Conversation;
-      await writeConversationToGraph(conv);
+      writeConversationToGraph(conv);
       if (conv.status !== 'active') {
         // Mirror the live status so resolve/abandon don't get dropped on reload.
-        await updateConversationInGraph(conv);
+        updateConversationInGraph(conv);
       }
     } catch (err) {
       console.warn(`[conversation] reindex skipped ${file}:`, err);
@@ -83,7 +83,7 @@ export async function create(
   if (options?.model) conv.model = options.model;
 
   await persist(conv);
-  await writeConversationToGraph(conv);
+  writeConversationToGraph(conv);
   return conv;
 }
 
@@ -176,7 +176,7 @@ async function setStatus(id: string, status: ConversationStatus): Promise<Conver
   }
 
   await persist(conv);
-  await updateConversationInGraph(conv);
+  updateConversationInGraph(conv);
 
   // On resolve, store as a thought:Source in the graph for provenance
   if (status === 'resolved') {
@@ -226,7 +226,7 @@ function clearConversationTriples(uri: string): void {
   graph.removeMatchingTriples(ctx, uri, 'http://purl.org/dc/terms/created');
 }
 
-async function writeConversationToGraph(conv: Conversation): Promise<void> {
+function writeConversationToGraph(conv: Conversation): void {
   const uri = convUri(conv.id);
   const ctx = activeCtx();
   // contextNote needs a real IRI, not the raw `notes/foo.md` string —
@@ -249,7 +249,7 @@ async function writeConversationToGraph(conv: Conversation): Promise<void> {
   graph.parseIntoStore(ctx, turtle);
 }
 
-async function updateConversationInGraph(conv: Conversation): Promise<void> {
+function updateConversationInGraph(conv: Conversation): void {
   const uri = convUri(conv.id);
   const statusMap: Record<ConversationStatus, string> = {
     active: 'active',

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -158,7 +158,7 @@ export async function executeNotebaseTool(
   try {
     switch (name) {
       case 'search_notes':
-        return { content: await runSearch(ctx, input), isError: false };
+        return { content: runSearch(ctx, input), isError: false };
       case 'read_note':
         return { content: await runRead(ctx, input), isError: false };
       case 'query_graph':
@@ -174,7 +174,7 @@ export async function executeNotebaseTool(
   }
 }
 
-async function runSearch(ctx: ToolContext, input: unknown): Promise<string> {
+function runSearch(ctx: ToolContext, input: unknown): string {
   const { query, limit } = input as { query: string; limit?: number };
   if (typeof query !== 'string' || !query.trim()) {
     throw new Error('query is required');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,7 +13,7 @@ import { shutdownAllKernels } from './compute/python-kernel';
 
 app.setName('Minerva');
 
-void app.whenReady().then(async () => {
+void app.whenReady().then(() => {
   installCsp();
   registerIpcHandlers();
   registerBuiltinExecutors();

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -96,8 +96,8 @@ export async function releaseProject(rootPath: string, winId: number): Promise<v
   } catch (err) {
     console.warn(`[project-context] final persist failed for ${rootPath}:`, err);
   }
-  await tables.disposeProject(rec.ctx);
-  await search.disposeProject(rec.ctx);
+  tables.disposeProject(rec.ctx);
+  search.disposeProject(rec.ctx);
   graph.disposeProject(rec.ctx);
   projects.delete(rootPath);
 }

--- a/src/main/publish/exporters/markdown.ts
+++ b/src/main/publish/exporters/markdown.ts
@@ -23,6 +23,11 @@ export const markdownExporter: Exporter = {
   label: 'Markdown (passthrough)',
   accepts: (input) => input.kind !== 'tree',
   acceptedKinds: ['single-note', 'folder', 'project'],
+  // Exporter contract requires Promise<ExportOutput>; this trivial
+  // exporter has nothing to await but its async siblings (HTML, PDF,
+  // tree, site) do. Keep the signature uniform so the registry doesn't
+  // care which exporters happen to be sync today.
+  // eslint-disable-next-line @typescript-eslint/require-await
   async run(plan) {
     const ctx = buildLinkResolverContext(plan);
     const files = plan.inputs

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -28,7 +28,7 @@ export async function initSearch(ctx: ProjectContext): Promise<void> {
   await state.provider.load(indexPath(state));
 }
 
-export async function disposeProject(ctx: ProjectContext): Promise<void> {
+export function disposeProject(ctx: ProjectContext): void {
   states.delete(ctx.rootPath);
 }
 

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -46,7 +46,7 @@ export async function initTablesDb(ctx: ProjectContext): Promise<void> {
   });
 }
 
-export async function disposeProject(ctx: ProjectContext): Promise<void> {
+export function disposeProject(ctx: ProjectContext): void {
   const state = states.get(ctx.rootPath);
   if (!state) return;
   try { state.connection.closeSync(); } catch { /* already closed */ }

--- a/tests/main/compute/sql-executor.test.ts
+++ b/tests/main/compute/sql-executor.test.ts
@@ -29,7 +29,7 @@ describe('executeSql (#240)', () => {
   });
 
   afterAll(async () => {
-    await disposeProject(ctx);
+    disposeProject(ctx);
     await fsp.rm(root, { recursive: true, force: true });
   });
 

--- a/tests/main/sources/tables-csv.test.ts
+++ b/tests/main/sources/tables-csv.test.ts
@@ -65,7 +65,7 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
   });
 
   afterEach(async () => {
-    await disposeProject(ctx);
+    disposeProject(ctx);
     await fsp.rm(root, { recursive: true, force: true });
   });
 

--- a/tests/main/sources/tables.test.ts
+++ b/tests/main/sources/tables.test.ts
@@ -9,8 +9,8 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
     await initTablesDb(ctx);
   });
 
-  afterAll(async () => {
-    await disposeProject(ctx);
+  afterAll(() => {
+    disposeProject(ctx);
   });
 
   it('runs the trivial round-trip query', async () => {
@@ -76,7 +76,7 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
       const inSecond = await runQuery(otherCtx, `SELECT COUNT(*) AS n FROM scratch`);
       expect(inSecond.ok).toBe(false);
     } finally {
-      await disposeProject(otherCtx);
+      disposeProject(otherCtx);
     }
   });
 });


### PR DESCRIPTION
## Summary
Closes the require-await line on #382 (37 sites). Rule now fails the build on async functions that don't await.

## Changes by site
**Dropped async + updated callers** (truly sync helpers):
- \`src/main/llm/conversation.ts\` — \`writeConversationToGraph\`, \`updateConversationInGraph\`
- \`src/main/llm/tools.ts\` — \`runSearch\`
- \`src/main/search/index.ts\` — \`disposeProject\`
- \`src/main/sources/tables.ts\` — \`disposeProject\`
- \`src/main/main.ts\` — \`app.whenReady().then(...)\` outer arrow
- \`src/main/ipc.ts\` — two ipcMain.handle outer wrappers

**Kept async with eslint-disable + comment** (contract-bound):
- \`src/main/graph/index.ts\` \`indexNote\` — async-by-contract public API
- \`src/main/publish/exporters/markdown.ts\` \`run\` — Exporter contract requires \`Promise<ExportOutput>\`

**Tests**: added a \`tests/**/*.ts\` override turning require-await off. Test mocks routinely satisfy Promise-returning interfaces with \`async () => stub\` bodies — that's the whole point of the mock.

Side-effect: dropping \`disposeProject\` async re-flagged 4 test sites that were awaiting it (await-thenable). Fixed in the same pass.

## Test plan
- [x] \`pnpm lint\` clean (0 errors)
- [x] \`pnpm test\` — 1587 passed
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)