### PR TITLE
design: left sidebar polish — hybrid rail, panel header, file icons, weighted tag chips, editorial sources (#546)

### DIFF
--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -48,10 +48,22 @@ async function readDirectory(dirPath: string, rootPath: string): Promise<NoteFil
         children,
       });
     } else if (INDEXABLE_EXTS.has(path.extname(entry.name))) {
+      // mtime drives the "2h / 5d / 1mo" stamp on each file row in the
+      // sidebar (§5.3 of the 2026-05 design review). One extra stat per
+      // file at listing time; for typical thoughtbase sizes this is
+      // dwarfed by the existing graph indexing.
+      let mtimeMs: number | undefined;
+      try {
+        mtimeMs = (await fs.stat(fullPath)).mtimeMs;
+      } catch {
+        // Race against deletion or a transient permission glitch — drop
+        // the stamp rather than fail the whole listing.
+      }
       files.push({
         name: entry.name,
         relativePath,
         isDirectory: false,
+        mtimeMs,
       });
     }
   }

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -2,6 +2,7 @@
   import type { NoteFile } from '../../../shared/types';
   import FileTree from './FileTree.svelte';
   import Icon from './Icon.svelte';
+  import { formatRelativeTime } from '../utils/format-relative-time';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { extractTagsFromContent } from '../../../shared/refactor/auto-tag';
@@ -173,8 +174,11 @@
           ondragleave={handleDragLeave}
           ondrop={(e) => handleDrop(e, file.relativePath)}
         >
-          <span class="icon">{expanded[file.relativePath] ? '▾' : '▸'}</span>
-          {file.name}
+          <span class="chev">
+            <Icon name={expanded[file.relativePath] ? 'chevronDown' : 'chevronRight'} size={11} />
+          </span>
+          <Icon name={expanded[file.relativePath] ? 'folderOpen' : 'folder'} size={14} />
+          <span class="row-label">{file.name}</span>
         </button>
         {#if expanded[file.relativePath] && file.children}
           <FileTree
@@ -217,8 +221,16 @@
           draggable={true}
           ondragstart={(e) => handleDragStart(e, file.relativePath)}
         >
-          <span class="icon">📄</span>
-          {file.name.replace(/\.(md|ttl|csv)$/, '')}
+          <span class="chev"></span>
+          <Icon
+            name="notes"
+            size={13}
+            color={activeFilePath === file.relativePath ? 'var(--accent)' : 'var(--text-faint)'}
+          />
+          <span class="row-label">{file.name.replace(/\.(md|ttl|csv)$/, '')}</span>
+          {#if file.mtimeMs !== undefined}
+            <span class="mtime">{formatRelativeTime(file.mtimeMs)}</span>
+          {/if}
         </button>
       {/if}
     </li>
@@ -318,57 +330,75 @@
   .tree-item {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     width: 100%;
-    padding: 4px 8px;
+    padding: 5px 12px 5px;
     border: none;
+    border-left: 2px solid transparent;
     background: none;
     color: var(--text);
     font-size: 13px;
     cursor: pointer;
     text-align: left;
-    border-radius: 4px;
   }
 
   .tree-item:hover {
-    background: var(--bg-button);
+    background: color-mix(in oklch, var(--text) 4%, transparent);
   }
 
   .tree-item.active {
-    background: var(--bg-button-hover);
-    color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    border-left-color: var(--accent);
+    color: var(--text);
   }
 
   .tree-item.selected {
-    background: var(--bg-button);
-    outline: 1px solid var(--accent);
+    background: color-mix(in oklch, var(--accent) 10%, transparent);
+    outline: 1px solid color-mix(in oklch, var(--accent) 50%, transparent);
     outline-offset: -1px;
   }
   .tree-item.selected.active {
-    background: var(--bg-button-hover);
+    background: color-mix(in oklch, var(--accent) 18%, transparent);
   }
-  /* Keyboard cursor (#428): a faint left bar marks the row arrow keys
-     would move from. Distinct from `.selected` so multi-selection stays
-     legible — the cursor sits on top of the selection styling. */
-  .tree-item.kb-focused {
+  /* Keyboard cursor (#428): the active-row's accent rail doubles as
+     the kb-focus signal on the active row; on non-active rows we use a
+     thicker inset shadow on the left to mark "arrow keys move from here". */
+  .tree-item.kb-focused:not(.active) {
     box-shadow: inset 2px 0 0 var(--accent);
   }
 
   .tree-item.drop-hover {
-    background: var(--bg-button-hover);
+    background: color-mix(in oklch, var(--accent) 16%, transparent);
     outline: 1px dashed var(--accent);
     outline-offset: -1px;
   }
 
-  .icon {
-    font-size: 11px;
-    width: 14px;
+  /* Disclosure chevron — fixed-width gutter so file and folder rows
+     have aligned icon/label columns. */
+  .chev {
+    width: 11px;
     flex-shrink: 0;
-    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
   }
 
-  .dir .icon {
-    font-size: 12px;
+  .row-label {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Modified-time stamp on file rows (§5.3) — right-aligned, mono. */
+  .mtime {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
   }
 
   .context-menu {

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -13,6 +13,28 @@
 
   type PanelType = 'notes' | 'sites' | 'tags' | 'tables';
 
+  /** Hybrid icon-rail definition: the active tab shows the label, the
+   *  others are icon-only. Per IMPLEMENTATION.md §5.1. */
+  const PANELS: ReadonlyArray<{ id: PanelType; label: string; icon: 'notes' | 'sites' | 'tags' | 'tables' }> = [
+    { id: 'notes',  label: 'Notes',  icon: 'notes' },
+    { id: 'sites',  label: 'Sites',  icon: 'sites' },
+    { id: 'tags',   label: 'Tags',   icon: 'tags' },
+    { id: 'tables', label: 'Tables', icon: 'tables' },
+  ];
+
+  /** Recursively count files (not folders) in the tree — drives the
+   *  count chip in the Notes panel header. Cheap; the renderer already
+   *  recursively walks `files` in other places (selection counting). */
+  function countFiles(nodes: NoteFile[] | undefined): number {
+    if (!nodes) return 0;
+    let n = 0;
+    for (const node of nodes) {
+      if (node.isDirectory) n += countFiles(node.children);
+      else n++;
+    }
+    return n;
+  }
+
   interface Props {
     files: NoteFile[];
     /** Project name shown as the synthetic root row above the file
@@ -49,6 +71,8 @@
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
+  const notesCount = $derived(countFiles(files));
+  const activeLabel = $derived(PANELS.find((p) => p.id === activePanel)?.label ?? '');
   /** Mirrored from sidebar/settings so the toolbar toggle reflects the
    *  current state and persists changes write-through. */
   let autoReveal = $state(getSidebarSettings().autoReveal);
@@ -397,30 +421,27 @@
   <div class="resize-handle" class:dragging onmousedown={startResize}></div>
 
   <div class="panel-tabs">
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'notes'}
-      onclick={() => activePanel = 'notes'}
-      title="Notes"
-    ><Icon name="notes" size={14} /></button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'sites'}
-      onclick={() => activePanel = 'sites'}
-      title="Sites"
-    ><Icon name="sites" size={14} /></button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'tags'}
-      onclick={() => activePanel = 'tags'}
-      title="Tags"
-    ><Icon name="tags" size={14} /></button>
-    <button
-      class="panel-tab"
-      class:active={activePanel === 'tables'}
-      onclick={() => activePanel = 'tables'}
-      title="Tables"
-    ><Icon name="tables" size={14} /></button>
+    {#each PANELS as p (p.id)}
+      {@const active = activePanel === p.id}
+      <button
+        class="panel-tab"
+        class:active
+        onclick={() => activePanel = p.id}
+        title={p.label}
+      >
+        <Icon name={p.icon} size={14} color={active ? 'var(--accent)' : 'currentColor'} />
+        {#if active}<span class="panel-tab-label">{p.label}</span>{/if}
+      </button>
+    {/each}
+  </div>
+
+  <div class="panel-header">
+    <h2 class="panel-title">{activeLabel}</h2>
+    <div class="panel-actions">
+      {#if activePanel === 'notes'}
+        <span class="panel-count" title="{notesCount} notes">{notesCount}</span>
+      {/if}
+    </div>
   </div>
 
   <div class="panel-content">
@@ -486,8 +507,11 @@
               onclick={() => rootExpanded = !rootExpanded}
               title={rootName}
             >
-              <span class="icon">{rootExpanded ? '▾' : '▸'}</span>
-              {rootName}
+              <span class="chev">
+                <Icon name={rootExpanded ? 'chevronDown' : 'chevronRight'} size={11} />
+              </span>
+              <Icon name={rootExpanded ? 'folderOpen' : 'folder'} size={14} />
+              <span class="row-label">{rootName}</span>
             </button>
           {/if}
           {#if rootExpanded}
@@ -584,8 +608,7 @@
   .panel-tabs {
     display: flex;
     gap: 2px;
-    padding: 6px 8px;
-    border-bottom: 1px solid var(--border);
+    padding: 10px 10px 4px;
     flex-shrink: 0;
     overflow-x: auto;
     scrollbar-width: thin;
@@ -600,22 +623,62 @@
 
   .panel-tab {
     flex-shrink: 0;
-    padding: 4px 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
     border: none;
-    border-radius: 4px;
+    border-radius: 7px;
     background: none;
     color: var(--text-muted);
-    font-size: 14px;
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 450;
     cursor: pointer;
   }
 
-  .panel-tab:hover {
-    background: var(--bg-button);
+  .panel-tab:hover:not(.active) {
+    color: var(--text);
   }
 
   .panel-tab.active {
-    background: var(--bg-button-hover);
+    padding: 6px 10px;
+    background: var(--bg);
     color: var(--text);
+    font-weight: 500;
+    box-shadow: inset 0 0 0 1px var(--border);
+  }
+
+  .panel-tab-label {
+    line-height: 1;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding: 10px 16px 8px;
+    flex-shrink: 0;
+  }
+  .panel-title {
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    margin: 0;
+    color: var(--text);
+  }
+  .panel-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--text-faint);
+  }
+  .panel-count {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
   }
 
   .panel-content {
@@ -700,26 +763,38 @@
   .tree-item.root-item {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     width: 100%;
-    padding: 4px 8px;
+    padding: 5px 12px 5px;
     border: none;
+    border-left: 2px solid transparent;
     background: none;
     color: var(--text);
     font-size: 13px;
-    font-weight: 600;
+    font-weight: 500;
     cursor: pointer;
     text-align: left;
-    border-radius: 4px;
   }
   .tree-item.root-item:hover {
-    background: var(--bg-button);
+    background: color-mix(in oklch, var(--text) 4%, transparent);
   }
-  .tree-item.root-item .icon {
-    font-size: 12px;
-    width: 14px;
+  .tree-item.root-item :global(svg) {
     flex-shrink: 0;
-    text-align: center;
+  }
+  .tree-item.root-item .chev {
+    width: 11px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
+  }
+  .tree-item.root-item .row-label {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .empty {

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -67,13 +67,11 @@
     });
   });
 
-  function formatByline(creators: string[], year: string | null): string {
-    const who = creators.length === 0 ? ''
-      : creators.length === 1 ? creators[0]
-      : creators.length === 2 ? `${creators[0]} and ${creators[1]}`
-      : `${creators[0]} et al.`;
-    if (who && year) return `${who} · ${year}`;
-    return who || (year ?? '');
+  function formatCreators(creators: string[]): string {
+    if (creators.length === 0) return '';
+    if (creators.length === 1) return creators[0];
+    if (creators.length === 2) return `${creators[0]} and ${creators[1]}`;
+    return `${creators[0]} et al.`;
   }
 </script>
 
@@ -99,7 +97,10 @@
         >
           <div class="source-title">{s.title ?? s.sourceId}</div>
           {#if s.creators.length > 0 || s.year}
-            <div class="source-byline">{formatByline(s.creators, s.year)}</div>
+            {@const who = formatCreators(s.creators)}
+            <div class="source-byline">
+              {#if who}{who}{/if}{#if who && s.year} · {/if}{#if s.year}<span class="year">{s.year}</span>{/if}
+            </div>
           {/if}
         </button>
       {/each}
@@ -183,36 +184,53 @@
     padding-bottom: 6px;
   }
 
+  /* Editorial-row treatment (§5.5). Each source reads like a
+     bibliography entry: italic display-serif title, sans+mono byline.
+     The 2px accent rail still marks hover/active for parity with the
+     file tree. */
   .source-item {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     text-align: left;
-    padding: 4px 12px;
+    padding: 10px 16px;
     background: none;
     border: none;
-    color: var(--text);
-    font-size: 12px;
-    cursor: pointer;
+    border-top: 1px solid var(--border);
     border-left: 2px solid transparent;
+    color: var(--text);
+    cursor: pointer;
+  }
+  .source-list .source-item:first-child {
+    border-top: none;
   }
   .source-item:hover {
-    background: var(--bg-button);
+    background: color-mix(in oklch, var(--text) 4%, transparent);
     border-left-color: var(--accent);
   }
 
   .source-title {
-    font-weight: 500;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--text);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .source-byline {
-    font-size: 10px;
+    font-size: 11px;
     color: var(--text-muted);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    margin-top: 1px;
+    margin-top: 2px;
+  }
+  /* The year (and any other mono fragment in the byline) reads as a
+     citation locator — switch to the mono face for tabular feel. */
+  .source-byline :global(.year) {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
   }
 </style>

--- a/src/renderer/lib/components/TagPanel.svelte
+++ b/src/renderer/lib/components/TagPanel.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import type { TagInfo, TaggedNote, TaggedSource } from '../../../shared/types';
   import { api } from '../ipc/client';
+  import Chip from './ui/Chip.svelte';
+
+  /** Tags that always render in the accent variant, no matter their
+   *  count. Per IMPLEMENTATION.md §5.4 the default list is `entrypoint`
+   *  and `open-question` — the two tags Minerva treats as
+   *  navigationally significant. */
+  const ACCENT_TAGS: ReadonlySet<string> = new Set(['entrypoint', 'open-question']);
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
@@ -14,6 +21,22 @@
   let taggedNotes = $state<TaggedNote[]>([]);
   let taggedSources = $state<TaggedSource[]>([]);
   let showSources = $state(true);
+
+  /** Threshold above which a chip renders with the `big` size — top
+   *  quartile by frequency. Recomputed whenever the tag list changes. */
+  const bigThreshold = $derived.by(() => {
+    if (tags.length === 0) return Infinity;
+    const sorted = tags.map((t) => t.count).sort((a, b) => b - a);
+    const idx = Math.max(0, Math.floor(sorted.length / 4) - 1);
+    return sorted[idx];
+  });
+
+  function chipTone(tag: string): 'accent' | 'default' {
+    return ACCENT_TAGS.has(tag) ? 'accent' : 'default';
+  }
+  function chipSize(count: number): 'sm' | 'md' {
+    return count >= bigThreshold ? 'md' : 'sm';
+  }
 
   export async function refresh() {
     tags = await api.tags.list();
@@ -63,15 +86,17 @@
     <div class="empty">No tags yet</div>
   {:else}
     <div class="tag-list">
-      {#each tags as { tag, count }}
-        <button
-          class="tag-item"
-          class:active={activeTag === tag}
+      {#each tags as { tag, count } (tag)}
+        {@const active = activeTag === tag}
+        <Chip
+          tone={active ? 'accent' : chipTone(tag)}
+          size={chipSize(count)}
           onclick={() => showNotesForTag(tag)}
+          title={`#${tag} · ${count}`}
         >
           <span class="tag-name">#{tag}</span>
-          <span class="tag-count">{count}</span>
-        </button>
+          <span class="count">{count}</span>
+        </Chip>
       {/each}
     </div>
   {/if}
@@ -142,38 +167,19 @@
   .tag-list {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
-    padding: 0 8px 8px;
+    gap: 5px;
+    padding: 4px 14px 14px;
   }
 
-  .tag-item {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    background: none;
-    color: var(--text-muted);
-    font-size: 11px;
-    cursor: pointer;
-    transition: all 0.15s;
+  .tag-name {
+    font-family: var(--font-sans);
   }
 
-  .tag-item:hover {
-    background: var(--bg-button);
-    color: var(--text);
-  }
-
-  .tag-item.active {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
-  }
-
-  .tag-count {
-    font-size: 10px;
-    opacity: 0.7;
+  .count {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 10.5px;
+    color: var(--text-faint);
   }
 
   .notes-section {

--- a/src/renderer/lib/utils/format-relative-time.ts
+++ b/src/renderer/lib/utils/format-relative-time.ts
@@ -1,0 +1,25 @@
+/**
+ * Compact relative-time stamp for sidebar file rows ("2h", "5d", "1mo").
+ *
+ * Brevity over precision — the row is 24px tall and the stamp shares it
+ * with the file name, so we collapse to a single unit. Anything under a
+ * minute is "now"; anything over a year is "Yy".
+ */
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+export function formatRelativeTime(mtimeMs: number, now: number = Date.now()): string {
+  const delta = Math.max(0, now - mtimeMs);
+  if (delta < MIN) return 'now';
+  if (delta < HOUR) return `${Math.floor(delta / MIN)}m`;
+  if (delta < DAY) return `${Math.floor(delta / HOUR)}h`;
+  if (delta < WEEK) return `${Math.floor(delta / DAY)}d`;
+  if (delta < MONTH) return `${Math.floor(delta / WEEK)}w`;
+  if (delta < YEAR) return `${Math.floor(delta / MONTH)}mo`;
+  return `${Math.floor(delta / YEAR)}y`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,11 @@ export interface NoteFile {
   relativePath: string;
   isDirectory: boolean;
   children?: NoteFile[];
+  /** mtime in ms since epoch. Populated for files only; the renderer
+   *  formats this into the relative-time stamp shown on each file row
+   *  ("2h", "5d", "1mo"). Optional so callers/fixtures that don't have
+   *  an mtime can omit it. */
+  mtimeMs?: number;
 }
 
 export interface NotebaseMeta {

--- a/tests/renderer/format-relative-time.test.ts
+++ b/tests/renderer/format-relative-time.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Compact relative-time stamp shown on sidebar file rows (#546).
+ * Verifies each bucket boundary and the rounding behaviour.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '../../src/renderer/lib/utils/format-relative-time';
+
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+describe('formatRelativeTime', () => {
+  const NOW = 1_700_000_000_000; // arbitrary reference
+
+  it('returns "now" for sub-minute deltas', () => {
+    expect(formatRelativeTime(NOW, NOW)).toBe('now');
+    expect(formatRelativeTime(NOW - 59 * SEC, NOW)).toBe('now');
+  });
+
+  it('rounds down to the nearest unit', () => {
+    expect(formatRelativeTime(NOW - MIN, NOW)).toBe('1m');
+    expect(formatRelativeTime(NOW - 59 * MIN, NOW)).toBe('59m');
+    expect(formatRelativeTime(NOW - 2 * HOUR, NOW)).toBe('2h');
+    expect(formatRelativeTime(NOW - 23 * HOUR, NOW)).toBe('23h');
+    expect(formatRelativeTime(NOW - 5 * DAY, NOW)).toBe('5d');
+    expect(formatRelativeTime(NOW - 6 * DAY - 23 * HOUR, NOW)).toBe('6d');
+    expect(formatRelativeTime(NOW - 2 * WEEK, NOW)).toBe('2w');
+    expect(formatRelativeTime(NOW - 3 * MONTH, NOW)).toBe('3mo');
+    expect(formatRelativeTime(NOW - 2 * YEAR, NOW)).toBe('2y');
+  });
+
+  it('clamps negative deltas to "now"', () => {
+    // Disk mtime newer than wall clock (clock skew, future-dated files)
+    expect(formatRelativeTime(NOW + DAY, NOW)).toBe('now');
+  });
+});


### PR DESCRIPTION
Closes #546. Part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §5. Reference: [`components/left-sidebar.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/left-sidebar.jsx).

## Summary

- **Hybrid icon-rail** (§5.1) — `Sidebar.svelte` panel tabs: active shows icon + label with accent-tinted icon + inset border ring; inactive is icon-only at text-muted. Data-driven over a `PANELS` constant.
- **Per-panel header** (§5.2) — display-serif H1 with mono-faint count chip. Notes panel shows file count (derived from a recursive walk).
- **File rows** (§5.3) —
  - Folder rows: chevron icon + `folder`/`folderOpen` icon
  - File rows: `notes` icon (accent on active, faint otherwise)
  - **Active row treatment**: 2px accent left rail + `color-mix(in oklch, var(--accent) 14%, transparent)` tint — selection / kb-focus / drop-hover all use accent-tinted color-mixes so they layer cleanly
  - Right-aligned modified-stamp slot in mono-faint, fed by `formatRelativeTime()` on the new `NoteFile.mtimeMs`
  - Root project row in `Sidebar.svelte` adopts the same chev + folder icon
- **mtime plumbing** — `NoteFile` gains optional `mtimeMs`; `main/notebase/fs.ts` stats each file during `readDirectory`. One extra stat per file at listing time, dwarfed by existing graph indexing. New `formatRelativeTime` util collapses delta to a single unit (`now`/`5m`/`2h`/`3d`/`2w`/`5mo`/`1y`).
- **Weighted tag chips** (§5.4) — `TagPanel.svelte` rewritten over the `<Chip>` primitive. Top quartile by count → `size="md"`; `#entrypoint` and `#open-question` always `tone="accent"`; active tag → `tone="accent"`.
- **Editorial sources** (§5.5) — `SourcesPanel.svelte` rows become italic display-serif title + sans byline with font-mono year. 1px border-top separators.

## Out of scope (called out in commit body)
- Source citation-count chip — needs cite count on `SourceMetadata`, will land with #548 Citations panel.
- Panel `+` / `search` action buttons in the header — slot kept, owners TBD (only notes has obvious actions).

## Trust principle / CLAUDE.md compliance
- No danger styling — every row state (active, selection, kb-focus, drop-hover) uses accent-tinted `color-mix`, never red.
- Stay out of the way — no new modals; visual-only changes.

## Test plan
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm test` passes (2197 tests; +3 new for `formatRelativeTime`)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: launch `pnpm dev` and confirm:
  - Left sidebar tabs: only the active tab shows its label; icon recolors to accent
  - Below the rail: a display-serif "Notes / Sites / Tags / Tables" with a mono count (notes only)
  - File rows: folder chevrons + folder icon; file rows lead with the `notes` icon; the active file shows the accent rail + tint
  - File rows: right-aligned `2h`/`5d`/`1mo` stamp in mono-faint
  - Tags panel: chips wrap, some are bigger (top quartile), `#entrypoint`/`#open-question` always accent-tinted, active tag accent
  - Sources panel: italic display-serif titles with sans+mono bylines

I could not launch the desktop app in this session, so the visual walkthrough is on you.

## Unblocks
- #547 right sidebar regroup (independent but shares the per-panel-header pattern)
- #548 right sidebar panel bodies (which will follow the same header pattern)

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)