### PR TITLE
Publication: consolidated bibliography for tree-html bundles (#300)

### DIFF
--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -142,6 +142,25 @@ export class CitationRenderer {
   }
 
   /**
+   * Build a bibliography from an explicit list of source ids — decoupled
+   * from the per-render `citedIds` set so a tree-html bundle can
+   * consolidate citations across many per-note renderers (#300).
+   *
+   * Unknown ids are silently dropped; valid ids that have already been
+   * cited through this engine are fine (citeproc-js de-dupes
+   * internally). Returns the same shape as `renderBibliography`.
+   */
+  renderBibliographyFor(ids: string[]): RenderedBibliography {
+    const known = ids.filter((id) => this.items.has(id));
+    if (known.length === 0) return { entries: [], isNote: this.isNoteStyle };
+    this.engine.updateItems(known);
+    const result = this.engine.makeBibliography();
+    if (!result) return { entries: [], isNote: this.isNoteStyle };
+    const [, rawEntries] = result as [{ hangingindent?: boolean; 'second-field-align'?: string }, string[]];
+    return { entries: rawEntries, isNote: this.isNoteStyle };
+  }
+
+  /**
    * Render every cited item as a bibliography. Order follows the CSL
    * style's rules. Returns an empty result when no citations fired —
    * exporters should skip emitting the References section in that case.

--- a/src/main/publish/exporters/note-html/index.ts
+++ b/src/main/publish/exporters/note-html/index.ts
@@ -13,6 +13,26 @@ import type { Exporter, ExportOutput } from '../../types';
 import type { CitationRenderer } from '../../csl';
 
 /**
+ * Render the collected footnote bodies for note-class styles as a
+ * `<section class="footnotes">` (#297). Returns the empty string when
+ * no footnotes fired or the renderer isn't a note style — exporters
+ * concatenate the result so an empty section just disappears.
+ *
+ * Exposed (not private) so the tree-html bundle exporter can emit
+ * per-note footnotes while consolidating the Bibliography at bundle
+ * level (#300).
+ */
+export function renderFootnotesSection(renderer: CitationRenderer): string {
+  if (!renderer.isNoteStyle) return '';
+  const fns = renderer.renderFootnotes().notes;
+  if (fns.length === 0) return '';
+  const lis = fns.map((n) => (
+    `<li id="fn-${n.index}">${n.body} <a href="#fnref-${n.index}" class="footnote-back" aria-label="Back to text">↩</a></li>`
+  )).join('\n');
+  return `\n<section class="footnotes">\n<h2>Footnotes</h2>\n<ol>\n${lis}\n</ol>\n</section>`;
+}
+
+/**
  * Append the rendered bibliography (or footnotes, for note-class styles
  * like Chicago full-note — #297). Emits nothing when no citations
  * fired so the exported HTML doesn't grow an empty-references divot.
@@ -23,11 +43,8 @@ import type { CitationRenderer } from '../../csl';
  */
 function appendCitationsTail(body: string, renderer: CitationRenderer): string {
   if (renderer.isNoteStyle) {
-    const fns = renderer.renderFootnotes().notes;
-    if (fns.length === 0) return body;
-    const lis = fns.map((n) => (
-      `<li id="fn-${n.index}">${n.body} <a href="#fnref-${n.index}" class="footnote-back" aria-label="Back to text">↩</a></li>`
-    )).join('\n');
+    const footnotes = renderFootnotesSection(renderer);
+    if (!footnotes) return body;
     // Note styles ship a Bibliography too — alphabetised, full-form,
     // separate from the inline footnotes. Emit it after the footnotes
     // when citeproc gave us bibliography entries.
@@ -35,7 +52,7 @@ function appendCitationsTail(body: string, renderer: CitationRenderer): string {
     const bibSection = bib.entries.length > 0
       ? `\n<section class="references">\n<h2>Bibliography</h2>\n<ol>\n${bib.entries.map((e) => `<li>${e}</li>`).join('\n')}\n</ol>\n</section>`
       : '';
-    return `${body}\n<section class="footnotes">\n<h2>Footnotes</h2>\n<ol>\n${lis}\n</ol>\n</section>${bibSection}`;
+    return `${body}${footnotes}${bibSection}`;
   }
   const bib = renderer.renderBibliography();
   if (bib.entries.length === 0) return body;

--- a/src/main/publish/exporters/note-html/style.ts
+++ b/src/main/publish/exporters/note-html/style.ts
@@ -136,6 +136,16 @@ th { background: var(--code-bg); font-weight: 600; }
   font-size: 0.8em;
   text-align: right;
 }
+/* Tree-html bundle: per-note "References →" footer link to references.html (#300). */
+.bundle-refs-link {
+  margin-top: 2em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--border);
+  font-size: 0.9em;
+  text-align: right;
+}
+.bundle-refs-link a { color: var(--accent); text-decoration: none; }
+.bundle-refs-link a:hover { text-decoration: underline; }
 
 /* highlight.js token styling — minimal light theme so code fences
  * render readably without pulling an external stylesheet. */

--- a/src/main/publish/exporters/tree-html/index.ts
+++ b/src/main/publish/exporters/tree-html/index.ts
@@ -7,13 +7,18 @@
  * forced to `follow-to-file` and the root renamed to `index.html`.
  * Cross-links inside the bundle resolve relative to each page.
  *
+ * Each note gets its own `CitationRenderer` so per-note footnote
+ * numbering is local (Chicago full-note, etc.); cited-id sets are
+ * unioned across notes and the merged bibliography lands in a single
+ * `references.html` at the bundle root (#300).
+ *
  * Deferred to follow-up tickets: shared external stylesheet, sidebar
- * navigation, consolidated bibliography (needs #247), manual
- * deselection of notes in the preview dialog.
+ * navigation (#292), manual deselection of notes (#293).
  */
 
 import { renderNoteBody, inlineImages } from '../note-html/render';
 import { wrapHtml } from '../note-html/shell';
+import { renderFootnotesSection } from '../note-html';
 import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../../types';
 
 export const treeHtmlExporter: Exporter = {
@@ -36,21 +41,57 @@ export const treeHtmlExporter: Exporter = {
     // to work, and inline-title is the wrong default here.
     const bundlePlan: ExportPlan = { ...plan, linkPolicy: 'follow-to-file' };
 
+    // Track cited ids across every note so the bundle-level References
+    // page de-dupes (a single Brooks 1986 entry, even when 5 notes
+    // cite it). Note-style footnotes stay per-note since the inline
+    // `<sup>1</sup>` markers anchor to that note's `fn-1` — running
+    // the counter bundle-wide would only confuse readers.
+    const allCitedIds = new Set<string>();
+    let isNoteStyle = false;
+
     const files: ExportOutput['files'] = [];
     for (const note of notes) {
-      const rawBody = renderNoteBody(note, bundlePlan);
-      const body = await inlineImages(rawBody, note, rootPath, bundlePlan.assetPolicy);
+      const renderer = bundlePlan.citations?.createRenderer();
+      const rawBody = renderNoteBody(note, bundlePlan, renderer);
+      // Note styles: append the per-note footnotes (the inline `<sup>`
+      // markers anchor to them). In-text styles: nothing here — the
+      // bundle-level References page below carries the bibliography.
+      const noteHasCites = (renderer?.cited().size ?? 0) > 0;
+      const withFootnotes = renderer ? `${rawBody}${renderFootnotesSection(renderer)}` : rawBody;
+      const withRefLink = appendBundleReferenceLink(withFootnotes, note, rootNote, noteHasCites);
+      const body = await inlineImages(withRefLink, note, rootPath, bundlePlan.assetPolicy);
       const html = wrapHtml({ title: note.title, body });
       files.push({
         path: outputPathFor(note, rootNote),
         contents: html,
       });
+      if (renderer) {
+        for (const id of renderer.cited()) allCitedIds.add(id);
+        if (renderer.isNoteStyle) isNoteStyle = true;
+      }
+    }
+
+    // Bundle-level References page. Emitted only when at least one
+    // note actually cited something — empty bundles don't grow a
+    // useless `references.html` stub.
+    if (allCitedIds.size > 0 && bundlePlan.citations) {
+      const consolidator = bundlePlan.citations.createRenderer();
+      const bib = consolidator.renderBibliographyFor([...allCitedIds]);
+      if (bib.entries.length > 0) {
+        const heading = isNoteStyle ? 'Bibliography' : 'References';
+        const entries = bib.entries.map((e) => `<li>${e}</li>`).join('\n');
+        const refsBody = `<h1>${heading}</h1>\n<section class="references">\n<ol>\n${entries}\n</ol>\n</section>`;
+        files.push({
+          path: 'references.html',
+          contents: wrapHtml({ title: heading, body: refsBody }),
+        });
+      }
     }
 
     const excluded = plan.excluded.length;
     const summary = excluded > 0
-      ? `Bundle of ${files.length} note${files.length === 1 ? '' : 's'} (${excluded} excluded).`
-      : `Bundle of ${files.length} note${files.length === 1 ? '' : 's'}.`;
+      ? `Bundle of ${files.length} file${files.length === 1 ? '' : 's'} (${excluded} excluded).`
+      : `Bundle of ${files.length} file${files.length === 1 ? '' : 's'}.`;
     return { files, summary };
   },
 };
@@ -65,4 +106,24 @@ export const treeHtmlExporter: Exporter = {
 function outputPathFor(note: ExportPlanFile, rootNote: ExportPlanFile): string {
   if (note.relativePath === rootNote.relativePath) return 'index.html';
   return note.relativePath.replace(/\.md$/i, '.html');
+}
+
+/**
+ * Add a "References →" footer link in each note that actually cited
+ * something, pointing at the bundle's `references.html`. The href is
+ * computed relative to the emitting note so deep-nested notes still
+ * resolve cleanly. Suppressed when the note has no citations — most
+ * pages in a bundle don't, so an always-on link would be visual noise.
+ */
+function appendBundleReferenceLink(
+  body: string,
+  note: ExportPlanFile,
+  rootNote: ExportPlanFile,
+  hasCites: boolean,
+): string {
+  if (!hasCites) return body;
+  const relPath = note.relativePath === rootNote.relativePath
+    ? 'references.html'
+    : '../'.repeat(note.relativePath.split('/').length - 1) + 'references.html';
+  return `${body}\n<p class="bundle-refs-link"><a href="${relPath}">References →</a></p>`;
 }

--- a/tests/main/publish/tree-html.test.ts
+++ b/tests/main/publish/tree-html.test.ts
@@ -89,3 +89,123 @@ describe('tree-html exporter (#251) — through the pipeline', () => {
     expect(indexHtml).toContain('href="b.html"');
   });
 });
+
+// ── Consolidated bibliography across the bundle (#300) ───────────────────
+
+describe('tree-html consolidated bibliography (#300)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`,
+      'utf-8');
+    await fsp.mkdir(path.join(root, '.minerva/sources/bar-2021'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/bar-2021/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Bar Considered" ;
+  dc:creator "Bar, Bob" ;
+  dc:issued "2021"^^xsd:gYear .\n`,
+      'utf-8');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('emits one references.html with deduplicated entries across all notes', async () => {
+    // Three notes; both Foo and Bar are cited from multiple notes.
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\nSee [[cite::foo-2020]] and [[b]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'),
+      '# B\n\nPer [[cite::foo-2020]], also [[cite::bar-2021]] and [[c]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'c.md'),
+      '# C\n\nFinally [[cite::bar-2021]].\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 3 });
+    const output = await runExporter(treeHtmlExporter, plan);
+
+    const paths = output.files.map((f) => f.path).sort();
+    expect(paths).toContain('references.html');
+
+    const refs = String(output.files.find((f) => f.path === 'references.html')!.contents);
+    // One entry per source despite four total cite occurrences.
+    expect(refs).toContain('Foo');
+    expect(refs).toContain('Bar');
+    expect(refs).toContain('<title>References</title>');
+    // No duplicate Foo entries — count occurrences of "Foo Studies".
+    const fooMatches = (refs.match(/Foo Studies/g) ?? []).length;
+    expect(fooMatches).toBe(1);
+  });
+
+  it('each cite-bearing note grows a "References →" footer link to references.html', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\n[[cite::foo-2020]] and [[b]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'),
+      '# B\n\nNo cites here.\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 3 });
+    const output = await runExporter(treeHtmlExporter, plan);
+
+    const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    const bHtml = String(output.files.find((f) => f.path === 'b.html')!.contents);
+    expect(indexHtml).toContain('class="bundle-refs-link"');
+    expect(indexHtml).toContain('href="references.html"');
+    // Note b.md has no citations, so no "References →" footer.
+    expect(bHtml).not.toContain('class="bundle-refs-link"');
+  });
+
+  it('nested-path notes get a relative href to references.html', async () => {
+    await fsp.mkdir(path.join(root, 'sub'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\n[[sub/deep]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'sub/deep.md'),
+      '# Deep\n\n[[cite::foo-2020]]\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 3 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    const deepHtml = String(output.files.find((f) => f.path === 'sub/deep.html')!.contents);
+    // sub/deep.html is one directory deeper than the bundle root, so
+    // the link climbs one level: ../references.html.
+    expect(deepHtml).toContain('href="../references.html"');
+  });
+
+  it('omits references.html when no notes cite anything', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n[[b]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '# B\nno cites\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 3 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    expect(output.files.map((f) => f.path)).not.toContain('references.html');
+  });
+
+  it('note-style export: per-note Footnotes + bundle-level Bibliography', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\n[[cite::foo-2020]] and [[b]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'),
+      '# B\n\n[[cite::bar-2021]]\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'a.md', maxDepth: 3 },
+      { citationStyle: 'chicago-notes-bibliography' },
+    );
+    const output = await runExporter(treeHtmlExporter, plan);
+
+    const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    const bHtml = String(output.files.find((f) => f.path === 'b.html')!.contents);
+    // Each note has its own footnote section starting at 1.
+    expect(indexHtml).toContain('<section class="footnotes">');
+    expect(indexHtml).toContain('id="fn-1"');
+    expect(bHtml).toContain('<section class="footnotes">');
+    expect(bHtml).toContain('id="fn-1"');
+
+    // Bundle-level Bibliography page (heading flips for note styles).
+    const refs = String(output.files.find((f) => f.path === 'references.html')!.contents);
+    expect(refs).toContain('<title>Bibliography</title>');
+    expect(refs).toContain('Foo');
+    expect(refs).toContain('Bar');
+  });
+});


### PR DESCRIPTION
## Summary

Tree-html bundles previously rendered citation marks inline but never emitted a References or Footnotes section anywhere — the inline marks pointed at nothing. Now the bundle ships one \`references.html\` at the root with the de-duplicated bibliography across every note in the closure; cite-bearing notes get a "References →" footer link pointing at it.

## Behaviour matrix

| Style class | Per-note | Bundle root |
|---|---|---|
| In-text (APA/MLA/IEEE/Vancouver/Chicago AD) | inline parentheticals + footer link to \`references.html\` | \`references.html\` titled "References" |
| Note (Chicago full-note) | \`<sup>\` markers + per-note Footnotes section + footer link | \`references.html\` titled "Bibliography" |

Per-note footnote numbering stays local — note A and note B both start at 1 — because the inline \`<sup>1</sup>\` markers anchor to that note's \`fn-1\`. The consolidated bibliography is alphabetised independent of citation order, so the dedupe is correct regardless of where Foo 2020 was first cited.

## How

- Each note still gets its own \`CitationRenderer\` for body rendering. Cited-ids accumulate into a bundle-wide \`Set\`.
- New \`renderBibliographyFor(ids)\` on \`CitationRenderer\` builds a bibliography from an explicit id list, decoupled from the per-render \`citedIds\` state — used by the bundle's "consolidator" renderer at the end.
- \`renderFootnotesSection()\` factored out of \`appendCitationsTail\` so tree-html can emit per-note footnotes without the per-note Bibliography that would duplicate the bundle one.
- Footer link href is computed relative to each note's depth: root → \`references.html\`, \`sub/deep.md\` → \`../references.html\`.
- \`references.html\` is suppressed when no notes in the bundle cited anything — empty bundles don't grow a useless stub file.

## Closes

Resolves #300. Closes the last bullet from #247's deferred list — the citation-rendering story is now end-to-end across single-note, multi-note folder, project, and tree-html bundle scopes.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/tree-html.test.ts\` — 10/10, 5 new tests for #300 covering: dedup across multiple notes, per-note footer link only when the note cites, relative href from a nested-path note, omission when no cites fired, note-style end-to-end (per-note Footnotes + bundle Bibliography).
- [x] \`pnpm vitest run tests/main/publish\` — 200/200
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a small wiki-linked tree under APA, confirm \`references.html\` opens cleanly with a single dedup'd entry per source. Repeat under Chicago notes & bibliography to confirm per-note footnotes still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)