### PR TITLE
Editor: hover preview for footnote references (#484)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -30,6 +30,7 @@
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { computeCellsExtension } from '../editor/compute-cells';
+  import { footnotePreview } from '../editor/footnote-preview';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
   import { clampMenuToViewport } from '../utils/menuClamp';
@@ -497,6 +498,7 @@
           : api.compute.runCell(language, code, filePath)
       ),
     }),
+    footnotePreview(),
     EditorView.domEventHandlers({
       // Snapshot the selection at the very start of a right-click, before
       // any built-in handling can collapse it. Then, when the click is

--- a/src/renderer/lib/editor/footnote-preview.ts
+++ b/src/renderer/lib/editor/footnote-preview.ts
@@ -1,0 +1,79 @@
+/**
+ * CodeMirror hover tooltip that previews a footnote definition when
+ * the user hovers over a `[^name]` reference in the editor (#484).
+ *
+ * Behavior:
+ *   - Hover over `[^foo]` → tooltip shows the definition body for
+ *     `[^foo]: …`, with continuation lines joined.
+ *   - Hover over a reference whose label has no definition → quiet
+ *     "No definition for `[^foo]`" tooltip, italic + muted.
+ *   - Hover over a definition opener `[^foo]:` → shows nothing
+ *     (the body is already on screen).
+ *
+ * Definitions are scanned from the current editor buffer on each
+ * tooltip request — that's O(n) over the file but the call rate is
+ * gated by CodeMirror's hover delay, so re-scanning on demand stays
+ * cheaper than maintaining a reactive index.
+ */
+
+import type { Extension } from '@codemirror/state';
+import { hoverTooltip, type Tooltip } from '@codemirror/view';
+import { scanFootnotes } from '../footnotes';
+
+const REF_RE = /(?<!\\)\[\^([\w-]+)\](?!:)/g;
+
+export function footnotePreview(): Extension {
+  return hoverTooltip((view, pos): Tooltip | null => {
+    const line = view.state.doc.lineAt(pos);
+    const text = line.text;
+    const col = pos - line.from;
+
+    // Skip definition openers — the body is already visible inline.
+    if (/^\[\^[\w-]+\]:/.test(text)) return null;
+
+    // Find a `[^name]` span that contains the hover position.
+    REF_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    let hit: { start: number; end: number; label: string } | null = null;
+    while ((m = REF_RE.exec(text)) !== null) {
+      const start = m.index;
+      const end = m.index + m[0].length;
+      if (col >= start && col <= end) {
+        hit = { start, end, label: m[1] };
+        break;
+      }
+    }
+    if (!hit) return null;
+
+    const scan = scanFootnotes(view.state.doc.toString());
+    const def = scan.definitions.find((d) => d.label === hit.label);
+
+    return {
+      pos: line.from + hit.start,
+      end: line.from + hit.end,
+      above: true,
+      create: () => {
+        const dom = document.createElement('div');
+        dom.className = 'cm-footnote-tooltip';
+        if (def) {
+          const label = document.createElement('div');
+          label.className = 'label';
+          label.textContent = `[^${hit.label}]`;
+          const body = document.createElement('div');
+          body.className = 'body';
+          body.textContent = def.body || '(empty definition)';
+          dom.appendChild(label);
+          dom.appendChild(body);
+        } else {
+          dom.classList.add('missing');
+          dom.textContent = `No definition for [^${hit.label}]`;
+        }
+        return { dom };
+      },
+    };
+  }, {
+    // Match the rest of the app's hover feel — short delay, no
+    // hideOnChange so the tooltip survives a stray mouse twitch.
+    hoverTime: 250,
+  });
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -239,3 +239,37 @@ details.callout[open] > summary.callout-title::after {
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* Footnote hover preview tooltip in the editor (#484). CodeMirror
+   tooltips mount outside the editor's scoped CSS, so the styling
+   lives here alongside the other shared markdown surfaces. */
+.cm-tooltip:has(.cm-footnote-tooltip) {
+  background: var(--bg-button);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  max-width: 360px;
+}
+.cm-footnote-tooltip {
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text);
+}
+.cm-footnote-tooltip .label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--accent);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.cm-footnote-tooltip .body {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.cm-footnote-tooltip.missing {
+  color: var(--text-muted);
+  font-style: italic;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}


### PR DESCRIPTION
Closes #484. Companion to #462 — the sidebar gives you a list view, this gives you in-context previews at the reference site.

## Summary
- New \`footnote-preview.ts\` CodeMirror extension using \`hoverTooltip\`. Hover \`[^name]\` → tooltip shows the matching \`[^name]: …\` body.
- Definition openers don't trigger (the body's already visible inline).
- Missing labels surface a quiet "No definition for \`[^foo]\`" tooltip in muted italic.
- Reuses the \`scanFootnotes\` parser from #462 so edge cases (continuation lines, fenced code, backslash escapes) stay in sync between the sidebar and hover.
- 250ms hover delay; tooltip styling in global.css (CodeMirror tooltips mount outside scoped CSS).

## Test plan
- [ ] Hover a \`[^x]\` reference with a matching definition → tooltip shows the body.
- [ ] Hover a \`[^x]\` reference with NO definition → tooltip says "No definition for [^x]".
- [ ] Hover the \`[^x]\` part of a definition opener \`[^x]: …\` → no tooltip.
- [ ] Edit the definition body → next hover shows updated text (live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)