### PR TITLE
Callouts: fix duplicated body and missing styling

### DIFF
--- a/src/renderer/lib/markdown/callout-plugin.ts
+++ b/src/renderer/lib/markdown/callout-plugin.ts
@@ -126,13 +126,11 @@ function calloutCoreRule(state: StateCore): void {
       // Strip the marker-only paragraph entirely (open + inline + close).
       tokens.splice(pIdx, 3);
     } else {
-      // Keep the body of the first paragraph minus the marker line.
-      // Re-tokenize inline so emphasis/links inside the remainder still
-      // render correctly.
+      // Strip the marker prefix; the core `inline` rule (which runs
+      // after this one) will tokenize `inline.content` into children.
+      // Don't touch `inline.children` here — that rule APPENDS to the
+      // existing children, so any pre-tokenization would render twice.
       inline.content = remainder;
-      const reparsed = state.md.parseInline(remainder, state.env);
-      const children = reparsed[0]?.children ?? null;
-      inline.children = children;
     }
   }
 }

--- a/tests/renderer/callout-plugin.test.ts
+++ b/tests/renderer/callout-plugin.test.ts
@@ -79,6 +79,12 @@ describe('callout-plugin: marker stripping', () => {
     expect(html).toContain('<strong>bold</strong>');
     expect(html).toContain('Body with');
   });
+
+  it('renders body text exactly once (regression: pre-tokenizing inline.children doubled output)', () => {
+    const html = md().render('> [!note]\n> Body.\n');
+    const occurrences = html.split('Body.').length - 1;
+    expect(occurrences).toBe(1);
+  });
 });
 
 describe('callout-plugin: nesting', () => {


### PR DESCRIPTION
Fix for #465 fallout reported just after #480 merged: body text rendered twice ("Body.Body.") and the user saw what looked like plain prose.

## Root cause
The core rule pre-tokenized \`inline.children\` via \`md.parseInline()\`, but markdown-it's \`inline\` core rule runs after ours and APPENDS to \`tok.children\` rather than resetting — so every body line ended up rendered twice. Stripping the marker from \`inline.content\` and letting the inline rule do its job is enough.

## Changes
- Drop the manual \`parseInline\` + \`children\` assignment in \`callout-plugin.ts\`.
- New regression test counts occurrences of the body text in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)