### PR TITLE
feat: manual source collections (#470 phase 1)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -72,6 +72,14 @@ import { renderInlineCitations, type InlineCiteRequest } from './citations/rende
 import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
 import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
+import {
+  loadCollections,
+  createCollection,
+  renameCollection,
+  deleteCollection,
+  addSourceToCollection,
+  removeSourceFromCollection,
+} from './sources/collections';
 import { importBibtex } from './sources/import-bibtex';
 import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
@@ -1582,6 +1590,54 @@ export function registerIpcHandlers(): void {
       }
       throw err;
     }
+  });
+
+  // ── Collections (#470) ────────────────────────────────────────────────────
+  const broadcastCollectionsChanged = (e: Electron.IpcMainInvokeEvent) => {
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.COLLECTIONS_CHANGED);
+  };
+
+  ipcMain.handle(Channels.COLLECTIONS_LIST, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return { collections: [] };
+    return await loadCollections(rootPath);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_CREATE, async (e, args: { name: string; parent?: string | null }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const result = await createCollection(rootPath, args);
+    broadcastCollectionsChanged(e);
+    return result;
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_RENAME, async (e, args: { id: string; name: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await renameCollection(rootPath, args.id, args.name);
+    broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_DELETE, async (e, id: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await deleteCollection(rootPath, id);
+    broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_ADD_SOURCE, async (e, args: { collectionId: string; sourceId: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await addSourceToCollection(rootPath, args.collectionId, args.sourceId);
+    broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_REMOVE_SOURCE, async (e, args: { collectionId: string; sourceId: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await removeSourceFromCollection(rootPath, args.collectionId, args.sourceId);
+    broadcastCollectionsChanged(e);
   });
 
   ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, async (e, params: {

--- a/src/main/sources/collections.ts
+++ b/src/main/sources/collections.ts
@@ -1,0 +1,215 @@
+/**
+ * Source collections (#470 phase 1 — manual, hierarchical).
+ *
+ * Zotero-style collections: named containers a researcher can drag a
+ * source into, nested as a tree, with one source allowed in many
+ * collections. This is organisational metadata, not a re-shaping of
+ * the underlying source store on disk — sources still live at
+ * `.minerva/sources/<id>/`.
+ *
+ * Storage: a single `.minerva/collections.json` file. Membership is
+ * embedded per-collection (matches Zotero's mental model and keeps
+ * "list members of X" trivial). Mutations are read-modify-write of
+ * the whole file — collections per project are typically O(10–50),
+ * so we don't need any of the contortions a graph-resident store
+ * would have imposed.
+ *
+ * Smart collections (#470 phase 2) will live in the same file later,
+ * with a separate top-level array — the manual side will not need to
+ * change.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface Collection {
+  id: string;
+  name: string;
+  /** Parent collection id, or null for a top-level collection. */
+  parent: string | null;
+  /** Source ids belonging to this collection. Order is preserved as
+   *  the user adds them; the UI sorts on display. */
+  members: string[];
+}
+
+export interface CollectionsFile {
+  collections: Collection[];
+}
+
+function filePath(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'collections.json');
+}
+
+/** Fresh empty file. Returned as a new object each call so callers
+ *  can read-modify-write without any chance of leaking state into
+ *  the next read. */
+function emptyFile(): CollectionsFile {
+  return { collections: [] };
+}
+
+export async function loadCollections(rootPath: string): Promise<CollectionsFile> {
+  try {
+    const raw = await fs.readFile(filePath(rootPath), 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return emptyFile();
+    const collections = Array.isArray((parsed as CollectionsFile).collections)
+      ? (parsed as CollectionsFile).collections
+      : [];
+    // Defensive: any record with a missing field falls through to safe defaults.
+    return {
+      collections: collections.map((c) => ({
+        id: String(c.id ?? ''),
+        name: String(c.name ?? ''),
+        parent: c.parent == null ? null : String(c.parent),
+        members: Array.isArray(c.members) ? c.members.map((m) => String(m)) : [],
+      })).filter((c) => c.id),
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyFile();
+    throw err;
+  }
+}
+
+async function saveCollections(rootPath: string, data: CollectionsFile): Promise<void> {
+  const p = filePath(rootPath);
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+/**
+ * Stable, human-readable id derived from the name. If a collision
+ * exists, append `-2`, `-3`, … until unique. We don't generate UUIDs
+ * here — when a user looks at `collections.json` they should be able
+ * to spot which row is "Reading list" without cross-referencing.
+ */
+function uniqueIdFor(name: string, existing: ReadonlyArray<Collection>): string {
+  const slug = name.toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'collection';
+  if (!existing.some((c) => c.id === slug)) return slug;
+  for (let i = 2; ; i++) {
+    const candidate = `${slug}-${i}`;
+    if (!existing.some((c) => c.id === candidate)) return candidate;
+  }
+}
+
+export interface CreateCollectionArgs {
+  name: string;
+  parent?: string | null;
+}
+
+export async function createCollection(rootPath: string, args: CreateCollectionArgs): Promise<Collection> {
+  const trimmed = args.name.trim();
+  if (!trimmed) throw new Error('Collection name cannot be empty.');
+  const data = await loadCollections(rootPath);
+  if (args.parent && !data.collections.some((c) => c.id === args.parent)) {
+    throw new Error(`Parent collection "${args.parent}" not found.`);
+  }
+  const collection: Collection = {
+    id: uniqueIdFor(trimmed, data.collections),
+    name: trimmed,
+    parent: args.parent ?? null,
+    members: [],
+  };
+  data.collections.push(collection);
+  await saveCollections(rootPath, data);
+  return collection;
+}
+
+export async function renameCollection(rootPath: string, id: string, newName: string): Promise<void> {
+  const trimmed = newName.trim();
+  if (!trimmed) throw new Error('Collection name cannot be empty.');
+  const data = await loadCollections(rootPath);
+  const target = data.collections.find((c) => c.id === id);
+  if (!target) throw new Error(`Collection "${id}" not found.`);
+  target.name = trimmed;
+  await saveCollections(rootPath, data);
+}
+
+/**
+ * Delete a collection. Its children are re-parented to root (less
+ * destructive than cascade-delete; per CLAUDE.md no-fear UX, we don't
+ * want a folder delete to silently take any nested folders with it).
+ * Sources themselves are never touched — membership is the only thing
+ * that disappears.
+ */
+export async function deleteCollection(rootPath: string, id: string): Promise<void> {
+  const data = await loadCollections(rootPath);
+  const before = data.collections.length;
+  data.collections = data.collections
+    .filter((c) => c.id !== id)
+    .map((c) => (c.parent === id ? { ...c, parent: null } : c));
+  if (data.collections.length === before) {
+    throw new Error(`Collection "${id}" not found.`);
+  }
+  await saveCollections(rootPath, data);
+}
+
+export async function addSourceToCollection(
+  rootPath: string,
+  collectionId: string,
+  sourceId: string,
+): Promise<void> {
+  const data = await loadCollections(rootPath);
+  const target = data.collections.find((c) => c.id === collectionId);
+  if (!target) throw new Error(`Collection "${collectionId}" not found.`);
+  if (!target.members.includes(sourceId)) {
+    target.members.push(sourceId);
+    await saveCollections(rootPath, data);
+  }
+}
+
+export async function removeSourceFromCollection(
+  rootPath: string,
+  collectionId: string,
+  sourceId: string,
+): Promise<void> {
+  const data = await loadCollections(rootPath);
+  const target = data.collections.find((c) => c.id === collectionId);
+  if (!target) throw new Error(`Collection "${collectionId}" not found.`);
+  const idx = target.members.indexOf(sourceId);
+  if (idx >= 0) {
+    target.members.splice(idx, 1);
+    await saveCollections(rootPath, data);
+  }
+}
+
+/**
+ * Sweep every collection for membership entries pointing at the given
+ * source id. Called by the source-delete and source-merge paths so a
+ * removed source doesn't linger as a dead entry forever.
+ */
+export async function scrubSourceFromCollections(rootPath: string, sourceId: string): Promise<void> {
+  const data = await loadCollections(rootPath);
+  let mutated = false;
+  for (const c of data.collections) {
+    const before = c.members.length;
+    c.members = c.members.filter((id) => id !== sourceId);
+    if (c.members.length !== before) mutated = true;
+  }
+  if (mutated) await saveCollections(rootPath, data);
+}
+
+/**
+ * When src is being merged into dest (#90 part 2), src's collection
+ * memberships should follow it: any collection that contained src
+ * should contain dest, and src itself should be scrubbed. Idempotent.
+ */
+export async function rewriteCollectionMemberships(
+  rootPath: string,
+  srcId: string,
+  destId: string,
+): Promise<void> {
+  if (srcId === destId) return;
+  const data = await loadCollections(rootPath);
+  let mutated = false;
+  for (const c of data.collections) {
+    const hasSrc = c.members.includes(srcId);
+    if (!hasSrc) continue;
+    c.members = c.members.filter((id) => id !== srcId);
+    if (!c.members.includes(destId)) c.members.push(destId);
+    mutated = true;
+  }
+  if (mutated) await saveCollections(rootPath, data);
+}

--- a/src/main/sources/delete-source.ts
+++ b/src/main/sources/delete-source.ts
@@ -15,6 +15,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
+import { scrubSourceFromCollections } from './collections';
 
 export interface DeleteSourceResult {
   sourceId: string;
@@ -43,6 +44,10 @@ export async function deleteSource(
   try {
     await fs.rm(sourceDir, { recursive: true, force: true });
   } catch { /* already gone */ }
+
+  // Scrub from any manually-curated collections (#470) so a removed
+  // source doesn't linger as a dead membership entry.
+  await scrubSourceFromCollections(rootPath, sourceId);
 
   return { sourceId, excerptsRemoved: excerptIds.length };
 }

--- a/src/main/sources/merge-sources.ts
+++ b/src/main/sources/merge-sources.ts
@@ -32,6 +32,7 @@ import * as notebaseFs from '../notebase/fs';
 import { rewriteTypedIdLinks } from '../notebase/link-rewriting';
 import { projectContext } from '../project-context-types';
 import { mergeMetaTtl, type SourceMetaUpdate } from './source-merge';
+import { rewriteCollectionMemberships } from './collections';
 
 export interface MergeSourcesResult {
   destId: string;
@@ -171,7 +172,11 @@ export async function mergeSources(
     }
   }
 
-  // 5. Drop src from graph + disk.
+  // 5. Move collection memberships src → dest (#470) so the dest
+  //    inherits every "Reading list" / "Lit review" the src was in.
+  await rewriteCollectionMemberships(rootPath, srcId, destId);
+
+  // 6. Drop src from graph + disk.
   graph.removeSource(ctx, srcId);
   await fs.rm(srcDir, { recursive: true, force: true });
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -271,6 +271,21 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.on(Channels.EXCERPTS_CHANGED, () => cb());
     },
   },
+  collections: {
+    list: () => ipcRenderer.invoke(Channels.COLLECTIONS_LIST),
+    create: (args: { name: string; parent?: string | null }) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_CREATE, args),
+    rename: (id: string, name: string) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_RENAME, { id, name }),
+    remove: (id: string) => ipcRenderer.invoke(Channels.COLLECTIONS_DELETE, id),
+    addSource: (collectionId: string, sourceId: string) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_ADD_SOURCE, { collectionId, sourceId }),
+    removeSource: (collectionId: string, sourceId: string) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_REMOVE_SOURCE, { collectionId, sourceId }),
+    onChanged: (cb: () => void) => {
+      ipcRenderer.on(Channels.COLLECTIONS_CHANGED, () => cb());
+    },
+  },
   formatter: {
     formatContent: (content: string, settings: unknown, relativePath?: string) =>
       ipcRenderer.invoke(Channels.FORMATTER_FORMAT_CONTENT, content, settings, relativePath),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -204,7 +204,7 @@
   }
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
-  let promptDialog = $state<{ message: string; suggestions?: string[]; resolve: (value: string | null) => void } | null>(null);
+  let promptDialog = $state<{ message: string; suggestions?: string[]; initial?: string; resolve: (value: string | null) => void } | null>(null);
   let confirmDialog = $state<{ message: string; confirmLabel: string; key: string; hideDontAskAgain?: boolean; resolve: (value: boolean) => void } | null>(null);
   let exportDialogFor = $state<string | null>(null);
   /**
@@ -217,9 +217,18 @@
   } | null>(null);
   const confirmSuppression = getConfirmSuppressionStore();
 
-  function showPrompt(message: string, options: { suggestions?: string[] } = {}): Promise<string | null> {
+  function showPrompt(
+    message: string,
+    initialOrOptions?: string | { suggestions?: string[]; initial?: string },
+  ): Promise<string | null> {
+    // Two overloads to keep call sites readable. New callers pass
+    // (message, "current name") for Rename-style flows; existing
+    // callers can keep their {suggestions} object.
+    const opts = typeof initialOrOptions === 'string'
+      ? { initial: initialOrOptions }
+      : (initialOrOptions ?? {});
     return new Promise((resolve) => {
-      promptDialog = { message, suggestions: options.suggestions, resolve };
+      promptDialog = { message, suggestions: opts.suggestions, initial: opts.initial, resolve };
     });
   }
 
@@ -2359,6 +2368,7 @@
           onSourceSelect={(id) => handleOpenSource(id)}
           onSourceDeleted={handleSourceDeleted}
           onShowConfirm={showConfirm}
+          onShowPrompt={showPrompt}
           onTableClick={(name) => editor.openQuery(`SELECT * FROM ${name}`, 'sql')}
           onOpenCsv={(rel) => handleFileSelect(rel)}
           onExternalDrop={handleExternalDrop}
@@ -2679,6 +2689,7 @@
     <PromptDialog
       message={promptDialog.message}
       suggestions={promptDialog.suggestions ?? []}
+      initial={promptDialog.initial ?? ''}
       onConfirm={handlePromptConfirm}
       onCancel={handlePromptCancel}
     />

--- a/src/renderer/lib/components/CollectionPickerDialog.svelte
+++ b/src/renderer/lib/components/CollectionPickerDialog.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import type { Collection } from '../../../shared/types';
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    collections: Collection[];
+    onSelect: (collectionId: string) => void;
+    onCancel: () => void;
+    title: string;
+    placeholder?: string;
+  }
+
+  let { collections, onSelect, onCancel, title, placeholder = 'Filter collections…' }: Props = $props();
+
+  let query = $state('');
+  let selectedIndex = $state(0);
+  let inputEl = $state<HTMLInputElement>();
+
+  /** Build the full breadcrumb path for each collection so the user can
+   *  disambiguate two like-named collections under different parents. */
+  const labels = $derived.by(() => {
+    const byId = new Map(collections.map((c) => [c.id, c]));
+    const buildLabel = (c: Collection): string => {
+      const parts: string[] = [c.name];
+      let cursor = c.parent;
+      while (cursor) {
+        const p = byId.get(cursor);
+        if (!p) break;
+        parts.unshift(p.name);
+        cursor = p.parent;
+      }
+      return parts.join(' / ');
+    };
+    return new Map(collections.map((c) => [c.id, buildLabel(c)]));
+  });
+
+  const results = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    const sorted = [...collections].sort((a, b) =>
+      (labels.get(a.id) ?? a.name).localeCompare(labels.get(b.id) ?? b.name),
+    );
+    if (!q) return sorted;
+    return sorted.filter((c) => (labels.get(c.id) ?? c.name).toLowerCase().includes(q));
+  });
+
+  $effect(() => {
+    results;
+    selectedIndex = 0;
+  });
+  $effect(() => { inputEl?.focus(); });
+  $effect(() => {
+    const el = document.querySelector('.cp-results .selected');
+    el?.scrollIntoView({ block: 'nearest' });
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIndex = Math.max(selectedIndex - 1, 0);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const picked = results[selectedIndex];
+      if (picked) onSelect(picked.id);
+    } else if (e.key === 'Escape') {
+      onCancel();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-label={title}>
+    <div class="header">{title}</div>
+    <div class="input-row">
+      <Icon name="search" size={14} color="var(--text-muted)" />
+      <input bind:this={inputEl} bind:value={query} type="text" class="input" {placeholder} />
+    </div>
+    {#if results.length > 0}
+      <ul class="cp-results">
+        {#each results as c, i (c.id)}
+          <li>
+            <button
+              class="result-item"
+              class:selected={i === selectedIndex}
+              onclick={() => onSelect(c.id)}
+              onmouseenter={() => { selectedIndex = i; }}
+            >
+              <span class="result-name">{labels.get(c.id) ?? c.name}</span>
+              <span class="result-count">{c.members.length}</span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {:else if collections.length === 0}
+      <div class="no-results">No collections yet. Create one from the Sources panel first.</div>
+    {:else}
+      <div class="no-results">No matching collections.</div>
+    {/if}
+    <footer class="palette-footer">
+      <span class="kbd-hint">↑↓ navigate · ↵ select · esc cancel</span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.45);
+    backdrop-filter: blur(2px);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 15vh 32px 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    width: 520px;
+    max-width: 100%;
+    max-height: 60vh;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+  .header {
+    padding: 12px 16px 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+  }
+  .input-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 4px 16px 12px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 15px;
+    outline: none;
+    padding: 0;
+  }
+  .input::placeholder { color: var(--text-muted); }
+  .cp-results {
+    list-style: none;
+    overflow-y: auto;
+    padding: 4px 0;
+    margin: 0;
+    flex: 1;
+  }
+  .result-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 16px;
+    border: none;
+    border-left: 2px solid transparent;
+    background: none;
+    color: var(--text);
+    cursor: pointer;
+    text-align: left;
+    font-size: 13px;
+  }
+  .result-item.selected {
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
+    border-left-color: var(--accent);
+  }
+  .result-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .result-count {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .no-results {
+    padding: 24px;
+    font-size: 13px;
+    color: var(--text-muted);
+    text-align: center;
+    font-style: italic;
+  }
+  .palette-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kbd-hint {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+</style>

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -11,10 +11,13 @@
      *  browser handles filtering + keyboard nav for free. Used by the
      *  bulk Add/Remove Tag flow; harmless when omitted. */
     suggestions?: string[];
+    /** Optional pre-seeded value (e.g. Rename) — the input opens
+     *  populated with this string, fully selected. */
+    initial?: string;
   }
 
-  let { message, onConfirm, onCancel, suggestions = [] }: Props = $props();
-  let value = $state('');
+  let { message, onConfirm, onCancel, suggestions = [], initial = '' }: Props = $props();
+  let value = $state(initial);
   let inputEl = $state<HTMLInputElement>();
   // Stable id so multiple PromptDialogs (rare, but possible during
   // overlapping flows) don't collide on the datalist anchor.
@@ -30,6 +33,9 @@
 
   $effect(() => {
     inputEl?.focus();
+    // Pre-select the seeded value so the user can type to replace
+    // it but Tab/Enter to accept as-is.
+    if (initial) inputEl?.select();
   });
 </script>
 

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -61,13 +61,14 @@
     onSourceSelect?: (sourceId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
+    onShowPrompt?: (message: string, initial?: string) => Promise<string | null>;
     onTableClick?: (tableName: string) => void;
     onOpenCsv?: (relativePath: string) => void;
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -573,8 +574,8 @@
         </div>
       {/if}
     {:else if activePanel === 'sites'}
-      {#if onSourceSelect && onShowConfirm}
-        <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} />
+      {#if onSourceSelect && onShowConfirm && onShowPrompt}
+        <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} {onShowPrompt} />
       {/if}
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1,23 +1,58 @@
 <script lang="ts">
   import { api } from '../ipc/client';
-  import type { SourceMetadata } from '../../../shared/types';
+  import type { SourceMetadata, Collection } from '../../../shared/types';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import SourcePickerDialog from './SourcePickerDialog.svelte';
+  import CollectionPickerDialog from './CollectionPickerDialog.svelte';
+  import Icon from './Icon.svelte';
 
   interface Props {
     onSourceSelect: (sourceId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
+    onShowPrompt: (message: string, initial?: string) => Promise<string | null>;
   }
 
-  let { onSourceSelect, onSourceDeleted, onShowConfirm }: Props = $props();
+  let { onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt }: Props = $props();
 
   let sources = $state<SourceMetadata[]>([]);
   let filter = $state('');
   let contextMenu = $state<{ x: number; y: number; source: SourceMetadata } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
+  let collectionMenu = $state<{ x: number; y: number; collection: Collection } | null>(null);
+  let collectionMenuEl = $state<HTMLDivElement | undefined>();
   /** When set, the merge picker is open with this source as the src. */
   let mergeSrc = $state<SourceMetadata | null>(null);
+  /** When set, the collection picker is open to add this source to one. */
+  let addToCollectionFor = $state<SourceMetadata | null>(null);
+
+  let collections = $state<Collection[]>([]);
+  /** Currently focused collection id; null = "All sources". */
+  let activeCollectionId = $state<string | null>(null);
+  /** Persisted expansion state of the collection tree (per project would
+   *  be nicer, but matches the convention already used by the right
+   *  sidebar's tag tree). */
+  const COLL_EXPAND_KEY = 'minerva.collections.expanded';
+  let expandedCollections = $state<Record<string, boolean>>(loadExpanded());
+
+  function loadExpanded(): Record<string, boolean> {
+    try {
+      const raw = localStorage.getItem(COLL_EXPAND_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const out: Record<string, boolean> = {};
+        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+          if (typeof v === 'boolean') out[k] = v;
+        }
+        return out;
+      }
+    } catch { /* ok */ }
+    return {};
+  }
+  function persistExpanded(): void {
+    try { localStorage.setItem(COLL_EXPAND_KEY, JSON.stringify(expandedCollections)); } catch { /* ok */ }
+  }
 
   $effect(() => {
     if (!contextMenu || !contextMenuEl) return;
@@ -26,12 +61,30 @@
       contextMenu = { ...contextMenu, ...next };
     }
   });
+  $effect(() => {
+    if (!collectionMenu || !collectionMenuEl) return;
+    const next = clampMenuToViewport(collectionMenu.x, collectionMenu.y, collectionMenuEl);
+    if (next.x !== collectionMenu.x || next.y !== collectionMenu.y) {
+      collectionMenu = { ...collectionMenu, ...next };
+    }
+  });
 
   // Fetch on mount so the panel populates whenever it's switched into,
   // not only when the host calls refresh().
   $effect(() => {
     void refresh();
+    void refreshCollections();
   });
+
+  // The main process broadcasts COLLECTIONS_CHANGED after any mutation
+  // (including from other windows / direct file edits). Keep our tree
+  // in sync without forcing the host to call refresh() explicitly.
+  api.collections.onChanged(() => { void refreshCollections(); });
+
+  async function refreshCollections(): Promise<void> {
+    const data = await api.collections.list();
+    collections = data.collections;
+  }
 
   function handleContextMenu(e: MouseEvent, source: SourceMetadata) {
     e.preventDefault();
@@ -93,16 +146,182 @@
     sources = await api.sources.listAll();
   }
 
+  /** Collection ids in the active subtree (the focused collection and
+   *  every descendant). Selecting a parent collection shows everything
+   *  filed under it — matches what users expect from Zotero's "include
+   *  child collections" default. */
+  const activeSubtree = $derived.by(() => {
+    if (!activeCollectionId) return null;
+    const out = new Set<string>([activeCollectionId]);
+    let added = true;
+    while (added) {
+      added = false;
+      for (const c of collections) {
+        if (c.parent && out.has(c.parent) && !out.has(c.id)) {
+          out.add(c.id);
+          added = true;
+        }
+      }
+    }
+    return out;
+  });
+
+  /** Source ids in the active subtree (union of all member arrays). */
+  const activeMembers = $derived.by(() => {
+    if (!activeSubtree) return null;
+    const out = new Set<string>();
+    for (const c of collections) {
+      if (activeSubtree.has(c.id)) for (const m of c.members) out.add(m);
+    }
+    return out;
+  });
+
+  /** Per-collection visible counts shown next to each row. Each count
+   *  reflects the subtree-rooted membership the user would see if they
+   *  clicked that row (i.e. includes descendants). */
+  const counts = $derived.by(() => {
+    const childrenOf = new Map<string | null, string[]>();
+    for (const c of collections) {
+      const arr = childrenOf.get(c.parent) ?? [];
+      arr.push(c.id);
+      childrenOf.set(c.parent, arr);
+    }
+    const subtreeMembers = new Map<string, Set<string>>();
+    const collect = (id: string): Set<string> => {
+      const cached = subtreeMembers.get(id);
+      if (cached) return cached;
+      const own = collections.find((c) => c.id === id);
+      const out = new Set<string>(own?.members ?? []);
+      for (const childId of childrenOf.get(id) ?? []) {
+        for (const m of collect(childId)) out.add(m);
+      }
+      subtreeMembers.set(id, out);
+      return out;
+    };
+    const result = new Map<string, number>();
+    for (const c of collections) result.set(c.id, collect(c.id).size);
+    return result;
+  });
+
   let visible = $derived.by(() => {
+    let base = sources;
+    if (activeMembers) base = base.filter((s) => activeMembers.has(s.sourceId));
     const q = filter.trim().toLowerCase();
-    if (!q) return sources;
-    return sources.filter((s) => {
+    if (!q) return base;
+    return base.filter((s) => {
       const title = (s.title ?? s.sourceId).toLowerCase();
       const byline = s.creators.join(' ').toLowerCase();
       const year = s.year ?? '';
       return title.includes(q) || byline.includes(q) || year.includes(q) || s.sourceId.includes(q);
     });
   });
+
+  interface CollectionRow {
+    collection: Collection;
+    depth: number;
+    hasChildren: boolean;
+  }
+  /** Display-order flattening of the tree, honouring expansion state. */
+  const collectionRows = $derived.by<CollectionRow[]>(() => {
+    const childrenOf = new Map<string | null, Collection[]>();
+    for (const c of collections) {
+      const arr = childrenOf.get(c.parent) ?? [];
+      arr.push(c);
+      childrenOf.set(c.parent, arr);
+    }
+    for (const arr of childrenOf.values()) arr.sort((a, b) => a.name.localeCompare(b.name));
+    const out: CollectionRow[] = [];
+    const walk = (parent: string | null, depth: number) => {
+      for (const c of childrenOf.get(parent) ?? []) {
+        const hasChildren = (childrenOf.get(c.id)?.length ?? 0) > 0;
+        out.push({ collection: c, depth, hasChildren });
+        if (hasChildren && expandedCollections[c.id]) walk(c.id, depth + 1);
+      }
+    };
+    walk(null, 0);
+    return out;
+  });
+
+  function toggleExpanded(id: string) {
+    expandedCollections = { ...expandedCollections, [id]: !expandedCollections[id] };
+    persistExpanded();
+  }
+
+  function selectCollection(id: string | null) {
+    activeCollectionId = id;
+  }
+
+  function handleCollectionContextMenu(e: MouseEvent, collection: Collection) {
+    e.preventDefault();
+    e.stopPropagation();
+    collectionMenu = { x: e.clientX, y: e.clientY, collection };
+    const close = () => { collectionMenu = null; window.removeEventListener('click', close); };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  async function handleNewCollection(parent: string | null = null): Promise<void> {
+    collectionMenu = null;
+    const name = await onShowPrompt('New collection name:');
+    if (!name) return;
+    try {
+      await api.collections.create({ name, parent });
+    } catch (err) {
+      console.error('[minerva] Create collection failed:', err);
+    }
+  }
+
+  async function handleRenameCollection(c: Collection): Promise<void> {
+    collectionMenu = null;
+    const name = await onShowPrompt('Rename collection:', c.name);
+    if (!name || name === c.name) return;
+    try {
+      await api.collections.rename(c.id, name);
+    } catch (err) {
+      console.error('[minerva] Rename collection failed:', err);
+    }
+  }
+
+  async function handleDeleteCollection(c: Collection): Promise<void> {
+    collectionMenu = null;
+    const confirmed = await onShowConfirm(
+      `Delete collection "${c.name}"? Its sources are kept; only the membership goes away. Any nested collections become top-level.`,
+      'delete-collection',
+      'Delete',
+    );
+    if (!confirmed) return;
+    if (activeCollectionId === c.id) activeCollectionId = null;
+    try {
+      await api.collections.remove(c.id);
+    } catch (err) {
+      console.error('[minerva] Delete collection failed:', err);
+    }
+  }
+
+  function handleAddToCollection(source: SourceMetadata) {
+    contextMenu = null;
+    addToCollectionFor = source;
+  }
+
+  async function handleAddToCollectionPick(collectionId: string) {
+    const src = addToCollectionFor;
+    addToCollectionFor = null;
+    if (!src) return;
+    try {
+      await api.collections.addSource(collectionId, src.sourceId);
+    } catch (err) {
+      console.error('[minerva] Add to collection failed:', err);
+    }
+  }
+
+  async function handleRemoveFromActiveCollection(source: SourceMetadata) {
+    contextMenu = null;
+    if (!activeCollectionId) return;
+    try {
+      await api.collections.removeSource(activeCollectionId, source.sourceId);
+    } catch (err) {
+      console.error('[minerva] Remove from collection failed:', err);
+    }
+  }
 
   function formatCreators(creators: string[]): string {
     if (creators.length === 0) return '';
@@ -113,14 +332,60 @@
 </script>
 
 <div class="sources-panel">
-  {#if sources.length === 0}
+  {#if sources.length === 0 && collections.length === 0}
     <div class="empty">No sources yet. File → Ingest URL… to start.</div>
   {:else}
+    <div class="collections-section">
+      <div class="collections-header">
+        <span class="collections-eyebrow">COLLECTIONS</span>
+        <button class="new-coll" onclick={() => handleNewCollection(null)} title="New collection">
+          <Icon name="plus" size={11} color="var(--text-muted)" />
+        </button>
+      </div>
+      <button
+        class="coll-row"
+        class:active={activeCollectionId === null}
+        onclick={() => selectCollection(null)}
+      >
+        <span class="chevron-spacer"></span>
+        <span class="coll-name">All sources</span>
+        <span class="coll-count">{sources.length}</span>
+      </button>
+      {#each collectionRows as row (row.collection.id)}
+        <button
+          class="coll-row"
+          class:active={activeCollectionId === row.collection.id}
+          style:padding-left="{row.depth * 14 + 8}px"
+          onclick={() => selectCollection(row.collection.id)}
+          oncontextmenu={(e) => handleCollectionContextMenu(e, row.collection)}
+          title={row.collection.id}
+        >
+          {#if row.hasChildren}
+            <span
+              class="chevron"
+              role="button"
+              tabindex="-1"
+              onclick={(e) => { e.stopPropagation(); toggleExpanded(row.collection.id); }}
+              onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleExpanded(row.collection.id); } }}
+            >
+              <Icon name={expandedCollections[row.collection.id] ? 'chevronDown' : 'chevronRight'} size={11} color="var(--text-faint)" />
+            </span>
+          {:else}
+            <span class="chevron-spacer"></span>
+          {/if}
+          <span class="coll-name">{row.collection.name}</span>
+          <span class="coll-count">{counts.get(row.collection.id) ?? 0}</span>
+        </button>
+      {/each}
+    </div>
+
     <div class="filter-row">
       <input
         type="text"
         class="filter-input"
-        placeholder="Filter sources…"
+        placeholder={activeCollectionId
+          ? `Filter "${collections.find((c) => c.id === activeCollectionId)?.name ?? 'collection'}"…`
+          : 'Filter sources…'}
         bind:value={filter}
       />
     </div>
@@ -142,7 +407,9 @@
         </button>
       {/each}
       {#if visible.length === 0}
-        <div class="empty">No matches.</div>
+        <div class="empty">
+          {activeCollectionId ? 'This collection is empty.' : 'No matches.'}
+        </div>
       {/if}
     </div>
   {/if}
@@ -154,8 +421,24 @@
       style:left="{contextMenu.x}px"
       style:top="{contextMenu.y}px"
     >
+      <button onclick={() => handleAddToCollection(contextMenu!.source)}>Add to collection…</button>
+      {#if activeCollectionId}
+        <button onclick={() => handleRemoveFromActiveCollection(contextMenu!.source)}>Remove from collection</button>
+      {/if}
       <button onclick={() => handleMergeStart(contextMenu!.source)}>Merge into…</button>
       <button onclick={() => handleDelete(contextMenu!.source)}>Delete Source</button>
+    </div>
+  {/if}
+  {#if collectionMenu}
+    <div
+      class="context-menu"
+      bind:this={collectionMenuEl}
+      style:left="{collectionMenu.x}px"
+      style:top="{collectionMenu.y}px"
+    >
+      <button onclick={() => handleNewCollection(collectionMenu!.collection.id)}>New nested collection…</button>
+      <button onclick={() => handleRenameCollection(collectionMenu!.collection)}>Rename…</button>
+      <button onclick={() => handleDeleteCollection(collectionMenu!.collection)}>Delete</button>
     </div>
   {/if}
 </div>
@@ -168,6 +451,15 @@
     excludeSourceId={mergeSrc.sourceId}
     onSelect={handleMergePick}
     onCancel={() => { mergeSrc = null; }}
+  />
+{/if}
+
+{#if addToCollectionFor}
+  <CollectionPickerDialog
+    {collections}
+    title={`Add "${addToCollectionFor.title ?? addToCollectionFor.sourceId}" to collection…`}
+    onSelect={handleAddToCollectionPick}
+    onCancel={() => { addToCollectionFor = null; }}
   />
 {/if}
 
@@ -282,4 +574,92 @@
     font-family: var(--font-mono);
     font-variant-numeric: tabular-nums;
   }
+
+  /* Collections section sits above the flat source list. Visual
+     density is between the file tree (row-per-line) and the
+     editorial source list — a short, scrollable region with a
+     muted eyebrow heading. */
+  .collections-section {
+    flex-shrink: 0;
+    max-height: 40%;
+    overflow-y: auto;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 4px;
+  }
+  .collections-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px 4px 14px;
+  }
+  .collections-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    letter-spacing: 0.06em;
+  }
+  .new-coll {
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .new-coll:hover {
+    background: var(--bg-button);
+    color: var(--text);
+  }
+  .coll-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    padding: 4px 12px 4px 8px;
+    background: none;
+    border: none;
+    border-left: 2px solid transparent;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .coll-row:hover {
+    background: color-mix(in oklch, var(--text) 4%, transparent);
+  }
+  .coll-row.active {
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
+    border-left-color: var(--accent);
+    color: var(--accent);
+  }
+  .chevron, .chevron-spacer {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .chevron { cursor: pointer; }
+  .coll-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .coll-count {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .coll-row.active .coll-count { color: var(--accent); }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -558,6 +558,7 @@ export interface IdeApi {
   refactor: RefactorApi;
   formatter: FormatterApi;
   sources: SourcesApi;
+  collections: CollectionsApi;
   sites: SitesApi;
   bibliography: BibliographyApi;
   csl: CslApi;
@@ -690,6 +691,19 @@ export interface SourcesApi {
   }): Promise<{ excerptId: string; relativePath: string; duplicate: boolean }>;
   /** Fires when an excerpt is added, updated, or removed. */
   onExcerptsChanged(cb: () => void): void;
+}
+
+/** Manually-curated source collections (#470 phase 1). */
+export interface CollectionsApi {
+  list(): Promise<import('../../../shared/types').CollectionsFile>;
+  create(args: { name: string; parent?: string | null }): Promise<import('../../../shared/types').Collection>;
+  rename(id: string, name: string): Promise<void>;
+  remove(id: string): Promise<void>;
+  addSource(collectionId: string, sourceId: string): Promise<void>;
+  removeSource(collectionId: string, sourceId: string): Promise<void>;
+  /** Fires when a collection is added, renamed, deleted, or its
+   *  membership changes. */
+  onChanged(cb: () => void): void;
 }
 
 declare global {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -233,6 +233,18 @@ export const Channels = {
   /** Merge two sources: fold src's metadata into dest, move excerpts,
    *  rewrite `[[cite::src]]`, delete src folder (#90). */
   SOURCES_MERGE: 'sources:merge',
+
+  // Collections (#470)
+  /** Read `.minerva/collections.json` as a CollectionsFile. */
+  COLLECTIONS_LIST: 'collections:list',
+  COLLECTIONS_CREATE: 'collections:create',
+  COLLECTIONS_RENAME: 'collections:rename',
+  COLLECTIONS_DELETE: 'collections:delete',
+  COLLECTIONS_ADD_SOURCE: 'collections:addSource',
+  COLLECTIONS_REMOVE_SOURCE: 'collections:removeSource',
+  /** Broadcast from main when the collections file changes so any open
+   *  sidebar refreshes its tree. */
+  COLLECTIONS_CHANGED: 'collections:changed',
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */
   SOURCES_CHANGED: 'sources:changed',
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -164,6 +164,22 @@ export interface SourceDetail {
   aboutNotes: SourceAboutNote[];
 }
 
+/** Manually-curated source collection (#470 phase 1). Sources can
+ *  live in many collections. Smart (query-driven) collections will
+ *  be a separate type in the same file later. */
+export interface Collection {
+  id: string;
+  name: string;
+  /** Parent collection id, or null for a top-level collection. */
+  parent: string | null;
+  /** Source ids the user has put into this collection. */
+  members: string[];
+}
+
+export interface CollectionsFile {
+  collections: Collection[];
+}
+
 // ── Bookmarks ────────────────────────────────────────────────────────────
 
 export interface Bookmark {

--- a/tests/main/sources/collections.test.ts
+++ b/tests/main/sources/collections.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Manual source collections (#470 phase 1).
+ *
+ * The whole module is a thin layer on top of a single JSON file, so
+ * these tests exercise the operations against a real temp project
+ * rather than mocking the fs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  loadCollections,
+  createCollection,
+  renameCollection,
+  deleteCollection,
+  addSourceToCollection,
+  removeSourceFromCollection,
+  scrubSourceFromCollections,
+  rewriteCollectionMemberships,
+} from '../../../src/main/sources/collections';
+
+function mkTemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-collections-'));
+}
+
+describe('source collections (#470)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkTemp();
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns an empty file when collections.json is absent', async () => {
+    const data = await loadCollections(root);
+    expect(data).toEqual({ collections: [] });
+  });
+
+  it('creates a collection with a slug id derived from its name', async () => {
+    const c = await createCollection(root, { name: 'Reading list' });
+    expect(c.id).toBe('reading-list');
+    expect(c.name).toBe('Reading list');
+    expect(c.parent).toBeNull();
+    expect(c.members).toEqual([]);
+    const onDisk = JSON.parse(fs.readFileSync(path.join(root, '.minerva', 'collections.json'), 'utf-8'));
+    expect(onDisk.collections).toHaveLength(1);
+  });
+
+  it('assigns -2 / -3 suffixes on slug collision', async () => {
+    const a = await createCollection(root, { name: 'Reading' });
+    const b = await createCollection(root, { name: 'Reading' });
+    const c = await createCollection(root, { name: 'Reading' });
+    expect([a.id, b.id, c.id]).toEqual(['reading', 'reading-2', 'reading-3']);
+  });
+
+  it('refuses an empty name', async () => {
+    await expect(createCollection(root, { name: '   ' })).rejects.toThrow(/empty/);
+  });
+
+  it('refuses an unknown parent', async () => {
+    await expect(createCollection(root, { name: 'Child', parent: 'nope' })).rejects.toThrow(/parent/i);
+  });
+
+  it('renames a collection', async () => {
+    const c = await createCollection(root, { name: 'Reading list' });
+    await renameCollection(root, c.id, 'Lit review');
+    const data = await loadCollections(root);
+    expect(data.collections[0].name).toBe('Lit review');
+    // Id stays the same — renaming is cosmetic.
+    expect(data.collections[0].id).toBe('reading-list');
+  });
+
+  it('deletes a collection and re-parents its children to root', async () => {
+    const parent = await createCollection(root, { name: 'Research' });
+    const child = await createCollection(root, { name: 'Phase 1', parent: parent.id });
+    await deleteCollection(root, parent.id);
+    const data = await loadCollections(root);
+    expect(data.collections.map((c) => c.id)).toEqual([child.id]);
+    expect(data.collections[0].parent).toBeNull();
+  });
+
+  it('add/remove of a source updates membership', async () => {
+    const c = await createCollection(root, { name: 'Reading' });
+    await addSourceToCollection(root, c.id, 'smith-2023');
+    await addSourceToCollection(root, c.id, 'jones-2024');
+    let data = await loadCollections(root);
+    expect(data.collections[0].members).toEqual(['smith-2023', 'jones-2024']);
+    await removeSourceFromCollection(root, c.id, 'smith-2023');
+    data = await loadCollections(root);
+    expect(data.collections[0].members).toEqual(['jones-2024']);
+  });
+
+  it('addSourceToCollection is idempotent', async () => {
+    const c = await createCollection(root, { name: 'Reading' });
+    await addSourceToCollection(root, c.id, 'smith-2023');
+    await addSourceToCollection(root, c.id, 'smith-2023');
+    const data = await loadCollections(root);
+    expect(data.collections[0].members).toEqual(['smith-2023']);
+  });
+
+  it('a source can live in multiple collections', async () => {
+    const a = await createCollection(root, { name: 'Reading' });
+    const b = await createCollection(root, { name: 'Citing in chapter 3' });
+    await addSourceToCollection(root, a.id, 'smith-2023');
+    await addSourceToCollection(root, b.id, 'smith-2023');
+    const data = await loadCollections(root);
+    expect(data.collections.find((c) => c.id === a.id)!.members).toEqual(['smith-2023']);
+    expect(data.collections.find((c) => c.id === b.id)!.members).toEqual(['smith-2023']);
+  });
+
+  it('scrubSourceFromCollections drops a removed source from every collection', async () => {
+    const a = await createCollection(root, { name: 'A' });
+    const b = await createCollection(root, { name: 'B' });
+    await addSourceToCollection(root, a.id, 'smith-2023');
+    await addSourceToCollection(root, b.id, 'smith-2023');
+    await addSourceToCollection(root, b.id, 'jones-2024');
+
+    await scrubSourceFromCollections(root, 'smith-2023');
+
+    const data = await loadCollections(root);
+    expect(data.collections.find((c) => c.id === a.id)!.members).toEqual([]);
+    expect(data.collections.find((c) => c.id === b.id)!.members).toEqual(['jones-2024']);
+  });
+
+  it('rewriteCollectionMemberships moves src → dest in every collection', async () => {
+    const a = await createCollection(root, { name: 'A' });
+    const b = await createCollection(root, { name: 'B' });
+    await addSourceToCollection(root, a.id, 'arxiv-1234');
+    await addSourceToCollection(root, b.id, 'doi-10-1');
+    await addSourceToCollection(root, b.id, 'arxiv-1234');
+
+    await rewriteCollectionMemberships(root, 'arxiv-1234', 'doi-10-1');
+
+    const data = await loadCollections(root);
+    expect(data.collections.find((c) => c.id === a.id)!.members).toEqual(['doi-10-1']);
+    // b already had dest; src is removed; no duplicate appended.
+    expect(data.collections.find((c) => c.id === b.id)!.members).toEqual(['doi-10-1']);
+  });
+
+  it('rewriteCollectionMemberships is a no-op when src === dest', async () => {
+    const c = await createCollection(root, { name: 'C' });
+    await addSourceToCollection(root, c.id, 'smith-2023');
+    await rewriteCollectionMemberships(root, 'smith-2023', 'smith-2023');
+    const data = await loadCollections(root);
+    expect(data.collections[0].members).toEqual(['smith-2023']);
+  });
+
+  it('tolerates a malformed collections.json by reading an empty file', async () => {
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva', 'collections.json'), 'not json', 'utf-8');
+    await expect(loadCollections(root)).rejects.toThrow(); // strict — better to surface than silently wipe
+  });
+
+  it('coerces partial records on load (defensive)', async () => {
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(
+      path.join(root, '.minerva', 'collections.json'),
+      JSON.stringify({
+        collections: [
+          { id: 'reading', name: 'Reading' /* members missing */ },
+          { name: 'no-id' }, // dropped
+          { id: 'with-string-parent', name: 'x', parent: 'reading', members: 'wrong-type' },
+        ],
+      }),
+      'utf-8',
+    );
+    const data = await loadCollections(root);
+    const ids = data.collections.map((c) => c.id);
+    expect(ids).toContain('reading');
+    expect(ids).toContain('with-string-parent');
+    expect(ids).not.toContain('');
+    // members defaulted to [] when the field was the wrong type
+    expect(data.collections.find((c) => c.id === 'with-string-parent')!.members).toEqual([]);
+  });
+});


### PR DESCRIPTION
First half of #470 — Zotero-style hierarchical, manually-curated collections of sources. Smart (query-driven) collections will follow in a separate PR.

## Data model
Single \`.minerva/collections.json\` file. Embedded membership per collection — matches Zotero's mental model and keeps "list members of X" trivial. Per-project collection counts are typically O(10–50), so the simpler file shape is fine; no graph-resident contortions needed.

\`\`\`json
{
  "collections": [
    {
      "id": "reading-list",
      "name": "Reading list",
      "parent": "research",
      "members": ["smith-2023", "jones-2024"]
    }
  ]
}
\`\`\`

Sources live in many collections; a collection has one parent (tree). Renaming is cosmetic (id stays stable). Deleting a collection re-parents its children to root rather than cascading — less destructive, no scary confirmation needed.

## Backend (\`src/main/sources/collections.ts\`)
- Full CRUD + membership ops (\`createCollection\`, \`renameCollection\`, \`deleteCollection\`, \`addSourceToCollection\`, \`removeSourceFromCollection\`).
- \`scrubSourceFromCollections\` wired into \`deleteSource\` so a removed source doesn't linger as dead membership.
- \`rewriteCollectionMemberships\` wired into \`mergeSources\` (#90 part 2) so a merge transfers src's memberships to dest.
- Defensive load: tolerates partial records, missing fields, wrong-type \`members\`. Malformed JSON surfaces an error rather than silently wiping — the user's data should never be lost to a typo.

## IPC
- New \`collections:{list,create,rename,delete,addSource,removeSource}\` channels.
- \`collections:changed\` broadcast — cross-window / direct-edit refresh.
- Preload exposes \`api.collections.*\`.

## UI (\`SourcesPanel.svelte\`)
- New "Collections" section above the source list. Tree with per-row counts (subtree-rooted), expansion state persisted to localStorage. "All sources" pseudo-row at the top clears the filter.
- Right-click a source → "Add to collection…" / "Remove from collection" (when one's focused) / "Merge into…" / "Delete".
- Right-click a collection → "New nested collection…" / "Rename…" / "Delete".
- New \`CollectionPickerDialog\` (parallel to \`SourcePickerDialog\`, same palette feel) with breadcrumb labels so two like-named nested collections disambiguate.
- \`onShowPrompt\` prop threaded App → Sidebar → SourcesPanel for rename / new-collection prompts.

## Bonus: \`PromptDialog\` \`initial\` prop
Pre-seeds the input (and selects it) for Rename-style flows. Two-overload \`showPrompt\` accepts either the existing \`{suggestions}\` object or a bare initial string — existing call sites unchanged.

## Tests
15 unit cases in \`collections.test.ts\` covering every operation, slug collision, partial-record load tolerance, idempotent adds, the \`src===dest\` no-op guard, and the scrub/rewrite hooks for delete & merge integration. Full suite 2273 / 2273 (+15).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Create a top-level collection \"Research\"; create \"Phase 1\" nested under it.
  2. Right-click a source → Add to collection → pick \"Research\". Click \"Research\" in the sidebar; the source appears.
  3. Right-click \"Research\" → Rename. Confirm the count survives and the active filter stays in sync.
  4. Right-click \"Research\" → Delete; \"Phase 1\" becomes top-level.
  5. Delete a source from the Sources panel — confirm it's also gone from any collection it was in.
  6. Merge source A into B (#90 part 2 flow) — confirm B inherits A's collection memberships.

## Out of scope (follow-up PRs)
- Smart collections (saved-query backed, tag-predicate first)
- Drag-and-drop assignment (right-click works; drag-drop is a separate UX increment)

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)