### PR TITLE
notebase: merge note into another (#464)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,6 +7,7 @@ import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
 import { isIndexable } from './notebase/indexable-files';
 import { renameWithLinkRewrites } from './notebase/rename';
+import { mergeNotes, previewMergeNotes } from './notebase/merge';
 import { renameAnchor } from './notebase/rename-anchor';
 import { renameSource, renameExcerpt } from './notebase/rename-source-excerpt';
 import * as gitOps from './git/index';
@@ -427,6 +428,44 @@ export function registerIpcHandlers(): void {
     }
 
     await persistIndexes(rootPath);
+  });
+
+  ipcMain.handle(Channels.NOTEBASE_MERGE_PREVIEW, async (e, sourceRelPath: string, targetRelPath: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return previewMergeNotes(rootPath, sourceRelPath, targetRelPath);
+  });
+
+  ipcMain.handle(Channels.NOTEBASE_MERGE, async (e, sourceRelPath: string, targetRelPath: string, separator?: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const ctx = projectContext(rootPath);
+    const result = await mergeNotes(rootPath, sourceRelPath, targetRelPath, {
+      separator,
+      markPathHandled,
+      reindexHook: (relPath, content) => {
+        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
+      },
+      removeHook: (relPath) => search.removeNote(ctx, relPath),
+    });
+    // Broadcast: source disappeared (RENAMED with one transition signals
+    // editor tabs to drop / reroute) plus the rewritten set so other
+    // windows reload affected files.
+    for (const targetWin of windowsForProject(rootPath)) {
+      targetWin.webContents.send(Channels.NOTEBASE_RENAMED, [
+        { old: sourceRelPath, new: '' /* sentinel: deletion */ },
+      ]);
+      if (result.rewrittenPaths.length > 0) {
+        targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, [
+          ...result.rewrittenPaths,
+          targetRelPath,
+        ]);
+      } else {
+        targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, [targetRelPath]);
+      }
+    }
+    await persistIndexes(rootPath);
+    return result;
   });
 
   ipcMain.handle(Channels.NOTEBASE_RENAME_SOURCE, async (e, oldId: string, newId: string) => {

--- a/src/main/notebase/merge.ts
+++ b/src/main/notebase/merge.ts
@@ -1,0 +1,238 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from './fs';
+import { rewriteWikiLinks, normalizePath as normalizeLinkPath } from './link-rewriting';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+import { isIndexable } from './indexable-files';
+
+/**
+ * Merge note (#464). Append the source note's body to a target note,
+ * rewrite every wiki-link `[[source]]` across the project to point at
+ * the target, and delete the source. Source frontmatter is dropped on
+ * merge — the target keeps its own.
+ *
+ * Conceptually: the inverse of "extract selection to new note." Borrowed
+ * from Obsidian's Note Composer plugin.
+ *
+ * Per CLAUDE.md, this is destructive-feeling but git-backed; the renderer
+ * surfaces a single Confirm before invoking. Failure mid-flight leaves
+ * the project in whatever state the partial writes produced — recovery
+ * is `git reset --hard HEAD` per Minerva's git-as-undo model.
+ */
+
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+
+export interface MergePreview {
+  /** Number of wiki-link occurrences across the project that will be
+   *  rewritten from source → target. */
+  linkOccurrences: number;
+  /** Number of files that contain at least one such link. */
+  affectedFiles: number;
+}
+
+export interface MergeResult {
+  /** Final relative path of the merged target note (== `targetRelPath`). */
+  targetPath: string;
+  /** Character offset in the merged target where the source body begins.
+   *  Renderer uses this to scroll the editor to the merge point. */
+  mergeOffset: number;
+  /** 1-based line number of the merge point. */
+  mergeLine: number;
+  /** Number of wiki-link occurrences rewritten. */
+  rewrittenLinks: number;
+  /** Other notes whose content was rewritten by the link-rewrite pass.
+   *  Excludes the target itself (which always changed). */
+  rewrittenPaths: string[];
+  /** Source path that was deleted as part of the merge. */
+  deletedSource: string;
+}
+
+export interface MergeOptions {
+  /** Inserted between the target's existing content and the source body.
+   *  Default `\n\n`. The merge point reported in `mergeOffset` is the
+   *  position immediately AFTER this separator (i.e., where the source
+   *  body actually starts). */
+  separator?: string;
+  /** Watcher dedupe hook — called for every relative path the merge
+   *  will write to or delete. Optional. */
+  markPathHandled?: (relativePath: string) => void;
+  /** Called with `(relativePath, content)` after each reindex. Optional. */
+  reindexHook?: (relativePath: string, content: string) => void;
+  /** Called with `relativePath` after the source is removed from the graph. */
+  removeHook?: (relativePath: string) => void;
+}
+
+/**
+ * Cheap pre-flight count of how many notes / link occurrences would be
+ * rewritten by a merge. The renderer surfaces this in the confirmation
+ * dialog so the user knows the blast radius. Pure read; no mutation.
+ */
+export async function previewMergeNotes(
+  rootPath: string,
+  sourceRelPath: string,
+  targetRelPath: string,
+): Promise<MergePreview> {
+  if (!isIndexable(sourceRelPath) || !isIndexable(targetRelPath)) {
+    throw new Error('mergeNotes: source and target must both be indexable .md files.');
+  }
+  if (sourceRelPath === targetRelPath) {
+    return { linkOccurrences: 0, affectedFiles: 0 };
+  }
+
+  const ctx = projectContext(rootPath);
+  // Graph-driven reverse-link query — fast for the common case where
+  // the source has only a handful of inbound links.
+  const referring = graph.findNotesLinkingTo(ctx, sourceRelPath);
+  let occurrences = 0;
+  let files = 0;
+  const sourceBase = normalizeLinkPath(sourceRelPath);
+  const re = buildLinkOccurrenceRegex(sourceBase);
+  for (const ref of referring) {
+    if (ref === sourceRelPath) continue; // self-references will vanish with the file
+    try {
+      const content = await notebaseFs.readFile(rootPath, ref);
+      const matches = content.match(re);
+      if (matches && matches.length > 0) {
+        occurrences += matches.length;
+        files++;
+      }
+    } catch {
+      // Read failure → file vanished or unreadable; skip silently.
+    }
+  }
+  return { linkOccurrences: occurrences, affectedFiles: files };
+}
+
+/**
+ * Compile a regex matching `[[<sourceBase>]]` and its variants
+ * (`![[…]]`, `[[…|alias]]`, `[[…#anchor]]`, with or without `.md`).
+ * Used only by `previewMergeNotes`; the actual rewrite delegates to
+ * `rewriteWikiLinks` which has its own parser.
+ */
+function buildLinkOccurrenceRegex(sourceBase: string): RegExp {
+  // Escape regex metachars in the path; allow optional .md, optional
+  // anchor (#…), and optional alias (|…). The leading `[[` may be
+  // preceded by `!` for embeds.
+  const escaped = sourceBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`!?\\[\\[\\s*${escaped}(?:\\.md)?\\s*(?:#[^\\]|]*)?\\s*(?:\\|[^\\]]*)?\\]\\]`, 'g');
+}
+
+export async function mergeNotes(
+  rootPath: string,
+  sourceRelPath: string,
+  targetRelPath: string,
+  opts: MergeOptions = {},
+): Promise<MergeResult> {
+  if (!isIndexable(sourceRelPath) || !isIndexable(targetRelPath)) {
+    throw new Error('mergeNotes: source and target must both be indexable .md files.');
+  }
+  if (sourceRelPath === targetRelPath) {
+    throw new Error('mergeNotes: source and target are the same note.');
+  }
+
+  const separator = opts.separator ?? '\n\n';
+  const ctx = projectContext(rootPath);
+
+  const [sourceContent, targetContent] = await Promise.all([
+    notebaseFs.readFile(rootPath, sourceRelPath),
+    notebaseFs.readFile(rootPath, targetRelPath),
+  ]);
+
+  const sourceBody = stripFrontmatter(sourceContent);
+
+  // Compose the merged target content. The merge point is the offset
+  // where the source body begins — i.e., target length + separator
+  // length. Use that to derive a 1-based line number for the renderer.
+  const mergeOffset = targetContent.length + separator.length;
+  const mergedContent = targetContent + separator + sourceBody;
+  const mergeLine = countLines(mergedContent.slice(0, mergeOffset));
+
+  // Build the link-rewrites map. `rewriteWikiLinks` keys are normalized
+  // paths (no `.md`). After the rewrite, links pointing at the source
+  // resolve to the target.
+  const rewrites = new Map<string, string>();
+  rewrites.set(normalizeLinkPath(sourceRelPath), normalizeLinkPath(targetRelPath));
+
+  // Find the set of referrers via the graph; cheaper than walking every
+  // note. The graph is up-to-date for saved files; unsaved buffers are
+  // the renderer's responsibility (autoSave will have flushed them
+  // before invoking, in the typical flow).
+  const referringSet = new Set(graph.findNotesLinkingTo(ctx, sourceRelPath));
+  // Drop the source itself — we're deleting it.
+  referringSet.delete(sourceRelPath);
+  // Drop the target — we'll rewrite its content separately (the merged
+  // body may itself contain `[[source]]` self-references that should
+  // become target self-references). Handled below.
+  referringSet.delete(targetRelPath);
+
+  // 1. Write the merged target. The merged content may contain
+  //    `[[source]]` references inherited from the source body — rewrite
+  //    those as part of the same write pass.
+  const targetRewritten = rewriteWikiLinks(mergedContent, rewrites);
+  opts.markPathHandled?.(targetRelPath);
+  await notebaseFs.writeFile(rootPath, targetRelPath, targetRewritten);
+  await graph.indexNote(ctx, targetRelPath, targetRewritten);
+  opts.reindexHook?.(targetRelPath, targetRewritten);
+
+  // 2. Rewrite links in every referring note. Count the total
+  //    occurrences so the renderer can surface the number in its
+  //    success toast.
+  let rewrittenLinks = 0;
+  const rewrittenPaths: string[] = [];
+  for (const ref of referringSet) {
+    let content: string;
+    try {
+      content = await notebaseFs.readFile(rootPath, ref);
+    } catch (err) {
+      console.error(`[merge] read failed for ${ref}:`, err instanceof Error ? err.message : err);
+      continue;
+    }
+    const rewritten = rewriteWikiLinks(content, rewrites);
+    if (rewritten === content) continue;
+    // Count occurrences by diffing. Cheap and accurate enough — wiki-link
+    // rewrites change exact substrings, so the regex pass is reliable.
+    const before = content.match(buildLinkOccurrenceRegex(normalizeLinkPath(sourceRelPath)));
+    rewrittenLinks += before?.length ?? 0;
+    try {
+      opts.markPathHandled?.(ref);
+      await notebaseFs.writeFile(rootPath, ref, rewritten);
+      await graph.indexNote(ctx, ref, rewritten);
+      opts.reindexHook?.(ref, rewritten);
+      rewrittenPaths.push(ref);
+    } catch (err) {
+      console.error(`[merge] write failed for ${ref}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  // 3. Delete the source. Last so a partial failure leaves the merged
+  //    target + rewritten links + the source still around — recoverable
+  //    by the user even without git.
+  opts.markPathHandled?.(sourceRelPath);
+  graph.removeNote(ctx, sourceRelPath);
+  opts.removeHook?.(sourceRelPath);
+  await fs.unlink(path.join(rootPath, sourceRelPath));
+
+  return {
+    targetPath: targetRelPath,
+    mergeOffset,
+    mergeLine,
+    rewrittenLinks,
+    rewrittenPaths,
+    deletedSource: sourceRelPath,
+  };
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(FRONTMATTER_RE, '');
+}
+
+function countLines(s: string): number {
+  // 1-based line number of the position at the end of `s`. Used to
+  // place the editor cursor at the start of the merged-in section.
+  let line = 1;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '\n') line++;
+  }
+  return line;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -41,6 +41,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.NOTEBASE_DELETE_FOLDER, relativePath),
     rename: (oldRelPath: string, newRelPath: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_RENAME, oldRelPath, newRelPath),
+    mergePreview: (sourceRelPath: string, targetRelPath: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_MERGE_PREVIEW, sourceRelPath, targetRelPath),
+    merge: (sourceRelPath: string, targetRelPath: string, separator?: string) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_MERGE, sourceRelPath, targetRelPath, separator),
     copy: (srcRelPath: string, destRelPath: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_COPY, srcRelPath, destRelPath),
     searchInNotes: (opts: unknown) => ipcRenderer.invoke(Channels.NOTEBASE_SEARCH_IN_NOTES, opts),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -218,6 +218,9 @@
   let pendingSearchQuery = $state<string | null>(null);
   let showGotoLine = $state(false);
   let showGotoNote = $state(false);
+  /** When non-null, the merge-target picker is shown. Holds the source
+   *  note path; the picker filters the source out of its candidates. */
+  let mergePickerSource = $state<string | null>(null);
   let showEditSavedQueries = $state(false);
   /** When non-null, the SaveQueryDialog is open with this initial state. */
   let saveQueryRequest = $state<{
@@ -733,6 +736,52 @@
       key,
       'OK',
     );
+  }
+
+  /**
+   * Merge note (#464). Two-step: open a target picker (a filtered
+   * GotoNoteDialog), then run `performMerge` against the chosen target.
+   * Flushes any unsaved buffer for the source so the merge sees the
+   * latest content rather than a stale on-disk copy.
+   */
+  function handleMerge(sourceRelPath: string) {
+    if (!notebase.meta) return;
+    editor.flushAutoSave();
+    mergePickerSource = sourceRelPath;
+  }
+
+  async function performMerge(sourceRelPath: string, targetRelPath: string) {
+    if (sourceRelPath === targetRelPath) return;
+    const sourceName = sourceRelPath.split('/').pop()?.replace(/\.md$/i, '') ?? sourceRelPath;
+    const targetName = targetRelPath.split('/').pop()?.replace(/\.md$/i, '') ?? targetRelPath;
+    try {
+      const preview = await withBusy('Counting incoming links…', () =>
+        api.notebase.mergePreview(sourceRelPath, targetRelPath),
+      );
+      const linkLine = preview.linkOccurrences > 0
+        ? `${preview.linkOccurrences} link${preview.linkOccurrences === 1 ? '' : 's'} across ${preview.affectedFiles} file${preview.affectedFiles === 1 ? '' : 's'} will be updated.`
+        : 'No incoming links — only the source content will move.';
+      const ok = await showConfirm(
+        `Merge "${sourceName}" into "${targetName}"?\n\n${linkLine}\n\nThe source note's content is appended to the target; its frontmatter is dropped; the source note is then deleted.`,
+        CONFIRM_KEYS.mergeNote,
+        'Merge',
+      );
+      if (!ok) return;
+      const result = await withBusy('Merging…', () =>
+        api.notebase.merge(sourceRelPath, targetRelPath),
+      );
+      // Open the target and scroll to the merge point. The
+      // NOTEBASE_RENAMED / NOTEBASE_REWRITTEN broadcasts handle tab
+      // cleanup for the source and any open referrers.
+      await editor.openFile(result.targetPath);
+      requestAnimationFrame(() => {
+        editorComponent?.gotoLineColumn(result.mergeLine, 1);
+      });
+      await notebase.refresh();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Merge failed: ${msg}`, CONFIRM_KEYS.mergeFailed, 'OK');
+    }
   }
 
   async function handleRename(relativePath: string) {
@@ -2073,6 +2122,7 @@
                     onRename={() => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); }}
                     onMove={() => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); }}
                     onCopyFile={() => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); }}
+                    onMerge={() => { if (editor.activeFilePath) handleMerge(editor.activeFilePath); }}
                     onAutoTag={() => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); }}
                     onAutoLink={() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); }}
                     onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
@@ -2195,6 +2245,16 @@
       files={notebase.files}
       onSelect={(path) => { showGotoNote = false; void handleFileSelect(path); }}
       onCancel={() => { showGotoNote = false; }}
+    />
+  {/if}
+  {#if mergePickerSource}
+    {@const source = mergePickerSource}
+    <GotoNoteDialog
+      files={notebase.files}
+      placeholder="Merge into note..."
+      excludePath={source}
+      onSelect={(path) => { mergePickerSource = null; void performMerge(source, path); }}
+      onCancel={() => { mergePickerSource = null; }}
     />
   {/if}
   {#if showGotoLine}

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -2255,12 +2255,15 @@
     />
   {/if}
   {#if mergePickerSource}
-    {@const source = mergePickerSource}
     <GotoNoteDialog
       files={notebase.files}
       placeholder="Merge into note..."
-      excludePath={source}
-      onSelect={(path) => { mergePickerSource = null; void performMerge(source, path); }}
+      excludePath={mergePickerSource}
+      onSelect={(path) => {
+        const src = mergePickerSource;
+        mergePickerSource = null;
+        if (src) void performMerge(src, path);
+      }}
       onCancel={() => { mergePickerSource = null; }}
     />
   {/if}

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -745,18 +745,12 @@
    * latest content rather than a stale on-disk copy.
    */
   function handleMerge(sourceRelPath: string) {
-    console.log('[merge] handleMerge invoked for', sourceRelPath);
-    if (!notebase.meta) {
-      console.warn('[merge] no notebase.meta — bailing');
-      return;
-    }
+    if (!notebase.meta) return;
     editor.flushAutoSave();
     mergePickerSource = sourceRelPath;
-    console.log('[merge] mergePickerSource set; dialog should mount');
   }
 
   async function performMerge(sourceRelPath: string, targetRelPath: string) {
-    console.log('[merge] performMerge', sourceRelPath, '→', targetRelPath);
     if (sourceRelPath === targetRelPath) return;
     const sourceName = sourceRelPath.split('/').pop()?.replace(/\.md$/i, '') ?? sourceRelPath;
     const targetName = targetRelPath.split('/').pop()?.replace(/\.md$/i, '') ?? targetRelPath;

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -745,12 +745,18 @@
    * latest content rather than a stale on-disk copy.
    */
   function handleMerge(sourceRelPath: string) {
-    if (!notebase.meta) return;
+    console.log('[merge] handleMerge invoked for', sourceRelPath);
+    if (!notebase.meta) {
+      console.warn('[merge] no notebase.meta — bailing');
+      return;
+    }
     editor.flushAutoSave();
     mergePickerSource = sourceRelPath;
+    console.log('[merge] mergePickerSource set; dialog should mount');
   }
 
   async function performMerge(sourceRelPath: string, targetRelPath: string) {
+    console.log('[merge] performMerge', sourceRelPath, '→', targetRelPath);
     if (sourceRelPath === targetRelPath) return;
     const sourceName = sourceRelPath.split('/').pop()?.replace(/\.md$/i, '') ?? sourceRelPath;
     const targetName = targetRelPath.split('/').pop()?.replace(/\.md$/i, '') ?? targetRelPath;
@@ -2013,6 +2019,7 @@
           onAddTag={handleAddTag}
           onRemoveTag={handleRemoveTag}
           onRename={handleRename}
+          onMerge={handleMerge}
           onCut={handleCut}
           onCopy={handleCopy}
           onPaste={handlePaste}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -81,6 +81,7 @@
     onRename?: () => void;
     onMove?: () => void;
     onCopyFile?: () => void;
+    onMerge?: () => void;
     onAutoTag?: () => void;
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
@@ -134,6 +135,7 @@
     onRename,
     onMove,
     onCopyFile,
+    onMerge,
     onAutoTag,
     onAutoLink,
     onAutoLinkInbound,
@@ -1039,7 +1041,7 @@
       </div>
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose || onCrystallize}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onMerge || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose || onCrystallize}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor &#x25B8;</span>
         <div class="submenu">
@@ -1052,7 +1054,10 @@
           {#if onCopyFile}
             <button onclick={() => handleMenuAction(() => onCopyFile?.())}>Copy&hellip;</button>
           {/if}
-          {#if onRename || onMove || onCopyFile}
+          {#if onMerge}
+            <button onclick={() => handleMenuAction(() => onMerge?.())}>Merge into&hellip;</button>
+          {/if}
+          {#if onRename || onMove || onCopyFile || onMerge}
             <div class="separator"></div>
           {/if}
           {#if onExtractSelection}

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -38,6 +38,7 @@
      *  hit an existing selection or not. */
     onContextMenuTarget?: (relativePath: string) => void;
     onRename: (relativePath: string) => void;
+    onMerge?: (relativePath: string) => void;
     onCut: (relativePath: string, isDirectory: boolean) => void;
     onCopy: (relativePath: string, isDirectory: boolean) => void;
     onPaste: (destDirectory: string) => void;
@@ -46,7 +47,7 @@
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
   }
 
-  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, focusedPath, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onContextMenuTarget, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onExternalDrop }: Props = $props();
+  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, focusedPath, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onContextMenuTarget, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onExternalDrop }: Props = $props();
 
   let contextMenu = $state<{ x: number; y: number; dir: string; target?: string; targetIsDir?: boolean } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
@@ -161,6 +162,7 @@
             {onRemoveTag}
             {onContextMenuTarget}
             {onRename}
+            {onMerge}
             {onCut}
             {onCopy}
             {onPaste}
@@ -224,6 +226,11 @@
       <button onclick={() => { onRename(contextMenu!.target!); contextMenu = null; }}>
         Rename
       </button>
+      {#if onMerge && !contextMenu.targetIsDir && contextMenu.target.endsWith('.md')}
+        <button onclick={() => { onMerge?.(contextMenu!.target!); contextMenu = null; }}>
+          Merge into&hellip;
+        </button>
+      {/if}
       <button onclick={() => { void navigator.clipboard.writeText(contextMenu!.target!); contextMenu = null; }}>
         Copy Path
       </button>

--- a/src/renderer/lib/components/GotoNoteDialog.svelte
+++ b/src/renderer/lib/components/GotoNoteDialog.svelte
@@ -5,9 +5,14 @@
     files: NoteFile[];
     onSelect: (relativePath: string) => void;
     onCancel: () => void;
+    /** Placeholder text inside the search input. Default "Go to note...". */
+    placeholder?: string;
+    /** Drop a single relativePath from the candidate list — used by Merge
+     *  Note (#464) so the user can't pick the source as the merge target. */
+    excludePath?: string;
   }
 
-  let { files, onSelect, onCancel }: Props = $props();
+  let { files, onSelect, onCancel, placeholder = 'Go to note...', excludePath }: Props = $props();
 
   let query = $state('');
   let selectedIndex = $state(0);
@@ -25,7 +30,7 @@
     return acc;
   }
 
-  const allNotes = flattenNotes(files);
+  const allNotes = flattenNotes(files).filter((n) => n.relativePath !== excludePath);
 
   // ── Matching logic ──────────────────────────────────────────────────────
 
@@ -160,7 +165,7 @@
       bind:value={query}
       type="text"
       class="input"
-      placeholder="Go to note..."
+      {placeholder}
     />
     {#if results.length > 0}
       <ul class="goto-results">

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -26,6 +26,7 @@
     onAddTag?: (relativePath: string, isDirectory: boolean) => void;
     onRemoveTag?: (relativePath: string, isDirectory: boolean) => void;
     onRename: (relativePath: string) => void;
+    onMerge?: (relativePath: string) => void;
     onCut: (relativePath: string, isDirectory: boolean) => void;
     onCopy: (relativePath: string, isDirectory: boolean) => void;
     onPaste: (destDirectory: string) => void;
@@ -40,7 +41,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -503,6 +504,7 @@
               {onRemoveTag}
               onContextMenuTarget={handleContextMenuTarget}
               {onRename}
+              {onMerge}
               {onCut}
               {onCopy}
               {onPaste}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -48,6 +48,10 @@ export const CONFIRM_KEYS = {
    *  machine-scoped, so the localStorage suppression mustn't fire. */
   pythonTrust: 'python-trust',
   exportComplete: 'export-complete',
+  /** Pre-merge confirmation (#464) — surfaced before "Merge note into…" runs. */
+  mergeNote: 'merge-note',
+  /** Surfaced when the merge IPC throws after the user confirmed (rare). */
+  mergeFailed: 'merge-failed',
   bibliographyResult: 'bibliography-result',
   bibliographyFailed: 'bibliography-failed',
 } as const;
@@ -246,6 +250,18 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Export complete',
     description:
       'Summary dialog after an export finishes (how many files were written and to which directory).',
+  },
+  {
+    key: CONFIRM_KEYS.mergeNote,
+    title: 'Merge note into…',
+    description:
+      'Pre-flight confirmation before merging the active note into another note (#464). Lists how many incoming wiki-links will be rewritten across how many files, since this rewrites multiple files in a single operation.',
+  },
+  {
+    key: CONFIRM_KEYS.mergeFailed,
+    title: 'Merge note failed',
+    description:
+      'Shown when "Merge note into…" errors out after the user confirmed — read failure, write failure mid-rewrite, etc. Recovery is `git reset --hard HEAD`.',
   },
   {
     key: CONFIRM_KEYS.bibliographyResult,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -27,6 +27,18 @@ export interface NotebaseApi {
   createFolder(relativePath: string): Promise<void>;
   deleteFolder(relativePath: string): Promise<void>;
   rename(oldRelPath: string, newRelPath: string): Promise<void>;
+  mergePreview(sourceRelPath: string, targetRelPath: string): Promise<{
+    linkOccurrences: number;
+    affectedFiles: number;
+  }>;
+  merge(sourceRelPath: string, targetRelPath: string, separator?: string): Promise<{
+    targetPath: string;
+    mergeOffset: number;
+    mergeLine: number;
+    rewrittenLinks: number;
+    rewrittenPaths: string[];
+    deletedSource: string;
+  }>;
   copy(srcRelPath: string, destRelPath: string): Promise<void>;
   searchInNotes(opts: SearchInNotesOptions): Promise<SearchInNotesFileResult[]>;
   replaceInNotes(opts: ReplaceInNotesOptions): Promise<ReplaceInNotesResult>;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -18,6 +18,10 @@ export const Channels = {
   NOTEBASE_CREATE_FOLDER: 'notebase:createFolder',
   NOTEBASE_DELETE_FOLDER: 'notebase:deleteFolder',
   NOTEBASE_RENAME: 'notebase:rename',
+  /** Pre-flight count of how many files / link occurrences a merge would touch (#464). */
+  NOTEBASE_MERGE_PREVIEW: 'notebase:mergePreview',
+  /** Merge source note into target: append body, rewrite incoming links, delete source (#464). */
+  NOTEBASE_MERGE: 'notebase:merge',
   NOTEBASE_COPY: 'notebase:copy',
   NOTEBASE_SEARCH_IN_NOTES: 'notebase:searchInNotes',
   NOTEBASE_REPLACE_IN_NOTES: 'notebase:replaceInNotes',

--- a/tests/main/notebase/merge.test.ts
+++ b/tests/main/notebase/merge.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { mergeNotes, previewMergeNotes } from '../../../src/main/notebase/merge';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-merge-test-'));
+}
+
+function writeNote(root: string, relPath: string, content: string): void {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+function readNote(root: string, relPath: string): string {
+  return fs.readFileSync(path.join(root, relPath), 'utf-8');
+}
+
+describe('mergeNotes — merge note into another (issue #464)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('appends source body to target, deletes source, rewrites incoming wiki-links', async () => {
+    writeNote(root, 'notes/source.md', '# Source\n\nBody from source.');
+    writeNote(root, 'notes/target.md', '# Target\n\nExisting target body.');
+    writeNote(root, 'notes/refer.md', 'Read [[notes/source]] and also [[notes/target]].');
+    await indexNote(ctx, 'notes/source.md', '# Source\n\nBody from source.');
+    await indexNote(ctx, 'notes/target.md', '# Target\n\nExisting target body.');
+    await indexNote(ctx, 'notes/refer.md', 'Read [[notes/source]] and also [[notes/target]].');
+
+    const result = await mergeNotes(root, 'notes/source.md', 'notes/target.md');
+
+    expect(fs.existsSync(path.join(root, 'notes/source.md'))).toBe(false);
+    expect(readNote(root, 'notes/target.md')).toBe(
+      '# Target\n\nExisting target body.\n\n# Source\n\nBody from source.',
+    );
+    expect(readNote(root, 'notes/refer.md')).toBe(
+      'Read [[notes/target]] and also [[notes/target]].',
+    );
+    expect(result.deletedSource).toBe('notes/source.md');
+    expect(result.targetPath).toBe('notes/target.md');
+    expect(result.rewrittenLinks).toBe(1);
+    expect(result.rewrittenPaths).toEqual(['notes/refer.md']);
+    // Merge offset is target length + separator length; mergeLine is its
+    // 1-based line number in the merged content.
+    expect(result.mergeOffset).toBe('# Target\n\nExisting target body.'.length + 2);
+    // Merged content lines: 1 "# Target", 2 "", 3 "Existing target body.",
+    // 4 "" (from the \n\n separator), 5 "# Source" — the source body
+    // starts on line 5.
+    expect(result.mergeLine).toBe(5);
+  });
+
+  it('drops the source frontmatter on merge but preserves the target frontmatter', async () => {
+    writeNote(
+      root,
+      'notes/source.md',
+      '---\ntags: [old]\n---\n# Source\n\nBody.',
+    );
+    writeNote(
+      root,
+      'notes/target.md',
+      '---\ntags: [keep]\n---\n# Target\n\nBody.',
+    );
+    await indexNote(ctx, 'notes/source.md', '---\ntags: [old]\n---\n# Source\n\nBody.');
+    await indexNote(ctx, 'notes/target.md', '---\ntags: [keep]\n---\n# Target\n\nBody.');
+
+    await mergeNotes(root, 'notes/source.md', 'notes/target.md');
+
+    const merged = readNote(root, 'notes/target.md');
+    // Target's frontmatter survives.
+    expect(merged.startsWith('---\ntags: [keep]\n---')).toBe(true);
+    // Source frontmatter is gone (no second ---) — the merged body is just
+    // the source's post-frontmatter content.
+    expect(merged.match(/---/g)?.length).toBe(2);
+    expect(merged).toContain('# Source\n\nBody.');
+    // Source's `tags: [old]` is gone — confirms frontmatter strip.
+    expect(merged).not.toContain('[old]');
+  });
+
+  it('preserves alias and anchor on rewritten wiki-links', async () => {
+    writeNote(root, 'notes/source.md', '# Source');
+    writeNote(root, 'notes/target.md', '# Target');
+    const referBody = [
+      'Plain [[notes/source]].',
+      'Aliased [[notes/source|see this]].',
+      'Anchored [[notes/source#a-section]].',
+      'Embed ![[notes/source]].',
+    ].join('\n');
+    writeNote(root, 'notes/refer.md', referBody);
+    await indexNote(ctx, 'notes/source.md', '# Source');
+    await indexNote(ctx, 'notes/target.md', '# Target');
+    await indexNote(ctx, 'notes/refer.md', referBody);
+
+    await mergeNotes(root, 'notes/source.md', 'notes/target.md');
+
+    const after = readNote(root, 'notes/refer.md');
+    expect(after).toContain('Plain [[notes/target]].');
+    expect(after).toContain('Aliased [[notes/target|see this]].');
+    expect(after).toContain('Anchored [[notes/target#a-section]].');
+    expect(after).toContain('Embed ![[notes/target]].');
+  });
+
+  it('rejects merging a note into itself', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    await expect(mergeNotes(root, 'notes/foo.md', 'notes/foo.md')).rejects.toThrow(
+      /same note/i,
+    );
+    expect(fs.existsSync(path.join(root, 'notes/foo.md'))).toBe(true);
+  });
+
+  it('uses a configurable separator', async () => {
+    writeNote(root, 'notes/source.md', 'source-body');
+    writeNote(root, 'notes/target.md', 'target-body');
+    await indexNote(ctx, 'notes/source.md', 'source-body');
+    await indexNote(ctx, 'notes/target.md', 'target-body');
+
+    await mergeNotes(root, 'notes/source.md', 'notes/target.md', {
+      separator: '\n\n---\n\n',
+    });
+
+    expect(readNote(root, 'notes/target.md')).toBe(
+      'target-body\n\n---\n\nsource-body',
+    );
+  });
+
+  it('rewrites self-references inside the source body to the target', async () => {
+    // Edge case: source contains `[[source]]` somewhere in its own body.
+    // After merge, the merged target should not retain a stale link to
+    // a now-deleted file — those references rewrite to the target.
+    writeNote(root, 'notes/source.md', 'See [[notes/source]] for more.');
+    writeNote(root, 'notes/target.md', '# Target');
+    await indexNote(ctx, 'notes/source.md', 'See [[notes/source]] for more.');
+    await indexNote(ctx, 'notes/target.md', '# Target');
+
+    await mergeNotes(root, 'notes/source.md', 'notes/target.md');
+
+    expect(readNote(root, 'notes/target.md')).toContain('[[notes/target]]');
+    expect(readNote(root, 'notes/target.md')).not.toContain('[[notes/source]]');
+  });
+});
+
+describe('previewMergeNotes — pre-flight count (issue #464)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('counts link occurrences and affected files', async () => {
+    writeNote(root, 'notes/source.md', '# Source');
+    writeNote(root, 'notes/target.md', '# Target');
+    writeNote(root, 'notes/a.md', '[[notes/source]] and [[notes/source|alias]]');
+    writeNote(root, 'notes/b.md', 'just one [[notes/source]]');
+    writeNote(root, 'notes/c.md', 'no link to source here');
+    await indexNote(ctx, 'notes/source.md', '# Source');
+    await indexNote(ctx, 'notes/target.md', '# Target');
+    await indexNote(ctx, 'notes/a.md', '[[notes/source]] and [[notes/source|alias]]');
+    await indexNote(ctx, 'notes/b.md', 'just one [[notes/source]]');
+    await indexNote(ctx, 'notes/c.md', 'no link to source here');
+
+    const preview = await previewMergeNotes(root, 'notes/source.md', 'notes/target.md');
+    expect(preview.linkOccurrences).toBe(3);
+    expect(preview.affectedFiles).toBe(2);
+  });
+
+  it('returns zero counts for source == target', async () => {
+    writeNote(root, 'notes/foo.md', '# Foo');
+    await indexNote(ctx, 'notes/foo.md', '# Foo');
+    const preview = await previewMergeNotes(root, 'notes/foo.md', 'notes/foo.md');
+    expect(preview).toEqual({ linkOccurrences: 0, affectedFiles: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #464. Adds a "Merge note into…" command — right-click → Refactor → Merge into…, pick a target, confirm with a count of incoming links to be rewritten, done.

Borrowed from Obsidian's Note Composer plugin.

## Mechanics
- New \`src/main/notebase/merge.ts\` with \`previewMergeNotes\` (graph-driven count for the confirm dialog) and \`mergeNotes\` (the actual operation: strip source frontmatter → append body → rewrite \`[[source]]\` everywhere → delete source).
- Two new IPC channels + preload + client surface.
- Handler broadcasts \`NOTEBASE_RENAMED\` and \`NOTEBASE_REWRITTEN\` so other windows refresh.

## UI
- Editor right-click menu's Refactor submenu gains "Merge into…".
- \`GotoNoteDialog\` extended with \`placeholder\` + \`excludePath\` props so the merge picker reuses it (filters source out, friendlier copy).
- Two new \`CONFIRM_KEYS\` (\`mergeNote\`, \`mergeFailed\`), both registered in the registry.

## Trust + transactionality
Confirmation is justified by the multi-file rewrite (per CLAUDE.md, no scary red styling but the "Don't ask again" checkbox is there). Mid-flight failure recovery is \`git reset --hard HEAD\` per Minerva's git-as-undo model — same posture as rename-with-link-rewrites. Source delete is last so a partial failure leaves both source and merged target on disk.

## Edge cases
- Source == target: rejected at both preview and merge layers.
- Aliased / anchored / embedded wiki-links (\`[[s|alias]]\`, \`[[s#anchor]]\`, \`![[s]]\`): \`rewriteWikiLinks\` preserves all of those.
- Source frontmatter dropped; target frontmatter preserved.
- Source self-references (the source body contains \`[[source]]\`): rewrite to target on merge.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 2117/2117 pass (8 new in \`tests/main/notebase/merge.test.ts\` covering happy path, frontmatter strip, link variants, custom separator, self-references, source==target, preview counts)
- [x] Manual: right-click → Refactor → Merge into…, pick a target, confirm; verify (a) target opens scrolled to merge point, (b) source vanishes from sidebar, (c) referrers update.

## Out of scope (per the issue)
- Extract selection to new note (inverse).
- Split note at heading.
- Three-way / conflict-resolution UI.
- Creating a new target if the picker query has no match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)