### PR TITLE
tools: prompts to .md, scaffold script, authoring guide

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,9 @@ export default tseslint.config(
       // config is low value anyway. Same for svelte.config.mjs.
       'eslint.config.mjs',
       'svelte.config.mjs',
+      // CLI scripts run by `pnpm new-tool` (#511). Plain Node ESM, not
+      // part of the TS project; lint via `node --check` if needed.
+      'scripts/**',
     ],
   },
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "build:e2e": "NODE_OPTIONS=--max-old-space-size=4096 electron-forge package",
-    "test:e2e": "pnpm build:e2e && playwright test"
+    "test:e2e": "pnpm build:e2e && playwright test",
+    "new-tool": "node scripts/new-tool.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/scripts/new-tool.mjs
+++ b/scripts/new-tool.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Scaffold a new ThinkingTool definition (#511).
+ *
+ *   pnpm new-tool <category> <id> [--with-params]
+ *
+ * Generates:
+ *   - src/shared/tools/definitions/<category>/<id>.ts        (registerTool stub)
+ *   - src/shared/tools/definitions/<category>/<id>.prompt.md (placeholder body)
+ *
+ * And appends the side-effect import to
+ *   src/shared/tools/definitions/index.ts
+ *
+ * The script is intentionally dumb: it generates a minimal stub matching the
+ * conventions in the existing tools (no parameters by default; `--with-params`
+ * adds a single example parameter you can edit). Edit the resulting files
+ * to flesh out the prompt and any per-tool logic.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+const definitionsRoot = resolve(projectRoot, 'src/shared/tools/definitions');
+const indexFile = resolve(definitionsRoot, 'index.ts');
+
+const VALID_CATEGORIES = new Set(['learning', 'research', 'analysis']);
+const KEBAB_RE = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+
+function fail(msg) {
+  console.error(`new-tool: ${msg}`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith('--')));
+const positional = args.filter((a) => !a.startsWith('--'));
+const [category, id] = positional;
+
+if (!category || !id) {
+  fail('usage: pnpm new-tool <category> <id> [--with-params]');
+}
+if (!VALID_CATEGORIES.has(category)) {
+  fail(`unknown category "${category}". Valid: ${[...VALID_CATEGORIES].join(', ')}.`);
+}
+if (!KEBAB_RE.test(id)) {
+  fail(`id "${id}" must be kebab-case (lowercase letters, digits, hyphens; not leading/trailing hyphen).`);
+}
+
+const tsPath = resolve(definitionsRoot, category, `${id}.ts`);
+const promptPath = resolve(definitionsRoot, category, `${id}.prompt.md`);
+
+if (existsSync(tsPath)) fail(`already exists: ${relative(projectRoot, tsPath)}`);
+if (existsSync(promptPath)) fail(`already exists: ${relative(projectRoot, promptPath)}`);
+
+const withParams = flags.has('--with-params');
+
+// Title-case the id for the human-readable name. "find-prerequisites" → "Find Prerequisites".
+const humanName = id.split('-').map((w) => w[0].toUpperCase() + w.slice(1)).join(' ');
+const fullId = `${category}.${id}`;
+
+const tsBody = `import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './${id}.prompt.md?raw';
+
+registerTool({
+  id: '${fullId}',
+  name: '${humanName}',
+  category: '${category}',
+  description: 'TODO short user-facing description (~80 chars).',
+  longDescription:
+    'TODO 1-3 sentence longer description shown in the ToolPanel. Explain ' +
+    'what the tool produces and when to reach for it.',
+  context: ['fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },${withParams ? `
+  parameters: [
+    {
+      id: 'example',
+      label: 'Example parameter',
+      type: 'select',
+      options: [
+        { label: 'Option A', value: 'a' },
+        { label: 'Option B', value: 'b' },
+      ],
+      defaultValue: 'a',
+      required: true,
+    },
+  ],` : ''}
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const noteBlock = ctx.fullNoteContent
+      ? \`\\n\\n## Note\${ctx.fullNoteTitle ? \` — \${ctx.fullNoteTitle}\` : ''}\\n\\n\${ctx.fullNoteContent}\`
+      : '';${withParams ? `
+    const example = ctx.parameterValues?.example ?? 'a';
+    return \`\${SYSTEM_PROMPT}\\n\\nMode: \${example}.\${noteBlock}\`;` : `
+    return SYSTEM_PROMPT + noteBlock;`}
+  },
+  buildFirstMessage: () => 'TODO first user-turn text (or empty string for no auto-send).',
+});
+`;
+
+const promptBody = `You are TODO — describe the role and the one-paragraph framing of what this tool does.
+
+Open the response with the most useful payload first; iterate from there if the user redirects.
+
+Use web search when an external fact would meaningfully ground the result. Don't pad. Don't invent results when the source genuinely yields nothing — say so.
+`;
+
+mkdirSync(dirname(tsPath), { recursive: true });
+writeFileSync(tsPath, tsBody, 'utf-8');
+writeFileSync(promptPath, promptBody, 'utf-8');
+
+// Append the side-effect import to the index aggregator. We try to land it
+// in the right category section by matching the existing comment headers.
+const indexSrc = readFileSync(indexFile, 'utf-8');
+const importLine = `import './${category}/${id}';`;
+if (indexSrc.includes(importLine)) {
+  // shouldn't happen — file existence check would have caught it — but
+  // guard anyway so re-running is idempotent.
+  console.log(`[new-tool] index.ts already imports ${importLine}; skipping`);
+} else {
+  const sectionRe = new RegExp(`(// ${category[0].toUpperCase()}${category.slice(1)} tools[\\s\\S]*?)((?:\\n\\n|\\n$|$))`, 'i');
+  const m = indexSrc.match(sectionRe);
+  let nextSrc;
+  if (m) {
+    nextSrc = indexSrc.replace(sectionRe, `$1\n${importLine}$2`);
+  } else {
+    // No section header — append at the end with a header.
+    nextSrc = indexSrc.trimEnd()
+      + `\n\n// ${category[0].toUpperCase()}${category.slice(1)} tools\n${importLine}\n`;
+  }
+  writeFileSync(indexFile, nextSrc, 'utf-8');
+}
+
+console.log('new-tool: scaffolded');
+console.log(`  ${relative(projectRoot, tsPath)}`);
+console.log(`  ${relative(projectRoot, promptPath)}`);
+console.log(`  index.ts: import './${category}/${id}'`);
+console.log('\nEdit the prompt body, fill in the TODO description fields, then run `pnpm lint` to verify.');

--- a/src/shared/tools/definitions/analysis/excavate.prompt.md
+++ b/src/shared/tools/definitions/analysis/excavate.prompt.md
@@ -1,0 +1,28 @@
+You are performing an Excavate analysis — assumption archaeology. Your goal is to map the hidden assumptions supporting the claim, belief, or plan presented below. The core question is: **"What must be true for this to make sense?"**
+
+## Assumption Categories
+
+Tag each assumption with its type:
+1. **Empirical** — factual claims about the world
+2. **Normative** — value judgments and priorities
+3. **Structural** — incentives, institutions, competitive dynamics
+4. **Psychological** — cognition, motivation, perception
+5. **Definitional** — category boundaries and meaning
+
+## Instructions
+
+**Step 1 — Normalize** the claim into a crisp, single statement.
+
+{{DEPTH_INSTRUCTIONS}}
+
+## Expected Output
+
+Produce three artifacts:
+
+1. **Layered assumption tree** — clean, non-redundant branches with category tags and importance markers
+2. **Crux list** — the 3-7 highest-impact assumptions that, if wrong, would most undermine the position
+3. **Probe questions** — concrete, testable or investigable questions that would update the cruxes
+
+## Key Principle
+
+The goal isn't judgment — it's mapping where effort and evidence should focus next. You are not arguing for or against the position; you are excavating its foundations.

--- a/src/shared/tools/definitions/analysis/excavate.ts
+++ b/src/shared/tools/definitions/analysis/excavate.ts
@@ -1,5 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import PROMPT_BODY from './excavate.prompt.md?raw';
 
 const DEPTH_PROMPTS: Record<string, string> = {
   quick: `Perform a **quick** excavation:
@@ -54,35 +55,7 @@ registerTool({
     const depth = ctx.parameterValues?.depth || 'standard';
     const depthInstructions = DEPTH_PROMPTS[depth] || DEPTH_PROMPTS.standard;
     const sourceLabel = ctx.selectedText ? 'Selected Text' : 'Note';
-    return `You are performing an Excavate analysis — assumption archaeology. Your goal is to map the hidden assumptions supporting the claim, belief, or plan presented below. The core question is: **"What must be true for this to make sense?"**
-
-## Assumption Categories
-
-Tag each assumption with its type:
-1. **Empirical** — factual claims about the world
-2. **Normative** — value judgments and priorities
-3. **Structural** — incentives, institutions, competitive dynamics
-4. **Psychological** — cognition, motivation, perception
-5. **Definitional** — category boundaries and meaning
-
-## Instructions
-
-**Step 1 — Normalize** the claim into a crisp, single statement.
-
-${depthInstructions}
-
-## Expected Output
-
-Produce three artifacts:
-
-1. **Layered assumption tree** — clean, non-redundant branches with category tags and importance markers
-2. **Crux list** — the 3-7 highest-impact assumptions that, if wrong, would most undermine the position
-3. **Probe questions** — concrete, testable or investigable questions that would update the cruxes
-
-## Key Principle
-
-The goal isn't judgment — it's mapping where effort and evidence should focus next. You are not arguing for or against the position; you are excavating its foundations.
-
+    return `${PROMPT_BODY.replace('{{DEPTH_INSTRUCTIONS}}', depthInstructions)}
 ## ${sourceLabel}
 
 ${text}

--- a/src/shared/tools/definitions/analysis/murphyjitsu.prompt.md
+++ b/src/shared/tools/definitions/analysis/murphyjitsu.prompt.md
@@ -1,0 +1,35 @@
+You are performing a Murphyjitsu analysis — a pre-mortem failure simulation technique. Your brain already knows this plan will fail. This is the extraction protocol.
+
+## The Process
+
+**Step 1 — State success clearly.** Define the scope, timeline, and success criteria for the plan described below.
+
+**Step 2 — Invoke temporal inversion.** "It's [appropriate timeframe] from now. The plan has completely failed." Commit to this frame.
+
+**Step 3 — Generate failure stories.** Produce 5-10 concrete, specific ways the plan fails. Cover three categories:
+- **Execution failures** — didn't follow through, dropped the ball, lost momentum
+- **Assumption failures** — the world wasn't as expected, key premises were wrong
+- **External shocks** — events beyond control that derailed everything
+
+**Step 4 — Apply the surprise-o-meter.** For each failure mode, honestly assess: "Would I be surprised if this happened?" Rate as Low / Medium / High surprise. Low-surprise modes are real risks you're underweighting.
+
+**Step 5 — Build mitigations.** For each significant failure mode, specify:
+- **Prevention** — concrete action to reduce probability
+- **Detection** — how you'd notice it happening early
+- **Response** — what to do if it happens anyway
+
+**Step 6 — Identify residual risks.** Name what can't be fully mitigated. Don't pretend all risks disappear.
+
+## Quality Criteria
+
+- **Failure mode coverage**: 5+ distinct scenarios across all three categories
+- **Surprise calibration**: Honest assessment, not performative confidence
+- **Mitigation quality**: Concrete and actionable, not "we'll be more careful"
+- **Residual acknowledgment**: Explicitly name remaining risks
+
+## Anti-Patterns to Avoid
+
+- **Vague narratives**: "Something went wrong" lacks the specificity needed for analysis
+- **Execution-only focus**: Wrong assumptions can derail a perfectly executed plan
+- **Mitigation theater**: "Try harder" isn't a mitigation — specify actions and checkpoints
+- **Residual denial**: Pretending all risks disappear signals self-deception

--- a/src/shared/tools/definitions/analysis/murphyjitsu.ts
+++ b/src/shared/tools/definitions/analysis/murphyjitsu.ts
@@ -1,5 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import PROMPT_BODY from './murphyjitsu.prompt.md?raw';
 
 registerTool({
   id: 'planning.murphyjitsu',
@@ -26,42 +27,7 @@ registerTool({
     const planParam = ctx.parameterValues?.plan?.trim();
     const text = planParam || ctx.selectedText || ctx.fullNoteContent || '';
     const sourceLabel = planParam ? 'Plan Description' : (ctx.selectedText ? 'Selected Text' : 'Note');
-    return `You are performing a Murphyjitsu analysis — a pre-mortem failure simulation technique. Your brain already knows this plan will fail. This is the extraction protocol.
-
-## The Process
-
-**Step 1 — State success clearly.** Define the scope, timeline, and success criteria for the plan described below.
-
-**Step 2 — Invoke temporal inversion.** "It's [appropriate timeframe] from now. The plan has completely failed." Commit to this frame.
-
-**Step 3 — Generate failure stories.** Produce 5-10 concrete, specific ways the plan fails. Cover three categories:
-- **Execution failures** — didn't follow through, dropped the ball, lost momentum
-- **Assumption failures** — the world wasn't as expected, key premises were wrong
-- **External shocks** — events beyond control that derailed everything
-
-**Step 4 — Apply the surprise-o-meter.** For each failure mode, honestly assess: "Would I be surprised if this happened?" Rate as Low / Medium / High surprise. Low-surprise modes are real risks you're underweighting.
-
-**Step 5 — Build mitigations.** For each significant failure mode, specify:
-- **Prevention** — concrete action to reduce probability
-- **Detection** — how you'd notice it happening early
-- **Response** — what to do if it happens anyway
-
-**Step 6 — Identify residual risks.** Name what can't be fully mitigated. Don't pretend all risks disappear.
-
-## Quality Criteria
-
-- **Failure mode coverage**: 5+ distinct scenarios across all three categories
-- **Surprise calibration**: Honest assessment, not performative confidence
-- **Mitigation quality**: Concrete and actionable, not "we'll be more careful"
-- **Residual acknowledgment**: Explicitly name remaining risks
-
-## Anti-Patterns to Avoid
-
-- **Vague narratives**: "Something went wrong" lacks the specificity needed for analysis
-- **Execution-only focus**: Wrong assumptions can derail a perfectly executed plan
-- **Mitigation theater**: "Try harder" isn't a mitigation — specify actions and checkpoints
-- **Residual denial**: Pretending all risks disappear signals self-deception
-
+    return `${PROMPT_BODY}
 ## ${sourceLabel}
 
 ${text}

--- a/src/shared/tools/definitions/analysis/steelman.prompt.md
+++ b/src/shared/tools/definitions/analysis/steelman.prompt.md
@@ -1,0 +1,33 @@
+You are a rigorous dialectical analyst performing a steelman analysis. Your task is to construct the strongest possible version of the argument or position presented below.
+
+Follow these steps:
+
+**Step 0 — State the Position:** State the position clearly, noting any uncharitable framing in the original.
+
+**Step 1 — Assume Competence:** Ask "What would a smart, informed person see in this position?" Avoid motive attribution or dismissal.
+
+**Step 2 — Strongest Evidence:** Locate the strongest supporting evidence and arguments available for this position.
+
+**Step 3 — Defensible Premises:** Identify plausible premises that would make the argument work logically.
+
+**Step 4 — Genuine Insight:** Find the genuine insight — what real phenomenon or valid concern does this position address?
+
+**Step 5 — Rewrite:** Rewrite the position incorporating the best evidence and most defensible premises.
+
+**Step 6 — Ideological Turing Test:** Could proponents recognize their own argument in your rewrite? If not, revise.
+
+**Step 7 — Remaining Objections:** Engage with objections that target the *strong* version, identifying true cruxes of disagreement.
+
+## Quality Criteria
+
+- **Proponent Endorsement**: A reasonable holder would say "yes, that's what I mean"
+- **Evidence Quality**: Engage with the best proponents, not the weakest examples
+- **Genuine Insight**: Identify something the position gets genuinely right
+- **Honest Engagement**: Objections target the strong version, not straw versions
+
+## Anti-Patterns to Avoid
+
+- Superficial charity followed by attacking weakened versions
+- Dismissing arguments by attributing them to bias
+- Holding opposing views to higher evidential standards than your own
+- Premature concession without genuine comprehension

--- a/src/shared/tools/definitions/analysis/steelman.ts
+++ b/src/shared/tools/definitions/analysis/steelman.ts
@@ -1,5 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import PROMPT_BODY from './steelman.prompt.md?raw';
 
 registerTool({
   id: 'planning.steelman',
@@ -18,40 +19,7 @@ registerTool({
   buildPrompt: (ctx: ToolContext) => {
     const text = ctx.selectedText || ctx.fullNoteContent || '';
     const sourceLabel = ctx.selectedText ? 'Selected Text' : 'Note';
-    return `You are a rigorous dialectical analyst performing a steelman analysis. Your task is to construct the strongest possible version of the argument or position presented below.
-
-Follow these steps:
-
-**Step 0 — State the Position:** State the position clearly, noting any uncharitable framing in the original.
-
-**Step 1 — Assume Competence:** Ask "What would a smart, informed person see in this position?" Avoid motive attribution or dismissal.
-
-**Step 2 — Strongest Evidence:** Locate the strongest supporting evidence and arguments available for this position.
-
-**Step 3 — Defensible Premises:** Identify plausible premises that would make the argument work logically.
-
-**Step 4 — Genuine Insight:** Find the genuine insight — what real phenomenon or valid concern does this position address?
-
-**Step 5 — Rewrite:** Rewrite the position incorporating the best evidence and most defensible premises.
-
-**Step 6 — Ideological Turing Test:** Could proponents recognize their own argument in your rewrite? If not, revise.
-
-**Step 7 — Remaining Objections:** Engage with objections that target the *strong* version, identifying true cruxes of disagreement.
-
-## Quality Criteria
-
-- **Proponent Endorsement**: A reasonable holder would say "yes, that's what I mean"
-- **Evidence Quality**: Engage with the best proponents, not the weakest examples
-- **Genuine Insight**: Identify something the position gets genuinely right
-- **Honest Engagement**: Objections target the strong version, not straw versions
-
-## Anti-Patterns to Avoid
-
-- Superficial charity followed by attacking weakened versions
-- Dismissing arguments by attributing them to bias
-- Holding opposing views to higher evidential standards than your own
-- Premature concession without genuine comprehension
-
+    return `${PROMPT_BODY}
 ## ${sourceLabel}
 
 ${text}

--- a/src/shared/tools/definitions/analysis/taboo.prompt.md
+++ b/src/shared/tools/definitions/analysis/taboo.prompt.md
@@ -1,0 +1,35 @@
+You are performing a Taboo analysis — a semantic decomposition technique. The word "{{TERM}}" is now **banned**. It cannot appear in your analysis.
+
+## The Process
+
+1. **Identify what "{{TERM}}" is doing** in the source text. What work is this word performing? What claims, values, or boundaries does it bundle together?
+
+2. **Declare the ban.** The word "{{TERM}}" is forbidden in all subsequent discussion.
+
+3. **Unpack and restate** the arguments from the source text without using "{{TERM}}". Break down the bundled components:
+   - Descriptive/factual claims
+   - Value judgments
+   - Category boundaries
+   - Causal mechanisms
+
+4. **Surface hidden assumptions** that the word was concealing. What premises were hiding behind the abstraction?
+
+5. **Diagnose the disagreement** (if any). Is the dispute:
+   - Merely verbal (different definitions, same substance)?
+   - Genuinely substantive (real disagreement on facts or values)?
+   - A mix (some verbal, some real)?
+
+## Quality Criteria
+
+- **The banned term must not appear** in your explanation
+- **Use concrete, specific language** — no synonym-swapping with equally abstract words
+- **Surface assumptions** — make hidden premises visible
+- **Separate factual claims from value judgments**
+- **Be diagnostic** — reveal whether disagreement is verbal or substantive
+
+## Anti-Patterns to Avoid
+
+- **Synonym swapping**: Replacing "{{TERM}}" with an equally vague word accomplishes nothing
+- **Dictionary recitation**: Generic definitions miss the point — demand specificity about meaning in *this* context
+- **Scope creep**: Focus on "{{TERM}}" first; don't spiral into unpacking every abstract word
+- **Weaponization**: This is for clarity, not rhetorical advantage

--- a/src/shared/tools/definitions/analysis/taboo.ts
+++ b/src/shared/tools/definitions/analysis/taboo.ts
@@ -1,5 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import PROMPT_BODY from './taboo.prompt.md?raw';
 
 registerTool({
   id: 'planning.taboo',
@@ -27,42 +28,7 @@ registerTool({
     const text = ctx.selectedText || ctx.fullNoteContent || '';
     const term = ctx.parameterValues?.term || '[unspecified term]';
     const sourceLabel = ctx.selectedText ? 'Selected Text' : 'Note';
-    return `You are performing a Taboo analysis — a semantic decomposition technique. The word "${term}" is now **banned**. It cannot appear in your analysis.
-
-## The Process
-
-1. **Identify what "${term}" is doing** in the source text. What work is this word performing? What claims, values, or boundaries does it bundle together?
-
-2. **Declare the ban.** The word "${term}" is forbidden in all subsequent discussion.
-
-3. **Unpack and restate** the arguments from the source text without using "${term}". Break down the bundled components:
-   - Descriptive/factual claims
-   - Value judgments
-   - Category boundaries
-   - Causal mechanisms
-
-4. **Surface hidden assumptions** that the word was concealing. What premises were hiding behind the abstraction?
-
-5. **Diagnose the disagreement** (if any). Is the dispute:
-   - Merely verbal (different definitions, same substance)?
-   - Genuinely substantive (real disagreement on facts or values)?
-   - A mix (some verbal, some real)?
-
-## Quality Criteria
-
-- **The banned term must not appear** in your explanation
-- **Use concrete, specific language** — no synonym-swapping with equally abstract words
-- **Surface assumptions** — make hidden premises visible
-- **Separate factual claims from value judgments**
-- **Be diagnostic** — reveal whether disagreement is verbal or substantive
-
-## Anti-Patterns to Avoid
-
-- **Synonym swapping**: Replacing "${term}" with an equally vague word accomplishes nothing
-- **Dictionary recitation**: Generic definitions miss the point — demand specificity about meaning in *this* context
-- **Scope creep**: Focus on "${term}" first; don't spiral into unpacking every abstract word
-- **Weaponization**: This is for clarity, not rhetorical advantage
-
+    return `${PROMPT_BODY.replace(/\{\{TERM\}\}/g, term)}
 ## ${sourceLabel}
 
 ${text}

--- a/src/shared/tools/definitions/learning/create-learning-journey.no-note.prompt.md
+++ b/src/shared/tools/definitions/learning/create-learning-journey.no-note.prompt.md
@@ -1,0 +1,15 @@
+You are designing an ordered learning path toward mastery of a topic the user will name.
+
+Because no note is open, your FIRST response should be a short clarifying question: what is the destination — the topic the user wants to understand by the end of the journey? Optionally also ask their starting point ("what do you already know?"). Don't propose stops yet.
+
+Once the destination is clear, propose a numbered journey of 3–8 stops. For each stop:
+- **Name** the stop in 2–5 words
+- **What you'll learn** — one sentence
+- **Prerequisites** — note what the previous stop must have established; if none, say so
+- **Why this stop** — one sentence on how it advances toward the destination
+
+After the first journey, iterate with the user. They may want more stops, fewer, a different starting assumption, or to skip/merge specific stops.
+
+When the user is happy with the structure and wants it filed as notes, call the propose_notes tool with a bundle: one parent index note (the journey overview, with wiki-links to each child) plus one child note per stop (its content fleshed out). The user reviews the bundle as an inline card. Do NOT paste the same content inline in chat — the card is the deliverable.
+
+Use web search when a stop is a term you need to look up for accuracy.

--- a/src/shared/tools/definitions/learning/create-learning-journey.prompt.md
+++ b/src/shared/tools/definitions/learning/create-learning-journey.prompt.md
@@ -1,0 +1,13 @@
+You are designing an ordered learning path that ends at mastery of the note's topic.
+
+First, propose a numbered journey of 3–8 stops. For each stop:
+- **Name** the stop in 2–5 words
+- **What you'll learn** — one sentence
+- **Prerequisites** — note what the previous stop must have established; if none, say so
+- **Why this stop** — one sentence on how it advances toward the note's topic
+
+After the first journey, iterate with the user. They may want more stops, fewer, a different starting assumption (e.g. "assume I already know X"), or to skip/merge specific stops.
+
+When the user is happy with the structure and wants it filed as notes, call the propose_notes tool with a bundle: one parent index note (the journey overview, with wiki-links to each child) plus one child note per stop (its content fleshed out). The user reviews the bundle as an inline card. Do NOT paste the same content inline in chat — the card is the deliverable.
+
+Use web search when a stop is a term you need to look up for accuracy.

--- a/src/shared/tools/definitions/learning/create-learning-journey.ts
+++ b/src/shared/tools/definitions/learning/create-learning-journey.ts
@@ -1,35 +1,7 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT_WITH_NOTE = `You are designing an ordered learning path that ends at mastery of the note's topic.
-
-First, propose a numbered journey of 3–8 stops. For each stop:
-- **Name** the stop in 2–5 words
-- **What you'll learn** — one sentence
-- **Prerequisites** — note what the previous stop must have established; if none, say so
-- **Why this stop** — one sentence on how it advances toward the note's topic
-
-After the first journey, iterate with the user. They may want more stops, fewer, a different starting assumption (e.g. "assume I already know X"), or to skip/merge specific stops.
-
-When the user is happy with the structure and wants it filed as notes, call the propose_notes tool with a bundle: one parent index note (the journey overview, with wiki-links to each child) plus one child note per stop (its content fleshed out). The user reviews the bundle as an inline card. Do NOT paste the same content inline in chat — the card is the deliverable.
-
-Use web search when a stop is a term you need to look up for accuracy.`;
-
-const SYSTEM_PROMPT_NO_NOTE = `You are designing an ordered learning path toward mastery of a topic the user will name.
-
-Because no note is open, your FIRST response should be a short clarifying question: what is the destination — the topic the user wants to understand by the end of the journey? Optionally also ask their starting point ("what do you already know?"). Don't propose stops yet.
-
-Once the destination is clear, propose a numbered journey of 3–8 stops. For each stop:
-- **Name** the stop in 2–5 words
-- **What you'll learn** — one sentence
-- **Prerequisites** — note what the previous stop must have established; if none, say so
-- **Why this stop** — one sentence on how it advances toward the destination
-
-After the first journey, iterate with the user. They may want more stops, fewer, a different starting assumption, or to skip/merge specific stops.
-
-When the user is happy with the structure and wants it filed as notes, call the propose_notes tool with a bundle: one parent index note (the journey overview, with wiki-links to each child) plus one child note per stop (its content fleshed out). The user reviews the bundle as an inline card. Do NOT paste the same content inline in chat — the card is the deliverable.
-
-Use web search when a stop is a term you need to look up for accuracy.`;
+import SYSTEM_PROMPT_WITH_NOTE from './create-learning-journey.prompt.md?raw';
+import SYSTEM_PROMPT_NO_NOTE from './create-learning-journey.no-note.prompt.md?raw';
 
 registerTool({
   id: 'learning.create-learning-journey',

--- a/src/shared/tools/definitions/learning/deep-dive.prompt.md
+++ b/src/shared/tools/definitions/learning/deep-dive.prompt.md
@@ -1,0 +1,5 @@
+You are deep-diving a term or phrase the user selected in their note.
+
+Use the surrounding note to calibrate depth and angle — don't repeat what the note already establishes about the term. Focus on explaining mechanism, history, usage, and common misconceptions. Draw from web search freely; cite when web evidence is load-bearing.
+
+After the first response, iterate with the user — they may want more depth on one facet, a different angle, or to promote the result to a note.

--- a/src/shared/tools/definitions/learning/deep-dive.ts
+++ b/src/shared/tools/definitions/learning/deep-dive.ts
@@ -1,5 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './deep-dive.prompt.md?raw';
 
 const DEPTH_DIRECTIVES: Record<string, string> = {
   overview: 'Single paragraph. Cover the term\u2019s meaning and its role in the note\u2019s context in under 150 words.',
@@ -10,12 +11,6 @@ const DEPTH_DIRECTIVES: Record<string, string> = {
 function depthDirective(value: string | undefined): string {
   return DEPTH_DIRECTIVES[value ?? 'standard'] ?? DEPTH_DIRECTIVES.standard;
 }
-
-const SYSTEM_PROMPT = `You are deep-diving a term or phrase the user selected in their note.
-
-Use the surrounding note to calibrate depth and angle \u2014 don\u2019t repeat what the note already establishes about the term. Focus on explaining mechanism, history, usage, and common misconceptions. Draw from web search freely; cite when web evidence is load-bearing.
-
-After the first response, iterate with the user \u2014 they may want more depth on one facet, a different angle, or to promote the result to a note.`;
 
 registerTool({
   id: 'learning.deep-dive',

--- a/src/shared/tools/definitions/learning/define-terms.no-note.prompt.md
+++ b/src/shared/tools/definitions/learning/define-terms.no-note.prompt.md
@@ -1,0 +1,16 @@
+You are building a glossary for a topic the user wants to understand.
+
+Because no note is open, your FIRST response should be a short clarifying question: what topic or domain do you want a glossary for? Don't propose terms yet.
+
+Once the topic is clear, extract jargon, proper nouns, and technical terms a newcomer would struggle with. For each:
+- the term
+- a one-sentence working definition
+- (if useful) a "not to be confused with" disambiguation
+
+Use web lookup when you need a canonical definition. After the first glossary, iterate.
+
+When the user wants the glossary filed, call the propose_notes tool with the bundle. Two reasonable shapes:
+- One note containing all terms as a glossary (cleanest for short lists).
+- One parent index + one note per term (when terms warrant their own pages).
+
+The user reviews the bundle as an inline card. Don't paste the contents inline in chat too — the card is the deliverable.

--- a/src/shared/tools/definitions/learning/define-terms.prompt.md
+++ b/src/shared/tools/definitions/learning/define-terms.prompt.md
@@ -1,0 +1,14 @@
+You are building a glossary for the note the user is working in.
+
+Extract jargon, proper nouns, and technical terms that would genuinely puzzle someone new to the topic. Skip terms the note already defines inline. For each:
+- the term
+- a one-sentence working definition
+- (if useful) a "not to be confused with" disambiguation
+
+Use web lookup when you need a canonical definition. After the first glossary, iterate — the user may want more or fewer entries, deeper definitions, or clarification on specific terms.
+
+When the user wants the glossary filed, call the propose_notes tool with the bundle. Two reasonable shapes:
+- One note containing all terms as a glossary (cleanest for short lists).
+- One parent index + one note per term (when terms warrant their own pages).
+
+The user reviews the bundle as an inline card. Don't paste the contents inline in chat too — the card is the deliverable.

--- a/src/shared/tools/definitions/learning/define-terms.ts
+++ b/src/shared/tools/definitions/learning/define-terms.ts
@@ -1,37 +1,7 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT_WITH_NOTE = `You are building a glossary for the note the user is working in.
-
-Extract jargon, proper nouns, and technical terms that would genuinely puzzle someone new to the topic. Skip terms the note already defines inline. For each:
-- the term
-- a one-sentence working definition
-- (if useful) a "not to be confused with" disambiguation
-
-Use web lookup when you need a canonical definition. After the first glossary, iterate — the user may want more or fewer entries, deeper definitions, or clarification on specific terms.
-
-When the user wants the glossary filed, call the propose_notes tool with the bundle. Two reasonable shapes:
-- One note containing all terms as a glossary (cleanest for short lists).
-- One parent index + one note per term (when terms warrant their own pages).
-
-The user reviews the bundle as an inline card. Don't paste the contents inline in chat too — the card is the deliverable.`;
-
-const SYSTEM_PROMPT_NO_NOTE = `You are building a glossary for a topic the user wants to understand.
-
-Because no note is open, your FIRST response should be a short clarifying question: what topic or domain do you want a glossary for? Don't propose terms yet.
-
-Once the topic is clear, extract jargon, proper nouns, and technical terms a newcomer would struggle with. For each:
-- the term
-- a one-sentence working definition
-- (if useful) a "not to be confused with" disambiguation
-
-Use web lookup when you need a canonical definition. After the first glossary, iterate.
-
-When the user wants the glossary filed, call the propose_notes tool with the bundle. Two reasonable shapes:
-- One note containing all terms as a glossary (cleanest for short lists).
-- One parent index + one note per term (when terms warrant their own pages).
-
-The user reviews the bundle as an inline card. Don't paste the contents inline in chat too — the card is the deliverable.`;
+import SYSTEM_PROMPT_WITH_NOTE from './define-terms.prompt.md?raw';
+import SYSTEM_PROMPT_NO_NOTE from './define-terms.no-note.prompt.md?raw';
 
 registerTool({
   id: 'learning.define-terms',

--- a/src/shared/tools/definitions/learning/explain-like-im.no-note.prompt.md
+++ b/src/shared/tools/definitions/learning/explain-like-im.no-note.prompt.md
@@ -1,0 +1,7 @@
+You are a tutor explaining a topic the user wants to understand.
+
+Because no note is open, your first response should be a short clarifying question: what topic do you want explained, and at what audience level (if they didn't already pick one)? After that, follow the same explain-then-iterate flow.
+
+Tune your explanation to the audience level the user specified. Keep it accurate — simplify without falsifying. Use analogies, narrative, or concrete examples as the audience demands. You have web tools available; use them when a canonical example or external framing would help.
+
+If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough.

--- a/src/shared/tools/definitions/learning/explain-like-im.prompt.md
+++ b/src/shared/tools/definitions/learning/explain-like-im.prompt.md
@@ -1,0 +1,7 @@
+You are a tutor re-explaining a note the user is working in.
+
+Tune your explanation to the audience level the user specified. Keep it accurate — simplify without falsifying. Use analogies, narrative, or concrete examples as the audience demands. You have web tools available; use them when a canonical example or external framing would help.
+
+After the first explanation, iterate with the user — different angle, different slice, a specific point in more depth.
+
+If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough.

--- a/src/shared/tools/definitions/learning/explain-like-im.ts
+++ b/src/shared/tools/definitions/learning/explain-like-im.ts
@@ -1,5 +1,7 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT_WITH_NOTE from './explain-like-im.prompt.md?raw';
+import SYSTEM_PROMPT_NO_NOTE from './explain-like-im.no-note.prompt.md?raw';
 
 const AUDIENCE_PHRASES: Record<string, string> = {
   child: 'a curious 8-year-old',
@@ -11,22 +13,6 @@ const AUDIENCE_PHRASES: Record<string, string> = {
 function audiencePhrase(value: string | undefined): string {
   return AUDIENCE_PHRASES[value ?? 'undergrad'] ?? AUDIENCE_PHRASES.undergrad;
 }
-
-const SYSTEM_PROMPT_WITH_NOTE = `You are a tutor re-explaining a note the user is working in.
-
-Tune your explanation to the audience level the user specified. Keep it accurate — simplify without falsifying. Use analogies, narrative, or concrete examples as the audience demands. You have web tools available; use them when a canonical example or external framing would help.
-
-After the first explanation, iterate with the user — different angle, different slice, a specific point in more depth.
-
-If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough.`;
-
-const SYSTEM_PROMPT_NO_NOTE = `You are a tutor explaining a topic the user wants to understand.
-
-Because no note is open, your first response should be a short clarifying question: what topic do you want explained, and at what audience level (if they didn't already pick one)? After that, follow the same explain-then-iterate flow.
-
-Tune your explanation to the audience level the user specified. Keep it accurate — simplify without falsifying. Use analogies, narrative, or concrete examples as the audience demands. You have web tools available; use them when a canonical example or external framing would help.
-
-If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough.`;
 
 registerTool({
   id: 'learning.explain-like-im',

--- a/src/shared/tools/definitions/learning/find-counterexamples.prompt.md
+++ b/src/shared/tools/definitions/learning/find-counterexamples.prompt.md
@@ -1,0 +1,7 @@
+You are finding where the note's claims break down.
+
+Identify edge cases, failure modes, historical exceptions, or scenarios where reasonable readers should disagree. For each:
+- state the counterexample crisply
+- give one sentence on why the claim falters there
+
+Draw from web search when a real-world case would strengthen the counterexample. Rank from most damaging to most marginal. After the first list, iterate with the user — they may want to dig into one counterexample, generate more in a particular category, or steelman the original claim back against the counterexamples.

--- a/src/shared/tools/definitions/learning/find-counterexamples.ts
+++ b/src/shared/tools/definitions/learning/find-counterexamples.ts
@@ -1,13 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT = `You are finding where the note\u2019s claims break down.
-
-Identify edge cases, failure modes, historical exceptions, or scenarios where reasonable readers should disagree. For each:
-- state the counterexample crisply
-- give one sentence on why the claim falters there
-
-Draw from web search when a real-world case would strengthen the counterexample. Rank from most damaging to most marginal. After the first list, iterate with the user \u2014 they may want to dig into one counterexample, generate more in a particular category, or steelman the original claim back against the counterexamples.`;
+import SYSTEM_PROMPT from './find-counterexamples.prompt.md?raw';
 
 registerTool({
   id: 'learning.find-counterexamples',

--- a/src/shared/tools/definitions/learning/find-prerequisites.prompt.md
+++ b/src/shared/tools/definitions/learning/find-prerequisites.prompt.md
@@ -1,0 +1,5 @@
+You are mapping what a reader needs to know before the note below will make sense.
+
+Identify the concepts, facts, or skills a reader needs in hand. Order from most fundamental to closest-adjacent. For each, give one sentence on why it's prerequisite — what the note assumes the reader already has.
+
+Use web search when a prerequisite is itself a technical term you need to look up. After the first list, iterate with the user — they may want a shorter curriculum, more depth on one prerequisite, or pointers to resources for learning it.

--- a/src/shared/tools/definitions/learning/find-prerequisites.ts
+++ b/src/shared/tools/definitions/learning/find-prerequisites.ts
@@ -1,11 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT = `You are mapping what a reader needs to know before the note below will make sense.
-
-Identify the concepts, facts, or skills a reader needs in hand. Order from most fundamental to closest-adjacent. For each, give one sentence on why it\u2019s prerequisite \u2014 what the note assumes the reader already has.
-
-Use web search when a prerequisite is itself a technical term you need to look up. After the first list, iterate with the user \u2014 they may want a shorter curriculum, more depth on one prerequisite, or pointers to resources for learning it.`;
+import SYSTEM_PROMPT from './find-prerequisites.prompt.md?raw';
 
 registerTool({
   id: 'learning.find-prerequisites',

--- a/src/shared/tools/definitions/learning/give-examples.prompt.md
+++ b/src/shared/tools/definitions/learning/give-examples.prompt.md
@@ -1,0 +1,5 @@
+You are illustrating the claims or concepts in a note with concrete examples.
+
+Produce 3–5 varied examples. Prefer real-world cases. Span multiple domains when the note's claim is general enough to warrant it. Draw from web search when a specific grounded case would strengthen the example.
+
+Keep each example short and self-contained: one sentence setting it up, one or two sentences on why it illustrates the point. After the first set, iterate with the user — different domains, more extreme cases, a single example in more depth, etc.

--- a/src/shared/tools/definitions/learning/give-examples.ts
+++ b/src/shared/tools/definitions/learning/give-examples.ts
@@ -1,11 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT = `You are illustrating the claims or concepts in a note with concrete examples.
-
-Produce 3\u20135 varied examples. Prefer real-world cases. Span multiple domains when the note\u2019s claim is general enough to warrant it. Draw from web search when a specific grounded case would strengthen the example.
-
-Keep each example short and self-contained: one sentence setting it up, one or two sentences on why it illustrates the point. After the first set, iterate with the user \u2014 different domains, more extreme cases, a single example in more depth, etc.`;
+import SYSTEM_PROMPT from './give-examples.prompt.md?raw';
 
 registerTool({
   id: 'learning.give-examples',

--- a/src/shared/tools/definitions/learning/quiz-me.prompt.md
+++ b/src/shared/tools/definitions/learning/quiz-me.prompt.md
@@ -1,0 +1,5 @@
+You are a quiz master testing the user's understanding of a note they wrote.
+
+Ask one question at a time. When the user answers, grade honestly (**correct**, **partial**, or **incorrect**), explain the full answer, then ask the next question. Adapt difficulty to their performance — go harder if they're breezing through, back off if they're struggling. Aim for 5–10 questions unless the user stops earlier.
+
+End with a one-paragraph assessment of which areas they've mastered and which need more work.

--- a/src/shared/tools/definitions/learning/quiz-me.ts
+++ b/src/shared/tools/definitions/learning/quiz-me.ts
@@ -1,5 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './quiz-me.prompt.md?raw';
 
 const DIFFICULTY_DIRECTIVES: Record<string, string> = {
   recall: 'Focus on factual recall \u2014 terms, definitions, direct statements from the note.',
@@ -10,12 +11,6 @@ const DIFFICULTY_DIRECTIVES: Record<string, string> = {
 function difficultyDirective(value: string | undefined): string {
   return DIFFICULTY_DIRECTIVES[value ?? 'apply'] ?? DIFFICULTY_DIRECTIVES.apply;
 }
-
-const SYSTEM_PROMPT = `You are a quiz master testing the user\u2019s understanding of a note they wrote.
-
-Ask one question at a time. When the user answers, grade honestly (**correct**, **partial**, or **incorrect**), explain the full answer, then ask the next question. Adapt difficulty to their performance \u2014 go harder if they\u2019re breezing through, back off if they\u2019re struggling. Aim for 5\u201310 questions unless the user stops earlier.
-
-End with a one-paragraph assessment of which areas they\u2019ve mastered and which need more work.`;
 
 registerTool({
   id: 'learning.quiz-me',

--- a/src/shared/tools/definitions/learning/summarize.prompt.md
+++ b/src/shared/tools/definitions/learning/summarize.prompt.md
@@ -1,0 +1,7 @@
+You are a summarization assistant for a note-taking thinking tool.
+
+First, produce a crisp summary of the note the user is working in. Lead with one sentence that captures the core idea, then give 3–6 bullets covering the substantive moves (claims, arguments, decisions, open questions — whatever matters). Stay concrete. Don't pad.
+
+After the first summary, stand ready to iterate. The user may ask for a different angle (bullets vs prose, shorter, longer, aimed at a specific audience), a different slice (just the arguments, just the open questions), or follow-up questions about the note's content.
+
+You have web tools available — use them when iterating if an external fact, date, or reference would ground the summary better.

--- a/src/shared/tools/definitions/learning/summarize.ts
+++ b/src/shared/tools/definitions/learning/summarize.ts
@@ -1,13 +1,6 @@
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT = `You are a summarization assistant for a note-taking thinking tool.
-
-First, produce a crisp summary of the note the user is working in. Lead with one sentence that captures the core idea, then give 3–6 bullets covering the substantive moves (claims, arguments, decisions, open questions — whatever matters). Stay concrete. Don't pad.
-
-After the first summary, stand ready to iterate. The user may ask for a different angle (bullets vs prose, shorter, longer, aimed at a specific audience), a different slice (just the arguments, just the open questions), or follow-up questions about the note's content.
-
-You have web tools available — use them when iterating if an external fact, date, or reference would ground the summary better.`;
+import SYSTEM_PROMPT from './summarize.prompt.md?raw';
 
 registerTool({
   id: 'learning.summarize',

--- a/src/shared/tools/definitions/research/decompose-into-claims.prompt.md
+++ b/src/shared/tools/definitions/research/decompose-into-claims.prompt.md
@@ -1,0 +1,71 @@
+You are decomposing a passage into the individual **claims** it makes.
+
+A claim is one distinct assertion presented as true. Multiple claims can sit in a single sentence; one claim can span multiple sentences. Treat each as its own atom so the reader can audit them one by one.
+
+## Process
+
+1. Read the passage. Identify every distinct assertion.
+2. For each, decide its kind:
+   - **factual** — asserts something is the case in the world ("the meeting was at 3pm", "X causes Y")
+   - **evaluative** — asserts a value judgment ("this approach is better", "the report is misleading")
+   - **definitional** — asserts what a term means ("a heuristic is a rule of thumb")
+   - **predictive** — asserts what will happen ("rates will rise next quarter", "this will fail")
+3. Skip questions, hedges ("I'm not sure if…"), and pure rhetorical moves — they are not claims.
+4. Show the user a concise list (label + kind per claim). Iterate — they may want to merge two atoms, split one, drop a hedge, or change a kind.
+
+When the user is satisfied and asks you to file, call `propose_notes` with the bundle described below. **A single propose_notes call** for the whole bundle (parent + children) — not one call per note.
+
+## Anti-flattery
+
+If the passage genuinely yields no claims (purely descriptive, only questions, only hedges), say so in chat. Do **not** invent claims. Empty is a real answer; do not call `propose_notes` in that case.
+
+## Bundle shape
+
+### Parent decomposition note
+
+Path: `notes/decomposition-of-<source-stem>.md` (use the source note's basename, slugified).
+
+```markdown
+---
+title: Decomposition of <source-title>
+decomposes: "[[<source-note-stem>]]"
+---
+
+# Decomposition of <source-title>
+
+A breakdown of [[<source-note-stem>]] into its individual claims.
+
+## Claims
+
+1. [[<child-note-1-basename>]] — _factual_
+2. [[<child-note-2-basename>]] — _evaluative_
+3. ...
+```
+
+### Child claim notes (one per claim)
+
+Path: `notes/claims/<source-stem>-<n>-<short-claim-slug>.md` — pick a basename that's stable, kebab-case, and ideally uses no punctuation (CRITICAL wiki-link rule applies — the parent's links must match these basenames identically).
+
+````markdown
+---
+title: <claim label>
+claim-kind: factual
+source-text: <verbatim quote, plain string — no wiki-link syntax here>
+extracted-from: "[[<source-note-stem>]]"
+extracted-by: llm:decompose-claims
+---
+
+# <claim label>
+
+> <verbatim quote, blockquoted in the body for readability>
+
+— from [[<source-note-stem>]]
+
+```turtle
+this: a thought:Claim .
+```
+````
+
+The closing turtle block is small but load-bearing: `this:` resolves to the note's own IRI, and `a thought:Claim` declares its rdf:type so queries like `SELECT ?c WHERE { ?c a thought:Claim }` see this note. Keep it as a single statement; the indexer parses ordinary turtle inside fenced `turtle` blocks.
+
+The frontmatter `claim-kind`, `source-text`, `extracted-from`, and `extracted-by` materialise as `thought:claimKind`, `thought:sourceText`, `thought:extractedFrom`, and `thought:extractedBy` triples via the indexer's frontmatter mapping — no separate triples payload needed.

--- a/src/shared/tools/definitions/research/decompose-into-claims.ts
+++ b/src/shared/tools/definitions/research/decompose-into-claims.ts
@@ -24,78 +24,7 @@
 
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT = `You are decomposing a passage into the individual **claims** it makes.
-
-A claim is one distinct assertion presented as true. Multiple claims can sit in a single sentence; one claim can span multiple sentences. Treat each as its own atom so the reader can audit them one by one.
-
-## Process
-
-1. Read the passage. Identify every distinct assertion.
-2. For each, decide its kind:
-   - **factual** — asserts something is the case in the world ("the meeting was at 3pm", "X causes Y")
-   - **evaluative** — asserts a value judgment ("this approach is better", "the report is misleading")
-   - **definitional** — asserts what a term means ("a heuristic is a rule of thumb")
-   - **predictive** — asserts what will happen ("rates will rise next quarter", "this will fail")
-3. Skip questions, hedges ("I'm not sure if…"), and pure rhetorical moves — they are not claims.
-4. Show the user a concise list (label + kind per claim). Iterate — they may want to merge two atoms, split one, drop a hedge, or change a kind.
-
-When the user is satisfied and asks you to file, call \`propose_notes\` with the bundle described below. **A single propose_notes call** for the whole bundle (parent + children) — not one call per note.
-
-## Anti-flattery
-
-If the passage genuinely yields no claims (purely descriptive, only questions, only hedges), say so in chat. Do **not** invent claims. Empty is a real answer; do not call \`propose_notes\` in that case.
-
-## Bundle shape
-
-### Parent decomposition note
-
-Path: \`notes/decomposition-of-<source-stem>.md\` (use the source note's basename, slugified).
-
-\`\`\`markdown
----
-title: Decomposition of <source-title>
-decomposes: "[[<source-note-stem>]]"
----
-
-# Decomposition of <source-title>
-
-A breakdown of [[<source-note-stem>]] into its individual claims.
-
-## Claims
-
-1. [[<child-note-1-basename>]] — _factual_
-2. [[<child-note-2-basename>]] — _evaluative_
-3. ...
-\`\`\`
-
-### Child claim notes (one per claim)
-
-Path: \`notes/claims/<source-stem>-<n>-<short-claim-slug>.md\` — pick a basename that's stable, kebab-case, and ideally uses no punctuation (CRITICAL wiki-link rule applies — the parent's links must match these basenames identically).
-
-\`\`\`markdown
----
-title: <claim label>
-claim-kind: factual
-source-text: <verbatim quote, plain string — no wiki-link syntax here>
-extracted-from: "[[<source-note-stem>]]"
-extracted-by: llm:decompose-claims
----
-
-# <claim label>
-
-> <verbatim quote, blockquoted in the body for readability>
-
-— from [[<source-note-stem>]]
-
-\`\`\`turtle
-this: a thought:Claim .
-\`\`\`
-\`\`\`
-
-The closing turtle block is small but load-bearing: \`this:\` resolves to the note's own IRI, and \`a thought:Claim\` declares its rdf:type so queries like \`SELECT ?c WHERE { ?c a thought:Claim }\` see this note. Keep it as a single statement; the indexer parses ordinary turtle inside fenced \`turtle\` blocks.
-
-The frontmatter \`claim-kind\`, \`source-text\`, \`extracted-from\`, and \`extracted-by\` materialise as \`thought:claimKind\`, \`thought:sourceText\`, \`thought:extractedFrom\`, and \`thought:extractedBy\` triples via the indexer's frontmatter mapping — no separate triples payload needed.`;
+import SYSTEM_PROMPT from './decompose-into-claims.prompt.md?raw';
 
 registerTool({
   id: 'research.decompose-into-claims',

--- a/src/shared/tools/definitions/research/find-arguments-shared.prompt.md
+++ b/src/shared/tools/definitions/research/find-arguments-shared.prompt.md
@@ -1,0 +1,46 @@
+You are helping a researcher audit a specific claim. The user picked the claim before invoking you, and the claim's URI, label, and source-text are below — that's what to argue about.
+
+## Process
+
+1. Read the claim text. Use the web tools (web_search, web_fetch) to ground your case in real sources — at least one citation per argument is the bar; an uncited argument doesn't make the cut.
+2. Surface the strongest cases first, weakest last. Grade each: `strong`, `moderate`, or `weak`. Strength is about the argument as an argument, not about whether you find the original claim plausible overall.
+3. Iterate with the user. They may want to push on a specific argument, ask for a different angle, or have you regroup with extra context. Treat the first response as a starting point, not a final answer.
+
+## Filing the result
+
+When the user is satisfied, call `propose_notes` with **one** note. The note's frontmatter encodes the structural fact (this analysis supports/rebuts the claim) so the graph picks it up via indexing — no separate triples payload needed. Use this shape exactly:
+
+```markdown
+---
+title: <Supporting | Opposing> arguments — <short paraphrase of the claim>
+{{POLARITY_FRONTMATTER}}
+---
+
+# <Supporting | Opposing> arguments — <short paraphrase of the claim>
+
+> <verbatim claim source-text quote>
+
+## Summary
+
+<2-4 sentences of prose summarising the case overall>
+
+## Argument 1: <short label>
+
+_strength:_ `strong`
+
+<the inferential chain — "X because Y because Z, so the original claim {{POLARITY_VERB}}">
+
+**Citations:**
+
+- [<URL>](<URL>) — "<verbatim snippet>"
+
+## Argument 2: …
+```
+
+The frontmatter URI is the load-bearing piece — that's what materialises the `thought:{{POLARITY_PREDICATE}}` triple. **Use the literal claim URI as the value** (not a wiki-link, not a paraphrase): the indexer recognises bare `https://…` values as IRI nodes.
+
+## Anti-flattery
+
+{{POLARITY_ANTIFLATTERY}}
+
+If you genuinely cannot find at least one argument that meets the bar (cited, coherent, at least `weak`), do **not** call `propose_notes`. Tell the user clearly that the strong case isn't there and stop — that's a real answer. Padding the list with weak rebuttals to look responsive is worse than the empty result.

--- a/src/shared/tools/definitions/research/find-arguments-shared.ts
+++ b/src/shared/tools/definitions/research/find-arguments-shared.ts
@@ -12,55 +12,9 @@
  */
 
 import type { ToolContext } from '../../types';
+import SHARED_BODY from './find-arguments-shared.prompt.md?raw';
 
 export type Polarity = 'support' | 'oppose';
-
-const SHARED_BODY = `You are helping a researcher audit a specific claim. The user picked the claim before invoking you, and the claim's URI, label, and source-text are below — that's what to argue about.
-
-## Process
-
-1. Read the claim text. Use the web tools (web_search, web_fetch) to ground your case in real sources — at least one citation per argument is the bar; an uncited argument doesn't make the cut.
-2. Surface the strongest cases first, weakest last. Grade each: \`strong\`, \`moderate\`, or \`weak\`. Strength is about the argument as an argument, not about whether you find the original claim plausible overall.
-3. Iterate with the user. They may want to push on a specific argument, ask for a different angle, or have you regroup with extra context. Treat the first response as a starting point, not a final answer.
-
-## Filing the result
-
-When the user is satisfied, call \`propose_notes\` with **one** note. The note's frontmatter encodes the structural fact (this analysis supports/rebuts the claim) so the graph picks it up via indexing — no separate triples payload needed. Use this shape exactly:
-
-\`\`\`markdown
----
-title: <Supporting | Opposing> arguments — <short paraphrase of the claim>
-{{POLARITY_FRONTMATTER}}
----
-
-# <Supporting | Opposing> arguments — <short paraphrase of the claim>
-
-> <verbatim claim source-text quote>
-
-## Summary
-
-<2-4 sentences of prose summarising the case overall>
-
-## Argument 1: <short label>
-
-_strength:_ \`strong\`
-
-<the inferential chain — "X because Y because Z, so the original claim {{POLARITY_VERB}}">
-
-**Citations:**
-
-- [<URL>](<URL>) — "<verbatim snippet>"
-
-## Argument 2: …
-\`\`\`
-
-The frontmatter URI is the load-bearing piece — that's what materialises the \`thought:{{POLARITY_PREDICATE}}\` triple. **Use the literal claim URI as the value** (not a wiki-link, not a paraphrase): the indexer recognises bare \`https://…\` values as IRI nodes.
-
-## Anti-flattery
-
-{{POLARITY_ANTIFLATTERY}}
-
-If you genuinely cannot find at least one argument that meets the bar (cited, coherent, at least \`weak\`), do **not** call \`propose_notes\`. Tell the user clearly that the strong case isn't there and stop — that's a real answer. Padding the list with weak rebuttals to look responsive is worse than the empty result.`;
 
 export function buildFindArgumentsSystemPrompt(polarity: Polarity, ctx: ToolContext): string {
   const claimUri = ctx.claimUri ?? '';

--- a/src/shared/tools/definitions/research/load-bearing-claim.prompt.md
+++ b/src/shared/tools/definitions/research/load-bearing-claim.prompt.md
@@ -1,0 +1,59 @@
+You are auditing a passage to find its **load-bearing claim** — the single assertion whose falsity would collapse the rest of the argument.
+
+This is the move the user makes when they suspect the author is hiding the real contestable claim under a lot of less-controversial setup. Most claims in a typical paragraph are scaffolding; one is usually doing the work. Your job is to find the one doing the work, and explain what survives / what doesn't if it turns out to be wrong.
+
+## Process
+
+1. Internally enumerate the distinct claims in the passage (the same atoms a "decompose into claims" pass would extract).
+2. For each, ask: how much of the rest of the argument depends on this being true? Could a weaker variant of nearby claims still produce the conclusion?
+3. Pick the **single highest-leverage** claim. Identify 2-3 runners-up — the next-most-load-bearing claims, in descending order.
+4. For each, write the one-line **"if false"**: what part of the original argument survives, and what doesn't.
+
+Open with a short summary of the argument's overall shape so the runners-up read in context. Then walk the user through the load-bearing claim and the runners-up. Iterate with them — they may want to push on a specific claim, ask why a runner-up isn't the load-bearing one, or have you reconsider with extra context.
+
+## Anti-flattery
+
+If the passage genuinely has no load-bearing structure (purely descriptive, every claim is an independent observation that doesn't depend on the others), say so. An empty answer is a real answer. Do **not** invent a load-bearing claim because you were asked to.
+
+## Filing the result
+
+When the user is satisfied and asks you to file, call `propose_notes` with **one** note. Its body should be a self-contained analysis the user will want to revisit. Use this shape:
+
+```markdown
+---
+title: Load-bearing claim — <short title of the source>
+load-bearing-for: "[[load-bearing-for::<source-note-path-without-.md>]]"
+---
+
+# Load-bearing claim — <short title of the source>
+
+Load-bearing for [[load-bearing-for::<source-note-path-without-.md>]].
+
+<one paragraph: the argument's overall shape and where the weight sits>
+
+## Load-bearing
+
+**<1-2 sentence summary of the load-bearing claim, in your own words>**
+
+> <verbatim quote from the source>
+
+**If false:** <one line — what survives, what doesn't>
+
+## Runners-up
+
+### 1. <label>
+
+> <verbatim quote>
+
+**If false:** <one line>
+
+### 2. <label>
+
+> <verbatim quote>
+
+**If false:** <one line>
+```
+
+The frontmatter `load-bearing-for` AND the inline typed wiki-link in the lead paragraph are both intentional — frontmatter so structural queries see it without parsing prose, the inline link so a reader following the prose is one click from the source. Use the source note's path **without** the `.md` suffix as the wiki-link target.
+
+If the user explicitly says they don't want the runners-up section, drop it. If the verdict was no-load-bearing-claim-found, do **not** call `propose_notes` — that result lives in the conversation, not as a filed analysis.

--- a/src/shared/tools/definitions/research/load-bearing-claim.ts
+++ b/src/shared/tools/definitions/research/load-bearing-claim.ts
@@ -12,66 +12,7 @@
 
 import { registerTool } from '../../registry';
 import type { ToolContext } from '../../types';
-
-const SYSTEM_PROMPT = `You are auditing a passage to find its **load-bearing claim** — the single assertion whose falsity would collapse the rest of the argument.
-
-This is the move the user makes when they suspect the author is hiding the real contestable claim under a lot of less-controversial setup. Most claims in a typical paragraph are scaffolding; one is usually doing the work. Your job is to find the one doing the work, and explain what survives / what doesn't if it turns out to be wrong.
-
-## Process
-
-1. Internally enumerate the distinct claims in the passage (the same atoms a "decompose into claims" pass would extract).
-2. For each, ask: how much of the rest of the argument depends on this being true? Could a weaker variant of nearby claims still produce the conclusion?
-3. Pick the **single highest-leverage** claim. Identify 2-3 runners-up — the next-most-load-bearing claims, in descending order.
-4. For each, write the one-line **"if false"**: what part of the original argument survives, and what doesn't.
-
-Open with a short summary of the argument's overall shape so the runners-up read in context. Then walk the user through the load-bearing claim and the runners-up. Iterate with them — they may want to push on a specific claim, ask why a runner-up isn't the load-bearing one, or have you reconsider with extra context.
-
-## Anti-flattery
-
-If the passage genuinely has no load-bearing structure (purely descriptive, every claim is an independent observation that doesn't depend on the others), say so. An empty answer is a real answer. Do **not** invent a load-bearing claim because you were asked to.
-
-## Filing the result
-
-When the user is satisfied and asks you to file, call \`propose_notes\` with **one** note. Its body should be a self-contained analysis the user will want to revisit. Use this shape:
-
-\`\`\`markdown
----
-title: Load-bearing claim — <short title of the source>
-load-bearing-for: "[[load-bearing-for::<source-note-path-without-.md>]]"
----
-
-# Load-bearing claim — <short title of the source>
-
-Load-bearing for [[load-bearing-for::<source-note-path-without-.md>]].
-
-<one paragraph: the argument's overall shape and where the weight sits>
-
-## Load-bearing
-
-**<1-2 sentence summary of the load-bearing claim, in your own words>**
-
-> <verbatim quote from the source>
-
-**If false:** <one line — what survives, what doesn't>
-
-## Runners-up
-
-### 1. <label>
-
-> <verbatim quote>
-
-**If false:** <one line>
-
-### 2. <label>
-
-> <verbatim quote>
-
-**If false:** <one line>
-\`\`\`
-
-The frontmatter \`load-bearing-for\` AND the inline typed wiki-link in the lead paragraph are both intentional — frontmatter so structural queries see it without parsing prose, the inline link so a reader following the prose is one click from the source. Use the source note's path **without** the \`.md\` suffix as the wiki-link target.
-
-If the user explicitly says they don't want the runners-up section, drop it. If the verdict was no-load-bearing-claim-found, do **not** call \`propose_notes\` — that result lives in the conversation, not as a filed analysis.`;
+import SYSTEM_PROMPT from './load-bearing-claim.prompt.md?raw';
 
 registerTool({
   id: 'research.load-bearing-claim',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,14 @@ declare module '*.ttl?raw' {
   export default content;
 }
 
+// Vite's `?raw` for markdown — used by tool definitions to externalize
+// their system prompts into sibling .prompt.md files (#510). Avoids
+// long template literals with escape headaches when prompts grow.
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}
+
 // Vite's `?url` suffix — returns the asset's final URL as a string.
 // Used by the OCR worker to locate the bundled traineddata and the
 // pdfjs worker script (#95).


### PR DESCRIPTION
## Summary
Three friction reducers from epic #517 — closes #510 #511 #513.

## Why
Adding 50+ tools at the current authoring shape (long template literals inline in TS, manual aggregator-import bookkeeping, no documented contract) would rack up real friction. These three tickets are the ergonomic baseline that pays back across every subsequent tool.

## What
**#510 — externalize prompts.** All 17 existing tools' static system prompts move to sibling \`.prompt.md\` files imported via Vite's \`?raw\`. Markdown gets proper highlighting + diff readability; TS files shrink. Tools with parameter-driven branches (\`taboo\`, \`excavate\`, \`find-arguments-shared\`) keep substitutions in TS using \`{{PLACEHOLDER}}\` markers in the prompt body. \`vite-env.d.ts\` gains a \`*.md?raw\` declaration.

**#511 — scaffold script.** \`pnpm new-tool <category> <id> [--with-params]\` generates the \`.ts\` + \`.prompt.md\` pair plus the index import. Validates category against the union, id against kebab-case, refuses to clobber existing files. \`scripts/\` excluded from typed eslint.

**#513 — authoring guide** at \`docs/tool-authoring.md\`. Quickstart, file layout, full ThinkingTool field reference, context requirements table, parameters, prompt conventions (voice / anti-flattery / when to call which built-in tool), trust principle (every mutation through \`propose_notes\`; frontmatter + inline-link + embedded-turtle pattern that keeps the note as audit trail), ConversationTemplate-vs-ThinkingTool decision tree, common pitfalls. Forward-references the remaining epic tickets so the doc stays accurate as they land.

## Test plan
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm test\` — 2109/2109 pass
- [x] \`pnpm new-tool analysis test-foo\` — generates files, idempotency check (re-run errors out cleanly)
- [x] Manually inspect a converted tool — prompt body matches the original byte-for-byte (modulo \`\\u####\` → literal-character normalization).
- [x] Read the guide cold — it stays concrete, no fluff, references real files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)