### PR TITLE
Publication: parse [[cite::id|locator]] alias into CSL locator (#299)

### DIFF
--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -62,26 +62,40 @@ export class CitationRenderer {
       this.missingIds.add(id);
       return `<span class="csl-missing">[missing: ${escapeHtml(id)}]</span>`;
     }
-    this.citedIds.add(id);
-    const citationItem: Record<string, unknown> = { id };
-    if (locator) {
-      citationItem.locator = locator;
-      citationItem.label = 'page';
-    }
+    return this.renderCitationCluster([{ id, locator }]);
+  }
+
+  /**
+   * Render multiple cites as a single in-text mark — `(Foo 2020; Bar 2021)`
+   * in author-date styles, `[1, 2]` in numeric styles, etc. (#298).
+   *
+   * Caller is responsible for filtering out unknown ids; this method
+   * trusts every entry resolves through `retrieveItem`. Empty input
+   * returns an empty string. Single-item input is equivalent to
+   * `renderCitation` and is the path that single `[[cite::]]` takes.
+   */
+  renderCitationCluster(items: Array<{ id: string; locator?: string }>): string {
+    if (items.length === 0) return '';
+    for (const item of items) this.citedIds.add(item.id);
+    const citationItems = items.map((item) => {
+      const c: Record<string, unknown> = { id: item.id };
+      if (item.locator) {
+        c.locator = item.locator;
+        c.label = 'page';
+      }
+      return c;
+    });
     try {
       const result = this.engine.processCitationCluster(
-        {
-          citationItems: [citationItem],
-          properties: { noteIndex: this.noteIndex++ },
-        },
+        { citationItems, properties: { noteIndex: this.noteIndex++ } },
         [],
         [],
       );
-      // citeproc returns [updateInfo, [[index, text, id], ...]]
       const pairs = result[1];
       return pairs.length > 0 ? pairs[0][1] : '';
     } catch (err) {
-      return `<span class="csl-error" title="${escapeHtml(String(err))}">[citation error: ${escapeHtml(id)}]</span>`;
+      const ids = items.map((i) => i.id).join(', ');
+      return `<span class="csl-error" title="${escapeHtml(String(err))}">[citation error: ${escapeHtml(ids)}]</span>`;
     }
   }
 

--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -55,14 +55,16 @@ export class CitationRenderer {
   /**
    * Render a single in-text citation. `locator` is a page or range
    * string; when set, citeproc emits "Smith 2020, p. 12" style output.
-   * The rendered string is HTML (citeproc's default `html` output mode).
+   * `label` is the CSL locator label ("page", "chapter", "section", …);
+   * defaults to "page" for back-compat (#299). The rendered string is
+   * HTML (citeproc's default `html` output mode).
    */
-  renderCitation(id: string, locator?: string): string {
+  renderCitation(id: string, locator?: string, label?: string): string {
     if (!this.items.has(id)) {
       this.missingIds.add(id);
       return `<span class="csl-missing">[missing: ${escapeHtml(id)}]</span>`;
     }
-    return this.renderCitationCluster([{ id, locator }]);
+    return this.renderCitationCluster([{ id, locator, label }]);
   }
 
   /**
@@ -73,15 +75,16 @@ export class CitationRenderer {
    * trusts every entry resolves through `retrieveItem`. Empty input
    * returns an empty string. Single-item input is equivalent to
    * `renderCitation` and is the path that single `[[cite::]]` takes.
+   * Per-item `label` defaults to "page" when omitted (#299).
    */
-  renderCitationCluster(items: Array<{ id: string; locator?: string }>): string {
+  renderCitationCluster(items: Array<{ id: string; locator?: string; label?: string }>): string {
     if (items.length === 0) return '';
     for (const item of items) this.citedIds.add(item.id);
     const citationItems = items.map((item) => {
       const c: Record<string, unknown> = { id: item.id };
       if (item.locator) {
         c.locator = item.locator;
-        c.label = 'page';
+        c.label = item.label ?? 'page';
       }
       return c;
     });

--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -181,7 +181,14 @@ function installCiteStubRule(
 interface ParsedCite {
   kind: 'cite' | 'quote';
   id: string;
+  /** Alias-derived locator + label (#299). null when no parseable locator was supplied. */
+  aliasLocator: ParsedLocator | null;
   endPos: number;
+}
+
+interface ParsedLocator {
+  locator: string;
+  label: string;
 }
 
 function parseCiteAt(src: string, pos: number): ParsedCite | null {
@@ -191,12 +198,71 @@ function parseCiteAt(src: string, pos: number): ParsedCite | null {
   const inner = src.slice(pos + 2, close);
   const m = inner.match(/^(cite|quote)::(.+)$/i);
   if (!m) return null;
+  const rawTarget = m[2];
+  const pipe = rawTarget.indexOf('|');
+  const id = (pipe >= 0 ? rawTarget.slice(0, pipe) : rawTarget).trim();
+  const alias = pipe >= 0 ? rawTarget.slice(pipe + 1).trim() : '';
   return {
     kind: m[1].toLowerCase() as 'cite' | 'quote',
-    id: m[2].trim(),
+    id,
+    aliasLocator: parseLocatorAlias(alias),
     endPos: close + 2,
   };
 }
+
+/**
+ * Map common locator-shaped aliases to CSL `{ locator, label }` (#299).
+ *
+ * Recognises bare page references (`42`, `42-45`, `iv-xii`), `p.` / `pp.`
+ * prefixes, and the ten most-used CSL labels (chapter, section, figure,
+ * table, note, paragraph, volume, line, verse, column). Anything else
+ * returns null and the caller drops the alias silently — matches
+ * wiki-link convention: an alias that doesn't parse as a locator is
+ * display text, and citations don't have display text.
+ */
+export function parseLocatorAlias(alias: string): ParsedLocator | null {
+  if (!alias) return null;
+  // Match all hyphen-shaped dashes: ASCII '-', en-dash, em-dash, figure-dash.
+  const RANGE = '[\\u2010-\\u2015\\-]';
+  const PAGE_LIKE_RE = new RegExp(`^[0-9ivxlcdm]+(?:${RANGE}[0-9ivxlcdm]+)?$`, 'i');
+
+  // Labelled form: "ch. 3", "chapter 3", "§ 4", "¶ 7".
+  const labelled = alias.match(/^([A-Za-z§¶]+)\.?\s+(.+)$/);
+  if (labelled) {
+    const tag = labelled[1].toLowerCase();
+    const value = labelled[2].trim();
+    const label = LOCATOR_LABEL_BY_TAG[tag];
+    if (label) {
+      // For page labels, prefer the bare-number form: "pp. 42-45" → "42-45".
+      // Other labels keep what's provided ("section 4.2", "ch. 3").
+      return { locator: value, label };
+    }
+  }
+  // Bare form: "42", "42-45", "iv-xii".
+  if (PAGE_LIKE_RE.test(alias)) {
+    return { locator: alias.trim(), label: 'page' };
+  }
+  return null;
+}
+
+/**
+ * Common label aliases → canonical CSL locator label. Keep the keys
+ * lowercased; matched case-insensitively. Page-y synonyms collapse to
+ * 'page' since CSL has only one page-locator label.
+ */
+const LOCATOR_LABEL_BY_TAG: Record<string, string> = {
+  p: 'page', pp: 'page', page: 'page', pages: 'page',
+  ch: 'chapter', chap: 'chapter', chapter: 'chapter', chapters: 'chapter',
+  sec: 'section', section: 'section', sections: 'section', '§': 'section',
+  fig: 'figure', figure: 'figure', figures: 'figure',
+  tbl: 'table', table: 'table', tables: 'table',
+  n: 'note', note: 'note', notes: 'note',
+  para: 'paragraph', paragraph: 'paragraph', paragraphs: 'paragraph', '¶': 'paragraph',
+  vol: 'volume', volume: 'volume', volumes: 'volume',
+  l: 'line', line: 'line', lines: 'line',
+  v: 'verse', verse: 'verse', verses: 'verse',
+  col: 'column', column: 'column', columns: 'column',
+};
 
 function isInlineWhitespace(code: number): boolean {
   return code === 0x20 /* space */ || code === 0x09 /* tab */ || code === 0x0a /* LF */ || code === 0x0d /* CR */;
@@ -213,20 +279,30 @@ function renderCiteRun(
       .join(' ');
   }
 
-  // Resolve each item to (sourceId, locator). Missing markers preserve
-  // the original kind so users see "missing excerpt" vs "missing source".
+  // Resolve each item to (sourceId, locator, label). Missing markers
+  // preserve the original kind so users see "missing excerpt" vs
+  // "missing: source-id". For locators (#299): an explicit alias
+  // (`[[cite::id|p. 42]]`) wins; otherwise a quote falls back to the
+  // excerpt's intrinsic page/range; bare cites have no locator.
   type Resolved =
-    | { ok: true; sourceId: string; locator?: string }
+    | { ok: true; sourceId: string; locator?: string; label?: string }
     | { ok: false; missingMarker: string };
   const resolved: Resolved[] = items.map((item) => {
     if (item.kind === 'quote') {
       const ex = citations.excerpts.get(item.id);
       if (!ex) return { ok: false, missingMarker: `<span class="csl-missing">[missing excerpt: ${escapeHtml(item.id)}]</span>` };
       if (!citations.items.has(ex.sourceId)) return { ok: false, missingMarker: `<span class="csl-missing">[missing: ${escapeHtml(ex.sourceId)}]</span>` };
-      return { ok: true, sourceId: ex.sourceId, locator: ex.locator };
+      const locator = item.aliasLocator?.locator ?? ex.locator;
+      const label = item.aliasLocator?.label;
+      return { ok: true, sourceId: ex.sourceId, locator, label };
     }
     if (!citations.items.has(item.id)) return { ok: false, missingMarker: `<span class="csl-missing">[missing: ${escapeHtml(item.id)}]</span>` };
-    return { ok: true, sourceId: item.id, locator: undefined };
+    return {
+      ok: true,
+      sourceId: item.id,
+      locator: item.aliasLocator?.locator,
+      label: item.aliasLocator?.label,
+    };
   });
 
   // Any missing → render each item independently so missing markers
@@ -234,7 +310,7 @@ function renderCiteRun(
   // independent (no merge to perform).
   if (items.length === 1 || resolved.some((r) => !r.ok)) {
     return resolved
-      .map((r) => (r.ok ? activeRenderer.renderCitation(r.sourceId, r.locator) : r.missingMarker))
+      .map((r) => (r.ok ? activeRenderer.renderCitation(r.sourceId, r.locator, r.label) : r.missingMarker))
       .join(' ');
   }
 
@@ -243,7 +319,7 @@ function renderCiteRun(
     resolved.map((r) => {
       // Type narrowing: we proved every r is { ok: true } above.
       const ok = r as Extract<Resolved, { ok: true }>;
-      return { id: ok.sourceId, locator: ok.locator };
+      return { id: ok.sourceId, locator: ok.locator, label: ok.label };
     }),
   );
 }

--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -138,6 +138,12 @@ function installTagRule(_md: MarkdownIt): void {
  * then `plan.citations.createRenderer()` at rule-install time. Without
  * either, falls back to a visible stub so nothing leaks raw wiki-link
  * syntax into the exported output.
+ *
+ * Consecutive cites separated only by whitespace are collected into a
+ * single citation cluster (#298) — `[[cite::a]] [[cite::b]]` becomes
+ * `(Foo 2020; Bar 2021)` instead of two adjacent parentheticals. The
+ * merge is skipped when any id in the run is missing so each missing
+ * marker stays visible in its original position.
  */
 function installCiteStubRule(
   md: MarkdownIt,
@@ -150,34 +156,96 @@ function installCiteStubRule(
   md.inline.ruler.after('wiki_link', 'cite_stub', (state, silent) => {
     const src = state.src;
     const pos = state.pos;
-    if (src.charCodeAt(pos) !== 0x5b || src.charCodeAt(pos + 1) !== 0x5b) return false;
-    const close = src.indexOf(']]', pos + 2);
-    if (close < 0) return false;
-    const inner = src.slice(pos + 2, close);
-    const m = inner.match(/^(cite|quote)::(.+)$/i);
-    if (!m) return false;
-    if (silent) { state.pos = close + 2; return true; }
-    const kind = m[1].toLowerCase();
-    const id = m[2].trim();
-    const token = state.push('html_inline', '', 0);
+    const first = parseCiteAt(src, pos);
+    if (!first) return false;
+    if (silent) { state.pos = first.endPos; return true; }
 
-    if (activeRenderer && citations) {
-      if (kind === 'quote') {
-        const ex = citations.excerpts.get(id);
-        if (ex) {
-          token.content = activeRenderer.renderCitation(ex.sourceId, ex.locator);
-        } else {
-          token.content = `<span class="csl-missing">[missing excerpt: ${escapeHtml(id)}]</span>`;
-        }
-      } else {
-        token.content = activeRenderer.renderCitation(id);
-      }
-    } else {
-      token.content = `<sup class="cite-stub" title="${escapeAttr(kind + ': ' + id)}">[${escapeHtml(id)}]</sup>`;
+    const items: ParsedCite[] = [first];
+    let scanPos = first.endPos;
+    while (true) {
+      let p = scanPos;
+      while (p < src.length && isInlineWhitespace(src.charCodeAt(p))) p++;
+      const next = parseCiteAt(src, p);
+      if (!next) break;
+      items.push(next);
+      scanPos = next.endPos;
     }
-    state.pos = close + 2;
+
+    const token = state.push('html_inline', '', 0);
+    token.content = renderCiteRun(items, activeRenderer, citations);
+    state.pos = scanPos;
     return true;
   });
+}
+
+interface ParsedCite {
+  kind: 'cite' | 'quote';
+  id: string;
+  endPos: number;
+}
+
+function parseCiteAt(src: string, pos: number): ParsedCite | null {
+  if (src.charCodeAt(pos) !== 0x5b /* [ */ || src.charCodeAt(pos + 1) !== 0x5b) return null;
+  const close = src.indexOf(']]', pos + 2);
+  if (close < 0) return null;
+  const inner = src.slice(pos + 2, close);
+  const m = inner.match(/^(cite|quote)::(.+)$/i);
+  if (!m) return null;
+  return {
+    kind: m[1].toLowerCase() as 'cite' | 'quote',
+    id: m[2].trim(),
+    endPos: close + 2,
+  };
+}
+
+function isInlineWhitespace(code: number): boolean {
+  return code === 0x20 /* space */ || code === 0x09 /* tab */ || code === 0x0a /* LF */ || code === 0x0d /* CR */;
+}
+
+function renderCiteRun(
+  items: ParsedCite[],
+  activeRenderer: CitationRenderer | null,
+  citations: ExportPlan['citations'],
+): string {
+  if (!activeRenderer || !citations) {
+    return items
+      .map((item) => `<sup class="cite-stub" title="${escapeAttr(item.kind + ': ' + item.id)}">[${escapeHtml(item.id)}]</sup>`)
+      .join(' ');
+  }
+
+  // Resolve each item to (sourceId, locator). Missing markers preserve
+  // the original kind so users see "missing excerpt" vs "missing source".
+  type Resolved =
+    | { ok: true; sourceId: string; locator?: string }
+    | { ok: false; missingMarker: string };
+  const resolved: Resolved[] = items.map((item) => {
+    if (item.kind === 'quote') {
+      const ex = citations.excerpts.get(item.id);
+      if (!ex) return { ok: false, missingMarker: `<span class="csl-missing">[missing excerpt: ${escapeHtml(item.id)}]</span>` };
+      if (!citations.items.has(ex.sourceId)) return { ok: false, missingMarker: `<span class="csl-missing">[missing: ${escapeHtml(ex.sourceId)}]</span>` };
+      return { ok: true, sourceId: ex.sourceId, locator: ex.locator };
+    }
+    if (!citations.items.has(item.id)) return { ok: false, missingMarker: `<span class="csl-missing">[missing: ${escapeHtml(item.id)}]</span>` };
+    return { ok: true, sourceId: item.id, locator: undefined };
+  });
+
+  // Any missing → render each item independently so missing markers
+  // stay visible in their original positions. Single item → also
+  // independent (no merge to perform).
+  if (items.length === 1 || resolved.some((r) => !r.ok)) {
+    return resolved
+      .map((r) => (r.ok ? activeRenderer.renderCitation(r.sourceId, r.locator) : r.missingMarker))
+      .join(' ');
+  }
+
+  // All items resolved → single merged cluster.
+  return activeRenderer.renderCitationCluster(
+    resolved.map((r) => {
+      // Type narrowing: we proved every r is { ok: true } above.
+      const ok = r as Extract<Resolved, { ok: true }>;
+      return { id: ok.sourceId, locator: ok.locator };
+    }),
+  );
 }
 
 // ── Asset inlining ─────────────────────────────────────────────────────────

--- a/tests/main/publish/csl.test.ts
+++ b/tests/main/publish/csl.test.ts
@@ -12,6 +12,7 @@ import {
 import { loadCitationAssets } from '../../../src/main/publish/csl';
 import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
 import { noteHtmlExporter } from '../../../src/main/publish/exporters/note-html';
+import { parseLocatorAlias } from '../../../src/main/publish/exporters/note-html/render';
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csl-test-'));
@@ -419,5 +420,158 @@ describe('consecutive-cite merging (#298)', () => {
     expect(html).toContain('Foo');
     expect(html).toContain('2020');
     expect(html).not.toContain('[[cite::foo-2020]]');
+  });
+});
+
+// ── Locator alias parsing (#299) ─────────────────────────────────────────
+//
+// `[[cite::id|p. 42]]` should populate the citeproc locator + label so
+// the rendered citation reads "(Toulmin 1958, p. 42)" instead of
+// dropping the alias on the floor.
+
+describe('parseLocatorAlias (#299)', () => {
+  it('bare digits → page locator', () => {
+    expect(parseLocatorAlias('42')).toEqual({ locator: '42', label: 'page' });
+  });
+
+  it('bare digit range → page locator', () => {
+    expect(parseLocatorAlias('42-45')).toEqual({ locator: '42-45', label: 'page' });
+    // Real-world dashes from typography-aware editors.
+    expect(parseLocatorAlias('42–45')).toEqual({ locator: '42–45', label: 'page' });
+  });
+
+  it('roman numerals → page locator (front-matter pages)', () => {
+    expect(parseLocatorAlias('iv')).toEqual({ locator: 'iv', label: 'page' });
+    expect(parseLocatorAlias('iv-xii')).toEqual({ locator: 'iv-xii', label: 'page' });
+  });
+
+  it('p. / pp. prefix → page locator with the prefix stripped', () => {
+    expect(parseLocatorAlias('p. 42')).toEqual({ locator: '42', label: 'page' });
+    expect(parseLocatorAlias('pp. 42-45')).toEqual({ locator: '42-45', label: 'page' });
+    expect(parseLocatorAlias('page 42')).toEqual({ locator: '42', label: 'page' });
+    expect(parseLocatorAlias('pages 42–45')).toEqual({ locator: '42–45', label: 'page' });
+  });
+
+  it('chapter / section / figure / paragraph labels', () => {
+    expect(parseLocatorAlias('ch. 3')).toEqual({ locator: '3', label: 'chapter' });
+    expect(parseLocatorAlias('chapter 3')).toEqual({ locator: '3', label: 'chapter' });
+    expect(parseLocatorAlias('sec. 4.2')).toEqual({ locator: '4.2', label: 'section' });
+    expect(parseLocatorAlias('§ 4')).toEqual({ locator: '4', label: 'section' });
+    expect(parseLocatorAlias('fig. 7')).toEqual({ locator: '7', label: 'figure' });
+    expect(parseLocatorAlias('¶ 12')).toEqual({ locator: '12', label: 'paragraph' });
+  });
+
+  it('non-locator alias falls through (returns null)', () => {
+    expect(parseLocatorAlias('the seminal essay')).toBeNull();
+    expect(parseLocatorAlias('see below')).toBeNull();
+    expect(parseLocatorAlias('')).toBeNull();
+    // Unknown label tag — drop the whole thing rather than guessing.
+    expect(parseLocatorAlias('xyz. 3')).toBeNull();
+  });
+});
+
+describe('locator alias renders into citations (#299)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await fsp.mkdir(path.join(root, '.minerva/sources/toulmin-1958'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/toulmin-1958/meta.ttl'),
+      `this: a thought:Book ;
+  dc:title "The Uses of Argument" ;
+  dc:creator "Toulmin, Stephen" ;
+  dc:issued "1958"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    // Excerpt with its own page so we can verify alias overrides intrinsic.
+    await fsp.mkdir(path.join(root, '.minerva/excerpts'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/excerpts/ex-toulmin-foundations.ttl'),
+      `this: a thought:Excerpt ;
+  thought:fromSource sources:toulmin-1958 ;
+  thought:page 11 .\n`,
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('[[cite::id|42]] renders with "p. 42" inline', async () => {
+    await fsp.writeFile(path.join(root, 'cite-bare.md'),
+      'See [[cite::toulmin-1958|42]].\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'cite-bare.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('Toulmin');
+    expect(html).toContain('p.');
+    expect(html).toContain('42');
+    expect(html).not.toContain('[missing:');
+  });
+
+  it('[[cite::id|pp. 42-45]] renders the range', async () => {
+    await fsp.writeFile(path.join(root, 'cite-range.md'),
+      'See [[cite::toulmin-1958|pp. 42-45]].\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'cite-range.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toMatch(/42[-–]45/);
+    expect(html).toContain('pp.');
+  });
+
+  it('[[cite::id|ch. 3]] renders with chapter label', async () => {
+    await fsp.writeFile(path.join(root, 'cite-chapter.md'),
+      'See [[cite::toulmin-1958|ch. 3]].\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'cite-chapter.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    // APA renders chapter labels as "Chapter 3" or "ch. 3" depending on
+    // style; either way the digit + a chapter token must appear.
+    expect(html).toMatch(/[Cc]hap?\.|[Cc]hapter/);
+    expect(html).toContain('3');
+  });
+
+  it('non-locator alias is dropped (citation still renders, no locator)', async () => {
+    await fsp.writeFile(path.join(root, 'cite-prose.md'),
+      'See [[cite::toulmin-1958|the seminal essay]] here.\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'cite-prose.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('Toulmin');
+    expect(html).toContain('1958');
+    // Alias text doesn't leak into the rendered citation.
+    expect(html).not.toContain('the seminal essay');
+    expect(html).not.toContain('[missing:');
+  });
+
+  it('[[quote::id|p. 99]] alias overrides the excerpt\'s intrinsic page', async () => {
+    await fsp.writeFile(path.join(root, 'quote-override.md'),
+      'See [[quote::ex-toulmin-foundations|p. 99]].\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'quote-override.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('99');
+    // The excerpt's own page (11) should not also appear in the citation.
+    expect(html).not.toMatch(/p\.\s*11\b/);
+  });
+
+  it('locator survives the merge path: two cites with locators in one cluster', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/popper-1959'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/popper-1959/meta.ttl'),
+      `this: a thought:Book ;
+  dc:title "The Logic of Scientific Discovery" ;
+  dc:creator "Popper, Karl" ;
+  dc:issued "1959"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'cite-merge.md'),
+      'See [[cite::toulmin-1958|p. 42]] [[cite::popper-1959|p. 100]].\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'cite-merge.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    // One merged paren containing both authors + both pages.
+    expect(html).not.toContain(') (');
+    expect(html).toContain('Toulmin');
+    expect(html).toContain('Popper');
+    expect(html).toContain('42');
+    expect(html).toContain('100');
   });
 });

--- a/tests/main/publish/csl.test.ts
+++ b/tests/main/publish/csl.test.ts
@@ -243,3 +243,181 @@ describe('CSL integration through the export pipeline', () => {
     expect(html).not.toContain('<section class="references">');
   });
 });
+
+// ── Consecutive-cite merging (#298) ──────────────────────────────────────
+//
+// `[[cite::a]] [[cite::b]]` should render as a single merged
+// parenthetical — `(Foo 2020; Bar 2021)` in author-date styles — rather
+// than two adjacent ones. The merge is gated on every id resolving so
+// missing markers stay visible at their original positions.
+
+describe('consecutive-cite merging (#298)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/sources/bar-2021'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/bar-2021/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Bar Considered" ;
+  dc:creator "Bar, Bob" ;
+  dc:issued "2021"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/excerpts'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/excerpts/ex-foo-1.ttl'),
+      `this: a thought:Excerpt ;
+  thought:fromSource sources:foo-2020 ;
+  thought:page 7 .\n`,
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('renderCitationCluster merges two ids into one APA parenthetical', async () => {
+    const assets = await loadCitationAssets(root);
+    const renderer = assets.createRenderer();
+    const rendered = renderer.renderCitationCluster([
+      { id: 'foo-2020' },
+      { id: 'bar-2021' },
+    ]);
+    // APA: "(Bar, 2021; Foo, 2020)" — alphabetised, single parenthetical.
+    expect(rendered).toMatch(/^\([^)]*\)$/);
+    expect(rendered).toContain('Bar');
+    expect(rendered).toContain('Foo');
+    expect(rendered).toContain(';');
+    // Both ids are tracked as cited so they appear in the bibliography.
+    expect(renderer.cited().has('foo-2020')).toBe(true);
+    expect(renderer.cited().has('bar-2021')).toBe(true);
+  });
+
+  it('two adjacent [[cite::]] in markdown render as a single merged mark', async () => {
+    await fsp.writeFile(path.join(root, 'merge.md'),
+      '# Merge\n\nAs [[cite::foo-2020]] [[cite::bar-2021]] showed.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'merge.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+
+    // Exactly one citation parenthetical, containing both names + a
+    // semicolon separator. Two separate parens would show up as
+    // ") (" somewhere in the rendered text.
+    expect(html).not.toContain(') (');
+    const inText = html.match(/\([^)]*Foo[^)]*Bar[^)]*\)|\([^)]*Bar[^)]*Foo[^)]*\)/);
+    expect(inText).not.toBeNull();
+    expect(inText![0]).toContain(';');
+  });
+
+  it('three consecutive cites separated by single spaces all merge', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/baz-2022'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/baz-2022/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Baz Notes" ;
+  dc:creator "Baz, Carol" ;
+  dc:issued "2022"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.writeFile(path.join(root, 'three.md'),
+      'See [[cite::foo-2020]] [[cite::bar-2021]] [[cite::baz-2022]].\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'three.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+
+    // Single paren containing all three names + two semicolons.
+    const matches = html.match(/\([^)]+\)/g) ?? [];
+    const citationParen = matches.find((p) => /Foo|Bar|Baz/.test(p));
+    expect(citationParen).toBeDefined();
+    expect(citationParen).toContain('Foo');
+    expect(citationParen).toContain('Bar');
+    expect(citationParen).toContain('Baz');
+    // Two `; ` separators for three items in one cluster.
+    expect((citationParen!.match(/;/g) ?? []).length).toBe(2);
+  });
+
+  it('newline-separated cites also merge (whitespace, not punctuation)', async () => {
+    await fsp.writeFile(path.join(root, 'wrapped.md'),
+      'Per [[cite::foo-2020]]\n[[cite::bar-2021]] this holds.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'wrapped.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).not.toContain(') (');
+    expect(html).toMatch(/\([^)]*(Foo|Bar)[^)]*;[^)]*\)/);
+  });
+
+  it('cite + quote with locator merges and the locator survives', async () => {
+    await fsp.writeFile(path.join(root, 'mixed.md'),
+      'Per [[cite::bar-2021]] [[quote::ex-foo-1]].\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'mixed.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    // One paren, both names, the page locator from the excerpt.
+    expect(html).not.toContain(') (');
+    const paren = (html.match(/\([^)]*\)/g) ?? []).find((p) => /Foo|Bar/.test(p));
+    expect(paren).toBeDefined();
+    expect(paren).toContain('Foo');
+    expect(paren).toContain('Bar');
+    expect(paren).toContain('7');
+  });
+
+  it('non-whitespace separator (comma) prevents the merge', async () => {
+    await fsp.writeFile(path.join(root, 'comma.md'),
+      'Per [[cite::foo-2020]], [[cite::bar-2021]] showed.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'comma.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    // Two separate parentheticals, each with a single name.
+    const parens = (html.match(/\([^)]+\)/g) ?? []).filter((p) => /Foo|Bar/.test(p));
+    expect(parens.length).toBe(2);
+    expect(parens.some((p) => p.includes('Foo') && !p.includes('Bar'))).toBe(true);
+    expect(parens.some((p) => p.includes('Bar') && !p.includes('Foo'))).toBe(true);
+  });
+
+  it('missing id in a run falls back to per-item rendering so [missing: x] stays visible', async () => {
+    await fsp.writeFile(path.join(root, 'missing.md'),
+      'See [[cite::foo-2020]] [[cite::nope-2099]] [[cite::bar-2021]].\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'missing.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('[missing: nope-2099]');
+    // Each present cite renders as its own parenthetical when a sibling
+    // is missing — no merged cluster swallows them.
+    const parens = (html.match(/\([^)]+\)/g) ?? []).filter((p) => /Foo|Bar/.test(p));
+    expect(parens.some((p) => p.includes('Foo') && !p.includes('Bar'))).toBe(true);
+    expect(parens.some((p) => p.includes('Bar') && !p.includes('Foo'))).toBe(true);
+  });
+
+  it('single [[cite::]] (no neighbour) still works exactly as before', async () => {
+    await fsp.writeFile(path.join(root, 'single.md'),
+      'Just [[cite::foo-2020]] alone.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'single.md' });
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('Foo');
+    expect(html).toContain('2020');
+    expect(html).not.toContain('[[cite::foo-2020]]');
+  });
+});


### PR DESCRIPTION
> **Stacked on #437** — this branch builds on \`issue-298-consecutive-cite-merging\`. Merge that one first.

## Summary

\`[[cite::toulmin-1958|p. 42]]\` now renders as a real \"(Toulmin 1958, p. 42)\" inline mark instead of dropping the alias and either citing the bare id or — depending on input shape — treating the whole \`id|alias\` string as the source key and rendering \`[missing: …]\`.

## How

1. The cite rule splits the inner target on \`|\`. The id is everything before the pipe; the alias is everything after.
2. New \`parseLocatorAlias()\` maps the alias string to \`{ locator, label }\` if it parses cleanly:
   - bare digits / ranges / roman numerals → \`page\`
   - \`p.\` / \`pp.\` / \`page\` / \`pages\` → \`page\` (prefix stripped)
   - \`ch.\` / \`chapter\` → \`chapter\`; \`sec.\` / \`section\` / \`§\` → \`section\`
   - plus \`fig.\`, \`tbl.\`, \`n.\`, \`para.\` / \`¶\`, \`vol.\`, \`l.\`, \`v.\`, \`col.\`
   - anything else → \`null\` (alias silently dropped — matches the wiki-link convention that an unparseable alias is just display text)
3. Renderer's \`renderCitation\` and \`renderCitationCluster\` grew an optional \`label\` parameter that defaults to \`'page'\` for back-compat. Non-page labels round-trip through the merge path.

## Behaviour

| Input | Renders |
|---|---|
| \`[[cite::id|42]]\` | \`(Foo 2020, p. 42)\` |
| \`[[cite::id|pp. 42-45]]\` | \`(Foo 2020, pp. 42–45)\` |
| \`[[cite::id|ch. 3]]\` | \`(Foo 2020, Chapter 3)\` |
| \`[[cite::id|the seminal essay]]\` | \`(Foo 2020)\` (alias dropped) |
| \`[[quote::ex|p. 99]]\` | overrides the excerpt's intrinsic page |

## Closes

Resolves #299. Knocks out one more bullet from #247's deferred list.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/csl.test.ts\` — 41/41, 12 new tests covering each locator shape, label override on quote, alias survival through the merge path
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a note with \`[[cite::id|p. 42]]\` under each bundled style and confirm the locator renders correctly per style

🤖 Generated with [Claude Code](https://claude.com/claude-code)