### PR TITLE
lint: no-unsafe-* family preparation pass (progress on #382)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,12 +74,17 @@ export default tseslint.config(
       // a hundred-line PR that mixes lint setup with real fixes.
       // Re-enable each in its own PR after the underlying cleanups land.
       // Still off — sites > 0; tracked in #382, batched separately.
+      // After the cleanup pass that landed alongside this config the
+      // remaining ~160 no-unsafe-* sites are concentrated in
+      // App.svelte (119), Preview.svelte (17), ConversationDialog (7),
+      // Sidebar (6), StatusBar (6), and a handful of singletons.
+      // Promote these to error once those files are typed.
       '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-unsafe-assignment': 'off',             // 77 sites
-      '@typescript-eslint/no-unsafe-member-access': 'off',          // 108 sites
-      '@typescript-eslint/no-unsafe-call': 'off',                   // 99 sites
-      '@typescript-eslint/no-unsafe-argument': 'off',               // 79 sites
-      '@typescript-eslint/no-unsafe-return': 'off',                 // 23 sites
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/require-await': 'error',
       // checksVoidReturn.arguments off: the "Promise returned where void
       // was expected" check fires on every `setTimeout(async () => …)` /
@@ -115,6 +120,14 @@ export default tseslint.config(
       // `async () => stub` bodies that have nothing to await. That's the
       // whole point of the mock — the production interface IS async.
       '@typescript-eslint/require-await': 'off',
+      // Tests legitimately reach into `unknown`-typed query results and
+      // mock-returned shapes without re-typing every field; the
+      // strictness pays off in production code, not tests.
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   {

--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -119,7 +119,7 @@ async function spawnKernel(rootPath: string): Promise<KernelState> {
   rl.on('line', (line) => {
     let event: KernelEvent;
     try {
-      event = JSON.parse(line);
+      event = JSON.parse(line) as KernelEvent;
     } catch {
       console.warn('[python-kernel] non-JSON event line:', line);
       return;

--- a/src/main/compute/rpc-server.ts
+++ b/src/main/compute/rpc-server.ts
@@ -220,7 +220,7 @@ export async function startRpcServer(rootPath: string): Promise<RpcServer> {
     rl.on('line', async (line) => {
       let req: RpcRequest;
       try {
-        req = JSON.parse(line);
+        req = JSON.parse(line) as RpcRequest;
       } catch {
         // Malformed line — caller protocol bug. Drop it; the Python
         // side will time out on its own.

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -201,7 +201,7 @@ function configPath(rootPath: string): string {
 
 function readConfig(rootPath: string): ProjectConfig | null {
   try {
-    return JSON.parse(fsSync.readFileSync(configPath(rootPath), 'utf-8'));
+    return JSON.parse(fsSync.readFileSync(configPath(rootPath), 'utf-8')) as ProjectConfig;
   } catch { return null; }
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -814,7 +814,7 @@ export function registerIpcHandlers(): void {
     try {
       const p = path.join(rootPath, '.minerva', 'formatter.json');
       const data = await fs.readFile(p, 'utf-8');
-      const parsed = JSON.parse(data);
+      const parsed = JSON.parse(data) as { enabled?: Record<string, boolean>; configs?: Record<string, unknown> };
       return {
         enabled: (parsed?.enabled && typeof parsed.enabled === 'object') ? parsed.enabled : {},
         configs: (parsed?.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
@@ -1267,7 +1267,7 @@ export function registerIpcHandlers(): void {
     try {
       const bmPath = path.join(rootPath, '.minerva', 'bookmarks.json');
       const data = await fs.readFile(bmPath, 'utf-8');
-      return JSON.parse(data);
+      return JSON.parse(data) as unknown[];
     } catch { return []; }
   });
 

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -134,7 +134,7 @@ export async function setModel(id: string, model: string | undefined): Promise<C
 export async function load(id: string): Promise<Conversation | null> {
   try {
     const data = await fs.readFile(convPath(id), 'utf-8');
-    return JSON.parse(data);
+    return JSON.parse(data) as Conversation;
   } catch {
     return null;
   }
@@ -149,7 +149,7 @@ export async function listAll(): Promise<Conversation[]> {
       if (!file.endsWith('.json')) continue;
       try {
         const data = await fs.readFile(path.join(dir, file), 'utf-8');
-        convs.push(JSON.parse(data));
+        convs.push(JSON.parse(data) as Conversation);
       } catch { /* skip malformed */ }
     }
     convs.sort((a, b) => b.startedAt.localeCompare(a.startedAt));

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -33,7 +33,7 @@ function settingsPath(): string {
 export async function getSettings(): Promise<LLMSettings> {
   try {
     const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw);
+    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
     return {
       apiKey: parsed.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '',
       model: resolveModel(parsed.model),

--- a/src/main/notebase/link-rewriting.ts
+++ b/src/main/notebase/link-rewriting.ts
@@ -28,7 +28,7 @@ export function normalizePath(p: string): string {
  */
 export function rewriteWikiLinks(content: string, rewrites: Map<string, string>): string {
   if (rewrites.size === 0) return content;
-  return content.replace(WIKI_LINK_RE, (match, inner) => {
+  return content.replace(WIKI_LINK_RE, (match: string, inner: string) => {
     const parsed = parseWikiInner(inner);
     // Typed links that target non-notes (cite/quote) are out of scope —
     // their targets are ids, not paths. Skip them.
@@ -56,7 +56,7 @@ export function rewriteTypedIdLinks(
   rewrites: Map<string, string>,
 ): string {
   if (rewrites.size === 0) return content;
-  return content.replace(WIKI_LINK_RE, (match, inner) => {
+  return content.replace(WIKI_LINK_RE, (match: string, inner: string) => {
     const parsed = parseWikiInner(inner);
     if (parsed.type !== linkTypeName) return match;
     const newId = rewrites.get(parsed.target);
@@ -78,7 +78,7 @@ export function rewriteAnchorInLinks(
   newAnchor: string,
 ): string {
   const normalizedTarget = normalizePath(targetPath);
-  return content.replace(WIKI_LINK_RE, (match, inner) => {
+  return content.replace(WIKI_LINK_RE, (match: string, inner: string) => {
     const parsed = parseWikiInner(inner);
     if (parsed.type === 'cite' || parsed.type === 'quote') return match;
     if (normalizePath(parsed.target) !== normalizedTarget) return match;

--- a/src/main/publish/pipeline.ts
+++ b/src/main/publish/pipeline.ts
@@ -210,7 +210,7 @@ function extractFrontmatter(content: string): Record<string, unknown> {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!m) return {};
   try {
-    const parsed = YAML.parse(m[1]);
+    const parsed: unknown = YAML.parse(m[1]);
     return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
   } catch {
     return {};

--- a/src/main/recent-projects.ts
+++ b/src/main/recent-projects.ts
@@ -8,7 +8,7 @@ const filePath = path.join(app.getPath('userData'), 'recent-projects.json');
 export function getRecentProjects(): string[] {
   try {
     const data = fs.readFileSync(filePath, 'utf-8');
-    return JSON.parse(data);
+    return JSON.parse(data) as string[];
   } catch {
     return [];
   }

--- a/src/main/search/minisearch-provider.ts
+++ b/src/main/search/minisearch-provider.ts
@@ -48,12 +48,12 @@ export class MiniSearchProvider implements SearchProvider {
     const limit = opts?.limit ?? 50;
     const raw = this.engine.search(query);
 
-    return raw.slice(0, limit).map((hit) => {
-      const doc = this.docs.get(hit.id as string);
+    return raw.slice(0, limit).map((hit: { id: string; title?: string; score: number }) => {
+      const doc = this.docs.get(hit.id);
       const snippet = doc ? extractSnippet(doc.content, query) : '';
       return {
-        relativePath: hit.id as string,
-        title: (hit as { title?: string }).title ?? doc?.title ?? hit.id,
+        relativePath: hit.id,
+        title: hit.title ?? doc?.title ?? hit.id,
         snippet,
         score: hit.score,
       };
@@ -76,7 +76,7 @@ export class MiniSearchProvider implements SearchProvider {
   async load(srcPath: string): Promise<void> {
     try {
       const raw = await fs.readFile(srcPath, 'utf-8');
-      const data = JSON.parse(raw);
+      const data = JSON.parse(raw) as { index: unknown; docs: Record<string, { title: string; content: string }> };
       this.engine = MiniSearch.loadJSON(JSON.stringify(data.index), {
         fields: ['title', 'content'],
         storeFields: ['title'],
@@ -84,7 +84,7 @@ export class MiniSearchProvider implements SearchProvider {
       });
       this.docs.clear();
       for (const [key, val] of Object.entries(data.docs)) {
-        this.docs.set(key, val as { title: string; content: string });
+        this.docs.set(key, val);
       }
     } catch {
       // No persisted index or corrupt — start fresh

--- a/src/main/session.ts
+++ b/src/main/session.ts
@@ -15,7 +15,7 @@ const filePath = path.join(app.getPath('userData'), 'session.json');
 export function loadSession(): WindowState[] {
   try {
     const data = fs.readFileSync(filePath, 'utf-8');
-    return JSON.parse(data);
+    return JSON.parse(data) as WindowState[];
   } catch {
     return [];
   }

--- a/src/main/sources/api-adapters/arxiv.ts
+++ b/src/main/sources/api-adapters/arxiv.ts
@@ -27,7 +27,10 @@ export async function fetchArxivMetadata(
 }
 
 export function parseArxivAtom(xml: string, arxivId: string): ArticleMetadata {
-  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  // linkedom's DOMParser is structurally compatible with the DOM `Document`
+  // type from the standard lib, but its declared return type is `any`. Cast
+  // once at the boundary so downstream queries are type-checked.
+  const doc = new DOMParser().parseFromString(xml, 'text/xml') as unknown as Document;
   const entry = doc.querySelector('entry');
   if (!entry) throw new Error(`arXiv: no <entry> in response for ${arxivId}`);
 

--- a/src/main/sources/api-adapters/pubmed.ts
+++ b/src/main/sources/api-adapters/pubmed.ts
@@ -43,7 +43,7 @@ async function fetchSummary(pmid: string, fetchImpl: typeof fetch): Promise<Pubm
   const url = `${PUBMED_SUMMARY}?db=pubmed&id=${encodeURIComponent(pmid)}&retmode=json`;
   const res = await fetchImpl(url);
   if (!res.ok) throw new Error(`PubMed esummary ${res.status}: ${res.statusText}`);
-  return await res.json();
+  return await res.json() as PubmedEsummary;
 }
 
 async function fetchAbstract(pmid: string, fetchImpl: typeof fetch): Promise<string | null> {
@@ -56,7 +56,9 @@ async function fetchAbstract(pmid: string, fetchImpl: typeof fetch): Promise<str
 
 /** Exposed for tests. */
 export function parseAbstractXml(xml: string): string | null {
-  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  // linkedom's DOMParser returns `any`; cast at the boundary so downstream
+  // queries are type-checked. (Same pattern as arxiv.ts.)
+  const doc = new DOMParser().parseFromString(xml, 'text/xml') as unknown as Document;
   const parts: string[] = [];
   for (const el of doc.querySelectorAll('AbstractText')) {
     const text = el.textContent?.trim();

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,15 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { Channels } from '../shared/channels';
 
+/**
+ * Subscribe to an IPC channel and forward the typed payload to `cb`.
+ * Centralises the unavoidable cast at the IPC boundary — the main
+ * process owns the wire shape, so each subscriber names what it expects.
+ */
+function subscribeIpc<T>(channel: string, cb: (payload: T) => void): void {
+  ipcRenderer.on(channel, (_e, payload: unknown) => cb(payload as T));
+}
+
 contextBridge.exposeInMainWorld('api', {
   notebase: {
     open: () => ipcRenderer.invoke(Channels.NOTEBASE_OPEN),
@@ -30,21 +39,12 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.NOTEBASE_COPY, srcRelPath, destRelPath),
     searchInNotes: (opts: unknown) => ipcRenderer.invoke(Channels.NOTEBASE_SEARCH_IN_NOTES, opts),
     replaceInNotes: (opts: unknown) => ipcRenderer.invoke(Channels.NOTEBASE_REPLACE_IN_NOTES, opts),
-    onFileChanged: (cb: (path: string) => void) => {
-      ipcRenderer.on(Channels.NOTEBASE_FILE_CHANGED, (_e, p) => cb(p));
-    },
-    onFileCreated: (cb: (path: string) => void) => {
-      ipcRenderer.on(Channels.NOTEBASE_FILE_CREATED, (_e, p) => cb(p));
-    },
-    onFileDeleted: (cb: (path: string) => void) => {
-      ipcRenderer.on(Channels.NOTEBASE_FILE_DELETED, (_e, p) => cb(p));
-    },
-    onRenamed: (cb: (transitions: Array<{ old: string; new: string }>) => void) => {
-      ipcRenderer.on(Channels.NOTEBASE_RENAMED, (_e, transitions) => cb(transitions));
-    },
-    onRewritten: (cb: (paths: string[]) => void) => {
-      ipcRenderer.on(Channels.NOTEBASE_REWRITTEN, (_e, paths) => cb(paths));
-    },
+    onFileChanged: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_CHANGED, cb),
+    onFileCreated: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_CREATED, cb),
+    onFileDeleted: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_DELETED, cb),
+    onRenamed: (cb: (transitions: Array<{ old: string; new: string }>) => void) =>
+      subscribeIpc(Channels.NOTEBASE_RENAMED, cb),
+    onRewritten: (cb: (paths: string[]) => void) => subscribeIpc(Channels.NOTEBASE_REWRITTEN, cb),
     onHeadingRenameSuggested: (cb: (candidate: {
       relativePath: string;
       oldSlug: string;
@@ -52,9 +52,7 @@ contextBridge.exposeInMainWorld('api', {
       newSlug: string;
       newText: string;
       incomingLinkCount: number;
-    }) => void) => {
-      ipcRenderer.on(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, (_e, c) => cb(c));
-    },
+    }) => void) => subscribeIpc(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, cb),
     renameAnchor: (targetRelativePath: string, oldSlug: string, newSlug: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_RENAME_ANCHOR, targetRelativePath, oldSlug, newSlug),
     renameSource: (oldId: string, newId: string) =>
@@ -151,9 +149,7 @@ contextBridge.exposeInMainWorld('api', {
     listActive: () => ipcRenderer.invoke(Channels.CONVERSATION_LIST_ACTIVE),
     send: (convId: string, userMessage: string, systemPrompt?: string) =>
       ipcRenderer.invoke(Channels.CONVERSATION_SEND, convId, userMessage, systemPrompt),
-    onStream: (cb: (chunk: string) => void) => {
-      ipcRenderer.on(Channels.CONVERSATION_STREAM, (_e, chunk) => cb(chunk));
-    },
+    onStream: (cb: (chunk: string) => void) => subscribeIpc(Channels.CONVERSATION_STREAM, cb),
     cancel: () => ipcRenderer.invoke(Channels.CONVERSATION_CANCEL),
     crystallize: (text: string, conversationId: string) =>
       ipcRenderer.invoke(Channels.CONVERSATION_CRYSTALLIZE, text, conversationId),
@@ -199,13 +195,11 @@ contextBridge.exposeInMainWorld('api', {
     finishPdfOcr: (sourceId: string, pages: string[]) =>
       ipcRenderer.invoke(Channels.SOURCES_FINISH_PDF_OCR, sourceId, pages),
     importBibtex: () => ipcRenderer.invoke(Channels.SOURCES_IMPORT_BIBTEX),
-    onImportBibtexProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) => {
-      ipcRenderer.on(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, (_e, progress) => cb(progress));
-    },
+    onImportBibtexProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) =>
+      subscribeIpc(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, cb),
     importZoteroRdf: () => ipcRenderer.invoke(Channels.SOURCES_IMPORT_ZOTERO_RDF),
-    onImportZoteroRdfProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) => {
-      ipcRenderer.on(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, (_e, progress) => cb(progress));
-    },
+    onImportZoteroRdfProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) =>
+      subscribeIpc(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, cb),
     listAll: () => ipcRenderer.invoke(Channels.SOURCES_LIST_ALL),
     delete: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_DELETE, sourceId),
     onChanged: (cb: () => void) => {
@@ -237,14 +231,10 @@ contextBridge.exposeInMainWorld('api', {
     execute: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_EXECUTE, request),
     prepareConversation: (request: unknown) => ipcRenderer.invoke(Channels.TOOL_PREPARE_CONVERSATION, request),
     cancel: () => ipcRenderer.invoke(Channels.TOOL_CANCEL),
-    onStream: (cb: (chunk: string) => void) => {
-      ipcRenderer.on(Channels.TOOL_STREAM, (_e, chunk) => cb(chunk));
-    },
+    onStream: (cb: (chunk: string) => void) => subscribeIpc(Channels.TOOL_STREAM, cb),
     getSettings: () => ipcRenderer.invoke(Channels.TOOL_GET_SETTINGS),
     setSettings: (settings: unknown) => ipcRenderer.invoke(Channels.TOOL_SET_SETTINGS, settings),
-    onInvoke: (cb: (toolId: string) => void) => {
-      ipcRenderer.on(Channels.TOOL_INVOKE, (_e, toolId) => cb(toolId));
-    },
+    onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
   },
   menu: {
     onNewNote: (cb: () => void) => {
@@ -301,9 +291,8 @@ contextBridge.exposeInMainWorld('api', {
     onNewQuery: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_NEW_QUERY, () => cb());
     },
-    onOpenStockQuery: (cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void) => {
-      ipcRenderer.on(Channels.MENU_OPEN_STOCK_QUERY, (_e, payload) => cb(payload));
-    },
+    onOpenStockQuery: (cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void) =>
+      subscribeIpc(Channels.MENU_OPEN_STOCK_QUERY, cb),
     onEditSavedQueries: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_EDIT_SAVED_QUERIES, () => cb());
     },
@@ -319,9 +308,7 @@ contextBridge.exposeInMainWorld('api', {
     onNewProject: (cb: () => void) => {
       ipcRenderer.on('menu:newProject', () => cb());
     },
-    onOpenRecentProject: (cb: (path: string) => void) => {
-      ipcRenderer.on('menu:openRecentProject', (_e, p) => cb(p));
-    },
+    onOpenRecentProject: (cb: (path: string) => void) => subscribeIpc('menu:openRecentProject', cb),
     onCloseProject: (cb: () => void) => {
       ipcRenderer.on('menu:closeProject', () => cb());
     },
@@ -385,18 +372,15 @@ contextBridge.exposeInMainWorld('api', {
     onIngestPdf: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_INGEST_PDF, () => cb());
     },
-    onExport: (cb: (exporterId: string) => void) => {
-      ipcRenderer.on(Channels.MENU_EXPORT, (_e, id) => cb(id));
-    },
+    onExport: (cb: (exporterId: string) => void) => subscribeIpc(Channels.MENU_EXPORT, cb),
     onImportBibtex: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_IMPORT_BIBTEX, () => cb());
     },
     onImportZoteroRdf: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_IMPORT_ZOTERO_RDF, () => cb());
     },
-    onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) => {
-      ipcRenderer.on('project:opened', (_e, meta) => cb(meta));
-    },
+    onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) =>
+      subscribeIpc('project:opened', cb),
   },
 });
 

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -677,7 +677,7 @@
     const mountedFilePath = filePath;
     return () => {
       view.scrollDOM.removeEventListener('scroll', onScroll);
-      const historySnapshot = view.state.toJSON({ history: historyField });
+      const historySnapshot = view.state.toJSON({ history: historyField }) as Record<string, unknown>;
       onEditorStateSave?.(
         mountedFilePath,
         view.state.selection.main.head,

--- a/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
@@ -64,14 +64,14 @@
 <div class="links-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find mention…"
     sortOptions={[
       { id: 'type', label: 'By type' },
       { id: 'title', label: 'Alphabetical' },
     ]}
     {sortId}
-    onSort={(id) => { sortId = id as 'type' | 'title'; }}
+    onSort={(id: string) => { sortId = id as 'type' | 'title'; }}
     onExpandAll={sortId === 'type' ? expandAll : undefined}
     onCollapseAll={sortId === 'type' ? collapseAll : undefined}
   />

--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -110,7 +110,7 @@
 <div class="bookmarks-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find bookmark…"
     onExpandAll={expandAll}
     onCollapseAll={collapseAll}

--- a/src/renderer/lib/components/right-sidebar/CitationsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/CitationsPanel.svelte
@@ -81,7 +81,7 @@
 <div class="cite-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find citation…"
     sortOptions={[
       { id: 'document', label: 'Document order' },
@@ -89,7 +89,7 @@
       { id: 'kind', label: 'By kind' },
     ]}
     {sortId}
-    onSort={(id) => { sortId = id as 'document' | 'alpha' | 'kind'; }}
+    onSort={(id: string) => { sortId = id as 'document' | 'alpha' | 'kind'; }}
   />
   <div class="scroll">
     {#if entries().length === 0}

--- a/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
@@ -81,14 +81,14 @@
 <div class="inspections-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find inspection…"
     sortOptions={[
       { id: 'severity', label: 'By severity' },
       { id: 'type', label: 'By type' },
     ]}
     {sortId}
-    onSort={(id) => { sortId = id as 'severity' | 'type'; }}
+    onSort={(id: string) => { sortId = id as 'severity' | 'type'; }}
   />
   <div class="panel-header">
     <span class="count">

--- a/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
@@ -67,14 +67,14 @@
 <div class="links-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find link…"
     sortOptions={[
       { id: 'type', label: 'By type' },
       { id: 'title', label: 'Alphabetical' },
     ]}
     {sortId}
-    onSort={(id) => { sortId = id as 'type' | 'title'; }}
+    onSort={(id: string) => { sortId = id as 'type' | 'title'; }}
     onExpandAll={sortId === 'type' ? expandAll : undefined}
     onCollapseAll={sortId === 'type' ? collapseAll : undefined}
   />

--- a/src/renderer/lib/components/right-sidebar/OutlinePanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutlinePanel.svelte
@@ -71,7 +71,7 @@
 <div class="outline-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find heading…"
     onExpandAll={expandAll}
     onCollapseAll={collapseAll}

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -82,14 +82,14 @@
 <div class="proposals-panel" onkeydown={handleKeydown} tabindex="-1">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find proposal…"
     sortOptions={[
       { id: 'time', label: 'Newest first' },
       { id: 'type', label: 'By type' },
     ]}
     {sortId}
-    onSort={(id) => { sortId = id as 'time' | 'type'; }}
+    onSort={(id: string) => { sortId = id as 'time' | 'type'; }}
   />
   {#if shown().length === 0}
     <p class="empty">{proposals.length === 0 ? 'No pending proposals' : 'No matches'}</p>

--- a/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
@@ -68,7 +68,7 @@
 <div class="tables-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find table…"
   />
   <div class="scroll">

--- a/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
@@ -45,7 +45,7 @@
 <div class="tags-panel">
   <Ribbon
     {search}
-    onSearch={(q) => { search = q; }}
+    onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find tag…"
   />
   {#if tags().length === 0}

--- a/src/renderer/lib/refactor/settings.ts
+++ b/src/renderer/lib/refactor/settings.ts
@@ -66,7 +66,7 @@ function readFromStorage(): RefactorSettings {
     if (typeof localStorage === 'undefined') return { ...DEFAULT_REFACTOR_SETTINGS };
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULT_REFACTOR_SETTINGS };
-    const parsed = JSON.parse(raw);
+    const parsed = JSON.parse(raw) as Partial<RefactorSettings> | null;
     if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_REFACTOR_SETTINGS };
     return { ...DEFAULT_REFACTOR_SETTINGS, ...parsed };
   } catch {

--- a/src/shared/formatter/parse-cache.ts
+++ b/src/shared/formatter/parse-cache.ts
@@ -152,7 +152,8 @@ function findMath(content: string): Range[] {
   // Inline math: single `$...$`. Skip anything already inside a block match.
   const inlineRe = /\$[^\n$]+?\$/g;
   while ((m = inlineRe.exec(content)) !== null) {
-    const inside = out.some((r) => m!.index >= r.start && m!.index < r.end);
+    const idx = m.index;
+    const inside = out.some((r) => idx >= r.start && idx < r.end);
     if (inside) continue;
     out.push({ start: m.index, end: m.index + m[0].length });
   }

--- a/src/shared/formatter/rules/footnote/re-index-footnotes.ts
+++ b/src/shared/formatter/rules/footnote/re-index-footnotes.ts
@@ -36,11 +36,11 @@ function reindex(seg: string): string {
   const mapping = new Map<string, string>();
   order.forEach((oldName, i) => mapping.set(oldName, String(i + 1)));
 
-  const rewrittenRefs = seg.replace(REF_RE, (match, open, name, close) => {
+  const rewrittenRefs = seg.replace(REF_RE, (match: string, open: string, name: string, close: string) => {
     const next = mapping.get(name);
     return next ? `${open}${next}${close}` : match;
   });
-  return rewrittenRefs.replace(DEF_RE, (match, open, name, close) => {
+  return rewrittenRefs.replace(DEF_RE, (match: string, open: string, name: string, close: string) => {
     const next = mapping.get(name);
     return next ? `${open}${next}${close}` : match;
   });


### PR DESCRIPTION
## Summary
Took the no-unsafe-* family from **307 → 160 sites** without yet enabling the rules — sets the stage for a final promote-to-error PR once App.svelte / Preview.svelte are typed.

## Where the wins came from
- **\`api-adapters/arxiv.ts\` (53 sites → 0)**: cast linkedom's \`parseFromString\` return to the standard DOM \`Document\` type at the boundary. Downstream Element queries type-check.
- **\`api-adapters/pubmed.ts\` (8 sites → 0)**: same Document cast + typed JSON parse.
- **\`preload.ts\` (15 sites → 0)**: introduced \`subscribeIpc<T>(channel, cb)\` to centralise the unavoidable cast at the IPC payload boundary; converted every \`ipcRenderer.on(...)\` site to use it. Each subscriber names what it expects.
- **Right-sidebar Ribbon callsites (9 sites)**: annotated inline \`(q) => …\` / \`(id) => …\` callbacks as \`(q: string)\` etc. — svelte-eslint-parser doesn't propagate prop types into Svelte attribute callbacks.
- **Misc per-file fixes**: typed JSON.parse boundaries in \`settings.ts\`, \`search/minisearch-provider.ts\`, \`conversation.ts\`, \`refactor/settings.ts\`, \`graph/index.ts\`, \`recent-projects.ts\`, \`session.ts\`, \`compute/{python-kernel,rpc-server}.ts\`, \`ipc.ts\`, \`publish/pipeline.ts\`. Typed \`String.prototype.replace\` callbacks in \`link-rewriting.ts\` + \`re-index-footnotes.ts\`.
- **Tests**: added \`no-unsafe-*\` to the existing \`tests/**/*.ts\` override block. Tests legitimately reach into \`unknown\` shapes without re-typing every field.

## Why the rules stay off
160 sites remain, concentrated in:
- App.svelte (119)
- Preview.svelte (17)
- ConversationDialog (7)
- Sidebar (6)
- StatusBar (6)
- handful of singletons

Each is a real typing project (App.svelte's 119 are mostly IPC-result destructuring). Once those land the rule promotion is one config flip.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 22 warnings — unrelated unused-vars)
- [x] \`pnpm test\` — 1587 passed
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)