### PR TITLE
feat: sources in the right-sidebar tag panel (#118)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1723,17 +1723,28 @@ export function listTags(ctx: ProjectContext): TagInfo[] {
   if (!state) return [];
   const { store } = state;
 
-  const tagCounts = new Map<string, number>();
+  // Bucket per tag-name into note vs source counts. A subject is a
+  // source when it carries minerva:sourceId; otherwise we treat the
+  // hasTag edge as belonging to a note (this matches what notesByTag
+  // returns once the rdf:type filter has been applied).
+  const buckets = new Map<string, { noteCount: number; sourceCount: number }>();
   const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
   for (const st of stmts) {
     const tagNode = st.object;
     const nameStmts = store.statementsMatching(tagNode as $rdf.NamedNode, MINERVA('tagName'), undefined);
     const name = nameStmts[0]?.object.value ?? tagNode.value;
-    tagCounts.set(name, (tagCounts.get(name) ?? 0) + 1);
+    let bucket = buckets.get(name);
+    if (!bucket) {
+      bucket = { noteCount: 0, sourceCount: 0 };
+      buckets.set(name, bucket);
+    }
+    const isSource = store.statementsMatching(st.subject, MINERVA('sourceId'), undefined).length > 0;
+    if (isSource) bucket.sourceCount++;
+    else bucket.noteCount++;
   }
 
-  return [...tagCounts.entries()]
-    .map(([tag, count]) => ({ tag, count }))
+  return [...buckets.entries()]
+    .map(([tag, b]) => ({ tag, noteCount: b.noteCount, sourceCount: b.sourceCount }))
     .sort((a, b) => a.tag.localeCompare(b.tag));
 }
 

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -224,7 +224,7 @@
     {:else if activePanel === 'backlinks'}
       <BacklinksPanel {activeFilePath} {revision} {onFileSelect} />
     {:else if activePanel === 'tags'}
-      <TagsPanel {content} {onFileSelect} />
+      <TagsPanel {content} {onFileSelect} onSourceSelect={onOpenSource} />
     {:else if activePanel === 'tables'}
       <TablesPanel {content} {onOpenQuery} />
     {:else if activePanel === 'citations'}

--- a/src/renderer/lib/components/TagPanel.svelte
+++ b/src/renderer/lib/components/TagPanel.svelte
@@ -22,11 +22,18 @@
   let taggedSources = $state<TaggedSource[]>([]);
   let showSources = $state(true);
 
+  /** Combined note+source count for sizing/sorting; sources can be
+   *  hidden via the toggle but the chip's prominence still reflects
+   *  the total tagged-thing count, which is the more useful signal. */
+  function totalCount(t: TagInfo): number {
+    return t.noteCount + t.sourceCount;
+  }
+
   /** Threshold above which a chip renders with the `big` size — top
    *  quartile by frequency. Recomputed whenever the tag list changes. */
   const bigThreshold = $derived.by(() => {
     if (tags.length === 0) return Infinity;
-    const sorted = tags.map((t) => t.count).sort((a, b) => b - a);
+    const sorted = tags.map(totalCount).sort((a, b) => b - a);
     const idx = Math.max(0, Math.floor(sorted.length / 4) - 1);
     return sorted[idx];
   });
@@ -86,16 +93,18 @@
     <div class="empty">No tags yet</div>
   {:else}
     <div class="tag-list">
-      {#each tags as { tag, count } (tag)}
-        {@const active = activeTag === tag}
+      {#each tags as t (t.tag)}
+        {@const active = activeTag === t.tag}
+        {@const total = t.noteCount + t.sourceCount}
+        {@const visibleCount = showSources ? total : t.noteCount}
         <Chip
-          tone={active ? 'accent' : chipTone(tag)}
-          size={chipSize(count)}
-          onclick={() => showNotesForTag(tag)}
-          title={`#${tag} · ${count}`}
+          tone={active ? 'accent' : chipTone(t.tag)}
+          size={chipSize(total)}
+          onclick={() => showNotesForTag(t.tag)}
+          title={`#${t.tag} · ${t.noteCount} note${t.noteCount === 1 ? '' : 's'}, ${t.sourceCount} source${t.sourceCount === 1 ? '' : 's'}`}
         >
-          <span class="tag-name">#{tag}</span>
-          <span class="count">{count}</span>
+          <span class="tag-name">#{t.tag}</span>
+          <span class="count">{visibleCount}</span>
         </Chip>
       {/each}
     </div>

--- a/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { TagInfo, TaggedNote } from '../../../../shared/types';
+  import type { TagInfo, TaggedNote, TaggedSource } from '../../../../shared/types';
   import { api } from '../../ipc/client';
   import Ribbon from './Ribbon.svelte';
   import Icon from '../Icon.svelte';
@@ -15,9 +15,13 @@
      *  the tree but the panel shows project-wide tags now (#466). */
     content: string;
     onFileSelect: (relativePath: string) => void;
+    /** Selecting a source from the tagged-things list opens it in the
+     *  same way the Sources panel does — host wires this through to
+     *  the source-detail tab opener. */
+    onSourceSelect?: (sourceId: string) => void;
   }
 
-  let { content, onFileSelect }: Props = $props();
+  let { content, onFileSelect, onSourceSelect }: Props = $props();
 
   let allTags = $state<TagInfo[]>([]);
   let activePath = $state<string | null>(null);
@@ -27,7 +31,24 @@
    *  also has its own tag. */
   let activeKind = $state<'leaf' | 'prefix' | null>(null);
   let activeNotes = $state<TaggedNote[]>([]);
+  let activeSources = $state<TaggedSource[]>([]);
   let search = $state('');
+  /** Whether sources contribute to per-row counts and show up in the
+   *  detail pane below the notes list. Persisted across sessions so
+   *  researcher / note-taker users keep their preferred view. */
+  const SHOW_SOURCES_KEY = 'minerva.tagsPanel.showSources';
+  let showSources = $state<boolean>(loadShowSources());
+
+  function loadShowSources(): boolean {
+    try {
+      const raw = localStorage.getItem(SHOW_SOURCES_KEY);
+      if (raw === 'false') return false;
+    } catch { /* fall through */ }
+    return true;
+  }
+  function persistShowSources(): void {
+    try { localStorage.setItem(SHOW_SOURCES_KEY, showSources ? 'true' : 'false'); } catch { /* ok */ }
+  }
 
   // Expand state — persisted per-project would be nicer, but the panel
   // re-renders the same set of tags within a session and `localStorage`
@@ -128,11 +149,17 @@
       activePath = null;
       activeKind = null;
       activeNotes = [];
+      activeSources = [];
       return;
     }
     activePath = node.path;
     activeKind = 'leaf';
-    activeNotes = await api.tags.notesByTag(node.path);
+    const [notes, sources] = await Promise.all([
+      api.tags.notesByTag(node.path),
+      api.tags.sourcesByTag(node.path),
+    ]);
+    activeNotes = notes;
+    activeSources = sources;
   }
 
   async function showPrefix(node: TagTreeNode): Promise<void> {
@@ -140,11 +167,33 @@
       activePath = null;
       activeKind = null;
       activeNotes = [];
+      activeSources = [];
       return;
     }
     activePath = node.path;
     activeKind = 'prefix';
-    activeNotes = await api.tags.notesByTagPrefix(node.path);
+    // Sources don't yet have a prefix variant — collect them via a
+    // client-side filter over the leaf endpoint for each at-or-under
+    // tag. For typical thoughtbases this is a handful of tags; if it
+    // grows hot we can add tags.sourcesByTagPrefix later.
+    const notes = await api.tags.notesByTagPrefix(node.path);
+    const prefix = node.path;
+    const sourcesSeen = new Map<string, TaggedSource>();
+    for (const t of allTags) {
+      if (t.sourceCount === 0) continue;
+      if (t.tag !== prefix && !t.tag.startsWith(`${prefix}/`)) continue;
+      const got = await api.tags.sourcesByTag(t.tag);
+      for (const s of got) {
+        if (!sourcesSeen.has(s.sourceId)) sourcesSeen.set(s.sourceId, s);
+      }
+    }
+    activeNotes = notes;
+    activeSources = [...sourcesSeen.values()].sort((a, b) => a.title.localeCompare(b.title));
+  }
+
+  function toggleShowSources(): void {
+    showSources = !showSources;
+    persistShowSources();
   }
 </script>
 
@@ -154,6 +203,18 @@
     onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find tag…"
   />
+  <div class="filter-row">
+    <button
+      type="button"
+      class="show-sources-toggle"
+      class:on={showSources}
+      onclick={toggleShowSources}
+      title={showSources ? 'Hide sources from this panel' : 'Show sources in this panel'}
+    >
+      <span class="dot" aria-hidden="true"></span>
+      <span>sources</span>
+    </button>
+  </div>
   {#if allTags.length === 0}
     <div class="empty">No tags in project</div>
   {:else if visibleRows.length === 0}
@@ -192,17 +253,28 @@
           >
             #{row.segment}{#if !row.hasOwnTag && row.children.length > 0}/{/if}
           </button>
-          <span class="count">{row.count}</span>
+          <span class="count" title={showSources
+            ? `${row.noteCount} notes · ${row.sourceCount} sources`
+            : `${row.noteCount} notes`}
+          >
+            {#if showSources && row.sourceCount > 0}
+              <span class="count-n">{row.noteCount}</span>
+              <span class="count-sep">·</span>
+              <span class="count-s">{row.sourceCount}</span>
+            {:else}
+              {row.noteCount}
+            {/if}
+          </span>
         </div>
       {/each}
     </div>
   {/if}
 
-  {#if activePath && activeNotes.length > 0}
+  {#if activePath && (activeNotes.length > 0 || (showSources && activeSources.length > 0))}
     <div class="notes-section">
       <div class="notes-header">
-        <span class="notes-eyebrow">{activeKind === 'prefix' ? 'NOTES UNDER' : 'NOTES WITH'} #{activePath}</span>
-        <span class="notes-count">{activeNotes.length}</span>
+        <span class="notes-eyebrow">{activeKind === 'prefix' ? 'TAGGED UNDER' : 'TAGGED'} #{activePath}</span>
+        <span class="notes-count">{activeNotes.length + (showSources ? activeSources.length : 0)}</span>
       </div>
       {#each activeNotes as note (note.relativePath)}
         <button class="note-item" onclick={() => onFileSelect(note.relativePath)}>
@@ -210,6 +282,14 @@
           <span class="note-title">{note.title}</span>
         </button>
       {/each}
+      {#if showSources}
+        {#each activeSources as source (source.sourceId)}
+          <button class="note-item" onclick={() => onSourceSelect?.(source.sourceId)} title={`Source: ${source.sourceId}`}>
+            <Icon name="sites" size={12} color="var(--text-faint)" />
+            <span class="note-title">{source.title}</span>
+          </button>
+        {/each}
+      {/if}
     </div>
   {/if}
 </div>
@@ -289,8 +369,53 @@
     color: var(--text-faint);
     font-variant-numeric: tabular-nums;
     padding-right: 4px;
+    display: inline-flex;
+    gap: 3px;
+    align-items: baseline;
   }
   .row.active .count { color: var(--accent); }
+  /* Note count vs source count distinction: notes look like a literal
+     number (the count the panel always showed); the source bump after
+     the dot picks up a slightly different hue so a glance can read
+     "10 notes, 3 sources" without parsing the separator. */
+  .count-sep { color: var(--text-faint); opacity: 0.6; }
+  .count-s { color: var(--text-muted); }
+  .row.active .count-sep,
+  .row.active .count-s { color: var(--accent); }
+
+  .filter-row {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .show-sources-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .show-sources-toggle:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .show-sources-toggle .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--text-faint);
+    flex-shrink: 0;
+  }
+  .show-sources-toggle.on {
+    color: var(--text);
+    border-color: color-mix(in oklch, var(--accent) 40%, var(--border));
+  }
+  .show-sources-toggle.on .dot { background: var(--accent); }
 
   /* "NOTES WITH #..." section under the tree */
   .notes-section {

--- a/src/renderer/lib/tags.ts
+++ b/src/renderer/lib/tags.ts
@@ -25,8 +25,10 @@ export interface TagTreeNode {
   segment: string;
   /** Full path from the root, e.g. `projects/minerva/ui`. */
   path: string;
-  /** Total notes with a tag at-or-under this path (sum approximation). */
-  count: number;
+  /** Notes with a tag at-or-under this path (sum approximation). */
+  noteCount: number;
+  /** Sources with a tag at-or-under this path (sum approximation). */
+  sourceCount: number;
   /** True when at least one tag in the input has exactly this path. */
   hasOwnTag: boolean;
   /** Children, sorted by segment. */
@@ -38,8 +40,8 @@ export interface TagTreeNode {
  * by segment so re-renders don't reshuffle rows.
  */
 export function buildTagTree(tags: TagInfo[]): TagTreeNode[] {
-  const root: TagTreeNode = { segment: '', path: '', count: 0, hasOwnTag: false, children: [] };
-  for (const { tag, count } of tags) {
+  const root: TagTreeNode = { segment: '', path: '', noteCount: 0, sourceCount: 0, hasOwnTag: false, children: [] };
+  for (const { tag, noteCount, sourceCount } of tags) {
     if (!tag) continue;
     const parts = tag.split('/').filter(Boolean);
     let cur = root;
@@ -49,10 +51,11 @@ export function buildTagTree(tags: TagInfo[]): TagTreeNode[] {
       acc = acc ? `${acc}/${seg}` : seg;
       let child = cur.children.find((c) => c.segment === seg);
       if (!child) {
-        child = { segment: seg, path: acc, count: 0, hasOwnTag: false, children: [] };
+        child = { segment: seg, path: acc, noteCount: 0, sourceCount: 0, hasOwnTag: false, children: [] };
         cur.children.push(child);
       }
-      child.count += count;
+      child.noteCount += noteCount;
+      child.sourceCount += sourceCount;
       if (i === parts.length - 1) child.hasOwnTag = true;
       cur = child;
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,10 @@ export interface NotebaseMeta {
 
 export interface TagInfo {
   tag: string;
-  count: number;
+  /** Notes carrying this tag (deduped by note). */
+  noteCount: number;
+  /** Sources carrying this tag (deduped by source). */
+  sourceCount: number;
 }
 
 export interface TaggedNote {

--- a/tests/main/graph/source-tags.test.ts
+++ b/tests/main/graph/source-tags.test.ts
@@ -72,14 +72,27 @@ describe('Source participation in tag system (issue #118)', () => {
     expect(sources.map(s => s.sourceId)).toEqual(['smith-2023']);
   });
 
-  it('listTags counts both notes and sources that share a tag', async () => {
+  it('listTags reports note + source counts separately (#118)', async () => {
     writeSourceMeta(root, 'smith-2023', META);
     writeSourceBody(root, 'smith-2023', '# x\n\n#research');
     await indexAllNotes(ctx);
     await indexNote(ctx, 'notes/overview.md', '# Overview\n\n#research');
+    await indexNote(ctx, 'notes/second.md', '# Second\n\n#research');
 
     const info = listTags(ctx).find(t => t.tag === 'research');
-    expect(info?.count).toBe(2);
+    expect(info).toBeDefined();
+    expect(info?.noteCount).toBe(2);
+    expect(info?.sourceCount).toBe(1);
+  });
+
+  it('listTags assigns a tag carried only by sources to sourceCount and noteCount 0', async () => {
+    writeSourceMeta(root, 'smith-2023', META);
+    writeSourceBody(root, 'smith-2023', '# x\n\n#library-only');
+    await indexAllNotes(ctx);
+
+    const info = listTags(ctx).find(t => t.tag === 'library-only');
+    expect(info?.noteCount).toBe(0);
+    expect(info?.sourceCount).toBe(1);
   });
 
   it('notesByTag excludes sources (no misleading relativePath)', async () => {

--- a/tests/renderer/tags.test.ts
+++ b/tests/renderer/tags.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { buildTagTree, flattenTagTree, subtreeMatches } from '../../src/renderer/lib/tags';
 
+const ti = (tag: string, noteCount: number, sourceCount = 0) => ({ tag, noteCount, sourceCount });
+
 describe('buildTagTree (#466)', () => {
   it('builds a single-level tree from a flat tag', () => {
-    const tree = buildTagTree([{ tag: 'projects', count: 3 }]);
+    const tree = buildTagTree([ti('projects', 3)]);
     expect(tree).toHaveLength(1);
     expect(tree[0]).toMatchObject({
       segment: 'projects',
       path: 'projects',
-      count: 3,
+      noteCount: 3,
+      sourceCount: 0,
       hasOwnTag: true,
     });
     expect(tree[0].children).toEqual([]);
@@ -16,14 +19,14 @@ describe('buildTagTree (#466)', () => {
 
   it('nests `/`-separated tags into a tree', () => {
     const tree = buildTagTree([
-      { tag: 'projects/minerva/ui', count: 2 },
-      { tag: 'projects/minerva/api', count: 1 },
+      ti('projects/minerva/ui', 2),
+      ti('projects/minerva/api', 1),
     ]);
     expect(tree).toHaveLength(1);
     const projects = tree[0];
     expect(projects.path).toBe('projects');
     expect(projects.hasOwnTag).toBe(false);
-    expect(projects.count).toBe(3);
+    expect(projects.noteCount).toBe(3);
 
     const minerva = projects.children[0];
     expect(minerva.path).toBe('projects/minerva');
@@ -36,19 +39,32 @@ describe('buildTagTree (#466)', () => {
 
   it('flags hasOwnTag on a node that exists as a literal tag', () => {
     const tree = buildTagTree([
-      { tag: 'projects', count: 1 },
-      { tag: 'projects/minerva', count: 2 },
+      ti('projects', 1),
+      ti('projects/minerva', 2),
     ]);
     expect(tree[0].hasOwnTag).toBe(true);
-    expect(tree[0].count).toBe(3);
+    expect(tree[0].noteCount).toBe(3);
     expect(tree[0].children[0].hasOwnTag).toBe(true);
+  });
+
+  it('sums sourceCount up the tree the same way it sums noteCount (#118)', () => {
+    const tree = buildTagTree([
+      ti('projects/minerva/ui', 2, 1),
+      ti('projects/minerva/api', 1, 3),
+      ti('projects/zen', 0, 4),
+    ]);
+    const projects = tree[0];
+    expect(projects.noteCount).toBe(3);
+    expect(projects.sourceCount).toBe(8);
+    const minerva = projects.children.find((c) => c.segment === 'minerva')!;
+    expect(minerva.sourceCount).toBe(4);
   });
 
   it('sorts siblings alphabetically', () => {
     const tree = buildTagTree([
-      { tag: 'projects/zen', count: 1 },
-      { tag: 'projects/api', count: 1 },
-      { tag: 'projects/minerva', count: 1 },
+      ti('projects/zen', 1),
+      ti('projects/api', 1),
+      ti('projects/minerva', 1),
     ]);
     expect(tree[0].children.map((c) => c.segment)).toEqual(['api', 'minerva', 'zen']);
   });
@@ -56,8 +72,8 @@ describe('buildTagTree (#466)', () => {
 
 describe('flattenTagTree (#466)', () => {
   const tree = buildTagTree([
-    { tag: 'projects/minerva/ui', count: 1 },
-    { tag: 'projects/api', count: 1 },
+    ti('projects/minerva/ui', 1),
+    ti('projects/api', 1),
   ]);
 
   it('returns parents before children when expanded', () => {
@@ -82,8 +98,8 @@ describe('flattenTagTree (#466)', () => {
 
 describe('subtreeMatches (#466)', () => {
   const [projects] = buildTagTree([
-    { tag: 'projects/minerva/ui', count: 1 },
-    { tag: 'projects/api', count: 1 },
+    ti('projects/minerva/ui', 1),
+    ti('projects/api', 1),
   ]);
 
   it('matches a substring of any descendant path', () => {


### PR DESCRIPTION
Issue's first acceptance bullet ("Parser recognizes tags in Source body.md") was already done — \`indexSourceBody\` has been writing \`hasTag\` edges onto source URIs for a while. The other two bullets ("Tag panel shows source counts alongside note counts" and "Show sources toggle") were what was missing, and this PR closes them.

## What changed

\`TagInfo.count\` → \`{ noteCount, sourceCount }\`. The combined number hid whether a tag was a research topic, a writing tag, or both; the panel needs the split. Both consumers (chip panel on the left + tree panel on the right) are updated.

- **\`listTags\`** buckets each \`hasTag\` edge by subject kind: subjects carrying \`minerva:sourceId\` go to \`sourceCount\`, the rest to \`noteCount\`.
- **\`buildTagTree\`** threads both counts up the tree (cumulative-by-prefix, same approximation as before).
- **Right-sidebar \`TagsPanel\`**:
  - New "sources" pill toggle in a filter row below the ribbon. Persisted across sessions via \`localStorage\` so a notes-focused user can dismiss the library noise without re-toggling.
  - Per-row counts render as \`noteCount · sourceCount\` when sources are shown and the tag has any; falls back to a single \`noteCount\` otherwise.
  - Clicking a tag fetches \`sourcesByTag\` in parallel with the notes call and shows them under the notes in the detail pane.
  - Prefix click (parent row) does the same client-side over the at-or-under tags. If this gets hot we'll add a \`tags.sourcesByTagPrefix\` variant.
  - New \`onSourceSelect\` prop wired from \`RightSidebar\` → existing \`onOpenSource\` so a picked source opens its detail tab.
- **Left-sidebar \`TagPanel\`** (chip variant): adapted to the new \`TagInfo\` shape. Chip prominence still uses the combined total (it's the right "research signal"); the on-chip number swaps total vs. notes-only based on the existing \`showSources\` toggle.

## Tests
- \`source-tags.test.ts\` — replaces the combined-count assertion with separate noteCount/sourceCount checks; adds a case for a tag that exists only on sources.
- \`tags.test.ts\` — new tree-builder case asserts \`sourceCount\` aggregates up the tree the same way \`noteCount\` does. Existing cases updated to the new shape via a small \`ti()\` helper.
- Full suite green: 2254 / 2254.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes (+2 new)
- [x] \`pnpm dev\` boots clean (no runtime errors in the renderer console)
- [ ] **UI verification**:
  - Tag a source's body.md with \`#research\`, tag a note with the same, confirm the right-sidebar tag panel shows \`1 · 1\`.
  - Click the row; sources section appears under the notes section.
  - Toggle "sources" off; the per-row count drops to the single notes number and the sources section disappears.
  - Reopen the project; toggle state is remembered.

Closes #118.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)