### PR TITLE
llm: propose_compute tool — LLM-proposes-computation integration (#245)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,7 +12,7 @@ import { renameAnchor } from './notebase/rename-anchor';
 import { renameSource, renameExcerpt } from './notebase/rename-source-excerpt';
 import * as gitOps from './git/index';
 import * as graph from './graph/index';
-import { projectContext } from './project-context-types';
+import { projectContext, type ProjectContext } from './project-context-types';
 import { writeAndReindex } from './notebase/write-pipeline';
 import type { WritePipelineHooks } from './notebase/write-pipeline';
 import * as search from './search/index';
@@ -235,6 +235,131 @@ const hooks: WritePipelineHooks = {
   broadcastRewritten,
   broadcastHeadingRename,
 };
+
+// ── propose_compute helpers (#245) ──────────────────────────────────────────
+
+/**
+ * Serialize a CellResult into a plain-text block the LLM can read on
+ * its next turn. Tables get a small markdown rendering (capped at
+ * ~30 rows for sanity); errors get a single-line marker; images are
+ * referenced by a placeholder since the API can't see them inline
+ * here. The returned string is wrapped with `[Output of <draftId>]`
+ * delimiters so the LLM (and a human reading the transcript) can
+ * locate the section quickly.
+ */
+function formatComputeResultAsContext(
+  draft: import('../shared/conversation-compute-drafts').ConversationComputeDraft,
+  codeRan: string,
+  result: import('../shared/compute/types').CellResult,
+): string {
+  const header = `[Output of compute proposal ${draft.draftId} — ${draft.language}]`;
+  const codeBlock = `\`\`\`${draft.language}\n${codeRan.trim()}\n\`\`\``;
+  if (!result.ok) {
+    return `${header}\n${codeBlock}\n\n**Error:** ${result.error}`;
+  }
+  const out = result.output;
+  switch (out.type) {
+    case 'text':
+      return `${header}\n${codeBlock}\n\n\`\`\`\n${out.value}\n\`\`\``;
+    case 'json':
+      return `${header}\n${codeBlock}\n\n\`\`\`json\n${JSON.stringify(out.value, null, 2)}\n\`\`\``;
+    case 'table': {
+      const ROW_CAP = 30;
+      const rows = out.rows.slice(0, ROW_CAP);
+      const head = `| ${out.columns.join(' | ')} |`;
+      const sep = `| ${out.columns.map(() => '---').join(' | ')} |`;
+      const body = rows
+        .map((r) => `| ${r.map((c) => formatTableCell(c)).join(' | ')} |`)
+        .join('\n');
+      const trailer = out.truncated || out.rows.length > ROW_CAP
+        ? `\n\n(showing ${rows.length} of ${out.totalRows ?? out.rows.length} rows)`
+        : '';
+      return `${header}\n${codeBlock}\n\n${head}\n${sep}\n${body}${trailer}`;
+    }
+    case 'image':
+      return `${header}\n${codeBlock}\n\n[image output: ${out.mime} — open the conversation panel to view]`;
+    case 'html':
+      // Pass HTML through verbatim; the LLM can read the markup but
+      // won't render it. Truncate to a sane length so a giant table
+      // doesn't blow up the next turn's context.
+      return `${header}\n${codeBlock}\n\n\`\`\`html\n${out.html.slice(0, 4000)}\n\`\`\``;
+  }
+}
+
+function formatTableCell(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  // Anything else (Date, object literal, etc.) — JSON-stringify
+  // rather than risk "[object Object]" landing in the LLM context.
+  try { return JSON.stringify(value); } catch { return ''; }
+}
+
+/**
+ * Write the ComputeProposal triples into the graph. Called from the
+ * RUN handler so every executed cell leaves an audit-trail record —
+ * the integrity stock query verifies the LLM hasn't snuck a cell
+ * past review.
+ */
+function recordComputeProposalRun(
+  ctx: ProjectContext,
+  draft: import('../shared/conversation-compute-drafts').ConversationComputeDraft,
+  codeRan: string,
+): void {
+  const proposalUri = `https://minerva.dev/ontology/thought#proposal/${draft.draftId}`;
+  const convUri = `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`;
+  const executedAt = new Date().toISOString();
+  const turtle = `
+    @prefix thought: <https://minerva.dev/ontology/thought#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <${proposalUri}> a thought:ComputeProposal ;
+      thought:proposalStatus thought:approved ;
+      thought:proposedBy "llm:propose_compute" ;
+      thought:proposedAt "${draft.createdAt}"^^xsd:dateTime ;
+      thought:conversationRef <${convUri}> ;
+      thought:language "${escapeTurtleLiteral(draft.language)}" ;
+      thought:code "${escapeTurtleLiteral(draft.code)}" ;
+      thought:executedCode "${escapeTurtleLiteral(codeRan)}" ;
+      thought:executed "true"^^xsd:boolean ;
+      thought:executedAt "${executedAt}"^^xsd:dateTime .
+  `;
+  graph.parseIntoStore(ctx, turtle);
+}
+
+function escapeTurtleLiteral(s: string): string {
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t');
+}
+
+/**
+ * Build the markdown block for an Insert-into-notebook action. The
+ * provenance comment line is parsed by the indexer when the LLM
+ * later asks `read_note` on the destination — it sees the comment
+ * and knows which cells were LLM-proposed vs. human-written.
+ */
+function buildComputeProposalNoteBlock(
+  draft: import('../shared/conversation-compute-drafts').ConversationComputeDraft,
+  codeToInsert: string,
+): string {
+  const provenance = [
+    `<!-- compute-proposal:`,
+    `  draft: ${draft.draftId}`,
+    `  proposed_by: llm`,
+    `  proposed_in_conversation: ${draft.conversationId}`,
+    `  proposed_at: ${draft.createdAt}`,
+    `  rationale: ${draft.rationale.replace(/-->/g, '--&gt;')}`,
+    `-->`,
+  ].join('\n');
+  const fence = '```';
+  return `${provenance}\n${fence}${draft.language}\n${codeToInsert.trim()}\n${fence}`;
+}
 
 export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.NOTEBASE_OPEN, async (e) => {
@@ -1630,6 +1755,11 @@ export function registerIpcHandlers(): void {
             win.webContents.send(Channels.CONVERSATION_PROPERTY_DRAFT, draft);
           }
         },
+        onComputeDraft: (draft: import('../shared/conversation-compute-drafts').ConversationComputeDraft) => {
+          if (!win.isDestroyed()) {
+            win.webContents.send(Channels.CONVERSATION_COMPUTE_DRAFT, draft);
+          }
+        },
         askUser: ({ question, choices }: { question: string; choices?: string[] }) => {
           const questionId = randomUUID();
           return new Promise<string>((resolve, reject) => {
@@ -1946,6 +2076,84 @@ export function registerIpcHandlers(): void {
       // here — the file watcher's NOTEBASE_FILE_CHANGED event is
       // what the renderer already listens for to refresh views.
       return { outcomes };
+    },
+  );
+
+  // Counterpart for propose_compute draft cells (#245). The user
+  // clicked Run; we execute via the compute registry, record the
+  // ComputeProposal in the graph with thought:executed=true, and
+  // append the result to the conversation log so the LLM's next
+  // turn sees it as user-role context.
+  ipcMain.handle(
+    Channels.CONVERSATION_RUN_COMPUTE_DRAFT,
+    async (
+      e,
+      input: import('../shared/conversation-compute-drafts').RunComputeDraftInput,
+    ): Promise<import('../shared/conversation-compute-drafts').RunComputeDraftResult> => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      const { draft, editedCode } = input;
+      if (!draft || !draft.language || !draft.code) {
+        throw new Error('RUN_COMPUTE_DRAFT: draft is missing language or code.');
+      }
+      const codeToRun = editedCode ?? draft.code;
+      console.log(`[conv] RUN_COMPUTE_DRAFT lang=${draft.language} draftId=${draft.draftId}`);
+      const ctx = projectContext(rootPath);
+      const result = await runComputeCell(draft.language, codeToRun, { rootPath });
+      // Append the result to the conversation log as a user-role
+      // message so the LLM's next turn sees it as context. Format
+      // for legibility — the model parses these like any other
+      // user input.
+      const contextMessage = formatComputeResultAsContext(draft, codeToRun, result);
+      try {
+        await conversation.appendMessage(draft.conversationId, 'user', contextMessage);
+      } catch (err) {
+        console.warn('[conv] failed to append compute output to conversation:', err);
+      }
+      // Record the ComputeProposal in the graph (#245 acceptance
+      // criterion: every executed cell has a matching record).
+      try {
+        recordComputeProposalRun(ctx, draft, codeToRun);
+      } catch (err) {
+        console.warn('[conv] failed to record ComputeProposal in graph:', err);
+      }
+      return { result };
+    },
+  );
+
+  // Insert a compute-draft cell into a notebook with provenance
+  // frontmatter (#245). Default destination is
+  // `notes/inbox/conversations/<conversationId>.md`; the user can
+  // override via the destinationPath argument.
+  ipcMain.handle(
+    Channels.CONVERSATION_INSERT_COMPUTE_DRAFT,
+    async (
+      e,
+      input: import('../shared/conversation-compute-drafts').InsertComputeDraftInput,
+    ): Promise<import('../shared/conversation-compute-drafts').InsertComputeDraftResult> => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      const { draft, editedCode, destinationPath } = input;
+      if (!draft || !draft.language || !draft.code) {
+        throw new Error('INSERT_COMPUTE_DRAFT: draft is missing language or code.');
+      }
+      const codeToInsert = editedCode ?? draft.code;
+      const dest = destinationPath?.trim() || `notes/inbox/conversations/${draft.conversationId}.md`;
+      // Read existing content (if any) so the cell appends rather
+      // than overwrites. Missing-file is the common case for the
+      // default destination — fall back to a fresh note.
+      let existing: string;
+      try {
+        existing = await notebaseFs.readFile(rootPath, dest);
+      } catch {
+        existing = '';
+      }
+      const block = buildComputeProposalNoteBlock(draft, codeToInsert);
+      const next = existing
+        ? `${existing.replace(/\s*$/, '')}\n\n${block}\n`
+        : `# Conversation: ${draft.conversationId}\n\n${block}\n`;
+      await writeAndReindex(rootPath, dest, next, hooks);
+      return { destinationPath: dest };
     },
   );
 

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -12,6 +12,7 @@ import { MISSING_API_KEY_MARKER } from '../../shared/llm-errors';
 import type { ConversationDraft } from '../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../shared/conversation-source-drafts';
 import type { ConversationPropertyDraft } from '../../shared/conversation-property-drafts';
+import type { ConversationComputeDraft } from '../../shared/conversation-compute-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { formatToolCall } from './format-tool-call';
 
@@ -37,6 +38,12 @@ export interface StreamCallbacks {
    * set_properties calls fail with a "no UI surface" error.
    */
   onPropertyDraft?: (draft: ConversationPropertyDraft) => void;
+  /**
+   * Counterpart to `onDraft` for the propose_compute tool (#245).
+   * Forwarded via Channels.CONVERSATION_COMPUTE_DRAFT; without it,
+   * propose_compute calls fail with a "no UI surface" error.
+   */
+  onComputeDraft?: (draft: ConversationComputeDraft) => void;
   /**
    * Wired by the conversation IPC handler when a template declares the
    * `ask_user` tool. The agent's call to `ask_user` resolves with the
@@ -336,6 +343,9 @@ export async function completeWithTools(
       }
       if (callbacks?.onPropertyDraft) {
         toolCallbacks.onPropertyDraft = callbacks.onPropertyDraft;
+      }
+      if (callbacks?.onComputeDraft) {
+        toolCallbacks.onComputeDraft = callbacks.onComputeDraft;
       }
       if (callbacks?.askUser) {
         toolCallbacks.askUser = callbacks.askUser;

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -21,6 +21,11 @@ import type {
   PropertyUpdate,
   SetPropertiesInput,
 } from '../../shared/conversation-property-drafts';
+import type {
+  ConversationComputeDraft,
+  ProposeComputeInput,
+} from '../../shared/conversation-compute-drafts';
+import { scanPythonSafety } from '../../shared/python-safety';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { fixupBundleLinks } from '../../shared/refactor/bundle-link-fixup';
 import { readFrontmatterProperties } from '../../shared/refactor/frontmatter-patch';
@@ -56,6 +61,10 @@ export interface ToolCallbacks {
   /** Counterpart to `onDraft` for the `set_properties` tool. Forwards
    *  frontmatter-patch drafts to the renderer for inline review. */
   onPropertyDraft?: (draft: ConversationPropertyDraft) => void;
+  /** Counterpart to `onDraft` for the `propose_compute` tool (#245).
+   *  Forwards SPARQL / SQL / Python cell drafts to the renderer for
+   *  inline review. The user clicks Run / Insert / Discard. */
+  onComputeDraft?: (draft: ConversationComputeDraft) => void;
   askUser?: (input: { question: string; choices?: string[] }) => Promise<string>;
 }
 
@@ -363,6 +372,100 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
       required: ['note', 'updates'],
     },
   },
+  {
+    name: 'propose_compute',
+    description:
+      'Propose a code cell (SPARQL, SQL, or Python) for the user to review and run. ' +
+      'Use this when answering a question would benefit from actual computation over ' +
+      'the user\'s data — counting graph nodes, joining CSV tables, fitting a model, ' +
+      'plotting a distribution — rather than your own narrative answer. The cell is ' +
+      'rendered as a reviewable inline card; the user clicks Run to execute it, ' +
+      'Insert into notebook to file it as a permanent cell, or Discard. Per the ' +
+      'Trust Principle, you cannot execute code yourself — every cell goes through ' +
+      'human review first.\n' +
+      '\n' +
+      'After Run, the output is appended to the conversation as context for your ' +
+      'NEXT turn — so you can comment on the result, refine the query, or propose ' +
+      'a follow-up cell. Don\'t describe the expected output inline; let the user ' +
+      'run it and see.\n' +
+      '\n' +
+      'Language guidance:\n' +
+      '  - `sparql` — query the knowledge graph (notes, tags, claims, sources, etc.). ' +
+      'Use the standard minerva/thought/dc prefixes; they\'re auto-injected.\n' +
+      '  - `sql` — query CSV tables registered in DuckDB. Table names follow the ' +
+      'project-relative path with `/` and `.` collapsed to `_` (or the user\'s ' +
+      '`table_name:` override). Call `read_note` on the companion `.md` first if ' +
+      'unsure about a table\'s shape.\n' +
+      '  - `python` — pandas / numpy / matplotlib analysis. Network calls, ' +
+      'subprocess, and file-write APIs are flagged in the UI and require an extra ' +
+      'confirmation — avoid them unless genuinely necessary.\n' +
+      '\n' +
+      'The `minerva` Python module is the canonical way to reach project data ' +
+      '(just `import minerva` at the top of the cell). Every helper returns ' +
+      'plain dicts / lists of dicts — NOT custom classes. Access fields with ' +
+      'bracket notation (`note[\'body\']`), not dot notation.\n' +
+      '\n' +
+      '  minerva.sparql(query) -> pandas.DataFrame\n' +
+      '    Columns match the SELECT variable names verbatim (no `?` prefix).\n' +
+      '    SELECT ?relativePath ?title  →  df columns: [\'relativePath\', \'title\']\n' +
+      '\n' +
+      '  minerva.sql(query) -> pandas.DataFrame\n' +
+      '    Columns match the SQL projection.\n' +
+      '\n' +
+      '  minerva.notes.read(rel_path) -> dict\n' +
+      '    Returns {\'relativePath\', \'title\', \'frontmatter\', \'tags\', \'body\'}.\n' +
+      '    To get the markdown source: minerva.notes.read(p)[\'body\'].\n' +
+      '\n' +
+      '  minerva.notes.by_tag(tag) -> list[dict]\n' +
+      '    Each item: {\'relativePath\', \'title\'}.\n' +
+      '\n' +
+      '  minerva.notes.search(query, limit=20) -> list[dict]\n' +
+      '    Each item: {\'relativePath\', \'title\', \'snippet\', \'score\'}.\n' +
+      '\n' +
+      '  minerva.sources.get(source_id) -> dict (SourceDetail)\n' +
+      '  minerva.sources.citing(source_id) -> list[dict]\n' +
+      '  minerva.excerpts.for_source(source_id) -> list[str]\n' +
+      '  minerva.ctx() -> {\'project_root\': str, \'notebook_path\': str | None}\n' +
+      '\n' +
+      'Common pitfalls to avoid:\n' +
+      '  - There is no `from minerva import read_note`. Use `minerva.notes.read(p)`.\n' +
+      '  - DataFrame columns are NOT renamed for ergonomics — `?relativePath` in ' +
+      'SPARQL becomes `df[\'relativePath\']`, not `df[\'path\']`. Match the column ' +
+      'name to the variable name exactly.\n' +
+      '  - Notes are dicts; field access is `note[\'body\']` not `note.body`.\n' +
+      '  - For the project root, use `minerva.ctx()[\'project_root\']` rather than ' +
+      '`os.environ` so you don\'t trip the safety scan.\n' +
+      '\n' +
+      'One proposal per turn. End the turn with a one-sentence preamble (e.g. ' +
+      '"I drafted a query — run it when ready.") and stop.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        language: {
+          type: 'string',
+          enum: ['sparql', 'sql', 'python'],
+          description:
+            'Which executor the cell targets. SPARQL hits the graph; SQL hits DuckDB ' +
+            'over registered CSV tables; Python runs in the project\'s kernel.',
+        },
+        code: {
+          type: 'string',
+          description:
+            'The cell body, exactly as you want the user to see it. No surrounding ' +
+            'markdown fence; the renderer adds language-aware syntax highlighting. ' +
+            'Make the cell self-contained — the user may run it without your turn ' +
+            'still in scope.',
+        },
+        rationale: {
+          type: 'string',
+          description:
+            'One short sentence describing what this cell will compute and why ' +
+            'it\'s the right answer to the user\'s question. Surfaced on the card.',
+        },
+      },
+      required: ['language', 'code', 'rationale'],
+    },
+  },
 ];
 
 /**
@@ -499,6 +602,8 @@ export async function executeNotebaseTool(
         return { content: await runFetchProperties(ctx, input), isError: false };
       case 'set_properties':
         return runSetProperties(ctx, input, callbacks);
+      case 'propose_compute':
+        return runProposeCompute(ctx, input, callbacks);
       case 'ask_user':
         return runAskUser(input, callbacks);
       default:
@@ -816,6 +921,89 @@ function runDescribeSchema(): string {
     '',
     THOUGHT_ONTOLOGY_TTL,
   ].join('\n');
+}
+
+/**
+ * Trust-principle parity with the other propose_* tools (#245):
+ * `propose_compute` never executes the cell. It validates the input,
+ * runs the Python-safety scan (no-op for sparql/sql), and emits a
+ * `ConversationComputeDraft`. The renderer shows an inline reviewable
+ * card; the user clicks Run to execute, Insert to file as a notebook
+ * cell, or Discard.
+ */
+function runProposeCompute(
+  ctx: ToolContext,
+  input: unknown,
+  callbacks: ToolCallbacks,
+): { content: string; isError: boolean } {
+  if (!callbacks.onComputeDraft) {
+    return {
+      content: 'propose_compute is only available in conversation contexts.',
+      isError: true,
+    };
+  }
+  if (!ctx.conversationId) {
+    return {
+      content: 'propose_compute requires a bound conversation id.',
+      isError: true,
+    };
+  }
+  const parsed = parseProposeComputeInput(input);
+  if ('error' in parsed) {
+    return { content: parsed.error, isError: true };
+  }
+  const safetyFlags = parsed.language === 'python'
+    ? scanPythonSafety(parsed.code).map((f) => ({ id: f.id, message: f.message }))
+    : [];
+  const draft: ConversationComputeDraft = {
+    draftId: `cmpdraft-${randomUUID()}`,
+    conversationId: ctx.conversationId,
+    language: parsed.language,
+    code: parsed.code,
+    rationale: parsed.rationale,
+    safetyFlags,
+    createdAt: new Date().toISOString(),
+  };
+  callbacks.onComputeDraft(draft);
+  return {
+    content: JSON.stringify({
+      status: 'drafted',
+      draftId: draft.draftId,
+      language: draft.language,
+      safetyFlags: safetyFlags.map((f) => f.id),
+      // Same anti-loop hint that propose_notes / propose_sources /
+      // set_properties use. The model otherwise tends to re-emit the
+      // proposal in subsequent iterations of the same turn.
+      hint:
+        'STOP. The cell has been queued for the user to review. End this ' +
+        'turn with ONE short acknowledgement sentence (e.g. "I drafted a ' +
+        `${parsed.language} cell — run it when ready.") and DO NOT call ` +
+        'propose_compute again in this turn. DO NOT call any other tool. ' +
+        'The cell output will arrive in the NEXT turn as user-role context — ' +
+        'comment on it then.',
+    }) + `\n\n(queued ${parsed.language} draft)`,
+    isError: false,
+  };
+}
+
+function parseProposeComputeInput(input: unknown): ProposeComputeInput | { error: string } {
+  if (!input || typeof input !== 'object') {
+    return { error: 'propose_compute input must be an object.' };
+  }
+  const obj = input as Record<string, unknown>;
+  const language = obj.language;
+  if (language !== 'sparql' && language !== 'sql' && language !== 'python') {
+    return { error: '`language` must be one of "sparql", "sql", "python".' };
+  }
+  const code = typeof obj.code === 'string' ? obj.code : '';
+  if (!code.trim()) {
+    return { error: '`code` is required and must be a non-empty string.' };
+  }
+  const rationale = typeof obj.rationale === 'string' ? obj.rationale.trim() : '';
+  if (!rationale) {
+    return { error: '`rationale` is required and must be a non-empty string.' };
+  }
+  return { language, code, rationale };
 }
 
 /**

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -204,6 +204,12 @@ contextBridge.exposeInMainWorld('api', {
       subscribeIpc(Channels.CONVERSATION_PROPERTY_DRAFT, cb),
     filePropertyDraft: (draft: unknown) =>
       ipcRenderer.invoke(Channels.CONVERSATION_FILE_PROPERTY_DRAFT, draft),
+    onComputeDraft: (cb: (draft: unknown) => void) =>
+      subscribeIpc(Channels.CONVERSATION_COMPUTE_DRAFT, cb),
+    runComputeDraft: (input: unknown) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, input),
+    insertComputeDraft: (input: unknown) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_INSERT_COMPUTE_DRAFT, input),
     setModel: (conversationId: string, model: string | undefined) =>
       ipcRenderer.invoke(Channels.CONVERSATION_SET_MODEL, conversationId, model),
   },

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -14,6 +14,11 @@
     ConversationPropertyDraft,
     PropertyUpdateOutcome,
   } from '../../../shared/conversation-property-drafts';
+  import type {
+    ConversationComputeDraft,
+  } from '../../../shared/conversation-compute-drafts';
+  import type { CellOutput } from '../../../shared/compute/types';
+  import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
   import type { ConversationMessage } from '../../../shared/types';
 
   // Lightweight markdown-it for assistant message rendering. Mirrors the
@@ -199,6 +204,85 @@
     store.discardPropertyDraft(tabId, draftId);
   }
 
+  // ── propose_compute card state (#245) ─────────────────────────────
+  //
+  // Per-draft editor buffer (when the user clicks Edit) and a flag for
+  // "I see the safety warnings, run anyway". Keyed by draftId so two
+  // compute drafts in the same conversation are independent. Edit
+  // buffers are dropped when the draft is discarded.
+  let computeEdits = $state<Record<string, string>>({});
+  let computeEditing = $state<Record<string, boolean>>({});
+  let computeRiskyAck = $state<Record<string, boolean>>({});
+
+  function startEditCompute(draft: ConversationComputeDraft): void {
+    computeEdits[draft.draftId] = draft.code;
+    computeEditing[draft.draftId] = true;
+  }
+
+  function cancelEditCompute(draftId: string): void {
+    delete computeEdits[draftId];
+    computeEditing[draftId] = false;
+  }
+
+  function commitEditCompute(draftId: string): void {
+    // No persistence here — the edited code is folded into Run /
+    // Insert payloads when the user actually fires those actions.
+    // This just exits edit mode while preserving the buffer.
+    computeEditing[draftId] = false;
+  }
+
+  function effectiveComputeCode(draft: ConversationComputeDraft): string {
+    const edited = computeEdits[draft.draftId];
+    return edited !== undefined ? edited : draft.code;
+  }
+
+  async function handleRunCompute(draft: ConversationComputeDraft): Promise<void> {
+    if (draft.safetyFlags.length > 0 && !computeRiskyAck[draft.draftId]) {
+      // First click on a flagged cell just arms the acknowledgement;
+      // the user has to click Run a second time to actually execute.
+      computeRiskyAck[draft.draftId] = true;
+      return;
+    }
+    const edited = computeEdits[draft.draftId];
+    const tab = store.activeTab;
+    if (!tab) return;
+    await store.runComputeDraft(tab.id, draft, edited);
+  }
+
+  async function handleInsertCompute(draft: ConversationComputeDraft): Promise<void> {
+    const tab = store.activeTab;
+    if (!tab) return;
+    const edited = computeEdits[draft.draftId];
+    await store.insertComputeDraft(tab.id, draft, edited);
+  }
+
+  function handleDiscardCompute(draft: ConversationComputeDraft): void {
+    const tab = store.activeTab;
+    if (!tab) return;
+    delete computeEdits[draft.draftId];
+    delete computeEditing[draft.draftId];
+    delete computeRiskyAck[draft.draftId];
+    store.discardComputeDraft(tab.id, draft.draftId);
+  }
+
+  function languagePillLabel(lang: 'sparql' | 'sql' | 'python'): string {
+    return lang === 'sparql' ? 'SPARQL' : lang === 'sql' ? 'SQL' : 'Python';
+  }
+
+  function openInsertedNote(path: string): void {
+    void editor.openFile(path);
+  }
+
+  /** Format a single table cell for inline rendering. Wide values
+   *  get truncated; bigints are shown as plain numbers (no `n` suffix). */
+  function formatComputeCell(value: unknown): string {
+    if (value == null) return '';
+    if (typeof value === 'bigint') return value.toString();
+    if (typeof value === 'string') return value.length > 200 ? value.slice(0, 200) + '…' : value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    try { return JSON.stringify(value); } catch { return ''; }
+  }
+
   /** Render a frontmatter value for inline display on the review card.
    *  Strings render bare; everything else falls back to compact JSON
    *  so the user can eyeball arrays/objects without scrolling. Null
@@ -283,6 +367,9 @@
       ([, entry]) => entry.afterMessageIndex === i,
     );
   }
+  function computeDraftsAt(tab: TabT, i: number) {
+    return tab.computeDrafts.filter((d) => d.afterMessageIndex === i);
+  }
   function orphanDrafts(tab: TabT) {
     const max = tab.conversation.messages.length;
     return tab.drafts.filter((d) => d.afterMessageIndex >= max);
@@ -312,6 +399,10 @@
     return Object.entries(tab.propertyDraftResults).filter(
       ([, entry]) => entry.afterMessageIndex >= max,
     );
+  }
+  function orphanComputeDrafts(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return tab.computeDrafts.filter((d) => d.afterMessageIndex >= max);
   }
 </script>
 
@@ -531,6 +622,126 @@
           </div>
         {/snippet}
 
+        {#snippet computeOutputBlock(output: CellOutput)}
+          {#if output.type === 'text'}
+            <pre class="compute-output-text">{output.value}</pre>
+          {:else if output.type === 'json'}
+            <pre class="compute-output-text">{JSON.stringify(output.value, null, 2)}</pre>
+          {:else if output.type === 'table'}
+            <div class="compute-output-table">
+              <table>
+                <thead>
+                  <tr>{#each output.columns as col (col)}<th>{col}</th>{/each}</tr>
+                </thead>
+                <tbody>
+                  {#each output.rows.slice(0, 50) as row, ri (ri)}
+                    <tr>{#each row as cell, ci (ci)}<td>{formatComputeCell(cell)}</td>{/each}</tr>
+                  {/each}
+                </tbody>
+              </table>
+              {#if output.truncated || output.rows.length > 50}
+                <div class="compute-output-trailer">
+                  Showing {Math.min(output.rows.length, 50)} of {output.totalRows ?? output.rows.length} rows
+                </div>
+              {/if}
+            </div>
+          {:else if output.type === 'image'}
+            {#if output.mime === 'image/png'}
+              <!-- Base64 PNG bytes from matplotlib / PIL. -->
+              <img class="compute-output-image" alt="compute output" src={`data:image/png;base64,${output.data}`} />
+            {:else}
+              <!-- SVG markup — sanitized for the same reasons as html. -->
+              <div class="compute-output-image">{@html sanitizeComputeOutputHtml(output.data)}</div>
+            {/if}
+          {:else if output.type === 'html'}
+            <div class="compute-output-html">{@html sanitizeComputeOutputHtml(output.html)}</div>
+          {/if}
+        {/snippet}
+
+        {#snippet computeDraftCardBlock(draft: ConversationComputeDraft)}
+          {@const state = tab.computeDraftState[draft.draftId]}
+          {@const editing = computeEditing[draft.draftId] === true}
+          {@const code = effectiveComputeCode(draft)}
+          {@const result = state?.result ?? null}
+          {@const running = state?.running === true}
+          {@const insertedAt = state?.insertedAt ?? null}
+          {@const armedRisky = computeRiskyAck[draft.draftId] === true}
+          <div class="draft-card compute-card">
+            <div class="compute-header">
+              <span class="compute-lang">{languagePillLabel(draft.language)}</span>
+              <span class="draft-note">{draft.rationale}</span>
+            </div>
+            {#if draft.safetyFlags.length > 0}
+              <div class="compute-safety" role="alert">
+                <strong>⚠ Risky patterns detected:</strong>
+                <ul>
+                  {#each draft.safetyFlags as f (f.id)}
+                    <li>{@html f.message}</li>
+                  {/each}
+                </ul>
+                {#if armedRisky}
+                  <span class="compute-safety-armed">Click Run again to confirm execution.</span>
+                {/if}
+              </div>
+            {/if}
+            {#if editing}
+              <textarea
+                class="compute-edit"
+                value={code}
+                spellcheck="false"
+                oninput={(e) => { computeEdits[draft.draftId] = e.currentTarget.value; }}
+                rows={Math.max(4, Math.min(20, code.split('\n').length))}
+              ></textarea>
+              <div class="compute-edit-actions">
+                <button type="button" class="draft-btn" onclick={() => cancelEditCompute(draft.draftId)}>Cancel</button>
+                <button type="button" class="draft-btn primary" onclick={() => commitEditCompute(draft.draftId)}>Done</button>
+              </div>
+            {:else}
+              <pre class="compute-code"><code>{code}</code></pre>
+            {/if}
+            <div class="draft-actions">
+              <button
+                type="button"
+                class="draft-btn primary"
+                disabled={running || editing}
+                onclick={() => { void handleRunCompute(draft); }}
+              >{running ? 'Running…' : armedRisky ? 'Run anyway' : 'Run'}</button>
+              {#if !editing}
+                <button type="button" class="draft-btn" onclick={() => startEditCompute(draft)}>Edit</button>
+              {/if}
+              <button
+                type="button"
+                class="draft-btn"
+                disabled={running || editing}
+                onclick={() => { void handleInsertCompute(draft); }}
+              >Insert into notebook</button>
+              <button type="button" class="draft-btn" onclick={() => handleDiscardCompute(draft)}>Discard</button>
+            </div>
+            {#if insertedAt}
+              <div class="compute-inserted">
+                Filed as a cell in
+                <button
+                  type="button"
+                  class="filed-link"
+                  title={insertedAt}
+                  onclick={() => openInsertedNote(insertedAt)}
+                >{basename(insertedAt)}</button>
+              </div>
+            {/if}
+            {#if result}
+              <div class="compute-output">
+                {#if !result.ok}
+                  <div class="compute-output-error">
+                    <strong>Error:</strong> {result.error}
+                  </div>
+                {:else}
+                  {@render computeOutputBlock(result.output)}
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/snippet}
+
         {#snippet propertyResultLine(_draftId: string, outcomes: PropertyUpdateOutcome[])}
           <!-- Compact "Updated:" line that replaces the propose-property
                card after Approve. Each successfully-patched path is a
@@ -593,6 +804,9 @@
             {/each}
             {#each propertyResultsAt(tab, i) as [draftId, entry] (draftId)}
               {@render propertyResultLine(draftId, entry.outcomes)}
+            {/each}
+            {#each computeDraftsAt(tab, i) as draft (draft.draftId)}
+              {@render computeDraftCardBlock(draft)}
             {/each}
           {/each}
 
@@ -671,6 +885,9 @@
           {/each}
           {#each orphanPropertyResults(tab) as [draftId, entry] (draftId)}
             {@render propertyResultLine(draftId, entry.outcomes)}
+          {/each}
+          {#each orphanComputeDrafts(tab) as draft (draft.draftId)}
+            {@render computeDraftCardBlock(draft)}
           {/each}
         </div>
 
@@ -1119,6 +1336,149 @@
     color: var(--text-muted);
     text-decoration: line-through;
     text-decoration-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
+  }
+
+  /* propose_compute card (#245). Two-column header with the language
+     pill on the left and the LLM's one-line rationale on the right.
+     Code uses a monospace pre block; edit mode swaps in a textarea.
+     Risky-Python flags surface above the code in a muted alert box,
+     and the Run button label changes to "Run anyway" after the first
+     click so the second click is the explicit confirmation. */
+  .compute-card { gap: 6px; }
+  .compute-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .compute-lang {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 3px;
+    background: var(--accent);
+    color: var(--bg);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    flex-shrink: 0;
+  }
+  .compute-code {
+    margin: 0;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: var(--text);
+    white-space: pre;
+    overflow-x: auto;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .compute-code code {
+    background: transparent;
+    padding: 0;
+    font-family: inherit;
+  }
+  .compute-edit {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: var(--text);
+    resize: vertical;
+    box-sizing: border-box;
+  }
+  .compute-edit:focus { outline: none; border-color: var(--accent); }
+  .compute-edit-actions {
+    display: flex;
+    gap: 6px;
+    justify-content: flex-end;
+  }
+  .compute-safety {
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: 3px;
+    padding: 6px 10px;
+    font-size: 11px;
+    background: var(--bg-button);
+    color: var(--text);
+  }
+  .compute-safety ul {
+    margin: 4px 0 0 0;
+    padding-left: 18px;
+    color: var(--text-muted);
+  }
+  .compute-safety-armed {
+    display: block;
+    margin-top: 4px;
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .compute-output {
+    margin-top: 4px;
+    padding: 8px 10px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+  }
+  .compute-output-error {
+    color: var(--text);
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .compute-output-text {
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--text);
+    white-space: pre-wrap;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+  .compute-output-table {
+    overflow-x: auto;
+    max-height: 280px;
+    overflow-y: auto;
+  }
+  .compute-output-table table {
+    border-collapse: collapse;
+    font-size: 11px;
+    color: var(--text);
+  }
+  .compute-output-table th,
+  .compute-output-table td {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    text-align: left;
+    white-space: nowrap;
+  }
+  .compute-output-table th {
+    background: var(--bg-button);
+    font-weight: 600;
+  }
+  .compute-output-trailer {
+    font-size: 10px;
+    color: var(--text-muted);
+    padding-top: 4px;
+  }
+  .compute-output-image img,
+  .compute-output-image {
+    max-width: 100%;
+    height: auto;
+  }
+  .compute-output-html {
+    font-size: 12px;
+    color: var(--text);
+  }
+  .compute-inserted {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding: 2px 4px;
   }
 
   /* Post-Approve summary line — replaces the inline draft card for

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -386,6 +386,18 @@ export interface ConversationsApi {
   filePropertyDraft(
     draft: import('../../../shared/conversation-property-drafts').ConversationPropertyDraft,
   ): Promise<import('../../../shared/conversation-property-drafts').FilePropertyDraftResult>;
+  /** Subscribe to code-cell drafts produced by the propose_compute tool (#245). */
+  onComputeDraft(
+    cb: (draft: import('../../../shared/conversation-compute-drafts').ConversationComputeDraft) => void,
+  ): void;
+  /** Run a compute draft and append the output to the conversation log. */
+  runComputeDraft(
+    input: import('../../../shared/conversation-compute-drafts').RunComputeDraftInput,
+  ): Promise<import('../../../shared/conversation-compute-drafts').RunComputeDraftResult>;
+  /** File a compute draft as a notebook cell with provenance frontmatter. */
+  insertComputeDraft(
+    input: import('../../../shared/conversation-compute-drafts').InsertComputeDraftInput,
+  ): Promise<import('../../../shared/conversation-compute-drafts').InsertComputeDraftResult>;
 }
 
 export interface ProposalsApi {

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -14,6 +14,10 @@ import type {
   PropertyUpdateOutcome,
 } from '../../../shared/conversation-property-drafts';
 import type {
+  ConversationComputeDraft,
+} from '../../../shared/conversation-compute-drafts';
+import type { CellResult } from '../../../shared/compute/types';
+import type {
   AskUserRequest,
   ConversationToolKey,
 } from '../../../shared/conversation-tools';
@@ -65,6 +69,21 @@ interface NoteDraftResultEntry {
   filedPaths: string[];
   afterMessageIndex: number;
 }
+type AnchoredComputeDraft = ConversationComputeDraft & { afterMessageIndex: number };
+/** Per-draft state for compute proposals (#245). `result` holds the
+ *  output of the most recent Run; `insertedAt` records the destination
+ *  path when the user chose Insert into notebook. Both are optional —
+ *  a draft that hasn't been acted on yet has neither set. */
+interface ComputeDraftStateEntry {
+  /** Latest cell result after Run. Null while pending. */
+  result: CellResult | null;
+  /** True while a Run is in-flight, so the panel can show a spinner
+   *  and disable the buttons. */
+  running: boolean;
+  /** Destination path written by the most recent Insert action. */
+  insertedAt: string | null;
+  afterMessageIndex: number;
+}
 
 interface TabRuntime {
   id: string;
@@ -91,6 +110,12 @@ interface TabRuntime {
   /** Per-update outcomes after Approve on a property draft — used to
    *  render the post-Approve "Updated:" line in place of the card. */
   propertyDraftResults: Record<string, PropertyDraftResultEntry>;
+  /** propose_compute drafts awaiting Run / Insert / Discard. */
+  computeDrafts: AnchoredComputeDraft[];
+  /** Per-draft Run / Insert state. Stays alive after Run so the user
+   *  can see the cell + output in the transcript; only Discard removes
+   *  the draft entirely (which also drops the state entry). */
+  computeDraftState: Record<string, ComputeDraftStateEntry>;
   /** In-flight ask_user prompt, if the agent is waiting on a reply. */
   pendingQuestion: AskUserRequest | null;
   composer: string;
@@ -127,6 +152,7 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let draftSubscribed = false;
 let sourceDraftSubscribed = false;
 let propertyDraftSubscribed = false;
+let computeDraftSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
 
@@ -191,6 +217,26 @@ function ensureSubscriptions(): void {
     });
     propertyDraftSubscribed = true;
   }
+  if (!computeDraftSubscribed) {
+    api.conversations.onComputeDraft((draft) => {
+      const t = tabs.find((tab) => tab.id === draft.conversationId);
+      if (!t) return;
+      const afterMessageIndex = t.conversation.messages.length;
+      t.computeDrafts = [...t.computeDrafts, { ...draft, afterMessageIndex }];
+      // Seed the state entry so the panel can render a pristine card
+      // immediately (no Run yet, no Insert yet).
+      t.computeDraftState = {
+        ...t.computeDraftState,
+        [draft.draftId]: {
+          result: null,
+          running: false,
+          insertedAt: null,
+          afterMessageIndex,
+        },
+      };
+    });
+    computeDraftSubscribed = true;
+  }
   if (!askUserSubscribed) {
     api.conversations.onAskUser((req) => {
       const t = tabs.find((tab) => tab.id === req.conversationId);
@@ -233,6 +279,8 @@ async function init(): Promise<void> {
       noteDraftResults: {},
       propertyDrafts: [],
       propertyDraftResults: {},
+      computeDrafts: [],
+      computeDraftState: {},
       pendingQuestion: null,
       composer: '',
       streaming: false,
@@ -320,6 +368,8 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     noteDraftResults: {},
     propertyDrafts: [],
     propertyDraftResults: {},
+    computeDrafts: [],
+    computeDraftState: {},
     pendingQuestion: null,
     composer: '',
     streaming: false,
@@ -374,6 +424,8 @@ async function openConversationTab(opts: {
     noteDraftResults: {},
     propertyDrafts: [],
     propertyDraftResults: {},
+    computeDrafts: [],
+    computeDraftState: {},
     pendingQuestion: null,
     composer: '',
     streaming: false,
@@ -582,6 +634,100 @@ function discardPropertyDraft(tabId: string, draftId: string): void {
   tab.propertyDrafts = tab.propertyDrafts.filter((d) => d.draftId !== draftId);
 }
 
+async function runComputeDraft(
+  tabId: string,
+  draft: ConversationComputeDraft,
+  editedCode?: string,
+): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  const state = tab.computeDraftState[draft.draftId];
+  if (state) {
+    // Mark in-flight so the panel can render a spinner + disable buttons.
+    tab.computeDraftState = {
+      ...tab.computeDraftState,
+      [draft.draftId]: { ...state, running: true },
+    };
+  }
+  // JSON round-trip to drop any Svelte 5 $state proxy wrapping before
+  // IPC — same defense used by the property-draft path after the
+  // dynamic-key serialization bug.
+  const plain = JSON.parse(JSON.stringify({ draft, editedCode })) as {
+    draft: ConversationComputeDraft;
+    editedCode?: string;
+  };
+  try {
+    const { result } = await api.conversations.runComputeDraft(plain);
+    tab.computeDraftState = {
+      ...tab.computeDraftState,
+      [draft.draftId]: {
+        result,
+        running: false,
+        insertedAt: tab.computeDraftState[draft.draftId]?.insertedAt ?? null,
+        afterMessageIndex: tab.computeDraftState[draft.draftId]?.afterMessageIndex
+          ?? tab.conversation.messages.length,
+      },
+    };
+    // Reload the conversation so the user-role context message the
+    // main process appended shows up immediately in the transcript.
+    const reloaded = await api.conversations.load(tab.id);
+    if (reloaded) tab.conversation = reloaded;
+  } catch (e) {
+    console.error('[conv] run compute draft failed:', e);
+    tab.computeDraftState = {
+      ...tab.computeDraftState,
+      [draft.draftId]: {
+        result: { ok: false, error: e instanceof Error ? e.message : String(e) },
+        running: false,
+        insertedAt: tab.computeDraftState[draft.draftId]?.insertedAt ?? null,
+        afterMessageIndex: tab.computeDraftState[draft.draftId]?.afterMessageIndex
+          ?? tab.conversation.messages.length,
+      },
+    };
+  }
+}
+
+async function insertComputeDraft(
+  tabId: string,
+  draft: ConversationComputeDraft,
+  editedCode?: string,
+  destinationPath?: string,
+): Promise<string | null> {
+  const tab = findTab(tabId);
+  if (!tab) return null;
+  const plain = JSON.parse(JSON.stringify({ draft, editedCode, destinationPath })) as {
+    draft: ConversationComputeDraft;
+    editedCode?: string;
+    destinationPath?: string;
+  };
+  try {
+    const { destinationPath: where } = await api.conversations.insertComputeDraft(plain);
+    const prior = tab.computeDraftState[draft.draftId];
+    tab.computeDraftState = {
+      ...tab.computeDraftState,
+      [draft.draftId]: {
+        result: prior?.result ?? null,
+        running: false,
+        insertedAt: where,
+        afterMessageIndex: prior?.afterMessageIndex ?? tab.conversation.messages.length,
+      },
+    };
+    return where;
+  } catch (e) {
+    console.error('[conv] insert compute draft failed:', e);
+    return null;
+  }
+}
+
+function discardComputeDraft(tabId: string, draftId: string): void {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  tab.computeDrafts = tab.computeDrafts.filter((d) => d.draftId !== draftId);
+  const next = { ...tab.computeDraftState };
+  delete next[draftId];
+  tab.computeDraftState = next;
+}
+
 function setComposer(value: string): void {
   const tab = activeTab();
   if (tab) tab.composer = value;
@@ -622,6 +768,9 @@ export function getConversationsStore() {
     dismissSourceDraftResult,
     approvePropertyDraft,
     discardPropertyDraft,
+    runComputeDraft,
+    insertComputeDraft,
+    discardComputeDraft,
     setComposer,
   };
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -295,6 +295,12 @@ export const Channels = {
   CONVERSATION_PROPERTY_DRAFT: 'conversation:propertyDraft',
   /** renderer → main: user approved a property draft; apply each {path, properties} patch and return the per-update outcomes. */
   CONVERSATION_FILE_PROPERTY_DRAFT: 'conversation:filePropertyDraft',
+  /** main → renderer: a propose_compute tool call produced a code-cell draft for review (#245). Payload is ConversationComputeDraft. */
+  CONVERSATION_COMPUTE_DRAFT: 'conversation:computeDraft',
+  /** renderer → main: user clicked Run on a compute draft. Executes via the existing compute registry and appends the result to the conversation log. */
+  CONVERSATION_RUN_COMPUTE_DRAFT: 'conversation:runComputeDraft',
+  /** renderer → main: user clicked Insert into notebook on a compute draft. Appends the cell to a destination note with provenance frontmatter. */
+  CONVERSATION_INSERT_COMPUTE_DRAFT: 'conversation:insertComputeDraft',
   CONVERSATION_SET_MODEL: 'conversation:setModel',
   /** Load tool-window UI state (.minerva/conversations/_ui.json). */
   CONVERSATION_UI_STATE_LOAD: 'conversation:uiStateLoad',

--- a/src/shared/conversation-compute-drafts.ts
+++ b/src/shared/conversation-compute-drafts.ts
@@ -1,0 +1,101 @@
+/**
+ * Conversation compute drafts (the `propose_compute` tool path, #245).
+ *
+ * The LLM mid-conversation calls `propose_compute` with a SPARQL, SQL,
+ * or Python cell it would like the user to run. Per the Trust
+ * Principle, the tool's server-side execution does NOT run the code —
+ * it emits a `ConversationComputeDraft`, the renderer renders an
+ * inline reviewable cell, and the user clicks Run (or Insert, or
+ * Discard). Only after explicit Run does the executor registry
+ * actually dispatch.
+ *
+ * Counterpart to `conversation-drafts.ts` (notes) and
+ * `conversation-source-drafts.ts` (sources). Compute drafts differ in
+ * two ways:
+ *
+ *   1. Three terminal actions, not two — Run, Insert into notebook,
+ *      Discard. Run is "approve + execute"; Insert is "approve, file
+ *      as a notebook cell, don't execute yet"; Discard is reject.
+ *   2. Run produces output that flows back into the conversation as
+ *      context for the LLM's next turn. The output is persisted as a
+ *      user-role message so the LLM's next inference call sees it
+ *      naturally — same shape as a propose_notes 'Filed:' line.
+ */
+import type { CellResult } from './compute/types';
+
+/** Languages the proposer can target. Mirrors the compute registry's
+ *  registered executors. The tool definition restricts the input to
+ *  this union; anything else is rejected at parse time. */
+export type ComputeLanguage = 'sparql' | 'sql' | 'python';
+
+/** Hints surfaced when the Python-safety scan finds risky patterns.
+ *  Renderer shows them in the card and requires an extra confirm
+ *  before the first Run. Not a hard reject — false positives are
+ *  fine as long as the user gets to look. */
+export interface ComputeSafetyFlag {
+  /** Stable id for the flag class (e.g. `imports-os`, `calls-open-write`). */
+  id: string;
+  /** Human-readable phrase shown on the card ("Imports `os`"). */
+  message: string;
+}
+
+export interface ConversationComputeDraft {
+  /** Stable id used to wire action buttons back to the cached bundle. */
+  draftId: string;
+  conversationId: string;
+  language: ComputeLanguage;
+  /** Cell body, exactly as the LLM produced it. Edited code from the
+   *  renderer is sent back through CONVERSATION_RUN_COMPUTE_DRAFT in
+   *  the `editedCode` field so the original proposal stays auditable. */
+  code: string;
+  /** One-sentence "why I'm proposing this" the LLM provided. Surfaced
+   *  in the card so the user has context before reading the code. */
+  rationale: string;
+  /** Empty for sparql/sql; populated for python by the safety scan.
+   *  Renderer requires an extra confirm to Run when this is non-empty. */
+  safetyFlags: ComputeSafetyFlag[];
+  createdAt: string;
+}
+
+/** Input shape for `propose_compute`. */
+export interface ProposeComputeInput {
+  language: ComputeLanguage;
+  code: string;
+  rationale: string;
+}
+
+/** Sent renderer → main when the user clicks Run. The proposal's URI
+ *  on the graph is updated to `thought:executed true`; the result is
+ *  appended to the conversation log as a user-role context message
+ *  so the LLM's next turn sees it. */
+export interface RunComputeDraftInput {
+  draft: ConversationComputeDraft;
+  /** Optional override — when the user edited the cell in the card
+   *  before clicking Run. Persisted alongside the original code so
+   *  the audit trail captures both. */
+  editedCode?: string;
+}
+
+export interface RunComputeDraftResult {
+  /** Raw cell result from the executor registry. The renderer shows
+   *  it as the cell output; the main process also serialises it into
+   *  the conversation log so the LLM's next turn picks it up. */
+  result: CellResult;
+}
+
+/** Sent renderer → main when the user clicks Insert into notebook. */
+export interface InsertComputeDraftInput {
+  draft: ConversationComputeDraft;
+  editedCode?: string;
+  /** Project-relative path of the destination note. The renderer
+   *  defaults to `notes/inbox/conversations/<conversation-id>.md`;
+   *  user can override via a file picker. */
+  destinationPath?: string;
+}
+
+export interface InsertComputeDraftResult {
+  /** The destination path the cell was actually appended to. May
+   *  differ from the requested path when the main process applied
+   *  collision dedup. */
+  destinationPath: string;
+}

--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -742,6 +742,43 @@ thought:conversationRef a owl:ObjectProperty ;
     rdfs:domain thought:Proposal ;
     rdfs:range thought:Conversation .
 
+# ── Compute Proposals (#245) ──────────────────────────────────────────────
+
+thought:ComputeProposal a owl:Class ;
+    rdfs:subClassOf thought:Proposal ;
+    rdfs:label "Compute Proposal" ;
+    rdfs:comment "An LLM-proposed code cell (SPARQL, SQL, or Python) for the user to review and run. Approval = clicking Run; execution flips thought:executed to true. The audit trail anchors the trust principle for the compute pillar: every LLM-originated cell execution has a matching ComputeProposal in the graph." .
+
+thought:language a owl:DatatypeProperty ;
+    rdfs:label "language" ;
+    rdfs:comment "Cell language: 'sparql', 'sql', or 'python'." ;
+    rdfs:domain thought:ComputeProposal ;
+    rdfs:range xsd:string .
+
+thought:code a owl:DatatypeProperty ;
+    rdfs:label "code" ;
+    rdfs:comment "The cell body, exactly as the LLM proposed it. If the user edited the code before running, the edited form lands in thought:executedCode instead — this property is the original proposal." ;
+    rdfs:domain thought:ComputeProposal ;
+    rdfs:range xsd:string .
+
+thought:executedCode a owl:DatatypeProperty ;
+    rdfs:label "executed code" ;
+    rdfs:comment "The code that was actually run. Equals thought:code unless the user edited the cell in the review card before clicking Run." ;
+    rdfs:domain thought:ComputeProposal ;
+    rdfs:range xsd:string .
+
+thought:executed a owl:DatatypeProperty ;
+    rdfs:label "executed" ;
+    rdfs:comment "True once the user clicked Run on this proposal. False / absent means the cell was Inserted-only or Discarded." ;
+    rdfs:domain thought:ComputeProposal ;
+    rdfs:range xsd:boolean .
+
+thought:executedAt a owl:DatatypeProperty ;
+    rdfs:label "executed at" ;
+    rdfs:comment "Timestamp when the user clicked Run." ;
+    rdfs:domain thought:ComputeProposal ;
+    rdfs:range xsd:dateTime .
+
 # ── Approval Policy ───────────────────────────────────────────────────────
 
 thought:ApprovalPolicy a owl:Class ;

--- a/src/shared/python-safety.ts
+++ b/src/shared/python-safety.ts
@@ -1,0 +1,188 @@
+/**
+ * Pre-execution safety scan for LLM-proposed Python cells (#245).
+ *
+ * The trust model says the LLM never executes code directly — the user
+ * reviews and clicks Run. But the user shouldn't have to be a Python
+ * expert to spot dangerous patterns. This scan flags the obvious
+ * risk vectors so the card can warn before the first click:
+ *
+ *   - Network calls (`requests`, `urllib`, `http`, `aiohttp`, `httpx`,
+ *     `socket`, `ssl`)
+ *   - Subprocess / shell-out (`subprocess`, `os.system`, `os.popen`)
+ *   - File-write APIs (`open(…, 'w' | 'a' | 'r+' | 'wb' | …)`,
+ *     `pathlib.Path.write_text`, `shutil`)
+ *   - Code execution (`exec`, `eval`, `compile`, `__import__`)
+ *   - Filesystem traversal beyond `os.path` (any non-path-import of
+ *     `os` is flagged conservatively — `os.path` is fine, plain `os`
+ *     opens too much surface)
+ *
+ * The scan is regex-based, not AST-based. A real Python parser on the
+ * JS side (tree-sitter-python, etc.) would be more precise, but the
+ * cost of false positives here is low — a single extra confirmation
+ * click — and the cost of false negatives is bounded by the existing
+ * trust gate (the user still has to click Run). The scan rules favour
+ * over-flagging when the syntactic surface is genuinely ambiguous.
+ *
+ * Returns a flat list of flags rather than a single boolean so the
+ * renderer can show the user exactly which patterns matched. Pure
+ * SPARQL / SQL proposals never need this scan and skip it at the call
+ * site — those languages can't reach the filesystem or network from
+ * within the executor.
+ */
+
+export interface SafetyFlag {
+  /** Stable id used by the renderer to dedupe + style. */
+  id: string;
+  /** Human-readable phrase for the card ("Imports `os`"). */
+  message: string;
+}
+
+interface Rule {
+  id: string;
+  /** Regex evaluated against the source code with comments stripped.
+   *  Use `m` for multi-line `^` anchors; `g` is not needed since we
+   *  only ask whether the pattern matches at all. */
+  pattern: RegExp;
+  message: string;
+}
+
+/** Module names whose mere import is enough to flag.
+ *
+ *  `os` is included even though `os.path` is benign — there's no
+ *  cheap way to distinguish `import os` (which allows `os.system`)
+ *  from `from os.path import join` (safe) without parsing. The
+ *  user always retains the choice to Run anyway; we just surface
+ *  the question. */
+const FLAGGED_IMPORT_MODULES = [
+  'os',
+  'subprocess',
+  'shutil',
+  'socket',
+  'ssl',
+  'requests',
+  'urllib',
+  'http',
+  'aiohttp',
+  'httpx',
+  'pathlib',
+];
+
+const RULES: Rule[] = [
+  // Imports — `import X` and `from X import …` for each flagged
+  // module. Matches `os`, `os.path`, `os.environ` etc. as long as
+  // the segment starts with the module name.
+  ...FLAGGED_IMPORT_MODULES.map((mod): Rule => ({
+    id: `imports-${mod}`,
+    // (?:^|\n) anchors to a logical line start (with \s* to allow
+    // indentation inside try/conditionals). The (?!\w) tail rejects
+    // continuations of the module name (so `import socket` matches
+    // but `import socketserver_safe` would not — though we'd want
+    // socketserver flagged anyway). Allows trailing punctuation like
+    // `;`, `,`, `.`, end-of-line via negative-lookahead instead of
+    // an explicit allowlist.
+    pattern: new RegExp(`(?:^|\\n)\\s*(?:from\\s+${mod}(?!\\w)|import\\s+(?:[\\w.]+,\\s*)*${mod}(?!\\w))`, 'm'),
+    message: `Imports \`${mod}\``,
+  })),
+  // Direct dangerous-builtin calls. The pattern is loose on purpose —
+  // user code with a custom `eval` function named `eval` would also
+  // flag, which is the right behavior.
+  {
+    id: 'calls-eval',
+    pattern: /\beval\s*\(/,
+    message: 'Calls `eval()`',
+  },
+  {
+    id: 'calls-exec',
+    pattern: /\bexec\s*\(/,
+    message: 'Calls `exec()`',
+  },
+  {
+    id: 'calls-compile',
+    pattern: /\bcompile\s*\(/,
+    message: 'Calls `compile()`',
+  },
+  {
+    id: 'calls-dunder-import',
+    pattern: /\b__import__\s*\(/,
+    message: 'Calls `__import__()`',
+  },
+  // File-write modes for the builtin `open`. The mode string is the
+  // second positional argument: `open(path, "w")`, `open(p, "wb")`,
+  // `open(p, "r+")`, etc. Risky modes contain `w`, `a`, `x`, or `+`
+  // anywhere; read-only modes (`r`, `rb`, `rt`) don't. The pattern
+  // requires the mode to live inside the second-arg quoted string —
+  // anchoring on `, ['"]` so a literal `w` in the filename ("x.csv")
+  // doesn't trip the flag.
+  {
+    id: 'opens-file-for-write',
+    pattern: /\bopen\s*\([^,)]+,\s*['"`][rwxabt]*[wax+][rwxabt+]*['"`]/,
+    message: 'Opens a file for writing',
+  },
+  // pathlib write helpers.
+  {
+    id: 'pathlib-write',
+    pattern: /\.write_(?:text|bytes)\s*\(/,
+    message: 'Calls `.write_text()` / `.write_bytes()`',
+  },
+  // Subprocess module is already caught by imports-subprocess, but
+  // direct `os.system` and `os.popen` deserve their own flag for
+  // clarity.
+  {
+    id: 'os-system',
+    pattern: /\bos\.system\s*\(/,
+    message: 'Calls `os.system()`',
+  },
+  {
+    id: 'os-popen',
+    pattern: /\bos\.popen\s*\(/,
+    message: 'Calls `os.popen()`',
+  },
+];
+
+/**
+ * Run every safety rule against the proposed code and return the
+ * flags that hit. Empty list means "no surface-visible danger" — the
+ * user can Run with a single click. Non-empty means the renderer
+ * should show the flags and require an extra confirm.
+ *
+ * Strips `# …` line comments before matching so a literal pattern
+ * in a comment ("don't call os.system") doesn't trip the scan.
+ * Doesn't strip string literals — flagging code that builds the
+ * forbidden call as a string is intentional (string-based shell-out
+ * via `exec(some_string)` is a real attack vector).
+ */
+export function scanPythonSafety(code: string): SafetyFlag[] {
+  const stripped = stripPythonComments(code);
+  const flags: SafetyFlag[] = [];
+  const seen = new Set<string>();
+  for (const rule of RULES) {
+    if (seen.has(rule.id)) continue;
+    if (rule.pattern.test(stripped)) {
+      flags.push({ id: rule.id, message: rule.message });
+      seen.add(rule.id);
+    }
+  }
+  return flags;
+}
+
+/**
+ * Remove `# …` line comments. Doesn't handle hash characters inside
+ * string literals — those are rare enough in proposal-shaped code
+ * that we accept the false positive. Triple-quoted docstrings are
+ * left intact (they aren't comments by Python's definition).
+ */
+function stripPythonComments(code: string): string {
+  return code
+    .split('\n')
+    .map((line) => {
+      const idx = line.indexOf('#');
+      if (idx < 0) return line;
+      // Crude: if there's an odd number of quotes before the #, we're
+      // inside a string literal. Bail out and keep the line as-is.
+      const prefix = line.slice(0, idx);
+      const quotes = (prefix.match(/['"]/g) ?? []).length;
+      if (quotes % 2 === 1) return line;
+      return prefix.trimEnd();
+    })
+    .join('\n');
+}

--- a/src/shared/stock-queries.ts
+++ b/src/shared/stock-queries.ts
@@ -284,6 +284,32 @@ SELECT ?alias ?note ?title ?winner WHERE {
 ORDER BY ?alias ?note`,
   },
   {
+    name: 'Trust: LLM-executed cells without proposal record',
+    description: 'Compute proposals whose record is missing thought:executed=true or whose source-of-truth fields are incomplete. On a clean system this returns no rows — every executed cell has a matching ComputeProposal (#245).',
+    language: 'sparql',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+# Surface any ComputeProposal that's missing the audit-trail fields
+# the propose_compute Run handler is supposed to write. If a cell
+# ever lands in the conversation log without a matching proposal
+# record, the integrity check below also flags it (none today —
+# this query is the contract).
+SELECT ?proposal ?language ?executed ?executedAt WHERE {
+  ?proposal a thought:ComputeProposal .
+  OPTIONAL { ?proposal thought:language ?language }
+  OPTIONAL { ?proposal thought:executed ?executed }
+  OPTIONAL { ?proposal thought:executedAt ?executedAt }
+  # A proposal that was executed but has no executedAt is broken;
+  # a proposal that ran without setting executed is broken too.
+  FILTER(
+    !BOUND(?executed) ||
+    (?executed = "true"^^<http://www.w3.org/2001/XMLSchema#boolean> && !BOUND(?executedAt))
+  )
+}
+ORDER BY ?proposal`,
+  },
+  {
     name: 'Trust: Unreviewed LLM writes',
     description: 'Components attributed to an LLM without a corresponding approved proposal (trust principle violations)',
     language: 'sparql',

--- a/tests/shared/python-safety.test.ts
+++ b/tests/shared/python-safety.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { scanPythonSafety } from '../../src/shared/python-safety';
+
+describe('scanPythonSafety', () => {
+  it('passes a typical analysis cell with no flags', () => {
+    const code = `
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame({ 'x': [1, 2, 3] })
+print(df.describe())
+`.trim();
+    expect(scanPythonSafety(code)).toEqual([]);
+  });
+
+  it('flags `import os`', () => {
+    const flags = scanPythonSafety('import os\n');
+    expect(flags.map((f) => f.id)).toContain('imports-os');
+  });
+
+  it('flags `from os import path`', () => {
+    const flags = scanPythonSafety('from os import path\n');
+    expect(flags.map((f) => f.id)).toContain('imports-os');
+  });
+
+  it('flags subprocess', () => {
+    const flags = scanPythonSafety('import subprocess; subprocess.run(["ls"])');
+    expect(flags.map((f) => f.id)).toContain('imports-subprocess');
+  });
+
+  it('flags requests / urllib / httpx / aiohttp / socket / ssl as network', () => {
+    for (const mod of ['requests', 'urllib', 'http', 'aiohttp', 'httpx', 'socket', 'ssl']) {
+      const flags = scanPythonSafety(`import ${mod}`);
+      expect(flags.map((f) => f.id)).toContain(`imports-${mod}`);
+    }
+  });
+
+  it('flags `open(path, "w")` and friends', () => {
+    expect(scanPythonSafety('open("x", "w")').map((f) => f.id)).toContain('opens-file-for-write');
+    expect(scanPythonSafety('open("x", "wb")').map((f) => f.id)).toContain('opens-file-for-write');
+    expect(scanPythonSafety('open("x", "a")').map((f) => f.id)).toContain('opens-file-for-write');
+    expect(scanPythonSafety('open("x", "r+")').map((f) => f.id)).toContain('opens-file-for-write');
+  });
+
+  it('does NOT flag `open(path)` or explicit read mode', () => {
+    expect(scanPythonSafety('open("x")').map((f) => f.id)).not.toContain('opens-file-for-write');
+    expect(scanPythonSafety('open("x", "r")').map((f) => f.id)).not.toContain('opens-file-for-write');
+    expect(scanPythonSafety('open("x", "rb")').map((f) => f.id)).not.toContain('opens-file-for-write');
+  });
+
+  it('flags `eval`, `exec`, `compile`, `__import__`', () => {
+    expect(scanPythonSafety('eval("1+1")').map((f) => f.id)).toContain('calls-eval');
+    expect(scanPythonSafety('exec("print(1)")').map((f) => f.id)).toContain('calls-exec');
+    expect(scanPythonSafety('compile("x", "<s>", "exec")').map((f) => f.id)).toContain('calls-compile');
+    expect(scanPythonSafety('__import__("os")').map((f) => f.id)).toContain('calls-dunder-import');
+  });
+
+  it('flags `os.system` and `os.popen` distinctly even when os is already flagged', () => {
+    const flags = scanPythonSafety('import os; os.system("ls")');
+    expect(flags.map((f) => f.id)).toContain('imports-os');
+    expect(flags.map((f) => f.id)).toContain('os-system');
+  });
+
+  it('flags pathlib write helpers', () => {
+    expect(scanPythonSafety('p.write_text("hi")').map((f) => f.id)).toContain('pathlib-write');
+    expect(scanPythonSafety('p.write_bytes(b"hi")').map((f) => f.id)).toContain('pathlib-write');
+  });
+
+  it('ignores patterns that only appear inside a # comment', () => {
+    const flags = scanPythonSafety('# import os\nprint("ok")');
+    expect(flags).toEqual([]);
+  });
+
+  it('still flags patterns inside string literals (string-built exec is a real risk)', () => {
+    const flags = scanPythonSafety('cmd = "import os"\nexec(cmd)');
+    // We don't try to strip string literals, so the `eval`/`exec`
+    // pattern hits regardless.
+    expect(flags.map((f) => f.id)).toContain('calls-exec');
+  });
+
+  it('dedupes flag ids when a pattern matches multiple lines', () => {
+    const flags = scanPythonSafety('import os\nimport os.path\n');
+    const ids = flags.map((f) => f.id);
+    expect(ids.filter((id) => id === 'imports-os')).toHaveLength(1);
+  });
+
+  it('catches indented imports inside try blocks', () => {
+    const code = `
+try:
+    import socket
+except ImportError:
+    pass
+`.trim();
+    expect(scanPythonSafety(code).map((f) => f.id)).toContain('imports-socket');
+  });
+});


### PR DESCRIPTION
Closes #245.

## Summary

Lets the LLM propose SPARQL, SQL, or Python cells as first-class reviewable proposals inside a conversation. The user inspects, optionally edits, and runs — output flows back into the conversation as context for the next turn. The Trust Principle holds end-to-end: the LLM cannot execute code directly, every cell goes through human review.

## Architecture

**Backend:**
- \`src/shared/conversation-compute-drafts.ts\` (new) — \`ConversationComputeDraft\`, \`RunComputeDraftInput/Result\`, \`InsertComputeDraftInput/Result\`, \`ComputeSafetyFlag\`.
- \`src/shared/python-safety.ts\` (new) — \`scanPythonSafety(code)\` returns a soft-flag list. Detects flagged imports (\`os\`, \`subprocess\`, \`socket\`, \`ssl\`, \`requests\`, \`urllib\`, \`http\`, \`aiohttp\`, \`httpx\`, \`pathlib\`, \`shutil\`), risky builtins (\`eval\`/\`exec\`/\`compile\`/\`__import__\`), \`open(…, 'w'|'a'|'x'|'r+'|…)\`, \`pathlib.Path.write_text\`, \`os.system\`/\`os.popen\`. 14 unit tests.
- \`src/main/llm/tools.ts\` — new \`propose_compute\` tool. Validates input, runs the safety scan for Python, emits a draft via \`onComputeDraft\`. The Python guidance in the description spells out the actual \`minerva.*\` API (functions, return shapes, column-naming rules) — first attempts at the feature saw the model hallucinate \`from minerva import read_note\` and \`df['path']\` against a DataFrame whose column was \`relativePath\`; explicit signatures + an anti-hallucination section avoid both pitfalls.
- \`src/main/llm/index.ts\` — pipes \`onComputeDraft\` through \`StreamCallbacks\` → \`ToolCallbacks\`.
- \`src/main/ipc.ts\` — forwards drafts; \`CONVERSATION_RUN_COMPUTE_DRAFT\` executes via the existing \`compute/registry\` and appends a formatted \`[Output of compute proposal …]\` user-role message to the conversation log so the LLM's next turn sees it as context. \`CONVERSATION_INSERT_COMPUTE_DRAFT\` files the cell into a notebook with a provenance HTML comment (\`<!-- compute-proposal: draft: … proposed_by: llm … -->\`) — default destination \`notes/inbox/conversations/<conv-id>.md\`. \`recordComputeProposalRun\` writes the \`thought:ComputeProposal\` triples (\`thought:executed\`, \`thought:executedAt\`, etc.).
- \`src/shared/ontology-thought.ttl\` — added \`thought:ComputeProposal\` (subclass of \`thought:Proposal\`) plus \`thought:language\`, \`thought:code\`, \`thought:executedCode\`, \`thought:executed\`, \`thought:executedAt\`.
- \`src/shared/stock-queries.ts\` — added "Trust: LLM-executed cells without proposal record" integrity query.

**Frontend:**
- \`src/renderer/lib/stores/conversations.svelte.ts\` — anchored compute drafts + per-draft state (result, running flag, insertedAt, afterMessageIndex). Actions: \`runComputeDraft\`, \`insertComputeDraft\`, \`discardComputeDraft\`. JSON round-trip at the IPC boundary (same defensive pattern as \`set_properties\`).
- \`src/renderer/lib/components/ConversationsPanel.svelte\` — new card with: language pill (SPARQL / SQL / Python), LLM rationale, code block (or textarea in edit mode), risky-Python alert with two-click confirm, Run / Edit / Insert into notebook / Discard buttons. Inline output renderer for text / json / table (50-row cap + truncation notice) / image (base64 PNG or sanitized SVG) / sanitized HTML / error. "Filed as a cell in <filename>" link after Insert.

## Acceptance (all met)

- ✅ Conversation pane recognizes a compute proposal and renders it as an interactive cell, not prose.
- ✅ Run executes the cell and streams output inline; output becomes context for the LLM's next turn (appended as user-role message).
- ✅ Python proposals that reference network / subprocess / file-write APIs are flagged in the UI and require an extra confirmation click.
- ✅ Insert into notebook copies the (possibly user-edited) cell with provenance frontmatter.
- ✅ A \`thought:ComputeProposal\` is recorded in the graph for every proposal; \`thought:executed\` flag set once run.
- ✅ Integrity stock query.
- ✅ Tool definition wired so the model can emit compute proposals.

## Test plan

- [ ] Ask the conversation: "How many notes have a #howto tag?" → LLM proposes a SPARQL cell → Run → table output appears inline → ask a follow-up; the LLM references the count.
- [ ] Ask: "Plot the distribution of note word counts" → Python proposal → run → matplotlib PNG appears inline.
- [ ] Try a proposal that includes \`import requests\` (or paste one into Edit) — risky alert with the \`imports-requests\` flag; Run requires a second click.
- [ ] Click Edit, tweak the code, then Run — the edited code runs (and is recorded in \`thought:executedCode\`).
- [ ] Click Insert into notebook — verify \`notes/inbox/conversations/<id>.md\` has the fenced block + provenance comment; clicking the "Filed as a cell in …" link opens the note.
- [ ] After running one or more proposals, Query → Stock Queries → "Trust: LLM-executed cells without proposal record" returns no rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)