### PR TITLE
tools: port FUTURE_TOKENS skills to analysis/ category

### DIFF
--- a/src/shared/tools/definitions/analysis/_shared.ts
+++ b/src/shared/tools/definitions/analysis/_shared.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helpers for analysis ThinkingTools (#508 / #512 ports). Most
+ * analysis tools have the same shape: take the active note's selection
+ * (or whole body if nothing selected), append it to a system prompt
+ * pulled from a sibling .prompt.md, fire a short "for X, do Y" first
+ * message. Extracted here so per-tool files can stay 15-20 lines.
+ *
+ * If a tool needs a non-default shape (parameters, claim-under-cursor,
+ * different framing), it should write its own builders inline rather
+ * than try to extend these.
+ */
+
+import type { ToolContext } from '../../types';
+
+/**
+ * Append the source passage to a tool's system prompt body. Prefers a
+ * non-empty selection over the whole-note content.
+ */
+export function analysisSourceBlock(ctx: ToolContext): string {
+  const selected = ctx.selectedText?.trim();
+  const full = ctx.fullNoteContent?.trim();
+  if (selected) {
+    return `\n\n## Selection\n\n${selected}`;
+  }
+  if (full) {
+    const title = ctx.fullNoteTitle ? ` — ${ctx.fullNoteTitle}` : '';
+    return `\n\n## Note${title}\n\n${full}`;
+  }
+  return '';
+}
+
+/**
+ * Build a short first user-turn for an analysis tool. `verb` is the
+ * tool's action phrase ("find the rhymes", "surface the assumptions",
+ * "synthesize", etc.) — one short imperative.
+ */
+export function analysisFirstMessage(ctx: ToolContext, verb: string): string {
+  const subject = ctx.selectedText?.trim() ? 'this selection' : 'this note';
+  return `For ${subject}, ${verb}.`;
+}

--- a/src/shared/tools/definitions/analysis/antithesize.prompt.md
+++ b/src/shared/tools/definitions/analysis/antithesize.prompt.md
@@ -1,0 +1,623 @@
+
+## tl;dr
+
+antithesis is NOT just one thing. it's a menu of distinct moves:
+
+**what you're trying to do determines which move to use:**
+
+- **falsify** → refutation, counterexample, selection critique
+- **replace** → rival thesis, reparameterization, causal inversion
+- **robustify** → adversarial example, boundary case, objective flip to worst-case
+- **clarify values** → axiological inversion, performative mirror
+- **reframe** → axis shift, phenomenological counter, foil
+
+**the move i've been teaching**: RIVAL THESIS (coherent alternative, standalone counter-model)
+
+- stands alone (comprehensible without reading original)
+- accepts same facts (but reinterprets valence)
+- reaches opposite conclusion
+- generates different action/recommendation
+
+this is ONE powerful move, but not the only one. see full taxonomy below.
+
+**critical upstream**: identify GENRE + PURPOSE first, then pick antithesis type.
+
+-----
+
+## antithesis types (full menu)
+
+different moves exert different kinds of pressure. pick based on what you're trying to accomplish.
+
+### **refutation** (logical negation)
+
+**what**: show ¬p, contradiction, counterexample, or reductio
+**when**: you want falsification pressure, truth-testing
+**example**: "thesis claims remote work cuts productivity. panel data with instrumented shocks shows no drop."
+
+### **rival thesis** (coherent alternative)
+
+**what**: full counter-model with different primitives/priors that fits data better
+**when**: you want replacement, not just teardown
+**example**: "preference isn't discovered—it's regime-generated. constraints create wants, not hide them."
+**note**: this is the move i've been teaching in detail below.
+
+### **objective flip** (same facts, different loss)
+
+**what**: optimize recall not precision; CVaR not mean; latency not throughput
+**when**: misalignment is about goals, not facts
+**example**: "if objective = retention or female participation, remote work strictly dominates in-office."
+
+### **axis shift** (orthogonalization)
+
+**what**: change the question, hold the answer fixed; challenge relevance, not truth
+**when**: you want to escape frame-lock
+**example**: "sure bigger models win on capability. but for reliability/compliance, alignment infrastructure compounds faster."
+
+### **causal inversion**
+
+**what**: reverse arrows or condition on different node ("you've mistaken effect for cause")
+**when**: the causal story smells post-hoc
+**example**: "success didn't cause the strategy—survivors retroactively claim the strategy caused success."
+
+### **role/quantifier swap**
+
+**what**: swap ∀/∃, min/max, buyer/seller, regulator/regulated
+**when**: edge-case ambushes, exposing hidden quantifiers
+**example**: "works for SOME users" ≠ "works for ALL users"
+
+### **boundary/limit case**
+
+**what**: test at extremes or degenerate regimes (n→∞, liquidity→0, adversary→adaptive)
+**when**: exposing hidden assumptions, scale behavior
+**example**: "your coordination mechanism works at n=10. at n=1000, it collapses due to gossip overhead."
+
+### **adversarial example** (stress test)
+
+**what**: craft worst-case inputs that satisfy constraints yet violate intent
+**when**: robustness audits, red-teaming
+**example**: "your content filter passes benign test cases but fails on unicode edge cases adversary will exploit."
+
+### **duality/reparameterization**
+
+**what**: express same system in dual space (primal/dual, time/frequency, price/quantity)
+**when**: seeing conserved quantities, alternative formulations
+**example**: "in tooling market, stable abstractions are scarce capital; model scale is commodity. dual of capability race."
+
+### **selection/measurement critique**
+
+**what**: attack the pipeline (sampling, survivorship, goodharting, leakage)
+**when**: results look "too clean," external validity suspect
+**example**: "capability evals cherry-pick leaderboards optimized by scale. selection bias."
+
+### **axiological inversion**
+
+**what**: reorder values (equity > efficiency instead of vice versa), see if policy survives
+**when**: norm conflicts, value disagreements
+**example**: "optimizing for average hides tail suffering. if you weight equity, opposite policy."
+
+### **phenomenological counter**
+
+**what**: lived-experience report that map misses ("your 'average' erases tails; i live in a tail")
+**when**: locating aleatoric vs epistemic error, representation failures
+**example**: "your model says garden leave is recovery. but it FEELS like generating new preferences under new regime."
+
+### **performative/strategic mirror**
+
+**what**: "if we make your claim common knowledge, equilibrium shifts (reflexivity)"
+**when**: second-order effects, strategy-proofness
+**example**: "publishing 'SAT predicts success' makes everyone optimize SAT, destroying the signal."
+
+### **null model / ablation**
+
+**what**: "a dumb baseline does as well; your gears add no marginal evidence"
+**when**: puncturing ornamentation, checking necessity
+**example**: "your 12-step framework performs same as 'just try stuff and see.' mechanisms are cosplay."
+
+### **foil/negative space**
+
+**what**: delineate what thesis DOESN'T say to reveal scope errors
+**when**: deconfusing, clarifying boundaries
+**example**: "you claim X helps decision-making. but you never specify WHICH decisions, at WHAT stakes."
+
+-----
+
+## picking the right antithesis type
+
+**fast heuristics by purpose:**
+
+|your goal                                  |use these moves                                                 |
+|-------------------------------------------|----------------------------------------------------------------|
+|truth pressure (is this even true?)        |refutation, counterexample, selection critique                  |
+|better model (what's the right story?)     |rival thesis, causal inversion, reparameterization              |
+|robustness (will this break?)              |adversarial example, boundary case, objective flip to worst-case|
+|value clarity (what should we optimize?)   |axiological inversion, performative mirror                      |
+|reframe (are we asking the right question?)|axis shift, phenomenological counter, foil                      |
+
+**generators** (concrete ways to mint antithesis):
+
+- flip the sign (benefit ↔ harm), timeframe (short ↔ long), or unit of analysis (individual ↔ system)
+- swap the objective (mean → tail; accuracy → calibration; growth → resilience)
+- invert causality (B causes A), roles (principal ↔ agent), or quantifiers (∀ → ∃)
+- push to limits (resource → 0/∞; noise → 0/∞; adversary → adaptive)
+- re-express via dual (Lagrangian, Fourier, supply ↔ demand)
+- ablate one gear; if predictions don't move, that gear was cosplay
+
+-----
+
+## rival thesis deep-dive (the main move i've been teaching)
+
+**what**: a complete alternative worldview that stands alone, accepts same facts, reaches opposite conclusion.
+
+**why this one specifically**:
+
+- hardest to do well (requires full positive theory, not just negation)
+- most useful for synthesis (gives you two complete models to combine/partition)
+- most intellectually honest (forces you to propose alternative, not just critique)
+
+**requirements for rival thesis**:
+
+- standalone (comprehensible without reading original)
+- positive claims (not just negation)
+- steel-man first (oppose strongest version)
+- context-appropriate (understand actual constraints)
+
+### genre-specific patterns (for rival thesis)
+
+**note**: these patterns apply specifically to RIVAL THESIS type. other antithesis types (refutation, boundary case, adversarial example) may not need genre-specific structure.
+
+for rival thesis, genre determines opposition structure:
+
+### **review / recommendation**
+
+**thesis**: "X is good, i recommend it"
+
+**antithesis structure**:
+
+- ACCEPT: the experience/facts (what happened)
+- FLIP: the evaluation (good → bad, feature → bug)
+- REVERSE: the recommendation (do → don't, extend → end)
+
+**example**:
+
+- thesis: "garden leave is awesome, i'd extend it, predicts happy retirement"
+- antithesis: "garden leave is seductive stagnation, end it now, extending makes retirement harder"
+  - same facts: you experienced time freedom, exploration, recovery
+  - flipped valence: freedom → drift, exploration → dependence, recovery → atrophy
+  - opposite action: extend → end
+
+### **philosophical essay / argument**
+
+**thesis**: "X causes Y, therefore Z"
+
+**antithesis structure**:
+
+- ACCEPT: the observations (Y is real)
+- SWAP: the mechanism (not X causes Y, but W causes Y, or Y causes X)
+- CONCLUDE: opposite implication
+
+**example**:
+
+- thesis: "removing pressure reveals authentic preference"
+- antithesis: "preference is regime-generated, not discovered; removing pressure creates different preferences, doesn't uncover hidden ones"
+
+### **technical argument / code**
+
+**thesis**: "approach X solves problem P"
+
+**antithesis structure**:
+
+- ACCEPT: problem P exists and matters
+- CRITIQUE: X has failure modes A, B, C that matter in practice
+- PROPOSE: approach Y solves P better, or P is wrong problem to solve
+
+### **guide / instruction**
+
+**thesis**: "do X to achieve Y"
+
+**antithesis structure**:
+
+- ACCEPT: Y is desirable goal
+- ARGUE: X doesn't reliably produce Y, or produces anti-Y
+- RECOMMEND: do Z instead, or abandon Y as goal
+
+### **business case / decision doc**
+
+**thesis**: "we should do X because benefits > costs"
+
+**antithesis structure**:
+
+- ACCEPT: the situation/constraints are real
+- REINTERPRET: costs are higher than stated, benefits are illusory, or incentives are misaligned
+- RECOMMEND: do opposite of X, or do nothing
+
+### **memoir / narrative**
+
+**thesis**: "event X meant Y to me"
+
+**antithesis structure**:
+
+- ACCEPT: event X happened as described
+- REINTERPRET: X actually means Z (different significance)
+- SUGGEST: alternative framing with different implications for future
+
+**key principle**: antithesis is NOT "you're wrong"—it's "here's an equally coherent but opposite interpretation of same reality"
+
+-----
+
+## critical requirements
+
+### **standalone test** (non-negotiable)
+
+antithesis MUST be comprehensible to someone who never read the thesis.
+
+**test questions**:
+
+- can i understand this without reading the original?
+- does it make positive claims, or just negate other claims?
+- could this have been written FIRST, with thesis as response to IT?
+
+**bad** (parasitic): "jordan's wrong about preference discovery because he's confusing recovery with revelation"
+
+- only makes sense if you know what jordan said
+- defined by opposition, not by its own claims
+- negative framing ("wrong about…")
+
+**good** (standalone): "preference is regime-dependent: scarcity generates survival-optimized wants, abundance generates meaning-optimized wants. garden leave doesn't reveal hidden essence—it creates new preference-structure under new constraints."
+
+- makes sense without reading jordan's essay
+- positive claims about how preference works
+- thesis becomes a special case of this framework
+
+### **steel-man first** (intellectual honesty)
+
+before opposing, state the STRONGEST version of thesis:
+
+- what's the best interpretation?
+- what would make it true?
+- which parts are hardest to argue against?
+
+oppose the steel-man, not the weak version.
+
+**bad**: "jordan says skills are valuable but they're actually just premature optimization after n=2 examples"
+
+- attacks early-draft messiness
+- ignores that iteration is the point
+
+**good**: "even after skills stabilize (n=50+), formalization might not improve output quality. if legibility ≠ efficacy, skills become cargo cult rigor."
+
+- opposes the strong form (mature skills)
+- takes best case seriously
+
+### **context-appropriate constraints**
+
+understand the ACTUAL constraint structure, not hypothetical:
+
+- who bears the costs?
+- what are real failure modes vs imagined?
+- what resources/capabilities actually exist?
+
+**bad**: "skills are expensive to maintain" (assumes human solo work)
+**good**: "skills might not improve output quality" (recognizes LLM-human collab costs are near-zero, so quality is only real metric)
+
+-----
+
+## process (step by step)
+
+### step -1: identify purpose (REQUIRED FIRST)
+
+what are you trying to accomplish with antithesis?
+
+|purpose                                      |recommended antithesis types                      |
+|---------------------------------------------|--------------------------------------------------|
+|**falsify** (is this even true?)             |refutation, counterexample, selection critique    |
+|**replace** (what's the right story?)        |rival thesis, causal inversion, reparameterization|
+|**robustify** (will this break?)             |adversarial example, boundary case, objective flip|
+|**clarify values** (what should we optimize?)|axiological inversion, performative mirror        |
+|**reframe** (wrong question?)                |axis shift, phenomenological counter, foil        |
+
+most of the time you want **replace** (rival thesis), which is the deep-dive below. but know your options.
+
+### step 0: identify genre (if doing rival thesis)
+
+**if you chose RIVAL THESIS** from step -1:
+
+- **what KIND of thing is this?** (review/essay/guide/code/conversation/recipe/decision-doc)
+- **what is it TRYING to do?** (persuade/inform/recommend/instruct/decide/express)
+- **what would opposite look like in this genre?**
+
+use genre patterns above to guide structure.
+
+**if genre is ambiguous**: you may need to explore multiple frames first.
+
+**if you chose other antithesis types** (refutation, adversarial, etc): genre may be less critical. skip to step 1.
+
+### step 1: choose axis (what to oppose)
+
+**note**: axis selection is most relevant for RIVAL THESIS. other antithesis types may not need explicit axis.
+
+axis = the dimension along which you'll generate opposition.
+
+**quick triage by symptom**:
+
+|you notice                      |axis                        |key question                         |
+|--------------------------------|----------------------------|-------------------------------------|
+|claim optimizes wrong thing     |pragmatic                   |what's actual objective?             |
+|data feels shaky / cherry-picked|epistemic / statistical     |what's base rate + reference class?  |
+|story feels post-hoc            |methodological              |what would've predicted this ex ante?|
+|mechanism unclear / confounded  |causal                      |which arrow cuts effect?             |
+|incentives seem misaligned      |incentive                   |who wins under this?                 |
+|works in-sample, dies OOD       |distributional              |what shift breaks it first?          |
+|scales weirdly                  |scaling / limit             |what happens at 0, 1, ∞?             |
+|tail risk / ruin ignored        |resource / ergodicity       |time-average vs ensemble?            |
+|words as social moves           |performative / simulacra    |if costly to say, would you?         |
+|group ≠ individual outcomes     |institutional / coordination|mechanism design issue?              |
+|category errors                 |ontological / type          |what KIND of thing is this?          |
+|hand-wavey compute/time         |computational               |asymptotic budget?                   |
+|values conflict, not facts      |axiological                 |which weights flip sign?             |
+|experience mismatch             |phenomenological            |what would opposite feel like?       |
+
+**rule**: pick TWO axes—one mechanistic (causal/incentive/stats/compute) + one normative (axiology/phenomenology/performative). cross-term generates useful friction.
+
+### step 2: choose operator (how to oppose)
+
+operator = the specific move you make along chosen axis.
+
+**core operators** (name · what it does · micro-example):
+
+- **objective_swap** — optimize different (truer) goal · accuracy → calibration
+- **dualize** — view from constraint's perspective · allocate vs price
+- **quantifier_flip** — some ↔ all · "works for me" ≠ "works generally"
+- **boundary_case** — test 0/1/∞, edge conditions · your policy at 10 users? 1M users?
+- **counter_model** — build minimal world where it fails · same priors, different outcome
+- **loss_change** — swap loss function · MAE vs MSE vs proper score
+- **subgroup_slice** — stratify and look for sign flips · p10 vs p90 behavior
+- **adversarial_perturb** — minimal change that breaks it · one bit flip and you're toast
+- **refclass_shift** — reindex the baseline · firm → industry → economy
+- **causal_surgery** (do()) — cut an edge, see if effect survives · intervene on A, observe B
+- **incentive_remap** — change payoffs/status · make metric career-neutral
+- **temporal_refactor** — near-term win, long-term ruin · time-average vs ensemble
+- **units_check** — demand dimensional sanity · divide out the vibes
+- **paradox_trap** — condition/marginalize to flip · both true under different gates
+- **simulacrum_test** — make utterance costly, see if persists · truth vs troupe
+- **ideological_turing** — write opposite policy under opposite belief · then evaluate
+- **goodhart_invert** — push proxy until mission breaks · metric defeats goal
+- **type_safety** — enforce kind discipline · process ≠ object; preference ≠ belief
+
+### step 3: set intensity + contract
+
+**intensity** (how hard to push):
+
+- lvl 1: contrast (gentle disagreement, mostly aligned)
+- lvl 2: counterpoint (substantive disagreement, still respectful)
+- lvl 3: stress-test (find breaking points, surgical pressure)
+- lvl 4: frame inversion (flip fundamental assumptions)
+- lvl 5: core challenge (question the entire enterprise)
+
+**contract** (tone/permissions):
+
+- **gentle**: cozy, collaborative, assume good faith
+- **adversarial**: sport, debate-mode, sharp but fair
+- **identity_ok**: permission to press on self-concept, core beliefs
+
+**rule**: increase levels only after logging a crux. always state the contract upfront.
+
+### step 4: generate antithesis
+
+using genre structure + chosen axes/operators + intensity/contract:
+
+1. **restate thesis in strongest form** (steel-man)
+1. **identify core claims** that will be opposed
+1. **accept shared reality** (facts, observations, constraints)
+1. **reinterpret valence** (flip evaluation: good → bad, feature → bug)
+1. **propose opposite mechanism** (if causal claim)
+1. **reach opposite conclusion** (different implication, recommendation, action)
+1. **verify standalone** (would this make sense without reading thesis?)
+
+### step 5: extract outputs
+
+**antithesis** — the constructed opposite case (main output)
+
+**failure_modes** — specific ways thesis breaks:
+
+- brittle assumptions (what has to stay true for thesis to work?)
+- bad priors (what beliefs does thesis require?)
+- incentive leaks (who benefits from this framing?)
+- boundary violations (where does it break down?)
+
+**cruxes** — minimal belief changes that flip conclusion:
+
+- empirical cruxes: "if X is measured and found to be Y, thesis collapses"
+- axiological cruxes: "if you weight value A over value B, opposite conclusion"
+
+**evidence_hooks** — what to measure next to resolve:
+
+- specific experiments, data to collect, comparisons to run
+- ways to adjudicate between thesis and antithesis
+
+-----
+
+## axes reference (deep cuts)
+
+**epistemic** — truth claims · thin priors, assertive tone · overfitting to anecdotes
+
+**methodological** — how you reasoned · after-the-fact coherence · cargo-cult rigor
+
+**axiological** — value weights · moral heat without statistics · incommensurability as fact
+
+**phenomenological** — lived texture · "not what it feels like" · projection
+
+**performative** — rhetoric as act · applause-line energy · clout over truth
+
+**pragmatic** — does it work · pretty theory, ugly ops · metric drift
+
+**causal** — arrows not nodes · wiggle input, nothing moves · confounding
+
+**incentive** — payoff surfaces · nice words, perverse rewards · cobra effect
+
+**statistical** — priors, baselines · small-n swagger · aggregation fallacy
+
+**computational** — tractability/time · exponential hand-waving · impossibility hiding in vibes
+
+**distributional** — OOD fragility · changes domain, keeps claim · training set myopia
+
+**scaling/limit** — asymptotics · linear intuition, nonlinear world · sign flips at scale
+
+**resource/ergodicity** — conservation/ruin · average win, catastrophic path · time vs ensemble
+
+**simulacra** — truth as signal · tracks status over reality · level-mixing
+
+**institutional/coordination** — mechanism design · individually rational, collectively dumb · commons tragedy
+
+**ontological/type** — kind errors · reifying process as object · category bleed
+
+-----
+
+## mini-examples (same thesis, different antithesis types)
+
+**thesis 1**: "remote work cuts productivity"
+
+- **refutation**: multi-firm panel with instrumented shocks shows no drop
+- **rival thesis**: productivity ↑ for deep-work roles, ↓ for coord-heavy—heterogeneous effects dominate mean
+- **objective flip**: if objective = retention or female participation, remote strictly dominates
+- **adversarial example**: during outages/childcare spikes, hybrid collapses harder than remote-native (resilience > average)
+
+**thesis 2**: "bigger models beat alignment techniques over 3-5y"
+
+- **axis shift**: for capability, maybe; for reliability/compliance, alignment infra compounds faster
+- **selection critique**: capability evals cherry-pick leaderboards optimized by scale
+- **duality**: in tooling market, stable abstractions (skills/primitives) are scarce capital; model scale is commodity
+- **rival thesis**: scaling has diminishing returns; rotation to algorithms imminent as we hit data wall
+
+**thesis 3**: "garden leave reveals authentic preference"
+
+- **rival thesis**: preference is regime-generated, not discovered; constraints create wants, not hide them
+- **causal inversion**: you think freedom reveals self; actually, new constraints generate new self
+- **phenomenological counter**: it FEELS like discovery because novelty is inherently revelatory, regardless of mechanism
+- **boundary case**: works for 1-year leave with exit option; breaks for permanent retirement with no reversibility
+
+-----
+
+## quality checklist
+
+**for all antithesis types:**
+
+- [ ] **purpose-aligned**: does this exert the right kind of pressure (falsify/replace/robustify/reframe)?
+- [ ] **steel-man**: opposes strongest version, not weak form
+- [ ] **context-aware**: understands actual constraints, not hypothetical
+
+**additionally for RIVAL THESIS:**
+
+- [ ] **standalone**: makes sense without reading thesis
+- [ ] **positive claims**: says what IS true, not just what's false
+- [ ] **genre-appropriate**: uses correct opposition structure for genre
+- [ ] **accepts facts**: doesn't deny observations, reinterprets them
+- [ ] **flips conclusion**: reaches opposite recommendation/implication
+
+**additionally for REFUTATION:**
+
+- [ ] **specific counterexample**: concrete case where thesis fails
+- [ ] **shows contradiction**: or reductio, or logical impossibility
+
+**additionally for ADVERSARIAL EXAMPLE:**
+
+- [ ] **satisfies constraints**: meets thesis's stated requirements
+- [ ] **violates intent**: but produces opposite outcome thesis wants
+
+**outputs to extract (all types)**:
+
+- [ ] **failure_modes**: specific ways thesis breaks
+- [ ] **cruxes**: minimal belief changes that flip conclusion
+- [ ] **evidence_hooks**: what to measure to resolve
+
+-----
+
+## common failures (anti-patterns)
+
+### **parasitic refutation**
+
+symptom: antithesis only makes sense if you've read thesis
+cause: negating claims instead of making positive counter-claims
+fix: write antithesis FIRST, then check if thesis is needed to understand it
+
+### **weak-man attacking**
+
+symptom: opposing early-draft messiness, not mature form
+cause: taking easy target instead of strongest version
+fix: steel-man first, explicitly state best case, THEN oppose
+
+### **genre confusion**
+
+symptom: treating review as philosophical essay, memoir as argument
+cause: not identifying what KIND of thing you're antithesizing
+fix: run step 0 (identify genre) before anything else
+
+### **hypothetical constraints**
+
+symptom: arguing against costs/problems that don't exist in context
+cause: importing constraints from different setting
+fix: understand actual constraint structure first
+
+### **both-sides-ism**
+
+symptom: "thesis has good points, antithesis has good points"
+cause: false balance, not true opposition
+fix: this is synthesis failure, not antithesis. antithesis must COMMIT to opposite view.
+
+-----
+
+## examples (worked)
+
+### example 1: review genre
+
+**thesis**: "hades 2 is brilliant, buy it now"
+
+**antithesis**: "hades 2 is competent but hollow, wait for sale"
+
+- accepts: game has polish, mechanical depth
+- flips: polish → soulless iteration, depth → overwhelming bloat
+- reverses: buy now → wait for sale
+
+### example 2: philosophical essay
+
+**thesis**: "LLM scaling will continue indefinitely, AGI via scale"
+
+**antithesis**: "returns to scale are real but diminishing, rotation to algorithms imminent"
+
+- accepts: scaling has worked so far
+- swaps mechanism: not "scale = all you need" but "scale had high ROI in regime 1, entering regime 2 where algorithms matter more"
+- concludes: portfolio approach, not all-in on scale
+
+### example 3: business case
+
+**thesis**: "we should adopt microservices because scalability"
+
+**antithesis**: "microservices will kill our velocity for hypothetical scale we don't need"
+
+- accepts: we might need scale someday
+- reinterprets: operational complexity cost >> scaling benefit for our actual traffic
+- recommends: monolith now, extract services when ACTUALLY constrained
+
+-----
+
+## integration with other skills
+
+**related skills**:
+
+- **rhyme**: finds patterns to guide mechanism-swap
+- **dimensionalize**: turns axes into scoreable dimensions
+- **metaphorize**: can inform counter_model generation
+
+-----
+
+## meta-note
+
+antithesis is PROSOCIAL DISAGREEMENT. you're helping thesis-holder by:
+
+- stress-testing their claims
+- surfacing hidden assumptions
+- identifying cruxes
+- making opposition legible
+
+done well, thesis-holder should say "that's a strong counter, i need to think about it" not "you're attacking me."
+
+the goal isn't to WIN—it's to find TRUTH via collision of complete worldviews.

--- a/src/shared/tools/definitions/analysis/antithesize.ts
+++ b/src/shared/tools/definitions/analysis/antithesize.ts
@@ -1,0 +1,56 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `antithesize.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './antithesize.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.antithesize',
+  name: 'Antithesize',
+  category: 'analysis',
+  description: 'Generate a standalone opposition — a complete rival worldview',
+  longDescription:
+    'Produces an antithesis that stands on its own — comprehensible without reading the original ' +
+    'thesis. Not refutation; an alternative complete worldview. Pairs with Steelman (which strengthens ' +
+    "the original) and Synthesize (which compresses thesis + antithesis into a unified frame). Use a " +
+    'higher intensity to push the opposition further from the original.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-opus-4-7',
+  web: { defaultEnabled: false },
+  parameters: [
+    {
+      id: 'intensity',
+      label: 'Intensity',
+      type: 'select',
+      options: [
+        { label: 'Gentle — civil disagreement, shared frame', value: 'gentle' },
+        { label: 'Standard — strong opposition, fair fight', value: 'standard' },
+        { label: 'Adversarial — push to the far edge of plausibility', value: 'adversarial' },
+      ],
+      defaultValue: 'standard',
+    },
+  ],
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const intensity = ctx.parameterValues?.intensity ?? 'standard';
+    const directive = `\n\nContract: ${intensity}. ` + intensityDirective(intensity);
+    return SYSTEM_PROMPT + directive + analysisSourceBlock(ctx);
+  },
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'generate the antithesis'),
+});
+
+function intensityDirective(value: string): string {
+  switch (value) {
+    case 'gentle':
+      return 'Stay within a shared analytic frame — disagree civilly, not destructively. The author would still recognise the disagreement as fair.';
+    case 'adversarial':
+      return 'Push the opposition to the far edge of plausibility. The author should find this view alien but not strawmanned. Identity-attacking moves are fine if they cut at real assumptions.';
+    case 'standard':
+    default:
+      return 'Strong opposition, fair fight. The opposition should be load-bearing and complete, not tactical jabs.';
+  }
+}

--- a/src/shared/tools/definitions/analysis/dimensionalize.prompt.md
+++ b/src/shared/tools/definitions/analysis/dimensionalize.prompt.md
@@ -1,0 +1,278 @@
+
+# Dimensionalize
+
+## Overview
+
+Dimensionalization is naming the handful of dials that actually move a system. A good dial scores high on three meta-dimensions: **fidelity**, **leverage**, and low on **complexity**.
+
+Claude should use this Skill when the user:
+- Explicitly asks to "dimensionalize" something
+- Faces a complex decision with competing factors
+- Wants to understand what actually moves a system
+- Needs to compare options across different attributes
+- Asks "what dimensions matter here?" or similar
+
+## Core Framework
+
+### The Three Meta-Dimensions
+
+| Meta-Dim | Sub-Dims | Mnemonic |
+|----------|----------|----------|
+| **Fidelity** | validity · stability | "is it *real* and does it hold up?" |
+| **Leverage** | actionability · impact | "can i twist it, and does twisting matter?" |
+| **Complexity** | cognitive load · overfitting risk | "can i juggle it, or does it drown me?" |
+
+**Remember: F=valid+stable, L=action+impact, C=load+overfit**
+
+### Meta-Dimension 1: Fidelity
+> *Does the dial carve reality at the joints?*
+
+**Validity** = tracks an actual difference that exists  
+**Stability** = keeps tracking when zoom, time, or context shift
+
+**High-Fidelity examples:**
+- Factor exposure (finance)
+- Latency (systems)
+- Tempo (music)
+
+**Low-Fidelity examples:**
+- "Vibe"
+- "Tech debt" (without specification)
+- Generic "efficiency"
+
+### Meta-Dimension 2: Leverage
+> *Twist → consequence*
+
+**Actionability** = you control the slider  
+**Impact** = slider moves the outcome
+
+**Good Leverage examples:**
+- Autonomy vs stimulation (parenting decisions)
+- Modularity (software architecture)
+- Remote vs on-site (work arrangements)
+
+**Bad Leverage examples:**
+- "Be more strategic" (no clear control)
+- "Gym-playlist BPM" (minimal impact)
+- "Market conditions" (external, uncontrollable)
+
+### Meta-Dimension 3: Complexity
+> *Few enough dials to stay in head-RAM*
+
+**Cognitive load** = how many sliders you must juggle  
+**Overfitting** = dials that add theoretical resolution but no practical gain
+
+**Low-Complexity examples:**
+- Strength · endurance · recovery (fitness)
+- Price · quality · speed (product)
+
+**High-Complexity examples:**
+- 30 biometric streams for a workout plan
+- 50+ OKRs for five people
+- More than 9 dimensions for any decision
+
+**Complexity ceiling: 7 axes maximum (ideally 3-5)**
+
+## LLM Quick-Cast Recipe
+
+When dimensionalizing, follow this protocol:
+```
+[[dimensionalize]]
+[[goal: <decision / system>]]
+[[fidelity_floor: validity+stability]]
+[[leverage_floor: action+impact]]
+[[complexity_ceiling: 7 axes]]
+[[remember: mark each axis (F,L,C) score]]
+```
+
+## Systematic Process
+
+### 1. Identify the System
+What needs dimensionalizing?
+- A decision (career, purchase, strategy)
+- A system (team dynamics, codebase, market)
+- A concept (happiness, productivity, design)
+
+### 2. Generate Candidate Dimensions
+Brainstorm 10-20 possible dials, then filter using F·L·C criteria
+
+### 3. Score Each Dimension
+Rate each candidate on 1-5 scale:
+
+**Fidelity:**
+- Validity: 1 (vague) → 5 (precisely measurable)
+- Stability: 1 (context-dependent) → 5 (holds across contexts)
+- Combined F score: average of validity + stability
+
+**Leverage:**
+- Actionability: 1 (no control) → 5 (direct control)
+- Impact: 1 (negligible effect) → 5 (major effect)
+- Combined L score: average of actionability + impact
+
+**Complexity:**
+- Cognitive load: 1 (simple) → 5 (hard to track)
+- Overfitting: 1 (essential) → 5 (theoretical polish)
+- Combined C score: average of load + overfitting
+- **Lower is better for complexity**
+
+### 4. Filter and Refine
+Keep dimensions with:
+- F ≥ 3.5
+- L ≥ 3.5
+- C ≤ 2.5
+
+Aim for 3-7 final dimensions
+
+### 5. Validate
+For each dimension, answer:
+- Can you measure/score real options on it?
+- Does changing it actually change outcomes?
+- Can you hold all dimensions in working memory?
+- Are dimensions relatively independent?
+
+## Output Format
+
+For each dimension, provide:
+```
+**[Dimension Name]** ⟦F: X.X, L: X.X, C: X.X⟧
+- What it measures: [one sentence]
+- Range: [low end] → [high end]
+- Control lever: [how to adjust it]
+- Why it matters: [connection to outcome]
+```
+
+## Example: Career Decision
+
+**Goal:** Choose next career move
+
+**Dimensions:**
+
+1. **Value-Capture Efficiency** ⟦F: 5.0, L: 4.5, C: 1.0⟧
+   - What: Post-tax compensation per unit of effort+risk
+   - Range: $50/hr → $500/hr equivalent
+   - Lever: Negotiation, equity %, role choice
+   - Why: Direct impact on financial security
+
+2. **Counterfactual Impact** ⟦F: 4.0, L: 4.0, C: 2.0⟧
+   - What: Good that happens because you showed up
+   - Range: Maintenance → transformative
+   - Lever: Choose high-leverage vs support roles
+   - Why: Long-term meaning and satisfaction
+
+3. **Option Surface Area** ⟦F: 4.5, L: 5.0, C: 1.0⟧
+   - What: Future doors unlocked (network, brand, skills)
+   - Range: Dead-end → exponential
+   - Lever: Prestige vs stealth, industry choice
+   - Why: Compounds across career
+
+4. **Personal Excitation** ⟦F: 4.0, L: 4.0, C: 1.0⟧
+   - What: Will you wake up energized for 18+ months?
+   - Range: Dread → flow state
+   - Lever: Scope negotiation, problem domain fit
+   - Why: Performance and sustainability
+
+5. **Autonomy Bandwidth** ⟦F: 5.0, L: 4.0, C: 1.0⟧
+   - What: Decision-making freedom
+   - Range: Micromanaged → self-directed
+   - Lever: Title, reporting structure, remote options
+   - Why: Agency and execution speed
+
+6. **Skill Compounding Rate** ⟦F: 4.0, L: 4.0, C: 2.0⟧
+   - What: How fast rare capabilities grow
+   - Range: Plateau → steep learning curve
+   - Lever: Problem complexity, mentor density
+   - Why: Long-term career capital
+
+7. **Lifestyle Stability** ⟦F: 5.0, L: 4.0, C: 1.0⟧
+   - What: Stress, hours, location flexibility
+   - Range: Burnout risk → sustainable
+   - Lever: Team size, sector, remote policy
+   - Why: Everything else requires this foundation
+
+## Common Failure Modes
+
+**Too many dimensions (>9)**
+- Solution: Merge correlated ones, drop low-leverage
+- Ask: "If I had to pick just 5, which matter most?"
+
+**Vague dimensions**
+- Bad: "Strategic alignment", "Culture fit"
+- Good: "% of roadmap you control", "Team turnover rate"
+- Fix: Demand concrete measurement criteria
+
+**No-control dimensions**
+- Bad: "Market timing", "Regulatory environment"
+- Good: "Entry timing choice", "Sector selection"
+- Fix: Reframe to controllable version or drop
+
+**Overfitted dimensions**
+- Bad: Separate dims for "email velocity" and "slack response time"
+- Good: Single "communication cadence" dimension
+- Fix: Collapse correlated dials
+
+**Hidden dependencies**
+- Check: If dimension X is high, does that force dimension Y?
+- Fix: Keep only the upstream dimension or treat as constraint
+
+## Advanced Techniques
+
+### Constraint Handling
+Some factors are binary gates, not dimensions:
+- "Must be remote" → constraint, not dimension
+- "Salary > $X" → threshold, not slider
+- Apply constraints first, dimensionalize remaining space
+
+### Weighting
+Context determines relative importance:
+- New parent → boost lifestyle stability weight
+- Early career → boost skill compounding weight
+- Pre-exit → boost value capture weight
+
+### Dimension Discovery via Rhyme
+Stuck on dimensions? Use the Rhyme skill:
+- "What is this decision structurally similar to?"
+- Import proven dimensions from analogous domain
+- Example: Career choice ← Athletic training ← Research project
+
+### Meta-Dimensionalization
+You can dimensionalize the dimensions themselves using F·L·C scores to validate your framework
+
+## Integration with Other Skills
+
+**Rhyme:** Find analogous systems, borrow their dimensions
+**Metaphorize:** Port complete dimension frameworks across domains
+
+## Quality Checklist
+
+Before finalizing dimensionalization:
+
+- [ ] 3-7 dimensions total (not too many, not too few)
+- [ ] Each dimension: F ≥ 3.5
+- [ ] Each dimension: L ≥ 3.5
+- [ ] Each dimension: C ≤ 2.5
+- [ ] Can score 5+ real options on each dimension
+- [ ] Dimensions are relatively independent
+- [ ] Covers 80%+ of what matters
+- [ ] Can hold all dimensions in working memory
+- [ ] Each dimension has clear measurement criteria
+- [ ] Each dimension has identifiable control lever
+
+## When NOT to Use
+
+Avoid dimensionalization for:
+- Simple binary choices (overhead exceeds value)
+- Pure gut decisions (some things resist analysis)
+- Time-critical decisions (use faster heuristics)
+- When excellent framework already exists
+- Emotionally fraught choices where analysis obscures values
+
+## References
+
+For theoretical foundation:
+https://www.lesswrong.com/posts/LSFiKt4zGxXcX2oxi/dimensionalization
+
+For practical examples:
+https://jordanmrubin.substack.com/p/use-ai-to-dimensionalize
+
+Canonical definitions:
+https://github.com/jordanrubin/FUTURE_TOKENS/blob/main/dimensionalize.md

--- a/src/shared/tools/definitions/analysis/dimensionalize.ts
+++ b/src/shared/tools/definitions/analysis/dimensionalize.ts
@@ -1,0 +1,43 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `dimensionalize.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './dimensionalize.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.dimensionalize',
+  name: 'Dimensionalize',
+  category: 'analysis',
+  description: 'Reduce a decision to 3-7 measurable dimensions',
+  longDescription:
+    'Pulls the load-bearing dimensions out of a fuzzy decision or comparison: 3-7 axes you could ' +
+    'actually measure or rank along. Each dimension comes with what it would mean to score "high" or ' +
+    '"low" and which existing arguments engage it. Reach for this before evaluating options head-to-head.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  parameters: [
+    {
+      id: 'target_count',
+      label: 'Target dimension count',
+      type: 'select',
+      options: [
+        { label: 'Tight — 3 dimensions', value: '3' },
+        { label: 'Standard — 5 dimensions', value: '5' },
+        { label: 'Generous — 7 dimensions', value: '7' },
+      ],
+      defaultValue: '5',
+    },
+  ],
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const target = ctx.parameterValues?.target_count ?? '5';
+    const directive = `\n\nTarget dimension count: aim for ~${target}; deviate only if the source genuinely demands more or fewer.`;
+    return SYSTEM_PROMPT + directive + analysisSourceBlock(ctx);
+  },
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'extract the dimensions'),
+});

--- a/src/shared/tools/definitions/analysis/handlize.prompt.md
+++ b/src/shared/tools/definitions/analysis/handlize.prompt.md
@@ -1,0 +1,89 @@
+
+# handlize
+
+handlize strips rhetoric, tests novelty, and returns only **handles**—concepts or distinctions with operational grip. It answers: **"what here could actually change what I do?"** Not summary, not critique—just residue extraction.
+
+## Definition: what counts as a handle
+
+A handle is a concept, frame, or distinction that:
+- **Constrain or enable action:** changes what decisions or designs are viable.
+- **Operationalizable:** can be measured, modeled, or intervened on.
+- **Non-rhetorical:** not merely a justification or applause light.
+
+Each handle is classified by context as **live** (executable, low decay), **burned** (real referent but term degraded), or **dead** (no operational content).
+
+## Dials
+
+| Dial | Range | Purpose | Failure modes |
+| --- | --- | --- | --- |
+| **Extraction strictness** | permissive → strict | How aggressively to discard non-executable material | Too permissive → summary drift; too strict → false negatives |
+| **Novelty threshold** | contextual → primitive | How new a concept must be | Too low → repackaged common sense; too high → only research-grade ideas |
+| **Operational demand** | sketch → concrete | How fully the handle must be cashed out | Too low → vibes pass; too high → early ideas rejected |
+| **Burned handle policy** | ignore / drop / rehabilitate | How to treat socially degraded terms | Ignore → buzzword drift; drop → lose real phenomena; rehabilitate → raises operational demand for burned terms |
+
+**Implicit dial: context.** Always state which domain/audience/problem frame is assumed; handle status is context-relative.
+
+## When to use
+- A text feels dense but unclear which ideas change action.
+- You need to separate executable concepts from rhetoric before planning.
+- You want to rehabilitate or discard buzzwords based on operational content.
+
+## When not to use
+- You need a summary or critique (use @synthesize / @antithesize).
+- There is no concrete situation or audience—context-free inputs make status classification meaningless.
+
+## Core operation (high-level)
+1. **Strip rhetorical mass:** drop throat-clearing, prestige adjectives, moral signaling, and audience-calibration fluff.
+2. **Identify candidate handles:** claims, frames, or distinctions that would shift choices or protocols.
+3. **Test candidates:** actionability, operationalizability, novelty relative to context.
+4. **Classify status:** live vs burned vs dead (context-aware). Burned terms must be operationalized to survive.
+5. **Check gestalt risk:** if decomposition loses causal grip, preserve as a single handle and flag **gestalt-dependent**.
+6. **Output executable residue:** only handles that pass the tests; allow null output if none survive.
+
+## Process (explicit steps)
+1. **Set context + dials:** state assumed domain/audience/problem; set strictness, novelty, operational demand, burned-handle policy; note interactions (rehabilitate ⇒ higher operational bar for burned terms).
+2. **Remove rhetorical mass:** excise non-load-bearing rhetoric; keep just enough wording to preserve candidate meaning.
+3. **Harvest candidates:** pull any concept, frame, or distinction implying different decisions, models, or interventions.
+4. **Evaluate each candidate:**
+   - Actionability: would this change a decision boundary, design, or protocol?
+   - Operationalizability: can it be expressed in variables, mechanisms, metrics, or levers?
+   - Novelty: is it new to this context vs just renamed common sense?
+5. **Classify status (context-relative):**
+   - **Live:** executable, underused, low decay.
+   - **Burned:** real referent but term degraded; keep only if operationalized (and raise operational demand when policy = rehabilitate).
+   - **Dead:** no operational content; drop.
+6. **Gestalt check:** if breaking into parts removes causal grip, keep it as one handle and mark **gestalt-dependent**.
+7. **Emit residue:** use the output schema; include a null result if nothing survives.
+
+## Output schema (required)
+
+For each surviving handle:
+- **handle:** concise formulation
+- **status:** live | burned | dead
+- **context:** assumed domain/audience
+- **why it matters:** what action, model, or decision it enables
+- **operationalization sketch:** variables, mechanism, possible measurement or test (for live/burned)
+- **gestalt-dependent:** yes | no
+
+If no handles survive: state **"no executable residue found"** and briefly why.
+
+## Quality criteria
+- States context and dial settings up front.
+- Discards rhetoric without erasing candidate meaning.
+- Distinguishes live vs burned vs dead with justification.
+- Raises operational bar when rehabilitating burned terms.
+- Flags gestalt dependence instead of fragmenting useful constructs.
+- Allows null output; no forced handles.
+
+## Common failure modes to avoid
+- **Summary drift:** turning into a tidy recap instead of residue extraction.
+- **Buzzword laundering:** relabeling burned terms without mechanism.
+- **False novelty:** treating reframes of common sense as new handles.
+- **Over-rehabilitation:** rescuing concepts that were always empty.
+- **Over-pruning:** strictness so high that viable proto-handles are dropped.
+
+## Examples (abbreviated)
+- **Live:** "orgs as simulable dynamical systems, not static snapshots" → enables modeling flows and interventions.
+- **Burned (rehabilitated):** "alignment" in corporate strategy → only keep if tied to measurable gradient matching between stated objectives and incentives.
+- **Dead:** "future-proofing" → no operational content; drop.
+

--- a/src/shared/tools/definitions/analysis/handlize.ts
+++ b/src/shared/tools/definitions/analysis/handlize.ts
@@ -1,0 +1,26 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `handlize.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './handlize.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.handlize',
+  name: 'Handlize',
+  category: 'analysis',
+  description: 'Extract operational "handles" — short phrases you can grab and use',
+  longDescription:
+    'Pulls operational handles out of arguments or narratives — short, memorable phrases that compress ' +
+    'a load-bearing idea so you can wield it later. Think Pithy-Stickers, not summaries: each handle ' +
+    'is a one-line lever you can apply to other situations.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'extract the handles'),
+});

--- a/src/shared/tools/definitions/analysis/inductify.prompt.md
+++ b/src/shared/tools/definitions/analysis/inductify.prompt.md
@@ -1,0 +1,181 @@
+
+# inductify
+
+inductify extracts non-obvious structural commonalities across multiple substantial examples. It identifies latent patterns, shared mechanisms, axiological rhymes, and parallel constraint-structures. Unlike rhyme (lightweight analogy), inductify is heavy induction: decomposing each case, cross-referencing mechanisms, and stress-testing emergent generalizations. The goal is to reveal transferable structure without hallucinating spurious patterns.
+
+**TL;DR:** inductify → derive latent structure from n≥2 examples.
+
+It asks: "what hidden mechanisms, assumptions, values, or constraints recur across these cases—and why?" The output is predictive, falsifiable pattern-families, not vibes.
+
+## When to use
+
+Use inductify when:
+- You have multiple substantial cases (≥2 paragraphs each)
+- Surface similarity feels unsatisfying
+- You want cross-case structure, principles, mechanisms
+- You want a heuristic or generalization grounded in evidence
+- You're noticing a rhyme but don't yet know the shape
+
+Don't use when:
+- You only have one example
+- Examples are nearly identical
+- You need deduction, not induction
+
+Rule of thumb: inductify = pattern extraction + mechanism grounding + predictive slack.
+
+## Input requirements
+
+Inductify must judge and tag input richness.
+
+- 1 sentence → REJECT — insufficient material for induction
+- 2–3 sentences → MARGINAL — proceed with [LOW ROBUSTNESS] tag
+- 2+ paragraphs → MINIMUM viable
+- 2+ essays/cases → IDEAL — robust induction surface
+
+For n=2, default robustness → fragile unless examples are unusually rich and diverse.
+
+## Pattern domains to scan
+
+- **Structural:** shared mechanisms, causal gears; isomorphic constraints; parallel failure modes; phase transitions and thresholds
+- **Epistemic:** common assumptions; evidence-shape similarities; inference parallelism; uncertainty topology
+- **Axiological:** shared values and priorities; similar optimization targets; parallel moral/goal tradeoffs
+- **Behavioral:** recurring strategies; common adaptation patterns; attractor dynamics; escalation symmetries
+- **Temporal:** common rhythms, cycles, origin/decay patterns; trigger → response latencies
+
+## Signature
+
+```
+inductify(examples[], focus?) → {obvious, induced_patterns, pattern_families, confidence, next_moves}
+  examples[]: list of ≥2 substantial cases
+  focus: optional domain emphases (structural | epistemic | axiological | behavioral | temporal)
+```
+
+Output includes:
+- Obvious similarities (acknowledged + dismissed)
+- Induced patterns (ranked, mechanistic, predictive, falsifiable)
+- Pattern families (clustered latent factors)
+- Confidence calibration
+- Recommended next moves
+
+## Process
+
+**Step 0: Validate input**
+- Count examples and assess richness
+- If insufficient, return rejection + rationale
+- If marginal, proceed with [LOW ROBUSTNESS] tag
+
+**Step 1: Surface the obvious (table stakes)**
+- List shared surface features anyone would notice; tag as [surface]
+- Do not promote these as induced patterns by default
+- Purpose: clear cognitive space for deeper structure
+- If something is obvious but profound, it may be re-promoted later only if it meets mechanism + predictive criteria (tag [plain-sight deep structure])
+
+**Step 2: Decompose each example**
+For each instance, extract:
+- Mechanisms (how it works)
+- Assumptions (what must be true)
+- Values (what's optimized)
+- Constraints (what limits action)
+- Outcomes (what happened / is expected)
+- Optionally integrate @excavate for deeper assumption-archaeology.
+
+**Step 3: Cross-reference**
+- Build a loose comparison matrix across examples
+- Identify non-obvious overlaps and structural isomorphisms (different content, same shape)
+- Identify absent commonalities (negative-space patterning): properties you'd expect to be shared but are not
+- Tag candidate patterns by domain (structural / epistemic / axiological / behavioral / temporal)
+
+**Step 4: Rank + mechanism-ground**
+Score candidate patterns by:
+- Non-obviousness (relative to table stakes)
+- Explanatory power (how much variance they account for)
+- Mechanism strength (causal / constraint / info-flow)
+- Predictive slack (what they say about unseen cases)
+
+Discard the weak; elevate the few strong. Fewer strong patterns > many weak ones.
+
+Each promoted pattern must specify:
+- What: description
+- Evidence: how it appears in each example
+- Mechanism: why it recurs (causal, constraint, or information-flow)
+- Surprise-level: [plain-sight deep structure / non-obvious subtle]
+- Predictive claim: implication for a new case
+- Breaking condition: what would falsify it
+- Span: [narrow / moderate / broad applicability]
+
+Cluster patterns into pattern families where they share a latent factor (e.g., "status-protection dynamics," "coordination-friction," "exploration–exploitation tension").
+
+**Step 5: Stress-test induction**
+- Test each major pattern against a hypothetical (n+1)th example
+- Explicitly ask: what would break this pattern? (boundary conditions)
+- Perform a base-rate sanity check: is this relationship actually unusual in the domain?
+- Actively search for counter-patterns with comparable effort
+- Tag any pattern with weak gears as [MECHANISM UNKNOWN] or downgrade robustness
+
+## Output format
+
+```
+## obvious similarities (acknowledged + set aside)
+- [surface 1]
+- [surface 2]
+
+## induced patterns (ranked by leverage)
+
+### 1. [pattern name]
+- what: ...
+- evidence: ...
+- mechanism: ...
+- surprise-level: [plain-sight deep structure / non-obvious subtle]
+- predictive claim: ...
+- breaking condition: ...
+- span: [narrow / moderate / broad]
+
+### 2. [pattern 2]
+...
+
+## pattern families
+- [family name]: [brief description of shared latent factor + member patterns]
+
+## confidence calibration
+- input richness: [sparse / adequate / rich]
+- robustness: [fragile / moderate / strong]
+- spurious-risk: [high / medium / low]
+- meta-risk: [selection bias / narrative smoothing / anthropic filtering]
+
+## suggested next moves
+- test strongest pattern(s) on a new case
+- @stressify the highest-leverage induction
+- @operationalize any pattern that you want to turn into a heuristic
+- gather targeted evidence to confirm/disconfirm edge cases
+```
+
+## Quality criteria
+
+- Input validated: ≥2 substantial examples, richness tagged
+- Obvious similarities surfaced and explicitly excluded from induced patterns by default
+- Non-obvious patterns prioritized; count kept small and strong
+- Mechanisms explicit and plausible (or tagged [MECHANISM UNKNOWN])
+- Predictions + falsifiers specified for each major pattern
+- Pattern families identified where latent factors exist
+- Base-rate sanity check performed (is this pattern actually interesting?)
+- Negative space considered (what's conspicuously not shared)
+- Calibrated confidence including meta-risks
+
+## Anti-patterns
+
+- **Shallow reformulation:** pattern merely rephrases the surface similarity
+- **Overfitting to n=2:** pattern is perfectly tailored but has no predictive slack
+- **Mechanism-free mysticism:** "deep pattern" with no gears; must be tagged [MECHANISM UNKNOWN] or discarded
+- **Galaxy-brain pareidolia:** connections too subtle to be real; base-rates + counterexamples disagree
+- **Confirmation bias:** pattern suspiciously aligned with prior belief; no serious search for alternatives
+
+## Integration with other ops
+
+- **Upstream:** @framestorm → generate candidate lenses before pattern-search; @excavate → prep each example's assumption stack
+- **Downstream:** @operationalize → convert robust pattern → actionable heuristic or rule-of-thumb; @stressify → adversarially test the most important inductions
+- **Parallel:** @rhyme → lightweight analogical patterning (lower effort, lower rigor); @metaphorize → single-source mapping (one example to a new domain), versus multi-source induction
+
+## Meta-note
+
+inductify = structured induction + mechanistic grounding + negative-space awareness + calibrated scope. Its job is not to generate pretty generalizations; it's to extract robust, falsifiable structure from messy particulars and make clear where you're extrapolating vs guessing.
+

--- a/src/shared/tools/definitions/analysis/inductify.ts
+++ b/src/shared/tools/definitions/analysis/inductify.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `inductify.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './inductify.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.inductify',
+  name: 'Inductify',
+  category: 'analysis',
+  description: 'Cross-example pattern extraction — what underlies these cases?',
+  longDescription:
+    'Given several cases, examples, or anecdotes, extracts the unifying pattern behind them. Output is ' +
+    'a stated regularity plus the cases it covers and the cases that resist it — calibrated, not ' +
+    'sweeping. Reach for this when you have a pile of "kinda similar" things and need to name what ' +
+    'actually links them.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'extract the inductive pattern'),
+});

--- a/src/shared/tools/definitions/analysis/metaphorize.prompt.md
+++ b/src/shared/tools/definitions/analysis/metaphorize.prompt.md
@@ -1,0 +1,561 @@
+
+# Metaphorization
+
+## Overview
+
+**Metaphorization** builds an explicit, high-coverage mapping from a familiar source **s** onto a live target **t** so that rules, heuristics, and intuitions from **s** can be systematically **ported** into testable hypotheses or prompts for **t**. 
+
+Heavier than tier-2 **rhyme**; lighter than a fully formal mapping. Preserve as many invariants as are useful; fence off the rest. When **s** has math, **carry the math**: equations, units, objective functions, constraints, and standard metrics.
+
+Claude should use this Skill when the user:
+- Explicitly asks to "metaphorize" something
+- Has identified a good rhyme and wants complete structural mapping
+- Needs to transfer strategy/rules from one domain to another systematically
+- Wants to port mathematical formalism across domains
+- Says "build the full mapping" or "what transfers from X to Y?"
+- Needs testable hypotheses from cross-domain analogy
+
+## How It Runs
+
+### 1. Select Source (s)
+Pick a domain with robust, worked rules that meaningfully fits **t**.
+
+**Quality criteria:**
+- Mature formalism (equations, metrics, known failure modes)
+- Structural similarity to target (from rhyme analysis)
+- Rich playbook of proven strategies
+- Well-understood constraints and invariants
+
+### 2. List Primitives
+Enumerate entities, relations, operations in **s** that drive behavior.
+
+**Entity types:**
+- Objects/agents (patients, servers, tokens)
+- Resources (capacity, budget, attention)
+- States (waiting, processing, complete)
+- Flows (arrival, departure, transformation)
+- Control structures (gates, priorities, feedback loops)
+
+### 3. Mine Formalism & Metrics (MANDATORY when available)
+Harvest **s**'s named formulas, laws, and scorekeeping:
+
+**Equations & Constraints:**
+- Little's Law, Bayes' theorem, PID control
+- Stock-flow equations, hazard functions
+- Markov chains, S-curves, learning curves
+- Conservation laws, balance equations
+
+**Objective/Penalty Functions:**
+- Loss functions, regret measures
+- Cost of delay, opportunity cost
+- Utility functions, risk premiums
+
+**Standard Metrics:**
+- SLA/SLO definitions
+- Brier/log-loss/AUC scores
+- Throughput, WIP, cycle time
+- Quality gates, defect rates
+
+**Units & Dimensions:**
+- Carry units explicitly
+- Perform dimensional analysis
+- Check unit consistency across mapping
+
+**Parameter Sets:**
+- Parameters needing estimation (θ)
+- Priors/bounds on parameters
+- Data requirements for fitting
+- Validation strategies
+
+### 4. Draft Mapping `m : s → t`
+Name counterparts in **t** for each primitive in **s**. Mark gaps. Attach adapters with typed signatures.
+
+**Adapter examples:**
+```
+priority_s:int → class_t:{p0,p1,p2,p3}
+severity_s → risk_t := p(event) × impact
+rate_s [1/time] → rate_t [items/day]
+capacity_s [beds] → capacity_t [parallel workers]
+```
+
+**Mapping table format:**
+| Source (s) | Target (t) | Adapter | Units |
+|------------|------------|---------|-------|
+| Entity_s | Entity_t | Type signature | [units] |
+
+### 5. Name Invariants (Make them checkable)
+Specify transforms/constraints from **s** to preserve under **m**, **with units**. Write as assertions or tests.
+
+**Invariant categories:**
+- Queue discipline (FIFO, priority, preemptive)
+- Conservation laws (mass, energy, tokens)
+- Budget constraints (capacity, time, money)
+- Escalation semantics (how priorities change)
+- Feedback loops (positive/negative, sign)
+- Stability conditions (ρ < 1, convergence)
+
+**Format as testable assertions:**
+```
+ASSERT: λ < c·μ  (stability condition)
+ASSERT: sum(inflow) = sum(outflow) + Δstock  (conservation)
+ASSERT: high_priority_wait < low_priority_wait  (priority discipline)
+```
+
+### 6. Metric Plan
+Define how success/failure will be measured in **t**:
+
+**Primary metrics:** Target values, acceptable ranges
+**Secondary metrics:** Supporting indicators
+**Counter-metrics:** What you refuse to optimize
+**Baselines:** Current state, historical average
+**Acceptance thresholds:** Pass/fail criteria
+**Evaluation cadence:** How often to measure
+
+### 7. Estimation & Calibration
+Lay out how θ will be identified/fit:
+
+**Estimation method:** MLE, MAP, robust regression, Bayesian updating
+**Data needed:** Sample size, time window, granularity
+**Sampling window:** Historical period for fitting
+**Validation strategy:** Cross-validation, holdout, backtesting
+**Error decomposition:** Bias/variance, aleatoric/epistemic
+
+### 8. Package
+Compress into a table/diagram/substitution kit + a **formula shelf** others can apply without you.
+
+**Deliverables:**
+- Primitive mapping table
+- Formula shelf with relabeled equations
+- Invariant list with units
+- Metric plan with baselines
+- Worked examples (rule-throughs)
+- Explicit exclusion list
+
+### 9. Probe
+Run representative rules from **s** through **m**; compute; compare to baselines; note failure modes at the seam.
+
+**Test protocol:**
+- Select 3-5 core rules from **s**
+- Apply mapping to translate to **t**
+- Compute numerical predictions
+- Compare to observed behavior in **t**
+- Document where mapping breaks
+
+## Parameters (Knobs)
+
+| Knob | Range / Values | Effect |
+|------|----------------|--------|
+| **tightness** | loose ↔ strict | Similarity required to accept the map |
+| **coverage** | sparse ↔ broad | Fraction of **s** given counterparts in **t** |
+| **invariant count** | few ↔ many | How much disciplined behavior is demanded |
+| **invariant strength** | soft hints ↔ hard constraints | How binding the invariants are during transfer |
+| **scope** | local element ↔ process ↔ system | Region of **t** the map is allowed to touch |
+| **directionality** | s→t / t→s / bidirectional | Where rules originate vs interrogated |
+| **claim strength** | framing ↔ hypothesis ↔ provisional policy | Rhetorical weight of the mapping |
+| **medium** | words / diagram / table / code / equations | Packaging; affects reuse and error rate |
+| **exclusion clarity** | informal notes ↔ explicit exclusion set | Leak-prevention fidelity |
+| **test budget** | quick spot-checks ↔ adversarial stress tests | Confidence in transfer |
+| **source maturity** | folk schema ↔ codified playbook | Reliability of imported intuition |
+| **math depth** | heuristics ↔ relabeled, unitful equations | Extent of formal carryover |
+| **unit fidelity** | implicit ↔ explicit units + dim. analysis | Prevents type errors across the seam |
+| **metric rigor** | vanity counts ↔ decision-useful eval w/ baselines | Quality of scorekeeping |
+
+## Output Format
+
+A compact **translation guide** `m(s → t)`—shareable and reusable—plus:
+
+### Formula Shelf
+Relabeled equations/constraints with units and variable glossary
+```
+[Formula Name]
+Source: [equation in s notation]
+Target: [equation in t notation]
+Variables: [glossary with units]
+Constraints: [parameter bounds]
+Estimation: [how to fit θ]
+```
+
+### Hypothesis Set
+What should be true in **t** if the map holds (quantified)
+```
+H1: [quantified prediction with units]
+H2: [quantified prediction with units]
+...
+Test protocol: [how to validate]
+```
+
+### Rule-Throughs
+Worked examples `rule_s ⟶ rule_t` with numbers
+```
+Rule in s: [description]
+Numerical example in s: [with units]
+Mapped to t: [description]
+Numerical example in t: [with units]
+Prediction: [what should happen]
+```
+
+### Metric Sheet
+Primary/secondary metrics, targets, and review cadence
+
+## Detailed Example: GitHub Issues ← ER Triage
+
+**Target (t):** Backlog of GitHub issues  
+**Source (s):** Hospital emergency-room triage (queueing + priority scheduling)
+
+### Primitive Mapping
+
+| s (ER) | t (Issues) | Adapter | Units |
+|--------|------------|---------|-------|
+| patient | ticket | 1:1 | [entities] |
+| triage nurse | intake bot | 1:1 | [agent] |
+| severity level | priority class | severity:int → {p0,p1,p2,p3} | [class] |
+| attending physician | ticket owner | 1:1 | [agent] |
+| beds / staff | parallel servers (devs) | beds:int → devs:int, capacity `c` | [workers] |
+| arrival rate `λ` | issue inflow | λ:[patients/hr] → λ:[issues/day] | [1/time] |
+| service rate `μ` | resolve rate per dev | μ:[patients/hr/doc] → μ:[issues/day/dev] | [1/time/worker] |
+| utilization `ρ=λ/(cμ)` | load factor | direct port | [dimensionless] |
+| wait-time SLA | breach threshold | direct port with adapted time units | [time] |
+
+### Preserved Structure (with Math)
+
+**Little's Law:**
+```
+Source: L = λ·W  [patients = (patients/hr)·(hr)]
+Target: Backlog = λ·W  [issues = (issues/day)·(days)]
+Invariant: Conservation of items in system
+```
+
+**Stability Condition:**
+```
+Source: ρ = λ/(c·μ) < 1  (stable queue)
+Target: ρ = λ/(c·μ) < 1  (stable backlog)
+Invariant: If λ ≥ c·μ, queue grows without bound
+Action: Must throttle intake or add capacity
+```
+
+**Priority Discipline:**
+```
+Source: Preemptive priority reduces W for high severity at cost to low
+Target: P0 issues reduce cycle time for critical bugs at cost to P3 features
+Invariant: W_high < W_low when priority enforced
+```
+
+**Handoff Protocol:**
+```
+Source: Patient reassignment requires explicit attending acknowledgment
+Target: Issue reassignment requires explicit owner acceptance
+Invariant: No orphaned work items
+```
+
+### Rule-Through (Numerical)
+
+**Scenario:** Unstable queue
+
+**Given parameters:**
+- λ = 5 issues/day (measured from last 30 days)
+- μ = 2 issues/day/dev (historical average)
+- c = 2 devs (current team)
+
+**Calculation:**
+```
+ρ = λ/(c·μ) = 5/(2·2) = 1.25 > 1  ⟹  UNSTABLE
+```
+
+**Interpretation:** Queue will grow without bound. Backlog accumulates faster than resolution.
+
+**Options to restore stability (ρ < 1):**
+
+(a) **Raise c to 3 devs:**
+```
+ρ = 5/(3·2) = 0.833 < 1  ✓ stable
+Expected backlog reduction: ~40%
+```
+
+(b) **Reduce λ via intake gate:**
+```
+Target: λ = 3 issues/day
+ρ = 3/(2·2) = 0.75 < 1  ✓ stable
+Method: Stricter triage, merge similar issues
+```
+
+(c) **Increase μ via process improvement:**
+```
+Target: μ = 2.5 issues/day/dev
+ρ = 5/(2·2.5) = 1.0  (marginal stability)
+Method: Swarming, reduce non-work items, automation
+```
+
+**New SLA:** Set `P(W > 5 days) < 0.05` and monitor weekly
+
+### Metrics
+
+**Primary metrics:**
+- Cycle time [days] - time from open to close
+- Breach rate [%] - fraction exceeding SLA
+- ρ [dimensionless] - utilization factor
+- Throughput [issues/day] - completion rate
+- Age of WIP [days] - time issues spend in progress
+
+**Secondary metrics:**
+- Preemption count [count/week] - priority overrides
+- Handoff latency [hours] - time for owner acceptance
+- Reopen rate [%] - fraction reopened after close
+
+**Counter-metrics (refuse to optimize):**
+- Issue close rate if quality drops
+- Dev velocity if measured narrowly
+
+**Evaluation:**
+- Weekly CFD (cumulative flow diagram)
+- Alert when ρ crosses 0.9
+- Alert when P0 cycle time slope ↑ two weeks running
+
+### Breakpoints (Explicit Exclusions)
+
+**Does NOT port from ER to issues:**
+- Mortality consequences (life/death stakes)
+- Informed consent requirements
+- Bedside manner / patient care ethics
+- HIPAA compliance
+- Physical resource constraints (ambulances, equipment)
+- Triage under mass casualty protocols
+
+**Why these matter:** Prevents overreach where high-stakes medical decision-making ethics get inappropriately mapped to software bug prioritization.
+
+## Dimensionalization of Metaphorization Quality
+
+Score mappings on these dimensions (0.0 → 1.0):
+
+### 1. Pillar Integrity
+Do exclusions avoid cutting the beams the map stands on?
+- **0.0** = Nukes a core transform
+- **0.5** = Some bleed between preserved/excluded
+- **1.0** = Exclusions orthogonal to core structure
+
+### 2. Counterpart Clarity  
+Unambiguous primitive mapping (1→1 or explicit 1→n with adapters)?
+- **0.0** = Mushy "this ≈ that"
+- **0.5** = Mostly crisp
+- **1.0** = Crisp with documented degeneracy
+
+### 3. Invariant Set Quality
+Preserved bits are operators/constraints (queues, budgets, feedback), not motifs
+- **0.0** = Ornaments only
+- **0.5** = Roles/flows align
+- **1.0** = Core transforms that do computational work
+
+### 4. Formal Leverage
+Portable math/algorithms carried (Little's law, PID, Bayes, stock-flow, hazard)
+- **0.0** = No formalism
+- **0.5** = Heuristics + back-of-envelope
+- **1.0** = Named equations with units + glossary
+
+### 5. Adapter Load
+How many/complex adapters to make types line up?
+- **0.0** = Adapter spaghetti
+- **0.5** = A few shims
+- **1.0** = Minimal, typed, local adapters
+
+### 6. Failure Localization
+Do errors surface at the seam they're caused (good metaphors fail noisily)?
+- **0.0** = Errors smear across domains
+- **0.5** = Sometimes localized
+- **1.0** = Seam-tight: breakpoints catch misuse
+
+### 7. Scope & Edge Crispness
+Bounded region where map holds + explicit edges
+- **0.0** = Grand theory / toy slice
+- **0.5** = Process-level scope
+- **1.0** = Process↔system slice with clear borders
+
+### 8. Metric Rigor
+Are we scoring what matters with baselines/thresholds?
+- **0.0** = Vanity counts
+- **0.5** = Mixed useful/vanity
+- **1.0** = Decision-useful eval with counter-metrics
+
+### 9. Unit Discipline
+Explicit units + dimensional checks?
+- **0.0** = Unitless vibes
+- **0.5** = Partial unit tracking
+- **1.0** = Unit-clean throughout with dimensional analysis
+
+**Quality threshold:** Strong metaphors score ≥0.7 on formal leverage, counterpart clarity, invariant set quality, and unit discipline.
+
+## Formula Shelf (Starter Kit to Port)
+
+### Queueing Theory
+```
+Little's Law: L = λ·W
+  L: average items in system [items]
+  λ: arrival rate [items/time]
+  W: average time in system [time]
+
+M/M/1 Queue Wait: W_q = ρ/(μ-λ)
+  ρ: utilization = λ/μ [dimensionless]
+  μ: service rate [items/time]
+  
+M/M/c Stability: ρ = λ/(c·μ) < 1
+  c: number of servers [count]
+```
+
+### Bayesian Inference
+```
+Bayes' Theorem: P(H|D) ∝ P(D|H)·P(H)
+  H: hypothesis
+  D: data
+  
+Calibration metrics:
+  Brier score: (1/N)Σ(f_i - o_i)²
+  Log loss: -(1/N)Σ[o_i·log(f_i) + (1-o_i)·log(1-f_i)]
+```
+
+### Control Theory
+```
+PID Controller: u(t) = K_p·e(t) + K_i·∫e(t)dt + K_d·de/dt
+  e(t): error = setpoint - measurement
+  u(t): control signal
+  K_p, K_i, K_d: tuning parameters
+  
+Map e to: gap vs target metric
+```
+
+### Stock-Flow Accounting
+```
+Stock Evolution: stock_{t+1} = stock_t + inflow - outflow
+  All terms must have same units [items]
+  Conservation: Δstock = ∫(inflow - outflow)dt
+```
+
+### Survival Analysis
+```
+Survival Function: S(t) = exp(-∫₀ᵗ h(τ)dτ)
+  h(t): hazard rate [1/time]
+  S(t): probability of surviving past time t
+  
+Applications: retention, time-to-defect, churn
+```
+
+### Learning Curves
+```
+Experience Curve: cost ∝ n^(-β)
+  n: cumulative production [units]
+  β: learning rate [dimensionless]
+  
+Map to: throughput/quality improvements over time
+```
+
+**Usage:** For each formula:
+1. Relabel variables for target domain
+2. Specify units explicitly
+3. Document parameter estimation plan
+4. List data requirements
+5. Define validation tests
+
+## Common Pitfalls & Patches
+
+| Pitfall | Symptom | Patch |
+|---------|---------|-------|
+| **Underreach** | Vibes-only mapping; no formulas/units/metrics | Run steps 3-7; build formula shelf; add unit checks + metric sheet |
+| **Leakage** | Irrelevant parts of **s** infect **t** | Expand exclusion set; make non-ports explicit |
+| **Overreach** | Mapping treated as truth | Keep invariants listed; label as provisional scaffold |
+| **Mushy primitives** | Ambiguous counterparts | Reduce coverage; redefine crisper primitives first |
+| **Cliché drag** | Stale metaphors bias attention | Generate counter-maps; prefer cleaner, less-worn sources |
+| **Untested transfer** | No friction checks | Run adversarial rule-throughs; hunt contradictions/edges |
+| **Unit errors** | Dimensional mismatches | Add explicit unit tracking; run dimensional analysis |
+| **Metric confusion** | Vanity metrics vs decision-useful | Add counter-metrics; demand baselines and thresholds |
+
+## Downstream Moves & Compounding
+
+### Dimensionalize
+Score the map's complexity, leverage, fidelity; pick the best among alternative mappings
+
+**Process:**
+1. Generate 2-3 candidate metaphors
+2. Score each on the 9 quality dimensions
+3. Select highest-scoring map (≥0.7 on key dimensions)
+
+## Integration Protocol
+
+### Rhyme → Metaphorize Pipeline
+1. Use Rhyme to identify 3-5 candidate source domains
+2. Score candidates on quality dimensions from Rhyme skill
+3. Select best source (high on parallel density, source maturity, transfer leverage)
+4. Run full Metaphorization protocol on selected source
+5. Validate with rule-throughs and numerical examples
+
+### Metaphorize → Dimensionalize Pipeline
+1. Complete metaphor mapping
+2. Use Dimensionalize to evaluate mapping quality
+3. Score on F·L·C criteria
+4. Refine mapping based on dimension scores
+
+## Quality Checklist
+
+Before finalizing metaphorization:
+
+- [ ] Primitive mapping table complete with adapters
+- [ ] All carried formulas have explicit units
+- [ ] Dimensional analysis performed (units consistent)
+- [ ] Invariants listed as testable assertions
+- [ ] Metric plan includes baselines and thresholds
+- [ ] Counter-metrics identified (what not to optimize)
+- [ ] Exclusion list explicit and documented
+- [ ] 3+ rule-throughs with numerical examples
+- [ ] Estimation/calibration plan for parameters
+- [ ] Scored ≥0.7 on: formal leverage, counterpart clarity, invariant quality, unit discipline
+- [ ] Probed for failure modes at domain seam
+- [ ] Packaged for reuse (formula shelf, glossary, worked examples)
+
+## When NOT to Use
+
+Avoid metaphorization for:
+- Domains without rich formalism (use rhyme instead)
+- When precise formal proof required (use mathematical modeling)
+- Source domain poorly understood (strengthen source knowledge first)
+- Target domain too different (poor rhyme scores)
+- Time-critical decisions (too heavyweight)
+- When simple heuristics suffice
+
+## Advanced Techniques
+
+### Multi-Source Synthesis
+Combine mappings from multiple source domains:
+```
+Domain A → [process flow]
+Domain B → [resource allocation]  
+Domain C → [failure modes]
+Synthesized map: composite structure
+```
+
+### Bidirectional Mapping
+Map s↔t instead of just s→t:
+- Validates symmetry of structure
+- Reveals hidden assumptions
+- Tests for accidental complexity
+
+### Adaptive Mapping
+Evolve mapping over time as understanding deepens:
+- Version mappings (v1.0, v1.1, etc.)
+- Track which predictions held/failed
+- Refine based on empirical validation
+
+### Constraint-Based Mapping
+Specify hard requirements on mapping:
+- "Must preserve conservation laws"
+- "Must carry at least 3 equations"
+- "Exclusions must be orthogonal to core"
+
+## References
+
+Canonical definition:
+https://github.com/jordanrubin/FUTURE_TOKENS/blob/main/metaphorize.md
+
+Examples and workflows:
+https://jordanmrubin.substack.com/p/conceptual-rhyme-and-metaphor
+
+Related concepts:
+- Structure mapping theory (Gentner)
+- Analogical reasoning (Hofstadter)
+- Dimensional analysis (Buckingham π theorem)
+- Queueing theory (Kendall notation)

--- a/src/shared/tools/definitions/analysis/metaphorize.ts
+++ b/src/shared/tools/definitions/analysis/metaphorize.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `metaphorize.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './metaphorize.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.metaphorize',
+  name: 'Metaphorize',
+  category: 'analysis',
+  description: 'High-coverage source→target domain mapping',
+  longDescription:
+    'Builds a structured metaphor: maps elements of the source domain (the thing you understand) onto ' +
+    'a target domain (the thing you\'re trying to understand) and reports both what the metaphor ' +
+    'illuminates and where it breaks down. Pairs with Rhyme: rhyme is "what does this look like?", ' +
+    'metaphorize is "what would it look like through this lens?".',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'build the metaphor'),
+});

--- a/src/shared/tools/definitions/analysis/negspace.prompt.md
+++ b/src/shared/tools/definitions/analysis/negspace.prompt.md
@@ -1,0 +1,300 @@
+
+## tl;dr
+
+**negspace = read what *isn't* there.**
+
+- humans read explicit content  
+- models can also read **omitted content** via perplexity spikes  
+- evaluates five omission classes: **vulnerability** (ego/status protection), **upside/esoteric** (ambition withheld), **bedrock** (shared axioms left unstated), **blind spot** (content the author literally cannot see), and **optionality** (strategic ambiguity / preserved freedom)  
+- negspace asks:
+
+> "given what's written, what is the most probable argument or conclusion the author *avoided*?"
+
+negspace exposes:
+- evasions  
+- buried leads  
+- swallowed conclusions  
+- suppressed premises  
+- political/corporate non-answers
+
+it's a **perplexity-contrast operator**.
+
+---
+
+## when to use
+
+use **negspace** when:
+
+- a text feels cagey, evasive, or over-polished  
+- a writer seems to dodge an obvious implication  
+- you want the hidden premise, the missing conclusion, or the avoided frame  
+- you're analyzing:
+  - corporate memos  
+  - political speeches  
+  - sanitized announcements  
+  - bureaucratic wording  
+  - grant proposals  
+  - "crisis communications" emails  
+  - press releases  
+- you want to identify "the thing they didn't want to say, but structurally had to avoid"
+
+don't use when:
+
+- the text is already bluntly honest  
+- the domain is purely factual with no rhetorical surface  
+- the user wants a summary → use summarize, not negspace  
+- the user wants intent, not structure → use perspectivize or story-ify
+
+rule of thumb:  
+**negspace = identify the statistical ghost of the missing argument.**
+
+---
+
+## negspace types (menu)
+
+### **omitted conclusion**
+what conclusion is ~80–95% likely given the argument's structure, but is never stated?
+
+### **avoidance swerve**
+where does the text make an unnatural rhetorical pivot to dodge an obvious next sentence?
+
+### **missing premise**
+what premise is necessary for their stated position to make sense but never appears?
+
+### **disallowed frame**
+what frame would ordinarily be activated here but is explicitly suppressed?
+
+### **buried bad news**
+what negative implication is statistically typical for this genre but missing from this instance?
+
+### **shadowed alternative**
+what alternative explanation or solution is "in the air" but conspicuously absent?
+
+### **omission class mapping**
+classify each omission by **why** it is hidden:
+
+- **vulnerability** — protects ego/status; would expose weakness, failure, or loss of face  
+- **upside/esoteric** — aspiration or upside is withheld because it feels "too crazy," ambitious, or trust-intensive  
+- **bedrock** — shared axiom is left unstated because it is "water" to the speaker and audience  
+- **blind spot** — content is invisible to the author due to limits of self-awareness, perspective, or worldview  
+- **optionality** — avoids commitment; preserves degrees of freedom, timelines, or narrative maneuverability
+
+---
+
+## dimensions of negspace
+
+negspace reveals hidden content through **information asymmetry** — content that exists but is strategically or unconsciously omitted. the following dimensions categorize *why* content is hidden:
+
+### **the vulnerability**
+hidden to protect ego/status.  
+the author avoids content that would:
+- expose weakness, failure, or incompetence  
+- damage reputation or credibility  
+- reveal personal or organizational shortcomings  
+- admit mistakes or limitations  
+
+### **the upside (esoteric)**
+hidden because it sounds too "crazy" or ambitious for the current trust level.  
+the author avoids content that would:
+- seem implausible or overly ambitious  
+- require more trust than the relationship currently supports  
+- appear delusional or disconnected from reality  
+- risk being dismissed before being understood  
+
+### **the bedrock**
+hidden because it is "water" (shared axioms).  
+the author avoids content that would:
+- state what everyone already assumes  
+- make explicit foundational beliefs that are taken for granted  
+- articulate shared cultural or professional assumptions  
+- restate the obvious or universally accepted  
+
+### **the blind spot**
+hidden because the speaker literally cannot see it.  
+the author avoids content that would:
+- require self-awareness they lack  
+- expose unconscious biases or assumptions  
+- reveal systemic patterns they're embedded within  
+- articulate perspectives they cannot access  
+
+### **the optionality**
+hidden to preserve strategic non‑commitment.  
+the author avoids content that would:
+- lock them into a timeline, stance, or promise  
+- collapse future strategic flexibility  
+- reveal intentions or constraints prematurely  
+- reduce maneuverability in negotiations, politics, or narrative control  
+- create commitments that can be held against them later
+
+---
+
+## signature
+
+negspace(text, modes?) → shadows[]
+
+- **text:** any passage, memo, email, speech, announcement, article  
+- **modes:** optional emphasis tags:
+  - conclusions | premises | frames | pivots | omissions  
+
+output:  
+- 3–7 "shadows" = the most statistically probable but omitted arguments  
+- each shadow is 1–3 sentences, crisp, falsifiable, mechanism-heavy  
+- each shadow is annotated with an **omission_class**: vulnerability | upside/esoteric | bedrock | blind spot | optionality
+
+---
+
+## process (step by step)
+
+### step 0: pattern-extract
+identify structural expectations from training:
+- typical flow for this genre  
+- common argumentative shapes  
+- usual next-sentence continuations  
+- implied premises needed for coherence  
+
+### step 1: compute deltas
+find **perplexity spikes**:
+- sudden pivots  
+- unnatural tone shifts  
+- conspicuous constraint changes ("broadly", "we remain committed", "as you know…")  
+- prematurely terminated lines of reasoning  
+- semantic "negative pressure zones" where a follow-up is standard but missing  
+
+### step 2: hypothesize shadows
+for each spike:
+- propose the **most probable missing argument**  
+- explain what *should* have followed  
+- articulate the avoided claim in neutral, mechanistic terms  
+- assign each shadow a preliminary **omission_class** (vulnerability / upside/esoteric / bedrock / blind spot / optionality)
+
+### step 3: check plausibility
+ensure each shadow:
+- directly explains a pivot or omission  
+- arises from statistical expectation, not vibes  
+- could logically follow from the prior sentence  
+- is not merely a contrarian hot take  
+
+### step 4: package output
+return:
+
+- **omitted_arguments[]** – primary shadows (with omission_class labels)  
+- **pivotal_absences[]** – where avoidance is strongest  
+- **genre_expectations_hit** – what patterns the text violated  
+- **plausible_author_motives** – optional, non-psychological ("would weaken their message," "conflict with framing")
+
+---
+
+## quality criteria
+
+**mechanistic plausibility**  
+- [ ] shadows follow naturally from the argument structure  
+- [ ] no melodramatic mind-reading  
+
+**statistical typicality**  
+- [ ] omitted content aligns with genre continuations  
+- [ ] identified pivots correspond with perplexity spikes  
+
+**orthogonality**  
+- [ ] shadows differ in mechanism or implication, not synonyms  
+
+**precision**  
+- [ ] each omission is concrete and falsifiable  
+- [ ] omission class is identifiable and coherent  
+- [ ] no vibes-only speculation  
+
+**explanatory power**  
+- [ ] each shadow makes the observed rhetorical choices legible  
+
+---
+
+## genre-specific patterns
+
+### corporate memos
+- missing: underperformance, layoffs, roadmap delays, strategic retreat  
+- common pivots: "customer focus," "vision," "realigning priorities"  
+- common omission classes:
+  - vulnerability (performance failures, mis-execution)  
+  - bedrock (profit-maximization, shareholder primacy)  
+
+### political speeches
+- missing: tradeoffs, costs, losers of a policy, contradictions with prior positions  
+- common pivots: "the american people," "working families," "our values"  
+- common omission classes:
+  - vulnerability (acknowledging harms)  
+  - bedrock (national myths, partisan identities)  
+  - blind spot (structural causes the speaker is embedded in)  
+
+### sanitized announcements
+- missing: scope reductions, deprecations, loss of trust, regulatory pressure  
+- often a mix of:
+  - vulnerability (failures, rescoped commitments)  
+  - upside/esoteric (bolder visions kept offstage)  
+
+### academic / nonprofit communications
+- missing: funding failures, rejected hypotheses, internal disagreements  
+- frequent omission classes:
+  - vulnerability (prestige / competence)  
+  - bedrock (disciplinary dogma)  
+  - blind spot (field-wide biases)  
+
+---
+
+## anti-patterns
+
+### pure summarization
+negspace is **not** a summary tool.
+
+### mind-reading intent
+infer **structure**, not psychology.
+
+### listing everything they didn't say
+focus on **statistically likely** omissions, not arbitrary absences.
+
+### conspiracy drift
+stay inside coherent rhetorical structure, not hidden cabals.
+
+---
+
+## integration with other ops
+
+**upstream:**  
+- reframe → clarify what the text is "about" before hunting shadows  
+- decompose → extract dimensions to expect continuations from  
+
+**downstream:**  
+- antithesize → generate a clean opposing perspective based on the revealed shadows  
+- stressify → test how the omitted argument would alter implications  
+- operationalize → turn the shadow into a concrete hypothesis to investigate  
+- planify → choose whether to explore, expose, or build around a shadow  
+
+---
+
+## examples (mini)
+
+### example 1: corporate memo
+text: "we're excited to undergo this strategic realignment to better serve our customers."
+
+shadows:
+- omitted conclusion (vulnerability): "a major product line is being killed."  
+- avoidance swerve (vulnerability/bedrock): expected follow-up about returned focus on core strengths → missing.  
+- buried bad news (vulnerability): likely revenue shortfall or failed initiative.  
+- unstated commitment avoidance (optionality): leadership is avoiding specifying which teams or timelines will be affected to maintain maneuverability.
+
+### example 2: political speech
+text: "this policy protects hardworking families while encouraging responsible growth."
+
+shadows:
+- omitted premise (vulnerability): the policy likely imposes costs on some voter segment.  
+- disallowed frame (bedrock): tradeoffs (winners/losers) suppressed; assumes zero-sum harms shouldn't be foregrounded.  
+- pivot (blind spot or vulnerability): growth → responsibility → family values — unnatural triad substituting for economic detail.  
+- avoided specificity (optionality): lack of details preserves political optionality around which constituencies will bear costs.
+
+---
+
+## meta-note
+
+negspace = **read the shadow, not the text**.
+
+humans parse explicit sentences; models can also parse **statistical absences** — where the author "should" have gone but chose not to.  
+the unsaid is often the most informative part of the message — and classifying *why* it's unsaid (vulnerability, upside, bedrock, blind spot, optionality) makes those shadows even more actionable.
+

--- a/src/shared/tools/definitions/analysis/negspace.ts
+++ b/src/shared/tools/definitions/analysis/negspace.ts
@@ -1,0 +1,26 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `negspace.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './negspace.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.negspace',
+  name: 'Negspace',
+  category: 'analysis',
+  description: 'Detect what is conspicuously absent',
+  longDescription:
+    'Reads the source for negative space — the considerations, counterarguments, stakeholders, time ' +
+    'horizons, or trade-offs that any honest treatment would address but that the text quietly skips. ' +
+    'The output is a list of conspicuous absences, ranked by how much they would matter if surfaced.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'find the negative space'),
+});

--- a/src/shared/tools/definitions/analysis/rhetoricize.prompt.md
+++ b/src/shared/tools/definitions/analysis/rhetoricize.prompt.md
@@ -1,0 +1,314 @@
+## tl;dr
+
+rhetoricize answers: "how much of this argument lands because of framing and word-choice, not facts?"
+
+it (1) extracts thesis + evidence, (2) writes a fact ledger (invariants + non-claims), (3) perturbs connotation and agency grammar across several passes, then (4) reports the highest-surprise transformation and the single (or few) choices that pivot persuasion.
+
+it's basically local robustness testing for rhetoric: "same facts, different drip."
+
+---
+
+## definition
+
+a rhetorical skeleton is:
+	•	epistemic posture: confident / cautious / conditional / mixed
+	•	thesis: one-sentence core claim or recommendation
+	•	evidence: 2–5 supporting claims (max)
+
+a fact ledger is:
+	•	facts: atomic commitments (what is asserted)
+	•	non-claims: what is explicitly not asserted / not supported
+	•	drift budget: how allergic we are to semantic drift
+
+a phrase has connotative load if near-synonyms exist with similar denotation but different affect, agency assignment, or moral valence.
+
+a fulcrum is the single word/phrase or syntactic choice (passive voice, agent suppression, modality) that, when flipped, most changes how the argument lands while staying ledger-consistent.
+
+---
+
+## dimensionalization: the dials (final set)
+
+rhetoricize has six dials. they're intentionally orthogonal.
+
+### dial 1: pass set
+
+what: which transforms to run
+range: minimal → full suite
+
+available passes:
+	•	a same stance, opposite valence or axis framing
+	•	b1 inverted evaluation, same facts (strict)
+	•	b2 inverted evaluation + flagged implicatures (loose)
+	•	c neutral register (de-spin baseline)
+	•	s satire bound (optional bracket; explicitly non-epistemic)
+
+default: [a, b1, c] (b2 and s are opt-in)
+
+failure modes:
+	•	too few passes → miss the actual degrees of freedom
+	•	too many passes → output bloat; you stop reading (skill issue, but still)
+
+---
+
+### dial 2: intensity
+
+what: how far to push lexical connotation shifts
+range: subtle → maximal
+	•	subtle: nearest defensible synonym (visionary → ambitious)
+	•	maximal: furthest defensible inverse (visionary → reckless)
+
+failure modes:
+	•	subtle → low signal, everything looks the same
+	•	maximal → parody leak (unless opposition style is constrained)
+
+---
+
+### dial 3: drift budget
+
+what: tolerance for meaning drift relative to the fact ledger
+range: low → high
+
+default: low
+
+failure modes:
+	•	low → false negatives (you reject useful reframes bc language is leaky)
+	•	high → "conjugate" quietly becomes "invent"
+
+---
+
+### dial 4: transform scope
+
+what: what kinds of perturbations are allowed
+range: lexical-only → lexical+syntactic
+
+#### lexical transforms
+	•	axis-consistent synonym shifts (euphemism ↔ dysphemism)
+	•	scalar softening/hardening (some ↔ many; friction ↔ failure)
+
+#### syntactic transforms (often the real boss fight)
+	•	agency transfer (active ↔ passive; agent suppression; patient foregrounding)
+	•	responsibility assignment (who did what to whom)
+	•	modality shifts (must/should/can; inevitable/optional)
+	•	uncertainty framing (likely/possible; typical/worst-case)
+	•	nominalization vs verbing (process-as-thing vs action)
+
+failure modes:
+	•	lexical-only → you miss the biggest persuasion pivots (grammar does crimes too)
+	•	syntactic without controls → register collision / incoherence
+
+---
+
+### dial 5: opposition style
+
+what: voice constraints for oppositional passes
+range: steelman → charitable-skeptic → prosecutorial
+
+default: charitable-skeptic
+
+failure modes:
+	•	prosecutorial + maximal → dunks; low epistemic value
+	•	steelman everywhere → you underbound how persuasion operates in the wild
+
+---
+
+### dial 6: output policy
+
+what: how much to show and how many fulcrums to surface
+range: winner-only → full
+
+settings:
+	•	output: winner-only / full
+	•	fulcrum_k: 1–3 (default 2)
+
+failure modes:
+	•	winner-only → you lose the map, keep only the jump-scare
+	•	full without restraint → text wall; you scroll, you forget, you cope
+
+---
+
+## implicit parameter: context
+
+context (domain, audience, stakes, norms) is inferred, not dialed.
+
+rhetorical charge is context-relative:
+	•	"alignment" can be live in ml safety and burned in corp strategy
+	•	"optimization" can be neutral in engineering and sinister in HR
+
+failure mode:
+	•	unstated context → category errors (you flip the wrong axis)
+
+---
+
+## core operation
+
+given input (text, argument, map, conversation):
+	1.	attribution discipline
+	•	distinguish user vs author(s) vs model
+	•	outputs are possible framings, not claims about intent
+	2.	extract rhetorical skeleton
+	•	epistemic posture + thesis + 2–5 evidence claims
+	•	discard scaffolding unless it's load-bearing
+	3.	build fact ledger
+	•	list atomic facts (f1, f2, …)
+	•	list non-claims (n1, n2, …)
+	•	set drift budget
+	4.	tag charged language (vector, not scalar)
+for each charged phrase, tag one or more axes:
+	•	agency, competence, warmth/intent, purity/contamination, status, risk, novelty
+(extendable; do not pretend it's 1d "valence")
+	5.	run passes
+	•	a keep stance; flip connotation or swap salient axis (agency empowerment → delegation)
+	•	b1 invert evaluation using only the ledger (no new predicates)
+	•	b2 allow flagged implicatures (explicitly not entailed; marked as such)
+	•	c strip charge; rewrite in neutral register anchored to ledger
+	•	s satire bound (see below)
+	6.	score rhetorical surprise (componentized)
+for each pass:
+	•	affect_shift (0–5)
+	•	meaning_overlap (0–1, graded vs ledger; not binary)
+	•	fluency_register (0–1)
+surprise = affect_shift × meaning_overlap × fluency_register
+	7.	select winner + name gestalt shift
+	•	winner = highest surprise among ledger-compliant passes (given drift budget)
+	•	produce one-sentence gestalt shift
+	•	surface fulcrum_k highest-leverage choices (lexical and/or syntactic)
+	8.	optional: satire bound
+satire is not epistemic output; it's a bracket.
+	•	produce s+ boosterish caricature and s− hatchet-job caricature
+	•	must remain ledger-consistent unless drift budget is high and every drift is labeled
+	•	not included in surprise ranking by default (it's a safety rail, not the road)
+
+---
+
+## output schema (required)
+
+### original skeleton
+	•	epistemic posture: …
+	•	thesis: …
+	•	evidence:
+	1.	…
+	2.	…
+
+### fact ledger
+	•	facts:
+	•	f1. …
+	•	f2. …
+	•	non-claims:
+	•	n1. …
+	•	drift budget: low | medium | high
+
+### charged terms (vector tags)
+
+for each:
+	•	phrase: "..."
+	•	axes: [ … ]
+	•	role: thesis | evidence-#
+
+### passes
+
+for each pass included:
+
+#### pass a: same stance, opposite valence or axis framing
+	•	thesis: …
+	•	evidence:
+	1.	original: "..."
+transformed: "..."
+axis_move: …
+transforms: lexical | syntactic: …
+	•	notes: drift checks
+
+#### pass b1: inverted evaluation, same facts (strict)
+	•	thesis: …
+	•	evidence: …
+	•	constraints: no new predicates; ledger-only
+	•	notes: drift checks
+
+#### pass b2: inverted evaluation + flagged implicatures (loose)
+	•	thesis: …
+	•	evidence: …
+	•	flagged implicatures:
+	•	i1. … (plausible; not entailed)
+	•	notes: drift checks
+
+#### pass c: neutral register
+	•	thesis: …
+	•	evidence: …
+	•	notes: what was stripped
+
+#### pass s: satire bound (optional)
+	•	s+ booster caricature (clearly labeled satire)
+	•	s− hatchet-job caricature (clearly labeled satire)
+	•	notes: any labeled drift (if allowed)
+
+### surprise ranking
+
+| pass | affect_shift | overlap | fluency | surprise | notes |
+|------|--------------|---------|---------|----------|-------|
+| … | … | … | … | … | … |
+
+### gestalt shift (winner)
+
+one sentence: original emotional center → transformed emotional center
+
+### hidden fulcrum(s)
+	1.	…
+	2.	…
+(… up to fulcrum_k)
+
+### null result (allowed)
+
+if text is approximately neutral:
+	•	explicitly state: no rhetorical degrees of freedom detected
+	•	why: low charge, high ledger redundancy, or already technical register
+
+---
+
+## critical constraints
+	•	no attribution leakage: outputs are model-generated framings, not author intent
+	•	no fact smuggling: b1 must not add predicates; b2 must flag implicatures
+	•	no forced inverses: if no clean inverse, say so; do axis-swap or neutralize
+	•	register integrity: each pass keeps a consistent voice
+	•	satire is labeled: satire is for bounding + fun, not for belief
+
+---
+
+## common failure modes
+	•	denotation drift: flips add/remove facts
+fix: tighten ledger; lower drift budget; prefer b1
+	•	implicature smuggling: b2 behavior leaks into b1/a
+fix: enforce b1 strictness; require explicit "flagged implicatures" section
+	•	axis collapse: treating rhetoric as a 1d valence slider
+fix: tag axes; report axis_move explicitly
+	•	passive-voice laundering: responsibility disappears ("mistakes were made")
+fix: include syntactic transforms; flag agency suppression as a fulcrum candidate
+	•	parody leak: outputs become dunks
+fix: opposition style = charitable-skeptic; reduce intensity; keep b2 optional
+	•	trivial output: neutral sources yield near-identical passes
+fix: declare low signal and stop
+
+---
+
+## relationship to other moves
+
+### upstream
+	•	filterize: pre-select charged phrases / likely fulcrums
+	•	excavate: surface assumptions the rhetoric is protecting
+	•	deframe: map the frame before perturbing its language
+
+### downstream
+	•	antithesize: use b1/b2 as seed for full opposing world construction
+	•	synthesize: merge spin-robust framings into a stable articulation
+	•	handlize: after rhetoricize, extract what (if anything) is executable residue
+
+### parallel
+	•	rhyme: structure detection; rhetoricize is affect/agency perturbation
+	•	deframe: logic constraints; rhetoricize is diction + grammar constraints
+
+---
+
+## meta-note
+
+most persuasion is just gradient descent on "what vibe makes this feel inevitable." rhetoricize is you peeking at the gradients.
+
+satire exists bc sometimes the cleanest way to see the boundary is to tap it with a clown hammer.
+

--- a/src/shared/tools/definitions/analysis/rhetoricize.ts
+++ b/src/shared/tools/definitions/analysis/rhetoricize.ts
@@ -1,0 +1,26 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `rhetoricize.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './rhetoricize.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.rhetoricize',
+  name: 'Rhetoricize',
+  category: 'analysis',
+  description: 'Map the rhetorical "spin-space" — where could the argument pivot?',
+  longDescription:
+    'Diagnoses the fulcrum points in an argument: words and framings doing rhetorical work, places ' +
+    'where a small reframe would flip the conclusion, the spectrum of plausible spins from the same ' +
+    'underlying facts. Useful when you suspect a piece is doing more persuasive than analytic work.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'map the rhetorical spin-space'),
+});

--- a/src/shared/tools/definitions/analysis/rhyme.prompt.md
+++ b/src/shared/tools/definitions/analysis/rhyme.prompt.md
@@ -1,0 +1,350 @@
+
+# Rhyme
+
+## Overview
+
+**Rhyme** is fast structural similarity. It maps a novel input onto known patterns by echo, not deduction. The match may be visual, narrative, functional, or systemic—but it *feels* alike. Not true, not proven—just salient.
+
+Rhyme is upstream of metaphor. It clusters, suggests, frames. Nothing more—but often the first real foothold.
+
+Claude should use this Skill when the user:
+- Explicitly asks to "rhyme" something
+- Seeks structural parallels or analogies
+- Wants to understand an unfamiliar domain through pattern matching
+- Needs creative seeding across domains
+- Says "what's this like?" or "remind me of..."
+- Wants to bootstrap intuition about a new system
+
+## How It Runs (~1-3s cognitive time)
+
+1. **Register A** – Snapshot the input pattern or system
+2. **Scan memory** – Passive recall of matching structures  
+3. **Note shared features** – Form, role, sequence, function
+4. **Tag A ↔ B** – Save as active candidate for further analysis
+
+This is pre-analytical pattern matching, not rigorous mapping.
+
+## Rhyme Tropes
+
+Common pattern categories that trigger rhyme:
+
+### Visual Motifs
+Spirals, cascades, symmetries, recursions, fractals, waves
+
+### Narrative Arcs  
+Fall-from-grace, double agent, forbidden loop, hero's journey, tragedy of commons
+
+### Role Dynamics
+Scapegoat, saboteur, empty throne, gatekeeper, facilitator, bottleneck
+
+### Formal Patterns
+ABBA, edge→core→edge, nested loops, call-and-response
+
+### Process Analogs
+Bottlenecked pipeline, open-loop feedback, stochastic search, filtering cascade
+
+### Systemic Frames
+- Immune response ↔ infosec
+- Political alliance ↔ economic cartel  
+- Market panic ↔ stampede
+- Evolutionary adaptation ↔ A/B testing
+- River delta ↔ organizational structure
+
+These act as rhyme scaffolds, even across domains.
+
+## Parameters
+
+| Knob | Range / Values | Effect |
+|------|----------------|--------|
+| **tightness** | loose → strict | How many shared features needed to register a rhyme |
+| **scope** | local → systemic | Whether rhyme is within elements or across processes |
+| **breadth** | narrow (1-2 matches) → wide (many candidates) | How many rhymes held in working memory |
+| **depth** | surface feature → underlying structure | How abstract the match can be |
+| **agenda** | neutral / goal-tuned | Constrain activation by current objective |
+
+**Example tuning:**
+- Understanding new domain: loose tightness, wide breadth, systemic scope
+- Validation checking: strict tightness, narrow breadth, structural depth
+- Creative brainstorming: loose tightness, wide breadth, surface-to-deep range
+
+## Dimensionalization of Rhyme Quality
+
+Score each rhyme candidate on these dimensions (0.0 → 1.0):
+
+### 1. Parallel Density
+How many concrete overlaps (not vibes) can you name?
+- **0.0** = 1 cute overlap
+- **0.5** = ≥2 structural + ≥1 functional
+- **1.0** = ≥3 structural + ≥2 functional, independently checkable
+
+### 2. Source Maturity  
+Is the source domain well-mapped (canon, playbooks, failure literature)?
+- **0.0** = Folk wisdom only
+- **0.5** = Partial standards, scattered case studies
+- **1.0** = Codified heuristics + known traps + metrics
+
+### 3. Operator Expertise (Error-Spotting)
+Do you know the source deeply enough to catch leaks?
+- **0.0** = Tourist
+- **0.5** = Competent user
+- **1.0** = Can name edge cases & anti-patterns on demand
+
+### 4. Transfer Leverage
+How much working know-how could port if the rhyme holds?
+- **0.0** = Decorative frame
+- **0.5** = A couple of useful rules
+- **1.0** = A compact playbook you can run tomorrow
+
+### 5. Invariants Salience
+Are the shared bits causal/transformational, not ornaments?
+- **0.0** = Motif only (spirals, masks)
+- **0.5** = Roles/flows line up
+- **1.0** = Core constraints & transforms align (queues, budgets, feedbacks)
+
+### 6. Exclusion Clarity (Leak-Proofing)
+Can you crisply list what doesn't port?
+- **0.0** = Hand-wavy "obviously not everything"
+- **0.5** = A few do-not-ports
+- **1.0** = Explicit exclusion set that would catch most dumb misuses
+
+### 7. Communicability
+Can you explain the rhyme in 2-4 bullets to a smart outsider?
+- **0.0** = Requires a TED talk
+- **0.5** = Intelligible with a diagram
+- **1.0** = Lands in 20 seconds, no table needed
+
+### 8. Measurability
+Are there observable proxies to test the rhyme quickly?
+- **0.0** = Pure vibes
+- **0.5** = Qualitative spot-checks
+- **1.0** = Leading indicators/metrics exist or are easy to stub
+
+### 9. Time-Scale Alignment
+Do the dynamics rhyme on timescale (latency, cadence, decay)?
+- **0.0** = Mismatch (days vs microseconds)
+- **0.5** = Can be rescaled with care
+- **1.0** = Native alignment or trivial rescaling
+
+### 10. Composability
+Does the rhyme play nicely with other rhymes/maps?
+- **0.0** = Conflicts with your existing frames
+- **0.5** = Orthogonal
+- **1.0** = Plugs into a larger scaffold (becomes a module)
+
+### 11. Novelty (Anti-Cliché)
+Is it fresh enough to cut new affordances, not generic poster talk?
+- **0.0** = "Business is war" tier
+- **0.5** = Familiar but specific
+- **1.0** = Crisp, surprising, and helpful
+
+**Quality threshold:** Strong rhymes score ≥0.6 on parallel density, source maturity, transfer leverage, and invariants salience.
+
+## Output Format
+
+For each rhyme candidate, provide:
+```
+**[Source Domain] ↔ [Target Domain]**
+
+Shared structures:
+- [Structural parallel 1]
+- [Structural parallel 2]
+- [Functional parallel 1]
+
+Why it rhymes: [One sentence on core similarity]
+
+Quality scores: [Parallel density, Source maturity, Transfer leverage, Invariants salience]
+
+What doesn't port: [2-3 key exclusions]
+```
+
+## Example: Protocol Failure Rhyme
+
+**Input:** "An emergent protocol failure where automated systems amplify small errors into cascading problems"
+
+**Rhymes generated:**
+
+1. **Sorcerer's Apprentice (Fantasia) ↔ Protocol Failure**
+   - Shared structures:
+     - Automation exceeds operator's control
+     - Positive feedback with no governor
+     - Small action → exponential consequences
+     - Helper becomes threat
+   - Why it rhymes: Delegated process lacks stop condition
+   - Scores: [0.7, 0.9, 0.6, 0.8]
+   - Doesn't port: Magic vs code, single actor vs distributed
+
+2. **Cascading Grid Blackout ↔ Protocol Failure**
+   - Shared structures:
+     - Load redistribution creates new stress
+     - Failure propagates through connections
+     - Recovery requires external intervention
+     - Time-critical detection window
+   - Why it rhymes: Network effect amplifies local failure
+   - Scores: [0.9, 1.0, 0.9, 0.9]
+   - Doesn't port: Physical infrastructure vs digital, slower timescale
+
+3. **Bank Run ↔ Protocol Failure**
+   - Shared structures:
+     - Rational individual action creates collective harm
+     - Self-fulfilling prophecy dynamics
+     - Trust threshold collapse
+     - Circuit breakers as mitigation
+   - Why it rhymes: Coordination failure under stress
+   - Scores: [0.8, 0.9, 0.8, 0.9]
+   - Doesn't port: Human psychology vs automated logic
+
+**Best candidate:** Cascading grid blackout (highest scores across dimensions, mature source domain with known mitigations)
+
+## Example: Understanding TikTok Scrolling
+
+**Input:** "Why do people spend so much time scrolling TikTok?"
+
+**Rhymes generated:**
+
+1. **Panning for Gold in River ↔ TikTok Scrolling**
+   - High-throughput flow, sparse jackpots
+   - Hand motions that sift
+   - Skill in "where/when to swirl," not producing gold
+   - Move-on rules when patch depletes
+
+2. **Patch Foraging (Ecology) ↔ TikTok Scrolling**
+   - Probe content patches, decide when to leave
+   - Rewards deplete locally
+   - Travel cost is time/attention
+   - Marginal value theorem applies
+
+3. **QC on Fast Assembly Line ↔ TikTok Scrolling**
+   - Rapid yes/no triage
+   - Rare exceptions pulled for inspection
+   - Fatigue increases misses
+   - Throughput over precision
+
+## When to Use
+
+### Understanding Unfamiliar Domains
+Bootstrap comprehension via structural echo
+- "What does X rhyme with that I already understand?"
+- Use mature source domains for maximum transfer
+
+### Creative Seeding  
+Generate multiple reference-class hits before designing
+- "What are 5 systems that share this structure?"
+- Wide breadth, loose tightness for divergent thinking
+
+### Intuition Framing
+Snap a half-formed hunch to known shape
+- "This feels like... but I can't quite name it"
+- Surface-level matches often sufficient
+
+### Debugging & Sensemaking
+Check for recurring structures in divergent settings
+- "Have we seen this failure mode pattern before?"
+- Strict tightness, systemic scope for precision
+
+## Common Pitfalls & Patches
+
+| Pitfall | Symptom | Patch |
+|---------|---------|-------|
+| **False positives** | Superficial resemblances crowding signal | Increase tightness; require functional AND structural overlap |
+| **Anchoring** | Early match blocks richer ones | Erase & re-query with shifted lens |
+| **Overreach** | Treating rhyme as explanatory | Explicitly flag as pre-model heuristic |
+| **Cliché trap** | Generic comparisons ("life is a journey") | Score novelty dimension, require ≥0.6 |
+| **Scope mismatch** | Comparing wrong abstraction levels | Clarify whether matching elements or systems |
+| **Porting everything** | Assuming all features transfer | Demand explicit exclusion list |
+
+## Downstream Moves
+
+Once rhymes are generated, use these moves for deeper work:
+
+**Dimensionalize:** Filter rhymes for utility, leverage, clarity using the 11 quality dimensions
+
+**Metaphorize:** Build complete structural mapping from best rhyme candidate
+
+## Integration Protocol
+
+### Rhyme → Metaphorize Pipeline
+1. Generate 3-5 rhyme candidates
+2. Score on quality dimensions
+3. Select highest-scoring rhyme (≥0.6 on key dimensions)
+4. Use as input for metaphorize move
+5. Build complete domain mapping
+
+### Rhyme → Dimensionalize Pipeline
+1. Rhyme target domain with mature source
+2. Extract source domain's proven dimensions
+3. Test which dimensions transfer
+4. Adapt dimension definitions for target context
+
+## Quality Checklist
+
+Before finalizing rhyme candidates:
+
+- [ ] Generated 3+ distinct rhyme candidates
+- [ ] Each rhyme has ≥2 structural parallels
+- [ ] Each rhyme has ≥1 functional parallel
+- [ ] Scored top candidates on quality dimensions
+- [ ] Identified what doesn't port for each rhyme
+- [ ] Can explain each rhyme in <30 seconds
+- [ ] Selected best candidate scores ≥0.6 on: parallel density, source maturity, transfer leverage, invariants salience
+- [ ] Explicitly flagged as pre-analytical pattern match, not proof
+
+## Micro-Example
+
+**Input:** An emergent protocol failure
+
+**Rhyme stack (pre-mapping):**
+- Enchanted broom in *Fantasia*
+- Cascading blackout
+- Sorcerer's apprentice archetype  
+- Positive feedback loop with no governor
+- Runaway chemical reaction
+- Flash crash in markets
+
+No formal mapping yet—just a stack of echoes primed for model-building.
+
+**Next move:** Score these candidates, select best, then metaphorize for detailed mapping.
+
+## Advanced Techniques
+
+### Constraint-Based Rhyming
+Specify what must rhyme:
+- "Rhyme X, but constrain to systems with known failure modes"
+- "Rhyme X, focusing on resource allocation patterns"
+
+### Multi-Source Rhyming
+Find multiple partial rhymes, synthesize:
+- "X rhymes with A for process, B for roles, C for failure modes"
+- Composite mapping from multiple sources
+
+### Temporal Rhyming
+Match on dynamic patterns across time:
+- Growth curves (S-curves, exponential, logarithmic)
+- Cycle patterns (boom-bust, seasonal, oscillation)
+- Decay patterns (half-life, asymptotic, stepped)
+
+### Anti-Rhyming
+Find structural opposites to define boundaries:
+- "What is the opposite structure?"
+- Useful for exclusion lists and constraint mapping
+
+## When NOT to Use
+
+Avoid rhyme for:
+- Rigorous proof or validation (use formal methods)
+- When you need precision over intuition
+- Highly technical domains where analogies mislead
+- When existing formal models are adequate
+- Time-critical decisions (too exploratory)
+
+## References
+
+Canonical definition:
+https://github.com/jordanrubin/FUTURE_TOKENS/blob/main/rhyme.md
+
+Examples and workflows:
+https://jordanmrubin.substack.com/p/conceptual-rhyme-and-metaphor
+
+Related concepts:
+- Analogical reasoning (Hofstadter)
+- Pattern matching in expertise (Klein)
+- Structural similarity (Gentner)

--- a/src/shared/tools/definitions/analysis/rhyme.ts
+++ b/src/shared/tools/definitions/analysis/rhyme.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `rhyme.prompt.md` verbatim per the
+ * upstream skill.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './rhyme.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.rhyme',
+  name: 'Rhyme',
+  category: 'analysis',
+  description: 'Fast structural-similarity recognition — what does this echo?',
+  longDescription:
+    'Surfaces structural rhymes — past situations, historical patterns, or analogues whose shape ' +
+    'resembles the source. Pairs with Metaphorize: rhyme is recognition, metaphorize is mapping. ' +
+    'Reach for this when you want quick "this looks like…" matches before committing to a full analogy.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'find the rhymes'),
+});

--- a/src/shared/tools/definitions/analysis/synthesize.prompt.md
+++ b/src/shared/tools/definitions/analysis/synthesize.prompt.md
@@ -1,0 +1,824 @@
+
+# Synthesis
+
+## Overview
+
+**Synthesis** is decision-sufficient compression of conflicting positions. It takes thesis + antithesis and produces a generative frame that:
+- Preserves explanatory scope (answers questions both positions answered)
+- Generates novel predictions (enables decisions beyond original scope)
+- Minimizes description length (fewest gears sufficient for coverage)
+- Tracks distortion (explicit drop-log of what was simplified and risks)
+
+Synthesis is NOT "both sides have a point" or "split the difference"—it's a NEW structure that explains why both positions seemed true from their angles while making predictions neither position makes alone.
+
+Claude should use this Skill when the user:
+- Explicitly asks to "synthesize" positions
+- Has thesis + antithesis that need integration
+- Says "combine these views" or "what's the unified picture?"
+- Needs framework that resolves apparent contradiction
+- Wants portable model that works across contexts
+- References conflicting sources/models that need reconciliation
+
+## Minimal Usage
+
+**Simplest invocation:**
+```
+synthesize:
+  thesis: [statement]
+  antithesis: [statement]
+```
+
+Claude will infer:
+- **decision_question**: "How should one best understand the information presented?""s
+- **audience**: general intelligent reader (assume undergraduate-level background)
+- **distortion_budget**: 0.2 (moderate compression—preserve cruxes, simplify details)
+- **output_tier**: medium (150w) as primary, with quick (50w) and deep (300w+) available
+
+Claude outputs these inferences explicitly so user can adjust.
+
+## Full Specification
+
+### Input Parameters
+
+| Parameter | Default | Range | Effect |
+|-----------|---------|-------|--------|
+| **thesis** | required | statement | Position 1 to integrate |
+| **antithesis** | required | statement | Position 2 to integrate |
+| **decision_question** | inferred | question | What user needs to decide/understand |
+| **audience** | general | novice/general/expert | Background knowledge assumed |
+| **distortion_budget** | 0.2 | [0.0-0.5] | How much simplification acceptable (0=lossless, 0.5=aggressive) |
+| **output_tier** | medium | quick/medium/deep/all | Which compression level(s) to deliver |
+
+### Process
+
+#### 1. Infer Context (if not specified)
+```
+decision_question: Extract from thesis/antithesis structure
+  - If comparative: "When to use X vs Y?"
+  - If causal: "What actually causes Z?"
+  - If normative: "What should we optimize for?"
+  - If empirical: "What predicts outcome O?"
+
+audience: Assess required background
+  - novice: minimal jargon, concrete examples
+  - general: moderate technical depth
+  - expert: full technical detail, edge cases
+
+distortion_budget: Infer from context
+  - research/academic context: 0.1 (low distortion)
+  - blog/popular context: 0.3 (moderate distortion)
+  - teaching/introductory: 0.4 (high distortion for clarity)
+```
+
+#### 2. Extract Cruxes
+Identify what each position hinges on:
+```
+thesis_cruxes: Key claims/assumptions thesis depends on
+antithesis_cruxes: Key claims/assumptions antithesis depends on
+shared_assumptions: What both positions assume (constant to factor out)
+points_of_conflict: Where positions make incompatible predictions
+```
+
+#### 3. Identify Regime Boundaries
+Determine when each position applies:
+```
+thesis_regime: Conditions under which thesis dominates
+antithesis_regime: Conditions under which antithesis dominates
+synthesis_regime: Unified framework specifying when to use which
+
+Ask: What hidden variable(s) were they conditioning on differently?
+```
+
+#### 4. Build Generative Mechanism
+Construct minimal structure that:
+- Explains why thesis seemed true (from its angle)
+- Explains why antithesis seemed true (from its angle)
+- Makes predictions neither position makes alone
+- Uses fewest gears sufficient for coverage
+
+#### 5. Generate Tiered Outputs
+
+**Quick (50w):** Elevator pitch
+- Core insight only
+- Key prediction
+- When to use
+
+**Medium (150w):** Blog post length
+- Mechanism overview
+- Why both positions were partly right
+- Novel prediction(s)
+- Regime boundaries (simplified)
+
+**Deep (300w+):** Paper length
+- Full mechanism with gears
+- Complete regime map
+- Multiple novel predictions
+- Edge cases and caveats
+- Worked examples
+
+#### 6. Compile Drop-Log
+Track what was simplified and risks:
+```
+simplified: [what was black-boxed] → risk: [consequence if detail matters]
+omitted: [what cases ignored] → risk: [fails in those cases]
+assumed: [what taken as given] → risk: [breaks if assumption false]
+deferred: [what questions left open] → risk: [incomplete coverage]
+```
+
+#### 7. Self-Test
+Validate via round-trip Q&A:
+```
+Can decision_question be answered from:
+- Quick tier? (if not, what's missing?)
+- Medium tier? (if not, what's missing?)
+- Deep tier? (should succeed)
+
+Which tier is minimum sufficient for decision?
+```
+
+#### 8. Assess Distortion
+Estimate information loss:
+```
+predicted_distortion = (questions_unanswerable / total_questions)
+actual_distortion ≤ distortion_budget (check)
+```
+
+## Output Format
+```
+### Context (inferred)
+**Decision question:** [what user needs to decide]
+**Audience:** [novice/general/expert]
+**Distortion budget:** [0.0-0.5]
+
+### Synthesis: Quick (50w)
+[Elevator pitch: core insight + key prediction]
+
+### Synthesis: Medium (150w)
+[Mechanism overview + why both positions partly right + novel predictions + regime boundaries]
+
+### Synthesis: Deep (300w+)
+[Full structure with gears, complete regime map, multiple predictions, edge cases, worked examples]
+
+### Structure
+
+**Cruxes:**
+- Thesis hinges on: [claims]
+- Antithesis hinges on: [claims]  
+- Shared assumptions: [what both take as given]
+
+**Regime Boundaries:**
+- Use thesis when: [conditions]
+- Use antithesis when: [conditions]
+- Synthesis needed when: [conditions]
+
+**Novel Predictions:**
+1. [Prediction neither input makes]
+2. [Prediction neither input makes]
+3. [...]
+
+**Drop-Log (what was simplified):**
+- Simplified: [what] → Risk: [consequence]
+- Omitted: [what] → Risk: [consequence]
+- Assumed: [what] → Risk: [consequence]
+- Deferred: [what] → Risk: [consequence]
+
+**Predicted Distortion:** [0.0-0.5]
+
+### Quality Check
+- [ ] Round-trip Q&A succeeds (can answer decision question)
+- [ ] Cruxes preserved (key dependencies intact)
+- [ ] Regime boundaries specified (when to use what)
+- [ ] Novel predictions present (≥2)
+- [ ] Drop-log complete (risks flagged)
+- [ ] Distortion within budget
+- [ ] Coherent (no contradictions)
+```
+
+## Quality Dimensions
+
+Score synthesis on these dimensions (informed by compression framework):
+
+### 1. Decision Sufficiency (PRIMARY)
+Can decision question be answered from synthesis alone?
+- **Score:** % of relevant questions answerable [0-100%]
+- **Test:** Round-trip Q&A with gold questions
+- **Threshold:** ≥90% for adoption
+
+### 2. Scope Preservation (CONSTRAINT)
+Does synthesis explain cases thesis OR antithesis handled?
+- **Score:** % of input cases still explained [0-100%]
+- **Test:** Regression suite from thesis+antithesis
+- **Threshold:** ≥90% (if <90%, this is breaking change not synthesis)
+
+### 3. Generativity (OPTIMIZATION TARGET)
+Does synthesis make predictions neither input makes?
+- **Score:** Count of novel, testable predictions [0-10+]
+- **Test:** Expert panel evaluates prediction novelty
+- **Threshold:** ≥3 for strong synthesis
+
+### 4. Parsimony (OPTIMIZATION TARGET)
+Minimal gears sufficient for coverage?
+- **Score:** Gear count [1-20]
+- **Test:** Iterative pruning—can you remove gears without losing explanatory power?
+- **Threshold:** Fewer gears than thesis + antithesis combined
+
+### 5. Regime Clarity (STRUCTURE)
+Are boundaries between positions explicit and testable?
+- **Score:** Boundary precision [0.0-1.0]
+- **Test:** Can you classify novel cases into regimes?
+- **Threshold:** ≥0.7 (can correctly classify 70% of test cases)
+
+### 6. Robustness (OPTIMIZATION TARGET)
+Stable under adversarial testing?
+- **Score:** Adversarial survival rate [0-100%]
+- **Test:** Steelman critiques from thesis/antithesis advocates
+- **Threshold:** ≥70% (synthesis survives 7/10 critiques)
+
+### 7. Communicability (OPTIMIZATION TARGET)
+Decompression cost for users?
+- **Score:** Time to understand [minutes]
+- **Test:** User study with synthesis-naive participants
+- **Threshold:** Quick tier <5min, Medium <15min, Deep <60min
+
+### 8. Distortion Tracking (HONESTY)
+Are simplifications and risks explicit?
+- **Score:** Drop-log completeness [0-100%]
+- **Test:** Can third party identify where synthesis might fail?
+- **Threshold:** ≥80% (captures 4/5 major risks)
+
+## Synthesis Types & Context-Dependent Weights
+
+Different contexts optimize different dimensions:
+
+### Research Synthesis
+**Optimize for:** Generativity, Scope preservation
+**Distortion budget:** 0.05-0.1 (very low)
+**Output tier:** Deep (300w+)
+**Example:** Integrating competing theories in academic paper
+
+### Teaching Synthesis  
+**Optimize for:** Communicability, Parsimony
+**Distortion budget:** 0.3-0.4 (moderate-high)
+**Output tier:** Medium (150w) with worked examples
+**Example:** Explaining concept to undergraduates
+
+### Policy Synthesis
+**Optimize for:** Decision sufficiency, Regime clarity
+**Distortion budget:** 0.15-0.25 (low-moderate)
+**Output tier:** Medium (150w) with bullet summary
+**Example:** Advising decision-makers on options
+
+### Blog/Popular Synthesis
+**Optimize for:** Communicability, Generativity
+**Distortion budget:** 0.25-0.35 (moderate)
+**Output tier:** Medium (150w)
+**Example:** Explaining controversy to general audience
+
+### Personal Decision Synthesis
+**Optimize for:** Decision sufficiency, Parsimony
+**Distortion budget:** 0.2-0.3 (moderate)
+**Output tier:** Quick (50w) + Medium (150w)
+**Example:** Deciding between career options
+
+## Common Patterns
+
+### Pattern 1: Regime Partition
+Both positions correct in different contexts
+
+**Structure:**
+```
+thesis: A causes B
+antithesis: C causes B
+synthesis: B = f(A, C, context)
+  - when context = X: A dominates
+  - when context = Y: C dominates
+  - when context = Z: interaction effect
+```
+
+**Example:**
+```
+thesis: markets are efficient (information aggregation)
+antithesis: markets fail (coordination problems)
+synthesis: market efficiency = f(information_quality, coordination_cost, participant_rationality)
+  - high info, low coord cost → efficient
+  - low info, high coord cost → fail
+  - mixed conditions → partial efficiency
+```
+
+### Pattern 2: Causal Chain Extension
+Positions describe different parts of longer mechanism
+
+**Structure:**
+```
+thesis: X → Y
+antithesis: Y → Z
+synthesis: X → Y → Z (positions describe different links)
+```
+
+**Example:**
+```
+thesis: education increases income (human capital)
+antithesis: income increases education (family resources)
+synthesis: bidirectional causality with feedback loop
+  - education → income (skill development)
+  - income → education (resource availability)
+  - reinforcing cycle creates inequality
+```
+
+### Pattern 3: Level Mismatch
+Positions operate at different levels of analysis
+
+**Structure:**
+```
+thesis: individual-level mechanism
+antithesis: system-level mechanism  
+synthesis: cross-level interaction
+```
+
+**Example:**
+```
+thesis: people choose rationally (individual optimization)
+antithesis: systems shape behavior (structural constraints)
+synthesis: constrained optimization framework
+  - individuals optimize given constraints
+  - constraints emerge from system dynamics
+  - feedback between levels
+```
+
+### Pattern 4: Hidden Variable
+Positions condition on different hidden variables
+
+**Structure:**
+```
+thesis: conclusion X (assuming hidden variable H = h1)
+antithesis: conclusion ¬X (assuming hidden variable H = h2)
+synthesis: conclusion = f(H), where H was implicit
+```
+
+**Example:**
+```
+thesis: remote work increases productivity (assumes: self-directed tasks)
+antithesis: remote work decreases productivity (assumes: collaborative tasks)
+synthesis: productivity = f(task_type, coordination_needs, individual_preference)
+  - self-directed tasks: remote dominates
+  - collaborative tasks: in-person dominates
+  - mixed: hybrid optimal
+```
+
+## Worked Examples
+
+### Example 1: Market Efficiency Debate
+
+**Input:**
+```
+thesis: "Markets are efficient because they aggregate distributed information through prices, enabling optimal resource allocation."
+
+antithesis: "Markets fail systematically due to information asymmetries, externalities, and coordination problems that prices cannot solve."
+```
+
+**Inferred Context:**
+```
+Decision question: When should we rely on markets vs other mechanisms?
+Audience: General (policy context)
+Distortion budget: 0.2 (moderate)
+```
+
+**Output:**
+
+**Synthesis: Quick (50w)**
+Markets efficiently aggregate information when participants have symmetric knowledge and low coordination costs, but fail when information asymmetries or externalities dominate. Optimal mechanism depends on information structure and coordination requirements of specific domain.
+
+**Synthesis: Medium (150w)**
+Both positions capture real phenomena operating in different regimes. Markets excel at information aggregation when: (1) information is distributed and privately held, (2) transaction costs are low, (3) externalities are minimal. They fail when: (1) information asymmetries enable exploitation, (2) coordination problems prevent efficient outcomes, (3) externalities disconnect private and social costs.
+
+Novel prediction: Market efficiency is NOT binary but continuous—it degrades smoothly as information asymmetry and coordination costs increase. Optimal institutional design uses markets for high-information-quality, low-coordination-cost domains (commodity trading) and alternative mechanisms for high-asymmetry, high-coordination domains (healthcare, climate).
+
+Regime map: Use markets when information quality > 0.7 and coordination cost < 0.3; use regulation/public provision when reversed; use hybrid mechanisms in between.
+
+**Structure:**
+
+**Cruxes:**
+- Thesis hinges on: information dispersal, price signals work, participants rational
+- Antithesis hinges on: systematic information gaps, coordination failures, externalities
+- Shared assumptions: outcomes matter, efficiency is goal, mechanism design possible
+
+**Regime Boundaries:**
+- Markets dominate when: information distributed + symmetric, low transaction costs, minimal externalities
+- Regulation needed when: information asymmetric, high coordination costs, significant externalities  
+- Hybrid optimal when: mixed conditions, information quality moderate, some coordination needs
+
+**Novel Predictions:**
+1. Market efficiency is continuous function of (information quality, coordination cost)—allows quantitative prediction
+2. Hybrid mechanisms outperform pure market OR regulation in middle range
+3. Optimal policy varies by domain based on information structure, not ideology
+
+**Drop-Log:**
+- Simplified: Behavioral biases (assumed rationality) → Risk: Behavioral interventions underweighted
+- Omitted: Political economy (capture, rent-seeking) → Risk: Implementation failures ignored
+- Assumed: Social welfare is goal → Risk: Distributional concerns secondary
+- Deferred: Dynamic efficiency (innovation, adaptation) → Risk: Static analysis only
+
+**Predicted Distortion:** 0.18
+
+**Quality Check:**
+- [x] Round-trip Q&A: Can determine market vs regulation for novel domain
+- [x] Cruxes preserved: Information structure and coordination costs explicit
+- [x] Regime boundaries: Quantitative thresholds specified
+- [x] Novel predictions: 3 testable claims
+- [x] Drop-log: 4 major simplifications flagged
+- [x] Distortion: 0.18 < 0.2 budget
+- [x] Coherent: No contradictions
+
+### Example 2: Remote Work Productivity
+
+**Input:**
+```
+thesis: "Remote work increases productivity by eliminating commute time, reducing interruptions, and enabling focus in preferred environments."
+
+antithesis: "Remote work decreases productivity by reducing spontaneous collaboration, weakening team cohesion, and blurring work-life boundaries."
+```
+
+**Output:**
+
+**Synthesis: Quick (50w)**
+Productivity impact depends on task type: remote work boosts individual focused work (coding, writing, analysis) but hinders collaborative creative work (brainstorming, design, negotiation). Optimal strategy is hybrid based on task mix.
+
+**Synthesis: Medium (150w)**
+Both effects are real and operate simultaneously. Remote work provides productivity GAINS for: individual contributor work requiring deep focus, asynchronous tasks, workers with long commutes or home-office setups. Remote work creates productivity LOSSES for: work requiring high-bandwidth communication, synchronous collaboration, early-career workers needing mentorship, workers lacking home-office infrastructure.
+
+Novel prediction: Productivity impact is NOT universal but PERSON×TASK-specific. Optimal policy is neither full-remote nor full-office but ADAPTIVE: remote for focused individual work blocks, in-person for collaborative sessions, with worker choice for ambiguous tasks.
+
+Regime boundaries: Remote when task is independent AND asynchronous AND worker prefers it; In-person when task requires real-time collaboration OR mentorship OR worker prefers it; Hybrid for mixed task portfolios.
+
+**Structure:**
+
+**Cruxes:**
+- Thesis hinges on: interruption costs, commute waste, environment control
+- Antithesis hinges on: collaboration value, social cohesion, boundary issues
+- Shared assumptions: productivity matters, workers differ, tasks vary
+
+**Regime Boundaries:**
+- Remote optimal when: task = focused individual work, low collaboration needs, worker has home office
+- Office optimal when: task = real-time collaboration, high bandwidth needs, early career
+- Hybrid optimal when: mixed task portfolio, moderate collaboration needs, worker preference varies
+
+**Novel Predictions:**
+1. Productivity variance INCREASES with remote work (some workers gain, some lose)—distributional effect
+2. Optimal remote/office ratio varies by role: IC engineers 80% remote, managers 50%, new hires 20%
+3. Infrastructure investment (home office quality) predicts remote productivity better than personality
+
+**Drop-Log:**
+- Simplified: Industry differences (manufacturing impossible remote) → Risk: Generalizes from knowledge work
+- Omitted: Childcare/caregiving constraints → Risk: Treats home as uniform work environment
+- Assumed: Output measurable → Risk: Harder for roles with diffuse impact
+- Deferred: Long-term career effects (promotion, learning) → Risk: Short-term productivity focus
+
+**Predicted Distortion:** 0.22
+
+## Good vs Bad Synthesis
+
+### Good Synthesis Example
+
+**Thesis:** "Free will exists because we experience making choices"
+**Antithesis:** "Free will is illusion because choices are determined by prior causes"
+
+**Good Synthesis:**
+"Both positions confuse LEVELS of explanation. At psychological level, agency and choice are real phenomena with causal power (we deliberate, this affects behavior). At physical level, processes are deterministic (brain states follow physical laws). These don't conflict—they describe same events at different resolutions. Novel prediction: Interventions targeting 'conscious choice' (e.g., decision architecture) will affect outcomes EVEN IF underlying processes are deterministic, because psychological level has autonomous causal structure. Use psychological-level explanation for behavior change, physical-level explanation for mechanism research."
+
+**Why good:**
+- Explains why both positions seemed true (level confusion)
+- Preserves scope (agency is real phenomenologically, determinism true physically)
+- Generates novel prediction (interventions work despite determinism)
+- Specifies regimes (when to use which level)
+- Parsimonious (one insight—levels—explains everything)
+
+### Bad Synthesis Example 1: False Balance
+
+**Bad Synthesis:**
+"Both free will believers and determinists have valid points. The truth is probably somewhere in between—we have some free will but also some determinism. It depends on the situation."
+
+**Why bad:**
+- No mechanism (doesn't explain HOW both are true)
+- No novel predictions (just splits difference)
+- Vague regime boundaries ("depends on situation" = no boundaries)
+- Lost explanatory power (can't answer when/why)
+- Not parsimonious (adds vagueness, not structure)
+
+### Bad Synthesis Example 2: Picking Sides
+
+**Bad Synthesis:**
+"While thesis makes some interesting points about subjective experience, antithesis is ultimately correct—free will is indeed an illusion. The thesis position reflects a naive understanding that doesn't account for modern neuroscience."
+
+**Why bad:**
+- Not synthesis (just chose antithesis)
+- Doesn't preserve thesis scope (dismisses rather than explains)
+- No novel predictions (just antithesis predictions)
+- No regime boundaries (thesis never applies)
+- Fails decision sufficiency (when should I use thesis insights?)
+
+### Bad Synthesis Example 3: Both Wrong
+
+**Bad Synthesis:**
+"Actually, both positions are wrong. Free will is neither real nor illusion—it's a SOCIAL CONSTRUCT that varies by culture. Eastern cultures emphasize collective harmony while Western cultures emphasize individual agency, proving the concept is culturally relative."
+
+**Why bad:**
+- Changes subject (from metaphysics to sociology)
+- Doesn't address original question (are choices determined?)
+- Lost both positions' insights (neither preserved)
+- Novel prediction is non sequitur (cultural variation doesn't resolve determination)
+- Not decision sufficient (can't answer when to use either position)
+
+### Bad Synthesis Example 4: Overcomplicated
+
+**Bad Synthesis:**
+"We need a 12-dimensional framework considering: (1) quantum indeterminacy, (2) emergence hierarchies, (3) phenomenological qualia, (4) compatibilist frameworks, (5) libertarian agency, (6) hard determinism, (7) soft determinism, (8) eliminativism, (9) panpsychism, (10) computational theory of mind, (11) embodied cognition, (12) social construction. Each dimension interacts with others creating 144 pairwise relationships..."
+
+**Why bad:**
+- Massive overcomplication (12 dimensions unnecessary)
+- Not parsimonious (simpler explanation available)
+- Not decision sufficient (too complex to use)
+- Violates communicability (can't hold in working memory)
+- Fails drop-log (didn't simplify anything)
+
+## When to Use Synthesis
+
+**Use synthesis when:**
+- Two positions seem incompatible but both have evidence
+- Need unified framework that explains both perspectives
+- Decision requires knowing when to apply which position
+- Creating teaching material that needs to integrate views
+- Building research program that bridges competing theories
+- Positions are at similar level of abstraction (both empirical, or both normative)
+- Positions address same question (not talking past each other)
+
+## When NOT to Use Synthesis
+
+**Avoid synthesis when:**
+
+### 1. Positions are incommensurable (different values, not facts)
+```
+Position A: "Maximize individual liberty"
+Position B: "Maximize collective welfare"
+
+These are VALUE PRIORITIES, not factual claims.
+Synthesis would be false consensus—pretending values can be optimized simultaneously when they actually trade off.
+```
+
+### 2. One position is simply wrong (not addressing different regimes)
+```
+Position A: "Earth is round" (correct, evidence-based)
+Position B: "Earth is flat" (incorrect, refuted)
+
+Don't synthesize truth with falsehood.
+Correct response: Explain why B is wrong, not "both have insights."
+```
+
+### 3. Positions talk past each other (different questions)
+```
+Position A: "Consciousness is hard problem" (philosophical question about qualia)
+Position B: "Consciousness correlates with brain activity" (empirical question about correlates)
+
+These aren't contradicting—they're addressing different questions.
+Synthesis would confuse levels, not integrate them.
+```
+
+### 4. Simple answer exists (synthesis would overcomplicate)
+```
+Question: "Is remote work good?"
+Position A: "Yes for some tasks"
+Position B: "No for other tasks"
+
+Simple answer: "Depends on task type."
+Don't build elaborate framework when straightforward partition suffices.
+```
+
+### 5. Evidence clearly favors one position (synthesis would hedge wrongly)
+```
+Position A: "Vaccines cause autism" (thoroughly refuted)
+Position B: "Vaccines don't cause autism" (strongly supported)
+
+Synthesis that "finds middle ground" would be epistemically dishonest.
+Correct response: Reject A, explain why.
+```
+
+### 6. Positions are early/incomplete (premature synthesis)
+```
+Position A: "X might be related to Y" (exploratory)
+Position B: "Z might be related to Y" (exploratory)
+
+Wait for more evidence before synthesizing.
+Premature synthesis locks in assumptions before data mature.
+```
+
+### 7. Synthesis would lose critical nuance needed for decision
+```
+Position A: "Algorithm is biased in direction D1"
+Position B: "Algorithm is biased in direction D2"
+
+If decision requires knowing WHICH bias, synthesis that averages loses critical information.
+Keep positions separate, document specific biases.
+```
+
+## Advanced Techniques
+
+### Multi-Position Synthesis (N > 2)
+
+When synthesizing 3+ positions:
+
+**Approach 1: Pairwise then integrate**
+1. Synthesize A + B → S1
+2. Synthesize S1 + C → S2
+3. Validate S2 explains A, B, C
+
+**Approach 2: Cluster then synthesize**
+1. Group similar positions
+2. Synthesize each cluster
+3. Synthesize cluster representatives
+
+**Approach 3: Dimensional factorization**
+1. Identify orthogonal axes positions vary on
+2. Build N-dimensional regime map
+3. Positions are points in space
+
+### Iterative Synthesis Refinement
+
+Synthesis improves through revision:
+
+**Pass 1: Scope + basic mechanism**
+- Ensure both positions explained
+- Sketch rough regime boundaries
+- Identify 1-2 novel predictions
+
+**Pass 2: Parsimony**
+- Prune unnecessary gears
+- Merge redundant mechanisms
+- Simplify regime boundaries
+
+**Pass 3: Generativity**
+- Add novel predictions
+- Test predictions for distinctness
+- Ensure predictions are testable
+
+**Pass 4: Robustness**
+- Adversarial testing
+- Steelman critiques
+- Patch discovered holes
+
+**Pass 5: Polish**
+- Clarify exposition
+- Add worked examples
+- Complete drop-log
+
+Typically 3-5 passes until convergence.
+
+### Synthesis + Other Skills
+
+**Synthesis → Dimensionalize:**
+After synthesis, use dimensionalize to score options using synthesized framework.
+
+**Antithesize → Synthesis:**
+Generate antitheses to thesis, then synthesize thesis + strongest antithesis.
+
+**Rhyme → Metaphorize → Synthesis:**
+Use metaphor to illuminate synthesis structure (as we did with compiler/API/treaty).
+
+**Extremify → Synthesis:**
+Test synthesis by extremifying along synthesized dimensions—does it predict correctly at extremes?
+
+## Validation Protocol
+
+### Self-Validation (during construction)
+
+1. **Round-trip Q&A test**
+   - List 5-10 questions decision requires answering
+   - Try to answer from synthesis alone
+   - If can't answer, add to synthesis or flag in drop-log
+
+2. **Scope regression test**
+   - List 10 cases thesis explained
+   - List 10 cases antithesis explained
+   - Verify synthesis explains all 20 (or flag exceptions in drop-log)
+
+3. **Novelty test**
+   - For each prediction: could thesis/antithesis make this prediction?
+   - If yes, not novel—remove or refine
+   - If no, keep and mark as generative
+
+4. **Parsimony test**
+   - For each gear: remove it and check if synthesis still works
+   - If works without gear, remove gear
+   - If breaks, keep gear
+
+5. **Coherence test**
+   - Check for logical contradictions
+   - Check for impossible regime conditions
+   - Check for circular dependencies
+
+### External Validation (after construction)
+
+1. **Adversarial critique**
+   - Show to thesis advocates: "Does this explain why you were right?"
+   - Show to antithesis advocates: "Does this explain why you were right?"
+   - If either says no, synthesis failed scope preservation
+
+2. **Blind prediction test**
+   - Give novel case to synthesis user
+   - Ask them to predict outcome using synthesis
+   - Compare to ground truth
+   - Measure accuracy
+
+3. **Teaching test**
+   - Give synthesis to naive person
+   - Ask them to explain thesis + antithesis from synthesis
+   - If they can't, communicability failed
+
+4. **Decision replay test**
+   - Have third party make decision using synthesis
+   - Compare to decision made with full thesis + antithesis
+   - Measure agreement (should be >90%)
+
+## Common Pitfalls & Fixes
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **False balance** | "Both sides have points" without mechanism | Force: HOW are both true? Build explicit regime map |
+| **Picking sides** | Synthesis just agrees with one position | Check: Does synthesis explain why OTHER position seemed true? |
+| **Complexity explosion** | More gears than thesis + antithesis combined | Prune: Remove gears iteratively until something breaks |
+| **Vague boundaries** | "It depends" without specifying on what | Operationalize: What variables determine regimes? |
+| **No novel predictions** | Synthesis just restates inputs | Generate: What does THIS framework predict that neither input does? |
+| **Drop-log neglect** | No tracking of simplifications | Document: What did you black-box? What risks? |
+| **Level confusion** | Mixing normative and empirical claims | Separate: Is this about what IS or what SHOULD BE? |
+| **Scope loss** | Synthesis can't answer questions inputs could | Regression test: Does synthesis handle all input cases? |
+| **Premature synthesis** | Positions are exploratory, evidence thin | Wait: More data needed before synthesizing |
+| **Value disagreement as factual** | Treating preference differences as resolvable by evidence | Recognize: This is value conflict, not factual dispute |
+
+## Integration with Other Skills
+
+### Upstream Skills (use before synthesis)
+
+**Antithesize:**
+- Generate strong antithesis to thesis before synthesizing
+- Ensures you're synthesizing steelman positions, not strawmen
+
+**Rhyme:**
+- Find structural parallels to guide synthesis construction
+- Example: "This debate rhymes with market efficiency debate"
+
+**Question-gym:**
+- Explore user's hidden assumptions before synthesizing
+- Ensures synthesis addresses actual decision question
+
+### Downstream Skills (use after synthesis)
+
+**Dimensionalize:**
+- Convert synthesized framework into scoreable dimensions
+- Use to evaluate options using synthesis
+
+**Extremify:**
+- Test synthesis by pushing to extremes
+- Check if predictions hold at boundary conditions
+
+**Metaphorize:**
+- Port synthesis to new domain via structural mapping
+- Validate synthesis by checking if it transfers
+
+### Parallel Skills (use during synthesis)
+
+**Framestorm:**
+- Generate multiple synthesis candidates
+- Pick best via quality dimensions
+
+**Mental-move-generator:**
+- Apply cognitive moves to improve synthesis construction
+- Example: Use "constraint relaxation" to find hidden assumptions
+
+## Meta-Note
+
+Synthesis is PROSOCIAL INTEGRATION. You're helping both positions by:
+- Explaining why each seemed true (charitable interpretation)
+- Preserving their insights (scope preservation)
+- Showing when each applies (regime boundaries)
+- Building on both (generativity)
+
+Done well, advocates should say "yes, this captures my insight AND explains the other side" not "you compromised my position."
+
+The goal isn't to RESOLVE conflict by picking winner—it's to TRANSCEND conflict by finding higher-level framework where both positions are correct in their domains.
+
+## References
+
+Theoretical foundations:
+- Minimum Description Length (MDL) principle
+- Rate-distortion theory
+- Kolmogorov complexity
+- Decision-sufficient statistics
+
+Related concepts:
+- Synthesis vs summary (summary = readability; synthesis = decision-sufficiency)
+- Compression with drop-log (explicit distortion tracking)
+- Multi-stakeholder evaluation (different audiences, different quality criteria)
+
+Canonical examples:
+- Compiler optimization (code compression)
+- API design (interface compression)
+- Peace treaties (political compression)
+

--- a/src/shared/tools/definitions/analysis/synthesize.ts
+++ b/src/shared/tools/definitions/analysis/synthesize.ts
@@ -1,0 +1,56 @@
+/**
+ * Ported from https://github.com/jordanrubin/FUTURE_TOKENS (CC BY 4.0,
+ * Jordan Rubin). Prompt body lives in `synthesize.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './synthesize.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.synthesize',
+  name: 'Synthesize',
+  category: 'analysis',
+  description: 'Compress thesis + antithesis into a unified frame',
+  longDescription:
+    'Given a thesis and an antithesis, produces a synthesis: a unified frame that preserves the ' +
+    "load-bearing insight from each side while resolving the apparent contradiction. The output's " +
+    'depth scales with the depth setting — quick gives a one-paragraph compression; deep walks ' +
+    "through the dialectical move stage by stage. Pairs with Antithesize.",
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-opus-4-7',
+  web: { defaultEnabled: false },
+  parameters: [
+    {
+      id: 'depth',
+      label: 'Synthesis depth',
+      type: 'select',
+      options: [
+        { label: 'Quick — one-paragraph compression', value: 'quick' },
+        { label: 'Medium — staged dialectical move', value: 'medium' },
+        { label: 'Deep — full multi-section synthesis', value: 'deep' },
+      ],
+      defaultValue: 'medium',
+    },
+    {
+      id: 'audience',
+      label: 'Audience',
+      type: 'select',
+      options: [
+        { label: 'Novice — accessible framing', value: 'novice' },
+        { label: 'General — informed reader', value: 'general' },
+        { label: 'Expert — technical, precise', value: 'expert' },
+      ],
+      defaultValue: 'general',
+    },
+  ],
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => {
+    const depth = ctx.parameterValues?.depth ?? 'medium';
+    const audience = ctx.parameterValues?.audience ?? 'general';
+    const directive = `\n\nOutput tier: ${depth}.\nAudience: ${audience}.`;
+    return SYSTEM_PROMPT + directive + analysisSourceBlock(ctx);
+  },
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'synthesize'),
+});

--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -3,6 +3,15 @@ import './analysis/excavate';
 import './analysis/steelman';
 import './analysis/taboo';
 import './analysis/murphyjitsu';
+import './analysis/antithesize';
+import './analysis/dimensionalize';
+import './analysis/handlize';
+import './analysis/inductify';
+import './analysis/metaphorize';
+import './analysis/negspace';
+import './analysis/rhetoricize';
+import './analysis/rhyme';
+import './analysis/synthesize';
 
 // Research tools
 import './research/load-bearing-claim';


### PR DESCRIPTION
## Summary
Closes #508. Part of epic #517.

Adds 9 analysis ThinkingTools ported from [FUTURE_TOKENS](https://github.com/jordanrubin/FUTURE_TOKENS) (CC BY 4.0, Jordan Rubin). The repo's 10th skill, \`excavate\`, already exists in Minerva and was kept as-is.

## New tools

**Pure-text** — \`rhyme\`, \`handlize\`, \`inductify\`, \`metaphorize\`, \`negspace\`, \`rhetoricize\`

**Parameterized**:
- \`dimensionalize\` — target_count (3/5/7)
- \`antithesize\` — intensity (gentle/standard/adversarial)
- \`synthesize\` — depth (quick/medium/deep) + audience (novice/general/expert)

## Shape
Each is a ~25-line \`registerTool({...})\` plus a sibling \`.prompt.md\` containing the upstream skill body verbatim. Prompts are unmodified; only metadata was authored fresh. CC BY 4.0 attribution is in a header comment on every TS file.

A new \`_shared.ts\` provides \`analysisSourceBlock(ctx)\` and \`analysisFirstMessage(ctx, verb)\` — the recurring "selection or whole note" framing that 7 of the 9 use unchanged. Parameterized tools build on the same source-block helper plus their own parameter directive.

## Test plan
- [x] \`pnpm lint\` clean
- [x] Tools surface under Analysis in the ToolPanel
- [x] Each tool's prompt body matches the upstream byte-for-byte (modulo frontmatter strip)

## Follow-ups
- ToolPanel crowding under Analysis after this + #512 is tracked in #525 (sub-menu organization).
- Cross-references to combat-epistemology siblings (steelman, etc.) resolve when #512 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)