### PR TITLE
Sidebar: auto-reveal active file + Expand/Collapse All (#460)

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -19,6 +19,11 @@
     type RefactorSettings,
   } from '../refactor/settings';
   import {
+    getSidebarSettings,
+    setSidebarSettings,
+    type SidebarSettings,
+  } from '../sidebar/settings';
+  import {
     getFormatSettings,
     setFormatSettings,
   } from '../formatter/settings';
@@ -58,6 +63,12 @@
   function patchRefactor(patch: Partial<RefactorSettings>): void {
     refactor = { ...refactor, ...patch };
     setRefactorSettings(patch);
+  }
+
+  let sidebar = $state<SidebarSettings>({ ...getSidebarSettings() });
+  function patchSidebar(patch: Partial<SidebarSettings>): void {
+    sidebar = { ...sidebar, ...patch };
+    setSidebarSettings(patch);
   }
 
   // Formatter settings (#154). Mirror the persisted map into local state so
@@ -508,6 +519,21 @@
           </div>
 
         {:else if activeTab === 'behaviors'}
+          <div class="field checkbox">
+            <label>
+              <input
+                type="checkbox"
+                checked={sidebar.autoReveal}
+                onchange={(e) => patchSidebar({ autoReveal: e.currentTarget.checked })}
+              />
+              Auto-reveal active file in sidebar
+            </label>
+            <p class="hint">
+              When the active editor changes, scroll the matching row into view in the
+              Notes panel and expand its parent folders. Never collapses anything you've
+              already opened.
+            </p>
+          </div>
           <div class="field">
             <label>Don't-ask-again confirmations</label>
             <p class="hint">

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -7,6 +7,7 @@
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { getSidebarSelectionStore } from '../stores/sidebar-selection.svelte';
   import { flattenVisible } from '../sidebar-tree-utils';
+  import { getSidebarSettings } from '../sidebar/settings';
   import { tick } from 'svelte';
 
   type PanelType = 'notes' | 'sites' | 'tags' | 'tables';
@@ -57,6 +58,75 @@
 
   function toggleDir(path: string): void {
     expanded = { ...expanded, [path]: !expanded[path] };
+  }
+
+  /** Walk every directory in the tree, regardless of current expanded
+   *  state. Used by Expand All. */
+  function collectAllDirPaths(nodes: NoteFile[]): string[] {
+    const out: string[] = [];
+    const walk = (ns: NoteFile[]) => {
+      for (const n of ns) {
+        if (n.isDirectory) {
+          out.push(n.relativePath);
+          if (n.children) walk(n.children);
+        }
+      }
+    };
+    walk(nodes);
+    return out;
+  }
+
+  function expandAll(): void {
+    const next: Record<string, boolean> = {};
+    for (const p of collectAllDirPaths(files)) next[p] = true;
+    expanded = next;
+    if (rootName) rootExpanded = true;
+  }
+
+  function collapseAll(): void {
+    expanded = {};
+  }
+
+  /** Expand every ancestor folder of `path` so the row becomes
+   *  visible. Pure-additive: never collapses anything the user has
+   *  open (#460). */
+  function expandAncestors(path: string): void {
+    if (!path) return;
+    const parts = path.split('/');
+    if (parts.length <= 1) return;
+    const patch: Record<string, boolean> = {};
+    let acc = '';
+    for (let i = 0; i < parts.length - 1; i++) {
+      acc = acc ? `${acc}/${parts[i]}` : parts[i];
+      if (!expanded[acc]) patch[acc] = true;
+    }
+    if (Object.keys(patch).length > 0) {
+      expanded = { ...expanded, ...patch };
+    }
+  }
+
+  /** Auto-reveal the active file in the tree (#460). Expands ancestor
+   *  folders and scrolls the row into view whenever the active file
+   *  changes. Disabled via the sidebar setting. Skipped when the
+   *  Notes panel isn't visible (no DOM target to scroll). */
+  $effect(() => {
+    const path = activeFilePath;
+    if (!path) return;
+    if (!getSidebarSettings().autoReveal) return;
+    if (activePanel !== 'notes') return;
+    if (rootName && !rootExpanded) rootExpanded = true;
+    expandAncestors(path);
+    void scrollPathIntoView(path);
+  });
+
+  async function scrollPathIntoView(path: string): Promise<void> {
+    await tick();
+    if (!fileListEl) return;
+    const escaped = (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(path) : path);
+    const row = fileListEl.querySelector(`[data-relative-path="${escaped}"]`);
+    if (row && row instanceof HTMLElement) {
+      row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
   }
 
   /**
@@ -344,6 +414,22 @@
   <div class="panel-content">
     {#if activePanel === 'notes'}
       {#if files.length > 0}
+        <div class="notes-toolbar">
+          <button
+            type="button"
+            class="tool-btn"
+            onclick={expandAll}
+            title="Expand all folders"
+            aria-label="Expand all folders"
+          >&#x2B0C;</button>
+          <button
+            type="button"
+            class="tool-btn"
+            onclick={collapseAll}
+            title="Collapse all folders"
+            aria-label="Collapse all folders"
+          >&#x2B0D;</button>
+        </div>
         {#if selectionStore.count > 0}
           <div class="selection-badge">
             <span class="count">{selectionStore.count} of {totalVisible} selected</span>
@@ -528,6 +614,28 @@
   }
   .file-list:focus-visible {
     box-shadow: inset 2px 0 0 var(--accent);
+  }
+
+  /* Toolbar above the file tree — Expand All / Collapse All (#460). */
+  .notes-toolbar {
+    display: flex;
+    gap: 2px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .tool-btn {
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .tool-btn:hover {
+    background: var(--bg-button);
+    color: var(--text);
   }
 
   /* Selection-count badge above the file tree (#428). */

--- a/src/renderer/lib/sidebar/settings.ts
+++ b/src/renderer/lib/sidebar/settings.ts
@@ -1,0 +1,49 @@
+/**
+ * Sidebar / file-explorer behavior settings (#460).
+ *
+ * Mirrors the synchronous-snapshot pattern used by refactor/settings.ts —
+ * a tiny wrapper around localStorage that the SettingsDialog writes
+ * through and Sidebar.svelte reads from.
+ */
+
+export interface SidebarSettings {
+  /** Auto-reveal the active file in the tree when it changes (#460). */
+  autoReveal: boolean;
+}
+
+export const DEFAULT_SIDEBAR_SETTINGS: SidebarSettings = {
+  autoReveal: true,
+};
+
+const STORAGE_KEY = 'sidebarSettings';
+
+function readFromStorage(): SidebarSettings {
+  try {
+    if (typeof localStorage === 'undefined') return { ...DEFAULT_SIDEBAR_SETTINGS };
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_SIDEBAR_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<SidebarSettings> | null;
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_SIDEBAR_SETTINGS };
+    return { ...DEFAULT_SIDEBAR_SETTINGS, ...parsed };
+  } catch {
+    return { ...DEFAULT_SIDEBAR_SETTINGS };
+  }
+}
+
+let settings: SidebarSettings = readFromStorage();
+
+export function getSidebarSettings(): SidebarSettings {
+  return settings;
+}
+
+export function setSidebarSettings(patch: Partial<SidebarSettings>): SidebarSettings {
+  settings = { ...settings, ...patch };
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }
+  return settings;
+}
+
+export function __resetSidebarSettingsForTests(): void {
+  settings = readFromStorage();
+}


### PR DESCRIPTION
Closes #460 (auto-reveal + expand/collapse all; per-project persistence intentionally deferred).

## Summary
- Auto-reveal: a `$effect` on `activeFilePath` expands ancestor folders and scrolls the matching row into view whenever the active file changes. Pure-additive — never collapses anything the user has open.
- Expand All / Collapse All toolbar buttons above the file tree.
- New **Behaviors** tab toggle (default on) controls auto-reveal, persisted via a tiny `sidebar/settings.ts` mirroring the existing `refactor/settings.ts` pattern.

## Test plan
- [ ] Open a file via wiki-link from a deeply-nested note → tree expands ancestor folders and scrolls the row into view.
- [ ] Manually collapse a folder, then open another file outside it → manually-collapsed folders stay collapsed.
- [ ] Settings → Behaviors → uncheck Auto-reveal → next file change does NOT scroll/expand.
- [ ] Click Expand All → every folder open. Click Collapse All → every folder closed.
- [ ] Reload app → Auto-reveal toggle persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)