### PR TITLE
feat: design-review gaps — Properties dead-link + Goto palette polish (#548, #552)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -202,6 +202,13 @@
   async function refreshSourcesCache(): Promise<void> {
     try { sourcesCache = await api.sources.listAll(); } catch { /* ignore */ }
   }
+  /** Lazy cache of saved queries — populated when the Goto palette
+   *  opens so its Queries scope chip has live counts without paying
+   *  the IPC cost on every keystroke. */
+  let savedQueriesCache = $state<import('../shared/types').SavedQuery[]>([]);
+  async function refreshSavedQueriesCache(): Promise<void> {
+    try { savedQueriesCache = await api.queries.list(); } catch { /* ignore */ }
+  }
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
   let promptDialog = $state<{ message: string; suggestions?: string[]; initial?: string; resolve: (value: string | null) => void } | null>(null);
@@ -2170,7 +2177,13 @@
     api.menu.onNavBack(() => handleNavBack());
     api.menu.onNavForward(() => handleNavForward());
     api.menu.onGotoLine(() => { if (editor.activeTab) showGotoLine = true; });
-    api.menu.onQuickOpen(() => { showGotoNote = true; });
+    api.menu.onQuickOpen(() => {
+      // Lazily refresh the palette's source + query backing data so
+      // its scope chip counts are fresh when the user opens it.
+      void refreshSourcesCache();
+      void refreshSavedQueriesCache();
+      showGotoNote = true;
+    });
     api.menu.onNewQuery(() => editor.openQuery());
     api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
     api.menu.onEditSavedQueries(() => { showEditSavedQueries = true; });
@@ -2339,7 +2352,11 @@
     canGoForward={nav.canGoForward}
     onNavBack={handleNavBack}
     onNavForward={handleNavForward}
-    onOpenGotoNote={() => { showGotoNote = true; }}
+    onOpenGotoNote={() => {
+      void refreshSourcesCache();
+      void refreshSavedQueriesCache();
+      showGotoNote = true;
+    }}
     onOpenSettings={() => { showSettings = true; }}
   />
 
@@ -2615,7 +2632,11 @@
   {#if showGotoNote}
     <GotoNoteDialog
       files={notebase.files}
+      sources={sourcesCache}
+      savedQueries={savedQueriesCache}
       onSelect={(path) => { showGotoNote = false; void handleFileSelect(path); }}
+      onSelectSource={(id) => { showGotoNote = false; handleOpenSource(id); }}
+      onSelectQuery={(q) => { showGotoNote = false; editor.openQuery(q.query, q.language ?? 'sparql'); }}
       onCancel={() => { showGotoNote = false; }}
     />
   {/if}

--- a/src/renderer/lib/components/GotoNoteDialog.svelte
+++ b/src/renderer/lib/components/GotoNoteDialog.svelte
@@ -1,89 +1,95 @@
 <script lang="ts">
-  import type { NoteFile } from '../../../shared/types';
+  import type { NoteFile, SourceMetadata, SavedQuery } from '../../../shared/types';
   import Icon from './Icon.svelte';
+  import type { IconName } from './icons/registry';
+  import { formatRelativeTime } from '../utils/format-relative-time';
+
+  type Scope = 'all' | 'notes' | 'sources' | 'queries';
+
+  interface NoteItem { kind: 'note'; name: string; relativePath: string; mtimeMs?: number; score: number }
+  interface SourceItem { kind: 'source'; name: string; sourceId: string; byline: string | null; score: number }
+  interface QueryItem { kind: 'query'; name: string; query: SavedQuery; score: number }
+  type PaletteItem = NoteItem | SourceItem | QueryItem;
 
   interface Props {
     files: NoteFile[];
     onSelect: (relativePath: string) => void;
     onCancel: () => void;
-    /** Placeholder text inside the search input. Default "Go to note...". */
+    /** Placeholder text inside the search input. Default "Go to..." */
     placeholder?: string;
     /** Drop a single relativePath from the candidate list — used by Merge
      *  Note (#464) so the user can't pick the source as the merge target. */
     excludePath?: string;
+    /** When supplied, sources participate in the palette and the
+     *  Sources scope chip appears. Required to make the chip useful;
+     *  callers like Merge-Note (notes-only) leave this out. */
+    sources?: SourceMetadata[];
+    /** When supplied, saved queries participate too. */
+    savedQueries?: SavedQuery[];
+    /** Called when the user picks a source row. Required when `sources`
+     *  is provided. */
+    onSelectSource?: (sourceId: string) => void;
+    /** Called when the user picks a query row. Required when
+     *  `savedQueries` is provided. */
+    onSelectQuery?: (query: SavedQuery) => void;
   }
 
-  let { files, onSelect, onCancel, placeholder = 'Go to note...', excludePath }: Props = $props();
+  let {
+    files, onSelect, onCancel, placeholder = 'Go to...', excludePath,
+    sources, savedQueries, onSelectSource, onSelectQuery,
+  }: Props = $props();
 
   let query = $state('');
+  let scope = $state<Scope>('all');
   let selectedIndex = $state(0);
   let inputEl = $state<HTMLInputElement>();
 
-  // Flatten the file tree into a list of note paths
-  function flattenNotes(items: NoteFile[], acc: { name: string; relativePath: string }[] = []): { name: string; relativePath: string }[] {
+  /** Whether the palette is in multi-scope mode. When false, the
+   *  scope chip row is hidden and behavior matches the notes-only
+   *  picker that Merge-Note has always used. */
+  const multiScope = $derived(!!(sources && sources.length > 0) || !!(savedQueries && savedQueries.length > 0));
+
+  // Flatten note tree.
+  function flattenNotes(items: NoteFile[], acc: { name: string; relativePath: string; mtimeMs?: number }[] = []): { name: string; relativePath: string; mtimeMs?: number }[] {
     for (const f of items) {
       if (f.isDirectory) {
         if (f.children) flattenNotes(f.children, acc);
       } else {
-        acc.push({ name: f.name.replace(/\.md$/, ''), relativePath: f.relativePath });
+        acc.push({
+          name: f.name.replace(/\.md$/, ''),
+          relativePath: f.relativePath,
+          mtimeMs: f.mtimeMs,
+        });
       }
     }
     return acc;
   }
 
   const allNotes = flattenNotes(files).filter((n) => n.relativePath !== excludePath);
+  const allSources = $derived(sources ?? []);
+  const allQueries = $derived(savedQueries ?? []);
 
-  // ── Matching logic ──────────────────────────────────────────────────────
+  // Per-scope unfiltered counts — drive the chip labels.
+  const totalCounts = $derived({
+    notes: allNotes.length,
+    sources: allSources.length,
+    queries: allQueries.length,
+  });
 
-  function matchNotes(q: string): { name: string; relativePath: string; score: number }[] {
-    if (!q.trim()) return allNotes.map((n) => ({ ...n, score: 0 }));
-
-    // Detect regex: contains unescaped regex metacharacters
-    if (/[.*+?^${}()|[\]\\]/.test(q)) {
-      try {
-        const re = new RegExp(q, 'i');
-        return allNotes
-          .filter((n) => re.test(n.name) || re.test(n.relativePath))
-          .map((n) => ({ ...n, score: 1 }));
-      } catch { /* fall through to fuzzy */ }
-    }
-
-    const scored: { name: string; relativePath: string; score: number }[] = [];
-
-    for (const note of allNotes) {
-      const score = scoreMatch(note.name, note.relativePath, q);
-      if (score > 0) scored.push({ ...note, score });
-    }
-
-    scored.sort((a, b) => b.score - a.score);
-    return scored;
-  }
-
-  function scoreMatch(name: string, path: string, q: string): number {
+  function scoreMatch(name: string, secondary: string | null, q: string): number {
     const lowerName = name.toLowerCase();
-    const lowerPath = path.toLowerCase();
+    const lowerSecondary = secondary?.toLowerCase() ?? '';
     const lowerQ = q.toLowerCase();
-
-    // Exact substring in name
     if (lowerName.includes(lowerQ)) return 100;
-    // Exact substring in path
-    if (lowerPath.includes(lowerQ)) return 80;
-
-    // First-letter matching: each char of query matches the first letter of a word
+    if (lowerSecondary && lowerSecondary.includes(lowerQ)) return 80;
     if (firstLetterMatch(name, q)) return 90;
-
-    // CamelCase matching: uppercase letters in query match uppercase transitions
     if (camelCaseMatch(name, q)) return 85;
-
-    // Fuzzy: all chars of query appear in order in name
     if (fuzzyMatch(lowerName, lowerQ)) return 50;
-    if (fuzzyMatch(lowerPath, lowerQ)) return 30;
-
+    if (lowerSecondary && fuzzyMatch(lowerSecondary, lowerQ)) return 30;
     return 0;
   }
 
   function firstLetterMatch(name: string, q: string): boolean {
-    // Split name into words by spaces, hyphens, underscores
     const words = name.split(/[\s\-_]+/);
     const letters = q.toLowerCase();
     if (letters.length > words.length) return false;
@@ -95,7 +101,6 @@
   }
 
   function camelCaseMatch(name: string, q: string): boolean {
-    // Extract capital letters / word starts from name
     const capitals: string[] = [];
     for (let i = 0; i < name.length; i++) {
       if (i === 0 || name[i] === name[i].toUpperCase() && name[i] !== name[i].toLowerCase()) {
@@ -120,13 +125,76 @@
     return true;
   }
 
-  // ── Derived results ─────────────────────────────────────────────────────
+  /**
+   * Combined, scored, scope-filtered, query-filtered result list. The
+   * three palette item kinds carry enough metadata for rendering and
+   * for the kind-specific onSelect dispatch.
+   */
+  const results = $derived.by<PaletteItem[]>(() => {
+    const q = query.trim();
+    const isRegex = q.length > 0 && /[.*+?^${}()|[\]\\]/.test(q);
+    let regex: RegExp | null = null;
+    if (isRegex) {
+      try { regex = new RegExp(q, 'i'); } catch { /* fall back to fuzzy */ }
+    }
 
-  let results = $derived(matchNotes(query).slice(0, 30));
+    const mkNote = (n: { name: string; relativePath: string; mtimeMs?: number }, score: number): NoteItem =>
+      ({ kind: 'note', name: n.name, relativePath: n.relativePath, mtimeMs: n.mtimeMs, score });
+    const mkSource = (s: SourceMetadata, score: number): SourceItem =>
+      ({ kind: 'source', name: s.title ?? s.sourceId, sourceId: s.sourceId, byline: formatByline(s), score });
+    const mkQuery = (qy: SavedQuery, score: number): QueryItem =>
+      ({ kind: 'query', name: qy.name, query: qy, score });
 
-  // Reset selection when results change
+    const noteItems: NoteItem[] = (scope === 'all' || scope === 'notes')
+      ? allNotes.flatMap((n) => {
+        if (!q) return [mkNote(n, 0)];
+        if (regex) return regex.test(n.name) || regex.test(n.relativePath) ? [mkNote(n, 1)] : [];
+        const s = scoreMatch(n.name, n.relativePath, q);
+        return s > 0 ? [mkNote(n, s)] : [];
+      })
+      : [];
+
+    const sourceItems: SourceItem[] = (scope === 'all' || scope === 'sources')
+      ? allSources.flatMap((s) => {
+        const name = s.title ?? s.sourceId;
+        if (!q) return [mkSource(s, 0)];
+        if (regex) return regex.test(name) || regex.test(s.sourceId) ? [mkSource(s, 1)] : [];
+        const score = scoreMatch(name, formatByline(s) ?? s.sourceId, q);
+        return score > 0 ? [mkSource(s, score)] : [];
+      })
+      : [];
+
+    const queryItems: QueryItem[] = (scope === 'all' || scope === 'queries')
+      ? allQueries.flatMap((qy) => {
+        if (!q) return [mkQuery(qy, 0)];
+        if (regex) return regex.test(qy.name) || regex.test(qy.description) ? [mkQuery(qy, 1)] : [];
+        const score = scoreMatch(qy.name, qy.description, q);
+        return score > 0 ? [mkQuery(qy, score)] : [];
+      })
+      : [];
+
+    const combined: PaletteItem[] = [...noteItems, ...sourceItems, ...queryItems];
+    combined.sort((a, b) => b.score - a.score);
+    return combined.slice(0, 60);
+  });
+
+  function formatByline(s: SourceMetadata): string | null {
+    const who = s.creators.length === 0 ? ''
+      : s.creators.length === 1 ? s.creators[0]
+      : `${s.creators[0]} et al.`;
+    if (who && s.year) return `${who} (${s.year})`;
+    return who || s.year || null;
+  }
+
+  function selectItem(item: PaletteItem): void {
+    if (item.kind === 'note') onSelect(item.relativePath);
+    else if (item.kind === 'source') onSelectSource?.(item.sourceId);
+    else if (item.kind === 'query') onSelectQuery?.(item.query);
+  }
+
+  // Reset selection when filtered results change.
   $effect(() => {
-    results; // track dependency
+    results;
     selectedIndex = 0;
   });
 
@@ -139,28 +207,29 @@
       selectedIndex = Math.max(selectedIndex - 1, 0);
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (results[selectedIndex]) {
-        onSelect(results[selectedIndex].relativePath);
-      }
+      const picked = results[selectedIndex];
+      if (picked) selectItem(picked);
     } else if (e.key === 'Escape') {
       onCancel();
     }
   }
 
-  $effect(() => {
-    inputEl?.focus();
-  });
-
-  // Keep selected item scrolled into view
+  $effect(() => { inputEl?.focus(); });
   $effect(() => {
     const el = document.querySelector('.goto-results .selected');
     el?.scrollIntoView({ block: 'nearest' });
   });
+
+  function kindIconName(kind: PaletteItem['kind']): IconName {
+    if (kind === 'note') return 'notes';
+    if (kind === 'source') return 'sites';
+    return 'query';
+  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-label="Go to note">
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Go to">
     <div class="input-row">
       <Icon name="search" size={14} color="var(--text-muted)" />
       <input
@@ -170,27 +239,61 @@
         class="input"
         {placeholder}
       />
-      <span class="input-kbd">⌘ K</span>
+      <span class="input-kbd">⌘ P</span>
     </div>
+
+    {#if multiScope}
+      <div class="scope-row" role="tablist">
+        <button class="scope-chip" class:active={scope === 'all'} onclick={() => { scope = 'all'; }} role="tab" aria-selected={scope === 'all'}>
+          <span>All</span>
+          <span class="scope-count">{totalCounts.notes + totalCounts.sources + totalCounts.queries}</span>
+        </button>
+        <button class="scope-chip" class:active={scope === 'notes'} onclick={() => { scope = 'notes'; }} role="tab" aria-selected={scope === 'notes'}>
+          <span>Notes</span>
+          <span class="scope-count">{totalCounts.notes}</span>
+        </button>
+        {#if totalCounts.sources > 0}
+          <button class="scope-chip" class:active={scope === 'sources'} onclick={() => { scope = 'sources'; }} role="tab" aria-selected={scope === 'sources'}>
+            <span>Sources</span>
+            <span class="scope-count">{totalCounts.sources}</span>
+          </button>
+        {/if}
+        {#if totalCounts.queries > 0}
+          <button class="scope-chip" class:active={scope === 'queries'} onclick={() => { scope = 'queries'; }} role="tab" aria-selected={scope === 'queries'}>
+            <span>Queries</span>
+            <span class="scope-count">{totalCounts.queries}</span>
+          </button>
+        {/if}
+      </div>
+    {/if}
 
     {#if results.length > 0}
       <ul class="goto-results">
-        {#each results as result, i}
-          {@const folder = result.relativePath.includes('/')
+        {#each results as result, i (`${result.kind}::${result.kind === 'note' ? result.relativePath : result.kind === 'source' ? result.sourceId : result.query.id}`)}
+          {@const folder = result.kind === 'note' && result.relativePath.includes('/')
             ? result.relativePath.slice(0, result.relativePath.lastIndexOf('/'))
             : ''}
           <li>
             <button
               class="result-item"
               class:selected={i === selectedIndex}
-              onclick={() => onSelect(result.relativePath)}
+              onclick={() => selectItem(result)}
               onmouseenter={() => { selectedIndex = i; }}
             >
-              <Icon name="notes" size={13} color={i === selectedIndex ? 'var(--accent)' : 'var(--text-faint)'} />
+              <Icon name={kindIconName(result.kind)} size={13} color={i === selectedIndex ? 'var(--accent)' : 'var(--text-faint)'} />
               <span class="result-body">
                 <span class="result-name">{result.name}</span>
-                {#if folder}
-                  <span class="result-path">{folder}</span>
+                {#if result.kind === 'note'}
+                  {#if folder}
+                    <span class="result-path">{folder}</span>
+                  {/if}
+                  {#if result.mtimeMs}
+                    <span class="result-meta">{formatRelativeTime(result.mtimeMs)}</span>
+                  {/if}
+                {:else if result.kind === 'source'}
+                  {#if result.byline}<span class="result-path">{result.byline}</span>{/if}
+                {:else if result.kind === 'query'}
+                  {#if result.query.description}<span class="result-path">{result.query.description}</span>{/if}
                 {/if}
               </span>
             </button>
@@ -198,7 +301,7 @@
         {/each}
       </ul>
     {:else if query.trim()}
-      <div class="no-results">No matching notes</div>
+      <div class="no-results">No matches</div>
     {/if}
 
     <footer class="palette-footer">
@@ -206,7 +309,7 @@
       <span class="result-count">
         {#if results.length > 0}
           <span class="nums">{results.length}</span>
-          {results.length === 1 ? 'note' : 'notes'}
+          {results.length === 1 ? 'result' : 'results'}
         {/if}
       </span>
     </footer>
@@ -276,6 +379,40 @@
     flex-shrink: 0;
   }
 
+  .scope-row {
+    display: flex;
+    gap: 6px;
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .scope-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .scope-chip:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .scope-chip.active {
+    color: var(--accent);
+    border-color: color-mix(in oklch, var(--accent) 45%, var(--border));
+    background: color-mix(in oklch, var(--accent) 10%, transparent);
+  }
+  .scope-count {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-faint);
+  }
+  .scope-chip.active .scope-count { color: var(--accent); }
+
   .goto-results {
     list-style: none;
     overflow-y: auto;
@@ -328,6 +465,14 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     flex-shrink: 1;
+  }
+  .result-meta {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    margin-left: auto;
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
   }
 
   .no-results {

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -20,6 +20,7 @@
   import { api } from '../../ipc/client';
   import AutocompleteDropdown from './AutocompleteDropdown.svelte';
   import Icon from '../Icon.svelte';
+  import { resolveWikiLinkTarget } from '../../wiki-link-resolver';
   import type { IconName } from '../icons/registry';
   import { CANONICAL_FRONTMATTER_KEYS } from '../../../../shared/frontmatter-canonical-keys';
 
@@ -338,22 +339,38 @@
   // Note basenames (relativePath without `.md`), for the wiki-link
   // value picker (#489). Same refresh cadence as projectKeys.
   let noteBasenames = $state<string[]>([]);
+  /** Flat note file list, retained to feed `resolveWikiLinkTarget` so
+   *  the wiki-chip can colour itself when its target is broken. */
+  let flatNotes = $state<{ relativePath: string; isDirectory: boolean }[]>([]);
+  let aliasMap = $state<Record<string, string>>({});
+
   async function refreshNoteBasenames(): Promise<void> {
     try {
       const files = await api.notebase.listFiles();
       const out: string[] = [];
+      const flat: { relativePath: string; isDirectory: boolean }[] = [];
       const walk = (nodes: import('../../../../shared/types').NoteFile[]) => {
         for (const n of nodes) {
           if (n.isDirectory && n.children) walk(n.children);
           else if (!n.isDirectory && n.relativePath.endsWith('.md')) {
             out.push(n.relativePath.replace(/\.md$/, ''));
+            flat.push({ relativePath: n.relativePath, isDirectory: false });
           }
         }
       };
       walk(files);
       out.sort((a, b) => a.localeCompare(b));
       noteBasenames = out;
+      flatNotes = flat;
     } catch { /* tree not ready yet */ }
+    try {
+      aliasMap = await api.graph.aliasMap();
+    } catch { /* not ready */ }
+  }
+
+  function wikiLinkResolves(target: string): boolean {
+    if (!target) return false;
+    return resolveWikiLinkTarget(target, flatNotes, aliasMap) !== null;
   }
   onMount(() => {
     void refreshProjectKeys();
@@ -586,15 +603,21 @@
                 />
               {:else}
                 {@const ws = row.shape}
+                {@const resolves = wikiLinkResolves(ws.target)}
                 <div class="wiki-chip-row">
                   <button
                     type="button"
                     class="wiki-chip"
-                    title="Open {ws.target}"
+                    class:broken={!resolves}
+                    title={resolves ? `Open ${ws.target}` : `No note matches "${ws.target}"`}
                     onclick={() => openWikiLink(ws.target)}
                     disabled={!onNavigate}
                   >
-                    <span class="wiki-chip-icon">🔗</span>
+                    {#if resolves}
+                      <span class="wiki-chip-icon"><Icon name="link" size={11} /></span>
+                    {:else}
+                      <span class="wiki-chip-icon"><Icon name="warn" size={11} color="var(--rust)" /></span>
+                    {/if}
                     <span class="wiki-chip-label">{ws.display ?? ws.target}</span>
                   </button>
                   <button
@@ -823,6 +846,17 @@
     cursor: default;
     color: var(--text-muted);
     text-decoration: none;
+  }
+  /* Broken wiki-link target — no matching note resolved. Rust tone
+     matches the right-sidebar Outgoing panel's dead-link treatment
+     (#548 §13.1). */
+  .wiki-chip.broken {
+    color: var(--rust);
+    text-decoration-color: color-mix(in srgb, var(--rust) 40%, transparent);
+  }
+  .wiki-chip.broken:hover:not(:disabled) {
+    border-color: var(--rust);
+    text-decoration-color: var(--rust);
   }
   .wiki-chip-icon { font-size: 10px; opacity: 0.7; }
   .wiki-chip-label { overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
Two of the three remaining design-review polish items. Closes out §13.1 (Properties) and §10.2 (Goto palette) end-to-end. The AutoLink confidence bar (§10.5) is the only remaining item and is filed for follow-up because it needs the LLM output to grow a confidence score before the UI can be honest.

## §13.1 Properties: broken wiki-link chip in rust
A frontmatter wiki-link value that doesn't resolve to any note now renders in \`var(--rust)\` with a warn icon, matching the dead-link treatment in the Outgoing Links panel. Resolution uses the existing \`resolveWikiLinkTarget\` helper (basename / exact path / alias / slug chain) so the chip's coloring matches what would happen if the user actually clicked it.

The panel already fetched the note tree for autocomplete; this hangs onto the flat list + alias map so the resolver can run.

## §10.2 Goto palette: multi-scope chips + modified stamp
The Goto-Note palette becomes a Goto-anything palette:
- New scope chip row above the results: **All / Notes / Sources / Queries** with live counts. The Sources and Queries chips render only when the caller passed those collections.
- Notes show their relative-time modified stamp (\`2h\`, \`5d\`, \`1mo\`) — the existing \`formatRelativeTime\` helper from the file tree.
- Sources show byline (creator(s) + year) as the secondary line.
- Saved queries show their description.
- Kind-specific icons (\`notes\` / \`sites\` / \`query\`) replace the one-size-fits-all \`notes\` icon.
- Each scope is selectable by Enter as before; the dispatch is routed to one of three callbacks: \`onSelect\` (notes — existing), \`onSelectSource\`, \`onSelectQuery\`.

Callers:
- The main "Go to..." command (Cmd-P) now passes \`sourcesCache\` + \`savedQueriesCache\`, lazily refreshed on open so the counts are fresh.
- The Merge-Note caller (notes-only context) leaves sources / queries unspecified; the chip row stays hidden and behavior is unchanged.

The Merge-Note path keeps \`placeholder="Merge into note..."\` and the \`excludePath\` filter; only the multi-scope plumbing is additive.

## Out of scope (filed for follow-up)
**§10.5 AutoLink confidence bar + "Select high-confidence (≥ 0.8)" bulk button.** The \`AutoLinkSuggestion\` shape doesn't carry a confidence score yet; landing those needs the LLM prompt + parser extended to produce one. Tracking that as a separate issue rather than blocking close on it.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes (2306 / 2306, no new tests — UI-only changes covered by manual verification)
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Add a frontmatter key like \`related: "[[no-such-note]]"\` to any note → the chip in the Properties panel renders in rust with a warn icon.
  2. Cmd-P → palette shows All / Notes / Sources / Queries chips with counts. Click Sources → notes hidden. Type a partial source title → matching sources surface.
  3. Note rows in the palette show a modified stamp on the right (\`2h\`, \`5d\`, etc.).
  4. Open from the Merge-Note path (e.g. via right-click → Merge into…) → chip row is hidden, behaviour matches prior dialog.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)