### PR TITLE
design: window chrome — title / tab / status bars (#549)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -2298,12 +2298,14 @@
 <div class="app">
   <TitleBar
     notebaseName={notebase.meta?.name ?? ''}
-    fileName={editor.activeFileName}
+    filePath={editor.activeFilePath}
     isDirty={editor.isDirty}
     canGoBack={nav.canGoBack}
     canGoForward={nav.canGoForward}
     onNavBack={handleNavBack}
     onNavForward={handleNavForward}
+    onOpenGotoNote={() => { showGotoNote = true; }}
+    onOpenSettings={() => { showSettings = true; }}
   />
 
   <div class="main">
@@ -2370,6 +2372,7 @@
             onReveal={handleRevealInSidebar}
             onOpenConversation={openConversation}
             onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
+            onNewTab={() => handleNewNote()}
           />
         {/if}
         {#if editor.activeTab?.type === 'note' && editor.activeTab.relativePath.endsWith('.csv')}
@@ -2490,6 +2493,8 @@
             theme={themeLabel}
             {inspectionCount}
             {backlinkCount}
+            isDirty={editor.isDirty}
+            hasActiveNote={editor.activeTab?.type === 'note'}
             onGotoLine={() => { showGotoLine = true; }}
             onCycleTheme={handleCycleTheme}
             onShowInspections={() => { rightSidebarVisible = true; }}

--- a/src/renderer/lib/components/StatusBar.svelte
+++ b/src/renderer/lib/components/StatusBar.svelte
@@ -11,6 +11,13 @@
      *  hides the item entirely — keeps the bar tidy for unlinked
      *  notes; we'll revisit if anyone wants the affirmative signal. */
     backlinkCount?: number;
+    /** Whether the active note has unsaved changes. Drives the
+     *  saved-state cue on the left (§7.3). When unset the cue is
+     *  hidden (e.g. on a query tab with no save concept). */
+    isDirty?: boolean;
+    /** True when an active note tab exists. Lets us hide the saved
+     *  cue entirely when no editable file is open. */
+    hasActiveNote?: boolean;
     onGotoLine: () => void;
     onCycleTheme: () => void;
     onShowInspections?: () => void;
@@ -22,38 +29,58 @@
   let {
     cursor, fontSize, theme,
     inspectionCount = 0, backlinkCount = 0,
+    isDirty = false, hasActiveNote = false,
     onGotoLine, onCycleTheme, onShowInspections, onShowBacklinks,
   }: Props = $props();
 </script>
 
 <div class="status-bar">
   <div class="status-left">
-    <button class="status-item clickable" onclick={onGotoLine} title="Go to Line (Cmd+G)">
-      Ln {cursor.line}, Col {cursor.column}
+    <button class="status-item nums clickable" onclick={onGotoLine} title="Go to Line (Cmd+G)">
+      L{cursor.line} · C{cursor.column}
     </button>
     {#if cursor.selectionLength > 0}
-      <span class="status-item">{cursor.selectionLength} selected</span>
+      <span class="rule" aria-hidden="true"></span>
+      <span class="status-item faint">{cursor.selectionLength} selected</span>
+    {/if}
+    {#if hasActiveNote}
+      <span class="rule" aria-hidden="true"></span>
+      <span class="status-item" class:faint={!isDirty}>
+        {#if isDirty}
+          <Icon name="dot" size={11} color="var(--accent)" />
+          unsaved
+        {:else}
+          <Icon name="check" size={11} color="var(--sage)" />
+          saved
+        {/if}
+      </span>
     {/if}
   </div>
   <div class="status-right">
     {#if backlinkCount > 0}
       <button
-        class="status-item clickable backlink-count"
+        class="status-item clickable"
         onclick={onShowBacklinks}
         title="Show backlinks ({backlinkCount} note{backlinkCount === 1 ? '' : 's'} link here)"
       >
-        <Icon name="backlinks" size={12} /> {backlinkCount}
+        <Icon name="backlinks" size={12} />
+        <span class="nums">{backlinkCount}</span>
       </button>
     {/if}
     {#if inspectionCount > 0}
       <button class="status-item clickable inspection-count" onclick={onShowInspections} title="Show inspections">
-        <Icon name="warn" size={12} /> {inspectionCount}
+        <Icon name="warn" size={12} />
+        <span class="nums">{inspectionCount}</span>
       </button>
     {/if}
-    <span class="status-item">{cursor.wordCount} words</span>
-    <span class="status-item">{fontSize}px</span>
-    <button class="status-item clickable" onclick={onCycleTheme} title="Cycle Theme (Cmd+Shift+T)">{theme}</button>
-    <span class="status-item">Markdown</span>
+    <span class="rule" aria-hidden="true"></span>
+    <span class="status-item faint nums">{cursor.wordCount} words</span>
+    <span class="status-item faint">·</span>
+    <span class="status-item faint nums">{fontSize}px</span>
+    <span class="status-item faint">·</span>
+    <button class="status-item faint clickable" onclick={onCycleTheme} title="Cycle Theme (Cmd+Shift+T)">{theme}</button>
+    <span class="status-item faint">·</span>
+    <span class="status-item faint">Markdown</span>
   </div>
 </div>
 
@@ -62,27 +89,32 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0 8px;
-    height: 22px;
+    padding: 0 12px;
+    height: 28px;
     background: var(--bg-toolbar);
     border-top: 1px solid var(--border);
     flex-shrink: 0;
+    font-family: var(--font-sans);
+    font-size: 11.5px;
+    color: var(--text-muted);
   }
 
   .status-left,
   .status-right {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 14px;
   }
 
   .status-item {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    font-size: 11px;
+    gap: 5px;
     color: var(--text-muted);
     white-space: nowrap;
+  }
+  .status-item.faint {
+    color: var(--text-faint);
   }
 
   .status-item.clickable {
@@ -91,13 +123,34 @@
     padding: 0;
     cursor: pointer;
     font-family: inherit;
+    font-size: inherit;
   }
-
   .status-item.clickable:hover {
     color: var(--text);
   }
 
+  /* Mono cells get tabular-nums so digit columns line up — L47 · C23,
+     word counts, font sizes. */
+  .nums {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* 1px hairline rule between item groups (§7.3). */
+  .rule {
+    display: inline-block;
+    width: 1px;
+    height: 11px;
+    background: var(--border);
+    flex-shrink: 0;
+  }
+
+  /* Inspections badge uses --rust (no hardcoded peach). */
   .inspection-count {
-    color: #f9e2af;
+    color: var(--rust);
+  }
+  .inspection-count:hover {
+    color: var(--rust);
+    opacity: 0.85;
   }
 </style>

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -14,9 +14,11 @@
     onReveal: (relativePath: string) => void;
     onOpenConversation?: () => void;
     onBookmark?: (relativePath: string) => void;
+    /** Trailing `+` button — opens a new note at the project root. */
+    onNewTab?: () => void;
   }
 
-  let { tabs, activeIndex, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark }: Props = $props();
+  let { tabs, activeIndex, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark, onNewTab }: Props = $props();
 
   let contextMenu = $state<{ x: number; y: number; index: number } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
@@ -49,11 +51,12 @@
 
 <div class="tab-bar">
   {#each tabs as tab, i}
+    {@const dirty = tab.type === 'note' && tab.content !== tab.savedContent}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="tab"
       class:active={i === activeIndex}
-      class:dirty={tab.type === 'note' && tab.content !== tab.savedContent}
+      class:dirty
       onclick={() => onSwitch(i)}
       onauxclick={(e) => handleMiddleClick(e, i)}
       oncontextmenu={(e) => handleContextMenu(e, i)}
@@ -61,16 +64,24 @@
       role="tab"
       tabindex="0"
     >
-      {#if tab.type === 'query'}<span class="tab-icon"><Icon name="query" size={12} /></span>{/if}
-      {#if tab.type === 'source'}<span class="tab-icon"><Icon name="source" size={12} /></span>{/if}
+      <!-- Leading slot: dirty pip OR type icon. The pip wins when the
+           note is dirty so the visual cue can't be missed (§7.2). -->
+      <span class="tab-lead">
+        {#if dirty}
+          <span class="dirty-dot" aria-label="Unsaved changes"></span>
+        {:else if tab.type === 'query'}
+          <Icon name="query" size={13} color="var(--text-faint)" />
+        {:else if tab.type === 'source'}
+          <Icon name="source" size={13} color="var(--text-faint)" />
+        {:else}
+          <Icon name="notes" size={13} color="var(--text-faint)" />
+        {/if}
+      </span>
       <span class="tab-name">
         {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
         {:else if tab.type === 'query'}{tab.title}
         {:else}{tab.sourceId}{/if}
       </span>
-      {#if tab.type === 'note' && tab.content !== tab.savedContent}
-        <span class="dirty-dot"></span>
-      {/if}
       <button
         class="close-btn"
         onclick={(e) => { e.stopPropagation(); onClose(i); }}
@@ -78,6 +89,11 @@
       ><Icon name="close" size={11} /></button>
     </div>
   {/each}
+  {#if onNewTab}
+    <button class="new-tab-btn" onclick={onNewTab} title="New note">
+      <Icon name="plus" size={13} color="var(--text-muted)" />
+    </button>
+  {/if}
 </div>
 
 {#if contextMenu}
@@ -110,10 +126,12 @@
 <style>
   .tab-bar {
     display: flex;
+    align-items: stretch;
     background: var(--bg-tabbar);
     border-bottom: 1px solid var(--border);
     overflow-x: auto;
     flex-shrink: 0;
+    height: 36px;
     scrollbar-width: none;
   }
 
@@ -124,20 +142,22 @@
   .tab {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 5px 8px 5px 12px;
+    gap: 8px;
+    padding: 0 8px 0 14px;
     border: none;
     border-right: 1px solid var(--border);
-    background: none;
+    background: transparent;
     color: var(--text-muted);
-    font-size: 12px;
+    font-family: var(--font-sans);
+    font-size: 13px;
     cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
+    position: relative;
   }
 
   .tab:hover {
-    background: var(--bg-button);
+    color: var(--text);
   }
 
   .tab.active {
@@ -145,20 +165,36 @@
     color: var(--text);
   }
 
-  .tab-icon {
-    font-size: 10px;
+  /* Active-tab indicator: a 2px accent rail along the bottom (§7.2).
+     Rendered as a pseudo-element so it sits at -1px and overlaps the
+     1px tab-bar bottom border for a flush look. */
+  .tab.active::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    height: 2px;
+    background: var(--accent);
+  }
+
+  .tab-lead {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
     flex-shrink: 0;
   }
 
   .tab-name {
-    max-width: 150px;
+    max-width: 180px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .dirty-dot {
-    width: 6px;
-    height: 6px;
+    width: 7px;
+    height: 7px;
     border-radius: 50%;
     background: var(--accent);
     flex-shrink: 0;
@@ -168,13 +204,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
     border: none;
-    border-radius: 3px;
+    border-radius: 4px;
     background: none;
-    color: var(--text-muted);
-    font-size: 14px;
+    color: var(--text-faint);
     line-height: 1;
     cursor: pointer;
     padding: 0;
@@ -183,11 +218,33 @@
 
   .tab:hover .close-btn,
   .tab.active .close-btn {
-    opacity: 1;
+    opacity: 0.8;
   }
 
   .close-btn:hover {
-    background: var(--bg-button-hover);
+    background: color-mix(in oklch, var(--text) 8%, transparent);
+    color: var(--text);
+    opacity: 1;
+  }
+
+  .new-tab-btn {
+    align-self: center;
+    margin: 0 6px 0 4px;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .new-tab-btn:hover {
+    background: color-mix(in oklch, var(--text) 8%, transparent);
     color: var(--text);
   }
 

--- a/src/renderer/lib/components/TitleBar.svelte
+++ b/src/renderer/lib/components/TitleBar.svelte
@@ -3,15 +3,42 @@
 
   interface Props {
     notebaseName: string;
-    fileName: string;
+    /** Project-relative path of the active file (e.g.
+     *  `essays/on-the-trust-principle.md`). The breadcrumb chain is
+     *  derived from the path segments — folder · folder · italic note
+     *  title — so the title bar reads as a real location, not just a
+     *  filename. `null` when no file is open. */
+    filePath: string | null;
     isDirty: boolean;
     canGoBack: boolean;
     canGoForward: boolean;
     onNavBack: () => void;
     onNavForward: () => void;
+    /** Opens the cmd-K Goto Note palette. Triggered by the search
+     *  affordance in the right cluster. */
+    onOpenGotoNote: () => void;
+    /** Opens Settings. Triggered by the cog button at the far right. */
+    onOpenSettings: () => void;
   }
 
-  let { notebaseName, fileName, isDirty, canGoBack, canGoForward, onNavBack, onNavForward }: Props = $props();
+  let {
+    notebaseName, filePath, isDirty,
+    canGoBack, canGoForward,
+    onNavBack, onNavForward,
+    onOpenGotoNote, onOpenSettings,
+  }: Props = $props();
+
+  /** Split the active file's path into folder segments and a leaf.
+   *  The leaf renders in italic display-serif; the folders in muted
+   *  sans. Strips the `.md`/`.ttl`/`.csv` extension off the leaf so
+   *  the title bar shows the human title, not the file name. */
+  const segments = $derived.by(() => {
+    if (!filePath) return null;
+    const parts = filePath.split('/').filter(Boolean);
+    if (parts.length === 0) return null;
+    const leaf = parts[parts.length - 1].replace(/\.(md|ttl|csv)$/, '');
+    return { folders: parts.slice(0, -1), leaf };
+  });
 </script>
 
 <div class="titlebar">
@@ -21,86 +48,194 @@
       disabled={!canGoBack}
       onclick={onNavBack}
       title="Back (Cmd+[)"
-    ><Icon name="back" size={14} /></button>
+    ><Icon name="back" size={15} /></button>
     <button
       class="nav-btn"
       disabled={!canGoForward}
       onclick={onNavForward}
       title="Forward (Cmd+])"
-    ><Icon name="forward" size={14} /></button>
+    ><Icon name="forward" size={15} /></button>
   </div>
-  <span class="titlebar-text">
+
+  <span class="nav-divider" aria-hidden="true"></span>
+
+  <div class="breadcrumb">
+    <span class="brand"><Icon name="minervaMark" size={14} color="var(--accent)" /></span>
     {#if notebaseName}
-      {notebaseName}
-      {#if fileName}
-        <span class="separator">/</span>
-        {fileName}{#if isDirty}<span class="dirty">*</span>{/if}
-      {/if}
-    {:else}
-      Minerva
+      <span class="crumb">{notebaseName}</span>
     {/if}
-  </span>
+    {#if segments}
+      {#each segments.folders as folder}
+        <span class="chev" aria-hidden="true">›</span>
+        <span class="crumb">{folder}</span>
+      {/each}
+      <span class="chev" aria-hidden="true">›</span>
+      <span class="leaf">{segments.leaf}</span>
+      {#if isDirty}<span class="dirty" title="Unsaved changes">•</span>{/if}
+    {/if}
+  </div>
+
+  <div class="right-cluster">
+    <button class="search-box" onclick={onOpenGotoNote} title="Goto Note (Cmd+K)">
+      <Icon name="search" size={13} color="var(--text-muted)" />
+      <span class="search-placeholder">Find…</span>
+      <span class="search-kbd">⌘ K</span>
+    </button>
+    <button class="icon-btn" onclick={onOpenSettings} title="Settings">
+      <Icon name="settings" size={15} color="var(--text-muted)" />
+    </button>
+  </div>
 </div>
 
 <style>
   .titlebar {
     -webkit-app-region: drag;
-    height: 38px;
+    height: 42px;
     display: flex;
     align-items: center;
-    justify-content: center;
-    background: var(--bg-titlebar);
+    gap: 12px;
+    background: var(--bg);
     border-bottom: 1px solid var(--border);
     flex-shrink: 0;
     padding-left: 80px;
+    padding-right: 14px;
     position: relative;
   }
 
+  /* Nav cluster — back/forward arrows */
   .nav-arrows {
     -webkit-app-region: no-drag;
     display: flex;
     gap: 2px;
-    position: absolute;
-    left: 80px;
+    flex-shrink: 0;
   }
-
   .nav-btn {
+    -webkit-app-region: no-drag;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--titlebar-text-muted);
+    cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 3px 6px;
-    border: none;
-    border-radius: 3px;
-    background: none;
-    color: var(--titlebar-text);
-    font-size: 14px;
-    cursor: pointer;
-    line-height: 1;
   }
-
   .nav-btn:hover:not(:disabled) {
-    background: var(--titlebar-button);
+    background: color-mix(in oklch, var(--text) 8%, transparent);
+    color: var(--titlebar-text);
   }
-
   .nav-btn:disabled {
-    color: var(--titlebar-text-muted);
-    opacity: 0.4;
+    opacity: 0.35;
     cursor: default;
   }
 
-  .titlebar-text {
-    font-size: 12px;
-    color: var(--titlebar-text-muted);
+  .nav-divider {
+    width: 1px;
+    height: 18px;
+    background: var(--border);
+    flex-shrink: 0;
+  }
+
+  /* Breadcrumb chain — mark · folder · folder · italic title · dirty-dot */
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--titlebar-text);
+    min-width: 0;
+    overflow: hidden;
     user-select: none;
   }
-
-  .separator {
-    margin: 0 4px;
-    opacity: 0.5;
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
   }
-
+  .crumb {
+    color: var(--titlebar-text-muted);
+    font-family: var(--font-sans);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .chev {
+    color: var(--text-faint);
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+  .leaf {
+    color: var(--titlebar-text);
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
   .dirty {
     color: var(--accent);
-    margin-left: 2px;
+    font-size: 16px;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  /* Right cluster — search affordance + settings cog */
+  .right-cluster {
+    -webkit-app-region: no-drag;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .search-box {
+    -webkit-app-region: no-drag;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 24px;
+    padding: 0 10px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-muted);
+    cursor: text;
+    font-family: var(--font-sans);
+  }
+  .search-box:hover {
+    border-color: var(--border-strong);
+  }
+  .search-placeholder {
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+  .search-kbd {
+    margin-left: 16px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+  .icon-btn {
+    -webkit-app-region: no-drag;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--titlebar-text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .icon-btn:hover {
+    background: color-mix(in oklch, var(--text) 8%, transparent);
+    color: var(--titlebar-text);
   }
 </style>


### PR DESCRIPTION
Closes #549. Part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §7. Reference: [`components/chrome.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/chrome.jsx).

## Summary

### Title bar (§7.1)
- Height 38 → 42; background now `var(--bg)` so it sits flush against the editor.
- **Breadcrumb chain** replaces the centered name/file text: brand mark + `folder · folder · italic display-serif title · dirty-dot`. Derives from a new `filePath` prop split into segments; leaf strips `.md`/`.ttl`/`.csv`.
- **Right cluster**: search affordance (opens cmd-K via `onOpenGotoNote`, shows ⌘ K kbd hint) + settings cog (`onOpenSettings`).
- Back/forward arrows already SVG from #555; bumped to size 15 for the taller bar.

### Tab bar (§7.2)
- Height ~24 → 36.
- **Leading slot**: dirty pip when unsaved, type icon (`notes`/`query`/`source`) otherwise. Pip wins so unsaved cue can't be missed.
- **Active tab**: 2px accent underline along the bottom (`::after` at -1px so it overlaps the tab-bar border for a flush look) in addition to the bg swap.
- Close × is the close `Icon`; new trailing `+ new tab` button wired to `handleNewNote()`.

### Status bar (§7.3)
- Height 22 → 28.
- L/C cell: `L47 · C23` in `--font-mono` with `tabular-nums`.
- 1px hairline rules between item groups (`.rule` spans).
- **New saved-state cue** on the left: `<check> saved` (sage) when clean, `<dot> unsaved` (accent) when dirty. Hidden when no active note tab.
- Inspections badge pinned to `var(--rust)` (no more hardcoded `#f9e2af` peach) — survives palette swaps; signal color, not red.

### App.svelte wiring
- TitleBar: `fileName` → `filePath` from `editor.activeFilePath`; new `onOpenGotoNote` / `onOpenSettings`.
- TabBar: new `onNewTab` → `handleNewNote()`.
- StatusBar: new `isDirty` + `hasActiveNote` props from `editor` store.

## Trust principle / CLAUDE.md compliance
- **No danger styling** — every accent surface uses `var(--accent)`; the rust badge is a signal color for inspections, never red.
- **Stay out of the way** — no new modals; new affordances just surface existing commands (Goto Note, Settings, New Note).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2197 tests)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: launch `pnpm dev` and confirm:
  - Title bar shows the breadcrumb chain with the brand mark, folder muted, leaf italic display-serif; dirty dot appears when typing
  - Search affordance (right of breadcrumb) opens Goto Note when clicked; cog opens Settings
  - Tab bar: each tab has a leading icon (or dirty pip when unsaved); active tab has a 2px accent rail at the bottom; trailing + button creates a new note
  - Status bar: `L47 · C23` in mono, "saved" cue on the left flips to "unsaved" while typing, inspection badge is now rust-colored

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)