### PR TITLE
Publication: clean-markdown exporter for "paste anywhere" output (#250)

### DIFF
--- a/src/main/publish/csl/citeproc.d.ts
+++ b/src/main/publish/csl/citeproc.d.ts
@@ -21,6 +21,8 @@ declare module 'citeproc' {
       citationsPre: unknown[],
       citationsPost: unknown[],
     ): [Record<string, unknown>, Array<[number, string, string]>];
+    /** Switch the engine's output format ("html" / "text" / "rtf"). */
+    setOutputFormat(fmt: 'html' | 'text' | 'rtf'): void;
     // Engine exposes more — we surface only the bits the wrapper reads.
     cslXml?: { dataObj?: { attrs?: { class?: string } } };
   }

--- a/src/main/publish/csl/index.ts
+++ b/src/main/publish/csl/index.ts
@@ -38,8 +38,13 @@ export interface CitationAssets {
   items: Map<string, CslItem>;
   excerpts: Map<string, { sourceId: string; locator?: string }>;
   knownSourceIds: string[];
-  /** Factory for a fresh renderer — one per note for per-note bibliographies. */
-  createRenderer(): CitationRenderer;
+  /**
+   * Factory for a fresh renderer — one per note for per-note
+   * bibliographies. The optional `outputFormat` switches citeproc-js
+   * to plain-text output for markdown / clean-text exporters (#250);
+   * defaults to HTML for note-html / tree-html.
+   */
+  createRenderer(opts?: { outputFormat?: 'html' | 'text' }): CitationRenderer;
 }
 
 /**
@@ -100,6 +105,6 @@ export async function loadCitationAssets(
     items,
     excerpts,
     knownSourceIds: [...items.keys()],
-    createRenderer: () => new CitationRenderer(style, locale, items),
+    createRenderer: (opts) => new CitationRenderer(style, locale, items, opts),
   };
 }

--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -54,8 +54,22 @@ export class CitationRenderer {
    */
   private readonly footnotes: Array<{ index: number; body: string }> = [];
 
-  constructor(style: string, locale: string, items: Map<string, CslItem>) {
+  /**
+   * Output format passed to citeproc-js. Default `html` matches the
+   * note-html / tree-html exporter's needs (italics as `<i>`, etc.);
+   * `text` produces clean prose for markdown / plain-text outputs
+   * where embedded HTML would be noise (#250).
+   */
+  readonly outputFormat: 'html' | 'text';
+
+  constructor(
+    style: string,
+    locale: string,
+    items: Map<string, CslItem>,
+    opts: { outputFormat?: 'html' | 'text' } = {},
+  ) {
     this.items = items;
+    this.outputFormat = opts.outputFormat ?? 'html';
     const sys = {
       retrieveItem: (id: string) => {
         const item = this.items.get(id);
@@ -69,6 +83,9 @@ export class CitationRenderer {
       retrieveLocale: () => locale,
     };
     this.engine = new CSL.Engine(sys, style);
+    if (this.outputFormat === 'text') {
+      this.engine.setOutputFormat('text');
+    }
     this.isNoteStyle = Boolean(this.engine.cslXml?.dataObj?.attrs?.class === 'note');
   }
 
@@ -82,7 +99,9 @@ export class CitationRenderer {
   renderCitation(id: string, locator?: string, label?: string): string {
     if (!this.items.has(id)) {
       this.missingIds.add(id);
-      return `<span class="csl-missing">[missing: ${escapeHtml(id)}]</span>`;
+      return this.outputFormat === 'text'
+        ? `[missing: ${id}]`
+        : `<span class="csl-missing">[missing: ${escapeHtml(id)}]</span>`;
     }
     return this.renderCitationCluster([{ id, locator, label }]);
   }
@@ -123,7 +142,12 @@ export class CitationRenderer {
       // footnotes section can render back-references.
       if (this.isNoteStyle) {
         this.footnotes.push({ index: noteIndex, body: text });
-        return `<sup class="footnote-ref" id="fnref-${noteIndex}"><a href="#fn-${noteIndex}">${noteIndex}</a></sup>`;
+        // Note-style marker shape depends on output format: Pandoc-style
+        // `[^N]` for markdown output, anchored `<sup>` for HTML so the
+        // exporter can wire up clickable back-references.
+        return this.outputFormat === 'text'
+          ? `[^${noteIndex}]`
+          : `<sup class="footnote-ref" id="fnref-${noteIndex}"><a href="#fn-${noteIndex}">${noteIndex}</a></sup>`;
       }
       return text;
     } catch (err) {

--- a/src/main/publish/exporters/note-markdown.ts
+++ b/src/main/publish/exporters/note-markdown.ts
@@ -1,0 +1,256 @@
+/**
+ * Clean-markdown exporter (#250).
+ *
+ * The "paste anywhere" exporter. Rewrites wiki-links via the plan's
+ * linkPolicy, replaces `[[cite::id]]` / `[[quote::id]]` with
+ * CSL-rendered prose, drops embedded Turtle blocks (not portable),
+ * and appends a `## References` (or footnote bodies for note-class
+ * styles) at the bottom of the file.
+ *
+ * Diverges from the passthrough `markdown` exporter: that one is for
+ * Minerva-internal use and preserves \`[[cite::]]\` syntax; this one
+ * produces output that renders correctly on GitHub, Substack, Hugo,
+ * and the wider markdown ecosystem outside Minerva.
+ *
+ * Deferred to follow-up tickets:
+ *   - copy-to-dir / inline-base64 image asset policies (this exporter
+ *     ships with `keep-relative` only)
+ *   - Hugo-flavoured frontmatter remapping
+ *   - preview-dialog warnings about dropped Turtle blocks / executable
+ *     cells (the warnings would need an IPC-side preview hook)
+ */
+
+import {
+  buildLinkResolverContext,
+  rewriteWikiLinksInContent,
+  type LinkResolverContext,
+} from '../link-resolver';
+import { parseLocatorAlias } from './note-html/render';
+import type { Exporter, ExportPlan } from '../types';
+import type { CitationRenderer } from '../csl';
+
+export const noteMarkdownExporter: Exporter = {
+  id: 'note-markdown',
+  label: 'Note as Clean Markdown',
+  // Single-note + folder + project; tree mode belongs to a future
+  // bundle-shaped markdown exporter (`#291`).
+  accepts: (input) => input.kind !== 'tree',
+  acceptedKinds: ['single-note', 'folder', 'project'],
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async run(plan) {
+    const ctx = buildLinkResolverContext(plan);
+    const notes = plan.inputs.filter((f) => f.kind === 'note');
+    // Single-note scope: drop the directory structure so a note at
+    // `notes/foo/bar.md` exported to `~/Desktop` lands as
+    // `~/Desktop/bar.md`. Multi-note keeps the source tree so
+    // `follow-to-file` cross-links still resolve.
+    const flatten = notes.length === 1;
+    const files = notes.map((f) => {
+      // Each note gets its own renderer — citeproc tracks citation
+      // ordering on the engine, so a per-note instance gives each
+      // page its own References section.
+      const renderer = plan.citations?.createRenderer({ outputFormat: 'text' });
+      const transformed = transformNoteBody(f.content, ctx, renderer, plan.citations);
+      const withRefs = renderer ? appendCitationsTail(transformed, renderer) : transformed;
+      return {
+        path: flatten ? basename(f.relativePath) : f.relativePath,
+        contents: withRefs,
+      };
+    });
+    const dropped = plan.excluded.length;
+    const summary = files.length === 1
+      ? `Exported "${plan.inputs[0]?.title ?? 'note'}" as clean markdown.`
+      : `${files.length} note${files.length === 1 ? '' : 's'} exported as clean markdown${dropped > 0 ? ` (${dropped} excluded)` : ''}.`;
+    return { files, summary };
+  },
+};
+
+/**
+ * Apply every body-level rewrite that has to happen before the
+ * References footer is appended.
+ *
+ * Order matters: citation rewrite first so the citation regex sees the
+ * raw `[[cite::]]` markers, then wiki-link rewrite (which deliberately
+ * skips cite/quote tokens), then Turtle-block strip last so we don't
+ * leave dangling `<-- minerva:turtle -->` HTML comments next to a
+ * rewritten link.
+ */
+function transformNoteBody(
+  content: string,
+  ctx: LinkResolverContext,
+  renderer: CitationRenderer | undefined,
+  citations: ExportPlan['citations'],
+): string {
+  let out = content;
+  if (renderer && citations) {
+    out = rewriteCitations(out, renderer, citations);
+  }
+  out = rewriteWikiLinksInContent(out, ctx);
+  out = stripTurtleBlocks(out);
+  return out;
+}
+
+/**
+ * Walk the markdown content for `[[cite::id]]` / `[[quote::id]]` runs
+ * (separated only by whitespace, the same merge gate the HTML exporter
+ * uses — #298) and replace each run with citeproc-rendered prose.
+ *
+ * Mirrors the parser logic in `note-html/render.ts` but emits plain
+ * text instead of HTML markers. Kept inline rather than shared because
+ * the markdown side has different escaping needs and a different
+ * handling for missing ids (no `<span>` wrapper).
+ */
+function rewriteCitations(
+  content: string,
+  renderer: CitationRenderer,
+  citations: NonNullable<ExportPlan['citations']>,
+): string {
+  // Skip rewriting inside fenced code blocks — `[[cite::]]` inside a
+  // code fence is example syntax, not a real citation.
+  const FENCE_RE = /^```[\s\S]*?^```/gm;
+  const fenceSpans: Array<{ start: number; end: number }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = FENCE_RE.exec(content)) !== null) {
+    fenceSpans.push({ start: m.index, end: m.index + m[0].length });
+  }
+  const isInsideFence = (idx: number): boolean =>
+    fenceSpans.some((s) => idx >= s.start && idx < s.end);
+
+  const out: string[] = [];
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] !== '[' || content[i + 1] !== '[' || isInsideFence(i)) {
+      out.push(content[i]);
+      i++;
+      continue;
+    }
+    const first = parseCiteAt(content, i);
+    if (!first) {
+      out.push(content[i]);
+      i++;
+      continue;
+    }
+    // Collect a whitespace-separated run, same as the HTML exporter.
+    const run: ParsedCite[] = [first];
+    let scanPos = first.endPos;
+    while (true) {
+      let p = scanPos;
+      while (p < content.length && /\s/.test(content[p])) p++;
+      const next = parseCiteAt(content, p);
+      if (!next) break;
+      run.push(next);
+      scanPos = next.endPos;
+    }
+    out.push(renderCiteRun(run, renderer, citations));
+    i = scanPos;
+  }
+  return out.join('');
+}
+
+interface ParsedCite {
+  kind: 'cite' | 'quote';
+  id: string;
+  aliasLocator: { locator: string; label: string } | null;
+  endPos: number;
+}
+
+function parseCiteAt(src: string, pos: number): ParsedCite | null {
+  if (src.charCodeAt(pos) !== 0x5b /* [ */ || src.charCodeAt(pos + 1) !== 0x5b) return null;
+  const close = src.indexOf(']]', pos + 2);
+  if (close < 0) return null;
+  const inner = src.slice(pos + 2, close);
+  const m = inner.match(/^(cite|quote)::(.+)$/i);
+  if (!m) return null;
+  const rawTarget = m[2];
+  const pipe = rawTarget.indexOf('|');
+  const id = (pipe >= 0 ? rawTarget.slice(0, pipe) : rawTarget).trim();
+  const alias = pipe >= 0 ? rawTarget.slice(pipe + 1).trim() : '';
+  return {
+    kind: m[1].toLowerCase() as 'cite' | 'quote',
+    id,
+    aliasLocator: parseLocatorAlias(alias),
+    endPos: close + 2,
+  };
+}
+
+/**
+ * Resolve a run of cites to a plain-text rendering. Mirrors the
+ * HTML-side missing-fallback semantics: any unresolvable id in a run
+ * disables the merge so the missing markers stay visible.
+ */
+function renderCiteRun(
+  items: ParsedCite[],
+  renderer: CitationRenderer,
+  citations: NonNullable<ExportPlan['citations']>,
+): string {
+  type Resolved =
+    | { ok: true; sourceId: string; locator?: string; label?: string }
+    | { ok: false; missingMarker: string };
+  const resolved: Resolved[] = items.map((item) => {
+    if (item.kind === 'quote') {
+      const ex = citations.excerpts.get(item.id);
+      if (!ex) return { ok: false, missingMarker: `[missing excerpt: ${item.id}]` };
+      if (!citations.items.has(ex.sourceId)) return { ok: false, missingMarker: `[missing: ${ex.sourceId}]` };
+      return {
+        ok: true,
+        sourceId: ex.sourceId,
+        locator: item.aliasLocator?.locator ?? ex.locator,
+        label: item.aliasLocator?.label,
+      };
+    }
+    if (!citations.items.has(item.id)) return { ok: false, missingMarker: `[missing: ${item.id}]` };
+    return {
+      ok: true,
+      sourceId: item.id,
+      locator: item.aliasLocator?.locator,
+      label: item.aliasLocator?.label,
+    };
+  });
+
+  if (items.length === 1 || resolved.some((r) => !r.ok)) {
+    return resolved
+      .map((r) => (r.ok ? renderer.renderCitation(r.sourceId, r.locator, r.label) : r.missingMarker))
+      .join(' ');
+  }
+  return renderer.renderCitationCluster(
+    resolved.map((r) => {
+      const ok = r as Extract<Resolved, { ok: true }>;
+      return { id: ok.sourceId, locator: ok.locator, label: ok.label };
+    }),
+  );
+}
+
+/**
+ * Append a References footer (in-text styles) or footnote bodies
+ * (note styles like Chicago full-note). Emits nothing when no
+ * citations fired — clean markdown with no References footer is the
+ * common case for non-academic notes.
+ */
+function appendCitationsTail(body: string, renderer: CitationRenderer): string {
+  if (renderer.isNoteStyle) {
+    const fns = renderer.renderFootnotes().notes;
+    if (fns.length === 0) return body;
+    // Pandoc-style footnote definitions: `[^N]: <body>` separated by
+    // blank lines. Pairs with the `[^N]` markers the renderer emitted.
+    const defs = fns.map((n) => `[^${n.index}]: ${n.body}`).join('\n\n');
+    return `${body.replace(/\s*$/, '')}\n\n${defs}\n`;
+  }
+  const bib = renderer.renderBibliography();
+  if (bib.entries.length === 0) return body;
+  const items = bib.entries.map((e) => `- ${e.trim()}`).join('\n');
+  return `${body.replace(/\s*$/, '')}\n\n## References\n\n${items}\n`;
+}
+
+/**
+ * Strip embedded Turtle blocks (\`\`\`turtle … \`\`\`) — they're meaningful
+ * inside Minerva (graph indexing) but noise outside it. Keeps other
+ * fenced blocks (sparql, sql, python, shell, prose) intact since
+ * those round-trip through standard markdown renderers.
+ */
+function stripTurtleBlocks(content: string): string {
+  return content.replace(/^```turtle\b[\s\S]*?^```\s*\n?/gm, '');
+}
+
+function basename(relativePath: string): string {
+  return relativePath.split('/').pop() ?? relativePath;
+}

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -8,6 +8,7 @@
 
 import { registerExporter } from './registry';
 import { markdownExporter } from './exporters/markdown';
+import { noteMarkdownExporter } from './exporters/note-markdown';
 import { noteHtmlExporter } from './exporters/note-html';
 import { notePdfExporter } from './exporters/note-pdf';
 import { treeHtmlExporter } from './exporters/tree-html';
@@ -16,6 +17,7 @@ import { bibtexExporter } from './exporters/bibtex';
 
 export function registerBuiltinExporters(): void {
   registerExporter(markdownExporter);
+  registerExporter(noteMarkdownExporter);
   registerExporter(noteHtmlExporter);
   registerExporter(notePdfExporter);
   registerExporter(treeHtmlExporter);

--- a/tests/main/publish/note-markdown.test.ts
+++ b/tests/main/publish/note-markdown.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Clean-markdown exporter (#250).
+ *
+ * Verifies the rewrites that turn Minerva-internal markdown into
+ * markdown that renders correctly outside Minerva (paste into GitHub,
+ * Substack, Hugo, etc.).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
+import { noteMarkdownExporter } from '../../../src/main/publish/exporters/note-markdown';
+
+function mkProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-md-export-'));
+}
+
+describe('clean-markdown exporter (#250)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkProject();
+    await fsp.mkdir(path.join(root, '.minerva/sources/toulmin-1958'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/toulmin-1958/meta.ttl'),
+      `this: a thought:Book ;
+  dc:title "The Uses of Argument" ;
+  dc:creator "Toulmin, Stephen" ;
+  dc:issued "1958"^^xsd:gYear .\n`,
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, '.minerva/excerpts'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/excerpts/ex-toulmin.ttl'),
+      `this: a thought:Excerpt ;
+  thought:fromSource sources:toulmin-1958 ;
+  thought:page 11 .\n`,
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('rewrites wiki-links via inline-title and removes [[ tokens', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# Heading\n\nSee [[other]] and [[notes/deep]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'other.md'),
+      '---\ntitle: The Other\n---\n# The Other\n', 'utf-8');
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/deep.md'),
+      '---\ntitle: Deep Thoughts\n---\n# Deep Thoughts\n', 'utf-8');
+
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { linkPolicy: 'inline-title' },
+    );
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const aFile = output.files.find((f) => f.path === 'a.md');
+    expect(aFile).toBeDefined();
+    const text = String(aFile!.contents);
+    expect(text).not.toContain('[[');
+    expect(text).toContain('The Other');
+    expect(text).toContain('Deep Thoughts');
+  });
+
+  it('renders [[cite::id]] as plain-text in-text mark + appends ## References', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\nAs [[cite::toulmin-1958]] showed.\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'single-note', relativePath: 'a.md' },
+      { citationStyle: 'apa' },
+    );
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+
+    // In-text mark contains the author + year, no HTML wrappers.
+    expect(text).toMatch(/Toulmin, 1958/);
+    expect(text).not.toContain('<i>');
+    expect(text).not.toContain('<span');
+    // References footer.
+    expect(text).toContain('## References');
+    // Bibliography entry shows as a markdown bullet, not an HTML <li>.
+    expect(text).toMatch(/^- Toulmin/m);
+    // No raw [[cite::]] left over.
+    expect(text).not.toContain('[[cite::');
+  });
+
+  it('renders [[quote::id]] with a page locator from the excerpt', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      'See [[quote::ex-toulmin]] for the foundations.\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'single-note', relativePath: 'a.md' },
+      { citationStyle: 'apa' },
+    );
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    expect(text).toContain('Toulmin');
+    expect(text).toContain('11'); // the excerpt's page locator
+    expect(text).not.toContain('[[quote::');
+  });
+
+  it('Chicago full-note → [^N] footnote markers + Pandoc footnote definitions', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\nFirst [[cite::toulmin-1958]] cite.\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'single-note', relativePath: 'a.md' },
+      { citationStyle: 'chicago-notes-bibliography' },
+    );
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    expect(text).toContain('[^1]');
+    // Pandoc-style footnote definition somewhere after the body.
+    expect(text).toMatch(/\n\[\^1\]: .*Toulmin/);
+    // No <sup> HTML markup leaking in (text mode).
+    expect(text).not.toContain('<sup');
+  });
+
+  it('drops embedded ```turtle blocks (not portable markdown)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\n\nProse.\n\n```turtle\n@prefix ex: <http://example.com/> .\nex:foo a ex:Bar .\n```\n\nMore prose.\n',
+      'utf-8',
+    );
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'a.md' });
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    expect(text).not.toContain('```turtle');
+    expect(text).not.toContain('@prefix');
+    expect(text).toContain('Prose.');
+    expect(text).toContain('More prose.');
+  });
+
+  it('preserves other fence languages (python / sparql / sql)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '```python\nprint("hi")\n```\n\n```sparql\nSELECT * WHERE { ?s ?p ?o }\n```\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'a.md' });
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    expect(text).toContain('```python');
+    expect(text).toContain('print("hi")');
+    expect(text).toContain('```sparql');
+    expect(text).toContain('SELECT *');
+  });
+
+  it('does not rewrite [[cite::]] inside fenced code blocks (example syntax)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      'Real cite: [[cite::toulmin-1958]].\n\n```\nExample syntax: [[cite::brooks-1986]]\n```\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'single-note', relativePath: 'a.md' },
+      { citationStyle: 'apa' },
+    );
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    // Real cite outside the fence got rendered.
+    expect(text).toContain('Toulmin');
+    // Example syntax inside the fence stays raw.
+    expect(text).toContain('[[cite::brooks-1986]]');
+  });
+
+  it('omits ## References when no citations fired', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n\nJust prose.\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'a.md' });
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    expect(text).not.toContain('## References');
+  });
+
+  it('preserves frontmatter verbatim (passes through to the output)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '---\ntitle: My Note\ntags: [foo, bar]\n---\n\n# My Note\n\nbody\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'a.md' });
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const text = String(output.files[0].contents);
+    expect(text).toMatch(/^---\ntitle: My Note\ntags: \[foo, bar\]\n---/);
+  });
+
+  it('flattens single-note path: notes/foo/bar.md → bar.md at output root', async () => {
+    await fsp.mkdir(path.join(root, 'notes/foo'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/foo/bar.md'), '# Bar\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'notes/foo/bar.md' });
+    const output = await runExporter(noteMarkdownExporter, plan);
+    expect(output.files[0].path).toBe('bar.md');
+  });
+
+  it('preserves source tree at folder/project scope so follow-to-file links resolve', async () => {
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'notes/a.md'), '# A\n[[notes/b]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'notes/b.md'), '# B\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { linkPolicy: 'follow-to-file' },
+    );
+    const output = await runExporter(noteMarkdownExporter, plan);
+    const paths = output.files.map((f) => f.path).sort();
+    expect(paths).toEqual(['notes/a.md', 'notes/b.md']);
+    const a = String(output.files.find((f) => f.path === 'notes/a.md')!.contents);
+    expect(a).toContain('[B](notes/b.md)');
+  });
+
+  it('exporter exposes the expected id and label for the registry', () => {
+    expect(noteMarkdownExporter.id).toBe('note-markdown');
+    expect(noteMarkdownExporter.label).toBe('Note as Clean Markdown');
+    expect(noteMarkdownExporter.acceptedKinds).toEqual(['single-note', 'folder', 'project']);
+    expect(noteMarkdownExporter.accepts({ kind: 'tree' })).toBe(false);
+    expect(noteMarkdownExporter.accepts({ kind: 'single-note' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

New exporter \`note-markdown\` that produces portable markdown for GitHub, Substack, Hugo, Jekyll, and similar tools. Distinct from the existing passthrough \`markdown\` exporter, which preserves Minerva's internal \`[[cite::]]\` syntax for round-tripping inside the app.

## Rewrites

- **Wiki-links** via the plan's linkPolicy (drop / inline-title / follow-to-file) using the existing link resolver
- **\`[[cite::]]\` / \`[[quote::]]\`** runs (with the #298 whitespace-merge gate) → CSL-rendered prose via the renderer's new \`outputFormat: 'text'\` mode
- **Note-class styles** emit \`[^N]\` Pandoc-style markers + matching \`[^N]: …\` definitions at the bottom
- **In-text styles** append a \`## References\` section with bullet-list bibliography entries
- **Embedded \`\`\`turtle blocks** are dropped (not portable; meaningful only inside Minerva's graph indexer). Other fence languages (python / sparql / sql / shell / prose) pass through.
- **Frontmatter** preserved verbatim

## Renderer extension

- \`CitationRenderer\` accepts \`outputFormat: 'html' | 'text'\` and routes to citeproc-js's \`setOutputFormat(...)\` so plain-text output drops the \`<i>\` / \`<sup>\` markup that's noise in markdown.
- Per-format note-style markers: \`<sup>\` for HTML, \`[^N]\` for text.
- Text-mode missing-id stub drops the \`<span>\` wrapper.

## Deferred (per scope discussion)

These are listed in the issue's acceptance criteria but easier to ship as follow-ups since they touch orthogonal subsystems:

- \`copy-to-dir\` / \`inline-base64\` image asset policies (the markdown exporter ships with \`keep-relative\` only)
- Hugo-flavoured frontmatter remapping (\`date\` ISO format, \`draft: false\`, etc.)
- Preview-dialog warnings about dropped turtle blocks / executable cells

## Closes

Resolves #250.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/note-markdown.test.ts\` — 12/12 covering: wiki-link rewrites with no \`[[\` residue, in-text APA citation prose + bullet References footer, quote with page locator, Chicago-fullnote \`[^N]\` markers + Pandoc footnote definitions, turtle block stripping, other fence languages preserved, fence-internal cite syntax left raw, no References footer when no cites, frontmatter passthrough, single-note flatten, multi-note tree-preservation
- [x] \`pnpm vitest run tests/main/publish\` — 212/212
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a note with cites + an image + a turtle block, paste into a GitHub gist, confirm renders cleanly with linked References

🤖 Generated with [Claude Code](https://claude.com/claude-code)