### PR TITLE
tools: fetch_properties + set_properties for YAML frontmatter

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -90,6 +90,7 @@ import { createExcerpt } from './sources/create-excerpt';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
+import { patchFrontmatterProperties } from '../shared/refactor/frontmatter-patch';
 import * as healthChecks from './graph/health-checks';
 import '../shared/tools/definitions/index';
 import { getSettings, saveSettings } from './llm/settings';
@@ -1612,6 +1613,11 @@ export function registerIpcHandlers(): void {
             win.webContents.send(Channels.CONVERSATION_SOURCE_DRAFT, draft);
           }
         },
+        onPropertyDraft: (draft: import('../shared/conversation-property-drafts').ConversationPropertyDraft) => {
+          if (!win.isDestroyed()) {
+            win.webContents.send(Channels.CONVERSATION_PROPERTY_DRAFT, draft);
+          }
+        },
         askUser: ({ question, choices }: { question: string; choices?: string[] }) => {
           const questionId = randomUUID();
           return new Promise<string>((resolve, reject) => {
@@ -1841,6 +1847,92 @@ export function registerIpcHandlers(): void {
           win.webContents.send(Channels.SOURCES_CHANGED);
         }
       }
+      return { outcomes };
+    },
+  );
+
+  // Counterpart to CONVERSATION_FILE_DRAFT for set_properties bundles.
+  // Reads each note, applies its frontmatter patch via
+  // `patchFrontmatterProperties`, and writes the result back. Per-note
+  // errors are non-fatal — the rest of the bundle still applies.
+  ipcMain.handle(
+    Channels.CONVERSATION_FILE_PROPERTY_DRAFT,
+    async (
+      e,
+      draft: import('../shared/conversation-property-drafts').ConversationPropertyDraft,
+    ): Promise<import('../shared/conversation-property-drafts').FilePropertyDraftResult> => {
+      console.log('[conv] FILE_PROPERTY_DRAFT received', {
+        draftId: draft?.draftId,
+        conversationId: draft?.conversationId,
+        updateCount: Array.isArray(draft?.updates) ? draft.updates.length : 'not-array',
+        // Log the actual properties keys per update — the original
+        // silent-failure bug was that this came across as an empty
+        // object on every entry, producing no writes. Surface it so a
+        // repeat of that hits a useful log line.
+        updateKeys: Array.isArray(draft?.updates)
+          ? draft.updates.map((u) => ({
+              relativePath: u?.relativePath,
+              keys: u?.properties ? Object.keys(u.properties) : null,
+            }))
+          : null,
+      });
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      if (!draft || !Array.isArray(draft.updates) || draft.updates.length === 0) {
+        throw new Error(
+          `FILE_PROPERTY_DRAFT: draft has no updates (received ${JSON.stringify(draft).slice(0, 200)}). ` +
+          `If this came from a Svelte 5 $state value, snapshot it before sending across IPC.`,
+        );
+      }
+      const outcomes: import('../shared/conversation-property-drafts').PropertyUpdateOutcome[] = [];
+      for (const u of draft.updates) {
+        try {
+          if (!u.properties || typeof u.properties !== 'object' || Object.keys(u.properties).length === 0) {
+            // Don't silently produce a no-op outcome — that's what hid
+            // the original cross-IPC serialization bug. Surface it as
+            // an explicit error so the user sees something on the
+            // Filed line and the log captures the bad payload.
+            outcomes.push({
+              relativePath: u.relativePath,
+              changedKeys: [],
+              deletedKeys: [],
+              error: 'properties payload arrived empty across IPC — frontmatter not written.',
+            });
+            continue;
+          }
+          const before = await notebaseFs.readFile(rootPath, u.relativePath);
+          const result = patchFrontmatterProperties(before, u.properties);
+          if (result.changedKeys.length > 0) {
+            // Route through the standard write pipeline rather than
+            // bare `notebaseFs.writeFile`. Without this the file lands
+            // on disk but the renderer's open editor + right-sidebar
+            // Properties panel don't refresh until the note is closed
+            // and reopened — the pipeline marks the watcher dedup,
+            // reindexes the graph + search, AND emits the
+            // NOTEBASE_REWRITTEN broadcast that triggers the in-place
+            // reload. Same flow auto-tag/auto-link use after their
+            // frontmatter mutations.
+            await writeAndReindex(rootPath, u.relativePath, result.content, hooks);
+          }
+          outcomes.push({
+            relativePath: u.relativePath,
+            changedKeys: result.changedKeys,
+            deletedKeys: result.deletedKeys,
+          });
+        } catch (err) {
+          console.warn(`[conv] FILE_PROPERTY_DRAFT patch failed for`, u.relativePath, err);
+          outcomes.push({
+            relativePath: u.relativePath,
+            changedKeys: [],
+            deletedKeys: [],
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      // The graph indexer watches for file changes, so reindexing
+      // happens automatically. We don't broadcast a separate event
+      // here — the file watcher's NOTEBASE_FILE_CHANGED event is
+      // what the renderer already listens for to refresh views.
       return { outcomes };
     },
   );

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -11,6 +11,7 @@ import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { MISSING_API_KEY_MARKER } from '../../shared/llm-errors';
 import type { ConversationDraft } from '../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../shared/conversation-source-drafts';
+import type { ConversationPropertyDraft } from '../../shared/conversation-property-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { formatToolCall } from './format-tool-call';
 
@@ -30,6 +31,12 @@ export interface StreamCallbacks {
    * propose_sources calls fail with a "no UI surface" error.
    */
   onSourceDraft?: (draft: ConversationSourceDraft) => void;
+  /**
+   * Counterpart to `onDraft` for the set_properties tool. Forwarded to
+   * the renderer via Channels.CONVERSATION_PROPERTY_DRAFT; without it,
+   * set_properties calls fail with a "no UI surface" error.
+   */
+  onPropertyDraft?: (draft: ConversationPropertyDraft) => void;
   /**
    * Wired by the conversation IPC handler when a template declares the
    * `ask_user` tool. The agent's call to `ask_user` resolves with the
@@ -326,6 +333,9 @@ export async function completeWithTools(
       }
       if (callbacks?.onSourceDraft) {
         toolCallbacks.onSourceDraft = callbacks.onSourceDraft;
+      }
+      if (callbacks?.onPropertyDraft) {
+        toolCallbacks.onPropertyDraft = callbacks.onPropertyDraft;
       }
       if (callbacks?.askUser) {
         toolCallbacks.askUser = callbacks.askUser;

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -16,8 +16,15 @@ import type {
   DraftSource,
   ProposeSourcesInput,
 } from '../../shared/conversation-source-drafts';
+import type {
+  ConversationPropertyDraft,
+  PropertyUpdate,
+  SetPropertiesInput,
+} from '../../shared/conversation-property-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { fixupBundleLinks } from '../../shared/refactor/bundle-link-fixup';
+import { readFrontmatterProperties } from '../../shared/refactor/frontmatter-patch';
+import type { PropertyPatch, PropertyValue } from '../../shared/refactor/frontmatter-patch';
 import { detectIdentifier } from '../sources/ingest-identifier';
 import { normalizeUrl } from '../sources/source-id';
 
@@ -46,6 +53,9 @@ export interface ToolCallbacks {
    *  propose_sources errors with "no UI surface" — same shape as
    *  propose_notes when invoked outside a conversation context. */
   onSourceDraft?: (draft: ConversationSourceDraft) => void;
+  /** Counterpart to `onDraft` for the `set_properties` tool. Forwards
+   *  frontmatter-patch drafts to the renderer for inline review. */
+  onPropertyDraft?: (draft: ConversationPropertyDraft) => void;
   askUser?: (input: { question: string; choices?: string[] }) => Promise<string>;
 }
 
@@ -265,6 +275,94 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
       required: ['note', 'sources'],
     },
   },
+  {
+    name: 'fetch_properties',
+    description:
+      'Read the YAML frontmatter properties of a note. Returns the ' +
+      'frontmatter as a JSON object — keys like `title`, `tags`, `status`, ' +
+      'custom user fields, etc. Returns `{}` when the note has no ' +
+      'frontmatter or the YAML is malformed. Use this before ' +
+      '`set_properties` when you need to read the existing value of a key ' +
+      'you intend to update (e.g. to append to an array rather than ' +
+      'replace it). Does not load the note body — call `read_note` for ' +
+      'that.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        relative_path: {
+          type: 'string',
+          description:
+            'Path relative to the thoughtbase root, including the `.md` ' +
+            'extension. Path traversal (..) is rejected.',
+        },
+      },
+      required: ['relative_path'],
+    },
+  },
+  {
+    name: 'set_properties',
+    description:
+      'Propose YAML-frontmatter property updates on one or more notes. ' +
+      'Use this for any structured-metadata change: setting a `status`, ' +
+      'editing `tags`, recording a custom field like `priority` or ' +
+      '`reviewed`, updating `title`, etc. The user reviews the bundle as ' +
+      'an inline card; on Approve, each note is read, its frontmatter ' +
+      'patched, and the file written back. On Discard nothing is written.\n' +
+      '\n' +
+      'Semantics: SHALLOW MERGE. Listed keys replace the value at that ' +
+      'key; setting a value to `null` deletes the key; other keys in the ' +
+      "frontmatter are left untouched. If you need to append to an array " +
+      'rather than replace it, call `fetch_properties` first to read the ' +
+      'current value, then submit the combined array.\n' +
+      '\n' +
+      'Use ONE `set_properties` call for the whole bundle (the user reviews ' +
+      'all updates as a single card) rather than calling it once per note. ' +
+      'When the only change is adding/removing a tag, you may still prefer ' +
+      '`set_properties` with `{ tags: [...] }` so the user sees the diff ' +
+      'instead of a silent tag mutation.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        note: {
+          type: 'string',
+          description:
+            'A short sentence describing why you are proposing this ' +
+            'update. Surfaced to the user on the inline review card.',
+        },
+        updates: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 64,
+          description:
+            'One or more per-note patches. Each entry targets one note ' +
+            'and shallow-merges its `properties` into the frontmatter.',
+          items: {
+            type: 'object',
+            properties: {
+              relativePath: {
+                type: 'string',
+                description:
+                  'Project-relative path to the note (include `.md`). The ' +
+                  'note must already exist — use `propose_notes` to ' +
+                  'create new notes.',
+              },
+              properties: {
+                type: 'object',
+                description:
+                  'Shallow patch. Each key is set to the given value; a ' +
+                  '`null` value deletes the key. Values may be strings, ' +
+                  'numbers, booleans, arrays, or nested objects — anything ' +
+                  'YAML can encode.',
+                additionalProperties: true,
+              },
+            },
+            required: ['relativePath', 'properties'],
+          },
+        },
+      },
+      required: ['note', 'updates'],
+    },
+  },
 ];
 
 /**
@@ -397,6 +495,10 @@ export async function executeNotebaseTool(
         return runProposeNotes(ctx, input, callbacks);
       case 'propose_sources':
         return runProposeSources(ctx, input, callbacks);
+      case 'fetch_properties':
+        return { content: await runFetchProperties(ctx, input), isError: false };
+      case 'set_properties':
+        return runSetProperties(ctx, input, callbacks);
       case 'ask_user':
         return runAskUser(input, callbacks);
       default:
@@ -714,4 +816,141 @@ function runDescribeSchema(): string {
     '',
     THOUGHT_ONTOLOGY_TTL,
   ].join('\n');
+}
+
+/**
+ * Read the frontmatter of a single note and return it as JSON. No
+ * approval gate — this is read-only and symmetric with `read_note`.
+ */
+async function runFetchProperties(ctx: ToolContext, input: unknown): Promise<string> {
+  const { relative_path } = input as { relative_path: string };
+  if (typeof relative_path !== 'string' || !relative_path) {
+    throw new Error('relative_path is required');
+  }
+  const content = await fs.readFile(ctx.rootPath, relative_path);
+  const props = readFrontmatterProperties(content);
+  return JSON.stringify(props, null, 2);
+}
+
+/**
+ * Trust-principle parity with `propose_notes` / `propose_sources`:
+ * `set_properties` does NOT write. It validates the bundle, emits a
+ * `ConversationPropertyDraft` for inline user review, and returns
+ * "drafted." The IPC handler for `CONVERSATION_FILE_PROPERTY_DRAFT`
+ * applies the writes once the user approves.
+ */
+function runSetProperties(
+  ctx: ToolContext,
+  input: unknown,
+  callbacks: ToolCallbacks,
+): { content: string; isError: boolean } {
+  if (!callbacks.onPropertyDraft) {
+    return {
+      content: 'set_properties is only available in conversation contexts.',
+      isError: true,
+    };
+  }
+  if (!ctx.conversationId) {
+    return {
+      content: 'set_properties requires a bound conversation id.',
+      isError: true,
+    };
+  }
+  const parsed = parseSetPropertiesInput(input);
+  if ('error' in parsed) {
+    return { content: parsed.error, isError: true };
+  }
+
+  const draft: ConversationPropertyDraft = {
+    draftId: `propdraft-${randomUUID()}`,
+    conversationId: ctx.conversationId,
+    note: parsed.note,
+    updates: parsed.updates,
+    createdAt: new Date().toISOString(),
+  };
+  callbacks.onPropertyDraft(draft);
+
+  const summary = parsed.updates
+    .map((u) => `${u.relativePath} (${Object.keys(u.properties).length} key${Object.keys(u.properties).length === 1 ? '' : 's'})`)
+    .join(', ');
+  return {
+    content: JSON.stringify({
+      status: 'drafted',
+      draftId: draft.draftId,
+      updateCount: parsed.updates.length,
+      proposed: parsed.updates.map((u) => ({
+        relativePath: u.relativePath,
+        keys: Object.keys(u.properties),
+      })),
+      // Same anti-loop hint as propose_notes / propose_sources — the
+      // model has historically retried draft-emitting tools when it
+      // didn't see a "successful" write effect in the result.
+      hint:
+        'STOP. The property bundle has been queued for user review. End ' +
+        'this turn with ONE short acknowledgement sentence ' +
+        '("Proposed N property update(s) for review.") and DO NOT call ' +
+        'set_properties again in this turn. DO NOT call any other tool. ' +
+        'DO NOT repeat the property values inline.',
+    }) + `\n\n(queued property draft: ${summary})`,
+    isError: false,
+  };
+}
+
+function parseSetPropertiesInput(
+  input: unknown,
+): SetPropertiesInput | { error: string } {
+  if (!input || typeof input !== 'object') {
+    return { error: 'set_properties input must be an object.' };
+  }
+  const obj = input as Record<string, unknown>;
+  const note = typeof obj.note === 'string' ? obj.note.trim() : '';
+  if (!note) return { error: '`note` is required and must be a non-empty string.' };
+  if (!Array.isArray(obj.updates) || obj.updates.length === 0) {
+    return { error: '`updates` must be a non-empty array.' };
+  }
+  const updates: PropertyUpdate[] = [];
+  for (const raw of obj.updates) {
+    if (!raw || typeof raw !== 'object') {
+      return { error: 'Each update entry must be an object.' };
+    }
+    const u = raw as Record<string, unknown>;
+    const relativePath = typeof u.relativePath === 'string' ? u.relativePath.trim() : '';
+    if (!relativePath) {
+      return { error: 'Each update entry must include a non-empty `relativePath`.' };
+    }
+    if (relativePath.includes('..')) {
+      return { error: `relativePath must not contain '..': ${relativePath}` };
+    }
+    if (!u.properties || typeof u.properties !== 'object' || Array.isArray(u.properties)) {
+      return { error: `update for ${relativePath}: \`properties\` must be a non-array object.` };
+    }
+    const props = u.properties as Record<string, unknown>;
+    if (Object.keys(props).length === 0) {
+      return { error: `update for ${relativePath}: \`properties\` must include at least one key.` };
+    }
+    // Validate each value can round-trip through YAML. We accept the
+    // loose PropertyValue shape (scalars, arrays, nested objects, null);
+    // anything outside that means the model sent something exotic
+    // (undefined, function, bigint) — reject early so the user doesn't
+    // approve a no-op patch.
+    const sanitized: PropertyPatch = {};
+    for (const [k, v] of Object.entries(props)) {
+      if (!isPropertyValue(v)) {
+        return { error: `update for ${relativePath}: value for key "${k}" is not a YAML-encodable scalar/array/object/null.` };
+      }
+      sanitized[k] = v;
+    }
+    updates.push({ relativePath, properties: sanitized });
+  }
+  return { note, updates };
+}
+
+function isPropertyValue(v: unknown): v is PropertyValue {
+  if (v === null) return true;
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return true;
+  if (Array.isArray(v)) return v.every(isPropertyValue);
+  if (typeof v === 'object') {
+    return Object.values(v as Record<string, unknown>).every(isPropertyValue);
+  }
+  return false;
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -195,6 +195,10 @@ contextBridge.exposeInMainWorld('api', {
       subscribeIpc(Channels.CONVERSATION_SOURCE_DRAFT, cb),
     fileSourceDraft: (draft: unknown) =>
       ipcRenderer.invoke(Channels.CONVERSATION_FILE_SOURCE_DRAFT, draft),
+    onPropertyDraft: (cb: (draft: unknown) => void) =>
+      subscribeIpc(Channels.CONVERSATION_PROPERTY_DRAFT, cb),
+    filePropertyDraft: (draft: unknown) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_FILE_PROPERTY_DRAFT, draft),
     setModel: (conversationId: string, model: string | undefined) =>
       ipcRenderer.invoke(Channels.CONVERSATION_SET_MODEL, conversationId, model),
   },

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -10,6 +10,10 @@
     ConversationSourceDraft,
     SourceIngestOutcome,
   } from '../../../shared/conversation-source-drafts';
+  import type {
+    ConversationPropertyDraft,
+    PropertyUpdateOutcome,
+  } from '../../../shared/conversation-property-drafts';
   import type { ConversationMessage } from '../../../shared/types';
 
   // Lightweight markdown-it for assistant message rendering. Mirrors the
@@ -183,6 +187,29 @@
     store.discardSourceDraft(tabId, draftId);
   }
 
+  async function handleApproveProperty(tabId: string, draft: ConversationPropertyDraft) {
+    try {
+      await store.approvePropertyDraft(tabId, draft);
+    } catch (e) {
+      console.error('[conv-panel] approve property failed:', e);
+    }
+  }
+
+  function handleDiscardProperty(tabId: string, draftId: string) {
+    store.discardPropertyDraft(tabId, draftId);
+  }
+
+  /** Render a frontmatter value for inline display on the review card.
+   *  Strings render bare; everything else falls back to compact JSON
+   *  so the user can eyeball arrays/objects without scrolling. Null
+   *  is shown as a deletion marker. */
+  function formatPropertyValue(v: unknown): string {
+    if (v === null) return '⌫ deleted';
+    if (typeof v === 'string') return v;
+    if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    try { return JSON.stringify(v) ?? ''; } catch { return '[unserializable]'; }
+  }
+
   function sourceLabel(s: { identifier?: string; url?: string }): string {
     return s.identifier ?? s.url ?? '(unknown source)';
   }
@@ -248,6 +275,14 @@
       ([, entry]) => entry.afterMessageIndex === i,
     );
   }
+  function propertyDraftsAt(tab: TabT, i: number) {
+    return tab.propertyDrafts.filter((d) => d.afterMessageIndex === i);
+  }
+  function propertyResultsAt(tab: TabT, i: number) {
+    return Object.entries(tab.propertyDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex === i,
+    );
+  }
   function orphanDrafts(tab: TabT) {
     const max = tab.conversation.messages.length;
     return tab.drafts.filter((d) => d.afterMessageIndex >= max);
@@ -265,6 +300,16 @@
   function orphanNoteResults(tab: TabT) {
     const max = tab.conversation.messages.length;
     return Object.entries(tab.noteDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex >= max,
+    );
+  }
+  function orphanPropertyDrafts(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return tab.propertyDrafts.filter((d) => d.afterMessageIndex >= max);
+  }
+  function orphanPropertyResults(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return Object.entries(tab.propertyDraftResults).filter(
       ([, entry]) => entry.afterMessageIndex >= max,
     );
   }
@@ -453,6 +498,75 @@
           </div>
         {/snippet}
 
+        {#snippet propertyDraftCardBlock(draft: ConversationPropertyDraft)}
+          <!-- set_properties review card. Mirrors the source/note card
+               chrome but shows the proposed frontmatter patch per note
+               instead of a flat list. Each value renders with its key
+               so the user can eyeball the diff without clicking
+               through to the file. -->
+          <div class="draft-card">
+            <div class="draft-summary">
+              <strong>🔑 {draft.updates.length} note{draft.updates.length === 1 ? '' : 's'}</strong>
+              <span class="draft-note">{draft.note}</span>
+            </div>
+            <ul class="property-update-list">
+              {#each draft.updates as u, ui (ui)}
+                <li class="property-update">
+                  <div class="property-update-path">{u.relativePath}</div>
+                  <ul class="property-kv-list">
+                    {#each Object.entries(u.properties) as [k, v] (k)}
+                      <li class="property-kv" class:property-kv-delete={v === null}>
+                        <span class="property-key">{k}:</span>
+                        <span class="property-value">{formatPropertyValue(v)}</span>
+                      </li>
+                    {/each}
+                  </ul>
+                </li>
+              {/each}
+            </ul>
+            <div class="draft-actions">
+              <button type="button" class="draft-btn primary" onclick={() => handleApproveProperty(tab.id, draft)}>Approve &amp; apply</button>
+              <button type="button" class="draft-btn" onclick={() => handleDiscardProperty(tab.id, draft.draftId)}>Discard</button>
+            </div>
+          </div>
+        {/snippet}
+
+        {#snippet propertyResultLine(_draftId: string, outcomes: PropertyUpdateOutcome[])}
+          <!-- Compact "Updated:" line that replaces the propose-property
+               card after Approve. Each successfully-patched path is a
+               clickable link that opens the note in the editor; the
+               count of changed keys is shown in parentheses so the user
+               can confirm the patch landed without re-reading the
+               frontmatter. -->
+          <div class="filed-line">
+            <span class="filed-prefix">🔑 Updated:</span>
+            {#if outcomes.length === 0}
+              <span class="filed-error">(no notes touched)</span>
+            {:else}
+              {#each outcomes as o, oi (oi)}
+                {#if oi > 0}<span class="filed-sep">·</span>{/if}
+                {#if o.error}
+                  <span class="filed-error" title={o.error}>⚠ {basename(o.relativePath)}</span>
+                {:else if o.changedKeys.length === 0}
+                  <button
+                    type="button"
+                    class="filed-link"
+                    title="{o.relativePath} — already up to date"
+                    onclick={() => openFiledNote(o.relativePath)}
+                  >{basename(o.relativePath)}<span class="filed-dup"> · no-op</span></button>
+                {:else}
+                  <button
+                    type="button"
+                    class="filed-link"
+                    title="{o.relativePath} — {o.changedKeys.join(', ')}"
+                    onclick={() => openFiledNote(o.relativePath)}
+                  >{basename(o.relativePath)}<span class="filed-dup"> · {o.changedKeys.length} key{o.changedKeys.length === 1 ? '' : 's'}</span></button>
+                {/if}
+              {/each}
+            {/if}
+          </div>
+        {/snippet}
+
         <div class="messages" bind:this={scrollEl}>
           <!-- Interleave: message → cards anchored to that message →
                next message. Keeps a draft visually attached to the
@@ -473,6 +587,12 @@
             {/each}
             {#each noteResultsAt(tab, i) as [draftId, entry] (draftId)}
               {@render noteResultLine(draftId, entry.filedPaths)}
+            {/each}
+            {#each propertyDraftsAt(tab, i) as draft (draft.draftId)}
+              {@render propertyDraftCardBlock(draft)}
+            {/each}
+            {#each propertyResultsAt(tab, i) as [draftId, entry] (draftId)}
+              {@render propertyResultLine(draftId, entry.outcomes)}
             {/each}
           {/each}
 
@@ -545,6 +665,12 @@
           {/each}
           {#each orphanNoteResults(tab) as [draftId, entry] (draftId)}
             {@render noteResultLine(draftId, entry.filedPaths)}
+          {/each}
+          {#each orphanPropertyDrafts(tab) as draft (draft.draftId)}
+            {@render propertyDraftCardBlock(draft)}
+          {/each}
+          {#each orphanPropertyResults(tab) as [draftId, entry] (draftId)}
+            {@render propertyResultLine(draftId, entry.outcomes)}
           {/each}
         </div>
 
@@ -941,6 +1067,58 @@
   .source-value {
     color: var(--text);
     overflow-wrap: anywhere;
+  }
+
+  /* set_properties review card interior. Each per-note patch is a
+     small block with the relative path as a header and a key:value
+     list underneath. Deleted keys render dimmed with a strikethrough
+     marker so removals are visually distinct from sets. */
+  .property-update-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .property-update {
+    border-left: 2px solid var(--border);
+    padding-left: 8px;
+  }
+  .property-update-path {
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 2px;
+  }
+  .property-kv-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .property-kv {
+    display: flex;
+    gap: 6px;
+    font-size: 12px;
+    padding: 1px 4px;
+    font-family: var(--font-mono, monospace);
+  }
+  .property-key {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+  .property-value {
+    color: var(--text);
+    overflow-wrap: anywhere;
+  }
+  .property-kv-delete .property-key,
+  .property-kv-delete .property-value {
+    color: var(--text-muted);
+    text-decoration: line-through;
+    text-decoration-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
   }
 
   /* Post-Approve summary line — replaces the inline draft card for

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -372,6 +372,14 @@ export interface ConversationsApi {
   fileSourceDraft(
     draft: import('../../../shared/conversation-source-drafts').ConversationSourceDraft,
   ): Promise<import('../../../shared/conversation-source-drafts').FileSourceDraftResult>;
+  /** Subscribe to frontmatter-patch drafts produced by the set_properties tool. */
+  onPropertyDraft(
+    cb: (draft: import('../../../shared/conversation-property-drafts').ConversationPropertyDraft) => void,
+  ): void;
+  /** Apply each {path, properties} patch in an approved draft. Returns per-update outcomes. */
+  filePropertyDraft(
+    draft: import('../../../shared/conversation-property-drafts').ConversationPropertyDraft,
+  ): Promise<import('../../../shared/conversation-property-drafts').FilePropertyDraftResult>;
 }
 
 export interface ProposalsApi {

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -10,6 +10,10 @@ import type {
   SourceIngestOutcome,
 } from '../../../shared/conversation-source-drafts';
 import type {
+  ConversationPropertyDraft,
+  PropertyUpdateOutcome,
+} from '../../../shared/conversation-property-drafts';
+import type {
   AskUserRequest,
   ConversationToolKey,
 } from '../../../shared/conversation-tools';
@@ -43,8 +47,13 @@ import { isMissingApiKeyError } from '../../../shared/llm-errors';
  */
 type AnchoredDraft = ConversationDraft & { afterMessageIndex: number };
 type AnchoredSourceDraft = ConversationSourceDraft & { afterMessageIndex: number };
+type AnchoredPropertyDraft = ConversationPropertyDraft & { afterMessageIndex: number };
 interface SourceDraftResultEntry {
   outcomes: SourceIngestOutcome[];
+  afterMessageIndex: number;
+}
+interface PropertyDraftResultEntry {
+  outcomes: PropertyUpdateOutcome[];
   afterMessageIndex: number;
 }
 /** Post-Approve summary for a propose_notes draft. Persists in the
@@ -77,6 +86,11 @@ interface TabRuntime {
    *  anchoring story as `sourceDraftResults` — the line sits where the
    *  card used to so the user isn't left wondering what landed. */
   noteDraftResults: Record<string, NoteDraftResultEntry>;
+  /** set_properties drafts awaiting Approve/Discard. */
+  propertyDrafts: AnchoredPropertyDraft[];
+  /** Per-update outcomes after Approve on a property draft — used to
+   *  render the post-Approve "Updated:" line in place of the card. */
+  propertyDraftResults: Record<string, PropertyDraftResultEntry>;
   /** In-flight ask_user prompt, if the agent is waiting on a reply. */
   pendingQuestion: AskUserRequest | null;
   composer: string;
@@ -112,6 +126,7 @@ let needsApiKey = $state(false);
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let draftSubscribed = false;
 let sourceDraftSubscribed = false;
+let propertyDraftSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
 
@@ -167,6 +182,15 @@ function ensureSubscriptions(): void {
     });
     sourceDraftSubscribed = true;
   }
+  if (!propertyDraftSubscribed) {
+    api.conversations.onPropertyDraft((draft) => {
+      const t = tabs.find((tab) => tab.id === draft.conversationId);
+      if (!t) return;
+      const afterMessageIndex = t.conversation.messages.length;
+      t.propertyDrafts = [...t.propertyDrafts, { ...draft, afterMessageIndex }];
+    });
+    propertyDraftSubscribed = true;
+  }
   if (!askUserSubscribed) {
     api.conversations.onAskUser((req) => {
       const t = tabs.find((tab) => tab.id === req.conversationId);
@@ -207,6 +231,8 @@ async function init(): Promise<void> {
       sourceDrafts: [],
       sourceDraftResults: {},
       noteDraftResults: {},
+      propertyDrafts: [],
+      propertyDraftResults: {},
       pendingQuestion: null,
       composer: '',
       streaming: false,
@@ -292,6 +318,8 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     sourceDrafts: [],
     sourceDraftResults: {},
     noteDraftResults: {},
+    propertyDrafts: [],
+    propertyDraftResults: {},
     pendingQuestion: null,
     composer: '',
     streaming: false,
@@ -344,6 +372,8 @@ async function openConversationTab(opts: {
     sourceDrafts: [],
     sourceDraftResults: {},
     noteDraftResults: {},
+    propertyDrafts: [],
+    propertyDraftResults: {},
     pendingQuestion: null,
     composer: '',
     streaming: false,
@@ -511,6 +541,47 @@ function discardSourceDraft(tabId: string, draftId: string): void {
   tab.sourceDrafts = tab.sourceDrafts.filter((d) => d.draftId !== draftId);
 }
 
+async function approvePropertyDraft(
+  tabId: string,
+  draft: ConversationPropertyDraft,
+): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  const anchored = tab.propertyDrafts.find((d) => d.draftId === draft.draftId);
+  const afterMessageIndex = anchored?.afterMessageIndex ?? tab.conversation.messages.length;
+  // Snapshot via JSON round-trip rather than `$state.snapshot` here.
+  // The propose_notes/propose_sources path uses `$state.snapshot` and
+  // works fine because its DraftPayload values are all primitives
+  // (relativePath/content/url/identifier strings). PropertyUpdate
+  // contains a nested `Record<string, unknown>` with arbitrary keys,
+  // and a reported bug — "set_properties approved but no frontmatter
+  // landed" — was traced to that inner object arriving on the main
+  // side empty after $state.snapshot → IPC structured-clone. The
+  // JSON round-trip drops any lingering Proxy wrapping unconditionally
+  // and produces a payload IPC can serialize without losing keys.
+  const plain = JSON.parse(JSON.stringify(draft)) as ConversationPropertyDraft;
+  console.log('[conv] approvePropertyDraft sending', {
+    draftId: plain.draftId,
+    updateCount: plain.updates.length,
+    propertyKeySamples: plain.updates.slice(0, 3).map((u) => ({
+      relativePath: u.relativePath,
+      keys: Object.keys(u.properties ?? {}),
+    })),
+  });
+  const result = await api.conversations.filePropertyDraft(plain);
+  tab.propertyDrafts = tab.propertyDrafts.filter((d) => d.draftId !== draft.draftId);
+  tab.propertyDraftResults = {
+    ...tab.propertyDraftResults,
+    [draft.draftId]: { outcomes: result.outcomes, afterMessageIndex },
+  };
+}
+
+function discardPropertyDraft(tabId: string, draftId: string): void {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  tab.propertyDrafts = tab.propertyDrafts.filter((d) => d.draftId !== draftId);
+}
+
 function setComposer(value: string): void {
   const tab = activeTab();
   if (tab) tab.composer = value;
@@ -549,6 +620,8 @@ export function getConversationsStore() {
     approveSourceDraft,
     discardSourceDraft,
     dismissSourceDraftResult,
+    approvePropertyDraft,
+    discardPropertyDraft,
     setComposer,
   };
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -284,6 +284,10 @@ export const Channels = {
   CONVERSATION_SOURCE_DRAFT: 'conversation:sourceDraft',
   /** renderer → main: user approved a source draft; run the ingest pipeline for each URL/identifier and return the per-source outcomes. */
   CONVERSATION_FILE_SOURCE_DRAFT: 'conversation:fileSourceDraft',
+  /** main → renderer: a set_properties tool call produced a frontmatter-patch draft for review. Payload is ConversationPropertyDraft. */
+  CONVERSATION_PROPERTY_DRAFT: 'conversation:propertyDraft',
+  /** renderer → main: user approved a property draft; apply each {path, properties} patch and return the per-update outcomes. */
+  CONVERSATION_FILE_PROPERTY_DRAFT: 'conversation:filePropertyDraft',
   CONVERSATION_SET_MODEL: 'conversation:setModel',
   /** Load tool-window UI state (.minerva/conversations/_ui.json). */
   CONVERSATION_UI_STATE_LOAD: 'conversation:uiStateLoad',

--- a/src/shared/conversation-property-drafts.ts
+++ b/src/shared/conversation-property-drafts.ts
@@ -1,0 +1,69 @@
+/**
+ * Conversation property drafts (the `set_properties` tool path).
+ *
+ * Counterpart to `conversation-drafts.ts` and `conversation-source-drafts.ts`.
+ * The LLM calls `set_properties` mid-conversation with one or more
+ * `{ relativePath, properties }` entries — a shallow patch of YAML
+ * frontmatter per note (null deletes a key, present values merge).
+ *
+ * Trust principle: the tool's server-side execution does NOT write —
+ * doing so would file the change behind the user's back. It emits a
+ * `ConversationPropertyDraft`, forwards it to the renderer via
+ * `Channels.CONVERSATION_PROPERTY_DRAFT`, and returns "queued for
+ * review." The renderer renders an inline card showing each note's
+ * proposed key/value diff. Approve hands the bundle back through
+ * `Channels.CONVERSATION_FILE_PROPERTY_DRAFT`; that handler reads each
+ * note, applies the patch via `patchFrontmatterProperties`, and writes
+ * it back atomically per file.
+ *
+ * Drafts live in renderer memory and are dropped when the conversation
+ * tab closes — same lifecycle as note/source drafts.
+ */
+
+import type { PropertyPatch } from './refactor/frontmatter-patch';
+
+/** A single per-note frontmatter patch. */
+export interface PropertyUpdate {
+  /** Project-relative target path. The handler resolves and reads
+   *  through the standard fs guard; path traversal is rejected. */
+  relativePath: string;
+  /** Shallow patch — keys to set or null-to-delete. Null deletes the
+   *  key from frontmatter; unmentioned keys are left untouched. */
+  properties: PropertyPatch;
+}
+
+export interface ConversationPropertyDraft {
+  /** Stable id used to wire Approve/Discard buttons back to the cached bundle. */
+  draftId: string;
+  /** Conversation that produced the draft. Used by the renderer to bucket. */
+  conversationId: string;
+  /** Bundle-level "why I'm proposing this" note from the LLM. */
+  note: string;
+  updates: PropertyUpdate[];
+  /** ISO timestamp when the draft was created. */
+  createdAt: string;
+}
+
+/** Per-update result returned by `CONVERSATION_FILE_PROPERTY_DRAFT`. */
+export interface PropertyUpdateOutcome {
+  /** Echoes the entry's path so the renderer can correlate. */
+  relativePath: string;
+  /** Keys actually changed (set or deleted). Empty when the patch was
+   *  a no-op against the current frontmatter. */
+  changedKeys: string[];
+  /** Keys deleted (subset of changedKeys). */
+  deletedKeys: string[];
+  /** Error message when the write failed for this entry. Other entries
+   *  in the bundle continue independently. */
+  error?: string;
+}
+
+export interface FilePropertyDraftResult {
+  outcomes: PropertyUpdateOutcome[];
+}
+
+/** Input shape for the `set_properties` tool. */
+export interface SetPropertiesInput {
+  note: string;
+  updates: PropertyUpdate[];
+}

--- a/src/shared/refactor/frontmatter-patch.ts
+++ b/src/shared/refactor/frontmatter-patch.ts
@@ -1,0 +1,156 @@
+import YAML from 'yaml';
+
+/**
+ * Patch a note's YAML frontmatter with a shallow key/value merge.
+ *
+ * Counterpart to the tag-focused helpers in `auto-tag.ts`. Used by the
+ * `set_properties` LLM tool flow — the LLM proposes a property bundle,
+ * the user approves, and the IPC handler runs this helper per note.
+ *
+ * Semantics:
+ *  - Existing keys are overwritten with the patched value.
+ *  - A `null` value deletes the key (lets the LLM clear properties
+ *    without needing a separate "delete" tool).
+ *  - Unmentioned keys are left untouched.
+ *  - If the patched frontmatter ends up empty, the entire `--- … ---`
+ *    block is removed — same convention as `removeTagsFromContent`,
+ *    keeps round-tripping clean.
+ *  - Notes without an existing frontmatter block get one created.
+ *  - Malformed YAML in the existing block is treated as "no frontmatter"
+ *    rather than thrown — overwriting a broken block with valid YAML is
+ *    a recoverable outcome; failing the whole tool call isn't.
+ */
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+/** Scalar | array of scalars | nested object | null. Mirrors what
+ *  `YAML.stringify` round-trips cleanly. The LLM's tool input is
+ *  validated against this loosely at runtime via `isPropertyValue`
+ *  in tools.ts; the static type is intentionally `unknown` rather
+ *  than a recursive union so the IPC boundary doesn't trip Svelte 5's
+ *  reactive-proxy type-inference (TS2589 "type instantiation is
+ *  excessively deep" when a `$state.snapshot()` of a recursive type
+ *  crosses an `api.*` call). */
+export type PropertyValue = unknown;
+
+export interface PropertyPatch {
+  [key: string]: PropertyValue;
+}
+
+export interface PatchResult {
+  content: string;
+  /** Keys whose value actually changed (set or deleted). Keys whose patch
+   *  value matched what was already there are omitted — lets the caller
+   *  report "no-op" cleanly when the LLM proposes a redundant update. */
+  changedKeys: string[];
+  /** Keys explicitly deleted (subset of `changedKeys`). Useful for the
+   *  approval-card "removed:" line. */
+  deletedKeys: string[];
+}
+
+export function patchFrontmatterProperties(content: string, patch: PropertyPatch): PatchResult {
+  const match = content.match(FRONTMATTER_RE);
+  let fm: Record<string, unknown> = {};
+  if (match) {
+    try {
+      const parsed: unknown = YAML.parse(match[1]);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        fm = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed frontmatter — treat as empty so the patch produces a
+      // valid block. The user's broken YAML is replaced, not preserved.
+    }
+  }
+
+  const changedKeys: string[] = [];
+  const deletedKeys: string[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      if (key in fm) {
+        delete fm[key];
+        changedKeys.push(key);
+        deletedKeys.push(key);
+      }
+      continue;
+    }
+    if (deepEqual(fm[key], value)) continue;
+    fm[key] = value;
+    changedKeys.push(key);
+  }
+
+  if (changedKeys.length === 0) {
+    return { content, changedKeys: [], deletedKeys: [] };
+  }
+
+  const body = match ? content.slice(match[0].length) : content;
+  if (Object.keys(fm).length === 0) {
+    // Frontmatter ended up empty — drop the block entirely. Same logic
+    // as removeTagsFromContent, so a note that gets all properties
+    // cleared doesn't end up with a vestigial `---\n---` header.
+    return {
+      content: body.replace(/^\n+/, ''),
+      changedKeys,
+      deletedKeys,
+    };
+  }
+
+  const yamlBlock = YAML.stringify(fm).trimEnd();
+  const rendered = `---\n${yamlBlock}\n---\n`;
+  const separator = body.startsWith('\n') || body === '' ? '' : '\n';
+  return { content: rendered + separator + body, changedKeys, deletedKeys };
+}
+
+/**
+ * Read frontmatter as a plain object. Returns `{}` when the note has no
+ * frontmatter or its YAML is malformed. Counterpart to the writer above;
+ * used by `fetch_properties` so the tool result is symmetric with what
+ * `set_properties` accepts.
+ */
+export function readFrontmatterProperties(content: string): Record<string, unknown> {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return {};
+  try {
+    const parsed: unknown = YAML.parse(match[1]);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* malformed — treat as empty */
+  }
+  return {};
+}
+
+/**
+ * Deep-equality on the JSON-shaped values frontmatter holds. Avoids
+ * `JSON.stringify` because object-key order would produce false
+ * inequalities. Pulled out to a helper so the patch's "did this key
+ * actually change?" check is consistent across cases (scalar swap,
+ * array reorder, nested mapping update).
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === 'object') {
+    if (typeof b !== 'object' || b === null || Array.isArray(b)) return false;
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const ak = Object.keys(ao);
+    const bk = Object.keys(bo);
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) {
+      if (!(k in bo)) return false;
+      if (!deepEqual(ao[k], bo[k])) return false;
+    }
+    return true;
+  }
+  return false;
+}

--- a/tests/shared/refactor/frontmatter-patch.test.ts
+++ b/tests/shared/refactor/frontmatter-patch.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  patchFrontmatterProperties,
+  readFrontmatterProperties,
+} from '../../../src/shared/refactor/frontmatter-patch';
+
+describe('patchFrontmatterProperties', () => {
+  it('creates a frontmatter block on a note that has none', () => {
+    const before = '# My Note\n\nSome body content.\n';
+    const result = patchFrontmatterProperties(before, { status: 'draft' });
+    expect(result.changedKeys).toEqual(['status']);
+    expect(result.content).toBe(
+      '---\nstatus: draft\n---\n\n# My Note\n\nSome body content.\n',
+    );
+  });
+
+  it('merges new keys into an existing frontmatter block', () => {
+    const before = '---\ntitle: Hello\n---\n\n# Hello\n';
+    const result = patchFrontmatterProperties(before, { status: 'draft' });
+    expect(result.changedKeys).toEqual(['status']);
+    expect(result.content).toContain('title: Hello');
+    expect(result.content).toContain('status: draft');
+    expect(result.content).toMatch(/^---\n[\s\S]*?\n---\n/);
+  });
+
+  it('overwrites an existing key when the value differs', () => {
+    const before = '---\nstatus: draft\n---\n\nbody\n';
+    const result = patchFrontmatterProperties(before, { status: 'published' });
+    expect(result.changedKeys).toEqual(['status']);
+    expect(readFrontmatterProperties(result.content).status).toBe('published');
+  });
+
+  it('treats an existing value matching the patch as a no-op', () => {
+    const before = '---\nstatus: draft\n---\n\nbody\n';
+    const result = patchFrontmatterProperties(before, { status: 'draft' });
+    expect(result.changedKeys).toEqual([]);
+    expect(result.content).toBe(before);
+  });
+
+  it('deletes a key when patch value is null', () => {
+    const before = '---\ntitle: Hello\nstatus: draft\n---\n\nbody\n';
+    const result = patchFrontmatterProperties(before, { status: null });
+    expect(result.deletedKeys).toEqual(['status']);
+    expect(readFrontmatterProperties(result.content)).toEqual({ title: 'Hello' });
+  });
+
+  it('removes the frontmatter block entirely when it ends up empty', () => {
+    const before = '---\nstatus: draft\n---\n\n# Note\n';
+    const result = patchFrontmatterProperties(before, { status: null });
+    expect(result.content).toBe('# Note\n');
+  });
+
+  it('handles array values', () => {
+    const before = '# Note\n';
+    const result = patchFrontmatterProperties(before, { tags: ['a', 'b'] });
+    expect(result.changedKeys).toEqual(['tags']);
+    expect(readFrontmatterProperties(result.content).tags).toEqual(['a', 'b']);
+  });
+
+  it('treats malformed existing frontmatter as empty (overwrites it)', () => {
+    const before = '---\n: : : not yaml\n---\n\nbody\n';
+    const result = patchFrontmatterProperties(before, { status: 'draft' });
+    expect(result.changedKeys).toEqual(['status']);
+    expect(readFrontmatterProperties(result.content).status).toBe('draft');
+  });
+});
+
+describe('readFrontmatterProperties', () => {
+  it('returns {} for a note without frontmatter', () => {
+    expect(readFrontmatterProperties('# Just a heading\n')).toEqual({});
+  });
+
+  it('parses a valid frontmatter block', () => {
+    expect(readFrontmatterProperties('---\nstatus: draft\ntags:\n  - a\n  - b\n---\n\nbody'))
+      .toEqual({ status: 'draft', tags: ['a', 'b'] });
+  });
+});


### PR DESCRIPTION
## Summary

Two new LLM tools surface YAML frontmatter to the agent in conversational mode, so structured metadata stops being an under-used surface:

- **`fetch_properties`** — read-only. Takes `{ relative_path }`, returns the note's frontmatter as a JSON object (or `{}` when none / malformed). Symmetric with `read_note` minus the body.
- **`set_properties`** — gated by inline review per the trust principle. Takes `{ note, updates: [{ relativePath, properties }, ...] }`. Shallow merge: listed keys are set, `null` deletes, unmentioned keys preserved. The user sees an inline card showing the per-note diff; on Approve the bundle runs through the standard `writeAndReindex` pipeline.

Mirrors the `propose_notes` / `propose_sources` draft-emit + approval-card pattern end to end. After approval the panel drops in a compact "🔑 Updated: foo.md · 2 keys" line with clickable filenames.

## Architecture

- `src/shared/refactor/frontmatter-patch.ts` (new) — `patchFrontmatterProperties()` + `readFrontmatterProperties()`. Round-trip safe, drops the `---…---` block when frontmatter ends up empty (matches the existing tag-remove convention), `deepEqual` no-op detection so a redundant patch doesn't rewrite the file.
- `src/shared/conversation-property-drafts.ts` (new) — `PropertyUpdate`, `ConversationPropertyDraft`, `PropertyUpdateOutcome`, `FilePropertyDraftResult`.
- `src/shared/channels.ts` — `CONVERSATION_PROPERTY_DRAFT` + `CONVERSATION_FILE_PROPERTY_DRAFT`.
- `src/main/llm/tools.ts` — tool definitions, `runFetchProperties`, `runSetProperties`, runtime `isPropertyValue` guard for YAML-encodable values.
- `src/main/llm/index.ts` — pipes `onPropertyDraft` through `StreamCallbacks` → `ToolCallbacks`.
- `src/main/ipc.ts` — forwards drafts to the renderer; `CONVERSATION_FILE_PROPERTY_DRAFT` handler applies the bundle via `writeAndReindex` (per-note errors non-fatal).
- Renderer store + panel — anchored drafts, per-update result line, deletion shown strikethrough.

## Integration bugs fixed in the same change

- **IPC payload arrived empty.** The `properties` field is a `Record<string, unknown>` with dynamic keys. `$state.snapshot()` + IPC structured-clone dropped the inner object's keys on the way to main, producing silent no-op writes (other draft tools' payloads are all primitives so they never hit this). Replaced with a `JSON.parse(JSON.stringify(draft))` round-trip at the IPC boundary in `approvePropertyDraft`. Defensive logging on both sides catches any future regression instead of swallowing it.
- **No in-place refresh after approval.** The handler was calling bare `notebaseFs.writeFile`, skipping the `writeAndReindex` pipeline. That meant `NOTEBASE_REWRITTEN` never fired and open editors / the right-sidebar Properties panel only picked up the change after the user closed and reopened the note. Now uses the same pipeline auto-tag and auto-link use.

## Test plan
- [ ] Ask the agent "fetch the properties of <note>" — JSON-shaped frontmatter (or `{}`) appears in the response.
- [ ] Ask it to set a property on a note that has no frontmatter — review card shows the proposed key/value diff; Approve writes `---\n…\n---\n` and the editor + Properties panel update in place without close-and-reopen.
- [ ] Ask it to set a property on a note that already has frontmatter — listed keys merge, others survive.
- [ ] Set a value to `null` — deletion shows strikethrough on the card; on approve the key disappears.
- [ ] Patch a value already at the requested value — Updated line shows "no-op" badge, file mtime does not change.
- [ ] Mixed bundle (some updates, some bad paths) — successful entries write; bad entries show ⚠ on the Updated line; other entries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)