### PR TITLE
Publication: manual per-note deselection in the export preview (#293)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1098,6 +1098,7 @@ export function registerIpcHandlers(): void {
     citationStyle?: string;
     citationLocale?: string;
     forceInclude?: string[];
+    forceExclude?: string[];
   }) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
@@ -1106,6 +1107,7 @@ export function registerIpcHandlers(): void {
       citationStyle: opts?.citationStyle,
       citationLocale: opts?.citationLocale,
       forceInclude: opts?.forceInclude,
+      forceExclude: opts?.forceExclude,
     });
     // Strip `content` + `frontmatter` from the wire payload — the preview
     // only needs to audit paths, kinds, and exclusion reasons; loading

--- a/src/main/publish/pipeline.ts
+++ b/src/main/publish/pipeline.ts
@@ -44,6 +44,12 @@ export interface ResolvePlanOptions {
    * `overridden: true` so the preview dialog can render the badge.
    */
   forceInclude?: string[];
+  /**
+   * Manual per-export deselection via the preview dialog (#293). Paths
+   * in this set are removed from `inputs` and surfaced in `excluded`
+   * with reason "manually excluded", regardless of the default rules.
+   */
+  forceExclude?: string[];
 }
 
 export async function resolvePlan(
@@ -54,6 +60,7 @@ export async function resolvePlan(
   let inputs: ExportPlanFile[];
   let excluded: ExportPlanExclusion[];
   const forceInclude = new Set(opts.forceInclude ?? []);
+  const forceExclude = new Set(opts.forceExclude ?? []);
   if (input.kind === 'tree') {
     ({ inputs, excluded } = await collectTreeEntries(rootPath, input, forceInclude));
   } else if (input.kind === 'source') {
@@ -66,6 +73,24 @@ export async function resolvePlan(
     ({ inputs, excluded } = await collectSourceEntry(rootPath, input));
   } else {
     ({ inputs, excluded } = await collectFilesystemEntries(rootPath, input, forceInclude));
+  }
+
+  // Apply manual deselection (#293): move force-excluded inputs to the
+  // excluded list with a clear reason. Done after resolution so the
+  // resolver's normal logic isn't bypassed; the user's manual call
+  // wins last.
+  if (forceExclude.size > 0) {
+    const kept: ExportPlanFile[] = [];
+    for (const f of inputs) {
+      if (forceExclude.has(f.relativePath)) {
+        excluded.push({ relativePath: f.relativePath, reason: 'manually excluded' });
+      } else {
+        kept.push(f);
+      }
+    }
+    inputs = kept;
+    // Sort excluded for deterministic preview ordering.
+    excluded.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
   }
 
   const citations = await loadCitationAssets(rootPath, {

--- a/src/main/publish/run-export.ts
+++ b/src/main/publish/run-export.ts
@@ -31,6 +31,11 @@ export interface RunExportInput {
    * private-by-default rules.
    */
   forceInclude?: string[];
+  /**
+   * Manual deselection: paths the user unchecked in the preview
+   * dialog's Including list (#293). Force-excluded from the export.
+   */
+  forceExclude?: string[];
 }
 
 export interface RunExportResult {
@@ -61,6 +66,7 @@ export async function runExport(
     citationStyle: args.citationStyle,
     citationLocale: args.citationLocale,
     forceInclude: args.forceInclude,
+    forceExclude: args.forceExclude,
     outputDir: args.outputDir,
   });
   const output = await runExporter(exporter, plan);

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -40,12 +40,23 @@
   // user has explicitly re-included; the pipeline force-includes them
   // even when the private-by-default rules would otherwise exclude.
   let overrides = $state(new Set<string>());
+  // Manual deselections (#293). Set of relative paths the user has
+  // unchecked in the Including list; the pipeline force-excludes them
+  // and surfaces them in Excluded with reason "manually excluded".
+  let deselections = $state(new Set<string>());
 
   function toggleOverride(relativePath: string): void {
     const next = new Set(overrides);
     if (next.has(relativePath)) next.delete(relativePath);
     else next.add(relativePath);
     overrides = next;
+  }
+
+  function toggleDeselection(relativePath: string): void {
+    const next = new Set(deselections);
+    if (next.has(relativePath)) next.delete(relativePath);
+    else next.add(relativePath);
+    deselections = next;
   }
 
   const activeFolder = $derived.by(() => {
@@ -80,6 +91,7 @@
         citationStyle,
         citationLocale,
         forceInclude: [...overrides],
+        forceExclude: [...deselections],
       });
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
@@ -123,6 +135,7 @@
     void citationLocale;
     void activeFilePath;
     void overrides;
+    void deselections;
     if (!acceptedLoaded) return;
     void refreshPlan();
   });
@@ -139,6 +152,7 @@
         citationStyle,
         citationLocale,
         forceInclude: [...overrides],
+        forceExclude: [...deselections],
       });
       if (result === null) return; // user cancelled the directory picker
       onExported(result);
@@ -234,13 +248,26 @@
                 {overrides.size} overridden
               </span>
             {/if}
+            {#if deselections.size > 0}
+              <span class="count override-count" title="{deselections.size} item{deselections.size === 1 ? '' : 's'} manually excluded for this export">
+                {deselections.size} unchecked
+              </span>
+            {/if}
           </h3>
           {#if plan.inputs.length === 0}
             <p class="empty">Nothing to export in this scope.</p>
           {:else}
+            <p class="hint">Uncheck a row to drop it from this export only.</p>
             <ul>
               {#each plan.inputs.slice(0, 40) as f (f.relativePath)}
                 <li class:overridden={f.overridden}>
+                  <input
+                    type="checkbox"
+                    class="row-check"
+                    checked
+                    onchange={() => toggleDeselection(f.relativePath)}
+                    title="Uncheck to drop this note from the export"
+                  />
                   <span class="title">
                     {f.title}
                     {#if f.overridden}
@@ -272,7 +299,11 @@
                 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions -->
                 <li
                   class="clickable"
-                  onclick={() => toggleOverride(ex.relativePath)}
+                  onclick={() => (
+                    ex.reason === 'manually excluded'
+                      ? toggleDeselection(ex.relativePath)
+                      : toggleOverride(ex.relativePath)
+                  )}
                   title="Click to re-include in the export"
                 >
                   <span class="title">{ex.relativePath}</span>
@@ -475,6 +506,29 @@
     font-size: 11px;
     color: var(--text-muted);
     font-style: italic;
+  }
+
+  /* Including-row checkbox for manual deselection (#293). */
+  .audit-section .row-check {
+    margin-right: 6px;
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin-top: 3px;
+  }
+  .audit-section li {
+    flex-direction: row;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .audit-section li > .title,
+  .audit-section li > .path,
+  .audit-section li > .reason {
+    flex-basis: 100%;
+  }
+  .audit-section li > .row-check ~ .title,
+  .audit-section li > .row-check ~ .path,
+  .audit-section li > .row-check ~ .reason {
+    flex-basis: calc(100% - 22px);
   }
 
   /* Excluded-row click affordance + override badge (#283). */

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -209,6 +209,8 @@ export interface RunExportInput {
   citationLocale?: string;
   /** Manual per-export exclusion overrides — relative paths to force-include (#283). */
   forceInclude?: string[];
+  /** Manual per-export deselection — relative paths to force-exclude (#293). */
+  forceExclude?: string[];
 }
 
 export interface RunExportResult {
@@ -230,6 +232,7 @@ export interface PublishApi {
       citationStyle?: string;
       citationLocale?: string;
       forceInclude?: string[];
+      forceExclude?: string[];
     },
   ): Promise<ExportPreviewPlan>;
   /**

--- a/tests/main/publish/force-include.test.ts
+++ b/tests/main/publish/force-include.test.ts
@@ -82,6 +82,66 @@ describe('forceInclude — per-export exclusion override (#283)', () => {
     expect(pub?.overridden).toBe(false);
   });
 
+  // ── #293 — manual per-note deselection mirror ─────────────────────────
+
+  it('forceExclude moves an included path into excluded with reason "manually excluded"', async () => {
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { forceExclude: ['public.md'] },
+    );
+    expect(plan.inputs.map((f) => f.relativePath)).not.toContain('public.md');
+    const manual = plan.excluded.find((e) => e.relativePath === 'public.md');
+    expect(manual).toBeDefined();
+    expect(manual!.reason).toBe('manually excluded');
+  });
+
+  it('forceExclude is independent of forceInclude — different paths each list', async () => {
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      {
+        forceInclude: ['private/secret.md'], // re-include a private one
+        forceExclude: ['public.md'],          // drop the only normal one
+      },
+    );
+    const includedPaths = plan.inputs.map((f) => f.relativePath).sort();
+    expect(includedPaths).toEqual(['private/secret.md']);
+    const excludedPaths = plan.excluded.map((e) => e.relativePath).sort();
+    expect(excludedPaths).toContain('flag.md'); // still excluded by default rules
+    expect(excludedPaths).toContain('public.md'); // manually excluded
+  });
+
+  it('tree mode honours forceExclude — a reachable note can be deselected', async () => {
+    await fsp.writeFile(path.join(root, 'tree-root.md'),
+      '---\ntitle: Root\n---\n# Root\n\n[[public]]\n', 'utf-8');
+    const plan = await resolvePlan(
+      root,
+      { kind: 'tree', relativePath: 'tree-root.md', maxDepth: 2 },
+      { forceExclude: ['public.md'] },
+    );
+    expect(plan.inputs.map((f) => f.relativePath)).not.toContain('public.md');
+    const manual = plan.excluded.find((e) => e.relativePath === 'public.md');
+    expect(manual?.reason).toBe('manually excluded');
+  });
+
+  it('forceExclude on a non-included path is a silent no-op', async () => {
+    // The default rules already exclude flag.md; force-excluding it
+    // should not double-add to excluded or otherwise misbehave.
+    const plan = await resolvePlan(
+      root,
+      { kind: 'project' },
+      { forceExclude: ['flag.md', 'nonexistent.md'] },
+    );
+    // flag.md is in excluded once, with the original reason (private:
+    // true via frontmatter), not "manually excluded".
+    const flag = plan.excluded.filter((e) => e.relativePath === 'flag.md');
+    expect(flag).toHaveLength(1);
+    expect(flag[0].reason).not.toBe('manually excluded');
+    // nonexistent.md doesn't appear at all.
+    expect(plan.excluded.find((e) => e.relativePath === 'nonexistent.md')).toBeUndefined();
+  });
+
   it('tree mode honours forceInclude for an otherwise-private linked note', async () => {
     await fsp.writeFile(path.join(root, 'root.md'),
       '---\ntitle: Root\n---\n# Root\n\n[[private/secret]]\n', 'utf-8');


### PR DESCRIPTION
## Summary

Mirror of #283 in the other direction. Each row in the Including list grows a checkbox; unchecking moves the entry to the Excluded list with reason "manually excluded" and re-checking moves it back. The Including header shows an audit count ("3 unchecked") so the user can't accidentally ship without realising they've trimmed the export.

## How

### Pipeline
- New \`forceExclude: string[]\` on \`ResolvePlanOptions\` and \`RunExportInput\`. Applied after resolution so the resolver's normal logic isn't bypassed — the manual call wins last.
- Excluded entries from \`forceExclude\` carry reason **"manually excluded"** — the dialog uses that reason to route Excluded-row clicks back through \`toggleDeselection\` (re-check) instead of \`toggleOverride\` (re-include via private-rule override).

### UI
- Dialog tracks \`deselections\` in a \`Set<string>\`; \`$effect\` re-resolves on every toggle.
- Row checkbox styled with flex-row layout so the title + path pair flows underneath cleanly.
- Clicking a "manually excluded" row in Excluded re-checks it; clicking any other excluded row force-includes it via the #283 path. Routing dispatched on \`ex.reason\` so the user gets the right behaviour without having to think about which case they're in.

## Closes

Resolves #293. Closes the last open ticket from #251's umbrella deferral list.

## Test plan

- [x] \`pnpm vitest run tests/main/publish/force-include.test.ts\` — 9/9 (4 new for #293: simple deselection, deselection + override compose, tree mode honours \`forceExclude\`, no-op for non-included paths).
- [x] \`pnpm vitest run tests/main/publish\` — 271/271
- [x] \`pnpm lint\` — clean
- [ ] Manual: open the dialog with a project, uncheck a row, confirm it appears in Excluded with the new reason; click it back, confirm it returns to Including.

🤖 Generated with [Claude Code](https://claude.com/claude-code)