### PR TITLE
tests: assertSafePath guard-call coverage (closes #397)

### DIFF
--- a/tests/main/notebase/assert-safe-path-coverage.test.ts
+++ b/tests/main/notebase/assert-safe-path-coverage.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Path-traversal guard coverage (#397).
+ *
+ * The bug-shaped concern is "a file/folder mutation handler forgets
+ * to validate its path argument and lets the renderer escape the
+ * project root." Existing coverage:
+ *
+ * - `tests/main/notebase/fs.test.ts` covers `assertSafePath` in
+ *   isolation (the rules it enforces).
+ *
+ * What was missing: a check that the wrapper functions exposed by
+ * `notebaseFs` (which is what every IPC handler calls) actually go
+ * through `assertSafePath`, AND a check that the path-taking IPC
+ * handlers route through those wrappers (rather than reaching past
+ * them to raw `fs.*`).
+ *
+ * Two tests close the gap:
+ *
+ * 1. **Wrappers**: spy on `assertSafePath`, invoke each
+ *    notebaseFs.<mutation> against a temp project, assert the spy
+ *    fired with the right (rootPath, relativePath) pair.
+ *
+ * 2. **Handlers**: the IPC handlers in `src/main/ipc.ts` for
+ *    path-taking mutation channels are listed here by name; each
+ *    line range in the source must reference one of the known-safe
+ *    sinks (notebaseFs.<x>, writeAndReindex, renameWithLinkRewrites,
+ *    drop-import). A handler that bypasses those would fail this
+ *    static check before the path-traversal regression hit
+ *    production.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import * as notebaseFs from '../../../src/main/notebase/fs';
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-asp-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+// Note: a direct vi.spyOn(notebaseFs, 'assertSafePath') doesn't
+// intercept module-internal calls because of how vitest binds ESM
+// exports. The traversal-rejection tests below are equivalent: a
+// traversal can only be rejected by assertSafePath, so passing them
+// proves the guard fires inside every mutation function.
+
+describe('every notebaseFs mutation rejects a traversal-style path (#397)', () => {
+  it.each([
+    ['writeFile', () => notebaseFs.writeFile(root, '../escape.md', 'x')],
+    ['createFile', () => notebaseFs.createFile(root, '../escape.md')],
+    ['deleteFile', () => notebaseFs.deleteFile(root, '../escape.md')],
+    ['createFolder', () => notebaseFs.createFolder(root, '../escape')],
+    ['deleteFolder', () => notebaseFs.deleteFolder(root, '../escape')],
+    ['rename (old)', () => notebaseFs.rename(root, '../escape.md', 'fine.md')],
+    ['rename (new)', () => notebaseFs.rename(root, 'fine.md', '../escape.md')],
+    ['copyItem (src)', () => notebaseFs.copyItem(root, '../escape.md', 'fine.md')],
+    ['copyItem (dest)', () => notebaseFs.copyItem(root, 'fine.md', '../escape.md')],
+  ])('%s throws Path traversal', async (_, op) => {
+    await expect(op()).rejects.toThrow('Path traversal');
+  });
+});
+
+describe('IPC handlers route path args through a known-safe sink (#397)', () => {
+  // Static check: read ipc.ts source, locate each path-taking IPC
+  // handler block, and assert its body contains a call to a
+  // known-safe sink. A new handler that goes straight to fs.promises
+  // (skipping notebaseFs / writeAndReindex / renameWithLinkRewrites
+  // / drop-import) fails this check.
+  const ipcSource = fs.readFileSync(
+    path.join(__dirname, '../../../src/main/ipc.ts'),
+    'utf-8',
+  );
+
+  // Each entry: a Channel constant whose handler must call one of
+  // the sinks below. The right-hand list is the ALLOWLIST — at
+  // least one must appear inside the handler's body.
+  const SAFE_SINKS = [
+    'notebaseFs.',           // any notebaseFs.* export — they all gate on assertSafePath
+    'writeAndReindex',       // wrapper around notebaseFs.writeFile (#341)
+    'renameWithLinkRewrites', // wrapper around notebaseFs.rename
+    'renameAnchor',          // notebaseFs-backed (#341 anchor variant)
+    'renameSource',          // notebase/rename-source-excerpt — also gates paths
+    'renameExcerpt',         // notebase/rename-source-excerpt
+    'dropImport',            // src/main/notebase/drop-import — calls assertSafePath itself
+  ] as const;
+
+  const PATH_TAKING_CHANNELS = [
+    'NOTEBASE_WRITE_FILE',
+    'NOTEBASE_CREATE_FILE',
+    'NOTEBASE_DELETE_FILE',
+    'NOTEBASE_CREATE_FOLDER',
+    'NOTEBASE_DELETE_FOLDER',
+    'NOTEBASE_RENAME',
+    'NOTEBASE_RENAME_SOURCE',
+    'NOTEBASE_RENAME_EXCERPT',
+    'NOTEBASE_COPY',
+    'FILES_DROP_IMPORT',
+  ] as const;
+
+  /** Find a handler block by its `Channels.X` ref and return the
+   *  text from the call open to its matching closing brace. */
+  function handlerBody(source: string, channelConst: string): string | null {
+    const startMarker = `Channels.${channelConst}`;
+    const idx = source.indexOf(startMarker);
+    if (idx < 0) return null;
+    // The handler block is `ipcMain.handle(Channels.X, async (...) => { … });`.
+    // Find the body open after the channel ref.
+    const arrowIdx = source.indexOf('=>', idx);
+    if (arrowIdx < 0) return null;
+    const braceIdx = source.indexOf('{', arrowIdx);
+    if (braceIdx < 0) return null;
+    let depth = 1;
+    let i = braceIdx + 1;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+      i++;
+    }
+    return source.slice(braceIdx, i);
+  }
+
+  it.each(PATH_TAKING_CHANNELS)('%s handler routes through a known-safe sink', (channel) => {
+    const body = handlerBody(ipcSource, channel);
+    expect(body, `Channels.${channel} handler not found in ipc.ts`).not.toBeNull();
+    const ok = SAFE_SINKS.some((sink) => body!.includes(sink));
+    expect(ok, `Channels.${channel} doesn't reference any of: ${SAFE_SINKS.join(', ')}`).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #397 — was P1 #3.4 in the 2026-04-26 quality review. The bug-shaped concern: a file/folder mutation handler forgets to validate its path argument and lets the renderer escape the project root. Existing coverage tested \`assertSafePath\` itself in isolation; nothing tested that the wrappers and the IPC handlers actually invoke it.

## Two-layer test (19 cases in \`tests/main/notebase/assert-safe-path-coverage.test.ts\`)

### Layer 1: every \`notebaseFs.<mutation>\` rejects \`../escape\`
The only path inside any wrapper that throws \`"Path traversal"\` is \`assertSafePath\`, so passing this proves each mutation calls the guard. Covers \`writeFile\`, \`createFile\`, \`deleteFile\`, \`createFolder\`, \`deleteFolder\`, \`rename\` (both args), \`copyItem\` (both args).

### Layer 2: every path-taking IPC handler routes through a known-safe sink
Static check over \`src/main/ipc.ts\`: locate each \`Channels.<X>\` handler block by brace-matching, assert its body references at least one of: \`notebaseFs.*\`, \`writeAndReindex\`, \`renameWithLinkRewrites\`, \`renameAnchor\`, \`renameSource\`, \`renameExcerpt\`, \`dropImport\`. A new handler that reaches past these to raw \`fs.promises\` fails this check **before** the path-traversal regression hits production.

Covers the 10 path-taking channels: \`NOTEBASE_WRITE_FILE\`, \`_CREATE_FILE\`, \`_DELETE_FILE\`, \`_CREATE_FOLDER\`, \`_DELETE_FOLDER\`, \`_RENAME\`, \`_RENAME_SOURCE\`, \`_RENAME_EXCERPT\`, \`_COPY\`, \`FILES_DROP_IMPORT\`.

## Note on test strategy
\`vi.spyOn(notebaseFs, 'assertSafePath')\` doesn't intercept module-internal calls because of how vitest binds ESM exports — internal callers reference the local function ref, not the export. The rejection test is the actual mechanism: equivalent guarantee without the mocking gymnastics.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 0 warnings)
- [x] \`pnpm test\` — 1647 passed (+19 new)
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)