### PR TITLE
lint: enable no-misused-promises (progress on #382)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,7 +81,15 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-argument': 'off',               // 79 sites
       '@typescript-eslint/no-unsafe-return': 'off',                 // 23 sites
       '@typescript-eslint/require-await': 'error',
-      '@typescript-eslint/no-misused-promises': 'off',              // 45 sites
+      // checksVoidReturn.arguments off: the "Promise returned where void
+      // was expected" check fires on every `setTimeout(async () => …)` /
+      // `el.on('event', async () => …)` — common, harmless patterns the
+      // framework discards on purpose. The rule's other detections
+      // (Promise in conditional, in boolean spread, etc.) are the real
+      // bug-finders and stay on.
+      '@typescript-eslint/no-misused-promises': ['error', {
+        checksVoidReturn: { arguments: false },
+      }],
       // Re-enabled (#382) — small-count rules cleaned up site-by-site
       // and now catch new offenders.
       '@typescript-eslint/restrict-template-expressions': 'error',

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -6,14 +6,17 @@ import { Channels } from '../../shared/channels';
 
 import { INDEXABLE_EXTS } from './indexable-files';
 
+// Callbacks may return a Promise; the watcher invokes them as
+// fire-and-forget. Typing the return as `void | Promise<void>` lets
+// callers be explicitly async without tripping no-misused-promises.
 export interface WatcherCallbacks {
-  onFileChanged: (relativePath: string) => void;
-  onFileCreated: (relativePath: string) => void;
-  onFileDeleted: (relativePath: string) => void;
-  onSourceMetaChanged?: (sourceId: string) => void;
-  onSourceMetaDeleted?: (sourceId: string) => void;
-  onExcerptChanged?: (excerptId: string) => void;
-  onExcerptDeleted?: (excerptId: string) => void;
+  onFileChanged: (relativePath: string) => void | Promise<void>;
+  onFileCreated: (relativePath: string) => void | Promise<void>;
+  onFileDeleted: (relativePath: string) => void | Promise<void>;
+  onSourceMetaChanged?: (sourceId: string) => void | Promise<void>;
+  onSourceMetaDeleted?: (sourceId: string) => void | Promise<void>;
+  onExcerptChanged?: (excerptId: string) => void | Promise<void>;
+  onExcerptDeleted?: (excerptId: string) => void | Promise<void>;
 }
 
 interface WatcherPair {
@@ -55,11 +58,13 @@ export function startWatching(
     ignoreInitial: true,
   });
 
+  // Callbacks may be async (interface allows void | Promise<void>); the
+  // watcher invokes them as fire-and-forget. `void` makes that explicit.
   notes.on('change', (filePath) => {
     if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
-      callbacks?.onFileChanged(relative);
+      void callbacks?.onFileChanged(relative);
     }
   });
 
@@ -67,7 +72,7 @@ export function startWatching(
     if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
-      callbacks?.onFileCreated(relative);
+      void callbacks?.onFileCreated(relative);
     }
   });
 
@@ -75,7 +80,7 @@ export function startWatching(
     if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_DELETED, relative);
-      callbacks?.onFileDeleted(relative);
+      void callbacks?.onFileDeleted(relative);
     }
   });
 
@@ -98,14 +103,14 @@ export function startWatching(
     if (win.isDestroyed()) return;
     const sourceId = extractSourceId(filePath);
     if (sourceId) {
-      if (kind === 'upsert') callbacks?.onSourceMetaChanged?.(sourceId);
-      else callbacks?.onSourceMetaDeleted?.(sourceId);
+      if (kind === 'upsert') void callbacks?.onSourceMetaChanged?.(sourceId);
+      else void callbacks?.onSourceMetaDeleted?.(sourceId);
       return;
     }
     const excerptId = extractExcerptId(filePath);
     if (excerptId) {
-      if (kind === 'upsert') callbacks?.onExcerptChanged?.(excerptId);
-      else callbacks?.onExcerptDeleted?.(excerptId);
+      if (kind === 'upsert') void callbacks?.onExcerptChanged?.(excerptId);
+      else void callbacks?.onExcerptDeleted?.(excerptId);
     }
   };
 


### PR DESCRIPTION
## Summary
Closes the no-misused-promises line on #382.

Of the 45 sites flagged, 40 were the harmless **"Promise returned in function argument where a void return was expected"** pattern fired by every \`setTimeout(async () => …)\`, \`el.on('event', async () => …)\`, ipcMain.handle wrapper, and Svelte event handler. The framework discards the returned Promise on purpose; flagging them adds zero bug-finding value and would force ~40 ugly wraps.

Configured the rule with \`checksVoidReturn: { arguments: false }\` — the genuinely-dangerous detections still fire (Promise in conditional, Promise in boolean spread, Promise-returning function assigned to a property typed as void) but the harmless event-handler pattern stays quiet.

The 5 sites the tightened config still flagged were all watcher callbacks declared as \`(p: string) => void\` on \`WatcherCallbacks\` but implemented as \`async (p) => {…}\` in \`window-manager.ts\`. Widened the interface return type to \`void | Promise<void>\` (the watcher invokes them as fire-and-forget anyway), then \`void\`-prefixed the watcher's own internal callback invocations to make the discard explicit.

## Test plan
- [x] \`pnpm lint\` clean (0 errors)
- [x] \`pnpm test\` — 1587 passed
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)