### PR TITLE
Preview: render Obsidian-style callouts (#465)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -14,6 +14,7 @@
   import 'highlight.js/styles/github-dark.min.css';
   import 'katex/dist/katex.min.css';
   import { installMath } from '../markdown/math-plugin';
+  import { installCallouts } from '../markdown/callout-plugin';
   import { getLinkType } from '../../../shared/link-types';
   import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
@@ -101,6 +102,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     },
   });
   installMath(md);
+  installCallouts(md);
 
   // Give every heading an id derived from its text so [[note#heading]] anchor
   // navigation can target it. Slugs must match the indexer's convention.
@@ -1484,6 +1486,99 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     padding: 4px 16px;
     color: var(--text-muted);
   }
+
+  /* Callouts (#465). Obsidian-style boxes built on top of the
+     blockquote primitive — no quote bar, accent color drives the
+     border + icon + title text. Per CLAUDE.md "no danger styling":
+     warning/failure/danger/bug use peach/mauve, not alarming reds. */
+  .preview :global(.callout) {
+    --callout-color: var(--accent);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--callout-color);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--callout-color) 8%, transparent);
+    margin: 0 0 12px;
+    padding: 0;
+    color: var(--text);
+    overflow: hidden;
+  }
+  .preview :global(.callout-title) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    font-weight: 600;
+    color: var(--callout-color);
+    user-select: none;
+  }
+  .preview :global(details.callout > summary.callout-title) {
+    cursor: pointer;
+    list-style: none;
+    border: none;
+    background: none;
+    width: 100%;
+    text-align: left;
+  }
+  .preview :global(details.callout > summary.callout-title::-webkit-details-marker) {
+    display: none;
+  }
+  .preview :global(details.callout > summary.callout-title::after) {
+    content: '▸';
+    margin-left: auto;
+    font-size: 11px;
+    transition: transform 0.15s;
+  }
+  .preview :global(details.callout[open] > summary.callout-title::after) {
+    transform: rotate(90deg);
+  }
+  .preview :global(.callout-icon) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    font-size: 13px;
+    line-height: 1;
+  }
+  .preview :global(.callout-content) {
+    padding: 0 12px 8px;
+  }
+  .preview :global(.callout-content > :first-child) { margin-top: 0; }
+  .preview :global(.callout-content > :last-child) { margin-bottom: 0; }
+
+  /* Type-specific accent colors. Catppuccin palette tokens, no reds. */
+  .preview :global(.callout-note)     { --callout-color: var(--accent); }
+  .preview :global(.callout-info)     { --callout-color: #8caaee; }
+  .preview :global(.callout-tip)      { --callout-color: #a6d189; }
+  .preview :global(.callout-success)  { --callout-color: #a6d189; }
+  .preview :global(.callout-question) { --callout-color: #e5c890; }
+  .preview :global(.callout-warning)  { --callout-color: #ef9f76; }
+  .preview :global(.callout-failure)  { --callout-color: #ef9f76; }
+  .preview :global(.callout-danger)   { --callout-color: #ef9f76; }
+  .preview :global(.callout-bug)      { --callout-color: #ca9ee6; }
+  .preview :global(.callout-example)  { --callout-color: #ca9ee6; }
+  .preview :global(.callout-quote)    { --callout-color: var(--text-muted); }
+  .preview :global(.callout-abstract) { --callout-color: #8caaee; }
+  .preview :global(.callout-todo)     { --callout-color: var(--accent); }
+  .preview :global(.callout-unknown)  { --callout-color: var(--accent); }
+
+  /* Type-specific icons via ::before. Plain unicode keeps us off the
+     iconfont treadmill — same pattern as the file-tree chevrons. */
+  .preview :global(.callout-note .callout-icon::before)     { content: '\270E'; }
+  .preview :global(.callout-info .callout-icon::before)     { content: '\24D8'; }
+  .preview :global(.callout-tip .callout-icon::before)      { content: '\2605'; }
+  .preview :global(.callout-success .callout-icon::before)  { content: '\2713'; }
+  .preview :global(.callout-question .callout-icon::before) { content: '?'; }
+  .preview :global(.callout-warning .callout-icon::before)  { content: '\26A0'; }
+  .preview :global(.callout-failure .callout-icon::before)  { content: '\2717'; }
+  .preview :global(.callout-danger .callout-icon::before)   { content: '\26A1'; }
+  .preview :global(.callout-bug .callout-icon::before)      { content: '\25CE'; }
+  .preview :global(.callout-example .callout-icon::before)  { content: '\2318'; }
+  .preview :global(.callout-quote .callout-icon::before)    { content: '\201C'; }
+  .preview :global(.callout-abstract .callout-icon::before) { content: '\2630'; }
+  .preview :global(.callout-todo .callout-icon::before)     { content: '\2610'; }
+  .preview :global(.callout-unknown .callout-icon::before)  { content: '\25CF'; }
 
   .preview :global(ul),
   .preview :global(ol) {

--- a/src/renderer/lib/markdown/callout-plugin.ts
+++ b/src/renderer/lib/markdown/callout-plugin.ts
@@ -1,0 +1,172 @@
+/**
+ * Markdown-it plugin that renders Obsidian-style callouts (#465).
+ *
+ * A blockquote whose first line is `[!type]` (optionally followed by
+ * `+` or `-` for collapsibility and a custom title) becomes a styled
+ * box with an icon and title bar. Examples:
+ *
+ *     > [!note]
+ *     > Body.
+ *
+ *     > [!warning] Custom title
+ *     > Body.
+ *
+ *     > [!tip]+ Default-expanded collapsible
+ *     > Body.
+ *
+ *     > [!info]- Default-collapsed collapsible
+ *     > Body hidden until clicked.
+ *
+ * Nested callouts work for free because nested blockquotes already do —
+ * the core rule walks every blockquote_open token independently.
+ *
+ * Collapsibles render as <details>/<summary> so keyboard a11y comes
+ * for free; non-collapsibles render as plain <div>s.
+ */
+
+import type MarkdownIt from 'markdown-it';
+import type StateCore from 'markdown-it/lib/rules_core/state_core.mjs';
+import type Token from 'markdown-it/lib/token.mjs';
+
+/**
+ * First-line marker. Title whitespace is restricted to spaces/tabs so a
+ * newline never sneaks the body's first line into the title (otherwise
+ * `> [!note]\n> Body.` would title the callout "Body.").
+ */
+const MARKER_RE = /^\[!([a-zA-Z][\w-]*)\]([+-]?)(?:[ \t]+([^\n]*?))?(?:\n|$)/;
+
+const TITLE_DEFAULTS: Record<string, string> = {
+  note: 'Note',
+  info: 'Info',
+  tip: 'Tip',
+  success: 'Success',
+  question: 'Question',
+  warning: 'Warning',
+  failure: 'Failure',
+  danger: 'Danger',
+  bug: 'Bug',
+  example: 'Example',
+  quote: 'Quote',
+  abstract: 'Abstract',
+  todo: 'Todo',
+};
+
+const KNOWN_TYPES = new Set(Object.keys(TITLE_DEFAULTS));
+
+export function installCallouts(md: MarkdownIt): void {
+  md.core.ruler.after('block', 'callout', (state) => calloutCoreRule(state));
+
+  const defaultBlockquoteOpen = md.renderer.rules.blockquote_open;
+  const defaultBlockquoteClose = md.renderer.rules.blockquote_close;
+
+  md.renderer.rules.blockquote_open = (tokens, idx, opts, env, self) => {
+    const tok = tokens[idx];
+    const type = tok.attrGet('data-callout');
+    if (type === null) {
+      return defaultBlockquoteOpen
+        ? defaultBlockquoteOpen(tokens, idx, opts, env, self)
+        : self.renderToken(tokens, idx, opts);
+    }
+    const title = tok.attrGet('data-callout-title') ?? '';
+    const fold = tok.attrGet('data-callout-fold');
+    const collapsible = fold === 'open' || fold === 'closed';
+    const isOpen = fold !== 'closed';
+    const known = KNOWN_TYPES.has(type);
+    const classes = [
+      'callout',
+      `callout-${known ? type : 'unknown'}`,
+      collapsible ? 'callout-collapsible' : null,
+    ].filter(Boolean).join(' ');
+    const titleInner = `<span class="callout-icon" aria-hidden="true"></span><span class="callout-title-text">${escapeHtml(title)}</span>`;
+    const safeType = escapeAttr(type);
+    if (collapsible) {
+      return `<details class="${classes}" data-callout="${safeType}"${isOpen ? ' open' : ''}><summary class="callout-title">${titleInner}</summary><div class="callout-content">\n`;
+    }
+    return `<div class="${classes}" data-callout="${safeType}"><div class="callout-title">${titleInner}</div><div class="callout-content">\n`;
+  };
+
+  md.renderer.rules.blockquote_close = (tokens, idx, opts, env, self) => {
+    const open = findMatchingBlockquoteOpen(tokens, idx);
+    if (open && open.attrGet('data-callout') !== null) {
+      const fold = open.attrGet('data-callout-fold');
+      const collapsible = fold === 'open' || fold === 'closed';
+      return collapsible ? '</div></details>\n' : '</div></div>\n';
+    }
+    return defaultBlockquoteClose
+      ? defaultBlockquoteClose(tokens, idx, opts, env, self)
+      : self.renderToken(tokens, idx, opts);
+  };
+}
+
+function calloutCoreRule(state: StateCore): void {
+  const tokens = state.tokens;
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].type !== 'blockquote_open') continue;
+    const pIdx = i + 1;
+    if (pIdx >= tokens.length || tokens[pIdx].type !== 'paragraph_open') continue;
+    const inlineIdx = pIdx + 1;
+    if (inlineIdx >= tokens.length || tokens[inlineIdx].type !== 'inline') continue;
+    const inline = tokens[inlineIdx];
+    const m = inline.content.match(MARKER_RE);
+    if (!m) continue;
+    const type = m[1].toLowerCase();
+    const fold = m[2];
+    const titleRaw = (m[3] ?? '').trim();
+    const title = titleRaw.length > 0
+      ? titleRaw
+      : (TITLE_DEFAULTS[type] ?? capitalize(type));
+
+    tokens[i].attrSet('data-callout', type);
+    tokens[i].attrSet('data-callout-title', title);
+    if (fold === '+') tokens[i].attrSet('data-callout-fold', 'open');
+    else if (fold === '-') tokens[i].attrSet('data-callout-fold', 'closed');
+
+    const remainder = inline.content.slice(m[0].length);
+    if (remainder.trim().length === 0) {
+      // Strip the marker-only paragraph entirely (open + inline + close).
+      tokens.splice(pIdx, 3);
+    } else {
+      // Keep the body of the first paragraph minus the marker line.
+      // Re-tokenize inline so emphasis/links inside the remainder still
+      // render correctly.
+      inline.content = remainder;
+      const reparsed = state.md.parseInline(remainder, state.env);
+      const children = reparsed[0]?.children ?? null;
+      inline.children = children;
+    }
+  }
+}
+
+/**
+ * Walk back from a `blockquote_close` to the matching `blockquote_open`
+ * at the same nesting level. Used by the close render rule to decide
+ * whether the close belongs to a callout (and therefore needs the
+ * wrapper close tags) or a plain blockquote.
+ */
+function findMatchingBlockquoteOpen(tokens: Token[], closeIdx: number): Token | null {
+  let depth = 0;
+  for (let i = closeIdx; i >= 0; i--) {
+    const t = tokens[i];
+    if (t.type === 'blockquote_close') depth++;
+    else if (t.type === 'blockquote_open') {
+      depth--;
+      if (depth === 0) return t;
+    }
+  }
+  return null;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s).replace(/"/g, '&quot;');
+}

--- a/tests/renderer/callout-plugin.test.ts
+++ b/tests/renderer/callout-plugin.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import MarkdownIt from 'markdown-it';
+import { installCallouts } from '../../src/renderer/lib/markdown/callout-plugin';
+
+function md(): MarkdownIt {
+  const m = new MarkdownIt({ html: true });
+  installCallouts(m);
+  return m;
+}
+
+describe('callout-plugin: basic rendering', () => {
+  it('renders a [!note] blockquote as a callout div', () => {
+    const html = md().render('> [!note]\n> Body.\n');
+    expect(html).toContain('class="callout callout-note"');
+    expect(html).toContain('data-callout="note"');
+    expect(html).toContain('class="callout-title-text">Note<');
+    expect(html).toContain('class="callout-content"');
+    expect(html).toContain('Body.');
+  });
+
+  it('uses the type-default title when no custom title is given', () => {
+    const html = md().render('> [!warning]\n> Watch out.\n');
+    expect(html).toContain('Warning');
+    expect(html).toContain('callout-warning');
+  });
+
+  it('uses a custom title after the marker', () => {
+    const html = md().render('> [!info] Pay attention\n> Body.\n');
+    expect(html).toContain('Pay attention');
+    expect(html).not.toMatch(/class="callout-title-text">Info</);
+  });
+
+  it('lowercases the type and tags unknown types as "unknown"', () => {
+    const html = md().render('> [!CUSTOMTYPE]\n> body\n');
+    expect(html).toContain('callout-unknown');
+    expect(html).toContain('data-callout="customtype"');
+  });
+
+  it('falls back to plain blockquote when the marker is absent', () => {
+    const html = md().render('> just a quote\n');
+    expect(html).toContain('<blockquote>');
+    expect(html).not.toContain('callout');
+  });
+});
+
+describe('callout-plugin: collapsible variants', () => {
+  it('+ marker renders as an open <details>', () => {
+    const html = md().render('> [!tip]+ Tap me\n> body\n');
+    expect(html).toContain('<details');
+    expect(html).toContain(' open');
+    expect(html).toContain('callout-collapsible');
+    expect(html).toContain('<summary class="callout-title">');
+  });
+
+  it('- marker renders as a closed <details>', () => {
+    const html = md().render('> [!info]- Hidden\n> body\n');
+    expect(html).toContain('<details');
+    expect(html).not.toContain(' open');
+    expect(html).toContain('callout-collapsible');
+  });
+
+  it('no fold marker renders as a <div> (non-collapsible)', () => {
+    const html = md().render('> [!note]\n> body\n');
+    expect(html).toContain('<div class="callout');
+    expect(html).not.toContain('<details');
+    expect(html).not.toContain('callout-collapsible');
+  });
+});
+
+describe('callout-plugin: marker stripping', () => {
+  it('drops the marker line when nothing else is on it', () => {
+    const html = md().render('> [!note]\n> Just the body.\n');
+    expect(html).not.toContain('[!note]');
+    expect(html).toContain('Just the body.');
+  });
+
+  it('keeps inline-formatted body content after the title line', () => {
+    const html = md().render('> [!note] Title\n> Body with **bold** text.\n');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('Body with');
+  });
+});
+
+describe('callout-plugin: nesting', () => {
+  it('detects callouts at every blockquote level independently', () => {
+    const src = [
+      '> [!note] Outer',
+      '> Outer body.',
+      '>',
+      '> > [!warning] Inner',
+      '> > Inner body.',
+      '',
+    ].join('\n');
+    const html = md().render(src);
+    expect(html).toContain('callout-note');
+    expect(html).toContain('callout-warning');
+    expect(html.indexOf('callout-note')).toBeLessThan(html.indexOf('callout-warning'));
+    // Both wrapper close tags should appear, and the inner one should
+    // come before the outer one.
+    const innerCloseIdx = html.lastIndexOf('callout-warning');
+    expect(innerCloseIdx).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #465. Preview-only support for now; editor decoration and exporter integration are explicitly out of scope (separate tickets if wanted).

## Summary
- New \`callout-plugin.ts\` registers a markdown-it core rule that detects \`[!type]\` markers on the first inline of any blockquote and rewrites the open/close render rules to emit a styled callout div.
- Collapsible variants (\`+\`/\`-\`) render as native \`<details>\`/\`<summary>\` so keyboard a11y comes for free, with a chevron and short transform transition.
- Nesting works because each blockquote level is checked independently.
- 13 standard types styled with catppuccin tokens — warning/failure/danger/bug use peach + mauve per CLAUDE.md "no danger styling." Unknown types fall back to the accent color but preserve the type on the DOM.
- 11 unit tests covering basic, collapsible, marker stripping, and nesting cases.

## Test plan
- [ ] Render a note with a basic \`> [!note]\` block — accent border, icon, "Note" title.
- [ ] \`> [!warning] Custom title\` — peach accent, custom title shown.
- [ ] \`> [!tip]+ Foldable\` — open by default, click to collapse, keyboard Enter/Space toggles.
- [ ] \`> [!info]- Hidden\` — collapsed by default.
- [ ] Nested callouts (warning inside note) render correctly.
- [ ] Plain blockquote still renders as a normal blockquote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)