### PR TITLE
tests: Svelte component wedge — OcrProgressDialog (closes #396)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@testing-library/svelte": "^5.3.1",
     "@types/katex": "^0.16.8",
     "@types/markdown-it": "^14.1.2",
     "@types/n3": "^1.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
         version: 5.1.1(svelte@5.55.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1))
       '@types/katex':
         specifier: ^0.16.8
         version: 0.16.8
@@ -213,6 +216,10 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -2218,6 +2225,29 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -2268,6 +2298,9 @@ packages:
 
   '@types/appdmg@0.5.5':
     resolution: {integrity: sha512-G+n6DgZTZFOteITE30LnWj+HRVIGr7wMlAiLWOO02uJFWVEitaPU9JVXm9wJokkgshBawb2O1OykdcsmkkZfgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -2640,6 +2673,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2652,6 +2689,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -3062,6 +3102,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3080,6 +3124,9 @@ packages:
 
   discontinuous-range@1.0.0:
     resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -3812,6 +3859,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   jsdom@29.0.2:
     resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -3988,6 +4038,10 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   macos-alias@0.2.12:
     resolution: {integrity: sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==}
@@ -4461,6 +4515,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proc-log@2.0.1:
     resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -4561,6 +4619,9 @@ packages:
 
   rdfxml-streaming-parser@2.4.0:
     resolution: {integrity: sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   read-binary-file-arch@1.0.6:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
@@ -5515,6 +5576,12 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9':
     optional: true
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -9639,6 +9706,30 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.0)':
+    dependencies:
+      svelte: 5.55.0
+
+  '@testing-library/svelte@5.3.1(svelte@5.55.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.55.0)
+      svelte: 5.55.0
+    optionalDependencies:
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vitest: 2.1.9(@types/node@25.5.0)(happy-dom@20.9.0)(jsdom@29.0.2)(terser@5.46.1)
+
   '@tootallnate/once@2.0.0': {}
 
   '@traqula/algebra-sparql-1-1@1.0.4':
@@ -9716,6 +9807,8 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -10187,6 +10280,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   appdmg@0.6.6:
@@ -10205,6 +10300,10 @@ snapshots:
     optional: true
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.1: {}
 
@@ -10631,6 +10730,8 @@ snapshots:
       object-keys: 1.1.1
     optional: true
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
@@ -10646,6 +10747,8 @@ snapshots:
       p-limit: 3.1.0
 
   discontinuous-range@1.0.0: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -11515,6 +11618,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-tokens@4.0.0: {}
+
   jsdom@29.0.2:
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
@@ -11729,6 +11834,8 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  lz-string@1.5.0: {}
 
   macos-alias@0.2.12:
     dependencies:
@@ -12175,6 +12282,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proc-log@2.0.1: {}
 
   process@0.11.10: {}
@@ -12331,6 +12444,8 @@ snapshots:
       readable-stream: 4.7.0
       relative-to-absolute-iri: 1.0.8
       validate-iri: 1.0.1
+
+  react-is@17.0.2: {}
 
   read-binary-file-arch@1.0.6:
     dependencies:

--- a/tests/renderer/components/OcrProgressDialog.test.ts
+++ b/tests/renderer/components/OcrProgressDialog.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Wedge test for Svelte component coverage (#396).
+ *
+ * happy-dom is already wired (#343 / run-ocr.test.ts) and proven to
+ * work for renderer-side tests. This is the first test that mounts a
+ * Svelte component via @testing-library/svelte — it pays the
+ * setup-cost once so future component tests are cheap.
+ *
+ * Scope is deliberately narrow: confirm the OCR-progress dialog
+ * renders the right stage, fires the right callbacks, and reflects
+ * the runOcr progress callback into the visible "Page N of M" text.
+ * The runOcr orchestration itself is covered by
+ * tests/renderer/ocr/run-ocr.test.ts.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+// Mock the runOcr import before the component imports it. We hand
+// the mock a settable behaviour so each test can stub a different
+// shape (resolve, reject with AbortError, fire-progress-then-resolve).
+const { runOcrMock } = vi.hoisted(() => ({ runOcrMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ocr/run-ocr', () => ({ runOcr: runOcrMock }));
+
+import OcrProgressDialog from '../../../src/renderer/lib/components/OcrProgressDialog.svelte';
+
+const fakeBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]); // %PDF-
+
+afterEach(() => {
+  cleanup();
+  runOcrMock.mockReset();
+});
+
+function defaultProps(overrides: Partial<Parameters<typeof OcrProgressDialog>[0]['props']> = {}) {
+  return {
+    pdfBytes: fakeBytes,
+    pageCount: 5,
+    title: 'scan.pdf',
+    onDone: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('OcrProgressDialog (#396 — first Svelte component test)', () => {
+  it('renders the confirm stage with title, page count, and estimate', () => {
+    const { getByText } = render(OcrProgressDialog, defaultProps());
+    expect(getByText('Run OCR on "scan.pdf"?')).toBeTruthy();
+    // 5 pages × ~3s/page = 15s, formatted as "15s".
+    expect(getByText(/5 pages.*15s/)).toBeTruthy();
+    expect(getByText('Skip')).toBeTruthy();
+    expect(getByText('Run OCR')).toBeTruthy();
+  });
+
+  it('singular "page" when pageCount is 1', () => {
+    const { getByText } = render(OcrProgressDialog, defaultProps({ pageCount: 1 }));
+    expect(getByText(/1 page\b.*\bestimated/)).toBeTruthy();
+  });
+
+  it('Skip fires onCancel; runOcr is never called', async () => {
+    const onCancel = vi.fn();
+    const { getByText } = render(OcrProgressDialog, defaultProps({ onCancel }));
+    await fireEvent.click(getByText('Skip'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(runOcrMock).not.toHaveBeenCalled();
+  });
+
+  it('Run OCR transitions to the running stage and invokes runOcr', async () => {
+    // Hold runOcr open so the running stage is visible. Resolve via
+    // the deferred promise once the test has asserted the UI.
+    let resolveRun: (pages: string[]) => void = () => undefined;
+    runOcrMock.mockImplementation(
+      (_bytes, _onProgress, _signal) => new Promise<string[]>((r) => { resolveRun = r; }),
+    );
+    const onDone = vi.fn();
+    const { getByText, findByText } = render(OcrProgressDialog, defaultProps({ onDone }));
+
+    await fireEvent.click(getByText('Run OCR'));
+
+    // The running-stage UI shows up while runOcr is pending.
+    expect(await findByText('Running OCR…')).toBeTruthy();
+    expect(getByText('Loading PDF…')).toBeTruthy(); // pre-first-progress text
+    expect(getByText('Cancel')).toBeTruthy();
+    expect(runOcrMock).toHaveBeenCalledTimes(1);
+    const [bytesArg, , signalArg] = runOcrMock.mock.calls[0];
+    expect(bytesArg).toBe(fakeBytes);
+    expect(signalArg).toBeInstanceOf(AbortSignal);
+
+    // Wrap up so the test doesn't leak a pending promise.
+    resolveRun(['extracted text']);
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(['extracted text']));
+  });
+
+  it('reflects the runOcr progress callback into "Page N of M" text', async () => {
+    let captureProgress: ((p: { page: number; totalPages: number; pageProgress?: number }) => void) | null = null;
+    runOcrMock.mockImplementation((_bytes, onProgress) => {
+      captureProgress = onProgress;
+      return new Promise<string[]>(() => undefined); // never resolves — we only care about progress UI
+    });
+    const { getByText, findByText } = render(OcrProgressDialog, defaultProps({ pageCount: 3 }));
+
+    await fireEvent.click(getByText('Run OCR'));
+    await findByText('Loading PDF…');
+
+    // Fire a synthetic progress event from runOcr's perspective.
+    captureProgress!({ page: 2, totalPages: 3, pageProgress: 0.5 });
+
+    expect(await findByText('Page 2 of 3')).toBeTruthy();
+  });
+
+  it('Cancel during running aborts via the controller (no onCancel call until rejection)', async () => {
+    let abortSignal: AbortSignal | null = null;
+    runOcrMock.mockImplementation((_bytes, _onProgress, signal: AbortSignal) => {
+      abortSignal = signal;
+      return new Promise<string[]>((_, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('OCR cancelled', 'AbortError'));
+        });
+      });
+    });
+    const onCancel = vi.fn();
+    const { getByText, findByText } = render(OcrProgressDialog, defaultProps({ onCancel }));
+
+    await fireEvent.click(getByText('Run OCR'));
+    await findByText('Cancel');
+
+    await fireEvent.click(getByText('Cancel'));
+    expect(abortSignal!.aborted).toBe(true);
+
+    // Wait for the rejection to flow through the catch.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the error stage when runOcr throws a non-abort error', async () => {
+    runOcrMock.mockRejectedValueOnce(new Error('tesseract bombed'));
+    const { getByText, findByText } = render(OcrProgressDialog, defaultProps());
+
+    await fireEvent.click(getByText('Run OCR'));
+
+    expect(await findByText('OCR failed')).toBeTruthy();
+    expect(getByText('tesseract bombed')).toBeTruthy();
+    expect(getByText('Close')).toBeTruthy();
+  });
+
+  it('Close on the error stage fires onCancel', async () => {
+    runOcrMock.mockRejectedValueOnce(new Error('boom'));
+    const onCancel = vi.fn();
+    const { getByText, findByText } = render(OcrProgressDialog, defaultProps({ onCancel }));
+
+    await fireEvent.click(getByText('Run OCR'));
+    await findByText('OCR failed');
+    await fireEvent.click(getByText('Close'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,25 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { svelteTesting } from '@testing-library/svelte/vite';
 
 export default defineConfig({
+  // Svelte + testing-library plugins let vitest transform `.svelte`
+  // imports — needed for renderer component tests (#396 / OcrProgressDialog
+  // onwards). `svelteTesting` adds the browser resolve condition and
+  // wires the auto-cleanup hook between tests.
+  //
+  // Custom no-op `style` preprocessor bypasses vite-plugin-svelte's
+  // CSS preprocessing pass — under vitest 2 + vite 6 it explodes
+  // inside vite's `PartialEnvironment` constructor ("Cannot create
+  // proxy with a non-object as target or handler"). Component tests
+  // don't care about CSS, so leaving styles raw is fine.
+  plugins: [
+    svelte({
+      hot: false,
+      preprocess: { style: ({ content }) => ({ code: content }) },
+    }),
+    svelteTesting(),
+  ],
   resolve: {
     alias: {
       '@shared': '/src/shared',


### PR DESCRIPTION
## Summary
Closes #396 — was P1 #3.3 in the 2026-04-26 quality review. happy-dom was paved by #343 but only OCR used it; this is the **first test that mounts a Svelte component** via \`@testing-library/svelte\`. Pays the setup cost once so future component tests are cheap.

\`OcrProgressDialog\` was the right wedge: small, prop-driven, and sits next to \`run-ocr.test.ts\` so the test infra colocates naturally.

## 8 cases
- Confirm stage renders title + page count + estimate ("5 pages · 15s"; singular form too).
- Skip button fires \`onCancel\`; \`runOcr\` never called.
- Run OCR button transitions to the running stage and invokes \`runOcr\` with the right \`pdfBytes\` + \`AbortSignal\`.
- Progress callback flows through to the visible "Page N of M" text.
- Cancel during running aborts via the controller; \`onCancel\` fires once the \`runOcr\` promise rejects with AbortError.
- \`runOcr\` non-abort error transitions to the error stage with the message visible.
- Close on the error stage fires \`onCancel\`.

## Wiring (vitest.config.mts)
- Add \`@sveltejs/vite-plugin-svelte\` and \`@testing-library/svelte/vite\` plugins so vitest can transform \`.svelte\` imports + auto-cleans up between tests.
- Custom **no-op \`style\` preprocessor** in vite-plugin-svelte. Without it, vite's \`preprocessCSS\` explodes inside \`PartialEnvironment\` (\`"Cannot create proxy with a non-object as target or handler"\`) — a known vite 6 + vitest 2 compat gap. Component tests don't care about CSS, so leaving styles raw is fine.

Devdep added: \`@testing-library/svelte\` 5.x.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 0 warnings)
- [x] \`pnpm test\` — 1655 passed (+8 new)
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)