### PR TITLE
feat: reading queue sidebar + status/due affordances (#116)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -2142,6 +2142,87 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
 }
 
 /**
+ * Built-in Reading Queue views (#116). Each view resolves to a set
+ * of sourceIds via a hardcoded predicate evaluated against the live
+ * graph — distinct from user-defined smart collections which can't
+ * (yet) express date-relative facets.
+ */
+export type ReadingQueueView = 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished';
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Source ids matching the given queue view. `now` is injectable for
+ * deterministic tests; production callers pass nothing and get the
+ * current wall clock.
+ *
+ *   unread           — readStatus is unset OR explicitly 'unread'
+ *   reading          — readStatus = 'reading'
+ *   dueThisWeek      — readDueBy is set AND ≤ now + 7 days (past-due included)
+ *   recentlyFinished — readStatus = 'read' AND dc:modified within last 30 days
+ */
+export function getReadingQueueSourceIds(
+  ctx: ProjectContext,
+  view: ReadingQueueView,
+  now: Date = new Date(),
+): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  // Walk every source. Project sizes are O(1000), so a single pass
+  // beats running multiple statementsMatching queries.
+  const sourceStmts = store.statementsMatching(undefined, MINERVA('sourceId'), undefined);
+  const matched: string[] = [];
+  const seen = new Set<string>();
+  for (const st of sourceStmts) {
+    const subject = st.subject;
+    const sourceId = st.object.value;
+    if (!sourceId || seen.has(sourceId)) continue;
+
+    const status = store.statementsMatching(subject, MINERVA('readStatus'), undefined)[0]?.object.value ?? null;
+
+    if (view === 'unread') {
+      if (status === null || status === 'unread') {
+        seen.add(sourceId); matched.push(sourceId);
+      }
+      continue;
+    }
+    if (view === 'reading') {
+      if (status === 'reading') {
+        seen.add(sourceId); matched.push(sourceId);
+      }
+      continue;
+    }
+    if (view === 'dueThisWeek') {
+      const due = store.statementsMatching(subject, MINERVA('readDueBy'), undefined)[0]?.object.value;
+      if (!due) continue;
+      const dueMs = Date.parse(due);
+      if (Number.isNaN(dueMs)) continue;
+      if (dueMs <= now.getTime() + 7 * DAY_MS) {
+        seen.add(sourceId); matched.push(sourceId);
+      }
+      continue;
+    }
+    if (view === 'recentlyFinished') {
+      if (status !== 'read') continue;
+      const modified = store.statementsMatching(subject, DC('modified'), undefined)[0]?.object.value;
+      if (!modified) continue;
+      const mMs = Date.parse(modified);
+      if (Number.isNaN(mMs)) continue;
+      if (mMs >= now.getTime() - 30 * DAY_MS) {
+        seen.add(sourceId); matched.push(sourceId);
+      }
+      continue;
+    }
+    // Exhaustiveness — tells future contributors when they extend the union.
+    const _exhaustive: never = view;
+    throw new Error(`Unknown queue view: ${String(_exhaustive)}`);
+  }
+  return matched;
+}
+
+/**
  * Sources tagged with a particular reading status (#116). Used by
  * the smart-collection resolver and by sidebar filters that surface
  * "Unread" / "Reading" / "Read" buckets.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -74,6 +74,7 @@ import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
 import type { ReadStatus } from '../shared/types';
+import type { ReadingQueueView } from './graph/index';
 import {
   loadCollections,
   createCollection,
@@ -1617,6 +1618,15 @@ export function registerIpcHandlers(): void {
     await persistIndexes(rootPath);
     const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
+  ipcMain.handle(Channels.SOURCES_QUEUE_MEMBERS, (e, view: ReadingQueueView) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    const ctx = projectContext(rootPath);
+    const ids = new Set(graph.getReadingQueueSourceIds(ctx, view));
+    if (ids.size === 0) return [];
+    return graph.listAllSources(ctx).filter((s) => ids.has(s.sourceId));
   });
 
   // ── Collections (#470) ────────────────────────────────────────────────────

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -261,6 +261,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SOURCES_SET_READ_STATUS, { sourceId, status }),
     setReadDueBy: (sourceId: string, dueBy: string | null) =>
       ipcRenderer.invoke(Channels.SOURCES_SET_READ_DUE_BY, { sourceId, dueBy }),
+    queueMembers: (view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished') =>
+      ipcRenderer.invoke(Channels.SOURCES_QUEUE_MEMBERS, view),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -216,6 +216,20 @@
     }
   }
 
+  async function handleSetReadDueBy(next: string | null): Promise<void> {
+    if (!detail) return;
+    // Normalise empty string from the date input to null so the
+    // backend clears the predicate rather than refusing the empty
+    // value.
+    const value = next && next.trim() ? next.trim() : null;
+    try {
+      await api.sources.setReadDueBy(sourceId, value);
+      await load(sourceId);
+    } catch (err) {
+      console.error('[minerva] setReadDueBy failed:', err);
+    }
+  }
+
   let creatingAbout = $state(false);
   async function handleNewAboutNote(): Promise<void> {
     if (!onCreateAboutNote || creatingAbout) return;
@@ -293,6 +307,20 @@
               </button>
             {/each}
           </div>
+        </span>
+      </div>
+      <div class="kv read-due-row">
+        <span class="k">Due by</span>
+        <span class="v">
+          <input
+            type="date"
+            class="due-input"
+            value={detail.metadata.readDueBy ?? ''}
+            onchange={(e) => handleSetReadDueBy((e.target as HTMLInputElement).value)}
+          />
+          {#if detail.metadata.readDueBy}
+            <button class="due-clear" onclick={() => handleSetReadDueBy(null)} title="Clear due date">Clear</button>
+          {/if}
         </span>
       </div>
       <div class="actions">
@@ -548,6 +576,39 @@
     background: color-mix(in oklch, var(--accent) 14%, transparent);
     color: var(--accent);
     font-weight: 500;
+  }
+
+  .read-due-row .v {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .due-input {
+    padding: 3px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+  .due-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .due-clear {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .due-clear:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
   }
   .k {
     color: var(--text-muted);

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
   import { api } from '../ipc/client';
-  import type { SourceMetadata, Collection, SmartCollection, SmartCollectionPredicate } from '../../../shared/types';
+  import type { SourceMetadata, Collection, SmartCollection, SmartCollectionPredicate, ReadStatus } from '../../../shared/types';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import SourcePickerDialog from './SourcePickerDialog.svelte';
   import CollectionPickerDialog from './CollectionPickerDialog.svelte';
   import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
   import Icon from './Icon.svelte';
+
+  type QueueView = 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished';
+  const QUEUE_VIEWS: { id: QueueView; label: string }[] = [
+    { id: 'unread', label: 'Unread' },
+    { id: 'reading', label: 'Reading' },
+    { id: 'dueThisWeek', label: 'Due this week' },
+    { id: 'recentlyFinished', label: 'Recently finished' },
+  ];
+  const STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
+    { value: 'unread', label: 'Mark unread' },
+    { value: 'reading', label: 'Mark reading' },
+    { value: 'read', label: 'Mark read' },
+    { value: 'skipped', label: 'Mark skipped' },
+  ];
 
   interface Props {
     onSourceSelect: (sourceId: string) => void;
@@ -26,6 +40,20 @@
   let mergeSrc = $state<SourceMetadata | null>(null);
   /** When set, the collection picker is open to add this source to one. */
   let addToCollectionFor = $state<SourceMetadata | null>(null);
+
+  /** Active queue view id, or null when no queue row is selected. The
+   *  queue rows and collection rows share the focus slot but live in
+   *  separate state vars because they resolve their members
+   *  differently (built-in vs. user-defined). */
+  let activeQueueView = $state<QueueView | null>(null);
+  /** Source ids for the active queue view, re-fetched on demand. */
+  let queueMembers = $state<Set<string> | null>(null);
+  /** Counts shown next to each queue row. Refreshed alongside the
+   *  source/collection lists so the user gets fresh numbers without
+   *  clicking. */
+  let queueCounts = $state<Record<QueueView, number>>({
+    unread: 0, reading: 0, dueThisWeek: 0, recentlyFinished: 0,
+  });
 
   let collections = $state<Collection[]>([]);
   let smartCollections = $state<SmartCollection[]>([]);
@@ -182,7 +210,25 @@
 
   export async function refresh(): Promise<void> {
     sources = await api.sources.listAll();
+    void refreshQueueCounts();
+    if (activeQueueView) {
+      queueMembers = new Set((await api.sources.queueMembers(activeQueueView)).map((s) => s.sourceId));
+    }
   }
+
+  async function refreshQueueCounts(): Promise<void> {
+    const entries = await Promise.all(
+      QUEUE_VIEWS.map(async (v) => [v.id, (await api.sources.queueMembers(v.id)).length] as const),
+    );
+    const next: Record<QueueView, number> = { unread: 0, reading: 0, dueThisWeek: 0, recentlyFinished: 0 };
+    for (const [id, count] of entries) next[id] = count;
+    queueCounts = next;
+  }
+
+  // Sources change → host App.svelte's sources.onChanged listener
+  // calls sidebar.refreshSources() which calls our refresh() above,
+  // and that already kicks off refreshQueueCounts(). No additional
+  // listener needed here.
 
   const activeIsSmart = $derived(
     !!activeCollectionId && smartCollections.some((s) => s.id === activeCollectionId),
@@ -212,8 +258,9 @@
 
   /** Source ids the active collection contributes. For manual: union
    *  of every member array in the subtree. For smart: the live
-   *  smartMembers set from the IPC. */
+   *  smartMembers set. For a queue view: the live queueMembers set. */
   const activeMembers = $derived.by(() => {
+    if (activeQueueView) return queueMembers;
     if (!activeCollectionId) return null;
     if (activeIsSmart) return smartMembers;
     if (!activeSubtree) return null;
@@ -297,10 +344,35 @@
 
   async function selectCollection(id: string | null) {
     activeCollectionId = id;
+    activeQueueView = null;
+    queueMembers = null;
     if (id && smartCollections.some((s) => s.id === id)) {
       smartMembers = new Set((await api.collections.smartMembers(id)).map((s) => s.sourceId));
     } else {
       smartMembers = null;
+    }
+  }
+
+  async function selectQueueView(view: QueueView) {
+    if (activeQueueView === view) {
+      // Click-to-toggle: deselecting returns to "All sources".
+      activeQueueView = null;
+      queueMembers = null;
+      return;
+    }
+    activeQueueView = view;
+    activeCollectionId = null;
+    smartMembers = null;
+    queueMembers = new Set((await api.sources.queueMembers(view)).map((s) => s.sourceId));
+  }
+
+  async function handleMarkStatus(source: SourceMetadata, status: ReadStatus | null): Promise<void> {
+    contextMenu = null;
+    try {
+      await api.sources.setReadStatus(source.sourceId, status);
+      // Host listener refreshes the panel; nothing more to do.
+    } catch (err) {
+      console.error('[minerva] Mark status failed:', err);
     }
   }
 
@@ -529,6 +601,22 @@
   {#if sources.length === 0 && collections.length === 0}
     <div class="empty">No sources yet. File → Ingest URL… to start.</div>
   {:else}
+    <div class="queue-section">
+      <div class="section-eyebrow">READING QUEUE</div>
+      {#each QUEUE_VIEWS as v (v.id)}
+        <button
+          class="coll-row queue-row"
+          class:active={activeQueueView === v.id}
+          onclick={() => selectQueueView(v.id)}
+          title={`Show ${v.label.toLowerCase()}`}
+        >
+          <span class="chevron-spacer"></span>
+          <span class="coll-name">{v.label}</span>
+          <span class="coll-count">{queueCounts[v.id]}</span>
+        </button>
+      {/each}
+    </div>
+
     <div class="collections-section">
       <div class="collections-header">
         <span class="collections-eyebrow">COLLECTIONS</span>
@@ -538,7 +626,7 @@
       </div>
       <button
         class="coll-row"
-        class:active={activeCollectionId === null}
+        class:active={activeCollectionId === null && activeQueueView === null}
         onclick={() => selectCollection(null)}
       >
         <span class="chevron-spacer"></span>
@@ -594,13 +682,15 @@
       <input
         type="text"
         class="filter-input"
-        placeholder={activeCollectionId
-          ? `Filter "${
-              collections.find((c) => c.id === activeCollectionId)?.name
-              ?? smartCollections.find((s) => s.id === activeCollectionId)?.name
-              ?? 'collection'
-            }"…`
-          : 'Filter sources…'}
+        placeholder={activeQueueView
+          ? `Filter "${QUEUE_VIEWS.find((v) => v.id === activeQueueView)?.label ?? 'queue'}"…`
+          : activeCollectionId
+            ? `Filter "${
+                collections.find((c) => c.id === activeCollectionId)?.name
+                ?? smartCollections.find((s) => s.id === activeCollectionId)?.name
+                ?? 'collection'
+              }"…`
+            : 'Filter sources…'}
         bind:value={filter}
       />
     </div>
@@ -632,7 +722,13 @@
       {/each}
       {#if visible.length === 0}
         <div class="empty">
-          {activeCollectionId ? 'This collection is empty.' : 'No matches.'}
+          {#if activeQueueView}
+            Nothing in this queue view.
+          {:else if activeCollectionId}
+            This collection is empty.
+          {:else}
+            No matches.
+          {/if}
         </div>
       {/if}
     </div>
@@ -646,9 +742,20 @@
       style:top="{contextMenu.y}px"
     >
       <button onclick={() => handleAddToCollection(contextMenu!.source)}>Add to collection…</button>
-      {#if activeCollectionId}
+      {#if activeCollectionId && !activeIsSmart}
         <button onclick={() => handleRemoveFromActiveCollection(contextMenu!.source)}>Remove from collection</button>
       {/if}
+      <div class="context-divider"></div>
+      {#each STATUS_OPTIONS as opt (opt.value)}
+        <button
+          class:current={contextMenu.source.readStatus === opt.value}
+          onclick={() => handleMarkStatus(contextMenu!.source, opt.value)}
+        >{opt.label}</button>
+      {/each}
+      {#if contextMenu.source.readStatus}
+        <button onclick={() => handleMarkStatus(contextMenu!.source, null)}>Clear status</button>
+      {/if}
+      <div class="context-divider"></div>
       <button onclick={() => handleMergeStart(contextMenu!.source)}>Merge into…</button>
       <button onclick={() => handleDelete(contextMenu!.source)}>Delete Source</button>
     </div>
@@ -948,4 +1055,34 @@
   .status-dot.status-read { color: color-mix(in oklch, var(--text-muted) 90%, transparent); }
   .status-dot.status-unread { color: var(--text-faint); }
   .status-dot.status-skipped { color: var(--text-faint); }
+
+  /* Reading-queue section sits above Collections — built-in views,
+     so no "+" button. Same row shape as the collection tree, just
+     without the chevron / context-menu affordances. */
+  .queue-section {
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 4px;
+  }
+  .section-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    letter-spacing: 0.06em;
+    padding: 10px 14px 4px;
+  }
+  .queue-row { /* re-uses .coll-row look */ }
+
+  /* Subtle separator inside the context menu. */
+  .context-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+  }
+  /* The user's current status row reads as a quiet indicator
+     ("you're already at this state") rather than an action. */
+  .context-menu button.current {
+    color: var(--accent);
+    font-weight: 500;
+  }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -683,6 +683,9 @@ export interface SourcesApi {
   setReadStatus(sourceId: string, status: import('../../../shared/types').ReadStatus | null): Promise<void>;
   /** Set / change / clear a source's due-by date (ISO YYYY-MM-DD). */
   setReadDueBy(sourceId: string, dueBy: string | null): Promise<void>;
+  /** Resolve a built-in Reading Queue view against the live graph. */
+  queueMembers(view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished'):
+    Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -237,6 +237,9 @@ export const Channels = {
   SOURCES_SET_READ_STATUS: 'sources:setReadStatus',
   /** Set/clear a source's due-by date (#116). */
   SOURCES_SET_READ_DUE_BY: 'sources:setReadDueBy',
+  /** Resolve a built-in Reading Queue view (unread / reading /
+   *  dueThisWeek / recentlyFinished) against the live graph (#116). */
+  SOURCES_QUEUE_MEMBERS: 'sources:queueMembers',
 
   // Collections (#470)
   /** Read `.minerva/collections.json` as a CollectionsFile. */

--- a/tests/main/graph/reading-queue.test.ts
+++ b/tests/main/graph/reading-queue.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Built-in Reading Queue views (#116). Date-relative semantics are
+ * easiest to validate via a deterministic `now`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexSource,
+  getReadingQueueSourceIds,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-reading-queue-'));
+}
+
+function buildMeta(extra = ''): string {
+  return `this: a thought:Article ;
+    dc:title "Test" ;
+${extra}    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+}
+
+describe('getReadingQueueSourceIds (#116)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  // Pin time so date-relative views are deterministic.
+  const NOW = new Date('2026-05-27T00:00:00Z');
+
+  beforeEach(async () => {
+    root = mkTemp();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  function makeSource(id: string, ttlExtra = ''): void {
+    const dir = path.join(root, '.minerva', 'sources', id);
+    fs.mkdirSync(dir, { recursive: true });
+    const ttl = buildMeta(ttlExtra);
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl);
+    indexSource(ctx, id, ttl);
+  }
+
+  it('"unread" returns sources with no readStatus AND those marked unread', () => {
+    makeSource('no-status'); // no status set
+    makeSource('explicit-unread', '    minerva:readStatus "unread" ;\n');
+    makeSource('reading', '    minerva:readStatus "reading" ;\n');
+
+    expect(getReadingQueueSourceIds(ctx, 'unread', NOW).sort()).toEqual(['explicit-unread', 'no-status']);
+  });
+
+  it('"reading" returns only explicit readStatus = reading', () => {
+    makeSource('a', '    minerva:readStatus "reading" ;\n');
+    makeSource('b', '    minerva:readStatus "read" ;\n');
+    makeSource('c'); // implicit unread doesn't match
+
+    expect(getReadingQueueSourceIds(ctx, 'reading', NOW)).toEqual(['a']);
+  });
+
+  it('"dueThisWeek" includes due-today, future-within-7-days, and overdue', () => {
+    makeSource('today', '    minerva:readDueBy "2026-05-27"^^xsd:date ;\n');
+    makeSource('in-3-days', '    minerva:readDueBy "2026-05-30"^^xsd:date ;\n');
+    makeSource('in-7-days', '    minerva:readDueBy "2026-06-03"^^xsd:date ;\n');
+    makeSource('overdue', '    minerva:readDueBy "2026-05-20"^^xsd:date ;\n');
+    makeSource('in-10-days', '    minerva:readDueBy "2026-06-06"^^xsd:date ;\n');
+    makeSource('no-due-date'); // excluded — no due field
+
+    expect(getReadingQueueSourceIds(ctx, 'dueThisWeek', NOW).sort()).toEqual([
+      'in-3-days', 'in-7-days', 'overdue', 'today',
+    ]);
+  });
+
+  it('"recentlyFinished" wants status=read AND modified within the last 30 days', () => {
+    // mtime is set from the meta.ttl file's actual mtime, so to test
+    // the date threshold we manually backdate one of the files.
+    makeSource('just-finished', '    minerva:readStatus "read" ;\n');
+    makeSource('old-read', '    minerva:readStatus "read" ;\n');
+    // 60 days back — outside the 30-day window. Touch the file then
+    // re-index so dc:modified reflects the backdated mtime.
+    const old = new Date(NOW.getTime() - 60 * 86_400_000);
+    fs.utimesSync(path.join(root, '.minerva', 'sources', 'old-read', 'meta.ttl'), old, old);
+    indexSource(
+      ctx,
+      'old-read',
+      fs.readFileSync(path.join(root, '.minerva', 'sources', 'old-read', 'meta.ttl'), 'utf-8'),
+    );
+
+    makeSource('reading-still', '    minerva:readStatus "reading" ;\n'); // wrong status
+
+    expect(getReadingQueueSourceIds(ctx, 'recentlyFinished', NOW)).toEqual(['just-finished']);
+  });
+
+  it('returns an empty list when no sources match', () => {
+    makeSource('a', '    minerva:readStatus "skipped" ;\n');
+    expect(getReadingQueueSourceIds(ctx, 'reading', NOW)).toEqual([]);
+    expect(getReadingQueueSourceIds(ctx, 'recentlyFinished', NOW)).toEqual([]);
+    expect(getReadingQueueSourceIds(ctx, 'dueThisWeek', NOW)).toEqual([]);
+  });
+
+  it('handles malformed date literals gracefully (skips the source)', () => {
+    makeSource('bad-date', '    minerva:readDueBy "next Tuesday" ;\n');
+    makeSource('good-date', '    minerva:readDueBy "2026-05-30"^^xsd:date ;\n');
+
+    expect(getReadingQueueSourceIds(ctx, 'dueThisWeek', NOW)).toEqual(['good-date']);
+  });
+});


### PR DESCRIPTION
Closes out #116. Adds the dedicated sidebar section the issue called for, plus the missing inline affordances for setting status and due-by from outside the source detail view.

## Sidebar: READING QUEUE section
New built-in section above Collections with four always-present rows, each backed by a hardcoded predicate evaluated against the live graph:

- **Unread** — \`readStatus\` is unset OR explicitly \`'unread'\` (so new sources surface here by default).
- **Reading** — \`readStatus = 'reading'\`.
- **Due this week** — \`readDueBy\` set AND ≤ now + 7 days. Past-due items are included; if it's overdue the user definitely wants to see it.
- **Recently finished** — \`readStatus = 'read'\` AND \`dc:modified\` within the last 30 days.

Each row shows a live count and click-to-toggle selection (clicking the active row returns to "All sources"). The four are distinct from user-defined smart collections because they need date-relative logic the predicate union doesn't (yet) express.

## SourceDetail: due-by date input
A second metadata row under the status segmented buttons. Native \`<input type="date">\` for the calendar picker, with a small "Clear" button when a date is set.

## SourcesPanel context menu: inline status options
Right-click on a source row now exposes **Mark unread** / **Mark reading** / **Mark read** / **Mark skipped** (and **Clear status** when one is set), grouped between the collection actions and the destructive Merge/Delete options via thin dividers. The user's current status reads in the accent colour rather than muted text so "you're already here" stands out from "this is an action".

## Backend
- \`getReadingQueueSourceIds(ctx, view, now?)\` in \`graph/index.ts\`. Single store pass walks every source and applies the view's predicate. \`now\` is injectable for deterministic tests.
- New IPC \`sources:queueMembers(view)\` → \`SourceMetadata[]\`.

## Tests
6 new cases in \`reading-queue.test.ts\`:
- \`unread\` covers no-status AND explicit-unread
- \`reading\` is strict on the enum value
- \`dueThisWeek\` includes today, future-within-7d, and overdue; excludes future > 7d and sources without a due date
- \`recentlyFinished\` requires status=read AND mtime within 30d (a backdated meta.ttl is filtered out)
- empty results when nothing matches
- malformed date literals are skipped rather than crashing

Full suite **2306 / 2306** (+6).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Sidebar shows the new READING QUEUE section with four rows + live counts.
  2. Click Unread → shows sources with no status set (the default for newly-ingested sources). Right-click one → Mark reading. The source moves from Unread into the Reading row.
  3. Open a source detail. Set Due by via the date input; the source appears under "Due this week" (if within 7 days).
  4. Mark a source as Read. It appears under "Recently finished" until 30 days post-mtime.
  5. Right-click a source with a status → "Clear status" returns it to Unread.

## Out of scope (next)
- Date-relative predicates as first-class smart-collection facets (would unify with user-defined smart collections; the four queue views can stay built-in until that lands)
- Cycling status by clicking the source-list glyph (right-click menu covers the workflow)

Closes #116.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)