### PR TITLE
feat: Merge Sources command (#90 part 2)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -71,6 +71,7 @@ import {
 import { renderInlineCitations, type InlineCiteRequest } from './citations/render-inline';
 import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
 import { deleteSource } from './sources/delete-source';
+import { mergeSources, MergeSourcesError } from './sources/merge-sources';
 import { importBibtex } from './sources/import-bibtex';
 import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
@@ -1557,6 +1558,30 @@ export function registerIpcHandlers(): void {
       win.webContents.send(Channels.EXCERPTS_CHANGED);
     }
     return result;
+  });
+
+  ipcMain.handle(Channels.SOURCES_MERGE, async (e, params: { srcId: string; destId: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    try {
+      const result = await mergeSources(rootPath, params.srcId, params.destId);
+      await persistIndexes(rootPath);
+      const win = winFromEvent(e);
+      if (!win.isDestroyed()) {
+        win.webContents.send(Channels.SOURCES_CHANGED);
+        win.webContents.send(Channels.EXCERPTS_CHANGED);
+      }
+      return result;
+    } catch (err) {
+      if (err instanceof MergeSourcesError) {
+        // Carry the structured code through to the renderer so the UI
+        // can distinguish a same-source / not-found error from a real crash.
+        const wrapped = new Error(err.message);
+        (wrapped as Error & { code?: string }).code = err.code;
+        throw wrapped;
+      }
+      throw err;
+    }
   });
 
   ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, async (e, params: {

--- a/src/main/sources/merge-sources.ts
+++ b/src/main/sources/merge-sources.ts
@@ -1,0 +1,247 @@
+/**
+ * Merge one Source into another (#90 part 2).
+ *
+ * Two source folders sometimes describe the same work: a paper ingested
+ * first by URL (no DOI yet) then later by DOI ends up at two different
+ * canonical ids when the first ingest didn't carry the DOI through.
+ * Re-ingest's metadata-merge (#90 part 1) handles the case where the
+ * second ingest *resolves* to the same canonical id. This command
+ * handles the case where it doesn't — the user explicitly picks two
+ * folders and asks for them to become one.
+ *
+ * Operation, in order:
+ *   1. Parse src/meta.ttl into a SourceMetaUpdate.
+ *   2. Merge into dest/meta.ttl (reuses #90 part 1 conservative merge:
+ *      add when missing, never overwrite).
+ *   3. Copy body.md / original.* from src → dest ONLY if dest lacks
+ *      them. Dest's identity always wins.
+ *   4. For every excerpt with thought:fromSource sources:src, rewrite
+ *      the .ttl in-place to point at dest and re-index.
+ *   5. Find every note citing src and rewrite [[cite::src]] → [[cite::dest]].
+ *   6. Remove src from the graph + delete src folder on disk.
+ *
+ * Excerpt ids are globally unique within a project (the .ttl filename
+ * IS the id), so collisions between src and dest can't arise.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Parser } from 'n3';
+import * as graph from '../graph/index';
+import * as notebaseFs from '../notebase/fs';
+import { rewriteTypedIdLinks } from '../notebase/link-rewriting';
+import { projectContext } from '../project-context-types';
+import { mergeMetaTtl, type SourceMetaUpdate } from './source-merge';
+
+export interface MergeSourcesResult {
+  destId: string;
+  removedId: string;
+  /** Excerpts whose fromSource pointer was rewritten src → dest. */
+  excerptsMoved: number;
+  /** Notes whose `[[cite::src]]` was rewritten to `[[cite::dest]]`. */
+  notesRewritten: number;
+  /** Predicate localnames added to dest's meta.ttl (`doi`, `publisher`, …). */
+  metadataAdded: string[];
+  /** Names of files copied src → dest because dest lacked them (`body.md`, `original.pdf`, …). */
+  artifactsCopied: string[];
+}
+
+export class MergeSourcesError extends Error {
+  constructor(message: string, public readonly code: MergeSourcesErrorCode) {
+    super(message);
+    this.name = 'MergeSourcesError';
+  }
+}
+
+export type MergeSourcesErrorCode =
+  | 'same-source'
+  | 'source-not-found'
+  | 'dest-not-found';
+
+export async function mergeSources(
+  rootPath: string,
+  srcId: string,
+  destId: string,
+): Promise<MergeSourcesResult> {
+  if (srcId === destId) {
+    throw new MergeSourcesError('Cannot merge a source into itself.', 'same-source');
+  }
+
+  const sourcesDir = path.join(rootPath, '.minerva', 'sources');
+  const srcDir = path.join(sourcesDir, srcId);
+  const destDir = path.join(sourcesDir, destId);
+
+  const srcMetaPath = path.join(srcDir, 'meta.ttl');
+  const destMetaPath = path.join(destDir, 'meta.ttl');
+
+  let srcMetaTtl: string;
+  try {
+    srcMetaTtl = await fs.readFile(srcMetaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new MergeSourcesError(`Source "${srcId}" not found.`, 'source-not-found');
+    }
+    throw err;
+  }
+  let destMetaTtl: string;
+  try {
+    destMetaTtl = await fs.readFile(destMetaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new MergeSourcesError(`Destination source "${destId}" not found.`, 'dest-not-found');
+    }
+    throw err;
+  }
+
+  const ctx = projectContext(rootPath);
+
+  // Excerpt ids are globally unique (filenames under .minerva/excerpts/)
+  // so collision between src and dest can't naturally arise.
+  const srcExcerpts = graph.excerptIdsForSource(ctx, srcId);
+
+  // 1. Merge metadata.
+  const update = parseSourceMetaTtl(srcMetaTtl);
+  const { ttl: mergedDestTtl, added } = mergeMetaTtl(destMetaTtl, update);
+  if (added.length > 0) {
+    await fs.writeFile(destMetaPath, mergedDestTtl, 'utf-8');
+  }
+
+  // 2. Copy artifacts dest is missing. body.md + original.* only — we
+  //    don't sweep the whole folder so that hand-added scratch files in
+  //    src don't pollute dest.
+  const artifactsCopied: string[] = [];
+  for (const name of ['body.md', 'original.html', 'original.pdf']) {
+    const srcPath = path.join(srcDir, name);
+    const destPath = path.join(destDir, name);
+    try {
+      await fs.access(destPath);
+      continue; // dest already has it — keep dest's
+    } catch { /* dest missing — proceed */ }
+    try {
+      await fs.copyFile(srcPath, destPath);
+      artifactsCopied.push(name);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      // src doesn't have it either — nothing to copy.
+    }
+  }
+
+  // If dest got a new body.md, re-index it so the graph picks up the body.
+  if (artifactsCopied.includes('body.md') || added.length > 0) {
+    const finalMeta = await fs.readFile(destMetaPath, 'utf-8');
+    let body: string | undefined;
+    try { body = await fs.readFile(path.join(destDir, 'body.md'), 'utf-8'); } catch { /* ok */ }
+    graph.indexSource(ctx, destId, finalMeta, body);
+  }
+
+  // 3. Move excerpts: rewrite each .ttl's `thought:fromSource sources:src`
+  //    to point at dest and re-index.
+  let excerptsMoved = 0;
+  for (const excerptId of srcExcerpts) {
+    const excerptPath = path.join(rootPath, '.minerva', 'excerpts', `${excerptId}.ttl`);
+    try {
+      const original = await fs.readFile(excerptPath, 'utf-8');
+      const rewritten = rewriteExcerptFromSource(original, srcId, destId);
+      if (rewritten !== original) {
+        await fs.writeFile(excerptPath, rewritten, 'utf-8');
+      }
+      graph.removeExcerpt(ctx, excerptId);
+      graph.indexExcerpt(ctx, excerptId, rewritten);
+      excerptsMoved++;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+
+  // 4. Rewrite [[cite::src]] → [[cite::dest]] in every referring note.
+  const referringNotes = graph.findNotesCitingSource(ctx, srcId);
+  const rewrites = new Map([[srcId, destId]]);
+  let notesRewritten = 0;
+  for (const notePath of referringNotes) {
+    try {
+      const content = await notebaseFs.readFile(rootPath, notePath);
+      const next = rewriteTypedIdLinks(content, 'cite', rewrites);
+      if (next === content) continue;
+      await notebaseFs.writeFile(rootPath, notePath, next);
+      await graph.indexNote(ctx, notePath, next);
+      notesRewritten++;
+    } catch (err) {
+      console.error(`[minerva] cite rewrite failed for ${notePath}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  // 5. Drop src from graph + disk.
+  graph.removeSource(ctx, srcId);
+  await fs.rm(srcDir, { recursive: true, force: true });
+
+  return {
+    destId,
+    removedId: srcId,
+    excerptsMoved,
+    notesRewritten,
+    metadataAdded: added,
+    artifactsCopied,
+  };
+}
+
+/**
+ * Pull the fields a SourceMetaUpdate consumes out of a meta.ttl string.
+ * Uses n3 so escaped quotes inside abstracts and unconventional
+ * whitespace from hand edits don't break us. The on-disk meta.ttl
+ * relies on project-global prefix declarations, so we inline the
+ * subset we need before handing the string to the parser.
+ */
+const META_TTL_PREAMBLE =
+  '@prefix this: <https://minerva.dev/this/> .\n' +
+  '@prefix dc: <http://purl.org/dc/terms/> .\n' +
+  '@prefix bibo: <http://purl.org/ontology/bibo/> .\n' +
+  '@prefix schema: <http://schema.org/> .\n' +
+  '@prefix thought: <https://minerva.dev/ontology/thought#> .\n' +
+  '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n';
+
+function parseSourceMetaTtl(ttl: string): SourceMetaUpdate {
+  const parser = new Parser();
+  const quads = parser.parse(META_TTL_PREAMBLE + ttl);
+
+  const pred = (suffix: string, namespace: string): ((q: { predicate: { value: string } }) => boolean) =>
+    (q) => q.predicate.value === namespace + suffix;
+  const DC_NS = 'http://purl.org/dc/terms/';
+  const BIBO_NS = 'http://purl.org/ontology/bibo/';
+  const SCHEMA_NS = 'http://schema.org/';
+
+  const firstObj = (matcher: (q: { predicate: { value: string } }) => boolean): string | null => {
+    for (const q of quads) if (matcher(q)) return q.object.value;
+    return null;
+  };
+  const allObj = (matcher: (q: { predicate: { value: string } }) => boolean): string[] => {
+    const out: string[] = [];
+    for (const q of quads) if (matcher(q)) out.push(q.object.value);
+    return out;
+  };
+
+  return {
+    doi: firstObj(pred('doi', BIBO_NS)),
+    isbn: firstObj(pred('isbn', BIBO_NS)),
+    uri: firstObj(pred('uri', BIBO_NS)),
+    issued: firstObj(pred('issued', DC_NS)),
+    publisher: firstObj(pred('publisher', DC_NS)),
+    containerTitle: firstObj(pred('inContainer', SCHEMA_NS)),
+    abstract: firstObj(pred('abstract', DC_NS)),
+    creators: allObj(pred('creator', DC_NS)),
+  };
+}
+
+/**
+ * Rewrite `thought:fromSource sources:srcId` → `… sources:destId` in an
+ * excerpt .ttl. Handles surrounding whitespace + comma-continuation
+ * (`fromSource sources:foo, sources:bar` is legal but our writer doesn't
+ * emit it; we still tolerate it for hand edits).
+ */
+export function rewriteExcerptFromSource(ttl: string, srcId: string, destId: string): string {
+  // Match `sources:<srcId>` where srcId is preceded by `sources:` and
+  // followed by a non-identifier char (semicolon, comma, whitespace, `.`).
+  const escaped = srcId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(sources:)${escaped}(?=[\\s,;.]|$)`, 'g');
+  return ttl.replace(re, `$1${destId}`);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -255,6 +255,8 @@ contextBridge.exposeInMainWorld('api', {
       subscribeIpc(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, cb),
     listAll: () => ipcRenderer.invoke(Channels.SOURCES_LIST_ALL),
     delete: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_DELETE, sourceId),
+    merge: (srcId: string, destId: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_MERGE, { srcId, destId }),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/lib/components/SourcePickerDialog.svelte
+++ b/src/renderer/lib/components/SourcePickerDialog.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+  import type { SourceMetadata } from '../../../shared/types';
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    sources: SourceMetadata[];
+    onSelect: (sourceId: string) => void;
+    onCancel: () => void;
+    /** Title in the dialog header. */
+    title: string;
+    /** Placeholder in the filter input. */
+    placeholder?: string;
+    /** Drop a single sourceId from the candidate list — used by Merge
+     *  Sources so the user can't pick the source as its own merge target. */
+    excludeSourceId?: string;
+  }
+
+  let { sources, onSelect, onCancel, title, placeholder = 'Filter sources…', excludeSourceId }: Props = $props();
+
+  let query = $state('');
+  let selectedIndex = $state(0);
+  let inputEl = $state<HTMLInputElement>();
+
+  const candidates = $derived(
+    excludeSourceId ? sources.filter((s) => s.sourceId !== excludeSourceId) : sources,
+  );
+
+  const results = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter((s) => {
+      const title = (s.title ?? s.sourceId).toLowerCase();
+      const byline = s.creators.join(' ').toLowerCase();
+      const year = s.year ?? '';
+      return title.includes(q) || byline.includes(q) || year.includes(q) || s.sourceId.toLowerCase().includes(q);
+    });
+  });
+
+  $effect(() => {
+    results; // re-track
+    selectedIndex = 0;
+  });
+
+  $effect(() => {
+    inputEl?.focus();
+  });
+
+  $effect(() => {
+    const el = document.querySelector('.sp-results .selected');
+    el?.scrollIntoView({ block: 'nearest' });
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIndex = Math.max(selectedIndex - 1, 0);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const picked = results[selectedIndex];
+      if (picked) onSelect(picked.sourceId);
+    } else if (e.key === 'Escape') {
+      onCancel();
+    }
+  }
+
+  function formatCreators(creators: string[]): string {
+    if (creators.length === 0) return '';
+    if (creators.length === 1) return creators[0];
+    if (creators.length === 2) return `${creators[0]} and ${creators[1]}`;
+    return `${creators[0]} et al.`;
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-label={title}>
+    <div class="header">{title}</div>
+    <div class="input-row">
+      <Icon name="search" size={14} color="var(--text-muted)" />
+      <input bind:this={inputEl} bind:value={query} type="text" class="input" {placeholder} />
+    </div>
+
+    {#if results.length > 0}
+      <ul class="sp-results">
+        {#each results as s, i (s.sourceId)}
+          {@const who = formatCreators(s.creators)}
+          <li>
+            <button
+              class="result-item"
+              class:selected={i === selectedIndex}
+              onclick={() => onSelect(s.sourceId)}
+              onmouseenter={() => { selectedIndex = i; }}
+            >
+              <Icon name="sites" size={13} color={i === selectedIndex ? 'var(--accent)' : 'var(--text-faint)'} />
+              <span class="result-body">
+                <span class="result-title">{s.title ?? s.sourceId}</span>
+                {#if who || s.year}
+                  <span class="result-byline">
+                    {#if who}{who}{/if}{#if who && s.year} · {/if}{#if s.year}<span class="year">{s.year}</span>{/if}
+                  </span>
+                {/if}
+              </span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {:else if query.trim()}
+      <div class="no-results">No matching sources</div>
+    {:else}
+      <div class="no-results">No other sources to pick from.</div>
+    {/if}
+
+    <footer class="palette-footer">
+      <span class="kbd-hint">↑↓ navigate · ↵ select · esc cancel</span>
+      <span class="result-count">
+        {#if results.length > 0}
+          <span class="nums">{results.length}</span>
+          {results.length === 1 ? 'source' : 'sources'}
+        {/if}
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.45);
+    backdrop-filter: blur(2px);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 15vh 32px 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    width: 640px;
+    max-width: 100%;
+    max-height: 60vh;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+  .header {
+    padding: 12px 16px 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    letter-spacing: 0.02em;
+  }
+  .input-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 4px 16px 12px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    outline: none;
+    padding: 0;
+  }
+  .input::placeholder { color: var(--text-muted); }
+  .sp-results {
+    list-style: none;
+    overflow-y: auto;
+    padding: 4px 0;
+    margin: 0;
+    flex: 1;
+  }
+  .result-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 16px;
+    border: none;
+    border-left: 2px solid transparent;
+    background: none;
+    color: var(--text);
+    cursor: pointer;
+    text-align: left;
+  }
+  .result-item.selected {
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
+    border-left-color: var(--accent);
+  }
+  .result-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .result-title {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .result-byline {
+    font-size: 11px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-top: 2px;
+  }
+  .result-byline .year {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .no-results {
+    padding: 24px;
+    font-size: 13px;
+    color: var(--text-muted);
+    text-align: center;
+    font-style: italic;
+  }
+  .palette-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kbd-hint {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .result-count { font-size: 10.5px; color: var(--text-faint); }
+  .nums {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+  }
+</style>

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -2,6 +2,7 @@
   import { api } from '../ipc/client';
   import type { SourceMetadata } from '../../../shared/types';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import SourcePickerDialog from './SourcePickerDialog.svelte';
 
   interface Props {
     onSourceSelect: (sourceId: string) => void;
@@ -15,6 +16,8 @@
   let filter = $state('');
   let contextMenu = $state<{ x: number; y: number; source: SourceMetadata } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
+  /** When set, the merge picker is open with this source as the src. */
+  let mergeSrc = $state<SourceMetadata | null>(null);
 
   $effect(() => {
     if (!contextMenu || !contextMenuEl) return;
@@ -50,6 +53,40 @@
     await api.sources.delete(source.sourceId);
     onSourceDeleted?.(source.sourceId);
     await refresh();
+  }
+
+  function handleMergeStart(source: SourceMetadata) {
+    contextMenu = null;
+    mergeSrc = source;
+  }
+
+  async function handleMergePick(destId: string) {
+    const src = mergeSrc;
+    mergeSrc = null;
+    if (!src) return;
+    const srcLabel = src.title ?? src.sourceId;
+    const dest = sources.find((s) => s.sourceId === destId);
+    const destLabel = dest?.title ?? destId;
+    const confirmed = await onShowConfirm(
+      `Merge "${srcLabel}" into "${destLabel}"?\n\nExcerpts and citations of "${srcLabel}" will move to "${destLabel}", then "${srcLabel}" will be removed.`,
+      'merge-sources',
+      'Merge',
+    );
+    if (!confirmed) return;
+    try {
+      await api.sources.merge(src.sourceId, destId);
+      onSourceDeleted?.(src.sourceId);
+      await refresh();
+    } catch (err) {
+      console.error('[minerva] Merge sources failed:', err);
+      // No dedicated error toast yet — surface the message via the
+      // confirm dialog as an informational pop, dismissable via OK.
+      await onShowConfirm(
+        `Merge failed: ${err instanceof Error ? err.message : String(err)}`,
+        'merge-sources-error',
+        'OK',
+      );
+    }
   }
 
   export async function refresh(): Promise<void> {
@@ -117,10 +154,22 @@
       style:left="{contextMenu.x}px"
       style:top="{contextMenu.y}px"
     >
+      <button onclick={() => handleMergeStart(contextMenu!.source)}>Merge into…</button>
       <button onclick={() => handleDelete(contextMenu!.source)}>Delete Source</button>
     </div>
   {/if}
 </div>
+
+{#if mergeSrc}
+  <SourcePickerDialog
+    {sources}
+    title={`Merge "${mergeSrc.title ?? mergeSrc.sourceId}" into…`}
+    placeholder="Pick the source to keep…"
+    excludeSourceId={mergeSrc.sourceId}
+    onSelect={handleMergePick}
+    onCancel={() => { mergeSrc = null; }}
+  />
+{/if}
 
 <style>
   .context-menu {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -666,6 +666,18 @@ export interface SourcesApi {
   listAll(): Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Delete a source + cascade-delete its excerpts. */
   delete(sourceId: string): Promise<{ sourceId: string; excerptsRemoved: number }>;
+  /** Merge src into dest: dest keeps its identity but gains any
+   *  metadata fields / body / artifacts src had and dest didn't. All
+   *  excerpts of src move to dest; every `[[cite::src]]` is rewritten
+   *  to `[[cite::dest]]`. Src folder is removed. (#90) */
+  merge(srcId: string, destId: string): Promise<{
+    destId: string;
+    removedId: string;
+    excerptsMoved: number;
+    notesRewritten: number;
+    metadataAdded: string[];
+    artifactsCopied: string[];
+  }>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -230,6 +230,9 @@ export const Channels = {
   SOURCES_LIST_ALL: 'sources:listAll',
   /** Delete a source + cascade-delete its excerpts. */
   SOURCES_DELETE: 'sources:delete',
+  /** Merge two sources: fold src's metadata into dest, move excerpts,
+   *  rewrite `[[cite::src]]`, delete src folder (#90). */
+  SOURCES_MERGE: 'sources:merge',
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */
   SOURCES_CHANGED: 'sources:changed',
 

--- a/tests/main/sources/merge-sources.test.ts
+++ b/tests/main/sources/merge-sources.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Merge Sources command (#90 part 2).
+ *
+ * Spot-checks the major branches of mergeSources end-to-end on a temp
+ * project, plus a few units on the helper exports.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph, indexSource, indexExcerpt, indexNote,
+  listAllSources, excerptIdsForSource, findNotesCitingSource, getExcerptSource,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import {
+  mergeSources,
+  rewriteExcerptFromSource,
+} from '../../../src/main/sources/merge-sources';
+
+function mkTemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-merge-sources-'));
+}
+
+function writeMeta(root: string, id: string, ttl: string): string {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl);
+  return dir;
+}
+
+function writeExcerpt(root: string, id: string, ttl: string): string {
+  const dir = path.join(root, '.minerva', 'excerpts');
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, `${id}.ttl`);
+  fs.writeFileSync(filePath, ttl);
+  return filePath;
+}
+
+function writeNote(root: string, relPath: string, content: string): void {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+const minimalMeta = (title: string): string =>
+  `this: a thought:Article ;\n    dc:title "${title}" ;\n    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .\n`;
+
+describe('mergeSources (#90 part 2)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTemp();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('folds richer src metadata into dest, moves excerpts, rewrites cites, deletes src folder', async () => {
+    const srcId = 'arxiv-1234.5678';
+    const destId = 'doi-10.1-foo';
+
+    const srcTtl = `this: a thought:Article ;\n    dc:title "The Paper" ;\n    dc:creator "Smith, J." ;\n    bibo:doi "10.1/foo" ;\n    dc:abstract "Abstract text." ;\n    dc:issued "2024-03-15"^^xsd:date ;\n    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .\n`;
+    const destTtl = `this: a thought:Article ;\n    dc:title "The Paper (alt title)" ;\n    bibo:doi "10.1/foo" ;\n    thought:accessedAt "2026-05-02T00:00:00Z"^^xsd:dateTime .\n`;
+
+    writeMeta(root, srcId, srcTtl);
+    writeMeta(root, destId, destTtl);
+    indexSource(ctx, srcId, srcTtl);
+    indexSource(ctx, destId, destTtl);
+
+    // Excerpt pointing at src.
+    const excerptTtl = `this: a thought:Excerpt ;\n    thought:fromSource sources:${srcId} ;\n    thought:citedText "An excerpt." .\n`;
+    writeExcerpt(root, 'ex-paper-claim', excerptTtl);
+    indexExcerpt(ctx, 'ex-paper-claim', excerptTtl);
+
+    // Note that cites src.
+    writeNote(root, 'paper.md', 'See [[cite::' + srcId + ']] for context.\n');
+    await indexNote(ctx, 'paper.md', 'See [[cite::' + srcId + ']] for context.\n');
+
+    const result = await mergeSources(root, srcId, destId);
+
+    expect(result.destId).toBe(destId);
+    expect(result.removedId).toBe(srcId);
+    expect(result.metadataAdded.sort()).toEqual(['abstract', 'creator', 'issued']);
+    expect(result.excerptsMoved).toBe(1);
+    expect(result.notesRewritten).toBe(1);
+
+    // Dest meta gained the missing predicates but kept its existing title + doi.
+    const destFinal = fs.readFileSync(path.join(root, '.minerva', 'sources', destId, 'meta.ttl'), 'utf-8');
+    expect(destFinal).toContain('dc:title "The Paper (alt title)"');
+    expect(destFinal).toContain('bibo:doi "10.1/foo"');
+    expect(destFinal).toContain('dc:creator "Smith, J."');
+    expect(destFinal).toContain('dc:abstract "Abstract text."');
+    expect(destFinal).toContain('dc:issued');
+
+    // Excerpt's fromSource was rewritten on disk.
+    const excerptOnDisk = fs.readFileSync(path.join(root, '.minerva', 'excerpts', 'ex-paper-claim.ttl'), 'utf-8');
+    expect(excerptOnDisk).toContain(`sources:${destId}`);
+    expect(excerptOnDisk).not.toContain(`sources:${srcId}`);
+
+    // Graph reflects the move.
+    expect(excerptIdsForSource(ctx, srcId)).toEqual([]);
+    expect(excerptIdsForSource(ctx, destId)).toEqual(['ex-paper-claim']);
+    expect(getExcerptSource(ctx, 'ex-paper-claim')?.sourceId).toBe(destId);
+
+    // Note was rewritten.
+    const noteContent = fs.readFileSync(path.join(root, 'paper.md'), 'utf-8');
+    expect(noteContent).toContain(`[[cite::${destId}]]`);
+    expect(noteContent).not.toContain(`[[cite::${srcId}]]`);
+    expect(findNotesCitingSource(ctx, srcId)).toEqual([]);
+    expect(findNotesCitingSource(ctx, destId)).toEqual(['paper.md']);
+
+    // src folder removed from disk + graph.
+    expect(fs.existsSync(path.join(root, '.minerva', 'sources', srcId))).toBe(false);
+    expect(listAllSources(ctx).some((s) => s.sourceId === srcId)).toBe(false);
+  });
+
+  it('copies body.md from src when dest lacks one, but never overwrites dest body', async () => {
+    const srcId = 'src-a';
+    const destId = 'src-b';
+    writeMeta(root, srcId, minimalMeta('A'));
+    writeMeta(root, destId, minimalMeta('B'));
+    indexSource(ctx, srcId, minimalMeta('A'));
+    indexSource(ctx, destId, minimalMeta('B'));
+
+    await fsp.writeFile(path.join(root, '.minerva', 'sources', srcId, 'body.md'), '# Source A body\n');
+
+    const result = await mergeSources(root, srcId, destId);
+
+    expect(result.artifactsCopied).toContain('body.md');
+    const destBody = fs.readFileSync(path.join(root, '.minerva', 'sources', destId, 'body.md'), 'utf-8');
+    expect(destBody).toBe('# Source A body\n');
+  });
+
+  it('keeps dest body.md when both sources have one', async () => {
+    const srcId = 'src-a';
+    const destId = 'src-b';
+    writeMeta(root, srcId, minimalMeta('A'));
+    writeMeta(root, destId, minimalMeta('B'));
+    indexSource(ctx, srcId, minimalMeta('A'));
+    indexSource(ctx, destId, minimalMeta('B'));
+
+    await fsp.writeFile(path.join(root, '.minerva', 'sources', srcId, 'body.md'), '# Source A body\n');
+    await fsp.writeFile(path.join(root, '.minerva', 'sources', destId, 'body.md'), '# Source B body (preserved)\n');
+
+    const result = await mergeSources(root, srcId, destId);
+
+    expect(result.artifactsCopied).not.toContain('body.md');
+    const destBody = fs.readFileSync(path.join(root, '.minerva', 'sources', destId, 'body.md'), 'utf-8');
+    expect(destBody).toBe('# Source B body (preserved)\n');
+  });
+
+  it('copies original.pdf when dest lacks one', async () => {
+    const srcId = 'src-a';
+    const destId = 'src-b';
+    writeMeta(root, srcId, minimalMeta('A'));
+    writeMeta(root, destId, minimalMeta('B'));
+    indexSource(ctx, srcId, minimalMeta('A'));
+    indexSource(ctx, destId, minimalMeta('B'));
+    await fsp.writeFile(path.join(root, '.minerva', 'sources', srcId, 'original.pdf'), Buffer.from('%PDF-1.4 test'));
+
+    const result = await mergeSources(root, srcId, destId);
+
+    expect(result.artifactsCopied).toContain('original.pdf');
+    expect(fs.existsSync(path.join(root, '.minerva', 'sources', destId, 'original.pdf'))).toBe(true);
+  });
+
+  it('refuses to merge a source into itself', async () => {
+    writeMeta(root, 'src-a', minimalMeta('A'));
+    await expect(mergeSources(root, 'src-a', 'src-a')).rejects.toMatchObject({
+      name: 'MergeSourcesError',
+      code: 'same-source',
+    });
+  });
+
+  it('errors with source-not-found when src is missing', async () => {
+    writeMeta(root, 'src-b', minimalMeta('B'));
+    await expect(mergeSources(root, 'src-missing', 'src-b')).rejects.toMatchObject({
+      code: 'source-not-found',
+    });
+  });
+
+  it('errors with dest-not-found when dest is missing', async () => {
+    writeMeta(root, 'src-a', minimalMeta('A'));
+    await expect(mergeSources(root, 'src-a', 'src-missing')).rejects.toMatchObject({
+      code: 'dest-not-found',
+    });
+  });
+
+  it('is a no-op merge (just folder removal) when src has no enriching metadata, no excerpts, no citing notes', async () => {
+    const srcId = 'src-a';
+    const destId = 'src-b';
+    writeMeta(root, srcId, minimalMeta('A'));
+    writeMeta(root, destId, minimalMeta('B'));
+    indexSource(ctx, srcId, minimalMeta('A'));
+    indexSource(ctx, destId, minimalMeta('B'));
+
+    const result = await mergeSources(root, srcId, destId);
+
+    expect(result.metadataAdded).toEqual([]);
+    expect(result.excerptsMoved).toBe(0);
+    expect(result.notesRewritten).toBe(0);
+    expect(fs.existsSync(path.join(root, '.minerva', 'sources', srcId))).toBe(false);
+    expect(fs.existsSync(path.join(root, '.minerva', 'sources', destId))).toBe(true);
+  });
+});
+
+describe('rewriteExcerptFromSource', () => {
+  it('rewrites a sources:srcId reference to sources:destId', () => {
+    const ttl = 'this: a thought:Excerpt ;\n  thought:fromSource sources:foo ;\n  thought:citedText "..." .\n';
+    const out = rewriteExcerptFromSource(ttl, 'foo', 'bar');
+    expect(out).toContain('sources:bar');
+    expect(out).not.toContain('sources:foo');
+  });
+
+  it('does not touch unrelated source ids that share a prefix', () => {
+    const ttl = 'sources:foo ; sources:foobar .';
+    const out = rewriteExcerptFromSource(ttl, 'foo', 'baz');
+    expect(out).toContain('sources:baz');
+    expect(out).toContain('sources:foobar');
+  });
+
+  it('returns the original when the srcId is not referenced', () => {
+    const ttl = 'this: a thought:Excerpt ; thought:fromSource sources:other ; .';
+    const out = rewriteExcerptFromSource(ttl, 'foo', 'bar');
+    expect(out).toBe(ttl);
+  });
+});


### PR DESCRIPTION
Second half of #90 — closes the "User-visible Merge Sources command" acceptance bullet. Builds on part 1 (#579, merged): re-uses \`mergeMetaTtl\` for the metadata fold.

## What it does
Right-click any source in the Sources panel → **Merge into…** → pick the source to keep → confirm. The picked source absorbs the other; the other folder goes away.

Operation, in order:
1. **Metadata fold**: src/meta.ttl → dest/meta.ttl via the conservative merger from #579 — adds predicates dest is missing, never overwrites. Dest's identity always wins.
2. **Artifact copy**: \`body.md\` / \`original.html\` / \`original.pdf\` from src → dest only when dest lacks them.
3. **Excerpt move**: every excerpt with \`thought:fromSource sources:src\` is rewritten on disk to point at dest and re-indexed. Excerpt ids stay the same.
4. **Cite rewrite**: every \`[[cite::src]]\` across the thoughtbase becomes \`[[cite::dest]]\` via the existing \`rewriteTypedIdLinks\` pipeline used by source-rename.
5. **Cleanup**: src removed from graph + folder deleted.

Excerpt ids are globally unique (the .ttl filename IS the id), so collisions can't naturally arise — no collision guard needed.

## UX
- New right-click menu item on the Sources panel, ordered above Delete.
- Reusable \`SourcePickerDialog\` (modeled on \`GotoNoteDialog\`) with title-aware filter and an exclusion for the source being merged.
- Confirmation routes through \`showConfirm\` with the new \`merge-sources\` "Don't ask again" key — fits the design principle that destructive-but-mundane ops should be dismissable.
- Errors (\`same-source\`, \`source-not-found\`, \`dest-not-found\`) surface to the user via the same dialog.

## API surface
- New IPC channel \`SOURCES_MERGE\` ↔ \`api.sources.merge(srcId, destId)\`.
- \`mergeSources(rootPath, srcId, destId)\` in \`src/main/sources/merge-sources.ts\` returns \`{ excerptsMoved, notesRewritten, metadataAdded, artifactsCopied }\` so future UI surfaces can show what happened.

## Tests
- 8 end-to-end cases in \`merge-sources.test.ts\`: full merge (metadata + excerpts + cite rewrites + folder removal), \`body.md\` / \`original.pdf\` copy semantics, same-source refusal, source/dest not-found, no-op merge.
- 3 units on the exported \`rewriteExcerptFromSource\`: target rewrite, prefix-safety (\"foo\" doesn't match \"foobar\"), no-op pass-through.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes (2252 tests, +11 new)
- [ ] **UI verification**: ingest the same paper twice with two different identifiers so it lands at two canonical ids; create an excerpt off one and \`[[cite::]]\` the other from a note; right-click the first → Merge into → pick the second; confirm the excerpt now belongs to the second source and the cite was rewritten.

Closes #90.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)