### PR TITLE
Publication: merge consecutive [[cite::]] runs into one cluster (#298)

### DIFF
--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -62,26 +62,40 @@ export class CitationRenderer {
       this.missingIds.add(id);
       return `<span class="csl-missing">[missing: ${escapeHtml(id)}]</span>`;
     }
-    this.citedIds.add(id);
-    const citationItem: Record<string, unknown> = { id };
-    if (locator) {
-      citationItem.locator = locator;
-      citationItem.label = 'page';
-    }
+    return this.renderCitationCluster([{ id, locator }]);
+  }
+
+  /**
+   * Render multiple cites as a single in-text mark — `(Foo 2020; Bar 2021)`
+   * in author-date styles, `[1, 2]` in numeric styles, etc. (#298).
+   *
+   * Caller is responsible for filtering out unknown ids; this method
+   * trusts every entry resolves through `retrieveItem`. Empty input
+   * returns an empty string. Single-item input is equivalent to
+   * `renderCitation` and is the path that single `[[cite::]]` takes.
+   */
+  renderCitationCluster(items: Array<{ id: string; locator?: string }>): string {
+    if (items.length === 0) return '';
+    for (const item of items) this.citedIds.add(item.id);
+    const citationItems = items.map((item) => {
+      const c: Record<string, unknown> = { id: item.id };
+      if (item.locator) {
+        c.locator = item.locator;
+        c.label = 'page';
+      }
+      return c;
+    });
     try {
       const result = this.engine.processCitationCluster(
-        {
-          citationItems: [citationItem],
-          properties: { noteIndex: this.noteIndex++ },
-        },
+        { citationItems, properties: { noteIndex: this.noteIndex++ } },
         [],
         [],
       );
-      // citeproc returns [updateInfo, [[index, text, id], ...]]
       const pairs = result[1];
       return pairs.length > 0 ? pairs[0][1] : '';
     } catch (err) {
-      return `<span class="csl-error" title="${escapeHtml(String(err))}">[citation error: ${escapeHtml(id)}]</span>`;
+      const ids = items.map((i) => i.id).join(', ');
+      return `<span class="csl-error" title="${escapeHtml(String(err))}">[citation error: ${escapeHtml(ids)}]</span>`;
     }
   }
 

--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -138,6 +138,12 @@ function installTagRule(_md: MarkdownIt): void {
  * then `plan.citations.createRenderer()` at rule-install time. Without
  * either, falls back to a visible stub so nothing leaks raw wiki-link
  * syntax into the exported output.
+ *
+ * Consecutive cites separated only by whitespace are collected into a
+ * single citation cluster (#298) — `[[cite::a]] [[cite::b]]` becomes
+ * `(Foo 2020; Bar 2021)` instead of two adjacent parentheticals. The
+ * merge is skipped when any id in the run is missing so each missing
+ * marker stays visible in its original position.
  */
 function installCiteStubRule(
   md: MarkdownIt,
@@ -150,34 +156,96 @@ function installCiteStubRule(
   md.inline.ruler.after('wiki_link', 'cite_stub', (state, silent) => {
     const src = state.src;
     const pos = state.pos;
-    if (src.charCodeAt(pos) !== 0x5b || src.charCodeAt(pos + 1) !== 0x5b) return false;
-    const close = src.indexOf(']]', pos + 2);
-    if (close < 0) return false;
-    const inner = src.slice(pos + 2, close);
-    const m = inner.match(/^(cite|quote)::(.+)$/i);
-    if (!m) return false;
-    if (silent) { state.pos = close + 2; return true; }
-    const kind = m[1].toLowerCase();
-    const id = m[2].trim();
-    const token = state.push('html_inline', '', 0);
+    const first = parseCiteAt(src, pos);
+    if (!first) return false;
+    if (silent) { state.pos = first.endPos; return true; }
 
-    if (activeRenderer && citations) {
-      if (kind === 'quote') {
-        const ex = citations.excerpts.get(id);
-        if (ex) {
-          token.content = activeRenderer.renderCitation(ex.sourceId, ex.locator);
-        } else {
-          token.content = `<span class="csl-missing">[missing excerpt: ${escapeHtml(id)}]</span>`;
-        }
-      } else {
-        token.content = activeRenderer.renderCitation(id);
-      }
-    } else {
-      token.content = `<sup class="cite-stub" title="${escapeAttr(kind + ': ' + id)}">[${escapeHtml(id)}]</sup>`;
+    const items: ParsedCite[] = [first];
+    let scanPos = first.endPos;
+    while (true) {
+      let p = scanPos;
+      while (p < src.length && isInlineWhitespace(src.charCodeAt(p))) p++;
+      const next = parseCiteAt(src, p);
+      if (!next) break;
+      items.push(next);
+      scanPos = next.endPos;
     }
-    state.pos = close + 2;
+
+    const token = state.push('html_inline', '', 0);
+    token.content = renderCiteRun(items, activeRenderer, citations);
+    state.pos = scanPos;
     return true;
   });
+}
+
+interface ParsedCite {
+  kind: 'cite' | 'quote';
+  id: string;
+  endPos: number;
+}
+
+function parseCiteAt(src: string, pos: number): ParsedCite | null {
+  if (src.charCodeAt(pos) !== 0x5b /* [ */ || src.charCodeAt(pos + 1) !== 0x5b) return null;
+  const close = src.indexOf(']]', pos + 2);
+  if (close < 0) return null;
+  const inner = src.slice(pos + 2, close);
+  const m = inner.match(/^(cite|quote)::(.+)$/i);
+  if (!m) return null;
+  return {
+    kind: m[1].toLowerCase() as 'cite' | 'quote',
+    id: m[2].trim(),
+    endPos: close + 2,
+  };
+}
+
+function isInlineWhitespace(code: number): boolean {
+  return code === 0x20 /* space */ || code === 0x09 /* tab */ || code === 0x0a /* LF */ || code === 0x0d /* CR */;
+}
+
+function renderCiteRun(
+  items: ParsedCite[],
+  activeRenderer: CitationRenderer | null,
+  citations: ExportPlan['citations'],
+): string {
+  if (!activeRenderer || !citations) {
+    return items
+      .map((item) => `<sup class="cite-stub" title="${escapeAttr(item.kind + ': ' + item.id)}">[${escapeHtml(item.id)}]</sup>`)
+      .join(' ');
+  }
+
+  // Resolve each item to (sourceId, locator). Missing markers preserve
+  // the original kind so users see "missing excerpt" vs "missing source".
+  type Resolved =
+    | { ok: true; sourceId: string; locator?: string }
+    | { ok: false; missingMarker: string };
+  const resolved: Resolved[] = items.map((item) => {
+    if (item.kind === 'quote') {
+      const ex = citations.excerpts.get(item.id);
+      if (!ex) return { ok: false, missingMarker: `<span class="csl-missing">[missing excerpt: ${escapeHtml(item.id)}]</span>` };
+      if (!citations.items.has(ex.sourceId)) return { ok: false, missingMarker: `<span class="csl-missing">[missing: ${escapeHtml(ex.sourceId)}]</span>` };
+      return { ok: true, sourceId: ex.sourceId, locator: ex.locator };
+    }
+    if (!citations.items.has(item.id)) return { ok: false, missingMarker: `<span class="csl-missing">[missing: ${escapeHtml(item.id)}]</span>` };
+    return { ok: true, sourceId: item.id, locator: undefined };
+  });
+
+  // Any missing → render each item independently so missing markers
+  // stay visible in their original positions. Single item → also
+  // independent (no merge to perform).
+  if (items.length === 1 || resolved.some((r) => !r.ok)) {
+    return resolved
+      .map((r) => (r.ok ? activeRenderer.renderCitation(r.sourceId, r.locator) : r.missingMarker))
+      .join(' ');
+  }
+
+  // All items resolved → single merged cluster.
+  return activeRenderer.renderCitationCluster(
+    resolved.map((r) => {
+      // Type narrowing: we proved every r is { ok: true } above.
+      const ok = r as Extract<Resolved, { ok: true }>;
+      return { id: ok.sourceId, locator: ok.locator };
+    }),
+  );
 }
 
 // ── Asset inlining ─────────────────────────────────────────────────────────

--- a/tests/main/publish/csl.test.ts
+++ b/tests/main/publish/csl.test.ts
@@ -294,3 +294,181 @@ describe('bundled CSL styles render end-to-end (#296)', () => {
     expect({ inText, entry: entries[0], isNote }).toMatchSnapshot();
   });
 });
+
+// ── Consecutive-cite merging (#298) ──────────────────────────────────────
+//
+// `[[cite::a]] [[cite::b]]` should render as a single merged
+// parenthetical — `(Foo 2020; Bar 2021)` in author-date styles — rather
+// than two adjacent ones. The merge is gated on every id resolving so
+// missing markers stay visible at their original positions.
+
+describe('consecutive-cite merging (#298)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/sources/bar-2021'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/bar-2021/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Bar Considered" ;
+  dc:creator "Bar, Bob" ;
+  dc:issued "2021"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/excerpts'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/excerpts/ex-foo-1.ttl'),
+      `this: a thought:Excerpt ;
+  thought:fromSource sources:foo-2020 ;
+  thought:page 7 .\n`,
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('renderCitationCluster merges two ids into one APA parenthetical', async () => {
+    const assets = await loadCitationAssets(root);
+    const renderer = assets.createRenderer();
+    const rendered = renderer.renderCitationCluster([
+      { id: 'foo-2020' },
+      { id: 'bar-2021' },
+    ]);
+    // APA: "(Bar, 2021; Foo, 2020)" — alphabetised, single parenthetical.
+    expect(rendered).toMatch(/^\([^)]*\)$/);
+    expect(rendered).toContain('Bar');
+    expect(rendered).toContain('Foo');
+    expect(rendered).toContain(';');
+    // Both ids are tracked as cited so they appear in the bibliography.
+    expect(renderer.cited().has('foo-2020')).toBe(true);
+    expect(renderer.cited().has('bar-2021')).toBe(true);
+  });
+
+  it('two adjacent [[cite::]] in markdown render as a single merged mark', async () => {
+    await fsp.writeFile(path.join(root, 'merge.md'),
+      '# Merge\n\nAs [[cite::foo-2020]] [[cite::bar-2021]] showed.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'merge.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+
+    // Exactly one citation parenthetical, containing both names + a
+    // semicolon separator. Two separate parens would show up as
+    // ") (" somewhere in the rendered text.
+    expect(html).not.toContain(') (');
+    const inText = html.match(/\([^)]*Foo[^)]*Bar[^)]*\)|\([^)]*Bar[^)]*Foo[^)]*\)/);
+    expect(inText).not.toBeNull();
+    expect(inText![0]).toContain(';');
+  });
+
+  it('three consecutive cites separated by single spaces all merge', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/baz-2022'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/baz-2022/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Baz Notes" ;
+  dc:creator "Baz, Carol" ;
+  dc:issued "2022"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.writeFile(path.join(root, 'three.md'),
+      'See [[cite::foo-2020]] [[cite::bar-2021]] [[cite::baz-2022]].\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'three.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+
+    // Single paren containing all three names + two semicolons.
+    const matches = html.match(/\([^)]+\)/g) ?? [];
+    const citationParen = matches.find((p) => /Foo|Bar|Baz/.test(p));
+    expect(citationParen).toBeDefined();
+    expect(citationParen).toContain('Foo');
+    expect(citationParen).toContain('Bar');
+    expect(citationParen).toContain('Baz');
+    // Two `; ` separators for three items in one cluster.
+    expect((citationParen!.match(/;/g) ?? []).length).toBe(2);
+  });
+
+  it('newline-separated cites also merge (whitespace, not punctuation)', async () => {
+    await fsp.writeFile(path.join(root, 'wrapped.md'),
+      'Per [[cite::foo-2020]]\n[[cite::bar-2021]] this holds.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'wrapped.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).not.toContain(') (');
+    expect(html).toMatch(/\([^)]*(Foo|Bar)[^)]*;[^)]*\)/);
+  });
+
+  it('cite + quote with locator merges and the locator survives', async () => {
+    await fsp.writeFile(path.join(root, 'mixed.md'),
+      'Per [[cite::bar-2021]] [[quote::ex-foo-1]].\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'mixed.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    // One paren, both names, the page locator from the excerpt.
+    expect(html).not.toContain(') (');
+    const paren = (html.match(/\([^)]*\)/g) ?? []).find((p) => /Foo|Bar/.test(p));
+    expect(paren).toBeDefined();
+    expect(paren).toContain('Foo');
+    expect(paren).toContain('Bar');
+    expect(paren).toContain('7');
+  });
+
+  it('non-whitespace separator (comma) prevents the merge', async () => {
+    await fsp.writeFile(path.join(root, 'comma.md'),
+      'Per [[cite::foo-2020]], [[cite::bar-2021]] showed.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'comma.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    // Two separate parentheticals, each with a single name.
+    const parens = (html.match(/\([^)]+\)/g) ?? []).filter((p) => /Foo|Bar/.test(p));
+    expect(parens.length).toBe(2);
+    expect(parens.some((p) => p.includes('Foo') && !p.includes('Bar'))).toBe(true);
+    expect(parens.some((p) => p.includes('Bar') && !p.includes('Foo'))).toBe(true);
+  });
+
+  it('missing id in a run falls back to per-item rendering so [missing: x] stays visible', async () => {
+    await fsp.writeFile(path.join(root, 'missing.md'),
+      'See [[cite::foo-2020]] [[cite::nope-2099]] [[cite::bar-2021]].\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'missing.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('[missing: nope-2099]');
+    // Each present cite renders as its own parenthetical when a sibling
+    // is missing — no merged cluster swallows them.
+    const parens = (html.match(/\([^)]+\)/g) ?? []).filter((p) => /Foo|Bar/.test(p));
+    expect(parens.some((p) => p.includes('Foo') && !p.includes('Bar'))).toBe(true);
+    expect(parens.some((p) => p.includes('Bar') && !p.includes('Foo'))).toBe(true);
+  });
+
+  it('single [[cite::]] (no neighbour) still works exactly as before', async () => {
+    await fsp.writeFile(path.join(root, 'single.md'),
+      'Just [[cite::foo-2020]] alone.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'single.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('Foo');
+    expect(html).toContain('2020');
+    expect(html).not.toContain('[[cite::foo-2020]]');
+  });
+});


### PR DESCRIPTION
## Summary

`[[cite::a]] [[cite::b]]` now renders as a single merged in-text mark — `(Foo 2020; Bar 2021)` in author-date styles, `[1, 2]` in numeric — instead of the two adjacent parentheticals it produced before.

## How

- New `CitationRenderer.renderCitationCluster(items)` wraps citeproc-js's multi-item cluster API. `renderCitation(id, locator)` becomes a single-item shim over it.
- The cite rule in `note-html/render.ts` does source-level lookahead from each match, collecting consecutive `cite::` / `quote::` tokens separated only by whitespace (space / tab / LF / CR), then routes the run through `renderCitationCluster`.
- **Missing-aware merge gate**: if any id in a run is missing, the merge is skipped and each item renders independently so `[missing: x]` markers stay visible at their original position.

## Behaviour matrix

| Input | Before | After |
|---|---|---|
| `[[cite::a]] [[cite::b]]` | `(Foo 2020) (Bar 2021)` | `(Bar 2021; Foo 2020)` |
| `[[cite::a]]\n[[cite::b]]` | two parens | merged |
| `[[cite::a]], [[cite::b]]` | two parens | two parens (comma blocks merge) |
| `[[cite::a]] [[cite::missing]] [[cite::b]]` | `(a) [missing: m] (b)` | `(a) [missing: m] (b)` (unchanged) |
| `[[cite::a]] [[quote::ex]]` | two parens | merged with locator preserved |
| `[[cite::a]]` (alone) | `(a)` | `(a)` (unchanged) |

## Closes

Resolves #298. Knocks out one bullet from #247's deferred list.

## Test plan

- [x] `pnpm vitest run tests/main/publish/csl.test.ts` — 29/29, 8 new tests covering merge, three-way merge, newline separator, mixed cite+quote with locator, comma blocker, missing-id fallback, single-cite passthrough
- [x] `pnpm lint` — clean
- [ ] Manual: export a note with `[[cite::a]] [[cite::b]]` under each bundled style, confirm one merged mark per style

🤖 Generated with [Claude Code](https://claude.com/claude-code)