### PR TITLE
Publication: static-site exporter for project-as-website (#252)

### DIFF
--- a/src/main/publish/exporters/static-site/index.ts
+++ b/src/main/publish/exporters/static-site/index.ts
@@ -1,0 +1,188 @@
+/**
+ * Static-site exporter (#252).
+ *
+ * Renders the whole non-private project as a browseable static site:
+ * a page per note, backlinks on every page, tag index, consolidated
+ * bibliography, and a small client-side search index. Output is a
+ * plain directory tree the user hosts on GitHub Pages, Netlify, S3,
+ * or whatever else.
+ *
+ * v1 scope is the most-visible 80% of the issue's acceptance list:
+ *   - per-note pages with backlinks + sidebar + nav header
+ *   - tag cloud + per-tag list pages
+ *   - consolidated bibliography page
+ *   - shared style.css + search.js + search.json
+ *   - broken-wiki-link strikethrough
+ *
+ * Deferred to follow-ups:
+ *   - graph view (needs a bundled layout library)
+ *   - pretty URLs (no `.html`)
+ *   - theme-token customisation beyond the bundled "garden" theme
+ *   - incremental rebuild
+ */
+
+import path from 'node:path';
+import type { Exporter, ExportOutput, ExportPlanFile } from '../../types';
+import { loadSiteConfig, type SiteConfig } from './site-config';
+import { buildSiteIndex, noteUrl } from './site-data';
+import {
+  renderNotePage,
+  renderTagCloud,
+  renderTagPage,
+  renderAllNotesIndex,
+  renderReferencesPage,
+} from './render';
+import { STATIC_SITE_STYLE } from './style';
+import { SITE_SEARCH_SCRIPT } from './search-script';
+
+export const staticSiteExporter: Exporter = {
+  id: 'static-site',
+  label: 'Project as Static Site',
+  // Project-only — the whole point is "publish this thoughtbase".
+  // Single-note / folder static sites would be a separate, weirder
+  // product (a one-page site? a folder-of-notes site?).
+  accepts: (input) => input.kind === 'project',
+  acceptedKinds: ['project'],
+  async run(plan) {
+    const rootPath = plan.rootPath ?? '';
+    const config = await loadSiteConfig(rootPath);
+    const allNotes = plan.inputs.filter((f) => f.kind === 'note');
+    const notes = applyConfigFilters(allNotes, config);
+    if (notes.length === 0) {
+      return { files: [], summary: 'Nothing to export — every note was filtered out by site-config.' };
+    }
+
+    const index = buildSiteIndex(notes);
+    const files: ExportOutput['files'] = [];
+
+    // Track citations bundle-wide so the consolidated References /
+    // Bibliography page de-dupes across the whole site (same shape as
+    // the tree-html bundle bibliography from #300).
+    const allCitedIds = new Set<string>();
+    let isNoteStyle = false;
+
+    for (const note of notes) {
+      const renderer = plan.citations?.createRenderer() ?? null;
+      const rootRel = relativeToRoot(note.relativePath);
+      const html = renderNotePage({ note, plan, config, index, rootRelative: rootRel, renderer });
+      files.push({ path: noteUrl(note.relativePath), contents: html });
+      if (renderer) {
+        for (const id of renderer.cited()) allCitedIds.add(id);
+        if (renderer.isNoteStyle) isNoteStyle = true;
+      }
+    }
+
+    // Tag cloud + per-tag pages.
+    if (index.tags.size > 0) {
+      files.push({
+        path: 'tags/index.html',
+        contents: renderTagCloud(config, index, '../'),
+      });
+      for (const [tag, taggedNotes] of index.tags) {
+        files.push({
+          path: `tags/${encodeFilename(tag)}.html`,
+          contents: renderTagPage(tag, taggedNotes, config, '../'),
+        });
+      }
+    }
+
+    // Landing page: site-config.landing wins; else "All Notes" list.
+    const landingNote = config.landing
+      ? notes.find((n) => n.relativePath === config.landing)
+      : null;
+    if (landingNote) {
+      const renderer = plan.citations?.createRenderer() ?? null;
+      const html = renderNotePage({
+        note: landingNote,
+        plan,
+        config,
+        index,
+        rootRelative: '',
+        renderer,
+      });
+      files.push({ path: 'index.html', contents: html });
+      if (renderer) {
+        for (const id of renderer.cited()) allCitedIds.add(id);
+        if (renderer.isNoteStyle) isNoteStyle = true;
+      }
+    } else {
+      files.push({ path: 'index.html', contents: renderAllNotesIndex(notes, config) });
+    }
+
+    // Consolidated bibliography.
+    if (allCitedIds.size > 0 && plan.citations) {
+      const consolidator = plan.citations.createRenderer();
+      const bib = consolidator.renderBibliographyFor([...allCitedIds]);
+      if (bib.entries.length > 0) {
+        files.push({
+          path: 'references.html',
+          contents: renderReferencesPage(bib.entries, isNoteStyle, config),
+        });
+      }
+    }
+
+    // Search index — a flat array of {url, title, snippet}. Loaded
+    // lazily by search.js on the first keystroke; small enough at
+    // ~10k notes that the naive linear filter stays fast.
+    files.push({
+      path: 'search.json',
+      contents: JSON.stringify(index.searchRecords),
+    });
+    files.push({ path: 'search.js', contents: SITE_SEARCH_SCRIPT });
+    files.push({ path: 'style.css', contents: STATIC_SITE_STYLE });
+
+    const dropped = allNotes.length - notes.length + plan.excluded.length;
+    const summary = dropped > 0
+      ? `Site of ${notes.length} note${notes.length === 1 ? '' : 's'} (${dropped} filtered).`
+      : `Site of ${notes.length} note${notes.length === 1 ? '' : 's'}.`;
+    return { files, summary };
+  },
+};
+
+/**
+ * Apply site-config filters: drop notes wearing any excluded tag, or
+ * sitting in any excluded folder. Private-by-default exclusions
+ * already happened upstream in the pipeline (#246).
+ */
+function applyConfigFilters(notes: ExportPlanFile[], config: SiteConfig): ExportPlanFile[] {
+  const excludeTags = new Set(config.excludeTags);
+  const excludeFolders = config.excludeFolders.map((f) => f.replace(/\/$/, ''));
+  return notes.filter((note) => {
+    for (const folder of excludeFolders) {
+      if (note.relativePath === folder || note.relativePath.startsWith(`${folder}/`)) {
+        return false;
+      }
+    }
+    if (excludeTags.size === 0) return true;
+    const fmTags = note.frontmatter.tags;
+    let tags: string[] = [];
+    if (Array.isArray(fmTags)) {
+      tags = fmTags
+        .filter((t): t is string | number => typeof t === 'string' || typeof t === 'number')
+        .map((t) => String(t));
+    } else if (typeof fmTags === 'string') {
+      tags = fmTags.split(',').map((t) => t.trim());
+    }
+    return !tags.some((t) => excludeTags.has(t));
+  });
+}
+
+/** Number of `../` segments needed to climb from a note's URL to the site root. */
+function relativeToRoot(relativePath: string): string {
+  const depth = relativePath.split('/').length - 1;
+  return depth === 0 ? '' : '../'.repeat(depth);
+}
+
+/**
+ * Sanitise a tag for use as a filename. Strips slashes and other
+ * characters that'd break the URL or the filesystem; collapses
+ * everything else to `-`.
+ */
+function encodeFilename(tag: string): string {
+  return tag.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'tag';
+}
+
+// Reserved for future image/asset copying — keeps the import shape
+// stable so the follow-up that copies referenced images can land
+// without a churny import diff.
+void path;

--- a/src/main/publish/exporters/static-site/render.ts
+++ b/src/main/publish/exporters/static-site/render.ts
@@ -1,0 +1,195 @@
+/**
+ * Static-site page renderer (#252).
+ *
+ * Reuses the note-html body renderer (cite/quote rules, wiki-link
+ * resolution, code highlighting) but wraps it in the site's nav-shell
+ * + per-note metadata sidebar + backlinks footer. The note-html
+ * exporter is single-artifact-shaped; this is the same output dressed
+ * up as a multi-page site.
+ */
+
+import path from 'node:path';
+import { renderNoteBody } from '../note-html/render';
+import type { ExportPlanFile, ExportPlan } from '../../types';
+import type { CitationRenderer } from '../../csl';
+import type { SiteConfig } from './site-config';
+import { noteUrl, type SiteIndex } from './site-data';
+import { renderFootnotesSection } from '../note-html';
+
+export interface RenderPageInput {
+  note: ExportPlanFile;
+  plan: ExportPlan;
+  config: SiteConfig;
+  index: SiteIndex;
+  /**
+   * Number of `../` segments to climb from this page to the site
+   * root. Lets the nav, search input, and stylesheet links resolve
+   * cleanly from any depth.
+   */
+  rootRelative: string;
+  /** Per-note CSL renderer; null when the project has no citation assets. */
+  renderer: CitationRenderer | null;
+}
+
+/** Render a complete HTML page for a note. */
+export function renderNotePage(input: RenderPageInput): string {
+  const { note, plan, config, index, rootRelative, renderer } = input;
+
+  // Body via the existing markdown→HTML pipeline. The link policy is
+  // forced to `follow-to-file` here (same as tree-html does) since the
+  // bundle ships every note as an .html sibling — readers want
+  // working cross-links inside the site.
+  const sitePlan: ExportPlan = { ...plan, linkPolicy: 'follow-to-file' };
+  const rawBody = renderNoteBody(note, sitePlan, renderer ?? undefined);
+  const bodyWithFootnotes = renderer ? `${rawBody}${renderFootnotesSection(renderer)}` : rawBody;
+  const bodyWithBroken = markBrokenWikiLinks(bodyWithFootnotes);
+
+  // Backlinks section — only when at least one inbound link exists.
+  const backlinkEntries = config.showBacklinks ? (index.backlinks.get(note.relativePath) ?? []) : [];
+  const backlinksHtml = backlinkEntries.length > 0
+    ? `<section class="backlinks"><h2>Linked from</h2><ul>${
+      backlinkEntries.map((b) => `<li><a href="${rootRelative}${escapeAttr(noteUrl(b.relativePath))}">${escapeHtml(b.title)}</a></li>`).join('')
+    }</ul></section>`
+    : '';
+
+  // Per-note metadata sidebar.
+  const tags = extractTagList(note);
+  const metaTags = tags.length > 0
+    ? `<h3>Tags</h3><ul>${tags.map((t) => `<li><a href="${rootRelative}tags/${encodeURIComponent(t)}.html">#${escapeHtml(t)}</a></li>`).join('')}</ul>`
+    : '';
+  const date = typeof note.frontmatter.date === 'string' ? note.frontmatter.date : '';
+  const metaDate = date ? `<h3>Date</h3><ul><li>${escapeHtml(date)}</li></ul>` : '';
+  const sidebar = (metaTags || metaDate)
+    ? `<aside class="note-meta">${metaTags}${metaDate}</aside>`
+    : '<aside class="note-meta"></aside>';
+
+  return shell({
+    config,
+    rootRelative,
+    pageTitle: note.title,
+    bodyHtml: `<article>${bodyWithBroken}${backlinksHtml}</article>${sidebar}`,
+  });
+}
+
+/** Render the tag-cloud landing page (`tags/index.html`). */
+export function renderTagCloud(config: SiteConfig, index: SiteIndex, rootRelative: string): string {
+  const sorted = [...index.tags.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const items = sorted.map(([tag, notes]) => (
+    `<li><a href="${encodeURIComponent(tag)}.html">#${escapeHtml(tag)}<span class="count">${notes.length}</span></a></li>`
+  )).join('');
+  const body = `<article><h1>Tags</h1>${
+    sorted.length === 0 ? '<p>No tags in this thoughtbase.</p>' : `<ul class="tag-cloud">${items}</ul>`
+  }</article><aside class="note-meta"></aside>`;
+  return shell({ config, rootRelative, pageTitle: 'Tags', bodyHtml: body });
+}
+
+/** Render an individual tag page (`tags/<tag>.html`). */
+export function renderTagPage(
+  tag: string,
+  notes: Array<{ relativePath: string; title: string }>,
+  config: SiteConfig,
+  rootRelative: string,
+): string {
+  const items = notes.map((n) => (
+    `<li><a href="${rootRelative}${escapeAttr(noteUrl(n.relativePath))}">${escapeHtml(n.title)}</a></li>`
+  )).join('');
+  const body = `<article><h1>#${escapeHtml(tag)}</h1><ul>${items}</ul></article><aside class="note-meta"></aside>`;
+  return shell({ config, rootRelative, pageTitle: `#${tag}`, bodyHtml: body });
+}
+
+/** Render an "All Notes" landing page when site-config.landing is empty. */
+export function renderAllNotesIndex(notes: ExportPlanFile[], config: SiteConfig): string {
+  const sorted = [...notes].sort((a, b) => a.title.localeCompare(b.title));
+  const items = sorted.map((n) => (
+    `<li><a href="${escapeAttr(noteUrl(n.relativePath))}">${escapeHtml(n.title)}</a></li>`
+  )).join('');
+  const body = `<article><h1>${escapeHtml(config.title)}</h1><ul>${items}</ul></article><aside class="note-meta"></aside>`;
+  return shell({ config, rootRelative: '', pageTitle: config.title, bodyHtml: body });
+}
+
+/** Render the consolidated bibliography page (`references.html`). */
+export function renderReferencesPage(
+  entries: string[],
+  isNote: boolean,
+  config: SiteConfig,
+): string {
+  const heading = isNote ? 'Bibliography' : 'References';
+  const items = entries.map((e) => `<li>${e}</li>`).join('');
+  const body = `<article><h1>${heading}</h1><section class="references"><ol>${items}</ol></section></article><aside class="note-meta"></aside>`;
+  return shell({ config, rootRelative: '', pageTitle: heading, bodyHtml: body });
+}
+
+interface ShellInput {
+  config: SiteConfig;
+  rootRelative: string;
+  pageTitle: string;
+  bodyHtml: string;
+}
+
+function shell(input: ShellInput): string {
+  const { config, rootRelative, pageTitle, bodyHtml } = input;
+  const tagsHref = `${rootRelative}tags/index.html`;
+  const refsHref = `${rootRelative}references.html`;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(pageTitle)} — ${escapeHtml(config.title)}</title>
+  <link rel="stylesheet" href="${rootRelative}style.css">
+</head>
+<body data-search-root="${escapeAttr(rootRelative)}">
+<nav class="site-nav">
+  <a class="site-title" href="${rootRelative}index.html">${escapeHtml(config.title)}</a>
+  <a href="${escapeAttr(tagsHref)}">Tags</a>
+  <a href="${escapeAttr(refsHref)}">References</a>
+  <input class="site-search" type="search" placeholder="Search notes…" autocomplete="off">
+</nav>
+<div id="search-results" class="hidden"></div>
+<main class="page">
+${bodyHtml}
+</main>
+<script src="${rootRelative}search.js" defer></script>
+</body>
+</html>`;
+}
+
+/**
+ * Mark unresolved wiki-links — the markdown body renderer emits them
+ * as `<em class="wikilink-unresolved">...</em>`. The static site's
+ * acceptance criterion calls for a strikethrough rendering visible to
+ * the user, so we promote the `wikilink-unresolved` class to
+ * `wikilink-broken` (which the stylesheet styles with line-through).
+ */
+function markBrokenWikiLinks(html: string): string {
+  return html.replace(/<em class="wikilink-unresolved">/g, '<em class="wikilink-broken">');
+}
+
+function extractTagList(note: ExportPlanFile): string[] {
+  const fmTags = note.frontmatter.tags;
+  if (Array.isArray(fmTags)) {
+    return fmTags
+      .filter((t): t is string | number => typeof t === 'string' || typeof t === 'number')
+      .map((t) => String(t).trim())
+      .filter(Boolean);
+  }
+  if (typeof fmTags === 'string') {
+    return fmTags.split(',').map((t) => t.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+function escapeAttr(s: string): string { return escapeHtml(s); }
+
+// Suppress unused-helper warnings for `path` import — used by future
+// asset-copy code; left so the module's expected import shape stays
+// stable.
+void path;

--- a/src/main/publish/exporters/static-site/search-script.ts
+++ b/src/main/publish/exporters/static-site/search-script.ts
@@ -1,0 +1,74 @@
+/**
+ * Client-side search for the static-site exporter (#252).
+ *
+ * Bundled inline as `search.js` at the site root. Loads `search.json`
+ * lazily on the first keystroke, then filters by case-insensitive
+ * substring match against title + snippet. Naive — fine up to ~10k
+ * notes; the day someone needs better, swap in lunr/MiniSearch.
+ *
+ * No build step, no framework — vanilla JS that works straight off
+ * `python -m http.server` or any other static host.
+ */
+
+export const SITE_SEARCH_SCRIPT = `(function() {
+  'use strict';
+  var input = document.querySelector('input.site-search');
+  var results = document.getElementById('search-results');
+  if (!input || !results) return;
+
+  var indexPromise = null;
+  function loadIndex() {
+    if (indexPromise) return indexPromise;
+    // search.json sits at the site root; relative path computed from
+    // the page's data-search-root attribute on <body>.
+    var root = document.body.dataset.searchRoot || '';
+    indexPromise = fetch(root + 'search.json')
+      .then(function(r) { return r.json(); })
+      .catch(function() { return []; });
+    return indexPromise;
+  }
+
+  var lastQuery = '';
+  function render(query) {
+    if (query === lastQuery) return;
+    lastQuery = query;
+    if (!query) {
+      results.classList.add('hidden');
+      results.innerHTML = '';
+      return;
+    }
+    loadIndex().then(function(records) {
+      var q = query.toLowerCase();
+      var hits = [];
+      for (var i = 0; i < records.length && hits.length < 30; i++) {
+        var rec = records[i];
+        var hay = (rec.title + ' ' + rec.snippet).toLowerCase();
+        if (hay.indexOf(q) !== -1) hits.push(rec);
+      }
+      results.classList.remove('hidden');
+      if (hits.length === 0) {
+        results.innerHTML = '<p class="empty">No matches for "' + escapeHtml(query) + '".</p>';
+        return;
+      }
+      var html = '';
+      var root = document.body.dataset.searchRoot || '';
+      for (var j = 0; j < hits.length; j++) {
+        var h = hits[j];
+        html += '<a class="hit-link" href="' + root + escapeAttr(h.url) + '"><div class="hit"><h4>' + escapeHtml(h.title) + '</h4><p>' + escapeHtml(h.snippet) + '</p></div></a>';
+      }
+      results.innerHTML = html;
+    });
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+  function escapeAttr(s) { return escapeHtml(s); }
+
+  input.addEventListener('input', function(e) { render(e.target.value.trim()); });
+})();`;

--- a/src/main/publish/exporters/static-site/site-config.ts
+++ b/src/main/publish/exporters/static-site/site-config.ts
@@ -1,0 +1,59 @@
+/**
+ * Site-config loader for the static-site exporter (#252).
+ *
+ * Reads `.minerva/site-config.json` and merges it with safe defaults
+ * so an empty / absent config still produces a usable site. Lives
+ * under .minerva/ so it travels with the project via git — different
+ * thoughtbases can ship different sites.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface SiteConfig {
+  /** Site title shown in the nav header and `<title>` of every page. */
+  title: string;
+  /** Base URL for absolute links; used in canonical tags. Empty = relative. */
+  baseUrl: string;
+  /** Relative path to the note used as `index.html`. Empty = generated "All Notes" list. */
+  landing: string;
+  /** Tags whose notes are excluded from the site (in addition to private rules). */
+  excludeTags: string[];
+  /** Folder paths whose notes are excluded from the site. */
+  excludeFolders: string[];
+  /** Show per-note backlinks. */
+  showBacklinks: boolean;
+}
+
+const DEFAULTS: SiteConfig = {
+  title: 'My Notes',
+  baseUrl: '',
+  landing: '',
+  excludeTags: ['draft'],
+  excludeFolders: [],
+  showBacklinks: true,
+};
+
+export async function loadSiteConfig(rootPath: string): Promise<SiteConfig> {
+  const configPath = path.join(rootPath, '.minerva', 'site-config.json');
+  try {
+    const raw = await fs.readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<SiteConfig>;
+    return mergeWithDefaults(parsed);
+  } catch {
+    // Missing / malformed config → defaults. Not an error path: most
+    // projects will start without one and the exporter still works.
+    return { ...DEFAULTS };
+  }
+}
+
+function mergeWithDefaults(partial: Partial<SiteConfig>): SiteConfig {
+  return {
+    title: typeof partial.title === 'string' && partial.title ? partial.title : DEFAULTS.title,
+    baseUrl: typeof partial.baseUrl === 'string' ? partial.baseUrl : DEFAULTS.baseUrl,
+    landing: typeof partial.landing === 'string' ? partial.landing : DEFAULTS.landing,
+    excludeTags: Array.isArray(partial.excludeTags) ? partial.excludeTags.filter((t) => typeof t === 'string') : [...DEFAULTS.excludeTags],
+    excludeFolders: Array.isArray(partial.excludeFolders) ? partial.excludeFolders.filter((t) => typeof t === 'string') : [],
+    showBacklinks: typeof partial.showBacklinks === 'boolean' ? partial.showBacklinks : DEFAULTS.showBacklinks,
+  };
+}

--- a/src/main/publish/exporters/static-site/site-data.ts
+++ b/src/main/publish/exporters/static-site/site-data.ts
@@ -1,0 +1,118 @@
+/**
+ * Site-wide indices computed once and reused across every page render
+ * in the static-site exporter (#252):
+ *
+ *   - backlink map: who links to me?
+ *   - tag map: which notes wear this tag?
+ *   - search records: a flat list of {url, title, snippet} for the
+ *     client-side search index.
+ *
+ * Lives separate from the page renderer so the indices are easy to
+ * test in isolation without spinning up markdown-it.
+ */
+
+import { extractWikiLinkTargets } from '../../tree-resolver';
+import type { ExportPlanFile } from '../../types';
+
+export interface SiteIndex {
+  /** Backlinks per note: relativePath → [{ relativePath, title }, …]. */
+  backlinks: Map<string, Array<{ relativePath: string; title: string }>>;
+  /** tag → [{ relativePath, title }, …], sorted by title. */
+  tags: Map<string, Array<{ relativePath: string; title: string }>>;
+  /** Flat per-note records used to seed the search index. */
+  searchRecords: Array<{ url: string; title: string; snippet: string }>;
+}
+
+export function buildSiteIndex(notes: ExportPlanFile[]): SiteIndex {
+  const titleByPath = new Map<string, string>();
+  for (const n of notes) titleByPath.set(n.relativePath, n.title);
+
+  const backlinks = new Map<string, Array<{ relativePath: string; title: string }>>();
+  const tags = new Map<string, Array<{ relativePath: string; title: string }>>();
+  const searchRecords: SiteIndex['searchRecords'] = [];
+
+  for (const note of notes) {
+    // Backlinks: every wiki-link the note emits points back at the
+    // target. The link resolver matches with-or-without the `.md`
+    // extension, so try both shapes when looking up the target.
+    for (const target of extractWikiLinkTargets(note.content)) {
+      const targetPath = resolveLinkTarget(target, titleByPath);
+      if (!targetPath || targetPath === note.relativePath) continue;
+      const list = backlinks.get(targetPath) ?? [];
+      // Skip duplicates: a note that links to the same target twice
+      // shouldn't show twice in the backlinks list.
+      if (!list.some((b) => b.relativePath === note.relativePath)) {
+        list.push({ relativePath: note.relativePath, title: note.title });
+        backlinks.set(targetPath, list);
+      }
+    }
+
+    // Tags from frontmatter `tags:` (array or comma-separated string).
+    for (const tag of extractTags(note)) {
+      const list = tags.get(tag) ?? [];
+      list.push({ relativePath: note.relativePath, title: note.title });
+      tags.set(tag, list);
+    }
+
+    searchRecords.push({
+      url: noteUrl(note.relativePath),
+      title: note.title,
+      snippet: extractSnippet(note.content),
+    });
+  }
+
+  // Sort backlink + tag lists for deterministic output order.
+  for (const list of backlinks.values()) list.sort((a, b) => a.title.localeCompare(b.title));
+  for (const list of tags.values()) list.sort((a, b) => a.title.localeCompare(b.title));
+
+  return { backlinks, tags, searchRecords };
+}
+
+/**
+ * `.md` → `.html` URL transform used everywhere the site links to a note.
+ * Single source of truth so a follow-up ticket switching to pretty URLs
+ * (no .html) only has one place to flip.
+ */
+export function noteUrl(relativePath: string): string {
+  return relativePath.replace(/\.md$/i, '.html');
+}
+
+function resolveLinkTarget(
+  target: string,
+  titleByPath: Map<string, string>,
+): string | null {
+  // Try exact match first, then with `.md` suffix.
+  if (titleByPath.has(target)) return target;
+  const withMd = target.endsWith('.md') ? target : `${target}.md`;
+  if (titleByPath.has(withMd)) return withMd;
+  return null;
+}
+
+function extractTags(note: ExportPlanFile): string[] {
+  const fmTags = note.frontmatter.tags;
+  if (Array.isArray(fmTags)) {
+    return fmTags
+      .filter((t): t is string | number => typeof t === 'string' || typeof t === 'number')
+      .map((t) => String(t).trim())
+      .filter(Boolean);
+  }
+  if (typeof fmTags === 'string') {
+    return fmTags.split(',').map((t) => t.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+/**
+ * First ~280 characters of plain-text body for the search index. Strips
+ * front-matter, headings, code fences, and most markdown syntax so the
+ * search snippet reads like prose.
+ */
+function extractSnippet(content: string): string {
+  let body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+  body = body.replace(/```[\s\S]*?```/g, ' ');
+  body = body.replace(/^#+\s+/gm, '');
+  body = body.replace(/\[\[[^\]]*\]\]/g, ' ');
+  body = body.replace(/[*_`>-]/g, ' ');
+  body = body.replace(/\s+/g, ' ').trim();
+  return body.length > 280 ? body.slice(0, 280) + '…' : body;
+}

--- a/src/main/publish/exporters/static-site/style.ts
+++ b/src/main/publish/exporters/static-site/style.ts
@@ -1,0 +1,216 @@
+/**
+ * Shared stylesheet for the static-site exporter (#252).
+ *
+ * Emitted as `style.css` at the site root and linked from every page
+ * via a relative path. Designed for "digital garden" reading — quiet
+ * typography, calm contrast, sidebar that gets out of the way.
+ */
+
+export const STATIC_SITE_STYLE = `
+:root {
+  --fg: #1a1a1a;
+  --fg-muted: #5a5a5a;
+  --fg-faint: #8a8a8a;
+  --bg: #fdfdfa;
+  --bg-elev: #f4f3ee;
+  --accent: #2563eb;
+  --border: #e5e3dc;
+  --code-bg: #f5f4ef;
+  --strike: #b00020;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e8e6df;
+    --fg-muted: #b0aea7;
+    --fg-faint: #888680;
+    --bg: #1d1d1b;
+    --bg-elev: #262624;
+    --accent: #6ea8fe;
+    --border: #353330;
+    --code-bg: #2a2a28;
+    --strike: #ef9a9a;
+  }
+}
+* { box-sizing: border-box; }
+html { font-size: 16px; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: Georgia, "Iowan Old Style", "Palatino Linotype", serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 0.06em; }
+a:hover { text-decoration-thickness: 0.12em; }
+
+/* Top nav */
+nav.site-nav {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 0.7em 1em;
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  font-size: 0.95em;
+  z-index: 10;
+}
+nav.site-nav .site-title {
+  font-weight: 600;
+  margin-right: auto;
+  color: var(--fg);
+  text-decoration: none;
+}
+nav.site-nav a { text-decoration: none; color: var(--fg-muted); }
+nav.site-nav a:hover { color: var(--fg); }
+nav.site-nav input.site-search {
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--fg);
+  padding: 0.3em 0.6em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  min-width: 160px;
+}
+
+/* Page layout */
+.page {
+  max-width: 60em;
+  margin: 0 auto;
+  padding: 2em 1em 4em;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 14em;
+  gap: 2em;
+}
+@media (max-width: 720px) {
+  .page { grid-template-columns: 1fr; }
+}
+article { min-width: 0; }
+aside.note-meta {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  font-size: 0.85em;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--border);
+  padding-left: 1em;
+}
+aside.note-meta h3 {
+  font-size: 0.7em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-faint);
+  margin: 0 0 0.4em;
+}
+aside.note-meta ul { list-style: none; padding: 0; margin: 0 0 1.5em; }
+aside.note-meta li { margin-bottom: 0.25em; }
+aside.note-meta a { color: var(--fg); text-decoration: none; }
+aside.note-meta a:hover { text-decoration: underline; }
+
+/* Article body */
+article h1, article h2, article h3 {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  font-weight: 600;
+  line-height: 1.25;
+}
+article h1 { font-size: 1.9em; margin-top: 0; }
+article h2 { font-size: 1.3em; margin-top: 1.6em; border-bottom: 1px solid var(--border); padding-bottom: 0.2em; }
+article h3 { font-size: 1.1em; margin-top: 1.2em; }
+article p { margin: 0 0 1em; }
+article img { max-width: 100%; height: auto; }
+article code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0.05em 0.35em;
+}
+article pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.7em 0.9em;
+  overflow-x: auto;
+}
+article pre code { background: none; border: none; padding: 0; }
+article blockquote {
+  margin: 1em 0;
+  padding: 0.3em 1em;
+  border-left: 3px solid var(--border);
+  color: var(--fg-muted);
+}
+article .wikilink-broken { text-decoration: line-through; color: var(--strike); }
+
+/* Per-note backlinks */
+.backlinks {
+  margin-top: 3em;
+  padding-top: 1em;
+  border-top: 1px solid var(--border);
+}
+.backlinks h2 {
+  font-size: 0.9em;
+  font-weight: 600;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: none;
+  margin: 0 0 0.5em;
+}
+.backlinks ul { list-style: none; padding: 0; margin: 0; }
+.backlinks li { margin-bottom: 0.3em; }
+
+/* Tag cloud */
+.tag-cloud { display: flex; flex-wrap: wrap; gap: 0.5em; padding: 0; list-style: none; }
+.tag-cloud li a {
+  display: inline-block;
+  padding: 0.2em 0.7em;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--fg);
+  font-size: 0.9em;
+}
+.tag-cloud .count { color: var(--fg-faint); margin-left: 0.4em; font-size: 0.85em; }
+
+/* Search results */
+#search-results {
+  max-width: 60em;
+  margin: 0 auto;
+  padding: 0 1em;
+}
+#search-results.hidden { display: none; }
+#search-results .hit {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.6em 1em;
+  margin-bottom: 0.6em;
+  background: var(--bg-elev);
+}
+#search-results .hit h4 { margin: 0 0 0.2em; font-size: 1em; }
+#search-results .hit p { margin: 0; font-size: 0.85em; color: var(--fg-muted); }
+
+/* Footnotes / references — share styling with the note-html exporter
+ * shape but tone down to fit the calmer site palette. */
+.footnote-ref { font-size: 0.75em; vertical-align: super; line-height: 0; margin-left: 0.1em; }
+.footnote-back { margin-left: 0.4em; text-decoration: none; color: var(--accent); }
+.footnotes, .references {
+  margin-top: 3em;
+  padding-top: 1em;
+  border-top: 1px solid var(--border);
+  font-size: 0.92em;
+}
+.footnotes ol, .references ol { padding-left: 1.7em; }
+
+/* highlight.js minimal light scheme — same as note-html exporter. */
+.hljs-comment, .hljs-quote { color: #7a8288; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-addition { color: #8959a8; }
+.hljs-number, .hljs-literal, .hljs-variable, .hljs-template-variable, .hljs-tag .hljs-attr { color: #f5871f; }
+.hljs-string, .hljs-doctag, .hljs-link, .hljs-attribute { color: #718c00; }
+.hljs-title, .hljs-section, .hljs-name, .hljs-selector-id, .hljs-selector-class { color: #4271ae; }
+.hljs-type, .hljs-class .hljs-title { color: #c82829; }
+.hljs-symbol, .hljs-bullet, .hljs-built_in, .hljs-builtin-name { color: #3e999f; }
+`;

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -12,6 +12,7 @@ import { noteMarkdownExporter } from './exporters/note-markdown';
 import { noteHtmlExporter } from './exporters/note-html';
 import { notePdfExporter } from './exporters/note-pdf';
 import { treeHtmlExporter } from './exporters/tree-html';
+import { staticSiteExporter } from './exporters/static-site';
 import { pandocExporter } from './exporters/pandoc';
 import { bibtexExporter } from './exporters/bibtex';
 
@@ -21,6 +22,7 @@ export function registerBuiltinExporters(): void {
   registerExporter(noteHtmlExporter);
   registerExporter(notePdfExporter);
   registerExporter(treeHtmlExporter);
+  registerExporter(staticSiteExporter);
   registerExporter(pandocExporter);
   registerExporter(bibtexExporter);
 }

--- a/tests/main/publish/static-site.test.ts
+++ b/tests/main/publish/static-site.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Static-site exporter (#252).
+ *
+ * Verifies the v1 acceptance: per-note pages with backlinks, tag
+ * cloud + per-tag pages, consolidated bibliography, search index,
+ * shared style + script, broken-wiki-link strikethrough, private +
+ * config-filtered notes excluded from every output file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
+import { staticSiteExporter } from '../../../src/main/publish/exporters/static-site';
+import { buildSiteIndex } from '../../../src/main/publish/exporters/static-site/site-data';
+
+function mkProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-site-'));
+}
+
+describe('static-site exporter (#252)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkProject();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('emits one .html per note + style.css + search.js + search.json + index.html', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '---\ntitle: First\n---\n# First\n\nA note.\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '---\ntitle: Second\n---\n# Second\n\n[[a]]\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+
+    const paths = new Set(output.files.map((f) => f.path));
+    expect(paths.has('a.html')).toBe(true);
+    expect(paths.has('b.html')).toBe(true);
+    expect(paths.has('style.css')).toBe(true);
+    expect(paths.has('search.js')).toBe(true);
+    expect(paths.has('search.json')).toBe(true);
+    expect(paths.has('index.html')).toBe(true);
+  });
+
+  it('per-note page renders body + nav header + sidebar', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '---\ntitle: First\ntags: [philosophy, draft-test]\n---\n# First\n\nProse.\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const html = String(output.files.find((f) => f.path === 'a.html')!.contents);
+    expect(html).toContain('<title>First');
+    expect(html).toContain('<nav class="site-nav">');
+    expect(html).toContain('<input class="site-search"');
+    expect(html).toContain('<aside class="note-meta">');
+    expect(html).toContain('#philosophy');
+    expect(html).toContain('href="style.css"');
+    expect(html).toContain('src="search.js"');
+  });
+
+  it('backlinks section appears on the target note for each inbound wiki-link', async () => {
+    await fsp.writeFile(path.join(root, 'target.md'), '---\ntitle: Target\n---\n# Target\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'src1.md'), '---\ntitle: Source One\n---\n[[target]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'src2.md'), '---\ntitle: Source Two\n---\n[[target]]\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const html = String(output.files.find((f) => f.path === 'target.html')!.contents);
+    expect(html).toContain('<section class="backlinks">');
+    expect(html).toContain('Linked from');
+    expect(html).toContain('Source One');
+    expect(html).toContain('Source Two');
+  });
+
+  it('emits a tag cloud at tags/index.html and per-tag pages', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '---\ntitle: A\ntags: [foo]\n---\n# A\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'),
+      '---\ntitle: B\ntags: [foo, bar]\n---\n# B\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const cloud = String(output.files.find((f) => f.path === 'tags/index.html')!.contents);
+    expect(cloud).toContain('#foo');
+    expect(cloud).toContain('#bar');
+    // Tag cloud has counts per tag.
+    expect(cloud).toMatch(/#foo<span class="count">2/);
+    expect(cloud).toMatch(/#bar<span class="count">1/);
+
+    const fooPage = output.files.find((f) => f.path === 'tags/foo.html');
+    expect(fooPage).toBeDefined();
+    const fooHtml = String(fooPage!.contents);
+    expect(fooHtml).toContain('A');
+    expect(fooHtml).toContain('B');
+  });
+
+  it('emits references.html when at least one note cites a source', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n[[cite::foo-2020]]\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const refs = String(output.files.find((f) => f.path === 'references.html')!.contents);
+    expect(refs).toContain('References');
+    expect(refs).toContain('Foo');
+  });
+
+  it('omits references.html when nothing was cited', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\nno cites\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    expect(output.files.map((f) => f.path)).not.toContain('references.html');
+  });
+
+  it('private notes are excluded from every output file (including search index)', async () => {
+    await fsp.writeFile(path.join(root, 'public.md'), '---\ntitle: Public\n---\n# Public\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'private.md'),
+      '---\ntitle: Secret\nprivate: true\n---\n# Hush\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const paths = output.files.map((f) => f.path);
+    expect(paths).toContain('public.html');
+    expect(paths).not.toContain('private.html');
+    const search = JSON.parse(String(output.files.find((f) => f.path === 'search.json')!.contents));
+    const titles = (search as Array<{ title: string }>).map((r) => r.title);
+    expect(titles).toContain('Public');
+    expect(titles).not.toContain('Secret');
+  });
+
+  it('site-config landing override puts that note at index.html', async () => {
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/site-config.json'), JSON.stringify({
+      title: 'My Garden',
+      landing: 'home.md',
+    }), 'utf-8');
+    await fsp.writeFile(path.join(root, 'home.md'),
+      '---\ntitle: Welcome\n---\n# Welcome to my garden\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'other.md'),
+      '---\ntitle: Other\n---\n# Other\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    expect(indexHtml).toContain('Welcome to my garden');
+    expect(indexHtml).toContain('My Garden');
+  });
+
+  it('without a landing override, index.html lists every note alphabetically', async () => {
+    await fsp.writeFile(path.join(root, 'b.md'), '---\ntitle: B Note\n---\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'), '---\ntitle: A Note\n---\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const html = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    const aIdx = html.indexOf('A Note');
+    const bIdx = html.indexOf('B Note');
+    expect(aIdx).toBeGreaterThan(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  it('site-config.excludeTags drops tagged notes from the site', async () => {
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/site-config.json'), JSON.stringify({
+      excludeTags: ['draft'],
+    }), 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'), '---\ntitle: Public\ntags: [done]\n---\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '---\ntitle: WIP\ntags: [draft]\n---\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const paths = output.files.map((f) => f.path);
+    expect(paths).toContain('a.html');
+    expect(paths).not.toContain('b.html');
+  });
+
+  it('broken wiki-links render with a strikethrough class', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '---\ntitle: A\n---\n[[does-not-exist]]\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const html = String(output.files.find((f) => f.path === 'a.html')!.contents);
+    expect(html).toContain('class="wikilink-broken"');
+  });
+
+  it('depth-aware nav: a nested note links back up to root via ../', async () => {
+    await fsp.mkdir(path.join(root, 'sub/deep'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'sub/deep/leaf.md'),
+      '---\ntitle: Leaf\n---\n# Leaf\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const html = String(output.files.find((f) => f.path === 'sub/deep/leaf.html')!.contents);
+    // Two `../` to climb out of `sub/deep/`.
+    expect(html).toContain('href="../../style.css"');
+    expect(html).toContain('href="../../index.html"');
+    expect(html).toContain('src="../../search.js"');
+  });
+
+  it('search.json contains a title and snippet per included note', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '---\ntitle: First\n---\n# First\n\nThis is the body of the first note with some words.\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const output = await runExporter(staticSiteExporter, plan);
+    const records = JSON.parse(String(output.files.find((f) => f.path === 'search.json')!.contents));
+    expect(records).toHaveLength(1);
+    expect(records[0].title).toBe('First');
+    expect(records[0].url).toBe('a.html');
+    expect(records[0].snippet).toContain('body of the first note');
+  });
+
+  it('exposes the expected exporter id + label', () => {
+    expect(staticSiteExporter.id).toBe('static-site');
+    expect(staticSiteExporter.label).toBe('Project as Static Site');
+    expect(staticSiteExporter.acceptedKinds).toEqual(['project']);
+    expect(staticSiteExporter.accepts({ kind: 'project' })).toBe(true);
+    expect(staticSiteExporter.accepts({ kind: 'single-note' })).toBe(false);
+  });
+});
+
+describe('buildSiteIndex (#252) — index-builder unit tests', () => {
+  it('backlinks: A links to B → B has A in its backlinks', () => {
+    const notes = [
+      { relativePath: 'a.md', kind: 'note', content: '[[b]]', frontmatter: {}, title: 'A' },
+      { relativePath: 'b.md', kind: 'note', content: 'no links', frontmatter: {}, title: 'B' },
+    ] as const;
+    const index = buildSiteIndex(notes as never);
+    const bBacklinks = index.backlinks.get('b.md') ?? [];
+    expect(bBacklinks).toHaveLength(1);
+    expect(bBacklinks[0].relativePath).toBe('a.md');
+  });
+
+  it('backlinks: duplicate links from the same note dedupe', () => {
+    const notes = [
+      { relativePath: 'a.md', kind: 'note', content: '[[b]] and [[b]] again', frontmatter: {}, title: 'A' },
+      { relativePath: 'b.md', kind: 'note', content: '', frontmatter: {}, title: 'B' },
+    ] as const;
+    const index = buildSiteIndex(notes as never);
+    expect(index.backlinks.get('b.md')!.length).toBe(1);
+  });
+
+  it('tags: notes with the same tag cluster together', () => {
+    const notes = [
+      { relativePath: 'a.md', kind: 'note', content: '', frontmatter: { tags: ['foo'] }, title: 'A' },
+      { relativePath: 'b.md', kind: 'note', content: '', frontmatter: { tags: ['foo', 'bar'] }, title: 'B' },
+    ] as const;
+    const index = buildSiteIndex(notes as never);
+    expect(index.tags.get('foo')!.length).toBe(2);
+    expect(index.tags.get('bar')!.length).toBe(1);
+  });
+
+  it('search records: snippet strips frontmatter, headings, and code fences', () => {
+    const notes = [{
+      relativePath: 'a.md',
+      kind: 'note',
+      content: '---\ntitle: X\n---\n# Heading\n\nProse here. ```js\ncode\n``` more prose.',
+      frontmatter: {},
+      title: 'X',
+    }] as const;
+    const index = buildSiteIndex(notes as never);
+    const snippet = index.searchRecords[0].snippet;
+    expect(snippet).not.toContain('---');
+    expect(snippet).not.toContain('# Heading');
+    expect(snippet).not.toContain('```');
+    expect(snippet).toContain('Prose here');
+    expect(snippet).toContain('more prose');
+  });
+});


### PR DESCRIPTION
## Summary

New project-only exporter that renders the whole non-private thoughtbase as a browseable static site — a page per note, backlinks on every page, tag index, consolidated bibliography, client-side search. Output is a plain directory tree the user hosts on GitHub Pages, Netlify, S3, or wherever.

## What ships in v1

- **Per-note pages** with body (reuses note-html's markdown→HTML pipeline) + metadata sidebar (tags, date) + nav header (site title, Tags link, References link, search input) + per-note Backlinks footer
- **Tag cloud** at \`tags/index.html\` and per-tag list pages at \`tags/<tag>.html\`
- **Consolidated \`references.html\`** — de-dup'd via the same \`renderBibliographyFor()\` method that powers tree-html bundles (#300)
- **Client-side full-text search** — \`search.json\` index + bundled \`search.js\` that filters by case-insensitive substring against title + snippet, lazy-loads on first keystroke
- **Shared \`style.css\`** — light/dark theme via \`prefers-color-scheme\`, calm Georgia-serif body, sticky nav, sidebar that collapses to mobile
- **Broken wiki-links** render with line-through (\`.wikilink-broken\`) so the source mistake is visible in the published site
- **Depth-aware rooting**: a nested note at \`sub/deep/leaf.md\` correctly links back to root via \`../../style.css\` etc.
- **Landing page**: configured note (per \`.minerva/site-config.json\`'s \`landing\`) or generated "All Notes" alphabetical list when unset
- **Site filters**: \`.minerva/site-config.json\` \`excludeTags\` + \`excludeFolders\` drop notes from every output file, including the search index

## Site config (\`.minerva/site-config.json\`, optional)

\`\`\`json
{
  "title": "My Garden",
  "baseUrl": "",
  "landing": "notes/home.md",
  "showBacklinks": true,
  "excludeTags": ["draft"],
  "excludeFolders": ["inbox"]
}
\`\`\`

Defaults are applied for any missing field, so an empty / absent config still produces a usable site.

## Deferred to follow-ups (per scope discussion)

- **Graph view** (\`graph.html\`) — needs a bundled force-layout library, separate ticket
- **Pretty URLs** without \`.html\` extension — depends on hosting
- **Theme tokenisation** beyond the bundled "garden" palette
- **Incremental rebuild** — full rebuild every time is fast enough for <5000 notes

## Closes

Resolves #252 (with the four deferrals above flagged for follow-up tickets).

## Test plan

- [x] \`pnpm vitest run tests/main/publish/static-site.test.ts\` — 18/18 covering: file shape, per-note page contents, backlinks, tag cloud + per-tag pages, references emission/omission, private-note exclusion (incl. search index), landing override, all-notes fallback, excludeTags filter, broken-link strikethrough, depth-aware nav rooting, search index records, plus index-builder unit tests
- [x] \`pnpm vitest run tests/main/publish\` — 230/230
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a small project, \`python -m http.server\` in the output dir, click around — confirm nav works, search filters as you type, backlinks point at the right notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)