### PR TITLE
design: UI primitives — Dialog, Toggle, Stepper, Kbd, Eyebrow, Chip, SegmentedControl (#545)

### DIFF
--- a/src/renderer/lib/components/ui/Chip.svelte
+++ b/src/renderer/lib/components/ui/Chip.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type Tone = 'default' | 'accent' | 'sage' | 'rust' | 'iris' | 'muted';
+  type Size = 'sm' | 'md';
+
+  interface Props {
+    /** Visual tone. 'accent' uses --accent, 'sage'/'rust'/'iris' for typed
+     *  signals, 'muted' for de-emphasized chips. */
+    tone?: Tone;
+    /** 'sm' (default) is the everyday chip; 'md' bumps padding + font size
+     *  for the "big" weighted-tag variant in §5.4. */
+    size?: Size;
+    /** When provided, the chip renders as a <button>; otherwise a <span>. */
+    onclick?: (e: MouseEvent) => void;
+    /** Native title (tooltip). */
+    title?: string;
+    children: Snippet;
+  }
+
+  let { tone = 'default', size = 'sm', onclick, title, children }: Props = $props();
+</script>
+
+{#if onclick}
+  <button type="button" class="chip" class:big={size === 'md'} data-tone={tone} {title} {onclick}>
+    {@render children()}
+  </button>
+{:else}
+  <span class="chip" class:big={size === 'md'} data-tone={tone} {title}>
+    {@render children()}
+  </span>
+{/if}
+
+<style>
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-family: inherit;
+    font-size: 11.5px;
+    line-height: 1.2;
+    cursor: default;
+    white-space: nowrap;
+  }
+  button.chip {
+    cursor: pointer;
+  }
+  .chip.big {
+    padding: 4px 10px;
+    font-size: 12.5px;
+  }
+  .chip[data-tone='accent'] {
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--accent);
+    border-color: color-mix(in oklch, var(--accent) 30%, transparent);
+  }
+  .chip[data-tone='sage'] {
+    background: color-mix(in oklch, var(--sage) 14%, transparent);
+    color: var(--sage);
+    border-color: color-mix(in oklch, var(--sage) 30%, transparent);
+  }
+  .chip[data-tone='rust'] {
+    background: color-mix(in oklch, var(--rust) 14%, transparent);
+    color: var(--rust);
+    border-color: color-mix(in oklch, var(--rust) 30%, transparent);
+  }
+  .chip[data-tone='iris'] {
+    background: color-mix(in oklch, var(--iris) 14%, transparent);
+    color: var(--iris);
+    border-color: color-mix(in oklch, var(--iris) 30%, transparent);
+  }
+  .chip[data-tone='muted'] {
+    color: var(--text-muted);
+  }
+</style>

--- a/src/renderer/lib/components/ui/Dialog.svelte
+++ b/src/renderer/lib/components/ui/Dialog.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { onMount } from 'svelte';
+
+  interface Props {
+    /** Card width in px. Spec defaults: confirm 440, prompt 460, palette 640. */
+    width?: number;
+    /** Backdrop scrim opacity (0–1). Spec defaults around .45–.55. */
+    scrim?: number;
+    /** Click on the backdrop / Escape key. Both are routed here. */
+    onClose?: () => void;
+    /** Optional aria-labelledby — typically the eyebrow + title elements id'd
+     *  by the caller. When omitted we set role="dialog" with no label. */
+    'aria-labelledby'?: string;
+    /** Header eyebrow (mono-uppercase). */
+    eyebrow?: Snippet;
+    /** Header title (display-serif H1). */
+    title?: Snippet;
+    /** Main body content. */
+    body?: Snippet;
+    /** Footer left slot — kbd hints. */
+    footerLeft?: Snippet;
+    /** Footer right slot — buttons (Cancel · primary CTA). */
+    footerRight?: Snippet;
+  }
+
+  let {
+    width = 440,
+    scrim = 0.5,
+    onClose,
+    'aria-labelledby': ariaLabelledBy,
+    eyebrow,
+    title,
+    body,
+    footerLeft,
+    footerRight,
+  }: Props = $props();
+
+  function onBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) onClose?.();
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      onClose?.();
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  });
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div
+  class="backdrop"
+  style:--scrim={scrim}
+  onclick={onBackdropClick}
+>
+  <div
+    class="card"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={ariaLabelledBy}
+    style:width="{width}px"
+  >
+    {#if eyebrow || title}
+      <header class="card-header">
+        {#if eyebrow}<div class="eyebrow">{@render eyebrow()}</div>{/if}
+        {#if title}<h2 class="title">{@render title()}</h2>{/if}
+      </header>
+    {/if}
+
+    {#if body}
+      <div class="card-body">{@render body()}</div>
+    {/if}
+
+    {#if footerLeft || footerRight}
+      <footer class="card-footer">
+        <div class="footer-left">
+          {#if footerLeft}{@render footerLeft()}{/if}
+        </div>
+        <div class="footer-right">
+          {#if footerRight}{@render footerRight()}{/if}
+        </div>
+      </footer>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+    background: rgba(20, 14, 6, var(--scrim, 0.5));
+    backdrop-filter: blur(2px);
+  }
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    margin: 0;
+  }
+  .card-body {
+    padding: 14px 24px 18px;
+    overflow: auto;
+    flex: 1;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .footer-left {
+    margin-right: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+</style>

--- a/src/renderer/lib/components/ui/Eyebrow.svelte
+++ b/src/renderer/lib/components/ui/Eyebrow.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    children: Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+<div class="eyebrow">{@render children()}</div>
+
+<style>
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+</style>

--- a/src/renderer/lib/components/ui/Kbd.svelte
+++ b/src/renderer/lib/components/ui/Kbd.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    children: Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+<kbd>{@render children()}</kbd>
+
+<style>
+  kbd {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 6px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-faint);
+    line-height: 1;
+  }
+</style>

--- a/src/renderer/lib/components/ui/SegmentedControl.svelte
+++ b/src/renderer/lib/components/ui/SegmentedControl.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  interface Option {
+    value: string;
+    label: string;
+    /** Optional count or trailing string (e.g. "23 matches"). */
+    sub?: string;
+  }
+
+  interface Props {
+    value: string;
+    options: ReadonlyArray<Option>;
+    onchange?: (next: string) => void;
+    disabled?: boolean;
+    'aria-label'?: string;
+  }
+
+  let {
+    value = $bindable(''),
+    options,
+    onchange,
+    disabled = false,
+    'aria-label': ariaLabel,
+  }: Props = $props();
+
+  function pick(next: string) {
+    if (disabled || next === value) return;
+    value = next;
+    onchange?.(next);
+  }
+</script>
+
+<div class="segmented" role="tablist" aria-label={ariaLabel}>
+  {#each options as opt (opt.value)}
+    <button
+      type="button"
+      role="tab"
+      class="segment"
+      class:active={value === opt.value}
+      aria-selected={value === opt.value}
+      {disabled}
+      onclick={() => pick(opt.value)}
+    >
+      {opt.label}{#if opt.sub}<span class="sub">{opt.sub}</span>{/if}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .segmented {
+    display: inline-flex;
+    padding: 3px;
+    gap: 2px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+  }
+  .segment {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 450;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .segment:hover:not(.active):not(:disabled) {
+    color: var(--text);
+  }
+  .segment.active {
+    background: var(--bg-elev);
+    color: var(--text);
+    font-weight: 500;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+  .segment:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  .sub {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .segment.active .sub {
+    color: var(--text-muted);
+  }
+</style>

--- a/src/renderer/lib/components/ui/Stepper.svelte
+++ b/src/renderer/lib/components/ui/Stepper.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  interface Props {
+    value: number;
+    onchange?: (next: number) => void;
+    step?: number;
+    min?: number;
+    max?: number;
+    /** Trailing unit string (e.g. "px"). Rendered next to the value. */
+    unit?: string;
+    /** Decimal places for display. Inferred from `step` when omitted. */
+    precision?: number;
+    disabled?: boolean;
+    'aria-label'?: string;
+  }
+
+  let {
+    value = $bindable(0),
+    onchange,
+    step = 1,
+    min,
+    max,
+    unit = '',
+    precision,
+    disabled = false,
+    'aria-label': ariaLabel,
+  }: Props = $props();
+
+  const decimals = $derived(
+    precision ?? (step < 1 ? Math.max(0, -Math.floor(Math.log10(step))) : 0),
+  );
+
+  function clamp(n: number) {
+    if (min !== undefined && n < min) n = min;
+    if (max !== undefined && n > max) n = max;
+    return n;
+  }
+
+  function bump(delta: number) {
+    if (disabled) return;
+    const next = clamp(Number((value + delta * step).toFixed(decimals)));
+    value = next;
+    onchange?.(next);
+  }
+</script>
+
+<div class="stepper" role="group" aria-label={ariaLabel}>
+  <button
+    type="button"
+    class="step-btn"
+    {disabled}
+    aria-label="Decrease"
+    onclick={() => bump(-1)}
+  >−</button>
+  <span class="value">{value.toFixed(decimals)}{unit}</span>
+  <button
+    type="button"
+    class="step-btn"
+    {disabled}
+    aria-label="Increase"
+    onclick={() => bump(1)}
+  >+</button>
+</div>
+
+<style>
+  .stepper {
+    display: inline-flex;
+    align-items: center;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .step-btn {
+    padding: 5px 8px;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1;
+  }
+  .step-btn:hover:not(:disabled) {
+    background: var(--bg-elev-2);
+    color: var(--text);
+  }
+  .step-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+  .value {
+    padding: 5px 10px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text);
+    border-left: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+    min-width: 48px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/renderer/lib/components/ui/Toggle.svelte
+++ b/src/renderer/lib/components/ui/Toggle.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  interface Props {
+    /** The on/off state. Use bind:checked to mutate from the parent. */
+    checked: boolean;
+    /** Optional change callback (alternative to bind:checked). */
+    onchange?: (next: boolean) => void;
+    /** Disabled state — visual + interactive. */
+    disabled?: boolean;
+    /** Accessible label (provided by a sibling SettingRow label when in a form). */
+    'aria-label'?: string;
+    'aria-labelledby'?: string;
+  }
+
+  let {
+    checked = $bindable(false),
+    onchange,
+    disabled = false,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+  }: Props = $props();
+
+  function toggle() {
+    if (disabled) return;
+    checked = !checked;
+    onchange?.(checked);
+  }
+</script>
+
+<button
+  type="button"
+  role="switch"
+  aria-checked={checked}
+  aria-label={ariaLabel}
+  aria-labelledby={ariaLabelledBy}
+  {disabled}
+  class="toggle"
+  class:on={checked}
+  onclick={toggle}
+>
+  <span class="thumb" class:on={checked}></span>
+</button>
+
+<style>
+  .toggle {
+    display: inline-flex;
+    width: 32px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    border-radius: 999px;
+    background: var(--border-strong);
+    position: relative;
+    cursor: pointer;
+    transition: background 0.15s;
+    vertical-align: middle;
+  }
+  .toggle.on {
+    background: var(--accent);
+  }
+  .toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: white;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    transition: left 0.15s;
+  }
+  .thumb.on {
+    left: 16px;
+  }
+</style>

--- a/tests/renderer/components/ui-primitives.test.ts
+++ b/tests/renderer/components/ui-primitives.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Smoke coverage for the UI primitives introduced for the 2026-05
+ * design review (#545). The components have no app callers yet —
+ * they'll be consumed by the dialogs sweep (#552) — so these tests
+ * just lock in the contract: render, fire callbacks, reflect bindings.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+import Toggle from '../../../src/renderer/lib/components/ui/Toggle.svelte';
+import Stepper from '../../../src/renderer/lib/components/ui/Stepper.svelte';
+import SegmentedControl from '../../../src/renderer/lib/components/ui/SegmentedControl.svelte';
+
+afterEach(cleanup);
+
+describe('Toggle', () => {
+  it('renders the on state and flips on click', async () => {
+    let value = false;
+    const { container, rerender } = render(Toggle, {
+      props: {
+        checked: value,
+        onchange: (next) => { value = next; },
+        'aria-label': 'enable',
+      },
+    });
+    const btn = container.querySelector('button[role="switch"]')!;
+    expect(btn.getAttribute('aria-checked')).toBe('false');
+
+    await fireEvent.click(btn);
+    expect(value).toBe(true);
+
+    // Re-render with the latest value to confirm the visual state tracks
+    await rerender({
+      checked: value,
+      onchange: (next: boolean) => { value = next; },
+      'aria-label': 'enable',
+    });
+    expect(btn.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('does not flip when disabled', async () => {
+    let value = false;
+    const { container } = render(Toggle, {
+      props: { checked: value, disabled: true, onchange: (n) => { value = n; } },
+    });
+    await fireEvent.click(container.querySelector('button[role="switch"]')!);
+    expect(value).toBe(false);
+  });
+});
+
+describe('Stepper', () => {
+  it('bumps the value by step, clamped to min/max', async () => {
+    let value = 5;
+    const { container } = render(Stepper, {
+      props: { value, step: 2, min: 0, max: 10, onchange: (n) => { value = n; } },
+    });
+    const [minus, plus] = Array.from(container.querySelectorAll('button.step-btn'));
+    await fireEvent.click(plus); // 5 → 7
+    expect(value).toBe(7);
+    await fireEvent.click(plus); // 7 → 9
+    await fireEvent.click(plus); // 9 → 10 (clamped)
+    expect(value).toBe(10);
+    await fireEvent.click(minus); // 10 → 8
+    expect(value).toBe(8);
+  });
+
+  it('honours unit and precision in display', () => {
+    const { container } = render(Stepper, {
+      props: { value: 1.55, step: 0.05, unit: '×' },
+    });
+    expect(container.querySelector('.value')!.textContent).toBe('1.55×');
+  });
+});
+
+describe('SegmentedControl', () => {
+  it('selects the clicked option and fires onchange', async () => {
+    let value: string = 'a';
+    const { container } = render(SegmentedControl, {
+      props: {
+        value,
+        options: [
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B', sub: '23' },
+          { value: 'c', label: 'C' },
+        ],
+        onchange: (next) => { value = next; },
+      },
+    });
+    const segments = Array.from(container.querySelectorAll('button.segment'));
+    expect(segments[0].classList.contains('active')).toBe(true);
+
+    await fireEvent.click(segments[1]);
+    expect(value).toBe('b');
+  });
+});


### PR DESCRIPTION
Closes #545. Part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §12. References: [`dialogs-common.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/dialogs-common.jsx), [`dialogs-settings.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/dialogs-settings.jsx), [`bits.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/bits.jsx).

## Summary
Seven reusable primitives in `src/renderer/lib/components/ui/`. No app callers yet — they're consumed by the dialogs sweep (#552), right-sidebar panel bodies (#548), and several other surface PRs in the epic.

- **`Dialog.svelte`** — backdrop + 12px-radius card with named-snippet slots (eyebrow, title, body, footerLeft, footerRight). Backdrop click + Escape both fire `onClose`. `role="dialog"` + `aria-modal="true"`.
- **`Toggle.svelte`** — bindable `checked`, accent track when on, `role="switch"` + `aria-checked`.
- **`Stepper.svelte`** — minus/value/plus with tabular-nums, bindable `value`, min/max clamping, configurable step/unit/precision.
- **`Kbd.svelte`** — keyboard glyph badge (`⌘`, `↵`, `esc`).
- **`Eyebrow.svelte`** — the mono-uppercase label used above every dialog title.
- **`Chip.svelte`** — pill with tone variants (default/accent/sage/rust/iris/muted) and sm/md sizes. Becomes a `<button>` when `onclick` is passed.
- **`SegmentedControl.svelte`** — `role="tablist"` segmented toggle with optional per-option `sub` (counts in mono-faint).

## Trust principle / CLAUDE.md compliance
- **No danger styling** — no tone variant produces red. The Dialog shell hands the primary-CTA color to the caller, but the spec is explicit that every dialog (incl. Delete) uses `--accent`.
- **"Don't ask again"** lives at the `ConfirmDialog` level (untouched in this PR) — `Dialog` is just the shell.

## Generics note
`SegmentedControl` is non-generic (string value). Svelte 5's `generics="…"` requires the Props interface to be exported via `<script module>`, which is awkward for a single component. Callers can cast at the binding site if narrow types matter. Discussed in the commit message.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test tests/renderer/components/ui-primitives.test.ts` — 5 new tests pass (Toggle flip + disabled, Stepper bump + clamp + precision, SegmentedControl click + active class)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user when consumed**: these primitives have no callers yet. Visual verification happens when #552 (dialogs sweep) and #548 (panel bodies) consume them and the user walks the resulting surfaces.

Note: an unrelated tree-markdown export test timed out under full-suite load but passes in isolation — not introduced by this PR.

## Unblocks
- #552 (dialogs sweep) consumes Dialog, Toggle, Stepper, Kbd, Eyebrow, SegmentedControl
- #548 (right-sidebar panel bodies) consumes Toggle, Chip
- #553 (onboarding) consumes SegmentedControl

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)