### PR TITLE
design: onboarding — two-column brand panel + form (#553)

### DIFF
--- a/src/renderer/lib/components/OnboardingDialog.svelte
+++ b/src/renderer/lib/components/OnboardingDialog.svelte
@@ -7,11 +7,15 @@
    * conversation pre-loaded with a system prompt that instructs the
    * agent to draft an index + linked child notes via `propose_notes`.
    *
-   * The dialog is intentionally a single page (not a wizard) — four
-   * fields fits comfortably and a multi-step flow felt heavyweight for
-   * something a user might dismiss on sight. "Don't show again" is a
-   * per-thoughtbase opt-out wired through `notebase.setOnboardingDismissed`.
+   * Layout follows IMPLEMENTATION.md §11: two columns — a 280px brand
+   * panel on the left (mark + wordmark + tagline + Hegel epigraph) and
+   * the form on the right (eyebrow + display H1 + 4 fields + footer).
+   *
+   * "Don't show again" is per-thoughtbase via `notebase.setOnboardingDismissed`.
    */
+  import Icon from './Icon.svelte';
+  import SegmentedControl from './ui/SegmentedControl.svelte';
+
   export interface OnboardingAnswers {
     subject: string;
     expertise: 'beginner' | 'familiar' | 'expert';
@@ -36,6 +40,18 @@
   $effect(() => { subjectInput?.focus(); });
 
   const canSubmit = $derived(subject.trim().length > 0);
+
+  const EXPERTISE_OPTIONS = [
+    { value: 'beginner', label: 'new to it' },
+    { value: 'familiar', label: 'familiar' },
+    { value: 'expert',   label: 'expert' },
+  ] as const;
+
+  const DEPTH_OPTIONS = [
+    { value: 'quick',    label: 'quick',    sub: '3–5 notes' },
+    { value: 'moderate', label: 'moderate', sub: '8–12 notes' },
+    { value: 'deep',     label: 'deep',     sub: '15–25 notes' },
+  ] as const;
 
   function handleAccept() {
     if (!canSubmit) return;
@@ -62,79 +78,93 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) handleDecline(); }}>
   <div class="dialog" role="dialog" aria-labelledby="onboarding-title">
-    <h2 id="onboarding-title" class="title">Welcome to your new thoughtbase</h2>
-    <p class="lede">
-      Want a head start? Tell me what you’re curious about and I’ll draft an
-      index plus a set of linked notes you can edit, branch from, or throw out.
-    </p>
-
-    <label class="field">
-      <span class="label">What would you like an overview of?</span>
-      <input
-        bind:this={subjectInput}
-        bind:value={subject}
-        type="text"
-        class="text-input"
-        placeholder="e.g. game theory, the Reformation, gene regulatory networks…"
-        onkeydown={(e) => { if (e.key === 'Enter' && canSubmit) handleAccept(); }}
-      />
-    </label>
-
-    <fieldset class="field">
-      <legend class="label">How familiar are you with this topic?</legend>
-      <div class="radio-row">
-        <label class="radio">
-          <input type="radio" name="expertise" value="beginner" bind:group={expertise} />
-          <span>New to it</span>
-        </label>
-        <label class="radio">
-          <input type="radio" name="expertise" value="familiar" bind:group={expertise} />
-          <span>Some familiarity</span>
-        </label>
-        <label class="radio">
-          <input type="radio" name="expertise" value="expert" bind:group={expertise} />
-          <span>Already deep</span>
-        </label>
+    <!-- Left brand panel -->
+    <aside class="brand-panel">
+      <div class="brand-rule" aria-hidden="true"></div>
+      <div class="brand-top">
+        <Icon name="minervaMark" size={64} color="var(--accent)" />
+        <div class="wordmark">Minerva</div>
+        <div class="tagline">Software for superhumans</div>
       </div>
-    </fieldset>
+      <blockquote class="epigraph">
+        <p>“The owl of Minerva spreads her wings only with the falling of the dusk.”</p>
+        <cite>— Hegel</cite>
+      </blockquote>
+    </aside>
 
-    <label class="field">
-      <span class="label">How do you plan to use these notes? <span class="optional">(optional)</span></span>
-      <input
-        bind:value={use}
-        type="text"
-        class="text-input"
-        placeholder="study, writing, research, teaching, exploration…"
-      />
-    </label>
+    <!-- Right form -->
+    <div class="form-panel">
+      <header class="form-header">
+        <div class="eyebrow">New thoughtbase · step 1 of 1</div>
+        <h1 id="onboarding-title" class="title">What would you like to think about?</h1>
+        <p class="lede">
+          I'll draft a starter set of linked notes — an index plus a handful of
+          children — and you can approve, edit, or discard the whole thing
+          with one keystroke.
+        </p>
+      </header>
 
-    <fieldset class="field">
-      <legend class="label">How deep should the overview go?</legend>
-      <div class="radio-row">
-        <label class="radio">
-          <input type="radio" name="depth" value="quick" bind:group={depth} />
-          <span>Quick orientation <em>(3–5 notes)</em></span>
-        </label>
-        <label class="radio">
-          <input type="radio" name="depth" value="moderate" bind:group={depth} />
-          <span>Moderate <em>(8–12)</em></span>
-        </label>
-        <label class="radio">
-          <input type="radio" name="depth" value="deep" bind:group={depth} />
-          <span>Deep dive <em>(15–25)</em></span>
-        </label>
+      <div class="fields">
+        <div class="field">
+          <label class="label" for="onb-subject">Subject</label>
+          <input
+            id="onb-subject"
+            bind:this={subjectInput}
+            bind:value={subject}
+            type="text"
+            class="text-input"
+            placeholder="e.g. the epistemology of dialogue"
+            onkeydown={(e) => { if (e.key === 'Enter' && canSubmit) handleAccept(); }}
+          />
+        </div>
+
+        <div class="field field-inline">
+          <span class="label">Reader</span>
+          <SegmentedControl
+            bind:value={expertise as unknown as string}
+            options={EXPERTISE_OPTIONS}
+            aria-label="Reader expertise"
+          />
+        </div>
+
+        <div class="field field-inline">
+          <span class="label">Depth</span>
+          <SegmentedControl
+            bind:value={depth as unknown as string}
+            options={DEPTH_OPTIONS}
+            aria-label="Overview depth"
+          />
+        </div>
+
+        <div class="field">
+          <label class="label" for="onb-use">
+            For
+            <span class="optional">· optional</span>
+          </label>
+          <input
+            id="onb-use"
+            bind:value={use}
+            type="text"
+            class="text-input"
+            placeholder="e.g. a graduate seminar I'm preparing"
+          />
+        </div>
       </div>
-    </fieldset>
 
-    <div class="footer">
-      <label class="dont-ask">
-        <input type="checkbox" bind:checked={dontAskAgain} />
-        Don’t show this for this thoughtbase
-      </label>
-      <div class="actions">
-        <button class="btn secondary" onclick={handleDecline}>Not now</button>
-        <button class="btn primary" disabled={!canSubmit} onclick={handleAccept}>Get started</button>
-      </div>
+      <div class="spacer"></div>
+
+      <footer class="footer">
+        <button class="btn primary" disabled={!canSubmit} onclick={handleAccept}>
+          <Icon name="sparkle" size={12} />
+          Draft my thoughtbase
+        </button>
+        <button class="btn secondary" onclick={handleDecline}>I'll start from scratch</button>
+        <span class="spacer-inline"></span>
+        <label class="dont-ask">
+          <input type="checkbox" bind:checked={dontAskAgain} />
+          Don't ask again
+        </label>
+      </footer>
     </div>
   </div>
 </div>
@@ -144,126 +174,230 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.55);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 20px 22px;
-    min-width: 460px;
-    max-width: 540px;
-    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: stretch;
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 820px;
+    max-width: 100%;
+    min-height: 520px;
+    max-height: calc(100vh - 64px);
+    overflow: hidden;
+    color: var(--text);
+    font-family: var(--font-sans);
+  }
+
+  /* ── Left brand panel ─────────────────────────────────────────── */
+  .brand-panel {
+    width: 280px;
+    padding: 36px;
+    background: var(--bg-elev);
+    border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    justify-content: space-between;
+    position: relative;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+  /* Subtle paper-ruling */
+  .brand-rule {
+    position: absolute;
+    inset: 0;
+    opacity: 0.05;
+    pointer-events: none;
+    background-image: repeating-linear-gradient(
+      0deg,
+      transparent 0 30px,
+      var(--text) 30px 30.5px
+    );
+  }
+  .brand-top {
+    position: relative;
+  }
+  .wordmark {
+    font-family: var(--font-display);
+    font-size: 36px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    margin-top: 16px;
+    line-height: 1;
+    color: var(--text);
+  }
+  .tagline {
+    font-family: var(--font-display);
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 13px;
+    margin-top: 4px;
+  }
+  .epigraph {
+    position: relative;
+    margin: 0;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--text-muted);
+  }
+  .epigraph p {
+    margin: 0;
+  }
+  .epigraph cite {
+    display: block;
+    margin-top: 8px;
+    font-size: 11px;
+    font-family: var(--font-mono);
+    font-style: normal;
+    color: var(--text-faint);
+  }
+
+  /* ── Right form ───────────────────────────────────────────────── */
+  .form-panel {
+    flex: 1;
+    padding: 44px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    min-width: 0;
+    overflow: auto;
+  }
+  .form-header .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    margin-bottom: 8px;
   }
   .title {
     margin: 0;
-    font-size: 16px;
-    font-weight: 600;
+    font-family: var(--font-display);
+    font-size: 30px;
+    font-weight: 500;
+    letter-spacing: -0.015em;
+    line-height: 1.1;
     color: var(--text);
   }
   .lede {
-    margin: 0;
-    font-size: 13px;
-    line-height: 1.45;
+    margin: 10px 0 0;
+    font-size: 13.5px;
     color: var(--text-muted);
+    line-height: 1.55;
+    max-width: 460px;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    max-width: 460px;
   }
   .field {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    border: none;
-    padding: 0;
-    margin: 0;
     min-width: 0;
+  }
+  .field-inline {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
   }
   .label {
     font-size: 12px;
-    color: var(--text);
-    font-weight: 500;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
   }
   .optional {
-    color: var(--text-muted);
-    font-weight: 400;
+    color: var(--text-faint);
+    margin-left: 4px;
   }
   .text-input {
-    padding: 7px 9px;
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg-inset);
+    color: var(--text);
     border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--bg);
-    color: var(--text);
+    border-radius: 6px;
+    font-family: var(--font-sans);
     font-size: 13px;
-    font-family: inherit;
+    outline: none;
   }
-  .text-input:focus { outline: none; border-color: var(--accent); }
-  .radio-row {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+  .text-input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
   }
-  .radio {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    color: var(--text);
-    font-size: 13px;
-    cursor: pointer;
-    padding: 2px 4px;
-    border-radius: 3px;
+
+  .spacer {
+    flex: 1;
   }
-  .radio:hover { background: var(--bg-button); }
-  .radio input { cursor: pointer; }
-  .radio em {
-    color: var(--text-muted);
-    font-style: normal;
-    font-size: 12px;
+  .spacer-inline {
+    flex: 1;
   }
+
+  /* ── Footer ──────────────────────────────────────────────────── */
   .footer {
     display: flex;
     align-items: center;
-    gap: 16px;
-    margin-top: 4px;
-  }
-  .dont-ask {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--text-muted);
-    font-size: 12px;
-    cursor: pointer;
-  }
-  .dont-ask input { cursor: pointer; }
-  .actions {
-    display: flex;
-    gap: 8px;
-    margin-left: auto;
+    gap: 14px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
   }
   .btn {
-    padding: 6px 14px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
-    cursor: pointer;
+    padding: 9px 18px;
+    border: none;
+    border-radius: 7px;
     font-family: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
   }
-  .secondary {
-    background: var(--bg-button);
+  .btn.primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    font-weight: 600;
+  }
+  .btn.primary:hover:not(:disabled) {
+    opacity: 0.92;
+  }
+  .btn.primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .btn.secondary {
+    background: transparent;
+    color: var(--text-muted);
+    padding: 9px 12px;
+  }
+  .btn.secondary:hover {
     color: var(--text);
   }
-  .secondary:hover { background: var(--bg-button-hover); }
-  .primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
+  .dont-ask {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11.5px;
+    color: var(--text-faint);
+    cursor: pointer;
   }
-  .primary:hover:not(:disabled) { opacity: 0.9; }
-  .primary:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
+  .dont-ask input {
+    accent-color: var(--accent);
+    cursor: pointer;
   }
 </style>


### PR DESCRIPTION
Closes #553. Part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §11. Reference: [`components/onboarding.jsx`](../blob/main/docs/design/2026-05-design-review/project/components/onboarding.jsx).

## Summary
Two-column 820px dialog (vs. the previous 460px single-page form). `OnboardingAnswers` shape and `buildOnboardingPrompts` logic in App.svelte are **unchanged**.

### Left brand panel (280px)
- Subtle paper-ruling background (5% opacity repeating-linear-gradient).
- Minerva mark (64px, accent) + display-serif wordmark + italic tagline.
- Hegel epigraph at the bottom in italic display-serif with mono attribution.

### Right form
- Mono-uppercase eyebrow: "NEW THOUGHTBASE · STEP 1 OF 1"
- Display-serif H1: "What would you like to think about?"
- Four fields:
  1. Subject (text input)
  2. Reader → `SegmentedControl` (new to it / familiar / expert)
  3. Depth → `SegmentedControl` with `sub` labels showing note-count bands in mono-faint
  4. For (optional)
- Footer: primary "Draft my thoughtbase" with leading `sparkle` icon, secondary "I'll start from scratch", "Don't ask again" pushed right.

### Wiring
- Reuses `SegmentedControl` from the #545 primitives PR.
- `Icon` for brand mark + sparkle CTA.
- App.svelte plumbing unchanged: `OnboardingAnswers` shape is the same.
- "Don't ask again" remains per-thoughtbase via `notebase.setOnboardingDismissed`.

## Trust principle / CLAUDE.md
- **Stay out of the way** — still a single page, not a wizard.
- **No danger styling** — Decline is a ghost secondary.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2197 tests)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: open an empty thoughtbase to trigger onboarding. Confirm:
  - Two-column dialog with brand panel on the left (paper-ruling, owl mark, Hegel quote)
  - Right form: mono eyebrow, display-serif H1, segmented controls for Reader + Depth (with note-count sub-labels)
  - Primary CTA shows a sparkle icon and accent bg; "Don't ask again" sits at the far right

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)