### PR TITLE
feat: finish #473 — settings + smart paste + DOI inline + invalid-DOI inspection + body-text DOI ingest

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -38,6 +38,7 @@ export async function runAllChecks(ctx: ProjectContext): Promise<Inspection[]> {
       checkStaleness(ctx, 30), // 30 days
       checkEvidenceGaps(ctx),
       checkContradictions(ctx),
+      checkInvalidDois(ctx),
     ]);
     const flat = results.flat();
     lastResultsByProject.set(ctx.rootPath, flat);
@@ -154,6 +155,41 @@ async function checkEvidenceGaps(ctx: ProjectContext): Promise<Inspection[]> {
   }
 
   return inspections;
+}
+
+/**
+ * Sources carrying a `bibo:doi` literal that doesn't match the
+ * Crossref DOI shape (#473). Shape-only check — we don't hit
+ * doi.org. Surfacing it through the inspections panel keeps the
+ * warning soft and non-blocking, per the issue's "no popup" note.
+ */
+const VALID_DOI_RE = /^10\.\d{4,9}\/[-._;/:a-zA-Z0-9()]+$/;
+
+async function checkInvalidDois(ctx: ProjectContext): Promise<Inspection[]> {
+  const results = await queryGraph(ctx, `
+    PREFIX bibo: <http://purl.org/ontology/bibo/>
+    PREFIX dc: <http://purl.org/dc/terms/>
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    SELECT ?source ?sourceId ?title ?doi WHERE {
+      ?source minerva:sourceId ?sourceId .
+      ?source bibo:doi ?doi .
+      OPTIONAL { ?source dc:title ?title }
+    }
+  `);
+
+  return (results.results as Record<string, string>[]).flatMap((r, i) => {
+    if (!r.doi || VALID_DOI_RE.test(r.doi)) return [];
+    const label = r.title || r.sourceId;
+    return [{
+      id: `invalid-doi-${i}`,
+      type: 'invalid_doi',
+      severity: 'warning' as const,
+      nodeUri: r.source,
+      nodeLabel: label,
+      message: `Source "${label}" has a DOI that doesn't look right: ${r.doi}`,
+      suggestedAction: 'Open the source meta.ttl and correct the bibo:doi value.',
+    }];
+  });
 }
 
 async function checkContradictions(ctx: ProjectContext): Promise<Inspection[]> {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -74,6 +74,8 @@ import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
 import { stripUpstreamTags } from './sources/strip-upstream-tags';
+import { getIngestSettings, saveIngestSettings, type IngestSettings } from './sources/ingest-settings';
+import { ingestSmart } from './sources/ingest-smart';
 import type { ReadStatus } from '../shared/types';
 import type { ReadingQueueView } from './graph/index';
 import {
@@ -1302,8 +1304,27 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(Channels.SOURCES_INGEST_IDENTIFIER, async (e, identifier: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
-    return await ingestIdentifier(rootPath, identifier, { fetchImpl: privilegedFetch });
+    const ingestSettings = await getIngestSettings();
+    return await ingestIdentifier(rootPath, identifier, {
+      fetchImpl: privilegedFetch,
+      importUpstreamTags: ingestSettings.importUpstreamTags,
+    });
   });
+
+  ipcMain.handle(Channels.SOURCES_INGEST_SMART, async (e, rawInput: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const ingestSettings = await getIngestSettings();
+    return await ingestSmart(rootPath, rawInput, {
+      fetchImpl: privilegedFetch,
+      importUpstreamTags: ingestSettings.importUpstreamTags,
+    });
+  });
+
+  ipcMain.handle(Channels.INGEST_GET_SETTINGS, () => getIngestSettings());
+  ipcMain.handle(Channels.INGEST_SET_SETTINGS, (_e, settings: IngestSettings) =>
+    saveIngestSettings(settings),
+  );
 
   ipcMain.handle(Channels.FILES_DROP_IMPORT, async (e, targetFolder: string, localPaths: string[]) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/main/sources/ingest-identifier.ts
+++ b/src/main/sources/ingest-identifier.ts
@@ -43,6 +43,10 @@ export interface IdentifierIngestResult {
 
 export interface IdentifierIngestOptions {
   fetchImpl?: typeof fetch;
+  /** When false, upstream subject tags from the API are dropped
+   *  before writing the meta.ttl. Mirrors the per-machine
+   *  IngestSettings toggle (#473) — wired by the IPC handler. */
+  importUpstreamTags?: boolean;
 }
 
 /**
@@ -72,7 +76,13 @@ export async function ingestIdentifier(
   }
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
 
-  const metadata = await fetchMetadataFor(identifier, fetchImpl);
+  const fetched = await fetchMetadataFor(identifier, fetchImpl);
+  // Strip upstream tags up front if the user has the import toggle
+  // off — keeps the meta.ttl clean of `minerva:upstreamTag` lines
+  // they didn't ask for. Default is on.
+  const metadata = opts.importUpstreamTags === false
+    ? { ...fetched, keywords: [] }
+    : fetched;
 
   // Compute the canonical id from every identifier we've now got — we may
   // have started with an arXiv id and come back with a DOI cross-reference,

--- a/src/main/sources/ingest-settings.ts
+++ b/src/main/sources/ingest-settings.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-machine ingest preferences (#473). Default-on: a fresh install
+ * picks up CrossRef / arXiv / PubMed subject tags on identifier
+ * ingest. Users who don't want that taxonomy in their tag panel can
+ * toggle it off via Settings → Ingest.
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+export interface IngestSettings {
+  /** When true, the identifier-ingest adapters extract upstream
+   *  subject tags (CrossRef.subject / arXiv categories / MeSH terms)
+   *  and apply them as `crossref/...` / `arxiv/...` / `mesh/...`
+   *  tags on the source. */
+  importUpstreamTags: boolean;
+}
+
+export const DEFAULT_INGEST_SETTINGS: IngestSettings = {
+  importUpstreamTags: true,
+};
+
+function settingsPath(): string {
+  return path.join(app.getPath('userData'), 'ingest-settings.json');
+}
+
+export async function getIngestSettings(): Promise<IngestSettings> {
+  try {
+    const raw = await fs.readFile(settingsPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<IngestSettings>;
+    return {
+      importUpstreamTags:
+        typeof parsed.importUpstreamTags === 'boolean'
+          ? parsed.importUpstreamTags
+          : DEFAULT_INGEST_SETTINGS.importUpstreamTags,
+    };
+  } catch {
+    return { ...DEFAULT_INGEST_SETTINGS };
+  }
+}
+
+export async function saveIngestSettings(settings: IngestSettings): Promise<void> {
+  await fs.writeFile(settingsPath(), JSON.stringify(settings, null, 2), 'utf-8');
+}

--- a/src/main/sources/ingest-smart.ts
+++ b/src/main/sources/ingest-smart.ts
@@ -1,0 +1,66 @@
+/**
+ * Smart-route ingest (#473). Given a raw string from a clipboard
+ * paste or the Sources panel's "+" button, pick the right ingest
+ * path:
+ *
+ *   1. Bare DOI / DOI URL / arXiv id / arXiv URL / PMID / PubMed URL
+ *      → identifier flow (CrossRef / arXiv / PubMed adapter).
+ *   2. Bare URL (http/https) → URL flow (Readability extraction).
+ *   3. Free text with an embedded DOI → extract + identifier flow
+ *      (so a copy-paste of "see 10.1145/foo for context" still
+ *      works).
+ *
+ * Returns the same shape as `ingestUrl` / `ingestIdentifier` so the
+ * UI can open the resulting source uniformly.
+ */
+
+import { ingestIdentifier, detectIdentifier, type IdentifierIngestResult } from './ingest-identifier';
+import { ingestUrl, type IngestResult } from './ingest';
+
+export type SmartIngestResult =
+  | (IdentifierIngestResult & { route: 'identifier' })
+  | (IngestResult & { route: 'url' });
+
+export interface SmartIngestOptions {
+  fetchImpl?: typeof fetch;
+  importUpstreamTags?: boolean;
+}
+
+/** Crossref DOI shape. Used to fish a DOI out of surrounding prose. */
+const DOI_IN_TEXT_RE = /\b10\.\d{4,9}\/[-._;/:a-zA-Z0-9]+/;
+
+export async function ingestSmart(
+  rootPath: string,
+  rawInput: string,
+  opts: SmartIngestOptions = {},
+): Promise<SmartIngestResult> {
+  const input = rawInput.trim();
+  if (!input) throw new Error('Empty input.');
+
+  // 1. If the whole string is a recognized identifier (or an
+  //    identifier-bearing URL — detectIdentifier handles arXiv/PubMed
+  //    URLs via normalizeArxivId/normalizePubmedId), prefer that.
+  if (detectIdentifier(input)) {
+    const r = await ingestIdentifier(rootPath, input, opts);
+    return { ...r, route: 'identifier' };
+  }
+
+  // 2. URL — Readability ingest.
+  if (/^https?:\/\//i.test(input)) {
+    const r = await ingestUrl(rootPath, input, opts);
+    return { ...r, route: 'url' };
+  }
+
+  // 3. Free text with an embedded DOI — extract the first DOI we
+  //    see and feed it through the identifier path.
+  const m = input.match(DOI_IN_TEXT_RE);
+  if (m) {
+    // Trim trailing punctuation the regex might have eaten when the
+    // DOI sat at end-of-sentence.
+    const doi = m[0].replace(/[.,;:!?)]+$/, '');
+    const r = await ingestIdentifier(rootPath, doi, opts);
+    return { ...r, route: 'identifier' };
+  }
+
+  throw new Error(`Not a recognised URL, DOI, arXiv id, or PubMed id: ${rawInput}`);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -265,6 +265,11 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SOURCES_QUEUE_MEMBERS, view),
     stripUpstreamTags: (sourceId: string) =>
       ipcRenderer.invoke(Channels.SOURCES_STRIP_UPSTREAM_TAGS, sourceId),
+    getIngestSettings: () => ipcRenderer.invoke(Channels.INGEST_GET_SETTINGS),
+    setIngestSettings: (settings: { importUpstreamTags: boolean }) =>
+      ipcRenderer.invoke(Channels.INGEST_SET_SETTINGS, settings),
+    ingestSmart: (rawInput: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_INGEST_SMART, rawInput),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1778,6 +1778,37 @@
     setTimeout(() => handleOpenSource(sourceId), 150);
   }
 
+  /**
+   * Click on a bare-DOI link inside the markdown preview (#473).
+   * If the DOI already maps to an ingested source, open it. Otherwise
+   * offer to ingest — dismissable, keyed so the user can suppress
+   * the prompt project-wide once they've made up their mind.
+   */
+  async function handleDoiClick(doi: string): Promise<void> {
+    if (!notebase.meta) return;
+    // Normalise — sources store DOIs case-folded; user input might
+    // have mixed case from the rendered link text.
+    const target = doi.toLowerCase();
+    const existing = sourcesCache.find((s) => (s.doi ?? '').toLowerCase() === target);
+    if (existing) {
+      handleOpenSource(existing.sourceId);
+      return;
+    }
+    const confirmed = await showConfirm(
+      `Ingest this DOI as a new source?\n\n${doi}`,
+      CONFIRM_KEYS.ingestDoiFromBody,
+      'Ingest',
+    );
+    if (!confirmed) return;
+    try {
+      const result = await withBusy('Looking up…', () => api.sources.ingestIdentifier(doi));
+      setTimeout(() => handleOpenSource(result.sourceId), 150);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
   async function handleIngestIdentifier() {
     if (!notebase.meta) return;
     const raw = await showPrompt('DOI, arXiv id, or PubMed id:');
@@ -2538,6 +2569,7 @@
                   pendingAnchor={pendingPreviewAnchor}
                   onAnchorResolved={() => { pendingPreviewAnchor = null; }}
                   onTaskToggle={handleTaskToggle}
+                  onDoiClick={handleDoiClick}
                   onSaveCellOutput={handleSaveCellOutput}
                   onToolInvoke={handleToolInvoke}
                   onOpenConversation={openConversation}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -15,6 +15,7 @@
   import 'highlight.js/styles/github-dark.min.css';
   import 'katex/dist/katex.min.css';
   import { installMath } from '../../../shared/markdown/math-plugin';
+  import { installDoiAutolink } from '../../../shared/markdown/doi-plugin';
   import { installCallouts } from '../markdown/callout-plugin';
   import { hydrateMermaidBlocks, invalidateMermaidTheme } from '../markdown/mermaid-renderer';
   import { getLinkType } from '../../../shared/link-types';
@@ -87,6 +88,13 @@
      * regular doc edit.
      */
     onApplyCellOutputEdit?: (newContent: string) => void;
+    /**
+     * Click on a bare-DOI link the DOI plugin rendered (#473).
+     * The host decides what to do: open the matching source if it
+     * exists, otherwise offer to ingest. Without the callback,
+     * DOI links open externally like any other link.
+     */
+    onDoiClick?: (doi: string) => void;
   }
 
   let {
@@ -105,6 +113,7 @@
     onBookmark,
     onRunCell,
     onApplyCellOutputEdit,
+    onDoiClick,
   }: Props = $props();
 
   // Per-fence collapse state, keyed by the fence's opening line in the
@@ -173,6 +182,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   });
   installMath(md);
   installCallouts(md);
+  installDoiAutolink(md);
   // Footnotes — markdown-it-footnote renders `[^id]` as a numbered
   // superscript anchored to a back-of-note `<section class="footnotes">`,
   // and each footnote body links back to the ref. Both jumps fire
@@ -1308,6 +1318,18 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         void runFenceAt(openingLine);
         return;
       }
+    }
+
+    // DOI link click — the doi-plugin auto-linker rendered this. The
+    // host decides between "open existing source" and "offer to
+    // ingest" based on whether the DOI matches a known source. (#473)
+    const doiAnchor = el.closest<HTMLAnchorElement>('a[href^="https://doi.org/"]');
+    if (doiAnchor && onDoiClick) {
+      e.preventDefault();
+      const href = doiAnchor.getAttribute('href') ?? '';
+      const doi = href.replace(/^https:\/\/doi\.org\//, '');
+      if (doi) onDoiClick(doi);
+      return;
     }
 
     // Internal anchor click (footnote ref ↔ body, heading anchor jumps,

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -54,7 +54,7 @@
 
   let { onApplyEditor, onThemeChanged, onClose, initialTab }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'sites' | 'bibliography' | 'compute' | 'ai';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'ingest' | 'sites' | 'bibliography' | 'compute' | 'ai';
 
   /** Restructure per IMPLEMENTATION.md §10.4 — 10 flat tabs become 4
    *  semantic groups. Group labels render in mono-uppercase above each
@@ -89,6 +89,7 @@
       label: 'Ingest & compute',
       items: [
         { id: 'web',     label: 'Web',     sub: 'Default ingest rules' },
+        { id: 'ingest',  label: 'Ingest',  sub: 'Identifier lookups · upstream tags' },
         { id: 'sites',   label: 'Sites',   sub: 'Privileged-domain logins' },
         { id: 'compute', label: 'Compute', sub: 'Python interpreter · trust' },
       ],
@@ -337,6 +338,8 @@
   let webEnabled = $state(true);
   let allowedDomainsText = $state('');
   let blockedDomainsText = $state('');
+  // Ingest settings — per-machine, used by identifier ingest paths (#473).
+  let importUpstreamTags = $state(true);
   let model = $state('claude-sonnet-4-6');
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');
@@ -425,6 +428,12 @@
     await reloadSites();
     await loadBibliographySettings();
     await loadComputeSettings();
+    try {
+      const ingest = await api.sources.getIngestSettings();
+      importUpstreamTags = ingest.importUpstreamTags;
+    } catch (e) {
+      console.error('[settings] failed to load ingest settings:', e);
+    }
   });
 
   function setToolOverride(toolId: string, value: string) {
@@ -474,6 +483,12 @@
       await api.tools.setSettings(next);
     } catch (e) {
       console.error('[settings] failed to save LLM settings:', e);
+    }
+
+    try {
+      await api.sources.setIngestSettings({ importUpstreamTags });
+    } catch (e) {
+      console.error('[settings] failed to save ingest settings:', e);
     }
 
     onClose();
@@ -853,6 +868,22 @@
             ></textarea>
             <p class="hint">
               Ignored when an allowlist is set. The API accepts one or the other.
+            </p>
+          </div>
+
+        {:else if activeTab === 'ingest'}
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={importUpstreamTags} />
+              Import upstream subject tags on source ingest
+            </label>
+            <p class="hint">
+              When on, identifier ingest (DOI / arXiv id / PMID) applies the
+              subject taxonomy each API surfaces as namespaced tags on the
+              source: <code>crossref/sociology</code>,
+              <code>arxiv/cs-lg</code>, <code>mesh/genetics</code>. Use the
+              source's right-click "Strip upstream tags" to remove them
+              after the fact.
             </p>
           </div>
 

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -575,7 +575,7 @@
       {/if}
     {:else if activePanel === 'sites'}
       {#if onSourceSelect && onShowConfirm && onShowPrompt}
-        <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} {onShowPrompt} />
+        <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} {onShowPrompt} onSourceOpened={onSourceSelect} />
       {/if}
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -26,9 +26,13 @@
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
     onShowPrompt: (message: string, initial?: string) => Promise<string | null>;
+    /** Open a freshly-ingested source in a tab. Wired by the host so
+     *  the "+" button's smart-paste path lands the user on the new
+     *  source without an extra click. (#473) */
+    onSourceOpened?: (sourceId: string) => void;
   }
 
-  let { onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt }: Props = $props();
+  let { onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onSourceOpened }: Props = $props();
 
   let sources = $state<SourceMetadata[]>([]);
   let filter = $state('');
@@ -393,6 +397,33 @@
     }
   }
 
+  let adding = $state(false);
+  async function handleAddSource(): Promise<void> {
+    if (adding) return;
+    const raw = await onShowPrompt('URL, DOI, arXiv id, or PubMed id:');
+    if (!raw) return;
+    const input = raw.trim();
+    if (!input) return;
+    adding = true;
+    try {
+      const result = await api.sources.ingestSmart(input);
+      await refresh();
+      onSourceOpened?.(result.sourceId);
+      if (result.duplicate) {
+        void onShowConfirm(
+          `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
+          'ingest-duplicate',
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      void onShowConfirm(`Ingest failed: ${msg}`, 'ingest-failed', 'OK');
+    } finally {
+      adding = false;
+    }
+  }
+
   function handleCollectionContextMenu(e: MouseEvent, collection: Collection) {
     e.preventDefault();
     e.stopPropagation();
@@ -710,6 +741,16 @@
             : 'Filter sources…'}
         bind:value={filter}
       />
+      <button
+        type="button"
+        class="add-source-btn"
+        disabled={adding}
+        onclick={handleAddSource}
+        title="Add source from URL, DOI, arXiv id, or PubMed id"
+        aria-label="Add source"
+      >
+        <Icon name="plus" size={11} color="var(--text-muted)" />
+      </button>
     </div>
     <div class="source-list">
       {#each visible as s (s.sourceId)}
@@ -888,10 +929,34 @@
 
   .filter-row {
     padding: 8px 8px 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
   }
+  .add-source-btn {
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg);
+    color: var(--text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .add-source-btn:hover:not(:disabled) {
+    background: var(--bg-button);
+    color: var(--text);
+    border-color: var(--accent);
+  }
+  .add-source-btn:disabled { opacity: 0.5; cursor: default; }
 
   .filter-input {
-    width: 100%;
+    flex: 1;
+    min-width: 0;
     padding: 4px 8px;
     background: var(--bg);
     color: var(--text);

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -37,6 +37,9 @@ export const CONFIRM_KEYS = {
   ingestDuplicate: 'ingest-duplicate',
   ingestFailed: 'ingest-failed',
   ingestPdfFailed: 'ingest-pdf-failed',
+  /** DOI clicked in the preview that doesn't match an existing source
+   *  yet (#473). User confirms before we hit CrossRef. */
+  ingestDoiFromBody: 'ingest-doi-from-body',
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
@@ -213,6 +216,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Ingest identifier: PDF fetch failed',
     description:
       'Shown when identifier ingest succeeds on metadata but the advertised open-access PDF cannot be fetched (paywall, 403, network error). The source lands without the PDF.',
+  },
+  {
+    key: CONFIRM_KEYS.ingestDoiFromBody,
+    title: 'Ingest DOI from body',
+    description:
+      'Shown when you click a bare DOI in the preview that doesn\'t match an existing source — confirms before fetching CrossRef.',
   },
   {
     key: CONFIRM_KEYS.dropImportRejected,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -689,6 +689,17 @@ export interface SourcesApi {
   /** Strip API-derived `minerva:upstreamTag` triples from a source.
    *  Returns the count of dropped tags. */
   stripUpstreamTags(sourceId: string): Promise<{ removed: number }>;
+  /** Per-machine ingest preferences (#473). */
+  getIngestSettings(): Promise<{ importUpstreamTags: boolean }>;
+  setIngestSettings(settings: { importUpstreamTags: boolean }): Promise<void>;
+  /** Smart-route ingest: detect DOI / arXiv id / PMID / URL in
+   *  `rawInput` and dispatch to the matching ingest path (#473). */
+  ingestSmart(rawInput: string): Promise<{
+    sourceId: string;
+    duplicate: boolean;
+    title: string;
+    route: 'identifier' | 'url';
+  }>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -243,6 +243,14 @@ export const Channels = {
   /** Drop every API-derived `minerva:upstreamTag` from a source's
    *  meta.ttl and re-index (#473). User-authored body tags survive. */
   SOURCES_STRIP_UPSTREAM_TAGS: 'sources:stripUpstreamTags',
+  /** Per-machine ingest preferences (#473): "Import upstream subject
+   *  tags on source ingest" and friends. */
+  INGEST_GET_SETTINGS: 'ingest:getSettings',
+  INGEST_SET_SETTINGS: 'ingest:setSettings',
+  /** Smart-route ingest: takes a raw string from a clipboard paste or
+   *  the "+" button, detects whether it's a DOI / arXiv id / PMID /
+   *  URL, and dispatches to the matching ingest path (#473). */
+  SOURCES_INGEST_SMART: 'sources:ingestSmart',
 
   // Collections (#470)
   /** Read `.minerva/collections.json` as a CollectionsFile. */

--- a/src/shared/markdown/doi-plugin.ts
+++ b/src/shared/markdown/doi-plugin.ts
@@ -1,0 +1,114 @@
+/**
+ * Markdown-it plugin that turns bare DOIs into clickable doi.org
+ * links (#473).
+ *
+ * `linkify` already auto-links DOI URLs (`https://doi.org/...`).
+ * What it misses is the bare form a researcher actually types:
+ *
+ *   See 10.1145/3677999.3678002 for the data.
+ *
+ * The plugin runs as a `core` rule that walks every text token,
+ * splices DOI matches into separate `text` + `link_open` + `text` +
+ * `link_close` token triples, and lets the standard renderer take
+ * over. No custom render rule; the resulting links use the default
+ * `<a href=…>` shape so external-link interception (Preview.svelte)
+ * works unchanged.
+ */
+
+import type MarkdownIt from 'markdown-it';
+import type Token from 'markdown-it/lib/token.mjs';
+import type StateCore from 'markdown-it/lib/rules_core/state_core.mjs';
+
+/**
+ * DOI form per Crossref: `10.NNNN/...` where NNNN is a 4–9 digit
+ * registry, the suffix allows the characters Crossref actually uses
+ * in the wild. Trailing punctuation we strip after matching so a DOI
+ * at end of sentence doesn't eat the period.
+ *
+ * The `\b` boundary keeps `2.10.4321/foo` from matching mid-token —
+ * a DOI must start at a word boundary.
+ */
+const DOI_RE = /\b10\.\d{4,9}\/[-._;/:a-zA-Z0-9]+/g;
+/** Trailing punctuation we never want as part of the DOI itself.
+ *  Includes `.` so a sentence-final DOI doesn't gain a stray period. */
+const DOI_TRAILING_PUNCT = /[.,;:!?)]+$/;
+
+export function installDoiAutolink(md: MarkdownIt): void {
+  md.core.ruler.after('linkify', 'doi_autolink', (state) => {
+    for (const blockToken of state.tokens) {
+      if (blockToken.type !== 'inline' || !blockToken.children) continue;
+      const next: Token[] = [];
+      // Skip text inside an existing `<a>` (linkify-produced or
+      // hand-authored) — re-linking the visible URL would nest
+      // anchors and steal the click target.
+      let linkDepth = 0;
+      for (const child of blockToken.children) {
+        if (child.type === 'link_open') linkDepth++;
+        if (child.type === 'link_close') { linkDepth = Math.max(0, linkDepth - 1); next.push(child); continue; }
+        if (child.type !== 'text' || linkDepth > 0) {
+          next.push(child);
+          continue;
+        }
+        const replaced = splitTextOnDoi(state, child, blockToken.level);
+        for (const t of replaced) next.push(t);
+      }
+      blockToken.children = next;
+    }
+  });
+}
+
+function splitTextOnDoi(
+  state: StateCore,
+  textToken: Token,
+  level: number,
+): Token[] {
+  const content = textToken.content;
+  DOI_RE.lastIndex = 0;
+  const out: Token[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = DOI_RE.exec(content)) !== null) {
+    // Trim trailing punctuation that doesn't belong to the DOI.
+    let raw = match[0];
+    const punct = raw.match(DOI_TRAILING_PUNCT);
+    if (punct) raw = raw.slice(0, -punct[0].length);
+    if (raw.length === 0) continue;
+
+    // Pre-DOI text.
+    if (match.index > cursor) {
+      const pre = new state.Token('text', '', 0);
+      pre.content = content.slice(cursor, match.index);
+      pre.level = level;
+      out.push(pre);
+    }
+
+    const open = new state.Token('link_open', 'a', 1);
+    open.attrSet('href', `https://doi.org/${raw}`);
+    open.markup = 'doi';
+    open.level = level;
+    out.push(open);
+
+    const inner = new state.Token('text', '', 0);
+    inner.content = raw;
+    inner.level = level + 1;
+    out.push(inner);
+
+    const close = new state.Token('link_close', 'a', -1);
+    close.markup = 'doi';
+    close.level = level;
+    out.push(close);
+
+    // Advance past the matched DOI; the stripped trailing punctuation
+    // becomes prose in the next iteration's pre-DOI slice.
+    cursor = match.index + raw.length;
+  }
+  // Tail.
+  if (cursor === 0) return [textToken];
+  if (cursor < content.length) {
+    const tail = new state.Token('text', '', 0);
+    tail.content = content.slice(cursor);
+    tail.level = level;
+    out.push(tail);
+  }
+  return out;
+}

--- a/tests/main/graph/invalid-doi-inspection.test.ts
+++ b/tests/main/graph/invalid-doi-inspection.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Invalid-DOI inspection (#473). The inspection is shape-only —
+ * it doesn't hit doi.org, just flags `bibo:doi` values that don't
+ * match the Crossref `10.NNNN/...` form.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexSource } from '../../../src/main/graph/index';
+import { runAllChecks } from '../../../src/main/graph/health-checks';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const META = (doi: string | null) => `this: a thought:Article ;
+    dc:title "Test" ;
+${doi ? `    bibo:doi "${doi}" ;\n` : ''}    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+describe('checkInvalidDois (#473)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-invalid-doi-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  function addSource(id: string, doi: string | null): void {
+    const dir = path.join(root, '.minerva', 'sources', id);
+    fs.mkdirSync(dir, { recursive: true });
+    const ttl = META(doi);
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl);
+    indexSource(ctx, id, ttl);
+  }
+
+  it('flags a source whose DOI does not match the Crossref shape', async () => {
+    addSource('bad-shape', 'not-a-doi');
+    const inspections = await runAllChecks(ctx);
+    const invalid = inspections.filter((i) => i.type === 'invalid_doi');
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0].severity).toBe('warning');
+    expect(invalid[0].message).toContain('not-a-doi');
+  });
+
+  it('does not flag a well-formed DOI', async () => {
+    addSource('good', '10.1145/3677999.3678002');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'invalid_doi')).toBe(false);
+  });
+
+  it('does not flag a source with no DOI at all', async () => {
+    addSource('no-doi', null);
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'invalid_doi')).toBe(false);
+  });
+
+  it('flags only the bad rows when multiple sources exist', async () => {
+    addSource('good', '10.1145/3677999.3678002');
+    addSource('bad', '10.SHORT');
+    const inspections = await runAllChecks(ctx);
+    const invalid = inspections.filter((i) => i.type === 'invalid_doi');
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0].nodeLabel).toBe('Test');
+  });
+});

--- a/tests/main/sources/ingest-smart.test.ts
+++ b/tests/main/sources/ingest-smart.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Smart-route ingest (#473) — exercise the dispatch logic with
+ * stubbed adapters / network so we can assert which path was taken
+ * without making real HTTP calls.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph } from '../../../src/main/graph/index';
+import { projectContext } from '../../../src/main/project-context-types';
+
+// Stub the two heavy ingest paths so we just observe which one was
+// called and pass through a synthetic result.
+vi.mock('../../../src/main/sources/ingest-identifier', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/main/sources/ingest-identifier')>(
+    '../../../src/main/sources/ingest-identifier',
+  );
+  return {
+    ...actual,
+    ingestIdentifier: vi.fn(async (_root: string, raw: string) => ({
+      sourceId: `id::${raw}`,
+      relativePath: 'meta.ttl',
+      duplicate: false,
+      title: 'identifier-route',
+      kind: 'doi',
+      pdfSaved: false,
+      pdfError: null,
+    })),
+  };
+});
+
+vi.mock('../../../src/main/sources/ingest', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/main/sources/ingest')>(
+    '../../../src/main/sources/ingest',
+  );
+  return {
+    ...actual,
+    ingestUrl: vi.fn(async (_root: string, url: string) => ({
+      sourceId: `url::${url}`,
+      relativePath: 'meta.ttl',
+      duplicate: false,
+      title: 'url-route',
+    })),
+  };
+});
+
+import { ingestSmart } from '../../../src/main/sources/ingest-smart';
+import { ingestIdentifier } from '../../../src/main/sources/ingest-identifier';
+import { ingestUrl } from '../../../src/main/sources/ingest';
+
+describe('ingestSmart (#473)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-ingest-smart-'));
+    await initGraph(projectContext(root));
+    vi.clearAllMocks();
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('routes a bare DOI to identifier ingest', async () => {
+    const result = await ingestSmart(root, '10.1145/3677999.3678002');
+    expect(result.route).toBe('identifier');
+    expect(ingestIdentifier).toHaveBeenCalledWith(root, '10.1145/3677999.3678002', expect.anything());
+    expect(ingestUrl).not.toHaveBeenCalled();
+  });
+
+  it('routes a DOI URL to identifier ingest (detectIdentifier handles it)', async () => {
+    await ingestSmart(root, 'https://doi.org/10.1145/3677999.3678002');
+    expect(ingestIdentifier).toHaveBeenCalled();
+    expect(ingestUrl).not.toHaveBeenCalled();
+  });
+
+  it('routes an arXiv id to identifier ingest', async () => {
+    await ingestSmart(root, '2301.12345');
+    expect(ingestIdentifier).toHaveBeenCalled();
+    expect(ingestUrl).not.toHaveBeenCalled();
+  });
+
+  it('routes a bare URL to URL ingest', async () => {
+    const result = await ingestSmart(root, 'https://example.com/article');
+    expect(result.route).toBe('url');
+    expect(ingestUrl).toHaveBeenCalledWith(root, 'https://example.com/article', expect.anything());
+    expect(ingestIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('extracts a DOI from surrounding text and routes to identifier', async () => {
+    await ingestSmart(root, 'See 10.1145/3677999.3678002 for details.');
+    expect(ingestIdentifier).toHaveBeenCalledWith(root, '10.1145/3677999.3678002', expect.anything());
+    expect(ingestUrl).not.toHaveBeenCalled();
+  });
+
+  it('strips trailing period when extracting a DOI from prose', async () => {
+    await ingestSmart(root, 'cite 10.1145/3677999.3678002.');
+    expect(ingestIdentifier).toHaveBeenCalledWith(root, '10.1145/3677999.3678002', expect.anything());
+  });
+
+  it('throws on unrecognised input', async () => {
+    await expect(ingestSmart(root, 'banana')).rejects.toThrow(/Not a recognised/);
+    await expect(ingestSmart(root, '')).rejects.toThrow(/Empty/);
+  });
+});

--- a/tests/shared/markdown/doi-plugin.test.ts
+++ b/tests/shared/markdown/doi-plugin.test.ts
@@ -1,0 +1,80 @@
+/**
+ * DOI auto-link markdown-it plugin (#473).
+ */
+
+import { describe, it, expect } from 'vitest';
+import MarkdownIt from 'markdown-it';
+import { installDoiAutolink } from '../../../src/shared/markdown/doi-plugin';
+
+function md(): MarkdownIt {
+  const m = new MarkdownIt({ html: true, linkify: true });
+  installDoiAutolink(m);
+  return m;
+}
+
+describe('doi-plugin: bare DOI auto-link', () => {
+  it('wraps a standalone DOI in a doi.org link', () => {
+    const html = md().render('See 10.1145/3677999.3678002 for details.');
+    expect(html).toContain('<a href="https://doi.org/10.1145/3677999.3678002">10.1145/3677999.3678002</a>');
+  });
+
+  it('does not eat a trailing period at end-of-sentence', () => {
+    const html = md().render('See 10.1145/3677999.3678002.');
+    // The DOI body lives inside the anchor, the period stays outside.
+    expect(html).toContain('href="https://doi.org/10.1145/3677999.3678002"');
+    expect(html).toContain('>10.1145/3677999.3678002</a>.');
+  });
+
+  it('does not eat trailing punctuation other than period', () => {
+    const html = md().render('Cite 10.1234/foo, then 10.5678/bar; finally 10.9999/baz)');
+    expect(html).toContain('>10.1234/foo</a>,');
+    expect(html).toContain('>10.5678/bar</a>;');
+    expect(html).toContain('>10.9999/baz</a>)');
+  });
+
+  it('handles multiple DOIs in one paragraph', () => {
+    const html = md().render('10.1234/a and 10.5678/b');
+    const matches = html.match(/href="https:\/\/doi\.org\/[^"]+"/g);
+    expect(matches).toEqual([
+      'href="https://doi.org/10.1234/a"',
+      'href="https://doi.org/10.5678/b"',
+    ]);
+  });
+
+  it('does not link non-DOI numbers that happen to start with 10.', () => {
+    const html = md().render('10.4 of the spec, or 10.42% of users.');
+    expect(html).not.toContain('doi.org');
+  });
+
+  it('leaves linkify-handled DOI URLs alone', () => {
+    // linkify turns the URL into a link before our rule fires;
+    // we shouldn't double-wrap the DOI portion.
+    const html = md().render('See https://doi.org/10.1234/foo.');
+    expect(html).toContain('<a href="https://doi.org/10.1234/foo">');
+    // No nested anchor inside the linkify-produced anchor.
+    expect(html).not.toMatch(/<a[^>]*><a/);
+  });
+
+  it('handles a DOI inside a sentence with surrounding text', () => {
+    const html = md().render('Before 10.1234/foo after.');
+    expect(html).toContain('Before <a href="https://doi.org/10.1234/foo">10.1234/foo</a> after.');
+  });
+
+  it('does not break inside code spans', () => {
+    const html = md().render('`10.1234/foo` should stay raw');
+    expect(html).toContain('<code>10.1234/foo</code>');
+    expect(html).not.toMatch(/<code>[^<]*doi\.org/);
+  });
+
+  it('does not break inside fenced code blocks', () => {
+    const html = md().render('```\n10.1234/foo\n```');
+    expect(html).not.toContain('doi.org');
+  });
+
+  it('preserves the inner DOI text verbatim', () => {
+    // No url-encoding inside the visible link text — what the user
+    // sees matches what's on the page.
+    const html = md().render('10.1234/under_score-dot.in-suffix');
+    expect(html).toContain('>10.1234/under_score-dot.in-suffix</a>');
+  });
+});


### PR DESCRIPTION
Five remaining surfaces from #473 in one PR. Closes the issue end-to-end.

## DOI auto-link in preview
New \`src/shared/markdown/doi-plugin.ts\`. \`linkify\` already catches DOI URLs; this catches the bare form a researcher actually types:

> See 10.1145/3677999.3678002 for the data.

becomes a real link to https://doi.org/.... Conservative: strict \`10.NNNN/...\` shape; skips text inside an existing \`<a>\` (so we don't nest anchors); strips trailing sentence punctuation; never fires inside code spans or fenced blocks.

## Body-text DOI ingest (one click)
Clicking a DOI link in the preview:
- If the DOI matches an existing source → opens that source.
- Otherwise → asks "Ingest as new source?" via the standard \`showConfirm\` with a \`don't ask again\` key. Confirm → identifier ingest, opens the new source.

The host-side decision lives in \`App.svelte\`; \`Preview\` just fires \`onDoiClick(doi)\`. Per CLAUDE.md no-fear UX: one offer, dismissable.

## Smart paste from the Sources panel
New "+" button next to the filter input. Takes free-form input — URL / DOI / DOI URL / arXiv id / arXiv URL / PMID / PubMed URL, or prose with an embedded DOI — and dispatches to the right ingest path. Backend in \`src/main/sources/ingest-smart.ts\`; IPC \`sources:ingestSmart\` carries the through-line.

## Settings toggle: "Import upstream subject tags on source ingest"
New **Settings → Ingest** tab. Default on. When off, identifier ingest drops the \`keywords\` array before writing \`meta.ttl\`, so no \`minerva:upstreamTag\` literals land. Persisted via \`ingest-settings.json\` in the user-data dir (mirrors the LLM settings shape).

## Invalid-DOI inspection
Adds \`checkInvalidDois\` to the existing health-checks pass. Walks every source's \`bibo:doi\` and flags ones that don't match the Crossref shape. Soft warning, not blocking — surfaces in the inspections panel alongside the other checks.

## Tests
- \`doi-plugin.test.ts\`: 10 cases — bare DOI, trailing-punct, multi-DOI paragraphs, no false positives on numbers starting with \`10.\`, no double-wrap with linkify, no firing inside code.
- \`ingest-smart.test.ts\`: 7 cases — route DOI / DOI URL / arXiv id / URL / DOI-in-prose; trailing-period handling; refusal on unrecognised input.
- \`invalid-doi-inspection.test.ts\`: 4 cases — bad shape flagged, good shape silent, no-DOI silent, multi-source isolation.
- \`confirm-keys.test.ts\`: passing — registry entry added for the new \`ingest-doi-from-body\` key.

Full suite **2343 / 2343** (+21 new).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Open a note that mentions \`10.1145/3677999.3678002\`. Preview shows it as a link.
  2. Click it (the source isn't ingested yet) → confirm dialog "Ingest as new source?". Click Ingest → source appears in the sidebar, tab opens.
  3. Click the same link again → opens the existing source (no prompt).
  4. Sources panel: click the "+" button, paste a DOI URL → ingests via identifier path. Paste an arbitrary HTTPS URL → ingests via URL path. Paste "see 10.1145/foo for details" → extracts the DOI and ingests.
  5. Settings → Ingest → uncheck "Import upstream subject tags". Re-ingest a DOI you know has CrossRef subjects → the new source has no \`crossref/...\` tags.
  6. Hand-edit a source's \`meta.ttl\` to set \`bibo:doi "not-a-doi"\`. Run Inspections → the source shows up under "invalid_doi".

Closes #473.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)