### PR TITLE
design: SVG icon set replaces Unicode glyphs (#544)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -6,6 +6,7 @@
   import QueryPanel from './lib/components/QueryPanel.svelte';
   import RightSidebar from './lib/components/RightSidebar.svelte';
   import StatusBar from './lib/components/StatusBar.svelte';
+  import Icon from './lib/components/Icon.svelte';
   import type { CursorInfo } from './lib/components/Editor.svelte';
   import Preview from './lib/components/Preview.svelte';
   import SourceDetail from './lib/components/SourceDetail.svelte';
@@ -2400,7 +2401,7 @@
               class:active={rightSidebarVisible}
               onclick={() => { rightSidebarVisible = !rightSidebarVisible; }}
               title="Toggle Right Sidebar (Cmd+Shift+B)"
-            >&#x2759;</button>
+            ><Icon name="outline" size={12} /></button>
           </div>
           <div class="editor-content" class:split={viewMode === 'split'}>
             {#if viewMode === 'source' || viewMode === 'split'}

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import Icon from './Icon.svelte';
   import { getConversationsStore } from '../stores/conversations.svelte';
   import { getEditorStore } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
@@ -430,13 +431,13 @@
               class="tab-close"
               aria-label="Close conversation"
               onclick={(e) => handleCloseTab(tab.id, e)}
-            >&#x2715;</button>
+            ><Icon name="close" size={10} /></button>
           </div>
         {/each}
         <button type="button" class="new-tab" onclick={handleNewTab} title="New conversation">+</button>
       </div>
       <div class="header-controls">
-        <button type="button" class="hide-btn" onclick={store.hide} title="Hide panel (does not archive any conversations)">&#x2715;</button>
+        <button type="button" class="hide-btn" onclick={store.hide} title="Hide panel (does not archive any conversations)"><Icon name="close" size={11} /></button>
       </div>
     </div>
 

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import Icon from './Icon.svelte';
   import { EditorView, keymap } from '@codemirror/view';
   import { basicSetup } from 'codemirror';
   import { markdown } from '@codemirror/lang-markdown';
@@ -955,7 +956,7 @@
     {/if}
     <div class="separator"></div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Format &#x25B8;</span>
+      <span class="submenu-trigger">Format<Icon name="chevronRight" size={10} /></span>
       <div class="submenu">
         <button onclick={() => runCmd(toggleBold)}>Bold</button>
         <button onclick={() => runCmd(toggleItalic)}>Italic</button>
@@ -964,7 +965,7 @@
       </div>
     </div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Paragraph &#x25B8;</span>
+      <span class="submenu-trigger">Paragraph<Icon name="chevronRight" size={10} /></span>
       <div class="submenu">
         <button onclick={() => runCmd(toggleH1)}>Heading 1</button>
         <button onclick={() => runCmd(toggleH2)}>Heading 2</button>
@@ -976,7 +977,7 @@
       </div>
     </div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Insert &#x25B8;</span>
+      <span class="submenu-trigger">Insert<Icon name="chevronRight" size={10} /></span>
       <div class="submenu">
         <button onclick={() => runCmd(insertWikiLink)}>Wiki Link</button>
         <button onclick={() => runCmd(insertLink)}>URL Link</button>
@@ -999,7 +1000,7 @@
       <div class="separator"></div>
       {#if learningTools.length > 0}
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Learning &#x25B8;</span>
+          <span class="submenu-trigger">Learning<Icon name="chevronRight" size={10} /></span>
           <div class="submenu">
             {#each learningTools.filter((t) => contextMenu!.hasSelection || !t.requiresSelection) as tool}
               <button onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
@@ -1009,7 +1010,7 @@
       {/if}
       {#if analysisTools.length > 0}
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Analysis &#x25B8;</span>
+          <span class="submenu-trigger">Analysis<Icon name="chevronRight" size={10} /></span>
           <div class="submenu">
             {#each analysisTools as tool}
               <button onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
@@ -1020,7 +1021,7 @@
     {/if}
     {#if onToolInvoke}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
-        <span class="submenu-trigger">Research &#x25B8;</span>
+        <span class="submenu-trigger">Research<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           <!-- Decompose into Claims is a conversational tool
                (research.decompose-into-claims). Routes through the
@@ -1050,7 +1051,7 @@
     <div class="separator"></div>
     {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onMerge || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose || onCrystallize}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
-        <span class="submenu-trigger">Refactor &#x25B8;</span>
+        <span class="submenu-trigger">Refactor<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           {#if onRename}
             <button onclick={() => handleMenuAction(() => onRename?.())}>Rename&hellip;</button>
@@ -1111,7 +1112,7 @@
     <button onclick={() => handleMenuAction(() => onBookmark?.())}>Bookmark This Note</button>
     <div class="separator"></div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Open In &#x25B8;</span>
+      <span class="submenu-trigger">Open In<Icon name="chevronRight" size={10} /></span>
       <div class="submenu">
         <button onclick={() => { void api.shell.revealFile(filePath); closeMenu(); }}>Reveal in Finder</button>
         <button onclick={() => { void api.shell.openInDefault(filePath); closeMenu(); }}>Open in Default App</button>
@@ -1216,7 +1217,10 @@
   }
 
   .submenu-trigger {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 6px 12px;
     font-size: 12px;
     color: var(--text);

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { NoteFile } from '../../../shared/types';
   import FileTree from './FileTree.svelte';
+  import Icon from './Icon.svelte';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { extractTagsFromContent } from '../../../shared/refactor/auto-tag';
@@ -275,7 +276,7 @@
         {/if}
       {/if}
       <div class="submenu-item">
-        <span class="submenu-trigger">Open In &#x25B8;</span>
+        <span class="submenu-trigger">Open In <Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           <button onclick={() => { void api.shell.revealFile(contextMenu!.target); contextMenu = null; }}>Reveal in Finder</button>
           <button onclick={() => { void api.shell.openInDefault(contextMenu!.target!); contextMenu = null; }}>Open in Default App</button>
@@ -408,7 +409,10 @@
   }
 
   .submenu-trigger {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 6px 12px;
     font-size: 12px;
     color: var(--text);

--- a/src/renderer/lib/components/Icon.svelte
+++ b/src/renderer/lib/components/Icon.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { ICONS, type IconName } from './icons/registry';
+
+  interface Props {
+    name: IconName;
+    size?: number;
+    color?: string;
+    title?: string;
+  }
+
+  let { name, size = 16, color, title }: Props = $props();
+
+  const path = $derived(ICONS[name]);
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 16 16"
+  fill="none"
+  stroke={color ?? 'currentColor'}
+  stroke-width="1.4"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  role={title ? 'img' : undefined}
+  aria-label={title}
+  aria-hidden={title ? undefined : true}
+  style="display:block;flex-shrink:0"
+>
+  {@html path}
+</svg>

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import MarkdownIt from 'markdown-it';
   // The Token *value* (used below for `new Token(...)` to inject a
   // task-list checkbox) is now recovered from `inlineTok.constructor`
@@ -1724,7 +1725,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   >
     {#if onToolInvoke && learningTools.length > 0}
       <div class="submenu-item" onmouseenter={adjustNoteSubmenu}>
-        <span class="submenu-trigger">Learning &#x25B8;</span>
+        <span class="submenu-trigger">Learning<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           {#each learningTools as tool}
             <button onclick={() => runMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
@@ -1734,7 +1735,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     {/if}
     {#if onToolInvoke && analysisTools.length > 0}
       <div class="submenu-item" onmouseenter={adjustNoteSubmenu}>
-        <span class="submenu-trigger">Analysis &#x25B8;</span>
+        <span class="submenu-trigger">Analysis<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           {#each analysisTools as tool}
             <button onclick={() => runMenuAction(() => onToolInvoke?.(tool.id))}>{tool.name}</button>
@@ -1744,7 +1745,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     {/if}
     {#if onToolInvoke}
       <div class="submenu-item" onmouseenter={adjustNoteSubmenu}>
-        <span class="submenu-trigger">Research &#x25B8;</span>
+        <span class="submenu-trigger">Research<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           <button onclick={() => runMenuAction(() => onToolInvoke?.('research.decompose-into-claims'))}>Decompose into Claims</button>
         </div>
@@ -1762,7 +1763,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     {#if notePath}
       <div class="separator"></div>
       <div class="submenu-item" onmouseenter={adjustNoteSubmenu}>
-        <span class="submenu-trigger">Open In &#x25B8;</span>
+        <span class="submenu-trigger">Open In<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           <button onclick={() => { if (notePath) void api.shell.revealFile(notePath); noteMenu = null; }}>Reveal in Finder</button>
           <button onclick={() => { if (notePath) void api.shell.openInDefault(notePath); noteMenu = null; }}>Open in Default App</button>
@@ -2471,7 +2472,10 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   .note-context-menu button:hover { background: var(--bg-button); }
   .note-context-menu .submenu-item { position: relative; }
   .note-context-menu .submenu-trigger {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 6px 12px;
     font-size: 12px;
     color: var(--text);

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -10,10 +10,26 @@
   import ProposalsPanel from './right-sidebar/ProposalsPanel.svelte';
   import TablesPanel from './right-sidebar/TablesPanel.svelte';
   import CitationsPanel from './right-sidebar/CitationsPanel.svelte';
+  import Icon from './Icon.svelte';
+  import type { IconName } from './icons/registry';
 
   type PanelType =
     | 'outline' | 'footnotes' | 'properties' | 'outgoing' | 'backlinks' | 'tags' | 'tables' | 'citations'
     | 'bookmarks' | 'inspections' | 'proposals';
+
+  const PANEL_TABS: ReadonlyArray<{ id: PanelType; label: string; icon: IconName }> = [
+    { id: 'outline',     label: 'Outline',        icon: 'outline' },
+    { id: 'footnotes',   label: 'Footnotes',      icon: 'footnotes' },
+    { id: 'properties',  label: 'Properties',     icon: 'properties' },
+    { id: 'outgoing',    label: 'Outgoing Links', icon: 'outgoing' },
+    { id: 'backlinks',   label: 'Backlinks',      icon: 'backlinks' },
+    { id: 'tags',        label: 'Tags',           icon: 'tags' },
+    { id: 'tables',      label: 'Tables',         icon: 'tables' },
+    { id: 'citations',   label: 'Citations',      icon: 'citations' },
+    { id: 'bookmarks',   label: 'Bookmarks',      icon: 'bookmark' },
+    { id: 'inspections', label: 'Inspections',    icon: 'inspections' },
+    { id: 'proposals',   label: 'Proposals',      icon: 'proposals' },
+  ];
 
   interface Props {
     activeFilePath: string | null;
@@ -93,72 +109,14 @@
   <!-- svelte-ignore a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
   <div class="resize-handle" class:dragging onmousedown={startResize}></div>
   <div class="panel-tabs">
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'outline'}
-      onclick={() => activePanel = 'outline'}
-      title="Outline"
-    >&#x2630;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'footnotes'}
-      onclick={() => activePanel = 'footnotes'}
-      title="Footnotes"
-    >&#x2042;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'properties'}
-      onclick={() => activePanel = 'properties'}
-      title="Properties"
-    >&#x2261;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'outgoing'}
-      onclick={() => activePanel = 'outgoing'}
-      title="Outgoing Links"
-    >&#x2192;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'backlinks'}
-      onclick={() => activePanel = 'backlinks'}
-      title="Backlinks"
-    >&#x2190;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'tags'}
-      onclick={() => activePanel = 'tags'}
-      title="Tags"
-    >#</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'tables'}
-      onclick={() => activePanel = 'tables'}
-      title="Tables"
-    >&#x229E;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'citations'}
-      onclick={() => activePanel = 'citations'}
-      title="Citations"
-    >&#x201C;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'bookmarks'}
-      onclick={() => activePanel = 'bookmarks'}
-      title="Bookmarks"
-    >&#x2606;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'inspections'}
-      onclick={() => activePanel = 'inspections'}
-      title="Inspections"
-    >&#x26A0;</button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'proposals'}
-      onclick={() => activePanel = 'proposals'}
-      title="Proposals"
-    >&#x2713;</button>
+    {#each PANEL_TABS as t (t.id)}
+      <button
+        class="panel-tab"
+        class:active={activePanel === t.id}
+        onclick={() => activePanel = t.id}
+        title={t.label}
+      ><Icon name={t.icon} size={14} /></button>
+    {/each}
   </div>
 
   <div class="panel-content">

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -4,6 +4,7 @@
   import TagPanel from './TagPanel.svelte';
   import SourcesPanel from './SourcesPanel.svelte';
   import TablesPanel from './TablesPanel.svelte';
+  import Icon from './Icon.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { getSidebarSelectionStore } from '../stores/sidebar-selection.svelte';
   import { flattenVisible } from '../sidebar-tree-utils';
@@ -401,25 +402,25 @@
       class:active={activePanel === 'notes'}
       onclick={() => activePanel = 'notes'}
       title="Notes"
-    >&#x25A4;</button>
+    ><Icon name="notes" size={14} /></button>
     <button
       class="panel-tab"
       class:active={activePanel === 'sites'}
       onclick={() => activePanel = 'sites'}
       title="Sites"
-    >&#x2761;</button>
+    ><Icon name="sites" size={14} /></button>
     <button
       class="panel-tab"
       class:active={activePanel === 'tags'}
       onclick={() => activePanel = 'tags'}
       title="Tags"
-    >#</button>
+    ><Icon name="tags" size={14} /></button>
     <button
       class="panel-tab"
       class:active={activePanel === 'tables'}
       onclick={() => activePanel = 'tables'}
       title="Tables"
-    >&#x229E;</button>
+    ><Icon name="tables" size={14} /></button>
   </div>
 
   <div class="panel-content">
@@ -432,14 +433,14 @@
             onclick={expandAll}
             title="Expand all folders"
             aria-label="Expand all folders"
-          >&#x2B0C;</button>
+          ><Icon name="expandAll" size={14} /></button>
           <button
             type="button"
             class="tool-btn"
             onclick={collapseAll}
             title="Collapse all folders"
             aria-label="Collapse all folders"
-          >&#x2B0D;</button>
+          ><Icon name="collapseAll" size={14} /></button>
           <button
             type="button"
             class="tool-btn"
@@ -448,7 +449,7 @@
             title={autoReveal ? 'Auto-reveal active file: on' : 'Auto-reveal active file: off'}
             aria-label="Toggle auto-reveal active file"
             aria-pressed={autoReveal}
-          >&#x29BF;</button>
+          ><Icon name="reveal" size={14} /></button>
         </div>
         {#if selectionStore.count > 0}
           <div class="selection-badge">

--- a/src/renderer/lib/components/StatusBar.svelte
+++ b/src/renderer/lib/components/StatusBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CursorInfo } from './Editor.svelte';
+  import Icon from './Icon.svelte';
 
   interface Props {
     cursor: CursorInfo;
@@ -41,12 +42,12 @@
         onclick={onShowBacklinks}
         title="Show backlinks ({backlinkCount} note{backlinkCount === 1 ? '' : 's'} link here)"
       >
-        &#x2190; {backlinkCount}
+        <Icon name="backlinks" size={12} /> {backlinkCount}
       </button>
     {/if}
     {#if inspectionCount > 0}
       <button class="status-item clickable inspection-count" onclick={onShowInspections} title="Show inspections">
-        &#x26A0; {inspectionCount}
+        <Icon name="warn" size={12} /> {inspectionCount}
       </button>
     {/if}
     <span class="status-item">{cursor.wordCount} words</span>
@@ -76,6 +77,9 @@
   }
 
   .status-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     font-size: 11px;
     color: var(--text-muted);
     white-space: nowrap;

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -2,6 +2,7 @@
   import type { Tab } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import Icon from './Icon.svelte';
 
   interface Props {
     tabs: Tab[];
@@ -60,8 +61,8 @@
       role="tab"
       tabindex="0"
     >
-      {#if tab.type === 'query'}<span class="tab-icon">&#x25B7;</span>{/if}
-      {#if tab.type === 'source'}<span class="tab-icon">&#x1F4D6;</span>{/if}
+      {#if tab.type === 'query'}<span class="tab-icon"><Icon name="query" size={12} /></span>{/if}
+      {#if tab.type === 'source'}<span class="tab-icon"><Icon name="source" size={12} /></span>{/if}
       <span class="tab-name">
         {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
         {:else if tab.type === 'query'}{tab.title}
@@ -74,7 +75,7 @@
         class="close-btn"
         onclick={(e) => { e.stopPropagation(); onClose(i); }}
         title="Close"
-      >&times;</button>
+      ><Icon name="close" size={11} /></button>
     </div>
   {/each}
 </div>
@@ -95,7 +96,7 @@
       <button onclick={() => { onSwitch(contextMenu!.index); contextMenu = null; onOpenConversation?.(); }}>Ask About This...</button>
       <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') onBookmark?.(t.relativePath); contextMenu = null; }}>Bookmark This Note</button>
       <div class="submenu-item">
-        <span class="submenu-trigger">Open In &#x25B8;</span>
+        <span class="submenu-trigger">Open In <Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
           <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') void api.shell.revealFile(t.relativePath); contextMenu = null; }}>Reveal in Finder</button>
           <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') void api.shell.openInDefault(t.relativePath); contextMenu = null; }}>Open in Default App</button>
@@ -228,7 +229,10 @@
   }
 
   .submenu-trigger {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 6px 12px;
     font-size: 12px;
     color: var(--text);

--- a/src/renderer/lib/components/TitleBar.svelte
+++ b/src/renderer/lib/components/TitleBar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
+
   interface Props {
     notebaseName: string;
     fileName: string;
@@ -19,13 +21,13 @@
       disabled={!canGoBack}
       onclick={onNavBack}
       title="Back (Cmd+[)"
-    >&#x2190;</button>
+    ><Icon name="back" size={14} /></button>
     <button
       class="nav-btn"
       disabled={!canGoForward}
       onclick={onNavForward}
       title="Forward (Cmd+])"
-    >&#x2192;</button>
+    ><Icon name="forward" size={14} /></button>
   </div>
   <span class="titlebar-text">
     {#if notebaseName}
@@ -63,7 +65,10 @@
   }
 
   .nav-btn {
-    padding: 2px 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3px 6px;
     border: none;
     border-radius: 3px;
     background: none;

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -2,6 +2,7 @@
   import { getToolPanelStore } from '../stores/tool-panel.svelte';
   import { handleToolOutput } from '../tools/output';
   import { api } from '../ipc/client';
+  import Icon from './Icon.svelte';
   import type { ToolContext } from '../../../shared/tools/types';
   import { isMissingApiKeyError } from '../../../shared/llm-errors';
 
@@ -148,7 +149,7 @@
         <span class="tool-name">{panel.activeTool?.name ?? 'Tool'}</span>
         <span class="tool-desc">{panel.activeTool?.description ?? ''}</span>
       </div>
-      <button class="close-btn" onclick={() => { panel.close(); running = false; }}>&#x2715;</button>
+      <button class="close-btn" onclick={() => { panel.close(); running = false; }}><Icon name="close" size={11} /></button>
     </div>
 
     {#if panel.panelState === 'configure'}

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -1,0 +1,122 @@
+/**
+ * Minerva icon set — monoline, 1.4 stroke, 16px native.
+ *
+ * Source of truth is the design-review JSX reference at
+ * docs/design/2026-05-design-review/project/components/icons.jsx — keep
+ * this file in sync. Each entry is the inner SVG markup for a 16×16
+ * viewBox, dropped into <Icon> with {@html ...}.
+ *
+ * Style notes from the spec: each icon's grid is built around (8, 8).
+ * Classical, slightly editorial; owl-coded where it suits. Avoid fills
+ * unless the symbol absolutely requires it (the brand mark, dots, and
+ * the query play-triangle do).
+ */
+export const ICONS = {
+  // ── Navigation ────────────────────────────────────────────────────
+  back: '<path d="M10 3 4.5 8 10 13"/><path d="M4.5 8H13"/>',
+  forward: '<path d="M6 3 11.5 8 6 13"/><path d="M11.5 8H3"/>',
+
+  // ── Left sidebar panels ───────────────────────────────────────────
+  notes:
+    '<path d="M3.5 2.5h6L12.5 5.5v8H3.5z"/>' +
+    '<path d="M9.5 2.5v3h3"/>' +
+    '<path d="M5.5 8h5M5.5 10.5h3.5"/>',
+  sites:
+    '<path d="M3 3h10v10H3z"/><path d="M3 5h10"/><path d="M5.5 3v10"/>',
+  tags:
+    '<path d="M2.5 7.5V3h4.5l6.5 6.5-4.5 4.5L2.5 7.5z"/>' +
+    '<circle cx="5.25" cy="5.75" r=".75"/>',
+  tables:
+    '<rect x="2.5" y="3" width="11" height="10" rx=".5"/>' +
+    '<path d="M2.5 6h11M2.5 9.5h11M6.5 6v7M10 6v7"/>',
+
+  // ── Right sidebar panels ──────────────────────────────────────────
+  outline: '<path d="M3 4h2M3 8h2M3 12h2"/><path d="M7 4h6M7 8h5M7 12h4"/>',
+  footnotes:
+    '<circle cx="4.5" cy="4.5" r="1.2"/>' +
+    '<circle cx="4.5" cy="11.5" r="1.2"/>' +
+    '<path d="M7.5 4.5h6M7.5 11.5h6"/>' +
+    '<path d="M4.5 7v2"/>',
+  properties:
+    '<circle cx="4" cy="5" r=".75"/>' +
+    '<circle cx="4" cy="11" r=".75"/>' +
+    '<path d="M6.5 5h6.5M6.5 11h4.5"/>',
+  outgoing:
+    '<circle cx="5.5" cy="8" r="2.5"/>' +
+    '<path d="M8.5 8H14"/>' +
+    '<path d="M11.5 5.5 14 8l-2.5 2.5"/>',
+  backlinks:
+    '<circle cx="10.5" cy="8" r="2.5"/>' +
+    '<path d="M8 8H2"/>' +
+    '<path d="M4.5 5.5 2 8l2.5 2.5"/>',
+  citations:
+    '<path d="M3 5.5c0-1 .5-1.5 1.5-1.5M5.5 4c-1 .5-1.5 1-1.5 2.5v3H6V6.5H4.5"/>' +
+    '<path d="M9.5 5.5c0-1 .5-1.5 1.5-1.5M12 4c-1 .5-1.5 1-1.5 2.5v3h2V6.5H11"/>',
+  bookmark: '<path d="M4 2.5h8v11l-4-2.5-4 2.5z"/>',
+  inspections:
+    '<circle cx="8" cy="8" r="5"/>' +
+    '<circle cx="8" cy="8" r="2"/>' +
+    '<circle cx="8" cy="8" r=".6" fill="currentColor"/>',
+  proposals:
+    '<circle cx="8" cy="8" r="5.5"/>' +
+    '<path d="m5.5 8.25 1.75 1.75L10.5 6.5"/>',
+
+  // ── Tab icons ─────────────────────────────────────────────────────
+  query:
+    '<path d="M3 4h2M3 12h2M11 4h2M11 12h2M3 4v8M13 4v8"/>' +
+    '<path d="m6.5 6 3.5 2-3.5 2z" fill="currentColor" stroke="none"/>',
+  source:
+    '<path d="M3.5 3.5h6.5a2.5 2.5 0 0 1 2.5 2.5v7h-7a2 2 0 0 0-2 2v-9a2 2 0 0 1 2-2z"/>' +
+    '<path d="M3.5 11.5h9"/>' +
+    '<path d="M6 6.5h3.5"/>',
+
+  // ── Tree / disclosure ─────────────────────────────────────────────
+  chevronRight: '<path d="m6 4 4 4-4 4"/>',
+  chevronDown: '<path d="m4 6 4 4 4-4"/>',
+  expandAll: '<path d="m4 6 4-3 4 3"/><path d="m4 10 4 3 4-3"/>',
+  collapseAll: '<path d="m4 3 4 3 4-3"/><path d="m4 13 4-3 4 3"/>',
+  reveal:
+    '<circle cx="8" cy="8" r="2"/>' +
+    '<path d="M2 8c1.5-3 3.5-4.5 6-4.5s4.5 1.5 6 4.5c-1.5 3-3.5 4.5-6 4.5S3.5 11 2 8z"/>',
+
+  // ── Actions / status ──────────────────────────────────────────────
+  close: '<path d="m4 4 8 8M12 4l-8 8"/>',
+  plus: '<path d="M8 3v10M3 8h10"/>',
+  search: '<circle cx="7" cy="7" r="3.5"/><path d="m9.5 9.5 3.5 3.5"/>',
+  settings:
+    '<circle cx="8" cy="8" r="2"/>' +
+    '<path d="M8 2v1.5M8 12.5V14M3.05 3.05l1.06 1.06M11.89 11.89l1.06 1.06M2 8h1.5M12.5 8H14M3.05 12.95l1.06-1.06M11.89 4.11l1.06-1.06"/>',
+  warn:
+    '<path d="M8 3 14 13H2z"/>' +
+    '<path d="M8 6.5v3.5"/>' +
+    '<circle cx="8" cy="11.6" r=".5" fill="currentColor" stroke="none"/>',
+  check: '<path d="m3.5 8.25 3 3L12.5 5.5"/>',
+  dot: '<circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none"/>',
+
+  // ── Editor / formatting ───────────────────────────────────────────
+  link:
+    '<path d="M6.5 9.5 9.5 6.5"/>' +
+    '<path d="M7 4.5h2.5a2.5 2.5 0 0 1 0 5H8.5"/>' +
+    '<path d="M9 11.5H6.5a2.5 2.5 0 0 1 0-5H7.5"/>',
+  folder:
+    '<path d="M2.5 4.5a1 1 0 0 1 1-1H6l1.5 1.5h5a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1z"/>',
+  folderOpen:
+    '<path d="M2.5 12V5a1 1 0 0 1 1-1H6l1.5 1.5h5a1 1 0 0 1 1 1v.5"/>' +
+    '<path d="m2.5 12 1.4-4.5h10L12.5 12z"/>',
+
+  // ── Conversations / LLM ───────────────────────────────────────────
+  conversation:
+    '<path d="M2.5 4.5a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H6.5L4 13v-2.5H3.5a1 1 0 0 1-1-1z"/>',
+  sparkle:
+    '<path d="M8 2.5v3M8 10.5v3M2.5 8h3M10.5 8h3"/>' +
+    '<path d="m4.5 4.5 1.5 1.5M10 10l1.5 1.5M11.5 4.5 10 6M6 10l-1.5 1.5"/>',
+  send: '<path d="M2.5 8 13.5 3 11 13.5 7.5 9.5z"/>',
+
+  // ── Brand ─────────────────────────────────────────────────────────
+  minervaMark:
+    '<circle cx="8" cy="8" r="6"/>' +
+    '<circle cx="8" cy="8" r="2.5"/>' +
+    '<circle cx="8" cy="8" r=".8" fill="currentColor" stroke="none"/>',
+} as const;
+
+export type IconName = keyof typeof ICONS;

--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -2,6 +2,7 @@
   import { getBookmarksStore } from '../../stores/bookmarks.svelte';
   import type { BookmarkNode } from '../../../../shared/types';
   import Ribbon from './Ribbon.svelte';
+  import Icon from '../Icon.svelte';
   import { clampMenuToViewport } from '../../utils/menuClamp';
 
   interface Props {
@@ -155,7 +156,7 @@
       ondragover={handleDragOver}
       ondrop={(e) => { e.stopPropagation(); handleDrop(e, node.id); }}
     >
-      <span class="bm-icon">{expanded[node.id] ? '&#x25BE;' : '&#x25B8;'}</span>
+      <span class="bm-icon"><Icon name={expanded[node.id] ? 'chevronDown' : 'chevronRight'} size={11} /></span>
       <span class="bm-name">{node.name}</span>
     </div>
     {#if expanded[node.id] || search.trim()}
@@ -175,7 +176,7 @@
       draggable={true}
       ondragstart={(e) => handleDragStart(e, node.id)}
     >
-      <span class="bm-icon">&#x2606;</span>
+      <span class="bm-icon"><Icon name="bookmark" size={11} /></span>
       <span class="bm-name">{node.name}</span>
     </div>
   {/if}
@@ -236,6 +237,9 @@
   .bm-item:hover { background: var(--bg-button); }
 
   .bm-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-size: 11px;
     width: 12px;
     flex-shrink: 0;

--- a/src/renderer/lib/components/right-sidebar/Ribbon.svelte
+++ b/src/renderer/lib/components/right-sidebar/Ribbon.svelte
@@ -8,6 +8,7 @@
    * it actually has — a sort selector without sort options would be
    * noise, same for expand/collapse on a flat list.
    */
+  import Icon from '../Icon.svelte';
 
   interface SortOption {
     id: string;
@@ -60,10 +61,10 @@
     </select>
   {/if}
   {#if onCollapseAll}
-    <button class="icon-btn" onclick={onCollapseAll} title="Collapse all">&#x2303;</button>
+    <button class="icon-btn" onclick={onCollapseAll} title="Collapse all"><Icon name="collapseAll" size={12} /></button>
   {/if}
   {#if onExpandAll}
-    <button class="icon-btn" onclick={onExpandAll} title="Expand all">&#x2304;</button>
+    <button class="icon-btn" onclick={onExpandAll} title="Expand all"><Icon name="expandAll" size={12} /></button>
   {/if}
 </div>
 


### PR DESCRIPTION
Closes #544. Part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §4. Icon paths from [`components/icons.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/icons.jsx).

## Summary
- **`Icon.svelte`** + **`icons/registry.ts`** — 36 SVG icons (16×16, 1.4 stroke, currentColor), typed via `IconName = keyof typeof ICONS`. `title` prop drives `role="img"` + `aria-label`; without it the SVG is `aria-hidden`.
- **Every `&#x` markup glyph in the renderer swapped.** Verified by `rg -n '&#x' src/renderer` → zero hits (only CSS `content:` uses, if any, remain).
- **RightSidebar's 11 panel tabs** collapsed from 11 nearly-identical buttons to a data-driven `{#each PANEL_TABS}` loop — sets up #547 (regroup) for a clean diff.
- Minor CSS touch-ups so SVG children sit centered:
  - `submenu-trigger` (Editor / Preview / TabBar / FileTree): `display: flex; justify-content: space-between` pins the chevron right
  - `StatusBar .status-item`: `inline-flex` + `gap: 4px` so icons sit beside counts without baseline drift
  - `TitleBar .nav-btn`: inline-flex centered for the SVG arrow
  - `BookmarksPanel .bm-icon`: inline-flex centered for the disclosure SVG

## Trust principle / CLAUDE.md compliance
- **No danger styling**: close `×` stays neutral; the warn icon's color is unchanged this PR. Inspections badge will pin to `--rust` in chrome PR #549 per spec §7.3.
- **Stay out of the way**: every swap is 1:1, no new modals or behavior changes.

## Test plan
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm test` passes (2189 tests)
- [x] `pnpm test:e2e` passes
- [x] `rg -n '&#x' src/renderer` returns 0 hits in markup
- [ ] **UI verification by user**: launch `pnpm dev` and confirm:
  - Left sidebar tabs (Notes / Sites / Tags / Tables) show their new SVG icons
  - Right sidebar's 11 tabs all render with the right icon
  - Title bar back/forward arrows render as SVG strokes
  - Tab bar query / source tab icons + close × appear correctly
  - Status bar backlinks + warn line up with their counts
  - Editor / Preview / FileTree submenu triggers still show "Open In ▸" with the chevron right-pinned
  - Bookmarks panel disclosure chevrons + ★ bookmark glyph render
  - Right-sidebar-toggle button in the editor toolbar still works

I could not launch the desktop app in this session, so the visual walkthrough is on you. The lint + unit + e2e checks confirm the swap doesn't break any logic or the smoke test.

## Follow-ups unblocked
- #546 (left sidebar polish), #547 (right sidebar regroup), #549 (chrome), #550 (editor surface) — they all reference `<Icon name="...">`.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)