### PR TITLE
lint: clean 22 unused-vars + promote rule to error (closes #401)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,7 +60,9 @@ export default tseslint.config(
       // Unused-vars/imports as warnings, with the standard `_`-prefix
       // escape hatch so tests/handlers can name args they intentionally
       // ignore.
-      '@typescript-eslint/no-unused-vars': ['warn', {
+      // Promoted to `error` after #401 swept the existing 22 sites —
+      // fresh dead imports/vars now fail the build.
+      '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_',

--- a/src/main/git/index.ts
+++ b/src/main/git/index.ts
@@ -1,6 +1,5 @@
 import git from 'isomorphic-git';
 import fs from 'node:fs';
-import path from 'node:path';
 
 export interface GitFileStatus {
   filepath: string;

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -3,7 +3,6 @@ import { QueryEngine } from '@comunica/query-sparql-rdfjs';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 import { parseMarkdown, type ParsedTable, type FrontmatterValue } from './parser';
 import { getLinkType, type LinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
@@ -107,12 +106,6 @@ const states = new Map<string, GraphState>();
 
 function getState(ctx: ProjectContext): GraphState | null {
   return states.get(ctx.rootPath) ?? null;
-}
-
-function requireState(ctx: ProjectContext): GraphState {
-  const s = states.get(ctx.rootPath);
-  if (!s) throw new Error(`graph: no state for project "${ctx.rootPath}"`);
-  return s;
 }
 
 function invalidate(state: GraphState): void {
@@ -1338,10 +1331,6 @@ async function walkAndIndexExcerpts(ctx: ProjectContext, rootPath: string): Prom
 }
 
 // ── Query ───────────────────────────────────────────────────────────────────
-
-const SPARQL_PREFIXES = STANDARD_PREFIXES
-  .map(([prefix, iri]) => `PREFIX ${prefix}: <${iri}>`)
-  .join('\n') + '\n';
 
 export function injectSparqlPrefixes(sparql: string): string {
   // Only inject prefixes the user hasn't already declared. SPARQL's

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, shell, app, dialog, BrowserWindow } from 'electron';
+import { Menu, shell, dialog, BrowserWindow } from 'electron';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { getRecentProjects } from './recent-projects';

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -1,5 +1,4 @@
 import { BrowserWindow } from 'electron';
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { startWatching, stopWatching } from './notebase/watcher';

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1220,10 +1220,11 @@
     }
   }
 
-  async function openConversationWithMessage(message: string) {
+  async function openConversationWithMessage(_message: string) {
     await openConversation();
-    // The conversation is now open; set the input to the message
-    // The user can review and send it
+    // TODO: actually thread `_message` into the dialog input. The
+    // call site exists, the wiring through ConversationDialog
+    // doesn't yet.
   }
 
   async function openConversation() {

--- a/src/renderer/lib/components/AutoLinkInboundDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkInboundDialog.svelte
@@ -38,10 +38,6 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') onCancel();
   }
-
-  function stemOf(p: string): string {
-    return p.replace(/\.md$/i, '');
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -23,7 +23,7 @@
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
-  import { computeCellsExtension, computeCellsStyles } from '../editor/compute-cells';
+  import { computeCellsExtension } from '../editor/compute-cells';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
   import { clampMenuToViewport } from '../utils/menuClamp';

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -9,7 +9,7 @@
   } from '../appearance/settings';
   import { getThemeMode, setThemeMode, type ThemeMode } from '../theme';
   import { api } from '../ipc/client';
-  import type { LLMSettings, WebSettings } from '../../../shared/tools/types';
+  import type { LLMSettings } from '../../../shared/tools/types';
   import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
   import { CONFIRM_REGISTRY, confirmRegistryEntry } from '../confirm-keys';
   import {
@@ -27,7 +27,6 @@
     CATEGORY_ORDER,
   } from '../../../shared/formatter/registry';
   import '../../../shared/formatter/rules/index';
-  import type { FormatterRule } from '../../../shared/formatter/types';
   import type { FormatSettings } from '../../../shared/formatter/engine';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
   import { getAllToolInfos } from '../tools/tool-registry';

--- a/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
@@ -10,7 +10,6 @@
    * when a fence references a table the CSV watcher hasn't picked up.
    */
   import { api } from '../../ipc/client';
-  import type { TableInfo } from '../../ipc/client';
   import Ribbon from './Ribbon.svelte';
 
   interface Props {

--- a/src/renderer/lib/stores/conversation.svelte.ts
+++ b/src/renderer/lib/stores/conversation.svelte.ts
@@ -1,5 +1,5 @@
 import { api } from '../ipc/client';
-import type { Conversation, ContextBundle, ConversationMessage } from '../../../shared/types';
+import type { Conversation, ContextBundle } from '../../../shared/types';
 
 let activeConversation = $state<Conversation | null>(null);
 let allConversations = $state<Conversation[]>([]);

--- a/src/shared/formatter/parse-cache.ts
+++ b/src/shared/formatter/parse-cache.ts
@@ -67,7 +67,6 @@ function findFencedCodeBlocks(content: string): Range[] {
   const out: Range[] = [];
   const lines = splitLines(content);
   let i = 0;
-  let offset = 0;
   const lineOffsets: number[] = [];
   // Pre-compute line start offsets for range math.
   {
@@ -83,7 +82,6 @@ function findFencedCodeBlocks(content: string): Range[] {
     const line = lines[i];
     const fenceMatch = /^[ \t]{0,3}(`{3,}|~{3,})/.exec(line);
     if (!fenceMatch) {
-      offset += line.length;
       i++;
       continue;
     }
@@ -100,7 +98,6 @@ function findFencedCodeBlocks(content: string): Range[] {
     const blockEnd = j < lines.length ? lineOffsets[j] : lineOffsets[lines.length];
     out.push({ start: blockStart, end: blockEnd });
     i = j;
-    offset = lineOffsets[j] ?? content.length;
   }
   return out;
 }

--- a/src/shared/sparql-format.ts
+++ b/src/shared/sparql-format.ts
@@ -211,12 +211,6 @@ function tokenize(src: string): Token[] {
 
 // ── Emitter ──────────────────────────────────────────────────────────────
 
-function isKeyword(tok: Token, ...names: string[]): boolean {
-  if (tok.type !== 'word') return false;
-  const upper = tok.text.toUpperCase();
-  return names.includes(upper);
-}
-
 function emit(tokens: Token[]): string {
   let out = '';
   let line = '';
@@ -231,18 +225,6 @@ function emit(tokens: Token[]): string {
     lastFlushedFirstWord = (line.trimStart().split(/\s+/, 1)[0] ?? '').toUpperCase();
     out += line.trimEnd() + '\n';
     line = '';
-  }
-
-  function startLine(extraIndent = 0) {
-    flush();
-    line = '  '.repeat(depth + extraIndent);
-  }
-
-  function appendToken(tokText: string, glue: 'space' | 'none' = 'space') {
-    if (line.length > 0 && line.trimEnd() === line && glue === 'space') {
-      line += ' ';
-    }
-    line += tokText;
   }
 
   // Top-level loop.

--- a/tests/main/compute/python-kernel.test.ts
+++ b/tests/main/compute/python-kernel.test.ts
@@ -7,7 +7,7 @@
  * doesn't have Python on PATH.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { execSync } from 'node:child_process';
 import {
   runPython,

--- a/tests/main/compute/python-library.test.ts
+++ b/tests/main/compute/python-library.test.ts
@@ -21,7 +21,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { runPython, shutdownAllKernels, stopKernel } from '../../../src/main/compute/python-kernel';
 import { initGraph, indexNote } from '../../../src/main/graph/index';
-import { initSearch, indexNote as searchIndex } from '../../../src/main/search/index';
+import { initSearch } from '../../../src/main/search/index';
 import { initTablesDb } from '../../../src/main/sources/tables';
 import { projectContext } from '../../../src/main/project-context-types';
 

--- a/tests/main/graph/excerpt-ontology.test.ts
+++ b/tests/main/graph/excerpt-ontology.test.ts
@@ -7,7 +7,6 @@ const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
 const RDF = $rdf.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
 const RDFS = $rdf.Namespace('http://www.w3.org/2000/01/rdf-schema#');
 const OWL = $rdf.Namespace('http://www.w3.org/2002/07/owl#');
-const DC = $rdf.Namespace('http://purl.org/dc/terms/');
 const XSD = $rdf.Namespace('http://www.w3.org/2001/XMLSchema#');
 
 const ONTOLOGY_PATH = path.join(__dirname, '../../../src/shared/ontology-thought.ttl');

--- a/tests/main/graph/write-guard.test.ts
+++ b/tests/main/graph/write-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { enterLLMContext, exitLLMContext, isInLLMContext } from '../../../src/main/graph/index';
 
 describe('LLM write guard', () => {

--- a/tests/main/notebase/rename-source-excerpt.test.ts
+++ b/tests/main/notebase/rename-source-excerpt.test.ts
@@ -4,7 +4,6 @@ import path from 'node:path';
 import os from 'node:os';
 import {
   initGraph,
-  indexNote,
   indexAllNotes,
   findNotesCitingSource,
   findNotesQuotingExcerpt,


### PR DESCRIPTION
## Summary
Closes #401 — was P2 #3.8 in the 2026-04-26 quality review. All 22 sites swept; \`pnpm exec eslint .\` now produces no output. Promoted \`@typescript-eslint/no-unused-vars\` from \`warn\` to \`error\` so fresh dead imports/vars fail the build.

## Cleanup pattern
- **Pure dead imports** (most of them): deleted from the import line or whole import statement.
- **Dead helpers** that no caller still references (after prior refactors): \`requireState\` in \`graph/index.ts\`, \`SPARQL_PREFIXES\` constant, \`stemOf\` in AutoLinkInboundDialog, \`isKeyword\`/\`startLine\`/\`appendToken\` in sparql-format.
- **One intentional unused arg**: \`openConversationWithMessage(message)\` in App.svelte is a wired-up call site whose threading into ConversationDialog isn't done yet — prefixed with \`_message\` and tagged with a TODO.

## Files touched
- \`src/main/{git,graph,menu,window-manager}\`
- \`src/renderer/App.svelte\`, \`Editor.svelte\`, \`SettingsDialog.svelte\`, \`AutoLinkInboundDialog.svelte\`, \`TablesPanel.svelte\`, \`stores/conversation.svelte.ts\`
- \`src/shared/{formatter/parse-cache,sparql-format}.ts\`
- \`tests/main/{compute/python-kernel,compute/python-library,graph/excerpt-ontology,graph/write-guard,notebase/rename-source-excerpt}.test.ts\`
- \`eslint.config.mjs\` — \`warn\` → \`error\` for the rule

## Test plan
- [x] \`pnpm lint\` exit 0; \`pnpm exec eslint .\` zero output
- [x] \`pnpm test\` — 1623 passed
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)