### PR TITLE
design: Settings dialog — 4-group sidebar + section headers (§10.4)

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -50,18 +50,60 @@
   let { onApplyEditor, onThemeChanged, onClose, initialTab }: Props = $props();
 
   type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'sites' | 'bibliography' | 'compute' | 'ai';
-  const TABS: { id: TabId; label: string }[] = [
-    { id: 'editor', label: 'Editor' },
-    { id: 'appearance', label: 'Appearance' },
-    { id: 'behaviors', label: 'Behaviors' },
-    { id: 'refactoring', label: 'Refactoring' },
-    { id: 'formatter', label: 'Formatter' },
-    { id: 'web', label: 'Web' },
-    { id: 'sites', label: 'Sites' },
-    { id: 'bibliography', label: 'Bibliography' },
-    { id: 'compute', label: 'Compute' },
-    { id: 'ai', label: 'AI' },
+
+  /** Restructure per IMPLEMENTATION.md §10.4 — 10 flat tabs become 4
+   *  semantic groups. Group labels render in mono-uppercase above each
+   *  cluster in the sidebar. Sub-lines describe what each tab covers. */
+  interface TabDef {
+    id: TabId;
+    label: string;
+    sub: string;
+  }
+  interface GroupDef {
+    label: string;
+    items: ReadonlyArray<TabDef>;
+  }
+  const SETTINGS_GROUPS: ReadonlyArray<GroupDef> = [
+    {
+      label: 'Workspace',
+      items: [
+        { id: 'editor',     label: 'Editor',     sub: 'Tab size · word wrap · line numbers' },
+        { id: 'appearance', label: 'Appearance', sub: 'Theme · font · density' },
+        { id: 'behaviors',  label: 'Behaviors',  sub: 'Confirm dialogs · sidebar' },
+      ],
+    },
+    {
+      label: 'Authoring',
+      items: [
+        { id: 'refactoring',  label: 'Refactoring',  sub: 'Default destination · merge rules' },
+        { id: 'formatter',    label: 'Formatter',    sub: 'On-save rules' },
+        { id: 'bibliography', label: 'Bibliography', sub: 'Citation style · locale' },
+      ],
+    },
+    {
+      label: 'Ingest & compute',
+      items: [
+        { id: 'web',     label: 'Web',     sub: 'Default ingest rules' },
+        { id: 'sites',   label: 'Sites',   sub: 'Privileged-domain logins' },
+        { id: 'compute', label: 'Compute', sub: 'Python interpreter · trust' },
+      ],
+    },
+    {
+      label: 'AI',
+      items: [
+        { id: 'ai', label: 'AI', sub: 'Model · API key · tool prefs' },
+      ],
+    },
   ];
+
+  /** Reverse lookup: tab → its containing group label. Used for the
+   *  body-section eyebrow above each panel's content. */
+  const TAB_TO_GROUP: ReadonlyMap<TabId, string> = new Map(
+    SETTINGS_GROUPS.flatMap((g) => g.items.map((t) => [t.id, g.label] as const)),
+  );
+  const TAB_DEFS: ReadonlyMap<TabId, TabDef> = new Map(
+    SETTINGS_GROUPS.flatMap((g) => g.items.map((t) => [t.id, t] as const)),
+  );
 
   let refactor = $state<RefactorSettings>({ ...getRefactorSettings() });
   function patchRefactor(patch: Partial<RefactorSettings>): void {
@@ -450,15 +492,31 @@
     </header>
     <div class="body">
       <nav class="tabs" aria-label="Settings sections">
-        {#each TABS as tab}
-          <button
-            class="tab"
-            class:active={activeTab === tab.id}
-            onclick={() => { activeTab = tab.id; }}
-          >{tab.label}</button>
+        {#each SETTINGS_GROUPS as group}
+          <div class="tab-group">
+            <div class="tab-group-label">{group.label}</div>
+            {#each group.items as tab (tab.id)}
+              <button
+                class="tab"
+                class:active={activeTab === tab.id}
+                onclick={() => { activeTab = tab.id; }}
+              >
+                <span class="tab-label">{tab.label}</span>
+                <span class="tab-sub">{tab.sub}</span>
+              </button>
+            {/each}
+          </div>
         {/each}
       </nav>
       <section class="panel">
+        {#if TAB_DEFS.get(activeTab)}
+          {@const def = TAB_DEFS.get(activeTab)!}
+          <div class="panel-header">
+            <div class="panel-eyebrow">{TAB_TO_GROUP.get(activeTab) ?? ''}</div>
+            <h3 class="panel-title">{def.label}</h3>
+            <p class="panel-sub">{def.sub}</p>
+          </div>
+        {/if}
         {#if activeTab === 'editor'}
           <div class="field">
             <label for="tab-size">Tab size</label>
@@ -1123,8 +1181,8 @@
     background: var(--bg-elev);
     border: 1px solid var(--border-strong);
     border-radius: 12px;
-    min-width: 560px;
-    max-width: 720px;
+    min-width: 720px;
+    max-width: 880px;
     min-height: 420px;
     max-height: calc(100vh - 64px);
     box-shadow:
@@ -1157,43 +1215,109 @@
   }
 
   .tabs {
-    width: 140px;
+    width: 200px;
     border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
-    padding: 8px 0;
+    padding: 12px 0;
     background: var(--bg);
     flex-shrink: 0;
+    overflow-y: auto;
   }
 
+  /* Group cluster per §10.4 — mono-uppercase label above its tabs. */
+  .tab-group {
+    display: flex;
+    flex-direction: column;
+    padding: 0 0 8px;
+  }
+  .tab-group + .tab-group {
+    margin-top: 4px;
+  }
+  .tab-group-label {
+    padding: 8px 16px 6px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  /* Tab rows show label + sub-line */
   .tab {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
     text-align: left;
-    padding: 7px 14px;
+    padding: 7px 16px 7px 18px;
     border: none;
     background: none;
     color: var(--text);
-    font-size: 12px;
+    font-family: var(--font-sans);
     cursor: pointer;
     border-left: 2px solid transparent;
   }
-
   .tab:hover {
-    background: var(--bg-button);
+    background: color-mix(in oklch, var(--text) 4%, transparent);
   }
-
   .tab.active {
-    background: var(--bg-button-hover);
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
     border-left-color: var(--accent);
     color: var(--text);
+  }
+  .tab-label {
+    font-size: 12.5px;
+    font-weight: 450;
+  }
+  .tab.active .tab-label {
+    font-weight: 500;
+    color: var(--accent);
+  }
+  .tab-sub {
+    font-size: 10.5px;
+    color: var(--text-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .panel {
     flex: 1;
-    padding: 16px 20px;
+    padding: 20px 28px 16px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 14px;
+  }
+
+  /* Per-panel header — mono eyebrow + display-serif H1 + sub line.
+     Matches the §10 header pattern. */
+  .panel-header {
+    margin-bottom: 8px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--border);
+  }
+  .panel-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+  .panel-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+    color: var(--text);
+  }
+  .panel-sub {
+    margin: 4px 0 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
   }
 
   .field {


### PR DESCRIPTION
Follow-up from #552 / part of epic #542. Spec: [`IMPLEMENTATION.md`](../blob/main/docs/design/2026-05-design-review/project/IMPLEMENTATION.md) §10.4.

## Summary
Restructures the flat 10-tab sidebar into the four §10.4 semantic groups, with each tab carrying a sub-line and each panel carrying the §10 header pattern.

### Sidebar groups
- **Workspace** → Editor, Appearance, Behaviors
- **Authoring** → Refactoring, Formatter, Bibliography
- **Ingest & compute** → Web, Sites, Compute
- **AI** → AI

Each group renders a mono-uppercase label above its tab rows. TabId set unchanged.

### Tab rows
Two-line: 12.5px sans label + 10.5px mono-faint sub line. Hover: 4% text tint. Active: 12% accent tint + 2px accent left rail + accent-colored label (matches file-tree treatment).

### Panel section headers
Each panel now leads with the §10 header pattern: mono eyebrow (group label) + display-serif H1 (22px) + sub-line in `--text-muted`. Hairline divider below.

### Sidebar width + dialog size
Sidebar 140 → 200px for sub lines. Dialog min-width 560 → 720, max 720 → 880 for comfortable content reading.

## Deferred
- **Reusable Toggle / Stepper / SettingRow primitive adoption** — would require rewriting ~1000 lines of per-panel HTML. Pairs better with a focused SettingRow extraction PR.
- **"Reset section to defaults" footer button** — needs per-section reset functions; out of scope.

## Trust principle / CLAUDE.md
- **Stay out of the way** — no settings logic changes, no new modals. Section headers + group labels are pure organization.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2197 tests)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: open Settings. Confirm 4 group headers in mono-uppercase; each tab shows a sub-line; active tab has accent rail + tint + accent label; panel content sits below a serif header with the group eyebrow.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)