### PR TITLE
research tools: Find Supporting / Opposing Arguments (closes #409, closes #410)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -28,6 +28,7 @@ import {
 } from './llm/auto-link';
 import { suggestDecomposition, type DecomposeHints } from './llm/decompose';
 import { decomposeClaims, type DecomposeClaimsArgs } from './llm/decompose-claims';
+import { findArguments, type FindArgumentsArgs } from './llm/find-arguments';
 import {
   formatNoteContent,
   formatFile as formatFileOnDisk,
@@ -824,6 +825,15 @@ export function registerIpcHandlers(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
       return decomposeClaims(projectContext(rootPath), args);
+    },
+  );
+
+  ipcMain.handle(
+    Channels.RESEARCH_FIND_ARGUMENTS,
+    async (e, args: FindArgumentsArgs) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      return findArguments(projectContext(rootPath), args);
     },
   );
 

--- a/src/main/llm/find-arguments.ts
+++ b/src/main/llm/find-arguments.ts
@@ -1,0 +1,253 @@
+/**
+ * "Find supporting / opposing arguments" orchestrator (#409 + #410).
+ *
+ * Looks up the target Claim from the graph, asks the LLM (with web
+ * tools enabled) to enumerate the strongest cases for or against it,
+ * and files the result as a single approval-engine Proposal:
+ *   - one `note` payload (prose summary + per-argument breakdown)
+ *   - N `graph-triples` payloads (one thought:Grounds each, linked via
+ *     thought:supports or thought:rebuts to the original Claim, with
+ *     thought:hasCitation triples for every URL the LLM cited).
+ *
+ * If the LLM returns the no-strong-arguments-found verdict (anti-flattery
+ * rule from the tickets — empty is a valid answer), no Proposal is
+ * filed; the caller surfaces the verdict directly to the user.
+ *
+ * Trust-gated as `evidence_link` → `requires_approval`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { completeWithTools } from './index';
+import { proposeWrite } from './approval';
+import * as graph from '../graph/index';
+import { queryGraph } from '../graph/index';
+import {
+  buildFindArgumentsSystemPrompt,
+  buildFindArgumentsUserMessage,
+  parseFindArgumentsResponse,
+  escapeTurtleLiteral,
+  type ArgumentRecord,
+  type Polarity,
+  type Verdict,
+} from '../../shared/refactor/find-arguments';
+import type { ProjectContext } from '../project-context-types';
+import type { ProposalPayload } from './approval';
+
+export interface FindArgumentsArgs {
+  polarity: Polarity;
+  /** URI of the existing thought:Claim to argue for/against. Must resolve in the graph. */
+  claimUri: string;
+  /** Per-call model override. Falls back to the global default. */
+  model?: string;
+  /** What to attribute the proposal to. Default depends on polarity. */
+  proposedBy?: string;
+}
+
+export interface FindArgumentsResultPayload {
+  verdict: Verdict;
+  argumentCount: number;
+  /** URI of the resulting Proposal. Null when the verdict was no-strong-arguments-found. */
+  proposalUri: string | null;
+  /** Diagnostic populated when the LLM response couldn't be parsed; empty on success. */
+  error: string;
+}
+
+export async function findArguments(
+  ctx: ProjectContext,
+  args: FindArgumentsArgs,
+): Promise<FindArgumentsResultPayload> {
+  graph.enterLLMContext();
+  try {
+    const claim = await loadClaim(ctx, args.claimUri);
+    if (!claim) {
+      return {
+        verdict: 'no-strong-arguments-found',
+        argumentCount: 0,
+        proposalUri: null,
+        error: `No thought:Claim found at <${args.claimUri}>.`,
+      };
+    }
+
+    const system = buildFindArgumentsSystemPrompt(args.polarity);
+    const userMessage = buildFindArgumentsUserMessage({
+      polarity: args.polarity,
+      claimLabel: claim.label,
+      claimSourceText: claim.sourceText,
+    });
+
+    const { text } = await completeWithTools({
+      system,
+      messages: [{ role: 'user', content: userMessage }],
+      toolContext: { rootPath: ctx.rootPath },
+      ...(args.model ? { model: args.model } : {}),
+    });
+
+    const { result, error } = parseFindArgumentsResponse(text);
+    if (error || !result) {
+      return {
+        verdict: 'no-strong-arguments-found',
+        argumentCount: 0,
+        proposalUri: null,
+        error: error || 'Empty result from parser.',
+      };
+    }
+
+    if (result.verdict === 'no-strong-arguments-found') {
+      // Anti-flattery rule: an empty verdict is a real answer, not a
+      // failure — no Proposal is filed. The caller surfaces the verdict
+      // and summary back to the user.
+      return {
+        verdict: 'no-strong-arguments-found',
+        argumentCount: 0,
+        proposalUri: null,
+        error: '',
+      };
+    }
+
+    const groundsRecords = result.arguments.map((arg) => ({
+      arg,
+      uri: mintGroundsUri(),
+    }));
+
+    const proposedBy = args.proposedBy ?? extractedBy(args.polarity);
+    const notePayload: ProposalPayload = {
+      kind: 'note',
+      relativePath: noteRelPath(args.polarity, claim.label),
+      content: buildNoteBody(args.polarity, claim.label, result.summary, groundsRecords),
+    };
+    const triplesPayloads: ProposalPayload[] = groundsRecords.map(({ arg, uri }) => ({
+      kind: 'graph-triples',
+      turtle: buildGroundsTurtle(args.polarity, args.claimUri, uri, arg, proposedBy),
+      affectsNodeUris: [uri],
+    }));
+
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'evidence_link',
+      payloads: [notePayload, ...triplesPayloads],
+      note: `${verbForNote(args.polarity)} ${result.arguments.length} argument${
+        result.arguments.length === 1 ? '' : 's'
+      } for "${truncate(claim.label, 80)}"`,
+      proposedBy,
+    });
+
+    return {
+      verdict: 'arguments-found',
+      argumentCount: result.arguments.length,
+      proposalUri: proposal?.uri ?? null,
+      error: '',
+    };
+  } finally {
+    graph.exitLLMContext();
+  }
+}
+
+interface LoadedClaim {
+  label: string;
+  sourceText: string;
+}
+
+async function loadClaim(ctx: ProjectContext, claimUri: string): Promise<LoadedClaim | null> {
+  const r = await queryGraph(ctx, `
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    SELECT ?label ?sourceText WHERE {
+      <${claimUri}> a thought:Claim ;
+                    thought:label ?label .
+      OPTIONAL { <${claimUri}> thought:sourceText ?sourceText . }
+    } LIMIT 1
+  `);
+  const rows = r.results as Array<{ label: string; sourceText?: string }>;
+  if (rows.length === 0) return null;
+  return {
+    label: rows[0].label ?? '',
+    sourceText: rows[0].sourceText ?? '',
+  };
+}
+
+function extractedBy(polarity: Polarity): string {
+  return polarity === 'support'
+    ? 'llm:find-supporting-arguments'
+    : 'llm:find-opposing-arguments';
+}
+
+function verbForNote(polarity: Polarity): string {
+  return polarity === 'support' ? 'Found' : 'Found';
+}
+
+function noteRelPath(polarity: Polarity, claimLabel: string): string {
+  const stem = slugify(claimLabel) || 'claim';
+  const tag = polarity === 'support' ? 'supporting' : 'opposing';
+  return `notes/${tag}-arguments-for-${stem}.md`;
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function mintGroundsUri(): string {
+  return `https://minerva.dev/c/grounds-${randomUUID()}`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}
+
+function buildNoteBody(
+  polarity: Polarity,
+  claimLabel: string,
+  summary: string,
+  records: Array<{ arg: ArgumentRecord; uri: string }>,
+): string {
+  const heading = polarity === 'support'
+    ? `# Supporting arguments for: ${claimLabel}`
+    : `# Opposing arguments for: ${claimLabel}`;
+
+  const summaryBlock = summary ? `\n${summary}\n` : '';
+  const argSections = records.map(({ arg, uri }, i) => {
+    const cites = arg.citations.length > 0
+      ? `\n\n**Citations:**\n` + arg.citations
+        .map((c) => c.snippet
+          ? `- [${c.url}](${c.url}) — "${c.snippet}"`
+          : `- [${c.url}](${c.url})`,
+        ).join('\n')
+      : '\n\n_No citations._';
+    return [
+      `## ${i + 1}. ${arg.label}`,
+      ``,
+      `_strength:_ \`${arg.strength}\``,
+      ``,
+      arg.structure,
+      cites,
+      ``,
+      `<${uri}>`,
+    ].join('\n');
+  });
+
+  return `${heading}\n${summaryBlock}\n## Arguments\n\n${argSections.join('\n\n')}\n`;
+}
+
+function buildGroundsTurtle(
+  polarity: Polarity,
+  claimUri: string,
+  groundsUri: string,
+  arg: ArgumentRecord,
+  proposedBy: string,
+): string {
+  const linkPredicate = polarity === 'support' ? 'thought:supports' : 'thought:rebuts';
+  const lines = [
+    `<${groundsUri}> a thought:Grounds ;`,
+    `  thought:label "${escapeTurtleLiteral(arg.label)}" ;`,
+    `  thought:argumentStructure "${escapeTurtleLiteral(arg.structure)}" ;`,
+    `  thought:strength "${arg.strength}" ;`,
+    `  ${linkPredicate} <${claimUri}> ;`,
+    `  thought:extractedBy "${proposedBy}" ;`,
+    `  thought:hasStatus thought:proposed .`,
+  ];
+  for (const c of arg.citations) {
+    lines.push(`<${groundsUri}> thought:hasCitation <${c.url}> .`);
+  }
+  return lines.join('\n');
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -430,6 +430,17 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           toolTip: 'Pull every distinct assertion in the selection (or the whole note) out as a typed thought:Claim. Files a Proposal.',
           click: () => send(Channels.MENU_RESEARCH_DECOMPOSE_CLAIMS),
         }),
+        { type: 'separator' },
+        gate({
+          label: 'Find Supporting Arguments',
+          toolTip: 'For the Claim under the cursor, generate the strongest cases in favour of it (web-grounded). Files a Proposal of Grounds nodes.',
+          click: () => send(Channels.MENU_RESEARCH_FIND_SUPPORTING),
+        }),
+        gate({
+          label: 'Find Opposing Arguments',
+          toolTip: 'For the Claim under the cursor, generate the strongest cases against it (web-grounded). Files a Proposal of Grounds nodes.',
+          click: () => send(Channels.MENU_RESEARCH_FIND_OPPOSING),
+        }),
       ],
     },
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -195,6 +195,8 @@ contextBridge.exposeInMainWorld('api', {
   research: {
     decomposeClaims: (args: unknown) =>
       ipcRenderer.invoke(Channels.RESEARCH_DECOMPOSE_CLAIMS, args),
+    findArguments: (args: unknown) =>
+      ipcRenderer.invoke(Channels.RESEARCH_FIND_ARGUMENTS, args),
   },
   sources: {
     ingestUrl: (url: string) => ipcRenderer.invoke(Channels.SOURCES_INGEST_URL, url),
@@ -366,6 +368,12 @@ contextBridge.exposeInMainWorld('api', {
     },
     onResearchDecomposeClaims: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_RESEARCH_DECOMPOSE_CLAIMS, () => cb());
+    },
+    onResearchFindSupporting: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_RESEARCH_FIND_SUPPORTING, () => cb());
+    },
+    onResearchFindOpposing: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_RESEARCH_FIND_OPPOSING, () => cb());
     },
     onFormatCurrentNote: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_FORMAT_CURRENT_NOTE, () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1061,6 +1061,57 @@
     sidebar?.refreshTags();
   }
 
+  async function handleFindArguments(polarity: 'support' | 'oppose') {
+    if (!notebase.meta) return;
+    const claimUri = editorComponent?.getClaimUriAtCursor() ?? null;
+    if (!claimUri) {
+      await showConfirm(
+        'Place the cursor on (or select) a line containing a claim URI — for example, the `<https://minerva.dev/c/claim-…>` line in a decomposition note.',
+        polarity === 'support'
+          ? CONFIRM_KEYS.findArgumentsNoClaim
+          : CONFIRM_KEYS.findArgumentsNoClaim,
+        'OK',
+      );
+      return;
+    }
+    try {
+      const result = await withBusy(
+        polarity === 'support' ? 'Finding supporting arguments…' : 'Finding opposing arguments…',
+        () => api.research.findArguments({ polarity, claimUri }),
+      );
+      if (result.error) {
+        await showConfirm(
+          `${polarity === 'support' ? 'Find Supporting' : 'Find Opposing'} Arguments failed: ${result.error}`,
+          CONFIRM_KEYS.findArgumentsFailed,
+          'OK',
+        );
+        return;
+      }
+      if (result.verdict === 'no-strong-arguments-found') {
+        await showConfirm(
+          polarity === 'support'
+            ? 'The LLM found no strong supporting arguments for this claim. (That is a real answer, not a failure — see the anti-flattery rule.)'
+            : 'The LLM found no strong opposing arguments for this claim. (That is a real answer, not a failure — see the anti-flattery rule.)',
+          CONFIRM_KEYS.findArgumentsNoStrong,
+          'OK',
+        );
+        return;
+      }
+      await showConfirm(
+        `Filed ${result.argumentCount} ${polarity === 'support' ? 'supporting' : 'opposing'} argument${result.argumentCount === 1 ? '' : 's'} as a Proposal — review in the Proposals panel.`,
+        CONFIRM_KEYS.findArgumentsFiled,
+        'OK',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(
+        `${polarity === 'support' ? 'Find Supporting' : 'Find Opposing'} Arguments failed: ${msg}`,
+        CONFIRM_KEYS.findArgumentsFailed,
+        'OK',
+      );
+    }
+  }
+
   async function handleDecomposeClaims() {
     if (!notebase.meta) return;
     const tab = editor.activeNoteTab;
@@ -1498,6 +1549,8 @@
     api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); });
     api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); });
     api.menu.onResearchDecomposeClaims(() => { void handleDecomposeClaims(); });
+    api.menu.onResearchFindSupporting(() => { void handleFindArguments('support'); });
+    api.menu.onResearchFindOpposing(() => { void handleFindArguments('oppose'); });
 
     // Format menu (issue #153)
     api.menu.onFormatCurrentNote(() => handleFormatCurrentNote());
@@ -1743,6 +1796,8 @@
                     onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
                     onDecompose={() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); }}
                     onDecomposeClaims={() => { void handleDecomposeClaims(); }}
+                    onFindSupportingArguments={() => { void handleFindArguments('support'); }}
+                    onFindOpposingArguments={() => { void handleFindArguments('oppose'); }}
                     onFormatCurrentNote={() => handleFormatCurrentNote()}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -27,6 +27,7 @@
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { extractClaimUri } from '../../../shared/refactor/find-arguments';
 
   export interface CursorInfo {
     line: number;
@@ -78,6 +79,8 @@
     onAutoLinkInbound?: () => void;
     onDecompose?: () => void;
     onDecomposeClaims?: () => void;
+    onFindSupportingArguments?: () => void;
+    onFindOpposingArguments?: () => void;
     onFormatCurrentNote?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
@@ -112,6 +115,8 @@
     onAutoLinkInbound,
     onDecompose,
     onDecomposeClaims,
+    onFindSupportingArguments,
+    onFindOpposingArguments,
     onFormatCurrentNote,
     getNotePaths,
     getSources,
@@ -124,7 +129,7 @@
   let editorContainer: HTMLDivElement;
   let view: EditorView;
   let ignoreNextUpdate = false;
-  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean; docPos: number | null } | null>(null);
+  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean; docPos: number | null; claimUri: string | null } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
   // Separate from the main context menu: right-click anywhere in the
   // gutter opens a tiny toggle for line-number visibility. Keeps the
@@ -269,14 +274,24 @@
     let link: LinkRange | null = null;
     let hasSelection = false;
     let docPos: number | null = null;
+    let claimUri: string | null = null;
     if (view) {
       const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
       docPos = pos ?? null;
       if (pos != null) link = findLinkAt(view.state, pos);
       const sel = view.state.selection.main;
       hasSelection = sel.from !== sel.to;
+      // Resolve a thought:Claim URI from (1) the active selection, then
+      // (2) the line under the right-click. Powers Find Supporting /
+      // Opposing Arguments — those need a Claim node to link Grounds to.
+      const selText = hasSelection ? view.state.sliceDoc(sel.from, sel.to) : '';
+      claimUri = extractClaimUri(selText);
+      if (!claimUri && pos != null) {
+        const line = view.state.doc.lineAt(pos);
+        claimUri = extractClaimUri(line.text);
+      }
     }
-    contextMenu = { x: e.clientX, y: e.clientY, link, hasSelection, docPos };
+    contextMenu = { x: e.clientX, y: e.clientY, link, hasSelection, docPos, claimUri };
     const close = () => {
       closeMenu();
       window.removeEventListener('click', close);
@@ -568,6 +583,27 @@
     return { from: main.from, to: main.to };
   }
 
+  /**
+   * Resolve a thought:Claim URI from the active selection, then the
+   * line under the cursor. Returns null when nothing matches. Used by
+   * Find Supporting / Opposing Arguments to identify their target.
+   *
+   * Prefers the right-click context (savedSelection / contextMenu) when
+   * one is open, since the menu may have moved focus off the editor by
+   * the time the App handler runs.
+   */
+  export function getClaimUriAtCursor(): string | null {
+    if (!view) return null;
+    if (contextMenu?.claimUri) return contextMenu.claimUri;
+    const sel = view.state.selection.main;
+    if (sel.from !== sel.to) {
+      const hit = extractClaimUri(view.state.sliceDoc(sel.from, sel.to));
+      if (hit) return hit;
+    }
+    const line = view.state.doc.lineAt(sel.head);
+    return extractClaimUri(line.text);
+  }
+
   export function gotoOffset(offset: number) {
     if (!view) return;
     const clamped = Math.max(0, Math.min(offset, view.state.doc.length));
@@ -847,11 +883,30 @@
         </div>
       {/if}
     {/if}
-    {#if onDecomposeClaims}
+    {#if onDecomposeClaims || onFindSupportingArguments || onFindOpposingArguments}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Research &#x25B8;</span>
         <div class="submenu">
-          <button onclick={() => handleMenuAction(() => onDecomposeClaims?.())}>Decompose into Claims</button>
+          {#if onDecomposeClaims}
+            <button onclick={() => handleMenuAction(() => onDecomposeClaims?.())}>Decompose into Claims</button>
+          {/if}
+          {#if onFindSupportingArguments || onFindOpposingArguments}
+            {#if onDecomposeClaims}<div class="separator"></div>{/if}
+            {#if onFindSupportingArguments}
+              <button
+                onclick={() => handleMenuAction(() => onFindSupportingArguments?.())}
+                disabled={!contextMenu?.claimUri}
+                title={contextMenu?.claimUri ? '' : 'Right-click on a line containing a claim URI'}
+              >Find Supporting Arguments</button>
+            {/if}
+            {#if onFindOpposingArguments}
+              <button
+                onclick={() => handleMenuAction(() => onFindOpposingArguments?.())}
+                disabled={!contextMenu?.claimUri}
+                title={contextMenu?.claimUri ? '' : 'Right-click on a line containing a claim URI'}
+              >Find Opposing Arguments</button>
+            {/if}
+          {/if}
         </div>
       </div>
     {/if}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -24,6 +24,10 @@ export const CONFIRM_KEYS = {
   decomposeClaimsNoClaims: 'decompose-claims-no-claims',
   decomposeClaimsFiled: 'decompose-claims-filed',
   decomposeClaimsFailed: 'decompose-claims-failed',
+  findArgumentsNoClaim: 'find-arguments-no-claim',
+  findArgumentsNoStrong: 'find-arguments-no-strong',
+  findArgumentsFiled: 'find-arguments-filed',
+  findArgumentsFailed: 'find-arguments-failed',
   formatFailed: 'format-failed',
   formatComplete: 'format-complete',
   formatAllConfirm: 'format-all-confirm',
@@ -135,6 +139,30 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Decompose into Claims failed',
     description:
       'Shown when Decompose into Claims errors out (network failure, missing API key, malformed LLM response, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.findArgumentsNoClaim,
+    title: 'Find Arguments: no claim under cursor',
+    description:
+      'Shown when Find Supporting / Opposing Arguments is invoked without a thought:Claim URI in the selection or current line.',
+  },
+  {
+    key: CONFIRM_KEYS.findArgumentsNoStrong,
+    title: 'Find Arguments: no strong arguments found',
+    description:
+      'Shown when the LLM honestly reports it cannot find strong supporting / opposing arguments for the claim. (Anti-flattery rule — this is a real answer, not a failure.)',
+  },
+  {
+    key: CONFIRM_KEYS.findArgumentsFiled,
+    title: 'Find Arguments: proposal filed',
+    description:
+      'Shown after Find Supporting / Opposing Arguments successfully files N Grounds nodes as a Proposal — review in the Proposals panel.',
+  },
+  {
+    key: CONFIRM_KEYS.findArgumentsFailed,
+    title: 'Find Arguments failed',
+    description:
+      'Shown when Find Supporting / Opposing Arguments errors out (network failure, missing API key, malformed LLM response, etc).',
   },
   {
     key: CONFIRM_KEYS.formatFailed,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -379,6 +379,8 @@ export interface MenuApi {
   onRefactorAutoLinkInbound(cb: () => void): void;
   onRefactorDecompose(cb: () => void): void;
   onResearchDecomposeClaims(cb: () => void): void;
+  onResearchFindSupporting(cb: () => void): void;
+  onResearchFindOpposing(cb: () => void): void;
   onFormatCurrentNote(cb: () => void): void;
   onFormatFolder(cb: () => void): void;
   onFormatAll(cb: () => void): void;
@@ -424,6 +426,18 @@ export interface ResearchApi {
     proposedBy?: string;
     model?: string;
   }): Promise<{ claimCount: number; proposalUri: string | null; error: string }>;
+  /** #409 / #410 — find supporting / opposing arguments for an existing thought:Claim. Web-grounded; the no-strong-arguments-found verdict is a real answer (no Proposal filed). */
+  findArguments(args: {
+    polarity: 'support' | 'oppose';
+    claimUri: string;
+    proposedBy?: string;
+    model?: string;
+  }): Promise<{
+    verdict: 'arguments-found' | 'no-strong-arguments-found';
+    argumentCount: number;
+    proposalUri: string | null;
+    error: string;
+  }>;
 }
 
 export interface SourcesApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -129,6 +129,12 @@ export const Channels = {
   RESEARCH_DECOMPOSE_CLAIMS: 'research:decomposeClaims',
   /** Editor right-click → "Decompose into Claims". */
   MENU_RESEARCH_DECOMPOSE_CLAIMS: 'menu:research:decomposeClaims',
+  /** Research tool: find supporting / opposing arguments for a Claim (#409 / #410). Single channel, polarity in args. */
+  RESEARCH_FIND_ARGUMENTS: 'research:findArguments',
+  /** Menu bar / right-click → "Find Supporting Arguments". */
+  MENU_RESEARCH_FIND_SUPPORTING: 'menu:research:findSupporting',
+  /** Menu bar / right-click → "Find Opposing Arguments". */
+  MENU_RESEARCH_FIND_OPPOSING: 'menu:research:findOpposing',
 
   /** Ingest a URL (#93). Fetches, runs Readability, persists under .minerva/sources/<id>/. */
   SOURCES_INGEST_URL: 'sources:ingestUrl',

--- a/src/shared/refactor/find-arguments.ts
+++ b/src/shared/refactor/find-arguments.ts
@@ -1,0 +1,256 @@
+/**
+ * "Find supporting / opposing arguments" (#409 + #410): for a given
+ * thought:Claim, generate the strongest cases for or against it,
+ * web-grounded.
+ *
+ * Pure shared piece — prompt builders + JSON response parser. The
+ * orchestrator that calls the LLM and files the ProposalBundle lives in
+ * `src/main/llm/find-arguments.ts`.
+ *
+ * Both polarities use the same shape and the same parser. The system
+ * prompt diverges to enforce the anti-flattery rules per ticket:
+ *   - support: don't soften the case if you disagree.
+ *   - oppose: don't weaken the opposition just because the user prefers
+ *     the original claim.
+ */
+
+export type Polarity = 'support' | 'oppose';
+
+export type ArgumentStrength = 'strong' | 'moderate' | 'weak';
+
+export const ARGUMENT_STRENGTHS: readonly ArgumentStrength[] = [
+  'strong',
+  'moderate',
+  'weak',
+] as const;
+
+export interface ArgumentCitation {
+  /** Verbatim URL the LLM cited. */
+  url: string;
+  /** Short snippet from the cited page that grounds the argument. May be empty if the model omitted it. */
+  snippet: string;
+}
+
+export interface ArgumentRecord {
+  /** 1-sentence summary of THIS argument (not the original claim). */
+  label: string;
+  /** Inferential structure — "X because Y because Z, so the claim follows". */
+  structure: string;
+  strength: ArgumentStrength;
+  citations: ArgumentCitation[];
+}
+
+export type Verdict = 'arguments-found' | 'no-strong-arguments-found';
+
+export interface FindArgumentsResult {
+  verdict: Verdict;
+  /** Human-readable prose summarising the case. Empty string when verdict is no-strong-arguments-found. */
+  summary: string;
+  /** May be empty when verdict is no-strong-arguments-found. */
+  arguments: ArgumentRecord[];
+}
+
+export interface BuildFindArgumentsPromptArgs {
+  polarity: Polarity;
+  claimLabel: string;
+  /** Optional verbatim source passage the claim was extracted from — useful context for the LLM. */
+  claimSourceText?: string;
+}
+
+const SHARED_RULES = `
+- Cite the web. Use the web_search and web_fetch tools to ground every argument; an argument without at least one citation is not strong enough to include.
+- Distinguish argument strength from your personal confidence. Grade each argument as \`strong\`, \`moderate\`, or \`weak\` based on how good the argument is *as an argument* — not whether you find the original claim plausible overall.
+- One claim per atom. Each entry in \`arguments\` should be a single inferential chain, not a bundle.
+- If you genuinely cannot find at least one argument that meets the bar (cited, coherent, at least \`weak\`), return \`{"verdict": "no-strong-arguments-found", "summary": "", "arguments": []}\`. Returning a fake or padded list is a worse outcome than this verdict.
+
+## Output
+
+Return ONLY a JSON object of this shape — no prose, no code fence, no commentary:
+
+{
+  "verdict": "arguments-found" | "no-strong-arguments-found",
+  "summary": "a few sentences of human-readable prose summarising the case (empty string when no arguments found)",
+  "arguments": [
+    {
+      "label": "1-sentence claim of THIS argument",
+      "structure": "the inferential chain — \\"X because Y because Z, so the original claim follows\\"",
+      "strength": "strong" | "moderate" | "weak",
+      "citations": [
+        { "url": "https://example.com/article", "snippet": "verbatim quote from the cited page" }
+      ]
+    }
+  ]
+}
+`.trim();
+
+export function buildFindArgumentsSystemPrompt(polarity: Polarity): string {
+  if (polarity === 'support') {
+    return `You are helping a researcher audit a specific claim by surfacing the strongest cases **in favour of it**.
+
+## Anti-flattery rule
+
+Do NOT soften the case if you personally disagree with the claim. Do NOT inflate the case beyond what the citations actually support. If the genuine state of the evidence is "there are no strong supporting arguments here", say so via the no-strong-arguments-found verdict — that is a valid and useful answer.
+
+${SHARED_RULES}`;
+  }
+  return `You are helping a researcher audit a specific claim by surfacing the strongest cases **against it**.
+
+## Anti-flattery rule
+
+Do NOT weaken the opposition because the user clearly prefers the original claim or because earlier conversation context suggests they want it defended. The user is explicitly asking you to argue the other side — your job is to do that as forcefully as the evidence allows. If you genuinely cannot find a strong opposing case, the no-strong-arguments-found verdict is the right answer; do not pad with weak rebuttals to look responsive.
+
+${SHARED_RULES}`;
+}
+
+export function buildFindArgumentsUserMessage(args: BuildFindArgumentsPromptArgs): string {
+  const polarityVerb = args.polarity === 'support' ? 'support' : 'rebut';
+  const sourceBlock = args.claimSourceText
+    ? `\n\n## Source passage (for context)\n\n> ${args.claimSourceText.split(/\r?\n/).map((l) => l).join('\n> ')}`
+    : '';
+  return `## Claim to ${polarityVerb}
+
+${args.claimLabel}${sourceBlock}
+
+Find the strongest arguments that ${polarityVerb} this claim. Web search is available; use it.`;
+}
+
+export interface ParseFindArgumentsResult {
+  result: FindArgumentsResult | null;
+  error: string;
+}
+
+export function parseFindArgumentsResponse(raw: string): ParseFindArgumentsResult {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { result: null, error: 'LLM returned an empty response.' };
+  }
+
+  const stripped = stripCodeFence(trimmed);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (e) {
+    return {
+      result: null,
+      error: `Could not parse LLM response as JSON: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { result: null, error: 'Response was not a JSON object.' };
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  const verdictRaw = typeof obj.verdict === 'string' ? obj.verdict : '';
+  if (verdictRaw !== 'arguments-found' && verdictRaw !== 'no-strong-arguments-found') {
+    return {
+      result: null,
+      error: `Unknown verdict: ${JSON.stringify(verdictRaw)}.`,
+    };
+  }
+  const summary = typeof obj.summary === 'string' ? obj.summary.trim() : '';
+
+  if (verdictRaw === 'no-strong-arguments-found') {
+    return {
+      result: { verdict: 'no-strong-arguments-found', summary, arguments: [] },
+      error: '',
+    };
+  }
+
+  const argsRaw = obj.arguments;
+  if (!Array.isArray(argsRaw)) {
+    return { result: null, error: '"arguments" was not an array.' };
+  }
+
+  const argumentRecords: ArgumentRecord[] = [];
+  for (const a of argsRaw) {
+    if (!a || typeof a !== 'object') continue;
+    const rec = a as Record<string, unknown>;
+    const label = typeof rec.label === 'string' ? rec.label.trim() : '';
+    const structure = typeof rec.structure === 'string' ? rec.structure.trim() : '';
+    const strengthRaw = typeof rec.strength === 'string' ? rec.strength.toLowerCase() : '';
+    if (!label || !structure) continue;
+    if (!isStrength(strengthRaw)) continue;
+    argumentRecords.push({
+      label,
+      structure,
+      strength: strengthRaw,
+      citations: parseCitations(rec.citations),
+    });
+  }
+
+  if (argumentRecords.length === 0) {
+    // The LLM said "arguments-found" but every entry was malformed. That's
+    // either a parse-bug-ish state or a genuine "I tried but had nothing".
+    // Treat it as the explicit no-strong-arguments-found verdict so the
+    // caller's UX is consistent.
+    return {
+      result: { verdict: 'no-strong-arguments-found', summary, arguments: [] },
+      error: '',
+    };
+  }
+
+  return {
+    result: {
+      verdict: 'arguments-found',
+      summary,
+      arguments: argumentRecords,
+    },
+    error: '',
+  };
+}
+
+function parseCitations(raw: unknown): ArgumentCitation[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ArgumentCitation[] = [];
+  for (const c of raw) {
+    if (!c || typeof c !== 'object') continue;
+    const rec = c as Record<string, unknown>;
+    const url = typeof rec.url === 'string' ? rec.url.trim() : '';
+    const snippet = typeof rec.snippet === 'string' ? rec.snippet.trim() : '';
+    if (!url) continue;
+    if (!isHttpUrl(url)) continue;
+    out.push({ url, snippet });
+  }
+  return out;
+}
+
+function isHttpUrl(s: string): boolean {
+  return /^https?:\/\//i.test(s);
+}
+
+function isStrength(s: string): s is ArgumentStrength {
+  return (ARGUMENT_STRENGTHS as readonly string[]).includes(s);
+}
+
+function stripCodeFence(s: string): string {
+  const fence = /^```[a-zA-Z0-9_-]*\n?([\s\S]*?)\n?```$/;
+  const m = fence.exec(s);
+  return m ? m[1] : s;
+}
+
+/**
+ * Extract the first absolute Minerva-style claim URI from a snippet of
+ * text — used by the renderer to detect "is the cursor near a claim?"
+ * before enabling the Find Supporting / Find Opposing menu items.
+ *
+ * Matches `<https://…/c/claim-…>` or bare `https://…/c/claim-…`. Returns
+ * null when nothing matches. The caller is responsible for verifying the
+ * URI actually resolves to a thought:Claim in the graph.
+ */
+export function extractClaimUri(text: string): string | null {
+  const re = /<?(https?:\/\/[^\s<>"]*\/c\/claim-[^\s<>"]+)>?/i;
+  const m = re.exec(text);
+  return m ? m[1] : null;
+}
+
+/** Escape for use as a Turtle literal — same rules as decompose-claims. */
+export function escapeTurtleLiteral(s: string): string {
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t');
+}

--- a/tests/main/llm/find-arguments-integration.test.ts
+++ b/tests/main/llm/find-arguments-integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Integration coverage for the find-arguments orchestrator (#409 / #410).
+ *
+ * Drives both polarities through the full pipe: graph lookup → LLM call
+ * (mocked) → JSON parse → ProposalBundle (note + N Grounds triples) →
+ * proposeWrite → optional approve → SPARQL verification of supports /
+ * rebuts edges and citation links.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const { completeWithToolsMock, completeMock } = vi.hoisted(() => ({
+  completeWithToolsMock: vi.fn(),
+  completeMock: vi.fn(),
+}));
+vi.mock('../../../src/main/llm/index', () => ({
+  complete: completeMock,
+  completeWithTools: completeWithToolsMock,
+}));
+
+import { findArguments } from '../../../src/main/llm/find-arguments';
+import {
+  approveProposal,
+  proposeWrite,
+  listProposals,
+  resetPolicy,
+} from '../../../src/main/llm/approval';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const CLAIM_URI = 'https://minerva.dev/c/claim-target-of-arguments';
+const CLAIM_TURTLE = `
+<${CLAIM_URI}> a thought:Claim ;
+  thought:label "The meeting started at 3pm." ;
+  thought:sourceText "We started the meeting at 3pm sharp." ;
+  thought:hasStatus thought:proposed .
+`;
+
+async function plantClaim(ctx: ProjectContext): Promise<void> {
+  const p = await proposeWrite(ctx, {
+    operationType: 'tag_addition',
+    payloads: [{
+      kind: 'graph-triples',
+      turtle: CLAIM_TURTLE,
+      affectsNodeUris: [CLAIM_URI],
+    }],
+    note: 'autonomous tier — landed directly',
+    proposedBy: 'unit-test-fixture',
+  });
+  expect(p).toBeNull();
+}
+
+const SUPPORTING_RESPONSE = JSON.stringify({
+  verdict: 'arguments-found',
+  summary: 'Multiple internal records corroborate the 3pm start.',
+  arguments: [
+    {
+      label: 'The calendar invite shows 3pm.',
+      structure: 'Invite says 3pm; attendees synced from the invite; therefore the meeting started at 3pm.',
+      strength: 'strong',
+      citations: [
+        { url: 'https://example.com/calendar', snippet: 'invite for 3:00 PM' },
+      ],
+    },
+    {
+      label: 'The slack #general post-meeting message is timestamped 3:48pm.',
+      structure: 'Post-meeting note arrived 3:48pm; meetings of this type run ~45min; therefore start ~3pm.',
+      strength: 'moderate',
+      citations: [
+        { url: 'https://slack.example.com/archive/abc', snippet: 'thanks all, ttyl' },
+      ],
+    },
+  ],
+});
+
+const OPPOSING_RESPONSE = JSON.stringify({
+  verdict: 'arguments-found',
+  summary: 'Two independent timestamps contradict the 3pm claim.',
+  arguments: [
+    {
+      label: 'Door-badge logs show entries between 3:05 and 3:14.',
+      structure: 'Late entries imply the meeting had not yet started; therefore 3pm is too early.',
+      strength: 'strong',
+      citations: [
+        { url: 'https://badge.example.com/log', snippet: 'entries 15:05–15:14' },
+      ],
+    },
+  ],
+});
+
+const NO_ARGUMENTS_RESPONSE = JSON.stringify({
+  verdict: 'no-strong-arguments-found',
+  summary: '',
+  arguments: [],
+});
+
+describe('findArguments() integration (#409 / #410)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-find-arguments-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+    completeWithToolsMock.mockReset();
+    completeMock.mockReset();
+    await plantClaim(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('support polarity: files a Proposal whose Grounds link via thought:supports', async () => {
+    completeWithToolsMock.mockResolvedValueOnce({ text: SUPPORTING_RESPONSE, citations: [] });
+
+    const result = await findArguments(ctx, {
+      polarity: 'support',
+      claimUri: CLAIM_URI,
+    });
+    expect(result.error).toBe('');
+    expect(result.verdict).toBe('arguments-found');
+    expect(result.argumentCount).toBe(2);
+    expect(result.proposalUri).not.toBeNull();
+
+    const [pending] = await listProposals(ctx, 'pending');
+    expect(pending.operationType).toBe('evidence_link');
+    expect(pending.proposedBy).toBe('llm:find-supporting-arguments');
+    // 1 note + 2 graph-triples
+    expect(pending.payloads).toHaveLength(3);
+    expect(pending.payloads[0].kind).toBe('note');
+
+    expect(await approveProposal(ctx, pending.uri)).toBe(true);
+
+    // Supports edges land on the Claim.
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?g ?label ?strength WHERE {
+        ?g a thought:Grounds ;
+           thought:supports <${CLAIM_URI}> ;
+           thought:label ?label ;
+           thought:strength ?strength ;
+           thought:extractedBy "llm:find-supporting-arguments" .
+      }
+    `);
+    expect(r.results.length).toBe(2);
+
+    // Note landed.
+    const note = await fsp.readFile(
+      path.join(root, 'notes/supporting-arguments-for-the-meeting-started-at-3pm.md'),
+      'utf-8',
+    );
+    expect(note).toContain('Supporting arguments');
+    expect(note).toContain('The calendar invite shows 3pm.');
+  });
+
+  it('oppose polarity: files a Proposal whose Grounds link via thought:rebuts', async () => {
+    completeWithToolsMock.mockResolvedValueOnce({ text: OPPOSING_RESPONSE, citations: [] });
+
+    const result = await findArguments(ctx, {
+      polarity: 'oppose',
+      claimUri: CLAIM_URI,
+    });
+    expect(result.argumentCount).toBe(1);
+
+    const [pending] = await listProposals(ctx, 'pending');
+    expect(pending.proposedBy).toBe('llm:find-opposing-arguments');
+    expect(await approveProposal(ctx, pending.uri)).toBe(true);
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      ASK { ?g a thought:Grounds ; thought:rebuts <${CLAIM_URI}> . }
+    `);
+    expect(r.results).toBeDefined();
+    // queryGraph returns boolean ASK as a row with `_ask: true`; some
+    // engines surface it differently. Use a SELECT count instead for
+    // robustness.
+    const counted = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT (COUNT(?g) AS ?n) WHERE { ?g a thought:Grounds ; thought:rebuts <${CLAIM_URI}> . }
+    `);
+    const rows = counted.results as Array<{ n: string }>;
+    expect(Number(rows[0].n)).toBe(1);
+
+    const note = await fsp.readFile(
+      path.join(root, 'notes/opposing-arguments-for-the-meeting-started-at-3pm.md'),
+      'utf-8',
+    );
+    expect(note).toContain('Opposing arguments');
+  });
+
+  it('attaches thought:hasCitation triples for every cited URL', async () => {
+    completeWithToolsMock.mockResolvedValueOnce({ text: SUPPORTING_RESPONSE, citations: [] });
+    await findArguments(ctx, { polarity: 'support', claimUri: CLAIM_URI });
+    const [pending] = await listProposals(ctx, 'pending');
+    expect(await approveProposal(ctx, pending.uri)).toBe(true);
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?cite WHERE {
+        ?g a thought:Grounds ; thought:hasCitation ?cite .
+      }
+      ORDER BY ?cite
+    `);
+    const cites = (r.results as Array<{ cite: string }>).map((row) => row.cite).sort();
+    expect(cites).toEqual([
+      'https://example.com/calendar',
+      'https://slack.example.com/archive/abc',
+    ]);
+  });
+
+  it('no-strong-arguments-found verdict files NO Proposal and surfaces the verdict', async () => {
+    completeWithToolsMock.mockResolvedValueOnce({ text: NO_ARGUMENTS_RESPONSE, citations: [] });
+
+    const result = await findArguments(ctx, {
+      polarity: 'support',
+      claimUri: CLAIM_URI,
+    });
+    expect(result.verdict).toBe('no-strong-arguments-found');
+    expect(result.argumentCount).toBe(0);
+    expect(result.proposalUri).toBeNull();
+    expect(await listProposals(ctx)).toHaveLength(0);
+  });
+
+  it('returns an error and files no Proposal when the LLM body cannot be parsed', async () => {
+    completeWithToolsMock.mockResolvedValueOnce({ text: 'not json', citations: [] });
+
+    const result = await findArguments(ctx, {
+      polarity: 'support',
+      claimUri: CLAIM_URI,
+    });
+    expect(result.error).toMatch(/parse/i);
+    expect(result.proposalUri).toBeNull();
+    expect(await listProposals(ctx)).toHaveLength(0);
+  });
+
+  it('returns a clear error when the claim URI does not exist in the graph', async () => {
+    const result = await findArguments(ctx, {
+      polarity: 'support',
+      claimUri: 'https://minerva.dev/c/claim-does-not-exist',
+    });
+    expect(result.error).toMatch(/no thought:claim/i);
+    expect(completeWithToolsMock).not.toHaveBeenCalled();
+    expect(result.proposalUri).toBeNull();
+  });
+
+  it('threads the model override into completeWithTools', async () => {
+    completeWithToolsMock.mockResolvedValueOnce({ text: NO_ARGUMENTS_RESPONSE, citations: [] });
+    await findArguments(ctx, {
+      polarity: 'support',
+      claimUri: CLAIM_URI,
+      model: 'claude-opus-4-7',
+    });
+
+    expect(completeWithToolsMock).toHaveBeenCalledTimes(1);
+    const opts = completeWithToolsMock.mock.calls[0][0];
+    expect(opts.model).toBe('claude-opus-4-7');
+    expect(opts.system).toMatch(/in favour of it/i);
+  });
+});

--- a/tests/shared/refactor/find-arguments.test.ts
+++ b/tests/shared/refactor/find-arguments.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit coverage for the pure shared piece of #409 / #410 — prompt
+ * builders, JSON parser, claim-URI extractor, anti-flattery verdict.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildFindArgumentsSystemPrompt,
+  buildFindArgumentsUserMessage,
+  parseFindArgumentsResponse,
+  extractClaimUri,
+  escapeTurtleLiteral,
+  ARGUMENT_STRENGTHS,
+} from '../../../src/shared/refactor/find-arguments';
+
+describe('buildFindArgumentsSystemPrompt', () => {
+  it('embeds the support anti-flattery rule for support polarity', () => {
+    const out = buildFindArgumentsSystemPrompt('support');
+    expect(out).toMatch(/in favour of it/i);
+    expect(out).toMatch(/Do NOT soften/i);
+  });
+
+  it('embeds the oppose anti-flattery rule for oppose polarity', () => {
+    const out = buildFindArgumentsSystemPrompt('oppose');
+    expect(out).toMatch(/against it/i);
+    expect(out).toMatch(/Do NOT weaken the opposition/i);
+  });
+
+  it('asks for grounded citations and exposes the no-strong-arguments-found verdict', () => {
+    const out = buildFindArgumentsSystemPrompt('support');
+    expect(out).toContain('web_search');
+    expect(out).toContain('no-strong-arguments-found');
+  });
+
+  it('lists every argument-strength bucket', () => {
+    const out = buildFindArgumentsSystemPrompt('support');
+    for (const s of ARGUMENT_STRENGTHS) {
+      expect(out).toContain(`"${s}"`);
+    }
+  });
+});
+
+describe('buildFindArgumentsUserMessage', () => {
+  it('includes the claim label verbatim', () => {
+    const out = buildFindArgumentsUserMessage({
+      polarity: 'support',
+      claimLabel: 'Water boils at 100C at 1atm.',
+    });
+    expect(out).toContain('Water boils at 100C at 1atm.');
+  });
+
+  it('includes the source passage as a blockquote when supplied', () => {
+    const out = buildFindArgumentsUserMessage({
+      polarity: 'oppose',
+      claimLabel: 'X.',
+      claimSourceText: 'paragraph 1\nparagraph 2',
+    });
+    expect(out).toContain('> paragraph 1');
+    expect(out).toContain('> paragraph 2');
+  });
+
+  it('uses the right verb per polarity', () => {
+    expect(buildFindArgumentsUserMessage({ polarity: 'support', claimLabel: 'X' }))
+      .toMatch(/support/i);
+    expect(buildFindArgumentsUserMessage({ polarity: 'oppose', claimLabel: 'X' }))
+      .toMatch(/rebut/i);
+  });
+});
+
+describe('parseFindArgumentsResponse', () => {
+  it('parses an arguments-found body with citations', () => {
+    const body = JSON.stringify({
+      verdict: 'arguments-found',
+      summary: 'Two strong cases here.',
+      arguments: [
+        {
+          label: 'Argument 1',
+          structure: 'Because A, then B, then claim.',
+          strength: 'strong',
+          citations: [
+            { url: 'https://example.com/a', snippet: 'Direct quote.' },
+            { url: 'https://example.org/b', snippet: '' },
+          ],
+        },
+      ],
+    });
+    const r = parseFindArgumentsResponse(body);
+    expect(r.error).toBe('');
+    expect(r.result?.verdict).toBe('arguments-found');
+    expect(r.result?.arguments).toHaveLength(1);
+    expect(r.result?.arguments[0].citations).toHaveLength(2);
+    expect(r.result?.arguments[0].citations[0].url).toBe('https://example.com/a');
+  });
+
+  it('passes through the no-strong-arguments-found verdict (anti-flattery rule)', () => {
+    const r = parseFindArgumentsResponse(JSON.stringify({
+      verdict: 'no-strong-arguments-found',
+      summary: '',
+      arguments: [],
+    }));
+    expect(r.error).toBe('');
+    expect(r.result?.verdict).toBe('no-strong-arguments-found');
+    expect(r.result?.arguments).toEqual([]);
+  });
+
+  it('strips a ```json code fence', () => {
+    const wrapped = '```json\n' + JSON.stringify({
+      verdict: 'arguments-found',
+      summary: 's',
+      arguments: [{ label: 'a', structure: 'b', strength: 'moderate', citations: [] }],
+    }) + '\n```';
+    const r = parseFindArgumentsResponse(wrapped);
+    expect(r.error).toBe('');
+    expect(r.result?.arguments).toHaveLength(1);
+  });
+
+  it('returns an error for a non-JSON body', () => {
+    const r = parseFindArgumentsResponse('totally not json');
+    expect(r.result).toBeNull();
+    expect(r.error).toMatch(/parse/i);
+  });
+
+  it('returns an error for an unknown verdict', () => {
+    const r = parseFindArgumentsResponse(JSON.stringify({
+      verdict: 'i-dunno',
+      summary: '',
+      arguments: [],
+    }));
+    expect(r.result).toBeNull();
+    expect(r.error).toMatch(/verdict/i);
+  });
+
+  it('drops arguments with unknown strength', () => {
+    const r = parseFindArgumentsResponse(JSON.stringify({
+      verdict: 'arguments-found',
+      summary: '',
+      arguments: [
+        { label: 'good', structure: 's', strength: 'strong', citations: [] },
+        { label: 'bad', structure: 's', strength: 'pretty-good-actually', citations: [] },
+      ],
+    }));
+    expect(r.error).toBe('');
+    expect(r.result?.arguments).toHaveLength(1);
+    expect(r.result?.arguments[0].label).toBe('good');
+  });
+
+  it('drops citations with non-http URLs', () => {
+    const r = parseFindArgumentsResponse(JSON.stringify({
+      verdict: 'arguments-found',
+      summary: '',
+      arguments: [
+        {
+          label: 'a',
+          structure: 'b',
+          strength: 'strong',
+          citations: [
+            { url: 'https://ok.com', snippet: '' },
+            { url: 'javascript:alert(1)', snippet: '' },
+            { url: 'mailto:x@y.com', snippet: '' },
+            { url: 'gopher://nostalgia', snippet: '' },
+          ],
+        },
+      ],
+    }));
+    expect(r.error).toBe('');
+    expect(r.result?.arguments[0].citations).toHaveLength(1);
+    expect(r.result?.arguments[0].citations[0].url).toBe('https://ok.com');
+  });
+
+  it('coerces an arguments-found verdict with all-malformed entries down to no-strong-arguments-found', () => {
+    // The LLM said "found" but every entry was missing label/structure.
+    // Treat that as the verdict the user actually wants to see.
+    const r = parseFindArgumentsResponse(JSON.stringify({
+      verdict: 'arguments-found',
+      summary: 'tried but nothing landed',
+      arguments: [
+        { label: '', structure: 's', strength: 'strong', citations: [] },
+        { label: 'a', structure: '', strength: 'strong', citations: [] },
+      ],
+    }));
+    expect(r.error).toBe('');
+    expect(r.result?.verdict).toBe('no-strong-arguments-found');
+    expect(r.result?.summary).toBe('tried but nothing landed');
+  });
+});
+
+describe('extractClaimUri', () => {
+  it('finds an angle-bracketed claim URI on the line', () => {
+    expect(extractClaimUri('something something <https://minerva.dev/c/claim-abc-123> trailing'))
+      .toBe('https://minerva.dev/c/claim-abc-123');
+  });
+
+  it('finds a bare claim URI', () => {
+    expect(extractClaimUri('cf https://minerva.dev/c/claim-xyz'))
+      .toBe('https://minerva.dev/c/claim-xyz');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(extractClaimUri('plain prose with no URI in sight')).toBeNull();
+  });
+
+  it('returns null for non-claim Minerva URIs', () => {
+    expect(extractClaimUri('<https://minerva.dev/c/grounds-foo>')).toBeNull();
+  });
+});
+
+describe('escapeTurtleLiteral', () => {
+  it('escapes the usual suspects', () => {
+    expect(escapeTurtleLiteral('a "b" \\c\nd\te'))
+      .toBe('a \\"b\\" \\\\c\\nd\\te');
+  });
+});


### PR DESCRIPTION
## Summary

For an existing \`thought:Claim\`, ask the LLM (web tools enabled) to enumerate the strongest cases **for** or **against** it. Result lands as one ProposalBundle:
- One \`note\` payload — prose summary + per-argument breakdown with linked citations.
- N \`graph-triples\` payloads — one \`thought:Grounds\` each, linked via \`thought:supports\` (or \`thought:rebuts\`) to the original Claim, plus \`thought:hasCitation\` triples for every URL the LLM cited.
- Trust-gated as \`evidence_link\` → \`requires_approval\`.

## Anti-flattery
The system prompts are explicit per the tickets: don't soften, don't inflate. **\`no-strong-arguments-found\` is a real verdict, not a failure** — when the LLM returns it, the orchestrator skips the Proposal entirely and the UI surfaces the verdict as a normal info dialog so the user sees the honest answer.

## Surfaces
- **Editor right-click → Research → Find Supporting / Opposing Arguments** — disabled when no Claim URI is detected in the selection or current line. URI shape: \`<https://minerva.dev/c/claim-…>\` (the form Decompose into Claims emits).
- **Research menu bar entries** — same handlers.

## Implementation
- \`src/shared/refactor/find-arguments.ts\` — Polarity type, polarity-specific system prompts, JSON parser (tolerates fence, drops non-http citations, coerces all-malformed → no-arguments).
- \`src/main/llm/find-arguments.ts\` — orchestrator: graph lookup → \`completeWithTools\` → parse → bundle.
- One IPC channel (\`RESEARCH_FIND_ARGUMENTS\`) with polarity in args; two menu entries.
- \`source\` payloads stay deferred (still NotImplementedError per #418); citations are inline in the note + on each Grounds via \`thought:hasCitation\`.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1713/1713 pass (27 new)
- [ ] Manual: open a decomposition note from #408, right-click on a Claim URI line, run Find Supporting / Opposing Arguments, verify the Proposal lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)