### PR TITLE
feat: upstream subject tags on ingest + Copy DOI / DOI URL (#473)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1357,6 +1357,19 @@ export function indexSource(ctx: ProjectContext, sourceId: string, metaTtl: stri
     console.error(`[minerva] Failed to parse source meta.ttl for ${sourceId}:`, e instanceof Error ? e.message : e);
   }
 
+  // Upstream subject tags (#473). Each `minerva:upstreamTag "..."`
+  // literal becomes a real `minerva:hasTag` edge to the
+  // corresponding tag URI, mirroring the body-tag pipeline so a
+  // CrossRef-imported tag and a hand-authored body tag look the
+  // same in the tag panel.
+  for (const st of store.statementsMatching(subject, MINERVA('upstreamTag'), undefined, graph)) {
+    const name = st.object.value;
+    if (!name) continue;
+    const tagNode = tagUri(state, name);
+    ensureTag(state, tagNode, name);
+    store.add(subject, MINERVA('hasTag'), tagNode, graph);
+  }
+
   if (bodyMd) indexSourceBody(state, sourceId, bodyMd, subject, graph);
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -73,6 +73,7 @@ import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest
 import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
+import { stripUpstreamTags } from './sources/strip-upstream-tags';
 import type { ReadStatus } from '../shared/types';
 import type { ReadingQueueView } from './graph/index';
 import {
@@ -1618,6 +1619,16 @@ export function registerIpcHandlers(): void {
     await persistIndexes(rootPath);
     const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
+  ipcMain.handle(Channels.SOURCES_STRIP_UPSTREAM_TAGS, async (e, sourceId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const result = await stripUpstreamTags(rootPath, sourceId);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    return result;
   });
 
   ipcMain.handle(Channels.SOURCES_QUEUE_MEMBERS, (e, view: ReadingQueueView) => {

--- a/src/main/sources/api-adapters/arxiv.ts
+++ b/src/main/sources/api-adapters/arxiv.ts
@@ -10,6 +10,7 @@
 
 import { DOMParser } from 'linkedom';
 import type { ArticleMetadata } from './types';
+import { buildUpstreamTags } from './upstream-tags';
 
 export const ARXIV_ENDPOINT = 'https://export.arxiv.org/api/query';
 
@@ -57,6 +58,17 @@ export function parseArxivAtom(xml: string, arxivId: string): ArticleMetadata {
     ?? entry.querySelector('category');
   if (primary) category = primary.getAttribute('term') || null;
 
+  // Every <category term="..."> on the entry — primary first, then
+  // any siblings. Used by #473 to materialise per-category tags
+  // (`arxiv/cs.LG`, `arxiv/cs.AI`, …). De-duped downstream by the
+  // upstream-tags builder.
+  const categoryTerms: string[] = [];
+  if (category) categoryTerms.push(category);
+  for (const c of entry.querySelectorAll('category')) {
+    const term = c.getAttribute('term');
+    if (term && !categoryTerms.includes(term)) categoryTerms.push(term);
+  }
+
   // Find the PDF link — arXiv advertises it as rel="related" type="application/pdf".
   let pdfUrl: string | null = null;
   for (const link of entry.querySelectorAll('link')) {
@@ -94,6 +106,7 @@ export function parseArxivAtom(xml: string, arxivId: string): ArticleMetadata {
     uri,
     pdfUrl,
     category,
+    keywords: buildUpstreamTags('arxiv', categoryTerms),
   };
 }
 

--- a/src/main/sources/api-adapters/crossref.ts
+++ b/src/main/sources/api-adapters/crossref.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ArticleMetadata } from './types';
+import { buildUpstreamTags } from './upstream-tags';
 
 /** Endpoint prefix; broken out for tests. */
 export const CROSSREF_ENDPOINT = 'https://api.crossref.org/works';
@@ -34,6 +35,10 @@ export interface CrossrefWork {
   abstract?: string;
   link?: Array<{ URL?: string; 'content-type'?: string; 'content-version'?: string }>;
   ISBN?: string[];
+  /** CrossRef's broad disciplinary subject taxonomy (e.g. "Computer
+   *  Science Applications"). Surfaced as `crossref/...` upstream
+   *  tags (#473). */
+  subject?: string[];
 }
 
 export async function fetchCrossrefMetadata(
@@ -92,6 +97,7 @@ export function parseCrossrefWork(work: CrossrefWork, doi: string): ArticleMetad
     uri: work.URL?.trim() || `https://doi.org/${doi}`,
     pdfUrl,
     category: null,
+    keywords: buildUpstreamTags('crossref', work.subject ?? []),
   };
 }
 

--- a/src/main/sources/api-adapters/pubmed.ts
+++ b/src/main/sources/api-adapters/pubmed.ts
@@ -10,6 +10,7 @@
 
 import { DOMParser } from 'linkedom';
 import type { ArticleMetadata } from './types';
+import { buildUpstreamTags } from './upstream-tags';
 
 export const PUBMED_SUMMARY = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi';
 export const PUBMED_FETCH = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi';
@@ -35,8 +36,12 @@ export async function fetchPubmedMetadata(
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<ArticleMetadata> {
   const summary = await fetchSummary(pmid, fetchImpl);
-  const abstract = await fetchAbstract(pmid, fetchImpl).catch(() => null);
-  return buildMetadata(pmid, summary, abstract);
+  // One efetch call carries both the abstract and the MeSH heading
+  // list, so we fetch the XML once and pull both apart.
+  const efetchXml = await fetchEfetchXml(pmid, fetchImpl).catch(() => null);
+  const abstract = efetchXml ? parseAbstractXml(efetchXml) : null;
+  const meshTerms = efetchXml ? parseMeshTerms(efetchXml) : [];
+  return buildMetadata(pmid, summary, abstract, meshTerms);
 }
 
 async function fetchSummary(pmid: string, fetchImpl: typeof fetch): Promise<PubmedEsummary> {
@@ -46,12 +51,11 @@ async function fetchSummary(pmid: string, fetchImpl: typeof fetch): Promise<Pubm
   return await res.json() as PubmedEsummary;
 }
 
-async function fetchAbstract(pmid: string, fetchImpl: typeof fetch): Promise<string | null> {
+async function fetchEfetchXml(pmid: string, fetchImpl: typeof fetch): Promise<string | null> {
   const url = `${PUBMED_FETCH}?db=pubmed&id=${encodeURIComponent(pmid)}&retmode=xml&rettype=abstract`;
   const res = await fetchImpl(url);
   if (!res.ok) return null;
-  const xml = await res.text();
-  return parseAbstractXml(xml);
+  return await res.text();
 }
 
 /** Exposed for tests. */
@@ -70,11 +74,32 @@ export function parseAbstractXml(xml: string): string | null {
   return parts.join(' ').replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Pull MeSH descriptor names out of an efetch XML response. PubMed
+ * surfaces a `<MeshHeadingList>` per article with one
+ * `<MeshHeading>` per term; we read the top-level `<DescriptorName>`
+ * for each and ignore qualifiers (which can pile up — a single MeSH
+ * term often carries 3+ qualifiers that aren't useful as tags).
+ *
+ * Exposed for tests.
+ */
+export function parseMeshTerms(xml: string): string[] {
+  const doc = new DOMParser().parseFromString(xml, 'text/xml') as unknown as Document;
+  const out: string[] = [];
+  for (const heading of doc.querySelectorAll('MeshHeading')) {
+    const descriptor = heading.querySelector('DescriptorName');
+    const name = descriptor?.textContent?.trim();
+    if (name) out.push(name);
+  }
+  return out;
+}
+
 /** Exposed for tests. */
 export function buildMetadata(
   pmid: string,
   summary: PubmedEsummary,
   abstract: string | null,
+  meshTerms: string[] = [],
 ): ArticleMetadata {
   const record = summary.result?.[pmid] as {
     title?: string;
@@ -120,6 +145,7 @@ export function buildMetadata(
     uri: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
     pdfUrl: null,
     category: null,
+    keywords: buildUpstreamTags('mesh', meshTerms),
   };
 }
 

--- a/src/main/sources/api-adapters/types.ts
+++ b/src/main/sources/api-adapters/types.ts
@@ -27,4 +27,14 @@ export interface ArticleMetadata {
   pdfUrl: string | null;
   /** For arXiv preprints: the subject category (`cs.AI`, `math.CO`). */
   category: string | null;
+  /**
+   * Provenance-namespaced subject tags extracted from the upstream
+   * record (#473). Each entry is already slugified and prefixed:
+   * `crossref/Computer-Science-Applications`, `arxiv/cs.LG`,
+   * `mesh/Genetics`. The ingest pipeline writes one
+   * `minerva:upstreamTag` literal per entry; the indexer turns
+   * those into `minerva:hasTag` edges on the source so they
+   * surface in the existing tag panel.
+   */
+  keywords: string[];
 }

--- a/src/main/sources/api-adapters/upstream-tags.ts
+++ b/src/main/sources/api-adapters/upstream-tags.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared helpers for #473 — turning upstream subject taxonomies into
+ * Minerva tag strings.
+ *
+ * Each adapter prepends its own namespace prefix so a glance at the
+ * tag tree tells you which API produced it. The slug rules below
+ * match what the tag indexer's regex accepts
+ * (`[a-zA-Z][\w-/]*` after the leading `#`).
+ */
+
+/**
+ * Conservative slug for an upstream subject string. Lowercased, runs
+ * of non-alphanumerics collapsed to a single hyphen, leading/trailing
+ * hyphens trimmed.
+ *
+ * arXiv categories like `cs.LG` keep the dot? No — the tag regex
+ * doesn't allow `.`, so we map it to a hyphen too. Result: `cs-lg`,
+ * which is a small sacrifice for portability across the rest of the
+ * tag system.
+ */
+export function slugForTag(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export type UpstreamSource = 'crossref' | 'arxiv' | 'mesh';
+
+/**
+ * Turn a list of raw upstream subjects into the namespaced tag form
+ * Minerva indexes. Drops empties and dedupes within the call so a
+ * single subject doesn't show up twice on the source.
+ */
+export function buildUpstreamTags(source: UpstreamSource, raws: ReadonlyArray<string | null | undefined>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of raws) {
+    if (!raw) continue;
+    const slug = slugForTag(raw);
+    if (!slug) continue;
+    const tag = `${source}/${slug}`;
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+  }
+  return out;
+}

--- a/src/main/sources/import-bibtex.ts
+++ b/src/main/sources/import-bibtex.ts
@@ -211,6 +211,7 @@ export function mapBibtexEntry(entry: BibtexEntryShape): ArticleMetadata {
     uri: uri ?? null,
     pdfUrl: null,
     category: null,
+    keywords: [],
   };
 }
 

--- a/src/main/sources/import-zotero-rdf.ts
+++ b/src/main/sources/import-zotero-rdf.ts
@@ -264,6 +264,7 @@ export function extractItem(store: IndexedFormula, subject: NamedNode): Extracte
     uri: urlFromIdentifier ?? uriFromSubject,
     pdfUrl: null,
     category: null,
+    keywords: [],
   };
 
   return { metadata, attachmentRelPath };

--- a/src/main/sources/ingest-identifier.ts
+++ b/src/main/sources/ingest-identifier.ts
@@ -215,6 +215,12 @@ export function buildMetaTtl(metadata: ArticleMetadata): string {
   if (metadata.isbn) lines.push(`    bibo:isbn ${ttlString(metadata.isbn)} ;`);
   if (metadata.uri) lines.push(`    bibo:uri ${ttlString(metadata.uri)} ;`);
   if (metadata.abstract) lines.push(`    dc:abstract ${ttlString(metadata.abstract)} ;`);
+  // Upstream subject tags (#473). One literal per keyword;
+  // `indexSource` turns each into a `minerva:hasTag` edge to the
+  // corresponding tag URI so the existing tag panel surfaces them.
+  for (const keyword of metadata.keywords) {
+    lines.push(`    minerva:upstreamTag ${ttlString(keyword)} ;`);
+  }
   lines.push(`    thought:accessedAt ${ttlString(new Date().toISOString())}^^xsd:dateTime .`);
   return lines.join('\n') + '\n';
 }

--- a/src/main/sources/site-handlers.ts
+++ b/src/main/sources/site-handlers.ts
@@ -308,6 +308,7 @@ export function structuredToArticleMetadata(
     uri: fallback.uri ?? null,
     pdfUrl: structured.pdfUrl ?? null,
     category: null,
+    keywords: [],
   };
 }
 

--- a/src/main/sources/strip-upstream-tags.ts
+++ b/src/main/sources/strip-upstream-tags.ts
@@ -1,0 +1,59 @@
+/**
+ * "Strip upstream tags" command (#473). Removes every
+ * `minerva:upstreamTag "..."` line from a source's meta.ttl, then
+ * re-indexes so the hasTag edges those tags produced go away too.
+ *
+ * Hand-edits to the user's own #tags in body.md are untouched —
+ * only the API-derived tag literals are dropped.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+
+export interface StripUpstreamResult {
+  /** Number of upstreamTag literals removed from meta.ttl. */
+  removed: number;
+}
+
+export async function stripUpstreamTags(rootPath: string, sourceId: string): Promise<StripUpstreamResult> {
+  const metaPath = path.join(rootPath, '.minerva', 'sources', sourceId, 'meta.ttl');
+  let ttl: string;
+  try {
+    ttl = await fs.readFile(metaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { removed: 0 };
+    throw err;
+  }
+  const { ttl: next, removed } = removeUpstreamTagLines(ttl);
+  if (removed === 0) return { removed: 0 };
+  await fs.writeFile(metaPath, next, 'utf-8');
+
+  // Re-index to drop the corresponding hasTag edges from the graph.
+  // The indexer always rebuilds source-scoped triples from the
+  // current meta.ttl, so the rebuilt edges no longer include the
+  // upstream ones.
+  const ctx = projectContext(rootPath);
+  let body: string | undefined;
+  try { body = await fs.readFile(path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md'), 'utf-8'); } catch { /* ok */ }
+  graph.indexSource(ctx, sourceId, next, body);
+
+  return { removed };
+}
+
+/**
+ * Remove every line whose first non-whitespace token is
+ * `minerva:upstreamTag`. Returns the new ttl + a count of dropped
+ * lines so callers can short-circuit when nothing changed.
+ *
+ * Exposed for tests.
+ */
+export function removeUpstreamTagLines(ttl: string): { ttl: string; removed: number } {
+  let removed = 0;
+  const next = ttl.replace(/^[ \t]*minerva:upstreamTag\s+[^\n]*\n?/gm, () => {
+    removed++;
+    return '';
+  });
+  return { ttl: next, removed };
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -263,6 +263,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SOURCES_SET_READ_DUE_BY, { sourceId, dueBy }),
     queueMembers: (view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished') =>
       ipcRenderer.invoke(Channels.SOURCES_QUEUE_MEMBERS, view),
+    stripUpstreamTags: (sourceId: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_STRIP_UPSTREAM_TAGS, sourceId),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -376,6 +376,23 @@
     }
   }
 
+  async function handleCopyDoi(source: SourceMetadata, kind: 'bare' | 'url'): Promise<void> {
+    contextMenu = null;
+    if (!source.doi) return;
+    const text = kind === 'url' ? `https://doi.org/${source.doi}` : source.doi;
+    try { await navigator.clipboard.writeText(text); }
+    catch (err) { console.error('[minerva] Copy DOI failed:', err); }
+  }
+
+  async function handleStripUpstreamTags(source: SourceMetadata): Promise<void> {
+    contextMenu = null;
+    try {
+      await api.sources.stripUpstreamTags(source.sourceId);
+    } catch (err) {
+      console.error('[minerva] Strip upstream tags failed:', err);
+    }
+  }
+
   function handleCollectionContextMenu(e: MouseEvent, collection: Collection) {
     e.preventDefault();
     e.stopPropagation();
@@ -755,7 +772,13 @@
       {#if contextMenu.source.readStatus}
         <button onclick={() => handleMarkStatus(contextMenu!.source, null)}>Clear status</button>
       {/if}
+      {#if contextMenu.source.doi}
+        <div class="context-divider"></div>
+        <button onclick={() => handleCopyDoi(contextMenu!.source, 'bare')}>Copy DOI</button>
+        <button onclick={() => handleCopyDoi(contextMenu!.source, 'url')}>Copy DOI URL</button>
+      {/if}
       <div class="context-divider"></div>
+      <button onclick={() => handleStripUpstreamTags(contextMenu!.source)}>Strip upstream tags</button>
       <button onclick={() => handleMergeStart(contextMenu!.source)}>Merge into…</button>
       <button onclick={() => handleDelete(contextMenu!.source)}>Delete Source</button>
     </div>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -686,6 +686,9 @@ export interface SourcesApi {
   /** Resolve a built-in Reading Queue view against the live graph. */
   queueMembers(view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished'):
     Promise<import('../../../shared/types').SourceMetadata[]>;
+  /** Strip API-derived `minerva:upstreamTag` triples from a source.
+   *  Returns the count of dropped tags. */
+  stripUpstreamTags(sourceId: string): Promise<{ removed: number }>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -240,6 +240,9 @@ export const Channels = {
   /** Resolve a built-in Reading Queue view (unread / reading /
    *  dueThisWeek / recentlyFinished) against the live graph (#116). */
   SOURCES_QUEUE_MEMBERS: 'sources:queueMembers',
+  /** Drop every API-derived `minerva:upstreamTag` from a source's
+   *  meta.ttl and re-index (#473). User-authored body tags survive. */
+  SOURCES_STRIP_UPSTREAM_TAGS: 'sources:stripUpstreamTags',
 
   // Collections (#470)
   /** Read `.minerva/collections.json` as a CollectionsFile. */

--- a/tests/main/sources/ingest-identifier.test.ts
+++ b/tests/main/sources/ingest-identifier.test.ts
@@ -67,6 +67,7 @@ describe('buildMetaTtl (#96)', () => {
     uri: 'https://doi.org/10.1038/x',
     pdfUrl: null,
     category: null,
+    keywords: [],
   };
 
   it('emits every populated predicate and declares the subtype', () => {

--- a/tests/main/sources/upstream-tags.test.ts
+++ b/tests/main/sources/upstream-tags.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Upstream subject tags (#473) — adapter extraction + the indexer
+ * translation that turns `minerva:upstreamTag` literals into real
+ * `minerva:hasTag` edges on the source.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import { slugForTag, buildUpstreamTags } from '../../../src/main/sources/api-adapters/upstream-tags';
+import { parseCrossrefWork } from '../../../src/main/sources/api-adapters/crossref';
+import { parseArxivAtom } from '../../../src/main/sources/api-adapters/arxiv';
+import { parseMeshTerms } from '../../../src/main/sources/api-adapters/pubmed';
+import {
+  initGraph,
+  indexSource,
+  sourcesByTag,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { removeUpstreamTagLines, stripUpstreamTags } from '../../../src/main/sources/strip-upstream-tags';
+import { buildMetaTtl } from '../../../src/main/sources/ingest-identifier';
+
+describe('slugForTag', () => {
+  it('lowercases and joins runs of non-alphanum with a single hyphen', () => {
+    expect(slugForTag('Computer Science Applications')).toBe('computer-science-applications');
+    expect(slugForTag('cs.LG')).toBe('cs-lg');
+    expect(slugForTag('Diabetes Mellitus, Type 2')).toBe('diabetes-mellitus-type-2');
+  });
+  it('trims leading and trailing hyphens', () => {
+    expect(slugForTag('—Genetics—')).toBe('genetics');
+  });
+  it('returns empty string for inputs with no alphanumeric content', () => {
+    expect(slugForTag('   ')).toBe('');
+    expect(slugForTag('—')).toBe('');
+  });
+});
+
+describe('buildUpstreamTags', () => {
+  it('prefixes each entry with the source namespace', () => {
+    expect(buildUpstreamTags('crossref', ['Sociology', 'Computer Science Applications'])).toEqual([
+      'crossref/sociology',
+      'crossref/computer-science-applications',
+    ]);
+  });
+  it('dedupes within a single call', () => {
+    expect(buildUpstreamTags('mesh', ['Genetics', 'Genetics', 'Computational Biology'])).toEqual([
+      'mesh/genetics',
+      'mesh/computational-biology',
+    ]);
+  });
+  it('drops null / undefined / empty entries', () => {
+    expect(buildUpstreamTags('arxiv', ['cs.LG', null, '', undefined, '   '])).toEqual(['arxiv/cs-lg']);
+  });
+});
+
+describe('CrossRef adapter keywords', () => {
+  it('extracts the subject array into crossref-prefixed tags', () => {
+    const result = parseCrossrefWork({
+      title: ['On Foo'],
+      subject: ['Computer Science Applications', 'Sociology'],
+    }, '10.1/foo');
+    expect(result.keywords).toEqual([
+      'crossref/computer-science-applications',
+      'crossref/sociology',
+    ]);
+  });
+  it('returns empty keywords when subject is absent', () => {
+    const result = parseCrossrefWork({ title: ['Bar'] }, '10.1/bar');
+    expect(result.keywords).toEqual([]);
+  });
+});
+
+describe('arXiv adapter keywords', () => {
+  const ATOM = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <title>Test paper</title>
+    <summary>An abstract.</summary>
+    <published>2024-01-01T00:00:00Z</published>
+    <author><name>Author A</name></author>
+    <arxiv:primary_category term="cs.LG"/>
+    <category term="cs.LG"/>
+    <category term="cs.AI"/>
+    <category term="stat.ML"/>
+  </entry>
+</feed>`;
+  it('collects every <category term="..."> into arxiv-prefixed tags', () => {
+    const result = parseArxivAtom(ATOM, '2401.00001');
+    expect(result.keywords.sort()).toEqual([
+      'arxiv/cs-ai',
+      'arxiv/cs-lg',
+      'arxiv/stat-ml',
+    ]);
+    // The legacy `category` field still carries the primary term.
+    expect(result.category).toBe('cs.LG');
+  });
+});
+
+describe('parseMeshTerms', () => {
+  it('extracts MeshHeading > DescriptorName text', () => {
+    const xml = `<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D005819">Genetics</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000465">Algorithms</DescriptorName>
+          <QualifierName>methods</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>`;
+    expect(parseMeshTerms(xml)).toEqual(['Genetics', 'Algorithms']);
+  });
+  it('returns an empty list when no MeshHeadingList is present', () => {
+    expect(parseMeshTerms('<empty/>')).toEqual([]);
+  });
+});
+
+describe('indexSource → hasTag edges from upstreamTag literals (#473)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-upstream-tags-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('writes minerva:hasTag edges for each upstreamTag literal', () => {
+    const ttl = `this: a thought:Article ;
+    dc:title "Test" ;
+    minerva:upstreamTag "crossref/sociology" ;
+    minerva:upstreamTag "crossref/computer-science-applications" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+    indexSource(ctx, 'doi-test', ttl);
+    expect(sourcesByTag(ctx, 'crossref/sociology').map((s) => s.sourceId)).toEqual(['doi-test']);
+    expect(sourcesByTag(ctx, 'crossref/computer-science-applications').map((s) => s.sourceId)).toEqual(['doi-test']);
+  });
+
+  it('end-to-end: buildMetaTtl + indexSource yields tag panel rows', () => {
+    const meta = buildMetaTtl({
+      subtype: 'Article',
+      title: 'X',
+      creators: [],
+      abstract: null,
+      issued: null,
+      publisher: null,
+      containerTitle: null,
+      doi: '10.1/x',
+      isbn: null,
+      arxiv: null,
+      pubmed: null,
+      uri: 'https://doi.org/10.1/x',
+      pdfUrl: null,
+      category: null,
+      keywords: ['crossref/sociology', 'arxiv/cs-lg'],
+    });
+    indexSource(ctx, 'x', meta);
+    expect(sourcesByTag(ctx, 'crossref/sociology').map((s) => s.sourceId)).toEqual(['x']);
+    expect(sourcesByTag(ctx, 'arxiv/cs-lg').map((s) => s.sourceId)).toEqual(['x']);
+  });
+});
+
+describe('strip upstream tags (#473)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const sourceId = 'doi-test';
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-strip-upstream-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    const dir = path.join(root, '.minerva', 'sources', sourceId);
+    fs.mkdirSync(dir, { recursive: true });
+    const ttl = `this: a thought:Article ;
+    dc:title "Test" ;
+    minerva:upstreamTag "crossref/sociology" ;
+    minerva:upstreamTag "crossref/computer-science-applications" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl);
+    indexSource(ctx, sourceId, ttl);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('removes every upstreamTag line and dedupes hasTag edges from the graph', async () => {
+    const result = await stripUpstreamTags(root, sourceId);
+    expect(result.removed).toBe(2);
+
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).not.toContain('minerva:upstreamTag');
+
+    expect(sourcesByTag(ctx, 'crossref/sociology')).toEqual([]);
+    expect(sourcesByTag(ctx, 'crossref/computer-science-applications')).toEqual([]);
+  });
+
+  it('leaves other predicates alone', async () => {
+    await stripUpstreamTags(root, sourceId);
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).toContain('dc:title "Test"');
+    expect(ttl).toContain('thought:accessedAt');
+  });
+
+  it('is a no-op on a meta.ttl with no upstream tags', () => {
+    const ttl = `this: a thought:Article ;
+    dc:title "x" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+    expect(removeUpstreamTagLines(ttl)).toEqual({ ttl, removed: 0 });
+  });
+});


### PR DESCRIPTION
Headline half of #473. CrossRef / arXiv / PubMed adapters now extract upstream subject taxonomies during ingest and apply them as provenance-namespaced tags on the source.

## Tag namespaces
- CrossRef \`subject[]\` → \`crossref/<slug>\` (e.g. \`crossref/sociology\`)
- arXiv \`<category term="…">\` → \`arxiv/<slug>\` (e.g. \`arxiv/cs-lg\`)
- PubMed MeSH \`DescriptorName\` → \`mesh/<slug>\` (e.g. \`mesh/genetics\`)

Provenance is visible at a glance; users can collapse all CrossRef-imported tags by hiding \`crossref/...\` in the tag tree.

## Pipeline shape
- \`ArticleMetadata\` gains \`keywords: string[]\` — pre-formatted, pre-slugified, namespaced strings.
- \`buildUpstreamTags(source, raws)\` slugs (lowercase, non-alphanum → hyphen), dedupes, prefixes.
- \`buildMetaTtl\` writes one \`minerva:upstreamTag "..."\` literal per keyword.
- \`indexSource\` translates each literal into a real \`minerva:hasTag\` edge to the corresponding tag URI — same shape as body-tag indexing (#118), so the existing tag panel surfaces upstream tags alongside user-authored ones.

PubMed efetch is now called once and parsed for *both* the abstract and the MeSH heading list, instead of twice for unrelated reasons.

## "Strip upstream tags" command
Right-click a source → **Strip upstream tags**. Removes every \`minerva:upstreamTag\` line from meta.ttl and re-indexes (the hasTag edges those tags produced go away too). User-authored body tags survive.

## Copy DOI / Copy DOI URL
Right-click → **Copy DOI** / **Copy DOI URL**. Only appear when the source actually has a DOI. Clipboard via \`navigator.clipboard.writeText\`.

## DOI dedup
The "DOI → existing source" behaviour from the issue is already in place via canonical-id (#90). Resolving a DOI that matches an existing source merges metadata into it (re-ingest dedup) rather than creating a duplicate. No change needed.

## Tests
16 new cases in \`upstream-tags.test.ts\`:
- \`slugForTag\` rules + edge cases
- \`buildUpstreamTags\` namespacing + dedup
- CrossRef / arXiv / PubMed extraction
- indexer round-trip: \`minerva:upstreamTag\` literal → tag panel entry
- strip command removes the literals + drops graph edges; leaves other predicates untouched

\`ingest-identifier.test.ts\` fixture updated to include the new \`keywords: []\` field. Full suite **2322 / 2322** (+16).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Ingest a DOI via the identifier menu (any paper with \`subject\` in CrossRef — most journal articles).
  2. Open the source; right-click in the Sources panel → confirm Copy DOI / Copy DOI URL appear; pasting elsewhere matches expected formats.
  3. Tag panel shows \`crossref/<slug>\` entries; clicking surfaces the source under it.
  4. Right-click → Strip upstream tags. Tags disappear from the panel; \`meta.ttl\` no longer has the \`minerva:upstreamTag\` lines.
  5. Same flow for an arXiv id (gets \`arxiv/cs-lg\` etc.) and a PMID (gets \`mesh/...\`).

## Out of scope (next)
- Settings toggle to disable upstream-tag import per project. Strip command covers the "I changed my mind" case for now.
- Smart paste of DOI/URL outside the existing ingest flows.
- Body-text DOI detection with offer-to-ingest.
- DOI inline rendering in the markdown preview.
- Invalid-DOI surfacing via the inspections panel.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)