### PR TITLE
feat: create collection inline from the Add-to-collection picker (#470)

### DIFF
--- a/src/renderer/lib/components/CollectionPickerDialog.svelte
+++ b/src/renderer/lib/components/CollectionPickerDialog.svelte
@@ -8,13 +8,22 @@
     onCancel: () => void;
     title: string;
     placeholder?: string;
+    /** When provided, an inline "Create new collection: <query>" row
+     *  appears whenever the typed name doesn't match an existing
+     *  collection. Activating it creates the collection, then the
+     *  dialog auto-selects the new id — one-shot "make + pick"
+     *  without bouncing through a separate modal. (#470) */
+    onCreate?: (name: string) => Promise<string>;
   }
 
-  let { collections, onSelect, onCancel, title, placeholder = 'Filter collections…' }: Props = $props();
+  let { collections, onSelect, onCancel, title, placeholder = 'Filter collections…', onCreate }: Props = $props();
 
   let query = $state('');
   let selectedIndex = $state(0);
   let inputEl = $state<HTMLInputElement>();
+  /** Set while we're awaiting onCreate so the user can't trigger a
+   *  duplicate during the round-trip. */
+  let creating = $state(false);
 
   /** Build the full breadcrumb path for each collection so the user can
    *  disambiguate two like-named collections under different parents. */
@@ -43,8 +52,39 @@
     return sorted.filter((c) => (labels.get(c.id) ?? c.name).toLowerCase().includes(q));
   });
 
+  /** Whether to offer the "create new" affordance. We hide it when
+   *  the typed name is identical (case-insensitive) to an existing
+   *  collection — picking the existing one is what the user
+   *  probably wants. */
+  const canCreate = $derived.by(() => {
+    if (!onCreate) return false;
+    const q = query.trim();
+    if (!q) return false;
+    const lower = q.toLowerCase();
+    return !collections.some((c) => c.name.toLowerCase() === lower);
+  });
+
+  /** When canCreate is true, the create row sits at index 0 and the
+   *  existing results are offset by 1. Keep this derivation in one
+   *  place so keyboard nav doesn't drift from the rendered list. */
+  const createRowOffset = $derived(canCreate ? 1 : 0);
+  const itemCount = $derived(results.length + createRowOffset);
+
+  async function activateCreate(): Promise<void> {
+    if (!onCreate || creating) return;
+    creating = true;
+    try {
+      const newId = await onCreate(query.trim());
+      onSelect(newId);
+    } catch (err) {
+      console.error('[minerva] CollectionPickerDialog: create failed:', err);
+    } finally {
+      creating = false;
+    }
+  }
+
   $effect(() => {
-    results;
+    itemCount;
     selectedIndex = 0;
   });
   $effect(() => { inputEl?.focus(); });
@@ -56,13 +96,17 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
+      selectedIndex = Math.min(selectedIndex + 1, Math.max(0, itemCount - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       selectedIndex = Math.max(selectedIndex - 1, 0);
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      const picked = results[selectedIndex];
+      if (canCreate && selectedIndex === 0) {
+        void activateCreate();
+        return;
+      }
+      const picked = results[selectedIndex - createRowOffset];
       if (picked) onSelect(picked.id);
     } else if (e.key === 'Escape') {
       onCancel();
@@ -78,15 +122,33 @@
       <Icon name="search" size={14} color="var(--text-muted)" />
       <input bind:this={inputEl} bind:value={query} type="text" class="input" {placeholder} />
     </div>
-    {#if results.length > 0}
+    {#if itemCount > 0}
       <ul class="cp-results">
+        {#if canCreate}
+          <li>
+            <button
+              class="result-item create-row"
+              class:selected={selectedIndex === 0}
+              disabled={creating}
+              onclick={() => void activateCreate()}
+              onmouseenter={() => { selectedIndex = 0; }}
+            >
+              <Icon name="plus" size={12} color={selectedIndex === 0 ? 'var(--accent)' : 'var(--text-faint)'} />
+              <span class="result-name">
+                <span class="create-prefix">Create new collection:</span>
+                <span class="create-name">{query.trim()}</span>
+              </span>
+            </button>
+          </li>
+        {/if}
         {#each results as c, i (c.id)}
+          {@const rowIndex = i + createRowOffset}
           <li>
             <button
               class="result-item"
-              class:selected={i === selectedIndex}
+              class:selected={rowIndex === selectedIndex}
               onclick={() => onSelect(c.id)}
-              onmouseenter={() => { selectedIndex = i; }}
+              onmouseenter={() => { selectedIndex = rowIndex; }}
             >
               <span class="result-name">{labels.get(c.id) ?? c.name}</span>
               <span class="result-count">{c.members.length}</span>
@@ -94,8 +156,10 @@
           </li>
         {/each}
       </ul>
-    {:else if collections.length === 0}
+    {:else if collections.length === 0 && !onCreate}
       <div class="no-results">No collections yet. Create one from the Sources panel first.</div>
+    {:else if collections.length === 0}
+      <div class="no-results">No collections yet. Type a name to create one.</div>
     {:else}
       <div class="no-results">No matching collections.</div>
     {/if}
@@ -182,6 +246,18 @@
     border-left-color: var(--accent);
   }
   .result-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .create-row .create-prefix {
+    color: var(--text-faint);
+    margin-right: 6px;
+  }
+  .create-row .create-name {
+    color: var(--text);
+    font-weight: 500;
+  }
+  .create-row.selected .create-prefix {
+    color: color-mix(in oklch, var(--accent) 70%, var(--text-muted));
+  }
+  .create-row:disabled { opacity: 0.6; cursor: default; }
   .result-count {
     font-family: var(--font-mono);
     font-size: 10.5px;

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -313,6 +313,22 @@
     }
   }
 
+  /** Used by the Add-to-collection picker's inline "Create new
+   *  collection: <typed name>" affordance. Creates the collection,
+   *  refreshes the local cache so the picker can resolve labels for
+   *  it, and returns the new id so the picker can complete its
+   *  selection flow. (#470) */
+  async function handleCreateFromPicker(name: string): Promise<string> {
+    const created = await api.collections.create({ name, parent: null });
+    // The COLLECTIONS_CHANGED broadcast will fire too, but kicking
+    // off a refresh here avoids the millisecond gap where the
+    // picker might list the new collection without resolving its
+    // breadcrumb label (since labels are derived from the local
+    // `collections` snapshot).
+    await refreshCollections();
+    return created.id;
+  }
+
   async function handleRemoveFromActiveCollection(source: SourceMetadata) {
     contextMenu = null;
     if (!activeCollectionId) return;
@@ -460,6 +476,7 @@
     title={`Add "${addToCollectionFor.title ?? addToCollectionFor.sourceId}" to collection…`}
     onSelect={handleAddToCollectionPick}
     onCancel={() => { addToCollectionFor = null; }}
+    onCreate={handleCreateFromPicker}
   />
 {/if}
 


### PR DESCRIPTION
Small UX follow-up to #583 (manual collections). When the user reaches for "Add to collection…" but the right collection doesn't exist yet, they had to cancel, create one via the sidebar's \`+\`, then re-open the picker. This adds the Linear-style inline-create affordance: type a name that doesn't match anything, hit Enter, the dialog creates the collection and immediately picks it.

## Behavior
- A "Create new collection: <typed name>" row appears at the top of the result list whenever there's a typed query AND no existing collection has that exact name (case-insensitive). Typing an existing name suppresses the create row — picking the duplicate is what the user almost certainly wants.
- Keyboard nav respects the new row: ↓ lands on Create (when present), ↑ lands back on Create, Enter activates whichever row is selected.
- A \`creating\` flag suppresses double-fire during the IPC round trip.

## Wiring
- \`CollectionPickerDialog\` gains an optional \`onCreate(name) => Promise<string>\` prop. When omitted (future read-only pickers), the affordance is hidden and behavior matches the prior version exactly.
- \`SourcesPanel.handleCreateFromPicker\` creates a top-level collection via the existing \`api.collections.create\` and refreshes the local snapshot so the picker can resolve the breadcrumb label for the new collection without a tick of "Untitled".

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes (2273 / 2273, no new tests — render-only logic)
- [ ] **UI verification**:
  1. Right-click a source → Add to collection…
  2. Type a name no collection has → see "Create new collection: <name>" row at the top.
  3. Press Enter → collection appears in the sidebar; source is added to it.
  4. Type the name of an existing collection → only the existing row shows (no Create row), to avoid duplicates.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)