### PR TITLE
tools: requiresTools on ThinkingTool — propagate ask_user opt-in

### DIFF
--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -87,6 +87,9 @@ export function buildConversationPayload(
     firstMessage: tool.buildFirstMessage ? tool.buildFirstMessage(request.context) : '',
     ...(model ? { model } : {}),
     webEnabled: tool.web?.defaultEnabled ?? false,
+    ...(tool.requiresTools && tool.requiresTools.length > 0
+      ? { requiresTools: [...tool.requiresTools] }
+      : {}),
   };
 }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1649,6 +1649,9 @@
       systemPrompt: prep.systemPrompt,
       ...(prep.model ? { model: prep.model } : {}),
       ...(prep.firstMessage ? { initialMessage: prep.firstMessage } : {}),
+      ...(prep.requiresTools && prep.requiresTools.length > 0
+        ? { extraTools: prep.requiresTools }
+        : {}),
     });
   }
 

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -247,6 +247,10 @@ async function openConversationTab(opts: {
   systemPrompt?: string;
   model?: string;
   initialMessage?: string;
+  /** Template-scoped tools (e.g. `'ask_user'`) the agent should have in
+   *  scope for this conversation. Mirrors ConversationTemplate's
+   *  `requiresTools` and ThinkingTool's `requiresTools` (#514). */
+  extraTools?: ConversationToolKey[];
 }): Promise<TabRuntime> {
   ensureSubscriptions();
   const bundle: ContextBundle = opts.notePath ? { notePath: opts.notePath } : {};
@@ -267,7 +271,7 @@ async function openConversationTab(opts: {
     composer: '',
     streaming: false,
     streamedChunks: '',
-    extraTools: [],
+    extraTools: opts.extraTools ? [...opts.extraTools] : [],
   };
   tabs = [...tabs, tab];
   activeTabId = tab.id;

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -85,6 +85,14 @@ export interface ThinkingToolDef {
   web?: ToolWebHint;
   /** When true, the tool refuses to run without a non-empty `ctx.selectedText`. The editor right-click hides it, the menu-bar entry fails fast with a clear error. */
   requiresSelection?: boolean;
+  /**
+   * Template-scoped tools the agent should have access to in this
+   * conversation, on top of the default toolset. Today the only entry
+   * is `'ask_user'` — declare it when the prompt needs to collect a
+   * decision the `parameters` form couldn't have collected upfront.
+   * Mirrors the same field on `ConversationTemplate` (#514).
+   */
+  requiresTools?: import('../conversation-templates').ConversationToolKey[];
 }
 
 /** Serializable subset of ThinkingToolDef sent over IPC (no functions). */
@@ -126,6 +134,8 @@ export interface ConversationToolPayload {
   model?: string;
   /** Whether the tool wants web access on. Actual effect also depends on global `LLMSettings.web.enabled`. */
   webEnabled: boolean;
+  /** Template-scoped tools to enable on the resulting conversation, mirroring the tool's `requiresTools` declaration (#514). */
+  requiresTools?: import('../conversation-templates').ConversationToolKey[];
 }
 
 export interface WebSettings {


### PR DESCRIPTION
## Summary
Closes #514. Part of epic #517.

## What
\`ThinkingTool\` gains \`requiresTools?: ConversationToolKey[]\` to mirror the field on \`ConversationTemplate\` (#500). Authors who need mid-conversation \`ask_user\` declare it on the def, and the gate threads through \`ConversationToolPayload\` → \`openConversationTab({ extraTools })\` → per-tab \`extraTools\` → existing send pipeline (already forwards to \`completeWithTools\`).

No tools change. The infrastructure is here for #512 / #508 ports that want it.

## Decision tree (per the issue's open question)
- **\`parameters\`** — collect upfront, before the agent starts.
- **\`requiresTools: ['ask_user']\`** — collect mid-flight, when ambiguity becomes visible only after the agent reads the source.

Most ThinkingTools should reach for \`parameters\` first. \`ask_user\` is the escape hatch.

## Test plan
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm test\` — 2109/2109 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)