### PR TITLE
Onboarding journey + actionable LLM-error feedback

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -50,6 +50,8 @@ import {
   setBibliographyStyleId,
   getPythonTrust,
   setPythonTrust,
+  getOnboardingDismissed,
+  setOnboardingDismissed,
 } from './project-config';
 import { DEFAULT_STYLE } from './publish/csl/assets';
 import { buildCitationAudit } from './publish/csl/audit';
@@ -1202,6 +1204,18 @@ export function registerIpcHandlers(): void {
     setPythonTrust(rootPath, trusted === true);
   });
 
+  ipcMain.handle(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return false;
+    return getOnboardingDismissed(rootPath);
+  });
+
+  ipcMain.handle(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, (e, dismissed: boolean) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    setOnboardingDismissed(rootPath, dismissed === true);
+  });
+
   ipcMain.handle(Channels.COMPUTE_BROWSE_PYTHON, async (e) => {
     const win = winFromEvent(e);
     const result = await dialog.showOpenDialog(win, {
@@ -1495,10 +1509,11 @@ export function registerIpcHandlers(): void {
     if (!rootPath) return null;
     return approval.getProposal(projectContext(rootPath), uri);
   });
-  ipcMain.handle(Channels.PROPOSAL_APPROVE, (e, uri: string) => {
+  ipcMain.handle(Channels.PROPOSAL_APPROVE, async (e, uri: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return false;
-    return approval.approveProposal(projectContext(rootPath), uri);
+    const result = await approval.approveProposal(projectContext(rootPath), uri);
+    return result.ok;
   });
   ipcMain.handle(Channels.PROPOSAL_REJECT, (e, uri: string) => {
     const rootPath = rootPathFromEvent(e);
@@ -1738,12 +1753,15 @@ export function registerIpcHandlers(): void {
         conversationUri: `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`,
         proposedBy: `llm:conversation:${draft.conversationId}`,
       });
+      let filedPaths: string[] = [];
       if (proposal) {
-        await approval.approveProposal(ctx, proposal.uri);
+        const result = await approval.approveProposal(ctx, proposal.uri);
+        filedPaths = result.filedPaths;
       }
       return {
         proposalUri: proposal?.uri ?? null,
         applied: true,
+        filedPaths,
       };
     },
   );

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -200,9 +200,20 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
 /**
  * Approve a pending proposal: apply its bundle and update status.
  */
-export async function approveProposal(ctx: ProjectContext, uri: string): Promise<boolean> {
+export interface ApproveResult {
+  ok: boolean;
+  /** Project-relative paths of files written by `note` payloads in this
+   *  bundle, in apply order. Empty when the bundle had no note payloads
+   *  or when approve returned `ok: false`. Used by callers that want to
+   *  surface "filed: X.md" feedback inline (e.g. the conversation panel)
+   *  — collisions are dedup'd at apply time so the resolved path can
+   *  differ from `p.relativePath`. */
+  filedPaths: string[];
+}
+
+export async function approveProposal(ctx: ProjectContext, uri: string): Promise<ApproveResult> {
   const proposal = await getProposal(ctx, uri);
-  if (!proposal || proposal.status !== 'pending') return false;
+  if (!proposal || proposal.status !== 'pending') return { ok: false, filedPaths: [] };
 
   if (proposal.payloads.length === 0) {
     // Don't quietly flip status to approved on an empty bundle — that's
@@ -218,9 +229,12 @@ export async function approveProposal(ctx: ProjectContext, uri: string): Promise
     proposal.payloads.map((p) => p.kind).join(', '),
   );
 
-  await applyBundle(ctx, proposal.payloads);
+  const applied = await applyBundle(ctx, proposal.payloads);
   await updateProposalStatus(ctx, uri, 'approved');
-  return true;
+  const filedPaths = applied
+    .filter((a): a is AppliedRecord & { kind: 'note' } => a.kind === 'note')
+    .map((a) => (a.rollbackData as { resolvedPath: string }).resolvedPath);
+  return { ok: true, filedPaths };
 }
 
 /**
@@ -396,7 +410,7 @@ interface AppliedRecord {
   rollbackData: unknown;
 }
 
-async function applyBundle(ctx: ProjectContext, payloads: ProposalPayload[]): Promise<void> {
+async function applyBundle(ctx: ProjectContext, payloads: ProposalPayload[]): Promise<AppliedRecord[]> {
   // Apply file-system payloads first, triples last. Lets a triples
   // parse failure roll back FS effects without needing an rdflib
   // snapshot.
@@ -411,6 +425,7 @@ async function applyBundle(ctx: ProjectContext, payloads: ProposalPayload[]): Pr
       const rollbackData = await dispatchApply(ctx, p);
       applied.push({ kind: p.kind, rollbackData });
     }
+    return applied;
   } catch (err) {
     // Reverse-order rollback. Best-effort — log but don't mask the
     // original error.

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -8,6 +8,7 @@ import {
 } from './tools';
 import type { Citation } from '../../shared/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
+import { MISSING_API_KEY_MARKER } from '../../shared/llm-errors';
 import type { ConversationDraft } from '../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../shared/conversation-source-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
@@ -91,8 +92,12 @@ async function getClient(): Promise<{
 }> {
   const settings = await getSettings();
   if (!settings.apiKey) {
+    // Message starts with MISSING_API_KEY_MARKER so the renderer can
+    // detect this specific failure across IPC and surface an actionable
+    // "Open Settings" dialog instead of the silent log message that was
+    // the only feedback before. See `shared/llm-errors.ts`.
     throw new Error(
-      'Anthropic API key not configured. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.',
+      `${MISSING_API_KEY_MARKER}. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.`,
     );
   }
   return {

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -27,6 +27,14 @@ export interface ProjectConfigShape {
      */
     pythonTrusted?: boolean;
   };
+  /** New-thoughtbase onboarding journey state. Per-project so the
+   *  user can disable it for an empty scratch thoughtbase without
+   *  blocking the modal on their next fresh one. */
+  onboarding?: {
+    /** User chose "Don't show again" — the modal won't reappear for
+     *  this thoughtbase even if it's reopened while still empty. */
+    dismissed?: boolean;
+  };
 }
 
 function configPath(rootPath: string): string {
@@ -74,4 +82,16 @@ export function setPythonTrust(rootPath: string, trusted: boolean): void {
   // so a future `compute.<other>` field doesn't get clobbered.
   const existing = readProjectConfig(rootPath).compute ?? {};
   patchProjectConfig(rootPath, { compute: { ...existing, pythonTrusted: trusted } });
+}
+
+/** Per-project onboarding-dismissed flag. Default false (= show modal
+ *  when the thoughtbase is empty). Once true, the modal stays
+ *  suppressed even if the user later empties the thoughtbase again. */
+export function getOnboardingDismissed(rootPath: string): boolean {
+  return readProjectConfig(rootPath).onboarding?.dismissed === true;
+}
+
+export function setOnboardingDismissed(rootPath: string, dismissed: boolean): void {
+  const existing = readProjectConfig(rootPath).onboarding ?? {};
+  patchProjectConfig(rootPath, { onboarding: { ...existing, dismissed } });
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -69,6 +69,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.NOTEBASE_RENAME_SOURCE, oldId, newId),
     renameExcerpt: (oldId: string, newId: string) =>
       ipcRenderer.invoke(Channels.NOTEBASE_RENAME_EXCERPT, oldId, newId),
+    getOnboardingDismissed: () =>
+      ipcRenderer.invoke(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED),
+    setOnboardingDismissed: (dismissed: boolean) =>
+      ipcRenderer.invoke(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, dismissed),
   },
   links: {
     outgoing: (relativePath: string) => ipcRenderer.invoke(Channels.LINKS_OUTGOING, relativePath),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -38,6 +38,8 @@
   import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
   import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
   import SettingsDialog from './lib/components/SettingsDialog.svelte';
+  import OnboardingDialog from './lib/components/OnboardingDialog.svelte';
+  import type { OnboardingAnswers } from './lib/components/OnboardingDialog.svelte';
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
   import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
@@ -48,6 +50,8 @@
   import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
   import { getConfirmSuppressionStore } from './lib/stores/confirm-suppression.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
+  import { isMissingApiKeyError } from '../shared/llm-errors';
+  import { ENTRYPOINT_TAG } from '../shared/entrypoint';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
   import {
     planExtract,
@@ -72,6 +76,15 @@
   const conversationsStore = getConversationsStore();
   const bookmarkStore = getBookmarksStore();
   let showSettings = $state(false);
+  /** Tab the SettingsDialog should land on when next opened. Cleared
+   *  on close so the next manual open returns to the default Editor
+   *  tab. Set by `handleMissingApiKey` to jump straight to the AI tab
+   *  where the API key field lives. */
+  let settingsInitialTab = $state<'ai' | undefined>(undefined);
+  /** Onboarding modal visibility. Triggered by onProjectOpened when
+   *  the thoughtbase has zero notes AND its per-project
+   *  `onboarding.dismissed` flag is false. */
+  let showOnboarding = $state(false);
 
   /** Pending Auto-link suggestions to review. Non-null means the AutoLinkDialog is shown. */
   let autoLinkReview = $state<{
@@ -138,6 +151,18 @@
     // change without needing a manual onTabChange hook.
     void editor.activeFilePath;
     void refreshBacklinkCount();
+  });
+
+  // Surface the missing-API-key dialog whenever the conversations
+  // store flags it. The store flips the flag from its send() catch
+  // block on `isMissingApiKeyError`; we read the flag here (which makes
+  // it a reactive dep), show the modal, then call dismiss so a follow-up
+  // failure can re-fire the dialog.
+  $effect(() => {
+    if (conversationsStore.needsApiKey) {
+      conversationsStore.dismissApiKeyDialog();
+      void handleMissingApiKey();
+    }
   });
 
   // ConversationsPanel handles its own per-project init via onMount,
@@ -213,6 +238,169 @@
   function handleConfirmCancel() {
     confirmDialog?.resolve(false);
     confirmDialog = null;
+  }
+
+  /**
+   * Surfaced when any LLM-backed action fails because the user hasn't
+   * configured an Anthropic API key. Replaces the previous behavior —
+   * a console.error in the conversations panel, or a generic
+   * "<feature> failed: …" confirm in auto-link/auto-tag — with an
+   * actionable dialog that opens the Settings dialog on the AI tab.
+   *
+   * Idempotent: if a dialog is already open the second call is a no-op
+   * (showConfirm replaces the in-flight dialog, but we don't want
+   * cascading prompts when several LLM actions fail in quick succession).
+   * The dialog hides Don't-ask-again so muting it can't return us to the
+   * previous silent-failure state.
+   */
+  let missingApiKeyPromptShown = false;
+  /** Convenience for try/catch blocks around LLM-backed actions: if the
+   *  caught error is a missing-API-key, show the actionable dialog and
+   *  return true so the caller can skip its generic "X failed: …"
+   *  confirm. Returns false for any other error so the caller's
+   *  existing error path runs untouched. */
+  async function maybeHandleMissingApiKey(err: unknown): Promise<boolean> {
+    if (!isMissingApiKeyError(err)) return false;
+    await handleMissingApiKey();
+    return true;
+  }
+  async function handleMissingApiKey(): Promise<void> {
+    if (missingApiKeyPromptShown) return;
+    missingApiKeyPromptShown = true;
+    try {
+      const ok = await showConfirm(
+        'This action needs an Anthropic API key, which isn’t configured yet. ' +
+          'Open Settings → AI to paste your key, or set the ANTHROPIC_API_KEY ' +
+          'environment variable before launching the app.',
+        CONFIRM_KEYS.missingApiKey,
+        'Open Settings',
+        { hideDontAskAgain: true },
+      );
+      if (ok) {
+        settingsInitialTab = 'ai';
+        showSettings = true;
+      }
+    } finally {
+      missingApiKeyPromptShown = false;
+    }
+  }
+
+  /** Build the system prompt + first message for the new-thoughtbase
+   *  onboarding journey. The prompt instructs the agent to draft an
+   *  index + linked child notes via `propose_notes` so the user gets
+   *  the same review-the-bundle UX as the decompose tool. Depth maps
+   *  to a target note count.
+   */
+  function buildOnboardingPrompts(a: OnboardingAnswers): {
+    systemPrompt: string;
+    firstMessage: string;
+  } {
+    const depthSpec = {
+      quick: { count: '3–5', label: 'a quick orientation' },
+      moderate: { count: '8–12', label: 'a moderate overview' },
+      deep: { count: '15–25', label: 'a deep-dive overview' },
+    }[a.depth];
+    const expertiseSpec = {
+      beginner: 'They are new to this topic — assume no prior vocabulary, define jargon on first use, and prefer concrete examples over abstractions.',
+      familiar: 'They have some working familiarity — skip 101 framing but explain non-obvious terms inline.',
+      expert: 'They are already deep — pitch the notes at peer level, focus on structure, debates, and frontiers rather than fundamentals.',
+    }[a.expertise];
+    const useLine = a.use ? `Intended use: ${a.use}.` : 'Intended use: not specified.';
+    const systemPrompt =
+      `You are kicking off a brand-new thoughtbase for the user. This is their first conversation in this project — the file tree is empty. Your job is to draft ${depthSpec.label} of the subject they named, filed as a single bundle of linked notes the user can review and approve.\n\n` +
+      `## Subject\n${a.subject}\n\n` +
+      `## Reader\n${expertiseSpec} ${useLine}\n\n` +
+      `## Output\nProduce ONE \`propose_notes\` call containing ${depthSpec.count} notes:\n\n` +
+      `1. An **index note** at the top level (e.g. \`${slugifyForPath(a.subject)}.md\`) that opens with a 1–3 paragraph orientation and then a bulleted list of wiki-links to each child note. The bullets should be in a sensible reading order (foundations first, then branches).\n` +
+      `2. **Child notes** in a folder named after the subject (e.g. \`${slugifyForPath(a.subject)}/<topic>.md\`). Each child stands on its own — a short framing paragraph, then sections sized for the depth level above. Cross-link freely between children where it helps; use \`[[note-name]]\` syntax.\n\n` +
+      `Children should partition the subject — overlap is fine where ideas span boundaries, but don't write the same content twice.\n\n` +
+      `## Style\n- Markdown body. Use \`#\` for the note title at the top.\n- No frontmatter unless you have a strong reason — keep the surface clean for the user's first encounter.\n- Wiki-links use \`[[note-name]]\` against the bare basename; the system resolves them.\n- Plain prose. Avoid bullet-listing everything; some paragraphs make notes feel like a tour rather than a checklist.\n\n## Process\nIf the subject is ambiguous (e.g. 'Mercury' — planet? element? messenger god?), use \`ask_user\` ONCE to disambiguate before drafting. Otherwise proceed directly. Don't ask the user to review your plan — just produce the bundle. They'll approve or reject the whole thing in the inline review card.`;
+    const firstMessage = `Build the overview as instructed.`;
+    return { systemPrompt, firstMessage };
+  }
+
+  /** Cheap slug for path placeholders in the system prompt. The agent
+   *  may override these paths; this is just a sensible default. */
+  function slugifyForPath(s: string): string {
+    return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'overview';
+  }
+
+  async function handleOnboardingAccept(answers: OnboardingAnswers, dontAskAgain: boolean) {
+    showOnboarding = false;
+    if (dontAskAgain) {
+      try { await api.notebase.setOnboardingDismissed(true); }
+      catch (e) { console.warn('[onboarding] persist dismiss failed:', e); }
+    }
+    const { systemPrompt, firstMessage } = buildOnboardingPrompts(answers);
+    await conversationsStore.openConversationTab({
+      systemPrompt,
+      initialMessage: firstMessage,
+      extraTools: ['ask_user'],
+    });
+  }
+
+  async function handleOnboardingDecline(dontAskAgain: boolean) {
+    showOnboarding = false;
+    if (dontAskAgain) {
+      try { await api.notebase.setOnboardingDismissed(true); }
+      catch (e) { console.warn('[onboarding] persist dismiss failed:', e); }
+    }
+  }
+
+  /**
+   * Check whether the just-opened thoughtbase should trigger the
+   * onboarding modal. Called from every project-open path (the
+   * `project:opened` event AND the in-window New/Open/Open-Recent
+   * handlers) — only the new-window paths fire the event, so without
+   * this helper "New Thoughtbase" in the current window silently
+   * skipped the modal.
+   *
+   * Idempotent: re-entering on a project that already has notes is a
+   * no-op, so callers don't need to guard.
+   */
+  async function maybeShowOnboarding(): Promise<void> {
+    if (countNotes(notebase.files) > 0) return;
+    try {
+      const dismissed = await api.notebase.getOnboardingDismissed();
+      if (!dismissed) showOnboarding = true;
+    } catch (e) {
+      console.warn('[onboarding] read dismiss flag failed:', e);
+    }
+  }
+
+  /**
+   * Open every note tagged `entrypoint` if the editor came up with no
+   * note tabs restored from the saved session. Query/source/saved-query
+   * tabs don't suppress — the user's intent for entrypoints is to land
+   * them on actual prose, not whatever query they were running last.
+   * The graph index may still be warming up the moment a project
+   * opens, so the tag query can return empty; we re-query if so.
+   *
+   * Idempotent: if a note tab is already open the function returns
+   * early; if the editor reopens an entrypoint already in the tab list
+   * `openFile` is a no-op tab-switch.
+   */
+  async function maybeOpenEntrypoints(): Promise<void> {
+    if (editor.tabs.some((t) => t.type === 'note')) return;
+    try {
+      const entries = await api.tags.notesByTag(ENTRYPOINT_TAG);
+      if (entries.length === 0) return;
+      // Sort by title for deterministic active-tab choice. `notesByTag`
+      // already sorts but be defensive.
+      const sorted = [...entries].sort((a, b) => a.title.localeCompare(b.title));
+      // `openFile` resolves activeIndex to the latest tab — open in
+      // order, then snap back to index 0 so the first entry is the
+      // one the user sees.
+      for (const note of sorted) {
+        await editor.openFile(note.relativePath);
+      }
+      // First-entry-active. The list above may include paths that
+      // failed to read, but `openFile` only appends when the read
+      // succeeds, so index 0 is whichever opened first.
+      if (editor.tabs.length > 0) editor.switchTab(0);
+    } catch (e) {
+      console.warn('[entrypoint] auto-open failed:', e);
+    }
   }
 
   let pendingSearchQuery = $state<string | null>(null);
@@ -837,6 +1025,7 @@
       const activeBody = raw.replace(/^---\n[\s\S]*?\n---\n?/, '');
       autoLinkReview = { relativePath, suggestions, activeBody };
     } catch (err) {
+      if (await maybeHandleMissingApiKey(err)) return;
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
     } finally {
@@ -861,6 +1050,7 @@
       }
       autoLinkInboundReview = { relativePath, suggestions };
     } catch (err) {
+      if (await maybeHandleMissingApiKey(err)) return;
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-link failed: ${msg}`, CONFIRM_KEYS.autoLinkFailed, 'OK');
     } finally {
@@ -1058,6 +1248,35 @@
 
     sidebar?.refreshTags();
     await reportBulkTagSummary('Remove', tag, targets.length, changed, failures);
+  }
+
+  /**
+   * Toggle the `entrypoint` tag on a single note. Adds it when absent,
+   * removes it when present — the menu prefetches the current state to
+   * label itself, but the actual decision happens here against the
+   * just-read content (the file might have been edited between the
+   * prefetch and the click). Refreshes the sidebar Tags panel so the
+   * change is visible immediately.
+   */
+  async function handleToggleEntrypoint(relativePath: string, _currentlyEntrypoint: boolean): Promise<void> {
+    if (!notebase.meta) return;
+    void _currentlyEntrypoint; // label-only; we re-check from disk
+    try {
+      const content = await api.notebase.readFile(relativePath);
+      const hasIt = extractTagsFromContent(content)
+        .some((t) => t.toLowerCase() === ENTRYPOINT_TAG);
+      if (hasIt) {
+        const { content: next, removedTags } = removeTagsFromContent(content, [ENTRYPOINT_TAG]);
+        if (removedTags.length > 0) await api.notebase.writeFile(relativePath, next);
+      } else {
+        const { content: next, addedTags } = mergeTagsIntoContent(content, [ENTRYPOINT_TAG]);
+        if (addedTags.length > 0) await api.notebase.writeFile(relativePath, next);
+      }
+      sidebar?.refreshTags();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Toggle entrypoint failed: ${msg}`, CONFIRM_KEYS.bulkTagFailed, 'OK');
+    }
   }
 
   async function reportBulkTagSummary(
@@ -1331,18 +1550,31 @@
     // "This Window" — clear the editor so stale tabs from the previous
     // thoughtbase don't survive into the new one.
     editor.clear();
-    await notebase.open();
+    const opened = await notebase.open();
+    if (opened) {
+      await maybeShowOnboarding();
+      await maybeOpenEntrypoints();
+    }
   }
 
   async function handleNewThoughtbase(): Promise<void> {
     const choice = await askOpenTarget('A thoughtbase is already open in this window. Create the new one in:');
     if (choice === 'cancel') return;
     if (choice === 'new') {
+      // New-window path emits `project:opened`, so the onProjectOpened
+      // handler in onMount fires maybeShowOnboarding there.
       await api.notebase.newProjectInNewWindow();
       return;
     }
     editor.clear();
-    await notebase.newProject();
+    // Guard on the IPC result — a cancelled directory picker leaves
+    // the previous project in place; we don't want to re-trigger the
+    // onboarding modal on a thoughtbase the user already declined.
+    const opened = await notebase.newProject();
+    if (opened) {
+      await maybeShowOnboarding();
+      await maybeOpenEntrypoints();
+    }
   }
 
   async function handleOpenRecentThoughtbase(rootPath: string): Promise<void> {
@@ -1353,7 +1585,11 @@
       return;
     }
     editor.clear();
-    await notebase.openPath(rootPath);
+    const opened = await notebase.openPath(rootPath);
+    if (opened) {
+      await maybeShowOnboarding();
+      await maybeOpenEntrypoints();
+    }
   }
 
   async function handleSaveCellOutput(payload: {
@@ -1514,6 +1750,7 @@
       // On success, the NOTEBASE_REWRITTEN listener reloads the note so the
       // user sees the new frontmatter tags appear in the editor.
     } catch (err) {
+      if (await maybeHandleMissingApiKey(err)) return;
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-tag failed: ${msg}`, CONFIRM_KEYS.autoTagFailed, 'OK');
     }
@@ -1718,13 +1955,14 @@
   // Refresh tags when notebase opens
   const originalOpen = notebase.open;
   notebase.open = async () => {
-    await originalOpen();
+    const result = await originalOpen();
     setTimeout(() => {
       sidebar?.refreshTags();
       sidebar?.refreshSources();
       sidebar?.refreshTables();
       void refreshSourcesCache();
     }, 100);
+    return result;
   };
 
   // Main broadcasts when the sources watcher reindexes or removes a source.
@@ -1981,8 +2219,30 @@
           editorComponent?.restorePosition(activeTab.cursorOffset!, activeTab.scrollTop);
         });
       }
+
+      // Offer the onboarding journey on empty thoughtbases. Files have
+      // already been loaded by `notebase.openPath` above, so the count
+      // is current. Helper is shared with the in-window New/Open paths.
+      await maybeShowOnboarding();
+      // Auto-open any `entrypoint`-tagged notes when restoreTabs left
+      // the editor with no note tabs. Runs after the onboarding check
+      // because an empty thoughtbase has no entrypoints anyway, but
+      // ordering doesn't matter beyond that.
+      await maybeOpenEntrypoints();
     });
   });
+
+  /** Count .md notes anywhere in the tree (recursive over folder
+   *  children). The onboarding trigger uses this to decide whether
+   *  the thoughtbase is "empty" — folders alone don't disqualify. */
+  function countNotes(files: import('../shared/types').NoteFile[]): number {
+    let n = 0;
+    for (const f of files) {
+      if (!f.isDirectory && f.name.endsWith('.md')) n++;
+      else if (f.isDirectory && f.children) n += countNotes(f.children);
+    }
+    return n;
+  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -2019,6 +2279,7 @@
           onPaste={handlePaste}
           onMove={handleMove}
           onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
+          onToggleEntrypoint={handleToggleEntrypoint}
           onSourceSelect={(id) => handleOpenSource(id)}
           onSourceDeleted={handleSourceDeleted}
           onShowConfirm={showConfirm}
@@ -2192,6 +2453,7 @@
             bind:this={toolPanelComponent}
             onNoteCreated={() => { void notebase.refresh(); sidebar?.refreshTags(); }}
             onOpenConversation={handleOpenConversationFromTool}
+            onMissingApiKey={() => { void handleMissingApiKey(); }}
           />
         {:else if editor.activeTab?.type === 'query'}
           <QueryPanel
@@ -2393,7 +2655,14 @@
         queryPanelComponent?.updateTheme();
         previewComponent?.updateTheme();
       }}
-      onClose={() => { showSettings = false; }}
+      onClose={() => { showSettings = false; settingsInitialTab = undefined; }}
+      initialTab={settingsInitialTab}
+    />
+  {/if}
+  {#if showOnboarding}
+    <OnboardingDialog
+      onAccept={(answers, dontAskAgain) => { void handleOnboardingAccept(answers, dontAskAgain); }}
+      onDecline={(dontAskAgain) => { void handleOnboardingDecline(dontAskAgain); }}
     />
   {/if}
 </div>

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import { getConversationsStore } from '../stores/conversations.svelte';
+  import { getEditorStore } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
   import MarkdownIt from 'markdown-it';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
@@ -32,6 +33,7 @@
   let { currentNotePath }: Props = $props();
 
   const store = getConversationsStore();
+  const editor = getEditorStore();
 
   let composerEl = $state<HTMLTextAreaElement>();
   let scrollEl = $state<HTMLDivElement>();
@@ -181,12 +183,25 @@
     store.discardSourceDraft(tabId, draftId);
   }
 
-  function dismissSourceResult(tabId: string, draftId: string) {
-    store.dismissSourceDraftResult(tabId, draftId);
-  }
-
   function sourceLabel(s: { identifier?: string; url?: string }): string {
     return s.identifier ?? s.url ?? '(unknown source)';
+  }
+
+  /** Last segment of a project-relative path — the only part the user
+   *  needs to recognize the filed note in the compact "Filed:" line.
+   *  Full path is still on the link's `title` for hover disambiguation
+   *  when two filings have the same basename. */
+  function basename(p: string): string {
+    const slash = p.lastIndexOf('/');
+    return slash >= 0 ? p.slice(slash + 1) : p;
+  }
+
+  function openFiledNote(relativePath: string) {
+    void editor.openFile(relativePath);
+  }
+
+  function openFiledSource(sourceId: string) {
+    editor.openSource(sourceId);
   }
 
   /** Cheap heuristic for the "doi / arxiv / pmid / url" pill — exact
@@ -200,22 +215,6 @@
     if (/^\d{4}\.\d{4,5}$|^[a-z-]+(?:\.[a-z-]+)?\/\d{7}$/i.test(stripped)) return 'arxiv';
     if (/^\d+$/.test(stripped)) return 'pmid';
     return 'id';
-  }
-
-  function summarizeSourceOutcomes(outcomes: SourceIngestOutcome[]): string {
-    let added = 0;
-    let dupes = 0;
-    let failed = 0;
-    for (const o of outcomes) {
-      if (o.error) failed++;
-      else if (o.duplicate) dupes++;
-      else added++;
-    }
-    const parts: string[] = [];
-    if (added) parts.push(`Filed ${added} source${added === 1 ? '' : 's'}`);
-    if (dupes) parts.push(`${dupes} already in library`);
-    if (failed) parts.push(`${failed} failed`);
-    return parts.join(' · ') || 'No sources processed';
   }
 
   function hostOf(url: string): string {
@@ -244,6 +243,11 @@
       ([, entry]) => entry.afterMessageIndex === i,
     );
   }
+  function noteResultsAt(tab: TabT, i: number) {
+    return Object.entries(tab.noteDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex === i,
+    );
+  }
   function orphanDrafts(tab: TabT) {
     const max = tab.conversation.messages.length;
     return tab.drafts.filter((d) => d.afterMessageIndex >= max);
@@ -255,6 +259,12 @@
   function orphanSourceResults(tab: TabT) {
     const max = tab.conversation.messages.length;
     return Object.entries(tab.sourceDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex >= max,
+    );
+  }
+  function orphanNoteResults(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return Object.entries(tab.noteDraftResults).filter(
       ([, entry]) => entry.afterMessageIndex >= max,
     );
   }
@@ -393,30 +403,53 @@
           </div>
         {/snippet}
 
-        {#snippet sourceResultCardBlock(draftId: string, outcomes: SourceIngestOutcome[])}
-          <div class="source-result-card">
-            <div class="source-result-summary">
-              <strong>📚 {summarizeSourceOutcomes(outcomes)}</strong>
-              <button type="button" class="source-result-dismiss" aria-label="Dismiss" onclick={() => dismissSourceResult(tab.id, draftId)}>&#x2715;</button>
-            </div>
-            <ul class="source-result-list">
-              {#each outcomes as o, oi (oi)}
-                <li class:error={!!o.error}>
-                  {#if o.error}
-                    <span class="source-result-status">⚠</span>
-                    <span class="source-value">{sourceLabel(o.input)}</span>
-                    <span class="source-result-error">{o.error}</span>
-                  {:else if o.duplicate}
-                    <span class="source-result-status">↩</span>
-                    <span class="source-value">{o.title ?? sourceLabel(o.input)}</span>
-                    <span class="source-result-note">already in library</span>
-                  {:else}
-                    <span class="source-result-status">✓</span>
-                    <span class="source-value">{o.title ?? sourceLabel(o.input)}</span>
-                  {/if}
-                </li>
+        {#snippet sourceResultLine(_draftId: string, outcomes: SourceIngestOutcome[])}
+          <!-- Compact "Filed:" line that replaces the propose_sources
+               card after Approve. Each successfully filed source title
+               is a clickable link that opens the source in the editor;
+               failures are shown muted in-line so the user can see what
+               didn't land without losing the click-to-open story. The
+               line is persistent (no dismiss) — it lives in the
+               transcript so the user can scroll back later. -->
+          <div class="filed-line">
+            <span class="filed-prefix">📚 Filed:</span>
+            {#each outcomes as o, oi (oi)}
+              {#if oi > 0}<span class="filed-sep">·</span>{/if}
+              {#if o.error}
+                <span class="filed-error" title={o.error}>⚠ {sourceLabel(o.input)}</span>
+              {:else if o.sourceId}
+                <button
+                  type="button"
+                  class="filed-link"
+                  title={o.duplicate ? 'Already in library — open' : 'Open source'}
+                  onclick={() => openFiledSource(o.sourceId!)}
+                >{o.title ?? sourceLabel(o.input)}{#if o.duplicate}<span class="filed-dup"> · already in library</span>{/if}</button>
+              {:else}
+                <span class="filed-error">{sourceLabel(o.input)}</span>
+              {/if}
+            {/each}
+          </div>
+        {/snippet}
+
+        {#snippet noteResultLine(_draftId: string, filedPaths: string[])}
+          <!-- Counterpart to sourceResultLine for propose_notes. Drops
+               in where the draft card was so the user knows what filed
+               and can jump to any of the new notes with one click. -->
+          <div class="filed-line">
+            <span class="filed-prefix">📝 Filed:</span>
+            {#if filedPaths.length === 0}
+              <span class="filed-error">(no notes written)</span>
+            {:else}
+              {#each filedPaths as p, pi (p)}
+                {#if pi > 0}<span class="filed-sep">·</span>{/if}
+                <button
+                  type="button"
+                  class="filed-link"
+                  title={p}
+                  onclick={() => openFiledNote(p)}
+                >{basename(p)}</button>
               {/each}
-            </ul>
+            {/if}
           </div>
         {/snippet}
 
@@ -436,7 +469,10 @@
               {@render sourceDraftCardBlock(draft)}
             {/each}
             {#each sourceResultsAt(tab, i) as [draftId, entry] (draftId)}
-              {@render sourceResultCardBlock(draftId, entry.outcomes)}
+              {@render sourceResultLine(draftId, entry.outcomes)}
+            {/each}
+            {#each noteResultsAt(tab, i) as [draftId, entry] (draftId)}
+              {@render noteResultLine(draftId, entry.filedPaths)}
             {/each}
           {/each}
 
@@ -505,7 +541,10 @@
             {@render sourceDraftCardBlock(draft)}
           {/each}
           {#each orphanSourceResults(tab) as [draftId, entry] (draftId)}
-            {@render sourceResultCardBlock(draftId, entry.outcomes)}
+            {@render sourceResultLine(draftId, entry.outcomes)}
+          {/each}
+          {#each orphanNoteResults(tab) as [draftId, entry] (draftId)}
+            {@render noteResultLine(draftId, entry.filedPaths)}
           {/each}
         </div>
 
@@ -904,57 +943,39 @@
     overflow-wrap: anywhere;
   }
 
-  /* Post-Approve status card — replaces the inline draft card after
-     ingest finishes so the user can see what landed without flipping
-     to the Sources panel. */
-  .source-result-card {
-    margin-top: 4px;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 8px 12px;
-    background: var(--bg-button);
+  /* Post-Approve summary line — replaces the inline draft card for
+     both propose_notes and propose_sources. Single-line, no chrome,
+     clickable filenames/titles. Persistent (no dismiss) so the user
+     can scroll back later and still navigate to filed resources. */
+  .filed-line {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .source-result-summary {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 13px;
-    color: var(--text);
-  }
-  .source-result-summary strong { font-weight: 600; }
-  .source-result-dismiss {
-    margin-left: auto;
-    border: none;
-    background: none;
-    color: var(--text-muted);
-    font-size: 11px;
-    cursor: pointer;
-    padding: 2px 6px;
-    border-radius: 3px;
-  }
-  .source-result-dismiss:hover { background: var(--bg, var(--bg-sidebar)); color: var(--text); }
-  .source-result-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; }
-  .source-result-list li {
-    display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
-    gap: 8px;
-    padding: 2px 6px;
+    gap: 6px;
+    padding: 6px 4px;
     font-size: 12px;
+    color: var(--text-muted);
   }
-  .source-result-list li.error .source-value { color: var(--text-muted); }
-  .source-result-status {
-    display: inline-block;
-    width: 14px;
-    text-align: center;
+  .filed-prefix {
     color: var(--text-muted);
     flex-shrink: 0;
   }
-  .source-result-list li:not(.error) .source-result-status { color: var(--accent); }
-  .source-result-note { color: var(--text-muted); font-size: 11px; margin-left: auto; }
-  .source-result-error { color: var(--text-muted); font-size: 11px; }
+  .filed-sep { color: var(--border); }
+  .filed-link {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: var(--accent);
+    font: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+  .filed-link:hover { text-decoration-color: var(--accent); }
+  .filed-dup { color: var(--text-muted); text-decoration: none; }
+  .filed-error { color: var(--text-muted); }
   .draft-btn {
     padding: 4px 10px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -3,6 +3,8 @@
   import FileTree from './FileTree.svelte';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { extractTagsFromContent } from '../../../shared/refactor/auto-tag';
+  import { ENTRYPOINT_TAG } from '../../../shared/entrypoint';
 
   interface Props {
     files: NoteFile[];
@@ -44,12 +46,17 @@
     onPaste: (destDirectory: string) => void;
     onMove: (srcPath: string, destDirectory: string) => void;
     onBookmark?: (relativePath: string) => void;
+    /** Toggle the `entrypoint` tag on a note. The handler decides whether
+     *  to add or remove based on the note's current frontmatter; we
+     *  prefetch the current state here purely to render the right label
+     *  (Mark vs Unmark) on the menu item. */
+    onToggleEntrypoint?: (relativePath: string, currentlyEntrypoint: boolean) => void;
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
   }
 
-  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, focusedPath, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onContextMenuTarget, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onExternalDrop }: Props = $props();
+  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, focusedPath, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onContextMenuTarget, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onExternalDrop }: Props = $props();
 
-  let contextMenu = $state<{ x: number; y: number; dir: string; target?: string; targetIsDir?: boolean } | null>(null);
+  let contextMenu = $state<{ x: number; y: number; dir: string; target?: string; targetIsDir?: boolean; targetIsEntrypoint?: boolean | null } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
 
   $effect(() => {
@@ -112,7 +119,31 @@
     // menu opens — actions read selection at click time, so the menu
     // and the action layer must agree on what's selected.
     if (target !== undefined) onContextMenuTarget?.(target);
-    contextMenu = { x: e.clientX, y: e.clientY, dir: dirPath, target, targetIsDir };
+    // Open the menu immediately with `targetIsEntrypoint = null` (=
+    // unknown); the async read below upgrades the label from
+    // "Toggle Entrypoint" to "Mark/Unmark as Entrypoint" once the
+    // frontmatter has been parsed. Avoids a perceptible delay between
+    // right-click and menu appearance for the common case where the
+    // user doesn't need the entrypoint item anyway.
+    contextMenu = { x: e.clientX, y: e.clientY, dir: dirPath, target, targetIsDir, targetIsEntrypoint: null };
+    if (target && !targetIsDir && target.endsWith('.md') && onToggleEntrypoint) {
+      const t = target;
+      void (async () => {
+        try {
+          const content = await api.notebase.readFile(t);
+          const isEntry = extractTagsFromContent(content)
+            .some((tag) => tag.toLowerCase() === ENTRYPOINT_TAG);
+          // Guard against stale resolution: another right-click may have
+          // closed/replaced the menu while we awaited. Only patch when
+          // the current menu is still the one we opened.
+          if (contextMenu && contextMenu.target === t) {
+            contextMenu = { ...contextMenu, targetIsEntrypoint: isEntry };
+          }
+        } catch {
+          // Leave label as the unknown-state fallback.
+        }
+      })();
+    }
     const close = () => {
       contextMenu = null;
       window.removeEventListener('click', close);
@@ -168,6 +199,7 @@
             {onPaste}
             {onMove}
             {onBookmark}
+            {onToggleEntrypoint}
             {onExternalDrop}
           />
         {/if}
@@ -236,6 +268,11 @@
       </button>
       {#if !contextMenu.targetIsDir}
         <button onclick={() => { onBookmark?.(contextMenu!.target!); contextMenu = null; }}>Bookmark</button>
+        {#if onToggleEntrypoint && contextMenu.target?.endsWith('.md')}
+          <button onclick={() => { onToggleEntrypoint?.(contextMenu!.target!, contextMenu!.targetIsEntrypoint === true); contextMenu = null; }}>
+            {#if contextMenu.targetIsEntrypoint === true}Unmark as Entrypoint{:else if contextMenu.targetIsEntrypoint === false}Mark as Entrypoint{:else}Toggle Entrypoint{/if}
+          </button>
+        {/if}
       {/if}
       <div class="submenu-item">
         <span class="submenu-trigger">Open In &#x25B8;</span>

--- a/src/renderer/lib/components/OnboardingDialog.svelte
+++ b/src/renderer/lib/components/OnboardingDialog.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+  /**
+   * First-run onboarding modal shown when an empty thoughtbase is opened.
+   * Mounted by App.svelte after `onProjectOpened` if the directory has
+   * zero notes AND `getOnboardingDismissed()` is false. The user picks a
+   * subject + a few framing answers; on confirm the parent kicks off a
+   * conversation pre-loaded with a system prompt that instructs the
+   * agent to draft an index + linked child notes via `propose_notes`.
+   *
+   * The dialog is intentionally a single page (not a wizard) — four
+   * fields fits comfortably and a multi-step flow felt heavyweight for
+   * something a user might dismiss on sight. "Don't show again" is a
+   * per-thoughtbase opt-out wired through `notebase.setOnboardingDismissed`.
+   */
+  export interface OnboardingAnswers {
+    subject: string;
+    expertise: 'beginner' | 'familiar' | 'expert';
+    use: string;
+    depth: 'quick' | 'moderate' | 'deep';
+  }
+
+  interface Props {
+    onAccept: (answers: OnboardingAnswers, dontAskAgain: boolean) => void;
+    onDecline: (dontAskAgain: boolean) => void;
+  }
+
+  let { onAccept, onDecline }: Props = $props();
+
+  let subject = $state('');
+  let expertise = $state<OnboardingAnswers['expertise']>('familiar');
+  let use = $state('');
+  let depth = $state<OnboardingAnswers['depth']>('moderate');
+  let dontAskAgain = $state(false);
+  let subjectInput = $state<HTMLInputElement>();
+
+  $effect(() => { subjectInput?.focus(); });
+
+  const canSubmit = $derived(subject.trim().length > 0);
+
+  function handleAccept() {
+    if (!canSubmit) return;
+    onAccept(
+      {
+        subject: subject.trim(),
+        expertise,
+        use: use.trim(),
+        depth,
+      },
+      dontAskAgain,
+    );
+  }
+
+  function handleDecline() {
+    onDecline(dontAskAgain);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') handleDecline();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) handleDecline(); }}>
+  <div class="dialog" role="dialog" aria-labelledby="onboarding-title">
+    <h2 id="onboarding-title" class="title">Welcome to your new thoughtbase</h2>
+    <p class="lede">
+      Want a head start? Tell me what you’re curious about and I’ll draft an
+      index plus a set of linked notes you can edit, branch from, or throw out.
+    </p>
+
+    <label class="field">
+      <span class="label">What would you like an overview of?</span>
+      <input
+        bind:this={subjectInput}
+        bind:value={subject}
+        type="text"
+        class="text-input"
+        placeholder="e.g. game theory, the Reformation, gene regulatory networks…"
+        onkeydown={(e) => { if (e.key === 'Enter' && canSubmit) handleAccept(); }}
+      />
+    </label>
+
+    <fieldset class="field">
+      <legend class="label">How familiar are you with this topic?</legend>
+      <div class="radio-row">
+        <label class="radio">
+          <input type="radio" name="expertise" value="beginner" bind:group={expertise} />
+          <span>New to it</span>
+        </label>
+        <label class="radio">
+          <input type="radio" name="expertise" value="familiar" bind:group={expertise} />
+          <span>Some familiarity</span>
+        </label>
+        <label class="radio">
+          <input type="radio" name="expertise" value="expert" bind:group={expertise} />
+          <span>Already deep</span>
+        </label>
+      </div>
+    </fieldset>
+
+    <label class="field">
+      <span class="label">How do you plan to use these notes? <span class="optional">(optional)</span></span>
+      <input
+        bind:value={use}
+        type="text"
+        class="text-input"
+        placeholder="study, writing, research, teaching, exploration…"
+      />
+    </label>
+
+    <fieldset class="field">
+      <legend class="label">How deep should the overview go?</legend>
+      <div class="radio-row">
+        <label class="radio">
+          <input type="radio" name="depth" value="quick" bind:group={depth} />
+          <span>Quick orientation <em>(3–5 notes)</em></span>
+        </label>
+        <label class="radio">
+          <input type="radio" name="depth" value="moderate" bind:group={depth} />
+          <span>Moderate <em>(8–12)</em></span>
+        </label>
+        <label class="radio">
+          <input type="radio" name="depth" value="deep" bind:group={depth} />
+          <span>Deep dive <em>(15–25)</em></span>
+        </label>
+      </div>
+    </fieldset>
+
+    <div class="footer">
+      <label class="dont-ask">
+        <input type="checkbox" bind:checked={dontAskAgain} />
+        Don’t show this for this thoughtbase
+      </label>
+      <div class="actions">
+        <button class="btn secondary" onclick={handleDecline}>Not now</button>
+        <button class="btn primary" disabled={!canSubmit} onclick={handleAccept}>Get started</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px 22px;
+    min-width: 460px;
+    max-width: 540px;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .lede {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--text-muted);
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    border: none;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+  }
+  .label {
+    font-size: 12px;
+    color: var(--text);
+    font-weight: 500;
+  }
+  .optional {
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+  .text-input {
+    padding: 7px 9px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 13px;
+    font-family: inherit;
+  }
+  .text-input:focus { outline: none; border-color: var(--accent); }
+  .radio-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .radio {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 3px;
+  }
+  .radio:hover { background: var(--bg-button); }
+  .radio input { cursor: pointer; }
+  .radio em {
+    color: var(--text-muted);
+    font-style: normal;
+    font-size: 12px;
+  }
+  .footer {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-top: 4px;
+  }
+  .dont-ask {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-muted);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .dont-ask input { cursor: pointer; }
+  .actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+  }
+  .btn {
+    padding: 6px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .secondary {
+    background: var(--bg-button);
+    color: var(--text);
+  }
+  .secondary:hover { background: var(--bg-button-hover); }
+  .primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+  .primary:hover:not(:disabled) { opacity: 0.9; }
+  .primary:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -41,9 +41,13 @@
     onApplyEditor: (s: EditorSettings) => void;
     onThemeChanged: () => void;
     onClose: () => void;
+    /** Tab to land on when the dialog opens. Defaults to 'editor'. The
+     *  missing-API-key flow passes 'ai' so the user lands on the key
+     *  field directly instead of hunting through tabs. */
+    initialTab?: TabId;
   }
 
-  let { onApplyEditor, onThemeChanged, onClose }: Props = $props();
+  let { onApplyEditor, onThemeChanged, onClose, initialTab }: Props = $props();
 
   type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'sites' | 'bibliography' | 'compute' | 'ai';
   const TABS: { id: TabId; label: string }[] = [
@@ -119,7 +123,7 @@
     [...confirmSuppression.suppressed].filter((k) => !confirmRegistryEntry(k))
   );
   let suppressedCount = $derived(confirmRows.filter((r) => r.suppressed).length);
-  let activeTab = $state<TabId>('editor');
+  let activeTab = $state<TabId>(initialTab ?? 'editor');
 
   // Editor settings
   let editor = $state<EditorSettings>(getEditorSettings());

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -32,6 +32,9 @@
     onPaste: (destDirectory: string) => void;
     onMove: (srcPath: string, destDirectory: string) => void;
     onBookmark?: (relativePath: string) => void;
+    /** Toggle the `entrypoint` tag on a note. Wired by App.svelte;
+     *  passed through to FileTree for the context-menu item. */
+    onToggleEntrypoint?: (relativePath: string, currentlyEntrypoint: boolean) => void;
     onSourceSelect?: (sourceId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
@@ -41,7 +44,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -510,6 +513,7 @@
               {onPaste}
               {onMove}
               {onBookmark}
+              {onToggleEntrypoint}
               {onExternalDrop}
             />
           {/if}

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -3,14 +3,21 @@
   import { handleToolOutput } from '../tools/output';
   import { api } from '../ipc/client';
   import type { ToolContext } from '../../../shared/tools/types';
+  import { isMissingApiKeyError } from '../../../shared/llm-errors';
 
   interface Props {
     onNoteCreated?: () => void;
     /** Called when the user invokes a tool whose outputMode is `openConversation`. */
     onOpenConversation?: (invocation: { toolId: string; context: ToolContext }) => void;
+    /** Called when a tool execution fails because no Anthropic API key
+     *  is configured. App-level handler shows an actionable Open
+     *  Settings dialog; without this hook the user would only see
+     *  "Anthropic API key not configured…" as the tool's failure
+     *  string with no path to fix it. */
+    onMissingApiKey?: () => void;
   }
 
-  let { onNoteCreated, onOpenConversation }: Props = $props();
+  let { onNoteCreated, onOpenConversation, onMissingApiKey }: Props = $props();
 
   const panel = getToolPanelStore();
   let paramValues = $state<Record<string, string>>({});
@@ -41,7 +48,17 @@
       panel.complete(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      panel.fail(message);
+      if (isMissingApiKeyError(err)) {
+        // Close the tool panel and let the App-level handler surface
+        // the Open-Settings dialog. The panel's inline error string
+        // still mentioned the missing key, but with no actionable
+        // path; punting up to the App keeps the user inside one
+        // canonical "configure your key" flow.
+        panel.close();
+        onMissingApiKey?.();
+      } else {
+        panel.fail(message);
+      }
     } finally {
       running = false;
     }

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -54,6 +54,11 @@ export const CONFIRM_KEYS = {
   mergeFailed: 'merge-failed',
   bibliographyResult: 'bibliography-result',
   bibliographyFailed: 'bibliography-failed',
+  /** Shown when an LLM-backed action runs without an Anthropic API key
+   *  configured. The confirm button label is "Open Settings" and the
+   *  dialog hides the Don't-ask-again checkbox — silencing it would
+   *  return the user to the previous silent-fail behavior. */
+  missingApiKey: 'missing-api-key',
 } as const;
 
 export type ConfirmKey = typeof CONFIRM_KEYS[keyof typeof CONFIRM_KEYS];
@@ -274,6 +279,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Bibliography failed',
     description:
       'Shown when Insert/Update Bibliography errors out (file read failure, citeproc engine error, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.missingApiKey,
+    title: 'Anthropic API key not configured',
+    description:
+      'Shown when an LLM-backed action (conversation, auto-tag, auto-link, decompose, etc.) tries to run without an API key. The dialog hides Don’t-ask-again so the user can’t accidentally re-silence the very condition that blocks LLM features.',
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -51,6 +51,10 @@ export interface NotebaseApi {
   renameAnchor(targetRelativePath: string, oldSlug: string, newSlug: string): Promise<{ rewrittenPaths: string[] }>;
   renameSource(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
   renameExcerpt(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
+  /** Per-project flag toggled by the "Don't show again" control on the
+   *  new-thoughtbase onboarding modal. Default false; set on user opt-out. */
+  getOnboardingDismissed(): Promise<boolean>;
+  setOnboardingDismissed(dismissed: boolean): Promise<void>;
 }
 
 export interface SearchInNotesOptions {
@@ -359,7 +363,7 @@ export interface ConversationsApi {
   /** File a draft as a Proposal AND auto-approve it (the user already reviewed the inline card). */
   fileDraft(
     draft: import('../../../shared/conversation-drafts').ConversationDraft,
-  ): Promise<{ proposalUri: string | null; applied: boolean }>;
+  ): Promise<import('../../../shared/conversation-drafts').FileDraftResult>;
   /** Subscribe to drafts produced by the propose_sources tool. */
   onSourceDraft(
     cb: (draft: import('../../../shared/conversation-source-drafts').ConversationSourceDraft) => void,

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -13,6 +13,7 @@ import type {
   AskUserRequest,
   ConversationToolKey,
 } from '../../../shared/conversation-tools';
+import { isMissingApiKeyError } from '../../../shared/llm-errors';
 
 /**
  * Multi-tab conversations store backing the bottom-docked tool window.
@@ -46,6 +47,15 @@ interface SourceDraftResultEntry {
   outcomes: SourceIngestOutcome[];
   afterMessageIndex: number;
 }
+/** Post-Approve summary for a propose_notes draft. Persists in the
+ *  conversation transcript so the user can still click through to filed
+ *  notes after scrolling past the approval. `filedPaths` is what the
+ *  approval engine actually wrote (collision-deduped), not what was
+ *  proposed. */
+interface NoteDraftResultEntry {
+  filedPaths: string[];
+  afterMessageIndex: number;
+}
 
 interface TabRuntime {
   id: string;
@@ -58,13 +68,15 @@ interface TabRuntime {
   /** propose_sources drafts awaiting Approve/Discard. */
   sourceDrafts: AnchoredSourceDraft[];
   /** Outcomes from the most recent fileSourceDraft call per draft id —
-   *  shown in place of the card for a few seconds after Approve so the
-   *  user sees "Filed 3 sources; 1 already in library." before the
-   *  status fades. Keyed by draftId; entries are cleared when the user
-   *  dismisses. Inherits `afterMessageIndex` from the originating
-   *  draft so the result card stays anchored to the same assistant
-   *  message as the draft it replaces. */
+   *  rendered as a compact "Filed:" line in place of the card. Keyed by
+   *  draftId; inherits `afterMessageIndex` from the originating draft
+   *  so the result line stays anchored to the same assistant message
+   *  as the draft it replaces. */
   sourceDraftResults: Record<string, SourceDraftResultEntry>;
+  /** Filed-paths summary per approved propose_notes draft id. Same
+   *  anchoring story as `sourceDraftResults` — the line sits where the
+   *  card used to so the user isn't left wondering what landed. */
+  noteDraftResults: Record<string, NoteDraftResultEntry>;
   /** In-flight ask_user prompt, if the agent is waiting on a reply. */
   pendingQuestion: AskUserRequest | null;
   composer: string;
@@ -90,6 +102,10 @@ let visible = $state(false);
 let height = $state(DEFAULT_HEIGHT);
 let activeTabId = $state<string | null>(null);
 let tabs = $state<TabRuntime[]>([]);
+/** One-shot flag flipped to true when a `send()` failed because no
+ *  Anthropic API key is configured. App.svelte's `$effect` reads it,
+ *  shows the missing-key dialog, then calls `dismissApiKeyDialog()`. */
+let needsApiKey = $state(false);
 // In-flight save coalescer — UI state changes a lot (every keystroke on a
 // resize, every visibility toggle) and we don't want to fan out a write
 // per change. Debounced via a single timeout that re-arms.
@@ -190,6 +206,7 @@ async function init(): Promise<void> {
       drafts: [],
       sourceDrafts: [],
       sourceDraftResults: {},
+      noteDraftResults: {},
       pendingQuestion: null,
       composer: '',
       streaming: false,
@@ -274,6 +291,7 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     drafts: [],
     sourceDrafts: [],
     sourceDraftResults: {},
+    noteDraftResults: {},
     pendingQuestion: null,
     composer: '',
     streaming: false,
@@ -325,6 +343,7 @@ async function openConversationTab(opts: {
     drafts: [],
     sourceDrafts: [],
     sourceDraftResults: {},
+    noteDraftResults: {},
     pendingQuestion: null,
     composer: '',
     streaming: false,
@@ -385,7 +404,16 @@ async function send(content: string, currentNotePath?: string): Promise<void> {
     const reloaded = await api.conversations.load(tab.id);
     if (reloaded) tab.conversation = reloaded;
   } catch (e) {
-    if (!String(e).includes('abort')) {
+    if (isMissingApiKeyError(e)) {
+      // Surface as an actionable modal at the App level rather than a
+      // silent console.error — the user's optimistic message would
+      // otherwise just sit in the transcript with no explanation. Also
+      // drop that optimistic insert so the transcript isn't littered
+      // with un-replied turns after the user wires up a key.
+      tab.conversation.messages = tab.conversation.messages.slice(0, -1);
+      tab.composer = text;
+      needsApiKey = true;
+    } else if (!String(e).includes('abort')) {
       console.error('[conv] send failed:', e);
     }
   } finally {
@@ -421,11 +449,22 @@ async function cancel(): Promise<void> {
 async function approveDraft(tabId: string, draft: ConversationDraft): Promise<void> {
   const tab = findTab(tabId);
   if (!tab) return;
+  // Inherit the draft's anchor so the result line lands on the same
+  // assistant turn the card was attached to.
+  const anchored = tab.drafts.find((d) => d.draftId === draft.draftId);
+  const afterMessageIndex = anchored?.afterMessageIndex ?? tab.conversation.messages.length;
   // Snapshot before crossing IPC — Svelte 5 `$state` Proxies fail
   // structured-clone otherwise (see project memory).
   const snapshot = $state.snapshot(draft);
-  await api.conversations.fileDraft(snapshot);
+  const result = await api.conversations.fileDraft(snapshot);
+  // Drop the in-flight card and replace it with a persistent "Filed:"
+  // summary keyed by the same draftId. `filedPaths` reflects the actual
+  // post-collision-dedup paths the approval engine wrote.
   tab.drafts = tab.drafts.filter((d) => d.draftId !== draft.draftId);
+  tab.noteDraftResults = {
+    ...tab.noteDraftResults,
+    [draft.draftId]: { filedPaths: result.filedPaths, afterMessageIndex },
+  };
 }
 
 function discardDraft(tabId: string, draftId: string): void {
@@ -477,6 +516,10 @@ function setComposer(value: string): void {
   if (tab) tab.composer = value;
 }
 
+function dismissApiKeyDialog(): void {
+  needsApiKey = false;
+}
+
 export function getConversationsStore() {
   return {
     get initialized() { return initialized; },
@@ -485,6 +528,8 @@ export function getConversationsStore() {
     get tabs() { return tabs; },
     get activeTabId() { return activeTabId; },
     get activeTab() { return activeTab(); },
+    get needsApiKey() { return needsApiKey; },
+    dismissApiKeyDialog,
     init,
     reset,
     show,

--- a/src/renderer/lib/stores/notebase.svelte.ts
+++ b/src/renderer/lib/stores/notebase.svelte.ts
@@ -5,26 +5,29 @@ let meta = $state<NotebaseMeta | null>(null);
 let files = $state<NoteFile[]>([]);
 
 export function getNotebaseStore() {
-  async function open() {
+  async function open(): Promise<NotebaseMeta | null> {
     const result = await api.notebase.open();
     if (result) {
       meta = result;
       files = await api.notebase.listFiles();
     }
+    return result;
   }
 
-  async function openPath(rootPath: string) {
+  async function openPath(rootPath: string): Promise<NotebaseMeta | null> {
     const result = await api.notebase.openPath(rootPath);
     meta = result;
     files = await api.notebase.listFiles();
+    return result;
   }
 
-  async function newProject() {
+  async function newProject(): Promise<NotebaseMeta | null> {
     const result = await api.notebase.newProject();
     if (result) {
       meta = result;
       files = await api.notebase.listFiles();
     }
+    return result;
   }
 
   function close() {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -34,6 +34,11 @@ export const Channels = {
   NOTEBASE_RENAMED: 'notebase:renamed',
   /** Emitted after link-rewrites touched other notes' content. Payload is string[] (relativePaths). */
   NOTEBASE_REWRITTEN: 'notebase:rewritten',
+  /** Per-project new-thoughtbase onboarding dismissal flag. Read on
+   *  project open to decide whether to surface the onboarding modal,
+   *  written when the user clicks "Don't show again". */
+  NOTEBASE_GET_ONBOARDING_DISMISSED: 'notebase:getOnboardingDismissed',
+  NOTEBASE_SET_ONBOARDING_DISMISSED: 'notebase:setOnboardingDismissed',
   /** Emitted when indexNote detects a single-heading rename with incoming links (main → renderer). */
   NOTEBASE_HEADING_RENAME_SUGGESTED: 'notebase:headingRenameSuggested',
   /** Renderer-initiated rewrite of `[[path#oldSlug]]` → `[[path#newSlug]]`. */

--- a/src/shared/conversation-drafts.ts
+++ b/src/shared/conversation-drafts.ts
@@ -45,3 +45,14 @@ export interface ProposeNotesInput {
   note: string;
   payloads: DraftPayload[];
 }
+
+/** Result returned by `CONVERSATION_FILE_DRAFT` after Approve. The renderer
+ *  uses `filedPaths` to render a compact "Filed: foo.md · bar.md" line in
+ *  place of the draft card so the user knows exactly which notes landed —
+ *  collision dedup at apply time means the path may differ from the
+ *  proposed `relativePath`, so we surface what was actually written. */
+export interface FileDraftResult {
+  proposalUri: string | null;
+  applied: boolean;
+  filedPaths: string[];
+}

--- a/src/shared/entrypoint.ts
+++ b/src/shared/entrypoint.ts
@@ -1,0 +1,12 @@
+/**
+ * Convention: a note tagged `entrypoint` is a designated starting
+ * surface for the thoughtbase. The renderer auto-opens any entrypoint
+ * notes when a project loads with no notes already in the editor; the
+ * publishing pipeline will (eventually) use the same marker to decide
+ * which note maps to `index.html`.
+ *
+ * Just a regular tag — users can hand-edit `tags:` in frontmatter or
+ * use the sidebar "Mark as Entrypoint" toggle. Both write the same
+ * lowercase tag, so the two paths are interchangeable.
+ */
+export const ENTRYPOINT_TAG = 'entrypoint';

--- a/src/shared/llm-errors.ts
+++ b/src/shared/llm-errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Stable marker substring carried by the Error thrown when the
+ * Anthropic API key is not configured. Lives in `shared/` so both the
+ * main process (which throws it) and the renderer (which detects it
+ * across the IPC boundary) reference the same constant — IPC strips
+ * the Error class, so message-matching is what we have.
+ *
+ * Detection across IPC: Electron's `invoke` rejects with a plain Error
+ * whose `.message` carries the main-process error's message (prefixed
+ * with "Error invoking remote method '…': "), so the marker still
+ * appears as a substring in the rejection's message.
+ */
+export const MISSING_API_KEY_MARKER = 'Anthropic API key not configured';
+
+export function isMissingApiKeyError(err: unknown): boolean {
+  if (err == null) return false;
+  if (err instanceof Error) return err.message.includes(MISSING_API_KEY_MARKER);
+  if (typeof err === 'string') return err.includes(MISSING_API_KEY_MARKER);
+  return false;
+}

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -103,7 +103,7 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
       'https://minerva.dev/ontology/thought#pending',
     ]);
 
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
     expect(await statusesFor(proposal!.uri)).toEqual([
       'https://minerva.dev/ontology/thought#approved',
     ]);

--- a/tests/main/llm/proposal-bundle.test.ts
+++ b/tests/main/llm/proposal-bundle.test.ts
@@ -54,7 +54,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       proposedBy: 'unit-test',
     });
     expect(proposal).not.toBeNull();
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
 
     const r = await queryGraph(ctx, `
       PREFIX thought: <https://minerva.dev/ontology/thought#>
@@ -77,7 +77,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       proposedBy: 'unit-test',
     });
     expect(proposal).not.toBeNull();
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
 
     const onDisk = await fsp.readFile(path.join(root, 'notes/from-bundle.md'), 'utf-8');
     expect(onDisk).toContain('From bundle');
@@ -110,7 +110,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'note + triples',
       proposedBy: 'unit-test',
     });
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
 
     expect(fs.existsSync(path.join(root, 'notes/explanation.md'))).toBe(true);
     const r = await queryGraph(ctx, `
@@ -166,7 +166,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'collision test',
       proposedBy: 'unit-test',
     });
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
 
     // Original file untouched.
     expect(await fsp.readFile(path.join(root, 'notes/colliding.md'), 'utf-8'))

--- a/tests/main/llm/proposal-large-bundle.test.ts
+++ b/tests/main/llm/proposal-large-bundle.test.ts
@@ -120,7 +120,7 @@ describe('large-bundle approval (the 27-note silent-failure regression)', () => 
       note: 'Distributed Consensus journey',
       proposedBy: 'unit-test',
     });
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
 
     expect(fs.existsSync(path.join(root, 'notes/journey-parent.md'))).toBe(true);
     for (let i = 1; i <= 26; i++) {

--- a/tests/main/llm/turtle-fence-tolerance.test.ts
+++ b/tests/main/llm/turtle-fence-tolerance.test.ts
@@ -96,7 +96,7 @@ describe('approval engine: tolerates fenced graph-triples payloads (#420 follow-
     });
     expect(proposal).not.toBeNull();
     // This is the call that was throwing before the fix.
-    expect(await approveProposal(ctx, proposal!.uri)).toBe(true);
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
 
     const r = await queryGraph(ctx, `
       PREFIX thought: <https://minerva.dev/ontology/thought#>


### PR DESCRIPTION
## Summary

Five UX improvements aimed at first-run friction and ambient feedback on LLM-backed actions:

- **Filed-paths inline summary** — after Approve on a `propose_notes` / `propose_sources` card, drop a compact `Filed: foo.md · bar.md` line into the transcript with clickable links instead of the card silently vanishing.
- **Missing-API-key dialog** — detect the marker across IPC and show an "Open Settings" dialog (landed on the AI tab) instead of a `console.error` (conversations) or generic "X failed: …" confirm (auto-link, auto-tag, tool executor).
- **New-thoughtbase onboarding modal** — friendly form (subject, expertise, intended use, depth) on empty thoughtbases that opens a conversation pre-loaded to draft an index + linked notes via `propose_notes`. Per-project dismissable.
- **Onboarding trigger consistency** — in-window New / Open / Open Recent didn't fire `project:opened`, so the modal only appeared on app restart. Extracted `maybeShowOnboarding()` and called from all four project-open paths.
- **Entrypoint tag** — notes tagged `entrypoint` auto-open when a thoughtbase loads with no note tabs already restored. Right-click → Mark/Unmark as Entrypoint toggles the standard frontmatter tag; hand-editing works just as well. Foundation for the future Publish-as-Website `index.html` mapping.

## Test plan
- [ ] Approve a `propose_notes` bundle in a conversation → Filed line replaces the card; clicking each filename opens the note.
- [ ] Approve a `propose_sources` bundle → Filed line shows source titles; clicking opens the source. Failed entries show muted, non-clickable.
- [ ] Clear the Anthropic API key in Settings → send a conversation message → Open Settings dialog appears, lands on AI tab.
- [ ] Same with auto-tag, auto-link, and a Thinking Tool — all route to the same dialog.
- [ ] Open an empty thoughtbase via app restart → onboarding modal appears.
- [ ] File → New Thoughtbase in the current window → modal appears (regression fix verified).
- [ ] File → New Thoughtbase → cancel directory picker → modal does NOT reappear on the existing project.
- [ ] Tick "Don't show this for this thoughtbase" → reopen the same empty thoughtbase → modal does not appear.
- [ ] Right-click a `.md` note in the sidebar → Mark as Entrypoint → tag lands in frontmatter; menu now reads "Unmark as Entrypoint".
- [ ] Close all tabs, restart the app on a thoughtbase with entrypoint-tagged notes → those notes auto-open, first by title is active.
- [ ] Restart with a saved note tab → no auto-open (user session wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)