### PR TITLE
Publication: tree-markdown zip exporter (#291)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "citeproc": "^2.4.63",
     "date-fns": "^4.1.0",
     "isomorphic-git": "^1.27.1",
+    "jszip": "^3.10.1",
     "katex": "^0.16.45",
     "linkedom": "^0.18.12",
     "markdown-it-footnote": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       isomorphic-git:
         specifier: ^1.27.1
         version: 1.37.4
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       katex:
         specifier: ^0.16.45
         version: 0.16.45
@@ -2997,6 +3000,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -3700,6 +3706,9 @@ packages:
     engines: {node: '>=6.9.0'}
     hasBin: true
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
@@ -3817,6 +3826,9 @@ packages:
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -3921,6 +3933,9 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   junk@3.1.0:
     resolution: {integrity: sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==}
     engines: {node: '>=8'}
@@ -3952,6 +3967,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -4523,6 +4541,9 @@ packages:
     resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -4640,6 +4661,9 @@ packages:
 
   readable-stream-node-to-web@1.0.1:
     resolution: {integrity: sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -4929,6 +4953,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -10626,6 +10653,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  core-util-is@1.0.3: {}
+
   crc-32@1.2.2: {}
 
   crelt@1.0.6: {}
@@ -11477,6 +11506,8 @@ snapshots:
   image-size@0.7.5:
     optional: true
 
+  immediate@3.0.6: {}
+
   immutable@5.1.5: {}
 
   imul@1.0.1:
@@ -11562,6 +11593,8 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-url@1.2.4: {}
+
+  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
@@ -11723,6 +11756,13 @@ snapshots:
   jsonpointer@5.0.1:
     optional: true
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   junk@3.1.0: {}
 
   just-permutations@2.2.1: {}
@@ -11747,6 +11787,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@2.1.0: {}
 
@@ -12290,6 +12334,8 @@ snapshots:
 
   proc-log@2.0.1: {}
 
+  process-nextick-args@2.0.1: {}
+
   process@0.11.10: {}
 
   progress@2.0.3: {}
@@ -12470,6 +12516,16 @@ snapshots:
       readable-stream: 4.7.0
 
   readable-stream-node-to-web@1.0.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -12808,6 +12864,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:

--- a/src/main/publish/exporters/note-markdown-shared.ts
+++ b/src/main/publish/exporters/note-markdown-shared.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared markdown-rewriting helpers for the clean-markdown exporters
+ * (#250 single-note + #291 tree zip).
+ *
+ * Both exporters need the same cite/quote → CSL prose rewrite and
+ * the same turtle-block strip. They diverge on what tail to append:
+ *
+ *   - Single-note: per-note footnotes (note styles) OR per-note
+ *     `## References` (in-text styles).
+ *   - Tree zip: per-note footnotes only (note styles' `[^N]` markers
+ *     anchor locally); the consolidated `references.md` lives at the
+ *     bundle root.
+ */
+
+import { parseLocatorAlias } from './note-html/render';
+import type { ExportPlan } from '../types';
+import type { CitationRenderer } from '../csl';
+
+export interface ParsedCite {
+  kind: 'cite' | 'quote';
+  id: string;
+  aliasLocator: { locator: string; label: string } | null;
+  endPos: number;
+}
+
+/**
+ * Walk the content for `[[cite::id]]` / `[[quote::id]]` runs and
+ * replace each run with citeproc-rendered prose. Skips fenced code
+ * blocks (where `[[cite::]]` is example syntax). Whitespace-merge
+ * gate matches the HTML exporter (#298).
+ */
+export function rewriteCitations(
+  content: string,
+  renderer: CitationRenderer,
+  citations: NonNullable<ExportPlan['citations']>,
+): string {
+  const FENCE_RE = /^```[\s\S]*?^```/gm;
+  const fenceSpans: Array<{ start: number; end: number }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = FENCE_RE.exec(content)) !== null) {
+    fenceSpans.push({ start: m.index, end: m.index + m[0].length });
+  }
+  const isInsideFence = (idx: number): boolean =>
+    fenceSpans.some((s) => idx >= s.start && idx < s.end);
+
+  const out: string[] = [];
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] !== '[' || content[i + 1] !== '[' || isInsideFence(i)) {
+      out.push(content[i]);
+      i++;
+      continue;
+    }
+    const first = parseCiteAt(content, i);
+    if (!first) {
+      out.push(content[i]);
+      i++;
+      continue;
+    }
+    const run: ParsedCite[] = [first];
+    let scanPos = first.endPos;
+    while (true) {
+      let p = scanPos;
+      while (p < content.length && /\s/.test(content[p])) p++;
+      const next = parseCiteAt(content, p);
+      if (!next) break;
+      run.push(next);
+      scanPos = next.endPos;
+    }
+    out.push(renderCiteRun(run, renderer, citations));
+    i = scanPos;
+  }
+  return out.join('');
+}
+
+export function parseCiteAt(src: string, pos: number): ParsedCite | null {
+  if (src.charCodeAt(pos) !== 0x5b /* [ */ || src.charCodeAt(pos + 1) !== 0x5b) return null;
+  const close = src.indexOf(']]', pos + 2);
+  if (close < 0) return null;
+  const inner = src.slice(pos + 2, close);
+  const m = inner.match(/^(cite|quote)::(.+)$/i);
+  if (!m) return null;
+  const rawTarget = m[2];
+  const pipe = rawTarget.indexOf('|');
+  const id = (pipe >= 0 ? rawTarget.slice(0, pipe) : rawTarget).trim();
+  const alias = pipe >= 0 ? rawTarget.slice(pipe + 1).trim() : '';
+  return {
+    kind: m[1].toLowerCase() as 'cite' | 'quote',
+    id,
+    aliasLocator: parseLocatorAlias(alias),
+    endPos: close + 2,
+  };
+}
+
+function renderCiteRun(
+  items: ParsedCite[],
+  renderer: CitationRenderer,
+  citations: NonNullable<ExportPlan['citations']>,
+): string {
+  type Resolved =
+    | { ok: true; sourceId: string; locator?: string; label?: string }
+    | { ok: false; missingMarker: string };
+  const resolved: Resolved[] = items.map((item) => {
+    if (item.kind === 'quote') {
+      const ex = citations.excerpts.get(item.id);
+      if (!ex) return { ok: false, missingMarker: `[missing excerpt: ${item.id}]` };
+      if (!citations.items.has(ex.sourceId)) return { ok: false, missingMarker: `[missing: ${ex.sourceId}]` };
+      return {
+        ok: true,
+        sourceId: ex.sourceId,
+        locator: item.aliasLocator?.locator ?? ex.locator,
+        label: item.aliasLocator?.label,
+      };
+    }
+    if (!citations.items.has(item.id)) return { ok: false, missingMarker: `[missing: ${item.id}]` };
+    return {
+      ok: true,
+      sourceId: item.id,
+      locator: item.aliasLocator?.locator,
+      label: item.aliasLocator?.label,
+    };
+  });
+  if (items.length === 1 || resolved.some((r) => !r.ok)) {
+    return resolved
+      .map((r) => (r.ok ? renderer.renderCitation(r.sourceId, r.locator, r.label) : r.missingMarker))
+      .join(' ');
+  }
+  return renderer.renderCitationCluster(
+    resolved.map((r) => {
+      const ok = r as Extract<Resolved, { ok: true }>;
+      return { id: ok.sourceId, locator: ok.locator, label: ok.label };
+    }),
+  );
+}
+
+/**
+ * Strip embedded ```turtle blocks — meaningful inside Minerva (graph
+ * indexing) but noise outside it.
+ */
+export function stripTurtleBlocks(content: string): string {
+  return content.replace(/^```turtle\b[\s\S]*?^```\s*\n?/gm, '');
+}
+
+/**
+ * Append per-note Pandoc-style footnote definitions. Note-class
+ * styles only — in-text styles return the body unchanged.
+ */
+export function appendFootnoteDefs(body: string, renderer: CitationRenderer): string {
+  if (!renderer.isNoteStyle) return body;
+  const fns = renderer.renderFootnotes().notes;
+  if (fns.length === 0) return body;
+  const defs = fns.map((n) => `[^${n.index}]: ${n.body}`).join('\n\n');
+  return `${body.replace(/\s*$/, '')}\n\n${defs}\n`;
+}
+
+/**
+ * Append a per-note `## References` section. In-text styles only —
+ * note-class styles defer to `appendFootnoteDefs`.
+ */
+export function appendReferencesSection(body: string, renderer: CitationRenderer): string {
+  if (renderer.isNoteStyle) return body;
+  const bib = renderer.renderBibliography();
+  if (bib.entries.length === 0) return body;
+  const items = bib.entries.map((e) => `- ${e.trim()}`).join('\n');
+  return `${body.replace(/\s*$/, '')}\n\n## References\n\n${items}\n`;
+}
+
+/**
+ * Rewrite cites + strip turtle + append per-note footnote defs (note
+ * styles only). Used by the tree-zip exporter where the consolidated
+ * `references.md` carries the bibliography for in-text styles.
+ */
+export function rewriteCitationsAndCleanup(
+  content: string,
+  renderer: CitationRenderer | undefined,
+  citations: ExportPlan['citations'],
+): string {
+  let out = content;
+  if (renderer && citations) {
+    out = rewriteCitations(out, renderer, citations);
+  }
+  out = stripTurtleBlocks(out);
+  if (renderer) out = appendFootnoteDefs(out, renderer);
+  return out;
+}

--- a/src/main/publish/exporters/note-markdown.ts
+++ b/src/main/publish/exporters/note-markdown.ts
@@ -8,16 +8,17 @@
  * styles) at the bottom of the file.
  *
  * Diverges from the passthrough `markdown` exporter: that one is for
- * Minerva-internal use and preserves \`[[cite::]]\` syntax; this one
+ * Minerva-internal use and preserves `[[cite::]]` syntax; this one
  * produces output that renders correctly on GitHub, Substack, Hugo,
  * and the wider markdown ecosystem outside Minerva.
  *
+ * Shares its body-rewriting logic with `tree-markdown` via
+ * `note-markdown-shared.ts` (#291).
+ *
  * Deferred to follow-up tickets:
- *   - copy-to-dir / inline-base64 image asset policies (this exporter
- *     ships with `keep-relative` only)
+ *   - copy-to-dir / inline-base64 image asset policies
  *   - Hugo-flavoured frontmatter remapping
- *   - preview-dialog warnings about dropped Turtle blocks / executable
- *     cells (the warnings would need an IPC-side preview hook)
+ *   - preview-dialog warnings about dropped turtle blocks / executable cells
  */
 
 import {
@@ -25,7 +26,12 @@ import {
   rewriteWikiLinksInContent,
   type LinkResolverContext,
 } from '../link-resolver';
-import { parseLocatorAlias } from './note-html/render';
+import {
+  rewriteCitations,
+  stripTurtleBlocks,
+  appendFootnoteDefs,
+  appendReferencesSection,
+} from './note-markdown-shared';
 import type { Exporter, ExportPlan } from '../types';
 import type { CitationRenderer } from '../csl';
 
@@ -34,7 +40,7 @@ export const noteMarkdownExporter: Exporter = {
   label: 'Note as Clean Markdown',
   // Single-note + folder + project; tree mode belongs to a future
   // bundle-shaped markdown exporter (`#291`).
-  accepts: (input) => input.kind !== 'tree',
+  accepts: (input) => input.kind !== 'tree' && input.kind !== 'source',
   acceptedKinds: ['single-note', 'folder', 'project'],
   // eslint-disable-next-line @typescript-eslint/require-await
   async run(plan) {
@@ -51,10 +57,10 @@ export const noteMarkdownExporter: Exporter = {
       // page its own References section.
       const renderer = plan.citations?.createRenderer({ outputFormat: 'text' });
       const transformed = transformNoteBody(f.content, ctx, renderer, plan.citations);
-      const withRefs = renderer ? appendCitationsTail(transformed, renderer) : transformed;
+      const withTail = renderer ? appendCitationsTail(transformed, renderer) : transformed;
       return {
         path: flatten ? basename(f.relativePath) : f.relativePath,
-        contents: withRefs,
+        contents: withTail,
       };
     });
     const dropped = plan.excluded.length;
@@ -66,14 +72,10 @@ export const noteMarkdownExporter: Exporter = {
 };
 
 /**
- * Apply every body-level rewrite that has to happen before the
- * References footer is appended.
- *
- * Order matters: citation rewrite first so the citation regex sees the
- * raw `[[cite::]]` markers, then wiki-link rewrite (which deliberately
- * skips cite/quote tokens), then Turtle-block strip last so we don't
- * leave dangling `<-- minerva:turtle -->` HTML comments next to a
- * rewritten link.
+ * Rewrite citations → prose; rewrite wiki-links per the plan's
+ * linkPolicy; strip embedded turtle blocks. Order matters: citation
+ * rewrite first (sees raw `[[cite::]]`), then wiki-link rewrite
+ * (deliberately skips cite/quote tokens), then turtle strip last.
  */
 function transformNoteBody(
   content: string,
@@ -91,164 +93,13 @@ function transformNoteBody(
 }
 
 /**
- * Walk the markdown content for `[[cite::id]]` / `[[quote::id]]` runs
- * (separated only by whitespace, the same merge gate the HTML exporter
- * uses — #298) and replace each run with citeproc-rendered prose.
- *
- * Mirrors the parser logic in `note-html/render.ts` but emits plain
- * text instead of HTML markers. Kept inline rather than shared because
- * the markdown side has different escaping needs and a different
- * handling for missing ids (no `<span>` wrapper).
- */
-function rewriteCitations(
-  content: string,
-  renderer: CitationRenderer,
-  citations: NonNullable<ExportPlan['citations']>,
-): string {
-  // Skip rewriting inside fenced code blocks — `[[cite::]]` inside a
-  // code fence is example syntax, not a real citation.
-  const FENCE_RE = /^```[\s\S]*?^```/gm;
-  const fenceSpans: Array<{ start: number; end: number }> = [];
-  let m: RegExpExecArray | null;
-  while ((m = FENCE_RE.exec(content)) !== null) {
-    fenceSpans.push({ start: m.index, end: m.index + m[0].length });
-  }
-  const isInsideFence = (idx: number): boolean =>
-    fenceSpans.some((s) => idx >= s.start && idx < s.end);
-
-  const out: string[] = [];
-  let i = 0;
-  while (i < content.length) {
-    if (content[i] !== '[' || content[i + 1] !== '[' || isInsideFence(i)) {
-      out.push(content[i]);
-      i++;
-      continue;
-    }
-    const first = parseCiteAt(content, i);
-    if (!first) {
-      out.push(content[i]);
-      i++;
-      continue;
-    }
-    // Collect a whitespace-separated run, same as the HTML exporter.
-    const run: ParsedCite[] = [first];
-    let scanPos = first.endPos;
-    while (true) {
-      let p = scanPos;
-      while (p < content.length && /\s/.test(content[p])) p++;
-      const next = parseCiteAt(content, p);
-      if (!next) break;
-      run.push(next);
-      scanPos = next.endPos;
-    }
-    out.push(renderCiteRun(run, renderer, citations));
-    i = scanPos;
-  }
-  return out.join('');
-}
-
-interface ParsedCite {
-  kind: 'cite' | 'quote';
-  id: string;
-  aliasLocator: { locator: string; label: string } | null;
-  endPos: number;
-}
-
-function parseCiteAt(src: string, pos: number): ParsedCite | null {
-  if (src.charCodeAt(pos) !== 0x5b /* [ */ || src.charCodeAt(pos + 1) !== 0x5b) return null;
-  const close = src.indexOf(']]', pos + 2);
-  if (close < 0) return null;
-  const inner = src.slice(pos + 2, close);
-  const m = inner.match(/^(cite|quote)::(.+)$/i);
-  if (!m) return null;
-  const rawTarget = m[2];
-  const pipe = rawTarget.indexOf('|');
-  const id = (pipe >= 0 ? rawTarget.slice(0, pipe) : rawTarget).trim();
-  const alias = pipe >= 0 ? rawTarget.slice(pipe + 1).trim() : '';
-  return {
-    kind: m[1].toLowerCase() as 'cite' | 'quote',
-    id,
-    aliasLocator: parseLocatorAlias(alias),
-    endPos: close + 2,
-  };
-}
-
-/**
- * Resolve a run of cites to a plain-text rendering. Mirrors the
- * HTML-side missing-fallback semantics: any unresolvable id in a run
- * disables the merge so the missing markers stay visible.
- */
-function renderCiteRun(
-  items: ParsedCite[],
-  renderer: CitationRenderer,
-  citations: NonNullable<ExportPlan['citations']>,
-): string {
-  type Resolved =
-    | { ok: true; sourceId: string; locator?: string; label?: string }
-    | { ok: false; missingMarker: string };
-  const resolved: Resolved[] = items.map((item) => {
-    if (item.kind === 'quote') {
-      const ex = citations.excerpts.get(item.id);
-      if (!ex) return { ok: false, missingMarker: `[missing excerpt: ${item.id}]` };
-      if (!citations.items.has(ex.sourceId)) return { ok: false, missingMarker: `[missing: ${ex.sourceId}]` };
-      return {
-        ok: true,
-        sourceId: ex.sourceId,
-        locator: item.aliasLocator?.locator ?? ex.locator,
-        label: item.aliasLocator?.label,
-      };
-    }
-    if (!citations.items.has(item.id)) return { ok: false, missingMarker: `[missing: ${item.id}]` };
-    return {
-      ok: true,
-      sourceId: item.id,
-      locator: item.aliasLocator?.locator,
-      label: item.aliasLocator?.label,
-    };
-  });
-
-  if (items.length === 1 || resolved.some((r) => !r.ok)) {
-    return resolved
-      .map((r) => (r.ok ? renderer.renderCitation(r.sourceId, r.locator, r.label) : r.missingMarker))
-      .join(' ');
-  }
-  return renderer.renderCitationCluster(
-    resolved.map((r) => {
-      const ok = r as Extract<Resolved, { ok: true }>;
-      return { id: ok.sourceId, locator: ok.locator, label: ok.label };
-    }),
-  );
-}
-
-/**
- * Append a References footer (in-text styles) or footnote bodies
- * (note styles like Chicago full-note). Emits nothing when no
- * citations fired — clean markdown with no References footer is the
- * common case for non-academic notes.
+ * Per-note tail: footnote defs for note styles, `## References` for
+ * in-text. Empty when no citations fired.
  */
 function appendCitationsTail(body: string, renderer: CitationRenderer): string {
-  if (renderer.isNoteStyle) {
-    const fns = renderer.renderFootnotes().notes;
-    if (fns.length === 0) return body;
-    // Pandoc-style footnote definitions: `[^N]: <body>` separated by
-    // blank lines. Pairs with the `[^N]` markers the renderer emitted.
-    const defs = fns.map((n) => `[^${n.index}]: ${n.body}`).join('\n\n');
-    return `${body.replace(/\s*$/, '')}\n\n${defs}\n`;
-  }
-  const bib = renderer.renderBibliography();
-  if (bib.entries.length === 0) return body;
-  const items = bib.entries.map((e) => `- ${e.trim()}`).join('\n');
-  return `${body.replace(/\s*$/, '')}\n\n## References\n\n${items}\n`;
-}
-
-/**
- * Strip embedded Turtle blocks (\`\`\`turtle … \`\`\`) — they're meaningful
- * inside Minerva (graph indexing) but noise outside it. Keeps other
- * fenced blocks (sparql, sql, python, shell, prose) intact since
- * those round-trip through standard markdown renderers.
- */
-function stripTurtleBlocks(content: string): string {
-  return content.replace(/^```turtle\b[\s\S]*?^```\s*\n?/gm, '');
+  return renderer.isNoteStyle
+    ? appendFootnoteDefs(body, renderer)
+    : appendReferencesSection(body, renderer);
 }
 
 function basename(relativePath: string): string {

--- a/src/main/publish/exporters/tree-markdown.ts
+++ b/src/main/publish/exporters/tree-markdown.ts
@@ -1,0 +1,92 @@
+/**
+ * Note-tree markdown zip exporter (#291).
+ *
+ * Packages a root note's wiki-link closure as a directory of clean
+ * markdown files (each via the same rewrites as `note-markdown`) and
+ * zips it into `<root-slug>-tree.zip`. Portable to a Hugo/Jekyll
+ * site, a GitHub repo, or any markdown viewer that resolves relative
+ * paths.
+ *
+ * Cross-links inside the bundle resolve to relative `.md` paths so
+ * the zip browses naturally after extraction. Citations consolidate
+ * into a single `references.md` at the bundle root via the same
+ * `renderBibliographyFor` API the other tree exporters use (#300).
+ */
+
+import JSZip from 'jszip';
+import { rewriteCitationsAndCleanup } from './note-markdown-shared';
+import {
+  buildLinkResolverContext,
+  rewriteWikiLinksInContent,
+} from '../link-resolver';
+import type { Exporter, ExportPlan, ExportPlanFile } from '../types';
+
+export const treeMarkdownExporter: Exporter = {
+  id: 'tree-markdown',
+  label: 'Note Tree as Markdown Zip',
+  // Tree-only — same input shape as tree-html and tree-pdf.
+  accepts: (input) => input.kind === 'tree',
+  acceptedKinds: ['tree'],
+  async run(plan) {
+    const notes = plan.inputs.filter((f) => f.kind === 'note');
+    if (notes.length === 0) {
+      return { files: [], summary: 'Nothing to export in this tree.' };
+    }
+    const rootNote = notes[0];
+
+    // Force follow-to-file so the link resolver emits `.md` cross-links.
+    const bundlePlan: ExportPlan = { ...plan, linkPolicy: 'follow-to-file' };
+    const ctx = buildLinkResolverContext(bundlePlan);
+
+    const allCitedIds = new Set<string>();
+    let isNoteStyle = false;
+    const zip = new JSZip();
+
+    for (const note of notes) {
+      const renderer = bundlePlan.citations?.createRenderer({ outputFormat: 'text' });
+      let content = note.content;
+      // 1. Inline cite/quote → CSL prose; appends per-note Footnotes
+      //    or References. The same single-note `note-markdown`
+      //    pipeline does this; we share that helper.
+      const cleaned = rewriteCitationsAndCleanup(content, renderer, bundlePlan.citations);
+      // 2. Wiki-link rewrite — `[[other]]` → `[Title](other.md)`.
+      content = rewriteWikiLinksInContent(cleaned, ctx);
+      zip.file(note.relativePath, content);
+      if (renderer) {
+        for (const id of renderer.cited()) allCitedIds.add(id);
+        if (renderer.isNoteStyle) isNoteStyle = true;
+      }
+    }
+
+    // Consolidated `references.md` at the bundle root (#300 shape).
+    if (allCitedIds.size > 0 && bundlePlan.citations) {
+      const consolidator = bundlePlan.citations.createRenderer({ outputFormat: 'text' });
+      const bib = consolidator.renderBibliographyFor([...allCitedIds]);
+      if (bib.entries.length > 0) {
+        const heading = isNoteStyle ? 'Bibliography' : 'References';
+        const body = bib.entries.map((e) => `- ${e.trim()}`).join('\n');
+        zip.file('references.md', `# ${heading}\n\n${body}\n`);
+      }
+    }
+
+    const zipBytes = await zip.generateAsync({ type: 'uint8array' });
+    const zipName = `${slugify(rootNote.title || rootNote.relativePath)}-tree.zip`;
+    const summary = `Bundle of ${notes.length} note${notes.length === 1 ? '' : 's'} packaged as ${zipName}.`;
+    return {
+      files: [{ path: zipName, contents: zipBytes }],
+      summary,
+    };
+  },
+};
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\.md$/i, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'tree';
+}
+
+// Re-export the type so the exporter's `run` signature hangs together
+// without an unused-import warning when JSZip's types tighten.
+export type _Note = ExportPlanFile;

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -13,6 +13,7 @@ import { noteHtmlExporter } from './exporters/note-html';
 import { notePdfExporter } from './exporters/note-pdf';
 import { treeHtmlExporter } from './exporters/tree-html';
 import { treePdfExporter } from './exporters/tree-pdf';
+import { treeMarkdownExporter } from './exporters/tree-markdown';
 import { staticSiteExporter } from './exporters/static-site';
 import { annotatedReadingExporter } from './exporters/annotated-reading';
 import { pandocExporter } from './exporters/pandoc';
@@ -25,6 +26,7 @@ export function registerBuiltinExporters(): void {
   registerExporter(notePdfExporter);
   registerExporter(treeHtmlExporter);
   registerExporter(treePdfExporter);
+  registerExporter(treeMarkdownExporter);
   registerExporter(staticSiteExporter);
   registerExporter(annotatedReadingExporter);
   registerExporter(pandocExporter);

--- a/tests/main/publish/tree-markdown.test.ts
+++ b/tests/main/publish/tree-markdown.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tree-markdown zip exporter (#291).
+ *
+ * The zip output is decoded back into individual files (via JSZip's
+ * `loadAsync`) so each entry can be asserted on individually — that
+ * mirrors how a user actually consumes the export.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import JSZip from 'jszip';
+import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
+import { treeMarkdownExporter } from '../../../src/main/publish/exporters/tree-markdown';
+
+function mkProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tree-md-'));
+}
+
+async function loadZip(bytes: Uint8Array): Promise<Map<string, string>> {
+  const zip = await JSZip.loadAsync(bytes);
+  const out = new Map<string, string>();
+  await Promise.all(
+    Object.keys(zip.files).map(async (name) => {
+      const f = zip.files[name];
+      if (f.dir) return;
+      out.set(name, await f.async('string'));
+    }),
+  );
+  return out;
+}
+
+describe('tree-markdown zip exporter (#291)', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('emits a single .zip file containing every reachable note', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '---\ntitle: Thesis\n---\n# Thesis\n\nLinks to [[ch1]] and [[ch2]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'ch1.md'),
+      '---\ntitle: One\n---\n# One\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'ch2.md'),
+      '---\ntitle: Two\n---\n# Two\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 3 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    expect(output.files).toHaveLength(1);
+    expect(output.files[0].path).toBe('thesis-tree.zip');
+
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    const paths = [...unzipped.keys()].sort();
+    expect(paths).toEqual(['ch1.md', 'ch2.md', 'root.md']);
+  });
+
+  it('rewrites wiki-links in zip entries to relative .md paths', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '# Root\n\nSee [[ch1]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'ch1.md'),
+      '---\ntitle: Chapter One\n---\n# Chapter One\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    const rootContent = unzipped.get('root.md');
+    expect(rootContent).toBeDefined();
+    expect(rootContent).toContain('[Chapter One](ch1.md)');
+    expect(rootContent).not.toContain('[[ch1]]');
+  });
+
+  it('drops embedded turtle blocks but preserves other fenced blocks', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '# Root\n\n```turtle\n@prefix ex: <http://x.com/> .\n```\n\n```python\nprint("hi")\n```\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 1 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    const rootContent = unzipped.get('root.md')!;
+    expect(rootContent).not.toContain('```turtle');
+    expect(rootContent).not.toContain('@prefix');
+    expect(rootContent).toContain('```python');
+  });
+
+  it('emits references.md at the bundle root when any note cites a source', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '# Root\n[[a]] cites [[cite::foo-2020]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\nAlso cites [[cite::foo-2020]]\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    expect(unzipped.has('references.md')).toBe(true);
+    const refs = unzipped.get('references.md')!;
+    expect(refs).toMatch(/^# References/m);
+    expect(refs).toContain('Foo');
+    // De-duplicated: Foo cited from two notes appears once.
+    expect((refs.match(/Foo Studies/g) ?? []).length).toBe(1);
+  });
+
+  it('per-note files do NOT carry a ## References footer in tree mode (consolidated)', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'root.md'), '# Root\n[[cite::foo-2020]]\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 1 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    const rootContent = unzipped.get('root.md')!;
+    expect(rootContent).not.toContain('## References');
+    // But the consolidated references.md still appears.
+    expect(unzipped.has('references.md')).toBe(true);
+  });
+
+  it('Chicago notes & bibliography: per-note [^N]: footnote defs + bundle Bibliography', async () => {
+    await fsp.mkdir(path.join(root, '.minerva/sources/foo-2020'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/sources/foo-2020/meta.ttl'),
+      `this: a thought:Article ;
+  dc:title "Foo Studies" ;
+  dc:creator "Foo, Alice" ;
+  dc:issued "2020"^^xsd:gYear .\n`, 'utf-8');
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '# Root\nClaim [[cite::foo-2020]] [[a]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'),
+      '# A\nAlso [[cite::foo-2020]]\n', 'utf-8');
+
+    const plan = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'root.md', maxDepth: 2 },
+      { citationStyle: 'chicago-notes-bibliography' },
+    );
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    // Each note has its own [^1] inline marker + [^1]: footnote definition.
+    expect(unzipped.get('root.md')).toContain('[^1]');
+    expect(unzipped.get('root.md')).toMatch(/\[\^1\]: .*Foo/);
+    expect(unzipped.get('a.md')).toContain('[^1]');
+    expect(unzipped.get('a.md')).toMatch(/\[\^1\]: .*Foo/);
+    // Bundle-level Bibliography (heading flips for note styles).
+    const refs = unzipped.get('references.md')!;
+    expect(refs).toMatch(/^# Bibliography/m);
+  });
+
+  it('omits references.md when no notes cite anything', async () => {
+    await fsp.writeFile(path.join(root, 'root.md'), '# Root\n[[a]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\nno cites\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+    expect(unzipped.has('references.md')).toBe(false);
+  });
+
+  it('exposes the expected exporter id + label', () => {
+    expect(treeMarkdownExporter.id).toBe('tree-markdown');
+    expect(treeMarkdownExporter.label).toBe('Note Tree as Markdown Zip');
+    expect(treeMarkdownExporter.acceptedKinds).toEqual(['tree']);
+    expect(treeMarkdownExporter.accepts({ kind: 'tree' })).toBe(true);
+    expect(treeMarkdownExporter.accepts({ kind: 'project' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

New \`tree-markdown\` exporter that packages a root note's wiki-link closure as a directory of clean-markdown files, zipped into \`<root-slug>-tree.zip\`. Portable to a Hugo / Jekyll site, a GitHub repo, or any markdown viewer that resolves relative paths.

Cross-links inside the bundle resolve to relative \`.md\` paths so the zip browses naturally after extraction. Citations consolidate into a single \`references.md\` at the bundle root.

## Behaviour matrix

| Style class | Per-note tail | Bundle root |
|---|---|---|
| In-text (APA, MLA, IEEE, Vancouver, Chicago AD) | (none) | \`# References\` in \`references.md\` |
| Note (Chicago notes & bibliography) | \`[^N]: …\` footnote defs | \`# Bibliography\` in \`references.md\` |

For note styles, per-note Pandoc-style footnote definitions stay with each note since the inline \`[^N]\` markers anchor locally — note-style footnote numbering resets per note, same shape as tree-html and tree-pdf.

## Implementation

- New dependency: \`jszip\` (pure JS, MIT, no native build).
- Shared rewriting logic factored into \`note-markdown-shared.ts\` so both \`note-markdown\` (single-note) and \`tree-markdown\` (zip) use the same cite/quote → CSL prose rewrite + turtle-strip. Only the per-note tail diverges (single-note appends \`## References\`; tree mode lets \`references.md\` carry the consolidated bibliography).

## Closes

Resolves #291.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/tree-markdown.test.ts tests/main/publish/note-markdown.test.ts\` — 20/20 (8 new for #291; existing 12 for #250 still green after the shared-helper refactor).
- [x] \`pnpm vitest run tests/main/publish\` — 264/264
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a small wiki-linked tree, unzip, browse cross-links, confirm \`references.md\` opens cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)