### PR TITLE
Research tools: find the load-bearing claim (closes #413)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -458,6 +458,12 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           toolTip: 'For the Claim under the cursor, generate the strongest cases against it (web-grounded). Files a Proposal of Grounds nodes.',
           click: () => send(Channels.MENU_RESEARCH_FIND_OPPOSING),
         }),
+        { type: 'separator' },
+        gate({
+          label: 'Find Load-Bearing Claim',
+          toolTip: 'Open a conversation that identifies the single claim in the selection (or the whole note) whose falsity would collapse the rest of the argument, plus 2-3 runners-up. The model proposes a note for review.',
+          click: () => send(Channels.TOOL_INVOKE, 'research.load-bearing-claim'),
+        }),
       ],
     },
 

--- a/src/shared/link-types.ts
+++ b/src/shared/link-types.ts
@@ -40,6 +40,17 @@ export const LINK_TYPES: LinkType[] = [
     color: '#f38ba8', // red
   },
   {
+    // #413 — surfaces in load-bearing-claim analysis notes:
+    //   `Load-bearing for [[load-bearing-for::source-note]].`
+    // The indexer materialises this as a `thought:loadBearingFor` triple
+    // from the analysis note to the source it analyses.
+    name: 'load-bearing-for',
+    label: 'Load-bearing for',
+    predicate: 'loadBearingFor',
+    predicateNamespace: 'thought',
+    color: '#f9e2af', // yellow — high-leverage / "watch this"
+  },
+  {
     name: 'expands',
     label: 'Expands',
     predicate: 'expands',

--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -439,6 +439,11 @@ thought:supports a owl:ObjectProperty ;
     rdfs:domain thought:Component ;
     rdfs:range thought:Component .
 
+thought:loadBearingFor a owl:ObjectProperty ;
+    rdfs:label "load-bearing for" ;
+    rdfs:comment "This claim is the single highest-leverage assertion of another resource (typically a note containing a multi-claim passage): if it were false, the rest of that resource's argument would not survive. Filed by the find-load-bearing-claim research tool (#413)." ;
+    rdfs:domain thought:Claim .
+
 thought:challenges a owl:ObjectProperty ;
     rdfs:label "challenges" ;
     rdfs:comment "This component undermines or questions another." ;

--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -4,6 +4,9 @@ import './analysis/steelman';
 import './analysis/taboo';
 import './analysis/murphyjitsu';
 
+// Research tools
+import './research/load-bearing-claim';
+
 // Learning tools
 import './learning/summarize';
 import './learning/explain-like-im';

--- a/src/shared/tools/definitions/research/load-bearing-claim.ts
+++ b/src/shared/tools/definitions/research/load-bearing-claim.ts
@@ -1,0 +1,109 @@
+/**
+ * "Find the load-bearing claim" research tool (#413).
+ *
+ * Conversational, not one-shot: the user can push back, redirect, ask
+ * the model to reconsider a runner-up, or refuse the verdict. When
+ * the user is ready to file, the model calls `propose_notes` with a
+ * single note whose body encodes the structural fact via a typed
+ * wiki-link (`[[load-bearing-for::source-note]]`) — the indexer
+ * materialises that into a `thought:loadBearingFor` triple. No
+ * bespoke graph-triples payload; structure lives in the prose.
+ */
+
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+
+const SYSTEM_PROMPT = `You are auditing a passage to find its **load-bearing claim** — the single assertion whose falsity would collapse the rest of the argument.
+
+This is the move the user makes when they suspect the author is hiding the real contestable claim under a lot of less-controversial setup. Most claims in a typical paragraph are scaffolding; one is usually doing the work. Your job is to find the one doing the work, and explain what survives / what doesn't if it turns out to be wrong.
+
+## Process
+
+1. Internally enumerate the distinct claims in the passage (the same atoms a "decompose into claims" pass would extract).
+2. For each, ask: how much of the rest of the argument depends on this being true? Could a weaker variant of nearby claims still produce the conclusion?
+3. Pick the **single highest-leverage** claim. Identify 2-3 runners-up — the next-most-load-bearing claims, in descending order.
+4. For each, write the one-line **"if false"**: what part of the original argument survives, and what doesn't.
+
+Open with a short summary of the argument's overall shape so the runners-up read in context. Then walk the user through the load-bearing claim and the runners-up. Iterate with them — they may want to push on a specific claim, ask why a runner-up isn't the load-bearing one, or have you reconsider with extra context.
+
+## Anti-flattery
+
+If the passage genuinely has no load-bearing structure (purely descriptive, every claim is an independent observation that doesn't depend on the others), say so. An empty answer is a real answer. Do **not** invent a load-bearing claim because you were asked to.
+
+## Filing the result
+
+When the user is satisfied and asks you to file, call \`propose_notes\` with **one** note. Its body should be a self-contained analysis the user will want to revisit. Use this shape:
+
+\`\`\`markdown
+---
+title: Load-bearing claim — <short title of the source>
+load-bearing-for: "[[load-bearing-for::<source-note-path-without-.md>]]"
+---
+
+# Load-bearing claim — <short title of the source>
+
+Load-bearing for [[load-bearing-for::<source-note-path-without-.md>]].
+
+<one paragraph: the argument's overall shape and where the weight sits>
+
+## Load-bearing
+
+**<1-2 sentence summary of the load-bearing claim, in your own words>**
+
+> <verbatim quote from the source>
+
+**If false:** <one line — what survives, what doesn't>
+
+## Runners-up
+
+### 1. <label>
+
+> <verbatim quote>
+
+**If false:** <one line>
+
+### 2. <label>
+
+> <verbatim quote>
+
+**If false:** <one line>
+\`\`\`
+
+The frontmatter \`load-bearing-for\` AND the inline typed wiki-link in the lead paragraph are both intentional — frontmatter so structural queries see it without parsing prose, the inline link so a reader following the prose is one click from the source. Use the source note's path **without** the \`.md\` suffix as the wiki-link target.
+
+If the user explicitly says they don't want the runners-up section, drop it. If the verdict was no-load-bearing-claim-found, do **not** call \`propose_notes\` — that result lives in the conversation, not as a filed analysis.`;
+
+registerTool({
+  id: 'research.load-bearing-claim',
+  name: 'Find Load-Bearing Claim',
+  category: 'research',
+  description: 'Identify the single claim whose falsity would collapse the argument',
+  longDescription:
+    'Opens a conversation that audits the selected passage (or the whole note) for the single highest-leverage claim — the one whose falsity would collapse the rest of the argument — plus 2-3 runners-up, each with an "if false" line. ' +
+    'When you are satisfied with the analysis, ask the assistant to file it; you will see a draft note for review before anything lands.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const sourcePath = ctx.fullNotePath ?? '';
+    const sourceStem = sourcePath.replace(/\.md$/i, '');
+    const sourceLine = sourceStem
+      ? `\n\n## Source note\n\nThe passage comes from \`${sourcePath}\`. Use \`${sourceStem}\` as the wiki-link target (the path without the \`.md\` suffix).`
+      : '\n\n## Source note\n\nThe passage was not pulled from a saved note. Skip the `load-bearing-for` frontmatter and inline wiki-link — there is nothing to point them at.';
+    return SYSTEM_PROMPT + sourceLine;
+  },
+  buildFirstMessage: (ctx: ToolContext) => {
+    const passage = (ctx.selectedText && ctx.selectedText.trim())
+      || (ctx.fullNoteContent ?? '').trim();
+    if (!passage) {
+      return 'Find the load-bearing claim in the current passage.';
+    }
+    const sourceLabel = ctx.selectedText && ctx.selectedText.trim()
+      ? 'Selection from'
+      : 'Note';
+    const titleLine = ctx.fullNoteTitle ? `${sourceLabel}: ${ctx.fullNoteTitle}\n\n` : '';
+    return `Find the load-bearing claim in this passage.\n\n${titleLine}${passage}`;
+  },
+});

--- a/tests/main/graph/load-bearing-link.test.ts
+++ b/tests/main/graph/load-bearing-link.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Indexer integration for the `load-bearing-for` typed wiki-link (#413).
+ *
+ * The research tool's value depends entirely on the analysis note's
+ * `[[load-bearing-for::source]]` link materialising as a
+ * `thought:loadBearingFor` triple — that's the only thing that makes
+ * "show me every load-bearing analysis I've filed" queryable. If the
+ * link-types entry or the indexer drift, the structure silently
+ * disappears from the graph. This test pins the round-trip.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('load-bearing-for typed wiki-link → thought:loadBearingFor (#413)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-load-bearing-link-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('materialises a thought:loadBearingFor triple from analysis note → source note', async () => {
+    // The analysis note (the one the research tool would propose).
+    const analysisRel = 'notes/load-bearing-claim-of-standup.md';
+    const analysisBody = [
+      '---',
+      'title: Load-bearing claim — standup',
+      'load-bearing-for: "[[load-bearing-for::notes/standup]]"',
+      '---',
+      '',
+      '# Load-bearing claim — standup',
+      '',
+      'Load-bearing for [[load-bearing-for::notes/standup]].',
+      '',
+      'The argument rides on Z.',
+      '',
+    ].join('\n');
+
+    // Index the source note first so the link target resolves.
+    const sourceRel = 'notes/standup.md';
+    await indexNote(ctx, sourceRel, '# Standup\n');
+    await indexNote(ctx, analysisRel, analysisBody);
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?subject ?target WHERE {
+        ?subject thought:loadBearingFor ?target .
+      }
+    `);
+    const rows = r.results as Array<{ subject: string; target: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    // Subject is the analysis note's IRI; target is the source note's IRI.
+    expect(rows[0].subject).toMatch(/load-bearing-claim-of-standup/);
+    expect(rows[0].target).toMatch(/standup/);
+    expect(rows[0].target).not.toMatch(/load-bearing-claim-of-standup/);
+  });
+
+  it('emits one triple even when both frontmatter and inline link encode the same fact (dedup at link extraction)', async () => {
+    // Both surfaces are intentional in the prompt (frontmatter for
+    // structural queries, inline for navigation), but the indexer
+    // dedups on (target, type) so we don't double-count the predicate.
+    const analysisRel = 'notes/load-bearing-claim-of-thing.md';
+    const analysisBody = [
+      '---',
+      'load-bearing-for: "[[load-bearing-for::notes/thing]]"',
+      '---',
+      '',
+      'Load-bearing for [[load-bearing-for::notes/thing]].',
+      '',
+      'And again [[load-bearing-for::notes/thing|the same source]].',
+    ].join('\n');
+    await indexNote(ctx, 'notes/thing.md', '# Thing\n');
+    await indexNote(ctx, analysisRel, analysisBody);
+
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?target WHERE {
+        ?subject thought:loadBearingFor ?target .
+      }
+    `);
+    const rows = r.results as Array<{ target: string }>;
+    // One subject → one target — the indexer's seen-set in extractLinks
+    // dedups on (type, target, anchor).
+    const distinctTargets = new Set(rows.map((row) => row.target));
+    expect(distinctTargets.size).toBe(1);
+  });
+});

--- a/tests/shared/link-types.test.ts
+++ b/tests/shared/link-types.test.ts
@@ -65,3 +65,21 @@ describe('quote link type', () => {
     expect(quote.targetKind).toBe('excerpt');
   });
 });
+
+describe('load-bearing-for link type (#413)', () => {
+  const lbf = getLinkType('load-bearing-for');
+
+  it('uses the thought-namespaced predicate loadBearingFor', () => {
+    // The research tool's system prompt instructs the model to emit
+    // `[[load-bearing-for::source]]`; that has to materialise as
+    // `thought:loadBearingFor` in the graph. The indexer derives the
+    // predicate from this entry — keep them aligned.
+    expect(lbf.name).toBe('load-bearing-for');
+    expect(lbf.predicate).toBe('loadBearingFor');
+    expect(lbf.predicateNamespace).toBe('thought');
+  });
+
+  it('targets a note (default), not a source/excerpt', () => {
+    expect(lbf.targetKind ?? 'note').toBe('note');
+  });
+});

--- a/tests/shared/tools/research-tools.test.ts
+++ b/tests/shared/tools/research-tools.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Coverage for the research-category tool definitions (#413 onwards).
+ *
+ * Mirrors the learning-tools.test.ts pattern: the registry shape +
+ * the buildSystemPrompt / buildFirstMessage threading, since those are
+ * the only functions consumers touch directly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import '../../../src/shared/tools/definitions/index';
+import { getTool, getToolInfosByCategory } from '../../../src/shared/tools/registry';
+import { buildConversationPayload } from '../../../src/main/tools/executor';
+
+describe('research.load-bearing-claim (#413)', () => {
+  it('is registered under the research category', () => {
+    const ids = getToolInfosByCategory('research').map((t) => t.id);
+    expect(ids).toContain('research.load-bearing-claim');
+  });
+
+  it('is conversational + web-on by default', () => {
+    const tool = getTool('research.load-bearing-claim')!;
+    expect(tool.outputMode).toBe('openConversation');
+    expect(tool.web?.defaultEnabled).toBe(true);
+    expect(tool.preferredModel).toMatch(/^claude-(sonnet|opus|haiku)-/);
+    expect(tool.buildSystemPrompt).toBeDefined();
+    expect(tool.buildFirstMessage).toBeDefined();
+  });
+
+  it('does NOT require selection — running on the whole note is a valid use', () => {
+    // Selecting the whole paragraph and "do the analysis on the whole
+    // note" should both work; gating on selection would force the user
+    // to ⌘A every time.
+    const tool = getTool('research.load-bearing-claim')!;
+    expect(tool.requiresSelection).toBeFalsy();
+  });
+
+  it('threads the source path into the system prompt without the .md suffix', () => {
+    const tool = getTool('research.load-bearing-claim')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      {
+        context: {
+          fullNotePath: 'notes/standup-2026-04-26.md',
+          fullNoteTitle: 'standup-2026-04-26',
+          fullNoteContent: 'Some passage with a load-bearing claim.',
+        },
+      },
+    );
+    // Pin both forms in the prompt: the full file path (so the model
+    // knows where the passage came from) and the stem in
+    // backtick-fences (the literal target the model should use in the
+    // wiki-link). The regex catches the stem as a balanced
+    // `code-fenced` token without the .md suffix.
+    expect(payload.systemPrompt).toContain('notes/standup-2026-04-26.md');
+    expect(payload.systemPrompt).toMatch(/`notes\/standup-2026-04-26`/);
+  });
+
+  it('teaches the model the typed-wiki-link convention so structure flows through indexing', () => {
+    const tool = getTool('research.load-bearing-claim')!;
+    const sys = tool.buildSystemPrompt!({});
+    // The triple `thought:loadBearingFor` is materialised from this
+    // exact link form via the LINK_TYPES registry. If the prompt
+    // drifts to a different shape (e.g. plain `[[…]]`), the structural
+    // fact disappears from the graph silently — pin it here.
+    expect(sys).toContain('[[load-bearing-for::');
+    expect(sys).toContain('load-bearing-for:'); // frontmatter key
+    expect(sys).toMatch(/anti-flattery/i);
+    expect(sys).toContain('propose_notes');
+    expect(sys).toMatch(/runners-up/i);
+  });
+
+  it('falls back gracefully when the passage was not pulled from a saved note', () => {
+    const tool = getTool('research.load-bearing-claim')!;
+    const sys = tool.buildSystemPrompt!({});
+    // Without a source path, telling the model to write a wiki-link
+    // pointing nowhere would produce an unresolvable link. The prompt
+    // explicitly drops the frontmatter + inline link in that case.
+    expect(sys).toMatch(/skip the/i);
+    expect(sys).toMatch(/load-bearing-for/);
+  });
+
+  it('builds a first message that includes the passage and a source label', () => {
+    const tool = getTool('research.load-bearing-claim')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      {
+        context: {
+          selectedText: 'A then B then therefore C.',
+          fullNoteTitle: 'argument',
+        },
+      },
+    );
+    expect(payload.firstMessage).toContain('A then B then therefore C.');
+    expect(payload.firstMessage).toMatch(/Selection from: argument/);
+  });
+
+  it('handles the no-passage edge by asking the model to operate on the current passage', () => {
+    const tool = getTool('research.load-bearing-claim')!;
+    const payload = buildConversationPayload(
+      tool,
+      {},
+      { context: {} },
+    );
+    // Empty context shouldn't error — the user could have invoked the
+    // tool without a note open. The first message stays generic.
+    expect(payload.firstMessage).toContain('Find the load-bearing claim');
+  });
+});


### PR DESCRIPTION
## Resolves
Closes #413

## Summary
Conversational, not one-shot. The user picks **Find Load-Bearing Claim** from the Research menu; the existing `ConversationDialog` opens with a seeded system prompt + first message, and the user iterates with the model — push back, ask why a runner-up isn't the load-bearing one, have the model reconsider with extra context. When the user is satisfied, they ask the model to file; the model proposes a single note via the existing `propose_notes` tool, which the user reviews and approves before anything lands.

Structure flows through the note, not through a parallel triples payload. The analysis note encodes `thought:loadBearingFor` via:
- **Frontmatter**: `load-bearing-for: "[[load-bearing-for::source-note]]"`
- **Inline lead**: `Load-bearing for [[load-bearing-for::source-note]].`

Both are intentional — frontmatter so structural queries see it without parsing prose, inline so a reader following the prose is one click from the source. The indexer materialises the typed wiki-link as a `thought:loadBearingFor` triple via the existing `LINK_TYPES` registry.

## Implementation
- One new entry in `src/shared/link-types.ts` (`load-bearing-for`, namespace `thought`, predicate `loadBearingFor`).
- One new conversational tool def at `src/shared/tools/definitions/research/load-bearing-claim.ts` (`outputMode: openConversation`, web-on by default, with `buildSystemPrompt` + `buildFirstMessage` that thread the passage and source path).
- Menu entry routes through `Channels.TOOL_INVOKE` — no bespoke IPC channel, no main-side runner, no JSON parser. The existing tools-registry plumbing handles `prepareConversation` → seeded ConversationDialog → `propose_notes` flow.
- Ontology entry for `thought:loadBearingFor` documents the predicate.

## Anti-flattery
The system prompt instructs the model **not** to call `propose_notes` when the verdict is "no load-bearing claim found" — the conversation is the deliverable in that case.

## Test plan
- [x] `pnpm test` — 1803/1803 passing. New coverage:
  - `tests/shared/tools/research-tools.test.ts` — registry shape, prompt threading, source-stem stripping (`.md` removed for the wiki-link target), no-source fallback (skip the link to avoid pointing nowhere), typed-wiki-link convention pinned in the prompt so a future drift can't silently break the indexer round-trip.
  - `tests/shared/link-types.test.ts` — new block confirms `load-bearing-for` is registered with predicate `loadBearingFor` in the `thought` namespace.
  - `tests/main/graph/load-bearing-link.test.ts` — round-trip from note body through `indexNote` to a SPARQL query that pulls back the `thought:loadBearingFor` triple, plus dedup behaviour when frontmatter and inline both reference the same source.
- [x] `pnpm lint` — clean.
- [ ] Manual UI verification in the desktop app (not exercised in this branch — the agent that ran this work doesn't have an interactive Electron session).

## Why this redesign
The first attempt at this PR filed a `note + N graph-triples` ProposalBundle from a one-shot `complete()` call. After feedback, all research / learning / analysis tools should be conversational with notes as the primary deliverable; structure should fall out of indexing the note's wiki-links and frontmatter rather than being synthesized as a parallel triples payload. This PR is a full rework on those lines and sets the pattern for #408 / #409 / #410 to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)