### PR TITLE
research tools: decompose passage into individual claims (closes #408)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -27,6 +27,7 @@ import {
   applyInboundSuggestions,
 } from './llm/auto-link';
 import { suggestDecomposition, type DecomposeHints } from './llm/decompose';
+import { decomposeClaims, type DecomposeClaimsArgs } from './llm/decompose-claims';
 import {
   formatNoteContent,
   formatFile as formatFileOnDisk,
@@ -814,6 +815,15 @@ export function registerIpcHandlers(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
       return suggestDecomposition(rootPath, activeRelPath, hints ?? {});
+    },
+  );
+
+  ipcMain.handle(
+    Channels.RESEARCH_DECOMPOSE_CLAIMS,
+    async (e, args: DecomposeClaimsArgs) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      return decomposeClaims(projectContext(rootPath), args);
     },
   );
 

--- a/src/main/llm/decompose-claims.ts
+++ b/src/main/llm/decompose-claims.ts
@@ -1,0 +1,171 @@
+/**
+ * "Decompose into individual claims" orchestrator (#408).
+ *
+ * Calls the LLM with the user-selected passage, parses the JSON response
+ * into typed claims, and files the result as a single approval-engine
+ * proposal. The bundle has one `note` payload (a human-readable
+ * decomposition summary) plus N `graph-triples` payloads (one
+ * thought:Claim node per claim) — all-or-nothing through approve/reject.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { complete } from './index';
+import { proposeWrite } from './approval';
+import * as graph from '../graph/index';
+import {
+  buildDecomposeClaimsPrompt,
+  parseDecomposeClaimsResponse,
+  escapeTurtleLiteral,
+  type DecomposedClaim,
+} from '../../shared/refactor/decompose-claims';
+import type { ProjectContext } from '../project-context-types';
+import type { ProposalPayload } from './approval';
+
+const EXTRACTED_BY = 'llm:decompose-claims';
+
+export interface DecomposeClaimsArgs {
+  /** The passage to analyse. Trimmed; an empty passage is a no-op. */
+  passage: string;
+  /** Source-note path, used to title the output note. Optional. */
+  sourceRelPath?: string | null;
+  /** What to attribute the proposal to. Defaults to llm:decompose-claims. */
+  proposedBy?: string;
+  /** Per-call model override. Falls back to the global default. */
+  model?: string;
+}
+
+export interface DecomposeClaimsResult {
+  claimCount: number;
+  /** URI of the resulting Proposal. Null when the LLM returned no claims (no proposal filed). */
+  proposalUri: string | null;
+  /** Diagnostic populated when the LLM response couldn't be parsed; empty on success. */
+  error: string;
+}
+
+export async function decomposeClaims(
+  ctx: ProjectContext,
+  args: DecomposeClaimsArgs,
+): Promise<DecomposeClaimsResult> {
+  const passage = args.passage.trim();
+  if (!passage) {
+    return { claimCount: 0, proposalUri: null, error: '' };
+  }
+
+  graph.enterLLMContext();
+  try {
+    const sourceTitle = deriveSourceTitle(args.sourceRelPath);
+    const prompt = buildDecomposeClaimsPrompt({ sourceTitle, passage });
+
+    const raw = await complete(prompt, args.model ? { model: args.model } : undefined);
+    const { claims, error } = parseDecomposeClaimsResponse(raw);
+
+    if (error) {
+      return { claimCount: 0, proposalUri: null, error };
+    }
+    if (claims.length === 0) {
+      return { claimCount: 0, proposalUri: null, error: '' };
+    }
+
+    const stem = sourceStem(args.sourceRelPath);
+    const claimRecords = claims.map((c) => ({
+      claim: c,
+      uri: mintClaimUri(),
+    }));
+
+    const notePayload: ProposalPayload = {
+      kind: 'note',
+      relativePath: `notes/decomposition-of-${stem}.md`,
+      content: buildNoteBody(sourceTitle, claimRecords),
+    };
+
+    const triplesPayloads: ProposalPayload[] = claimRecords.map(({ claim, uri }) => ({
+      kind: 'graph-triples',
+      turtle: buildClaimTurtle(uri, claim),
+      affectsNodeUris: [uri],
+    }));
+
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation',
+      payloads: [notePayload, ...triplesPayloads],
+      note: `Decomposed ${claims.length} claim${claims.length === 1 ? '' : 's'}${
+        sourceTitle ? ` from "${sourceTitle}"` : ''
+      }`,
+      proposedBy: args.proposedBy ?? EXTRACTED_BY,
+    });
+
+    return {
+      claimCount: claims.length,
+      proposalUri: proposal?.uri ?? null,
+      error: '',
+    };
+  } finally {
+    graph.exitLLMContext();
+  }
+}
+
+function deriveSourceTitle(sourceRelPath?: string | null): string {
+  if (!sourceRelPath) return '';
+  const base = sourceRelPath.split('/').pop() ?? sourceRelPath;
+  return base.replace(/\.md$/i, '');
+}
+
+function sourceStem(sourceRelPath?: string | null): string {
+  const title = deriveSourceTitle(sourceRelPath);
+  if (!title) return 'passage';
+  return slugify(title);
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'passage';
+}
+
+function mintClaimUri(): string {
+  return `https://minerva.dev/c/claim-${randomUUID()}`;
+}
+
+interface ClaimRecord {
+  claim: DecomposedClaim;
+  uri: string;
+}
+
+function buildNoteBody(sourceTitle: string, records: ClaimRecord[]): string {
+  const heading = sourceTitle
+    ? `# Decomposition: ${sourceTitle}\n`
+    : `# Decomposition\n`;
+  const lead = sourceTitle
+    ? `Extracted from [[${sourceTitle}]].\n`
+    : `Extracted from selected passage.\n`;
+
+  const claimSections = records.map(({ claim, uri }, i) => {
+    const quoted = claim.sourceText
+      .split(/\r?\n/)
+      .map((line) => `> ${line}`)
+      .join('\n');
+    return [
+      `## ${i + 1}. ${claim.label}`,
+      ``,
+      `_kind:_ \`${claim.kind}\``,
+      ``,
+      quoted,
+      ``,
+      `<${uri}>`,
+    ].join('\n');
+  });
+
+  return `${heading}\n${lead}\n## Claims\n\n${claimSections.join('\n\n')}\n`;
+}
+
+function buildClaimTurtle(uri: string, claim: DecomposedClaim): string {
+  return [
+    `<${uri}> a thought:Claim ;`,
+    `  thought:label "${escapeTurtleLiteral(claim.label)}" ;`,
+    `  thought:sourceText "${escapeTurtleLiteral(claim.sourceText)}" ;`,
+    `  thought:claimKind "${claim.kind}" ;`,
+    `  thought:extractedBy "${EXTRACTED_BY}" ;`,
+    `  thought:hasStatus thought:proposed .`,
+  ].join('\n');
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -192,6 +192,10 @@ contextBridge.exposeInMainWorld('api', {
     decomposeSuggest: (relativePath: string, hints?: unknown) =>
       ipcRenderer.invoke(Channels.REFACTOR_DECOMPOSE_SUGGEST, relativePath, hints),
   },
+  research: {
+    decomposeClaims: (args: unknown) =>
+      ipcRenderer.invoke(Channels.RESEARCH_DECOMPOSE_CLAIMS, args),
+  },
   sources: {
     ingestUrl: (url: string) => ipcRenderer.invoke(Channels.SOURCES_INGEST_URL, url),
     ingestIdentifier: (identifier: string) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1061,6 +1061,53 @@
     sidebar?.refreshTags();
   }
 
+  async function handleDecomposeClaims() {
+    if (!notebase.meta) return;
+    const tab = editor.activeNoteTab;
+    if (!tab) return;
+    const selection = editorComponent?.getSelectionRange();
+    const passage = selection && selection.from !== selection.to
+      ? tab.content.slice(selection.from, selection.to)
+      : tab.content;
+    if (!passage.trim()) return;
+    try {
+      const result = await withBusy('Decomposing claims…', () =>
+        api.research.decomposeClaims({
+          passage,
+          sourceRelPath: tab.relativePath,
+        }),
+      );
+      if (result.error) {
+        await showConfirm(
+          `Decompose into Claims failed: ${result.error}`,
+          CONFIRM_KEYS.decomposeClaimsFailed,
+          'OK',
+        );
+        return;
+      }
+      if (result.claimCount === 0) {
+        await showConfirm(
+          'The passage did not yield any claims. Try a longer passage with concrete assertions.',
+          CONFIRM_KEYS.decomposeClaimsNoClaims,
+          'OK',
+        );
+        return;
+      }
+      await showConfirm(
+        `Filed ${result.claimCount} claim${result.claimCount === 1 ? '' : 's'} as a Proposal — review in the Proposals panel.`,
+        CONFIRM_KEYS.decomposeClaimsFiled,
+        'OK',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(
+        `Decompose into Claims failed: ${msg}`,
+        CONFIRM_KEYS.decomposeClaimsFailed,
+        'OK',
+      );
+    }
+  }
+
   async function handleAutoTag(relativePath: string) {
     if (!notebase.meta) return;
     try {
@@ -1694,6 +1741,7 @@
                     onAutoLink={() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); }}
                     onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
                     onDecompose={() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); }}
+                    onDecomposeClaims={() => { void handleDecomposeClaims(); }}
                     onFormatCurrentNote={() => handleFormatCurrentNote()}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -77,6 +77,7 @@
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
     onDecompose?: () => void;
+    onDecomposeClaims?: () => void;
     onFormatCurrentNote?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
@@ -110,6 +111,7 @@
     onAutoLink,
     onAutoLinkInbound,
     onDecompose,
+    onDecomposeClaims,
     onFormatCurrentNote,
     getNotePaths,
     getSources,
@@ -844,6 +846,14 @@
           </div>
         </div>
       {/if}
+    {/if}
+    {#if onDecomposeClaims}
+      <div class="submenu-item" onmouseenter={adjustSubmenu}>
+        <span class="submenu-trigger">Research &#x25B8;</span>
+        <div class="submenu">
+          <button onclick={() => handleMenuAction(() => onDecomposeClaims?.())}>Decompose into Claims</button>
+        </div>
+      </div>
     {/if}
     <div class="separator"></div>
     {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -21,6 +21,9 @@ export const CONFIRM_KEYS = {
   autoLinkFailed: 'auto-link-failed',
   decomposeFailed: 'decompose-failed',
   decomposeBadProposal: 'decompose-bad-proposal',
+  decomposeClaimsNoClaims: 'decompose-claims-no-claims',
+  decomposeClaimsFiled: 'decompose-claims-filed',
+  decomposeClaimsFailed: 'decompose-claims-failed',
   formatFailed: 'format-failed',
   formatComplete: 'format-complete',
   formatAllConfirm: 'format-all-confirm',
@@ -114,6 +117,24 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Decompose Note returned an unusable proposal',
     description:
       'Shown when the LLM\u2019s response can\u2019t be parsed into a valid parent + children structure.',
+  },
+  {
+    key: CONFIRM_KEYS.decomposeClaimsNoClaims,
+    title: 'Decompose into Claims: no claims found',
+    description:
+      'Shown when the LLM did not extract any claims from the selected passage (usually because the passage is too short or contains only questions / hedges).',
+  },
+  {
+    key: CONFIRM_KEYS.decomposeClaimsFiled,
+    title: 'Decompose into Claims: proposal filed',
+    description:
+      'Shown after Decompose into Claims successfully extracts N claims and files them as a single Proposal — review in the Proposals panel.',
+  },
+  {
+    key: CONFIRM_KEYS.decomposeClaimsFailed,
+    title: 'Decompose into Claims failed',
+    description:
+      'Shown when Decompose into Claims errors out (network failure, missing API key, malformed LLM response, etc).',
   },
   {
     key: CONFIRM_KEYS.formatFailed,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -409,9 +409,20 @@ export interface IdeApi {
   tabs: TabsApi;
   tools: ToolsApi;
   refactor: RefactorApi;
+  research: ResearchApi;
   formatter: FormatterApi;
   sources: SourcesApi;
   menu: MenuApi;
+}
+
+export interface ResearchApi {
+  /** #408 — decompose a passage into individual thought:Claim components. Returns a ProposalBundle URI when claims were extracted. */
+  decomposeClaims(args: {
+    passage: string;
+    sourceRelPath?: string | null;
+    proposedBy?: string;
+    model?: string;
+  }): Promise<{ claimCount: number; proposalUri: string | null; error: string }>;
 }
 
 export interface SourcesApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -125,6 +125,11 @@ export const Channels = {
   /** LLM-driven decomposition of a note into a parent index + children (#178). */
   REFACTOR_DECOMPOSE_SUGGEST: 'refactor:decomposeSuggest',
 
+  /** Research tool: decompose a passage into individual thought:Claim components (#408). */
+  RESEARCH_DECOMPOSE_CLAIMS: 'research:decomposeClaims',
+  /** Editor right-click → "Decompose into Claims". */
+  MENU_RESEARCH_DECOMPOSE_CLAIMS: 'menu:research:decomposeClaims',
+
   /** Ingest a URL (#93). Fetches, runs Readability, persists under .minerva/sources/<id>/. */
   SOURCES_INGEST_URL: 'sources:ingestUrl',
   /** Ingest a DOI / arXiv id / PubMed id (#96). Hits CrossRef / arXiv / PubMed. */

--- a/src/shared/refactor/decompose-claims.ts
+++ b/src/shared/refactor/decompose-claims.ts
@@ -1,0 +1,147 @@
+/**
+ * "Decompose into individual claims" (#408): pull every distinct
+ * assertion out of a passage as its own typed thought:Claim.
+ *
+ * This file is the pure shared piece — prompt builder, response parser,
+ * and the canonical claim-record shape. The main-side orchestrator
+ * (src/main/llm/decompose-claims.ts) handles the LLM call + builds the
+ * ProposalBundle; the apply path is whatever the approval engine does
+ * with that bundle.
+ */
+
+export type ClaimKind = 'factual' | 'evaluative' | 'definitional' | 'predictive';
+
+export const CLAIM_KINDS: readonly ClaimKind[] = [
+  'factual',
+  'evaluative',
+  'definitional',
+  'predictive',
+] as const;
+
+export interface DecomposedClaim {
+  /** 1-2 sentence summary the LLM wrote for this claim. */
+  label: string;
+  /** Verbatim passage the claim was lifted from. */
+  sourceText: string;
+  kind: ClaimKind;
+}
+
+export interface BuildDecomposeClaimsPromptArgs {
+  /** Optional human-readable label for the source. Used to orient the LLM, not parsed back. */
+  sourceTitle?: string;
+  /** The passage to decompose. Required and non-empty. */
+  passage: string;
+}
+
+export function buildDecomposeClaimsPrompt(args: BuildDecomposeClaimsPromptArgs): string {
+  const titleLine = args.sourceTitle
+    ? `## Source: ${args.sourceTitle}\n\n`
+    : '';
+  return `You are decomposing a passage into the individual **claims** it makes.
+
+A claim is one distinct assertion presented as true. Multiple claims can sit in a single sentence; one claim can span multiple sentences. Treat each as its own atom so the reader can audit them one by one.
+
+## Output
+
+Return ONLY a JSON object of this shape — no prose, no code fence, no commentary:
+
+{
+  "claims": [
+    {
+      "label": "1-2 sentence summary of the claim, in your own words",
+      "sourceText": "the verbatim text the claim came from (quote it exactly)",
+      "kind": "factual" | "evaluative" | "definitional" | "predictive"
+    }
+  ]
+}
+
+## Kinds
+
+- **factual** — asserts something is the case in the world ("the meeting was at 3pm", "X causes Y")
+- **evaluative** — asserts a value judgment ("this approach is better", "the report is misleading")
+- **definitional** — asserts what a term means ("a heuristic is a rule of thumb")
+- **predictive** — asserts what will happen ("rates will rise next quarter", "this will fail")
+
+## Rules
+
+- Verbatim quotes only in \`sourceText\`. Do not paraphrase that field.
+- One claim per atom. Do not coalesce two assertions into one entry.
+- Skip questions, hedges ("I'm not sure if…"), and pure rhetorical moves — they are not claims.
+- If the passage contains no claims at all, return \`{"claims": []}\`.
+
+${titleLine}## Passage
+
+${args.passage}`;
+}
+
+export interface ParseDecomposeClaimsResult {
+  claims: DecomposedClaim[];
+  /** Diagnostic message when the response couldn't be parsed. Empty string on success. */
+  error: string;
+}
+
+export function parseDecomposeClaimsResponse(raw: string): ParseDecomposeClaimsResult {
+  const trimmed = raw.trim();
+  if (!trimmed) return { claims: [], error: '' };
+
+  // Tolerate the model wrapping the JSON in a ```json fence even though
+  // the prompt asks not to. Strip the fence if present.
+  const stripped = stripCodeFence(trimmed);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (e) {
+    return {
+      claims: [],
+      error: `Could not parse LLM response as JSON: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object' || !('claims' in parsed)) {
+    return { claims: [], error: 'Response missing "claims" array.' };
+  }
+  const claimsRaw: unknown = parsed.claims;
+  if (!Array.isArray(claimsRaw)) {
+    return { claims: [], error: '"claims" was not an array.' };
+  }
+
+  const claims: DecomposedClaim[] = [];
+  for (const c of claimsRaw) {
+    if (!c || typeof c !== 'object') continue;
+    const rec = c as Record<string, unknown>;
+    const label = typeof rec.label === 'string' ? rec.label.trim() : '';
+    const sourceText = typeof rec.sourceText === 'string' ? rec.sourceText.trim() : '';
+    const kindRaw = typeof rec.kind === 'string' ? rec.kind.toLowerCase() : '';
+    if (!label || !sourceText) continue;
+    if (!isClaimKind(kindRaw)) continue;
+    claims.push({ label, sourceText, kind: kindRaw });
+  }
+
+  return { claims, error: '' };
+}
+
+function isClaimKind(s: string): s is ClaimKind {
+  return (CLAIM_KINDS as readonly string[]).includes(s);
+}
+
+function stripCodeFence(s: string): string {
+  // Match ``` or ```json (any language tag), and the closing ```.
+  const fence = /^```[a-zA-Z0-9_-]*\n?([\s\S]*?)\n?```$/;
+  const m = fence.exec(s);
+  return m ? m[1] : s;
+}
+
+/**
+ * Escape a string for use as a Turtle literal. Handles the backslash,
+ * double-quote, newline, and tab cases — enough for label and sourceText
+ * fields where the LLM may include quotes or paragraph breaks.
+ */
+export function escapeTurtleLiteral(s: string): string {
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t');
+}

--- a/tests/main/llm/decompose-claims-integration.test.ts
+++ b/tests/main/llm/decompose-claims-integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration coverage for the decompose-claims orchestrator (#408).
+ *
+ * Drives `decomposeClaims()` end-to-end with a mocked LLM response so
+ * the full path — prompt → LLM call → JSON parse → ProposalBundle
+ * (note + N triples) → proposeWrite → approval engine — is exercised as
+ * one unit. The pure prompt-builder / parser pieces have their own
+ * tests in shared; this file is the wiring + bundle-shape contract.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const { completeMock } = vi.hoisted(() => ({ completeMock: vi.fn() }));
+vi.mock('../../../src/main/llm/index', () => ({
+  complete: completeMock,
+}));
+
+import { decomposeClaims } from '../../../src/main/llm/decompose-claims';
+import {
+  approveProposal,
+  listProposals,
+  getProposal,
+  resetPolicy,
+} from '../../../src/main/llm/approval';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const FOUR_CLAIMS_RESPONSE = JSON.stringify({
+  claims: [
+    {
+      label: 'The meeting started at 3pm.',
+      sourceText: 'We started the meeting at 3pm sharp.',
+      kind: 'factual',
+    },
+    {
+      label: 'The discussion was unproductive.',
+      sourceText: 'Honestly the whole hour was a waste.',
+      kind: 'evaluative',
+    },
+    {
+      label: 'A "post-mortem" is a structured retrospective held after a notable event.',
+      sourceText: 'A post-mortem just means a structured retro after the fact.',
+      kind: 'definitional',
+    },
+    {
+      label: 'The next release will slip by two weeks.',
+      sourceText: 'We are going to slip the release by two weeks at least.',
+      kind: 'predictive',
+    },
+  ],
+});
+
+describe('decomposeClaims() integration (#408)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-decompose-claims-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+    completeMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('files a single Proposal whose payloads cover note + one triples-block per claim', async () => {
+    completeMock.mockResolvedValueOnce(FOUR_CLAIMS_RESPONSE);
+
+    const result = await decomposeClaims(ctx, {
+      passage: 'whatever — the LLM is mocked',
+      sourceRelPath: 'notes/standup-2026-04-26.md',
+    });
+    expect(result.error).toBe('');
+    expect(result.claimCount).toBe(4);
+    expect(result.proposalUri).not.toBeNull();
+
+    const proposals = await listProposals(ctx, 'pending');
+    expect(proposals).toHaveLength(1);
+    const p = proposals[0];
+    expect(p.operationType).toBe('component_creation');
+    expect(p.proposedBy).toBe('llm:decompose-claims');
+
+    // 1 note + 4 graph-triples = 5 payloads.
+    expect(p.payloads).toHaveLength(5);
+    expect(p.payloads[0].kind).toBe('note');
+    for (let i = 1; i <= 4; i++) {
+      expect(p.payloads[i].kind).toBe('graph-triples');
+    }
+
+    // Each triples payload affects exactly its own claim URI.
+    const triplesAffects = p.payloads.slice(1).flatMap((pl) =>
+      pl.kind === 'graph-triples' ? pl.affectsNodeUris : [],
+    );
+    expect(triplesAffects).toHaveLength(4);
+    expect(new Set(triplesAffects).size).toBe(4);
+    for (const uri of triplesAffects) {
+      expect(uri).toMatch(/^https:\/\/minerva\.dev\/c\/claim-/);
+    }
+    // The proposal's affectsNodeUris is the union of every payload's URIs:
+    // claim URIs from the triples blocks PLUS the note's project IRI added
+    // by the approval engine so the note shows up in integrity queries.
+    for (const uri of triplesAffects) {
+      expect(p.affectsNodeUris).toContain(uri);
+    }
+    expect(p.affectsNodeUris.length).toBeGreaterThanOrEqual(triplesAffects.length);
+  });
+
+  it('approving the bundle lands the note on disk AND every Claim in the graph', async () => {
+    completeMock.mockResolvedValueOnce(FOUR_CLAIMS_RESPONSE);
+    await decomposeClaims(ctx, {
+      passage: 'whatever',
+      sourceRelPath: 'notes/standup-2026-04-26.md',
+    });
+
+    const [pending] = await listProposals(ctx, 'pending');
+    expect(await approveProposal(ctx, pending.uri)).toBe(true);
+
+    // The note exists at the expected derived path.
+    const noteOnDisk = await fsp.readFile(
+      path.join(root, 'notes/decomposition-of-standup-2026-04-26.md'),
+      'utf-8',
+    );
+    expect(noteOnDisk).toContain('# Decomposition: standup-2026-04-26');
+    expect(noteOnDisk).toContain('The meeting started at 3pm.');
+    expect(noteOnDisk).toContain('_kind:_ `factual`');
+    expect(noteOnDisk).toContain('> We started the meeting at 3pm sharp.');
+
+    // Every Claim made it into the graph with its kind preserved.
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?label ?kind WHERE {
+        ?c a thought:Claim ;
+           thought:label ?label ;
+           thought:claimKind ?kind ;
+           thought:extractedBy "llm:decompose-claims" .
+      }
+      ORDER BY ?label
+    `);
+    const rows = r.results as Array<{ label: string; kind: string }>;
+    expect(rows).toHaveLength(4);
+    const kinds = rows.map((row) => row.kind).sort();
+    expect(kinds).toEqual(['definitional', 'evaluative', 'factual', 'predictive']);
+
+    // Proposal status flips to approved (one record, replaced — see #332).
+    const refreshed = await getProposal(ctx, pending.uri);
+    expect(refreshed?.status).toBe('approved');
+  });
+
+  it('returns claimCount=0 and files no proposal when the LLM returns an empty claims array', async () => {
+    completeMock.mockResolvedValueOnce(JSON.stringify({ claims: [] }));
+
+    const result = await decomposeClaims(ctx, {
+      passage: 'a passage with no real claims',
+    });
+    expect(result.claimCount).toBe(0);
+    expect(result.proposalUri).toBeNull();
+    expect(result.error).toBe('');
+    expect(await listProposals(ctx)).toHaveLength(0);
+  });
+
+  it('surfaces a parse error and files no proposal when the LLM returns garbage', async () => {
+    completeMock.mockResolvedValueOnce('this is not json at all');
+
+    const result = await decomposeClaims(ctx, { passage: 'whatever' });
+    expect(result.claimCount).toBe(0);
+    expect(result.proposalUri).toBeNull();
+    expect(result.error).toMatch(/parse/i);
+    expect(await listProposals(ctx)).toHaveLength(0);
+  });
+
+  it('skips the LLM entirely when the passage is empty / whitespace', async () => {
+    const result = await decomposeClaims(ctx, { passage: '   \n   ' });
+    expect(result.claimCount).toBe(0);
+    expect(result.proposalUri).toBeNull();
+    expect(completeMock).not.toHaveBeenCalled();
+  });
+
+  it('threads the model override into the underlying complete() call', async () => {
+    completeMock.mockResolvedValueOnce(JSON.stringify({ claims: [] }));
+    await decomposeClaims(ctx, {
+      passage: 'something',
+      model: 'claude-opus-4-7',
+    });
+
+    expect(completeMock).toHaveBeenCalledTimes(1);
+    expect(completeMock.mock.calls[0][1]).toEqual({ model: 'claude-opus-4-7' });
+  });
+
+  it('falls back to a generic stem when no source path is provided', async () => {
+    completeMock.mockResolvedValueOnce(JSON.stringify({
+      claims: [{
+        label: 'A thing is true.',
+        sourceText: 'A thing is true.',
+        kind: 'factual',
+      }],
+    }));
+    await decomposeClaims(ctx, { passage: 'A thing is true.' });
+
+    const [pending] = await listProposals(ctx, 'pending');
+    const note = pending.payloads.find((p) => p.kind === 'note');
+    expect(note?.kind).toBe('note');
+    if (note?.kind === 'note') {
+      expect(note.relativePath).toBe('notes/decomposition-of-passage.md');
+    }
+  });
+});

--- a/tests/shared/refactor/decompose-claims.test.ts
+++ b/tests/shared/refactor/decompose-claims.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit coverage for the pure shared piece of #408 — the prompt builder
+ * and the JSON-response parser. The orchestrator's integration test
+ * exercises this through the full pipe, but the parser deserves direct
+ * cases for malformed input, kind validation, and code-fence tolerance.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildDecomposeClaimsPrompt,
+  parseDecomposeClaimsResponse,
+  escapeTurtleLiteral,
+  CLAIM_KINDS,
+} from '../../../src/shared/refactor/decompose-claims';
+
+describe('buildDecomposeClaimsPrompt', () => {
+  it('embeds the passage verbatim in the prompt', () => {
+    const passage = 'A long passage with "quotes" and \\backslashes.';
+    const out = buildDecomposeClaimsPrompt({ passage });
+    expect(out).toContain(passage);
+  });
+
+  it('includes the source title when given', () => {
+    const out = buildDecomposeClaimsPrompt({
+      sourceTitle: 'standup-2026-04-26',
+      passage: 'x',
+    });
+    expect(out).toContain('## Source: standup-2026-04-26');
+  });
+
+  it('omits the source-title heading when absent', () => {
+    const out = buildDecomposeClaimsPrompt({ passage: 'x' });
+    expect(out).not.toContain('## Source:');
+  });
+
+  it('lists every supported claim kind so the model knows the closed set', () => {
+    const out = buildDecomposeClaimsPrompt({ passage: 'x' });
+    for (const kind of CLAIM_KINDS) {
+      expect(out).toContain(`**${kind}**`);
+    }
+  });
+});
+
+describe('parseDecomposeClaimsResponse', () => {
+  it('returns an empty list (no error) for an empty response', () => {
+    const r = parseDecomposeClaimsResponse('');
+    expect(r.claims).toEqual([]);
+    expect(r.error).toBe('');
+  });
+
+  it('parses a clean JSON body', () => {
+    const r = parseDecomposeClaimsResponse(JSON.stringify({
+      claims: [
+        { label: 'A', sourceText: 'a', kind: 'factual' },
+        { label: 'B', sourceText: 'b', kind: 'evaluative' },
+      ],
+    }));
+    expect(r.error).toBe('');
+    expect(r.claims).toHaveLength(2);
+    expect(r.claims[0].kind).toBe('factual');
+    expect(r.claims[1].kind).toBe('evaluative');
+  });
+
+  it('strips a ```json fence even though the prompt forbids it', () => {
+    const wrapped = '```json\n' + JSON.stringify({
+      claims: [{ label: 'X', sourceText: 'x', kind: 'predictive' }],
+    }) + '\n```';
+    const r = parseDecomposeClaimsResponse(wrapped);
+    expect(r.error).toBe('');
+    expect(r.claims).toHaveLength(1);
+    expect(r.claims[0].kind).toBe('predictive');
+  });
+
+  it('strips a bare ``` fence (no language tag)', () => {
+    const wrapped = '```\n' + JSON.stringify({
+      claims: [{ label: 'X', sourceText: 'x', kind: 'definitional' }],
+    }) + '\n```';
+    const r = parseDecomposeClaimsResponse(wrapped);
+    expect(r.error).toBe('');
+    expect(r.claims).toHaveLength(1);
+  });
+
+  it('returns a parse error when the body is not JSON at all', () => {
+    const r = parseDecomposeClaimsResponse('totally unrelated prose');
+    expect(r.claims).toEqual([]);
+    expect(r.error).toMatch(/parse/i);
+  });
+
+  it('returns a shape error when "claims" is missing', () => {
+    const r = parseDecomposeClaimsResponse(JSON.stringify({ stuff: [] }));
+    expect(r.claims).toEqual([]);
+    expect(r.error).toMatch(/claims/);
+  });
+
+  it('drops claims with unknown kinds rather than throwing', () => {
+    const r = parseDecomposeClaimsResponse(JSON.stringify({
+      claims: [
+        { label: 'ok', sourceText: 'ok', kind: 'factual' },
+        { label: 'bad', sourceText: 'bad', kind: 'speculative-with-vibes' },
+      ],
+    }));
+    expect(r.error).toBe('');
+    expect(r.claims).toHaveLength(1);
+    expect(r.claims[0].label).toBe('ok');
+  });
+
+  it('drops claims missing label or sourceText', () => {
+    const r = parseDecomposeClaimsResponse(JSON.stringify({
+      claims: [
+        { label: '', sourceText: 'x', kind: 'factual' },
+        { label: 'y', sourceText: '', kind: 'factual' },
+        { label: 'z', sourceText: 'z', kind: 'factual' },
+      ],
+    }));
+    expect(r.error).toBe('');
+    expect(r.claims).toHaveLength(1);
+    expect(r.claims[0].label).toBe('z');
+  });
+
+  it('case-folds the kind so "FACTUAL" and "Factual" both work', () => {
+    const r = parseDecomposeClaimsResponse(JSON.stringify({
+      claims: [
+        { label: 'a', sourceText: 'a', kind: 'FACTUAL' },
+        { label: 'b', sourceText: 'b', kind: 'Evaluative' },
+      ],
+    }));
+    expect(r.claims.map((c) => c.kind)).toEqual(['factual', 'evaluative']);
+  });
+
+  it('trims whitespace around label and sourceText', () => {
+    const r = parseDecomposeClaimsResponse(JSON.stringify({
+      claims: [{ label: '  hi  ', sourceText: '\n\nthere\n', kind: 'factual' }],
+    }));
+    expect(r.claims[0].label).toBe('hi');
+    expect(r.claims[0].sourceText).toBe('there');
+  });
+});
+
+describe('escapeTurtleLiteral', () => {
+  it('escapes backslashes and double-quotes', () => {
+    expect(escapeTurtleLiteral('he said "hi" \\o/'))
+      .toBe('he said \\"hi\\" \\\\o/');
+  });
+
+  it('escapes newlines and tabs as Turtle escape sequences', () => {
+    expect(escapeTurtleLiteral('a\nb\tc')).toBe('a\\nb\\tc');
+  });
+});


### PR DESCRIPTION
## Summary
- First of the Research-tools cluster. Right-click → **Research → Decompose into Claims** asks the LLM to enumerate every distinct assertion in a passage as a typed `thought:Claim` (factual / evaluative / definitional / predictive), with the verbatim quote retained.
- Output is one `ProposalBundle` (`#418`): a note payload (`notes/decomposition-of-<stem>.md`) + N `graph-triples` payloads (one Claim each). All-or-nothing. Trust-gated as `component_creation` → `requires_approval`.
- Surface: editor right-click menu (selection if any, otherwise the full note).

## Files

**Engine**
- `src/shared/refactor/decompose-claims.ts` — prompt builder, JSON parser (code-fence tolerant, kind-validated), Turtle literal escaping.
- `src/main/llm/decompose-claims.ts` — orchestrator: read passage, call `complete()`, parse, mint URIs, build bundle, `proposeWrite`.

**Wiring**
- `RESEARCH_DECOMPOSE_CLAIMS` IPC channel + preload + `ResearchApi` typing in `client.ts`.
- `Editor.svelte`: new "Research" submenu (parallel to Learning/Analysis).
- `App.svelte`: `handleDecomposeClaims` with `withBusy` + three new `CONFIRM_KEYS` entries (filed / no-claims / failed).

**Tests**
- `tests/shared/refactor/decompose-claims.test.ts` — 16 cases covering prompt content, JSON parsing, code-fence stripping, kind/case validation, Turtle escaping.
- `tests/main/llm/decompose-claims-integration.test.ts` — 7 cases: bundle shape, per-claim `affectsNodeUris`, approve flow lands note + every Claim, parse-error path, empty passage no-op, model override, default stem.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm test` — full suite passes
- [ ] Manual: select a passage with mixed assertions, run Research → Decompose into Claims, verify Proposals panel shows the bundle and approving lands both the note and the Claim nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)