### PR TITLE
tooling: make pnpm test one-shot, add pnpm test:watch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,7 @@ jobs:
         run: pnpm lint
 
       - name: Test
-        # `pnpm test` runs vitest in watch mode by default; force a single
-        # run for CI. Same effect as the local `pnpm coverage` minus the
-        # report.
-        run: pnpm exec vitest run
+        run: pnpm test
 
   e2e:
     # Runs in parallel with lint-and-test. Stays out of the unit loop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Minerva is a desktop markdown IDE built with Electron + Svelte 5 + TypeScript. I
 
 - `pnpm dev` — Start the dev server (electron-forge + Vite HMR)
 - `pnpm lint` — Type check: `tsc --noEmit` for `.ts` files, then `svelte-check --threshold error` for `.svelte` files (script/template drift, undefined references, wrong prop types). Warnings (a11y, state-referenced-locally) are not fatal.
-- `pnpm test` — Run tests (vitest)
+- `pnpm test` — Run tests once (vitest run). Use `pnpm test:watch` for the file-watcher loop.
 - `pnpm build` — Build distributable (electron-forge make)
 
 ## Architecture
@@ -54,7 +54,7 @@ To add a new main-process operation:
 
 ### File System
 - All paths are relative to the project root
-- `assertSafePath()` in `fs.ts` prevents path traversal — always use it
+- `assertSafePath()` in `fs.ts` prevents path traversal — always use it//
 - Hidden files (`.`) and `IGNORED_DIRS` (`.git`, `node_modules`, `.minerva`, `.obsidian`) are filtered from listings
 - Empty folders are shown in the sidebar (not filtered out)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "tsc --noEmit && svelte-check --threshold error && eslint .",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "build:e2e": "electron-forge package",
     "test:e2e": "pnpm build:e2e && playwright test"


### PR DESCRIPTION
## Summary
- \`pnpm test\` now runs vitest once and exits (currently it hangs on the file watcher's "press q to quit" prompt — wrong default for an unattended invocation, and it makes background CI-style runs from external tools hang indefinitely).
- \`pnpm test:watch\` keeps the watcher loop for in-editor flows.
- CI's \`pnpm exec vitest run\` workaround is gone — it now just runs \`pnpm test\`.
- CLAUDE.md command list updated.

## Test plan
- [x] \`pnpm test\` exits cleanly with the full pass/fail summary
- [x] \`pnpm test:watch\` enters the file-watcher loop as before
- [ ] CI still green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)