### PR TITLE
Tags: nested-tag tree view in right sidebar (#466)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1618,6 +1618,41 @@ export function listTags(ctx: ProjectContext): TagInfo[] {
     .sort((a, b) => a.tag.localeCompare(b.tag));
 }
 
+/**
+ * Notes with any tag at-or-under `prefix` (#466). Matches the literal
+ * `prefix` and any tag that starts with `prefix/…` so clicking a
+ * parent row in the tree returns the same set the cumulative count
+ * promised. Deduped by relativePath since one note can carry multiple
+ * matching tags.
+ */
+export function notesByTagPrefix(ctx: ProjectContext, prefix: string): TaggedNote[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  const seen = new Map<string, TaggedNote>();
+  const tagStmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
+  for (const tagStmt of tagStmts) {
+    const tagNode = tagStmt.object as $rdf.NamedNode;
+    const nameStmts = store.statementsMatching(tagNode, MINERVA('tagName'), undefined);
+    const name = nameStmts[0]?.object.value;
+    if (!name) continue;
+    if (name !== prefix && !name.startsWith(`${prefix}/`)) continue;
+    const subject = tagStmt.subject;
+    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
+    if (!isNote) continue;
+    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
+    const relativePath = pathStmts[0]?.object.value ?? '';
+    if (!relativePath || seen.has(relativePath)) continue;
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
+    seen.set(relativePath, {
+      title: titleStmts[0]?.object.value ?? subject.value,
+      relativePath,
+    });
+  }
+  return [...seen.values()].sort((a, b) => a.title.localeCompare(b.title));
+}
+
 export function notesByTag(ctx: ProjectContext, tag: string): TaggedNote[] {
   const state = getState(ctx);
   if (!state) return [];

--- a/src/main/graph/parser.ts
+++ b/src/main/graph/parser.ts
@@ -104,13 +104,36 @@ function extractTitle(content: string): string | null {
   return match ? match[1].trim() : null;
 }
 
+/** Each `/`-delimited segment of a nested tag must look like a normal
+ *  tag identifier — letter, then word chars or hyphens. Empty segments
+ *  (`#a//b`) and segments starting with non-letter (`#a/1b`) are
+ *  rejected so the tree view (#466) never sprouts garbage levels. */
+const TAG_SEGMENT_RE = /^[a-zA-Z][\w-]*$/;
+
 function extractTags(content: string): string[] {
   const tags = new Set<string>();
   let match;
+  TAG_RE.lastIndex = 0;
   while ((match = TAG_RE.exec(content)) !== null) {
-    tags.add(match[1]);
+    const cleaned = normalizeNestedTag(match[1]);
+    if (cleaned) tags.add(cleaned);
   }
   return [...tags];
+}
+
+/**
+ * Strip a trailing slash and validate every `/`-delimited segment.
+ * Returns null when any segment is malformed — the indexer treats
+ * that as "this isn't actually a tag", same as a bare `#` would be.
+ */
+function normalizeNestedTag(raw: string): string | null {
+  const trimmed = raw.replace(/\/+$/, '');
+  if (!trimmed) return null;
+  const parts = trimmed.split('/');
+  for (const p of parts) {
+    if (!TAG_SEGMENT_RE.test(p)) return null;
+  }
+  return parts.join('/');
 }
 
 function extractLinks(content: string): ParsedLink[] {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -679,6 +679,12 @@ export function registerIpcHandlers(): void {
     return graph.notesByTag(projectContext(rootPath), tag);
   });
 
+  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG_PREFIX, (e, prefix: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.notesByTagPrefix(projectContext(rootPath), prefix);
+  });
+
   ipcMain.handle(Channels.TAGS_SOURCES_BY_TAG, (e, tag: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return [];

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -114,6 +114,7 @@ contextBridge.exposeInMainWorld('api', {
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),
     notesByTag: (tag: string) => ipcRenderer.invoke(Channels.TAGS_NOTES_BY_TAG, tag),
+    notesByTagPrefix: (prefix: string) => ipcRenderer.invoke(Channels.TAGS_NOTES_BY_TAG_PREFIX, prefix),
     sourcesByTag: (tag: string) => ipcRenderer.invoke(Channels.TAGS_SOURCES_BY_TAG, tag),
     allNames: () => ipcRenderer.invoke(Channels.TAGS_ALL_NAMES),
   },

--- a/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
@@ -1,44 +1,149 @@
 <script lang="ts">
-  import type { TaggedNote } from '../../../../shared/types';
+  import type { TagInfo, TaggedNote } from '../../../../shared/types';
   import { api } from '../../ipc/client';
   import Ribbon from './Ribbon.svelte';
+  import {
+    buildTagTree,
+    flattenTagTree,
+    subtreeMatches,
+    type TagTreeNode,
+  } from '../../tags';
 
   interface Props {
+    /** Active note's content. Tags from this note are highlighted in
+     *  the tree but the panel shows project-wide tags now (#466). */
     content: string;
     onFileSelect: (relativePath: string) => void;
   }
 
   let { content, onFileSelect }: Props = $props();
 
-  let expandedTag = $state<string | null>(null);
-  let taggedNotes = $state<TaggedNote[]>([]);
+  let allTags = $state<TagInfo[]>([]);
+  let activePath = $state<string | null>(null);
+  /** Whether the active row resolved by exact tag (`leaf`) or by
+   *  prefix subtree (`prefix`). Tracking it explicitly keeps the
+   *  header and reload behaviour straight even when a prefix path
+   *  also has its own tag. */
+  let activeKind = $state<'leaf' | 'prefix' | null>(null);
+  let activeNotes = $state<TaggedNote[]>([]);
   let search = $state('');
 
-  // Extract tags from current note content (client-side)
-  const TAG_RE = /(?:^|\s)#([a-zA-Z][\w-/]*)/g;
-  const CODE_RE = /```[\s\S]*?```|`[^`\n]+`/g;
+  // Expand state — persisted per-project would be nicer, but the panel
+  // re-renders the same set of tags within a session and `localStorage`
+  // is the same convention we use for sidebar widths. Project-scoped
+  // expand state can be a follow-up if anyone notices.
+  const STORAGE_KEY = 'minerva.tagsPanel.expanded';
+  let expanded = $state<Record<string, boolean>>(loadExpanded());
 
-  let tags = $derived(() => {
-    const stripped = content.replace(CODE_RE, '');
-    const found = new Set<string>();
-    let match;
-    TAG_RE.lastIndex = 0;
-    while ((match = TAG_RE.exec(stripped)) !== null) {
-      found.add(match[1]);
-    }
-    const q = search.trim().toLowerCase();
-    const all = [...found].sort();
-    return q ? all.filter((t) => t.toLowerCase().includes(q)) : all;
+  function loadExpanded(): Record<string, boolean> {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const out: Record<string, boolean> = {};
+        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+          if (typeof v === 'boolean') out[k] = v;
+        }
+        return out;
+      }
+    } catch { /* fall through */ }
+    return {};
+  }
+  function persistExpanded(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(expanded));
+    } catch { /* localStorage full / disabled — non-fatal */ }
+  }
+
+  // Refresh on mount and whenever the active note's content changes
+  // (a save in this note may have added or removed a tag).
+  $effect(() => {
+    void content; // track as dependency
+    void refresh();
   });
 
-  async function toggleTag(tag: string) {
-    if (expandedTag === tag) {
-      expandedTag = null;
-      taggedNotes = [];
-    } else {
-      expandedTag = tag;
-      taggedNotes = await api.tags.notesByTag(tag);
+  export async function refresh(): Promise<void> {
+    allTags = await api.tags.list();
+  }
+
+  const tree = $derived<TagTreeNode[]>(buildTagTree(allTags));
+
+  /** Tags present in the active note — used to give those rows a
+   *  subtle highlight without filtering the project-wide tree. */
+  const ACTIVE_TAG_RE = /(?:^|\s)#([a-zA-Z][\w/-]*)/g;
+  const CODE_RE = /```[\s\S]*?```|`[^`\n]+`/g;
+  const tagsInActiveNote = $derived.by<Set<string>>(() => {
+    const stripped = content.replace(CODE_RE, '');
+    const found = new Set<string>();
+    ACTIVE_TAG_RE.lastIndex = 0;
+    let m;
+    while ((m = ACTIVE_TAG_RE.exec(stripped)) !== null) {
+      const cleaned = m[1].replace(/\/+$/, '');
+      if (cleaned) found.add(cleaned);
     }
+    return found;
+  });
+
+  /**
+   * Visible nodes after applying the search filter. A subtree-level
+   * match keeps every ancestor visible so the user can see where the
+   * hit lives. When no search is active, every node is visible
+   * (collapse state still controls render via `flattenTagTree`).
+   */
+  const visibleTree = $derived.by<TagTreeNode[]>(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return tree;
+    const filter = (nodes: TagTreeNode[]): TagTreeNode[] => {
+      const out: TagTreeNode[] = [];
+      for (const n of nodes) {
+        if (!subtreeMatches(n, q)) continue;
+        out.push({ ...n, children: filter(n.children) });
+      }
+      return out;
+    };
+    return filter(tree);
+  });
+
+  /**
+   * Search collapses the expand state — when filtering, every match's
+   * ancestor chain should be visible regardless of saved state. We
+   * compute this on the fly via a synthetic isExpanded function.
+   */
+  function isExpanded(path: string): boolean {
+    if (search.trim().length > 0) return true;
+    return !!expanded[path];
+  }
+
+  const visibleRows = $derived(flattenTagTree(visibleTree, isExpanded));
+
+  function toggle(path: string): void {
+    expanded = { ...expanded, [path]: !expanded[path] };
+    persistExpanded();
+  }
+
+  async function showLeaf(node: TagTreeNode): Promise<void> {
+    if (activePath === node.path && activeKind === 'leaf') {
+      activePath = null;
+      activeKind = null;
+      activeNotes = [];
+      return;
+    }
+    activePath = node.path;
+    activeKind = 'leaf';
+    activeNotes = await api.tags.notesByTag(node.path);
+  }
+
+  async function showPrefix(node: TagTreeNode): Promise<void> {
+    if (activePath === node.path && activeKind === 'prefix') {
+      activePath = null;
+      activeKind = null;
+      activeNotes = [];
+      return;
+    }
+    activePath = node.path;
+    activeKind = 'prefix';
+    activeNotes = await api.tags.notesByTagPrefix(node.path);
   }
 </script>
 
@@ -48,29 +153,57 @@
     onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find tag…"
   />
-  {#if tags().length === 0}
-    <div class="empty">No tags in this note</div>
+  {#if allTags.length === 0}
+    <div class="empty">No tags in project</div>
+  {:else if visibleRows.length === 0}
+    <div class="empty">No matches</div>
   {:else}
-    <div class="tag-list">
-      {#each tags() as tag}
-        <button
-          class="tag-item"
-          class:expanded={expandedTag === tag}
-          onclick={() => toggleTag(tag)}
+    <div class="tag-tree">
+      {#each visibleRows as row (row.path)}
+        <div
+          class="row"
+          class:active={activePath === row.path}
+          class:in-active-note={tagsInActiveNote.has(row.path)}
+          style:padding-left="{row.depth * 14 + 6}px"
         >
-          <span class="tag-name">#{tag}</span>
+          {#if row.children.length > 0}
+            <button
+              type="button"
+              class="chevron"
+              onclick={() => toggle(row.path)}
+              aria-label={isExpanded(row.path) ? 'Collapse' : 'Expand'}
+            >{isExpanded(row.path) ? '▾' : '▸'}</button>
+          {:else}
+            <span class="chevron-spacer"></span>
+          {/if}
+          <button
+            type="button"
+            class="tag-name"
+            title={row.children.length > 0
+              ? `Show notes tagged at-or-under #${row.path}`
+              : `Show notes tagged exactly #${row.path}`}
+            onclick={() => row.children.length > 0
+              ? void showPrefix(row)
+              : void showLeaf(row)
+            }
+          >
+            #{row.segment}{#if !row.hasOwnTag && row.children.length > 0}/{/if}
+          </button>
+          <span class="count">{row.count}</span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if activePath && activeNotes.length > 0}
+    <div class="notes-section">
+      <div class="notes-header">
+        {activeKind === 'prefix' ? 'Under' : 'Tagged'} #{activePath}
+      </div>
+      {#each activeNotes as note (note.relativePath)}
+        <button class="note-item" onclick={() => onFileSelect(note.relativePath)}>
+          {note.title}
         </button>
-        {#if expandedTag === tag && taggedNotes.length > 0}
-          <ul class="tagged-notes">
-            {#each taggedNotes as note}
-              <li>
-                <button class="note-link" onclick={() => onFileSelect(note.relativePath)}>
-                  {note.title}
-                </button>
-              </li>
-            {/each}
-          </ul>
-        {/if}
       {/each}
     </div>
   {/if}
@@ -84,52 +217,92 @@
     overflow: hidden;
   }
 
-  .tag-list {
+  .tag-tree {
     flex: 1;
     overflow-y: auto;
-    padding: 4px 4px;
+    padding: 4px 0;
   }
 
-  .tag-item {
-    display: block;
-    width: 100%;
-    padding: 4px 8px;
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px 2px 0;
+    font-size: 12px;
+    border-radius: 3px;
+  }
+  .row:hover {
+    background: var(--bg-button);
+  }
+  .row.active {
+    background: var(--bg-button);
+  }
+  .row.in-active-note .tag-name {
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  .chevron,
+  .chevron-spacer {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 10px;
+    text-align: center;
+    cursor: pointer;
+    padding: 0;
+  }
+  .chevron-spacer { cursor: default; }
+
+  .tag-name {
+    flex: 1;
+    min-width: 0;
     border: none;
     background: none;
     color: var(--accent);
     font-size: 12px;
     cursor: pointer;
     text-align: left;
-    border-radius: 3px;
+    padding: 2px 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .row:hover .tag-name { color: var(--text); }
+
+  .count {
+    flex-shrink: 0;
+    font-size: 10px;
+    color: var(--text-muted);
+    padding-right: 2px;
   }
 
-  .tag-item:hover {
-    background: var(--bg-button);
+  .notes-section {
+    border-top: 1px solid var(--border);
+    max-height: 50%;
+    overflow-y: auto;
+    flex-shrink: 0;
   }
-
-  .tag-item.expanded {
-    background: var(--bg-button);
+  .notes-header {
+    padding: 6px 12px;
+    font-size: 11px;
+    color: var(--text-muted);
   }
-
-  .tagged-notes {
-    list-style: none;
-    padding: 0 0 4px 16px;
-  }
-
-  .note-link {
+  .note-item {
     display: block;
     width: 100%;
-    padding: 3px 8px;
+    padding: 4px 12px;
     border: none;
     background: none;
     color: var(--text);
-    font-size: 11px;
+    font-size: 12px;
     cursor: pointer;
     text-align: left;
-    border-radius: 3px;
   }
-
-  .note-link:hover {
+  .note-item:hover {
     background: var(--bg-button);
   }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -157,6 +157,8 @@ export interface TablesApi {
 export interface TagsApi {
   list(): Promise<TagInfo[]>;
   notesByTag(tag: string): Promise<TaggedNote[]>;
+  /** Notes with any tag at-or-under `prefix` (#466). */
+  notesByTagPrefix(prefix: string): Promise<TaggedNote[]>;
   sourcesByTag(tag: string): Promise<TaggedSource[]>;
   allNames(): Promise<string[]>;
 }

--- a/src/renderer/lib/tags.ts
+++ b/src/renderer/lib/tags.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared helpers for the nested-tag tree (#466).
+ *
+ * The graph indexer stores tags as flat strings — `projects/minerva/ui`
+ * is a single tag, not three nodes. The tree shape lives entirely on
+ * the client; this module turns a flat `TagInfo[]` into the nested
+ * structure the right-sidebar panel renders.
+ *
+ * Counts are cumulative — every parent reports the deduped union of
+ * notes tagged at-or-under that prefix, not just notes whose literal
+ * tag equals the prefix. Clicking a parent in the panel uses the
+ * prefix-aware IPC and gets the same set the count promises.
+ *
+ * Counts here are computed from per-leaf `count` numbers as a sum,
+ * which is approximate when the same note carries two tags under the
+ * same prefix (e.g. `projects/minerva/ui` AND `projects/minerva/api`).
+ * For an exact count, the renderer queries `notesByTagPrefix` on
+ * demand. The summed count is fine as a sidebar hint.
+ */
+
+import type { TagInfo } from '../../shared/types';
+
+export interface TagTreeNode {
+  /** Last segment of the tag path, e.g. `ui` for `projects/minerva/ui`. */
+  segment: string;
+  /** Full path from the root, e.g. `projects/minerva/ui`. */
+  path: string;
+  /** Total notes with a tag at-or-under this path (sum approximation). */
+  count: number;
+  /** True when at least one tag in the input has exactly this path. */
+  hasOwnTag: boolean;
+  /** Children, sorted by segment. */
+  children: TagTreeNode[];
+}
+
+/**
+ * Build a tree from a flat list of tags. Nodes are sorted alphabetically
+ * by segment so re-renders don't reshuffle rows.
+ */
+export function buildTagTree(tags: TagInfo[]): TagTreeNode[] {
+  const root: TagTreeNode = { segment: '', path: '', count: 0, hasOwnTag: false, children: [] };
+  for (const { tag, count } of tags) {
+    if (!tag) continue;
+    const parts = tag.split('/').filter(Boolean);
+    let cur = root;
+    let acc = '';
+    for (let i = 0; i < parts.length; i++) {
+      const seg = parts[i];
+      acc = acc ? `${acc}/${seg}` : seg;
+      let child = cur.children.find((c) => c.segment === seg);
+      if (!child) {
+        child = { segment: seg, path: acc, count: 0, hasOwnTag: false, children: [] };
+        cur.children.push(child);
+      }
+      child.count += count;
+      if (i === parts.length - 1) child.hasOwnTag = true;
+      cur = child;
+    }
+  }
+  // Stable sort each layer.
+  const sortDeep = (n: TagTreeNode) => {
+    n.children.sort((a, b) => a.segment.localeCompare(b.segment));
+    for (const c of n.children) sortDeep(c);
+  };
+  sortDeep(root);
+  return root.children;
+}
+
+/**
+ * Walk the tree in display order (parent before children) and return
+ * every node as a flat list. Used by the panel for the visible-row
+ * list (after applying expand/search filters).
+ */
+export function flattenTagTree(
+  nodes: TagTreeNode[],
+  isExpanded: (path: string) => boolean,
+  depth = 0,
+): Array<TagTreeNode & { depth: number }> {
+  const out: Array<TagTreeNode & { depth: number }> = [];
+  for (const n of nodes) {
+    out.push({ ...n, depth });
+    if (n.children.length > 0 && isExpanded(n.path)) {
+      out.push(...flattenTagTree(n.children, isExpanded, depth + 1));
+    }
+  }
+  return out;
+}
+
+/**
+ * True when `node` (or any descendant) has a path that includes
+ * `query` as a substring. Used by the search filter — a hit anywhere
+ * in the subtree keeps every ancestor visible.
+ */
+export function subtreeMatches(node: TagTreeNode, query: string): boolean {
+  if (node.path.toLowerCase().includes(query)) return true;
+  return node.children.some((c) => subtreeMatches(c, query));
+}

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -84,6 +84,8 @@ export const Channels = {
   // Tags
   TAGS_LIST: 'tags:list',
   TAGS_NOTES_BY_TAG: 'tags:notesByTag',
+  /** Notes with any tag at-or-under a given prefix (#466). */
+  TAGS_NOTES_BY_TAG_PREFIX: 'tags:notesByTagPrefix',
   TAGS_SOURCES_BY_TAG: 'tags:sourcesByTag',
   TAGS_ALL_NAMES: 'tags:allNames',
 

--- a/tests/main/graph/notes-by-tag-prefix.test.ts
+++ b/tests/main/graph/notes-by-tag-prefix.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `notesByTagPrefix` returns notes whose tags fall at-or-under a
+ * given prefix (#466). Backs the parent-row click in the right-sidebar
+ * tag tree — clicking `#projects` should surface every note tagged
+ * `#projects`, `#projects/minerva`, `#projects/minerva/ui`, etc.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  initGraph,
+  indexNote,
+  notesByTag,
+  notesByTagPrefix,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('notesByTagPrefix (#466)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tag-prefix-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+
+    await indexNote(ctx, 'a.md', '# A\n\n#projects/minerva/ui\n');
+    await indexNote(ctx, 'b.md', '# B\n\n#projects/minerva/api\n');
+    await indexNote(ctx, 'c.md', '# C\n\n#projects/lemur\n');
+    await indexNote(ctx, 'd.md', '# D\n\n#unrelated\n');
+    await indexNote(ctx, 'e.md', '# E\n\n#projects\n');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns notes tagged exactly at the prefix and under it', () => {
+    const result = notesByTagPrefix(ctx, 'projects');
+    const paths = result.map((n) => n.relativePath).sort();
+    expect(paths).toEqual(['a.md', 'b.md', 'c.md', 'e.md']);
+  });
+
+  it('a deeper prefix narrows the result set', () => {
+    const result = notesByTagPrefix(ctx, 'projects/minerva');
+    const paths = result.map((n) => n.relativePath).sort();
+    expect(paths).toEqual(['a.md', 'b.md']);
+  });
+
+  it('a leaf prefix matches only the literal-tag note', () => {
+    const result = notesByTagPrefix(ctx, 'projects/minerva/ui');
+    expect(result.map((n) => n.relativePath)).toEqual(['a.md']);
+  });
+
+  it('does NOT match a sibling that shares the same opening segments', () => {
+    // `projects/lemur` should NOT match a `projects/le` prefix that doesn't
+    // align on the slash boundary — otherwise pre-leaf prefixes would
+    // surface unrelated tags.
+    const result = notesByTagPrefix(ctx, 'projects/le');
+    expect(result).toEqual([]);
+  });
+
+  it('exact-tag lookup still works alongside the prefix variant', () => {
+    const exact = notesByTag(ctx, 'projects/minerva/ui');
+    expect(exact.map((n) => n.relativePath)).toEqual(['a.md']);
+  });
+
+  it('dedupes when one note carries multiple matching tags', async () => {
+    await indexNote(ctx, 'multi.md', '# Multi\n\n#projects/minerva/ui #projects/minerva/api\n');
+    const result = notesByTagPrefix(ctx, 'projects/minerva');
+    const multiCount = result.filter((n) => n.relativePath === 'multi.md').length;
+    expect(multiCount).toBe(1);
+  });
+});

--- a/tests/main/graph/parser.test.ts
+++ b/tests/main/graph/parser.test.ts
@@ -140,6 +140,37 @@ describe('tag extraction', () => {
     const result = parseMarkdown('No tags here');
     expect(result.tags).toEqual([]);
   });
+
+  describe('nested tags (#466)', () => {
+    it('extracts a 3-segment nested tag as one entry', () => {
+      const result = parseMarkdown('See #projects/minerva/ui body');
+      expect(result.tags).toContain('projects/minerva/ui');
+    });
+
+    it('strips a trailing slash', () => {
+      const result = parseMarkdown('Pending: #projects/ tag');
+      expect(result.tags).toContain('projects');
+      expect(result.tags).not.toContain('projects/');
+    });
+
+    it('rejects tags with empty segments (#a//b)', () => {
+      const result = parseMarkdown('Bad: #foo//bar tag');
+      expect(result.tags).not.toContain('foo//bar');
+      expect(result.tags).not.toContain('foo');
+      expect(result.tags).not.toContain('bar');
+    });
+
+    it('rejects tags whose segment starts with a non-letter', () => {
+      const result = parseMarkdown('Bad: #foo/1bar tag');
+      expect(result.tags).not.toContain('foo/1bar');
+      expect(result.tags).not.toContain('foo');
+    });
+
+    it('keeps a valid sibling on the same line as a malformed nested tag', () => {
+      const result = parseMarkdown('Mix #foo//bad and #good/path here');
+      expect(result.tags).toContain('good/path');
+    });
+  });
 });
 
 // ── Link extraction ─────────────────────────────────────────────────────────

--- a/tests/renderer/tags.test.ts
+++ b/tests/renderer/tags.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { buildTagTree, flattenTagTree, subtreeMatches } from '../../src/renderer/lib/tags';
+
+describe('buildTagTree (#466)', () => {
+  it('builds a single-level tree from a flat tag', () => {
+    const tree = buildTagTree([{ tag: 'projects', count: 3 }]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({
+      segment: 'projects',
+      path: 'projects',
+      count: 3,
+      hasOwnTag: true,
+    });
+    expect(tree[0].children).toEqual([]);
+  });
+
+  it('nests `/`-separated tags into a tree', () => {
+    const tree = buildTagTree([
+      { tag: 'projects/minerva/ui', count: 2 },
+      { tag: 'projects/minerva/api', count: 1 },
+    ]);
+    expect(tree).toHaveLength(1);
+    const projects = tree[0];
+    expect(projects.path).toBe('projects');
+    expect(projects.hasOwnTag).toBe(false);
+    expect(projects.count).toBe(3);
+
+    const minerva = projects.children[0];
+    expect(minerva.path).toBe('projects/minerva');
+    expect(minerva.hasOwnTag).toBe(false);
+    expect(minerva.children.map((c) => c.path).sort()).toEqual([
+      'projects/minerva/api',
+      'projects/minerva/ui',
+    ]);
+  });
+
+  it('flags hasOwnTag on a node that exists as a literal tag', () => {
+    const tree = buildTagTree([
+      { tag: 'projects', count: 1 },
+      { tag: 'projects/minerva', count: 2 },
+    ]);
+    expect(tree[0].hasOwnTag).toBe(true);
+    expect(tree[0].count).toBe(3);
+    expect(tree[0].children[0].hasOwnTag).toBe(true);
+  });
+
+  it('sorts siblings alphabetically', () => {
+    const tree = buildTagTree([
+      { tag: 'projects/zen', count: 1 },
+      { tag: 'projects/api', count: 1 },
+      { tag: 'projects/minerva', count: 1 },
+    ]);
+    expect(tree[0].children.map((c) => c.segment)).toEqual(['api', 'minerva', 'zen']);
+  });
+});
+
+describe('flattenTagTree (#466)', () => {
+  const tree = buildTagTree([
+    { tag: 'projects/minerva/ui', count: 1 },
+    { tag: 'projects/api', count: 1 },
+  ]);
+
+  it('returns parents before children when expanded', () => {
+    const rows = flattenTagTree(tree, () => true);
+    expect(rows.map((r) => r.path)).toEqual([
+      'projects',
+      'projects/api',
+      'projects/minerva',
+      'projects/minerva/ui',
+    ]);
+  });
+
+  it('hides children of collapsed parents', () => {
+    const rows = flattenTagTree(tree, (path) => path !== 'projects/minerva');
+    expect(rows.map((r) => r.path)).toEqual([
+      'projects',
+      'projects/api',
+      'projects/minerva',
+    ]);
+  });
+});
+
+describe('subtreeMatches (#466)', () => {
+  const [projects] = buildTagTree([
+    { tag: 'projects/minerva/ui', count: 1 },
+    { tag: 'projects/api', count: 1 },
+  ]);
+
+  it('matches a substring of any descendant path', () => {
+    expect(subtreeMatches(projects, 'minerva')).toBe(true);
+    expect(subtreeMatches(projects, 'min')).toBe(true);
+  });
+
+  it('matches the node itself', () => {
+    expect(subtreeMatches(projects, 'projects')).toBe(true);
+  });
+
+  it('returns false when no descendant matches', () => {
+    expect(subtreeMatches(projects, 'unrelated')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #466. Hierarchical tags parsed today already; this makes the hierarchy meaningful in the UI and queryable in the graph.

## What changed
**Parser** (\`src/main/graph/parser.ts\`):
- Strip trailing \`/\` on extracted tag names.
- Reject tags whose \`/\`-segments aren't valid identifiers — empty segment (\`#a//b\`) or leading non-letter (\`#a/1b\`) — so the tree never grows garbage levels.

**Indexer** (\`src/main/graph/index.ts\`):
- New \`notesByTagPrefix(ctx, prefix)\` returns notes tagged at-or-under \`prefix\`, deduped. Plain-string match on the slash boundary so \`projects/le\` doesn't accidentally match \`projects/lemur\`.

**Renderer**:
- New \`src/renderer/lib/tags.ts\`: tree builder + flatten + subtree-match helpers. Shared so autocomplete / command palette can reuse later.
- Right-sidebar \`TagsPanel\` now shows **project-wide** tags as a tree. Chevrons collapse parents (state in localStorage). Counts cumulative.
- Leaf click → notes with that exact tag (existing semantics).
- Parent click → notes anywhere under that prefix.
- Search matches full path and keeps every ancestor visible for any subtree hit.
- Tags present in the active note get a subtle accent highlight in the tree — keeps the "this note's tags" signal that the old panel surfaced, without making it the main filter.

**API**:
- \`api.tags.notesByTagPrefix(prefix)\` IPC + preload + client typing.

## Behavior change worth flagging
The right-sidebar tags panel previously showed only the active note's tags. It now shows project-wide tags (the tree-view + parent-click features only make sense at project scope). The active note's tags are visually highlighted but not the filter. The left-sidebar \`TagPanel\` remains a flat chip list — separate ticket if you want the tree shape there too.

## Test plan
- [ ] Note with \`#projects/minerva/ui\` and \`#projects/api\` → tree shows \`projects (2)\` → \`api (1)\`, \`minerva (1)\` → \`ui (1)\`.
- [ ] Click \`projects\` (parent) → list of every note tagged at-or-under \`#projects\`.
- [ ] Click \`projects/minerva/ui\` (leaf) → only the literal-tagged note.
- [ ] Collapse \`projects\`; reload app — collapse persists.
- [ ] Search \`min\` keeps \`projects\` and \`projects/minerva\` visible.
- [ ] Active note's \`#projects/minerva/ui\` row reads in accent.
- [ ] \`#a//b\` doesn't appear; \`#a/1b\` doesn't either.

## Out of scope (file separately if wanted)
- Bulk tag rename across project (\`#projects/minerva\` → \`#projects/minerva-app\`).
- Tag aliases / canonical-form mapping.
- Verifying #427 (bulk tag add/remove) handles \`/\`-tags correctly — quick follow-up if you spot a regression there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)