### PR TITLE
chore: rename left-sidebar 'Sites' panel to 'Sources'

### DIFF
--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -17,7 +17,7 @@
    *  others are icon-only. Per IMPLEMENTATION.md §5.1. */
   const PANELS: ReadonlyArray<{ id: PanelType; label: string; icon: 'notes' | 'sites' | 'tags' | 'tables' }> = [
     { id: 'notes',  label: 'Notes',  icon: 'notes' },
-    { id: 'sites',  label: 'Sites',  icon: 'sites' },
+    { id: 'sites',  label: 'Sources',  icon: 'sites' },
     { id: 'tags',   label: 'Tags',   icon: 'tags' },
     { id: 'tables', label: 'Tables', icon: 'tables' },
   ];


### PR DESCRIPTION
Fix mislabel from the design-review work (#557): Claude Design renamed the left-sidebar Sources panel to "Sites", which confuses it with the privileged-domain logins concept living on the Settings tab. Putting the label back to "Sources".

\`PanelType\` id stays \`'sites'\` so the icon registry key + persisted state survive. Only the user-visible label changes; the \`sites\` icon (book-spine shape) stays for now per your call.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes (2229 tests)
- [x] \`pnpm test:e2e\` smoke passes
- [ ] **UI verification**: left sidebar tab now reads "Sources" again

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)