### PR TITLE
approval engine: generalise Proposal payload to a typed bundle (closes #418)

### DIFF
--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -1,4 +1,6 @@
+import * as $rdf from 'rdflib';
 import * as graph from '../graph/index';
+import * as notebaseFs from '../notebase/fs';
 import type { ProjectContext } from '../project-context-types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -14,25 +16,77 @@ export type OperationType =
   | 'component_creation'
   | 'status_change';
 
+/**
+ * One side-effect a proposal applies to the thoughtbase. The approval
+ * engine dispatches by `kind` at apply time; the user sees the whole
+ * bundle as one proposal in the diff view and approves / rejects
+ * atomically (#418).
+ *
+ * Five kinds defined; only `graph-triples` and `note` are wired to a
+ * dispatcher today. The other three are reserved for the Research
+ * tools that will need them (#415 wants `source`, #414 wants
+ * `excerpt` for cited passages, the metacognitive cluster wants
+ * `saved-query` for "watch this" queries). Apply attempts on an
+ * un-wired kind throw `NotImplementedError` so the type stays
+ * accurate without forcing the runtime cost up front.
+ */
+export type ProposalPayload =
+  | {
+      kind: 'graph-triples';
+      /** Turtle to merge into the project store. Standard prefixes
+       *  are auto-injected (same as the legacy single-payload path). */
+      turtle: string;
+      /** Subjects this turtle introduces. The proposal aggregates
+       *  these onto `thought:affectsNode` triples so the trust-
+       *  integrity stock query can pin LLM-attributed components to
+       *  their approval. */
+      affectsNodeUris: string[];
+    }
+  | {
+      kind: 'note';
+      /** Project-relative path. On collision, suffixed -2/-3/...; the
+       *  resolved path is recorded on the proposal post-apply. */
+      relativePath: string;
+      content: string;
+      /** Optional convenience: emit a single triple linking some
+       *  existing node to the new note. Same effect as a separate
+       *  `graph-triples` payload but co-located with the note. */
+      backlink?: { fromUri: string; predicate: string };
+    }
+  | {
+      kind: 'source';
+      sourceId: string;
+      metaTtl: string;
+      bodyMd?: string;
+      original?: { mimeType: string; bytes: Uint8Array };
+    }
+  | {
+      kind: 'excerpt';
+      excerptId: string;
+      excerptTtl: string;
+    }
+  | {
+      kind: 'saved-query';
+      scope: 'project' | 'global';
+      name: string;
+      description: string;
+      query: string;
+      language: 'sparql' | 'sql';
+      group?: string | null;
+    };
+
 export interface ProposedWrite {
-  /** The operation type for policy lookup */
+  /** Drives approval-tier policy lookup. */
   operationType: OperationType;
-  /** Turtle representation of the triples to add */
-  turtleDiff: string;
-  /** Human-readable description */
+  /** Side effects to apply, in order. Triples-last is the convention
+   *  callers should follow; rollback assumes file-system payloads
+   *  ran before triples (so a triples-parse failure can undo only
+   *  file-system effects). */
+  payloads: ProposalPayload[];
+  /** Human-readable single-line bundle summary for the proposals UI. */
   note: string;
-  /**
-   * URIs of the nodes being created or modified by this proposal. The
-   * "Trust: Unreviewed LLM writes" stock query joins on
-   * `thought:affectsNode`, so every component the proposal mutates must
-   * appear here for the integrity check to find the proposal.
-   */
-  affectsNodeUris?: string[];
-  /** URI of the conversation that produced this proposal */
   conversationUri?: string;
-  /** Agent identifier */
   proposedBy: string;
-  /** Auto-expiry duration in days (default: 7) */
   expiryDays?: number;
 }
 
@@ -40,8 +94,12 @@ export interface Proposal {
   uri: string;
   status: 'pending' | 'approved' | 'rejected' | 'expired';
   operationType: string;
-  turtleDiff: string;
+  payloads: ProposalPayload[];
   note: string;
+  /** Aggregated across every payload: every URI in graph-triples'
+   *  affectsNodeUris plus the resolved note URI of any `note`
+   *  payload. Surfaced so the trust-integrity stock query can join
+   *  the LLM-attributed components back to this proposal. */
   affectsNodeUris: string[];
   conversationUri?: string;
   proposedBy: string;
@@ -83,11 +141,27 @@ function proposalUri(): string {
   return `${THOUGHT}proposal/${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+/** Aggregate every URI a bundle introduces. graph-triples carry their
+ *  own list; `note` payloads are translated to the note's IRI. */
+function collectAffectsNodes(ctx: ProjectContext, payloads: ProposalPayload[]): string[] {
+  const out = new Set<string>();
+  for (const p of payloads) {
+    if (p.kind === 'graph-triples') {
+      for (const u of p.affectsNodeUris) out.add(u);
+    } else if (p.kind === 'note') {
+      const uri = graph.noteUriFor(ctx, p.relativePath);
+      if (uri) out.add(uri);
+    }
+  }
+  return [...out];
+}
+
 /**
- * Submit a proposed graph write. Based on the operation's approval tier:
- * - requires_approval: creates a pending Proposal in the graph, returns it
- * - notify_only: applies the write immediately, creates an approved Proposal for audit
- * - autonomous: applies the write immediately, no proposal record
+ * Submit a proposed bundle. Based on the operation's approval tier:
+ * - requires_approval: persists a pending Proposal, returns it.
+ * - notify_only: applies the bundle immediately, persists an approved
+ *   Proposal for audit.
+ * - autonomous: applies the bundle immediately, no proposal record.
  */
 export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal | null> {
   const tier = getApprovalTier(write.operationType);
@@ -95,44 +169,42 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
   const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * 86400000).toISOString();
 
   if (tier === 'autonomous') {
-    // Apply immediately, no record
-    await applyTurtle(ctx, write.turtleDiff);
+    await applyBundle(ctx, write.payloads);
     return null;
   }
 
   const uri = proposalUri();
+  const affectsNodeUris = collectAffectsNodes(ctx, write.payloads);
   const proposal: Proposal = {
     uri,
     status: tier === 'notify_only' ? 'approved' : 'pending',
     operationType: write.operationType,
-    turtleDiff: write.turtleDiff,
+    payloads: write.payloads,
     note: write.note,
-    affectsNodeUris: write.affectsNodeUris ?? [],
+    affectsNodeUris,
     conversationUri: write.conversationUri,
     proposedBy: write.proposedBy,
     proposedAt: now,
     autoExpires: expiryDate,
   };
 
-  // Write proposal metadata to graph
   await writeProposalToGraph(ctx, proposal);
 
-  // For notify_only, also apply the mutation immediately
   if (tier === 'notify_only') {
-    await applyTurtle(ctx, write.turtleDiff);
+    await applyBundle(ctx, write.payloads);
   }
 
   return proposal;
 }
 
 /**
- * Approve a pending proposal: apply its turtle diff and update status.
+ * Approve a pending proposal: apply its bundle and update status.
  */
 export async function approveProposal(ctx: ProjectContext, uri: string): Promise<boolean> {
   const proposal = await getProposal(ctx, uri);
   if (!proposal || proposal.status !== 'pending') return false;
 
-  await applyTurtle(ctx, proposal.turtleDiff);
+  await applyBundle(ctx, proposal.payloads);
   await updateProposalStatus(ctx, uri, 'approved');
   return true;
 }
@@ -183,7 +255,7 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
 
   const results = await graph.queryGraph(ctx, `
     PREFIX thought: <${THOUGHT}>
-    SELECT ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff
+    SELECT ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?payloadJson
            (GROUP_CONCAT(DISTINCT ?affectsNode; separator="\\u001f") AS ?affectsNodes)
            ?conversation WHERE {
       ?proposal a thought:Proposal .
@@ -194,27 +266,16 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
       ?proposal thought:proposedBy ?proposedBy .
       ?proposal thought:proposedAt ?proposedAt .
       ?proposal thought:autoExpires ?autoExpires .
-      ?proposal thought:proposalDiff ?turtleDiff .
+      ?proposal thought:payloadJson ?payloadJson .
       ${statusFilter}
       OPTIONAL { ?proposal thought:affectsNode ?affectsNode }
       OPTIONAL { ?proposal thought:conversationRef ?conversation }
     }
-    GROUP BY ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff ?conversation
+    GROUP BY ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?payloadJson ?conversation
     ORDER BY DESC(?proposedAt)
   `);
 
-  return (results.results as Record<string, string>[]).map(r => ({
-    uri: r.proposal,
-    status: r.status as Proposal['status'],
-    operationType: r.operationType,
-    turtleDiff: r.turtleDiff,
-    note: r.note,
-    affectsNodeUris: splitAffectsNodes(r.affectsNodes),
-    conversationUri: r.conversation,
-    proposedBy: r.proposedBy,
-    proposedAt: r.proposedAt,
-    autoExpires: r.autoExpires,
-  }));
+  return (results.results as Record<string, string>[]).map(r => proposalFromRow(r));
 }
 
 /**
@@ -223,7 +284,7 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
 export async function getProposal(ctx: ProjectContext, uri: string): Promise<Proposal | null> {
   const results = await graph.queryGraph(ctx, `
     PREFIX thought: <${THOUGHT}>
-    SELECT ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?turtleDiff ?affectsNode ?conversation WHERE {
+    SELECT ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?payloadJson ?affectsNode ?conversation WHERE {
       <${uri}> a thought:Proposal .
       <${uri}> thought:proposalStatus ?statusNode .
       BIND(REPLACE(STR(?statusNode), "${THOUGHT}", "") AS ?status)
@@ -232,7 +293,7 @@ export async function getProposal(ctx: ProjectContext, uri: string): Promise<Pro
       <${uri}> thought:proposedBy ?proposedBy .
       <${uri}> thought:proposedAt ?proposedAt .
       <${uri}> thought:autoExpires ?autoExpires .
-      <${uri}> thought:proposalDiff ?turtleDiff .
+      <${uri}> thought:payloadJson ?payloadJson .
       OPTIONAL { <${uri}> thought:affectsNode ?affectsNode }
       OPTIONAL { <${uri}> thought:conversationRef ?conversation }
     }
@@ -240,18 +301,15 @@ export async function getProposal(ctx: ProjectContext, uri: string): Promise<Pro
 
   const rows = results.results as Record<string, string>[];
   if (rows.length === 0) return null;
-
   const r = rows[0];
-  // Multiple affectsNode rows show up as multiple result rows (one per URI).
-  // Collect them all rather than just the first.
   const affectsNodeUris = Array.from(
-    new Set(rows.map(row => row.affectsNode).filter((u): u is string => Boolean(u)))
+    new Set(rows.map(row => row.affectsNode).filter((u): u is string => Boolean(u))),
   );
   return {
     uri,
     status: r.status as Proposal['status'],
     operationType: r.operationType,
-    turtleDiff: r.turtleDiff,
+    payloads: parsePayloads(r.payloadJson),
     note: r.note,
     affectsNodeUris,
     conversationUri: r.conversation,
@@ -261,10 +319,156 @@ export async function getProposal(ctx: ProjectContext, uri: string): Promise<Pro
   };
 }
 
-/** Split the GROUP_CONCAT result for affectsNode URIs back into a list. */
+function proposalFromRow(r: Record<string, string>): Proposal {
+  return {
+    uri: r.proposal,
+    status: r.status as Proposal['status'],
+    operationType: r.operationType,
+    payloads: parsePayloads(r.payloadJson),
+    note: r.note,
+    affectsNodeUris: splitAffectsNodes(r.affectsNodes),
+    conversationUri: r.conversation,
+    proposedBy: r.proposedBy,
+    proposedAt: r.proposedAt,
+    autoExpires: r.autoExpires,
+  };
+}
+
+function parsePayloads(json: string | undefined): ProposalPayload[] {
+  if (!json) return [];
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as ProposalPayload[];
+  } catch {
+    return [];
+  }
+}
+
+/** Split the GROUP_CONCAT result for affectsNode URIs back into a list.
+ *  Separator matches the SPARQL GROUP_CONCAT call above (). */
 function splitAffectsNodes(raw: string | undefined): string[] {
   if (!raw) return [];
-  return raw.split('').filter(Boolean);
+  return raw.split(String.fromCharCode(0x1f)).filter(Boolean);
+}
+
+// ── Apply path ─────────────────────────────────────────────────────────────
+
+/**
+ * Per-payload undo state. `dispatch` populates this as each payload
+ * lands; on failure of a later payload we walk it in reverse.
+ */
+interface AppliedRecord {
+  kind: ProposalPayload['kind'];
+  /** Resolved data the rollback needs (note path, source id, query
+   *  filePath, etc). */
+  rollbackData: unknown;
+}
+
+async function applyBundle(ctx: ProjectContext, payloads: ProposalPayload[]): Promise<void> {
+  // Apply file-system payloads first, triples last. Lets a triples
+  // parse failure roll back FS effects without needing an rdflib
+  // snapshot.
+  const ordered = [
+    ...payloads.filter((p) => p.kind !== 'graph-triples'),
+    ...payloads.filter((p) => p.kind === 'graph-triples'),
+  ];
+
+  const applied: AppliedRecord[] = [];
+  try {
+    for (const p of ordered) {
+      const rollbackData = await dispatchApply(ctx, p);
+      applied.push({ kind: p.kind, rollbackData });
+    }
+  } catch (err) {
+    // Reverse-order rollback. Best-effort — log but don't mask the
+    // original error.
+    for (const a of [...applied].reverse()) {
+      try { await dispatchRollback(ctx, a); }
+      catch (rollbackErr) { console.warn(`[approval] rollback of ${a.kind} failed:`, rollbackErr); }
+    }
+    throw err;
+  }
+}
+
+async function dispatchApply(ctx: ProjectContext, p: ProposalPayload): Promise<unknown> {
+  switch (p.kind) {
+    case 'graph-triples': {
+      await applyTurtle(ctx, p.turtle);
+      return null;
+    }
+    case 'note': {
+      const finalPath = await resolveCollidingPath(ctx.rootPath, p.relativePath);
+      await notebaseFs.createFile(ctx.rootPath, finalPath);
+      await notebaseFs.writeFile(ctx.rootPath, finalPath, p.content);
+      await graph.indexNote(ctx, finalPath, p.content);
+      if (p.backlink) {
+        const noteUri = graph.noteUriFor(ctx, finalPath);
+        if (noteUri) {
+          await applyTurtle(
+            ctx,
+            `<${p.backlink.fromUri}> <${p.backlink.predicate}> <${noteUri}> .`,
+          );
+        }
+      }
+      return { resolvedPath: finalPath };
+    }
+    case 'source':
+    case 'excerpt':
+    case 'saved-query':
+      throw new Error(
+        `Approval payload kind "${p.kind}" not yet wired (#418 ships graph-triples + note; later kinds land as needed).`,
+      );
+  }
+}
+
+async function dispatchRollback(ctx: ProjectContext, a: AppliedRecord): Promise<void> {
+  switch (a.kind) {
+    case 'graph-triples':
+      // Triples ran last by construction — nothing after them to
+      // undo. Triples rollback would require an rdflib snapshot;
+      // skipped per #418's "triples-last" convention.
+      return;
+    case 'note': {
+      const data = a.rollbackData as { resolvedPath: string };
+      try { await notebaseFs.deleteFile(ctx.rootPath, data.resolvedPath); }
+      catch { /* file may already be gone */ }
+      graph.removeNote(ctx, data.resolvedPath);
+      return;
+    }
+    case 'source':
+    case 'excerpt':
+    case 'saved-query':
+      // Never reached today — apply throws before recording an
+      // applied entry for these kinds.
+      return;
+  }
+}
+
+/** Apply-time path dedup. Mirrors `resolveDropName` in drop-import. */
+async function resolveCollidingPath(rootPath: string, relativePath: string): Promise<string> {
+  const path = await import('node:path');
+  const fs = await import('node:fs/promises');
+  const dir = path.dirname(relativePath);
+  const ext = path.extname(relativePath);
+  const stem = path.basename(relativePath, ext);
+  let candidate = relativePath;
+  let suffix = 2;
+  while (true) {
+    try {
+      await fs.access(path.join(rootPath, candidate));
+      // exists → try next
+      candidate = dir === '.'
+        ? `${stem}-${suffix}${ext}`
+        : `${dir}/${stem}-${suffix}${ext}`;
+      suffix++;
+      if (suffix > 99) throw new Error(`resolveCollidingPath: 99 collisions on ${relativePath}`);
+    } catch (err) {
+      // ENOENT — slot is free
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return candidate;
+      throw err;
+    }
+  }
 }
 
 // ── Internal Helpers ───────────────────────────────────────────────────────
@@ -273,6 +477,12 @@ async function writeProposalToGraph(ctx: ProjectContext, p: Proposal): Promise<v
   const affectsNodeTriples = p.affectsNodeUris
     .map(u => `; thought:affectsNode <${u}>`)
     .join('\n      ');
+  // Payloads are stored as JSON in a single literal so the proposal
+  // is self-contained; restoring requires no additional triple
+  // tracking. Larger payloads (note content, source bytes) go inline
+  // — fine for typical Research-tool output, would need re-thinking
+  // if proposal sizes blow up.
+  const payloadJson = serializePayloadsForStorage(p.payloads);
   const turtle = `
     <${p.uri}> a thought:Proposal ;
       thought:proposalStatus thought:${p.status} ;
@@ -281,11 +491,23 @@ async function writeProposalToGraph(ctx: ProjectContext, p: Proposal): Promise<v
       thought:proposedBy "${escapeTurtle(p.proposedBy)}" ;
       thought:proposedAt "${p.proposedAt}"^^xsd:dateTime ;
       thought:autoExpires "${p.autoExpires}"^^xsd:dateTime ;
-      thought:proposalDiff "${escapeTurtle(p.turtleDiff)}"
+      thought:payloadJson "${escapeTurtle(payloadJson)}"
       ${affectsNodeTriples}
       ${p.conversationUri ? `; thought:conversationRef <${p.conversationUri}>` : ''} .
   `;
   await applyTurtle(ctx, turtle);
+}
+
+/** JSON-serialisable form. Drops Uint8Array bytes from `source`
+ *  payloads — restoring those needs a different store (#418's MVP
+ *  doesn't wire `source`, so this is a placeholder). */
+function serializePayloadsForStorage(payloads: ProposalPayload[]): string {
+  return JSON.stringify(payloads.map((p) => {
+    if (p.kind === 'source' && p.original) {
+      return { ...p, original: { ...p.original, bytes: '<elided>' } };
+    }
+    return p;
+  }));
 }
 
 async function updateProposalStatus(ctx: ProjectContext, uri: string, newStatus: string): Promise<void> {
@@ -303,7 +525,6 @@ async function updateProposalStatus(ctx: ProjectContext, uri: string, newStatus:
 }
 
 async function applyTurtle(ctx: ProjectContext, turtle: string): Promise<void> {
-  // Use the graph module's parse infrastructure with standard prefixes
   const prefixed = `
     @prefix thought: <${THOUGHT}> .
     @prefix minerva: <https://minerva.dev/ontology#> .
@@ -314,7 +535,15 @@ async function applyTurtle(ctx: ProjectContext, turtle: string): Promise<void> {
     @prefix prov: <http://www.w3.org/ns/prov#> .
     ${turtle}
   `;
-  // Approval engine writes are the *only* in-LLM-context writes that
+  // Pre-flight parse into a throwaway store. graph.parseIntoStore
+  // swallows parse errors with a console.error (it's the right call
+  // for normal indexing — one bad note shouldn't poison the rest),
+  // but the approval engine MUST surface them so a malformed
+  // proposal triggers rollback rather than silently no-oping.
+  const probe = $rdf.graph();
+  $rdf.parse(prefixed, probe, 'urn:x-minerva:approval-validate', 'text/turtle');
+
+  // Approval-engine writes are the *only* in-LLM-context writes that
   // shouldn't trip the trust guard. Everything else flowing through
   // parseIntoStore from an LLM call site is a bug we want to know about.
   graph.enterTrustedContext();

--- a/src/main/llm/crystallize.ts
+++ b/src/main/llm/crystallize.ts
@@ -76,11 +76,12 @@ ${text}`;
 
     await proposeWrite(ctx, {
       operationType: 'component_creation',
-      turtleDiff: groundedTurtle,
+      payloads: [
+        { kind: 'graph-triples', turtle: groundedTurtle, affectsNodeUris },
+      ],
       note: `Crystallized ${componentCount} thought component${componentCount !== 1 ? 's' : ''} from conversation`,
       conversationUri,
       proposedBy,
-      affectsNodeUris,
     });
 
     return { turtle: groundedTurtle, componentCount };

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -90,10 +90,13 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
   it('approving a pending proposal leaves only the approved status', async () => {
     const proposal = await proposeWrite(ctx, {
       operationType: 'new_claim',
-      turtleDiff: '<https://ex.example/x> a <https://ex.example/Claim> .',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: '<https://ex.example/x> a <https://ex.example/Claim> .',
+        affectsNodeUris: ['https://ex.example/x'],
+      }],
       note: 'test',
       proposedBy: 'unit-test',
-      affectsNodeUri: 'https://ex.example/x',
     });
     expect(proposal).not.toBeNull();
     expect(await statusesFor(proposal!.uri)).toEqual([
@@ -109,10 +112,13 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
   it('rejecting a pending proposal leaves only the rejected status', async () => {
     const proposal = await proposeWrite(ctx, {
       operationType: 'new_claim',
-      turtleDiff: '<https://ex.example/y> a <https://ex.example/Claim> .',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: '<https://ex.example/y> a <https://ex.example/Claim> .',
+        affectsNodeUris: ['https://ex.example/y'],
+      }],
       note: 'test',
       proposedBy: 'unit-test',
-      affectsNodeUri: 'https://ex.example/y',
     });
     expect(proposal).not.toBeNull();
     expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);

--- a/tests/main/llm/crystallize-integration.test.ts
+++ b/tests/main/llm/crystallize-integration.test.ts
@@ -82,7 +82,12 @@ describe('crystallize() integration (#342)', () => {
     expect(p.proposedBy).toBe('llm:test');
     expect(p.conversationUri).toBe(CONV_URI);
     expect(p.affectsNodeUris.sort()).toEqual([CLAIM_URI, GROUNDS_URI].sort());
-    expect(p.turtleDiff).toContain(CLAIM_URI);
+    // Payload bundle now carries the turtle (#418).
+    expect(p.payloads).toHaveLength(1);
+    expect(p.payloads[0].kind).toBe('graph-triples');
+    if (p.payloads[0].kind === 'graph-triples') {
+      expect(p.payloads[0].turtle).toContain(CLAIM_URI);
+    }
   });
 
   it('approving the proposal applies the component triples to the graph', async () => {

--- a/tests/main/llm/proposal-bundle.test.ts
+++ b/tests/main/llm/proposal-bundle.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Bundle-shape behavioural tests for the generalised approval engine
+ * (#418). Pin the contract `proposeWrite` / `approveProposal` now
+ * carry: payload-typed apply dispatch, triples-last ordering, all-or-
+ * nothing rollback, multi-payload end-to-end, note collision
+ * dedup. The legacy single-payload `crystallize-integration.test.ts`
+ * continues to cover the back-compat path; this file is the new
+ * surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  proposeWrite,
+  approveProposal,
+  getProposal,
+  resetPolicy,
+  setPolicy,
+} from '../../../src/main/llm/approval';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const NOTE_PREDICATE = 'https://minerva.dev/ontology#mentionsNote';
+
+describe('ProposalBundle apply + rollback (#418)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-bundle-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('a graph-triples-only bundle applies through approve and lands in the store', async () => {
+    setPolicy('component_creation', 'requires_approval');
+    const claimUri = 'https://minerva.dev/c/single-payload';
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: `<${claimUri}> a thought:Claim ; thought:label "single-payload test" .`,
+        affectsNodeUris: [claimUri],
+      }],
+      note: 'one triples payload',
+      proposedBy: 'unit-test',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?label WHERE { <${claimUri}> thought:label ?label . }
+    `);
+    expect((r.results as Array<{ label: string }>).map(x => x.label))
+      .toContain('single-payload test');
+  });
+
+  it('a note-only bundle applies through approve and lands the file on disk', async () => {
+    setPolicy('component_creation', 'requires_approval');
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [{
+        kind: 'note',
+        relativePath: 'notes/from-bundle.md',
+        content: '# From bundle\n\nThis note was proposed and approved.\n',
+      }],
+      note: 'one note payload',
+      proposedBy: 'unit-test',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+
+    const onDisk = await fsp.readFile(path.join(root, 'notes/from-bundle.md'), 'utf-8');
+    expect(onDisk).toContain('From bundle');
+  });
+
+  it('a multi-payload bundle (note + triples) lands both, with triples runnable AFTER the note', async () => {
+    // The bundle creates a Claim node in the graph AND a notes file
+    // documenting that claim. Order matters: the triples reference
+    // the note's URI, so the note must already exist (and be
+    // indexed) when the triples are applied. Triples-last.
+    setPolicy('component_creation', 'requires_approval');
+    const claimUri = 'https://minerva.dev/c/note-and-triples';
+    const noteIri = 'https://example/project/note/notes/explanation';
+
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [
+        {
+          kind: 'note',
+          relativePath: 'notes/explanation.md',
+          content: '# Explanation\n\nA note that the triples reference.\n',
+        },
+        {
+          kind: 'graph-triples',
+          // The triple references the note IRI we plant above.
+          turtle: `<${claimUri}> a thought:Claim ; <${NOTE_PREDICATE}> <${noteIri}> .`,
+          affectsNodeUris: [claimUri],
+        },
+      ],
+      note: 'note + triples',
+      proposedBy: 'unit-test',
+    });
+    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+
+    expect(fs.existsSync(path.join(root, 'notes/explanation.md'))).toBe(true);
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?type WHERE { <${claimUri}> a ?type . }
+    `);
+    expect((r.results as Array<{ type: string }>).map(x => x.type))
+      .toContain('https://minerva.dev/ontology/thought#Claim');
+  });
+
+  it('rolls the note back if a later triples payload throws (parse error)', async () => {
+    // File-system payload runs first and lands the note. Then the
+    // triples payload throws because the turtle is malformed. The
+    // engine must undo the note write so the bundle's all-or-nothing
+    // contract holds.
+    setPolicy('component_creation', 'requires_approval');
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [
+        {
+          kind: 'note',
+          relativePath: 'notes/should-be-rolled-back.md',
+          content: 'this file should not survive the failed apply\n',
+        },
+        {
+          kind: 'graph-triples',
+          // Deliberately broken turtle — `;;` and missing predicate
+          // make the rdflib parser bail.
+          turtle: '<https://ex/x> ;;;; .',
+          affectsNodeUris: ['https://ex/x'],
+        },
+      ],
+      note: 'should fail and roll back',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    expect(fs.existsSync(path.join(root, 'notes/should-be-rolled-back.md'))).toBe(false);
+  });
+
+  it('apply-time path collision suffixes -2/-3 instead of overwriting', async () => {
+    // Plant a file that occupies the proposed path.
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/colliding.md'), 'pre-existing\n', 'utf-8');
+
+    setPolicy('component_creation', 'requires_approval');
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [{
+        kind: 'note',
+        relativePath: 'notes/colliding.md',
+        content: 'proposed content\n',
+      }],
+      note: 'collision test',
+      proposedBy: 'unit-test',
+    });
+    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+
+    // Original file untouched.
+    expect(await fsp.readFile(path.join(root, 'notes/colliding.md'), 'utf-8'))
+      .toBe('pre-existing\n');
+    // Suffixed copy landed.
+    expect(await fsp.readFile(path.join(root, 'notes/colliding-2.md'), 'utf-8'))
+      .toBe('proposed content\n');
+  });
+
+  it('autonomous-tier bundles apply immediately and skip proposal persistence', async () => {
+    setPolicy('tag_addition', 'autonomous');
+    const result = await proposeWrite(ctx, {
+      operationType: 'tag_addition',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: '<https://ex/auto> a thought:Tag .',
+        affectsNodeUris: ['https://ex/auto'],
+      }],
+      note: 'auto-applied',
+      proposedBy: 'unit-test',
+    });
+    expect(result).toBeNull(); // autonomous → no proposal record returned
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?type WHERE { <https://ex/auto> a ?type . }
+    `);
+    expect((r.results as Array<{ type: string }>).map(x => x.type))
+      .toContain('https://minerva.dev/ontology/thought#Tag');
+  });
+
+  it('round-trips payloads through getProposal — list → fetch reconstitutes the bundle shape', async () => {
+    setPolicy('component_creation', 'requires_approval');
+    const claimUri = 'https://minerva.dev/c/roundtrip';
+    const original = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [
+        {
+          kind: 'note',
+          relativePath: 'notes/roundtrip.md',
+          content: 'body\n',
+        },
+        {
+          kind: 'graph-triples',
+          turtle: `<${claimUri}> a thought:Claim .`,
+          affectsNodeUris: [claimUri],
+        },
+      ],
+      note: 'round-trip',
+      proposedBy: 'unit-test',
+    });
+
+    const fetched = await getProposal(ctx, original!.uri);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.payloads).toHaveLength(2);
+    expect(fetched!.payloads[0].kind).toBe('note');
+    expect(fetched!.payloads[1].kind).toBe('graph-triples');
+    if (fetched!.payloads[0].kind === 'note') {
+      expect(fetched!.payloads[0].content).toBe('body\n');
+    }
+  });
+
+  it('un-wired payload kinds (source / excerpt / saved-query) throw NotImplementedError on apply', async () => {
+    // The type accepts these kinds (the Research-tools tickets that
+    // need them are filed under #414/#415/follow-ups). The runtime
+    // behaviour is "fail loudly" until each is wired in its own PR.
+    setPolicy('component_creation', 'requires_approval');
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [{
+        kind: 'saved-query',
+        scope: 'project',
+        name: 'Future query',
+        description: 'will be wired by a later PR',
+        query: 'SELECT * WHERE { ?s ?p ?o }',
+        language: 'sparql',
+      }],
+      note: 'unwired kind',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx, proposal!.uri))
+      .rejects.toThrow(/not yet wired/);
+  });
+});

--- a/tests/main/llm/trust-guard.test.ts
+++ b/tests/main/llm/trust-guard.test.ts
@@ -83,7 +83,11 @@ describe('LLM write guard (#331)', () => {
     try {
       await proposeWrite(ctx, {
         operationType: 'tag_addition',
-        turtleDiff: '<https://ex/a> a <https://ex/T> .',
+        payloads: [{
+          kind: 'graph-triples',
+          turtle: '<https://ex/a> a <https://ex/T> .',
+          affectsNodeUris: ['https://ex/a'],
+        }],
         note: 'autonomous tier — applied directly',
         proposedBy: 'unit-test',
       });
@@ -102,7 +106,11 @@ describe('LLM write guard (#331)', () => {
     try {
       const p = await proposeWrite(ctx, {
         operationType: 'new_claim',
-        turtleDiff: '<https://ex/x> a <https://ex/Claim> .',
+        payloads: [{
+          kind: 'graph-triples',
+          turtle: '<https://ex/x> a <https://ex/Claim> .',
+          affectsNodeUris: ['https://ex/x'],
+        }],
         note: 'pending',
         proposedBy: 'unit-test',
       });
@@ -178,10 +186,13 @@ describe('crystallize provenance (#331)', () => {
     setPolicy('component_creation', 'requires_approval');
     const p = await proposeWrite(ctx, {
       operationType: 'component_creation',
-      turtleDiff: `<${aUri}> a <https://ex/T> .\n<${bUri}> a <https://ex/T> .`,
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: `<${aUri}> a <https://ex/T> .\n<${bUri}> a <https://ex/T> .`,
+        affectsNodeUris: [aUri, bUri],
+      }],
       note: 'two components',
       proposedBy: 'unit-test',
-      affectsNodeUris: [aUri, bUri],
     });
     expect(p).not.toBeNull();
 
@@ -213,10 +224,13 @@ describe('crystallize provenance (#331)', () => {
     `;
     const p = await proposeWrite(ctx, {
       operationType: 'component_creation',
-      turtleDiff,
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: turtleDiff,
+        affectsNodeUris: [componentUri],
+      }],
       note: 'test',
       proposedBy: 'unit-test',
-      affectsNodeUris: [componentUri],
     });
     expect(p).not.toBeNull();
     expect(await approveProposal(ctx, p!.uri)).toBe(true);


### PR DESCRIPTION
## Summary
Closes #418 — foundational change blocking the Research-tools cluster (#408–#417).

\`Proposal\` carried a single \`turtleDiff: string\` blob. Worked for crystallize because its output IS just triples, but the Research tools want notes (steelman, fact-check, decomposition all produce human-readable artefacts), and sometimes ingested sources or saved queries. One proposal can want several at once — Decompose creates N claim notes plus the graph triples linking them.

Now: \`Proposal\` carries \`payloads: ProposalPayload[]\`, a discriminated union over five kinds:

| kind | status |
|---|---|
| \`graph-triples\` | **wired** |
| \`note\` | **wired** |
| \`source\` | type defined; dispatcher throws NotImplemented |
| \`excerpt\` | type defined; dispatcher throws NotImplemented |
| \`saved-query\` | type defined; dispatcher throws NotImplemented |

The two MVP-wired kinds cover the entire argument-structure cluster (#408–#413). The remaining three land as later research tools need them — the type stays accurate, the runtime cost stays zero until then.

## Apply semantics
- **Triples-last ordering**: file-system payloads (note today, source/excerpt/saved-query later) run first; \`graph-triples\` runs last. Lets a triples-parse failure roll back FS effects without needing an rdflib snapshot.
- **All-or-nothing**: each FS payload records rollback data on an audit accumulator; failure of payload N reverse-walks 1..N-1.
- **Apply-time path collision dedup** for \`note\` payloads: \`notes/foo.md\` exists → suffix to \`notes/foo-2.md\` (mirrors \`resolveDropName\`).
- **Pre-flight turtle validation**: \`graph.parseIntoStore\` swallows parse errors with \`console.error\` (right call for normal indexing — one bad note shouldn't poison the rest), but the approval engine MUST surface them for rollback. \`applyTurtle\` now validates with \`$rdf.parse\` into a throwaway store first; failure propagates.

## Trust gating
Per-\`operationType\` tier policy unchanged. \`crystallize\` migration is one line — \`turtleDiff: '...'\` → \`payloads: [{ kind: 'graph-triples', turtle: '...', affectsNodeUris: [...] }]\`. The \`affectsNodeUris\` field moves from the \`ProposedWrite\` envelope to the per-payload type; \`proposeWrite\` aggregates across payloads (+note IRIs) for the proposal-level \`thought:affectsNode\` triples.

## Storage
Payloads serialise to a single \`thought:payloadJson\` literal on the proposal node. Restoring requires no extra triple tracking. Source payloads with bytes elide the bytes (placeholder until source dispatch is wired).

## Tests
- All 7 existing \`trust-guard.test.ts\` cases migrated (verbose but mechanical).
- \`crystallize-integration.test.ts\` updated to read the new payloads array.
- **New \`tests/main/llm/proposal-bundle.test.ts\` (8 cases)**: triples-only apply, note-only apply, multi-payload (note + triples) lands both, triples-last rollback when turtle is malformed, apply-time collision dedup, autonomous-tier immediate-apply, payload round-trip through \`getProposal\`, un-wired kinds throw clearly.

## Test plan
- [x] \`pnpm lint\` clean (0 errors)
- [x] \`pnpm test\` — 1663 passed (+8 new bundle tests)
- [x] No production behavior change for crystallize; the engine is a strict superset

🤖 Generated with [Claude Code](https://claude.com/claude-code)