### PR TITLE
StatusBar: backlink count for active note (#472)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -103,11 +103,41 @@
     proposal: DecomposeProposal;
   } | null>(null);
   let inspectionCount = $state(0);
+  let backlinkCount = $state(0);
 
   async function refreshInspectionCount() {
     const results = await api.graph.inspections();
     inspectionCount = (results as unknown[]).length;
   }
+
+  /**
+   * Refetch the backlink count for the active note (#472). Cheap IPC,
+   * called on tab switch and after auto-saves; not polled.
+   */
+  async function refreshBacklinkCount() {
+    const path = editor.activeFilePath;
+    if (!path) {
+      backlinkCount = 0;
+      return;
+    }
+    try {
+      const links = await api.links.backlinks(path);
+      // Guard against a tab switch racing the in-flight fetch.
+      if (editor.activeFilePath === path) {
+        backlinkCount = links.length;
+      }
+    } catch {
+      backlinkCount = 0;
+    }
+  }
+
+  $effect(() => {
+    // React to tab/file switches. Reading `editor.activeFilePath` here
+    // tracks it as a reactive dependency so this re-runs on every
+    // change without needing a manual onTabChange hook.
+    void editor.activeFilePath;
+    void refreshBacklinkCount();
+  });
   let viewMode = $state<ViewMode>('source');
   let sidebarVisible = $state(true);
   let sidebar = $state<Sidebar>();
@@ -314,6 +344,7 @@
     editor.flushAutoSave(); // cancel pending auto-save, save immediately
     sidebar?.refreshTags();
     rightSidebar?.refresh();
+    void refreshBacklinkCount();
   }
 
   async function handleSaveQuery() {
@@ -1812,6 +1843,7 @@
     editor.onAutoSaved = () => {
       sidebar?.refreshTags();
       rightSidebar?.refresh();
+      void refreshBacklinkCount();
     };
     window.addEventListener('beforeunload', () => {
       // Capture current editor state before persisting — the Editor
@@ -2167,9 +2199,14 @@
             fontSize={editorFontSize}
             theme={themeLabel}
             {inspectionCount}
+            {backlinkCount}
             onGotoLine={() => { showGotoLine = true; }}
             onCycleTheme={handleCycleTheme}
             onShowInspections={() => { rightSidebarVisible = true; }}
+            onShowBacklinks={() => {
+              rightSidebarVisible = true;
+              rightSidebar?.showPanel('backlinks');
+            }}
           />
           <ToolPanel
             bind:this={toolPanelComponent}

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -75,6 +75,13 @@
   export function refresh() {
     revision++;
   }
+
+  /** Programmatically switch which tab is showing. Used by the status
+   *  bar's backlink-count click to drop the user straight into the
+   *  Backlinks panel. */
+  export function showPanel(panel: PanelType) {
+    activePanel = panel;
+  }
 </script>
 
 <aside class="right-sidebar" style:width="{width}px">

--- a/src/renderer/lib/components/StatusBar.svelte
+++ b/src/renderer/lib/components/StatusBar.svelte
@@ -6,12 +6,23 @@
     fontSize: number;
     theme: string;
     inspectionCount?: number;
+    /** Number of incoming wiki-links to the active note (#472). 0
+     *  hides the item entirely — keeps the bar tidy for unlinked
+     *  notes; we'll revisit if anyone wants the affirmative signal. */
+    backlinkCount?: number;
     onGotoLine: () => void;
     onCycleTheme: () => void;
     onShowInspections?: () => void;
+    /** Click handler for the backlink-count item — App reveals + focuses
+     *  the right-sidebar Backlinks panel. */
+    onShowBacklinks?: () => void;
   }
 
-  let { cursor, fontSize, theme, inspectionCount = 0, onGotoLine, onCycleTheme, onShowInspections }: Props = $props();
+  let {
+    cursor, fontSize, theme,
+    inspectionCount = 0, backlinkCount = 0,
+    onGotoLine, onCycleTheme, onShowInspections, onShowBacklinks,
+  }: Props = $props();
 </script>
 
 <div class="status-bar">
@@ -24,6 +35,15 @@
     {/if}
   </div>
   <div class="status-right">
+    {#if backlinkCount > 0}
+      <button
+        class="status-item clickable backlink-count"
+        onclick={onShowBacklinks}
+        title="Show backlinks ({backlinkCount} note{backlinkCount === 1 ? '' : 's'} link here)"
+      >
+        &#x2190; {backlinkCount}
+      </button>
+    {/if}
     {#if inspectionCount > 0}
       <button class="status-item clickable inspection-count" onclick={onShowInspections} title="Show inspections">
         &#x26A0; {inspectionCount}


### PR DESCRIPTION
Closes #472. Filed two follow-ups for #471 deferrals: #488 (key autocomplete) and #489 (wiki-link picker).

## Summary
- New \`← N\` item near the right end of the status bar.
- Click reveals + focuses the Backlinks panel via a new \`RightSidebar.showPanel\` export.
- Hidden when count is 0 (issue's preferred default).
- Refetches on tab/file switch (\`\$effect\` on \`editor.activeFilePath\`) and after auto-save / explicit save. Race-guarded against tab switches mid-fetch. No polling.

## Test plan
- [ ] Open a note other notes link to → count appears in status bar.
- [ ] Click → right sidebar opens on Backlinks panel.
- [ ] Open a note nothing links to → no count item.
- [ ] Edit another note to add a wiki-link to the active note → save → count ticks up.
- [ ] Switch tabs → count updates per tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)