### PR TITLE
ci: add GitHub Actions running pnpm lint && pnpm test (closes #340)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+# CI for Minerva (#340).
+#
+# Runs `pnpm lint && pnpm test` on every push to main and on every pull
+# request. macOS runner per the issue: matches the dev machine, and the
+# chokidar watcher tests (#345) exercise macOS fsevents semantics — a
+# Linux runner would need different timing tolerances.
+#
+# No matrix: single Node + pnpm pinned to whatever the lockfile expects.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-flight runs when a new commit lands on the same branch — saves
+# minutes on a busy PR.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    runs-on: macos-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # Match the local dev version. Bump together with the dev's pnpm.
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (tsc + svelte-check + eslint)
+        run: pnpm lint
+
+      - name: Test
+        # `pnpm test` runs vitest in watch mode by default; force a single
+        # run for CI. Same effect as the local `pnpm coverage` minus the
+        # report.
+        run: pnpm exec vitest run


### PR DESCRIPTION
## Summary
Single \`.github/workflows/ci.yml\` running on every push to main and every PR. Cited as a P1 by the architecture, QA, and modernization reviews — local \`pnpm lint && pnpm test\` was the only gate.

## Workflow shape
- **macos-latest** — matches the dev machine. The chokidar watcher tests (#345) exercise macOS fsevents semantics that would need different timing tolerances on Linux; sticking to mac avoids per-platform fork in the test code.
- **pnpm 10 + Node 24** with pnpm-store cache via \`actions/setup-node\`'s built-in \`cache: pnpm\`.
- **Steps**: \`pnpm install --frozen-lockfile\` → \`pnpm lint\` → \`pnpm exec vitest run\`.
- **Concurrency**: in-flight runs on the same branch get cancelled when a new commit lands — saves minutes on PR iterations.
- **20-minute job timeout**.

## Non-goals (per the issue)
- No matrix across Node versions.
- No auto-release / changelog.
- Branch protection — left as a manual one-time setting in the GitHub UI.

## Test plan
- [x] \`pnpm lint\` clean locally
- [x] \`pnpm exec vitest run\` — 1587 passed locally
- [ ] First CI run (will appear on this PR once it lands; anything failing on macos-latest that I can't reproduce locally goes back into a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)