### PR TITLE
Publication: tree-PDF concatenated single-PDF exporter (#290)

### DIFF
--- a/src/main/publish/exporters/tree-pdf.ts
+++ b/src/main/publish/exporters/tree-pdf.ts
@@ -1,0 +1,229 @@
+/**
+ * Note-tree single-PDF exporter (#290).
+ *
+ * Walks the root note's wiki-link closure (using the same
+ * tree-resolved plan that powers tree-html, #251), concatenates every
+ * reachable note into one HTML document with a table-of-contents and
+ * page breaks between notes, then rasterises the result via the PDF
+ * pipeline (#249).
+ *
+ * Differs from `tree-html`'s multi-file bundle: this exporter
+ * produces a single self-contained PDF. Cross-links inside the
+ * concatenated document resolve to in-document anchors so the
+ * reader can click an inter-note reference and jump to that
+ * chapter. Citations consolidate at the end via the same
+ * `renderBibliographyFor` API tree-html uses (#300).
+ */
+
+import { app } from 'electron';
+import { renderNoteBody } from './note-html/render';
+import { renderFootnotesSection } from './note-html';
+import { resolveRenderOptions, toPrintToPdfArgs } from './note-pdf/options';
+import { renderPdfFromHtml } from './note-pdf/electron-render';
+import { NOTE_HTML_STYLE } from './note-html/style';
+import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../types';
+
+export interface BuildTreePdfHtmlResult {
+  html: string;
+  documentTitle: string;
+  chapterCount: number;
+}
+
+/**
+ * Pure HTML assembly — split out from `run()` so the bulk of the
+ * exporter can be unit-tested without spinning up an Electron runtime
+ * (Electron only kicks in inside `renderPdfFromHtml`).
+ */
+export function buildTreePdfHtml(plan: ExportPlan): BuildTreePdfHtmlResult {
+  const notes = plan.inputs.filter((f) => f.kind === 'note');
+  if (notes.length === 0) {
+    return { html: '', documentTitle: '', chapterCount: 0 };
+  }
+  const rootNote = notes[0];
+
+  const allCitedIds = new Set<string>();
+  let isNoteStyle = false;
+  const chapters: Array<{ note: ExportPlanFile; html: string }> = [];
+
+  // Force follow-to-file so the cite rule and wiki-link rule emit
+  // anchor tags. We then post-process those into in-document `#anchors`.
+  const chapterPlan: ExportPlan = { ...plan, linkPolicy: 'follow-to-file' };
+
+  for (const note of notes) {
+    const renderer = chapterPlan.citations?.createRenderer();
+    const rawBody = renderNoteBody(note, chapterPlan, renderer);
+    const withFootnotes = renderer ? `${rawBody}${renderFootnotesSection(renderer)}` : rawBody;
+    const rewritten = rewriteInterChapterLinks(withFootnotes, notes, rootNote);
+    chapters.push({ note, html: rewritten });
+    if (renderer) {
+      for (const id of renderer.cited()) allCitedIds.add(id);
+      if (renderer.isNoteStyle) isNoteStyle = true;
+    }
+  }
+
+  // Consolidated bibliography across the whole document.
+  let bibSection = '';
+  if (allCitedIds.size > 0 && plan.citations) {
+    const consolidator = plan.citations.createRenderer();
+    const bib = consolidator.renderBibliographyFor([...allCitedIds]);
+    if (bib.entries.length > 0) {
+      const heading = isNoteStyle ? 'Bibliography' : 'References';
+      bibSection = `<section class="references" id="chapter-bibliography">
+  <h1>${heading}</h1>
+  <ol>${bib.entries.map((e) => `<li>${e}</li>`).join('')}</ol>
+</section>`;
+    }
+  }
+
+  const documentTitle = rootNote.title;
+  const tocItems = chapters.map((c, idx) => {
+    const chapterNum = idx + 1;
+    return `<li><a href="#${anchorFor(c.note, rootNote)}"><span class="toc-num">${chapterNum}.</span> ${escapeHtml(c.note.title)}</a></li>`;
+  });
+  if (bibSection) {
+    tocItems.push(`<li><a href="#chapter-bibliography">${isNoteStyle ? 'Bibliography' : 'References'}</a></li>`);
+  }
+  const tocHtml = `<nav class="tree-pdf-toc">
+  <h1>Contents</h1>
+  <ol>${tocItems.join('')}</ol>
+</nav>`;
+
+  const chaptersHtml = chapters.map((c, idx) => (
+    `<section class="tree-pdf-chapter" id="${anchorFor(c.note, rootNote)}">
+  <header class="chapter-header"><span class="chapter-num">Chapter ${idx + 1}</span></header>
+  ${c.html}
+</section>`
+  )).join('\n');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(documentTitle)}</title>
+  <style>${NOTE_HTML_STYLE}${TREE_PDF_EXTRA_STYLE}</style>
+</head>
+<body>
+<article>
+<section class="tree-pdf-title-page">
+  <h1 class="document-title">${escapeHtml(documentTitle)}</h1>
+</section>
+${tocHtml}
+${chaptersHtml}
+${bibSection}
+</article>
+</body>
+</html>`;
+
+  return { html, documentTitle, chapterCount: chapters.length };
+}
+
+export const treePdfExporter: Exporter = {
+  id: 'tree-pdf',
+  label: 'Note Tree as Single PDF',
+  // Same input shape as tree-html — walking the wiki-link closure is
+  // the whole point.
+  accepts: (input) => input.kind === 'tree',
+  acceptedKinds: ['tree'],
+  async run(plan) {
+    const built = buildTreePdfHtml(plan);
+    if (built.chapterCount === 0) {
+      return { files: [], summary: 'Nothing to export in this tree.' };
+    }
+    const renderOptions = resolveRenderOptions(app.getLocale(), { title: built.documentTitle });
+    const args = toPrintToPdfArgs(renderOptions);
+    const pdf = await renderPdfFromHtml(built.html, args);
+    const files: ExportOutput['files'] = [
+      { path: `${slugify(built.documentTitle)}.pdf`, contents: pdf },
+    ];
+    const excluded = plan.excluded.length;
+    const summary = excluded > 0
+      ? `PDF bundle of ${built.chapterCount} chapter${built.chapterCount === 1 ? '' : 's'} (${excluded} excluded).`
+      : `PDF bundle of ${built.chapterCount} chapter${built.chapterCount === 1 ? '' : 's'}.`;
+    return { files, summary };
+  },
+};
+
+/** Stable per-note anchor id used in the TOC + intra-document links. */
+function anchorFor(note: ExportPlanFile, rootNote: ExportPlanFile): string {
+  if (note.relativePath === rootNote.relativePath) return 'chapter-root';
+  return `chapter-${slugify(note.relativePath.replace(/\.md$/i, ''))}`;
+}
+
+/**
+ * Rewrite inter-note `<a href="...html">` links emitted by the
+ * follow-to-file resolver into in-document `#chapter-*` anchors so
+ * reader clicks jump within the PDF instead of trying to open a
+ * non-existent file.
+ */
+function rewriteInterChapterLinks(
+  html: string,
+  notes: ExportPlanFile[],
+  rootNote: ExportPlanFile,
+): string {
+  let out = html;
+  for (const target of notes) {
+    const targetHtml = target.relativePath.replace(/\.md$/i, '.html');
+    const anchor = `#${anchorFor(target, rootNote)}`;
+    // Match both bare `href="x.html"` and the relative-path variants
+    // the link resolver might emit (e.g. `notes/x.html`).
+    const re = new RegExp(`href="(?:\\./)?${escapeRegex(targetHtml)}(?:#[^"]*)?"`, 'g');
+    out = out.replace(re, `href="${anchor}"`);
+  }
+  return out;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'document';
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+const TREE_PDF_EXTRA_STYLE = `
+.tree-pdf-title-page {
+  text-align: center;
+  margin: 8em 0;
+  page-break-after: always;
+}
+.tree-pdf-title-page .document-title {
+  font-size: 2.4em;
+  margin: 0;
+  border-bottom: none;
+}
+.tree-pdf-toc {
+  page-break-after: always;
+  margin: 0 auto 2em;
+}
+.tree-pdf-toc h1 { border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
+.tree-pdf-toc ol { list-style: none; padding-left: 0; }
+.tree-pdf-toc li { margin: 0.3em 0; font-size: 1em; }
+.tree-pdf-toc .toc-num {
+  display: inline-block;
+  min-width: 2.4em;
+  color: var(--fg-muted, #4a4a4a);
+}
+.tree-pdf-toc a { text-decoration: none; color: var(--fg, #1a1a1a); }
+.tree-pdf-toc a:hover { text-decoration: underline; }
+.tree-pdf-chapter {
+  page-break-before: always;
+}
+.tree-pdf-chapter .chapter-header {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted, #4a4a4a);
+  margin-bottom: 0.5em;
+}
+@media print {
+  .tree-pdf-toc, .tree-pdf-chapter, .tree-pdf-title-page { page-break-inside: auto; }
+}
+`;

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -12,6 +12,7 @@ import { noteMarkdownExporter } from './exporters/note-markdown';
 import { noteHtmlExporter } from './exporters/note-html';
 import { notePdfExporter } from './exporters/note-pdf';
 import { treeHtmlExporter } from './exporters/tree-html';
+import { treePdfExporter } from './exporters/tree-pdf';
 import { staticSiteExporter } from './exporters/static-site';
 import { annotatedReadingExporter } from './exporters/annotated-reading';
 import { pandocExporter } from './exporters/pandoc';
@@ -23,6 +24,7 @@ export function registerBuiltinExporters(): void {
   registerExporter(noteHtmlExporter);
   registerExporter(notePdfExporter);
   registerExporter(treeHtmlExporter);
+  registerExporter(treePdfExporter);
   registerExporter(staticSiteExporter);
   registerExporter(annotatedReadingExporter);
   registerExporter(pandocExporter);

--- a/tests/main/publish/tree-pdf.test.ts
+++ b/tests/main/publish/tree-pdf.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tree-PDF concatenation builder (#290).
+ *
+ * Covers the pure HTML-assembly side. Electron's `printToPDF` rendering
+ * is exercised at runtime — this suite validates the shape of the
+ * concatenated HTML the rasteriser eventually consumes: TOC, chapter
+ * order, in-document anchor linking, page-break CSS, consolidated
+ * bibliography.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { resolvePlan } from '../../../src/main/publish/pipeline';
+import { buildTreePdfHtml, treePdfExporter } from '../../../src/main/publish/exporters/tree-pdf';
+
+function mkProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tree-pdf-'));
+}
+
+describe('tree-pdf builder (#290)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('concatenates all reachable notes in BFS order with TOC + chapter sections', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '---\ntitle: The Thesis\n---\n# The Thesis\n\nLinks to [[ch1]] and [[ch2]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'ch1.md'),
+      '---\ntitle: Chapter One\n---\n# Chapter One\n\nThe first chapter.\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'ch2.md'),
+      '---\ntitle: Chapter Two\n---\n# Chapter Two\n\nThe second chapter.\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 3 });
+    const built = buildTreePdfHtml(plan);
+    expect(built.chapterCount).toBe(3);
+    expect(built.documentTitle).toBe('The Thesis');
+    // Title page + TOC + 3 chapter sections.
+    expect(built.html).toContain('<section class="tree-pdf-title-page">');
+    expect(built.html).toContain('<nav class="tree-pdf-toc">');
+    expect((built.html.match(/class="tree-pdf-chapter"/g) ?? []).length).toBe(3);
+    // TOC has each title in BFS order.
+    const tocBlock = built.html.match(/<nav class="tree-pdf-toc">[\s\S]*?<\/nav>/)![0];
+    const order = ['The Thesis', 'Chapter One', 'Chapter Two'];
+    let lastIdx = -1;
+    for (const t of order) {
+      const idx = tocBlock.indexOf(t);
+      expect(idx).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+  });
+
+  it('TOC links target intra-document chapter anchors', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'), '# Root\n[[chap]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'chap.md'),
+      '---\ntitle: A Chapter\n---\n# A Chapter\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const built = buildTreePdfHtml(plan);
+    expect(built.html).toContain('href="#chapter-root"');
+    expect(built.html).toContain('href="#chapter-chap"');
+    expect(built.html).toContain('id="chapter-root"');
+    expect(built.html).toContain('id="chapter-chap"');
+  });
+
+  it('inter-chapter wiki-links rewrite to in-document anchors (no broken file refs)', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '# Root\n\nSee [[chap]] for details.\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'chap.md'),
+      '---\ntitle: A Chapter\n---\n# A Chapter\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const built = buildTreePdfHtml(plan);
+    // No inter-note references that would fail in a single-file PDF.
+    expect(built.html).not.toContain('href="chap.html"');
+    expect(built.html).not.toContain('href="./chap.html"');
+    // The link to chap from root's body got rewritten to the anchor.
+    expect(built.html).toContain('href="#chapter-chap"');
+  });
+
+  it('emits page-break CSS so chapters start on fresh pages', async () => {
+    await fsp.writeFile(path.join(root, 'r.md'), '# R\n[[c]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'c.md'), '# C\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'r.md', maxDepth: 2 });
+    const built = buildTreePdfHtml(plan);
+    expect(built.html).toContain('.tree-pdf-chapter {');
+    expect(built.html).toContain('page-break-before: always');
+    expect(built.html).toContain('.tree-pdf-title-page');
+    expect(built.html).toContain('page-break-after: always');
+  });
+
+  it('frontmatter title beats H1 for chapter heading', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '---\ntitle: From Frontmatter\n---\n# Different In Body\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 1 });
+    const built = buildTreePdfHtml(plan);
+    expect(built.documentTitle).toBe('From Frontmatter');
+    // TOC entry uses frontmatter title.
+    expect(built.html).toMatch(/<nav class="tree-pdf-toc">[\s\S]*?From Frontmatter[\s\S]*?<\/nav>/);
+  });
+
+  it('consolidated bibliography appears once across all chapters', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '# Root\n[[a]]\nCites [[cite::foo-2020]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\nAlso cites [[cite::foo-2020]]\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const built = buildTreePdfHtml(plan);
+    expect(built.html).toContain('id="chapter-bibliography"');
+    expect(built.html).toContain('References');
+    // Bibliography lists Foo exactly once despite two cite references.
+    expect((built.html.match(/Foo Studies/g) ?? []).length).toBe(1);
+    // TOC includes the bibliography.
+    expect(built.html).toMatch(/<nav class="tree-pdf-toc">[\s\S]*?References[\s\S]*?<\/nav>/);
+  });
+
+  it('Chicago notes & bibliography: per-chapter footnotes + bundle Bibliography', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'root.md'), '# R\n[[a]]\n[[cite::foo-2020]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n[[cite::foo-2020]]\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'root.md', maxDepth: 2 },
+      { citationStyle: 'chicago-notes-bibliography' },
+    );
+    const built = buildTreePdfHtml(plan);
+    // Each chapter's footnote counter starts at 1.
+    expect(built.html).toContain('id="fn-1"');
+    expect((built.html.match(/id="fnref-1"/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    // Bundle-level Bibliography (heading flips for note styles).
+    expect(built.html).toContain('Bibliography');
+  });
+
+  it('builder returns an empty result when the plan has no notes', () => {
+    // Hand-roll a synthetic empty plan rather than going through
+    // resolvePlan (which requires a real root note).
+    const built = buildTreePdfHtml({
+      inputKind: 'tree',
+      inputs: [],
+      excluded: [],
+      linkPolicy: 'inline-title',
+      assetPolicy: 'keep-relative',
+      rootPath: root,
+    });
+    expect(built.chapterCount).toBe(0);
+    expect(built.html).toBe('');
+  });
+
+  it('exposes the expected exporter id + label', () => {
+    expect(treePdfExporter.id).toBe('tree-pdf');
+    expect(treePdfExporter.label).toBe('Note Tree as Single PDF');
+    expect(treePdfExporter.acceptedKinds).toEqual(['tree']);
+    expect(treePdfExporter.accepts({ kind: 'tree' })).toBe(true);
+    expect(treePdfExporter.accepts({ kind: 'project' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

New \`tree-pdf\` exporter that walks a root note's wiki-link closure (reusing the tree resolver from #251), concatenates every reachable note into one HTML document with a title page + TOC + chapter breaks, then rasterises through the existing #249 PDF pipeline.

Differs from \`tree-html\`'s multi-file bundle: this produces a **single self-contained PDF**. Inter-note \`[[other]]\` links rewrite to \`#chapter-other\` in-document anchors so reader clicks jump within the PDF instead of trying to open a non-existent file.

## Behaviour

- Chapters land in BFS order (matches tree-html); each starts on a fresh page via \`page-break-before: always\`.
- Title page + TOC at the front, both with \`page-break-after\`.
- Per-chapter \`CitationRenderer\` so note-style footnote indices reset to 1 per chapter (Chicago full-note shape readers expect from any multi-chapter document).
- Consolidated Bibliography / References at the end via the \`renderBibliographyFor\` API tree-html uses (#300); de-dup'd across chapters.
- Frontmatter \`title\` beats H1 for chapter heading + document title.

## Implementation note

HTML assembly factored into a pure \`buildTreePdfHtml(plan)\` so the bulk of the exporter is unit-testable without spinning up Electron — Electron only kicks in inside \`renderPdfFromHtml\`.

## Closes

Resolves #290.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/tree-pdf.test.ts\` — 9/9 covering: BFS ordering, TOC anchor links, inter-chapter link rewriting, page-break CSS emission, frontmatter-vs-H1 precedence, consolidated bibliography dedup, Chicago notes (per-chapter footnotes + bundle Bibliography heading), empty-input fallback, exporter id/label contract.
- [x] \`pnpm vitest run tests/main/publish\` — 256/256
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a 4-note tree under APA + Chicago notes & bibliography; verify TOC links, chapter page breaks, bibliography dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)