### PR TITLE
feat: auto-invalidate Python kernel module cache on .py edits (#529)

### DIFF
--- a/resources/python/minerva_kernel.py
+++ b/resources/python/minerva_kernel.py
@@ -11,6 +11,7 @@ Protocol — request:
   {"op": "exec", "cellId": "<uuid>", "notebookPath": "notes/x.md", "code": "..."}
   {"op": "reset", "notebookPath": "notes/x.md"}      # drop one notebook's namespace
   {"op": "reset"}                                     # drop everything
+  {"op": "invalidate", "modules": ["helpers", "python.utils"]}  # #529 — pop sys.modules
 
 Protocol — events:
   {"type": "ready"}                                   # once at startup
@@ -20,6 +21,7 @@ Protocol — events:
   {"cellId": ..., "type": "error",   "payload": {"ename","evalue","traceback"}}
   {"cellId": ..., "type": "done",    "executionTimeMs": <int>}
   {"type": "reset-ack"}
+  {"type": "invalidated", "popped": ["helpers"]}      # #529 — modules dropped from sys.modules
   {"type": "protocol-error", "message": "..."}        # malformed request
 """
 
@@ -29,6 +31,7 @@ import io
 import os
 import time
 import ast
+import importlib
 import traceback
 
 # Make user .py files in the notebase importable. The main process also
@@ -66,6 +69,38 @@ def reset_namespaces(notebook_path):
         namespaces.clear()
     else:
         namespaces.pop(notebook_path, None)
+
+
+def invalidate_modules(module_names):
+    """Drop each module name (and any submodule under it) from sys.modules
+    so the next `import` re-reads from disk (#529).
+
+    The path → module name conversion lives in TypeScript
+    (src/main/compute/python-kernel.ts); the kernel just receives a flat
+    list of dotted names. Per-notebook namespaces are NOT touched — names
+    already bound from `from helpers import X` keep their stale value
+    until the binding cell re-runs. That's the documented contract.
+
+    Returns the list of keys actually popped so the caller can surface a
+    UI hint ("Reloaded helpers — re-run cells that imported it.").
+    """
+    popped = []
+    for name in module_names:
+        if not isinstance(name, str) or not name:
+            continue
+        # Exact match + any submodule whose dotted prefix matches. We can't
+        # mutate sys.modules while iterating, so snapshot keys first.
+        prefix = name + '.'
+        for key in list(sys.modules.keys()):
+            if key == name or key.startswith(prefix):
+                sys.modules.pop(key, None)
+                popped.append(key)
+    if popped:
+        # Tell importlib the finder caches (pyc, namespace package paths,
+        # zip imports) are stale so the next `import` discovers the
+        # rewritten file rather than serving a stale entry.
+        importlib.invalidate_caches()
+    return popped
 
 
 def serialize_value(value):
@@ -414,6 +449,14 @@ def main():
         elif op == 'reset':
             reset_namespaces(req.get('notebookPath'))
             emit({'type': 'reset-ack'})
+        elif op == 'invalidate':
+            # #529 — fire-and-forget; we still emit a confirmation event
+            # so tests can observe the pop list and the renderer can show
+            # a subtle toast. An empty popped list (the module was never
+            # imported) is a no-op silently.
+            mods = req.get('modules') or []
+            popped = invalidate_modules(mods)
+            emit({'type': 'invalidated', 'popped': popped})
         else:
             emit({'type': 'protocol-error', 'message': f'Unknown op: {op}'})
 

--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -283,6 +283,74 @@ function isMimeBundle(value: unknown): value is KernelMimeBundle {
 }
 
 /**
+ * Convert a project-relative `.py` path to the dotted module name Python
+ * uses in `sys.modules` (#529). Strips the `.py` extension and turns
+ * path separators into dots so `python/utils.py → python.utils`.
+ *
+ * Returns null for paths that don't look like a Python module:
+ *   - non-`.py` extensions
+ *   - `__init__.py` (those make a package; the package name is the
+ *     parent directory, not the file)
+ *   - paths containing segments that aren't valid Python identifiers
+ *     (e.g. `2024/notes.py` — the leading digit makes `2024` invalid
+ *     as a module name, and Python wouldn't have imported it anyway)
+ *
+ * Exported so the watcher can pre-filter before sending an invalidate
+ * request — keeps the kernel from churning on edits to `.py` files
+ * the user is unlikely to have imported as a module.
+ */
+export function pathToModuleName(relativePath: string): string | null {
+  if (!relativePath.toLowerCase().endsWith('.py')) return null;
+  // Normalise both separators since chokidar reports forward slashes on
+  // POSIX and backslashes on Windows. Strip leading `./` if present.
+  const cleaned = relativePath.replace(/\\/g, '/').replace(/^\.\//, '');
+  // __init__.py marks a package; the package's importable name is the
+  // parent directory. An invalidate on the parent dir's module name
+  // handles the package itself + every submodule.
+  const segments = cleaned.split('/');
+  const last = segments[segments.length - 1];
+  if (last === '__init__.py') {
+    segments.pop();
+  } else {
+    segments[segments.length - 1] = last.slice(0, -3); // drop `.py`
+  }
+  if (segments.length === 0) return null;
+  // Each segment must be a valid Python identifier (ASCII letter/_ start,
+  // then letters/digits/_). Reject paths that couldn't have been imported
+  // anyway so we don't pollute sys.modules churn with no-op invalidates.
+  for (const seg of segments) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(seg)) return null;
+  }
+  return segments.join('.');
+}
+
+/**
+ * Invalidate Python modules in `rootPath`'s kernel so the next `import`
+ * re-reads from disk (#529). Fire-and-forget: if no kernel is running
+ * there's nothing to invalidate; if the kernel hasn't reached `ready`
+ * yet we silently drop (it can't have imported anything either).
+ *
+ * Module-name conversion happens here so the kernel-side handler stays
+ * simple and the path-handling logic is testable from TypeScript.
+ */
+export function invalidate(rootPath: string, relativePaths: string[]): void {
+  const state = kernels.get(rootPath);
+  if (!state || state.proc.exitCode !== null) return;
+  const modules = relativePaths
+    .map(pathToModuleName)
+    .filter((m): m is string => m !== null);
+  if (modules.length === 0) return;
+  const req = JSON.stringify({ op: 'invalidate', modules });
+  try {
+    state.proc.stdin.write(req + '\n');
+  } catch {
+    // Kernel died between the kernels.get check and the write — the
+    // exit handler will reap state; the next runPython respawns. Nothing
+    // to invalidate against the dead kernel anyway.
+  }
+}
+
+/**
  * Run a Python cell. Spawns the project's kernel on first call. A
  * crashed kernel is detected on the next call and respawned.
  */

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -7,6 +7,7 @@ import * as graph from './graph/index';
 import * as search from './search/index';
 import * as notebaseFs from './notebase/fs';
 import * as tables from './sources/tables';
+import { invalidate as invalidatePythonModules } from './compute/python-kernel';
 import { addRecentProject } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
@@ -164,6 +165,26 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     }, 1000);
   };
 
+  // Coalesce `.py` edits into a single kernel-invalidate call (#529).
+  // A flurry of editor saves (autosave, formatter pass, find-replace) on
+  // the same module shouldn't fan out into a separate invalidate per
+  // write — the kernel just needs to know "these modules are stale" once
+  // the writes settle. 300ms matches the responsiveness window for
+  // re-running an importing cell while still grouping a multi-file
+  // formatter pass.
+  let pyInvalidatePaths = new Set<string>();
+  let pyInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
+  const queuePyInvalidate = (relativePath: string) => {
+    pyInvalidatePaths.add(relativePath);
+    if (pyInvalidateTimer) clearTimeout(pyInvalidateTimer);
+    pyInvalidateTimer = setTimeout(() => {
+      const paths = [...pyInvalidatePaths];
+      pyInvalidatePaths = new Set();
+      pyInvalidateTimer = null;
+      invalidatePythonModules(rootPath, paths);
+    }, 300);
+  };
+
   // startWatching returns a ready-promise (#345); we don't await here
   // because the watcher works fine before its initial scan completes.
   /**
@@ -220,6 +241,13 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       } else {
         await reregisterSibling(relativePath);
       }
+      // #529 — editing a .py file invalidates its module in the running
+      // Python kernel so a re-run of an importing cell picks up the new
+      // definition without a manual Restart. Debounced + a no-op when
+      // no kernel is running.
+      if (relativePath.toLowerCase().endsWith('.py')) {
+        queuePyInvalidate(relativePath);
+      }
       // Sidecar yaml schemas aren't notes — skip the graph/search pass for
       // them. The watcher fires for them only so the registerCsv branch
       // above can update DuckDB.
@@ -244,6 +272,12 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       } else {
         await reregisterSibling(relativePath);
+      }
+      // A newly-added .py file with the same name as a previously-deleted
+      // one (e.g. via git checkout / restore) can land while a stale entry
+      // is still in sys.modules. Treat add the same as change for safety.
+      if (relativePath.toLowerCase().endsWith('.py')) {
+        queuePyInvalidate(relativePath);
       }
       if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {

--- a/tests/main/compute/path-to-module-name.test.ts
+++ b/tests/main/compute/path-to-module-name.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Path → Python module name conversion (#529).
+ *
+ * The kernel auto-invalidate watcher converts a project-relative `.py`
+ * path into the dotted name Python uses in `sys.modules`. This test
+ * locks in the conversion rules so we don't regress the edge cases
+ * (POSIX/Windows separators, packages, invalid identifiers).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pathToModuleName } from '../../../src/main/compute/python-kernel';
+
+describe('pathToModuleName (#529)', () => {
+  it('drops .py for a top-level module', () => {
+    expect(pathToModuleName('helpers.py')).toBe('helpers');
+  });
+
+  it('joins directory segments with dots', () => {
+    expect(pathToModuleName('python/utils.py')).toBe('python.utils');
+    expect(pathToModuleName('a/b/c.py')).toBe('a.b.c');
+  });
+
+  it('normalises backslashes to dots (Windows-style paths)', () => {
+    expect(pathToModuleName('python\\utils.py')).toBe('python.utils');
+  });
+
+  it('strips a leading ./', () => {
+    expect(pathToModuleName('./helpers.py')).toBe('helpers');
+  });
+
+  it('treats __init__.py as the parent package', () => {
+    expect(pathToModuleName('mypkg/__init__.py')).toBe('mypkg');
+    expect(pathToModuleName('a/b/__init__.py')).toBe('a.b');
+  });
+
+  it('returns null for non-.py files', () => {
+    expect(pathToModuleName('README.md')).toBeNull();
+    expect(pathToModuleName('data.csv')).toBeNull();
+    expect(pathToModuleName('notes/x.md')).toBeNull();
+  });
+
+  it('returns null for paths with non-identifier segments', () => {
+    // Leading digit — invalid Python identifier; Python wouldn't have
+    // imported it as a module anyway, so we skip rather than emit
+    // a bogus sys.modules key.
+    expect(pathToModuleName('2024/notes.py')).toBeNull();
+    expect(pathToModuleName('my-helper.py')).toBeNull();
+    expect(pathToModuleName('with space.py')).toBeNull();
+  });
+
+  it('handles a bare __init__.py (project root package — unusual)', () => {
+    // Stripping `__init__.py` from a top-level path leaves no segments
+    // — there's no parent package to name, so we drop it.
+    expect(pathToModuleName('__init__.py')).toBeNull();
+  });
+
+  it('is case-insensitive on the .py extension', () => {
+    // Windows users sometimes get `.PY`; chokidar surfaces the
+    // filesystem case so we accept either.
+    expect(pathToModuleName('helpers.PY')).toBe('helpers');
+  });
+});

--- a/tests/main/compute/python-kernel.test.ts
+++ b/tests/main/compute/python-kernel.test.ts
@@ -9,6 +9,9 @@
 
 import { describe, it, expect, afterAll } from 'vitest';
 import { execSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import {
   runPython,
   stopKernel,
@@ -16,6 +19,7 @@ import {
   interruptKernel,
   shutdownAllKernels,
   activeKernels,
+  invalidate,
 } from '../../../src/main/compute/python-kernel';
 
 function pythonAvailable(): boolean {
@@ -139,6 +143,114 @@ skipIfNoPython('python kernel (#241)', () => {
     expect(r.output.type).toBe('json');
     if (r.output.type !== 'json') return;
     expect(r.output.value).toBe(4);
+  });
+
+  // ── invalidate(): auto-reload .py modules (#529) ────────────────────
+
+  it('invalidate(): editing an imported .py file picks up new value on next import', async () => {
+    // Need a real project root so the kernel's PYTHONPATH inserts a
+    // directory where we can drop a helper module. Each test gets a
+    // fresh tmpdir so the module name doesn't collide across runs.
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-py-invalidate-'));
+    const helperPath = path.join(projectRoot, 'reload_helper.py');
+    try {
+      await fs.writeFile(helperPath, 'value = "before"\n', 'utf8');
+
+      // Prime: import the helper and assert the original value lands.
+      const before = await runPython(projectRoot, 'reload.md', 'import reload_helper\nreload_helper.value');
+      expect(before.ok).toBe(true);
+      if (!before.ok || before.output.type !== 'json') return;
+      expect(before.output.value).toBe('before');
+
+      // Edit the helper. Without invalidate, sys.modules still has the
+      // stale entry — a fresh `import` is a no-op (Python returns the
+      // cached module).
+      await fs.writeFile(helperPath, 'value = "after"\n', 'utf8');
+
+      // The stale baseline: a re-import without invalidate keeps the old
+      // value. This is the bug we're fixing — we assert it explicitly so
+      // a future change to Python's import semantics doesn't silently
+      // turn this test into a no-op.
+      const stale = await runPython(projectRoot, 'reload.md', 'import reload_helper\nreload_helper.value');
+      expect(stale.ok).toBe(true);
+      if (!stale.ok || stale.output.type !== 'json') return;
+      expect(stale.output.value).toBe('before');
+
+      // The fix: invalidate the module then re-import.
+      invalidate(projectRoot, ['reload_helper.py']);
+
+      const fresh = await runPython(projectRoot, 'reload.md', 'import reload_helper\nreload_helper.value');
+      expect(fresh.ok).toBe(true);
+      if (!fresh.ok || fresh.output.type !== 'json') return;
+      expect(fresh.output.value).toBe('after');
+    } finally {
+      await stopKernel(projectRoot);
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidate(): popping a never-imported module is a silent no-op', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-py-invalidate-'));
+    try {
+      // Get the kernel running.
+      await runPython(projectRoot, 'noop.md', '1');
+      // Module doesn't exist on disk, has never been imported. invalidate
+      // should not crash the kernel.
+      invalidate(projectRoot, ['never_imported.py']);
+      const after = await runPython(projectRoot, 'noop.md', '2 + 2');
+      expect(after.ok).toBe(true);
+      if (!after.ok || after.output.type !== 'json') return;
+      expect(after.output.value).toBe(4);
+    } finally {
+      await stopKernel(projectRoot);
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidate(): no-op when no kernel is running', () => {
+    // Should not throw. The function silently returns when the project
+    // has no live kernel — the watcher fires invalidate eagerly on
+    // every .py write regardless of whether a kernel has spawned yet.
+    expect(() => invalidate('/tmp/no-kernel-for-this-root-' + Date.now(), ['x.py'])).not.toThrow();
+  });
+
+  it('invalidate(): walks submodules under a package prefix', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-py-invalidate-'));
+    try {
+      // Build a package: pkg/__init__.py exposing version, pkg/sub.py.
+      const pkgDir = path.join(projectRoot, 'pkg');
+      await fs.mkdir(pkgDir, { recursive: true });
+      await fs.writeFile(path.join(pkgDir, '__init__.py'), 'from .sub import label\n', 'utf8');
+      await fs.writeFile(path.join(pkgDir, 'sub.py'), 'label = "v1"\n', 'utf8');
+
+      const before = await runPython(projectRoot, 'pkg.md', 'import pkg\npkg.label');
+      expect(before.ok).toBe(true);
+      if (!before.ok || before.output.type !== 'json') return;
+      expect(before.output.value).toBe('v1');
+
+      // Edit the submodule, then invalidate the package — the kernel
+      // should pop both `pkg` and `pkg.sub` so the next import re-walks
+      // the package's __init__.py and picks up the new submodule value.
+      //
+      // Bump the file's mtime explicitly. Python's .pyc cache uses
+      // source mtime to decide whether to reload; back-to-back rewrites
+      // in tests can land on the same second-level mtime on some
+      // filesystems, causing the cached .pyc to win and the assertion
+      // to flake. utimes with `now + 2s` guarantees a forward jump.
+      const subPath = path.join(pkgDir, 'sub.py');
+      await fs.writeFile(subPath, 'label = "v2"\n', 'utf8');
+      const future = new Date(Date.now() + 2000);
+      await fs.utimes(subPath, future, future);
+      invalidate(projectRoot, ['pkg/__init__.py']);
+
+      const after = await runPython(projectRoot, 'pkg.md', 'import pkg\npkg.label');
+      expect(after.ok).toBe(true);
+      if (!after.ok || after.output.type !== 'json') return;
+      expect(after.output.value).toBe('v2');
+    } finally {
+      await stopKernel(projectRoot);
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it('kernel crash → next cell call auto-respawns', async () => {


### PR DESCRIPTION
Closes #529.

## Summary
Editing a helper `.py` the user has previously imported, then re-running the importing cell, now picks up the new definition without a manual **Compute → Restart Python Kernel**.

## Mechanism

### `src/main/compute/python-kernel.ts`
- **`pathToModuleName(p)`** (exported): pure helper converting a project-relative `.py` path to the dotted name Python uses in `sys.modules` — `python/utils.py → python.utils`, `helpers.py → helpers`, `mypkg/__init__.py → mypkg`. Filters out paths that couldn't have been imported (non-`.py`, leading-digit segments, hyphens, spaces) so the kernel doesn't churn on no-op renames.
- **`invalidate(rootPath, paths)`**: fire-and-forget. Maps each path through `pathToModuleName`, drops nulls, writes `{op:'invalidate',modules:[…]}` to the kernel's stdin. No-op when no kernel is running.

### `resources/python/minerva_kernel.py`
- New `op: 'invalidate'` handler. Calls `invalidate_modules(names)` which walks `sys.modules` popping each exact match + any key under the dotted prefix (`pkg` pops `pkg`, `pkg.sub`, `pkg.sub.deep`). Calls `importlib.invalidate_caches()` so finder caches don't serve stale entries.
- Emits `{type:'invalidated', popped:[…]}` so the renderer can show a subtle toast and tests can observe the pop list.
- **Per-notebook namespaces are NOT touched** — names already bound from `from helpers import X` keep their stale value until the binding cell re-runs. Documented contract.

### `src/main/window-manager.ts`
- **`queuePyInvalidate()`** debouncer coalesces `.py` edits into one kernel call after 300ms quiescence. A flurry of editor saves on the same file fans into a single invalidate. Wired into both `onFileChanged` and `onFileCreated` (the latter handles e.g. `git restore` re-creating a previously-deleted module).
- Delete is intentionally NOT wired — letting the next import raise `ImportError` is the right signal that the file is gone.

## Tests
- **`tests/main/compute/path-to-module-name.test.ts`** (9 cases): every spec rule including `__init__.py`, backslash paths, case-insensitive `.py`, invalid-identifier rejection.
- **`tests/main/compute/python-kernel.test.ts`** (4 new integration cases):
  - edit `.py` → invalidate → re-import picks up new value (stale baseline asserted first)
  - never-imported module = silent no-op
  - invalidate with no running kernel doesn't throw
  - package + submodule walk: editing `pkg/sub.py` then invalidating `pkg/__init__.py` re-walks the package's `from .sub import label`
- Package test bumps the `sub.py` mtime forward via `fs.utimes` — Python's `.pyc` cache uses source mtime to decide whether to reload; back-to-back rewrites in tests can collide on the same mtime on some filesystems.

## Out of scope (per issue)
- IPython `%autoreload`-style live name rebinding
- AST-level module dependency tracking
- `.py` edits inside excluded folders (already filtered by chokidar)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2210 tests, +13 new)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**: open a `.py` file in the notebase, import it from a Python cell. Edit the file, re-run the cell (without restarting the kernel). Confirm the new value lands.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)