### PR TITLE
design: dialogs sweep — Confirm / Prompt / Busy + Settings shell (#552)

### DIFF
--- a/src/renderer/lib/components/BusyOverlay.svelte
+++ b/src/renderer/lib/components/BusyOverlay.svelte
@@ -1,15 +1,37 @@
 <script lang="ts">
+  /**
+   * Busy overlay refreshed per IMPLEMENTATION.md §10.6. A card with a
+   * spinner (12px arc rotating around a static ring) + verb-noun
+   * headline. Signature unchanged.
+   */
   interface Props {
     label: string;
+    /** Optional sub-line (e.g. "Rewriting 13 incoming links…"). */
+    sub?: string;
   }
 
-  let { label }: Props = $props();
+  let { label, sub }: Props = $props();
 </script>
 
-<div class="overlay">
-  <div class="box">
-    <div class="spinner" aria-hidden="true"></div>
+<div class="overlay" role="status" aria-live="polite">
+  <div class="card">
+    <div class="spinner" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="32" height="32">
+        <circle cx="12" cy="12" r="9" stroke="var(--border)" stroke-width="2" fill="none" />
+        <path
+          d="M21 12a9 9 0 0 1-9 9"
+          stroke="var(--accent)"
+          stroke-width="2"
+          fill="none"
+          stroke-linecap="round"
+          class="arc"
+        />
+      </svg>
+    </div>
     <div class="label">{label}</div>
+    {#if sub}
+      <div class="sub">{sub}</div>
+    {/if}
   </div>
 </div>
 
@@ -18,41 +40,60 @@
     position: fixed;
     inset: 0;
     z-index: 3000;
-    background: rgba(0, 0, 0, 0.4);
+    background: rgba(20, 14, 6, 0.35);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    padding: 26px 24px 22px;
+    width: 300px;
+    max-width: 100%;
+    text-align: center;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+
+  .spinner {
+    margin: 0 auto 14px;
+    width: 40px;
+    height: 40px;
     display: flex;
     align-items: center;
     justify-content: center;
   }
-
-  .box {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 10px;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 18px 22px;
-    min-width: 180px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  }
-
-  .spinner {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    border: 2px solid var(--border);
-    border-top-color: var(--accent);
-    animation: spin 0.9s linear infinite;
+  .arc {
+    transform-origin: 12px 12px;
+    animation: spin 1.2s linear infinite;
   }
 
   .label {
-    font-size: 12px;
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
     color: var(--text);
-    text-align: center;
+  }
+
+  .sub {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
   }
 
   @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+      transform: rotate(360deg);
+    }
   }
 </style>

--- a/src/renderer/lib/components/ConfirmDialog.svelte
+++ b/src/renderer/lib/components/ConfirmDialog.svelte
@@ -1,4 +1,11 @@
 <script lang="ts">
+  /**
+   * Confirm dialog refreshed per IMPLEMENTATION.md §10.1. Signature
+   * (`showConfirm(message, key, label, opts)`) is unchanged — only
+   * the rendering. Keeps the "Don't ask again" checkbox per CLAUDE.md
+   * unless `hideDontAskAgain` is set, and the primary CTA stays on
+   * the accent color even for destructive verbs (no danger styling).
+   */
   interface Props {
     message: string;
     confirmLabel?: string;
@@ -34,18 +41,31 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog">
-    <p class="message">{message}</p>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Confirm action</div>
+      <h2 class="title">{message}</h2>
+    </header>
+
     {#if !hideDontAskAgain}
-      <label class="dont-ask">
-        <input type="checkbox" bind:checked={dontAskAgain} />
-        Don't ask again
-      </label>
+      <div class="body">
+        <label class="dont-ask">
+          <input type="checkbox" bind:checked={dontAskAgain} />
+          Don't ask again
+        </label>
+      </div>
     {/if}
-    <div class="actions">
-      <button class="btn secondary" onclick={onCancel}>Cancel</button>
-      <button class="btn primary" bind:this={confirmBtn} onclick={() => onConfirm(dontAskAgain)}>{confirmLabel}</button>
-    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↵ confirm</span>
+      <span class="footer-actions">
+        <button class="btn secondary" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" bind:this={confirmBtn} onclick={() => onConfirm(dontAskAgain)}>
+          {confirmLabel}
+          <span class="btn-kbd">↵</span>
+        </button>
+      </span>
+    </footer>
   </div>
 </div>
 
@@ -54,73 +74,121 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
 
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
-    min-width: 300px;
-    max-width: 400px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 440px;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
   }
 
-  .message {
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
     color: var(--text);
+  }
+
+  .body {
+    padding: 14px 24px 18px;
     font-size: 13px;
   }
-
   .dont-ask {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .dont-ask input {
+    accent-color: var(--accent);
+    cursor: pointer;
+  }
+
+  .card-footer {
     display: flex;
     align-items: center;
-    gap: 6px;
-    color: var(--text-muted);
-    font-size: 12px;
-    cursor: pointer;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
   }
-
-  .dont-ask input {
-    cursor: pointer;
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
   }
-
-  .actions {
-    display: flex;
-    justify-content: flex-end;
+  .footer-actions {
+    display: inline-flex;
     gap: 8px;
   }
 
   .btn {
-    padding: 5px 14px;
+    padding: 7px 14px;
     border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
-
   .secondary {
-    background: var(--bg-button);
-    color: var(--text);
+    background: transparent;
+    color: var(--text-muted);
   }
-
   .secondary:hover {
-    background: var(--bg-button-hover);
+    color: var(--text);
+    border-color: var(--border-strong);
   }
-
+  /* "primary" not "danger" per CLAUDE.md — destructive verbs stay
+     on the accent color, never red. */
   .primary {
     background: var(--accent);
-    color: var(--bg);
+    color: var(--accent-ink);
     border-color: var(--accent);
+    font-weight: 600;
   }
-
   .primary:hover {
-    opacity: 0.9;
+    opacity: 0.92;
+  }
+  .btn-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    opacity: 0.7;
   }
 </style>

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  /**
+   * Prompt dialog refreshed per IMPLEMENTATION.md §10.1. Signature
+   * (`showPrompt(message, opts)`) is unchanged — only the rendering.
+   */
   interface Props {
     message: string;
     onConfirm: (value: string) => void;
@@ -31,27 +35,40 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog">
-    <label class="message">{message}</label>
-    <input
-      bind:this={inputEl}
-      bind:value
-      type="text"
-      class="input"
-      list={suggestions.length > 0 ? listId : undefined}
-      autocomplete="off"
-    />
-    {#if suggestions.length > 0}
-      <datalist id={listId}>
-        {#each suggestions as s}
-          <option value={s}></option>
-        {/each}
-      </datalist>
-    {/if}
-    <div class="actions">
-      <button class="btn cancel" onclick={onCancel}>Cancel</button>
-      <button class="btn confirm" disabled={!value.trim()} onclick={() => onConfirm(value.trim())}>OK</button>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Input</div>
+      <h2 class="title">{message}</h2>
+    </header>
+
+    <div class="body">
+      <input
+        bind:this={inputEl}
+        bind:value
+        type="text"
+        class="input"
+        list={suggestions.length > 0 ? listId : undefined}
+        autocomplete="off"
+      />
+      {#if suggestions.length > 0}
+        <datalist id={listId}>
+          {#each suggestions as s}
+            <option value={s}></option>
+          {/each}
+        </datalist>
+      {/if}
     </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↵ confirm</span>
+      <span class="footer-actions">
+        <button class="btn secondary" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={!value.trim()} onclick={() => onConfirm(value.trim())}>
+          OK
+          <span class="btn-kbd">↵</span>
+        </button>
+      </span>
+    </footer>
   </div>
 </div>
 
@@ -60,80 +77,122 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
 
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
-    min-width: 300px;
-    max-width: 400px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 460px;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-  }
-
-  .message {
+    font-family: var(--font-sans);
     color: var(--text);
-    font-size: 13px;
+    overflow: hidden;
   }
 
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+    color: var(--text);
+  }
+
+  .body {
+    padding: 14px 24px 18px;
+  }
   .input {
     width: 100%;
-    padding: 6px 10px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--bg);
+    padding: 8px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    background: var(--bg-inset);
     color: var(--text);
-    font-size: 13px;
+    font-family: var(--font-sans);
+    font-size: 14px;
     outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
   }
 
-  .input:focus {
-    border-color: var(--accent);
-  }
-
-  .actions {
+  .card-footer {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-actions {
+    display: inline-flex;
     gap: 8px;
   }
 
   .btn {
-    padding: 5px 14px;
+    padding: 7px 14px;
     border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
-
-  .cancel {
-    background: var(--bg-button);
+  .secondary {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .secondary:hover {
     color: var(--text);
+    border-color: var(--border-strong);
   }
-
-  .cancel:hover {
-    background: var(--bg-button-hover);
-  }
-
-  .confirm {
+  .primary {
     background: var(--accent);
-    color: var(--bg);
+    color: var(--accent-ink);
     border-color: var(--accent);
+    font-weight: 600;
   }
-
-  .confirm:hover {
-    opacity: 0.9;
+  .primary:hover:not(:disabled) {
+    opacity: 0.92;
   }
-
-  .confirm:disabled {
+  .primary:disabled {
     opacity: 0.4;
     cursor: default;
+  }
+  .btn-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    opacity: 0.7;
   }
 </style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -1109,35 +1109,44 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
 
+  /* Adopt the §10 dialog shell: 12px radius, --bg-elev with
+     --border-strong, layered shadow with inset highlight. */
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
     min-width: 560px;
     max-width: 720px;
     min-height: 420px;
-    max-height: 80vh;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    max-height: calc(100vh - 64px);
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
   }
 
   header {
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--border);
+    padding: 18px 22px 12px;
   }
 
   header h2 {
     margin: 0;
-    font-size: 14px;
+    font-family: var(--font-display);
+    font-size: 19px;
     font-weight: 500;
+    letter-spacing: -0.005em;
     color: var(--text);
   }
 


### PR DESCRIPTION
Part of #552 / epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §10.

## Summary
Brings the **common dialogs** (Confirm, Prompt, Busy) — which fire across nearly every flow — onto the new shell aesthetic, plus a shell-only refresh on Settings. `showConfirm` / `showPrompt` signatures are unchanged.

- **ConfirmDialog (§10.1)** — new shell (12px radius, `--bg-elev`, layered shadow + inset highlight, 32px viewport gutter). Header: mono "CONFIRM ACTION" eyebrow + display-serif title. Footer: kbd hint left, Cancel + Confirm right. Primary CTA stays accent (no danger styling).
- **PromptDialog (§10.1)** — same shell at 460px. Input field gets the accent ring (1px border + 3px 18% halo). Footer matches Confirm.
- **BusyOverlay (§10.6)** — card with SVG spinner (static `--border` ring + rotating `--accent` arc) + display-serif label. New optional `sub` prop for a one-line detail (e.g. "Rewriting 13 incoming links").
- **SettingsDialog — shell only** — overlay + dialog adopt the §10 shell. Header h2 → display-serif 19px.

## Deferred to follow-up issues
The spec also covers:
- GotoNote palette redesign (§10.2)
- Find / Replace (§10.3)
- Settings restructure into 4 groups with reusable SettingRow / Toggle / Stepper primitives (§10.4)
- SaveQuery / AutoLink / Export / OpenTarget (§10.5)

Each is a substantial per-dialog redesign. **This PR ships the "common" dialogs first** so the shell aesthetic propagates immediately across every flow; per-dialog redesigns can land in focused follow-up PRs.

I'll open separate follow-up issues for those, linked from the epic.

## Trust principle / CLAUDE.md
- **No danger styling** — Delete stays on `var(--accent)`.
- **Don't ask again** — checkbox layout unchanged; same `dontAskAgain` slot.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2197 tests)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: trigger any showConfirm (e.g. Delete note), showPrompt (e.g. New note name), or BusyOverlay (e.g. mid-rename). Confirm:
  - New 12px radius card with layered shadow
  - Mono eyebrow above the display-serif title
  - kbd hint in the footer left, accent CTA on the right
  - "Don't ask again" still appears on Confirm; checked state still persists

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)