### PR TITLE
RightSidebar: footnotes panel (#462)

### DIFF
--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import OutlinePanel from './right-sidebar/OutlinePanel.svelte';
+  import FootnotesPanel from './right-sidebar/FootnotesPanel.svelte';
   import OutgoingLinksPanel from './right-sidebar/OutgoingLinksPanel.svelte';
   import BacklinksPanel from './right-sidebar/BacklinksPanel.svelte';
   import TagsPanel from './right-sidebar/TagsPanel.svelte';
@@ -10,7 +11,7 @@
   import CitationsPanel from './right-sidebar/CitationsPanel.svelte';
 
   type PanelType =
-    | 'outline' | 'outgoing' | 'backlinks' | 'tags' | 'tables' | 'citations'
+    | 'outline' | 'footnotes' | 'outgoing' | 'backlinks' | 'tags' | 'tables' | 'citations'
     | 'bookmarks' | 'inspections' | 'proposals';
 
   interface Props {
@@ -85,6 +86,12 @@
     >&#x2630;</button>
     <button
       class="panel-tab"
+      class:active={activePanel === 'footnotes'}
+      onclick={() => activePanel = 'footnotes'}
+      title="Footnotes"
+    >&#x2042;</button>
+    <button
+      class="panel-tab"
       class:active={activePanel === 'outgoing'}
       onclick={() => activePanel = 'outgoing'}
       title="Outgoing Links"
@@ -136,6 +143,8 @@
   <div class="panel-content">
     {#if activePanel === 'outline'}
       <OutlinePanel {content} {onScrollToLine} />
+    {:else if activePanel === 'footnotes'}
+      <FootnotesPanel {content} {onScrollToLine} />
     {:else if activePanel === 'outgoing'}
       <OutgoingLinksPanel {activeFilePath} {revision} {onFileSelect} />
     {:else if activePanel === 'backlinks'}

--- a/src/renderer/lib/components/right-sidebar/FootnotesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/FootnotesPanel.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  import Ribbon from './Ribbon.svelte';
+  import { scanFootnotes, type FootnoteDefinition, type FootnoteReference } from '../../footnotes';
+
+  interface Props {
+    content: string;
+    onScrollToLine: (line: number) => void;
+  }
+
+  let { content, onScrollToLine }: Props = $props();
+
+  let search = $state('');
+
+  const scan = $derived(scanFootnotes(content));
+
+  /**
+   * View-model: one row per definition, plus a row per missing
+   * reference (those don't have a definition to anchor them).
+   * Definitions are listed in source order; missing-ref rows follow.
+   */
+  interface Row {
+    kind: 'def' | 'orphan' | 'missing';
+    label: string;
+    body: string;
+    /** Line to scroll to on click (1-based). */
+    targetLine: number;
+  }
+
+  const rows = $derived.by<Row[]>(() => {
+    const out: Row[] = [];
+    const refsByLabel = new Map<string, FootnoteReference[]>();
+    for (const r of scan.references) {
+      const arr = refsByLabel.get(r.label) ?? [];
+      arr.push(r);
+      refsByLabel.set(r.label, arr);
+    }
+    // Definitions first, in source order. Click jumps to first
+    // in-text reference if any, else to the definition itself —
+    // matches what users expect from "show me where this is used".
+    for (const d of scan.definitions) {
+      const refs = refsByLabel.get(d.label);
+      const isOrphan = !refs || refs.length === 0;
+      const target = refs && refs[0] ? refs[0].line : d.defLine;
+      out.push({
+        kind: isOrphan ? 'orphan' : 'def',
+        label: d.label,
+        body: previewBody(d),
+        targetLine: target,
+      });
+    }
+    // Missing references: one row per unique missing label, pointing
+    // at the first occurrence so the user can fix it.
+    const seenMissing = new Set<string>();
+    for (const r of scan.missingReferences) {
+      if (seenMissing.has(r.label)) continue;
+      seenMissing.add(r.label);
+      out.push({
+        kind: 'missing',
+        label: r.label,
+        body: 'No definition',
+        targetLine: r.line,
+      });
+    }
+    return out;
+  });
+
+  const visibleRows = $derived.by<Row[]>(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((r) => r.label.toLowerCase().includes(q) || r.body.toLowerCase().includes(q));
+  });
+
+  function previewBody(d: FootnoteDefinition): string {
+    const collapsed = d.body.replace(/\s+/g, ' ').trim();
+    if (collapsed.length <= 80) return collapsed;
+    return collapsed.slice(0, 77) + '…';
+  }
+
+  function rowTitle(r: Row): string {
+    if (r.kind === 'orphan') return `Footnote [^${r.label}] is defined but never referenced`;
+    if (r.kind === 'missing') return `Footnote [^${r.label}] is referenced but never defined`;
+    return `Jump to first use of [^${r.label}]`;
+  }
+</script>
+
+<div class="footnotes-panel">
+  <Ribbon
+    {search}
+    onSearch={(q: string) => { search = q; }}
+    searchPlaceholder="Find footnote…"
+  />
+  <div class="footnotes-scroll">
+    {#if rows.length === 0}
+      <div class="empty">No footnotes</div>
+    {:else if visibleRows.length === 0}
+      <div class="empty">No matches</div>
+    {:else}
+      <ul class="footnotes-list">
+        {#each visibleRows as r}
+          <li>
+            <button
+              class="footnote-item"
+              class:orphan={r.kind === 'orphan'}
+              class:missing={r.kind === 'missing'}
+              title={rowTitle(r)}
+              onclick={() => onScrollToLine(r.targetLine)}
+            >
+              <span class="label">[^{r.label}]</span>
+              <span class="body">{r.body}</span>
+              {#if r.kind === 'orphan'}
+                <span class="marker" aria-label="Unused">○</span>
+              {:else if r.kind === 'missing'}
+                <span class="marker" aria-label="Missing">?</span>
+              {/if}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .footnotes-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .footnotes-scroll {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .footnotes-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+  }
+
+  .footnote-item {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 10px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+    border-radius: 3px;
+  }
+
+  .footnote-item:hover {
+    background: var(--bg-button);
+  }
+
+  .label {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+
+  .body {
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+
+  .marker {
+    flex-shrink: 0;
+    font-size: 11px;
+    color: var(--text-muted);
+    width: 14px;
+    text-align: center;
+  }
+
+  .footnote-item.orphan .label,
+  .footnote-item.missing .label {
+    color: var(--text-muted);
+  }
+  .footnote-item.orphan .body,
+  .footnote-item.missing .body {
+    font-style: italic;
+  }
+
+  .empty {
+    padding: 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+</style>

--- a/src/renderer/lib/footnotes.ts
+++ b/src/renderer/lib/footnotes.ts
@@ -1,0 +1,141 @@
+/**
+ * Live-buffer footnote scanner (#462).
+ *
+ * Walks the editor text and pulls out:
+ *   - Definitions: `[^name]: body...` line-anchored at column 0,
+ *     with continuation lines that are either indented whitespace
+ *     OR a blank line followed by another indented line. Standard
+ *     Pandoc/CommonMark-extension footnote syntax.
+ *   - References: `[^name]` inline, NOT followed by `:`.
+ *
+ * Backslash-escaped `\[^foo]` is ignored. Code fences and inline
+ * code are skipped — a `[^foo]` inside `` ` `` is not a real ref.
+ *
+ * Output shape is shared by the sidebar panel (#462) and the planned
+ * inline hover-preview (#484); both want the same definition map.
+ */
+
+export interface FootnoteDefinition {
+  /** Label inside `[^…]:`, e.g. `foo` for `[^foo]:` */
+  label: string;
+  /** Body text, joined across continuation lines, leading indent stripped */
+  body: string;
+  /** 1-based line of the `[^name]:` opener */
+  defLine: number;
+  /** 0-based column of `[` on the opener line */
+  defColumn: number;
+}
+
+export interface FootnoteReference {
+  label: string;
+  /** 1-based line where the `[^…]` reference appears */
+  line: number;
+  /** 0-based column of `[` */
+  column: number;
+}
+
+export interface FootnoteScan {
+  definitions: FootnoteDefinition[];
+  references: FootnoteReference[];
+  /** Definitions that no in-text reference points at. */
+  orphanDefinitions: FootnoteDefinition[];
+  /** References whose label has no matching definition. */
+  missingReferences: FootnoteReference[];
+}
+
+const DEF_RE = /^\[\^([\w-]+)\]:\s?(.*)$/;
+const REF_RE = /(?<!\\)\[\^([\w-]+)\](?!:)/g;
+
+/**
+ * Scan `text` and return every footnote definition / reference plus
+ * the diagnostic mismatch sets. O(n) over input length; callers
+ * should still debounce for keystroke-frequency calls.
+ */
+export function scanFootnotes(text: string): FootnoteScan {
+  const lines = text.split('\n');
+  const definitions = collectDefinitions(lines);
+  const references = collectReferences(lines);
+
+  const defLabels = new Set(definitions.map((d) => d.label));
+  const refLabels = new Set(references.map((r) => r.label));
+
+  return {
+    definitions,
+    references,
+    orphanDefinitions: definitions.filter((d) => !refLabels.has(d.label)),
+    missingReferences: references.filter((r) => !defLabels.has(r.label)),
+  };
+}
+
+function collectDefinitions(lines: string[]): FootnoteDefinition[] {
+  const out: FootnoteDefinition[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(DEF_RE);
+    if (!m) continue;
+    const label = m[1];
+    const bodyParts: string[] = [m[2]];
+    // Continuation: subsequent lines that are indented OR are blank
+    // followed eventually by an indented line. Pandoc's "lazy
+    // continuation" — but a non-indented non-blank line ends the def.
+    let j = i + 1;
+    while (j < lines.length) {
+      const next = lines[j];
+      if (/^\s+\S/.test(next)) {
+        bodyParts.push(next.replace(/^\s+/, ''));
+        j++;
+        continue;
+      }
+      if (next === '' || /^\s*$/.test(next)) {
+        // Peek ahead — only treat the blank as a continuation gap if
+        // the next non-blank line is indented (still part of the def).
+        let k = j + 1;
+        while (k < lines.length && /^\s*$/.test(lines[k])) k++;
+        if (k < lines.length && /^\s+\S/.test(lines[k])) {
+          bodyParts.push('');
+          j++;
+          continue;
+        }
+      }
+      break;
+    }
+    out.push({
+      label,
+      body: bodyParts.join(' ').trim(),
+      defLine: i + 1,
+      defColumn: 0,
+    });
+    i = j - 1;
+  }
+  return out;
+}
+
+function collectReferences(lines: string[]): FootnoteReference[] {
+  const out: FootnoteReference[] = [];
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    // Skip definition lines themselves — `[^foo]:` matches REF_RE
+    // unless we explicitly skip.
+    if (DEF_RE.test(line)) continue;
+    // Drop inline-code spans before scanning; a `[^foo]` inside
+    // backticks is text, not a reference.
+    const stripped = stripInlineCode(line);
+    REF_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = REF_RE.exec(stripped)) !== null) {
+      out.push({ label: m[1], line: i + 1, column: m.index });
+    }
+  }
+  return out;
+}
+
+function stripInlineCode(line: string): string {
+  // Replace `…` runs with same-length spaces so column indices stay
+  // aligned with the original source.
+  return line.replace(/`[^`]*`/g, (s) => ' '.repeat(s.length));
+}

--- a/tests/renderer/footnotes.test.ts
+++ b/tests/renderer/footnotes.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { scanFootnotes } from '../../src/renderer/lib/footnotes';
+
+describe('scanFootnotes: definitions', () => {
+  it('finds a single-line definition', () => {
+    const r = scanFootnotes('Body. [^foo]\n\n[^foo]: definition body.\n');
+    expect(r.definitions).toHaveLength(1);
+    expect(r.definitions[0]).toMatchObject({
+      label: 'foo',
+      body: 'definition body.',
+      defLine: 3,
+    });
+  });
+
+  it('joins continuation lines with single spaces', () => {
+    const src = '[^x]\n\n[^x]: line one\n    line two\n    line three\n';
+    const r = scanFootnotes(src);
+    expect(r.definitions[0].body).toBe('line one line two line three');
+  });
+
+  it('stops at a non-indented line that is not blank', () => {
+    const src = '[^x]\n\n[^x]: only this line\nNot continuation.\n';
+    const r = scanFootnotes(src);
+    expect(r.definitions[0].body).toBe('only this line');
+    expect(r.references.map((ref) => ref.label)).toContain('x');
+  });
+});
+
+describe('scanFootnotes: references', () => {
+  it('finds inline [^name] references', () => {
+    const r = scanFootnotes('See note[^a] and[^b].\n[^a]: A.\n[^b]: B.\n');
+    expect(r.references.map((ref) => ref.label)).toEqual(['a', 'b']);
+  });
+
+  it('does not treat the definition opener as a reference', () => {
+    const r = scanFootnotes('[^foo]: just a def.\n');
+    expect(r.references).toHaveLength(0);
+    expect(r.definitions).toHaveLength(1);
+  });
+
+  it('skips refs inside backtick inline code', () => {
+    const r = scanFootnotes('Code: `[^nope]` real[^yes].\n[^yes]: y.\n');
+    expect(r.references.map((ref) => ref.label)).toEqual(['yes']);
+  });
+
+  it('skips refs inside fenced code blocks', () => {
+    const src = '```\n[^nope]\n```\nReal[^yes].\n[^yes]: y.\n';
+    const r = scanFootnotes(src);
+    expect(r.references.map((ref) => ref.label)).toEqual(['yes']);
+  });
+
+  it('ignores backslash-escaped references', () => {
+    const r = scanFootnotes('Literal \\[^nope] stays prose. Real[^yes].\n[^yes]: y.\n');
+    expect(r.references.map((ref) => ref.label)).toEqual(['yes']);
+  });
+});
+
+describe('scanFootnotes: mismatch diagnostics', () => {
+  it('flags definitions with no in-text reference as orphans', () => {
+    const r = scanFootnotes('Body.\n[^unused]: I am alone.\n');
+    expect(r.orphanDefinitions.map((d) => d.label)).toEqual(['unused']);
+  });
+
+  it('flags references with no matching definition as missing', () => {
+    const r = scanFootnotes('See[^ghost].\n');
+    expect(r.missingReferences.map((ref) => ref.label)).toEqual(['ghost']);
+  });
+
+  it('a defined-and-referenced footnote is neither orphan nor missing', () => {
+    const r = scanFootnotes('See[^a].\n[^a]: yes.\n');
+    expect(r.orphanDefinitions).toEqual([]);
+    expect(r.missingReferences).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #462. Spun out a follow-up issue (#484) for the inline hover-preview affordance, which #462 explicitly listed as out-of-scope.

## Summary
- New right-sidebar tab between Outline and Outgoing.
- Lists definitions in source order with a single-line body preview, plus rows for orphan defs (no in-text reference) and missing refs (no matching def). Each marked with a quiet \`○\` / \`?\` indicator — no red.
- Click → scrolls editor to first in-text reference, or to the definition if none.
- Live-updates via \`\$derived(scanFootnotes(content))\`. Search filter via the shared \`Ribbon\` component (matches Outline's UX).
- Parser extracted to \`lib/footnotes.ts\` so #484 can reuse the same scan.

## Test plan
- [ ] Open a note with footnotes — they appear in the panel.
- [ ] Type a new \`[^x]\` reference live — panel updates.
- [ ] Click an entry — editor scrolls to the reference.
- [ ] Define \`[^foo]\` without using it — appears with orphan marker.
- [ ] Reference \`[^bar]\` without defining it — appears with missing marker.
- [ ] Search filter narrows by label/body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)