### PR TITLE
Compute: image/SVG asset save + Copy-as-CSV + missing-source stock query (#244)

### DIFF
--- a/src/main/compute/save-cell-output.ts
+++ b/src/main/compute/save-cell-output.ts
@@ -81,16 +81,31 @@ export async function saveCellOutput(
   }
 
   const derivedPath = input.destPath ?? defaultDerivedNotePath(input.sourcePath, cellId);
-  const markdown = buildDerivedNote({
+  const { markdown, assets } = buildDerivedNote({
     title: input.title,
     output: input.output,
     sourcePath: input.sourcePath,
     cellId,
+    derivedPath,
   });
 
   const destFull = path.join(rootPath, derivedPath);
   await fs.mkdir(path.dirname(destFull), { recursive: true });
   await fs.writeFile(destFull, markdown, 'utf-8');
+
+  // Sidecar assets — image / SVG cell outputs land under
+  // `.minerva/assets/derived/` (#244 phase 2). Sequential rather than
+  // parallel since most saves emit zero or one asset; the parallel
+  // form would just add ceremony.
+  for (const asset of assets) {
+    const assetFull = path.join(rootPath, asset.relativePath);
+    await fs.mkdir(path.dirname(assetFull), { recursive: true });
+    if (typeof asset.contents === 'string') {
+      await fs.writeFile(assetFull, asset.contents, 'utf-8');
+    } else {
+      await fs.writeFile(assetFull, asset.contents);
+    }
+  }
 
   return { derivedPath, cellId, injectedId: wasNew };
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -317,6 +317,14 @@ export function registerIpcHandlers(): void {
     return notebaseFs.readFile(rootPath, relativePath);
   });
 
+  ipcMain.handle(Channels.NOTEBASE_READ_BINARY, async (e, relativePath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    // Pass the bytes back as a Buffer; Electron's structured-clone
+    // bridge wraps it in a Uint8Array on the renderer side.
+    return notebaseFs.readBinaryFile(rootPath, relativePath);
+  });
+
   ipcMain.handle(Channels.NOTEBASE_WRITE_FILE, async (e, relativePath: string, content: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -101,6 +101,20 @@ export async function readFile(rootPath: string, relativePath: string): Promise<
   return fs.readFile(fullPath, 'utf-8');
 }
 
+/**
+ * Binary-safe read for images / pdfs / other non-text assets the
+ * renderer needs to display inline (#244 image rendering, #243 image
+ * cell outputs persisted as sidecar files). Returns the raw bytes;
+ * the caller decides how to encode (base64 + data URL is typical).
+ *
+ * Same path-traversal guard as `readFile`: out-of-root reads throw.
+ */
+export async function readBinaryFile(rootPath: string, relativePath: string): Promise<Uint8Array> {
+  const fullPath = assertSafePath(rootPath, relativePath);
+  const buf = await fs.readFile(fullPath);
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
 export async function writeFile(rootPath: string, relativePath: string, content: string): Promise<void> {
   const fullPath = assertSafePath(rootPath, relativePath);
   await fs.mkdir(path.dirname(fullPath), { recursive: true });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -23,6 +23,8 @@ contextBridge.exposeInMainWorld('api', {
     listFiles: () => ipcRenderer.invoke(Channels.NOTEBASE_LIST_FILES),
     readFile: (relativePath: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_READ_FILE, relativePath),
+    readBinary: (relativePath: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_READ_BINARY, relativePath),
     writeFile: (relativePath: string, content: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_WRITE_FILE, relativePath, content),
     createFile: (relativePath: string) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1276,7 +1276,13 @@
       `Save cell output as note. Path (default: notes/derived/):`,
     );
     if (dest === null) return; // user cancelled
-    const trimmed = dest.trim();
+    let trimmed = dest.trim();
+    // Add `.md` if the user typed a bare path. The pipeline writes a
+    // markdown note unconditionally, so a missing extension would
+    // produce a file that `Open` doesn't recognise as a note.
+    if (trimmed.length > 0 && !/\.md$/i.test(trimmed)) {
+      trimmed += '.md';
+    }
     try {
       const result = await api.compute.saveCellOutput({
         sourcePath,
@@ -2124,6 +2130,7 @@
               <div class="preview-panel">
                 <Preview
                   content={editor.content}
+                  notePath={editor.activeFilePath}
                   onNavigate={handleNavigate}
                   onTagSelect={handleTagSelect}
                   onOpenSource={handleOpenSource}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -338,7 +338,14 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
    * project-rooted relative path (no leading `/`).
    */
   function resolveRelativeImagePath(src: string, fromNote: string | null | undefined): string {
-    const noteDir = fromNote ? fromNote.replace(/\/[^/]*$/, '') : '';
+    // Split off the note's parent directory. The regex form
+    // `/\/[^/]*$/` would silently fall back to the full string when
+    // there's no slash — i.e. for a project-root note like
+    // `graph.md`, `noteDir` would become `graph.md` and downstream
+    // resolution would treat the file itself as a directory (the
+    // ENOTDIR symptom). Use a guarded lastIndexOf instead.
+    const lastSlash = fromNote ? fromNote.lastIndexOf('/') : -1;
+    const noteDir = lastSlash > 0 && fromNote ? fromNote.slice(0, lastSlash) : '';
     const baseSegments = noteDir ? noteDir.split('/') : [];
     const srcSegments = src.split('/');
     const out: string[] = [...baseSegments];

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -23,6 +23,13 @@
 
   interface Props {
     content: string;
+    /**
+     * Project-relative path of the note being rendered. Used to
+     * resolve relative `![](image.png)` references against the note's
+     * directory (#244 image rendering). Null when no file is open or
+     * the editor's path isn't surfaced (preview-only contexts).
+     */
+    notePath?: string | null;
     onNavigate: (target: string) => void;
     onTagSelect?: (tag: string) => void;
     onOpenSource?: (sourceId: string) => void;
@@ -45,7 +52,7 @@
     }) => void;
   }
 
-  let { content, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved, onTaskToggle, onSaveCellOutput }: Props = $props();
+  let { content, notePath = null, onNavigate, onTagSelect, onOpenSource, onOpenExcerpt, pendingAnchor = null, onAnchorResolved, onTaskToggle, onSaveCellOutput }: Props = $props();
 
   // Query result cache: query text → results (survives re-renders)
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
@@ -251,6 +258,34 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     return `<span class="note-tag" data-tag="${escapeAttr(tag)}">#${escapeHtml(tag)}</span>`;
   };
 
+  /**
+   * Image rule (#244). markdown-it would normally emit `<img src="…">`
+   * with the URL untouched; in the renderer that breaks for relative
+   * paths because the document base is the Vite dev server / packaged
+   * app URL, not the user's project root.
+   *
+   * Strategy: emit a placeholder `<img class="local-image" data-rel="…">`
+   * for relative paths and let a post-render pass fetch each via
+   * `api.notebase.readBinary`, then swap in a data URL. http(s) /
+   * data: / file: pass through unchanged.
+   */
+  md.renderer.rules.image = (tokens, idx, options, env, self) => {
+    const tok = tokens[idx];
+    const srcIdx = tok.attrIndex('src');
+    if (srcIdx < 0) return self.renderToken(tokens, idx, options);
+    const src = tok.attrs![srcIdx][1];
+    if (/^(?:https?:|data:|file:|blob:|mailto:)/i.test(src) || src.startsWith('//')) {
+      // Absolute / data URL — render normally.
+      return self.renderToken(tokens, idx, options);
+    }
+    const rel = resolveRelativeImagePath(src, notePath);
+    const altIdx = tok.attrIndex('alt');
+    const alt = altIdx >= 0 ? tok.attrs![altIdx][1] : (tok.content ?? '');
+    const titleIdx = tok.attrIndex('title');
+    const title = titleIdx >= 0 ? ` title="${escapeAttr(tok.attrs![titleIdx][1])}"` : '';
+    return `<img class="local-image" data-rel="${escapeAttr(rel)}" alt="${escapeAttr(alt)}"${title} />`;
+  };
+
   // Compute-cell output blocks (#238). A ```output fence below an executable
   // fence carries the JSON payload the executor produced; render it as a
   // shape-specific artifact (table / error / text / pretty JSON) rather
@@ -295,6 +330,87 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       }
     }
     return null;
+  }
+
+  /**
+   * Resolve a relative `![](src)` reference against the note's
+   * directory and normalise so `..` segments collapse. Returns a
+   * project-rooted relative path (no leading `/`).
+   */
+  function resolveRelativeImagePath(src: string, fromNote: string | null | undefined): string {
+    const noteDir = fromNote ? fromNote.replace(/\/[^/]*$/, '') : '';
+    const baseSegments = noteDir ? noteDir.split('/') : [];
+    const srcSegments = src.split('/');
+    const out: string[] = [...baseSegments];
+    for (const seg of srcSegments) {
+      if (seg === '' || seg === '.') continue;
+      if (seg === '..') {
+        if (out.length > 0) out.pop();
+        continue;
+      }
+      out.push(seg);
+    }
+    return out.join('/');
+  }
+
+  /**
+   * Cache of {projectRelPath → data URL} for images referenced from
+   * the rendered note. Survives re-renders so panning around a long
+   * doc doesn't keep refetching the same `<img>` over and over.
+   * Cleared when the active note changes (the path-keyed cache stays
+   * project-scoped automatically since paths include the note dir).
+   */
+  const imageDataUrlCache = new Map<string, string>();
+
+  /** MIME guess from a relative-path extension; data URLs need it explicit. */
+  function mimeFromPath(rel: string): string {
+    const ext = rel.toLowerCase().match(/\.([^./\\]+)$/)?.[1] ?? '';
+    if (ext === 'png') return 'image/png';
+    if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
+    if (ext === 'gif') return 'image/gif';
+    if (ext === 'webp') return 'image/webp';
+    if (ext === 'svg') return 'image/svg+xml';
+    if (ext === 'avif') return 'image/avif';
+    return 'application/octet-stream';
+  }
+
+  /**
+   * Post-render hydration: walk every `.local-image[data-rel]`
+   * placeholder, fetch the asset bytes via the binary IPC, and
+   * inline as a data URL. Cached so re-renders are O(1) per image.
+   */
+  async function hydrateLocalImages(): Promise<void> {
+    const root = previewEl;
+    if (!root) return;
+    const imgs = Array.from(root.querySelectorAll<HTMLImageElement>('img.local-image[data-rel]'));
+    await Promise.all(imgs.map(async (img) => {
+      const rel = img.dataset.rel;
+      if (!rel) return;
+      const cached = imageDataUrlCache.get(rel);
+      if (cached) {
+        if (img.src !== cached) img.src = cached;
+        return;
+      }
+      try {
+        const bytes = await api.notebase.readBinary(rel);
+        // Buffer encoding via btoa over a small string is cheap; the
+        // chunked builder avoids "Maximum call stack" for big images.
+        let bin = '';
+        const view: Uint8Array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+        const CHUNK = 0x8000;
+        for (let i = 0; i < view.length; i += CHUNK) {
+          bin += String.fromCharCode.apply(null, Array.from(view.subarray(i, i + CHUNK)));
+        }
+        const url = `data:${mimeFromPath(rel)};base64,${btoa(bin)}`;
+        imageDataUrlCache.set(rel, url);
+        img.src = url;
+      } catch {
+        // Missing / unreadable — flag the placeholder visually so the
+        // user knows the path didn't resolve. Markdown-renderer-style
+        // alt-text fallback is handled by the browser itself.
+        img.classList.add('local-image-broken');
+      }
+    }));
   }
 
   function renderComputeOutput(content: string, source: { language: string; code: string } | null): string {
@@ -535,6 +651,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // metadata fetches. Citeproc-rendered markers replace the
       // raw cite/quote display text per the project's CSL style.
       void applyCslMarkers();
+      // Image hydration (#244) — same shape as CSL markers: walk the
+      // rendered DOM, fetch each `<img class="local-image">` via the
+      // binary IPC, swap in a data URL. Cached per-path so re-renders
+      // skip the round-trip.
+      void hydrateLocalImages();
     });
   });
 
@@ -1538,6 +1659,26 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     border-radius: 4px;
     background: #fff; /* Many matplotlib figures save with transparent bg */
     cursor: zoom-in;
+  }
+  /* Local images from `![](path)` references (#244). Pre-hydration
+     they're empty `<img>` placeholders; sized with a min-height so
+     the page doesn't reflow when the data URL lands. The .broken
+     state surfaces unresolvable paths so the user can spot the typo. */
+  .preview :global(img.local-image) {
+    max-width: 100%;
+    height: auto;
+    min-height: 1em;
+  }
+  .preview :global(img.local-image-broken) {
+    outline: 1px dashed var(--accent);
+    background: var(--bg-button);
+    min-height: 80px;
+  }
+  .preview :global(img.local-image-broken)::after {
+    content: 'image not found';
+    color: var(--text-muted);
+    font-size: 11px;
+    font-style: italic;
   }
   .preview :global(.compute-output-image.zoomed) {
     cursor: zoom-out;

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -392,6 +392,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         return;
       }
       try {
+        if (typeof api.notebase.readBinary !== 'function') {
+          throw new Error(
+            'api.notebase.readBinary is not exposed. Preload changes require a full Electron restart (Cmd-R reloads the renderer only).',
+          );
+        }
         const bytes = await api.notebase.readBinary(rel);
         // Buffer encoding via btoa over a small string is cheap; the
         // chunked builder avoids "Maximum call stack" for big images.
@@ -404,10 +409,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         const url = `data:${mimeFromPath(rel)};base64,${btoa(bin)}`;
         imageDataUrlCache.set(rel, url);
         img.src = url;
-      } catch {
-        // Missing / unreadable — flag the placeholder visually so the
-        // user knows the path didn't resolve. Markdown-renderer-style
-        // alt-text fallback is handled by the browser itself.
+      } catch (err) {
+        // Missing / unreadable — flag the placeholder visually and log
+        // the underlying error to the devtools console so a typo'd
+        // path or a missing asset is easy to debug.
+        console.warn('[preview] image hydration failed for', rel, err);
         img.classList.add('local-image-broken');
       }
     }));

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1011,6 +1011,34 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     outputMenu = null;
   }
 
+  function handleCopyAsCsv(): void {
+    if (!outputMenu || outputMenu.output.type !== 'table') return;
+    const csv = tableToCsv(outputMenu.output.columns, outputMenu.output.rows);
+    void navigator.clipboard.writeText(csv);
+    outputMenu = null;
+  }
+
+  /**
+   * RFC-4180-ish CSV: quote fields containing commas, quotes, or
+   * newlines; double internal quotes; CRLF row terminator. Pasted into
+   * Excel / Numbers / Sheets it parses back to the original table.
+   */
+  function tableToCsv(
+    columns: string[],
+    rows: Array<Array<string | number | boolean | null>>,
+  ): string {
+    const escape = (v: string | number | boolean | null): string => {
+      if (v == null) return '';
+      const s = String(v);
+      if (/[",\r\n]/.test(s)) {
+        return '"' + s.replace(/"/g, '""') + '"';
+      }
+      return s;
+    };
+    const lines = [columns.map(escape).join(','), ...rows.map((r) => r.map(escape).join(','))];
+    return lines.join('\r\n');
+  }
+
   function outputToMarkdownClipboard(output: import('../../../shared/compute/types').CellOutput): string {
     if (output.type === 'table') {
       if (output.columns.length === 0) return '*(empty result)*';
@@ -1138,6 +1166,9 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       <button role="menuitem" onclick={handleSaveAsNote}>Save as note…</button>
     {/if}
     <button role="menuitem" onclick={handleCopyAsMarkdown}>Copy as markdown</button>
+    {#if outputMenu.output.type === 'table'}
+      <button role="menuitem" onclick={handleCopyAsCsv}>Copy as CSV</button>
+    {/if}
   </div>
 {/if}
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -15,6 +15,8 @@ export interface NotebaseApi {
   clearRecent(): Promise<void>;
   listFiles(): Promise<NoteFile[]>;
   readFile(relativePath: string): Promise<string>;
+  /** Binary-safe read for images / pdfs / other non-text assets (#244). */
+  readBinary(relativePath: string): Promise<Uint8Array>;
   writeFile(relativePath: string, content: string): Promise<void>;
   createFile(relativePath: string): Promise<void>;
   deleteFile(relativePath: string): Promise<void>;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -3,6 +3,9 @@ export const Channels = {
   NOTEBASE_OPEN: 'notebase:open',
   NOTEBASE_LIST_FILES: 'notebase:listFiles',
   NOTEBASE_READ_FILE: 'notebase:readFile',
+  /** Read an arbitrary file as bytes — used by the Preview's image rule
+   *  to inline `![](...)` references as data URLs (#244 image rendering). */
+  NOTEBASE_READ_BINARY: 'notebase:readBinary',
   NOTEBASE_WRITE_FILE: 'notebase:writeFile',
   NOTEBASE_CREATE_FILE: 'notebase:createFile',
   NOTEBASE_DELETE_FILE: 'notebase:deleteFile',

--- a/src/shared/compute/derived-note.ts
+++ b/src/shared/compute/derived-note.ts
@@ -26,11 +26,35 @@ export interface BuildDerivedNoteInput {
   cellId: string;
   /** Override the timestamp (tests use a fixed clock). */
   now?: () => Date;
+  /**
+   * Relative path the derived note will be written to. Used to compute
+   * relative `![](…)` image paths so a saved chart resolves correctly
+   * regardless of how deep the derived note sits. When omitted, the
+   * default `notes/derived/<stem>-<cellId>.md` shape from
+   * `defaultDerivedNotePath` is assumed.
+   */
+  derivedPath?: string;
 }
 
-export function buildDerivedNote(input: BuildDerivedNoteInput): string {
+export interface BuildDerivedNoteResult {
+  /** The note's markdown body (frontmatter + heading + rendered output + backlink). */
+  markdown: string;
+  /**
+   * Sidecar files the saver should write alongside the note. Image and
+   * SVG outputs (#243) produce one entry here; tabular and JSON
+   * outputs leave the array empty.
+   *
+   * `relativePath` is project-relative (e.g.
+   * `.minerva/assets/derived/foo-123.png`); the markdown body
+   * references it via a path made relative to the note itself.
+   */
+  assets: Array<{ relativePath: string; contents: Uint8Array | string }>;
+}
+
+export function buildDerivedNote(input: BuildDerivedNoteInput): BuildDerivedNoteResult {
   const now = (input.now ?? (() => new Date()))().toISOString();
   const title = input.title ?? defaultTitleFrom(input.sourcePath, input.cellId);
+  const derivedPath = input.derivedPath ?? defaultDerivedNotePath(input.sourcePath, input.cellId);
 
   // `derived_from` is emitted as a wiki-link form so the frontmatter
   // indexer resolves it to the source note's URI — that's what lets
@@ -48,7 +72,11 @@ export function buildDerivedNote(input: BuildDerivedNoteInput): string {
     '---',
   ].join('\n');
 
-  const body = renderOutputToMarkdown(input.output);
+  const { body, assets } = renderOutputForDerivedNote(input.output, {
+    derivedPath,
+    cellId: input.cellId,
+    sourcePath: input.sourcePath,
+  });
 
   // Wiki-link target is the source note's basename (anchors on its
   // `cell-<id>` slug), matching Minerva's existing `[[path#anchor]]`
@@ -58,11 +86,22 @@ export function buildDerivedNote(input: BuildDerivedNoteInput): string {
   const backlinkTarget = linkTargetForSource(input.sourcePath);
   const backlink = `*Derived from [[${backlinkTarget}#cell-${input.cellId}]] on ${now.slice(0, 10)}.*`;
 
-  return `${frontmatter}\n\n# ${escapeHeading(title)}\n\n${body}\n\n${backlink}\n`;
+  const markdown = `${frontmatter}\n\n# ${escapeHeading(title)}\n\n${body}\n\n${backlink}\n`;
+  return { markdown, assets };
 }
 
 // ── Output → markdown ──────────────────────────────────────────────────────
 
+/**
+ * Render an output for the derived note. Pure body shape — no
+ * frontmatter, no backlink — used by the clipboard "Copy as markdown"
+ * affordance and by the asset-aware variant below.
+ *
+ * Image and HTML outputs (#243) get rendered through the asset-aware
+ * variant since they need sidecar files; this string-only path falls
+ * back to a code block so the clipboard helper still produces
+ * something legible.
+ */
 export function renderOutputToMarkdown(output: CellOutput): string {
   if (output.type === 'table') {
     return renderTableToMarkdown(output.columns, output.rows);
@@ -73,8 +112,72 @@ export function renderOutputToMarkdown(output: CellOutput): string {
   if (output.type === 'json') {
     return '```json\n' + JSON.stringify(output.value, null, 2) + '\n```';
   }
-  // Exhaustiveness — current CellOutput union covers the three above.
+  if (output.type === 'image') {
+    // Clipboard path for an image — embed as a data URL so a paste into
+    // GitHub/Substack/etc. still renders. The asset-aware path used by
+    // "Save as note" produces a sidecar file + relative `![](…)`.
+    if (output.mime === 'image/png') {
+      return `![](data:image/png;base64,${output.data})`;
+    }
+    return '```svg\n' + output.data + '\n```';
+  }
+  if (output.type === 'html') {
+    return output.html;
+  }
   return '```\n' + JSON.stringify(output) + '\n```';
+}
+
+/**
+ * Asset-aware variant: image and SVG outputs produce a sidecar file
+ * under `.minerva/assets/derived/` and an `![](relative-path)` body.
+ * Other output types route through the string-only path above.
+ */
+function renderOutputForDerivedNote(
+  output: CellOutput,
+  ctx: { derivedPath: string; cellId: string; sourcePath: string },
+): { body: string; assets: BuildDerivedNoteResult['assets'] } {
+  if (output.type === 'image') {
+    const ext = output.mime === 'image/png' ? 'png' : 'svg';
+    const stem = pathStem(ctx.sourcePath);
+    const assetRel = `.minerva/assets/derived/${stem}-${ctx.cellId}.${ext}`;
+    const contents: Uint8Array | string = output.mime === 'image/png'
+      ? base64ToBytes(output.data)
+      : output.data;
+    const relFromNote = relativeFromNoteToAsset(ctx.derivedPath, assetRel);
+    return {
+      body: `![](${relFromNote})`,
+      assets: [{ relativePath: assetRel, contents }],
+    };
+  }
+  return { body: renderOutputToMarkdown(output), assets: [] };
+}
+
+/**
+ * Path made relative from a note's directory to a project-rooted
+ * asset path. Independent of `node:path` so this stays usable in the
+ * renderer / browser without polyfills.
+ */
+function relativeFromNoteToAsset(notePath: string, assetPath: string): string {
+  const noteDir = notePath.includes('/') ? notePath.slice(0, notePath.lastIndexOf('/')) : '';
+  const noteSegments = noteDir ? noteDir.split('/') : [];
+  const assetSegments = assetPath.split('/');
+  let common = 0;
+  while (
+    common < noteSegments.length
+    && common < assetSegments.length
+    && noteSegments[common] === assetSegments[common]
+  ) common++;
+  const ups = noteSegments.length - common;
+  const upParts: string[] = Array.from({ length: ups }, () => '..');
+  const downs = assetSegments.slice(common);
+  return [...upParts, ...downs].join('/');
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  // Buffer is the cheapest path in Node; the renderer doesn't run this
+  // code (it sticks to renderOutputToMarkdown for clipboard rendering).
+  const buf = Buffer.from(b64, 'base64');
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
 function renderTableToMarkdown(
@@ -102,6 +205,15 @@ function defaultTitleFrom(sourcePath: string, cellId: string): string {
   const base = sourcePath.split('/').pop() ?? sourcePath;
   const stem = base.replace(/\.md$/i, '');
   return `${stem} — cell ${cellId}`;
+}
+
+function pathStem(relativePath: string): string {
+  const base = relativePath.split('/').pop() ?? 'note';
+  return base
+    .replace(/\.md$/i, '')
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'note';
 }
 
 /**

--- a/src/shared/stock-queries.ts
+++ b/src/shared/stock-queries.ts
@@ -235,6 +235,23 @@ SELECT ?sourceId ?title ?creator WHERE {
 ORDER BY ?sourceId`,
   },
   {
+    name: 'Compute: derived notes missing their source (#244)',
+    description: 'Notes saved via "Save cell output as note" whose source notebook no longer exists — surfaces breakage from a delete/rename that didn\'t fix up the derived note\'s provenance.',
+    language: 'sparql',
+    query: `${PREFIXES}
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT ?derived ?missingSource WHERE {
+  ?derived prov:wasDerivedFrom ?missingSource .
+  # The source URI doesn't appear as a subject anywhere in the graph
+  # — i.e. the indexer never saw a note at that path. Renaming a
+  # source without fixing up the derived note's frontmatter falls
+  # into this bucket.
+  FILTER NOT EXISTS { ?missingSource ?p ?o }
+}
+ORDER BY ?derived`,
+  },
+  {
     name: 'Trust: Unreviewed LLM writes',
     description: 'Components attributed to an LLM without a corresponding approved proposal (trust principle violations)',
     language: 'sparql',

--- a/tests/shared/compute/derived-note.test.ts
+++ b/tests/shared/compute/derived-note.test.ts
@@ -9,7 +9,7 @@ const FROZEN_NOW = () => new Date('2026-04-20T14:22:00.000Z');
 
 describe('buildDerivedNote (#244)', () => {
   it('produces a well-formed note with frontmatter, title, table body, and backlink', () => {
-    const md = buildDerivedNote({
+    const { markdown: md } = buildDerivedNote({
       output: {
         type: 'table',
         columns: ['station', 'trend'],
@@ -36,13 +36,91 @@ describe('buildDerivedNote (#244)', () => {
   });
 
   it('falls back to a sensible title when none is provided', () => {
-    const md = buildDerivedNote({
+    const { markdown: md } = buildDerivedNote({
       output: { type: 'text', value: 'hi' },
       sourcePath: 'notes/scratch.md',
       cellId: 'abc',
       now: FROZEN_NOW,
     });
     expect(md).toContain('title: "scratch — cell abc"');
+  });
+
+  it('image output: emits a sidecar asset + relative-path image embed (#244 phase 2)', () => {
+    // 1×1 transparent PNG (`base64 -d` of this is a valid 67-byte PNG).
+    const png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAuMB8DtXNJsAAAAASUVORK5CYII=';
+    const { markdown: md, assets } = buildDerivedNote({
+      output: { type: 'image', mime: 'image/png', data: png },
+      sourcePath: 'notes/analysis/chart.md',
+      cellId: 'abc123',
+      now: FROZEN_NOW,
+    });
+    // Asset shape: project-rooted under .minerva/assets/derived/, named
+    // after the source-stem + cellId, PNG bytes decoded from base64.
+    expect(assets).toHaveLength(1);
+    expect(assets[0].relativePath).toBe('.minerva/assets/derived/chart-abc123.png');
+    expect(assets[0].contents).toBeInstanceOf(Uint8Array);
+    // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+    const bytes = assets[0].contents as Uint8Array;
+    expect([...bytes.slice(0, 8)]).toEqual([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+    // Markdown body has a relative-path embed climbing from the
+    // default derived-note location (notes/derived/) to the asset.
+    expect(md).toContain('![](../../.minerva/assets/derived/chart-abc123.png)');
+    expect(md).not.toContain('data:image');
+  });
+
+  it('SVG output: emits the raw markup as a sidecar asset', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>';
+    const { markdown: md, assets } = buildDerivedNote({
+      output: { type: 'image', mime: 'image/svg+xml', data: svg },
+      sourcePath: 'notes/scratch.md',
+      cellId: 'abc',
+      now: FROZEN_NOW,
+    });
+    expect(assets).toHaveLength(1);
+    expect(assets[0].relativePath).toBe('.minerva/assets/derived/scratch-abc.svg');
+    expect(assets[0].contents).toBe(svg);
+    expect(md).toContain('![](../../.minerva/assets/derived/scratch-abc.svg)');
+  });
+
+  it('html output: inlines the markup directly into the body, no asset', () => {
+    const { markdown: md, assets } = buildDerivedNote({
+      output: { type: 'html', html: '<table><tr><td>cell</td></tr></table>' },
+      sourcePath: 'notes/scratch.md',
+      cellId: 'abc',
+      now: FROZEN_NOW,
+    });
+    expect(assets).toEqual([]);
+    expect(md).toContain('<table><tr><td>cell</td></tr></table>');
+  });
+
+  it('non-image outputs (table/text/json) emit no assets', () => {
+    for (const output of [
+      { type: 'table' as const, columns: ['x'], rows: [[1]] },
+      { type: 'text' as const, value: 'hi' },
+      { type: 'json' as const, value: { a: 1 } },
+    ]) {
+      const { assets } = buildDerivedNote({
+        output,
+        sourcePath: 'notes/x.md',
+        cellId: 'abc',
+        now: FROZEN_NOW,
+      });
+      expect(assets).toEqual([]);
+    }
+  });
+
+  it('honours an explicit destPath when computing the relative image path', () => {
+    const png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAuMB8DtXNJsAAAAASUVORK5CYII=';
+    const { markdown: md } = buildDerivedNote({
+      output: { type: 'image', mime: 'image/png', data: png },
+      sourcePath: 'notes/scratch.md',
+      cellId: 'abc',
+      // Custom location — the relative path must climb from there.
+      derivedPath: 'team/reports/2026/Q1/scratch-abc.md',
+      now: FROZEN_NOW,
+    });
+    // team/reports/2026/Q1 → root is 4 ups, then into .minerva/assets/derived/.
+    expect(md).toContain('![](../../../../.minerva/assets/derived/scratch-abc.png)');
   });
 });
 


### PR DESCRIPTION
## Summary

Knocks three items off #244's deferred list now that #243 phase 1 landed an \`image\`-typed \`CellOutput\`. Pin-to-notebook + overwrite-on-resave stay deferred — those are UX-heavy and worth their own ticket.

## What ships

### Image / SVG sidecars
- \`buildDerivedNote\` signature evolved from \`string\` to \`{markdown, assets}\`. Image and SVG outputs produce one asset entry; tabular / text / JSON / HTML stay zero-asset.
- Assets land under \`.minerva/assets/derived/<source-stem>-<cellId>.<ext>\` (project-rooted); markdown body references via a relative \`![]()\` computed from the derived note's location.
- PNG: bytes decoded from base64 and written binary. SVG: raw markup as utf-8.
- HTML output: markup inlined into the body so a saved Seaborn or pandas-style table survives the round-trip.

### Copy as CSV (Preview menu)
- New menu item, **table-only** — only renders when the output type is \`table\`.
- RFC-4180-shape: quoted fields when needed, doubled internal quotes, CRLF row terminator. Pastes back to the original table in Excel / Numbers / Sheets.

### Stock query — "Compute: derived notes missing their source"
- Surfaces derived notes whose \`prov:wasDerivedFrom\` points at a URI that no longer appears as a subject in the graph — i.e. a rename or delete that didn't fix up the derived note's frontmatter.

## Still deferred (separate follow-up)

- **Pin-to-notebook** per-cell flag with overwrite-on-resave
- **Overwrite-with-confirm** on re-save of an already-derived cell

## Test plan

- [x] \`pnpm vitest run tests/main/compute tests/shared/compute\` — 87/87 (5 new in derived-note: PNG roundtrip with magic-byte check, SVG markup, html inline, no-asset table/text/json, explicit destPath relative path).
- [x] \`pnpm lint\` — clean
- [ ] Manual: run a Python cell that returns a matplotlib Figure, click ⋯ → Save as note → confirm a PNG appears under \`.minerva/assets/derived/\` and the new note's \`![](…)\` resolves cleanly. Same for a DataFrame → Copy as CSV → paste into Numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)