### PR TITLE
design: right-sidebar panel bodies — Proposals + Footnotes (#548)

### DIFF
--- a/src/renderer/lib/components/right-sidebar/FootnotesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/FootnotesPanel.svelte
@@ -106,12 +106,14 @@
               onclick={() => onScrollToLine(r.targetLine)}
             >
               <span class="label">[^{r.label}]</span>
-              <span class="body">{r.body}</span>
-              {#if r.kind === 'orphan'}
-                <span class="marker" aria-label="Unused">○</span>
-              {:else if r.kind === 'missing'}
-                <span class="marker" aria-label="Missing">?</span>
-              {/if}
+              <span class="footnote-body">
+                <span class="body">{r.body}</span>
+                {#if r.kind === 'orphan'}
+                  <span class="caption">DEFINED · NEVER USED</span>
+                {:else if r.kind === 'missing'}
+                  <span class="caption">REFERENCED · NOT DEFINED</span>
+                {/if}
+              </span>
             </button>
           </li>
         {/each}
@@ -139,55 +141,71 @@
     padding: 4px 0;
   }
 
+  /* Footnote row (§13.2) — mono badge for the label, body text
+     wrapping next to it, mono caption underneath for orphan/missing. */
   .footnote-item {
     display: flex;
-    align-items: baseline;
-    gap: 6px;
+    align-items: flex-start;
+    gap: 8px;
     width: 100%;
-    padding: 6px 10px;
+    padding: 8px 12px;
     border: none;
     background: none;
     color: var(--text);
-    font-size: 12px;
+    font-family: var(--font-sans);
+    font-size: 12.5px;
     cursor: pointer;
     text-align: left;
-    border-radius: 3px;
   }
-
   .footnote-item:hover {
-    background: var(--bg-button);
+    background: color-mix(in oklch, var(--text) 4%, transparent);
   }
 
   .label {
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
     color: var(--accent);
     flex-shrink: 0;
+    line-height: 1.4;
   }
 
+  .footnote-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
   .body {
-    color: var(--text-muted);
+    color: var(--text);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 1;
+  }
+  .caption {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
   }
 
-  .marker {
-    flex-shrink: 0;
-    font-size: 11px;
-    color: var(--text-muted);
-    width: 14px;
-    text-align: center;
+  /* Orphan: muted badge, normal caption. */
+  .footnote-item.orphan .label {
+    color: var(--text-faint);
+    background: color-mix(in oklch, var(--text) 6%, transparent);
   }
+  .footnote-item.orphan .body { color: var(--text-muted); }
 
-  .footnote-item.orphan .label,
+  /* Missing: rust badge + caption. The signal color, not red. */
   .footnote-item.missing .label {
-    color: var(--text-muted);
+    color: var(--rust);
+    background: color-mix(in oklch, var(--rust) 14%, transparent);
   }
-  .footnote-item.orphan .body,
-  .footnote-item.missing .body {
-    font-style: italic;
-  }
+  .footnote-item.missing .body { color: var(--text-muted); font-style: italic; }
+  .footnote-item.missing .caption { color: var(--rust); }
 
   .empty {
     padding: 12px;

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -256,14 +256,14 @@
           class:selected={selectedUri === p.uri}
           onclick={() => selectedUri = selectedUri === p.uri ? null : p.uri}
         >
-          <span class="proposal-type">{p.operationType.replace(/_/g, ' ')}</span>
+          <span class="proposal-meta">
+            <span class="proposal-status status-{p.status}">{p.status}</span>
+            <span class="proposal-type">{p.operationType.replace(/_/g, ' ')}</span>
+            <span class="proposal-by">{p.proposedBy}</span>
+          </span>
           <span class="proposal-note">{p.note}</span>
           <span class="proposal-effects" title="What approving this proposal will create">
             {p.status === 'pending' ? 'Will create' : 'Created'}: {bundleEffectsSummary(p)}
-          </span>
-          <span class="proposal-meta">
-            <span class="proposal-status status-{p.status}">{p.status}</span>
-            <span class="proposal-by">{p.proposedBy}</span>
           </span>
         </button>
 
@@ -321,28 +321,28 @@
     outline: none;
   }
 
+  /* Filter chips (§13.8) — pill row instead of bordered rectangles. */
   .status-tabs {
     display: flex;
-    gap: 2px;
-    margin-bottom: 8px;
+    gap: 6px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
   }
   .status-tab {
-    flex: 1;
-    padding: 4px 6px;
+    padding: 3px 10px;
     border: 1px solid var(--border);
-    background: none;
+    background: var(--bg);
     color: var(--text-muted);
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    font-family: var(--font-sans);
+    font-size: 11.5px;
     cursor: pointer;
-    border-radius: 3px;
+    border-radius: 999px;
   }
-  .status-tab:hover { color: var(--text); }
+  .status-tab:hover:not(.active) { color: var(--text); }
   .status-tab.active {
-    color: var(--text);
-    border-color: var(--accent);
-    background: var(--bg-button);
+    color: var(--accent);
+    border-color: color-mix(in oklch, var(--accent) 30%, transparent);
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
   }
   .empty {
     color: var(--text-muted);
@@ -357,31 +357,76 @@
     gap: 4px;
   }
 
+  /* Proposal card (§13.8) — softer shell with the status pill at the
+     top in mono-uppercase, accent-tinted for pending / sage for
+     approved / muted for rejected. */
   .proposal-item {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: 6px 8px;
+    gap: 4px;
+    padding: 8px 10px;
     border: 1px solid var(--border);
-    border-radius: 4px;
-    background: none;
+    border-radius: 6px;
+    background: var(--bg);
     cursor: pointer;
     text-align: left;
     width: 100%;
+    font-family: var(--font-sans);
   }
 
-  .proposal-item:hover { background: var(--bg-button); }
-  .proposal-item.selected { border-color: var(--accent); background: var(--bg-button); }
+  .proposal-item:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .proposal-item.selected {
+    border-color: color-mix(in oklch, var(--accent) 40%, transparent);
+    background: color-mix(in oklch, var(--accent) 8%, transparent);
+  }
 
-  .proposal-type {
-    font-size: 11px;
+  /* Pending/approved/rejected pill at the top of the card. The
+     .proposal-status class on the existing span carries the status
+     variant; we drop the type label next to it. */
+  .proposal-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+  }
+  .proposal-status {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
     font-weight: 600;
-    color: var(--accent);
+    padding: 1px 6px;
+    border-radius: 999px;
     text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 1px solid transparent;
+  }
+  .proposal-status.status-pending {
+    color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+  .proposal-status.status-approved {
+    color: var(--sage);
+    background: color-mix(in oklch, var(--sage) 18%, transparent);
+  }
+  .proposal-status.status-rejected,
+  .proposal-status.status-expired {
+    color: var(--text-faint);
+    background: color-mix(in oklch, var(--text) 6%, transparent);
+  }
+  .proposal-type {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: lowercase;
+  }
+  .proposal-by {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
   }
 
   .proposal-note {
-    font-size: 12px;
+    font-size: 12.5px;
     color: var(--text);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -390,30 +435,8 @@
 
   .proposal-effects {
     font-size: 11px;
-    color: var(--accent);
-  }
-  .proposal-meta {
-    display: flex;
-    gap: 8px;
-    font-size: 10px;
     color: var(--text-muted);
   }
-  .proposal-by {
-    font-size: 10px;
-    color: var(--text-muted);
-  }
-  .proposal-status {
-    font-size: 10px;
-    padding: 1px 6px;
-    border-radius: 3px;
-    border: 1px solid var(--border);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-  .proposal-status.status-approved { color: var(--accent); border-color: var(--accent); }
-  .proposal-status.status-pending { color: var(--text); }
-  .proposal-status.status-rejected,
-  .proposal-status.status-expired { color: var(--text-muted); }
 
   .proposal-detail {
     border: 1px solid var(--border);
@@ -504,18 +527,32 @@
     border-top: 1px solid var(--border);
   }
 
+  /* Approve = accent CTA. Reject = ghost outline (no danger styling
+     per CLAUDE.md — reject is just a normal action). */
   .action-btn {
     flex: 1;
-    padding: 4px 8px;
+    padding: 5px 10px;
     border: 1px solid var(--border);
-    border-radius: 3px;
-    background: var(--bg-button);
-    color: var(--text);
-    font-size: 11px;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 11.5px;
     cursor: pointer;
   }
-
-  .action-btn:hover { background: var(--bg-button-hover); }
+  .action-btn:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
   .action-btn:disabled { opacity: 0.4; cursor: default; }
-  .action-btn.approve { border-color: var(--accent); }
+  .action-btn.approve {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .action-btn.approve:hover:not(:disabled) {
+    opacity: 0.92;
+    color: var(--accent-ink);
+  }
 </style>


### PR DESCRIPTION
Part of #548 / epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §13.

## Summary
The §6 regroup (#558) already gave each panel a parent-provided display-serif header. This PR redesigns the **bodies** of the two highest-value panels: Proposals (the activity heart) and Footnotes.

### Proposals (§13.8)
- **Filter chips** at the top are now accent-tinted pills (All / Pending / Approved / Rejected) instead of bordered rectangles.
- **Per-proposal card**: status pill leads the meta row in mono-uppercase. Tone follows status:
  - `pending` → accent
  - `approved` → sage
  - `rejected/expired` → faint
- Operation type renders in `--font-mono` in the meta row. Proposed-by floats right in mono-faint.
- **Action buttons**: Approve = accent CTA (accent bg, `--accent-ink`, weight 600). Reject = ghost outline (no red — `--text-muted` / border).

### Footnotes (§13.2)
- Row shows: mono badge `[^label]` (accent-tinted bg) + body text wrapping next to it + mono caption underneath for orphan/missing.
- **Orphan**: muted badge + caption `DEFINED · NEVER USED`.
- **Missing**: `--rust` badge + caption `REFERENCED · NOT DEFINED` (signal color, not red).

## Deferred to follow-up
The spec §13 also covers (each substantial enough to warrant its own PR):
- §13.1 **Properties** — typed-row editor with type icons + value controls per type + canonical-suggestion chips
- §13.3 **Outgoing/Backlinks** — 7×7 color squares per group + chevron icons + rust dead-link styling (LinkBadge already does most of the visual)
- §13.4 **Tags** (right sidebar) — hierarchical tree
- §13.5 **Tables** — SELECT * button
- §13.6 **Citations** — editorial italic source list + attached excerpts
- §13.7 **Bookmarks** — folder tree refinements

**Inspections is explicitly excluded** per the spec — that panel's functionality is changing.

## Trust principle / CLAUDE.md
- Approve still routes through the existing approval engine — rendering-only change.
- **No danger styling** — Reject is a ghost outline; rust badges are signal, not red.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2197 tests)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**:
  - Right sidebar → Activity group → Proposals: filter chip row is accent-tinted, per-card status pill leads, Approve is accent CTA / Reject is ghost
  - Right sidebar → Note group → Footnotes: orphan rows show muted "DEFINED · NEVER USED", missing rows show rust "REFERENCED · NOT DEFINED"

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)