### PR TITLE
Publication: import user CSL styles + locales from .minerva/ (#302)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -48,8 +48,21 @@ import {
   getBibliographyStyleId,
   setBibliographyStyleId,
 } from './project-config';
-import { BUNDLED_STYLES, BUNDLED_STYLE_LABELS, BUNDLED_LOCALES, DEFAULT_STYLE } from './publish/csl/assets';
+import { DEFAULT_STYLE } from './publish/csl/assets';
 import { buildCitationAudit } from './publish/csl/audit';
+import {
+  loadUserStyles,
+  loadUserLocales,
+  getMergedStyles,
+  getMergedLocales,
+  isValidCslStyle,
+  isValidCslLocale,
+  extractStyleTitle,
+  deriveStyleId,
+  deriveLocaleId,
+  USER_STYLES_DIR,
+  USER_LOCALES_DIR,
+} from './publish/csl/user-assets';
 import { renderInlineCitations, type InlineCiteRequest } from './citations/render-inline';
 import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
 import { deleteSource } from './sources/delete-source';
@@ -773,24 +786,113 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.SITES_LOGOUT, (_e, id: string) => logoutPrivilegedSite(id));
 
   // Bibliography (#113)
-  ipcMain.handle(Channels.BIBLIOGRAPHY_LIST_STYLES, () =>
-    Object.keys(BUNDLED_STYLES).map((id) => ({
+  ipcMain.handle(Channels.BIBLIOGRAPHY_LIST_STYLES, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    // Settings dialog opens before any project is loaded in some flows;
+    // fall back to the bundled set so the picker isn't empty.
+    const merged = rootPath
+      ? await getMergedStyles(rootPath)
+      : await getMergedStyles('');
+    return Object.keys(merged.styles).map((id) => ({
       id,
-      label: BUNDLED_STYLE_LABELS[id] ?? id,
-    })),
-  );
+      label: merged.labels[id] ?? id,
+      isUser: merged.userIds.has(id),
+    }));
+  });
   ipcMain.handle(Channels.BIBLIOGRAPHY_GET_STYLE, (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return DEFAULT_STYLE;
     return getBibliographyStyleId(rootPath) ?? DEFAULT_STYLE;
   });
-  ipcMain.handle(Channels.BIBLIOGRAPHY_SET_STYLE, (e, styleId: string) => {
+  ipcMain.handle(Channels.BIBLIOGRAPHY_SET_STYLE, async (e, styleId: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
-    if (!Object.prototype.hasOwnProperty.call(BUNDLED_STYLES, styleId)) {
+    const merged = await getMergedStyles(rootPath);
+    if (!Object.prototype.hasOwnProperty.call(merged.styles, styleId)) {
       throw new Error(`Unknown CSL style: ${styleId}`);
     }
     setBibliographyStyleId(rootPath, styleId);
+  });
+
+  // User-imported CSL styles + locales (#302)
+  ipcMain.handle(Channels.CSL_LIST_USER_STYLES, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return (await loadUserStyles(rootPath)).map((s) => ({
+      id: s.id,
+      label: s.label,
+      filePath: s.filePath,
+    }));
+  });
+  ipcMain.handle(Channels.CSL_LIST_USER_LOCALES, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return (await loadUserLocales(rootPath)).map((l) => ({
+      id: l.id,
+      filePath: l.filePath,
+    }));
+  });
+  ipcMain.handle(Channels.CSL_IMPORT_STYLE, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const win = winFromEvent(e);
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openFile'],
+      filters: [{ name: 'CSL style', extensions: ['csl', 'xml'] }],
+      title: 'Import CSL style',
+      buttonLabel: 'Import',
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    const sourcePath = result.filePaths[0];
+    const xml = await fs.readFile(sourcePath, 'utf-8');
+    if (!isValidCslStyle(xml)) {
+      throw new Error('File is not a valid CSL style (missing <style> element with the CSL namespace).');
+    }
+    const id = deriveStyleId(path.basename(sourcePath));
+    if (!id) throw new Error('Could not derive a style id from the filename.');
+    const destDir = path.join(rootPath, USER_STYLES_DIR);
+    await fs.mkdir(destDir, { recursive: true });
+    const destPath = path.join(destDir, `${id}.csl`);
+    await fs.writeFile(destPath, xml, 'utf-8');
+    return { id, label: extractStyleTitle(xml) ?? id, filePath: destPath };
+  });
+  ipcMain.handle(Channels.CSL_IMPORT_LOCALE, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const win = winFromEvent(e);
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openFile'],
+      filters: [{ name: 'CSL locale', extensions: ['xml'] }],
+      title: 'Import CSL locale',
+      buttonLabel: 'Import',
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    const sourcePath = result.filePaths[0];
+    const xml = await fs.readFile(sourcePath, 'utf-8');
+    if (!isValidCslLocale(xml)) {
+      throw new Error('File is not a valid CSL locale (missing <locale> element with the CSL namespace).');
+    }
+    const id = deriveLocaleId(path.basename(sourcePath));
+    if (!id) throw new Error('Could not derive a locale id from the filename.');
+    const destDir = path.join(rootPath, USER_LOCALES_DIR);
+    await fs.mkdir(destDir, { recursive: true });
+    const destPath = path.join(destDir, `${id}.xml`);
+    await fs.writeFile(destPath, xml, 'utf-8');
+    return { id, filePath: destPath };
+  });
+  ipcMain.handle(Channels.CSL_REMOVE_STYLE, async (e, id: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    if (!/^[a-z0-9_-]+$/i.test(id)) throw new Error('Invalid style id.');
+    const target = path.join(rootPath, USER_STYLES_DIR, `${id}.csl`);
+    await fs.unlink(target).catch(() => undefined);
+  });
+  ipcMain.handle(Channels.CSL_REMOVE_LOCALE, async (e, id: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    if (!/^[A-Za-z0-9_-]+$/.test(id)) throw new Error('Invalid locale id.');
+    const target = path.join(rootPath, USER_LOCALES_DIR, `${id}.xml`);
+    await fs.unlink(target).catch(() => undefined);
   });
   ipcMain.handle(Channels.CITATION_RENDER_INLINE, async (e, refs: InlineCiteRequest[]) => {
     const rootPath = rootPathFromEvent(e);
@@ -1010,6 +1112,11 @@ export function registerIpcHandlers(): void {
     const audit = plan.citations
       ? buildCitationAudit(plan.inputs, plan.citations)
       : { bySource: [], missing: [] };
+    // Project-scoped registry: bundled + user-imported (#302). Exposed
+    // through the preview so the picker reflects whatever the user has
+    // dropped in, without a separate roundtrip.
+    const merged = await getMergedStyles(rootPath);
+    const mergedLocales = await getMergedLocales(rootPath);
     return {
       exporterId: exporter?.id ?? '',
       exporterLabel: exporter?.label ?? '',
@@ -1022,11 +1129,11 @@ export function registerIpcHandlers(): void {
       citations: {
         styleId: plan.citations?.styleId ?? DEFAULT_STYLE,
         localeId: plan.citations?.localeId ?? 'en-US',
-        availableStyles: Object.keys(BUNDLED_STYLES).map((id) => ({
+        availableStyles: Object.keys(merged.styles).map((id) => ({
           id,
-          label: BUNDLED_STYLE_LABELS[id] ?? id,
+          label: merged.labels[id] ?? id,
         })),
-        availableLocales: Object.keys(BUNDLED_LOCALES).map((id) => ({ id, label: id })),
+        availableLocales: Object.keys(mergedLocales.locales).map((id) => ({ id, label: id })),
         bySource: audit.bySource,
         missing: audit.missing,
       },

--- a/src/main/publish/csl/index.ts
+++ b/src/main/publish/csl/index.ts
@@ -9,7 +9,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { CitationRenderer } from './renderer';
 import { sourceTtlToCsl, excerptTtlToInfo, type CslItem } from './source-to-csl';
-import { BUNDLED_STYLES, BUNDLED_LOCALES, DEFAULT_STYLE, DEFAULT_LOCALE } from './assets';
+import { DEFAULT_STYLE, DEFAULT_LOCALE } from './assets';
+import { getMergedStyles, getMergedLocales } from './user-assets';
 
 export { CitationRenderer } from './renderer';
 export type { CslItem, ExcerptInfo } from './source-to-csl';
@@ -51,10 +52,15 @@ export async function loadCitationAssets(
   rootPath: string,
   opts: BuildRendererOptions = {},
 ): Promise<CitationAssets> {
-  const styleId = opts.styleId && BUNDLED_STYLES[opts.styleId] ? opts.styleId : DEFAULT_STYLE;
-  const localeId = opts.localeId && BUNDLED_LOCALES[opts.localeId] ? opts.localeId : DEFAULT_LOCALE;
-  const style = BUNDLED_STYLES[styleId];
-  const locale = BUNDLED_LOCALES[localeId];
+  // Merged registry: bundled + user-imported under .minerva/csl-{styles,locales}/.
+  // User entries win on id collision so a project-specific override of a
+  // bundled style takes effect without code changes (#302).
+  const { styles: availableStyles } = await getMergedStyles(rootPath);
+  const { locales: availableLocales } = await getMergedLocales(rootPath);
+  const styleId = opts.styleId && availableStyles[opts.styleId] ? opts.styleId : DEFAULT_STYLE;
+  const localeId = opts.localeId && availableLocales[opts.localeId] ? opts.localeId : DEFAULT_LOCALE;
+  const style = availableStyles[styleId];
+  const locale = availableLocales[localeId];
 
   const items = new Map<string, CslItem>();
   const excerpts = new Map<string, { sourceId: string; locator?: string }>();

--- a/src/main/publish/csl/user-assets.ts
+++ b/src/main/publish/csl/user-assets.ts
@@ -1,0 +1,180 @@
+/**
+ * User-imported CSL styles + locales (#302).
+ *
+ * Project-scoped extension to the bundled style registry: a `.csl` file
+ * dropped in `.minerva/csl-styles/<id>.csl` is recognised at export time
+ * and exposed in the preview dialog's style picker. Same shape for
+ * locales under `.minerva/csl-locales/<locale-id>.xml`.
+ *
+ * Merge policy: project files **win** on id collision against the
+ * bundled set, so a user can override a built-in style with their own
+ * variant without touching app source.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { BUNDLED_STYLES, BUNDLED_STYLE_LABELS, BUNDLED_LOCALES } from './assets';
+
+export const USER_STYLES_DIR = '.minerva/csl-styles';
+export const USER_LOCALES_DIR = '.minerva/csl-locales';
+
+export interface UserStyleEntry {
+  id: string;
+  label: string;
+  /** Absolute path on disk — useful for the settings UI's "remove" action. */
+  filePath: string;
+  /** Raw CSL XML, ready to feed citeproc-js. */
+  xml: string;
+}
+
+export interface UserLocaleEntry {
+  id: string;
+  filePath: string;
+  xml: string;
+}
+
+/**
+ * Walk `.minerva/csl-styles/`, parse each `.csl` file, and return the
+ * loaded entries keyed by their filename stem (the imported id).
+ *
+ * Files that don't parse as a CSL `<style>` are silently skipped — the
+ * import path validates ahead of time, so the only way to land an
+ * invalid file here is to drop it in by hand. We keep going rather
+ * than failing the whole load.
+ */
+export async function loadUserStyles(rootPath: string): Promise<UserStyleEntry[]> {
+  const dir = path.join(rootPath, USER_STYLES_DIR);
+  let entries: Array<{ name: string; isFile: () => boolean }>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: UserStyleEntry[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.toLowerCase().endsWith('.csl')) continue;
+    const id = entry.name.replace(/\.csl$/i, '');
+    const filePath = path.join(dir, entry.name);
+    let xml: string;
+    try { xml = await fs.readFile(filePath, 'utf-8'); } catch { continue; }
+    if (!isValidCslStyle(xml)) continue;
+    out.push({ id, label: extractStyleTitle(xml) ?? id, filePath, xml });
+  }
+  out.sort((a, b) => a.label.localeCompare(b.label));
+  return out;
+}
+
+export async function loadUserLocales(rootPath: string): Promise<UserLocaleEntry[]> {
+  const dir = path.join(rootPath, USER_LOCALES_DIR);
+  let entries: Array<{ name: string; isFile: () => boolean }>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: UserLocaleEntry[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.toLowerCase().endsWith('.xml')) continue;
+    const id = entry.name.replace(/\.xml$/i, '').replace(/^locales-/, '');
+    const filePath = path.join(dir, entry.name);
+    let xml: string;
+    try { xml = await fs.readFile(filePath, 'utf-8'); } catch { continue; }
+    if (!isValidCslLocale(xml)) continue;
+    out.push({ id, filePath, xml });
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}
+
+/**
+ * Merged style registry: bundled + user, user wins on id collision.
+ * Returns both the raw XML map (for citeproc-js) and a labels map
+ * (for UI pickers).
+ */
+export async function getMergedStyles(rootPath: string): Promise<{
+  styles: Record<string, string>;
+  labels: Record<string, string>;
+  userIds: Set<string>;
+}> {
+  const styles: Record<string, string> = { ...BUNDLED_STYLES };
+  const labels: Record<string, string> = { ...BUNDLED_STYLE_LABELS };
+  const userIds = new Set<string>();
+  for (const entry of await loadUserStyles(rootPath)) {
+    styles[entry.id] = entry.xml;
+    labels[entry.id] = entry.label;
+    userIds.add(entry.id);
+  }
+  return { styles, labels, userIds };
+}
+
+export async function getMergedLocales(rootPath: string): Promise<{
+  locales: Record<string, string>;
+  userIds: Set<string>;
+}> {
+  const locales: Record<string, string> = { ...BUNDLED_LOCALES };
+  const userIds = new Set<string>();
+  for (const entry of await loadUserLocales(rootPath)) {
+    locales[entry.id] = entry.xml;
+    userIds.add(entry.id);
+  }
+  return { locales, userIds };
+}
+
+// ── Validation + metadata extraction ──────────────────────────────────────
+
+/**
+ * Cheap structural check for a CSL style file. Looks for the root
+ * `<style>` element and the CSL namespace. Doesn't validate against
+ * the full schema — citeproc-js will be the strict reader at render
+ * time. The point here is to catch obvious garbage at import.
+ */
+export function isValidCslStyle(xml: string): boolean {
+  return /<style\b[^>]*xmlns="http:\/\/purl\.org\/net\/xbiblio\/csl"/i.test(xml);
+}
+
+export function isValidCslLocale(xml: string): boolean {
+  return /<locale\b[^>]*xmlns="http:\/\/purl\.org\/net\/xbiblio\/csl"/i.test(xml);
+}
+
+/**
+ * Pull the human-readable title out of `<style><info><title>…</title></info>…`.
+ * Falls back to null when not present so the caller can use the id as
+ * a label of last resort.
+ */
+export function extractStyleTitle(xml: string): string | null {
+  // Constrain the search to the <info> block so we don't pick up titles
+  // appearing later in the body (e.g. macro examples).
+  const info = xml.match(/<info\b[\s\S]*?<\/info>/i);
+  if (!info) return null;
+  const m = info[0].match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  if (!m) return null;
+  return decodeXmlEntities(m[1].trim()) || null;
+}
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// ── Filename sanitisation ────────────────────────────────────────────────
+
+/**
+ * Turn an arbitrary import filename into a safe id. Allows letters,
+ * digits, `-`, and `_`; everything else collapses to `-`. Empty result
+ * means the caller should reject the import outright.
+ */
+export function deriveStyleId(filename: string): string {
+  const stem = filename.replace(/\.csl$/i, '').replace(/^locales-/, '');
+  const safe = stem.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return safe;
+}
+
+export function deriveLocaleId(filename: string): string {
+  const stem = filename.replace(/\.xml$/i, '').replace(/^locales-/, '');
+  // Locale ids are short (e.g. "en-GB"); preserve case for compatibility.
+  return stem.replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -262,6 +262,14 @@ contextBridge.exposeInMainWorld('api', {
     generate: (relativePath: string) =>
       ipcRenderer.invoke(Channels.BIBLIOGRAPHY_GENERATE, relativePath),
   },
+  csl: {
+    listUserStyles: () => ipcRenderer.invoke(Channels.CSL_LIST_USER_STYLES),
+    listUserLocales: () => ipcRenderer.invoke(Channels.CSL_LIST_USER_LOCALES),
+    importStyle: () => ipcRenderer.invoke(Channels.CSL_IMPORT_STYLE),
+    importLocale: () => ipcRenderer.invoke(Channels.CSL_IMPORT_LOCALE),
+    removeStyle: (id: string) => ipcRenderer.invoke(Channels.CSL_REMOVE_STYLE, id),
+    removeLocale: (id: string) => ipcRenderer.invoke(Channels.CSL_REMOVE_LOCALE, id),
+  },
   citations: {
     renderInline: (refs: { kind: 'cite' | 'quote'; id: string }[]) =>
       ipcRenderer.invoke(Channels.CITATION_RENDER_INLINE, refs),

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -184,17 +184,26 @@
   }
 
   // Bibliography style (per-project, persisted in .minerva/config.json).
-  let bibliographyStyles = $state<{ id: string; label: string }[]>([]);
+  let bibliographyStyles = $state<{ id: string; label: string; isUser?: boolean }[]>([]);
   let bibliographyStyleId = $state('apa');
+  // User-imported CSL assets (#302) — project-scoped under .minerva/.
+  let userStyles = $state<{ id: string; label: string; filePath: string }[]>([]);
+  let userLocales = $state<{ id: string; filePath: string }[]>([]);
+  let cslImportError = $state<string | null>(null);
+  let cslImporting = $state(false);
 
   async function loadBibliographySettings(): Promise<void> {
     try {
-      const [styles, current] = await Promise.all([
+      const [styles, current, uStyles, uLocales] = await Promise.all([
         api.bibliography.listStyles(),
         api.bibliography.getStyle(),
+        api.csl.listUserStyles(),
+        api.csl.listUserLocales(),
       ]);
       bibliographyStyles = styles;
       bibliographyStyleId = current;
+      userStyles = uStyles;
+      userLocales = uLocales;
     } catch (e) {
       console.error('[settings] failed to load bibliography settings:', e);
     }
@@ -206,6 +215,52 @@
       await api.bibliography.setStyle(next);
     } catch (e) {
       console.error('[settings] failed to save bibliography style:', e);
+    }
+  }
+
+  async function importUserStyle(): Promise<void> {
+    cslImportError = null;
+    cslImporting = true;
+    try {
+      const result = await api.csl.importStyle();
+      if (result) await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    } finally {
+      cslImporting = false;
+    }
+  }
+
+  async function importUserLocale(): Promise<void> {
+    cslImportError = null;
+    cslImporting = true;
+    try {
+      const result = await api.csl.importLocale();
+      if (result) await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    } finally {
+      cslImporting = false;
+    }
+  }
+
+  async function removeUserStyle(id: string): Promise<void> {
+    cslImportError = null;
+    try {
+      await api.csl.removeStyle(id);
+      await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function removeUserLocale(id: string): Promise<void> {
+    cslImportError = null;
+    try {
+      await api.csl.removeLocale(id);
+      await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
     }
   }
 
@@ -693,7 +748,9 @@
               onchange={(e) => { void setBibliographyStyle(e.currentTarget.value); }}
             >
               {#each bibliographyStyles as style (style.id)}
-                <option value={style.id}>{style.label}</option>
+                <option value={style.id}>
+                  {style.label}{style.isUser ? ' (imported)' : ''}
+                </option>
               {/each}
             </select>
             <p class="hint">
@@ -702,6 +759,71 @@
               follow different style guides.
             </p>
           </div>
+
+          <div class="field">
+            <label>Imported styles</label>
+            <p class="hint">
+              Drop additional <code>.csl</code> files into your project under
+              <code>.minerva/csl-styles/</code> — they show up in the picker above and
+              in the Export dialog. The Zotero Style Repository at
+              <code>zotero.org/styles</code> publishes 10,000+ open styles.
+            </p>
+            {#if userStyles.length === 0}
+              <p class="hint empty">No imported styles yet.</p>
+            {:else}
+              <ul class="csl-list">
+                {#each userStyles as s (s.id)}
+                  <li>
+                    <span class="csl-label">{s.label}</span>
+                    <span class="csl-id">{s.id}</span>
+                    <button class="link-btn" onclick={() => { void removeUserStyle(s.id); }}>
+                      Remove
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+            <button
+              class="action-btn"
+              onclick={() => { void importUserStyle(); }}
+              disabled={cslImporting}
+            >
+              Import .csl style…
+            </button>
+          </div>
+
+          <div class="field">
+            <label>Imported locales</label>
+            <p class="hint">
+              Optional. Bundled locale is en-US; import additional CSL
+              locale XML to render bibliographies in another language.
+            </p>
+            {#if userLocales.length === 0}
+              <p class="hint empty">No imported locales yet.</p>
+            {:else}
+              <ul class="csl-list">
+                {#each userLocales as l (l.id)}
+                  <li>
+                    <span class="csl-label">{l.id}</span>
+                    <button class="link-btn" onclick={() => { void removeUserLocale(l.id); }}>
+                      Remove
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+            <button
+              class="action-btn"
+              onclick={() => { void importUserLocale(); }}
+              disabled={cslImporting}
+            >
+              Import locale .xml…
+            </button>
+          </div>
+
+          {#if cslImportError}
+            <div class="csl-error">{cslImportError}</div>
+          {/if}
 
         {:else if activeTab === 'ai'}
           <div class="field">
@@ -1103,6 +1225,74 @@
     color: var(--text-muted);
     line-height: 1.5;
     margin: 0 0 16px 0;
+  }
+
+  /* User-imported CSL assets list (#302). Mirrors the privileged-sites
+     style — each row shows a label, id, and a Remove action. */
+  .csl-list {
+    list-style: none;
+    margin: 0 0 8px 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .csl-list li {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-button);
+    font-size: 12px;
+  }
+  .csl-list .csl-label {
+    flex: 1;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .csl-list .csl-id {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .csl-list .link-btn {
+    align-self: auto;
+    margin-top: 0;
+  }
+  .hint.empty {
+    font-style: italic;
+    margin: 0 0 8px 0;
+  }
+  .action-btn {
+    align-self: flex-start;
+    padding: 4px 12px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .action-btn:hover:not(:disabled) {
+    background: var(--bg-button-hover);
+  }
+  .action-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .csl-error {
+    margin-top: 8px;
+    padding: 6px 10px;
+    border-left: 3px solid var(--accent);
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    white-space: pre-wrap;
   }
 
   .section-intro code {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -444,6 +444,7 @@ export interface IdeApi {
   sources: SourcesApi;
   sites: SitesApi;
   bibliography: BibliographyApi;
+  csl: CslApi;
   citations: CitationsApi;
   menu: MenuApi;
 }
@@ -466,7 +467,8 @@ export interface SitesApi {
 }
 
 export interface BibliographyApi {
-  listStyles(): Promise<{ id: string; label: string }[]>;
+  /** List bundled + user-imported styles. `isUser` flags entries from `.minerva/csl-styles/` so the UI can render them differently. */
+  listStyles(): Promise<{ id: string; label: string; isUser?: boolean }[]>;
   getStyle(): Promise<string>;
   setStyle(styleId: string): Promise<void>;
   generate(relativePath: string): Promise<{
@@ -475,6 +477,21 @@ export interface BibliographyApi {
     changed: boolean;
     styleId: string;
   }>;
+}
+
+/**
+ * User-imported CSL assets (#302). Project-scoped; files live under
+ * `.minerva/csl-styles/` and `.minerva/csl-locales/` so they travel with
+ * the thoughtbase via git.
+ */
+export interface CslApi {
+  listUserStyles(): Promise<{ id: string; label: string; filePath: string }[]>;
+  listUserLocales(): Promise<{ id: string; filePath: string }[]>;
+  /** Open a file picker, validate, copy into `.minerva/csl-styles/`. Returns `null` when the user cancels. */
+  importStyle(): Promise<{ id: string; label: string; filePath: string } | null>;
+  importLocale(): Promise<{ id: string; filePath: string } | null>;
+  removeStyle(id: string): Promise<void>;
+  removeLocale(id: string): Promise<void>;
 }
 
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -135,6 +135,16 @@ export const Channels = {
   /** Persist the per-project CSL style id. (#113) */
   BIBLIOGRAPHY_SET_STYLE: 'bibliography:setStyle',
 
+  /** List user-imported CSL styles + locales for the Settings UI. (#302) */
+  CSL_LIST_USER_STYLES: 'csl:listUserStyles',
+  CSL_LIST_USER_LOCALES: 'csl:listUserLocales',
+  /** Open file picker, validate, copy into .minerva/csl-{styles,locales}/. (#302) */
+  CSL_IMPORT_STYLE: 'csl:importStyle',
+  CSL_IMPORT_LOCALE: 'csl:importLocale',
+  /** Delete a user-imported style/locale by id. (#302) */
+  CSL_REMOVE_STYLE: 'csl:removeStyle',
+  CSL_REMOVE_LOCALE: 'csl:removeLocale',
+
   /**
    * Render a batch of inline citations through citeproc using the
    * project's configured CSL style (#110). Input is the cite/quote

--- a/tests/main/publish/user-csl-assets.test.ts
+++ b/tests/main/publish/user-csl-assets.test.ts
@@ -1,0 +1,208 @@
+/**
+ * User-imported CSL styles + locales (#302).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  loadUserStyles,
+  loadUserLocales,
+  getMergedStyles,
+  getMergedLocales,
+  isValidCslStyle,
+  isValidCslLocale,
+  extractStyleTitle,
+  deriveStyleId,
+  deriveLocaleId,
+} from '../../../src/main/publish/csl/user-assets';
+import { loadCitationAssets } from '../../../src/main/publish/csl';
+import { BUNDLED_STYLES } from '../../../src/main/publish/csl/assets';
+
+function mkProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-user-csl-'));
+}
+
+const MIN_CSL = `<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text">
+  <info>
+    <title>My Custom Style</title>
+    <id>http://example.com/styles/custom</id>
+    <updated>2026-05-01T00:00:00+00:00</updated>
+  </info>
+  <citation><layout><text variable="title"/></layout></citation>
+</style>`;
+
+const MIN_LOCALE = `<?xml version="1.0" encoding="utf-8"?>
+<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-GB">
+  <terms><term name="and">and</term></terms>
+</locale>`;
+
+describe('CSL validation helpers (#302)', () => {
+  it('isValidCslStyle accepts a real CSL <style> root', () => {
+    expect(isValidCslStyle(MIN_CSL)).toBe(true);
+  });
+
+  it('isValidCslStyle rejects garbage', () => {
+    expect(isValidCslStyle('<html><body>nope</body></html>')).toBe(false);
+    expect(isValidCslStyle('not even xml')).toBe(false);
+    expect(isValidCslStyle('')).toBe(false);
+  });
+
+  it('isValidCslStyle rejects a locale file', () => {
+    expect(isValidCslStyle(MIN_LOCALE)).toBe(false);
+  });
+
+  it('isValidCslLocale accepts a real <locale> root', () => {
+    expect(isValidCslLocale(MIN_LOCALE)).toBe(true);
+  });
+
+  it('isValidCslLocale rejects a style file', () => {
+    expect(isValidCslLocale(MIN_CSL)).toBe(false);
+  });
+
+  it('extractStyleTitle pulls <info><title>…</title> out of the XML', () => {
+    expect(extractStyleTitle(MIN_CSL)).toBe('My Custom Style');
+  });
+
+  it('extractStyleTitle decodes XML entities and ignores body titles', () => {
+    const xml = `<style xmlns="http://purl.org/net/xbiblio/csl">
+      <info><title>Acme &amp; Co. Style</title></info>
+      <citation><layout><title>not this one</title></layout></citation>
+    </style>`;
+    expect(extractStyleTitle(xml)).toBe('Acme & Co. Style');
+  });
+
+  it('extractStyleTitle returns null when the title is absent', () => {
+    expect(extractStyleTitle('<style><info></info></style>')).toBeNull();
+  });
+});
+
+describe('id derivation (#302)', () => {
+  it('deriveStyleId lowercases, drops .csl, and slugifies', () => {
+    expect(deriveStyleId('Chicago Manual of Style.csl')).toBe('chicago-manual-of-style');
+    expect(deriveStyleId('apa.csl')).toBe('apa');
+    // Strip the Zotero "locales-" filename prefix that styles never wear.
+    expect(deriveStyleId('weird (variant).csl')).toBe('weird-variant');
+  });
+
+  it('deriveStyleId returns empty when input is junk', () => {
+    expect(deriveStyleId('---')).toBe('');
+    expect(deriveStyleId('.csl')).toBe('');
+  });
+
+  it('deriveLocaleId preserves case (locale ids like en-GB are case-significant)', () => {
+    expect(deriveLocaleId('locales-en-GB.xml')).toBe('en-GB');
+    expect(deriveLocaleId('de-DE.xml')).toBe('de-DE');
+  });
+});
+
+describe('loadUserStyles + loadUserLocales (#302)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('returns [] when the .minerva directories don\'t exist', async () => {
+    expect(await loadUserStyles(root)).toEqual([]);
+    expect(await loadUserLocales(root)).toEqual([]);
+  });
+
+  it('loads valid .csl files from .minerva/csl-styles/', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/csl-styles'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/csl-styles/custom.csl'), MIN_CSL, 'utf-8');
+    const styles = await loadUserStyles(root);
+    expect(styles).toHaveLength(1);
+    expect(styles[0].id).toBe('custom');
+    expect(styles[0].label).toBe('My Custom Style');
+  });
+
+  it('skips files that don\'t parse as CSL styles', async () => {
+    const dir = path.join(root, '.minerva/csl-styles');
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(path.join(dir, 'good.csl'), MIN_CSL, 'utf-8');
+    await fsp.writeFile(path.join(dir, 'bad.csl'), '<not-a-style/>', 'utf-8');
+    const styles = await loadUserStyles(root);
+    expect(styles.map((s) => s.id)).toEqual(['good']);
+  });
+
+  it('strips the "locales-" prefix when deriving a locale id', async () => {
+    const dir = path.join(root, '.minerva/csl-locales');
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(path.join(dir, 'locales-en-GB.xml'), MIN_LOCALE, 'utf-8');
+    const locales = await loadUserLocales(root);
+    expect(locales[0].id).toBe('en-GB');
+  });
+});
+
+describe('getMergedStyles (#302)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('returns the bundled set when the user dir is empty', async () => {
+    const merged = await getMergedStyles(root);
+    expect(Object.keys(merged.styles).sort()).toEqual(Object.keys(BUNDLED_STYLES).sort());
+    expect(merged.userIds.size).toBe(0);
+  });
+
+  it('user style appears alongside bundled set with userIds flagged', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/csl-styles'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/csl-styles/custom.csl'), MIN_CSL, 'utf-8');
+    const merged = await getMergedStyles(root);
+    expect(merged.styles['custom']).toBeTruthy();
+    expect(merged.labels['custom']).toBe('My Custom Style');
+    expect(merged.userIds.has('custom')).toBe(true);
+    expect(merged.styles['apa']).toBeTruthy(); // bundled still present
+  });
+
+  it('user style with id matching a bundled one wins on collision', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/csl-styles'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/csl-styles/apa.csl'), MIN_CSL, 'utf-8');
+    const merged = await getMergedStyles(root);
+    // Override XML wins.
+    expect(merged.styles['apa']).toBe(MIN_CSL);
+    expect(merged.labels['apa']).toBe('My Custom Style');
+    expect(merged.userIds.has('apa')).toBe(true);
+  });
+});
+
+describe('getMergedLocales (#302)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('user-imported en-GB locale joins the bundled en-US', async () => {
+    const dir = path.join(root, '.minerva/csl-locales');
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(path.join(dir, 'en-GB.xml'), MIN_LOCALE, 'utf-8');
+    const merged = await getMergedLocales(root);
+    expect(merged.locales['en-US']).toBeTruthy();
+    expect(merged.locales['en-GB']).toBe(MIN_LOCALE);
+    expect(merged.userIds.has('en-GB')).toBe(true);
+  });
+});
+
+describe('loadCitationAssets resolves user styles end-to-end (#302)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('opts.styleId pointing at a user style resolves through the merged registry', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/csl-styles'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/csl-styles/custom.csl'), MIN_CSL, 'utf-8');
+    const assets = await loadCitationAssets(root, { styleId: 'custom' });
+    expect(assets.styleId).toBe('custom');
+    expect(assets.style).toBe(MIN_CSL);
+  });
+
+  it('opts.styleId pointing at a still-unknown id falls back to default', async () => {
+    const assets = await loadCitationAssets(root, { styleId: 'nonexistent' });
+    expect(assets.styleId).toBe('apa');
+  });
+});


### PR DESCRIPTION
## Summary

Project-scoped CSL registry. Drop a \`.csl\` style file into \`.minerva/csl-styles/<id>.csl\` (or via the new Settings → Bibliography "Import .csl style…" button) and it shows up in the Export dialog's style picker. Same shape for locales under \`.minerva/csl-locales/\`. The Zotero Style Repository's 10,000+ open styles are now reachable without code changes.

## Merge policy

User-imported files **win on id collision**. A project's \`.minerva/csl-styles/apa.csl\` overrides the bundled APA for that thoughtbase only — useful for journal-specific tweaks.

## How

- New \`user-assets.ts\` walks \`.minerva/csl-{styles,locales}/\`, validates each file (root \`<style>\`/\`<locale>\` with the CSL namespace), and pulls a label from \`<info><title>\` for the picker.
- \`loadCitationAssets\` consults a merged registry (bundled + user) instead of the static \`BUNDLED_STYLES\`/\`BUNDLED_LOCALES\` maps.
- \`bibliography:listStyles\` and \`publish:resolvePlan\` IPC payloads now ship the merged set, so both Settings and the Export dialog see imported styles automatically.
- New IPC channels: \`csl:listUserStyles\`, \`csl:listUserLocales\`, \`csl:importStyle\` (file picker → validate → copy), \`csl:importLocale\`, \`csl:removeStyle\`, \`csl:removeLocale\`.
- Settings → Bibliography grew "Imported styles" / "Imported locales" sections with per-row Remove. Validation errors surface inline instead of crashing the dialog.

## Closes

Resolves #302. Last bullet from #247's deferred list except #297 (Chicago full-note rendering) and #300 (consolidated tree-html bibliography).

## Test plan

- [x] \`pnpm vitest run tests/main/publish\` — 189/189, 21 new tests covering: validation (good/bad/swapped style-vs-locale), title extraction with entity decoding, id derivation from messy filenames, slug rules, empty-dir handling, file filtering, merge with collisions favouring user, end-to-end through \`loadCitationAssets\`.
- [x] \`pnpm lint\` — clean
- [ ] Manual: open Settings → Bibliography, import a downloaded \`vancouver-superscript.csl\`, confirm it appears in both the bibliography picker and the Export dialog's Citation style dropdown; export a note under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)