### PR TITLE
Sidebar bulk Add/Remove Tag (closes #427)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -13,6 +13,11 @@
   import { getNotebaseStore } from './lib/stores/notebase.svelte';
   import { flattenNoteFiles, resolveWikiLinkTarget } from './lib/wiki-link-resolver';
   import { expandSelectionToNoteFiles, resolveSelectionTargets, pathExistsInTree } from './lib/sidebar-tree-utils';
+  import {
+    mergeTagsIntoContent,
+    removeTagsFromContent,
+    extractTagsFromContent,
+  } from '../shared/refactor/auto-tag';
   import { getEditorStore } from './lib/stores/editor.svelte';
   import PromptDialog from './lib/components/PromptDialog.svelte';
   import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
@@ -120,7 +125,7 @@
   }
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
-  let promptDialog = $state<{ message: string; resolve: (value: string | null) => void } | null>(null);
+  let promptDialog = $state<{ message: string; suggestions?: string[]; resolve: (value: string | null) => void } | null>(null);
   let confirmDialog = $state<{ message: string; confirmLabel: string; key: string; resolve: (value: boolean) => void } | null>(null);
   let exportDialogFor = $state<string | null>(null);
   /**
@@ -133,9 +138,9 @@
   } | null>(null);
   const confirmSuppression = getConfirmSuppressionStore();
 
-  function showPrompt(message: string): Promise<string | null> {
+  function showPrompt(message: string, options: { suggestions?: string[] } = {}): Promise<string | null> {
     return new Promise((resolve) => {
-      promptDialog = { message, resolve };
+      promptDialog = { message, suggestions: options.suggestions, resolve };
     });
   }
 
@@ -815,6 +820,169 @@
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
     }
+  }
+
+  /**
+   * Resolve the sidebar selection to the list of .md files a bulk-tag
+   * operation should touch. Returns null when nothing applies — the
+   * caller surfaces the "no .md files" dialog.
+   */
+  function bulkTagTargets(fallbackPath?: string, fallbackIsDir?: boolean): string[] | null {
+    const sel = sidebar?.getSelectionPaths() ?? [];
+    if (sel.length > 0) {
+      return expandSelectionToNoteFiles(new Set(sel), notebase.files);
+    }
+    if (fallbackPath && !fallbackIsDir && fallbackPath.endsWith('.md')) {
+      return [fallbackPath];
+    }
+    if (fallbackPath && fallbackIsDir) {
+      return expandSelectionToNoteFiles(new Set([fallbackPath]), notebase.files);
+    }
+    return null;
+  }
+
+  /**
+   * Bulk Add Tag. Prompts for a tag name (autocompleted from the
+   * thoughtbase vocabulary) and appends it to every .md in the
+   * selection. Per-note: noop if the tag is already present
+   * (mergeTagsIntoContent handles that). Per-batch: failures are
+   * collected into a summary instead of aborting.
+   */
+  async function handleAddTag(targetPath?: string, targetIsDir?: boolean) {
+    if (!notebase.meta) return;
+    const targets = bulkTagTargets(targetPath, targetIsDir);
+    if (targets === null || targets.length === 0) {
+      await showConfirm(
+        'The selection contains no .md files to tag.',
+        CONFIRM_KEYS.bulkTagNoSelection,
+        'OK',
+      );
+      return;
+    }
+
+    let vocab: string[];
+    try {
+      vocab = (await api.tags.list()).map((t) => t.tag);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Add Tag failed: ${msg}`, CONFIRM_KEYS.bulkTagFailed, 'OK');
+      return;
+    }
+
+    const raw = await showPrompt(
+      `Add tag to ${targets.length} note${targets.length === 1 ? '' : 's'}:`,
+      { suggestions: vocab },
+    );
+    if (!raw) return;
+    const tag = raw.trim().toLowerCase();
+    if (!tag) return;
+
+    let changed = 0;
+    const failures: Array<{ path: string; error: string }> = [];
+    for (const path of targets) {
+      try {
+        const content = await api.notebase.readFile(path);
+        const { content: next, addedTags } = mergeTagsIntoContent(content, [tag]);
+        if (addedTags.length > 0) {
+          await api.notebase.writeFile(path, next);
+          changed++;
+        }
+      } catch (err) {
+        failures.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    sidebar?.refreshTags();
+    await reportBulkTagSummary('Add', tag, targets.length, changed, failures);
+  }
+
+  /**
+   * Bulk Remove Tag. Prompts with the union of tags actually present
+   * on the selected .md files (so the autocomplete only offers
+   * tags it can plausibly remove). Per-note removal is
+   * case-insensitive.
+   */
+  async function handleRemoveTag(targetPath?: string, targetIsDir?: boolean) {
+    if (!notebase.meta) return;
+    const targets = bulkTagTargets(targetPath, targetIsDir);
+    if (targets === null || targets.length === 0) {
+      await showConfirm(
+        'The selection contains no .md files to tag.',
+        CONFIRM_KEYS.bulkTagNoSelection,
+        'OK',
+      );
+      return;
+    }
+
+    // Build the union of tags across the selection. We need the
+    // file contents anyway for the writes that follow, but the
+    // prompt has to come first — so do a read pass up-front.
+    const tagSet = new Set<string>();
+    const readFailures: Array<{ path: string; error: string }> = [];
+    const cache = new Map<string, string>();
+    for (const path of targets) {
+      try {
+        const content = await api.notebase.readFile(path);
+        cache.set(path, content);
+        for (const t of extractTagsFromContent(content)) tagSet.add(t);
+      } catch (err) {
+        readFailures.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+    if (tagSet.size === 0) {
+      await showConfirm(
+        'None of the selected notes have tags to remove.',
+        CONFIRM_KEYS.bulkTagNoTagsOnSelection,
+        'OK',
+      );
+      return;
+    }
+    const suggestions = [...tagSet].sort();
+    const raw = await showPrompt(
+      `Remove tag from ${targets.length} note${targets.length === 1 ? '' : 's'}:`,
+      { suggestions },
+    );
+    if (!raw) return;
+    const tag = raw.trim().toLowerCase();
+    if (!tag) return;
+
+    let changed = 0;
+    const failures: Array<{ path: string; error: string }> = [...readFailures];
+    for (const path of targets) {
+      // Skip files that already errored on read — we don't have
+      // content to operate on and re-reading would just re-fail.
+      if (!cache.has(path)) continue;
+      try {
+        const content = cache.get(path)!;
+        const { content: next, removedTags } = removeTagsFromContent(content, [tag]);
+        if (removedTags.length > 0) {
+          await api.notebase.writeFile(path, next);
+          changed++;
+        }
+      } catch (err) {
+        failures.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    sidebar?.refreshTags();
+    await reportBulkTagSummary('Remove', tag, targets.length, changed, failures);
+  }
+
+  async function reportBulkTagSummary(
+    op: 'Add' | 'Remove',
+    tag: string,
+    total: number,
+    changed: number,
+    failures: Array<{ path: string; error: string }>,
+  ): Promise<void> {
+    const verb = op === 'Add' ? 'tagged' : 'untagged';
+    let msg = `${verb} ${changed} of ${total} note${total === 1 ? '' : 's'} with "${tag}".`;
+    if (failures.length > 0) {
+      const head = failures.slice(0, 5).map((f) => `• ${f.path}: ${f.error}`).join('\n');
+      const tail = failures.length > 5 ? `\n…and ${failures.length - 5} more` : '';
+      msg += `\n\nFailed (${failures.length}):\n${head}${tail}`;
+    }
+    await showConfirm(msg, CONFIRM_KEYS.bulkTagComplete, 'OK');
   }
 
   /**
@@ -1877,6 +2045,8 @@
           onNewNote={handleNewNote}
           onNewFolder={handleNewFolder}
           onDelete={handleDelete}
+          onAddTag={handleAddTag}
+          onRemoveTag={handleRemoveTag}
           onRename={handleRename}
           onCut={handleCut}
           onCopy={handleCopy}
@@ -2160,6 +2330,7 @@
   {#if promptDialog}
     <PromptDialog
       message={promptDialog.message}
+      suggestions={promptDialog.suggestions ?? []}
       onConfirm={handlePromptConfirm}
       onCancel={handlePromptCancel}
     />

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -27,6 +27,8 @@
     onNewNote: (directory: string) => void;
     onNewFolder: (directory: string) => void;
     onDelete: (relativePath: string, isDirectory: boolean) => void;
+    onAddTag?: (relativePath: string, isDirectory: boolean) => void;
+    onRemoveTag?: (relativePath: string, isDirectory: boolean) => void;
     /** Fired right before a tree-item context menu opens. Lets the
      *  parent promote the right-clicked item into the selection (Finder
      *  / VS Code: right-clicking outside the selection drops it to a
@@ -42,7 +44,7 @@
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
   }
 
-  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onContextMenuTarget, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onExternalDrop }: Props = $props();
+  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onContextMenuTarget, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onExternalDrop }: Props = $props();
 
   let contextMenu = $state<{ x: number; y: number; dir: string; target?: string; targetIsDir?: boolean } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
@@ -141,6 +143,8 @@
             {onNewNote}
             {onNewFolder}
             {onDelete}
+            {onAddTag}
+            {onRemoveTag}
             {onContextMenuTarget}
             {onRename}
             {onCut}
@@ -218,6 +222,19 @@
           <button onclick={() => { void api.shell.openInTerminal(contextMenu!.target); contextMenu = null; }}>Open in Terminal</button>
         </div>
       </div>
+      {#if onAddTag || onRemoveTag}
+        <div class="separator"></div>
+        {#if onAddTag}
+          <button onclick={() => { onAddTag(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
+            Add Tag…
+          </button>
+        {/if}
+        {#if onRemoveTag}
+          <button onclick={() => { onRemoveTag(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
+            Remove Tag…
+          </button>
+        {/if}
+      {/if}
       <div class="separator"></div>
       <button onclick={() => { onDelete(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
         Delete

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -3,11 +3,18 @@
     message: string;
     onConfirm: (value: string) => void;
     onCancel: () => void;
+    /** Optional autocomplete pool. Rendered via <datalist> so the
+     *  browser handles filtering + keyboard nav for free. Used by the
+     *  bulk Add/Remove Tag flow; harmless when omitted. */
+    suggestions?: string[];
   }
 
-  let { message, onConfirm, onCancel }: Props = $props();
+  let { message, onConfirm, onCancel, suggestions = [] }: Props = $props();
   let value = $state('');
   let inputEl = $state<HTMLInputElement>();
+  // Stable id so multiple PromptDialogs (rare, but possible during
+  // overlapping flows) don't collide on the datalist anchor.
+  const listId = `prompt-dialog-suggestions-${Math.random().toString(36).slice(2, 9)}`;
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && value.trim()) {
@@ -31,7 +38,16 @@
       bind:value
       type="text"
       class="input"
+      list={suggestions.length > 0 ? listId : undefined}
+      autocomplete="off"
     />
+    {#if suggestions.length > 0}
+      <datalist id={listId}>
+        {#each suggestions as s}
+          <option value={s}></option>
+        {/each}
+      </datalist>
+    {/if}
     <div class="actions">
       <button class="btn cancel" onclick={onCancel}>Cancel</button>
       <button class="btn confirm" disabled={!value.trim()} onclick={() => onConfirm(value.trim())}>OK</button>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -15,6 +15,8 @@
     onNewNote: (directory: string) => void;
     onNewFolder: (directory: string) => void;
     onDelete: (relativePath: string, isDirectory: boolean) => void;
+    onAddTag?: (relativePath: string, isDirectory: boolean) => void;
+    onRemoveTag?: (relativePath: string, isDirectory: boolean) => void;
     onRename: (relativePath: string) => void;
     onCut: (relativePath: string, isDirectory: boolean) => void;
     onCopy: (relativePath: string, isDirectory: boolean) => void;
@@ -30,7 +32,7 @@
     canPaste?: boolean;
   }
 
-  let { files, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let rootDropHover = $state(false);
   let tagPanel = $state<TagPanel>();
   let sourcesPanel = $state<SourcesPanel>();
@@ -217,6 +219,8 @@
         {onNewNote}
         {onNewFolder}
         {onDelete}
+        {onAddTag}
+        {onRemoveTag}
         onContextMenuTarget={handleContextMenuTarget}
         {onRename}
         {onCut}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -29,6 +29,10 @@ export const CONFIRM_KEYS = {
   findArgumentsNoStrong: 'find-arguments-no-strong',
   findArgumentsFiled: 'find-arguments-filed',
   findArgumentsFailed: 'find-arguments-failed',
+  bulkTagFailed: 'bulk-tag-failed',
+  bulkTagComplete: 'bulk-tag-complete',
+  bulkTagNoSelection: 'bulk-tag-no-selection',
+  bulkTagNoTagsOnSelection: 'bulk-tag-no-tags-on-selection',
   formatFailed: 'format-failed',
   formatComplete: 'format-complete',
   formatAllConfirm: 'format-all-confirm',
@@ -170,6 +174,30 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Find Arguments failed',
     description:
       'Shown when Find Supporting / Opposing Arguments errors out (network failure, missing API key, malformed LLM response, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.bulkTagComplete,
+    title: 'Bulk Add/Remove Tag complete',
+    description:
+      'Summary dialog after a sidebar Add Tag / Remove Tag operation finishes (counts of notes changed and any per-note failures).',
+  },
+  {
+    key: CONFIRM_KEYS.bulkTagFailed,
+    title: 'Bulk Add/Remove Tag failed',
+    description:
+      'Shown when a bulk tag operation fails outright (e.g. fetching the tag vocabulary errored before the loop started).',
+  },
+  {
+    key: CONFIRM_KEYS.bulkTagNoSelection,
+    title: 'Bulk Tag: no .md files in selection',
+    description:
+      'Shown when Add Tag / Remove Tag is invoked on a sidebar selection that resolves to no .md files (e.g. only a .csv file selected).',
+  },
+  {
+    key: CONFIRM_KEYS.bulkTagNoTagsOnSelection,
+    title: 'Remove Tag: selection has no tags',
+    description:
+      'Shown when Remove Tag is invoked on a selection whose notes have no frontmatter tags — there is nothing to remove.',
   },
   {
     key: CONFIRM_KEYS.formatFailed,

--- a/src/shared/refactor/auto-tag.ts
+++ b/src/shared/refactor/auto-tag.ts
@@ -95,6 +95,76 @@ export interface MergeResult {
 }
 
 /**
+ * Reads the existing frontmatter `tags:` list out of a note. Returns
+ * an empty array when there's no frontmatter, no `tags` key, or the
+ * key isn't an array of strings. Used by the bulk-tag UI to compute
+ * the union of tags across a selection (so Remove Tag's autocomplete
+ * only offers tags actually present on the selected notes).
+ */
+export function extractTagsFromContent(content: string): string[] {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return [];
+  let parsed: unknown;
+  try { parsed = YAML.parse(match[1]); } catch { return []; }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+  const fm = parsed as Record<string, unknown>;
+  if (!Array.isArray(fm.tags)) return [];
+  return fm.tags.filter((t): t is string => typeof t === 'string');
+}
+
+export interface RemoveResult {
+  /** Updated note content. Equals the input when no removals applied. */
+  content: string;
+  /** Tags actually removed (case-insensitive match against `tagsToRemove`). */
+  removedTags: string[];
+}
+
+/**
+ * Removes `tagsToRemove` from the note's frontmatter `tags:` array,
+ * case-insensitively. Leaves the rest of the frontmatter untouched.
+ * If `tags` becomes empty, the key is dropped (rather than left as
+ * `tags: []`, which is noise in the indexer and on disk).
+ */
+export function removeTagsFromContent(content: string, tagsToRemove: string[]): RemoveResult {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return { content, removedTags: [] };
+  let parsed: unknown;
+  try { parsed = YAML.parse(match[1]); } catch { return { content, removedTags: [] }; }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { content, removedTags: [] };
+  }
+  const fm = parsed as Record<string, unknown>;
+  if (!Array.isArray(fm.tags)) return { content, removedTags: [] };
+
+  const removeSet = new Set(tagsToRemove.map((t) => t.toLowerCase()));
+  const removedTags: string[] = [];
+  const keptTags: unknown[] = [];
+  for (const t of fm.tags) {
+    if (typeof t !== 'string') { keptTags.push(t); continue; }
+    if (removeSet.has(t.toLowerCase())) {
+      removedTags.push(t);
+    } else {
+      keptTags.push(t);
+    }
+  }
+  if (removedTags.length === 0) return { content, removedTags: [] };
+
+  if (keptTags.length === 0) delete fm.tags;
+  else fm.tags = keptTags;
+
+  // If the frontmatter ends up empty (no remaining keys) drop the
+  // block entirely \u2014 same rationale as dropping an empty `tags:` key.
+  const body = content.slice(match[0].length);
+  if (Object.keys(fm).length === 0) {
+    return { content: body.replace(/^\n+/, ''), removedTags };
+  }
+  const yamlBlock = YAML.stringify(fm).trimEnd();
+  const rendered = `---\n${yamlBlock}\n---\n`;
+  const separator = body.startsWith('\n') || body === '' ? '' : '\n';
+  return { content: rendered + separator + body, removedTags };
+}
+
+/**
  * Merges `newTags` into the note\u2019s frontmatter `tags:` array. Skips tags
  * that are already present (case-insensitive). Creates a frontmatter block
  * when the note has none.

--- a/tests/shared/refactor/auto-tag.test.ts
+++ b/tests/shared/refactor/auto-tag.test.ts
@@ -4,6 +4,8 @@ import {
   buildAutoTagPrompt,
   parseAutoTagResponse,
   mergeTagsIntoContent,
+  removeTagsFromContent,
+  extractTagsFromContent,
 } from '../../../src/shared/refactor/auto-tag';
 
 describe('buildAutoTagPrompt (issue #174)', () => {
@@ -153,5 +155,78 @@ describe('mergeTagsIntoContent', () => {
     expect(out.content).toContain('# Title');
     expect(out.content).toContain('First para.');
     expect(out.content).toContain('Second para.');
+  });
+});
+
+describe('extractTagsFromContent', () => {
+  it('returns the tags array verbatim when present', () => {
+    const content = '---\ntags:\n  - alpha\n  - beta\n---\nbody\n';
+    expect(extractTagsFromContent(content)).toEqual(['alpha', 'beta']);
+  });
+  it('returns [] when there is no frontmatter', () => {
+    expect(extractTagsFromContent('plain body\n')).toEqual([]);
+  });
+  it('returns [] when frontmatter exists but has no tags key', () => {
+    expect(extractTagsFromContent('---\ntitle: x\n---\nbody\n')).toEqual([]);
+  });
+  it('returns [] when tags is not an array', () => {
+    expect(extractTagsFromContent('---\ntags: alpha\n---\nbody\n')).toEqual([]);
+  });
+  it('drops non-string entries from the tags array', () => {
+    const content = '---\ntags:\n  - alpha\n  - 42\n  - beta\n---\nbody\n';
+    expect(extractTagsFromContent(content)).toEqual(['alpha', 'beta']);
+  });
+  it('returns [] on malformed YAML rather than throwing', () => {
+    // The frontmatter regex matches but YAML.parse rejects it.
+    expect(extractTagsFromContent('---\ntags: [a, b\n---\nbody\n')).toEqual([]);
+  });
+});
+
+describe('removeTagsFromContent', () => {
+  it('removes a tag (case-insensitive) and reports it', () => {
+    const content = '---\ntitle: Note\ntags:\n  - alpha\n  - Beta\n---\nbody\n';
+    const out = removeTagsFromContent(content, ['BETA']);
+    expect(out.removedTags).toEqual(['Beta']);
+    const fm = YAML.parse(out.content.match(/^---\n([\s\S]*?)\n---/)![1]);
+    expect(fm.tags).toEqual(['alpha']);
+    expect(fm.title).toBe('Note');
+  });
+
+  it('drops the tags key entirely when the last tag is removed', () => {
+    const content = '---\ntitle: Note\ntags:\n  - only-one\n---\nbody\n';
+    const out = removeTagsFromContent(content, ['only-one']);
+    expect(out.removedTags).toEqual(['only-one']);
+    expect(out.content).not.toMatch(/^tags:/m);
+    expect(out.content).toMatch(/title: Note/);
+  });
+
+  it('drops the whole frontmatter block when removing the last tag leaves it empty', () => {
+    // tags was the only key — losing it strands the block, so we drop it
+    // entirely rather than leaving a `---\n---` artifact on disk.
+    const content = '---\ntags:\n  - solo\n---\nbody text\n';
+    const out = removeTagsFromContent(content, ['solo']);
+    expect(out.content).toBe('body text\n');
+  });
+
+  it('returns content unchanged when the tag is not present', () => {
+    const content = '---\ntags:\n  - alpha\n---\nbody\n';
+    const out = removeTagsFromContent(content, ['missing']);
+    expect(out.removedTags).toEqual([]);
+    expect(out.content).toBe(content);
+  });
+
+  it('returns content unchanged when there is no frontmatter', () => {
+    const out = removeTagsFromContent('bare body\n', ['anything']);
+    expect(out.removedTags).toEqual([]);
+    expect(out.content).toBe('bare body\n');
+  });
+
+  it('preserves other frontmatter keys', () => {
+    const content = '---\ntitle: T\nauthor: me\ntags:\n  - drop\n  - keep\n---\nbody\n';
+    const out = removeTagsFromContent(content, ['drop']);
+    const fm = YAML.parse(out.content.match(/^---\n([\s\S]*?)\n---/)![1]);
+    expect(fm.title).toBe('T');
+    expect(fm.author).toBe('me');
+    expect(fm.tags).toEqual(['keep']);
   });
 });


### PR DESCRIPTION
## Resolves
Closes #427

## Summary
- Right-click context menu now offers **Add Tag…** and **Remove Tag…**, acting on every .md in the current sidebar selection (recursing into selected folders).
- **Add Tag** prompts with the full thoughtbase tag vocabulary as autocomplete and appends to each note's frontmatter via the existing `mergeTagsIntoContent` (so re-tagging a note that already has the tag is a silent no-op).
- **Remove Tag** prompts with the **union of tags actually present** on the selected notes — the autocomplete only offers tags it can plausibly remove. Implemented with a single read pass that's cached for the subsequent writes.
- Per-note failures are collected and reported in one summary dialog; they don't abort the batch.

## Implementation notes
- New helper `extractTagsFromContent(content)` to compute the union for the Remove autocomplete.
- New helper `removeTagsFromContent(content, tags)` mirrors the existing `mergeTagsIntoContent` shape. When the last tag is dropped, the `tags:` key goes with it; when the whole frontmatter ends up empty, the block is removed entirely so no `---\n---` artifact is left on disk.
- `PromptDialog.svelte` gained an optional `suggestions: string[]` prop, surfaced via a `<datalist>` (browser handles the keyboard nav for free). `showPrompt` accepts an `options` bag, and existing call sites are unaffected.
- Bulk writes go through `api.notebase.writeFile`, which already routes through the canonical `writeAndReindex` pipeline — graph + search indexes update for free.

## Acceptance checks (from #427)
- [x] Select 10 notes → Add Tag "research" → all 10 get the tag in frontmatter (mergeTagsIntoContent appends to existing or creates the block).
- [x] Select a folder → Add Tag "wip" → every .md under the folder gets the tag (`expandSelectionToNoteFiles` recurses).
- [x] Remove Tag autocomplete only shows tags actually present on the selected notes (built from `extractTagsFromContent` over the selection's read pass).
- [x] Atomic-ish: per-note failures are reported in the summary, not raised as a hard abort.

## Test plan
- [x] `pnpm test` — 1791 / 1791 passing, including 12 new tests covering the empty-frontmatter, malformed-YAML, mixed-type tag-array, and last-tag-dropped paths.
- [x] `pnpm lint` — clean.
- [ ] Manual UI verification in the desktop app (not exercised in this branch — the agent that ran this work doesn't have an interactive Electron session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)