### PR TITLE
feat: clickable breadcrumbs bar above the editor (#476)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -6,6 +6,8 @@
   import QueryPanel from './lib/components/QueryPanel.svelte';
   import RightSidebar from './lib/components/RightSidebar.svelte';
   import StatusBar from './lib/components/StatusBar.svelte';
+  import BreadcrumbsBar from './lib/components/BreadcrumbsBar.svelte';
+  import { getBreadcrumbsSettings, type BreadcrumbsSettings } from './lib/breadcrumbs/settings';
   import Icon from './lib/components/Icon.svelte';
   import type { CursorInfo } from './lib/components/Editor.svelte';
   import Preview from './lib/components/Preview.svelte';
@@ -187,6 +189,12 @@
   let previewComponent = $state<Preview>();
   let toolPanelComponent = $state<ToolPanel>();
   let cursorInfo = $state<CursorInfo>({ line: 1, column: 1, selectionLength: 0, wordCount: 0 });
+
+  // Breadcrumbs bar above the editor (#476). Single toggle for the
+  // heading-chain second tier — held in local state so the bar reacts
+  // immediately when the user flips it from Settings (the dialog calls
+  // setBreadcrumbsSettings, then notifies via the same patch we keep here).
+  let breadcrumbsSettings = $state<BreadcrumbsSettings>({ ...getBreadcrumbsSettings() });
   // Cache of every indexed source, refreshed on `sources:changed` and on
   // project open. Feeds the Editor's `[[cite::…]]` autocomplete so typing
   // in the editor doesn't have to await an IPC round-trip per keystroke.
@@ -2375,6 +2383,16 @@
             onNewTab={() => handleNewNote()}
           />
         {/if}
+        {#if editor.activeTab?.type === 'note'}
+          <BreadcrumbsBar
+            filePath={editor.activeFilePath}
+            content={editor.activeTab.content}
+            cursorLine={cursorInfo.line}
+            showHeadings={breadcrumbsSettings.showHeadingChain}
+            onRevealFolder={(folder) => { void sidebar?.revealFolder(folder); }}
+            onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
+          />
+        {/if}
         {#if editor.activeTab?.type === 'note' && editor.activeTab.relativePath.endsWith('.csv')}
           <CsvTable
             relativePath={editor.activeTab.relativePath}
@@ -2710,7 +2728,13 @@
         queryPanelComponent?.updateTheme();
         previewComponent?.updateTheme();
       }}
-      onClose={() => { showSettings = false; settingsInitialTab = undefined; }}
+      onClose={() => {
+        showSettings = false;
+        settingsInitialTab = undefined;
+        // Re-read breadcrumb settings — the dialog wrote through to the
+        // module cache on change, but App's reactive state needs a nudge.
+        breadcrumbsSettings = { ...getBreadcrumbsSettings() };
+      }}
       initialTab={settingsInitialTab}
     />
   {/if}

--- a/src/renderer/lib/breadcrumbs/settings.ts
+++ b/src/renderer/lib/breadcrumbs/settings.ts
@@ -1,0 +1,51 @@
+/**
+ * BreadcrumbsBar settings (#476).
+ *
+ * Just one knob: whether the cursor-driven heading chain trails the
+ * file location. Some users want a stable bar that only changes on
+ * tab switches; for them the chain's per-cursor-move updates are
+ * noise. Off by default to honor "no surprises" — turn on from
+ * Settings > Workspace > Behaviors.
+ */
+
+export interface BreadcrumbsSettings {
+  /** Show the active-heading chain after the file location. */
+  showHeadingChain: boolean;
+}
+
+export const DEFAULT_BREADCRUMBS_SETTINGS: BreadcrumbsSettings = {
+  showHeadingChain: false,
+};
+
+const STORAGE_KEY = 'breadcrumbsSettings';
+
+function readFromStorage(): BreadcrumbsSettings {
+  try {
+    if (typeof localStorage === 'undefined') return { ...DEFAULT_BREADCRUMBS_SETTINGS };
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_BREADCRUMBS_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<BreadcrumbsSettings> | null;
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_BREADCRUMBS_SETTINGS };
+    return { ...DEFAULT_BREADCRUMBS_SETTINGS, ...parsed };
+  } catch {
+    return { ...DEFAULT_BREADCRUMBS_SETTINGS };
+  }
+}
+
+let settings: BreadcrumbsSettings = readFromStorage();
+
+export function getBreadcrumbsSettings(): BreadcrumbsSettings {
+  return settings;
+}
+
+export function setBreadcrumbsSettings(patch: Partial<BreadcrumbsSettings>): BreadcrumbsSettings {
+  settings = { ...settings, ...patch };
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }
+  return settings;
+}
+
+export function __resetBreadcrumbsSettingsForTests(): void {
+  settings = readFromStorage();
+}

--- a/src/renderer/lib/components/BreadcrumbsBar.svelte
+++ b/src/renderer/lib/components/BreadcrumbsBar.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  /**
+   * Thin clickable breadcrumbs bar above the editor pane (#476).
+   *
+   * Shows:
+   *   - Folder segments derived from the active file's relative path —
+   *     clicking a folder reveals + expands it in the left sidebar.
+   *   - The note's leaf name (no click target — you're already there).
+   *   - When `showHeadings` is on AND the cursor sits inside a heading,
+   *     a `·` separator and the heading chain (clickable, jump-to-line).
+   *
+   * Hidden when there's no active file. Updates to the heading chain are
+   *  debounced (60ms) so a flurry of keystrokes doesn't thrash the
+   *  cursor-→-chain computation, but folder breadcrumb is instant —
+   *  it only changes on tab switches.
+   */
+  import { extractHeadings, activeHeadingChain, type Heading } from '../markdown/headings';
+  import { untrack } from 'svelte';
+
+  interface Props {
+    /** Active file's project-relative path, or null when no file is open. */
+    filePath: string | null;
+    /** Active file's content — drives the heading chain extraction. */
+    content: string;
+    /** 1-based line of the editor cursor. Plumbed from App.svelte's
+     *  cursorInfo (already wired for StatusBar). */
+    cursorLine: number;
+    /** Toggle for the trailing heading chain. Stable bar when off. */
+    showHeadings: boolean;
+    /** Reveal a folder in the left sidebar — expands ancestors and
+     *  scrolls the row into view. Passed up to App.svelte which routes
+     *  to the Sidebar's exposed revealFolder(). */
+    onRevealFolder: (folderPath: string) => void;
+    /** Jump editor to a line (same callback used by OutlinePanel). */
+    onScrollToLine: (line: number) => void;
+  }
+
+  let { filePath, content, cursorLine, showHeadings, onRevealFolder, onScrollToLine }: Props = $props();
+
+  /** Folder segments + leaf name derived from filePath. Folder paths are
+   *  absolute-from-root so the reveal handler doesn't have to reassemble
+   *  them. Returns null when no file is open. */
+  const pathSegments = $derived.by(() => {
+    if (!filePath) return null;
+    const parts = filePath.split('/').filter(Boolean);
+    if (parts.length === 0) return null;
+    const leaf = parts[parts.length - 1].replace(/\.(md|ttl|csv|py)$/i, '');
+    const folders: Array<{ name: string; path: string }> = [];
+    let acc = '';
+    for (let i = 0; i < parts.length - 1; i++) {
+      acc = acc ? `${acc}/${parts[i]}` : parts[i];
+      folders.push({ name: parts[i], path: acc });
+    }
+    return { folders, leaf };
+  });
+
+  /** Cursor-driven heading chain. Debounced so typing inside a paragraph
+   *  doesn't recompute on every keystroke even though the result is
+   *  identical until the cursor crosses a heading boundary. */
+  let headings = $state<Heading[]>([]);
+  let chain = $state<Heading[]>([]);
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Re-parse headings whenever the document changes. Cheap (O(n) lines)
+  // but still worth not redoing on cursor moves.
+  $effect(() => {
+    if (!showHeadings || !filePath) {
+      headings = [];
+      chain = [];
+      return;
+    }
+    headings = extractHeadings(content);
+  });
+
+  // Recompute the chain when the cursor moves or the heading list
+  // changes. Debounced 60ms — the human eye can't resolve faster updates
+  // anyway and the throttle lets a held arrow key cruise without
+  // chain-rebuild overhead per row.
+  $effect(() => {
+    if (!showHeadings || !filePath) return;
+    const line = cursorLine;
+    const hs = headings;
+    if (pendingTimer) clearTimeout(pendingTimer);
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
+      untrack(() => {
+        chain = activeHeadingChain(hs, line);
+      });
+    }, 60);
+  });
+</script>
+
+{#if pathSegments}
+  <nav class="breadcrumbs" aria-label="File location">
+    {#each pathSegments.folders as folder (folder.path)}
+      <button
+        type="button"
+        class="crumb folder"
+        onclick={() => onRevealFolder(folder.path)}
+        title="Reveal {folder.path} in sidebar"
+      >{folder.name}</button>
+      <span class="sep" aria-hidden="true">›</span>
+    {/each}
+    <span class="crumb leaf" aria-current="page">{pathSegments.leaf}</span>
+
+    {#if showHeadings && chain.length > 0}
+      <span class="group-sep" aria-hidden="true">·</span>
+      {#each chain as h, i (h.line)}
+        <button
+          type="button"
+          class="crumb heading"
+          onclick={() => onScrollToLine(h.line)}
+          title="Jump to line {h.line}"
+        >{h.text}</button>
+        {#if i < chain.length - 1}
+          <span class="sep" aria-hidden="true">›</span>
+        {/if}
+      {/each}
+    {/if}
+  </nav>
+{/if}
+
+<style>
+  /* Compact, single line. Sits in the editor chrome — bg-toolbar binds
+     it to the chrome above (tab bar) and below (status bar). Truncates
+     middle folders first via min-width:0 on the leaf so root + leaf
+     stay visible when space is tight. */
+  .breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 14px;
+    background: var(--bg-toolbar);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-sans);
+    font-size: 11.5px;
+    color: var(--text-muted);
+    overflow: hidden;
+    flex-shrink: 0;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .crumb {
+    flex-shrink: 1;
+    min-width: 0;
+    padding: 0 4px;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    border-radius: 3px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .crumb.folder:hover,
+  .crumb.heading:hover {
+    color: var(--text);
+    background: color-mix(in oklch, var(--text) 6%, transparent);
+  }
+
+  /* Leaf is the current file — italic display-serif to echo the title
+     bar's note-title treatment. Not clickable, doesn't shrink. */
+  .crumb.leaf {
+    color: var(--text);
+    font-family: var(--font-display);
+    font-style: italic;
+    cursor: default;
+    flex-shrink: 0;
+  }
+  .crumb.leaf:hover {
+    background: none;
+  }
+
+  .sep {
+    color: var(--text-faint);
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+  /* `·` between the file location and the heading chain — slightly
+     heavier so the two groups read as distinct. */
+  .group-sep {
+    color: var(--text-faint);
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
+
+  /* Heading-chain leaf (the active heading at the cursor) gets a
+     subtle accent so the user can tell where they are. */
+  .crumb.heading:last-of-type {
+    color: var(--accent);
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -24,6 +24,11 @@
     type SidebarSettings,
   } from '../sidebar/settings';
   import {
+    getBreadcrumbsSettings,
+    setBreadcrumbsSettings,
+    type BreadcrumbsSettings,
+  } from '../breadcrumbs/settings';
+  import {
     getFormatSettings,
     setFormatSettings,
   } from '../formatter/settings';
@@ -115,6 +120,12 @@
   function patchSidebar(patch: Partial<SidebarSettings>): void {
     sidebar = { ...sidebar, ...patch };
     setSidebarSettings(patch);
+  }
+
+  let breadcrumbs = $state<BreadcrumbsSettings>({ ...getBreadcrumbsSettings() });
+  function patchBreadcrumbs(patch: Partial<BreadcrumbsSettings>): void {
+    breadcrumbs = { ...breadcrumbs, ...patch };
+    setBreadcrumbsSettings(patch);
   }
 
   // Formatter settings (#154). Mirror the persisted map into local state so
@@ -594,6 +605,21 @@
               When the active editor changes, scroll the matching row into view in the
               Notes panel and expand its parent folders. Never collapses anything you've
               already opened.
+            </p>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input
+                type="checkbox"
+                checked={breadcrumbs.showHeadingChain}
+                onchange={(e) => patchBreadcrumbs({ showHeadingChain: e.currentTarget.checked })}
+              />
+              Show heading chain in breadcrumbs
+            </label>
+            <p class="hint">
+              Append the current section's heading chain to the breadcrumbs bar above
+              the editor when the cursor sits inside a section. Updates as the cursor
+              moves between sections.
             </p>
           </div>
           <div class="field">

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -166,6 +166,30 @@
   }
 
   /**
+   * Imperative reveal for a folder path — switches to the Notes panel,
+   * expands the folder and every ancestor, scrolls it into view. Used
+   * by the BreadcrumbsBar above the editor (#476) when the user
+   * clicks a folder segment.
+   */
+  export async function revealFolder(folderPath: string): Promise<void> {
+    if (!folderPath) return;
+    activePanel = 'notes';
+    if (rootName && !rootExpanded) rootExpanded = true;
+    // Expand every prefix path (including the folder itself).
+    const parts = folderPath.split('/').filter(Boolean);
+    const patch: Record<string, boolean> = {};
+    let acc = '';
+    for (const part of parts) {
+      acc = acc ? `${acc}/${part}` : part;
+      if (!expanded[acc]) patch[acc] = true;
+    }
+    if (Object.keys(patch).length > 0) {
+      expanded = { ...expanded, ...patch };
+    }
+    await scrollPathIntoView(folderPath);
+  }
+
+  /**
    * Look up a node by its relative path. Linear walk; the tree is
    * small enough (typical thoughtbase < 5k notes) that the `Map`
    * variant in `sidebar-tree-utils` would be over-engineering for

--- a/src/renderer/lib/components/right-sidebar/OutlinePanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutlinePanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Ribbon from './Ribbon.svelte';
+  import { extractHeadings } from '../../markdown/headings';
 
   interface Props {
     content: string;
@@ -8,28 +9,10 @@
 
   let { content, onScrollToLine }: Props = $props();
 
-  interface Heading {
-    level: number;
-    text: string;
-    line: number;
-  }
-
   let collapsed = $state<Record<number, boolean>>({});
   let search = $state('');
 
   let headings = $derived(extractHeadings(content));
-
-  function extractHeadings(text: string): Heading[] {
-    const result: Heading[] = [];
-    const lines = text.split('\n');
-    for (let i = 0; i < lines.length; i++) {
-      const match = lines[i].match(/^(#{1,6})\s+(.+)$/);
-      if (match) {
-        result.push({ level: match[1].length, text: match[2].trim(), line: i + 1 });
-      }
-    }
-    return result;
-  }
 
   function hasChildren(index: number): boolean {
     if (index >= headings.length - 1) return false;

--- a/src/renderer/lib/markdown/headings.ts
+++ b/src/renderer/lib/markdown/headings.ts
@@ -1,0 +1,69 @@
+/**
+ * Markdown heading extraction (#476).
+ *
+ * Shared between OutlinePanel (right-sidebar tree) and BreadcrumbsBar
+ * (cursor-aware chain above the editor). Both want the same source-of-
+ * truth: a flat list of headings with level + text + line.
+ *
+ * Intentionally narrow: ATX-style only (`#` … `######`). Setext-style
+ * (`===` / `---` underlines) is not used in Minerva notebases and
+ * skipping it keeps the parser O(n) per line.
+ */
+
+export interface Heading {
+  /** ATX level: 1 (`#`) through 6 (`######`). */
+  level: number;
+  /** Heading text with the leading `#` markers + whitespace trimmed. */
+  text: string;
+  /** 1-based line number — matches CodeMirror's line numbering and the
+   *  `onScrollToLine` callback contract. */
+  line: number;
+}
+
+/** Parse all ATX-style headings out of a markdown document. */
+export function extractHeadings(text: string): Heading[] {
+  const out: Heading[] = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^(#{1,6})\s+(.+)$/);
+    if (match) {
+      out.push({ level: match[1].length, text: match[2].trim(), line: i + 1 });
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the active heading chain at `cursorLine` — the path from
+ * document root down through every ancestor heading that contains the
+ * cursor, ending at the most-recent heading whose line ≤ cursor.
+ *
+ * Example, given headings `# A` @1, `## B` @5, `### C` @9, `## D` @20:
+ *   - cursor at line 10 → [A, B, C]
+ *   - cursor at line 22 → [A, D]
+ *   - cursor at line 3 (before any heading) → []
+ *
+ * Returns `[]` when the cursor sits before the first heading.
+ */
+export function activeHeadingChain(headings: readonly Heading[], cursorLine: number): Heading[] {
+  // Walk forward to find the latest heading at-or-before the cursor.
+  let activeIdx = -1;
+  for (let i = 0; i < headings.length; i++) {
+    if (headings[i].line <= cursorLine) activeIdx = i;
+    else break;
+  }
+  if (activeIdx < 0) return [];
+
+  // Walk backward from `activeIdx` collecting headings whose level is
+  // strictly shallower than the previous one — that's the ancestor
+  // chain. The active heading itself is the leaf of the chain.
+  const chain: Heading[] = [headings[activeIdx]];
+  let needLevel = headings[activeIdx].level;
+  for (let i = activeIdx - 1; i >= 0 && needLevel > 1; i--) {
+    if (headings[i].level < needLevel) {
+      chain.unshift(headings[i]);
+      needLevel = headings[i].level;
+    }
+  }
+  return chain;
+}

--- a/tests/renderer/markdown/headings.test.ts
+++ b/tests/renderer/markdown/headings.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Heading extraction + cursor → active-chain (#476).
+ *
+ * Locks in the contract shared by OutlinePanel (right-sidebar) and
+ * BreadcrumbsBar (above-editor cursor chain).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractHeadings, activeHeadingChain } from '../../../src/renderer/lib/markdown/headings';
+
+describe('extractHeadings', () => {
+  it('parses ATX headings at every level (1–6)', () => {
+    const src = [
+      '# H1',
+      '## H2',
+      '### H3',
+      '#### H4',
+      '##### H5',
+      '###### H6',
+    ].join('\n');
+    const out = extractHeadings(src);
+    expect(out).toEqual([
+      { level: 1, text: 'H1', line: 1 },
+      { level: 2, text: 'H2', line: 2 },
+      { level: 3, text: 'H3', line: 3 },
+      { level: 4, text: 'H4', line: 4 },
+      { level: 5, text: 'H5', line: 5 },
+      { level: 6, text: 'H6', line: 6 },
+    ]);
+  });
+
+  it('records 1-based line numbers — matches CodeMirror', () => {
+    const src = '\n\n# First\n\n## Second\n';
+    const out = extractHeadings(src);
+    expect(out.map((h) => h.line)).toEqual([3, 5]);
+  });
+
+  it('ignores lines that look like headings but aren\'t (no space after #)', () => {
+    const src = ['#NotHeading', '# Real', '#### Also real'].join('\n');
+    const out = extractHeadings(src);
+    expect(out.map((h) => h.text)).toEqual(['Real', 'Also real']);
+  });
+
+  it('trims trailing whitespace and inline trailing space from heading text', () => {
+    const src = '## Title with trailing space   ';
+    const out = extractHeadings(src);
+    expect(out[0].text).toBe('Title with trailing space');
+  });
+
+  it('ignores 7+ hashes (CommonMark caps ATX at 6)', () => {
+    const src = '####### Not a heading';
+    const out = extractHeadings(src);
+    expect(out).toEqual([]);
+  });
+
+  it('returns an empty list for prose with no headings', () => {
+    const out = extractHeadings('just\nsome\nparagraphs');
+    expect(out).toEqual([]);
+  });
+});
+
+describe('activeHeadingChain', () => {
+  const sample = extractHeadings([
+    '# Root',                  // 1
+    '',                        // 2
+    'intro prose',             // 3
+    '## Background',           // 4
+    'background prose',        // 5
+    '### Prior work',          // 6
+    'prior work prose',        // 7
+    '### Current state',       // 8
+    'current state prose',     // 9
+    '## Method',               // 10
+    'method prose',            // 11
+  ].join('\n'));
+
+  it('returns empty when cursor sits before the first heading', () => {
+    expect(activeHeadingChain(sample, 0)).toEqual([]);
+    // Just above # Root — same result.
+  });
+
+  it('returns the H1 alone when cursor is in its body', () => {
+    const chain = activeHeadingChain(sample, 3);
+    expect(chain.map((h) => h.text)).toEqual(['Root']);
+  });
+
+  it('builds the parent chain for a deeper heading', () => {
+    const chain = activeHeadingChain(sample, 7);
+    expect(chain.map((h) => h.text)).toEqual(['Root', 'Background', 'Prior work']);
+  });
+
+  it('switches sibling without dragging the previous one along', () => {
+    const chain = activeHeadingChain(sample, 9);
+    expect(chain.map((h) => h.text)).toEqual(['Root', 'Background', 'Current state']);
+  });
+
+  it('drops back up the tree at a shallower sibling', () => {
+    // Cursor inside Method (H2) — Background's children disappear.
+    const chain = activeHeadingChain(sample, 11);
+    expect(chain.map((h) => h.text)).toEqual(['Root', 'Method']);
+  });
+
+  it('returns the heading itself when cursor sits ON the heading line', () => {
+    const chain = activeHeadingChain(sample, 6);
+    expect(chain.map((h) => h.text)).toEqual(['Root', 'Background', 'Prior work']);
+  });
+
+  it('handles a document that skips a level (## directly under #)', () => {
+    const skipped = extractHeadings([
+      '# A',
+      '',
+      '### C',  // jumps from H1 to H3
+      '',
+    ].join('\n'));
+    const chain = activeHeadingChain(skipped, 4);
+    // Build the chain conservatively: take the strictly-shallower
+    // ancestors we find. Missing levels are not synthesized.
+    expect(chain.map((h) => h.text)).toEqual(['A', 'C']);
+  });
+});


### PR DESCRIPTION
Closes #476.

## Summary
A thin clickable breadcrumbs strip above the editor pane. Folder segments reveal the folder in the left sidebar; an optional cursor-driven heading chain shows the active section path.

## Components

### Shared
- **`src/renderer/lib/markdown/headings.ts`** (new): exported `extractHeadings()` — ATX-style parser, formerly inline in `OutlinePanel` — plus `activeHeadingChain(headings, cursorLine)` that walks the list backwards from the most-recent heading at-or-before the cursor, collecting strictly-shallower ancestors.
- `OutlinePanel` now imports from here so we have a single source of truth.

### BreadcrumbsBar
- Folder segments → `onRevealFolder` callback (clickable).
- Leaf renders in italic display-serif (echoes the title-bar treatment), not clickable.
- When `showHeadings` is on AND the cursor sits in a section, appends a `·` separator + the heading chain. Debounced 60ms so held-arrow scroll doesn't thrash.
- Hidden entirely when no active file. Active heading (chain leaf) gets a subtle `--accent` color.

### Settings
- `src/renderer/lib/breadcrumbs/settings.ts`: single `showHeadingChain` toggle, **default off** ("no surprises" — flip on from Settings → Workspace → Behaviors).
- Toggle wired into SettingsDialog's Behaviors panel with explanatory hint copy.

### Wiring
- `Sidebar` exposes new `revealFolder(folderPath)` imperative — switches to Notes panel, expands the folder + every ancestor, scrolls into view.
- `App.svelte` mounts BreadcrumbsBar above the editor pane (inside the note branch only — CSV/query/source tabs don't get it), wires folder reveal through `sidebar.revealFolder()` and heading jump through `editorComponent.gotoLineColumn(line, 1)`. Re-reads breadcrumb settings on SettingsDialog close.

## Tests
- `tests/renderer/markdown/headings.test.ts` (13 cases): every ATX level, line numbering, parser edge cases, full activeHeadingChain matrix (before-first, in-body, deep chain, sibling switch, drop-back-up, ON-heading-line, level-skip).

## Honors issue's out-of-scope list
- No symbol breadcrumbs (SPARQL clause / RDF block / column)
- No drag-drop onto a breadcrumb segment
- No back/forward beyond the existing nav store

## Trust principle / CLAUDE.md
- **Stay out of the way** — heading chain off by default; the bar hides on non-note tabs; no behavior change to existing editor flow.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2223 tests, +13 new)
- [x] `pnpm test:e2e` smoke passes
- [ ] **UI verification by user**:
  - Open a note in a nested folder. Confirm thin bar above the editor shows `folder › subfolder › *italic leaf*`.
  - Click a folder segment — left sidebar reveals + expands it.
  - Settings → Workspace → Behaviors → enable "Show heading chain in breadcrumbs". Move cursor through `# H1` / `## H2` / `### H3` sections; chain updates with `·` separator. Click a heading — editor jumps to that line.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)