### PR TITLE
Editor: drag-and-drop + paste image upload (#455)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -325,6 +325,22 @@ export function registerIpcHandlers(): void {
     return notebaseFs.readBinaryFile(rootPath, relativePath);
   });
 
+  ipcMain.handle(Channels.NOTEBASE_WRITE_BINARY, async (e, relativePath: string, bytes: Uint8Array) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    // The renderer wraps payload as a Uint8Array; structured-clone
+    // hands us a Buffer at this end. Either way `writeBinaryFile`
+    // re-wraps as a strict Uint8Array view.
+    const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    await notebaseFs.writeBinaryFile(rootPath, relativePath, view);
+  });
+
+  ipcMain.handle(Channels.NOTEBASE_FILE_EXISTS, async (e, relativePath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return false;
+    return notebaseFs.fileExists(rootPath, relativePath);
+  });
+
   ipcMain.handle(Channels.NOTEBASE_WRITE_FILE, async (e, relativePath: string, content: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -115,6 +115,36 @@ export async function readBinaryFile(rootPath: string, relativePath: string): Pr
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
+/**
+ * Binary-safe write — pair to `readBinaryFile`. Used for image upload
+ * via drag-and-drop / paste in the editor (#455). Same path-traversal
+ * guard as `writeFile`; creates parent directories on demand.
+ */
+export async function writeBinaryFile(
+  rootPath: string,
+  relativePath: string,
+  bytes: Uint8Array,
+): Promise<void> {
+  const fullPath = assertSafePath(rootPath, relativePath);
+  await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.writeFile(fullPath, bytes);
+}
+
+/**
+ * True iff `relativePath` resolves to an existing file. Used by the
+ * asset-upload path to skip rewriting an asset that's already on
+ * disk under the same content-hashed name (#455).
+ */
+export async function fileExists(rootPath: string, relativePath: string): Promise<boolean> {
+  const fullPath = assertSafePath(rootPath, relativePath);
+  try {
+    const stat = await fs.stat(fullPath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
 export async function writeFile(rootPath: string, relativePath: string, content: string): Promise<void> {
   const fullPath = assertSafePath(rootPath, relativePath);
   await fs.mkdir(path.dirname(fullPath), { recursive: true });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -25,6 +25,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.NOTEBASE_READ_FILE, relativePath),
     readBinary: (relativePath: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_READ_BINARY, relativePath),
+    writeBinary: (relativePath: string, bytes: Uint8Array) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_WRITE_BINARY, relativePath, bytes),
+    fileExists: (relativePath: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_FILE_EXISTS, relativePath),
     writeFile: (relativePath: string, content: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_WRITE_FILE, relativePath, content),
     createFile: (relativePath: string) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -2116,6 +2116,12 @@
                     onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
                     onDecompose={() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); }}
                     onFormatCurrentNote={() => handleFormat()}
+                    onUploadError={(message) => {
+                      // Image-upload rejection (#455). Surface via the
+                      // existing confirm dialog with a dismissable key —
+                      // user-facing but not blocking.
+                      void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
+                    }}
                     onInsertQueryList={async () => {
                       const tag = await showPrompt('Tag name:');
                       if (!tag) return;

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -14,6 +14,12 @@
   import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
   import { historyField } from '@codemirror/commands';
   import { api } from '../ipc/client';
+  import {
+    uploadImage,
+    relativeAssetPathForNote,
+    rejectionMessage,
+    type UploadResult,
+  } from '../editor/image-upload';
   import { sortLines, selectionTracker } from '../editor/commands';
   import {
     toggleBold, toggleItalic, toggleCode, toggleStrikethrough,
@@ -83,6 +89,13 @@
     getNotePaths?: () => string[];
     /** Live list of Sources for `[[cite::…]]` autocomplete. */
     getSources?: () => readonly import('../../../shared/types').SourceMetadata[];
+    /**
+     * Callback for image upload rejections — too-large, unsupported
+     * MIME, etc. — so the host app can surface a toast / dialog (#455).
+     * Errors that aren't user-facing (write-failed mid-stream) also
+     * route through here.
+     */
+    onUploadError?: (message: string) => void;
   }
 
   let {
@@ -115,6 +128,7 @@
     getNotePaths,
     getSources,
     initialHistory,
+    onUploadError,
   }: Props = $props();
 
   const analysisTools = getToolInfosByCategory('analysis');
@@ -497,8 +511,97 @@
         showContextMenu(e);
         return true;
       },
+      // Drag-and-drop image upload (#455). When the dataTransfer
+      // carries one or more image files, intercept before CodeMirror's
+      // default text-drop handler runs — copy each into
+      // `.minerva/assets/inline/` and insert `![](relative-path)` at
+      // the drop position. Non-image drops (text, urls, internal CM
+      // moves) fall through to the default handler.
+      dragover: (e) => {
+        if (e.dataTransfer && hasImageFiles(e.dataTransfer)) {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'copy';
+          return true;
+        }
+        return false;
+      },
+      drop: (e, v) => {
+        if (!e.dataTransfer || !hasImageFiles(e.dataTransfer)) return false;
+        e.preventDefault();
+        const dropPos = v.posAtCoords({ x: e.clientX, y: e.clientY }) ?? v.state.selection.main.head;
+        const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith('image/'));
+        void handleImageUploads(files, dropPos);
+        return true;
+      },
+      // Paste-image upload (#455). Catches the macOS Cmd+Shift+Ctrl+4
+      // → Cmd+V workflow and any other clipboard image source. Non-
+      // image clipboard contents (text / html) fall through.
+      paste: (e, v) => {
+        const items = e.clipboardData?.items;
+        if (!items) return false;
+        const files: File[] = [];
+        for (const item of items) {
+          if (item.kind !== 'file') continue;
+          if (!item.type.startsWith('image/')) continue;
+          const f = item.getAsFile();
+          if (f) files.push(f);
+        }
+        if (files.length === 0) return false;
+        e.preventDefault();
+        void handleImageUploads(files, v.state.selection.main.head);
+        return true;
+      },
     }),
   ];
+
+  /** True iff the DataTransfer carries at least one image file. Used
+   *  by the dragover gate so a text-drop or internal-CM drop still
+   *  routes through the editor's default handlers. */
+  function hasImageFiles(dt: DataTransfer): boolean {
+    // `items` is the modern API; `files` is the fallback. Either
+    // surface lets us spot an image without consuming the data.
+    if (dt.items) {
+      for (const item of dt.items) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) return true;
+      }
+    }
+    if (dt.files) {
+      for (const f of dt.files) {
+        if (f.type.startsWith('image/')) return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Run the image-upload pipeline for each file, accumulate the
+   * resulting `![](…)` snippets, and insert them at the requested
+   * editor position in one transaction so undo collapses the whole
+   * batch into a single step.
+   */
+  async function handleImageUploads(files: File[], insertPos: number): Promise<void> {
+    if (!view || files.length === 0) return;
+    const snippets: string[] = [];
+    for (const file of files) {
+      const result: UploadResult = await uploadImage(file, { filename: file.name, mimeHint: file.type });
+      if (!result.ok) {
+        onUploadError?.(rejectionMessage(result));
+        continue;
+      }
+      const rel = relativeAssetPathForNote(filePath, result.relativePath);
+      const alt = (result.alt ?? '').replace(/\.[^.]+$/, '').replace(/[[\]]/g, '');
+      snippets.push(`![${alt}](${rel})`);
+    }
+    if (snippets.length === 0) return;
+    // Surround with newlines when the drop target isn't at the start
+    // of a line — most usefully, matches what a paste of a screenshot
+    // mid-paragraph produces in Obsidian / Bear / Notion.
+    const insert = '\n' + snippets.join('\n') + '\n';
+    view.dispatch({
+      changes: { from: insertPos, to: insertPos, insert },
+      selection: { anchor: insertPos + insert.length },
+    });
+  }
 
   async function tagCompletion(context: CompletionContext): Promise<CompletionResult | null> {
     const match = context.matchBefore(/#[\w-/]*/);

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -517,9 +517,16 @@
       // `.minerva/assets/inline/` and insert `![](relative-path)` at
       // the drop position. Non-image drops (text, urls, internal CM
       // moves) fall through to the default handler.
+      //
+      // Both handlers stopPropagation when they take the drop —
+      // App.svelte's `.editor-pane` wrapper has its own ondrop that
+      // routes to the project-import flow (PDFs, markdown imports).
+      // Without stopPropagation an image drop fires both handlers and
+      // the import path rejects the JPEG with "doesn't ingest *.jpeg".
       dragover: (e) => {
         if (e.dataTransfer && hasImageFiles(e.dataTransfer)) {
           e.preventDefault();
+          e.stopPropagation();
           e.dataTransfer.dropEffect = 'copy';
           return true;
         }
@@ -528,6 +535,7 @@
       drop: (e, v) => {
         if (!e.dataTransfer || !hasImageFiles(e.dataTransfer)) return false;
         e.preventDefault();
+        e.stopPropagation();
         const dropPos = v.posAtCoords({ x: e.clientX, y: e.clientY }) ?? v.state.selection.main.head;
         const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith('image/'));
         void handleImageUploads(files, dropPos);

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -41,6 +41,8 @@ export const CONFIRM_KEYS = {
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
   saveCellOutputFailed: 'save-cell-output-failed',
+  /** Image-upload rejection toast (#455) — too-large, unsupported MIME, etc. */
+  imageUploadFailed: 'image-upload-failed',
   exportComplete: 'export-complete',
   bibliographyResult: 'bibliography-result',
   bibliographyFailed: 'bibliography-failed',
@@ -222,6 +224,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Save cell output failed',
     description:
       'Shown when "Save as note" on a compute-cell output errors out (path collision, write error, etc). Kept separate from ingest-failed so suppressing one doesn\'t mute the other.',
+  },
+  {
+    key: CONFIRM_KEYS.imageUploadFailed,
+    title: 'Image upload rejected',
+    description:
+      'Shown when a drag-and-drop or paste image upload is rejected — too large (>5MB), unsupported MIME, empty blob, or write failure. Suppressing this won\'t silently swallow uploads; the editor still does nothing for unsupported drops, the user just stops getting the explanation.',
   },
   {
     key: CONFIRM_KEYS.exportComplete,

--- a/src/renderer/lib/editor/image-upload.ts
+++ b/src/renderer/lib/editor/image-upload.ts
@@ -1,0 +1,195 @@
+/**
+ * Image-upload helper for the editor (#455).
+ *
+ * Drag-and-drop and paste handlers in `Editor.svelte` route through
+ * `uploadImage`: validate against the MIME allowlist, hash the bytes
+ * for a stable filename, write to `.minerva/assets/inline/`, and
+ * return the project-relative path the editor inserts as
+ * `![alt](relative-path)` at the cursor.
+ *
+ * The hash-prefix shape (`<sha-prefix>-<safe-stem>.<ext>`) gives
+ * content-addressed dedup for free: two drops of the same file
+ * collapse to one asset on disk; pasting the same screenshot twice
+ * doesn't grow the project.
+ */
+
+import { api } from '../ipc/client';
+
+/** MIME allowlist. Anything not on this list is rejected with a
+ *  toast — keeps the upload path scoped to images and avoids
+ *  surprises with arbitrary binary blobs in the asset directory. */
+export const ALLOWED_IMAGE_MIMES = new Set<string>([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'image/avif',
+]);
+
+/** Per-file size cap. Matches the compute-output cap (#243) so the
+ *  user has one mental model: 5MB and the asset goes through;
+ *  bigger and they need to compress first. */
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/** Asset directory inside the project. `derived/` belongs to compute
+ *  output; this dir is editor-attached uploads, kept separate so
+ *  `.minerva/assets/inline/` doesn't collide with the
+ *  `.minerva/assets/derived/` namespace. */
+export const ASSET_DIR = '.minerva/assets/inline';
+
+export type UploadResult =
+  | { ok: true; relativePath: string; alt: string }
+  | { ok: false; reason: 'too-large' | 'unsupported-mime' | 'empty' | 'write-failed'; detail?: string };
+
+export interface UploadOptions {
+  /** Original filename when available (drops carry it; clipboard items don't). */
+  filename?: string;
+  /** MIME hint when the File/Blob doesn't carry one. */
+  mimeHint?: string;
+}
+
+/**
+ * Validate, hash, write, and return the relative asset path to embed
+ * in the editor. Caller handles toast feedback for the rejection
+ * cases via the `reason` field.
+ */
+export async function uploadImage(
+  file: Blob | File,
+  opts: UploadOptions = {},
+): Promise<UploadResult> {
+  const mime = file.type || opts.mimeHint || '';
+  if (!ALLOWED_IMAGE_MIMES.has(mime)) {
+    return { ok: false, reason: 'unsupported-mime', detail: mime || 'unknown' };
+  }
+  if (file.size === 0) {
+    return { ok: false, reason: 'empty' };
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return {
+      ok: false,
+      reason: 'too-large',
+      detail: `${(file.size / 1024 / 1024).toFixed(1)} MB > ${(MAX_IMAGE_BYTES / 1024 / 1024).toFixed(0)} MB`,
+    };
+  }
+
+  const buf = new Uint8Array(await file.arrayBuffer());
+  const ext = extensionFor(mime, opts.filename);
+  const hash = await sha256Prefix(buf);
+  const stem = sanitiseStem(opts.filename ?? 'image');
+  const filename = `${hash}-${stem}.${ext}`;
+  const relativePath = `${ASSET_DIR}/${filename}`;
+
+  // Skip the write when an identical hash-prefixed file already
+  // exists — dedup is the whole point of content addressing. The
+  // existence check is cheap (single fs.stat) and avoids a redundant
+  // disk write on a re-paste of the same screenshot.
+  const exists = await api.notebase.fileExists(relativePath).catch(() => false);
+  if (!exists) {
+    try {
+      await api.notebase.writeBinary(relativePath, buf);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'write-failed',
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+  return { ok: true, relativePath, alt: opts.filename ?? '' };
+}
+
+/**
+ * 12-hex-char prefix of SHA-256(content). Plenty of entropy for
+ * within-project uniqueness without making filenames unreadable.
+ */
+async function sha256Prefix(bytes: Uint8Array): Promise<string> {
+  // crypto.subtle.digest expects a strict ArrayBuffer-backed view.
+  // The Uint8Array we already have IS that view, but the TS lib types
+  // narrow `BufferSource` to ArrayBuffer-only — copy the bytes into a
+  // fresh ArrayBuffer-backed view to satisfy the constraint without
+  // the runtime cost of a deep copy in the engine (it's a memcpy on
+  // an already-resident buffer).
+  const ab = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(ab).set(bytes);
+  const hash = await crypto.subtle.digest('SHA-256', ab);
+  const view = new Uint8Array(hash);
+  let hex = '';
+  for (let i = 0; i < 6; i++) {
+    hex += view[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/**
+ * Sanitise an arbitrary filename into a filesystem-safe stem.
+ * Spaces and unsafe characters collapse to hyphens; the result is
+ * lowercased so two drops of "Screen Shot.png" and "screen shot.png"
+ * dedupe by hash prefix regardless of the user's case convention.
+ */
+function sanitiseStem(filename: string): string {
+  const stem = filename.replace(/\.[^.]+$/, '');
+  const safe = stem.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return safe || 'image';
+}
+
+/**
+ * Filename extension for the asset on disk. Prefer the original
+ * extension when the user dragged a real file (matches what they'd
+ * expect to see in Finder); fall back to a MIME-derived extension
+ * for clipboard pastes that ship without a name.
+ */
+function extensionFor(mime: string, filename: string | undefined): string {
+  if (filename) {
+    const m = filename.match(/\.([a-zA-Z0-9]+)$/);
+    if (m) return m[1].toLowerCase();
+  }
+  switch (mime) {
+    case 'image/png': return 'png';
+    case 'image/jpeg': return 'jpg';
+    case 'image/gif': return 'gif';
+    case 'image/webp': return 'webp';
+    case 'image/svg+xml': return 'svg';
+    case 'image/avif': return 'avif';
+    default: return 'bin';
+  }
+}
+
+/**
+ * Compute the markdown-link path to embed in a note at `notePath`.
+ * The asset lives at `assetRel` (project-rooted, e.g.
+ * `.minerva/assets/inline/<file>.png`). Returns the path made
+ * relative to the note's directory so `![](…)` resolves correctly
+ * via the Preview's image hydration (#244).
+ */
+export function relativeAssetPathForNote(notePath: string, assetRel: string): string {
+  const lastSlash = notePath.lastIndexOf('/');
+  const noteDir = lastSlash > 0 ? notePath.slice(0, lastSlash) : '';
+  if (!noteDir) return assetRel;
+  const noteSegments = noteDir.split('/');
+  const assetSegments = assetRel.split('/');
+  let common = 0;
+  while (
+    common < noteSegments.length
+    && common < assetSegments.length
+    && noteSegments[common] === assetSegments[common]
+  ) common++;
+  const ups = noteSegments.length - common;
+  const upParts: string[] = Array.from({ length: ups }, () => '..');
+  const downs = assetSegments.slice(common);
+  return [...upParts, ...downs].join('/');
+}
+
+/** Human-readable rejection messages for toast / status surfaces. */
+export function rejectionMessage(result: Extract<UploadResult, { ok: false }>): string {
+  switch (result.reason) {
+    case 'too-large':
+      return `Image too large to embed (${result.detail ?? '> 5MB'}).`;
+    case 'unsupported-mime':
+      return `Unsupported image type: ${result.detail ?? 'unknown'}. Use PNG, JPEG, GIF, WebP, SVG, or AVIF.`;
+    case 'empty':
+      return 'Empty image — nothing to embed.';
+    case 'write-failed':
+      return `Couldn't write image to project: ${result.detail ?? 'unknown error'}`;
+  }
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -17,6 +17,10 @@ export interface NotebaseApi {
   readFile(relativePath: string): Promise<string>;
   /** Binary-safe read for images / pdfs / other non-text assets (#244). */
   readBinary(relativePath: string): Promise<Uint8Array>;
+  /** Binary-safe write — used by the editor's image-upload path (#455). */
+  writeBinary(relativePath: string, bytes: Uint8Array): Promise<void>;
+  /** Cheap existence check — used to dedupe content-hashed assets (#455). */
+  fileExists(relativePath: string): Promise<boolean>;
   writeFile(relativePath: string, content: string): Promise<void>;
   createFile(relativePath: string): Promise<void>;
   deleteFile(relativePath: string): Promise<void>;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -6,6 +6,12 @@ export const Channels = {
   /** Read an arbitrary file as bytes — used by the Preview's image rule
    *  to inline `![](...)` references as data URLs (#244 image rendering). */
   NOTEBASE_READ_BINARY: 'notebase:readBinary',
+  /** Write a binary blob (image / pdf / etc.) under a project-relative
+   *  path. Used by the editor's image-upload-on-drop path (#455). */
+  NOTEBASE_WRITE_BINARY: 'notebase:writeBinary',
+  /** Cheap existence check — used by the upload path to dedupe
+   *  content-hashed assets (#455). */
+  NOTEBASE_FILE_EXISTS: 'notebase:fileExists',
   NOTEBASE_WRITE_FILE: 'notebase:writeFile',
   NOTEBASE_CREATE_FILE: 'notebase:createFile',
   NOTEBASE_DELETE_FILE: 'notebase:deleteFile',

--- a/tests/renderer/image-upload.test.ts
+++ b/tests/renderer/image-upload.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Image-upload helper unit tests (#455). The upload module talks to
+ * `api.notebase.fileExists` / `writeBinary` — mocked here so the
+ * tests stay fast and don't need a project on disk.
+ *
+ * jsdom rather than happy-dom because the helper uses
+ * `crypto.subtle.digest`, and jsdom 26 ships a full webcrypto API
+ * while happy-dom's coverage of subtle is patchy.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  uploadImage,
+  relativeAssetPathForNote,
+  rejectionMessage,
+  ALLOWED_IMAGE_MIMES,
+  MAX_IMAGE_BYTES,
+} from '../../src/renderer/lib/editor/image-upload';
+
+// Stub the IPC surface — the helper only calls these two methods on
+// the upload path. `__store` is the recorded write payload so the
+// asserts can verify what would have hit disk.
+const __writes = new Map<string, Uint8Array>();
+const __existsResponses = new Map<string, boolean>();
+
+vi.mock('../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    notebase: {
+      fileExists: vi.fn((rel: string) => Promise.resolve(__existsResponses.get(rel) ?? false)),
+      writeBinary: vi.fn((rel: string, bytes: Uint8Array) => {
+        __writes.set(rel, bytes);
+        return Promise.resolve();
+      }),
+    },
+  },
+}));
+
+beforeEach(() => {
+  __writes.clear();
+  __existsResponses.clear();
+});
+
+function makeBlob(bytes: number[], mime: string): Blob {
+  return new Blob([new Uint8Array(bytes)], { type: mime });
+}
+
+describe('uploadImage (#455)', () => {
+  it('writes a valid PNG and returns a hash-prefixed asset path', async () => {
+    const blob = makeBlob([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01], 'image/png');
+    const result = await uploadImage(blob, { filename: 'screenshot.png' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.relativePath).toMatch(/^\.minerva\/assets\/inline\/[0-9a-f]{12}-screenshot\.png$/);
+    expect(result.alt).toBe('screenshot.png');
+    expect(__writes.get(result.relativePath)?.byteLength).toBe(10);
+  });
+
+  it('rejects unsupported MIME types', async () => {
+    const blob = makeBlob([1, 2, 3], 'application/zip');
+    const result = await uploadImage(blob, { filename: 'notes.zip' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('unsupported-mime');
+    expect(result.detail).toBe('application/zip');
+    expect(__writes.size).toBe(0);
+  });
+
+  it('rejects empty blobs', async () => {
+    const blob = new Blob([], { type: 'image/png' });
+    const result = await uploadImage(blob, { filename: 'empty.png' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('empty');
+  });
+
+  it('rejects blobs over the size cap', async () => {
+    // 6MB > 5MB cap. We don't actually allocate 6MB — fake the size.
+    const blob = makeBlob([1], 'image/png');
+    Object.defineProperty(blob, 'size', { value: MAX_IMAGE_BYTES + 1 });
+    const result = await uploadImage(blob, { filename: 'huge.png' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-large');
+  });
+
+  it('content-hashes for dedupe — two drops of identical bytes share a path', async () => {
+    const bytes = [0x89, 0x50, 0x4E, 0x47, 0xFF];
+    const r1 = await uploadImage(makeBlob(bytes, 'image/png'), { filename: 'a.png' });
+    const r2 = await uploadImage(makeBlob(bytes, 'image/png'), { filename: 'a.png' });
+    expect(r1.ok && r2.ok).toBe(true);
+    if (!r1.ok || !r2.ok) return;
+    // Identical bytes → identical hash prefix → identical asset path.
+    expect(r1.relativePath).toBe(r2.relativePath);
+  });
+
+  it('skips the writeBinary call when an asset with the hash already exists', async () => {
+    const bytes = [0xFF, 0xD8, 0xFF];
+    // Pre-seed the existence-check response: the helper should believe
+    // the asset is already on disk and skip the write.
+    const r1 = await uploadImage(makeBlob(bytes, 'image/jpeg'), { filename: 'photo.jpg' });
+    if (!r1.ok) throw new Error('first upload should succeed');
+    __writes.clear();
+    __existsResponses.set(r1.relativePath, true);
+    const r2 = await uploadImage(makeBlob(bytes, 'image/jpeg'), { filename: 'photo.jpg' });
+    expect(r2.ok).toBe(true);
+    expect(__writes.size).toBe(0);
+  });
+
+  it('different content → different paths even when filenames match', async () => {
+    const r1 = await uploadImage(makeBlob([1, 2, 3], 'image/png'), { filename: 'shot.png' });
+    const r2 = await uploadImage(makeBlob([1, 2, 4], 'image/png'), { filename: 'shot.png' });
+    if (!r1.ok || !r2.ok) throw new Error('uploads should succeed');
+    expect(r1.relativePath).not.toBe(r2.relativePath);
+  });
+
+  it('SVG markup uploads with the right extension', async () => {
+    const blob = makeBlob([0x3C, 0x73, 0x76, 0x67], 'image/svg+xml');
+    const result = await uploadImage(blob, { filename: 'icon.svg' });
+    if (!result.ok) throw new Error('upload should succeed');
+    expect(result.relativePath).toMatch(/\.svg$/);
+  });
+
+  it('clipboard pastes (no filename) get a generated stem with the MIME-derived ext', async () => {
+    const blob = makeBlob([1, 2, 3, 4], 'image/png');
+    const result = await uploadImage(blob); // no opts.filename
+    if (!result.ok) throw new Error('upload should succeed');
+    // Generated stem is the fallback "image"; ext from MIME → png.
+    expect(result.relativePath).toMatch(/^\.minerva\/assets\/inline\/[0-9a-f]{12}-image\.png$/);
+  });
+
+  it('sanitises spaces and special chars in filenames', async () => {
+    const blob = makeBlob([1, 2, 3], 'image/png');
+    const result = await uploadImage(blob, { filename: 'My Screen Shot (v2).png' });
+    if (!result.ok) throw new Error('upload should succeed');
+    expect(result.relativePath).toMatch(/^\.minerva\/assets\/inline\/[0-9a-f]{12}-my-screen-shot-v2\.png$/);
+  });
+
+  it('every allowlist MIME is accepted', async () => {
+    for (const mime of ALLOWED_IMAGE_MIMES) {
+      const blob = makeBlob([1, 2, 3], mime);
+      const r = await uploadImage(blob, { filename: 'x.bin' });
+      expect(r.ok, `expected ${mime} to be accepted`).toBe(true);
+    }
+  });
+});
+
+describe('relativeAssetPathForNote (#455)', () => {
+  it('project-root note → asset path emitted as-is', () => {
+    const out = relativeAssetPathForNote('graph.md', '.minerva/assets/inline/abc.png');
+    expect(out).toBe('.minerva/assets/inline/abc.png');
+  });
+
+  it('nested note → climbs out via `../../`', () => {
+    const out = relativeAssetPathForNote('notes/derived/foo.md', '.minerva/assets/inline/abc.png');
+    expect(out).toBe('../../.minerva/assets/inline/abc.png');
+  });
+
+  it('deeply nested note → enough `..`s', () => {
+    const out = relativeAssetPathForNote('a/b/c/d.md', '.minerva/assets/inline/abc.png');
+    expect(out).toBe('../../../.minerva/assets/inline/abc.png');
+  });
+
+  it('shared-prefix path collapses correctly', () => {
+    // Asset and note both live under `.minerva/`.
+    const out = relativeAssetPathForNote('.minerva/scratch/note.md', '.minerva/assets/inline/abc.png');
+    expect(out).toBe('../assets/inline/abc.png');
+  });
+});
+
+describe('rejectionMessage (#455)', () => {
+  it('produces a human-readable message for each reject reason', () => {
+    expect(rejectionMessage({ ok: false, reason: 'too-large', detail: '6 MB > 5 MB' })).toContain('too large');
+    expect(rejectionMessage({ ok: false, reason: 'unsupported-mime', detail: 'application/zip' })).toContain('Unsupported');
+    expect(rejectionMessage({ ok: false, reason: 'empty' })).toContain('Empty');
+    expect(rejectionMessage({ ok: false, reason: 'write-failed', detail: 'EACCES' })).toContain('Couldn\'t write');
+  });
+});


### PR DESCRIPTION
## Summary

Drop a PNG / JPEG / GIF / WebP / SVG / AVIF onto the editor (or paste a clipboard screenshot via Cmd+Shift+Ctrl+4 → Cmd+V) and the image lands at \`.minerva/assets/inline/<hash>-<safe-stem>.<ext>\` with a \`![alt](relative-path)\` snippet inserted at the drop / cursor position.

## Pipeline

- New \`notebase:writeBinary\` + \`notebase:fileExists\` IPCs (paired to \`readBinary\` from #244). Same path-traversal guard as the text-write counterparts.
- Shared upload helper at \`editor/image-upload.ts\` that validates against the MIME allowlist + 5MB cap, computes a SHA-256 prefix over the bytes for content-addressed dedup, and skips the disk write when an identical asset already exists.
- Editor-side \`drop\` / \`dragover\` / \`paste\` handlers in the existing \`EditorView.domEventHandlers\` block. Drop position derived from coords; paste anchors on the current selection.
- Rejection messages route through a new \`onUploadError\` prop that App.svelte surfaces via the dismissable confirm dialog pattern used elsewhere.

## Filenames

\`<12-hex-sha256-prefix>-<safe-stem>.<ext>\`. Hash is enough entropy for project-scope uniqueness without making filenames unreadable; safe-stem comes from the original filename sanitised to \`[a-z0-9_-]\` so two drops of "Screen Shot.png" and "screen shot.png" dedupe. Clipboard pastes (no filename) get the literal stem \`image\` + a MIME-derived extension.

## Asset directory

\`.minerva/assets/inline/\` — kept separate from \`derived/\` so compute outputs and editor uploads don't collide in the same folder listing.

## Closes

Resolves #455.

## Test plan

- [x] \`pnpm vitest run tests/renderer/image-upload.test.ts\` — 16/16 covering: PNG roundtrip, MIME-allowlist gate, empty-blob reject, size-cap reject, content-hash dedup, existence-check skips re-write, distinct content yields distinct paths, SVG path, clipboard-paste no-filename fallback, filename sanitisation (special chars + case), every allowlist MIME accepted, relativeAssetPathForNote at 4 depths, rejection-message shapes.
- [x] \`pnpm vitest run tests/renderer\` — 257/257
- [x] \`pnpm lint\` — clean
- [ ] Manual: full restart Minerva, drag a PNG into the editor — appears at the drop point and renders in the Preview. Paste a screenshot via Cmd+Shift+Ctrl+4 → Cmd+V — same. Drop the same image twice — only one file under \`.minerva/assets/inline/\`. Drop a 10MB image — toast says "too large".

🤖 Generated with [Claude Code](https://claude.com/claude-code)