### PR TITLE
Publication: Chicago full-note / footnote rendering path (#297)

### DIFF
--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -27,13 +27,32 @@ export interface RenderedBibliography {
   isNote: boolean;
 }
 
+/** Footnote bodies collected during a render session, in note-index order. */
+export interface RenderedFootnotes {
+  /** [{ index: 1, body: '<i>Toulmin</i>, …' }, …] */
+  notes: Array<{ index: number; body: string }>;
+}
+
 export class CitationRenderer {
   private engine: CslEngine;
   private readonly items: Map<string, CslItem>;
   private readonly citedIds = new Set<string>();
   /** Ids we've been asked to render but couldn't find in `items`. */
   private readonly missingIds = new Set<string>();
-  private noteIndex = 0;
+  /**
+   * 1-based note counter. Note styles use this as the visible footnote
+   * marker; in-text styles ignore the value beyond bibliography ordering.
+   */
+  private noteIndex = 1;
+  /** True when the loaded CSL style is class="note" (Chicago full-note, Turabian, …). */
+  readonly isNoteStyle: boolean;
+  /**
+   * Footnote bodies for note-class styles (#297). Populated as
+   * `renderCitation` / `renderCitationCluster` fires; the citeproc-rendered
+   * text is stashed here and the inline mark is replaced with a `<sup>`
+   * marker. Empty for in-text styles.
+   */
+  private readonly footnotes: Array<{ index: number; body: string }> = [];
 
   constructor(style: string, locale: string, items: Map<string, CslItem>) {
     this.items = items;
@@ -50,6 +69,7 @@ export class CitationRenderer {
       retrieveLocale: () => locale,
     };
     this.engine = new CSL.Engine(sys, style);
+    this.isNoteStyle = Boolean(this.engine.cslXml?.dataObj?.attrs?.class === 'note');
   }
 
   /**
@@ -88,18 +108,37 @@ export class CitationRenderer {
       }
       return c;
     });
+    const noteIndex = this.noteIndex++;
     try {
       const result = this.engine.processCitationCluster(
-        { citationItems, properties: { noteIndex: this.noteIndex++ } },
+        { citationItems, properties: { noteIndex } },
         [],
         [],
       );
       const pairs = result[1];
-      return pairs.length > 0 ? pairs[0][1] : '';
+      const text = pairs.length > 0 ? pairs[0][1] : '';
+      // Note-class styles: stash the rendered text as a footnote body
+      // and emit a `<sup>` marker linking to it (#297). The marker uses
+      // a stable id-pair (`fnref-N` / `fn-N`) so the bottom-of-document
+      // footnotes section can render back-references.
+      if (this.isNoteStyle) {
+        this.footnotes.push({ index: noteIndex, body: text });
+        return `<sup class="footnote-ref" id="fnref-${noteIndex}"><a href="#fn-${noteIndex}">${noteIndex}</a></sup>`;
+      }
+      return text;
     } catch (err) {
       const ids = items.map((i) => i.id).join(', ');
       return `<span class="csl-error" title="${escapeHtml(String(err))}">[citation error: ${escapeHtml(ids)}]</span>`;
     }
+  }
+
+  /**
+   * Footnote bodies collected during this render session (#297). Empty
+   * for in-text styles. Order matches the noteIndex citeproc was given,
+   * which is the document order of `renderCitationCluster` calls.
+   */
+  renderFootnotes(): RenderedFootnotes {
+    return { notes: this.footnotes.slice() };
   }
 
   /**

--- a/src/main/publish/exporters/note-html/index.ts
+++ b/src/main/publish/exporters/note-html/index.ts
@@ -13,11 +13,30 @@ import type { Exporter, ExportOutput } from '../../types';
 import type { CitationRenderer } from '../../csl';
 
 /**
- * Append the rendered bibliography for everything cited in this note.
- * Emits nothing when no citations fired — skips the empty-references
- * divot in the exported HTML.
+ * Append the rendered bibliography (or footnotes, for note-class styles
+ * like Chicago full-note — #297). Emits nothing when no citations
+ * fired so the exported HTML doesn't grow an empty-references divot.
+ *
+ * For note styles the cite rule has already replaced inline citations
+ * with `<sup>` markers; here we render the collected footnote bodies
+ * as a `<section class="footnotes">` at the bottom of the note.
  */
-function appendReferences(body: string, renderer: CitationRenderer): string {
+function appendCitationsTail(body: string, renderer: CitationRenderer): string {
+  if (renderer.isNoteStyle) {
+    const fns = renderer.renderFootnotes().notes;
+    if (fns.length === 0) return body;
+    const lis = fns.map((n) => (
+      `<li id="fn-${n.index}">${n.body} <a href="#fnref-${n.index}" class="footnote-back" aria-label="Back to text">↩</a></li>`
+    )).join('\n');
+    // Note styles ship a Bibliography too — alphabetised, full-form,
+    // separate from the inline footnotes. Emit it after the footnotes
+    // when citeproc gave us bibliography entries.
+    const bib = renderer.renderBibliography();
+    const bibSection = bib.entries.length > 0
+      ? `\n<section class="references">\n<h2>Bibliography</h2>\n<ol>\n${bib.entries.map((e) => `<li>${e}</li>`).join('\n')}\n</ol>\n</section>`
+      : '';
+    return `${body}\n<section class="footnotes">\n<h2>Footnotes</h2>\n<ol>\n${lis}\n</ol>\n</section>${bibSection}`;
+  }
   const bib = renderer.renderBibliography();
   if (bib.entries.length === 0) return body;
   const entries = bib.entries.map((e) => `<li>${e}</li>`).join('\n');
@@ -48,7 +67,7 @@ export const noteHtmlExporter: Exporter = {
       // is a follow-up; this is the simple, correct v1.
       const renderer = plan.citations?.createRenderer();
       const rawBody = renderNoteBody(f, plan, renderer);
-      const withReferences = renderer ? appendReferences(rawBody, renderer) : rawBody;
+      const withReferences = renderer ? appendCitationsTail(rawBody, renderer) : rawBody;
       const body = await inlineImages(withReferences, f, rootPath, plan.assetPolicy);
       const html = wrapHtml({ title: f.title, body });
       files.push({

--- a/src/main/publish/exporters/note-html/style.ts
+++ b/src/main/publish/exporters/note-html/style.ts
@@ -86,6 +86,20 @@ table {
 }
 th, td { padding: 0.4em 0.8em; border: 1px solid var(--border); text-align: left; vertical-align: top; }
 th { background: var(--code-bg); font-weight: 600; }
+.footnote-ref {
+  font-size: 0.75em;
+  vertical-align: super;
+  line-height: 0;
+  margin-left: 0.1em;
+}
+.footnote-ref a { text-decoration: none; }
+.footnote-back {
+  margin-left: 0.4em;
+  text-decoration: none;
+  color: var(--accent);
+  font-size: 0.85em;
+}
+.footnote-back:hover { text-decoration: underline; }
 .footnotes {
   margin-top: 3em;
   padding-top: 1em;
@@ -93,7 +107,14 @@ th { background: var(--code-bg); font-weight: 600; }
   font-size: 0.9em;
   color: var(--fg-muted);
 }
+.footnotes h2 {
+  border-bottom: none;
+  margin: 0 0 0.6em;
+  font-size: 1.15em;
+  color: var(--fg);
+}
 .footnotes ol { padding-left: 2em; }
+.footnotes li { margin-bottom: 0.4em; }
 .references {
   margin-top: 3em;
   padding-top: 1em;

--- a/tests/main/publish/__snapshots__/csl.test.ts.snap
+++ b/tests/main/publish/__snapshots__/csl.test.ts.snap
@@ -13,7 +13,7 @@ exports[`bundled CSL styles render end-to-end (#296) > chicago-notes-bibliograph
 {
   "entry": "  <div class="csl-entry">Smith, Jane, and Bob Jones. “On the Growth of Things.” <i>Journal of Things</i> 12, no. 3 (2020): 45–67. https://doi.org/10.1234/foo.bar.</div>
 ",
-  "inText": "Jane Smith and Bob Jones, “On the Growth of Things,” <i>Journal of Things</i> 12, no. 3 (2020): 45–67, https://doi.org/10.1234/foo.bar.",
+  "inText": "<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1</a></sup>",
   "isNote": true,
 }
 `;

--- a/tests/main/publish/csl.test.ts
+++ b/tests/main/publish/csl.test.ts
@@ -626,3 +626,126 @@ describe('locator alias renders into citations (#299)', () => {
     expect(html).toContain('100');
   });
 });
+
+// ── Chicago full-note / footnote rendering (#297) ────────────────────────
+//
+// Chicago full-note (`chicago-notes-bibliography`) is a `class="note"`
+// CSL style. Citations in the rendered HTML should be `<sup>` markers
+// linking to a Footnotes section at the bottom; the actual citation
+// text becomes the footnote body. APA's inline-references behaviour
+// must remain unaffected.
+
+describe('Chicago full-note / footnote rendering (#297)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await fsp.mkdir(path.join(root, '.minerva/sources/brooks-1986'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/brooks-1986/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "No Silver Bullet" ;
+  dc:creator "Brooks, Frederick P." ;
+  dc:issued "1986"^^xsd:gYear ;
+  schema:inContainer "Computer" .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/sources/popper-1959'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/popper-1959/meta.ttl'),
+      `this: a thought:Book ;
+  dc:title "The Logic of Scientific Discovery" ;
+  dc:creator "Popper, Karl" ;
+  dc:issued "1959"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('renderer flags note-class styles via isNoteStyle', async () => {
+    const noteAssets = await loadCitationAssets(root, { styleId: 'chicago-notes-bibliography' });
+    expect(noteAssets.createRenderer().isNoteStyle).toBe(true);
+
+    const inlineAssets = await loadCitationAssets(root, { styleId: 'apa' });
+    expect(inlineAssets.createRenderer().isNoteStyle).toBe(false);
+  });
+
+  it('note-style renderCitation returns a <sup> marker, not the citation text inline', async () => {
+    const assets = await loadCitationAssets(root, { styleId: 'chicago-notes-bibliography' });
+    const renderer = assets.createRenderer();
+    const first = renderer.renderCitation('brooks-1986');
+    expect(first).toMatch(/^<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1<\/a><\/sup>$/);
+    const second = renderer.renderCitation('popper-1959');
+    expect(second).toContain('fnref-2');
+    expect(second).toContain('#fn-2');
+  });
+
+  it('renderFootnotes returns the bodies in note-index order', async () => {
+    const assets = await loadCitationAssets(root, { styleId: 'chicago-notes-bibliography' });
+    const renderer = assets.createRenderer();
+    renderer.renderCitation('brooks-1986');
+    renderer.renderCitation('popper-1959');
+    const fns = renderer.renderFootnotes().notes;
+    expect(fns).toHaveLength(2);
+    expect(fns[0].index).toBe(1);
+    expect(fns[1].index).toBe(2);
+    expect(fns[0].body).toContain('Brooks');
+    expect(fns[1].body).toContain('Popper');
+  });
+
+  it('in-text styles return empty footnotes (renderCitation keeps inline behavior)', async () => {
+    const assets = await loadCitationAssets(root, { styleId: 'apa' });
+    const renderer = assets.createRenderer();
+    const out = renderer.renderCitation('brooks-1986');
+    expect(out).toContain('Brooks');
+    expect(out).toContain('1986');
+    expect(out).not.toContain('footnote-ref');
+    expect(renderer.renderFootnotes().notes).toEqual([]);
+  });
+
+  it('note-html exporter emits a Footnotes section under chicago-notes-bibliography', async () => {
+    await fsp.writeFile(path.join(root, 'note.md'),
+      'See [[cite::brooks-1986]] and also [[cite::popper-1959]].\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'single-note', relativePath: 'note.md' },
+      { citationStyle: 'chicago-notes-bibliography' },
+    );
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+
+    // Inline marks: two <sup> footnote refs.
+    expect(html).toMatch(/<sup class="footnote-ref" id="fnref-1">/);
+    expect(html).toMatch(/<sup class="footnote-ref" id="fnref-2">/);
+    // Footnotes section at the bottom with both bodies + back-refs.
+    expect(html).toContain('<section class="footnotes">');
+    expect(html).toContain('<h2>Footnotes</h2>');
+    expect(html).toMatch(/<li id="fn-1">[\s\S]*?Brooks[\s\S]*?<\/li>/);
+    expect(html).toMatch(/<li id="fn-2">[\s\S]*?Popper[\s\S]*?<\/li>/);
+    expect(html).toContain('href="#fnref-1"');
+    expect(html).toContain('href="#fnref-2"');
+    // Bibliography section also appears for note styles (Chicago renders both).
+    expect(html).toContain('<section class="references">');
+    expect(html).toContain('<h2>Bibliography</h2>');
+  });
+
+  it('inline (APA) export still emits References, not Footnotes', async () => {
+    await fsp.writeFile(path.join(root, 'apa-note.md'),
+      'See [[cite::brooks-1986]].\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'single-note', relativePath: 'apa-note.md' },
+      { citationStyle: 'apa' },
+    );
+    const output = await runExporter(noteHtmlExporter, plan);
+    const html = String(output.files[0].contents);
+    expect(html).not.toContain('<section class="footnotes">');
+    expect(html).toContain('<section class="references">');
+    expect(html).toContain('<h2>References</h2>');
+    // No footnote `<sup>` markers — the inline rendering puts the
+    // citation text inline. (The CSS class `.footnote-ref` is in the
+    // embedded stylesheet but no element actually carries it.)
+    expect(html).not.toMatch(/<sup class="footnote-ref"/);
+  });
+});


### PR DESCRIPTION
## Summary

Note-class CSL styles (Chicago full-note, Turabian) render citations as \`<sup>\` markers linking to a Footnotes section instead of inline parentheticals + a References list. APA / MLA / IEEE / Vancouver / Chicago author-date keep their existing inline rendering.

## Output shape

**Inline styles** (unchanged):
\`\`\`html
As (Brooks, 1986) argued…
<section class="references">
  <h2>References</h2>
  <ol><li>Brooks, F. P. (1986)…</li></ol>
</section>
\`\`\`

**Note styles** (#297, new):
\`\`\`html
As<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1</a></sup> argued…
<section class="footnotes">
  <h2>Footnotes</h2>
  <ol>
    <li id="fn-1">Frederick P. Brooks, "No Silver Bullet"… <a href="#fnref-1" class="footnote-back" aria-label="Back to text">↩</a></li>
  </ol>
</section>
<section class="references">
  <h2>Bibliography</h2>
  <ol>…alphabetised full-form entries…</ol>
</section>
\`\`\`

## How

- \`CitationRenderer\` exposes \`isNoteStyle\` computed at construction (was already detected internally for \`renderBibliography\`'s \`isNote\` flag).
- When note style, \`renderCitationCluster\` stashes citeproc's rendered text as a footnote body and returns a stable \`<sup>\` marker with paired ids (\`fnref-N\` / \`fn-N\`).
- New \`renderFootnotes()\` returns the collected bodies in note-index order.
- \`noteIndex\` flipped from 0-based to 1-based so the visible footnote number matches what citeproc renders.
- Exporter's \`appendCitationsTail()\` (renamed from \`appendReferences\`) branches on \`renderer.isNoteStyle\`. Note styles emit Footnotes + Bibliography; inline styles emit References as before.

## Knock-on effects

- **PDF exporter** inherits automatically — it routes through the HTML exporter.
- **Tree-html exporter**: deferred to #300, which aggregates cited-id sets across notes for a single consolidated bibliography.
- **Markdown exporter**: skipped per design — it's a passthrough (cite syntax stays \`[[cite::id]]\`). Transforming to \`[^N]\` is a different feature; that's #250's territory (clean-markdown).
- **chicago-notes-bibliography snapshot from #296** updated to reflect the new \`<sup>\` in-text shape.

## Closes

Resolves #297.

## Test plan

- [x] \`pnpm vitest run tests/main/publish\` — 195/195, 6 new tests covering: \`isNoteStyle\` flag, \`<sup>\` marker emission with paired ids, footnote body collection in order, in-text styles unaffected, end-to-end note-html export with chicago-notes-bibliography, end-to-end APA export still emits References (no footnote markers leak in)
- [x] \`pnpm lint\` — clean
- [ ] Manual: open the Export dialog, pick "Chicago (notes & bibliography)", export a note with a couple of \`[[cite::]]\` references, confirm clickable footnote refs + back-links + a Bibliography section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)