### PR TITLE
properties: key autocomplete + wiki-link value picker (#488, #489)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -116,6 +116,13 @@ interface GraphState {
    *  superset of `aliasesPerNote.keys()` — notes without aliases still
    *  count for canonical-name conflicts. */
   indexedNotePaths: Set<string>;
+  /** Frontmatter keys present on each indexed note. Powers the
+   *  Properties panel's project-wide key autocomplete (#488) — the
+   *  graph already extracts frontmatter on every index, so capturing
+   *  the bare key list is essentially free. Kept as a string[] per
+   *  note (rather than a flat global Set) so removeNote can shrink
+   *  the union without scanning every note. */
+  frontmatterKeysPerNote: Map<string, string[]>;
 }
 
 const states = new Map<string, GraphState>();
@@ -144,6 +151,22 @@ export function getAliasMap(ctx: ProjectContext): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of state.aliasMap) out[k] = v;
   return out;
+}
+
+/**
+ * Deduped, alphabetically-sorted list of every frontmatter key
+ * currently in use across the project. Powers the Properties panel's
+ * Add-Property autocomplete (#488). Empty when the project has no
+ * graph state yet.
+ */
+export function getAllFrontmatterKeys(ctx: ProjectContext): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const seen = new Set<string>();
+  for (const keys of state.frontmatterKeysPerNote.values()) {
+    for (const k of keys) seen.add(k);
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b));
 }
 
 /**
@@ -598,6 +621,7 @@ export async function initGraph(ctx: ProjectContext): Promise<void> {
     aliasMap: new Map(),
     aliasesPerNote: new Map(),
     indexedNotePaths: new Set(),
+    frontmatterKeysPerNote: new Map(),
   };
 
   // Load persisted graph if it exists
@@ -676,6 +700,13 @@ export async function indexNote(
 
   // Parse markdown
   const parsed = parseMarkdown(content);
+
+  // Snapshot frontmatter keys for the Properties panel's project-wide
+  // autocomplete (#488). Captured before the per-key indexing loop
+  // below so we record every key the user actually typed, including
+  // `title` and `tags` (skipped by the predicate-mapping path because
+  // they're already wired through other paths).
+  state.frontmatterKeysPerNote.set(relativePath, Object.keys(parsed.frontmatter));
 
   // Title
   const title = parsed.title ?? path.basename(relativePath, '.md');
@@ -1203,6 +1234,10 @@ export function removeNote(ctx: ProjectContext, relativePath: string): void {
   // canonical-conflict pass no longer treats this path as a real file.
   const hadAliases = state.aliasesPerNote.delete(relativePath);
   const wasTracked = state.indexedNotePaths.delete(relativePath);
+  // Drop the deleted note's frontmatter-key snapshot so its keys stop
+  // appearing in the project-wide autocomplete (#488).
+  state.frontmatterKeysPerNote.delete(relativePath);
+  state.headingsPerNote.delete(relativePath);
   if (hadAliases || wasTracked) {
     rebuildAliasMap(state);
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -726,6 +726,12 @@ export function registerIpcHandlers(): void {
     return graph.getAliasMap(projectContext(rootPath));
   });
 
+  ipcMain.handle(Channels.GRAPH_FRONTMATTER_KEYS, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.getAllFrontmatterKeys(projectContext(rootPath));
+  });
+
   // Tags
   ipcMain.handle(Channels.TAGS_LIST, (e) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -6,8 +6,11 @@ import { Channels } from '../shared/channels';
  * Centralises the unavoidable cast at the IPC boundary — the main
  * process owns the wire shape, so each subscriber names what it expects.
  */
-function subscribeIpc<T>(channel: string, cb: (payload: T) => void): void {
-  ipcRenderer.on(channel, (_e, payload: unknown) => cb(payload as T));
+function subscribeIpc<T>(channel: string, cb: (payload: T) => void): () => void {
+  // Wrapper captured by reference so `off` removes the exact handler.
+  const handler = (_e: unknown, payload: unknown) => cb(payload as T);
+  ipcRenderer.on(channel, handler);
+  return () => { ipcRenderer.off(channel, handler); };
 }
 
 contextBridge.exposeInMainWorld('api', {
@@ -111,6 +114,7 @@ contextBridge.exposeInMainWorld('api', {
     excerptSource: (excerptId: string) => ipcRenderer.invoke(Channels.GRAPH_EXCERPT_SOURCE, excerptId),
     schemaForCompletion: () => ipcRenderer.invoke(Channels.GRAPH_SCHEMA_FOR_COMPLETION),
     aliasMap: () => ipcRenderer.invoke(Channels.GRAPH_ALIAS_MAP),
+    frontmatterKeys: () => ipcRenderer.invoke(Channels.GRAPH_FRONTMATTER_KEYS),
   },
   tables: {
     query: (sql: string) => ipcRenderer.invoke(Channels.TABLES_QUERY, sql),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -2486,6 +2486,7 @@
           activeFilePath={editor.activeFilePath}
           content={editor.content}
           onFileSelect={handleFileSelect}
+          onNavigate={handleNavigate}
           onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
           onShowPrompt={showPrompt}
           onOpenConversation={(msg) => { void openConversationWithMessage(msg); }}

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -19,6 +19,11 @@
     activeFilePath: string | null;
     content: string;
     onFileSelect: (relativePath: string) => void;
+    /** Short-form wiki-link resolver — handles `[[basename]]`, aliases,
+     *  and slug-fuzzy matches. Used by the Properties panel's wiki-link
+     *  value chip (#489) so clicking opens the right note regardless of
+     *  how the target is written. */
+    onNavigate?: (target: string) => void | Promise<void>;
     onScrollToLine: (line: number) => void;
     onShowPrompt: (message: string) => Promise<string | null>;
     onOpenConversation?: (message: string) => void;
@@ -29,7 +34,7 @@
   }
 
   let {
-    activeFilePath, content, onFileSelect, onScrollToLine, onShowPrompt,
+    activeFilePath, content, onFileSelect, onNavigate, onScrollToLine, onShowPrompt,
     onOpenConversation, onOpenQuery, onOpenSource, onOpenExcerpt,
     onContentChange,
   }: Props = $props();
@@ -163,7 +168,7 @@
       <FootnotesPanel {content} {onScrollToLine} />
     {:else if activePanel === 'properties'}
       {#if onContentChange}
-        <PropertiesPanel {content} {onContentChange} />
+        <PropertiesPanel {content} {onContentChange} {onNavigate} />
       {:else}
         <div class="panel-disabled">No active note.</div>
       {/if}

--- a/src/renderer/lib/components/right-sidebar/AutocompleteDropdown.svelte
+++ b/src/renderer/lib/components/right-sidebar/AutocompleteDropdown.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  /**
+   * Generic input + dropdown autocomplete used by the Properties
+   * panel for two roles:
+   *
+   *  - Add-Property key picker (#488) — source is project keys
+   *    union canonical keys minus what's already on the active note.
+   *  - Wiki-link value editor (#489) — source is the project's note
+   *    basenames (relativePath minus `.md`).
+   *
+   * Ranking is exact > prefix > substring, case-insensitive. Empty
+   * input shows the first 12 options unchanged so the user can browse
+   * without typing first.
+   *
+   * Keyboard model mirrors the editor's CodeMirror autocomplete:
+   *  - ↑/↓: move highlight (wraps).
+   *  - Enter: commit the highlighted suggestion (or the raw text if no
+   *    suggestion is highlighted AND `allowFreeText` is set).
+   *  - Tab: same as Enter.
+   *  - Esc: closes the popover; second Esc bubbles a cancel.
+   */
+  import { onMount, tick } from 'svelte';
+
+  interface Props {
+    value: string;
+    options: readonly string[];
+    placeholder?: string;
+    /** When true, Enter commits the raw input text even if it doesn't
+     *  appear in `options`. Default true — both call-sites want this
+     *  (new property keys and new wiki-link targets are valid). */
+    allowFreeText?: boolean;
+    /** Max rows in the popover. Default 8. */
+    maxRows?: number;
+    /** Optional extra class for the wrapper (lets the call-site shape
+     *  its own input chrome without forking the component). */
+    class?: string;
+    /** Whether to autofocus the input on mount. Default false. */
+    autofocus?: boolean;
+    onInput: (next: string) => void;
+    onCommit: (value: string) => void;
+    onCancel?: () => void;
+  }
+
+  let {
+    value,
+    options,
+    placeholder = '',
+    allowFreeText = true,
+    maxRows = 8,
+    class: className = '',
+    autofocus = false,
+    onInput,
+    onCommit,
+    onCancel,
+  }: Props = $props();
+
+  let inputEl = $state<HTMLInputElement | undefined>();
+  let open = $state(false);
+  let highlightIndex = $state(0);
+
+  onMount(() => {
+    if (autofocus && inputEl) inputEl.focus();
+  });
+
+  /** Rank options against the current input. Exact (after lowercasing)
+   *  beats prefix beats substring; ties fall back to lexicographic. */
+  const matches = $derived.by(() => {
+    const q = value.trim().toLowerCase();
+    if (!q) return options.slice(0, maxRows);
+    const exact: string[] = [];
+    const prefix: string[] = [];
+    const substring: string[] = [];
+    for (const opt of options) {
+      const lo = opt.toLowerCase();
+      if (lo === q) exact.push(opt);
+      else if (lo.startsWith(q)) prefix.push(opt);
+      else if (lo.includes(q)) substring.push(opt);
+    }
+    return [...exact, ...prefix, ...substring].slice(0, maxRows);
+  });
+
+  // Reset highlight to top whenever the match set changes — keeping a
+  // stale index past the new list's length would point at nothing.
+  $effect(() => {
+    void matches;
+    highlightIndex = 0;
+  });
+
+  function commitHighlight(): void {
+    const choice = matches[highlightIndex];
+    if (choice !== undefined) {
+      onCommit(choice);
+      open = false;
+      return;
+    }
+    if (allowFreeText && value.trim()) {
+      onCommit(value.trim());
+      open = false;
+    }
+  }
+
+  async function handleKeydown(e: KeyboardEvent): Promise<void> {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (matches.length === 0) return;
+      open = true;
+      highlightIndex = (highlightIndex + 1) % matches.length;
+      await scrollHighlightIntoView();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (matches.length === 0) return;
+      open = true;
+      highlightIndex = (highlightIndex - 1 + matches.length) % matches.length;
+      await scrollHighlightIntoView();
+    } else if (e.key === 'Enter' || e.key === 'Tab') {
+      // Tab here behaves like Enter: commit. Avoid stealing tab away
+      // from the user when the popover has no candidates AND no free
+      // text is allowed (let focus advance naturally).
+      if (matches.length === 0 && (!allowFreeText || !value.trim())) return;
+      e.preventDefault();
+      commitHighlight();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      if (open) {
+        open = false;
+      } else {
+        onCancel?.();
+      }
+    }
+  }
+
+  async function scrollHighlightIntoView(): Promise<void> {
+    await tick();
+    const el = document.querySelector<HTMLElement>(
+      '.autocomplete-dropdown .ac-option.active',
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }
+</script>
+
+<div class="autocomplete-dropdown {className}">
+  <input
+    bind:this={inputEl}
+    type="text"
+    class="ac-input"
+    {value}
+    {placeholder}
+    spellcheck="false"
+    autocomplete="off"
+    oninput={(e) => { onInput(e.currentTarget.value); open = true; }}
+    onfocus={() => { open = true; }}
+    onblur={() => {
+      // Defer close so an option click registers before the popover
+      // disappears (mousedown on a child fires before blur).
+      setTimeout(() => { open = false; }, 150);
+    }}
+    onkeydown={(e) => { void handleKeydown(e); }}
+  />
+  {#if open && matches.length > 0}
+    <ul class="ac-list" role="listbox" style="--ac-max-rows: {maxRows};">
+      {#each matches as opt, i (opt)}
+        <li
+          role="option"
+          aria-selected={i === highlightIndex}
+          class="ac-option"
+          class:active={i === highlightIndex}
+          onmousedown={(e) => {
+            e.preventDefault();
+            highlightIndex = i;
+            commitHighlight();
+          }}
+          onmouseenter={() => { highlightIndex = i; }}
+        >
+          {opt}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .autocomplete-dropdown {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+  }
+  .ac-input {
+    width: 100%;
+    background: var(--bg-button);
+    border: 1px solid transparent;
+    border-radius: 3px;
+    padding: 3px 6px;
+    color: var(--text);
+    font-size: 12px;
+    font-family: inherit;
+    box-sizing: border-box;
+  }
+  .ac-input:focus {
+    border-color: var(--accent);
+    outline: none;
+  }
+  .ac-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: 2px 0 0;
+    padding: 2px 0;
+    list-style: none;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 100;
+    max-height: calc(var(--ac-max-rows) * 22px + 4px);
+    overflow-y: auto;
+  }
+  .ac-option {
+    padding: 3px 8px;
+    font-size: 12px;
+    color: var(--text);
+    cursor: pointer;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .ac-option.active {
+    background: var(--accent);
+    color: var(--bg);
+  }
+</style>

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -16,14 +16,22 @@
    */
 
   import YAML from 'yaml';
-  import { tick } from 'svelte';
+  import { onMount, tick } from 'svelte';
+  import { api } from '../../ipc/client';
+  import AutocompleteDropdown from './AutocompleteDropdown.svelte';
+  import { CANONICAL_FRONTMATTER_KEYS } from '../../../../shared/frontmatter-canonical-keys';
 
   interface Props {
     content: string;
     onContentChange: (next: string) => void;
+    /** Wired by RightSidebar so a wiki-link chip can open the target
+     *  note via the same short-form resolver the editor uses for
+     *  `[[…]]` clicks (handles basenames, aliases, slug-fuzzy matches).
+     *  Optional — when absent the chip renders disabled. */
+    onNavigate?: (target: string) => void | Promise<void>;
   }
 
-  let { content, onContentChange }: Props = $props();
+  let { content, onContentChange, onNavigate }: Props = $props();
 
   type ValueShape =
     | { kind: 'string'; value: string }
@@ -31,6 +39,7 @@
     | { kind: 'boolean'; value: boolean }
     | { kind: 'date'; value: string }
     | { kind: 'string-list'; value: string[] }
+    | { kind: 'wiki-link'; target: string; display: string | null; raw: string }
     | { kind: 'yaml'; raw: string };
 
   interface Row {
@@ -111,6 +120,12 @@
     return null;
   }
 
+  /** Matches a single `[[target]]` or `[[target|display]]` (un-typed)
+   *  with no surrounding whitespace. Typed wiki-links (`type::target`)
+   *  fall through to the plain-string editor — the picker only knows
+   *  how to pick note paths. */
+  const WIKI_LINK_RE = /^\[\[([^|\]\n[]+)(?:\|([^\]\n]+))?\]\]$/;
+
   function detectShape(value: unknown): ValueShape {
     if (YAML.isScalar(value)) {
       const v = value.value;
@@ -121,6 +136,15 @@
       }
       if (typeof v === 'string') {
         if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return { kind: 'date', value: v };
+        const wl = v.match(WIKI_LINK_RE);
+        if (wl) {
+          return {
+            kind: 'wiki-link',
+            target: wl[1].trim(),
+            display: wl[2]?.trim() ?? null,
+            raw: v,
+          };
+        }
         return { kind: 'string', value: v };
       }
       // null, undefined, or an oddball scalar shape — treat as empty
@@ -275,9 +299,85 @@
   // ── Adding a new property ──────────────────────────────────────
 
   let newKey = $state('');
-  let newKeyInputEl = $state<HTMLInputElement | undefined>();
-  async function addProperty(): Promise<void> {
-    const k = newKey.trim();
+
+  // Project-wide frontmatter keys + canonical-key backfill, for the
+  // Add-Property autocomplete (#488). Fetched once on mount and
+  // refreshed when the file watcher reports any rewrite — so a
+  // freshly-added key (via `set_properties`, auto-tag, or a direct
+  // edit) shows up the next time the user opens the picker without
+  // a manual reload.
+  let projectKeys = $state<string[]>([]);
+  async function refreshProjectKeys(): Promise<void> {
+    try { projectKeys = await api.graph.frontmatterKeys(); }
+    catch { /* graph not ready yet — leave previous snapshot in place */ }
+  }
+  // Note basenames (relativePath without `.md`), for the wiki-link
+  // value picker (#489). Same refresh cadence as projectKeys.
+  let noteBasenames = $state<string[]>([]);
+  async function refreshNoteBasenames(): Promise<void> {
+    try {
+      const files = await api.notebase.listFiles();
+      const out: string[] = [];
+      const walk = (nodes: import('../../../../shared/types').NoteFile[]) => {
+        for (const n of nodes) {
+          if (n.isDirectory && n.children) walk(n.children);
+          else if (!n.isDirectory && n.relativePath.endsWith('.md')) {
+            out.push(n.relativePath.replace(/\.md$/, ''));
+          }
+        }
+      };
+      walk(files);
+      out.sort((a, b) => a.localeCompare(b));
+      noteBasenames = out;
+    } catch { /* tree not ready yet */ }
+  }
+  onMount(() => {
+    void refreshProjectKeys();
+    void refreshNoteBasenames();
+    const unsubscribeRewritten = api.notebase.onRewritten(() => {
+      void refreshProjectKeys();
+    });
+    const unsubscribeCreated = api.notebase.onFileCreated(() => {
+      void refreshNoteBasenames();
+    });
+    const unsubscribeDeleted = api.notebase.onFileDeleted(() => {
+      void refreshNoteBasenames();
+    });
+    return () => {
+      // subscribeIpc returns an unsubscribe — guarded because the
+      // preload bridge's type uses `void`-ish callbacks.
+      unsubscribeRewritten?.();
+      unsubscribeCreated?.();
+      unsubscribeDeleted?.();
+    };
+  });
+
+  /** Merged autocomplete pool for the Add-Property input:
+   *   1. Project keys (highest priority — what the user has been
+   *      using on other notes).
+   *   2. Canonical keys (well-known predicates worth suggesting even
+   *      if no note has used them yet).
+   *  Already-present keys on this note are filtered out so the
+   *  dropdown doesn't tempt the user to "re-add" something. */
+  const addPropertyOptions = $derived.by(() => {
+    const present = new Set(rows.map((r) => r.key));
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const k of projectKeys) {
+      if (present.has(k) || seen.has(k)) continue;
+      seen.add(k);
+      out.push(k);
+    }
+    for (const k of CANONICAL_FRONTMATTER_KEYS) {
+      if (present.has(k) || seen.has(k)) continue;
+      seen.add(k);
+      out.push(k);
+    }
+    return out;
+  });
+
+  async function addProperty(commitKey?: string): Promise<void> {
+    const k = (commitKey ?? newKey).trim();
     if (!k) return;
     if (rows.some((r) => r.key === k)) {
       // Already exists — just focus its input. Keep newKey so the
@@ -298,9 +398,57 @@
     return s.replace(/[\\"]/g, '\\$&');
   }
 
+  // ── Wiki-link value editing (#489) ──────────────────────────────
+  //
+  // When a row's value is a single `[[target]]` (optionally with a
+  // display alias), the panel renders a clickable chip. Clicking the
+  // chip opens the target via the standard onFileSelect plumbing;
+  // the ✎ button swaps the chip for an inline AutocompleteDropdown
+  // sourced from project note basenames. Editing keys are kept by
+  // row key so two wiki-link rows can be edited independently (rare
+  // but possible).
+  let editingLinkKey = $state<string | null>(null);
+  let editingLinkDraft = $state('');
+  let editingLinkDisplay = $state<string | null>(null);
+  function startEditLink(rowKey: string, target: string, display: string | null): void {
+    editingLinkKey = rowKey;
+    editingLinkDraft = target;
+    editingLinkDisplay = display;
+  }
+  function commitEditLink(value: string): void {
+    if (!editingLinkKey) return;
+    const target = value.trim();
+    if (!target) {
+      cancelEditLink();
+      return;
+    }
+    const raw = editingLinkDisplay
+      ? `[[${target}|${editingLinkDisplay}]]`
+      : `[[${target}]]`;
+    setKeyValue(editingLinkKey, raw);
+    editingLinkKey = null;
+    editingLinkDraft = '';
+    editingLinkDisplay = null;
+  }
+  function cancelEditLink(): void {
+    editingLinkKey = null;
+    editingLinkDraft = '';
+    editingLinkDisplay = null;
+  }
+  function openWikiLink(target: string): void {
+    if (!onNavigate) return;
+    void onNavigate(target);
+  }
+
   function createEmptyFrontmatter(): void {
-    if (!newKeyInputEl) return;
-    newKeyInputEl.focus();
+    // Best-effort focus on the autocomplete input rendered below.
+    // Querying by class is fragile; the autofocus prop on the
+    // dropdown handles the common path.
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLInputElement>(
+        '.properties-panel .empty .ac-input',
+      )?.focus();
+    });
   }
 </script>
 
@@ -314,13 +462,13 @@
   {:else if !hasFrontmatter && rows.length === 0}
     <div class="empty">
       <p>No frontmatter</p>
-      <input
-        type="text"
-        class="key-input"
+      <AutocompleteDropdown
+        value={newKey}
+        options={addPropertyOptions}
         placeholder="Add property…"
-        bind:value={newKey}
-        bind:this={newKeyInputEl}
-        onkeydown={(e) => { if (e.key === 'Enter') void addProperty(); }}
+        autofocus={false}
+        onInput={(v) => { newKey = v; }}
+        onCommit={(v) => { newKey = v; void addProperty(v); }}
       />
       <button class="add-btn" onclick={createEmptyFrontmatter}>+ Add property</button>
     </div>
@@ -393,6 +541,39 @@
                   }}
                 />
               </div>
+            {:else if row.shape.kind === 'wiki-link'}
+              {#if editingLinkKey === row.key}
+                <AutocompleteDropdown
+                  value={editingLinkDraft}
+                  options={noteBasenames}
+                  placeholder="Note name…"
+                  autofocus
+                  onInput={(v) => { editingLinkDraft = v; }}
+                  onCommit={commitEditLink}
+                  onCancel={cancelEditLink}
+                />
+              {:else}
+                {@const ws = row.shape}
+                <div class="wiki-chip-row">
+                  <button
+                    type="button"
+                    class="wiki-chip"
+                    title="Open {ws.target}"
+                    onclick={() => openWikiLink(ws.target)}
+                    disabled={!onNavigate}
+                  >
+                    <span class="wiki-chip-icon">🔗</span>
+                    <span class="wiki-chip-label">{ws.display ?? ws.target}</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="wiki-edit-btn"
+                    title="Edit link target"
+                    aria-label="Edit link target"
+                    onclick={() => startEditLink(row.key, ws.target, ws.display)}
+                  >✎</button>
+                </div>
+              {/if}
             {:else if row.shape.kind === 'yaml'}
               <pre class="yaml">{row.shape.raw}</pre>
               <span class="hint-inline">Edit in source — structured editor doesn't cover this shape.</span>
@@ -405,13 +586,12 @@
 
     {#if hasFrontmatter || rows.length > 0}
       <div class="add-row">
-        <input
-          type="text"
-          class="key-input"
+        <AutocompleteDropdown
+          value={newKey}
+          options={addPropertyOptions}
           placeholder="Add property…"
-          bind:value={newKey}
-          bind:this={newKeyInputEl}
-          onkeydown={(e) => { if (e.key === 'Enter') void addProperty(); }}
+          onInput={(v) => { newKey = v; }}
+          onCommit={(v) => { newKey = v; void addProperty(v); }}
         />
         <button class="add-btn" onclick={() => void addProperty()} disabled={!newKey.trim()}>+</button>
       </div>
@@ -536,6 +716,62 @@
     border-style: solid;
     border-color: var(--accent);
     outline: none;
+  }
+
+  /* Wiki-link value chip + adjacent edit button (#489). Mirrors the
+     existing string-list chip styling so the panel reads as one
+     consistent surface — chip is the open-target affordance, ✎ swaps
+     to the autocomplete edit input. */
+  .wiki-chip-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 0;
+  }
+  .wiki-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: var(--bg-button);
+    border: 1px solid transparent;
+    color: var(--accent);
+    padding: 1px 8px 1px 6px;
+    border-radius: 10px;
+    font-size: 11px;
+    cursor: pointer;
+    font-family: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .wiki-chip:hover:not(:disabled) {
+    border-color: var(--accent);
+    text-decoration-color: var(--accent);
+  }
+  .wiki-chip:disabled {
+    cursor: default;
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+  .wiki-chip-icon { font-size: 10px; opacity: 0.7; }
+  .wiki-chip-label { overflow: hidden; text-overflow: ellipsis; }
+  .wiki-edit-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1;
+    padding: 2px 4px;
+    border-radius: 3px;
+  }
+  .wiki-edit-btn:hover {
+    color: var(--text);
+    background: var(--bg-button);
   }
 
   .yaml {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -42,11 +42,11 @@ export interface NotebaseApi {
   copy(srcRelPath: string, destRelPath: string): Promise<void>;
   searchInNotes(opts: SearchInNotesOptions): Promise<SearchInNotesFileResult[]>;
   replaceInNotes(opts: ReplaceInNotesOptions): Promise<ReplaceInNotesResult>;
-  onFileChanged(cb: (path: string) => void): void;
-  onFileCreated(cb: (path: string) => void): void;
-  onFileDeleted(cb: (path: string) => void): void;
+  onFileChanged(cb: (path: string) => void): () => void;
+  onFileCreated(cb: (path: string) => void): () => void;
+  onFileDeleted(cb: (path: string) => void): () => void;
   onRenamed(cb: (transitions: Array<{ old: string; new: string }>) => void): void;
-  onRewritten(cb: (paths: string[]) => void): void;
+  onRewritten(cb: (paths: string[]) => void): () => void;
   onHeadingRenameSuggested(cb: (candidate: HeadingRenameCandidate) => void): void;
   renameAnchor(targetRelativePath: string, oldSlug: string, newSlug: string): Promise<{ rewrittenPaths: string[] }>;
   renameSource(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
@@ -150,6 +150,9 @@ export interface GraphApi {
   }>;
   /** Frontmatter alias → relativePath snapshot (#469). Lower-cased keys. */
   aliasMap(): Promise<Record<string, string>>;
+  /** Deduped, sorted list of every frontmatter key in use across the
+   *  project. Powers the Properties panel's Add-Property autocomplete (#488). */
+  frontmatterKeys(): Promise<string[]>;
 }
 
 export type TablesQueryResult =

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -89,6 +89,9 @@ export const Channels = {
   GRAPH_EXCERPT_SOURCE: 'graph:excerptSource',
   /** Frontmatter alias → relativePath map for wiki-link resolution (#469). */
   GRAPH_ALIAS_MAP: 'graph:aliasMap',
+  /** Project-wide frontmatter key list. Powers the Properties panel's
+   *  Add-Property autocomplete (#488). */
+  GRAPH_FRONTMATTER_KEYS: 'graph:frontmatterKeys',
 
   // Tags
   TAGS_LIST: 'tags:list',

--- a/src/shared/frontmatter-canonical-keys.ts
+++ b/src/shared/frontmatter-canonical-keys.ts
@@ -1,0 +1,63 @@
+/**
+ * Canonical frontmatter keys Minerva understands as first-class
+ * predicates. Used by the Properties panel as a secondary source of
+ * autocomplete suggestions (#488): the project's actually-in-use keys
+ * come first, then this list backfills well-known options that the
+ * user might want even if no note has them yet.
+ *
+ * Deliberately mirrored — not imported — from
+ * `src/main/graph/frontmatter-predicates.ts`. That module is main-only
+ * (it pulls in graph types) and the renderer can't import from main.
+ * The two lists must stay in sync, but the surface is small and easy
+ * to spot during review.
+ *
+ * Only canonical forms are listed. Aliases (`author`, `lang`, `date`,
+ * `url`, `pageRange`) are deliberately omitted — see
+ * `src/shared/formatter/rules/minerva/canonicalize-frontmatter-keys.ts`
+ * for the alias → canonical mapping. Suggesting aliases would push
+ * users toward keys that get rewritten away by the formatter.
+ */
+export const CANONICAL_FRONTMATTER_KEYS: readonly string[] = [
+  // Dublin Core
+  'title',
+  'creator',
+  'description',
+  'abstract',
+  'publisher',
+  'language',
+  'subject',
+  'created',
+  'modified',
+  'issued',
+
+  // BIBO (bibliographic)
+  'doi',
+  'isbn',
+  'uri',
+  'pages',
+  'volume',
+  'issue',
+  'numPages',
+
+  // schema.org
+  'inContainer',
+
+  // thought:* (source + analysis bits)
+  'accessedAt',
+  'archivedAt',
+  'supports',
+  'rebuts',
+  'claim-kind',
+  'source-text',
+  'extracted-by',
+  'extracted-from',
+  'decomposes',
+
+  // prov:* (provenance — derived notes)
+  'derived_from',
+  'derived_at',
+  'derived_from_cell',
+
+  // Universally-supported but predicate-free
+  'tags',
+];


### PR DESCRIPTION
Closes #488. Closes #489.

## Summary

Two Properties-panel improvements that make YAML frontmatter feel like a native surface:

- **Add-Property key autocomplete** — typing in the Add-Property input shows a dropdown sourced from (1) every frontmatter key in use across the thoughtbase and (2) a backfill of canonical Minerva predicate keys, minus what's already on the active note. Ranked exact > prefix > substring, case-insensitive. Refreshes on `NOTEBASE_REWRITTEN` so keys added via `set_properties`, auto-tag, or a direct edit show up without a manual reload.
- **Wiki-link value picker** — frontmatter values that parse as a single `[[target]]` or `[[target|display]]` now render as a chip. Click the chip → opens the target via the same short-form resolver the editor uses for `[[…]]` clicks (basename, alias, slug-fuzzy). ✎ button swaps the chip for an inline autocomplete-edit input sourced from project note basenames. Round-trips to plain `[[…]]` YAML.

## Architecture

- `src/renderer/lib/components/right-sidebar/AutocompleteDropdown.svelte` (new) — small reusable Svelte component, input + popover list with the editor's CodeMirror keyboard model (↑/↓/Enter/Esc). Used by both call-sites for visual consistency.
- `src/shared/frontmatter-canonical-keys.ts` (new) — renderer-accessible mirror of the main-only predicates map. Deliberately not imported from main; the surface is small and easy to spot at review.
- Graph state gains `frontmatterKeysPerNote: Map<string, string[]>`, populated by `indexNote` (captures `Object.keys(parsed.frontmatter)`) and cleaned by `removeNote`. Exposed via `getAllFrontmatterKeys(ctx)` and the new `api.graph.frontmatterKeys()` IPC.
- `subscribeIpc` in `preload.ts` now returns an unsubscribe function so panel components can clean up listeners on unmount. PropertiesPanel uses this for its NOTEBASE_REWRITTEN / file-created / file-deleted hooks — without it, panel switches would leak listeners.
- `RightSidebar` threads a new `onNavigate` prop (distinct from `onFileSelect`) so the wiki-link chip uses `App.handleNavigate`'s short-form resolution instead of the strict-path `handleFileSelect`. The chip's click works for `[[basename]]`, `[[Display Title]]`, and alias forms the same way an in-editor wiki-link click does.

## Test plan
- [ ] Open the Properties panel on a note; click Add Property → suggestions appear from project keys (other notes' keys) and canonical keys.
- [ ] Type 'pri' → 'priority' floats up; type 'tag' → 'tags' on top.
- [ ] Add a brand-new key on note A; switch to note B → the new key appears in note B's Add-Property autocomplete.
- [ ] Run an LLM `set_properties` that adds a new key → the autocomplete picks it up after approval without panel reload.
- [ ] Existing keys on the active note do NOT appear in the Add-Property dropdown.
- [ ] Set a frontmatter value to `[[some-note]]` (in source) → Properties panel shows it as a 🔗 chip. Click chip → opens the target. Click ✎ → autocomplete edit input.
- [ ] Type a partial note name in the edit input → matching basenames appear. Enter / Tab commits as `[[<basename>]]`.
- [ ] Wiki-link with display alias (`[[notes/foo|Friendly Name]]`) shows 'Friendly Name' on the chip; editing preserves the display alias.
- [ ] Switch panels (Outline ↔ Properties) several times — listeners don't pile up (verify in DevTools that the listener count is stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)