### PR TITLE
feat: Zotero-style "about this source" relation (#474)

### DIFF
--- a/src/main/graph/frontmatter-predicates.ts
+++ b/src/main/graph/frontmatter-predicates.ts
@@ -35,6 +35,11 @@ const MAP: Record<string, FrontmatterPredicate> = {
   language: DC('language'),
   lang: DC('language'),
   subject: DC('subject'),
+  // Zotero-style child-note relation (#474): a note declares which
+  // source(s) it's *about*. Maps to dc:subject so an existing user of
+  // `subject: …` keeps the same edge; `about: …` is the friendlier
+  // researcher-facing spelling for "this note belongs to that source".
+  about: DC('subject'),
   created: DC('created'),
   modified: DC('modified'),
   issued: DC('issued'),

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -441,11 +441,42 @@ function flattenFrontmatterStrings(value: FrontmatterValue): string[] {
 
 type FrontmatterScalarNonNull = Exclude<FrontmatterValue, null | FrontmatterValue[]>;
 
+/**
+ * Reconstitute YAML-eaten wiki-link shorthand. The user writes
+ *
+ *   about: [[sources/foo]]
+ *
+ * intending a wiki-link, but YAML's flow syntax interprets the outer
+ * `[…]` as an array literal and the inner `[…]` as a nested array,
+ * yielding `[['sources/foo']]`. The brackets the user typed are gone
+ * by the time we see the value.
+ *
+ * The narrow signature `[[<single string>]]` is unambiguous —
+ * authentic length-1 arrays of length-1 arrays of strings don't
+ * occur in normal frontmatter. Translate that one shape back into
+ * the wiki-link form a downstream consumer expects. Anything more
+ * complex (multi-element inner array, mixed types) is left alone —
+ * users who need lists should use the proper YAML list form anyway.
+ */
+function recoverYamlEatenWikiLink(value: FrontmatterValue): FrontmatterValue {
+  if (
+    Array.isArray(value)
+    && value.length === 1
+    && Array.isArray(value[0])
+    && value[0].length === 1
+    && typeof value[0][0] === 'string'
+  ) {
+    return `[[${value[0][0]}]]`;
+  }
+  return value;
+}
+
 /** Flatten nested arrays, dropping nulls. Scalars pass through in typed form. */
 function flattenFrontmatterScalars(value: FrontmatterValue): FrontmatterScalarNonNull[] {
-  if (value === null || value === undefined) return [];
-  if (Array.isArray(value)) return value.flatMap(flattenFrontmatterScalars);
-  return [value];
+  const recovered = recoverYamlEatenWikiLink(value);
+  if (recovered === null || recovered === undefined) return [];
+  if (Array.isArray(recovered)) return recovered.flatMap(flattenFrontmatterScalars);
+  return [recovered];
 }
 
 function resolveFrontmatterPredicate(key: string) {
@@ -488,6 +519,14 @@ function frontmatterValueToTerm(value: Exclude<FrontmatterValue, null | Frontmat
   const wiki = value.match(FRONTMATTER_WIKILINK_RE);
   if (wiki && projectBaseUri) {
     const target = wiki[1].trim();
+    // `[[sources/<id>]]` materialises as the actual source URI rather
+    // than a phantom note path (#474). Lets `about: [[sources/foo]]`
+    // become a real edge from this note to the foo source, queryable
+    // alongside the cite/quote backlinks the source detail collects.
+    if (target.startsWith('sources/')) {
+      const sourceId = target.slice('sources/'.length);
+      if (sourceId) return $rdf.sym(uriHelpers.sourceUri(projectBaseUri, sourceId));
+    }
     const noteRel = target.endsWith('.md') ? target : `${target}.md`;
     return $rdf.sym(uriHelpers.noteUri(projectBaseUri, noteRel));
   }
@@ -2034,7 +2073,7 @@ export function backlinks(ctx: ProjectContext, relativePath: string): Backlink[]
 
 // ── Source detail queries ───────────────────────────────────────────────────
 
-import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink } from '../../shared/types';
+import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink, SourceAboutNote } from '../../shared/types';
 
 export function getSourceDetail(ctx: ProjectContext, sourceId: string): SourceDetail | null {
   const state = getState(ctx);
@@ -2049,8 +2088,9 @@ export function getSourceDetail(ctx: ProjectContext, sourceId: string): SourceDe
   const metadata = collectSourceMetadata(state, sourceId, subject);
   const excerpts = collectExcerptsForSource(state, subject);
   const backlinks = collectSourceBacklinks(state, subject, excerpts);
+  const aboutNotes = collectSourceAboutNotes(state, subject);
 
-  return { metadata, excerpts, backlinks };
+  return { metadata, excerpts, backlinks, aboutNotes };
 }
 
 function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rdf.NamedNode): SourceMetadata {
@@ -2163,6 +2203,38 @@ function collectSourceBacklinks(
   }
 
   results.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return results;
+}
+
+/**
+ * Notes whose frontmatter declares them as *about* this source (#474).
+ * Driven by `dc:subject` edges from a Minerva note to the source URI —
+ * the frontmatter resolver materialises `about: [[sources/<id>]]` into
+ * exactly this triple. Distinct from cite/quote backlinks: this is
+ * subject-of, not reference-of.
+ */
+function collectSourceAboutNotes(state: GraphState, sourceSubject: $rdf.NamedNode): SourceAboutNote[] {
+  const { store } = state;
+  const results: SourceAboutNote[] = [];
+  const seen = new Set<string>();
+  for (const st of store.statementsMatching(undefined, DC('subject'), sourceSubject)) {
+    const subject = st.subject as $rdf.NamedNode;
+    // Only count actual notes — a future excerpt or proposal could
+    // carry dc:subject too, and the source detail's Notes section is
+    // specifically for prose commentary.
+    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
+    if (!isNote) continue;
+    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
+    const relativePath = pathStmts[0]?.object.value;
+    if (!relativePath || seen.has(relativePath)) continue;
+    seen.add(relativePath);
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
+    results.push({
+      relativePath,
+      title: titleStmts[0]?.object.value ?? relativePath,
+    });
+  }
+  results.sort((a, b) => a.title.localeCompare(b.title));
   return results;
 }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -687,6 +687,24 @@
     sidebar?.refreshTags();
   }
 
+  /** Zotero-style "New note about this source" (#474). Creates a note
+   *  pre-populated with `about: [[sources/<id>]]` frontmatter so it
+   *  immediately surfaces under the source's Notes section. */
+  async function handleNewAboutSourceNote(sourceId: string): Promise<string | null> {
+    if (!notebase.meta) return null;
+    const name = await showPrompt('Note name:');
+    if (!name) return null;
+    const filename = name.endsWith('.md') ? name : `${name}.md`;
+    const relativePath = filename;
+    const titleStem = name.replace(/\.md$/, '');
+    const initialContent = `---\nabout: [[sources/${sourceId}]]\n---\n\n# ${titleStem}\n\n`;
+    await api.notebase.writeFile(relativePath, initialContent);
+    await notebase.refresh();
+    await editor.openFile(relativePath);
+    sidebar?.refreshTags();
+    return relativePath;
+  }
+
   async function handleNewFolder(directory: string = '') {
     if (!notebase.meta) return;
     const name = await showPrompt('Folder name:');
@@ -2544,6 +2562,7 @@
               onNavigate={handleNavigate}
               onShowConfirm={showConfirm}
               onDeleted={handleSourceDeleted}
+              onCreateAboutNote={handleNewAboutSourceNote}
             />
           {/key}
         {:else}

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -10,9 +10,13 @@
     onNavigate: (target: string) => void;
     onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
     onDeleted?: (sourceId: string) => void;
+    /** Create a Zotero-style child note pre-populated with
+     *  `about: [[sources/<id>]]`, open it for editing, and refresh
+     *  this detail view so the new note shows under Notes (#474). */
+    onCreateAboutNote?: (sourceId: string) => Promise<string | null>;
   }
 
-  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted }: Props = $props();
+  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted, onCreateAboutNote }: Props = $props();
 
   async function handleDelete() {
     if (!detail) return;
@@ -191,6 +195,22 @@
   function backlinkLabel(b: SourceBacklink): string {
     return b.kind === 'cite' ? 'cites' : 'quotes';
   }
+
+  let creatingAbout = $state(false);
+  async function handleNewAboutNote(): Promise<void> {
+    if (!onCreateAboutNote || creatingAbout) return;
+    creatingAbout = true;
+    try {
+      const newPath = await onCreateAboutNote(sourceId);
+      // The host opens the new note; we just refresh the detail view
+      // so the new entry shows under Notes when the user navigates
+      // back. (If they leave a tab open we may never come back here
+      // until they switch; the explicit reload covers the common case.)
+      if (newPath) await load(sourceId);
+    } finally {
+      creatingAbout = false;
+    }
+  }
 </script>
 
 <div class="source-detail">
@@ -329,6 +349,30 @@
                   <span>{excerptLocation(excerpt)}</span>
                 {/if}
               </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <section>
+      <div class="section-header">
+        <h2>Notes ({detail.aboutNotes.length})</h2>
+        {#if onCreateAboutNote}
+          <button class="section-action" disabled={creatingAbout} onclick={handleNewAboutNote}>
+            {creatingAbout ? 'Creating…' : 'New note about this source'}
+          </button>
+        {/if}
+      </div>
+      {#if detail.aboutNotes.length === 0}
+        <p class="muted">No notes about this source yet.</p>
+      {:else}
+        <ul class="about-list">
+          {#each detail.aboutNotes as note (note.relativePath)}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <li onclick={() => onNavigate(note.relativePath)}>
+              <span class="about-title">{note.title}</span>
+              <span class="about-path mono">{note.relativePath}</span>
             </li>
           {/each}
         </ul>
@@ -669,6 +713,51 @@
     font-size: 10px;
     letter-spacing: 0.3px;
     font-weight: 600;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin: 0 0 8px;
+  }
+  .section-header h2 { margin: 0; }
+  .section-action {
+    font-family: var(--font-sans);
+    font-size: 12px;
+    color: var(--accent);
+    background: none;
+    border: 1px solid color-mix(in oklch, var(--accent) 40%, var(--border));
+    padding: 3px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .section-action:hover:not(:disabled) {
+    background: color-mix(in oklch, var(--accent) 10%, transparent);
+  }
+  .section-action:disabled { cursor: default; opacity: 0.5; }
+
+  .about-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .about-list li {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .about-list li:hover { background: var(--bg-button); }
+  .about-list li:last-child { border-bottom: none; }
+  .about-title { color: var(--accent); }
+  .about-path {
+    font-size: 11px;
+    color: var(--text-faint);
   }
 
   code {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -148,10 +148,20 @@ export interface SourceBacklink {
   viaExcerptId?: string;
 }
 
+/** A note declared to be *about* this source via frontmatter
+ *  (`about: [[sources/<id>]]` → dc:subject). Distinct from a backlink:
+ *  the user is asserting subject-of, not just referencing. (#474) */
+export interface SourceAboutNote {
+  relativePath: string;
+  title: string;
+}
+
 export interface SourceDetail {
   metadata: SourceMetadata;
   excerpts: SourceExcerpt[];
   backlinks: SourceBacklink[];
+  /** Notes whose frontmatter declares them as *about* this source. */
+  aboutNotes: SourceAboutNote[];
 }
 
 // ── Bookmarks ────────────────────────────────────────────────────────────

--- a/tests/main/graph/source-detail.test.ts
+++ b/tests/main/graph/source-detail.test.ts
@@ -116,6 +116,62 @@ describe('getSourceDetail', () => {
     expect(quotes[0].relativePath).toBe('c.md');
     expect(quotes[0].viaExcerptId).toBe('p42-graphs');
   });
+
+  it('lists notes that declare themselves about this source via frontmatter (#474)', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(ctx);
+    await indexNote(ctx, 'reading-notes.md', '---\nabout: [[sources/smith-2023]]\n---\n\n# Reading notes\n');
+    await indexNote(ctx, 'first-pass.md', '---\nabout: [[sources/smith-2023]]\n---\n\n# First-pass thoughts\n');
+    // A note that cites but does NOT declare about: should not appear in aboutNotes.
+    await indexNote(ctx, 'tangential.md', '# Tangential\n\n[[cite::smith-2023]] is also useful.');
+
+    const detail = getSourceDetail(ctx, 'smith-2023');
+    expect(detail!.aboutNotes.map(n => n.relativePath).sort()).toEqual([
+      'first-pass.md',
+      'reading-notes.md',
+    ]);
+    expect(detail!.aboutNotes.map(n => n.title).sort()).toEqual([
+      'First-pass thoughts',
+      'Reading notes',
+    ]);
+    // Tangential note appears under backlinks (cite), not aboutNotes.
+    expect(detail!.aboutNotes.some(n => n.relativePath === 'tangential.md')).toBe(false);
+  });
+
+  it('about: [[sources/<id>]] in frontmatter materialises a real dc:subject edge to the source URI', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(ctx);
+    // Unquoted shorthand — YAML's flow parser turns [[X]] into
+    // [[X]] (array-of-array). The indexer recovers the wiki-link
+    // form so the user doesn't have to remember to quote.
+    await indexNote(ctx, 'unquoted.md', '---\nabout: [[sources/smith-2023]]\n---\n\n# Reading\n');
+    // Quoted form — the canonical/explicit way.
+    await indexNote(ctx, 'quoted.md', '---\nabout: "[[sources/smith-2023]]"\n---\n\n# Reading\n');
+
+    const detail = getSourceDetail(ctx, 'smith-2023');
+    expect(detail!.aboutNotes.map(n => n.relativePath).sort()).toEqual(['quoted.md', 'unquoted.md']);
+  });
+
+  it('returns an empty aboutNotes list when no note declares aboutness', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(ctx);
+
+    const detail = getSourceDetail(ctx, 'smith-2023');
+    expect(detail!.aboutNotes).toEqual([]);
+  });
+
+  it('deduplicates a note that lists multiple about: entries pointing at the same source', async () => {
+    writeSourceMeta(root, 'smith-2023', ARTICLE_TTL);
+    await indexAllNotes(ctx);
+    // YAML list with the same source twice — defensive shape; the graph
+    // already dedupes triples, but the collector must dedupe by note
+    // relativePath anyway.
+    await indexNote(ctx, 'duped.md',
+      '---\nabout:\n  - "[[sources/smith-2023]]"\n  - "[[sources/smith-2023]]"\n---\n\n# Duped\n');
+
+    const detail = getSourceDetail(ctx, 'smith-2023');
+    expect(detail!.aboutNotes.map(n => n.relativePath)).toEqual(['duped.md']);
+  });
 });
 
 describe('getExcerptSource', () => {


### PR DESCRIPTION
Adds the missing primitive between citation and excerpt: a note can declare itself as *about* a source. The source's detail view picks up a "Notes" section listing its child notes. Distinct from cite/quote — this is subject-of, not reference-of.

## Authoring
Frontmatter on the note:
\`\`\`yaml
---
about: [[sources/smith-2023]]
---
\`\`\`

\`about\` maps to \`dc:subject\` (the well-known, ecosystem-friendly choice), with \`sources/\` as the disambiguating prefix that routes the wiki-link to \`sourceUri()\` rather than the default \`noteUri()\`. The standard YAML list form supports multiple entries:

\`\`\`yaml
about:
  - "[[sources/smith-2023]]"
  - "[[sources/jones-2024]]"
\`\`\`

## Bonus: YAML-eaten wiki-link recovery
The unquoted shorthand \`about: [[sources/foo]]\` looks right to a Minerva user but YAML's flow syntax interprets the outer \`[…]\` as a nested-array literal, yielding \`[['sources/foo']]\` — by the time the indexer sees the value, the wiki-link brackets are already gone. \`recoverYamlEatenWikiLink\` translates that narrow pattern back to a \`[[X]]\` string before scalar flattening, so unquoted shorthand works the way the user expects.

This benefits every wiki-link frontmatter predicate (\`derived_from\`, \`extracted-from\`, \`supports\`, …), not just \`about\`. The quoted form remains canonical / recommended; the recovery is a quality-of-life forgiveness.

## Surface
- \`SourceDetail.aboutNotes\` (new) — alongside \`backlinks\` and \`excerpts\`.
- \`collectSourceAboutNotes(state, subject)\` queries \`?note dc:subject sourceSubject\`, restricted to Minerva notes (so a future excerpt or proposal that carries \`dc:subject\` doesn't pollute the list).
- \`SourceDetail.svelte\` gains a "Notes" section between Excerpts and Referenced from, with a "New note about this source" button.
- \`handleNewAboutSourceNote\` in App.svelte: prompts for a name, writes a note pre-populated with the \`about:\` frontmatter, opens it for editing.

## Tests
- source-detail.test.ts: 4 new cases
  - notes that declare \`about: [[sources/<id>]]\` show up under \`aboutNotes\`
  - cite-only notes do NOT appear under \`aboutNotes\` (boundary check)
  - quoted + unquoted forms both produce the same edge
  - duplicates in a YAML list dedupe by relativePath
  - empty list when nothing declares aboutness
- Full suite: 2258 / 2258 (+4 new).

## Out of scope (per issue)
- Properties panel chip click-through to source detail (chip already renders the value; routing is a separate change).
- Migration of existing citations to \`about:\`.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Open a source detail.
  2. Click "New note about this source"; enter a name; the new note opens with \`about: [[sources/<id>]]\` frontmatter.
  3. Save / re-open the source detail; the note appears under "Notes".
  4. Hand-edit another note's frontmatter to \`about: [[sources/<id>]]\` unquoted; confirm it ALSO surfaces.

Closes #474.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)