### PR TITLE
Publication: preview-dialog Citations section with style/locale picker (#301)

### DIFF
--- a/src/main/bibliography/generate.ts
+++ b/src/main/bibliography/generate.ts
@@ -124,6 +124,5 @@ export async function generateBibliography(
   );
   // `loadCitationAssets` already falls back to APA when styleId is
   // unknown; surface what was actually used so the UI can confirm.
-  const usedStyleId = styleId && assets.style ? styleId : 'apa';
-  return { content, entriesCount, missingIds, changed, styleId: usedStyleId };
+  return { content, entriesCount, missingIds, changed, styleId: assets.styleId };
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -48,7 +48,8 @@ import {
   getBibliographyStyleId,
   setBibliographyStyleId,
 } from './project-config';
-import { BUNDLED_STYLES, BUNDLED_STYLE_LABELS, DEFAULT_STYLE } from './publish/csl/assets';
+import { BUNDLED_STYLES, BUNDLED_STYLE_LABELS, BUNDLED_LOCALES, DEFAULT_STYLE } from './publish/csl/assets';
+import { buildCitationAudit } from './publish/csl/audit';
 import { renderInlineCitations, type InlineCiteRequest } from './citations/render-inline';
 import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
 import { deleteSource } from './sources/delete-source';
@@ -992,14 +993,23 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.PUBLISH_RESOLVE_PLAN, async (e, input: publish.ExportInput, opts?: {
     exporterId?: string;
     linkPolicy?: publish.LinkPolicy;
+    citationStyle?: string;
+    citationLocale?: string;
   }) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
-    const plan = await publish.resolvePlan(rootPath, input, { linkPolicy: opts?.linkPolicy });
+    const plan = await publish.resolvePlan(rootPath, input, {
+      linkPolicy: opts?.linkPolicy,
+      citationStyle: opts?.citationStyle,
+      citationLocale: opts?.citationLocale,
+    });
     // Strip `content` + `frontmatter` from the wire payload — the preview
     // only needs to audit paths, kinds, and exclusion reasons; loading
     // every file's text over IPC is wasteful.
     const exporter = opts?.exporterId ? publish.getExporter(opts.exporterId) : null;
+    const audit = plan.citations
+      ? buildCitationAudit(plan.inputs, plan.citations)
+      : { bySource: [], missing: [] };
     return {
       exporterId: exporter?.id ?? '',
       exporterLabel: exporter?.label ?? '',
@@ -1009,6 +1019,17 @@ export function registerIpcHandlers(): void {
         title: f.title,
       })),
       excluded: plan.excluded,
+      citations: {
+        styleId: plan.citations?.styleId ?? DEFAULT_STYLE,
+        localeId: plan.citations?.localeId ?? 'en-US',
+        availableStyles: Object.keys(BUNDLED_STYLES).map((id) => ({
+          id,
+          label: BUNDLED_STYLE_LABELS[id] ?? id,
+        })),
+        availableLocales: Object.keys(BUNDLED_LOCALES).map((id) => ({ id, label: id })),
+        bySource: audit.bySource,
+        missing: audit.missing,
+      },
     };
   });
 

--- a/src/main/publish/csl/audit.ts
+++ b/src/main/publish/csl/audit.ts
@@ -1,0 +1,118 @@
+/**
+ * Citation audit for the export-preview dialog (#301).
+ *
+ * Walks every note in the resolved plan, scans for `[[cite::id]]` and
+ * `[[quote::id]]` references, groups them by their resolved source, and
+ * surfaces the counts + any missing ids so the preview UI can show the
+ * user exactly what'll be cited before they hit Export.
+ *
+ * Lives next to the rest of the citation engine because the audit
+ * needs the same `CitationAssets` map that powers the renderer — the
+ * audit answers "which sources will the renderer actually find" and
+ * "which won't it find," so the data has to come from the same source
+ * of truth.
+ */
+
+import type { CitationAssets } from './index';
+import { scanCitations } from '../../bibliography/scan-citations';
+
+export interface CitationAuditEntry {
+  sourceId: string;
+  /** Display title pulled from the loaded CSL item, or the bare id when unavailable. */
+  title: string;
+  /** Total inline references that resolve to this source — cites + quotes summed. */
+  refCount: number;
+}
+
+export interface CitationAuditMissing {
+  /** The id as written in the markdown (`cite::brooks-1986` → `brooks-1986`). */
+  id: string;
+  kind: 'cite' | 'quote';
+  refCount: number;
+}
+
+export interface CitationAudit {
+  /** Sources that'll appear in the rendered bibliography, ordered by reference count desc, then id. */
+  bySource: CitationAuditEntry[];
+  /** Cites/quotes whose ids couldn't be resolved against the project's sources/excerpts. */
+  missing: CitationAuditMissing[];
+}
+
+/**
+ * Build the audit from the plan's note contents + the loaded citation assets.
+ *
+ * Excerpt references resolve through `assets.excerpts` to their parent
+ * source — both `[[cite::brooks-1986]]` and `[[quote::brooks-essential]]`
+ * (where the excerpt's `thought:fromSource` is `brooks-1986`) count
+ * against the same Brooks bucket.
+ */
+export function buildCitationAudit(
+  notes: Array<{ relativePath: string; content: string }>,
+  assets: CitationAssets,
+): CitationAudit {
+  const bySource = new Map<string, CitationAuditEntry>();
+  const missing = new Map<string, CitationAuditMissing>();
+
+  for (const note of notes) {
+    for (const ref of scanCitations(note.content)) {
+      if (ref.kind === 'quote') {
+        const ex = assets.excerpts.get(ref.id);
+        if (!ex) {
+          bumpMissing(missing, ref.id, 'quote');
+          continue;
+        }
+        if (!assets.items.has(ex.sourceId)) {
+          // Excerpt found but its parent source is missing — surface
+          // the source id so the user knows what's actually wrong.
+          bumpMissing(missing, ex.sourceId, 'cite');
+          continue;
+        }
+        bumpSource(bySource, ex.sourceId, assets);
+        continue;
+      }
+      // kind === 'cite'
+      if (!assets.items.has(ref.id)) {
+        bumpMissing(missing, ref.id, 'cite');
+        continue;
+      }
+      bumpSource(bySource, ref.id, assets);
+    }
+  }
+
+  return {
+    bySource: [...bySource.values()].sort((a, b) =>
+      b.refCount - a.refCount || a.sourceId.localeCompare(b.sourceId),
+    ),
+    missing: [...missing.values()].sort((a, b) =>
+      b.refCount - a.refCount || a.id.localeCompare(b.id),
+    ),
+  };
+}
+
+function bumpSource(
+  map: Map<string, CitationAuditEntry>,
+  sourceId: string,
+  assets: CitationAssets,
+): void {
+  const existing = map.get(sourceId);
+  if (existing) {
+    existing.refCount += 1;
+    return;
+  }
+  const item = assets.items.get(sourceId);
+  const title = typeof item?.title === 'string' && item.title ? item.title : sourceId;
+  map.set(sourceId, { sourceId, title, refCount: 1 });
+}
+
+function bumpMissing(
+  map: Map<string, CitationAuditMissing>,
+  id: string,
+  kind: 'cite' | 'quote',
+): void {
+  const existing = map.get(id);
+  if (existing) {
+    existing.refCount += 1;
+    return;
+  }
+  map.set(id, { id, kind, refCount: 1 });
+}

--- a/src/main/publish/csl/index.ts
+++ b/src/main/publish/csl/index.ts
@@ -26,7 +26,13 @@ export interface BuildRendererOptions {
  * want a fresh session call `assets.createRenderer()` per note.
  */
 export interface CitationAssets {
+  /** Resolved CSL style id after fallback (e.g. 'apa'). Surfaced for the preview UI (#301). */
+  styleId: string;
+  /** Resolved CSL locale id after fallback (e.g. 'en-US'). */
+  localeId: string;
+  /** Raw CSL XML for the resolved style — what citeproc-js consumes. */
   style: string;
+  /** Raw locale XML. */
   locale: string;
   items: Map<string, CslItem>;
   excerpts: Map<string, { sourceId: string; locator?: string }>;
@@ -81,6 +87,8 @@ export async function loadCitationAssets(
   } catch { /* no .minerva/excerpts */ }
 
   return {
+    styleId,
+    localeId,
     style,
     locale,
     items,

--- a/src/main/publish/pipeline.ts
+++ b/src/main/publish/pipeline.ts
@@ -34,6 +34,7 @@ export interface ResolvePlanOptions {
   linkPolicy?: LinkPolicy;
   assetPolicy?: AssetPolicy;
   citationStyle?: string;
+  citationLocale?: string;
   outputDir?: string;
 }
 
@@ -48,6 +49,7 @@ export async function resolvePlan(
 
   const citations = await loadCitationAssets(rootPath, {
     styleId: opts.citationStyle,
+    localeId: opts.citationLocale,
   });
 
   return {
@@ -57,6 +59,7 @@ export async function resolvePlan(
     linkPolicy: opts.linkPolicy ?? 'inline-title',
     assetPolicy: opts.assetPolicy ?? 'keep-relative',
     citationStyle: opts.citationStyle,
+    citationLocale: opts.citationLocale,
     outputDir: opts.outputDir,
     rootPath,
     citations,

--- a/src/main/publish/run-export.ts
+++ b/src/main/publish/run-export.ts
@@ -21,6 +21,10 @@ export interface RunExportInput {
   outputDir: string;
   linkPolicy?: LinkPolicy;
   assetPolicy?: AssetPolicy;
+  /** CSL style id (#301). Falls back to the bundled default when absent. */
+  citationStyle?: string;
+  /** CSL locale id (#301). Falls back to en-US. */
+  citationLocale?: string;
 }
 
 export interface RunExportResult {
@@ -48,6 +52,8 @@ export async function runExport(
   const plan = await resolvePlan(rootPath, args.input, {
     linkPolicy: args.linkPolicy,
     assetPolicy: args.assetPolicy,
+    citationStyle: args.citationStyle,
+    citationLocale: args.citationLocale,
     outputDir: args.outputDir,
   });
   const output = await runExporter(exporter, plan);

--- a/src/main/publish/types.ts
+++ b/src/main/publish/types.ts
@@ -88,6 +88,8 @@ export interface ExportPlan {
   assetPolicy: AssetPolicy;
   /** CSL style id; exporters ignore when not set. */
   citationStyle?: string;
+  /** CSL locale id (#301). Exporters ignore when not set. */
+  citationLocale?: string;
   /** Absolute destination directory for exporters that write multiple files. */
   outputDir?: string;
   /**

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -24,6 +24,8 @@
 
   let scope = $state<Scope>('project');
   let linkPolicy = $state<LinkPolicy>('inline-title');
+  let citationStyle = $state<string>('apa');
+  let citationLocale = $state<string>('en-US');
   let plan = $state<ExportPreviewPlan | null>(null);
   let loading = $state(false);
   let exporting = $state(false);
@@ -57,7 +59,12 @@
     loading = true;
     error = null;
     try {
-      plan = await api.publish.resolvePlan(scopeInput(), { exporterId, linkPolicy });
+      plan = await api.publish.resolvePlan(scopeInput(), {
+        exporterId,
+        linkPolicy,
+        citationStyle,
+        citationLocale,
+      });
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
       plan = null;
@@ -88,12 +95,14 @@
     })();
   });
 
-  // Re-resolve whenever the scope or link policy changes. `$effect`
+  // Re-resolve whenever an input affecting the plan changes. `$effect`
   // re-runs on any tracked read, so wrapping refreshPlan() in here
-  // subscribes to scope, linkPolicy, activeFilePath, and activeFolder.
+  // subscribes to scope, linkPolicy, citationStyle/locale, activeFilePath.
   $effect(() => {
     void scope;
     void linkPolicy;
+    void citationStyle;
+    void citationLocale;
     void activeFilePath;
     if (!acceptedLoaded) return;
     void refreshPlan();
@@ -108,6 +117,8 @@
         exporterId,
         input: scopeInput(),
         linkPolicy,
+        citationStyle,
+        citationLocale,
       });
       if (result === null) return; // user cancelled the directory picker
       onExported(result);
@@ -171,6 +182,26 @@
       </select>
     </div>
 
+    {#if plan}
+      <div class="option-row">
+        <label for="citation-style">Citation style</label>
+        <select id="citation-style" bind:value={citationStyle}>
+          {#each plan.citations.availableStyles as s (s.id)}
+            <option value={s.id}>{s.label}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="citation-locale">Citation locale</label>
+        <select id="citation-locale" bind:value={citationLocale}>
+          {#each plan.citations.availableLocales as l (l.id)}
+            <option value={l.id}>{l.label}</option>
+          {/each}
+        </select>
+      </div>
+    {/if}
+
     {#if loading}
       <div class="status">Resolving plan…</div>
     {:else if plan}
@@ -213,6 +244,40 @@
           {/if}
         </div>
       </div>
+
+      {#if plan.citations.bySource.length > 0 || plan.citations.missing.length > 0}
+        <div class="audit-section citations-section">
+          <h3>
+            Citations <span class="count">{plan.citations.bySource.length}</span>
+            {#if plan.citations.missing.length > 0}
+              <span class="count missing-count">{plan.citations.missing.length} missing</span>
+            {/if}
+          </h3>
+          {#if plan.citations.missing.length > 0}
+            <ul class="missing-list">
+              {#each plan.citations.missing as m (m.kind + ':' + m.id)}
+                <li>
+                  <span class="title">[missing {m.kind}: {m.id}]</span>
+                  <span class="reason">{m.refCount} reference{m.refCount === 1 ? '' : 's'}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+          {#if plan.citations.bySource.length > 0}
+            <ul>
+              {#each plan.citations.bySource.slice(0, 60) as s (s.sourceId)}
+                <li>
+                  <span class="title">{s.title}</span>
+                  <span class="reason">{s.sourceId} · {s.refCount} ref{s.refCount === 1 ? '' : 's'}</span>
+                </li>
+              {/each}
+              {#if plan.citations.bySource.length > 60}
+                <li class="more">…and {plan.citations.bySource.length - 60} more</li>
+              {/if}
+            </ul>
+          {/if}
+        </div>
+      {/if}
     {/if}
 
     {#if error}
@@ -368,6 +433,26 @@
     font-size: 11px;
     color: var(--text-muted);
     font-style: italic;
+  }
+
+  /* Citations span the full grid width — they're a separate concern from
+     Including/Excluded so the user can audit them at full reading width. */
+  .citations-section {
+    grid-column: 1 / -1;
+    margin-top: 8px;
+  }
+  .citations-section .missing-count {
+    background: var(--bg-button);
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .citations-section .missing-list li .title {
+    color: var(--accent);
+  }
+  .citations-section .missing-list {
+    margin-bottom: 6px;
+    padding-bottom: 4px;
+    border-bottom: 1px dashed var(--border);
   }
   .audit-section .more {
     border-bottom: none;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -173,11 +173,25 @@ export interface FilesApi {
 export type { CellOutput, CellResult } from '../../../shared/compute/types';
 import type { CellResult } from '../../../shared/compute/types';
 
+export interface CitationAuditPayload {
+  /** Resolved style id after fallback (e.g. 'apa'). */
+  styleId: string;
+  /** Resolved locale id after fallback (e.g. 'en-US'). */
+  localeId: string;
+  availableStyles: Array<{ id: string; label: string }>;
+  availableLocales: Array<{ id: string; label: string }>;
+  /** Sources that'll appear in the rendered bibliography, ordered by ref count desc. */
+  bySource: Array<{ sourceId: string; title: string; refCount: number }>;
+  /** Cite/quote ids that couldn't be resolved against the project's sources/excerpts. */
+  missing: Array<{ id: string; kind: 'cite' | 'quote'; refCount: number }>;
+}
+
 export interface ExportPreviewPlan {
   exporterId: string;
   exporterLabel: string;
   inputs: Array<{ relativePath: string; kind: 'note' | 'source' | 'excerpt'; title: string }>;
   excluded: Array<{ relativePath: string; reason: string }>;
+  citations: CitationAuditPayload;
 }
 
 export type ExportInputKind = 'single-note' | 'folder' | 'project' | 'tree';
@@ -191,6 +205,8 @@ export interface RunExportInput {
   };
   outputDir: string;
   linkPolicy?: 'drop' | 'inline-title' | 'follow-to-file';
+  citationStyle?: string;
+  citationLocale?: string;
 }
 
 export interface RunExportResult {
@@ -206,7 +222,12 @@ export interface PublishApi {
   /** Resolve an ExportPlan without running it — for the preview dialog. */
   resolvePlan(
     input: RunExportInput['input'],
-    opts?: { exporterId?: string; linkPolicy?: RunExportInput['linkPolicy'] },
+    opts?: {
+      exporterId?: string;
+      linkPolicy?: RunExportInput['linkPolicy'];
+      citationStyle?: string;
+      citationLocale?: string;
+    },
   ): Promise<ExportPreviewPlan>;
   /**
    * Run the exporter. When `outputDir` is omitted, main opens a directory

--- a/tests/main/publish/citation-audit.test.ts
+++ b/tests/main/publish/citation-audit.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Audit-builder unit tests (#301).
+ *
+ * The audit groups every `[[cite::]]` / `[[quote::]]` reference in the
+ * plan's notes by resolved source id, counts occurrences, and surfaces
+ * missing ids. The preview dialog uses the result to show the user
+ * exactly what'll be cited before they hit Export.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { buildCitationAudit } from '../../../src/main/publish/csl/audit';
+import { resolvePlan } from '../../../src/main/publish/pipeline';
+import { type CitationAssets } from '../../../src/main/publish/csl';
+import type { CslItem } from '../../../src/main/publish/csl/source-to-csl';
+
+function fakeAssets(
+  items: Record<string, Pick<CslItem, 'title'>>,
+  excerpts: Record<string, { sourceId: string; locator?: string }> = {},
+): CitationAssets {
+  const itemMap = new Map<string, CslItem>(
+    Object.entries(items).map(([id, partial]) => [id, { id, type: 'article', ...partial }]),
+  );
+  return {
+    styleId: 'apa',
+    localeId: 'en-US',
+    style: '<style/>',
+    locale: '<locale/>',
+    items: itemMap,
+    excerpts: new Map(Object.entries(excerpts)),
+    knownSourceIds: [...itemMap.keys()],
+    createRenderer: () => { throw new Error('not used in audit tests'); },
+  };
+}
+
+describe('buildCitationAudit (#301)', () => {
+  it('groups [[cite::]] occurrences by source and counts them', () => {
+    const assets = fakeAssets({
+      'foo-2020': { title: 'Foo Studies' },
+      'bar-2021': { title: 'Bar Considered' },
+    });
+    const notes = [
+      { relativePath: 'a.md', content: 'See [[cite::foo-2020]] and [[cite::foo-2020]] again.' },
+      { relativePath: 'b.md', content: 'Per [[cite::bar-2021]], we have a result.' },
+    ];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.bySource).toEqual([
+      { sourceId: 'foo-2020', title: 'Foo Studies', refCount: 2 },
+      { sourceId: 'bar-2021', title: 'Bar Considered', refCount: 1 },
+    ]);
+    expect(audit.missing).toEqual([]);
+  });
+
+  it('resolves [[quote::]] through the excerpt to its parent source', () => {
+    const assets = fakeAssets(
+      { 'brooks-1986': { title: 'No Silver Bullet' } },
+      { 'ex-essence': { sourceId: 'brooks-1986', locator: '11' } },
+    );
+    const notes = [
+      { relativePath: 'note.md', content: '[[quote::ex-essence]] and [[cite::brooks-1986]].' },
+    ];
+    const audit = buildCitationAudit(notes, assets);
+    // Both refs collapse onto the same Brooks bucket.
+    expect(audit.bySource).toEqual([
+      { sourceId: 'brooks-1986', title: 'No Silver Bullet', refCount: 2 },
+    ]);
+    expect(audit.missing).toEqual([]);
+  });
+
+  it('surfaces missing cite ids', () => {
+    const assets = fakeAssets({ 'foo-2020': { title: 'Foo' } });
+    const notes = [
+      { relativePath: 'a.md', content: '[[cite::nope]] [[cite::foo-2020]] [[cite::nope]]' },
+    ];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.missing).toEqual([
+      { id: 'nope', kind: 'cite', refCount: 2 },
+    ]);
+    expect(audit.bySource).toEqual([
+      { sourceId: 'foo-2020', title: 'Foo', refCount: 1 },
+    ]);
+  });
+
+  it('surfaces missing quote ids (excerpt not in project)', () => {
+    const assets = fakeAssets({ 'foo-2020': { title: 'Foo' } }, {});
+    const notes = [
+      { relativePath: 'a.md', content: '[[quote::ghost-excerpt]]' },
+    ];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.missing).toEqual([
+      { id: 'ghost-excerpt', kind: 'quote', refCount: 1 },
+    ]);
+    expect(audit.bySource).toEqual([]);
+  });
+
+  it('surfaces a missing source even when the excerpt itself is loaded', () => {
+    // Excerpt's parent source got deleted but the excerpt TTL still exists.
+    const assets = fakeAssets(
+      {}, // no sources at all
+      { 'orphan-ex': { sourceId: 'gone-source', locator: '5' } },
+    );
+    const notes = [
+      { relativePath: 'a.md', content: '[[quote::orphan-ex]]' },
+    ];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.missing).toEqual([
+      // Surfaced as the *source* id so the user knows which ref is the
+      // load-bearing one to fix.
+      { id: 'gone-source', kind: 'cite', refCount: 1 },
+    ]);
+  });
+
+  it('orders bySource by refCount desc, then sourceId asc for ties', () => {
+    const assets = fakeAssets({
+      a: { title: 'A' },
+      b: { title: 'B' },
+      c: { title: 'C' },
+    });
+    const notes = [
+      { relativePath: 'n.md', content: '[[cite::c]] [[cite::a]] [[cite::a]] [[cite::b]] [[cite::b]]' },
+    ];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.bySource.map((e) => e.sourceId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('falls back to the bare id when the loaded source has no title', () => {
+    const assets = fakeAssets({ 'untitled-source': {} });
+    const notes = [{ relativePath: 'n.md', content: '[[cite::untitled-source]]' }];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.bySource[0].title).toBe('untitled-source');
+  });
+
+  it('respects scanCitations\' bibliography-block strip — refs inside it don\'t double-count', () => {
+    const assets = fakeAssets({ 'foo-2020': { title: 'Foo' } });
+    const notes = [{
+      relativePath: 'n.md',
+      content: '[[cite::foo-2020]]\n\n<!-- minerva:bibliography -->\n[[cite::foo-2020]]\n<!-- /minerva:bibliography -->',
+    }];
+    const audit = buildCitationAudit(notes, assets);
+    expect(audit.bySource).toEqual([
+      { sourceId: 'foo-2020', title: 'Foo', refCount: 1 },
+    ]);
+  });
+
+  it('handles empty input cleanly', () => {
+    const audit = buildCitationAudit([], fakeAssets({}));
+    expect(audit.bySource).toEqual([]);
+    expect(audit.missing).toEqual([]);
+  });
+});
+
+describe('audit integrates with resolvePlan against a real fixture (#301)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-audit-'));
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/excerpts'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/excerpts/ex-foo.ttl'),
+      `this: a thought:Excerpt ;
+  thought:fromSource sources:foo-2020 ;
+  thought:page 7 .\n`,
+      'utf-8',
+    );
+    await fsp.writeFile(path.join(root, 'note.md'),
+      'See [[cite::foo-2020]] and [[quote::ex-foo]] but also [[cite::missing-id]].\n',
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('end-to-end: plan + audit reports cited sources and the missing id', async () => {
+    const plan = await resolvePlan(root, { kind: 'project' });
+    expect(plan.citations).toBeDefined();
+    expect(plan.citations!.styleId).toBe('apa'); // default fallback
+    expect(plan.citations!.localeId).toBe('en-US');
+
+    const audit = buildCitationAudit(plan.inputs, plan.citations!);
+    expect(audit.bySource).toEqual([
+      // foo-2020 gets 2 refs: the [[cite::]] + the [[quote::]] resolving through ex-foo.
+      { sourceId: 'foo-2020', title: 'Foo Studies', refCount: 2 },
+    ]);
+    expect(audit.missing).toEqual([
+      { id: 'missing-id', kind: 'cite', refCount: 1 },
+    ]);
+  });
+
+  it('honours the citationStyle option through resolvePlan', async () => {
+    const plan = await resolvePlan(root, { kind: 'project' }, { citationStyle: 'mla' });
+    expect(plan.citations!.styleId).toBe('mla');
+  });
+
+  it('falls back to default style for unknown ids', async () => {
+    const plan = await resolvePlan(root, { kind: 'project' }, { citationStyle: 'no-such-style' });
+    expect(plan.citations!.styleId).toBe('apa');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the Citations bow on top of the citation work just landed (#247, #296, #298, #299). The Export preview dialog now shows the user **exactly what will be cited** before they hit Export:

- **Citation style** dropdown — populated from the bundled CSL registry (APA, Chicago author-date, Chicago notes, MLA, IEEE, Vancouver).
- **Citation locale** dropdown — currently just en-US, but plumbed end-to-end so #302 (user-supplied locales) drops in cleanly.
- **Cited-source list** — every \`[[cite::]]\` / \`[[quote::]]\` reference in the plan's notes, grouped by resolved source, with reference counts. Quote-resolved references roll up to their parent source.
- **Missing-id warning rows** — separate list at the top of the section, accent-coloured per the "no scary red" UX guideline. Surfaces the source id (not the excerpt id) when a quote's parent source is gone, since that's the load-bearing fix.

## How

### Pipeline
- \`resolvePlan\` accepts \`citationStyle\` + \`citationLocale\` (locale was previously only plumbed through the renderer constructor).
- \`CitationAssets\` now exposes resolved \`styleId\` / \`localeId\` *after* fallback so the preview can confirm what citeproc-js will actually use when the user picked an unknown id.
- New \`buildCitationAudit()\` runs once per \`resolvePlan\` call: walks every note via the existing \`scanCitations()\` helper, groups refs by resolved source, surfaces missing.

### UI
- Style + locale \`<select>\`s under the existing Link-handling row, only rendered after the first plan resolves (so we have the available list).
- Citations \`<section>\` spans the full audit-grid width; missing rows have a dashed separator above the resolved-source list.
- The plan auto-refreshes on style/locale change via the existing \`$effect\` so the audit always reflects the active selection.

### IPC
- \`ExportPreviewPlan\` grew a \`citations\` field with the audit + the available-styles/locales registry.
- \`RunExportInput\` accepts \`citationStyle\` + \`citationLocale\` so the eventual export uses the user's choice.

## Closes

Resolves #301. Last bullet from #247's deferred list before #297 (Chicago full-note rendering path) and #300 (consolidated tree-html bibliography).

## Test plan

- [x] \`pnpm vitest run tests/main/publish\` — 168/168, 12 new tests in \`citation-audit.test.ts\` covering: cite grouping, quote-to-source resolution, missing cites, missing quotes (excerpt absent), orphan excerpts (excerpt loaded but parent source gone), ordering by ref-count then id, untitled-source fallback, bibliography-block strip, empty input, and 3 end-to-end \`resolvePlan\` integration tests.
- [x] \`pnpm lint\` — clean
- [ ] Manual: open Export dialog with a project that has cites + a missing id; confirm the audit + missing warning render correctly under each style

🤖 Generated with [Claude Code](https://claude.com/claude-code)