### PR TITLE
Publication: per-export exclusion override in preview dialog (#283)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1097,6 +1097,7 @@ export function registerIpcHandlers(): void {
     linkPolicy?: publish.LinkPolicy;
     citationStyle?: string;
     citationLocale?: string;
+    forceInclude?: string[];
   }) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
@@ -1104,6 +1105,7 @@ export function registerIpcHandlers(): void {
       linkPolicy: opts?.linkPolicy,
       citationStyle: opts?.citationStyle,
       citationLocale: opts?.citationLocale,
+      forceInclude: opts?.forceInclude,
     });
     // Strip `content` + `frontmatter` from the wire payload — the preview
     // only needs to audit paths, kinds, and exclusion reasons; loading
@@ -1124,6 +1126,7 @@ export function registerIpcHandlers(): void {
         relativePath: f.relativePath,
         kind: f.kind,
         title: f.title,
+        overridden: f.overridden ?? false,
       })),
       excluded: plan.excluded,
       citations: {

--- a/src/main/publish/pipeline.ts
+++ b/src/main/publish/pipeline.ts
@@ -36,6 +36,14 @@ export interface ResolvePlanOptions {
   citationStyle?: string;
   citationLocale?: string;
   outputDir?: string;
+  /**
+   * Manual per-export exclusion override (#283). Paths in this set are
+   * force-included even when the exclusion rules would otherwise drop
+   * them (private folder, `private: true` frontmatter, `#private` tag).
+   * The plan's `inputs` row for an overridden file carries
+   * `overridden: true` so the preview dialog can render the badge.
+   */
+  forceInclude?: string[];
 }
 
 export async function resolvePlan(
@@ -45,8 +53,9 @@ export async function resolvePlan(
 ): Promise<ExportPlan> {
   let inputs: ExportPlanFile[];
   let excluded: ExportPlanExclusion[];
+  const forceInclude = new Set(opts.forceInclude ?? []);
   if (input.kind === 'tree') {
-    ({ inputs, excluded } = await collectTreeEntries(rootPath, input));
+    ({ inputs, excluded } = await collectTreeEntries(rootPath, input, forceInclude));
   } else if (input.kind === 'source') {
     // Source-as-input (#253): the exporter pulls the source body +
     // related excerpts + linking notes itself; the pipeline just needs
@@ -56,7 +65,7 @@ export async function resolvePlan(
     // uniformly across exporters.
     ({ inputs, excluded } = await collectSourceEntry(rootPath, input));
   } else {
-    ({ inputs, excluded } = await collectFilesystemEntries(rootPath, input));
+    ({ inputs, excluded } = await collectFilesystemEntries(rootPath, input, forceInclude));
   }
 
   const citations = await loadCitationAssets(rootPath, {
@@ -113,6 +122,7 @@ async function collectSourceEntry(
 async function collectTreeEntries(
   rootPath: string,
   input: ExportInput,
+  forceInclude: Set<string> = new Set(),
 ): Promise<{ inputs: ExportPlanFile[]; excluded: ExportPlanExclusion[] }> {
   if (!input.relativePath) {
     throw new Error('Tree export requires a root note (input.relativePath).');
@@ -128,17 +138,28 @@ async function collectTreeEntries(
         return null;
       }
     },
-    isExcluded: (rel: string, content: string) => checkExclusion(rel, content),
+    isExcluded: (rel: string, content: string) => {
+      // Force-included paths bypass exclusion entirely (#283); tree
+      // resolution still walks them as bridges between other notes.
+      if (forceInclude.has(rel)) return { excluded: false };
+      return checkExclusion(rel, content);
+    },
   });
 
   const inputs: ExportPlanFile[] = tree.included.map((entry) => {
     const { frontmatter, title } = parseHeader(entry.relativePath, entry.content);
+    // `overridden` flag is only meaningful for files that *would* have
+    // been excluded — re-evaluate the rule so legitimately-included
+    // files don't wear an unwarranted "overridden" badge.
+    const wouldExclude = forceInclude.has(entry.relativePath)
+      && checkExclusion(entry.relativePath, entry.content).excluded;
     return {
       relativePath: entry.relativePath,
       kind: 'note',
       content: entry.content,
       frontmatter,
       title,
+      overridden: wouldExclude,
     };
   });
   const excluded: ExportPlanExclusion[] = tree.excluded.map((e) => ({
@@ -153,6 +174,7 @@ async function collectTreeEntries(
 async function collectFilesystemEntries(
   rootPath: string,
   input: ExportInput,
+  forceInclude: Set<string> = new Set(),
 ): Promise<{ inputs: ExportPlanFile[]; excluded: ExportPlanExclusion[] }> {
   const candidatePaths = await collectCandidatePaths(rootPath, input);
 
@@ -169,7 +191,7 @@ async function collectFilesystemEntries(
     }
 
     const check = checkExclusion(rel, content);
-    if (check.excluded) {
+    if (check.excluded && !forceInclude.has(rel)) {
       excluded.push({ relativePath: rel, reason: check.reason ?? 'excluded' });
       continue;
     }
@@ -179,6 +201,7 @@ async function collectFilesystemEntries(
       kind: 'note',
       content,
       frontmatter,
+      overridden: check.excluded,
       title,
     });
   }

--- a/src/main/publish/run-export.ts
+++ b/src/main/publish/run-export.ts
@@ -25,6 +25,12 @@ export interface RunExportInput {
   citationStyle?: string;
   /** CSL locale id (#301). Falls back to en-US. */
   citationLocale?: string;
+  /**
+   * Manual exclusion overrides: paths the user re-included via the
+   * preview dialog (#283). Force-included regardless of the
+   * private-by-default rules.
+   */
+  forceInclude?: string[];
 }
 
 export interface RunExportResult {
@@ -54,6 +60,7 @@ export async function runExport(
     assetPolicy: args.assetPolicy,
     citationStyle: args.citationStyle,
     citationLocale: args.citationLocale,
+    forceInclude: args.forceInclude,
     outputDir: args.outputDir,
   });
   const output = await runExporter(exporter, plan);

--- a/src/main/publish/types.ts
+++ b/src/main/publish/types.ts
@@ -66,6 +66,13 @@ export interface ExportPlanFile {
   frontmatter: Record<string, unknown>;
   /** Title for link-resolver display — frontmatter.title, H1, or filename stem. */
   title: string;
+  /**
+   * True when the user manually re-included this file via the preview
+   * dialog's exclusion override (#283). The pipeline would otherwise
+   * have dropped it via the private-by-default rules. Surfaced so the
+   * preview can render an "overridden" badge.
+   */
+  overridden?: boolean;
 }
 
 export interface ExportPlanExclusion {

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -36,6 +36,17 @@
   let error = $state<string | null>(null);
   let acceptedKinds = $state<readonly Scope[]>(['single-note', 'folder', 'project']);
   let acceptedLoaded = $state(false);
+  // Per-export exclusion overrides (#283). Set of relative paths the
+  // user has explicitly re-included; the pipeline force-includes them
+  // even when the private-by-default rules would otherwise exclude.
+  let overrides = $state(new Set<string>());
+
+  function toggleOverride(relativePath: string): void {
+    const next = new Set(overrides);
+    if (next.has(relativePath)) next.delete(relativePath);
+    else next.add(relativePath);
+    overrides = next;
+  }
 
   const activeFolder = $derived.by(() => {
     if (!activeFilePath) return '';
@@ -68,6 +79,7 @@
         linkPolicy,
         citationStyle,
         citationLocale,
+        forceInclude: [...overrides],
       });
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
@@ -110,6 +122,7 @@
     void citationStyle;
     void citationLocale;
     void activeFilePath;
+    void overrides;
     if (!acceptedLoaded) return;
     void refreshPlan();
   });
@@ -125,6 +138,7 @@
         linkPolicy,
         citationStyle,
         citationLocale,
+        forceInclude: [...overrides],
       });
       if (result === null) return; // user cancelled the directory picker
       onExported(result);
@@ -213,14 +227,30 @@
     {:else if plan}
       <div class="audit">
         <div class="audit-section">
-          <h3>Including <span class="count">{plan.inputs.length}</span></h3>
+          <h3>
+            Including <span class="count">{plan.inputs.length}</span>
+            {#if overrides.size > 0}
+              <span class="count override-count" title="{overrides.size} item{overrides.size === 1 ? '' : 's'} re-included via override">
+                {overrides.size} overridden
+              </span>
+            {/if}
+          </h3>
           {#if plan.inputs.length === 0}
             <p class="empty">Nothing to export in this scope.</p>
           {:else}
             <ul>
               {#each plan.inputs.slice(0, 40) as f (f.relativePath)}
-                <li>
-                  <span class="title">{f.title}</span>
+                <li class:overridden={f.overridden}>
+                  <span class="title">
+                    {f.title}
+                    {#if f.overridden}
+                      <button
+                        class="badge-btn"
+                        onclick={() => toggleOverride(f.relativePath)}
+                        title="Click to remove the override and exclude this note again"
+                      >overridden ✕</button>
+                    {/if}
+                  </span>
                   <span class="path">{f.relativePath}</span>
                 </li>
               {/each}
@@ -236,9 +266,15 @@
           {#if plan.excluded.length === 0}
             <p class="empty">Nothing excluded.</p>
           {:else}
+            <p class="hint">Click any excluded row to re-include it in this export.</p>
             <ul>
               {#each plan.excluded.slice(0, 40) as ex (ex.relativePath)}
-                <li>
+                <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions -->
+                <li
+                  class="clickable"
+                  onclick={() => toggleOverride(ex.relativePath)}
+                  title="Click to re-include in the export"
+                >
                   <span class="title">{ex.relativePath}</span>
                   <span class="reason">{ex.reason}</span>
                 </li>
@@ -439,6 +475,43 @@
     font-size: 11px;
     color: var(--text-muted);
     font-style: italic;
+  }
+
+  /* Excluded-row click affordance + override badge (#283). */
+  .audit-section li.clickable {
+    cursor: pointer;
+  }
+  .audit-section li.clickable:hover {
+    background: var(--bg-button);
+  }
+  .audit-section .hint {
+    margin: 0 0 6px;
+    font-size: 10px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .audit-section li.overridden .title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .audit-section .badge-btn {
+    background: var(--bg-button);
+    color: var(--accent);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 9px;
+    font-weight: 500;
+    padding: 1px 8px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .audit-section .badge-btn:hover { background: var(--bg-button-hover); }
+  .audit-section .override-count {
+    background: var(--bg-button);
+    color: var(--accent);
+    font-weight: 600;
   }
 
   /* Citations span the full grid width — they're a separate concern from

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -189,7 +189,7 @@ export interface CitationAuditPayload {
 export interface ExportPreviewPlan {
   exporterId: string;
   exporterLabel: string;
-  inputs: Array<{ relativePath: string; kind: 'note' | 'source' | 'excerpt'; title: string }>;
+  inputs: Array<{ relativePath: string; kind: 'note' | 'source' | 'excerpt'; title: string; overridden: boolean }>;
   excluded: Array<{ relativePath: string; reason: string }>;
   citations: CitationAuditPayload;
 }
@@ -207,6 +207,8 @@ export interface RunExportInput {
   linkPolicy?: 'drop' | 'inline-title' | 'follow-to-file';
   citationStyle?: string;
   citationLocale?: string;
+  /** Manual per-export exclusion overrides — relative paths to force-include (#283). */
+  forceInclude?: string[];
 }
 
 export interface RunExportResult {
@@ -227,6 +229,7 @@ export interface PublishApi {
       linkPolicy?: RunExportInput['linkPolicy'];
       citationStyle?: string;
       citationLocale?: string;
+      forceInclude?: string[];
     },
   ): Promise<ExportPreviewPlan>;
   /**

--- a/tests/main/publish/force-include.test.ts
+++ b/tests/main/publish/force-include.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Per-export exclusion override (#283).
+ *
+ * The dialog lets the user click a row in the Excluded list to
+ * re-include it. The pipeline honours that via `forceInclude` in
+ * `ResolvePlanOptions`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { resolvePlan } from '../../../src/main/publish/pipeline';
+
+function mkProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-force-include-'));
+}
+
+describe('forceInclude — per-export exclusion override (#283)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkProject();
+    await fsp.writeFile(path.join(root, 'public.md'),
+      '---\ntitle: Public\n---\n# Public\n', 'utf-8');
+    await fsp.mkdir(path.join(root, 'private'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'private/secret.md'),
+      '---\ntitle: Secret\n---\n# Secret\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'flag.md'),
+      '---\ntitle: Flagged\nprivate: true\n---\n# Flagged\n', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('without forceInclude: private/ folder + private:true frontmatter excluded as usual', async () => {
+    const plan = await resolvePlan(root, { kind: 'project' });
+    const includedPaths = plan.inputs.map((f) => f.relativePath).sort();
+    expect(includedPaths).toEqual(['public.md']);
+    expect(plan.excluded.map((e) => e.relativePath).sort()).toEqual(['flag.md', 'private/secret.md']);
+  });
+
+  it('forceInclude moves a path from excluded into included with overridden:true', async () => {
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { forceInclude: ['private/secret.md'] },
+    );
+    const paths = plan.inputs.map((f) => f.relativePath).sort();
+    expect(paths).toEqual(['private/secret.md', 'public.md']);
+    const overridden = plan.inputs.find((f) => f.relativePath === 'private/secret.md');
+    expect(overridden?.overridden).toBe(true);
+    // The other included file is *not* overridden — it was always included.
+    const normal = plan.inputs.find((f) => f.relativePath === 'public.md');
+    expect(normal?.overridden).toBe(false);
+    // And it's no longer in the excluded list.
+    expect(plan.excluded.map((e) => e.relativePath)).not.toContain('private/secret.md');
+  });
+
+  it('forceInclude can re-include multiple paths in one export', async () => {
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { forceInclude: ['private/secret.md', 'flag.md'] },
+    );
+    const paths = plan.inputs.map((f) => f.relativePath).sort();
+    expect(paths).toEqual(['flag.md', 'private/secret.md', 'public.md']);
+    expect(plan.excluded).toEqual([]);
+    expect(plan.inputs.find((f) => f.relativePath === 'flag.md')?.overridden).toBe(true);
+    expect(plan.inputs.find((f) => f.relativePath === 'private/secret.md')?.overridden).toBe(true);
+  });
+
+  it('forceInclude on a path that was never excluded leaves overridden as false', async () => {
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { forceInclude: ['public.md'] },
+    );
+    const pub = plan.inputs.find((f) => f.relativePath === 'public.md');
+    expect(pub?.overridden).toBe(false);
+  });
+
+  it('tree mode honours forceInclude for an otherwise-private linked note', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '---\ntitle: Root\n---\n# Root\n\n[[private/secret]]\n', 'utf-8');
+    // Re-write secret to be reachable in the tree.
+    const planWithoutOverride = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'root.md', maxDepth: 2 },
+    );
+    expect(planWithoutOverride.inputs.map((f) => f.relativePath)).not.toContain('private/secret.md');
+
+    const planWithOverride = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'root.md', maxDepth: 2 },
+      { forceInclude: ['private/secret.md'] },
+    );
+    const secret = planWithOverride.inputs.find((f) => f.relativePath === 'private/secret.md');
+    expect(secret).toBeDefined();
+    expect(secret?.overridden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Excluded rows in the Export preview are now clickable to re-include the file in this one export — without editing tags or moving the file out of \`private/\`. The re-included row carries an "overridden" badge in the Including list (also clickable, to remove the override), and the Including header shows an audit count ("3 overridden") so the user can't accidentally ship something they meant to keep private.

## How

### Pipeline
- New \`forceInclude: string[]\` option on \`ResolvePlanOptions\` and \`RunExportInput\`. Paths in this set bypass the private-by-default rules in both filesystem and tree resolution.
- \`ExportPlanFile\` grew an \`overridden\` flag, **only set true when the file would have been excluded but for the override** — legitimately-included files don't wear an unwarranted badge.
- Tree mode re-evaluates the exclusion rule per included entry to set the flag correctly (the tree resolver doesn't surface that signal on its own).

### UI
- Dialog tracks overrides in a \`Set<string>\`; \`$effect\` re-resolves on every toggle so the audit list reflects the current selection.
- **Excluded rows**: clickable; hover reveals affordance via background change. Hint line at the top: "Click any excluded row to re-include it in this export."
- **Including rows with \`overridden: true\`**: small \`OVERRIDDEN ✕\` badge that's itself a click target to remove the override and exclude the note again.
- **Including header**: extra count chip "{N} overridden" when any are active, so the audit total stays visible even when the inputs list is scrolled.

## Closes

Resolves #283.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/force-include.test.ts\` — 5/5 covering: default exclusions still fire, single force-include moves a path with overridden:true, multiple paths, force-including a never-excluded path leaves overridden:false, tree mode honours forceInclude.
- [x] \`pnpm vitest run tests/main/publish\` — 247/247
- [x] \`pnpm lint\` — clean
- [ ] Manual: open the Export dialog with a project containing private notes, click an excluded row, confirm it appears in Including with the badge; click the badge, confirm it returns to Excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)