### PR TITLE
Publication: shared style.css + sidebar nav for tree-html bundles (#292)

### DIFF
--- a/src/main/publish/exporters/note-html/shell.ts
+++ b/src/main/publish/exporters/note-html/shell.ts
@@ -7,11 +7,29 @@ import { NOTE_HTML_STYLE } from './style';
 export interface HtmlShellInput {
   title: string;
   body: string;
+  /**
+   * When set, link to an external stylesheet via this href instead of
+   * inlining `NOTE_HTML_STYLE`. Used by the tree-html bundle exporter
+   * (#292) so all pages share one `style.css` at the bundle root.
+   */
+  stylesheetHref?: string;
+  /**
+   * Optional sidebar HTML rendered to the left of the article. The
+   * tree-html bundle uses this to surface a nav listing every page in
+   * the bundle (#292). When omitted, the page renders without a
+   * sidebar (single-note default).
+   */
+  sidebarHtml?: string;
 }
 
 export function wrapHtml(input: HtmlShellInput): string {
   const title = escapeHtml(input.title || 'Untitled');
   const generatedAt = new Date().toISOString();
+  const styleBlock = input.stylesheetHref
+    ? `<link rel="stylesheet" href="${escapeHtml(input.stylesheetHref)}">`
+    : `<style>${NOTE_HTML_STYLE}</style>`;
+  const articleClass = input.sidebarHtml ? 'minerva-export with-sidebar' : 'minerva-export';
+  const sidebarPrefix = input.sidebarHtml ? `<aside class="bundle-nav">${input.sidebarHtml}</aside>` : '';
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -20,9 +38,10 @@ export function wrapHtml(input: HtmlShellInput): string {
   <title>${title}</title>
   <meta name="generator" content="Minerva">
   <meta name="minerva-export-version" content="1">
-  <style>${NOTE_HTML_STYLE}</style>
+  ${styleBlock}
 </head>
-<body class="minerva-export">
+<body class="${articleClass}">
+  ${sidebarPrefix}
   <article>
 ${input.body}
     <footer class="export-meta">

--- a/src/main/publish/exporters/tree-html/index.ts
+++ b/src/main/publish/exporters/tree-html/index.ts
@@ -7,18 +7,23 @@
  * forced to `follow-to-file` and the root renamed to `index.html`.
  * Cross-links inside the bundle resolve relative to each page.
  *
+ * Every page links to a single shared `style.css` at the bundle root
+ * and carries a sidebar with the manifest tree (#292) — the current
+ * page is highlighted so a reader can jump around without back-button
+ * acrobatics.
+ *
  * Each note gets its own `CitationRenderer` so per-note footnote
  * numbering is local (Chicago full-note, etc.); cited-id sets are
  * unioned across notes and the merged bibliography lands in a single
  * `references.html` at the bundle root (#300).
  *
- * Deferred to follow-up tickets: shared external stylesheet, sidebar
- * navigation (#292), manual deselection of notes (#293).
+ * Deferred to follow-up tickets: manual deselection of notes (#293).
  */
 
 import { renderNoteBody, inlineImages } from '../note-html/render';
 import { wrapHtml } from '../note-html/shell';
 import { renderFootnotesSection } from '../note-html';
+import { NOTE_HTML_STYLE } from '../note-html/style';
 import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../../types';
 
 export const treeHtmlExporter: Exporter = {
@@ -60,7 +65,13 @@ export const treeHtmlExporter: Exporter = {
       const withFootnotes = renderer ? `${rawBody}${renderFootnotesSection(renderer)}` : rawBody;
       const withRefLink = appendBundleReferenceLink(withFootnotes, note, rootNote, noteHasCites);
       const body = await inlineImages(withRefLink, note, rootPath, bundlePlan.assetPolicy);
-      const html = wrapHtml({ title: note.title, body });
+      const rootRel = relativeToRoot(note.relativePath, rootNote);
+      const html = wrapHtml({
+        title: note.title,
+        body,
+        stylesheetHref: `${rootRel}style.css`,
+        sidebarHtml: renderSidebar(notes, rootNote, note.relativePath, rootRel),
+      });
       files.push({
         path: outputPathFor(note, rootNote),
         contents: html,
@@ -83,9 +94,24 @@ export const treeHtmlExporter: Exporter = {
         const refsBody = `<h1>${heading}</h1>\n<section class="references">\n<ol>\n${entries}\n</ol>\n</section>`;
         files.push({
           path: 'references.html',
-          contents: wrapHtml({ title: heading, body: refsBody }),
+          contents: wrapHtml({
+            title: heading,
+            body: refsBody,
+            stylesheetHref: 'style.css',
+            sidebarHtml: renderSidebar(notes, rootNote, 'references.html', ''),
+          }),
         });
       }
+    }
+
+    // Shared stylesheet at the bundle root (#292). Appended only when
+    // we actually emitted notes — empty bundles don't get a stub
+    // style.css.
+    if (files.length > 0) {
+      files.push({
+        path: 'style.css',
+        contents: `${NOTE_HTML_STYLE}\n${BUNDLE_NAV_STYLE}`,
+      });
     }
 
     const excluded = plan.excluded.length;
@@ -95,6 +121,115 @@ export const treeHtmlExporter: Exporter = {
     return { files, summary };
   },
 };
+
+/**
+ * Number of `../` segments needed to reach the bundle root from a
+ * given note's emitted path. The root note (index.html) sits at depth
+ * 0; `notes/foo.html` is depth 1 (one `../`); `sub/deep/leaf.html` is
+ * depth 2 (`../../`). Used for the per-page stylesheet + sidebar
+ * link hrefs so deep-nested pages still resolve cleanly.
+ */
+function relativeToRoot(relativePath: string, rootNote: ExportPlanFile): string {
+  if (relativePath === rootNote.relativePath) return '';
+  const depth = relativePath.split('/').length - 1;
+  return depth === 0 ? '' : '../'.repeat(depth);
+}
+
+/**
+ * Sidebar nav (#292): a flat list of every page in the bundle. The
+ * current page is marked with `aria-current="page"` and a CSS class
+ * so the reader knows where they are. Order follows the resolver's
+ * BFS manifest so the visual structure matches the underlying tree.
+ */
+function renderSidebar(
+  notes: ExportPlanFile[],
+  rootNote: ExportPlanFile,
+  currentPath: string,
+  rootRel: string,
+): string {
+  const items = notes.map((note) => {
+    const href = note.relativePath === rootNote.relativePath
+      ? `${rootRel}index.html`
+      : rootRel + note.relativePath.replace(/\.md$/i, '.html');
+    const isCurrent = note.relativePath === currentPath
+      || (currentPath === 'references.html' && false /* references is its own item below */);
+    const cls = isCurrent ? 'current' : '';
+    const aria = isCurrent ? ' aria-current="page"' : '';
+    return `<li class="${cls}"><a href="${escapeAttr(href)}"${aria}>${escapeHtml(note.title)}</a></li>`;
+  });
+  return `<nav class="bundle-tree"><h2 class="bundle-tree-heading">Pages</h2><ol>${items.join('')}</ol></nav>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+function escapeAttr(s: string): string { return escapeHtml(s); }
+
+const BUNDLE_NAV_STYLE = `
+/* Tree-html bundle: shared stylesheet + sidebar nav (#292). */
+body.with-sidebar {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  gap: 0;
+  align-items: start;
+  padding: 0;
+  max-width: none;
+}
+body.with-sidebar > article { padding: 48px 32px 96px; max-width: 72ch; min-width: 0; }
+body.with-sidebar aside.bundle-nav {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  background: var(--code-bg);
+  border-right: 1px solid var(--border);
+  padding: 24px 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  font-size: 0.9em;
+}
+.bundle-tree-heading {
+  font-size: 0.7em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin: 0 0 0.6em;
+}
+.bundle-tree ol { list-style: none; padding: 0; margin: 0; }
+.bundle-tree li { margin-bottom: 0.25em; }
+.bundle-tree a {
+  display: block;
+  padding: 0.25em 0.5em;
+  border-radius: 3px;
+  text-decoration: none;
+  color: var(--fg);
+}
+.bundle-tree a:hover { background: var(--quote-border); }
+.bundle-tree li.current a {
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 500;
+}
+@media (max-width: 720px) {
+  body.with-sidebar { grid-template-columns: 1fr; }
+  body.with-sidebar aside.bundle-nav {
+    position: static;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+}
+@media print {
+  body.with-sidebar aside.bundle-nav { display: none; }
+  body.with-sidebar { grid-template-columns: 1fr; }
+  body.with-sidebar > article { padding: 0; }
+}
+`;
 
 /**
  * Root note → `index.html` at the bundle root.

--- a/tests/main/publish/tree-html.test.ts
+++ b/tests/main/publish/tree-html.test.ts
@@ -34,7 +34,7 @@ describe('tree-html exporter (#251) — through the pipeline', () => {
     }, { linkPolicy: 'follow-to-file' });
     const output = await runExporter(treeHtmlExporter, plan);
 
-    const paths = output.files.map((f) => f.path).sort();
+    const paths = output.files.map((f) => f.path).filter((p) => p.endsWith('.html')).sort();
     expect(paths).toEqual(['index.html', 'notes/ch1.html', 'notes/ch2.html']);
 
     const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
@@ -51,7 +51,7 @@ describe('tree-html exporter (#251) — through the pipeline', () => {
     await fsp.writeFile(path.join(root, 'd.md'), 'deep\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 2 });
     const output = await runExporter(treeHtmlExporter, plan);
-    const paths = output.files.map((f) => f.path).sort();
+    const paths = output.files.map((f) => f.path).filter((p) => p.endsWith('.html')).sort();
     expect(paths).toEqual(['b.html', 'c.html', 'index.html']);
     expect(paths).not.toContain('d.html');
   });
@@ -64,7 +64,7 @@ describe('tree-html exporter (#251) — through the pipeline', () => {
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 3 });
     expect(plan.excluded.map((e) => e.relativePath)).toEqual(['private/secret.md']);
     const output = await runExporter(treeHtmlExporter, plan);
-    const paths = output.files.map((f) => f.path).sort();
+    const paths = output.files.map((f) => f.path).filter((p) => p.endsWith('.html')).sort();
     expect(paths).toEqual(['index.html', 'public.html']);
   });
 
@@ -73,7 +73,8 @@ describe('tree-html exporter (#251) — through the pipeline', () => {
     await fsp.writeFile(path.join(root, 'b.md'), '[[a]]\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 10 });
     const output = await runExporter(treeHtmlExporter, plan);
-    expect(output.files.map((f) => f.path).sort()).toEqual(['b.html', 'index.html']);
+    const paths = output.files.map((f) => f.path).filter((p) => p.endsWith('.html')).sort();
+    expect(paths).toEqual(['b.html', 'index.html']);
   });
 
   it('forces follow-to-file even when the plan arrived with inline-title', async () => {
@@ -180,6 +181,55 @@ describe('tree-html consolidated bibliography (#300)', () => {
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 3 });
     const output = await runExporter(treeHtmlExporter, plan);
     expect(output.files.map((f) => f.path)).not.toContain('references.html');
+  });
+
+  it('emits a single shared style.css and links every page to it (#292)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n[[b]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'), '# B\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 2 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    const paths = output.files.map((f) => f.path);
+    expect(paths).toContain('style.css');
+    // No inline <style> block in any page — they reference the external file instead.
+    for (const f of output.files) {
+      if (!f.path.endsWith('.html')) continue;
+      const html = String(f.contents);
+      expect(html).not.toContain('<style>');
+      expect(html).toContain('rel="stylesheet"');
+    }
+  });
+
+  it('per-page stylesheet href is depth-aware: nested pages climb up to root (#292)', async () => {
+    await fsp.mkdir(path.join(root, 'sub/deep'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n[[sub/deep/leaf]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'sub/deep/leaf.md'), '# Leaf\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 3 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    const root_ = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    const leaf = String(output.files.find((f) => f.path === 'sub/deep/leaf.html')!.contents);
+    expect(root_).toContain('href="style.css"');
+    expect(leaf).toContain('href="../../style.css"');
+  });
+
+  it('sidebar lists every page; current page marked with aria-current + class (#292)', async () => {
+    await fsp.writeFile(path.join(root, 'a.md'), '# A\n[[b]]\n[[c]]\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'b.md'),
+      '---\ntitle: Page B\n---\n# Page B\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'c.md'),
+      '---\ntitle: Page C\n---\n# Page C\n', 'utf-8');
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'a.md', maxDepth: 2 });
+    const output = await runExporter(treeHtmlExporter, plan);
+    const indexHtml = String(output.files.find((f) => f.path === 'index.html')!.contents);
+    expect(indexHtml).toContain('class="bundle-tree"');
+    expect(indexHtml).toContain('Page B');
+    expect(indexHtml).toContain('Page C');
+    // Root page is current → its <li> is `class="current"` and the <a> is aria-current.
+    expect(indexHtml).toMatch(/<li class="current"><a [^>]*aria-current="page">/);
+
+    const bHtml = String(output.files.find((f) => f.path === 'b.html')!.contents);
+    // On page B, B's row is current; the root note's row is not.
+    expect(bHtml).toMatch(/<li class="current"><a [^>]*>Page B<\/a><\/li>/);
+    expect(bHtml).not.toMatch(/<li class="current"><a [^>]*aria-current="page">[^<]*<\/a><\/li>[\s\S]*<li class="current">/);
   });
 
   it('note-style export: per-note Footnotes + bundle-level Bibliography', async () => {


### PR DESCRIPTION
## Summary

Tree-html bundles previously inlined the full stylesheet on every page (matched note-html exactly — one less moving part for the foundation ticket #251). Now the bundle ships a single shared \`style.css\` at the root and every page links to it via a depth-aware relative href, plus a sidebar nav with the manifest tree so the reader can jump between pages without back-button acrobatics.

## How

- \`wrapHtml\` grew optional \`stylesheetHref\` + \`sidebarHtml\` params. When set, emits \`<link rel="stylesheet">\` instead of \`<style>\` and wraps the article in a sidebar layout (CSS grid, sticky nav).
- Tree-html exporter computes per-page \`rootRel\` (number of \`../\`s) so \`style.css\` and inter-bundle links resolve cleanly from any depth.
- Sidebar lists every page in BFS manifest order; current page wears \`class="current"\` + \`aria-current="page"\`.
- \`style.css\` aggregates \`NOTE_HTML_STYLE\` + a small bundle-nav CSS block, so single-note exports stay unaffected (they keep their inline-style shape).
- Print stylesheet hides the sidebar so printed output collapses to the article column.

## Closes

Resolves #292.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/tree-html.test.ts\` — 13/13 (3 new for #292: stylesheet emission + per-page link, depth-aware href, sidebar with current-page marker).
- [x] \`pnpm vitest run tests/main/publish\` — 267/267
- [x] \`pnpm lint\` — clean
- [ ] Manual: export a wiki-linked tree, browse pages, confirm sidebar highlights the current page and \`style.css\` resolves from a deeply-nested page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)