### PR TITLE
feat: reading queue — readStatus + readDueBy on sources (#116)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -2073,7 +2073,9 @@ export function backlinks(ctx: ProjectContext, relativePath: string): Backlink[]
 
 // ── Source detail queries ───────────────────────────────────────────────────
 
-import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink, SourceAboutNote } from '../../shared/types';
+import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink, SourceAboutNote, ReadStatus } from '../../shared/types';
+
+const READ_STATUS_VALUES: ReadonlySet<ReadStatus> = new Set(['unread', 'reading', 'read', 'skipped']);
 
 export function getSourceDetail(ctx: ProjectContext, sourceId: string): SourceDetail | null {
   const state = getState(ctx);
@@ -2120,6 +2122,10 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
   };
 
   const issued = first(DC('issued'));
+  const rawReadStatus = first(MINERVA('readStatus'));
+  const readStatus = rawReadStatus && READ_STATUS_VALUES.has(rawReadStatus as ReadStatus)
+    ? rawReadStatus as ReadStatus
+    : null;
   return {
     sourceId,
     subtype,
@@ -2130,7 +2136,32 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
     doi: first(BIBO('doi')),
     uri: first(BIBO('uri')),
     abstract: first(DC('abstract')),
+    readStatus,
+    readDueBy: first(MINERVA('readDueBy')),
   };
+}
+
+/**
+ * Sources tagged with a particular reading status (#116). Used by
+ * the smart-collection resolver and by sidebar filters that surface
+ * "Unread" / "Reading" / "Read" buckets.
+ */
+export function sourcesByReadStatus(ctx: ProjectContext, status: ReadStatus): { sourceId: string }[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  const stmts = store.statementsMatching(undefined, MINERVA('readStatus'), $rdf.lit(status));
+  const out: { sourceId: string }[] = [];
+  const seen = new Set<string>();
+  for (const st of stmts) {
+    const idStmts = store.statementsMatching(st.subject, MINERVA('sourceId'), undefined);
+    const sourceId = idStmts[0]?.object.value;
+    if (!sourceId || seen.has(sourceId)) continue;
+    seen.add(sourceId);
+    out.push({ sourceId });
+  }
+  return out;
 }
 
 function collectExcerptsForSource(state: GraphState, sourceSubject: $rdf.NamedNode): SourceExcerpt[] {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -72,6 +72,8 @@ import { renderInlineCitations, type InlineCiteRequest } from './citations/rende
 import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
 import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
+import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
+import type { ReadStatus } from '../shared/types';
 import {
   loadCollections,
   createCollection,
@@ -1598,6 +1600,25 @@ export function registerIpcHandlers(): void {
     }
   });
 
+  // ── Reading queue (#116) ──────────────────────────────────────────────────
+  ipcMain.handle(Channels.SOURCES_SET_READ_STATUS, async (e, params: { sourceId: string; status: ReadStatus | null }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await setSourceReadStatus(rootPath, params.sourceId, params.status);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
+  ipcMain.handle(Channels.SOURCES_SET_READ_DUE_BY, async (e, params: { sourceId: string; dueBy: string | null }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await setSourceReadDueBy(rootPath, params.sourceId, params.dueBy);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
   // ── Collections (#470) ────────────────────────────────────────────────────
   const broadcastCollectionsChanged = (e: Electron.IpcMainInvokeEvent) => {
     const win = winFromEvent(e);
@@ -1685,7 +1706,10 @@ export function registerIpcHandlers(): void {
     // Resolve via the graph's existing source-by-tag helper. The graph
     // is the source of truth for hasTag edges (notes + sources) so we
     // get the same membership semantics the tag panel surfaces.
-    const matchingIds = resolveSmartMembers(smart.predicate, (tag) => graph.sourcesByTag(ctx, tag));
+    const matchingIds = resolveSmartMembers(smart.predicate, {
+      sourcesByTag: (tag) => graph.sourcesByTag(ctx, tag),
+      sourcesByReadStatus: (status) => graph.sourcesByReadStatus(ctx, status),
+    });
     if (matchingIds.size === 0) return [];
     const all = graph.listAllSources(ctx);
     return all.filter((s) => matchingIds.has(s.sourceId));

--- a/src/main/sources/collections.ts
+++ b/src/main/sources/collections.ts
@@ -21,7 +21,9 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { SmartCollection, SmartCollectionPredicate } from '../../shared/types';
+import type { SmartCollection, SmartCollectionPredicate, ReadStatus } from '../../shared/types';
+
+const READ_STATUS_VALUES: ReadonlySet<ReadStatus> = new Set(['unread', 'reading', 'read', 'skipped']);
 
 export interface Collection {
   id: string;
@@ -55,10 +57,16 @@ function emptyFile(): CollectionsFile {
  *  truly broken record vanishes from the sidebar instead of crashing. */
 function parsePredicate(value: unknown): SmartCollectionPredicate | null {
   if (!value || typeof value !== 'object') return null;
-  const v = value as { kind?: unknown; allOf?: unknown };
+  const v = value as { kind?: unknown; allOf?: unknown; status?: unknown };
   if (v.kind === 'tags') {
     const allOf = Array.isArray(v.allOf) ? v.allOf.filter((t): t is string => typeof t === 'string') : [];
     return { kind: 'tags', allOf };
+  }
+  if (v.kind === 'readStatus') {
+    const status = Array.isArray(v.status)
+      ? v.status.filter((s): s is ReadStatus => typeof s === 'string' && READ_STATUS_VALUES.has(s as ReadStatus))
+      : [];
+    return { kind: 'readStatus', status };
   }
   return null;
 }
@@ -322,33 +330,49 @@ function validatePredicate(p: SmartCollectionPredicate): void {
     }
     return;
   }
+  if (p.kind === 'readStatus') {
+    if (!Array.isArray(p.status)) throw new Error('Read-status predicate.status must be an array.');
+    for (const s of p.status) {
+      if (!READ_STATUS_VALUES.has(s)) {
+        throw new Error(`Read-status predicate.status contains invalid value: ${String(s)}`);
+      }
+    }
+    return;
+  }
   // Exhaustiveness: the type union ensures the compiler catches missing
   // branches when new predicate kinds land.
-  const _exhaustive: never = p.kind;
-  throw new Error(`Unsupported predicate kind: ${_exhaustive as string}`);
+  const _exhaustive: never = p;
+  throw new Error(`Unsupported predicate kind: ${String((_exhaustive as { kind?: string }).kind)}`);
+}
+
+export interface SmartCollectionLookups {
+  sourcesByTag: (tag: string) => ReadonlyArray<{ sourceId: string }>;
+  sourcesByReadStatus: (status: ReadStatus) => ReadonlyArray<{ sourceId: string }>;
 }
 
 /**
  * Compute the source ids that satisfy a smart-collection's predicate.
  *
- * Tags ALL-OF semantics: a source is a member iff its
- * `minerva:hasTag` edges include every tag in `allOf`. Empty `allOf`
- * matches nothing — a smart collection with no constraints is almost
- * certainly a half-edited mistake, and silently matching every
- * source would look like a bug.
+ *   tags allOf      — intersection across per-tag source sets
+ *   readStatus any  — union across per-status source sets
  *
- * Resolved against the in-memory graph via `sourcesByTag` so we get
- * the same predicate semantics the tag panel uses.
+ * Both predicate kinds treat an empty input array as "match
+ * nothing" — a no-constraint predicate is almost always a half-edit;
+ * silently matching every source would look like a bug.
+ *
+ * The lookups are injected so the resolver is a pure function
+ * (testable with stubs) and so the main process can wire them to
+ * the indexed graph.
  */
 export function resolveSmartMembers(
   predicate: SmartCollectionPredicate,
-  sourcesByTag: (tag: string) => ReadonlyArray<{ sourceId: string }>,
+  lookups: SmartCollectionLookups,
 ): Set<string> {
   if (predicate.kind === 'tags') {
     if (predicate.allOf.length === 0) return new Set();
     let acc: Set<string> | null = null;
     for (const tag of predicate.allOf) {
-      const ids = new Set(sourcesByTag(tag).map((s) => s.sourceId));
+      const ids = new Set(lookups.sourcesByTag(tag).map((s) => s.sourceId));
       if (acc === null) {
         acc = ids;
       } else {
@@ -358,6 +382,14 @@ export function resolveSmartMembers(
     }
     return acc ?? new Set();
   }
-  const _exhaustive: never = predicate.kind;
-  throw new Error(`Unsupported predicate kind: ${_exhaustive as string}`);
+  if (predicate.kind === 'readStatus') {
+    if (predicate.status.length === 0) return new Set();
+    const out = new Set<string>();
+    for (const s of predicate.status) {
+      for (const r of lookups.sourcesByReadStatus(s)) out.add(r.sourceId);
+    }
+    return out;
+  }
+  const _exhaustive: never = predicate;
+  throw new Error(`Unsupported predicate kind: ${String((_exhaustive as { kind?: string }).kind)}`);
 }

--- a/src/main/sources/read-status.ts
+++ b/src/main/sources/read-status.ts
@@ -1,0 +1,201 @@
+/**
+ * Reading-queue updates (#116).
+ *
+ * A source carries an optional `minerva:readStatus` enum and an
+ * optional `minerva:readDueBy` date in its `meta.ttl`. Setting either
+ * is a small text mutation: drop any existing line for the predicate,
+ * insert a fresh one before the closing `.`, then re-index so the
+ * graph and SourceMetadata reflect the new value.
+ *
+ * Same shape as the metadata-merge in #90 part 1 — we control the
+ * writer (`buildMetaTtl`) and the predicate is single-valued, so a
+ * line-oriented regex pass is reliable for our own output and tolerant
+ * of hand edits.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+import type { ReadStatus } from '../../shared/types';
+
+const VALID: ReadonlySet<ReadStatus> = new Set(['unread', 'reading', 'read', 'skipped']);
+
+export function isReadStatus(value: unknown): value is ReadStatus {
+  return typeof value === 'string' && VALID.has(value as ReadStatus);
+}
+
+/** Set, change, or clear a source's read status. `null` removes the
+ *  predicate entirely (i.e. the source goes back to "no status set"). */
+export async function setSourceReadStatus(
+  rootPath: string,
+  sourceId: string,
+  status: ReadStatus | null,
+): Promise<void> {
+  if (status !== null && !isReadStatus(status)) {
+    throw new Error(`Invalid read status: ${String(status)}`);
+  }
+  const metaPath = sourceMetaPath(rootPath, sourceId);
+  const ttl = await readMeta(metaPath);
+  const next = upsertSingleValuedPredicate(
+    ttl,
+    'minerva:readStatus',
+    status === null ? null : `${ttlString(status)}`,
+  );
+  if (next === ttl) return;
+  await fs.writeFile(metaPath, next, 'utf-8');
+  await reindexSource(rootPath, sourceId);
+}
+
+/** Set, change, or clear a source's due-by date. ISO date string
+ *  (`YYYY-MM-DD`); `null` removes the predicate. */
+export async function setSourceReadDueBy(
+  rootPath: string,
+  sourceId: string,
+  dueBy: string | null,
+): Promise<void> {
+  if (dueBy !== null && !/^\d{4}-\d{2}-\d{2}$/.test(dueBy)) {
+    throw new Error(`Invalid ISO date for readDueBy: ${dueBy}`);
+  }
+  const metaPath = sourceMetaPath(rootPath, sourceId);
+  const ttl = await readMeta(metaPath);
+  const next = upsertSingleValuedPredicate(
+    ttl,
+    'minerva:readDueBy',
+    dueBy === null ? null : `${ttlString(dueBy)}^^xsd:date`,
+  );
+  if (next === ttl) return;
+  await fs.writeFile(metaPath, next, 'utf-8');
+  await reindexSource(rootPath, sourceId);
+}
+
+function sourceMetaPath(rootPath: string, sourceId: string): string {
+  return path.join(rootPath, '.minerva', 'sources', sourceId, 'meta.ttl');
+}
+
+async function readMeta(metaPath: string): Promise<string> {
+  try {
+    return await fs.readFile(metaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Source meta.ttl not found: ${metaPath}`, { cause: err });
+    }
+    throw err;
+  }
+}
+
+async function reindexSource(rootPath: string, sourceId: string): Promise<void> {
+  const ctx = projectContext(rootPath);
+  const ttl = await readMeta(sourceMetaPath(rootPath, sourceId));
+  let body: string | undefined;
+  try {
+    body = await fs.readFile(path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md'), 'utf-8');
+  } catch { /* body optional */ }
+  graph.indexSource(ctx, sourceId, ttl, body);
+}
+
+/**
+ * Replace a single-valued predicate's value, or insert a fresh line
+ * before the closing `.` when the predicate is absent. Passing
+ * `null` for `value` deletes the predicate line entirely.
+ *
+ * Match scope: a whole TTL line whose first non-whitespace token is
+ * the prefixed predicate (`prefix:local`). We don't try to handle
+ * comma-continuations because our writer never emits them.
+ */
+export function upsertSingleValuedPredicate(
+  ttl: string,
+  predicate: string,
+  value: string | null,
+): string {
+  const escaped = predicate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Capture the indentation so we re-emit with the same shape.
+  const re = new RegExp(`^([ \\t]*)${escaped}\\s+[^\\n]*\\n?`, 'm');
+  const hadMatch = re.test(ttl);
+  if (hadMatch) {
+    if (value === null) {
+      // Delete the line. Take care: if the line we delete was the
+      // last predicate, the previous `;` becomes a stray separator.
+      // Cheap fix: after removal, ensure the line above the final
+      // `.` still ends with `;`.
+      const removed = ttl.replace(re, '');
+      return normaliseTrailingSeparator(removed);
+    }
+    return ttl.replace(re, (_match, indent: string) => `${indent}${predicate} ${value} ;\n`);
+  }
+  if (value === null) return ttl; // nothing to delete
+  return insertBeforeFinalDot(ttl, `    ${predicate} ${value} ;`);
+}
+
+/**
+ * After deleting a predicate line, the new line that now precedes
+ * the final `.` must terminate with `;` (since the deleted line had
+ * been the `.`-bearing one, or a middle `;`-terminated line). The
+ * existing writer always emits `; ;… .`, so as long as every
+ * non-final predicate ends with `;` we're well-formed. This walks
+ * back from the final `.` and replaces a stray trailing `;` on the
+ * predicate that's now the last with `.`.
+ *
+ * Concretely: when the writer originally produced
+ *   foo ;
+ *   readStatus ... ;
+ *   bar .
+ * and we remove the readStatus line, we get
+ *   foo ;
+ *   bar .
+ * which is already well-formed — every line ending the same as
+ * before. So this function is mostly a safety net for the edge
+ * case where the predicate we deleted was the bottom-most one.
+ */
+function normaliseTrailingSeparator(ttl: string): string {
+  // Find the trailing `.`
+  const trailing = ttl.match(/(\s*\.\s*)$/);
+  if (!trailing) return ttl;
+  const dotIdx = trailing.index ?? ttl.length;
+  // Walk back to the previous newline.
+  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
+  if (lineStart < 0) return ttl;
+  const lineBefore = ttl.slice(lineStart + 1, dotIdx);
+  // If the line before the `.` ends with `;`, switch it to `.` and
+  // drop the dangling `.`.
+  const trimmed = lineBefore.replace(/\s+$/, '');
+  if (trimmed.endsWith(';')) {
+    const fixed = trimmed.slice(0, -1).replace(/\s+$/, '') + ' .';
+    return ttl.slice(0, lineStart + 1) + fixed + '\n';
+  }
+  return ttl;
+}
+
+/**
+ * Insert a new predicate line immediately before the closing `.`.
+ * The writer always emits `... ;\n    pred value .\n`, so the line
+ * preceding the `.` already ends with `;` and we can safely splice
+ * a new `;`-terminated predicate before it without rewriting
+ * separators.
+ *
+ * Mirrors the technique in source-merge.ts; kept local because the
+ * matching semantics differ slightly (single line, not a batch).
+ */
+function insertBeforeFinalDot(ttl: string, newLine: string): string {
+  const trailing = ttl.match(/(\s*\.\s*)$/);
+  if (!trailing) {
+    // Malformed TTL — append + close.
+    return ttl + (ttl.endsWith('\n') ? '' : '\n') + newLine + '\n    .\n';
+  }
+  const dotIdx = trailing.index ?? ttl.length;
+  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
+  if (lineStart < 0) {
+    return ttl.slice(0, dotIdx).replace(/\s+$/, ' ;') + '\n' + newLine + '\n' + ttl.slice(dotIdx);
+  }
+  return ttl.slice(0, lineStart) + '\n' + newLine + ttl.slice(lineStart);
+}
+
+function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -257,6 +257,10 @@ contextBridge.exposeInMainWorld('api', {
     delete: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_DELETE, sourceId),
     merge: (srcId: string, destId: string) =>
       ipcRenderer.invoke(Channels.SOURCES_MERGE, { srcId, destId }),
+    setReadStatus: (sourceId: string, status: 'unread' | 'reading' | 'read' | 'skipped' | null) =>
+      ipcRenderer.invoke(Channels.SOURCES_SET_READ_STATUS, { sourceId, status }),
+    setReadDueBy: (sourceId: string, dueBy: string | null) =>
+      ipcRenderer.invoke(Channels.SOURCES_SET_READ_DUE_BY, { sourceId, dueBy }),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
+++ b/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
@@ -11,8 +11,17 @@
    * dialog with a kind-picker; for now the kind is hardcoded.
    */
   import { api } from '../ipc/client';
-  import type { SmartCollection, SmartCollectionPredicate, TagInfo } from '../../../shared/types';
+  import type { SmartCollection, SmartCollectionPredicate, TagInfo, ReadStatus } from '../../../shared/types';
   import Icon from './Icon.svelte';
+
+  const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
+    { value: 'unread', label: 'Unread' },
+    { value: 'reading', label: 'Reading' },
+    { value: 'read', label: 'Read' },
+    { value: 'skipped', label: 'Skipped' },
+  ];
+
+  type PredicateKind = SmartCollectionPredicate['kind'];
 
   interface Props {
     /** When provided, the dialog opens in edit mode pre-filled with
@@ -26,10 +35,14 @@
 
   const mode = $derived<'create' | 'edit'>(editing ? 'edit' : 'create');
   let name = $state(editing?.name ?? '');
+  let kind = $state<PredicateKind>(editing?.predicate.kind ?? 'tags');
   /** Picked tags (allOf), preserved as a Set for O(1) lookup in the
    *  template. Initialised from the editing predicate when present. */
-  let selected = $state<Set<string>>(new Set(
+  let selectedTags = $state<Set<string>>(new Set(
     editing && editing.predicate.kind === 'tags' ? editing.predicate.allOf : [],
+  ));
+  let selectedStatuses = $state<Set<ReadStatus>>(new Set(
+    editing && editing.predicate.kind === 'readStatus' ? editing.predicate.status : [],
   ));
   let tagFilter = $state('');
   let saving = $state(false);
@@ -45,7 +58,7 @@
     // project vocabulary (e.g. the predicate references a tag that's
     // since been removed from every source). We still show it so the
     // user can either keep it or uncheck it deliberately.
-    for (const t of selected) {
+    for (const t of selectedTags) {
       if (!allTags.some((info) => info.tag === t)) {
         allTags = [...allTags, { tag: t, noteCount: 0, sourceCount: 0 }];
       }
@@ -58,26 +71,44 @@
     // Pinned at top: anything currently selected, so the user can
     // see their picks even after filtering.
     return [...list].sort((a, b) => {
-      const aPicked = selected.has(a.tag) ? 0 : 1;
-      const bPicked = selected.has(b.tag) ? 0 : 1;
+      const aPicked = selectedTags.has(a.tag) ? 0 : 1;
+      const bPicked = selectedTags.has(b.tag) ? 0 : 1;
       if (aPicked !== bPicked) return aPicked - bPicked;
       return a.tag.localeCompare(b.tag);
     });
   });
 
   function toggleTag(tag: string) {
-    const next = new Set(selected);
+    const next = new Set(selectedTags);
     if (next.has(tag)) next.delete(tag); else next.add(tag);
-    selected = next;
+    selectedTags = next;
   }
 
-  const canSave = $derived(name.trim().length > 0 && selected.size > 0 && !saving);
+  function toggleStatus(status: ReadStatus) {
+    const next = new Set(selectedStatuses);
+    if (next.has(status)) next.delete(status); else next.add(status);
+    selectedStatuses = next;
+  }
+
+  const canSave = $derived.by(() => {
+    if (!name.trim() || saving) return false;
+    if (kind === 'tags') return selectedTags.size > 0;
+    if (kind === 'readStatus') return selectedStatuses.size > 0;
+    return false;
+  });
+
+  function currentPredicate(): SmartCollectionPredicate {
+    if (kind === 'readStatus') {
+      return { kind: 'readStatus', status: [...selectedStatuses] };
+    }
+    return { kind: 'tags', allOf: [...selectedTags] };
+  }
 
   async function handleSave(): Promise<void> {
     if (!canSave) return;
     saving = true;
     try {
-      await onSave(name.trim(), { kind: 'tags', allOf: [...selected] });
+      await onSave(name.trim(), currentPredicate());
     } finally {
       saving = false;
     }
@@ -104,38 +135,65 @@
     </header>
 
     <section class="body">
-      <div class="rule-label">Sources tagged with <strong>all</strong> of:</div>
-      <div class="tag-filter-row">
-        <Icon name="search" size={12} color="var(--text-muted)" />
-        <input
-          type="text"
-          class="tag-filter"
-          placeholder="Filter tags…"
-          bind:value={tagFilter}
-        />
-        <span class="picked-count">{selected.size} picked</span>
+      <div class="kind-row">
+        <label class="kind-radio">
+          <input type="radio" name="predicate-kind" value="tags" checked={kind === 'tags'} onchange={() => { kind = 'tags'; }} />
+          <span>Tag predicate</span>
+        </label>
+        <label class="kind-radio">
+          <input type="radio" name="predicate-kind" value="readStatus" checked={kind === 'readStatus'} onchange={() => { kind = 'readStatus'; }} />
+          <span>Reading status</span>
+        </label>
       </div>
-      <div class="tag-list">
-        {#if visibleTags.length === 0}
-          {#if allTags.length === 0}
-            <div class="empty">No tags in project yet.</div>
+
+      {#if kind === 'tags'}
+        <div class="rule-label">Sources tagged with <strong>all</strong> of:</div>
+        <div class="tag-filter-row">
+          <Icon name="search" size={12} color="var(--text-muted)" />
+          <input
+            type="text"
+            class="tag-filter"
+            placeholder="Filter tags…"
+            bind:value={tagFilter}
+          />
+          <span class="picked-count">{selectedTags.size} picked</span>
+        </div>
+        <div class="tag-list">
+          {#if visibleTags.length === 0}
+            {#if allTags.length === 0}
+              <div class="empty">No tags in project yet.</div>
+            {:else}
+              <div class="empty">No tags match "{tagFilter}".</div>
+            {/if}
           {:else}
-            <div class="empty">No tags match "{tagFilter}".</div>
+            {#each visibleTags as t (t.tag)}
+              <label class="tag-row" class:checked={selectedTags.has(t.tag)}>
+                <input
+                  type="checkbox"
+                  checked={selectedTags.has(t.tag)}
+                  onchange={() => toggleTag(t.tag)}
+                />
+                <span class="tag-name">#{t.tag}</span>
+                <span class="tag-count">{t.sourceCount}</span>
+              </label>
+            {/each}
           {/if}
-        {:else}
-          {#each visibleTags as t (t.tag)}
-            <label class="tag-row" class:checked={selected.has(t.tag)}>
+        </div>
+      {:else}
+        <div class="rule-label">Sources with <strong>any</strong> of these statuses:</div>
+        <div class="status-list">
+          {#each READ_STATUS_OPTIONS as opt (opt.value)}
+            <label class="tag-row" class:checked={selectedStatuses.has(opt.value)}>
               <input
                 type="checkbox"
-                checked={selected.has(t.tag)}
-                onchange={() => toggleTag(t.tag)}
+                checked={selectedStatuses.has(opt.value)}
+                onchange={() => toggleStatus(opt.value)}
               />
-              <span class="tag-name">#{t.tag}</span>
-              <span class="tag-count">{t.sourceCount}</span>
+              <span class="tag-name">{opt.label}</span>
             </label>
           {/each}
-        {/if}
-      </div>
+        </div>
+      {/if}
     </section>
 
     <footer class="card-footer">
@@ -204,11 +262,31 @@
     flex: 1;
     overflow: hidden;
   }
+  .kind-row {
+    display: flex;
+    gap: 16px;
+    font-size: 12px;
+    color: var(--text-muted);
+    padding-bottom: 4px;
+  }
+  .kind-radio {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .kind-radio input { cursor: pointer; }
   .rule-label {
     font-size: 12px;
     color: var(--text-muted);
   }
   .rule-label strong { color: var(--text); font-weight: 500; }
+  .status-list {
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    padding: 4px 0;
+  }
   .tag-filter-row {
     display: flex;
     align-items: center;

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -2,7 +2,14 @@
   import { api } from '../ipc/client';
   import Preview from './Preview.svelte';
   import { renderInlineWithMath } from '../markdown/inline-math';
-  import type { SourceDetail, SourceExcerpt, SourceBacklink } from '../../../shared/types';
+  import type { SourceDetail, SourceExcerpt, SourceBacklink, ReadStatus } from '../../../shared/types';
+
+  const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
+    { value: 'unread', label: 'Unread' },
+    { value: 'reading', label: 'Reading' },
+    { value: 'read', label: 'Read' },
+    { value: 'skipped', label: 'Skipped' },
+  ];
 
   interface Props {
     sourceId: string;
@@ -196,6 +203,19 @@
     return b.kind === 'cite' ? 'cites' : 'quotes';
   }
 
+  async function handleSetReadStatus(next: ReadStatus | null): Promise<void> {
+    if (!detail) return;
+    try {
+      await api.sources.setReadStatus(sourceId, next);
+      // Optimistic refresh — the SOURCES_CHANGED broadcast will also
+      // fire but the local round trip is faster for the same-window
+      // case.
+      await load(sourceId);
+    } catch (err) {
+      console.error('[minerva] setReadStatus failed:', err);
+    }
+  }
+
   let creatingAbout = $state(false);
   async function handleNewAboutNote(): Promise<void> {
     if (!onCreateAboutNote || creatingAbout) return;
@@ -256,6 +276,25 @@
         </div>
       {/if}
       <div class="kv"><span class="k">Source id</span><span class="v mono">{detail.metadata.sourceId}</span></div>
+      <div class="kv read-status-row">
+        <span class="k">Status</span>
+        <span class="v">
+          <div class="status-buttons" role="group" aria-label="Reading status">
+            {#each READ_STATUS_OPTIONS as opt (opt.value)}
+              <button
+                class="status-btn"
+                class:active={detail.metadata.readStatus === opt.value}
+                onclick={() => handleSetReadStatus(
+                  detail!.metadata.readStatus === opt.value ? null : opt.value,
+                )}
+                title={detail.metadata.readStatus === opt.value ? 'Click again to clear' : `Mark as ${opt.label.toLowerCase()}`}
+              >
+                {opt.label}
+              </button>
+            {/each}
+          </div>
+        </span>
+      </div>
       <div class="actions">
         <button class="action-btn" onclick={handleDelete}>Delete source</button>
       </div>
@@ -482,6 +521,34 @@
     cursor: pointer;
   }
   .action-btn:hover { background: var(--bg-button-hover); }
+
+  /* Reading-queue status (#116). Segmented buttons; the active one
+     picks up the accent rail/tint shared with selected affordances
+     elsewhere. Clicking the active button clears the status. */
+  .read-status-row .v { display: flex; }
+  .status-buttons {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .status-btn {
+    padding: 3px 10px;
+    background: transparent;
+    color: var(--text-muted);
+    border: none;
+    border-right: 1px solid var(--border);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .status-btn:last-child { border-right: none; }
+  .status-btn:hover { background: color-mix(in oklch, var(--text) 4%, transparent); color: var(--text); }
+  .status-btn.active {
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--accent);
+    font-weight: 500;
+  }
   .k {
     color: var(--text-muted);
     font-size: 13px;

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -344,6 +344,11 @@
       const tags = s.predicate.allOf.map((t) => `#${t}`).join(' AND ');
       return tags || s.id;
     }
+    if (s.predicate.kind === 'readStatus') {
+      return s.predicate.status.length > 0
+        ? `Status: ${s.predicate.status.join(' or ')}`
+        : s.id;
+    }
     return s.id;
   }
 
@@ -497,6 +502,27 @@
     if (creators.length === 2) return `${creators[0]} and ${creators[1]}`;
     return `${creators[0]} et al.`;
   }
+
+  /** Single character glyph for the status indicator dot. Picked for
+   *  ASCII-safety; users learn the mapping from the title attribute. */
+  function statusGlyph(status: SourceMetadata['readStatus']): string {
+    switch (status) {
+      case 'reading': return '◐';
+      case 'read': return '●';
+      case 'unread': return '○';
+      case 'skipped': return '×';
+      default: return '';
+    }
+  }
+  function statusTitle(status: SourceMetadata['readStatus']): string {
+    switch (status) {
+      case 'reading': return 'Reading';
+      case 'read': return 'Read';
+      case 'unread': return 'Unread';
+      case 'skipped': return 'Skipped';
+      default: return '';
+    }
+  }
 </script>
 
 <div class="sources-panel">
@@ -586,7 +612,16 @@
           oncontextmenu={(e) => handleContextMenu(e, s)}
           title={s.sourceId}
         >
-          <div class="source-title">{s.title ?? s.sourceId}</div>
+          <div class="source-title">
+            {#if s.readStatus}
+              <span
+                class="status-dot status-{s.readStatus}"
+                title={statusTitle(s.readStatus)}
+                aria-label={statusTitle(s.readStatus)}
+              >{statusGlyph(s.readStatus)}</span>
+            {/if}
+            {s.title ?? s.sourceId}
+          </div>
           {#if s.creators.length > 0 || s.year}
             {@const who = formatCreators(s.creators)}
             <div class="source-byline">
@@ -895,4 +930,22 @@
     padding: 8px 14px 2px;
   }
   .smart-row { gap: 6px; }
+
+  /* Reading-queue status dot in the source list (#116). Just a small
+     inline mark in front of the title so the user can scan for "what's
+     reading right now" without leaving the panel. */
+  .status-dot {
+    display: inline-block;
+    width: 1em;
+    text-align: center;
+    margin-right: 4px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1;
+    vertical-align: baseline;
+  }
+  .status-dot.status-reading { color: var(--accent); }
+  .status-dot.status-read { color: color-mix(in oklch, var(--text-muted) 90%, transparent); }
+  .status-dot.status-unread { color: var(--text-faint); }
+  .status-dot.status-skipped { color: var(--text-faint); }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -679,6 +679,10 @@ export interface SourcesApi {
     metadataAdded: string[];
     artifactsCopied: string[];
   }>;
+  /** Set / change / clear a source's reading-queue status (#116). */
+  setReadStatus(sourceId: string, status: import('../../../shared/types').ReadStatus | null): Promise<void>;
+  /** Set / change / clear a source's due-by date (ISO YYYY-MM-DD). */
+  setReadDueBy(sourceId: string, dueBy: string | null): Promise<void>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -233,6 +233,10 @@ export const Channels = {
   /** Merge two sources: fold src's metadata into dest, move excerpts,
    *  rewrite `[[cite::src]]`, delete src folder (#90). */
   SOURCES_MERGE: 'sources:merge',
+  /** Set/clear a source's reading-queue status (#116). */
+  SOURCES_SET_READ_STATUS: 'sources:setReadStatus',
+  /** Set/clear a source's due-by date (#116). */
+  SOURCES_SET_READ_DUE_BY: 'sources:setReadDueBy',
 
   // Collections (#470)
   /** Read `.minerva/collections.json` as a CollectionsFile. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,6 +102,10 @@ export interface TabSession {
 
 // ── Source detail ─────────────────────────────────────────────────────────
 
+/** Reading-queue status (#116). `null` = no status set (= effectively
+ *  "unread", but distinct from an explicit "unread" the user picked). */
+export type ReadStatus = 'unread' | 'reading' | 'read' | 'skipped';
+
 export interface SourceMetadata {
   sourceId: string;
   subtype: string | null;
@@ -112,6 +116,10 @@ export interface SourceMetadata {
   doi: string | null;
   uri: string | null;
   abstract: string | null;
+  /** Reading-queue status (#116). */
+  readStatus: ReadStatus | null;
+  /** ISO date by which the user wants to have finished this. */
+  readDueBy: string | null;
 }
 
 export interface SourceExcerpt {
@@ -183,7 +191,11 @@ export interface Collection {
  * predicate's storage shape. The renderer's predicate editor +
  * the main-process member resolver each branch on `kind`. */
 export type SmartCollectionPredicate =
-  | { kind: 'tags'; allOf: string[] };
+  | { kind: 'tags'; allOf: string[] }
+  /** Any of the listed statuses. Empty list matches nothing (mirrors
+   *  the `tags allOf` empty-set convention — a no-constraint
+   *  predicate is almost always a half-edit). (#116) */
+  | { kind: 'readStatus'; status: ReadStatus[] };
 
 /** Query-driven collection (#470 phase 2). Membership is computed
  *  live from the graph each time the user opens it — never

--- a/tests/main/sources/collections.test.ts
+++ b/tests/main/sources/collections.test.ts
@@ -250,43 +250,75 @@ describe('source collections (#470)', () => {
 });
 
 describe('resolveSmartMembers (#470 phase 2)', () => {
-  /** Stub graph: tag → source-id list. */
-  const sourcesByTag = (db: Record<string, string[]>) => (tag: string) =>
-    (db[tag] ?? []).map((sourceId) => ({ sourceId }));
+  /** Stub graph lookups. */
+  function lookups(opts: {
+    tags?: Record<string, string[]>;
+    status?: Partial<Record<'unread' | 'reading' | 'read' | 'skipped', string[]>>;
+  } = {}) {
+    return {
+      sourcesByTag: (tag: string) => (opts.tags?.[tag] ?? []).map((sourceId) => ({ sourceId })),
+      sourcesByReadStatus: (status: 'unread' | 'reading' | 'read' | 'skipped') =>
+        (opts.status?.[status] ?? []).map((sourceId) => ({ sourceId })),
+    };
+  }
 
   it('returns the intersection of sources across every tag in allOf', () => {
-    const lookup = sourcesByTag({
-      ml: ['a', 'b', 'c'],
-      review: ['b', 'c', 'd'],
-    });
-    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['ml', 'review'] }, lookup);
+    const ids = resolveSmartMembers(
+      { kind: 'tags', allOf: ['ml', 'review'] },
+      lookups({ tags: { ml: ['a', 'b', 'c'], review: ['b', 'c', 'd'] } }),
+    );
     expect([...ids].sort()).toEqual(['b', 'c']);
   });
 
   it('returns an empty set when allOf is empty', () => {
-    const ids = resolveSmartMembers({ kind: 'tags', allOf: [] }, sourcesByTag({}));
+    const ids = resolveSmartMembers({ kind: 'tags', allOf: [] }, lookups());
     expect(ids.size).toBe(0);
   });
 
   it('returns an empty set when any tag has no matching sources', () => {
-    const lookup = sourcesByTag({ ml: ['a'], review: [] });
-    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['ml', 'review'] }, lookup);
+    const ids = resolveSmartMembers(
+      { kind: 'tags', allOf: ['ml', 'review'] },
+      lookups({ tags: { ml: ['a'], review: [] } }),
+    );
     expect(ids.size).toBe(0);
   });
 
   it('single-tag predicate returns the full set for that tag', () => {
-    const lookup = sourcesByTag({ ml: ['a', 'b'] });
-    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['ml'] }, lookup);
+    const ids = resolveSmartMembers(
+      { kind: 'tags', allOf: ['ml'] },
+      lookups({ tags: { ml: ['a', 'b'] } }),
+    );
     expect([...ids].sort()).toEqual(['a', 'b']);
   });
 
   it('three-tag intersection narrows progressively', () => {
-    const lookup = sourcesByTag({
-      a: ['x', 'y', 'z'],
-      b: ['x', 'z'],
-      c: ['z', 'w'],
-    });
-    const ids = resolveSmartMembers({ kind: 'tags', allOf: ['a', 'b', 'c'] }, lookup);
+    const ids = resolveSmartMembers(
+      { kind: 'tags', allOf: ['a', 'b', 'c'] },
+      lookups({ tags: { a: ['x', 'y', 'z'], b: ['x', 'z'], c: ['z', 'w'] } }),
+    );
     expect([...ids]).toEqual(['z']);
+  });
+
+  // ── readStatus predicate (#116) ────────────────────────────────────────
+
+  it('readStatus predicate returns the union of sources across statuses', () => {
+    const ids = resolveSmartMembers(
+      { kind: 'readStatus', status: ['unread', 'reading'] },
+      lookups({ status: { unread: ['a', 'b'], reading: ['b', 'c'] } }),
+    );
+    expect([...ids].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('readStatus predicate with a single status', () => {
+    const ids = resolveSmartMembers(
+      { kind: 'readStatus', status: ['reading'] },
+      lookups({ status: { reading: ['a', 'b'] } }),
+    );
+    expect([...ids].sort()).toEqual(['a', 'b']);
+  });
+
+  it('readStatus predicate with an empty status list returns nothing', () => {
+    const ids = resolveSmartMembers({ kind: 'readStatus', status: [] }, lookups());
+    expect(ids.size).toBe(0);
   });
 });

--- a/tests/main/sources/read-status.test.ts
+++ b/tests/main/sources/read-status.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Reading queue (#116) — set/clear status + due-by on a source's
+ * meta.ttl, then re-index so the graph reflects the change.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  setSourceReadStatus,
+  setSourceReadDueBy,
+  upsertSingleValuedPredicate,
+  isReadStatus,
+} from '../../../src/main/sources/read-status';
+import {
+  initGraph,
+  indexSource,
+  getSourceDetail,
+  sourcesByReadStatus,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-read-status-'));
+}
+
+const META = `this: a thought:Article ;
+    dc:title "Test paper" ;
+    dc:creator "Alice" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+describe('upsertSingleValuedPredicate', () => {
+  it('inserts a fresh predicate line before the closing dot', () => {
+    const out = upsertSingleValuedPredicate(META, 'minerva:readStatus', '"reading"');
+    expect(out).toContain('minerva:readStatus "reading" ;');
+    expect(out.indexOf('minerva:readStatus')).toBeLessThan(out.indexOf('thought:accessedAt'));
+  });
+
+  it('replaces an existing predicate value in place', () => {
+    const withStatus = upsertSingleValuedPredicate(META, 'minerva:readStatus', '"unread"');
+    const updated = upsertSingleValuedPredicate(withStatus, 'minerva:readStatus', '"reading"');
+    expect(updated).toContain('minerva:readStatus "reading"');
+    expect(updated).not.toContain('"unread"');
+    // No duplicate predicate line.
+    expect((updated.match(/minerva:readStatus/g) ?? []).length).toBe(1);
+  });
+
+  it('deletes a predicate line when value is null', () => {
+    const withStatus = upsertSingleValuedPredicate(META, 'minerva:readStatus', '"reading"');
+    const removed = upsertSingleValuedPredicate(withStatus, 'minerva:readStatus', null);
+    expect(removed).not.toContain('minerva:readStatus');
+    // The other predicates survive.
+    expect(removed).toContain('dc:title');
+    expect(removed).toContain('thought:accessedAt');
+  });
+
+  it('null-on-absent is a no-op', () => {
+    const out = upsertSingleValuedPredicate(META, 'minerva:readStatus', null);
+    expect(out).toBe(META);
+  });
+
+  it('preserves the indent of the existing predicate when replacing', () => {
+    const initial = '    minerva:readStatus "unread" ;';
+    const ttl = `this: a thought:Article ;\n${initial}\n    dc:title "X" .\n`;
+    const out = upsertSingleValuedPredicate(ttl, 'minerva:readStatus', '"reading"');
+    expect(out).toContain('    minerva:readStatus "reading" ;');
+  });
+});
+
+describe('isReadStatus', () => {
+  it('accepts the four valid values', () => {
+    expect(isReadStatus('unread')).toBe(true);
+    expect(isReadStatus('reading')).toBe(true);
+    expect(isReadStatus('read')).toBe(true);
+    expect(isReadStatus('skipped')).toBe(true);
+  });
+  it('rejects everything else', () => {
+    expect(isReadStatus('UNREAD')).toBe(false);
+    expect(isReadStatus('done')).toBe(false);
+    expect(isReadStatus(null)).toBe(false);
+    expect(isReadStatus(42)).toBe(false);
+  });
+});
+
+describe('setSourceReadStatus (#116)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const sourceId = 'smith-2023';
+
+  beforeEach(async () => {
+    root = mkTemp();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    const dir = path.join(root, '.minerva', 'sources', sourceId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), META);
+    indexSource(ctx, sourceId, META);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('writes the status to meta.ttl and reflects it in the graph', async () => {
+    await setSourceReadStatus(root, sourceId, 'reading');
+
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).toContain('minerva:readStatus "reading"');
+
+    const detail = getSourceDetail(ctx, sourceId);
+    expect(detail?.metadata.readStatus).toBe('reading');
+    expect(sourcesByReadStatus(ctx, 'reading').map((s) => s.sourceId)).toEqual([sourceId]);
+  });
+
+  it('changing the status removes the old triple from the graph', async () => {
+    await setSourceReadStatus(root, sourceId, 'reading');
+    await setSourceReadStatus(root, sourceId, 'read');
+
+    const detail = getSourceDetail(ctx, sourceId);
+    expect(detail?.metadata.readStatus).toBe('read');
+    // The previous "reading" triple is gone.
+    expect(sourcesByReadStatus(ctx, 'reading')).toEqual([]);
+    expect(sourcesByReadStatus(ctx, 'read').map((s) => s.sourceId)).toEqual([sourceId]);
+  });
+
+  it('passing null clears the status', async () => {
+    await setSourceReadStatus(root, sourceId, 'reading');
+    await setSourceReadStatus(root, sourceId, null);
+
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).not.toContain('minerva:readStatus');
+
+    const detail = getSourceDetail(ctx, sourceId);
+    expect(detail?.metadata.readStatus).toBeNull();
+    expect(sourcesByReadStatus(ctx, 'reading')).toEqual([]);
+  });
+
+  it('refuses an unknown status', async () => {
+    // @ts-expect-error — test the runtime guard
+    await expect(setSourceReadStatus(root, sourceId, 'done')).rejects.toThrow(/Invalid read status/);
+  });
+});
+
+describe('setSourceReadDueBy (#116)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const sourceId = 'smith-2023';
+
+  beforeEach(async () => {
+    root = mkTemp();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    const dir = path.join(root, '.minerva', 'sources', sourceId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), META);
+    indexSource(ctx, sourceId, META);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('writes a due date with xsd:date datatype and surfaces it in metadata', async () => {
+    await setSourceReadDueBy(root, sourceId, '2026-06-30');
+
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).toContain('minerva:readDueBy "2026-06-30"^^xsd:date');
+
+    const detail = getSourceDetail(ctx, sourceId);
+    expect(detail?.metadata.readDueBy).toBe('2026-06-30');
+  });
+
+  it('refuses a non-ISO-date string', async () => {
+    await expect(setSourceReadDueBy(root, sourceId, 'next Tuesday')).rejects.toThrow(/Invalid ISO date/);
+  });
+
+  it('passing null clears the date', async () => {
+    await setSourceReadDueBy(root, sourceId, '2026-06-30');
+    await setSourceReadDueBy(root, sourceId, null);
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).not.toContain('minerva:readDueBy');
+  });
+});


### PR DESCRIPTION
A source carries an optional \`minerva:readStatus\` (\`unread\` / \`reading\` / \`read\` / \`skipped\`) and an optional \`minerva:readDueBy\` date. The source detail surfaces a segmented status toggle; the sidebar source list shows a small status glyph; smart collections gain a \`readStatus\` predicate kind so users can build "Reading", "Unread", "Done lately" without writing SPARQL.

## Predicates (in meta.ttl)
- \`minerva:readStatus "reading"\` — single-valued enum.
- \`minerva:readDueBy "2026-06-30"^^xsd:date\` — single-valued ISO date.

Storage lives directly in the source's existing \`meta.ttl\` rather than a separate file: status is part of the source's properties, queryable via SPARQL alongside DOI / tags / etc.

## Backend (\`src/main/sources/read-status.ts\`)
- \`setSourceReadStatus(root, sourceId, status)\` and \`setSourceReadDueBy(root, sourceId, dueBy)\` — both upsert a single line into meta.ttl via \`upsertSingleValuedPredicate\`, then re-index the source so the graph reflects the change immediately.
- \`null\` clears the predicate (line goes away, \`normaliseTrailingSeparator\` fixes the terminal \`;\` if needed). Validation refuses bogus enum values and non-ISO dates.

## Graph
- \`collectSourceMetadata\` now reads \`minerva:readStatus\` + \`minerva:readDueBy\` into the existing \`SourceMetadata\`.
- New \`sourcesByReadStatus(ctx, status)\` mirrors the existing \`sourcesByTag\` shape — used by the smart-collection resolver and available for future sidebar filters.

## Smart collections (#470 phase 2 extension)
- \`SmartCollectionPredicate\` union grows a \`readStatus\` variant: \`{ kind: 'readStatus'; status: ReadStatus[] }\` with OR-within semantics ("any of these statuses"). Empty array matches nothing, mirroring the tag-allOf convention.
- \`resolveSmartMembers\` now takes a \`lookups\` object \`{ sourcesByTag, sourcesByReadStatus }\` — pure-function pattern preserved; the main process wires both to the indexed graph.
- Defensive loader drops smart entries with unknown predicate kinds or invalid status values rather than crashing.

## UI
- \`SourceDetail\` gains a segmented "Status" row in the metadata block (Unread / Reading / Read / Skipped). Click the active button to clear. The current status syncs via the existing \`SOURCES_CHANGED\` broadcast.
- \`SourcesPanel\` shows a small glyph (◐ / ● / ○ / ×) before the title for sources with a status set. Colour-keyed via the accent for "reading".
- \`SmartCollectionEditorDialog\` gains a kind-picker (radio) at the top — Tag predicate vs Reading status. Switching kinds preserves the per-kind selection so the user can flip back and forth without losing their work.

## Tests
- \`read-status.test.ts\`: 14 cases — meta.ttl upsert/delete, graph reflection, status removal, invalid-input refusal, date validation, per-status indexing.
- \`collections.test.ts\`: 3 new cases for \`resolveSmartMembers\` with readStatus (union, single-status, empty). Existing tag-allOf tests updated to the new \`lookups\` object shape.
- Full suite **2300 / 2300** (+17).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Open a source, set Status to "Reading". Sidebar shows ◐ glyph next to the title.
  2. Click "Reading" again — status clears, glyph disappears.
  3. Create a smart collection with kind=Reading status, pick Reading + Unread. Collection lists those sources.
  4. Toggle a source to Read; the smart collection refreshes (re-click it in the sidebar; live re-fetch via SOURCES_CHANGED would be the polish next).
  5. Hand-edit a source's meta.ttl to add \`minerva:readDueBy "2026-06-30"^^xsd:date\`; \`api.graph.sourceDetail\` returns \`readDueBy: "2026-06-30"\`.

## Out of scope (next)
- Dedicated "Reading queue" sidebar view with default smart collections (Due this week, Recently finished, etc.). For now, users create these themselves via the editor.
- Date-relative predicates ("due in N days"). Date is stored; queries against it are SPARQL-only until the predicate union grows.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)