### PR TITLE
tests: menu accelerator-collision check (closes #398)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -23,7 +23,7 @@ export function buildMenu(_win?: BrowserWindow): void {
   rebuildMenu();
 }
 
-export function rebuildMenu(): void {
+export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
   const isMac = process.platform === 'darwin';
   const recentProjects = getRecentProjects();
   // Enablement gate: most editor / ingest / graph operations require an
@@ -609,4 +609,41 @@ export function rebuildMenu(): void {
 
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
+  return template;
+}
+
+/**
+ * Walk a menu template tree and collect every accelerator under each
+ * top-level menu. Returns a Map keyed by top-level menu label. Pure;
+ * no Electron runtime dependency. Used by the accelerator-collision
+ * test (#398).
+ */
+export function collectAcceleratorsByMenu(
+  template: Electron.MenuItemConstructorOptions[],
+): Map<string, Array<{ accelerator: string; path: string[] }>> {
+  const out = new Map<string, Array<{ accelerator: string; path: string[] }>>();
+  for (const top of template) {
+    const topLabel = String(top.label ?? top.role ?? '(unnamed)');
+    const found: Array<{ accelerator: string; path: string[] }> = [];
+    walkInto(top, [topLabel], found);
+    if (found.length > 0) out.set(topLabel, found);
+  }
+  return out;
+}
+
+function walkInto(
+  item: Electron.MenuItemConstructorOptions,
+  path: string[],
+  out: Array<{ accelerator: string; path: string[] }>,
+): void {
+  if (typeof item.accelerator === 'string') {
+    out.push({ accelerator: item.accelerator, path });
+  }
+  const sub = item.submenu;
+  if (Array.isArray(sub)) {
+    for (const child of sub) {
+      const childLabel = String(child.label ?? child.role ?? '(unnamed)');
+      walkInto(child, [...path, childLabel], out);
+    }
+  }
 }

--- a/tests/main/menu-accelerators.test.ts
+++ b/tests/main/menu-accelerators.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Menu accelerator-collision check (#398).
+ *
+ * The cheapest valuable menu test: build the application menu
+ * template, walk it, assert that no two items inside the same
+ * top-level menu share an accelerator. CodeMirror's keymap is
+ * separately tested; this catches the menu-side half of the cross-
+ * keymap collision risk by at least flagging within-menu duplicates,
+ * which would render the second item's accelerator dead.
+ *
+ * Mocks the entire Electron + project-state surface that menu.ts
+ * pulls in — the production code queries focused-window state, recent
+ * projects, saved queries, etc. at template-build time, and we don't
+ * care about any of that for the accelerator walk.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
+
+// ── Electron + project-state mocks ───────────────────────────────────────
+//
+// menu.ts imports BrowserWindow / Menu / shell / dialog / app from
+// 'electron' plus a half-dozen project modules at top level. The
+// template-build then queries them at call time. Stub each with the
+// thinnest shape the build path actually touches.
+
+vi.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: (t: unknown) => t,
+    setApplicationMenu: () => undefined,
+  },
+  BrowserWindow: {
+    getFocusedWindow: () => null,
+    getAllWindows: () => [],
+    fromId: () => null,
+  },
+  shell: { openExternal: () => Promise.resolve() },
+  dialog: {},
+  app: { getPath: () => os.tmpdir() },
+}));
+
+vi.mock('../../src/main/recent-projects', () => ({
+  getRecentProjects: () => [],
+  clearRecentProjects: () => undefined,
+}));
+
+vi.mock('../../src/main/window-manager', () => ({
+  createWindow: () => ({ webContents: { once: () => undefined, send: () => undefined } }),
+  openProjectInWindow: async () => undefined,
+  getRootPath: () => null,
+}));
+
+vi.mock('../../src/main/graph/index', () => ({ exportGraph: async () => undefined }));
+vi.mock('../../src/main/project-context-types', () => ({ projectContext: () => ({}) }));
+vi.mock('../../src/main/search/index', () => ({}));
+vi.mock('../../src/main/sources/tables', () => ({}));
+vi.mock('../../src/main/saved-queries', () => ({ listSavedQueries: () => [] }));
+vi.mock('../../src/main/compute/python-kernel', () => ({ restartKernel: () => undefined }));
+vi.mock('../../src/main/publish', () => ({
+  listExporters: () => [],
+}));
+
+// ── The actual test ──────────────────────────────────────────────────────
+
+import { rebuildMenu, collectAcceleratorsByMenu } from '../../src/main/menu';
+
+describe('collectAcceleratorsByMenu (#398)', () => {
+  it('returns empty for an empty template', () => {
+    expect(collectAcceleratorsByMenu([])).toEqual(new Map());
+  });
+
+  it('skips top-level menus that have no accelerators', () => {
+    const map = collectAcceleratorsByMenu([
+      { label: 'Help', submenu: [{ label: 'About' /* no accelerator */ }] },
+    ]);
+    expect(map.size).toBe(0);
+  });
+
+  it('collects accelerators per top-level menu, with the path', () => {
+    const map = collectAcceleratorsByMenu([
+      {
+        label: 'File',
+        submenu: [
+          { label: 'New', accelerator: 'CmdOrCtrl+N' },
+          { label: 'Open', accelerator: 'CmdOrCtrl+O' },
+        ],
+      },
+      {
+        label: 'Edit',
+        submenu: [
+          { label: 'Copy', accelerator: 'CmdOrCtrl+C' },
+        ],
+      },
+    ]);
+    expect(map.get('File')?.map((e) => e.accelerator).sort())
+      .toEqual(['CmdOrCtrl+N', 'CmdOrCtrl+O']);
+    expect(map.get('Edit')?.map((e) => e.accelerator)).toEqual(['CmdOrCtrl+C']);
+    expect(map.get('File')?.[0].path).toEqual(['File', 'New']);
+  });
+
+  it('descends into nested submenus', () => {
+    const map = collectAcceleratorsByMenu([
+      {
+        label: 'View',
+        submenu: [
+          {
+            label: 'Theme',
+            submenu: [
+              { label: 'Light', accelerator: 'CmdOrCtrl+1' },
+              { label: 'Dark', accelerator: 'CmdOrCtrl+2' },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(map.get('View')?.map((e) => e.accelerator)).toEqual(['CmdOrCtrl+1', 'CmdOrCtrl+2']);
+    expect(map.get('View')?.[0].path).toEqual(['View', 'Theme', 'Light']);
+  });
+});
+
+describe('production menu has no within-menu accelerator collisions (#398)', () => {
+  it('every top-level menu uses each accelerator at most once', () => {
+    const template = rebuildMenu();
+    const byMenu = collectAcceleratorsByMenu(template);
+    const collisions: string[] = [];
+    for (const [menuLabel, entries] of byMenu) {
+      const seen = new Map<string, string[][]>();
+      for (const { accelerator, path } of entries) {
+        const list = seen.get(accelerator) ?? [];
+        list.push(path);
+        seen.set(accelerator, list);
+      }
+      for (const [acc, paths] of seen) {
+        if (paths.length > 1) {
+          collisions.push(
+            `${menuLabel} ▸ ${acc} fires for ${paths.length} items: ${paths.map((p) => p.join(' › ')).join(' | ')}`,
+          );
+        }
+      }
+    }
+    expect(collisions, collisions.join('\n')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #398 — was P1 #3.5 in the 2026-04-26 quality review. \`menu.ts\` (612 LOC) had no tests; the realistic risk is two items inside the same top-level menu sharing an accelerator — the second item's accelerator is silently dead and the bug only surfaces when the user tries to use it.

## Changes
1. **\`menu.ts\`**: \`rebuildMenu()\` now also *returns* the built template (no functional change — still calls \`Menu.setApplicationMenu\`) so it's inspectable from a test. Adds a small pure helper \`collectAcceleratorsByMenu(template)\` that walks the tree and returns each accelerator under its top-level menu, with the path.

2. **\`tests/main/menu-accelerators.test.ts\`**: 5 cases.
   - Covers the walker in isolation (empty template, no-accelerator menus, simple collection, nested submenus).
   - One end-to-end check that imports \`menu.ts\` with electron + window-manager + recent-projects + saved-queries + publish + python-kernel mocked, calls \`rebuildMenu()\`, and asserts no within-menu accelerator collisions.

## Why the mocks are wide
\`menu.ts\` queries focused-window state, recent projects, saved queries, exporters etc. at template-build time. The mocks are contained to this one test file.

The CodeMirror-keymap side of the cross-keymap risk is already covered by \`tests/renderer/editor/commands.test.ts\`; this closes the menu side.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 0 warnings)
- [x] \`pnpm test\` — 1628 passed (+5 new)
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)