### PR TITLE
research menu: surface Decompose into Claims in the menu bar (#408 follow-up)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -421,6 +421,18 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
       ],
     },
 
+    // Research — LLM-powered tools that produce approval-gated proposals (#408 et al).
+    {
+      label: 'Research',
+      submenu: [
+        gate({
+          label: 'Decompose into Claims',
+          toolTip: 'Pull every distinct assertion in the selection (or the whole note) out as a typed thought:Claim. Files a Proposal.',
+          click: () => send(Channels.MENU_RESEARCH_DECOMPOSE_CLAIMS),
+        }),
+      ],
+    },
+
     // Tools for Thought — dynamic menus from tool registry
     ...CATEGORIES
       .filter(cat => getToolsByCategory(cat.id).length > 0)

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -364,6 +364,9 @@ contextBridge.exposeInMainWorld('api', {
     onRefactorDecompose: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_REFACTOR_DECOMPOSE, () => cb());
     },
+    onResearchDecomposeClaims: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_RESEARCH_DECOMPOSE_CLAIMS, () => cb());
+    },
     onFormatCurrentNote: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_FORMAT_CURRENT_NOTE, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1497,6 +1497,7 @@
     api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); });
     api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); });
     api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); });
+    api.menu.onResearchDecomposeClaims(() => { void handleDecomposeClaims(); });
 
     // Format menu (issue #153)
     api.menu.onFormatCurrentNote(() => handleFormatCurrentNote());

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -378,6 +378,7 @@ export interface MenuApi {
   onRefactorAutoLink(cb: () => void): void;
   onRefactorAutoLinkInbound(cb: () => void): void;
   onRefactorDecompose(cb: () => void): void;
+  onResearchDecomposeClaims(cb: () => void): void;
   onFormatCurrentNote(cb: () => void): void;
   onFormatFolder(cb: () => void): void;
   onFormatAll(cb: () => void): void;


### PR DESCRIPTION
## Summary
- Right-click menu had **Research → Decompose into Claims**; the title-bar menu didn't.
- Adds a top-level **Research** menu so the same command is reachable from the menu bar.
- Routes through the existing \`MENU_RESEARCH_DECOMPOSE_CLAIMS\` channel declared in #408 (it was unused on the renderer side until now).

## Test plan
- [x] \`pnpm lint\` clean
- [ ] Click Research → Decompose into Claims with a passage selected; verify a Proposal lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)