### PR TITLE
feat: smart source collections — tag predicate (#470 phase 2)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -79,7 +79,13 @@ import {
   deleteCollection,
   addSourceToCollection,
   removeSourceFromCollection,
+  createSmartCollection,
+  renameSmartCollection,
+  deleteSmartCollection,
+  updateSmartCollectionPredicate,
+  resolveSmartMembers,
 } from './sources/collections';
+import type { SmartCollectionPredicate } from '../shared/types';
 import { importBibtex } from './sources/import-bibtex';
 import { importZoteroRdf } from './sources/import-zotero-rdf';
 import { dropImport } from './notebase/drop-import';
@@ -1638,6 +1644,51 @@ export function registerIpcHandlers(): void {
     if (!rootPath) throw new Error('No project open');
     await removeSourceFromCollection(rootPath, args.collectionId, args.sourceId);
     broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_CREATE_SMART, async (e, args: { name: string; predicate: SmartCollectionPredicate }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const result = await createSmartCollection(rootPath, args);
+    broadcastCollectionsChanged(e);
+    return result;
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_RENAME_SMART, async (e, args: { id: string; name: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await renameSmartCollection(rootPath, args.id, args.name);
+    broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_DELETE_SMART, async (e, id: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await deleteSmartCollection(rootPath, id);
+    broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, async (e, args: { id: string; predicate: SmartCollectionPredicate }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await updateSmartCollectionPredicate(rootPath, args.id, args.predicate);
+    broadcastCollectionsChanged(e);
+  });
+
+  ipcMain.handle(Channels.COLLECTIONS_SMART_MEMBERS, async (e, id: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    const data = await loadCollections(rootPath);
+    const smart = data.smartCollections.find((s) => s.id === id);
+    if (!smart) return [];
+    const ctx = projectContext(rootPath);
+    // Resolve via the graph's existing source-by-tag helper. The graph
+    // is the source of truth for hasTag edges (notes + sources) so we
+    // get the same membership semantics the tag panel surfaces.
+    const matchingIds = resolveSmartMembers(smart.predicate, (tag) => graph.sourcesByTag(ctx, tag));
+    if (matchingIds.size === 0) return [];
+    const all = graph.listAllSources(ctx);
+    return all.filter((s) => matchingIds.has(s.sourceId));
   });
 
   ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, async (e, params: {

--- a/src/main/sources/collections.ts
+++ b/src/main/sources/collections.ts
@@ -21,6 +21,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import type { SmartCollection, SmartCollectionPredicate } from '../../shared/types';
 
 export interface Collection {
   id: string;
@@ -34,6 +35,7 @@ export interface Collection {
 
 export interface CollectionsFile {
   collections: Collection[];
+  smartCollections: SmartCollection[];
 }
 
 function filePath(rootPath: string): string {
@@ -44,7 +46,21 @@ function filePath(rootPath: string): string {
  *  can read-modify-write without any chance of leaking state into
  *  the next read. */
 function emptyFile(): CollectionsFile {
-  return { collections: [] };
+  return { collections: [], smartCollections: [] };
+}
+
+/** Coerce an unknown into a SmartCollectionPredicate or null. Defensive
+ *  load tolerates a missing/bad predicate by dropping the smart entry
+ *  rather than guessing — the user's hand-edits get respected; a
+ *  truly broken record vanishes from the sidebar instead of crashing. */
+function parsePredicate(value: unknown): SmartCollectionPredicate | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as { kind?: unknown; allOf?: unknown };
+  if (v.kind === 'tags') {
+    const allOf = Array.isArray(v.allOf) ? v.allOf.filter((t): t is string => typeof t === 'string') : [];
+    return { kind: 'tags', allOf };
+  }
+  return null;
 }
 
 export async function loadCollections(rootPath: string): Promise<CollectionsFile> {
@@ -55,14 +71,24 @@ export async function loadCollections(rootPath: string): Promise<CollectionsFile
     const collections = Array.isArray((parsed as CollectionsFile).collections)
       ? (parsed as CollectionsFile).collections
       : [];
-    // Defensive: any record with a missing field falls through to safe defaults.
+    const smartCollections = Array.isArray((parsed as CollectionsFile).smartCollections)
+      ? (parsed as CollectionsFile).smartCollections
+      : [];
     return {
+      // Defensive: any record with a missing field falls through to safe defaults.
       collections: collections.map((c) => ({
         id: String(c.id ?? ''),
         name: String(c.name ?? ''),
         parent: c.parent == null ? null : String(c.parent),
         members: Array.isArray(c.members) ? c.members.map((m) => String(m)) : [],
       })).filter((c) => c.id),
+      smartCollections: smartCollections.map((s) => {
+        const predicate = parsePredicate(s.predicate);
+        if (!predicate) return null;
+        const id = String(s.id ?? '');
+        if (!id) return null;
+        return { id, name: String(s.name ?? id), predicate };
+      }).filter((s): s is SmartCollection => s !== null),
     };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyFile();
@@ -81,17 +107,28 @@ async function saveCollections(rootPath: string, data: CollectionsFile): Promise
  * exists, append `-2`, `-3`, … until unique. We don't generate UUIDs
  * here — when a user looks at `collections.json` they should be able
  * to spot which row is "Reading list" without cross-referencing.
+ *
+ * Manual + smart collections share the id namespace so the sidebar can
+ * use a single `activeCollectionId` field without disambiguating by
+ * kind on every read.
  */
-function uniqueIdFor(name: string, existing: ReadonlyArray<Collection>): string {
+function uniqueIdFor(name: string, taken: ReadonlySet<string>): string {
   const slug = name.toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 60) || 'collection';
-  if (!existing.some((c) => c.id === slug)) return slug;
+  if (!taken.has(slug)) return slug;
   for (let i = 2; ; i++) {
     const candidate = `${slug}-${i}`;
-    if (!existing.some((c) => c.id === candidate)) return candidate;
+    if (!taken.has(candidate)) return candidate;
   }
+}
+
+function takenIds(data: CollectionsFile): Set<string> {
+  const out = new Set<string>();
+  for (const c of data.collections) out.add(c.id);
+  for (const s of data.smartCollections) out.add(s.id);
+  return out;
 }
 
 export interface CreateCollectionArgs {
@@ -107,7 +144,7 @@ export async function createCollection(rootPath: string, args: CreateCollectionA
     throw new Error(`Parent collection "${args.parent}" not found.`);
   }
   const collection: Collection = {
-    id: uniqueIdFor(trimmed, data.collections),
+    id: uniqueIdFor(trimmed, takenIds(data)),
     name: trimmed,
     parent: args.parent ?? null,
     members: [],
@@ -195,6 +232,9 @@ export async function scrubSourceFromCollections(rootPath: string, sourceId: str
  * When src is being merged into dest (#90 part 2), src's collection
  * memberships should follow it: any collection that contained src
  * should contain dest, and src itself should be scrubbed. Idempotent.
+ *
+ * Smart collections need no rewrite — their membership is derived
+ * from the graph, which the merge already updated.
  */
 export async function rewriteCollectionMemberships(
   rootPath: string,
@@ -212,4 +252,112 @@ export async function rewriteCollectionMemberships(
     mutated = true;
   }
   if (mutated) await saveCollections(rootPath, data);
+}
+
+// ─── Smart collections (#470 phase 2) ────────────────────────────────────
+
+export interface CreateSmartCollectionArgs {
+  name: string;
+  predicate: SmartCollectionPredicate;
+}
+
+export async function createSmartCollection(
+  rootPath: string,
+  args: CreateSmartCollectionArgs,
+): Promise<SmartCollection> {
+  const trimmed = args.name.trim();
+  if (!trimmed) throw new Error('Smart collection name cannot be empty.');
+  validatePredicate(args.predicate);
+  const data = await loadCollections(rootPath);
+  const smart: SmartCollection = {
+    id: uniqueIdFor(trimmed, takenIds(data)),
+    name: trimmed,
+    predicate: args.predicate,
+  };
+  data.smartCollections.push(smart);
+  await saveCollections(rootPath, data);
+  return smart;
+}
+
+export async function renameSmartCollection(rootPath: string, id: string, newName: string): Promise<void> {
+  const trimmed = newName.trim();
+  if (!trimmed) throw new Error('Smart collection name cannot be empty.');
+  const data = await loadCollections(rootPath);
+  const target = data.smartCollections.find((s) => s.id === id);
+  if (!target) throw new Error(`Smart collection "${id}" not found.`);
+  target.name = trimmed;
+  await saveCollections(rootPath, data);
+}
+
+export async function deleteSmartCollection(rootPath: string, id: string): Promise<void> {
+  const data = await loadCollections(rootPath);
+  const before = data.smartCollections.length;
+  data.smartCollections = data.smartCollections.filter((s) => s.id !== id);
+  if (data.smartCollections.length === before) {
+    throw new Error(`Smart collection "${id}" not found.`);
+  }
+  await saveCollections(rootPath, data);
+}
+
+export async function updateSmartCollectionPredicate(
+  rootPath: string,
+  id: string,
+  predicate: SmartCollectionPredicate,
+): Promise<void> {
+  validatePredicate(predicate);
+  const data = await loadCollections(rootPath);
+  const target = data.smartCollections.find((s) => s.id === id);
+  if (!target) throw new Error(`Smart collection "${id}" not found.`);
+  target.predicate = predicate;
+  await saveCollections(rootPath, data);
+}
+
+function validatePredicate(p: SmartCollectionPredicate): void {
+  if (p.kind === 'tags') {
+    if (!Array.isArray(p.allOf)) throw new Error('Tag predicate.allOf must be an array.');
+    for (const t of p.allOf) {
+      if (typeof t !== 'string' || !t.trim()) {
+        throw new Error('Tag predicate.allOf must contain non-empty strings.');
+      }
+    }
+    return;
+  }
+  // Exhaustiveness: the type union ensures the compiler catches missing
+  // branches when new predicate kinds land.
+  const _exhaustive: never = p.kind;
+  throw new Error(`Unsupported predicate kind: ${_exhaustive as string}`);
+}
+
+/**
+ * Compute the source ids that satisfy a smart-collection's predicate.
+ *
+ * Tags ALL-OF semantics: a source is a member iff its
+ * `minerva:hasTag` edges include every tag in `allOf`. Empty `allOf`
+ * matches nothing — a smart collection with no constraints is almost
+ * certainly a half-edited mistake, and silently matching every
+ * source would look like a bug.
+ *
+ * Resolved against the in-memory graph via `sourcesByTag` so we get
+ * the same predicate semantics the tag panel uses.
+ */
+export function resolveSmartMembers(
+  predicate: SmartCollectionPredicate,
+  sourcesByTag: (tag: string) => ReadonlyArray<{ sourceId: string }>,
+): Set<string> {
+  if (predicate.kind === 'tags') {
+    if (predicate.allOf.length === 0) return new Set();
+    let acc: Set<string> | null = null;
+    for (const tag of predicate.allOf) {
+      const ids = new Set(sourcesByTag(tag).map((s) => s.sourceId));
+      if (acc === null) {
+        acc = ids;
+      } else {
+        for (const x of acc) if (!ids.has(x)) acc.delete(x);
+      }
+      if (acc.size === 0) break;
+    }
+    return acc ?? new Set();
+  }
+  const _exhaustive: never = predicate.kind;
+  throw new Error(`Unsupported predicate kind: ${_exhaustive as string}`);
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -282,6 +282,15 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.COLLECTIONS_ADD_SOURCE, { collectionId, sourceId }),
     removeSource: (collectionId: string, sourceId: string) =>
       ipcRenderer.invoke(Channels.COLLECTIONS_REMOVE_SOURCE, { collectionId, sourceId }),
+    createSmart: (args: { name: string; predicate: { kind: 'tags'; allOf: string[] } }) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_CREATE_SMART, args),
+    renameSmart: (id: string, name: string) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_RENAME_SMART, { id, name }),
+    removeSmart: (id: string) => ipcRenderer.invoke(Channels.COLLECTIONS_DELETE_SMART, id),
+    updateSmartPredicate: (id: string, predicate: { kind: 'tags'; allOf: string[] }) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, { id, predicate }),
+    smartMembers: (id: string) =>
+      ipcRenderer.invoke(Channels.COLLECTIONS_SMART_MEMBERS, id),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.COLLECTIONS_CHANGED, () => cb());
     },

--- a/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
+++ b/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
@@ -1,0 +1,318 @@
+<script lang="ts">
+  /**
+   * Create / edit a smart collection backed by a tag predicate (#470 phase 2).
+   *
+   * v1 supports the `tags allOf` predicate only — the user picks N tags
+   * and a source is a member when it carries every one. The dialog
+   * surfaces project tag vocabulary via `api.tags.list()` so the user
+   * doesn't have to remember spellings.
+   *
+   * Future predicate kinds (faceted, raw SPARQL) will extend this
+   * dialog with a kind-picker; for now the kind is hardcoded.
+   */
+  import { api } from '../ipc/client';
+  import type { SmartCollection, SmartCollectionPredicate, TagInfo } from '../../../shared/types';
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    /** When provided, the dialog opens in edit mode pre-filled with
+     *  this collection's name + predicate. Omit for the create flow. */
+    editing?: SmartCollection;
+    onSave: (name: string, predicate: SmartCollectionPredicate) => Promise<void>;
+    onCancel: () => void;
+  }
+
+  let { editing, onSave, onCancel }: Props = $props();
+
+  const mode = $derived<'create' | 'edit'>(editing ? 'edit' : 'create');
+  let name = $state(editing?.name ?? '');
+  /** Picked tags (allOf), preserved as a Set for O(1) lookup in the
+   *  template. Initialised from the editing predicate when present. */
+  let selected = $state<Set<string>>(new Set(
+    editing && editing.predicate.kind === 'tags' ? editing.predicate.allOf : [],
+  ));
+  let tagFilter = $state('');
+  let saving = $state(false);
+  let allTags = $state<TagInfo[]>([]);
+  let nameInputEl = $state<HTMLInputElement>();
+
+  $effect(() => { void loadTags(); });
+  $effect(() => { nameInputEl?.focus(); });
+
+  async function loadTags(): Promise<void> {
+    allTags = await api.tags.list();
+    // Restore any pre-selected tag that doesn't appear in the live
+    // project vocabulary (e.g. the predicate references a tag that's
+    // since been removed from every source). We still show it so the
+    // user can either keep it or uncheck it deliberately.
+    for (const t of selected) {
+      if (!allTags.some((info) => info.tag === t)) {
+        allTags = [...allTags, { tag: t, noteCount: 0, sourceCount: 0 }];
+      }
+    }
+  }
+
+  const visibleTags = $derived.by(() => {
+    const q = tagFilter.trim().toLowerCase();
+    const list = q ? allTags.filter((t) => t.tag.toLowerCase().includes(q)) : allTags;
+    // Pinned at top: anything currently selected, so the user can
+    // see their picks even after filtering.
+    return [...list].sort((a, b) => {
+      const aPicked = selected.has(a.tag) ? 0 : 1;
+      const bPicked = selected.has(b.tag) ? 0 : 1;
+      if (aPicked !== bPicked) return aPicked - bPicked;
+      return a.tag.localeCompare(b.tag);
+    });
+  });
+
+  function toggleTag(tag: string) {
+    const next = new Set(selected);
+    if (next.has(tag)) next.delete(tag); else next.add(tag);
+    selected = next;
+  }
+
+  const canSave = $derived(name.trim().length > 0 && selected.size > 0 && !saving);
+
+  async function handleSave(): Promise<void> {
+    if (!canSave) return;
+    saving = true;
+    try {
+      await onSave(name.trim(), { kind: 'tags', allOf: [...selected] });
+    } finally {
+      saving = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+    else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void handleSave();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-label={mode === 'create' ? 'New smart collection' : 'Edit smart collection'}>
+    <header class="card-header">
+      <div class="eyebrow">{mode === 'create' ? 'NEW SMART COLLECTION' : 'EDIT SMART COLLECTION'}</div>
+      <input
+        bind:this={nameInputEl}
+        type="text"
+        class="name-input"
+        placeholder="Collection name"
+        bind:value={name}
+      />
+    </header>
+
+    <section class="body">
+      <div class="rule-label">Sources tagged with <strong>all</strong> of:</div>
+      <div class="tag-filter-row">
+        <Icon name="search" size={12} color="var(--text-muted)" />
+        <input
+          type="text"
+          class="tag-filter"
+          placeholder="Filter tags…"
+          bind:value={tagFilter}
+        />
+        <span class="picked-count">{selected.size} picked</span>
+      </div>
+      <div class="tag-list">
+        {#if visibleTags.length === 0}
+          {#if allTags.length === 0}
+            <div class="empty">No tags in project yet.</div>
+          {:else}
+            <div class="empty">No tags match "{tagFilter}".</div>
+          {/if}
+        {:else}
+          {#each visibleTags as t (t.tag)}
+            <label class="tag-row" class:checked={selected.has(t.tag)}>
+              <input
+                type="checkbox"
+                checked={selected.has(t.tag)}
+                onchange={() => toggleTag(t.tag)}
+              />
+              <span class="tag-name">#{t.tag}</span>
+              <span class="tag-count">{t.sourceCount}</span>
+            </label>
+          {/each}
+        {/if}
+      </div>
+    </section>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ⌘↵ save</span>
+      <span class="footer-actions">
+        <button class="btn secondary" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={!canSave} onclick={handleSave}>
+          {saving ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 520px;
+    max-width: 100%;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+  .card-header { padding: 18px 22px 12px; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+  }
+  .name-input {
+    width: 100%;
+    padding: 7px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 15px;
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+  .body {
+    padding: 8px 22px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1;
+    overflow: hidden;
+  }
+  .rule-label {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .rule-label strong { color: var(--text); font-weight: 500; }
+  .tag-filter-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+  }
+  .tag-filter {
+    flex: 1;
+    border: none;
+    background: transparent;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    outline: none;
+    padding: 0;
+  }
+  .picked-count {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .tag-list {
+    flex: 1;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 0;
+    background: var(--bg);
+  }
+  .empty {
+    padding: 16px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .tag-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 12px;
+    cursor: pointer;
+  }
+  .tag-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .tag-row.checked .tag-name { color: var(--accent); }
+  .tag-row input { cursor: pointer; }
+  .tag-name {
+    flex: 1;
+    min-width: 0;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tag-count {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-actions { display: inline-flex; gap: 8px; }
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .secondary {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .secondary:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover:not(:disabled) { opacity: 0.92; }
+  .primary:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { api } from '../ipc/client';
-  import type { SourceMetadata, Collection } from '../../../shared/types';
+  import type { SourceMetadata, Collection, SmartCollection, SmartCollectionPredicate } from '../../../shared/types';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import SourcePickerDialog from './SourcePickerDialog.svelte';
   import CollectionPickerDialog from './CollectionPickerDialog.svelte';
+  import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
   import Icon from './Icon.svelte';
 
   interface Props {
@@ -27,8 +28,26 @@
   let addToCollectionFor = $state<SourceMetadata | null>(null);
 
   let collections = $state<Collection[]>([]);
-  /** Currently focused collection id; null = "All sources". */
+  let smartCollections = $state<SmartCollection[]>([]);
+  /** Currently focused collection id; null = "All sources". Manual and
+   *  smart ids live in the same namespace (the backend uniqueIdFor
+   *  enforces this) so a single field is enough. */
   let activeCollectionId = $state<string | null>(null);
+  /** Members of the currently focused smart collection. Re-fetched
+   *  when activeCollectionId changes to a smart entry, since
+   *  membership is derived not stored. */
+  let smartMembers = $state<Set<string> | null>(null);
+  /** Smart-collection editor dialog state. `mode === 'edit'` carries
+   *  the existing collection so the dialog seeds its inputs. */
+  let smartEditor = $state<
+    | { mode: 'create' }
+    | { mode: 'edit'; collection: SmartCollection }
+    | null
+  >(null);
+  /** + button popover menu state — used to disambiguate "new manual"
+   *  vs "new smart". */
+  let newCollectionMenu = $state<{ x: number; y: number } | null>(null);
+  let newCollectionMenuEl = $state<HTMLDivElement | undefined>();
   /** Persisted expansion state of the collection tree (per project would
    *  be nicer, but matches the convention already used by the right
    *  sidebar's tag tree). */
@@ -84,7 +103,26 @@
   async function refreshCollections(): Promise<void> {
     const data = await api.collections.list();
     collections = data.collections;
+    smartCollections = data.smartCollections ?? [];
+    // If the active smart collection still exists, refresh its
+    // membership in case the predicate changed (rename doesn't, but
+    // edit-predicate does). Cheap enough to always do.
+    if (activeCollectionId && smartCollections.some((s) => s.id === activeCollectionId)) {
+      smartMembers = new Set((await api.collections.smartMembers(activeCollectionId)).map((s) => s.sourceId));
+    } else if (activeCollectionId && !collections.some((c) => c.id === activeCollectionId)) {
+      // The active collection was deleted by an out-of-band edit.
+      activeCollectionId = null;
+      smartMembers = null;
+    }
   }
+
+  $effect(() => {
+    if (!newCollectionMenu || !newCollectionMenuEl) return;
+    const next = clampMenuToViewport(newCollectionMenu.x, newCollectionMenu.y, newCollectionMenuEl);
+    if (next.x !== newCollectionMenu.x || next.y !== newCollectionMenu.y) {
+      newCollectionMenu = { ...newCollectionMenu, ...next };
+    }
+  });
 
   function handleContextMenu(e: MouseEvent, source: SourceMetadata) {
     e.preventDefault();
@@ -146,12 +184,18 @@
     sources = await api.sources.listAll();
   }
 
-  /** Collection ids in the active subtree (the focused collection and
-   *  every descendant). Selecting a parent collection shows everything
-   *  filed under it — matches what users expect from Zotero's "include
-   *  child collections" default. */
+  const activeIsSmart = $derived(
+    !!activeCollectionId && smartCollections.some((s) => s.id === activeCollectionId),
+  );
+
+  /** Collection ids in the active subtree (the focused manual
+   *  collection and every descendant). Selecting a parent shows
+   *  everything filed under it — matches what users expect from
+   *  Zotero's "include child collections" default. Returns null
+   *  when nothing is focused, or when the focused entry is a smart
+   *  collection (which has no subtree). */
   const activeSubtree = $derived.by(() => {
-    if (!activeCollectionId) return null;
+    if (!activeCollectionId || activeIsSmart) return null;
     const out = new Set<string>([activeCollectionId]);
     let added = true;
     while (added) {
@@ -166,8 +210,12 @@
     return out;
   });
 
-  /** Source ids in the active subtree (union of all member arrays). */
+  /** Source ids the active collection contributes. For manual: union
+   *  of every member array in the subtree. For smart: the live
+   *  smartMembers set from the IPC. */
   const activeMembers = $derived.by(() => {
+    if (!activeCollectionId) return null;
+    if (activeIsSmart) return smartMembers;
     if (!activeSubtree) return null;
     const out = new Set<string>();
     for (const c of collections) {
@@ -247,8 +295,13 @@
     persistExpanded();
   }
 
-  function selectCollection(id: string | null) {
+  async function selectCollection(id: string | null) {
     activeCollectionId = id;
+    if (id && smartCollections.some((s) => s.id === id)) {
+      smartMembers = new Set((await api.collections.smartMembers(id)).map((s) => s.sourceId));
+    } else {
+      smartMembers = null;
+    }
   }
 
   function handleCollectionContextMenu(e: MouseEvent, collection: Collection) {
@@ -257,6 +310,41 @@
     collectionMenu = { x: e.clientX, y: e.clientY, collection };
     const close = () => { collectionMenu = null; window.removeEventListener('click', close); };
     setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  let smartMenu = $state<{ x: number; y: number; smart: SmartCollection } | null>(null);
+  let smartMenuEl = $state<HTMLDivElement | undefined>();
+  $effect(() => {
+    if (!smartMenu || !smartMenuEl) return;
+    const next = clampMenuToViewport(smartMenu.x, smartMenu.y, smartMenuEl);
+    if (next.x !== smartMenu.x || next.y !== smartMenu.y) {
+      smartMenu = { ...smartMenu, ...next };
+    }
+  });
+
+  function handleSmartContextMenu(e: MouseEvent, smart: SmartCollection) {
+    e.preventDefault();
+    e.stopPropagation();
+    smartMenu = { x: e.clientX, y: e.clientY, smart };
+    const close = () => { smartMenu = null; window.removeEventListener('click', close); };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  function openNewCollectionMenu(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    newCollectionMenu = { x: rect.right, y: rect.bottom + 2 };
+    const close = () => { newCollectionMenu = null; window.removeEventListener('click', close); };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  function smartHoverHint(s: SmartCollection): string {
+    if (s.predicate.kind === 'tags') {
+      const tags = s.predicate.allOf.map((t) => `#${t}`).join(' AND ');
+      return tags || s.id;
+    }
+    return s.id;
   }
 
   async function handleNewCollection(parent: string | null = null): Promise<void> {
@@ -294,6 +382,70 @@
       await api.collections.remove(c.id);
     } catch (err) {
       console.error('[minerva] Delete collection failed:', err);
+    }
+  }
+
+  function handleNewSmartCollection(): void {
+    newCollectionMenu = null;
+    smartEditor = { mode: 'create' };
+  }
+
+  function handleEditSmart(smart: SmartCollection): void {
+    smartMenu = null;
+    smartEditor = { mode: 'edit', collection: smart };
+  }
+
+  async function handleRenameSmart(smart: SmartCollection): Promise<void> {
+    smartMenu = null;
+    const name = await onShowPrompt('Rename smart collection:', smart.name);
+    if (!name || name === smart.name) return;
+    try {
+      await api.collections.renameSmart(smart.id, name);
+    } catch (err) {
+      console.error('[minerva] Rename smart collection failed:', err);
+    }
+  }
+
+  async function handleDeleteSmart(smart: SmartCollection): Promise<void> {
+    smartMenu = null;
+    const confirmed = await onShowConfirm(
+      `Delete smart collection "${smart.name}"? Its result set is derived, so no sources are removed.`,
+      'delete-smart-collection',
+      'Delete',
+    );
+    if (!confirmed) return;
+    if (activeCollectionId === smart.id) {
+      activeCollectionId = null;
+      smartMembers = null;
+    }
+    try {
+      await api.collections.removeSmart(smart.id);
+    } catch (err) {
+      console.error('[minerva] Delete smart collection failed:', err);
+    }
+  }
+
+  async function handleSmartEditorSave(name: string, predicate: SmartCollectionPredicate): Promise<void> {
+    const editor = smartEditor;
+    smartEditor = null;
+    if (!editor) return;
+    try {
+      if (editor.mode === 'create') {
+        const created = await api.collections.createSmart({ name, predicate });
+        // Auto-focus the new collection so the user sees what they
+        // just made (mirrors the create-from-picker UX).
+        await selectCollection(created.id);
+      } else {
+        const c = editor.collection;
+        if (name !== c.name) await api.collections.renameSmart(c.id, name);
+        await api.collections.updateSmartPredicate(c.id, predicate);
+        // Re-fetch members if this is the active one.
+        if (activeCollectionId === c.id) {
+          smartMembers = new Set((await api.collections.smartMembers(c.id)).map((s) => s.sourceId));
+        }
+      }
+    } catch (err) {
+      console.error('[minerva] Save smart collection failed:', err);
     }
   }
 
@@ -354,7 +506,7 @@
     <div class="collections-section">
       <div class="collections-header">
         <span class="collections-eyebrow">COLLECTIONS</span>
-        <button class="new-coll" onclick={() => handleNewCollection(null)} title="New collection">
+        <button class="new-coll" onclick={openNewCollectionMenu} title="New collection…">
           <Icon name="plus" size={11} color="var(--text-muted)" />
         </button>
       </div>
@@ -393,6 +545,23 @@
           <span class="coll-count">{counts.get(row.collection.id) ?? 0}</span>
         </button>
       {/each}
+
+      {#if smartCollections.length > 0}
+        <div class="smart-divider">SMART</div>
+        {#each smartCollections as s (s.id)}
+          <button
+            class="coll-row smart-row"
+            class:active={activeCollectionId === s.id}
+            onclick={() => selectCollection(s.id)}
+            oncontextmenu={(e) => handleSmartContextMenu(e, s)}
+            title={smartHoverHint(s)}
+          >
+            <span class="chevron-spacer"></span>
+            <Icon name="search" size={11} color={activeCollectionId === s.id ? 'var(--accent)' : 'var(--text-faint)'} />
+            <span class="coll-name">{s.name}</span>
+          </button>
+        {/each}
+      {/if}
     </div>
 
     <div class="filter-row">
@@ -400,7 +569,11 @@
         type="text"
         class="filter-input"
         placeholder={activeCollectionId
-          ? `Filter "${collections.find((c) => c.id === activeCollectionId)?.name ?? 'collection'}"…`
+          ? `Filter "${
+              collections.find((c) => c.id === activeCollectionId)?.name
+              ?? smartCollections.find((s) => s.id === activeCollectionId)?.name
+              ?? 'collection'
+            }"…`
           : 'Filter sources…'}
         bind:value={filter}
       />
@@ -457,6 +630,29 @@
       <button onclick={() => handleDeleteCollection(collectionMenu!.collection)}>Delete</button>
     </div>
   {/if}
+  {#if smartMenu}
+    <div
+      class="context-menu"
+      bind:this={smartMenuEl}
+      style:left="{smartMenu.x}px"
+      style:top="{smartMenu.y}px"
+    >
+      <button onclick={() => handleEditSmart(smartMenu!.smart)}>Edit query…</button>
+      <button onclick={() => handleRenameSmart(smartMenu!.smart)}>Rename…</button>
+      <button onclick={() => handleDeleteSmart(smartMenu!.smart)}>Delete</button>
+    </div>
+  {/if}
+  {#if newCollectionMenu}
+    <div
+      class="context-menu"
+      bind:this={newCollectionMenuEl}
+      style:left="{newCollectionMenu.x}px"
+      style:top="{newCollectionMenu.y}px"
+    >
+      <button onclick={() => { newCollectionMenu = null; void handleNewCollection(null); }}>New collection…</button>
+      <button onclick={handleNewSmartCollection}>New smart collection…</button>
+    </div>
+  {/if}
 </div>
 
 {#if mergeSrc}
@@ -477,6 +673,14 @@
     onSelect={handleAddToCollectionPick}
     onCancel={() => { addToCollectionFor = null; }}
     onCreate={handleCreateFromPicker}
+  />
+{/if}
+
+{#if smartEditor}
+  <SmartCollectionEditorDialog
+    editing={smartEditor.mode === 'edit' ? smartEditor.collection : undefined}
+    onSave={handleSmartEditorSave}
+    onCancel={() => { smartEditor = null; }}
   />
 {/if}
 
@@ -679,4 +883,16 @@
     flex-shrink: 0;
   }
   .coll-row.active .coll-count { color: var(--accent); }
+
+  /* SMART subsection — kept visually subordinate so the manual tree
+     stays the primary affordance. Small uppercase divider, no count
+     badge (the row's hover tooltip carries the predicate). */
+  .smart-divider {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    padding: 8px 14px 2px;
+  }
+  .smart-row { gap: 6px; }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -693,7 +693,7 @@ export interface SourcesApi {
   onExcerptsChanged(cb: () => void): void;
 }
 
-/** Manually-curated source collections (#470 phase 1). */
+/** Source collections (#470). */
 export interface CollectionsApi {
   list(): Promise<import('../../../shared/types').CollectionsFile>;
   create(args: { name: string; parent?: string | null }): Promise<import('../../../shared/types').Collection>;
@@ -701,8 +701,16 @@ export interface CollectionsApi {
   remove(id: string): Promise<void>;
   addSource(collectionId: string, sourceId: string): Promise<void>;
   removeSource(collectionId: string, sourceId: string): Promise<void>;
-  /** Fires when a collection is added, renamed, deleted, or its
-   *  membership changes. */
+  /** Smart-collection CRUD (#470 phase 2 — tag predicate). */
+  createSmart(args: { name: string; predicate: import('../../../shared/types').SmartCollectionPredicate }):
+    Promise<import('../../../shared/types').SmartCollection>;
+  renameSmart(id: string, name: string): Promise<void>;
+  removeSmart(id: string): Promise<void>;
+  updateSmartPredicate(id: string, predicate: import('../../../shared/types').SmartCollectionPredicate): Promise<void>;
+  /** Resolve a smart collection's members against the live graph. */
+  smartMembers(id: string): Promise<import('../../../shared/types').SourceMetadata[]>;
+  /** Fires when a collection (manual or smart) is added, renamed,
+   *  deleted, or its membership changes. */
   onChanged(cb: () => void): void;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -245,6 +245,14 @@ export const Channels = {
   /** Broadcast from main when the collections file changes so any open
    *  sidebar refreshes its tree. */
   COLLECTIONS_CHANGED: 'collections:changed',
+  /** Smart-collection CRUD (#470 phase 2). */
+  COLLECTIONS_CREATE_SMART: 'collections:createSmart',
+  COLLECTIONS_RENAME_SMART: 'collections:renameSmart',
+  COLLECTIONS_DELETE_SMART: 'collections:deleteSmart',
+  COLLECTIONS_UPDATE_SMART_PREDICATE: 'collections:updateSmartPredicate',
+  /** Resolve a smart collection's members against the live graph.
+   *  Returns the matching SourceMetadata[] sorted by title. */
+  COLLECTIONS_SMART_MEMBERS: 'collections:smartMembers',
   /** Broadcast from main when a source is added/updated/removed so panels refresh. */
   SOURCES_CHANGED: 'sources:changed',
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -176,8 +176,31 @@ export interface Collection {
   members: string[];
 }
 
+/** Smart-collection predicate (#470 phase 2).
+ *
+ * Tagged union so future variants (read-status from #116, faceted
+ * filters, raw SPARQL) can join without disturbing the v1 tag
+ * predicate's storage shape. The renderer's predicate editor +
+ * the main-process member resolver each branch on `kind`. */
+export type SmartCollectionPredicate =
+  | { kind: 'tags'; allOf: string[] };
+
+/** Query-driven collection (#470 phase 2). Membership is computed
+ *  live from the graph each time the user opens it — never
+ *  persisted, so the result set tracks the underlying data as it
+ *  changes. Smart collections cannot be drag-targets; only
+ *  manual collections accept addSource. */
+export interface SmartCollection {
+  id: string;
+  name: string;
+  predicate: SmartCollectionPredicate;
+}
+
 export interface CollectionsFile {
   collections: Collection[];
+  /** Query-driven collections. Omitted when none are defined; the
+   *  loader normalises a missing field to `[]`. */
+  smartCollections?: SmartCollection[];
 }
 
 // ── Bookmarks ────────────────────────────────────────────────────────────

--- a/tests/main/sources/collections.test.ts
+++ b/tests/main/sources/collections.test.ts
@@ -20,6 +20,11 @@ import {
   removeSourceFromCollection,
   scrubSourceFromCollections,
   rewriteCollectionMemberships,
+  createSmartCollection,
+  renameSmartCollection,
+  deleteSmartCollection,
+  updateSmartCollectionPredicate,
+  resolveSmartMembers,
 } from '../../../src/main/sources/collections';
 
 function mkTemp(): string {
@@ -38,7 +43,7 @@ describe('source collections (#470)', () => {
 
   it('returns an empty file when collections.json is absent', async () => {
     const data = await loadCollections(root);
-    expect(data).toEqual({ collections: [] });
+    expect(data).toEqual({ collections: [], smartCollections: [] });
   });
 
   it('creates a collection with a slug id derived from its name', async () => {
@@ -156,6 +161,71 @@ describe('source collections (#470)', () => {
     await expect(loadCollections(root)).rejects.toThrow(); // strict — better to surface than silently wipe
   });
 
+  // ─── Smart collections (#470 phase 2) ──────────────────────────────────
+
+  it('creates a smart collection with a tag-allOf predicate', async () => {
+    const sc = await createSmartCollection(root, {
+      name: 'Reading',
+      predicate: { kind: 'tags', allOf: ['ml', 'review'] },
+    });
+    expect(sc.id).toBe('reading');
+    expect(sc.name).toBe('Reading');
+    expect(sc.predicate).toEqual({ kind: 'tags', allOf: ['ml', 'review'] });
+    const data = await loadCollections(root);
+    expect(data.smartCollections).toHaveLength(1);
+  });
+
+  it('smart and manual ids share a namespace', async () => {
+    await createCollection(root, { name: 'Reading' });
+    const smart = await createSmartCollection(root, {
+      name: 'Reading',
+      predicate: { kind: 'tags', allOf: ['x'] },
+    });
+    expect(smart.id).toBe('reading-2');
+  });
+
+  it('refuses empty predicate-tag entries', async () => {
+    await expect(createSmartCollection(root, {
+      name: 'Bad',
+      predicate: { kind: 'tags', allOf: ['ok', '   '] },
+    })).rejects.toThrow(/non-empty/);
+  });
+
+  it('rename / delete / update predicate operate on the smart entry', async () => {
+    const sc = await createSmartCollection(root, {
+      name: 'Reading',
+      predicate: { kind: 'tags', allOf: ['ml'] },
+    });
+    await renameSmartCollection(root, sc.id, 'Lit review');
+    await updateSmartCollectionPredicate(root, sc.id, { kind: 'tags', allOf: ['ml', 'review'] });
+    let data = await loadCollections(root);
+    expect(data.smartCollections[0]).toMatchObject({
+      name: 'Lit review',
+      predicate: { kind: 'tags', allOf: ['ml', 'review'] },
+    });
+    await deleteSmartCollection(root, sc.id);
+    data = await loadCollections(root);
+    expect(data.smartCollections).toEqual([]);
+  });
+
+  it('drops smart entries with an unknown predicate kind on load', async () => {
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(
+      path.join(root, '.minerva', 'collections.json'),
+      JSON.stringify({
+        collections: [],
+        smartCollections: [
+          { id: 'good', name: 'Good', predicate: { kind: 'tags', allOf: ['ml'] } },
+          { id: 'bad', name: 'Bad', predicate: { kind: 'aliens-from-the-future' } },
+          { id: 'no-predicate', name: 'No predicate' },
+        ],
+      }),
+      'utf-8',
+    );
+    const data = await loadCollections(root);
+    expect(data.smartCollections.map((s) => s.id)).toEqual(['good']);
+  });
+
   it('coerces partial records on load (defensive)', async () => {
     await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
     await fsp.writeFile(
@@ -176,5 +246,47 @@ describe('source collections (#470)', () => {
     expect(ids).not.toContain('');
     // members defaulted to [] when the field was the wrong type
     expect(data.collections.find((c) => c.id === 'with-string-parent')!.members).toEqual([]);
+  });
+});
+
+describe('resolveSmartMembers (#470 phase 2)', () => {
+  /** Stub graph: tag → source-id list. */
+  const sourcesByTag = (db: Record<string, string[]>) => (tag: string) =>
+    (db[tag] ?? []).map((sourceId) => ({ sourceId }));
+
+  it('returns the intersection of sources across every tag in allOf', () => {
+    const lookup = sourcesByTag({
+      ml: ['a', 'b', 'c'],
+      review: ['b', 'c', 'd'],
+    });
+    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['ml', 'review'] }, lookup);
+    expect([...ids].sort()).toEqual(['b', 'c']);
+  });
+
+  it('returns an empty set when allOf is empty', () => {
+    const ids = resolveSmartMembers({ kind: 'tags', allOf: [] }, sourcesByTag({}));
+    expect(ids.size).toBe(0);
+  });
+
+  it('returns an empty set when any tag has no matching sources', () => {
+    const lookup = sourcesByTag({ ml: ['a'], review: [] });
+    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['ml', 'review'] }, lookup);
+    expect(ids.size).toBe(0);
+  });
+
+  it('single-tag predicate returns the full set for that tag', () => {
+    const lookup = sourcesByTag({ ml: ['a', 'b'] });
+    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['ml'] }, lookup);
+    expect([...ids].sort()).toEqual(['a', 'b']);
+  });
+
+  it('three-tag intersection narrows progressively', () => {
+    const lookup = sourcesByTag({
+      a: ['x', 'y', 'z'],
+      b: ['x', 'z'],
+      c: ['z', 'w'],
+    });
+    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['a', 'b', 'c'] }, lookup);
+    expect([...ids]).toEqual(['z']);
   });
 });


### PR DESCRIPTION
Second half of #470. v1 supports a single predicate kind: "all of these tags". Membership is computed live each time the user opens the collection, never persisted — the result set tracks the underlying tag data as it changes.

The predicate type is a tagged union so future variants (read-status from #116, faceted filters, raw SPARQL) join without disturbing the v1 storage shape.

## Storage
Extends \`.minerva/collections.json\` with an optional \`smartCollections\` array. Manual + smart ids share a namespace so the sidebar's \`activeCollectionId\` doesn't need to discriminate by kind.

\`\`\`json
{
  "collections": [...],
  "smartCollections": [
    { "id": "reading",
      "name": "Reading",
      "predicate": { "kind": "tags", "allOf": ["ml", "review"] } }
  ]
}
\`\`\`

Defensive loader drops smart entries with an unknown predicate kind or a missing predicate rather than crashing — the rest of the file keeps working.

## Backend
- \`createSmartCollection\` / \`renameSmartCollection\` / \`deleteSmartCollection\` / \`updateSmartCollectionPredicate\`.
- \`resolveSmartMembers(predicate, sourcesByTag)\` — pure function, intersects per-tag source sets. Empty \`allOf\` returns an empty set (a no-constraint smart collection is almost certainly a half-edit; silently matching every source would look like a bug).
- \`validatePredicate\` enforces non-empty tag strings; an exhaustiveness check on \`predicate.kind\` will tell future contributors when they forget to extend a branch.
- IPC: \`collections:smartMembers(id)\` resolves via the existing \`graph.sourcesByTag\` (same semantics the tag panel uses). The existing \`COLLECTIONS_CHANGED\` broadcast covers all mutations.

## UI
- New \`SmartCollectionEditorDialog\` — name input + checkboxed tag picker (filtered, with selected tags pinned to the top).
- The "+" button on the Collections section now opens a small popover: **New collection…** or **New smart collection…**.
- Smart collections render in a SMART subsection under the manual tree. Each row carries a small search icon. The tooltip shows the predicate, e.g. "#ml AND #review".
- Selecting a smart row fetches \`smartMembers\` and filters the source list to the resolved set.
- Right-click smart row → **Edit query…** / **Rename…** / **Delete**.
- Smart collections aren't drag-targets; the source-row context menu's "Add to collection" only adds to manual collections (smart membership isn't writable).
- Saving the editor auto-focuses the new collection so the user sees what they just made.

## Tests
10 new cases in \`collections.test.ts\`:
- smart CRUD + shared id namespace with manual
- empty / single / multi-tag intersection semantics
- empty result when any tag has no matches
- empty \`allOf\` returns empty
- defensive load drops smart entries with unknown predicate kinds
- editor refuses empty tag entries

Full suite **2283 / 2283** (+10 new).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Tag a couple of sources in their body.md with \`#ml\` and \`#review\`.
  2. "+" → New smart collection → name "Reading", check both tags → Create.
  3. Smart collection appears under SMART. Click it; only sources with both tags show.
  4. Right-click → Edit query. Add a third tag the project doesn't have → empty result.
  5. Rename / Delete also work.
  6. Add or remove a tag from a source body.md, click off and back; the membership updates.

## Out of scope (next)
- Read-status / faceted predicates (#116 will extend the predicate union)
- Raw SPARQL escape hatch
- Tag → smart-collection drag-and-drop sugar

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)