### PR TITLE
feat: metadata merge on source re-ingest (#90 part 1)

### DIFF
--- a/src/main/sources/import-bibtex.ts
+++ b/src/main/sources/import-bibtex.ts
@@ -22,6 +22,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { parse as parseBibtex } from '@retorquere/bibtex-parser';
 import { canonicalSourceId } from './source-id';
+import { mergeMetaTtl } from './source-merge';
 import { buildMetaTtl } from './ingest-identifier';
 import type { ArticleMetadata } from './api-adapters/types';
 
@@ -104,11 +105,30 @@ export async function importBibtexContent(
       const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
       const metaPath = path.join(sourceDir, 'meta.ttl');
 
+      // Dedupe: existing meta.ttl → merge missing fields from this
+      // BibTeX entry (#90). Imports often happen in batches; a richer
+      // entry later in the batch can enrich an earlier minimal record.
       try {
-        await fs.access(metaPath);
+        const existingTtl = await fs.readFile(metaPath, 'utf-8');
+        const { ttl: merged, added } = mergeMetaTtl(existingTtl, {
+          doi: metadata.doi,
+          isbn: metadata.isbn,
+          uri: metadata.uri,
+          issued: metadata.issued,
+          publisher: metadata.publisher,
+          containerTitle: metadata.containerTitle,
+          abstract: metadata.abstract,
+          creators: metadata.creators,
+        });
+        if (added.length > 0) {
+          await fs.writeFile(metaPath, merged, 'utf-8');
+        }
         result.duplicate.push({ sourceId, title: metadata.title });
         continue;
-      } catch { /* not found — proceed */ }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        // Not found — proceed to fresh write.
+      }
 
       await fs.mkdir(sourceDir, { recursive: true });
       await fs.writeFile(metaPath, buildMetaTtl(metadata), 'utf-8');

--- a/src/main/sources/import-zotero-rdf.ts
+++ b/src/main/sources/import-zotero-rdf.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 import * as $rdf from 'rdflib';
 import type { IndexedFormula, NamedNode, Node } from 'rdflib';
 import { canonicalSourceId } from './source-id';
+import { mergeMetaTtl } from './source-merge';
 import { buildMetaTtl } from './ingest-identifier';
 import type { ArticleMetadata } from './api-adapters/types';
 
@@ -138,11 +139,30 @@ export async function importZoteroRdfContent(
       const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
       const metaPath = path.join(sourceDir, 'meta.ttl');
 
+      // Dedupe: existing meta.ttl → merge missing fields from this
+      // Zotero record (#90). Same reasoning as the BibTeX path — a
+      // later, richer Zotero export can enrich an earlier minimal one.
       try {
-        await fs.access(metaPath);
+        const existingTtl = await fs.readFile(metaPath, 'utf-8');
+        const { ttl: merged, added } = mergeMetaTtl(existingTtl, {
+          doi: metadata.doi,
+          isbn: metadata.isbn,
+          uri: metadata.uri,
+          issued: metadata.issued,
+          publisher: metadata.publisher,
+          containerTitle: metadata.containerTitle,
+          abstract: metadata.abstract,
+          creators: metadata.creators,
+        });
+        if (added.length > 0) {
+          await fs.writeFile(metaPath, merged, 'utf-8');
+        }
         result.duplicate.push({ sourceId, title: metadata.title });
         continue;
-      } catch { /* not found — proceed */ }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        // Not found — proceed to fresh write.
+      }
 
       await fs.mkdir(sourceDir, { recursive: true });
       await fs.writeFile(metaPath, buildMetaTtl(metadata), 'utf-8');

--- a/src/main/sources/ingest-identifier.ts
+++ b/src/main/sources/ingest-identifier.ts
@@ -14,6 +14,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { canonicalSourceId, normalizeDoi, normalizeArxivId, normalizePubmedId } from './source-id';
+import { mergeMetaTtl } from './source-merge';
 import type { ArticleMetadata } from './api-adapters/types';
 import { fetchCrossrefMetadata } from './api-adapters/crossref';
 import { fetchArxivMetadata } from './api-adapters/arxiv';
@@ -86,9 +87,24 @@ export async function ingestIdentifier(
   const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
   const relativePath = `.minerva/sources/${sourceId}/meta.ttl`;
 
-  // Dedupe: existing meta.ttl → bail without overwriting.
+  // Dedupe: existing meta.ttl → merge new metadata into it (#90).
+  // The merge only adds predicates the existing file lacks; existing
+  // values + hand edits to body.md are preserved.
   try {
-    await fs.access(path.join(sourceDir, 'meta.ttl'));
+    const existingTtl = await fs.readFile(path.join(sourceDir, 'meta.ttl'), 'utf-8');
+    const { ttl: merged, added } = mergeMetaTtl(existingTtl, {
+      doi: metadata.doi,
+      isbn: metadata.isbn,
+      uri: metadata.uri,
+      issued: metadata.issued,
+      publisher: metadata.publisher,
+      containerTitle: metadata.containerTitle,
+      abstract: metadata.abstract,
+      creators: metadata.creators,
+    });
+    if (added.length > 0) {
+      await fs.writeFile(path.join(sourceDir, 'meta.ttl'), merged, 'utf-8');
+    }
     return {
       sourceId,
       relativePath,
@@ -98,7 +114,11 @@ export async function ingestIdentifier(
       pdfSaved: false,
       pdfError: null,
     };
-  } catch { /* not found — proceed */ }
+  } catch (err) {
+    // ENOENT is the "no existing file" path — proceed to fresh ingest.
+    // Anything else is a real read/write failure; surface it.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
 
   await fs.mkdir(sourceDir, { recursive: true });
   await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildMetaTtl(metadata), 'utf-8');

--- a/src/main/sources/ingest-pdf.ts
+++ b/src/main/sources/ingest-pdf.ts
@@ -22,6 +22,7 @@ import path from 'node:path';
 import { Buffer } from 'node:buffer';
 import { extractText, getMeta } from 'unpdf';
 import { canonicalSourceId } from './source-id';
+import { mergeMetaTtl } from './source-merge';
 
 export interface PdfIngestResult {
   sourceId: string;
@@ -54,9 +55,20 @@ export async function ingestPdf(
 
   const meta = await readPdfMeta(freshCopy(buf));
 
-  // Dedupe on the destination meta.ttl — matches the URL / identifier flows.
+  // Dedupe: existing meta.ttl → merge enriching fields from this PDF's
+  // /Info dict (#90). The bytes were content-hashed so the title + DOI
+  // should match the first ingest, but PDFs can be re-saved with edited
+  // metadata, and a DOI scraped from a later /Info dict is worth picking
+  // up if the first ingest missed it.
   try {
-    await fs.access(path.join(sourceDir, 'meta.ttl'));
+    const existingTtl = await fs.readFile(path.join(sourceDir, 'meta.ttl'), 'utf-8');
+    const { ttl: merged, added } = mergeMetaTtl(existingTtl, {
+      doi: meta.doi,
+      creators: meta.creators.length > 0 ? meta.creators : null,
+    });
+    if (added.length > 0) {
+      await fs.writeFile(path.join(sourceDir, 'meta.ttl'), merged, 'utf-8');
+    }
     return {
       sourceId,
       relativePath,
@@ -65,7 +77,10 @@ export async function ingestPdf(
       pageCount: 0,
       needsOcr: false,
     };
-  } catch { /* not found — proceed */ }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    // Not found — proceed to fresh ingest.
+  }
 
   const { pages, totalPages } = await extractTextOrFail(freshCopy(buf));
   const needsOcr = pages.every((p) => p.trim().length === 0) && totalPages > 0;

--- a/src/main/sources/ingest.ts
+++ b/src/main/sources/ingest.ts
@@ -21,6 +21,7 @@ import { parseHTML } from 'linkedom';
 import { Readability } from '@mozilla/readability';
 import TurndownService from 'turndown';
 import { canonicalSourceId, normalizeUrl } from './source-id';
+import { mergeMetaTtl } from './source-merge';
 import { extractStructured, structuredToArticleMetadata } from './site-handlers';
 import { buildMetaTtl as buildArticleMetaTtl } from './ingest-identifier';
 
@@ -69,18 +70,55 @@ export async function ingestUrl(
   const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
   const relativePath = `.minerva/sources/${sourceId}/meta.ttl`;
 
-  // Dedupe: if meta.ttl already exists, bail. The user can delete-and-reingest
-  // for a refresh; auto-overwriting would risk clobbering hand edits they've
-  // made to body.md since first ingest.
-  try {
-    await fs.access(path.join(sourceDir, 'meta.ttl'));
-    const existing = await readExistingTitle(sourceDir).catch(() => '');
-    return { sourceId, relativePath, duplicate: true, title: existing };
-  } catch {
-    // Not found — proceed.
-  }
-
   const extracted = extractReadableFromDoc(document, normalized);
+
+  // Dedupe: if meta.ttl already exists, MERGE new metadata into it
+  // rather than overwrite or skip (#90). body.md and other files are
+  // left untouched so the user's hand edits there survive a re-ingest.
+  try {
+    const existingTtl = await fs.readFile(path.join(sourceDir, 'meta.ttl'), 'utf-8');
+    const update: Parameters<typeof mergeMetaTtl>[1] = structured
+      ? {
+          doi: structured.doi ?? null,
+          isbn: structured.isbn ?? null,
+          uri: normalized,
+          // Structured handlers may supply richer metadata — fold it in
+          // via structuredToArticleMetadata so the field shapes line up.
+          ...(() => {
+            const m = structuredToArticleMetadata(structured, {
+              title: extracted.title,
+              byline: extracted.byline,
+              abstract: extracted.excerpt,
+              issued: extracted.publishedTime,
+              publisher: extracted.siteName,
+              uri: normalized,
+            });
+            return {
+              issued: m.issued,
+              publisher: m.publisher,
+              containerTitle: m.containerTitle,
+              abstract: m.abstract,
+              creators: m.creators,
+            };
+          })(),
+        }
+      : {
+          uri: normalized,
+          publisher: extracted.siteName,
+          abstract: extracted.excerpt,
+          issued: extracted.publishedTime,
+          creators: extracted.byline ? [extracted.byline] : null,
+        };
+    const { ttl: merged, added } = mergeMetaTtl(existingTtl, update);
+    if (added.length > 0) {
+      await fs.writeFile(path.join(sourceDir, 'meta.ttl'), merged, 'utf-8');
+    }
+    const existingTitle = await readExistingTitle(sourceDir).catch(() => '');
+    return { sourceId, relativePath, duplicate: true, title: existingTitle || extracted.title };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    // Not found — proceed to fresh ingest.
+  }
 
   await fs.mkdir(sourceDir, { recursive: true });
   await fs.writeFile(path.join(sourceDir, 'original.html'), html, 'utf-8');

--- a/src/main/sources/source-merge.ts
+++ b/src/main/sources/source-merge.ts
@@ -1,0 +1,171 @@
+/**
+ * Metadata merge for re-ingested sources (#90).
+ *
+ * When the canonical id resolves to a source folder that already exists,
+ * earlier ingests landed at the same folder and returned `duplicate:
+ * true` without doing anything. That left enriching metadata on the
+ * floor — re-ingesting a paper by DOI (after first ingesting by URL)
+ * should pick up the DOI / ISBN / publisher / abstract fields the
+ * URL-only ingest didn't have.
+ *
+ * Conservative merge:
+ *   - Add a predicate ONLY when the existing meta.ttl lacks it.
+ *   - Never overwrite existing values — preserves the user's hand edits
+ *     (title corrections, abstract trimming, custom dc:subject lines).
+ *   - Skip multi-valued predicates (dc:creator) when ANY value exists,
+ *     so a richer second ingest doesn't append a contradictory
+ *     dc:creator alongside the first.
+ *   - Leave body.md and other files in the source dir untouched.
+ *
+ * The merge is text-based: we control the writer (`buildMetaTtl`) and
+ * the shape is line-per-predicate; spotting "predicate is/isn't present"
+ * with a regex is reliable for our own output and tolerant of common
+ * hand edits. A round-trip Turtle parse + reserialize would lose
+ * comments and incidental whitespace.
+ */
+
+export interface SourceMetaUpdate {
+  /** ISO date string (YYYY / YYYY-MM / YYYY-MM-DD) for dc:issued. */
+  issued?: string | null;
+  publisher?: string | null;
+  /** Journal / book / proceedings title → schema:inContainer. */
+  containerTitle?: string | null;
+  doi?: string | null;
+  isbn?: string | null;
+  /** Canonical URL → bibo:uri. */
+  uri?: string | null;
+  abstract?: string | null;
+  /** Multi-valued: only added if no dc:creator exists already. */
+  creators?: readonly string[] | null;
+}
+
+export interface MergeResult {
+  /** The merged TTL — equal to the input when nothing was added. */
+  ttl: string;
+  /** Predicate localnames that were added (`doi`, `isbn`, …). */
+  added: string[];
+}
+
+/**
+ * Merge `update` into `existingTtl`. Adds any predicate the existing
+ * file lacks; never overwrites. New predicate lines are inserted just
+ * before the closing `.` so the Turtle stays grammatical and the
+ * thought:accessedAt timestamp stays at the bottom where the writer
+ * always puts it.
+ */
+export function mergeMetaTtl(existingTtl: string, update: SourceMetaUpdate): MergeResult {
+  const present = detectPresentPredicates(existingTtl);
+  const additions: { predicate: string; ttlLine: string }[] = [];
+
+  if (update.doi && !present.has('bibo:doi')) {
+    additions.push({ predicate: 'doi', ttlLine: `    bibo:doi ${ttlString(update.doi)} ;` });
+  }
+  if (update.isbn && !present.has('bibo:isbn')) {
+    additions.push({ predicate: 'isbn', ttlLine: `    bibo:isbn ${ttlString(update.isbn)} ;` });
+  }
+  if (update.uri && !present.has('bibo:uri')) {
+    additions.push({ predicate: 'uri', ttlLine: `    bibo:uri ${ttlString(update.uri)} ;` });
+  }
+  if (update.issued && !present.has('dc:issued')) {
+    additions.push({ predicate: 'issued', ttlLine: `    dc:issued ${issuedLiteral(update.issued)} ;` });
+  }
+  if (update.publisher && !present.has('dc:publisher')) {
+    additions.push({ predicate: 'publisher', ttlLine: `    dc:publisher ${ttlString(update.publisher)} ;` });
+  }
+  if (update.containerTitle && !present.has('schema:inContainer')) {
+    additions.push({ predicate: 'containerTitle', ttlLine: `    schema:inContainer ${ttlString(update.containerTitle)} ;` });
+  }
+  if (update.abstract && !present.has('dc:abstract')) {
+    additions.push({ predicate: 'abstract', ttlLine: `    dc:abstract ${ttlString(update.abstract)} ;` });
+  }
+  if (update.creators && update.creators.length > 0 && !present.has('dc:creator')) {
+    for (const creator of update.creators) {
+      additions.push({ predicate: 'creator', ttlLine: `    dc:creator ${ttlString(creator)} ;` });
+    }
+  }
+
+  if (additions.length === 0) {
+    return { ttl: existingTtl, added: [] };
+  }
+
+  return {
+    ttl: insertBeforeFinalDot(existingTtl, additions.map((a) => a.ttlLine)),
+    // Dedupe predicate names: the creator path pushes one entry per
+    // author and the caller only needs to know "creators were added".
+    added: [...new Set(additions.map((a) => a.predicate))],
+  };
+}
+
+/**
+ * Pull every `prefix:localname` token that sits in a predicate position
+ * (start of a line after indentation, or right after the subject's `a`
+ * type clause). Tolerant of leading whitespace and hand-edited spacing.
+ */
+function detectPresentPredicates(ttl: string): Set<string> {
+  const out = new Set<string>();
+  // Match prefixed names that appear as predicates. A predicate sits
+  // after the subject (`this:`) and either `a` (for the type triple) or
+  // at the start of a line after whitespace. Either way: a `prefix:local`
+  // token followed by whitespace + a value.
+  const re = /(?:^|\s)([a-zA-Z][\w-]*:[a-zA-Z][\w-]*)\s+(?!a\s)/gm;
+  for (const m of ttl.matchAll(re)) {
+    out.add(m[1]);
+  }
+  // `a` is the rdf:type predicate — record it too in case a merge
+  // someday wants to add a type assertion.
+  if (/\sa\s+[a-zA-Z][\w-]*:[a-zA-Z][\w-]*\s*[,;]/.test(ttl)) {
+    out.add('rdf:type');
+  }
+  return out;
+}
+
+/**
+ * Insert lines immediately before the predicate-list-terminating `.`.
+ * The existing buildMetaTtl always ends with `... ;\n    pred value
+ * .\n`. We find the trailing `.` and inject the new `;`-terminated
+ * lines just above it.
+ *
+ * Failure mode: if the existing TTL doesn't end with a `.`-terminated
+ * triple (malformed file), we append the new lines + a `.` and trust
+ * the user to repair. Safer than dropping the new data.
+ */
+function insertBeforeFinalDot(ttl: string, newLines: string[]): string {
+  // Find the last `.` that terminates the predicate list. The shape we
+  // emit always has `thought:accessedAt "<iso>"^^xsd:dateTime .` as the
+  // final triple; that `.` follows `^^xsd:dateTime` or a quoted string.
+  // Match a `.` at the end (allowing trailing whitespace / newline).
+  const trailing = ttl.match(/(\s*\.\s*)$/);
+  if (!trailing) {
+    // Malformed input — append + terminate.
+    return ttl + (ttl.endsWith('\n') ? '' : '\n') + newLines.join('\n') + '\n    .\n';
+  }
+  const dotIdx = trailing.index ?? ttl.length;
+  // Walk back from the `.` to find the start of the final predicate's
+  // line so the inject lands on its own line, not mid-line. We look
+  // for the previous newline.
+  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
+  if (lineStart < 0) {
+    // Single-line TTL — append before the `.`.
+    return ttl.slice(0, dotIdx).replace(/\s+$/, ' ;') + '\n' + newLines.join('\n') + '\n' + ttl.slice(dotIdx);
+  }
+  // Inject the new lines on their own lines between the previous
+  // predicate's terminating `;` and the final predicate's line.
+  return ttl.slice(0, lineStart) + '\n' + newLines.join('\n') + ttl.slice(lineStart);
+}
+
+function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+function issuedLiteral(iso: string): string {
+  if (/^\d{4}$/.test(iso)) return `${ttlString(iso)}^^xsd:gYear`;
+  if (/^\d{4}-\d{2}$/.test(iso)) return `${ttlString(iso)}^^xsd:gYearMonth`;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return `${ttlString(iso)}^^xsd:date`;
+  return ttlString(iso);
+}

--- a/tests/main/sources/ingest.test.ts
+++ b/tests/main/sources/ingest.test.ts
@@ -232,6 +232,58 @@ describe('ingestUrl (#93)', () => {
     expect(body).toContain('Hand-edited');
   });
 
+  it('merges missing predicates into existing meta.ttl on duplicate (#90)', async () => {
+    // First ingest: page without an og:site_name → no dc:publisher in
+    // the emitted meta.ttl. (Readability still pulls a byline and
+    // excerpt from the markup, so we test against the field we
+    // deliberately leave out.)
+    const noSiteHtml = `<!doctype html><html><head><title>Page</title>
+      <meta name="author" content="Original Author"></head><body>
+      <article><h1>Page</h1>
+      <p>A first paragraph that's long enough to satisfy Readability's content threshold for short pages.</p>
+      <p>A second paragraph for good measure so the extraction doesn't bail.</p>
+      </article></body></html>`;
+    await ingestUrl(root, 'https://example.com/page', {
+      fetchImpl: mockFetch(noSiteHtml),
+    });
+    const sourceDir = path.join(root, '.minerva', 'sources');
+    const ids = await fsp.readdir(sourceDir);
+    const metaPath = path.join(sourceDir, ids[0], 'meta.ttl');
+    const before = await fsp.readFile(metaPath, 'utf-8');
+    expect(before).not.toContain('dc:publisher');
+
+    // Re-ingest with og:site_name set — merge should add dc:publisher.
+    await ingestUrl(root, 'https://example.com/page', {
+      fetchImpl: mockFetch(samplePageHtml({
+        title: 'Page',
+        siteName: 'Example Press',
+      })),
+    });
+    const after = await fsp.readFile(metaPath, 'utf-8');
+    expect(after).toContain('dc:publisher "Example Press"');
+    // Existing title and creator preserved (creator existed before).
+    expect(after).toContain('dc:title "Page"');
+    expect(after).toContain('Original Author');
+  });
+
+  it('preserves an existing predicate when re-ingest provides a different value (#90)', async () => {
+    await ingestUrl(root, 'https://example.com/foo', {
+      fetchImpl: mockFetch(samplePageHtml({ title: 'Original', byline: 'A. First' })),
+    });
+    const sourceDir = path.join(root, '.minerva', 'sources');
+    const ids = await fsp.readdir(sourceDir);
+    const metaPath = path.join(sourceDir, ids[0], 'meta.ttl');
+
+    // Re-ingest — different byline. Merge is conservative: existing
+    // dc:creator stays; the new one is dropped.
+    await ingestUrl(root, 'https://example.com/foo', {
+      fetchImpl: mockFetch(samplePageHtml({ title: 'Original', byline: 'B. Second' })),
+    });
+    const after = await fsp.readFile(metaPath, 'utf-8');
+    expect(after).toContain('dc:creator "A. First"');
+    expect(after).not.toContain('B. Second');
+  });
+
   it('rejects a non-URL input', async () => {
     await expect(
       ingestUrl(root, 'not a url', { fetchImpl: mockFetch('') }),

--- a/tests/main/sources/source-merge.test.ts
+++ b/tests/main/sources/source-merge.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Conservative metadata merge for re-ingested sources (#90).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+import { mergeMetaTtl } from '../../../src/main/sources/source-merge';
+
+const PREAMBLE = '@prefix this: <minerva://this#> .\n@prefix dc: <http://purl.org/dc/terms/> .\n@prefix bibo: <http://purl.org/ontology/bibo/> .\n@prefix schema: <http://schema.org/> .\n@prefix thought: <https://minerva.dev/ontology/thought#> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n';
+
+function makeExisting(predicates: string[]): string {
+  const lines = ['this: a thought:Article ;'];
+  for (const p of predicates) lines.push(`    ${p} ;`);
+  lines.push('    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .');
+  return lines.join('\n') + '\n';
+}
+
+/** Sanity: every assertion below should still produce parseable Turtle. */
+function assertParses(ttl: string): void {
+  const errors: Error[] = [];
+  new Parser().parse(PREAMBLE + ttl, (err) => { if (err) errors.push(err); });
+  if (errors.length > 0) {
+    throw new Error(`TTL did not parse:\n${ttl}\n\nerror: ${errors[0].message}`);
+  }
+}
+
+describe('mergeMetaTtl (#90)', () => {
+  it('adds a missing bibo:doi when the existing file lacks one', () => {
+    const existing = makeExisting(['dc:title "Foo"']);
+    const { ttl, added } = mergeMetaTtl(existing, { doi: '10.1/foo' });
+    expect(added).toEqual(['doi']);
+    expect(ttl).toContain('bibo:doi "10.1/foo"');
+    // Inserted before the final `.`, not after.
+    expect(ttl.indexOf('bibo:doi')).toBeLessThan(ttl.indexOf('thought:accessedAt'));
+    assertParses(ttl);
+  });
+
+  it('does NOT overwrite an existing bibo:doi', () => {
+    const existing = makeExisting(['dc:title "Foo"', 'bibo:doi "10.1/old"']);
+    const { ttl, added } = mergeMetaTtl(existing, { doi: '10.1/new' });
+    expect(added).toEqual([]);
+    expect(ttl).toContain('bibo:doi "10.1/old"');
+    expect(ttl).not.toContain('10.1/new');
+  });
+
+  it('adds multiple missing predicates in one merge', () => {
+    const existing = makeExisting(['dc:title "Foo"']);
+    const { ttl, added } = mergeMetaTtl(existing, {
+      doi: '10.1/foo',
+      isbn: '9780140449136',
+      publisher: 'Acme Books',
+      containerTitle: 'Journal of Foo',
+      abstract: 'Some abstract.',
+      issued: '2024',
+    });
+    expect(added.sort()).toEqual(['abstract', 'containerTitle', 'doi', 'isbn', 'issued', 'publisher']);
+    expect(ttl).toContain('bibo:doi "10.1/foo"');
+    expect(ttl).toContain('bibo:isbn "9780140449136"');
+    expect(ttl).toContain('dc:publisher "Acme Books"');
+    expect(ttl).toContain('schema:inContainer "Journal of Foo"');
+    expect(ttl).toContain('dc:abstract "Some abstract."');
+    expect(ttl).toContain('dc:issued "2024"^^xsd:gYear');
+    assertParses(ttl);
+  });
+
+  it('emits dc:issued with the right XSD datatype for each date shape', () => {
+    expect(mergeMetaTtl(makeExisting([]), { issued: '2024' }).ttl).toContain('"2024"^^xsd:gYear');
+    expect(mergeMetaTtl(makeExisting([]), { issued: '2024-05' }).ttl).toContain('"2024-05"^^xsd:gYearMonth');
+    expect(mergeMetaTtl(makeExisting([]), { issued: '2024-05-27' }).ttl).toContain('"2024-05-27"^^xsd:date');
+  });
+
+  it('skips dc:creator when any creator is already present', () => {
+    const existing = makeExisting(['dc:title "Foo"', 'dc:creator "Smith, A."']);
+    const { ttl, added } = mergeMetaTtl(existing, { creators: ['Smith, A.', 'Jones, B.'] });
+    expect(added).toEqual([]);
+    expect(ttl).toContain('dc:creator "Smith, A."');
+    expect(ttl).not.toContain('Jones, B.');
+  });
+
+  it('adds every creator when none exist', () => {
+    const existing = makeExisting(['dc:title "Foo"']);
+    const { ttl, added } = mergeMetaTtl(existing, { creators: ['Smith, A.', 'Jones, B.'] });
+    expect(added).toEqual(['creator']);
+    expect(ttl).toContain('dc:creator "Smith, A."');
+    expect(ttl).toContain('dc:creator "Jones, B."');
+    assertParses(ttl);
+  });
+
+  it('is a no-op when nothing new to add', () => {
+    const existing = makeExisting(['dc:title "Foo"', 'bibo:doi "10.1/x"']);
+    const { ttl, added } = mergeMetaTtl(existing, { doi: '10.1/x', isbn: undefined });
+    expect(added).toEqual([]);
+    expect(ttl).toBe(existing);
+  });
+
+  it('treats null and undefined fields as "no update"', () => {
+    const existing = makeExisting(['dc:title "Foo"']);
+    const { ttl, added } = mergeMetaTtl(existing, {
+      doi: null,
+      isbn: undefined,
+      publisher: null,
+      creators: null,
+    });
+    expect(added).toEqual([]);
+    expect(ttl).toBe(existing);
+  });
+
+  it('preserves hand-added predicates the writer doesn\'t know about', () => {
+    const existing = makeExisting([
+      'dc:title "Foo"',
+      'dc:subject "hand-added"',
+      'thought:hasStatus thought:established',
+    ]);
+    const { ttl } = mergeMetaTtl(existing, { doi: '10.1/foo' });
+    expect(ttl).toContain('dc:subject "hand-added"');
+    expect(ttl).toContain('thought:hasStatus thought:established');
+    expect(ttl).toContain('bibo:doi "10.1/foo"');
+    assertParses(ttl);
+  });
+
+  it('escapes special characters in string literals', () => {
+    const existing = makeExisting(['dc:title "Foo"']);
+    const { ttl } = mergeMetaTtl(existing, { abstract: 'Has "quotes" and\nnewlines.' });
+    // Quotes escaped, newlines escaped as \n.
+    expect(ttl).toContain('Has \\"quotes\\" and\\nnewlines.');
+    assertParses(ttl);
+  });
+});


### PR DESCRIPTION
First half of #90 — closes the "merge new metadata into the existing node" acceptance bullet. The "User-visible Merge Sources command" piece is part 2 (separate PR).

## Summary
Re-ingesting an already-ingested source no longer drops new metadata on the floor. The four ingest paths (URL, identifier, PDF, BibTeX, Zotero RDF) read the existing \`meta.ttl\`, conservatively add any predicates it's missing, and write it back. \`body.md\` and other sibling files are still untouched — hand edits survive the second ingest.

## Merge semantics (\`src/main/sources/source-merge.ts\`)
- **Add when missing, never overwrite.** Existing values + user hand-edits to the TTL are preserved.
- **Multi-valued (dc:creator)**: skip when any value exists — a richer second ingest can't append a contradictory author. When none exist, add every supplied creator.
- **Hand-added predicates** (e.g. user-added \`thought:hasStatus\`) pass through untouched.
- **Grammatical insertion**: new predicate lines slot in immediately before the closing \`.\` so the Turtle stays valid and the \`thought:accessedAt\` timestamp stays last.

## Wiring
- \`ingest-identifier.ts\`: existing-meta path now reads + merges + writes instead of bailing. Headline use: arXiv-id-first then later DOI for the same paper picks up the DOI cross-reference.
- \`ingest.ts\` (URL): same pattern, structured handler output preferred, Readability fallback.
- \`ingest-pdf.ts\`: merge what the /Info dict surfaces. Less benefit since content-hash ids only match identical bytes, but consistency.
- \`import-bibtex.ts\` + \`import-zotero-rdf.ts\`: same merge applied within-batch — a richer later record enriches an earlier minimal one.

**Bonus cleanup**: every dedupe-path catch now distinguishes ENOENT from other read failures (was silently swallowing permission / corrupt-file conditions).

## Tests
- 10 unit cases in \`source-merge.test.ts\`: missing-only add, never-overwrite, multi-field merge, XSD datatype selection for dc:issued, multi-valued creator skip-on-collision, no-op, null/undefined as no-update, hand-added passthrough, special-char escaping, round-trip parse via n3.
- 2 new integration cases in \`ingest.test.ts\`: merge adds dc:publisher when first ingest lacked og:site_name; conservative path leaves existing dc:creator alone when re-ingest supplies a different byline.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes (2241 tests, +12 new)
- [x] \`pnpm test:e2e\` smoke passes
- [ ] **UI verification**: ingest an arXiv id by URL (gets the URL-only meta), then re-ingest the same paper by DOI (gets the full Crossref record). Confirm the merged \`meta.ttl\` gains the DOI / publisher / issued fields without dropping the original title.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)