### PR TITLE
tools: selection-range context for ThinkingTools

### DIFF
--- a/src/renderer/lib/tools/context.ts
+++ b/src/renderer/lib/tools/context.ts
@@ -18,6 +18,23 @@ export async function gatherContext(
     }
   }
 
+  if (requirements.includes('selectionRange') && editorView) {
+    const { from, to } = editorView.state.selection.main;
+    if (from !== to) {
+      // Match CodeMirror's selection semantics: from is inclusive, to is
+      // exclusive. Lines are 1-based to match how the editor surfaces
+      // them in the status bar / goto-line dialog.
+      ctx.selectionStartOffset = from;
+      ctx.selectionEndOffset = to;
+      ctx.selectionStartLine = editorView.state.doc.lineAt(from).number;
+      // `to` can land on a line break that belongs to the next line; pull
+      // the line at `to - 1` so a multi-line selection that ends at a
+      // newline reports the visually-last line rather than the empty line
+      // after it.
+      ctx.selectionEndLine = editorView.state.doc.lineAt(Math.max(from, to - 1)).number;
+    }
+  }
+
   if (requirements.includes('claimUnderCursor') && editorView) {
     // Mirror Editor.svelte's getClaimUriAtCursor: prefer the active
     // selection, fall back to the current line. Centralising the URI

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -13,7 +13,20 @@ export type ContextRequirement =
    * `claimUri` is left undefined and the tool's `buildSystemPrompt`
    * is responsible for either erroring or producing a helpful message.
    */
-  | 'claimUnderCursor';
+  | 'claimUnderCursor'
+  /**
+   * Populates `selectionStartOffset` / `selectionEndOffset` (character
+   * offsets in the active note) and `selectionStartLine` /
+   * `selectionEndLine` (1-based, inclusive). Used by tools that
+   * propose edits anchored at the original passage (#509). Independent
+   * of `selectedText` — list both when you need verbatim text plus
+   * coordinates. When the editor has no selection (cursor only), the
+   * fields stay undefined; the tool decides whether to fall back or
+   * error. Coordinates are valid against the note's content at gather
+   * time; intervening edits between gather and apply may invalidate
+   * them, and tools that round-trip should verify.
+   */
+  | 'selectionRange';
 
 export type OutputMode =
   | 'newNote'
@@ -50,6 +63,20 @@ export interface ToolContext {
   /** thought:sourceText of the claim — the verbatim passage the
    *  claim was extracted from. May be empty. */
   claimSourceText?: string;
+  /**
+   * Populated by `selectionRange`. Character offset (0-based) of the
+   * selection's start in the active note's content. Undefined when
+   * no selection exists (cursor only) or when the requirement was not
+   * listed. Pair with `selectionEndOffset` for an inclusive-start /
+   * exclusive-end range, matching CodeMirror's `state.selection.main`.
+   */
+  selectionStartOffset?: number;
+  /** Character offset (0-based, exclusive) of the selection's end. */
+  selectionEndOffset?: number;
+  /** 1-based line number of the selection's start. */
+  selectionStartLine?: number;
+  /** 1-based line number of the selection's end (inclusive). */
+  selectionEndLine?: number;
   parameterValues?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary
Closes #509. Part of epic #517.

## What
\`ToolContext\` gains four new optional fields populated when a tool declares the new \`selectionRange\` \`ContextRequirement\`:

- \`selectionStartOffset\` / \`selectionEndOffset\` — 0-based, CodeMirror's inclusive-start / exclusive-end
- \`selectionStartLine\` / \`selectionEndLine\` — 1-based, inclusive

The gather pass reads from \`view.state.selection.main\` + \`doc.lineAt\` the same way the editor's status bar and goto-line dialog do, so coordinates round-trip cleanly. Independent of \`selectedText\` — list both when a tool needs verbatim text plus coordinates.

Empty-selection (cursor only) leaves the fields undefined; the tool decides whether to fall back to whole-note or error.

## Out of scope (per the issue)
- Anchor-based tracking that survives intervening edits. Coordinates are valid at gather time; tools that round-trip should verify before applying.

## Why
Unblocks edit-anchored tools — "rewrite this passage in active voice", "annotate this passage with claim brackets", anything that needs to know where in the source to write back. None of the existing 17 tools use it; a couple of the upcoming combat-epistemology / FUTURE_TOKENS ports likely will.

## Follow-up
The authoring guide on PR #521 footnotes this requirement as "(planned, #509)". After both PRs merge, that wording becomes stale; small one-line follow-up to drop the qualifier.

## Test plan
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm test\` — 2109/2109 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)