### PR TITLE
sql: CSV schema declarations via sidecar or companion frontmatter (#237)

### DIFF
--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -6,6 +6,21 @@ import { Channels } from '../../shared/channels';
 
 import { INDEXABLE_EXTS } from './indexable-files';
 
+/**
+ * Paths we want to surface as watcher events even though they aren't
+ * indexable in the usual sense. Today this is just the CSV schema
+ * sidecar (#237): `<stem>.csv.schema.yaml` next to a `.csv` doesn't
+ * land in the graph, but editing it must re-register the sibling CSV
+ * so DuckDB picks up the new column types. The downstream callback
+ * in window-manager.ts handles the actual re-registration; the
+ * watcher's job is just to surface the event.
+ */
+function isWatchable(filePath: string): boolean {
+  if (INDEXABLE_EXTS.has(path.extname(filePath))) return true;
+  if (filePath.endsWith('.csv.schema.yaml')) return true;
+  return false;
+}
+
 // Callbacks may return a Promise; the watcher invokes them as
 // fire-and-forget. Typing the return as `void | Promise<void>` lets
 // callers be explicitly async without tripping no-misused-promises.
@@ -61,7 +76,7 @@ export function startWatching(
   // Callbacks may be async (interface allows void | Promise<void>); the
   // watcher invokes them as fire-and-forget. `void` makes that explicit.
   notes.on('change', (filePath) => {
-    if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
+    if (isWatchable(filePath) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
       void callbacks?.onFileChanged(relative);
@@ -69,7 +84,7 @@ export function startWatching(
   });
 
   notes.on('add', (filePath) => {
-    if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
+    if (isWatchable(filePath) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
       void callbacks?.onFileCreated(relative);
@@ -77,7 +92,7 @@ export function startWatching(
   });
 
   notes.on('unlink', (filePath) => {
-    if (INDEXABLE_EXTS.has(path.extname(filePath)) && !win.isDestroyed()) {
+    if (isWatchable(filePath) && !win.isDestroyed()) {
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_DELETED, relative);
       void callbacks?.onFileDeleted(relative);

--- a/src/main/sources/csv-schema.ts
+++ b/src/main/sources/csv-schema.ts
@@ -1,0 +1,201 @@
+/**
+ * CSV schema declarations (#237).
+ *
+ * Pins column types and CSV-shape hints for files where DuckDB's
+ * `read_csv_auto` inference falls short (dates, categorical strings,
+ * mixed-type columns, unusual encodings).
+ *
+ * Two sources, checked in order:
+ *
+ *   1. A `csv:` block in the companion markdown note's frontmatter
+ *      (`<stem>.md` next to `<stem>.csv`). Consistent with how the
+ *      existing `table_name:` override works.
+ *   2. A `<stem>.csv.schema.yaml` sidecar next to the CSV. Useful when
+ *      no companion note exists.
+ *
+ * Both look like:
+ *
+ *   ```yaml
+ *   columns:
+ *     submitted_at: DATE
+ *     category: VARCHAR
+ *     score: DOUBLE
+ *   delimiter: "\t"
+ *   header: false
+ *   ```
+ *
+ * Returns `null` when no schema is present OR the candidate parsed but
+ * its shape is invalid (no `columns` map, or non-string values). The
+ * registration path falls back to `read_csv_auto` whenever this
+ * returns null — schema-less CSVs are still loaded by auto-inference.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import YAML from 'yaml';
+
+export interface CsvSchema {
+  /** Column name → DuckDB type literal (e.g. "VARCHAR", "DATE",
+   *  "DECIMAL(10,2)"). Values are passed through to DuckDB without
+   *  semantic validation — a typo surfaces as a registration warning. */
+  columns: Record<string, string>;
+  /** Single-character field delimiter. Omit for the DuckDB default
+   *  (auto-detect, usually `,`). */
+  delimiter?: string;
+  /** False if the first row of data isn't a header. Omit to let
+   *  DuckDB auto-detect. */
+  header?: boolean;
+}
+
+/**
+ * Resolve a CSV's schema declaration, if any. Companion-note
+ * frontmatter wins; sidecar YAML is the fallback. Returns null when
+ * neither source is present or readable as a valid schema.
+ */
+export async function loadCsvSchema(
+  rootPath: string,
+  csvRelPath: string,
+): Promise<CsvSchema | null> {
+  const fromCompanion = await readCompanionSchema(rootPath, csvRelPath);
+  if (fromCompanion) return fromCompanion;
+  return readSidecarSchema(rootPath, csvRelPath);
+}
+
+/** Sidecar path: `path/to/foo.csv` → `path/to/foo.csv.schema.yaml`. */
+export function sidecarSchemaPath(csvRelPath: string): string {
+  return `${csvRelPath}.schema.yaml`;
+}
+
+/** Companion note path: `path/to/foo.csv` → `path/to/foo.md`. */
+export function companionMdPath(csvRelPath: string): string {
+  const dir = path.dirname(csvRelPath);
+  const stem = path.basename(csvRelPath, path.extname(csvRelPath));
+  return dir === '.' ? `${stem}.md` : `${dir}/${stem}.md`;
+}
+
+async function readCompanionSchema(
+  rootPath: string,
+  csvRelPath: string,
+): Promise<CsvSchema | null> {
+  const companionAbs = path.join(rootPath, companionMdPath(csvRelPath));
+  let content: string;
+  try {
+    content = await fs.readFile(companionAbs, 'utf-8');
+  } catch {
+    return null;
+  }
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  let fm: unknown;
+  try {
+    fm = YAML.parse(m[1]);
+  } catch {
+    return null;
+  }
+  if (!fm || typeof fm !== 'object') return null;
+  const rec = fm as Record<string, unknown>;
+  const raw = rec.csv;
+  if (raw == null) return null;
+  return validateSchema(raw, `companion frontmatter for ${csvRelPath}`);
+}
+
+async function readSidecarSchema(
+  rootPath: string,
+  csvRelPath: string,
+): Promise<CsvSchema | null> {
+  const sidecarAbs = path.join(rootPath, sidecarSchemaPath(csvRelPath));
+  let content: string;
+  try {
+    content = await fs.readFile(sidecarAbs, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(content);
+  } catch (err) {
+    console.warn(
+      `[tables] Sidecar schema ${sidecarSchemaPath(csvRelPath)} is not valid YAML: ` +
+      (err instanceof Error ? err.message : String(err)),
+    );
+    return null;
+  }
+  return validateSchema(parsed, sidecarSchemaPath(csvRelPath));
+}
+
+/**
+ * Shape check. Accepts:
+ *   - `columns` is a non-empty mapping of string keys to string values.
+ *   - `delimiter` is optional; if present, a non-empty string.
+ *   - `header` is optional; if present, a boolean.
+ *
+ * Rejects (with a console warning) anything else so a typo in the
+ * schema file doesn't silently land an empty / broken registration.
+ */
+function validateSchema(raw: unknown, sourceLabel: string): CsvSchema | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    console.warn(`[tables] ${sourceLabel}: schema block must be a mapping.`);
+    return null;
+  }
+  const rec = raw as Record<string, unknown>;
+  const cols = rec.columns;
+  if (!cols || typeof cols !== 'object' || Array.isArray(cols)) {
+    console.warn(`[tables] ${sourceLabel}: \`columns\` must be a mapping of name → type.`);
+    return null;
+  }
+  const columns: Record<string, string> = {};
+  for (const [name, type] of Object.entries(cols as Record<string, unknown>)) {
+    if (typeof name !== 'string' || !name.trim()) continue;
+    if (typeof type !== 'string' || !type.trim()) {
+      console.warn(`[tables] ${sourceLabel}: column "${name}" has a non-string type; skipped.`);
+      continue;
+    }
+    columns[name] = type.trim();
+  }
+  if (Object.keys(columns).length === 0) {
+    console.warn(`[tables] ${sourceLabel}: \`columns\` is empty after validation.`);
+    return null;
+  }
+  const out: CsvSchema = { columns };
+  if (typeof rec.delimiter === 'string' && rec.delimiter.length > 0) {
+    out.delimiter = rec.delimiter;
+  }
+  if (typeof rec.header === 'boolean') {
+    out.header = rec.header;
+  }
+  return out;
+}
+
+/**
+ * Build the DuckDB SQL fragment to read a CSV with an explicit
+ * schema. Quoting follows DuckDB's SQL rules: single-quoted string
+ * literals with `'` doubled to escape. Column names go through the
+ * same single-quote treatment since they're STRUCT keys here.
+ *
+ * Type strings are passed through verbatim — DuckDB validates them at
+ * parse time and surfaces a useful error if the user wrote a bogus
+ * type. We intentionally don't allowlist DuckDB types here; the cost
+ * of getting that list wrong (DuckDB adds new types) is higher than
+ * the cost of "DuckDB couldn't parse `INT`" surfacing as a warning.
+ */
+export function buildReadCsvSql(absPath: string, schema: CsvSchema): string {
+  const pathLit = sqlString(absPath);
+  // Column-name keys are single-quoted strings rather than bare
+  // identifiers so names containing hyphens, spaces, or other
+  // identifier-unsafe characters round-trip through DuckDB's parser
+  // unchanged.
+  const cols = Object.entries(schema.columns)
+    .map(([name, type]) => `'${sqlString(name)}': '${sqlString(type)}'`)
+    .join(', ');
+  const parts = [`'${pathLit}'`, `columns = {${cols}}`];
+  if (schema.delimiter !== undefined) {
+    parts.push(`delim = '${sqlString(schema.delimiter)}'`);
+  }
+  if (schema.header !== undefined) {
+    parts.push(`header = ${schema.header}`);
+  }
+  return `read_csv(${parts.join(', ')})`;
+}
+
+function sqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -4,6 +4,7 @@ import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
 import type { ProjectContext } from '../project-context-types';
+import { loadCsvSchema, buildReadCsvSql } from './csv-schema';
 
 interface TablesState {
   rootPath: string;
@@ -162,10 +163,19 @@ export async function registerCsv(ctx: ProjectContext, relativePath: string): Pr
   }
 
   const absPath = path.join(rootPath, relativePath);
+  // Look for an explicit schema declaration (#237). When present, we
+  // call `read_csv(…, columns={…})` so the user's pinned types win
+  // over DuckDB's auto-inference. When absent, fall back to
+  // `read_csv_auto(…)` — schema-less CSVs are still loaded the
+  // same way they always were.
+  const schema = await loadCsvSchema(rootPath, relativePath);
   const escapedPath = absPath.replace(/'/g, "''");
+  const readExpr = schema
+    ? buildReadCsvSql(absPath, schema)
+    : `read_csv_auto('${escapedPath}')`;
   try {
     await connection.run(
-      `CREATE OR REPLACE VIEW "${tableName}" AS SELECT * FROM read_csv_auto('${escapedPath}')`,
+      `CREATE OR REPLACE VIEW "${tableName}" AS SELECT * FROM ${readExpr}`,
     );
     pathToTable.set(relativePath, tableName);
     tableToPath.set(tableName, relativePath);

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -166,6 +166,45 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
 
   // startWatching returns a ready-promise (#345); we don't await here
   // because the watcher works fine before its initial scan completes.
+  /**
+   * Given a watched path that might affect a CSV's registration,
+   * return the project-relative path of the CSV to re-register, or
+   * null when no sibling table needs updating (#237).
+   *
+   * Two trigger shapes:
+   *   - `<stem>.csv.schema.yaml` → re-register `<stem>.csv`.
+   *   - `<stem>.md` (companion note) → re-register `<stem>.csv` if it
+   *     exists on disk. The companion may declare `table_name:` or
+   *     a `csv:` schema block, either of which changes registration.
+   *
+   * The .csv itself is handled by the existing branch in the caller —
+   * this helper specifically covers the sibling-edit case.
+   */
+  async function siblingCsvForReregister(relativePath: string): Promise<string | null> {
+    if (relativePath.endsWith('.csv.schema.yaml')) {
+      return relativePath.slice(0, -'.schema.yaml'.length);
+    }
+    if (relativePath.toLowerCase().endsWith('.md')) {
+      const csvCandidate = relativePath.replace(/\.md$/i, '.csv');
+      try {
+        await notebaseFs.readFile(rootPath, csvCandidate);
+        return csvCandidate;
+      } catch { /* no sibling CSV — common case */ }
+    }
+    return null;
+  }
+
+  async function reregisterSibling(relativePath: string): Promise<void> {
+    const csvPath = await siblingCsvForReregister(relativePath);
+    if (!csvPath) return;
+    try {
+      await tables.registerCsv(projectCtx, csvPath);
+      if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+    } catch (err) {
+      console.warn(`[tables] sibling re-register failed for ${csvPath} (via ${relativePath}):`, err);
+    }
+  }
+
   void startWatching(rootPath, win, win.id, {
     onFileChanged: async (relativePath) => {
       if (wasHandled(relativePath)) return;
@@ -178,7 +217,13 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
           await tables.registerCsv(projectCtx, relativePath);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
+      } else {
+        await reregisterSibling(relativePath);
       }
+      // Sidecar yaml schemas aren't notes — skip the graph/search pass for
+      // them. The watcher fires for them only so the registerCsv branch
+      // above can update DuckDB.
+      if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(projectCtx, relativePath, content);
@@ -197,7 +242,10 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
           await tables.registerCsv(projectCtx, relativePath);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
+      } else {
+        await reregisterSibling(relativePath);
       }
+      if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(projectCtx, relativePath, content);
@@ -214,7 +262,13 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
           await tables.unregisterCsv(projectCtx, relativePath);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
+      } else {
+        // Schema sidecar deleted → CSV reverts to read_csv_auto. Same
+        // helper because the sibling lookup logic is identical; the CSV
+        // re-registers without the schema.
+        await reregisterSibling(relativePath);
       }
+      if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {
         search.removeNote(projectCtx, relativePath);
         graph.removeNote(projectCtx, relativePath);

--- a/tests/main/sources/csv-schema.test.ts
+++ b/tests/main/sources/csv-schema.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  loadCsvSchema,
+  buildReadCsvSql,
+  sidecarSchemaPath,
+  companionMdPath,
+} from '../../../src/main/sources/csv-schema';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csv-schema-test-'));
+}
+
+async function writeFile(root: string, rel: string, content: string): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, content, 'utf-8');
+}
+
+describe('sidecarSchemaPath / companionMdPath', () => {
+  it('derives the sidecar path by appending .schema.yaml to the CSV', () => {
+    expect(sidecarSchemaPath('data/foo.csv')).toBe('data/foo.csv.schema.yaml');
+    expect(sidecarSchemaPath('foo.csv')).toBe('foo.csv.schema.yaml');
+  });
+
+  it('derives the companion .md path by swapping the .csv extension', () => {
+    expect(companionMdPath('data/foo.csv')).toBe('data/foo.md');
+    expect(companionMdPath('foo.csv')).toBe('foo.md');
+  });
+});
+
+describe('loadCsvSchema', () => {
+  let root: string;
+  beforeEach(() => { root = mkTempProject(); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('returns null when no companion + no sidecar exist', async () => {
+    await writeFile(root, 'data/foo.csv', 'a,b\n1,2\n');
+    expect(await loadCsvSchema(root, 'data/foo.csv')).toBeNull();
+  });
+
+  it('reads a sidecar `<stem>.csv.schema.yaml`', async () => {
+    await writeFile(root, 'data/foo.csv', 'a,b\n1,2\n');
+    await writeFile(root, 'data/foo.csv.schema.yaml', 'columns:\n  a: INTEGER\n  b: VARCHAR\n');
+    const schema = await loadCsvSchema(root, 'data/foo.csv');
+    expect(schema).toEqual({ columns: { a: 'INTEGER', b: 'VARCHAR' } });
+  });
+
+  it('reads a companion .md `csv:` frontmatter block', async () => {
+    await writeFile(root, 'data/foo.csv', 'a,b\n1,2\n');
+    await writeFile(
+      root,
+      'data/foo.md',
+      [
+        '---',
+        'title: Foo readings',
+        'csv:',
+        '  columns:',
+        '    a: BIGINT',
+        '    b: DATE',
+        '---',
+        '# Foo',
+      ].join('\n'),
+    );
+    const schema = await loadCsvSchema(root, 'data/foo.csv');
+    expect(schema).toEqual({ columns: { a: 'BIGINT', b: 'DATE' } });
+  });
+
+  it('prefers the companion .md over the sidecar when both exist', async () => {
+    await writeFile(root, 'data/foo.csv', 'a\n1\n');
+    await writeFile(root, 'data/foo.csv.schema.yaml', 'columns:\n  a: VARCHAR\n');
+    await writeFile(
+      root,
+      'data/foo.md',
+      '---\ncsv:\n  columns:\n    a: INTEGER\n---\n',
+    );
+    const schema = await loadCsvSchema(root, 'data/foo.csv');
+    expect(schema?.columns).toEqual({ a: 'INTEGER' });
+  });
+
+  it('parses optional delimiter + header overrides', async () => {
+    await writeFile(root, 'data/tabs.csv', 'a\tb\n1\t2\n');
+    await writeFile(
+      root,
+      'data/tabs.csv.schema.yaml',
+      [
+        'columns:',
+        '  a: INTEGER',
+        '  b: INTEGER',
+        'delimiter: "\\t"',
+        'header: false',
+      ].join('\n'),
+    );
+    const schema = await loadCsvSchema(root, 'data/tabs.csv');
+    expect(schema).toEqual({
+      columns: { a: 'INTEGER', b: 'INTEGER' },
+      delimiter: '\t',
+      header: false,
+    });
+  });
+
+  it('returns null when the companion .md has no `csv:` block', async () => {
+    await writeFile(root, 'data/foo.csv', 'a\n1\n');
+    await writeFile(root, 'data/foo.md', '---\ntitle: Foo\ntable_name: notrelevant\n---\n');
+    expect(await loadCsvSchema(root, 'data/foo.csv')).toBeNull();
+  });
+
+  it('falls back to the sidecar when the companion .md exists but has no `csv:` block', async () => {
+    await writeFile(root, 'data/foo.csv', 'a\n1\n');
+    await writeFile(root, 'data/foo.md', '---\ntitle: Foo\n---\n');
+    await writeFile(root, 'data/foo.csv.schema.yaml', 'columns:\n  a: VARCHAR\n');
+    const schema = await loadCsvSchema(root, 'data/foo.csv');
+    expect(schema?.columns).toEqual({ a: 'VARCHAR' });
+  });
+
+  it('returns null when `columns` is missing from the schema block', async () => {
+    await writeFile(root, 'data/foo.csv', 'a\n1\n');
+    await writeFile(root, 'data/foo.csv.schema.yaml', 'delimiter: ","\n');
+    expect(await loadCsvSchema(root, 'data/foo.csv')).toBeNull();
+  });
+
+  it('returns null when the sidecar YAML is malformed', async () => {
+    await writeFile(root, 'data/foo.csv', 'a\n1\n');
+    await writeFile(root, 'data/foo.csv.schema.yaml', 'columns:\n  a: : :\n  bad indentation\n');
+    expect(await loadCsvSchema(root, 'data/foo.csv')).toBeNull();
+  });
+
+  it('skips columns whose value is not a string', async () => {
+    await writeFile(root, 'data/foo.csv', 'a,b\n1,2\n');
+    await writeFile(
+      root,
+      'data/foo.csv.schema.yaml',
+      'columns:\n  a: INTEGER\n  b: 42\n',
+    );
+    const schema = await loadCsvSchema(root, 'data/foo.csv');
+    expect(schema?.columns).toEqual({ a: 'INTEGER' });
+  });
+});
+
+describe('buildReadCsvSql', () => {
+  it('emits a read_csv call with quoted column names and types', () => {
+    const sql = buildReadCsvSql('/abs/foo.csv', {
+      columns: { a: 'INTEGER', b: 'VARCHAR' },
+    });
+    expect(sql).toBe(
+      `read_csv('/abs/foo.csv', columns = {'a': 'INTEGER', 'b': 'VARCHAR'})`,
+    );
+  });
+
+  it('includes delim when set', () => {
+    const sql = buildReadCsvSql('/abs/x.csv', {
+      columns: { a: 'INTEGER' },
+      delimiter: '\t',
+    });
+    expect(sql).toContain(`delim = '\t'`);
+  });
+
+  it('includes header when set', () => {
+    const sql = buildReadCsvSql('/abs/x.csv', {
+      columns: { a: 'INTEGER' },
+      header: false,
+    });
+    expect(sql).toContain('header = false');
+  });
+
+  it("doubles single quotes inside the path so a name like it's.csv stays quoted", () => {
+    const sql = buildReadCsvSql("/abs/it's.csv", { columns: { a: 'INTEGER' } });
+    expect(sql).toContain(`'/abs/it''s.csv'`);
+  });
+});

--- a/tests/main/sources/tables-csv.test.ts
+++ b/tests/main/sources/tables-csv.test.ts
@@ -124,6 +124,135 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
     expect(derived.ok).toBe(false);
   });
 
+  it('honours an explicit schema declared in the companion .md `csv:` block (#237)', async () => {
+    await writeCsv('events.csv', 'submitted_at,category,score\n2024-01-02,alpha,3.14\n');
+    await fsp.writeFile(
+      path.join(root, 'events.md'),
+      [
+        '---',
+        'csv:',
+        '  columns:',
+        '    submitted_at: DATE',
+        '    category: VARCHAR',
+        '    score: DOUBLE',
+        '---',
+        '# Events',
+      ].join('\n'),
+      'utf-8',
+    );
+    await registerCsv(ctx, 'events.csv');
+
+    const describe = await runQuery(ctx, `DESCRIBE events`);
+    expect(describe.ok).toBe(true);
+    if (describe.ok) {
+      const types = Object.fromEntries(
+        describe.rows.map((r) => [String(r.column_name), String(r.column_type)]),
+      );
+      expect(types.submitted_at).toBe('DATE');
+      expect(types.category).toBe('VARCHAR');
+      expect(types.score).toBe('DOUBLE');
+    }
+  });
+
+  it('falls back to a sidecar `<stem>.csv.schema.yaml` when no companion .md is present (#237)', async () => {
+    await writeCsv('events.csv', 'submitted_at,category,score\n2024-01-02,alpha,3.14\n');
+    await fsp.writeFile(
+      path.join(root, 'events.csv.schema.yaml'),
+      [
+        'columns:',
+        '  submitted_at: DATE',
+        '  category: VARCHAR',
+        '  score: DOUBLE',
+      ].join('\n'),
+      'utf-8',
+    );
+    await registerCsv(ctx, 'events.csv');
+
+    const describe = await runQuery(ctx, `DESCRIBE events`);
+    expect(describe.ok).toBe(true);
+    if (describe.ok) {
+      const types = Object.fromEntries(
+        describe.rows.map((r) => [String(r.column_name), String(r.column_type)]),
+      );
+      expect(types.submitted_at).toBe('DATE');
+      expect(types.category).toBe('VARCHAR');
+      expect(types.score).toBe('DOUBLE');
+    }
+  });
+
+  it('respects header: false from the schema (#237)', async () => {
+    await writeCsv('rows.csv', '1,alpha\n2,beta\n');
+    await fsp.writeFile(
+      path.join(root, 'rows.csv.schema.yaml'),
+      [
+        'columns:',
+        '  id: INTEGER',
+        '  name: VARCHAR',
+        'header: false',
+      ].join('\n'),
+      'utf-8',
+    );
+    await registerCsv(ctx, 'rows.csv');
+
+    const result = await runQuery(ctx, `SELECT * FROM rows ORDER BY id`);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // header: false means BOTH lines are data — auto would have
+      // consumed the first as a header.
+      expect(result.rows).toEqual([
+        { id: 1, name: 'alpha' },
+        { id: 2, name: 'beta' },
+      ]);
+    }
+  });
+
+  it('schema-less CSVs still load via auto-inference (#237 no-regression)', async () => {
+    await writeCsv('plain.csv', 'a,b\n1,2\n3,4\n');
+    await registerCsv(ctx, 'plain.csv');
+
+    const result = await runQuery(ctx, `SELECT a, b FROM plain ORDER BY a`);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // BIGINT inference is the existing auto-detect behavior; the
+      // schema branch didn't accidentally route schema-less CSVs
+      // through read_csv with empty types.
+      expect(result.rows).toEqual([{ a: 1n, b: 2n }, { a: 3n, b: 4n }]);
+    }
+  });
+
+  it('re-registers under a new schema when the sidecar is rewritten (#237)', async () => {
+    await writeCsv('events.csv', 'submitted_at,category\n2024-01-02,alpha\n');
+    // First: VARCHAR types
+    await fsp.writeFile(
+      path.join(root, 'events.csv.schema.yaml'),
+      'columns:\n  submitted_at: VARCHAR\n  category: VARCHAR\n',
+      'utf-8',
+    );
+    await registerCsv(ctx, 'events.csv');
+    let describe = await runQuery(ctx, `DESCRIBE events`);
+    if (describe.ok) {
+      const types = Object.fromEntries(
+        describe.rows.map((r) => [String(r.column_name), String(r.column_type)]),
+      );
+      expect(types.submitted_at).toBe('VARCHAR');
+    }
+
+    // Rewrite the sidecar to DATE for submitted_at, re-register.
+    await fsp.writeFile(
+      path.join(root, 'events.csv.schema.yaml'),
+      'columns:\n  submitted_at: DATE\n  category: VARCHAR\n',
+      'utf-8',
+    );
+    await registerCsv(ctx, 'events.csv');
+    describe = await runQuery(ctx, `DESCRIBE events`);
+    if (describe.ok) {
+      const types = Object.fromEntries(
+        describe.rows.map((r) => [String(r.column_name), String(r.column_type)]),
+      );
+      expect(types.submitted_at).toBe('DATE');
+    }
+  });
+
   it('unregisterCsv drops the view', async () => {
     await writeCsv('scratch.csv', 'a\n1\n');
     await registerCsv(ctx, 'scratch.csv');


### PR DESCRIPTION
Closes #237.

## Summary

DuckDB's \`read_csv_auto\` is good but gets caught out on dates, categorical strings, mixed-type columns, and unusual encodings. This adds a way to pin column types (plus delimiter / header) without leaving Minerva.

Two sources, checked in order:

1. **Companion-note frontmatter** — a \`csv:\` block in \`<stem>.md\` next to \`<stem>.csv\`. Consistent with how the existing \`table_name:\` override works.
2. **Sidecar YAML** — \`<stem>.csv.schema.yaml\` next to the CSV. Useful when no companion note exists.

Both shapes look like:

\`\`\`yaml
columns:
  submitted_at: DATE
  category: VARCHAR
  score: DOUBLE
delimiter: "\t"
header: false
\`\`\`

When a schema is found, \`registerCsv\` builds an explicit \`read_csv('path', columns = {…}, delim = …, header = …)\` call instead of \`read_csv_auto\`. Schema-less CSVs are unaffected.

## Architecture

- **\`src/main/sources/csv-schema.ts\`** (new) — \`loadCsvSchema(rootPath, csvRelPath)\` resolves the schema (companion-note primary, sidecar fallback). Validates shape; tolerates malformed YAML / missing \`columns\` by returning null + a console warning so a typo doesn't kill registration. Exports \`buildReadCsvSql\` with proper single-quote escaping for both the path and quoted-string STRUCT keys (handles column names with hyphens, spaces, etc.).
- **\`src/main/sources/tables.ts\`** — \`registerCsv\` now branches: schema present → \`buildReadCsvSql\`; otherwise the existing \`read_csv_auto\` path.
- **\`src/main/notebase/watcher.ts\`** — the watcher previously emitted events only for INDEXABLE_EXTS (\`.md\`/\`.ttl\`/\`.csv\`/\`.py\`), so sidecar yaml changes were invisible. New \`isWatchable\` filter adds \`*.csv.schema.yaml\`.
- **\`src/main/window-manager.ts\`** — new \`siblingCsvForReregister(path)\` helper. The watcher callbacks route sidecar changes AND companion-\`.md\` changes to re-register the corresponding CSV. Sidecar deletion reverts the CSV to \`read_csv_auto\`. Sidecar paths are excluded from graph/search indexing. As a side-benefit this also closes a pre-existing gap where editing \`table_name:\` in a companion note only took effect on the next full project rescan.

## Acceptance criteria (all met)

- ✅ A CSV with a sidecar (or companion frontmatter) schema loads with the declared types — verified by \`DESCRIBE\`.
- ✅ Editing the schema file and saving triggers re-registration — verified by the \"re-registers under a new schema\" test plus the watcher wiring.
- ✅ Schema-less CSVs still load via auto-inference — verified by the no-regression test.

## Test plan

- [ ] Add a \`.csv\` with no schema → \`DESCRIBE\` shows auto-inferred types as before.
- [ ] Drop a \`foo.csv.schema.yaml\` sidecar next to \`foo.csv\` → on save, the Tables panel / \`DESCRIBE foo\` shows the explicit types.
- [ ] Edit the sidecar's types and save → table re-registers with new types (no restart needed).
- [ ] Delete the sidecar → table reverts to auto-inferred types.
- [ ] Add a \`csv:\` block to a companion \`foo.md\` while a sidecar exists → frontmatter wins.
- [ ] Add a \`header: false\` schema to a header-less CSV → first row is data, not column names.
- [ ] A CSV with a tab-delimited file + \`delimiter: \"\\t\"\` parses correctly.
- [ ] Malformed sidecar YAML doesn't kill the registration — warning logged, table loads via auto-inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)