### PR TITLE
design: micro-dialogs sweep — SaveQuery / AutoLink / Export / OpenTarget (§10.5)

### DIFF
--- a/src/renderer/lib/components/AutoLinkDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkDialog.svelte
@@ -57,50 +57,59 @@
   onkeydown={handleKeydown}
   onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
 >
-  <div class="dialog">
-    <header>
-      <h2>Auto-link suggestions</h2>
-      <span class="count">{selectedCount} of {suggestions.length} selected</span>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Auto-link \u00b7 {suggestions.length} {suggestions.length === 1 ? 'candidate' : 'candidates'}</div>
+      <h2 class="title">Review link suggestions</h2>
     </header>
 
     {#if suggestions.length === 0}
-      <div class="empty">
-        The LLM didn\u2019t find any link candidates in this note. If the note is short or
-        doesn\u2019t mention concepts covered by other notes, that\u2019s the expected outcome.
+      <div class="body">
+        <div class="empty">
+          The LLM didn't find any link candidates in this note. If the note is short or
+          doesn't mention concepts covered by other notes, that's the expected outcome.
+        </div>
       </div>
     {:else}
-      <div class="bulk">
-        <button class="link-btn" onclick={() => toggleAll(true)}>Select all</button>
-        <button class="link-btn" onclick={() => toggleAll(false)}>Select none</button>
-      </div>
-      <div class="list">
-        {#each suggestions as s, i (i)}
-          <label class="row">
-            <input type="checkbox" bind:checked={selected[i]} />
-            <div class="details">
-              <div class="headline">
-                <span class="anchor">{s.anchorText}</span>
-                <span class="arrow">&rarr;</span>
-                <code class="target">[[{targetLabel(s.target)}]]</code>
+      <div class="body">
+        <div class="bulk-row">
+          <span class="bulk-count">{selectedCount} of {suggestions.length} selected</span>
+          <span class="bulk-spacer"></span>
+          <button class="bulk-btn" onclick={() => toggleAll(true)}>Select all</button>
+          <button class="bulk-btn" onclick={() => toggleAll(false)}>Select none</button>
+        </div>
+        <div class="list">
+          {#each suggestions as s, i (i)}
+            <label class="row" class:selected={selected[i]}>
+              <input type="checkbox" bind:checked={selected[i]} />
+              <div class="details">
+                <div class="headline">
+                  <span class="anchor">{s.anchorText}</span>
+                  <span class="arrow">\u2192</span>
+                  <code class="target">[[{targetLabel(s.target)}]]</code>
+                </div>
+                {#if s.rationale}
+                  <div class="rationale">{s.rationale}</div>
+                {/if}
+                <div class="context">{contextSnippet(s.anchorText)}</div>
               </div>
-              {#if s.rationale}
-                <div class="rationale">{s.rationale}</div>
-              {/if}
-              <div class="context">{contextSnippet(s.anchorText)}</div>
-            </div>
-          </label>
-        {/each}
+            </label>
+          {/each}
+        </div>
       </div>
     {/if}
 
-    <div class="actions">
-      <button class="btn" onclick={onCancel}>Cancel</button>
-      <button
-        class="btn primary"
-        disabled={selectedCount === 0}
-        onclick={apply}
-      >Apply {selectedCount}</button>
-    </div>
+    <footer class="card-footer">
+      <span class="kbd-hint">esc \u00b7 cancel</span>
+      <span class="footer-actions">
+        <button class="btn ghost" onclick={onCancel}>Cancel</button>
+        <button
+          class="btn primary"
+          disabled={selectedCount === 0}
+          onclick={apply}
+        >Apply {selectedCount}</button>
+      </span>
+    </footer>
   </div>
 </div>
 
@@ -109,69 +118,88 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
 
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
     width: 640px;
-    max-width: 92vw;
-    max-height: 80vh;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+
+  .card-header { padding: 20px 24px 0; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+
+  .body {
+    padding: 14px 24px 18px;
+    overflow: auto;
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 12px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  }
-
-  header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
-  }
-
-  h2 {
-    margin: 0;
-    font-size: 14px;
-    color: var(--text);
-    font-weight: 600;
-  }
-
-  .count {
-    font-size: 11px;
-    color: var(--text-muted);
   }
 
   .empty {
     font-size: 13px;
     color: var(--text-muted);
     line-height: 1.5;
-    padding: 16px 0;
   }
 
-  .bulk {
+  .bulk-row {
     display: flex;
-    gap: 8px;
+    align-items: center;
+    gap: 12px;
   }
-
-  .link-btn {
-    background: none;
-    border: none;
-    color: var(--accent);
-    padding: 0;
+  .bulk-count {
+    font-family: var(--font-mono);
     font-size: 11px;
-    cursor: pointer;
-    text-decoration: underline;
+    color: var(--text-faint);
   }
-
-  .link-btn:hover {
-    opacity: 0.8;
+  .bulk-spacer { flex: 1; }
+  .bulk-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 3px 9px;
+    border-radius: 5px;
+    font-family: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .bulk-btn:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
   }
 
   .list {
@@ -180,27 +208,30 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    padding-right: 4px;
   }
 
   .row {
     display: flex;
     align-items: flex-start;
     gap: 10px;
-    padding: 8px 10px;
+    padding: 10px 12px;
     border: 1px solid var(--border);
-    border-radius: 6px;
+    border-radius: 8px;
     background: var(--bg);
     cursor: pointer;
   }
-
   .row:hover {
-    border-color: var(--accent);
+    border-color: var(--border-strong);
+  }
+  .row.selected {
+    border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+    background: color-mix(in oklch, var(--accent) 8%, var(--bg));
   }
 
   .row input[type='checkbox'] {
-    margin-top: 2px;
+    margin-top: 3px;
     flex-shrink: 0;
+    accent-color: var(--accent);
   }
 
   .details {
@@ -214,75 +245,87 @@
   .headline {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 12px;
+    gap: 8px;
+    font-size: 12.5px;
     flex-wrap: wrap;
   }
 
   .anchor {
     color: var(--text);
-    font-weight: 600;
+    font-weight: 500;
   }
 
   .arrow {
-    color: var(--text-muted);
+    color: var(--text-faint);
+    font-family: var(--font-mono);
   }
 
   .target {
     color: var(--accent);
-    font-size: 11px;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
+    padding: 1px 6px;
+    border-radius: 4px;
   }
 
   .rationale {
     font-size: 12px;
-    color: var(--text);
-    line-height: 1.4;
+    color: var(--text-muted);
+    line-height: 1.45;
   }
 
   .context {
     font-size: 11px;
-    color: var(--text-muted);
-    line-height: 1.5;
-    font-family: var(--font-mono, ui-monospace, monospace);
-    padding: 4px 8px;
-    background: var(--bg-button);
+    color: var(--text-faint);
+    line-height: 1.55;
+    font-family: var(--font-mono);
+    padding: 5px 9px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     word-break: break-word;
   }
 
-  .actions {
+  .card-footer {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
     gap: 8px;
-    padding-top: 4px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
   }
+  .kbd-hint {
+    margin-right: auto;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .footer-actions { display: inline-flex; gap: 8px; }
 
   .btn {
-    padding: 5px 14px;
+    padding: 7px 14px;
     border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--bg-button);
-    color: var(--text);
-    font-size: 12px;
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
     cursor: pointer;
   }
-
-  .btn:hover:not(:disabled) {
-    background: var(--bg-button-hover);
+  .btn.ghost {
+    background: transparent;
+    color: var(--text-muted);
   }
-
+  .btn.ghost:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
   .btn.primary {
     background: var(--accent);
-    color: var(--bg);
+    color: var(--accent-ink);
     border-color: var(--accent);
+    font-weight: 600;
   }
-
-  .btn.primary:hover:not(:disabled) {
-    opacity: 0.9;
-  }
-
-  .btn:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
+  .btn.primary:hover:not(:disabled) { opacity: 0.92; }
+  .btn:disabled { opacity: 0.4; cursor: default; }
 </style>

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -375,27 +375,35 @@
     position: fixed;
     inset: 0;
     z-index: 200;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
 
   .export-dialog {
-    background: var(--bg);
+    background: var(--bg-elev);
     color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 8px;
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
     padding: 20px 24px;
-    width: 640px;
-    max-width: 90vw;
-    max-height: 85vh;
+    width: 720px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
     display: flex;
     flex-direction: column;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    font-family: var(--font-sans);
   }
 
   h2 {
+    font-family: var(--font-display);
+    font-weight: 500;
+    letter-spacing: -0.005em;
     margin: 0 0 16px;
     font-size: 16px;
     font-weight: 600;
@@ -574,13 +582,18 @@
     grid-column: 1 / -1;
     margin-top: 8px;
   }
+  /* Missing-source pill per §10.5 — rust signal color instead of accent.
+     Per CLAUDE.md "no danger styling" — rust is signal, not red. */
   .citations-section .missing-count {
-    background: var(--bg-button);
-    color: var(--accent);
+    background: color-mix(in oklch, var(--rust) 18%, transparent);
+    color: var(--rust);
+    font-family: var(--font-mono);
     font-weight: 600;
+    padding: 1px 7px;
+    border-radius: 999px;
   }
   .citations-section .missing-list li .title {
-    color: var(--accent);
+    color: var(--rust);
   }
   .citations-section .missing-list {
     margin-bottom: 6px;

--- a/src/renderer/lib/components/OpenTargetDialog.svelte
+++ b/src/renderer/lib/components/OpenTargetDialog.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
   /**
-   * Three-button dialog for "open thoughtbase — here or new window?".
+   * Dialog for "open thoughtbase — here or new window?".
    *
-   * Different from ConfirmDialog because the choice isn't binary:
-   *   - This Window  → clear tabs + open in the current window
-   *   - New Window   → spawn a fresh window for the project
-   *   - Cancel       → do nothing
-   *
-   * "This Window" is styled as the default (primary) — pressing Enter
-   * takes it, matching the less-disruptive choice for someone who just
-   * wanted to switch projects.
+   * Per IMPLEMENTATION.md §10.5: three buttons → two choice cards
+   * with kbd hints (↵ for the primary "this window", ⌘ ↵ for new
+   * window). Cancel becomes a footer ghost button.
    */
+  import Icon from './Icon.svelte';
+
   interface Props {
     message: string;
     onThisWindow: () => void;
@@ -22,8 +19,10 @@
   let thisBtn = $state<HTMLButtonElement>();
 
   function handleKeydown(e: KeyboardEvent): void {
-    if (e.key === 'Enter') onThisWindow();
-    else if (e.key === 'Escape') onCancel();
+    if (e.key === 'Enter') {
+      if (e.metaKey || e.ctrlKey) onNewWindow();
+      else onThisWindow();
+    } else if (e.key === 'Escape') onCancel();
   }
 
   $effect(() => { thisBtn?.focus(); });
@@ -31,13 +30,37 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog">
-    <p class="message">{message}</p>
-    <div class="actions">
-      <button class="btn secondary" onclick={onCancel}>Cancel</button>
-      <button class="btn secondary" onclick={onNewWindow}>New Window</button>
-      <button class="btn primary" bind:this={thisBtn} onclick={onThisWindow}>This Window</button>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Open thoughtbase</div>
+      <h2 class="title">{message}</h2>
+    </header>
+
+    <div class="body">
+      <div class="choices">
+        <button class="choice" bind:this={thisBtn} onclick={onThisWindow}>
+          <Icon name="forward" size={16} color="var(--accent)" />
+          <span class="choice-body">
+            <span class="choice-title">In this window</span>
+            <span class="choice-sub">Closes the current view and opens the project here. The current view is preserved in tab history.</span>
+          </span>
+          <span class="choice-kbd">↵</span>
+        </button>
+        <button class="choice" onclick={onNewWindow}>
+          <Icon name="plus" size={16} color="var(--text-muted)" />
+          <span class="choice-body">
+            <span class="choice-title">In a new window</span>
+            <span class="choice-sub">Keeps the current thoughtbase up and opens this one side by side.</span>
+          </span>
+          <span class="choice-kbd">⌘ ↵</span>
+        </button>
+      </div>
     </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel</span>
+      <button class="btn ghost" onclick={onCancel}>Cancel</button>
+    </footer>
   </div>
 </div>
 
@@ -46,38 +69,129 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
-    min-width: 320px;
-    max-width: 440px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 480px;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
   }
-  .message { color: var(--text); font-size: 13px; }
-  .actions { display: flex; justify-content: flex-end; gap: 8px; }
-  .btn {
-    padding: 5px 14px;
+  .card-header { padding: 20px 24px 0; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+  .body { padding: 14px 24px 18px; }
+
+  /* Two choice cards stacked (§10.5). Default-focused card gets the
+     accent ring; secondary card is ghost. */
+  .choices {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .choice {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .choice:focus {
+    outline: none;
+    border-color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 8%, var(--bg));
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+  .choice:hover {
+    border-color: var(--border-strong);
+  }
+  .choice-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .choice-title {
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .choice-sub {
+    font-size: 11.5px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+  .choice-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 6px;
+    background: var(--bg-inset);
     border: 1px solid var(--border);
     border-radius: 4px;
-    font-size: 12px;
+    color: var(--text-faint);
+    flex-shrink: 0;
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 12.5px;
+    font-family: inherit;
     cursor: pointer;
   }
-  .secondary { background: var(--bg-button); color: var(--text); }
-  .secondary:hover { background: var(--bg-button-hover); }
-  .primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
+  .btn.ghost:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
   }
-  .primary:hover { opacity: 0.9; }
 </style>

--- a/src/renderer/lib/components/SaveQueryDialog.svelte
+++ b/src/renderer/lib/components/SaveQueryDialog.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   /**
-   * Save Query dialog (#313). Asks for the query name + scope. When no
-   * thoughtbase is open, scope is forced to global and the picker
-   * collapses to a hint.
+   * Save Query dialog (#313). Per IMPLEMENTATION.md §10.5 the radio
+   * fieldset becomes two side-by-side choice cards explaining "In this
+   * thoughtbase" vs "Globally". When no project is open, scope is
+   * forced to global and the picker is hidden.
    */
+  import Icon from './Icon.svelte';
 
   interface Props {
     /** True when a project is open; controls whether Thoughtbase is offered. */
@@ -40,39 +42,69 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog">
-    <label class="message" for="save-query-name">Save query as</label>
-    <input
-      id="save-query-name"
-      bind:this={inputEl}
-      bind:value={name}
-      type="text"
-      class="input"
-      placeholder="Query name"
-    />
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Save query</div>
+      <h2 class="title">Where should this query live?</h2>
+    </header>
 
-    {#if projectOpen}
-      <fieldset class="scope">
-        <legend class="scope-label">Scope</legend>
-        <label class="radio">
-          <input type="radio" name="scope" value="project" bind:group={scope} />
-          <span>Thoughtbase</span>
-          <span class="hint">— this project only</span>
-        </label>
-        <label class="radio">
-          <input type="radio" name="scope" value="global" bind:group={scope} />
-          <span>Global</span>
-          <span class="hint">— available in every thoughtbase</span>
-        </label>
-      </fieldset>
-    {:else}
-      <p class="solo-hint">Saved as a Global query — no thoughtbase is open.</p>
-    {/if}
+    <div class="body">
+      <label class="field-label" for="save-query-name">Name</label>
+      <input
+        id="save-query-name"
+        bind:this={inputEl}
+        bind:value={name}
+        type="text"
+        class="input"
+        placeholder="e.g. Unreviewed LLM writes"
+      />
 
-    <div class="actions">
-      <button class="btn cancel" onclick={onCancel}>Cancel</button>
-      <button class="btn confirm" disabled={!name.trim()} onclick={() => onConfirm({ name: name.trim(), scope })}>Save</button>
+      {#if projectOpen}
+        <div class="scope-label">Scope</div>
+        <div class="scope-cards" role="radiogroup" aria-label="Save scope">
+          <button
+            class="scope-card"
+            class:selected={scope === 'project'}
+            type="button"
+            role="radio"
+            aria-checked={scope === 'project'}
+            onclick={() => { scope = 'project'; }}
+          >
+            <Icon name="folder" size={14} color={scope === 'project' ? 'var(--accent)' : 'var(--text-faint)'} />
+            <span class="scope-title">In this thoughtbase</span>
+            <span class="scope-sub">Saved next to the project's notes — others who open it will see this query.</span>
+          </button>
+          <button
+            class="scope-card"
+            class:selected={scope === 'global'}
+            type="button"
+            role="radio"
+            aria-checked={scope === 'global'}
+            onclick={() => { scope = 'global'; }}
+          >
+            <Icon name="settings" size={14} color={scope === 'global' ? 'var(--accent)' : 'var(--text-faint)'} />
+            <span class="scope-title">Globally</span>
+            <span class="scope-sub">Available in every thoughtbase you open on this machine.</span>
+          </button>
+        </div>
+      {:else}
+        <p class="solo-hint">
+          <Icon name="settings" size={12} color="var(--text-faint)" />
+          Saved as a Global query — no thoughtbase is open.
+        </p>
+      {/if}
     </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↵ save</span>
+      <span class="footer-actions">
+        <button class="btn ghost" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={!name.trim()} onclick={() => onConfirm({ name: name.trim(), scope })}>
+          Save
+          <span class="btn-kbd">↵</span>
+        </button>
+      </span>
+    </footer>
   </div>
 </div>
 
@@ -81,104 +113,169 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 32px;
   }
-
   .dialog {
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
-    min-width: 360px;
-    max-width: 440px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 520px;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-  }
-
-  .message {
+    overflow: hidden;
+    font-family: var(--font-sans);
     color: var(--text);
-    font-size: 13px;
+  }
+  .card-header { padding: 20px 24px 0; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
   }
 
+  .body { padding: 14px 24px 18px; display: flex; flex-direction: column; gap: 14px; }
+  .field-label {
+    font-family: var(--font-sans);
+    font-size: 12px;
+    color: var(--text-muted);
+  }
   .input {
     width: 100%;
-    padding: 6px 10px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--bg);
+    padding: 8px 10px;
+    background: var(--bg-inset);
     color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-family: var(--font-sans);
     font-size: 13px;
     outline: none;
-    box-sizing: border-box;
   }
-
-  .input:focus { border-color: var(--accent); }
-
-  .scope {
-    border: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+  .input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
   }
 
   .scope-label {
+    font-family: var(--font-sans);
+    font-size: 12px;
     color: var(--text-muted);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 4px;
+    margin-top: 2px;
   }
-
-  .radio {
+  /* Two side-by-side choice cards (§10.5) */
+  .scope-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .scope-card {
     display: flex;
-    align-items: center;
-    gap: 6px;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
     color: var(--text);
-    font-size: 13px;
+    font-family: inherit;
     cursor: pointer;
+    text-align: left;
   }
-
-  .hint { color: var(--text-muted); font-size: 12px; }
+  .scope-card:hover { border-color: var(--border-strong); }
+  .scope-card.selected {
+    border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+    background: color-mix(in oklch, var(--accent) 8%, var(--bg));
+  }
+  .scope-title {
+    font-size: 13px;
+    font-weight: 500;
+    margin-top: 4px;
+  }
+  .scope-card.selected .scope-title { color: var(--accent); }
+  .scope-sub {
+    font-size: 11.5px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
 
   .solo-hint {
     margin: 0;
-    padding: 6px 8px;
-    background: var(--bg-button);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    background: var(--bg-inset);
     border: 1px solid var(--border);
-    border-radius: 4px;
+    border-radius: 6px;
     color: var(--text-muted);
     font-size: 12px;
   }
 
-  .actions {
+  .card-footer {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
     gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
   }
-
+  .kbd-hint {
+    margin-right: auto;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .footer-actions { display: inline-flex; gap: 8px; }
   .btn {
-    padding: 5px 14px;
+    padding: 7px 14px;
     border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
-
-  .cancel { background: var(--bg-button); color: var(--text); }
-  .cancel:hover { background: var(--bg-button-hover); }
-
-  .confirm {
+  .btn.ghost {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .btn.ghost:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .btn.primary {
     background: var(--accent);
-    color: var(--bg);
+    color: var(--accent-ink);
     border-color: var(--accent);
+    font-weight: 600;
   }
-  .confirm:hover { opacity: 0.9; }
-  .confirm:disabled { opacity: 0.4; cursor: default; }
+  .btn.primary:hover:not(:disabled) { opacity: 0.92; }
+  .btn.primary:disabled { opacity: 0.4; cursor: default; }
+  .btn-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    opacity: 0.7;
+  }
 </style>


### PR DESCRIPTION
Follow-up from #552 / part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §10.5.

## Summary
Four dialogs adopt the §10 shell + each gets the §10.5-specific structural callouts. Signatures unchanged.

### OpenTargetDialog
Three-button row → two choice cards with kbd hints (`↵` for default "this window", `⌘ ↵` for new window). Cancel demoted to footer ghost.

### SaveQueryDialog
Scope radios → two side-by-side choice cards ("In this thoughtbase" with folder icon, "Globally" with settings icon), each with a sub-line. Display-serif title via the §10 shell; input gets the accent ring focus.

### AutoLinkDialog
§10 shell + display-serif title. Per-row card with accent-tint when selected. Target chip in `--accent-12%` bg. Context excerpt in `--bg-inset` with border (replaces `--bg-button` which read as active state, not code). Bulk row with count chip + ghost Select all/none. Accent Apply CTA.

### ExportDialog
Shell-only at 720px. **Missing-source count badge pinned to `var(--rust)`** (was `--accent` on `--bg-button`) — per spec, missing-source needs its own signal color. Missing-list source titles also switch to rust.

## Deferred
- **AutoLink confidence bar + "Select high-confidence (≥ 0.8)" bulk button** — `AutoLinkSuggestion` doesn't carry a confidence score yet. Needs a model output change + plumbing.
- **Export 3-column audit layout + segmented-control scope picker** — existing audit grid isn't organized as Including / Excluded / Citations in three explicit columns. Bigger refactor.

## Trust principle / CLAUDE.md
- **No danger styling** — Cancel is ghost, rust signals missing sources but never destructive verbs.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2197 tests)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: trigger each dialog. Confirm:
  - Open a different thoughtbase (without "always ask" off) — choice cards with kbd hints
  - Save Query (right-click a query tab) — two side-by-side scope cards
  - Tools menu → Auto-link this note — soft-shell card list with accent-tinted rows
  - File menu → Export thoughtbase — taller dialog, rust-colored missing-source badge

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)