### PR TITLE
tools: port combat-epistemology skills to analysis/ category

### DIFF
--- a/src/shared/tools/definitions/analysis/aversionfactor.prompt.md
+++ b/src/shared/tools/definitions/analysis/aversionfactor.prompt.md
@@ -1,0 +1,110 @@
+
+Apply aversionfactor to: $ARGUMENTS
+
+If no objection specified, identify the most salient stuck point or resistance pattern in the current conversation.
+
+## tl;dr
+
+**aversionfactor** asks: "what's the real objection hiding beneath the stated one?"
+
+It surfaces hidden resistance by repeatedly asking "and if that weren't true, would you do it?"
+
+> stated: "I don't have time"
+> real: "I'm afraid I'll fail and that would be humiliating"
+
+It's a **resistance decomposition operator**.
+
+## when to use
+
+Use **aversionfactor** when:
+
+- Someone (including yourself) keeps **not doing** something they claim to want
+- Objections seem to **shift** when addressed ("okay, but also...")
+- The stated reason feels like a **rationalization**
+- You've solved the practical problems but action still doesn't happen
+- There's an **ugh field** around a topic -- a felt sense of "I don't want to think about this"
+
+Don't use when:
+
+- The stated objection is genuine and sufficient -> just solve it
+- You're exploring goals, not resistance -> **goalfactor**
+- You want to surface assumptions -> **excavate**
+
+Rule of thumb: **aversionfactor = "if that problem were magically solved, would you do it? no? then what's the real reason?"**
+
+## the mechanism
+
+Stated objections are often not the real objections. The real objections are:
+
+1. **Too threatening to voice** -- "I'm afraid of failing" is harder to say than "I'm too busy"
+2. **Not consciously accessible** -- the person genuinely doesn't know what's blocking them
+3. **Multiply determined** -- several aversions stack up, but only one gets verbalized
+
+aversionfactor works by:
+
+1. **The magic wand test** -- "if [stated objection] were magically solved, would you do it?"
+2. **Iterative peeling** -- each "no" reveals another layer
+3. **Aversion taxonomy** -- categorizing what type of resistance this is
+4. **Direct addressing** -- engaging with the real aversion, not the proxy
+
+The insight: most procrastination and "stuck" patterns are protection against something. Finding what's being protected reveals what's actually going on.
+
+## signature
+
+```
+aversionfactor(stated_objection, desired_action) -> {aversion_stack, root_aversion, aversion_type, resolution_paths}
+```
+
+- **stated_objection:** the surface-level reason given ("I don't have time")
+- **desired_action:** what they're not doing but claim to want
+
+Output:
+
+- **aversion_stack** -- layers of objection from surface to root
+- **root_aversion** -- the deepest resistance
+- **aversion_type** -- category of the root aversion
+- **resolution_paths** -- ways to address or work around the real aversion
+
+## process (step by step)
+
+### step 0: identify the pattern
+Notice: what action is not happening despite stated intention? What reason is given?
+
+### step 1: apply the magic wand test
+"Imagine [stated objection] were completely solved -- you had infinite time/money/skill/whatever. Would you do it then?"
+
+- If **yes** -> the stated objection might be genuine; help solve it
+- If **hesitation or no** -> there's a deeper aversion; continue
+
+### step 2: surface the next objection
+"So if time weren't the issue, what would still make this hard?"
+
+Capture the new objection. Don't judge it.
+
+### step 3: iterate the magic wand
+Repeat steps 1-2 on the new objection. Continue until:
+- You hit something that feels like the real resistance
+- The person says "yeah, if that were solved, I'd actually do it"
+
+### step 4: classify the root aversion
+What type of resistance is this? (See aversion taxonomy in reference.md)
+
+### step 5: validate the aversion
+The aversion exists for a reason. Acknowledge it:
+- "It makes sense that you'd be afraid of [X]"
+- "That's a real risk/cost you're protecting against"
+
+Validation isn't agreement -- it's recognition that the aversion is doing something.
+
+### step 6: explore resolution paths
+Now that the real aversion is visible:
+- Can it be addressed directly?
+- Can the action be modified to reduce the aversion?
+- Can the aversion be accepted and acted through anyway?
+- Is the aversion revealing that you don't actually want the thing?
+
+---
+
+See [examples](examples.md) for worked demonstrations.
+
+See [reference](reference.md) for aversion taxonomy, quality criteria, anti-patterns, and integration points.

--- a/src/shared/tools/definitions/analysis/aversionfactor.ts
+++ b/src/shared/tools/definitions/analysis/aversionfactor.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `aversionfactor.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './aversionfactor.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.aversionfactor',
+  name: 'Aversion Factor',
+  category: 'analysis',
+  description: 'Decompose a stated objection into the underlying aversions',
+  longDescription:
+    'Inverse of goal-factor: takes a stated objection or hesitation and walks it down to the actual ' +
+    'aversions driving it. Output names the aversion crisply, identifies which actions would actually ' +
+    "address it (vs. accommodate it), and flags when a stated reason is doing motivated cover for a " +
+    'different felt sense.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'aversion-factor the underlying objection'),
+});

--- a/src/shared/tools/definitions/analysis/doublecrux.prompt.md
+++ b/src/shared/tools/definitions/analysis/doublecrux.prompt.md
@@ -1,0 +1,99 @@
+
+Apply doublecrux to: $ARGUMENTS
+
+If no positions are specified, identify the most significant disagreement or tension in the current conversation and find the crux.
+
+## tl;dr
+
+Find the belief that would change the conclusion if flipped. Disagreement resolution operator.
+
+> "what's the one thing that, if you learned you were wrong about it, would make you change your mind?"
+
+## when to use
+
+Use when:
+- Two parties hold **opposing positions** and neither is moving
+- An argument is **generating heat but not light**
+- You want to find out if a disagreement is **resolvable in principle**
+- You need to identify what **evidence would actually matter**
+- You're trying to understand **why you believe something**
+
+Don't use when:
+- The disagreement is purely semantic -- use **taboo**
+- You need to surface hidden assumptions -- use **excavate**
+- There's no genuine disagreement to resolve
+
+## the mechanism
+
+Most arguments are about conclusions, not reasons. People defend positions without examining what's actually holding them up. Doublecrux reverses this:
+
+1. **Identifying cruxes** -- beliefs that are necessary for the conclusion
+2. **Checking for shared cruxes** -- finding where both parties' conclusions depend on the same belief
+3. **Targeting the crux** -- investigating that specific claim rather than the whole debate
+
+The insight: if you find a crux that both parties agree would change their minds, you've transformed an argument into an investigation.
+
+**Double** crux means: the crux must be load-bearing for *both* sides. A believes X, B believes not-X. If both would flip their conclusion upon learning the truth about claim C, then C is the double crux.
+
+## signature
+
+`doublecrux(position_A, position_B) -> {cruxes_A, cruxes_B, double_cruxes, investigation_plan}`
+
+- **position_A:** first party's conclusion and reasoning
+- **position_B:** second party's conclusion and reasoning
+
+Output:
+- **cruxes_A** -- beliefs that A would need to change to flip
+- **cruxes_B** -- beliefs that B would need to change to flip
+- **double_cruxes** -- cruxes shared by both (the investigation targets)
+- **investigation_plan** -- how to resolve the double crux empirically or logically
+
+## process
+
+### step 0: clarify the disagreement
+State both positions clearly. Ensure you're disagreeing about the same thing (use **taboo** if needed).
+
+### step 1: generate cruxes for A
+Ask A: "List the beliefs that, if you learned they were false, would make you change your conclusion."
+
+For each belief, verify:
+- Is it actually necessary? (If this were false, would you really change your mind?)
+- Is it specific enough to test or investigate?
+
+Aim for 3-7 genuine cruxes.
+
+### step 2: generate cruxes for B
+Repeat for B. Same verification process.
+
+### step 3: identify double cruxes
+Compare the lists. Look for:
+- **Direct overlaps** -- same belief on both lists
+- **Inverse pairs** -- A's crux is "X is true," B's crux is "X is false"
+- **Upstream connections** -- both cruxes depend on a shared third belief
+
+A double crux is a belief where:
+- If A learned it was false, A would move toward B's position
+- If B learned it was true, B would move toward A's position
+
+### step 4: verify the double crux
+Ask both parties:
+- "If we discovered that [double crux] was actually [true/false], would you change your conclusion?"
+- "Is there anything else you'd need, or is this the crux?"
+
+If either says "no, I'd still believe my conclusion," it's not a real crux. Go back to step 1.
+
+### step 5: design the investigation
+For the verified double crux:
+- What evidence would resolve it?
+- What experiment, analysis, or research would help?
+- What would each outcome mean for the original disagreement?
+
+### step 6: investigate or acknowledge limits
+Either:
+- Pursue the investigation and update based on findings
+- Acknowledge that the crux is currently unresolvable (and the disagreement is therefore rational)
+
+## additional resources
+
+- For worked examples, see [examples.md](examples.md)
+- For quality criteria, anti-patterns, and integration points, see [reference.md](reference.md)

--- a/src/shared/tools/definitions/analysis/doublecrux.ts
+++ b/src/shared/tools/definitions/analysis/doublecrux.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `doublecrux.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './doublecrux.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.doublecrux',
+  name: 'Double Crux',
+  category: 'analysis',
+  description: 'Find the shared crux that would resolve a disagreement',
+  longDescription:
+    'Walks two positions back to a shared crux: the proposition both sides would update on if shown ' +
+    'evidence about. Output is the crux statement plus what evidence would move each side and which ' +
+    'cruxes are empirical vs definitional vs values-based. Reach for this when a disagreement is ' +
+    'going in circles and you suspect the parties are arguing past each other.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-opus-4-7',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'find the double crux'),
+});

--- a/src/shared/tools/definitions/analysis/goalfactor.prompt.md
+++ b/src/shared/tools/definitions/analysis/goalfactor.prompt.md
@@ -1,0 +1,98 @@
+
+Apply goalfactor to: $ARGUMENTS
+
+If no action specified, identify the most salient goal or commitment in the current conversation and decompose it.
+
+## tl;dr
+
+**goalfactor** asks: "why do you actually want this?"
+
+It decomposes actions into underlying goals, and those goals into deeper goals, until you find what you're really after.
+
+> "I want X" -> "why?" -> "to get Y" -> "why Y?" -> "because it gives me Z" -> "Z is terminal"
+
+It's a **motivation decomposition operator**.
+
+## when to use
+
+Use **goalfactor** when:
+
+- You're about to spend significant resources on something
+- You feel stuck or obligated to a particular path
+- Someone (including yourself) is defending an action without clear reasoning
+- You want to find **alternative paths** to the same outcome
+- You suspect the stated goal is a **proxy** for something else
+
+Don't use when:
+
+- You want to surface hidden objections -> **aversionfactor**
+- You want to stress-test a plan -> **murphyjitsu**
+- The goal is clearly terminal (e.g., "reduce suffering")
+
+Rule of thumb: **goalfactor = "what would achieving this actually get you?"**
+
+## the mechanism
+
+Most actions serve multiple goals, and most stated goals are instrumental to deeper goals. goalfactor works by:
+
+1. **Vertical decomposition** -- asking "why?" to find deeper goals
+2. **Horizontal mapping** -- identifying all the goals served by one action
+3. **Alternative generation** -- finding other ways to satisfy the deep goals
+4. **Efficiency check** -- is this action the best path to what you actually want?
+
+The insight: people often optimize for proxies while losing sight of what they actually want.
+
+**Terminal vs instrumental:**
+- **Terminal goals** = valued for their own sake (connection, autonomy, mastery, meaning, pleasure, security, status)
+- **Instrumental goals** = valued because they lead to terminal goals
+
+goalfactor traces instrumental -> terminal chains.
+
+## signature
+
+```
+goalfactor(action_or_desire) -> {goal_tree, terminal_goals, alternative_paths, efficiency_assessment}
+```
+
+- **action_or_desire:** the thing being examined ("I want to get an MBA")
+
+Output:
+
+- **goal_tree** -- hierarchical map of goals served by this action
+- **terminal_goals** -- the bottom-level values being pursued
+- **alternative_paths** -- other ways to satisfy the terminal goals
+- **efficiency_assessment** -- is the original action a good path?
+
+## process (step by step)
+
+### step 0: state the action or desire
+Be specific. "I want to be successful" is too vague. "I want to get promoted to VP by 2025" is workable.
+
+### step 1: ask "why do you want this?"
+Generate the immediate goals this action serves. Don't stop at one -- most actions serve multiple goals.
+
+### step 2: recurse on each goal
+For each goal from step 1, ask "why do you want that?" Continue until you hit terminal values or the chain starts looping.
+
+### step 3: identify terminal goals
+Mark the endpoints. Common terminals: connection, autonomy, mastery, meaning, security, pleasure, status.
+
+### step 4: map the goal tree
+Visualize the structure:
+```
+[action] -> [goal 1] -> [deeper goal] -> [terminal]
+         -> [goal 2] -> [terminal]
+         -> [goal 3] -> [deeper goal] -> [deeper goal] -> [terminal]
+```
+
+### step 5: generate alternative paths
+For each terminal goal, brainstorm other ways to achieve it that don't require the original action.
+
+### step 6: assess efficiency
+Compare paths: which has the best ratio of terminal goal satisfaction to cost? Does the original action have hidden costs? Are there alternatives that satisfy multiple terminal goals better?
+
+---
+
+See [examples](examples.md) for worked demonstrations.
+
+See [reference](reference.md) for quality criteria, anti-patterns, and integration points.

--- a/src/shared/tools/definitions/analysis/goalfactor.ts
+++ b/src/shared/tools/definitions/analysis/goalfactor.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `goalfactor.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './goalfactor.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.goalfactor',
+  name: 'Goal Factor',
+  category: 'analysis',
+  description: 'Decompose a goal into the underlying needs it serves',
+  longDescription:
+    'Walks a stated goal down to the needs it actually serves — separating the surface action from ' +
+    "the felt sense of why it matters. Surfaces alternative actions that would meet the same needs " +
+    'and helps you notice when a goal is doing more than one job at once. Useful when motivation ' +
+    'feels misaligned with the stated objective.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'goal-factor the underlying needs'),
+});

--- a/src/shared/tools/definitions/analysis/hamming.prompt.md
+++ b/src/shared/tools/definitions/analysis/hamming.prompt.md
@@ -1,0 +1,89 @@
+
+# hamming
+
+$ARGUMENTS
+
+**tl;dr**: Find the gap between what you're doing and what actually matters, then confront why the gap exists.
+
+> Core question: "What are the most important problems in your field, and why aren't you working on them?"
+
+## When to Use
+
+- Feeling busy but not impactful
+- Choosing between projects or priorities
+- Annual/quarterly planning and review
+- Sensing that your effort allocation doesn't match your stated values
+- When someone asks "am I working on the right things?"
+
+## When NOT to Use
+
+- In the middle of executing on a clear, validated plan (don't derail momentum)
+- When someone needs tactical help, not strategic reflection
+- When the domain is too narrow for meaningful prioritization
+
+## The Original Hamming Questions
+
+Richard Hamming would corner scientists at Bell Labs and ask three questions:
+
+1. **"What are the most important problems in your field?"**
+2. **"What are you working on?"**
+3. **"If what you're working on isn't important, why are you working on it?"**
+
+Most people could answer 1 and 2 but became uncomfortable at 3. That discomfort is the signal.
+
+## Mechanism
+
+1. **Identify the important problems** — What would matter most if solved?
+2. **Confront the gap** — Compare important problems with current allocation
+3. **Surface the reasons** — Why the gap exists (fear, comfort, inertia, politics)
+4. **Decide** — Either close the gap or articulate why the gap is justified
+
+## Signature
+
+```
+hamming(domain) → {
+  important_problems: [{problem, impact, tractability, neglectedness}],
+  current_work: [{activity, category, time_fraction}],
+  gaps: [{important_problem, reason_not_working_on_it, reason_type}],
+  decision: string
+}
+```
+
+## Process
+
+### Step 1: Define the Domain
+Bound the scope. "My career" is too broad; "my work as a data scientist at company X" is right. The domain should be specific enough that "important" has a clear meaning.
+
+### Step 2: Identify the Important Problems
+List the 3-5 most important problems in this domain. For each, assess:
+- **Impact**: How much would solving this matter?
+- **Tractability**: Could you actually make progress on it?
+- **Neglectedness**: Is anyone else working on it?
+
+Problems that are high-impact, tractable, and neglected are where the leverage lives.
+
+### Step 3: Categorize Current Work
+List what you actually spend time on. For each activity, estimate the fraction of your time it consumes. Categorize each as: important-and-working-on-it, important-but-not-working-on-it, unimportant-but-working-on-it, or maintenance/overhead.
+
+### Step 4: Compare and Find Gaps
+Place the important problems next to the current work. Identify: Which important problems get zero time? Which unimportant activities consume significant time?
+
+### Step 5: Diagnose the Reasons
+For each gap, ask *why* honestly. Common reasons:
+- **Fear of failure**: The important problem is hard and failure is visible
+- **Comfort**: Current work is familiar and provides regular wins
+- **Inertia**: "I've always worked on this"
+- **Social pressure**: Others expect you to do the less-important work
+- **False constraints**: "I can't work on that because..." (test the constraint)
+- **Legitimate reasons**: Sometimes the gap is justified (dependencies, timing, skill gaps)
+
+### Step 6: Decide
+For each gap, choose one:
+- **Close it**: Shift time toward the important problem. Specify how much, starting when.
+- **Justify it**: Articulate clearly why the gap should remain. If the justification sounds weak when written down, it probably is.
+- **Investigate**: If you can't tell whether closing the gap is feasible, make that investigation your next action.
+
+---
+
+See [examples.md](examples.md) for worked examples.
+See [reference.md](reference.md) for quality criteria, anti-patterns, and integration points.

--- a/src/shared/tools/definitions/analysis/hamming.ts
+++ b/src/shared/tools/definitions/analysis/hamming.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `hamming.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './hamming.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.hamming',
+  name: 'Hamming Question',
+  category: 'analysis',
+  description: 'Surface the most-important problem you are not working on',
+  longDescription:
+    'Applies Richard Hamming\'s question — what are the most important problems in your field, and ' +
+    'why aren\'t you working on them? — to the source. Output is the highest-leverage problem the ' +
+    'source either ignores or under-prioritises, plus the reasons it might be getting avoided. ' +
+    'Useful for portfolio-style decisions and yearly reviews.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-opus-4-7',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'apply the Hamming question'),
+});

--- a/src/shared/tools/definitions/analysis/innerloop.prompt.md
+++ b/src/shared/tools/definitions/analysis/innerloop.prompt.md
@@ -1,0 +1,74 @@
+
+# innerloop
+
+$ARGUMENTS
+
+**tl;dr**: Ask your gut what it actually expects, then take the answer seriously — especially when it disagrees with your verbal reasoning.
+
+> Core question: "If I imagine this actually happening, what do I *feel* will occur?"
+
+## When to Use
+
+- You've made a plan and something feels off but you can't say what
+- Your stated prediction and your felt prediction disagree
+- You want to access pattern-matching knowledge that hasn't been verbalized
+- Before committing to a decision, as a final check
+- When someone says "I think X will happen" but their body language says otherwise
+
+## When NOT to Use
+
+- The domain is genuinely outside your experience (no patterns to match)
+- You need precise quantitative estimates (use referenceclass)
+- You're in a strong emotional state that would distort simulation (angry, panicked, infatuated)
+
+## Mechanism
+
+1. **Quiet the verbal reasoning** — Stop constructing arguments. Stop optimizing the answer.
+2. **Query the simulator** — Imagine the scenario concretely. Watch what your gut expects.
+3. **Take the output seriously** — The simulator's answer is evidence, not noise.
+4. **Investigate discrepancies** — When gut and verbal disagree, the gap contains information.
+
+## The Surprise-O-Meter
+
+A useful sub-tool: after stating your prediction, ask "If the opposite happened, how surprised would I *actually* be?" Rate from 1 (not surprised at all) to 10 (completely shocked). If you predict X but would only be 3/10 surprised by not-X, your real probability for X is much lower than you're claiming.
+
+## Signature
+
+```
+innerloop(scenario_or_plan) → {
+  stated_expectation: string,
+  simulated_expectation: string,
+  surprise_rating: number,  // 1-10
+  discrepancy: string | null,
+  hidden_knowledge: string[],
+  revised_expectation: string
+}
+```
+
+## Process
+
+### Step 1: State the Official Prediction
+Write down what you say you expect, or what your plan assumes will happen. Be specific.
+
+### Step 2: Quiet Verbal Reasoning
+Stop arguing for or against the prediction. You're not trying to be right. You're trying to listen.
+
+### Step 3: Simulate Concretely
+Imagine the scenario unfolding in detail. Not "the project succeeds" but "it's Tuesday, the deadline is Friday, the code is..." Watch the movie in your head. Note what happens.
+
+### Step 4: Apply the Surprise-O-Meter
+Ask: "If this went differently than I predict, how surprised would I *actually* be?" Rate 1-10. If below 7, your real confidence is lower than stated.
+
+### Step 5: Name the Discrepancy
+If stated and simulated expectations differ, name the gap precisely. "I say we'll ship on time, but when I imagine Friday, I see us still debugging the integration layer."
+
+### Step 6: Extract Hidden Knowledge
+The discrepancy contains information. What does your simulator know that your verbal reasoning hasn't admitted? Common sources: past experience with similar situations, social dynamics you've observed but not articulated, physical intuitions about feasibility.
+
+### Step 7: Revise or Investigate
+Either update your prediction to match the simulator (if the simulator's track record is good in this domain) or flag the discrepancy for investigation (if you can't tell which source to trust).
+
+---
+
+See [examples.md](examples.md) for worked examples.
+See [reference.md](reference.md) for quality criteria, anti-patterns, and integration points.

--- a/src/shared/tools/definitions/analysis/innerloop.ts
+++ b/src/shared/tools/definitions/analysis/innerloop.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `innerloop.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './innerloop.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.innerloop',
+  name: 'Inner Loop',
+  category: 'analysis',
+  description: 'Sim the plan from the inside — what would actually happen?',
+  longDescription:
+    'Mentally simulates a plan or scenario from the inside, step by step, surfacing the friction ' +
+    "points the outside view tends to gloss. Output is a step-by-step inner monologue plus the moments " +
+    'where the simulation predicts a stumble and the user would course-correct in practice. ' +
+    'Complements murphyjitsu (failure-mode listing) — innerloop is "play it forward".',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'sim the inner loop'),
+});

--- a/src/shared/tools/definitions/analysis/noticing.prompt.md
+++ b/src/shared/tools/definitions/analysis/noticing.prompt.md
@@ -1,0 +1,88 @@
+
+# noticing
+
+$ARGUMENTS
+
+**tl;dr**: Catch the flicker of "wait, something's off" before your brain smooths it over, and flag it for investigation.
+
+> Core question: "What am I glossing over right now?"
+
+## When to Use
+
+- Something feels slightly wrong but you can't articulate what
+- You're about to move past a question without answering it
+- A conversation shifted topics and you're not sure why
+- You feel a twinge of discomfort that's easy to ignore
+- You realize you've been avoiding thinking about something
+- Someone mentions ugh fields, flinching, or "glossing over"
+
+## When NOT to Use
+
+- You already know the problem and need a solution (use a different skill)
+- In high-urgency situations requiring immediate action (notice later, act now)
+- When noticing becomes recursive avoidance of doing the actual work
+
+## Mechanism
+
+Your brain smooths over inconsistencies, discomfort, and confusion in milliseconds. By the time you're aware of a thought, the rough edges have been filed down and the threatening implications have been tucked away. Noticing is the skill of catching **step 1** — the raw signal before the smoothing.
+
+The signal is always brief: a flicker of confusion, a moment of "huh," a flinch away from a thought. If you don't catch it in the moment, your brain rewrites history to say it never happened.
+
+## What to Notice
+
+### Epistemic Signals
+- Confusion you're about to wave away: "I don't quite get that, but it's probably fine"
+- Inconsistency between two things you believe
+- An argument that's persuasive but you can't reconstruct the reasoning
+- Something being explained in suspiciously vague language
+
+### Emotional Signals
+- A flinch away from a topic (ugh field)
+- Relief when a subject changes
+- Defensiveness that arrives before a threat
+- Feeling "this is fine" in a way that protests too much
+
+### Social Signals
+- A topic the group silently agreed not to discuss
+- Someone's tone not matching their words
+- Your own urge to perform agreement you don't feel
+- The moment you decide not to ask the obvious question
+
+### Process Signals
+- Skipping a step and hoping it won't matter
+- Choosing the easy task over the important one
+- Rationalizing a decision you made for other reasons
+- Planning to do something you know you won't do
+
+## Signature
+
+```
+noticing(situation) → {
+  signals_detected: [{signal, type, raw_content}],
+  smoothing_attempts: string[],
+  flags_for_investigation: string[],
+  recommended_tool: string | null
+}
+```
+
+## Process
+
+### Step 1: Build Meta-Attention
+Before examining the situation, shift into observer mode. You're not trying to solve anything. You're trying to see what's there — especially what's trying to not be seen.
+
+### Step 2: Catch the Flicker
+Scan the situation for the four signal types: epistemic, emotional, social, process. For each, ask: "Is there a signal here that I'm about to ignore?" The question itself often surfaces the signal.
+
+### Step 3: Name It
+Give the signal a precise name. Not "something feels off" but "I notice I feel relief when the conversation moves away from the budget question." Naming it prevents your brain from re-smoothing it.
+
+### Step 4: Resist the First Explanation
+Your brain will immediately offer a comfortable explanation for the signal. "I'm relieved because the budget question is boring." Maybe. But the first explanation is often a cover story. Hold it at arm's length. Don't accept or reject it — just notice that it arrived very quickly.
+
+### Step 5: Investigate or Flag
+Either investigate now (using the appropriate skill — innerloop for predictions, aversionfactor for flinches, doublecrux for disagreements) or explicitly flag it for later. "I notice I'm avoiding thinking about the budget. I'm flagging this for investigation tomorrow." Flagging is acceptable; pretending you didn't notice is not.
+
+---
+
+See [examples.md](examples.md) for worked examples.
+See [reference.md](reference.md) for quality criteria, anti-patterns, and integration points.

--- a/src/shared/tools/definitions/analysis/noticing.ts
+++ b/src/shared/tools/definitions/analysis/noticing.ts
@@ -1,0 +1,27 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `noticing.prompt.md`.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './noticing.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.noticing',
+  name: 'Noticing',
+  category: 'analysis',
+  description: 'Surface the felt sense the prose isn\'t saying out loud',
+  longDescription:
+    'Reads the source for the things the writer is sensing but not yet articulating — confusion, ' +
+    'disagreement, hesitation, excitement, surprise. Output names each noticed felt sense, points ' +
+    'at the textual evidence for it, and asks one or two questions that would make the noticed ' +
+    'thing legible. Useful when prose feels like it\'s circling something it can\'t quite say.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: false },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'name what is being noticed'),
+});

--- a/src/shared/tools/definitions/analysis/referenceclass.prompt.md
+++ b/src/shared/tools/definitions/analysis/referenceclass.prompt.md
@@ -1,0 +1,74 @@
+
+# referenceclass
+
+$ARGUMENTS
+
+**tl;dr**: Before reasoning about why *this case* is different, find out what usually happens in cases like this.
+
+> Core question: "What's the base rate for things like this?"
+
+## When to Use
+
+- Making predictions or probability estimates
+- Estimating project timelines or budgets
+- Assessing likelihood of success for a venture
+- Any time you catch yourself thinking "but this time is different"
+- When you need to sanity-check an inside-view estimate
+
+## When NOT to Use
+
+- The situation is genuinely unprecedented (no reference class exists)
+- You need a causal model, not just a prediction
+- The reference class is so broad it carries no information
+
+## Inside View vs Outside View
+
+The **inside view** builds a model from the specifics of the situation: the team, the plan, the details. It asks "how will this unfold?" The **outside view** ignores the specifics and asks "what usually happens when people attempt things like this?" The inside view is seductive because it feels like real reasoning. The outside view is boring but calibrated. Referenceclass forces you to start from the outside view before allowing inside-view adjustments.
+
+## Mechanism
+
+1. **Identify the reference class** — What category does this belong to?
+2. **Find base rates** — What actually happens to things in that category?
+3. **Anchor on the base rate** — Start your estimate there, not from your model
+4. **Adjust cautiously** — Only move away from the base rate with strong, specific evidence
+
+## Signature
+
+```
+referenceclass(prediction_or_estimate) → {
+  reference_class: string,
+  base_rate: number | range,
+  inside_view_estimate: number,
+  adjustment_reasons: string[],
+  final_estimate: number | range,
+  confidence: string
+}
+```
+
+## Process
+
+### Step 1: State the Inside-View Estimate
+Write down your current prediction or estimate before looking at base rates. This is your anchor to compare against.
+
+### Step 2: Identify Candidate Reference Classes
+Generate at least 3 plausible reference classes at different levels of specificity. Too broad is uninformative; too narrow cherry-picks.
+
+### Step 3: Select the Best Reference Class
+Choose the class that is specific enough to be informative but broad enough to have sufficient data. State why you chose it.
+
+### Step 4: Find the Base Rate
+Look up or estimate actual outcomes for the reference class. Use real data when available. Note sample size and data quality.
+
+### Step 5: Compare Inside View to Base Rate
+Place your inside-view estimate and the base rate side by side. Note the gap. The gap is the territory you need to explain.
+
+### Step 6: Identify Legitimate Adjustment Factors
+List specific, verifiable reasons this case differs from the reference class. Each reason must shift the estimate in a stated direction by a stated amount. Be suspicious of adjustments that all go the same way.
+
+### Step 7: Produce Final Estimate
+Start from the base rate. Apply adjustments. The final estimate should be closer to the base rate than your original inside-view estimate in almost all cases. If it isn't, explain why with extreme clarity.
+
+---
+
+See [examples.md](examples.md) for worked examples.
+See [reference.md](reference.md) for quality criteria, anti-patterns, and integration points.

--- a/src/shared/tools/definitions/analysis/referenceclass.ts
+++ b/src/shared/tools/definitions/analysis/referenceclass.ts
@@ -1,0 +1,28 @@
+/**
+ * Ported from https://github.com/dgriffith/combat-epistemology (CC BY 4.0).
+ * Prompt body lives in `referenceclass.prompt.md` from the upstream
+ * SKILL.md verbatim.
+ */
+import { registerTool } from '../../registry';
+import type { ToolContext } from '../../types';
+import SYSTEM_PROMPT from './referenceclass.prompt.md?raw';
+import { analysisSourceBlock, analysisFirstMessage } from './_shared';
+
+registerTool({
+  id: 'analysis.referenceclass',
+  name: 'Reference Class',
+  category: 'analysis',
+  description: 'Forecast via base rates from the right outside view',
+  longDescription:
+    'Forces an outside view: pick a reference class of similar past situations, surface their base ' +
+    'rate, then check whether the current case has any features that should move the estimate off ' +
+    'that rate. Reach for this when an estimate or prediction is in the air and "this time is ' +
+    'different" thinking is doing more work than the inside view warrants.',
+  context: ['selectedText', 'fullNote'],
+  outputMode: 'openConversation',
+  preferredModel: 'claude-sonnet-4-6',
+  web: { defaultEnabled: true },
+  buildPrompt: () => '',
+  buildSystemPrompt: (ctx: ToolContext) => SYSTEM_PROMPT + analysisSourceBlock(ctx),
+  buildFirstMessage: (ctx: ToolContext) => analysisFirstMessage(ctx, 'find the reference class'),
+});

--- a/src/shared/tools/definitions/index.ts
+++ b/src/shared/tools/definitions/index.ts
@@ -12,6 +12,13 @@ import './analysis/negspace';
 import './analysis/rhetoricize';
 import './analysis/rhyme';
 import './analysis/synthesize';
+import './analysis/referenceclass';
+import './analysis/doublecrux';
+import './analysis/goalfactor';
+import './analysis/aversionfactor';
+import './analysis/hamming';
+import './analysis/innerloop';
+import './analysis/noticing';
 
 // Research tools
 import './research/load-bearing-claim';


### PR DESCRIPTION
## Summary
Closes #512. Part of epic #517.

Adds 7 analysis ThinkingTools ported from [combat-epistemology](https://github.com/dgriffith/combat-epistemology) (CC BY 4.0). The other 3 skills in the upstream — \`taboo\`, \`murphyjitsu\`, \`steelman\` — are already shipped in Minerva and were kept as-is.

## New tools
- \`referenceclass\` — outside-view forecasting via base rates
- \`doublecrux\` — surface the shared crux that would resolve a disagreement
- \`goalfactor\` — decompose a goal into its underlying needs
- \`aversionfactor\` — decompose an objection into its underlying aversions
- \`hamming\` — apply Hamming's question (what's the most important problem you're not working on?)
- \`innerloop\` — sim a plan from the inside, friction points and all
- \`noticing\` — surface the felt sense the prose isn't saying out loud

All open conversations against the selection (or whole note when nothing selected). None are parameterized — these tools want free-form input rather than upfront enums. Reuses \`_shared.ts\` helpers from the FUTURE_TOKENS port.

## Shape
Each is a ~25-line \`registerTool({...})\` plus a sibling \`.prompt.md\` containing the upstream SKILL.md body verbatim (frontmatter stripped). Prompts unmodified; only metadata authored fresh. CC BY 4.0 attribution in a header comment on every TS file.

## Cross-branch dependency
\`_shared.ts\` ships on PR #526 too. Both branches carry identical content; whichever merges second will see git resolve the duplicate cleanly.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 2109/2109 pass
- [x] All 7 surface under Analysis in the ToolPanel

## Follow-ups
- Sub-menu organization for the now-crowded Analysis category — #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)