### PR TITLE
editor: surface frontmatter aliases in wiki-link autocomplete (#492)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -154,6 +154,49 @@ export function getAliasMap(ctx: ProjectContext): Record<string, string> {
 }
 
 /**
+ * Entries form of the alias map, preserving original casing (#492).
+ * `getAliasMap` lowercases everything for case-insensitive resolution;
+ * the wiki-link autocomplete needs the original casing so picking a
+ * suggested alias inserts `[[JFK]]` rather than `[[jfk]]`.
+ *
+ * Same conflict policy as `rebuildAliasMap`:
+ *   - Alphabetical-first-writer wins on alias collisions.
+ *   - Aliases that lowercase-collide with a real note's path stem or
+ *     basename are dropped.
+ */
+export interface AliasEntry {
+  alias: string;
+  relativePath: string;
+}
+export function getAliasEntries(ctx: ProjectContext): AliasEntry[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const claimed = new Set<string>(); // lowercase aliases already taken
+  // Drop any alias whose lowercase form collides with a real note's
+  // canonical name — matches rebuildAliasMap's second pass.
+  const canonicals = new Set<string>();
+  for (const path of state.indexedNotePaths) {
+    const stem = path.replace(/\.md$/i, '').toLowerCase();
+    canonicals.add(stem);
+    const basename = stem.split('/').pop() ?? '';
+    if (basename) canonicals.add(basename);
+  }
+  const out: AliasEntry[] = [];
+  const paths = [...state.aliasesPerNote.keys()].sort();
+  for (const path of paths) {
+    const aliases = state.aliasesPerNote.get(path) ?? [];
+    for (const alias of aliases) {
+      const key = alias.toLowerCase();
+      if (canonicals.has(key)) continue;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      out.push({ alias, relativePath: path });
+    }
+  }
+  return out;
+}
+
+/**
  * Deduped, alphabetically-sorted list of every frontmatter key
  * currently in use across the project. Powers the Properties panel's
  * Add-Property autocomplete (#488). Empty when the project has no

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -726,6 +726,12 @@ export function registerIpcHandlers(): void {
     return graph.getAliasMap(projectContext(rootPath));
   });
 
+  ipcMain.handle(Channels.GRAPH_ALIAS_ENTRIES, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.getAliasEntries(projectContext(rootPath));
+  });
+
   ipcMain.handle(Channels.GRAPH_FRONTMATTER_KEYS, (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return [];

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -114,6 +114,7 @@ contextBridge.exposeInMainWorld('api', {
     excerptSource: (excerptId: string) => ipcRenderer.invoke(Channels.GRAPH_EXCERPT_SOURCE, excerptId),
     schemaForCompletion: () => ipcRenderer.invoke(Channels.GRAPH_SCHEMA_FOR_COMPLETION),
     aliasMap: () => ipcRenderer.invoke(Channels.GRAPH_ALIAS_MAP),
+    aliasEntries: () => ipcRenderer.invoke(Channels.GRAPH_ALIAS_ENTRIES),
     frontmatterKeys: () => ipcRenderer.invoke(Channels.GRAPH_FRONTMATTER_KEYS),
   },
   tables: {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -109,6 +109,10 @@
    *  graph changes so wiki-link nav resolves new aliases without a
    *  full project reload. */
   let aliasMap = $state<Record<string, string>>({});
+  /** Same data as `aliasMap` but in entries form with original casing,
+   *  so the editor's `[[…]]` autocomplete can suggest `JFK` (not
+   *  `jfk`) when the user types `[[jf` (#492). Refreshed in lockstep. */
+  let aliasEntries = $state<Array<{ alias: string; relativePath: string }>>([]);
 
   async function refreshAliasMap() {
     if (!notebase.meta) return;
@@ -116,6 +120,11 @@
       aliasMap = await api.graph.aliasMap();
     } catch {
       aliasMap = {};
+    }
+    try {
+      aliasEntries = await api.graph.aliasEntries();
+    } catch {
+      aliasEntries = [];
     }
   }
 
@@ -2377,6 +2386,7 @@
                     onOpenExcerpt={handleOpenExcerpt}
                     getNotePaths={() => flattenNotePaths(notebase.files)}
                     getSources={() => sourcesCache}
+                    getAliases={() => aliasEntries}
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -93,6 +93,9 @@
     getNotePaths?: () => string[];
     /** Live list of Sources for `[[cite::…]]` autocomplete. */
     getSources?: () => readonly import('../../../shared/types').SourceMetadata[];
+    /** Live list of frontmatter alias entries so wiki-link autocomplete
+     *  can suggest aliases alongside note paths (#492). */
+    getAliases?: () => readonly { alias: string; relativePath: string }[];
     /**
      * Callback for image upload rejections — too-large, unsupported
      * MIME, etc. — so the host app can surface a toast / dialog (#455).
@@ -145,6 +148,7 @@
     onFormatCurrentNote,
     getNotePaths,
     getSources,
+    getAliases,
     initialHistory,
     onUploadError,
     onRunCell,
@@ -804,6 +808,7 @@
     const linkCompletion = linkCompletionSource({
       getNotePaths: () => getNotePaths?.() ?? [],
       getSources: () => getSources?.() ?? [],
+      getAliases: () => getAliases?.() ?? [],
       readNote: (p) => api.notebase.readFile(p),
     });
 

--- a/src/renderer/lib/editor/link-autocomplete.ts
+++ b/src/renderer/lib/editor/link-autocomplete.ts
@@ -108,6 +108,27 @@ function notePathOptions(paths: string[]): Completion[] {
   });
 }
 
+/**
+ * Suggest frontmatter aliases alongside note paths (#492). The label
+ * carries the alias text in its original casing, so picking
+ * `[[jf…]] → JFK` inserts `[[JFK]]` rather than `[[jfk]]` — the user
+ * wrote the alias intentionally, the autocomplete should preserve
+ * their intent.
+ *
+ * `boost: 1` keeps aliases just below note paths in CodeMirror's
+ * default ranking when the typed prefix matches both — the user
+ * usually wants the canonical path first, with the alias as a
+ * memorable shortcut.
+ */
+export function aliasOptions(entries: readonly { alias: string; relativePath: string }[]): Completion[] {
+  return entries.map((e) => ({
+    label: e.alias,
+    detail: `→ ${normalizeTarget(e.relativePath)}`,
+    type: 'enum',
+    boost: 1,
+  }));
+}
+
 export function sourceOptions(sources: readonly SourceMetadata[]): Completion[] {
   return sources.map((s) => {
     const title = s.title ?? s.sourceId;
@@ -149,6 +170,10 @@ export interface LinkAutocompleteOptions {
   getNotePaths: () => string[];
   /** Returns the current list of indexed Sources (for `[[cite::…]]`). */
   getSources: () => readonly SourceMetadata[];
+  /** Returns the current frontmatter alias entries (#492). Optional —
+   *  the autocomplete still works without it, just without alias
+   *  suggestions. */
+  getAliases?: () => readonly { alias: string; relativePath: string }[];
   /** Fetch raw markdown for a note so we can scan its headings + block-ids. */
   readNote: (relativePath: string) => Promise<string>;
 }
@@ -188,12 +213,16 @@ export function linkCompletionSource(opts: LinkAutocompleteOptions) {
     if (phase.kind === 'none') return null;
 
     const paths = opts.getNotePaths();
+    const aliases = opts.getAliases?.() ?? [];
 
     if (phase.kind === 'type-or-path') {
       return {
         from: phase.innerStart,
-        options: [...linkTypeOptions(), ...notePathOptions(paths)],
-        validFor: /^[a-z0-9_\-/.: ]*$/i,
+        options: [...linkTypeOptions(), ...notePathOptions(paths), ...aliasOptions(aliases)],
+        // Loosened to include the punctuation users commonly drop into
+        // aliases (apostrophes in names, etc.). Same character class
+        // shape as before, plus the extras.
+        validFor: /^[\w\-/.:'’ ]*$/i,
       };
     }
 
@@ -213,8 +242,8 @@ export function linkCompletionSource(opts: LinkAutocompleteOptions) {
       }
       return {
         from: phase.innerStart,
-        options: notePathOptions(paths),
-        validFor: /^[a-z0-9_\-/. ]*$/i,
+        options: [...notePathOptions(paths), ...aliasOptions(aliases)],
+        validFor: /^[\w\-/.'’ ]*$/i,
       };
     }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -150,6 +150,9 @@ export interface GraphApi {
   }>;
   /** Frontmatter alias → relativePath snapshot (#469). Lower-cased keys. */
   aliasMap(): Promise<Record<string, string>>;
+  /** Entries form of the alias map preserving original casing — used
+   *  by the wiki-link autocomplete to suggest aliases (#492). */
+  aliasEntries(): Promise<Array<{ alias: string; relativePath: string }>>;
   /** Deduped, sorted list of every frontmatter key in use across the
    *  project. Powers the Properties panel's Add-Property autocomplete (#488). */
   frontmatterKeys(): Promise<string[]>;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -89,6 +89,10 @@ export const Channels = {
   GRAPH_EXCERPT_SOURCE: 'graph:excerptSource',
   /** Frontmatter alias → relativePath map for wiki-link resolution (#469). */
   GRAPH_ALIAS_MAP: 'graph:aliasMap',
+  /** Same data as GRAPH_ALIAS_MAP but in entries form, preserving the
+   *  original casing the user wrote in frontmatter. Powers the
+   *  wiki-link autocomplete's alias surfacing (#492). */
+  GRAPH_ALIAS_ENTRIES: 'graph:aliasEntries',
   /** Project-wide frontmatter key list. Powers the Properties panel's
    *  Add-Property autocomplete (#488). */
   GRAPH_FRONTMATTER_KEYS: 'graph:frontmatterKeys',

--- a/tests/renderer/editor/link-autocomplete.test.ts
+++ b/tests/renderer/editor/link-autocomplete.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { detectCompletionPhase, sourceOptions } from '../../../src/renderer/lib/editor/link-autocomplete';
+import {
+  detectCompletionPhase,
+  sourceOptions,
+  aliasOptions,
+} from '../../../src/renderer/lib/editor/link-autocomplete';
 import type { SourceMetadata } from '../../../src/shared/types';
 
 function source(partial: Partial<SourceMetadata> & { sourceId: string }): SourceMetadata {
@@ -163,5 +167,30 @@ describe('sourceOptions (#109)', () => {
   it('omits detail entirely when there is no byline and no year', () => {
     const [opt] = sourceOptions([source({ sourceId: 'plain' })]);
     expect(opt.detail).toBeUndefined();
+  });
+});
+
+describe('aliasOptions (#492)', () => {
+  it('uses the alias as the label, preserving original casing', () => {
+    const [opt] = aliasOptions([{ alias: 'JFK', relativePath: 'presidents/kennedy.md' }]);
+    expect(opt.label).toBe('JFK');
+  });
+
+  it('shows the target path in the detail with a → marker', () => {
+    const [opt] = aliasOptions([{ alias: 'JFK', relativePath: 'presidents/kennedy.md' }]);
+    expect(opt.detail).toBe('→ presidents/kennedy');
+  });
+
+  it('uses CompletionType `enum` to visually distinguish from note paths', () => {
+    const [opt] = aliasOptions([{ alias: 'JFK', relativePath: 'presidents/kennedy.md' }]);
+    expect(opt.type).toBe('enum');
+  });
+
+  it('returns one option per entry (multiple aliases for the same note are independent)', () => {
+    const opts = aliasOptions([
+      { alias: 'JFK', relativePath: 'presidents/kennedy.md' },
+      { alias: 'John F. Kennedy', relativePath: 'presidents/kennedy.md' },
+    ]);
+    expect(opts.map((o) => o.label)).toEqual(['JFK', 'John F. Kennedy']);
   });
 });


### PR DESCRIPTION
Closes #492.

## Summary

Typing `[[jf` now surfaces a `JFK → presidents/kennedy` suggestion alongside note-path matches, with the alias's original casing preserved in the inserted text.

## Architecture

- `getAliasEntries(ctx)` on the graph module returns the alias map in entries form `[{ alias, relativePath }]`, preserving the casing from each note's frontmatter. The existing `getAliasMap` lowercases everything for case-insensitive resolution and isn't suitable for insertion. Same conflict policy as `rebuildAliasMap`: alphabetical-first-writer wins, aliases that lowercase-collide with a canonical note name are dropped.
- New `api.graph.aliasEntries()` IPC. `App.svelte`'s existing `refreshAliasMap` now refreshes the entries snapshot in lockstep.
- `linkCompletionSource` accepts an optional `getAliases` callback. Aliases appear in both the `type-or-path` and `path` (non-cite) phases with CompletionType `enum` and `boost: 1` — canonical note paths still outrank aliases when the typed prefix matches both, but the alias is one click away.
- `validFor` regexes loosened from `[a-z0-9_\-/.:]` to `[\w\-/.:'']` so apostrophes and other punctuation aliases commonly carry don't dismiss the suggestion list mid-type.

## Test plan
- [ ] Add `aliases: [JFK]` to a note like `presidents/kennedy.md`. In another note, type `[[jfk` → dropdown shows `JFK → presidents/kennedy`. Pick it → inserts `[[JFK]]` (original casing preserved).
- [ ] With multiple aliases (`aliases: [JFK, John F. Kennedy]`), both surface as independent suggestions.
- [ ] An alias whose lowercase form collides with a real note's basename (e.g. `aliases: [readme]` on note A while `readme.md` exists) does NOT appear in suggestions.
- [ ] When the typed prefix matches both a note path and an alias, the note path ranks above the alias.
- [ ] `[[cite::…]]` still picks from Sources only — aliases don't leak into the citation picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)