### PR TITLE
feat: mine source bibliographies into stub Source nodes (#106)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -2086,7 +2086,7 @@ export function backlinks(ctx: ProjectContext, relativePath: string): Backlink[]
 
 // ── Source detail queries ───────────────────────────────────────────────────
 
-import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink, SourceAboutNote, ReadStatus } from '../../shared/types';
+import type { SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink, SourceAboutNote, SourceReference, ReadStatus } from '../../shared/types';
 
 const READ_STATUS_VALUES: ReadonlySet<ReadStatus> = new Set(['unread', 'reading', 'read', 'skipped']);
 
@@ -2104,8 +2104,35 @@ export function getSourceDetail(ctx: ProjectContext, sourceId: string): SourceDe
   const excerpts = collectExcerptsForSource(state, subject);
   const backlinks = collectSourceBacklinks(state, subject, excerpts);
   const aboutNotes = collectSourceAboutNotes(state, subject);
+  const references = collectSourceReferences(state, subject);
 
-  return { metadata, excerpts, backlinks, aboutNotes };
+  return { metadata, excerpts, backlinks, aboutNotes, references };
+}
+
+/**
+ * Outgoing `minerva:references` edges from this source (#106) —
+ * the bibliography stubs created by reference mining.
+ */
+function collectSourceReferences(state: GraphState, sourceSubject: $rdf.NamedNode): SourceReference[] {
+  const { store } = state;
+  const out: SourceReference[] = [];
+  const seen = new Set<string>();
+  for (const st of store.statementsMatching(sourceSubject, MINERVA('references'), undefined)) {
+    const targetSubject = st.object as $rdf.NamedNode;
+    const idStmts = store.statementsMatching(targetSubject, MINERVA('sourceId'), undefined);
+    const targetId = idStmts[0]?.object.value;
+    if (!targetId || seen.has(targetId)) continue;
+    seen.add(targetId);
+    const titleStmts = store.statementsMatching(targetSubject, DC('title'), undefined);
+    const stubStmts = store.statementsMatching(targetSubject, THOUGHT('stubStatus'), undefined);
+    out.push({
+      sourceId: targetId,
+      title: titleStmts[0]?.object.value ?? targetId,
+      stubStatus: stubStmts[0]?.object.value ?? null,
+    });
+  }
+  out.sort((a, b) => a.title.localeCompare(b.title));
+  return out;
 }
 
 function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rdf.NamedNode): SourceMetadata {
@@ -2151,6 +2178,7 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
     abstract: first(DC('abstract')),
     readStatus,
     readDueBy: first(MINERVA('readDueBy')),
+    stubStatus: first(THOUGHT('stubStatus')),
   };
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -76,6 +76,8 @@ import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
 import { stripUpstreamTags } from './sources/strip-upstream-tags';
 import { getIngestSettings, saveIngestSettings, type IngestSettings } from './sources/ingest-settings';
 import { ingestSmart } from './sources/ingest-smart';
+import { mineSourceReferences, type ParsedReference } from './sources/mine-references';
+import { createReferenceStubs } from './sources/create-reference-stubs';
 import type { ReadStatus } from '../shared/types';
 import type { ReadingQueueView } from './graph/index';
 import {
@@ -1319,6 +1321,22 @@ export function registerIpcHandlers(): void {
       fetchImpl: privilegedFetch,
       importUpstreamTags: ingestSettings.importUpstreamTags,
     });
+  });
+
+  ipcMain.handle(Channels.SOURCES_MINE_REFERENCES, async (e, sourceId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await mineSourceReferences(rootPath, sourceId);
+  });
+
+  ipcMain.handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, async (e, params: { sourceId: string; refs: ParsedReference[] }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const result = await createReferenceStubs(rootPath, params.sourceId, params.refs);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    return result;
   });
 
   ipcMain.handle(Channels.INGEST_GET_SETTINGS, () => getIngestSettings());

--- a/src/main/sources/create-reference-stubs.ts
+++ b/src/main/sources/create-reference-stubs.ts
@@ -1,0 +1,196 @@
+/**
+ * Materialise approved reference candidates into stub Source nodes
+ * (#106). Called after the renderer's "Approve N references" dialog
+ * fires — never speculatively, since stubs are user-confirmed graph
+ * mutations.
+ *
+ * Each accepted ParsedReference becomes a source folder at
+ * `.minerva/sources/<canonical-id>/meta.ttl` with:
+ *   - dc:title / dc:creator / dc:issued / schema:inContainer from
+ *     the LLM's parse
+ *   - bibo:doi / bibo:isbn / bibo:uri when present
+ *   - thought:stubStatus "unresolved" — distinguishes stubs from
+ *     fully-ingested sources in the SourceDetail UI and in queries
+ *   - thought:rawReference "<citation text>" — kept so the resolve
+ *     step (#107) can re-parse if needed
+ *
+ * The parent source's meta.ttl gains a `minerva:references <stub>`
+ * triple per accepted reference. Both files are re-indexed so the
+ * graph picks up the new shape immediately.
+ *
+ * Dedup: when the canonical id of a parsed reference matches an
+ * existing source (full or stub), we skip creating it and just add
+ * the references edge — same canonical-id rules as the rest of the
+ * ingest pipeline (#90).
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { canonicalSourceId } from './source-id';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+import type { ParsedReference } from './mine-references';
+
+export interface CreateStubsResult {
+  /** Stubs newly created on disk. */
+  created: { sourceId: string; title: string }[];
+  /** Parsed references whose canonical id already existed; the
+   *  parent source still got a `minerva:references` edge to them. */
+  matchedExisting: { sourceId: string; title: string }[];
+  /** Parsed references that couldn't be materialised (e.g. canonical
+   *  id collision with an unrelated row). */
+  skipped: { reason: string; raw: string }[];
+}
+
+export async function createReferenceStubs(
+  rootPath: string,
+  parentSourceId: string,
+  refs: readonly ParsedReference[],
+): Promise<CreateStubsResult> {
+  const parentDir = path.join(rootPath, '.minerva', 'sources', parentSourceId);
+  const parentMetaPath = path.join(parentDir, 'meta.ttl');
+  let parentTtl: string;
+  try {
+    parentTtl = await fs.readFile(parentMetaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Parent source "${parentSourceId}" has no meta.ttl.`, { cause: err });
+    }
+    throw err;
+  }
+
+  const created: CreateStubsResult['created'] = [];
+  const matchedExisting: CreateStubsResult['matchedExisting'] = [];
+  const skipped: CreateStubsResult['skipped'] = [];
+  const referencesEdges: string[] = [];
+
+  const sourcesRoot = path.join(rootPath, '.minerva', 'sources');
+
+  for (const ref of refs) {
+    let canonical;
+    try {
+      canonical = canonicalSourceId(
+        {
+          doi: ref.doi ?? undefined,
+          arxiv: ref.arxiv ?? undefined,
+          pubmed: ref.pubmed ?? undefined,
+          isbn: ref.isbn ?? undefined,
+          url: ref.url ?? undefined,
+        },
+        // Content-hash seed: title + first author + year is stable
+        // enough that re-mining the same source yields the same id.
+        `${ref.title}|${ref.authors[0] ?? ''}|${ref.year ?? ''}`,
+      );
+    } catch (err) {
+      skipped.push({ reason: err instanceof Error ? err.message : String(err), raw: ref.raw });
+      continue;
+    }
+
+    const stubId = canonical.id;
+    const stubDir = path.join(sourcesRoot, stubId);
+    const stubMetaPath = path.join(stubDir, 'meta.ttl');
+    referencesEdges.push(stubId);
+
+    // Existence check. If a meta.ttl already lives at this canonical
+    // id, treat it as a match — the parent will still get the edge,
+    // and we don't overwrite the existing file (it might be a
+    // resolved source the user has been hand-editing).
+    let exists = false;
+    try { await fs.access(stubMetaPath); exists = true; } catch { /* fresh */ }
+    if (exists) {
+      matchedExisting.push({ sourceId: stubId, title: ref.title });
+      continue;
+    }
+
+    await fs.mkdir(stubDir, { recursive: true });
+    await fs.writeFile(stubMetaPath, buildStubMetaTtl(ref), 'utf-8');
+    created.push({ sourceId: stubId, title: ref.title });
+    // Re-index immediately so the stub surfaces in queries before
+    // the file watcher catches up.
+    const ctx = projectContext(rootPath);
+    graph.indexSource(ctx, stubId, await fs.readFile(stubMetaPath, 'utf-8'));
+  }
+
+  // Add minerva:references edges to parent. We use the same
+  // upsert-single-valued helper as readStatus to add one line per
+  // edge — except the predicate is multi-valued, so we need a
+  // dedicated "append if missing" pass instead of replace-in-place.
+  if (referencesEdges.length > 0) {
+    const next = appendReferencesEdges(parentTtl, referencesEdges);
+    if (next !== parentTtl) {
+      await fs.writeFile(parentMetaPath, next, 'utf-8');
+      const ctx = projectContext(rootPath);
+      const body = await readBodyIfPresent(parentDir);
+      graph.indexSource(ctx, parentSourceId, next, body);
+    }
+  }
+
+  return { created, matchedExisting, skipped };
+}
+
+// Re-uses the on-disk shape buildMetaTtl emits, but stubs go light:
+// no thought:accessedAt timestamp (the user didn't fetch this), and
+// thought:stubStatus + thought:rawReference flag the partial state.
+function buildStubMetaTtl(ref: ParsedReference): string {
+  const lines: string[] = [`this: a thought:${ref.subtype} ;`];
+  lines.push(`    dc:title ${ttlString(ref.title)} ;`);
+  for (const c of ref.authors) lines.push(`    dc:creator ${ttlString(c)} ;`);
+  if (ref.year) lines.push(`    dc:issued ${ttlString(ref.year)}^^xsd:gYear ;`);
+  if (ref.containerTitle) lines.push(`    schema:inContainer ${ttlString(ref.containerTitle)} ;`);
+  if (ref.doi) lines.push(`    bibo:doi ${ttlString(ref.doi)} ;`);
+  if (ref.isbn) lines.push(`    bibo:isbn ${ttlString(ref.isbn)} ;`);
+  if (ref.url) lines.push(`    bibo:uri ${ttlString(ref.url)} ;`);
+  lines.push(`    thought:stubStatus ${ttlString('unresolved')} ;`);
+  lines.push(`    thought:rawReference ${ttlString(ref.raw)} .`);
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Add `minerva:references sources:<stubId>` triples to the parent
+ * source's meta.ttl, deduped against existing references edges
+ * already in the file. Insertion happens immediately before the
+ * closing `.` so the Turtle stays grammatical.
+ *
+ * Exposed for tests.
+ */
+export function appendReferencesEdges(parentTtl: string, stubIds: readonly string[]): string {
+  const existing = collectExistingReferences(parentTtl);
+  const fresh = stubIds.filter((id) => !existing.has(id));
+  if (fresh.length === 0) return parentTtl;
+  const lines = fresh.map((id) => `    minerva:references sources:${id} ;`);
+  // Walk back to the trailing `.` and inject before it. Mirrors the
+  // approach in source-merge.ts / read-status.ts.
+  const trailing = parentTtl.match(/(\s*\.\s*)$/);
+  if (!trailing) {
+    return parentTtl + (parentTtl.endsWith('\n') ? '' : '\n') + lines.join('\n') + '\n    .\n';
+  }
+  const dotIdx = trailing.index ?? parentTtl.length;
+  const lineStart = parentTtl.lastIndexOf('\n', dotIdx - 1);
+  if (lineStart < 0) {
+    return parentTtl.slice(0, dotIdx).replace(/\s+$/, ' ;') + '\n' + lines.join('\n') + '\n' + parentTtl.slice(dotIdx);
+  }
+  return parentTtl.slice(0, lineStart) + '\n' + lines.join('\n') + parentTtl.slice(lineStart);
+}
+
+function collectExistingReferences(ttl: string): Set<string> {
+  const out = new Set<string>();
+  const re = /minerva:references\s+sources:([\w.-]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(ttl)) !== null) out.add(m[1]);
+  return out;
+}
+
+async function readBodyIfPresent(dir: string): Promise<string | undefined> {
+  try { return await fs.readFile(path.join(dir, 'body.md'), 'utf-8'); } catch { return undefined; }
+}
+
+function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+

--- a/src/main/sources/mine-references.ts
+++ b/src/main/sources/mine-references.ts
@@ -1,0 +1,250 @@
+/**
+ * Mine a source's References section into stub Source nodes (#106).
+ *
+ * Two-phase parser:
+ *   1. Locate the references-list section in the source's body.md by
+ *      scanning for a "References" / "Bibliography" / "Works Cited"
+ *      heading. Take everything from that heading to the next
+ *      heading-of-equal-or-lower-depth (or EOF).
+ *   2. Split the section into per-entry raw strings (numbered list,
+ *      bulleted list, or paragraph-per-entry). Hand each entry to
+ *      the LLM with a JSON-output prompt so the model maps the
+ *      free-form citation into structured `{ title, authors, year,
+ *      doi, … }` records.
+ *
+ * Trust principle (CLAUDE.md): the mining call itself doesn't write
+ * to disk. It returns the parsed candidates so the renderer can
+ * surface a "approve N of these" dialog. The user confirms before
+ * any stub source is created — same pattern as the Auto-link
+ * suggestions dialog.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { complete } from '../llm';
+import type { ParsedReference } from '../../shared/mine-references';
+
+export type { ParsedReference } from '../../shared/mine-references';
+
+export interface MineReferencesOptions {
+  /** Dependency-injection seam for tests. Default is the real LLM. */
+  llmComplete?: (prompt: string) => Promise<string>;
+  /** Maximum entries to send to the LLM per call. Paginated when a
+   *  bibliography exceeds this — the prompt+response budget at large
+   *  N gets uncomfortable. Default: 30. */
+  batchSize?: number;
+}
+
+const DEFAULT_BATCH_SIZE = 30;
+
+/**
+ * High-level orchestrator: read body.md, find the references section,
+ * split into raw entries, call the LLM for structured parsing, return
+ * the candidates. The renderer then surfaces them for user approval
+ * before any stub gets written.
+ */
+export async function mineSourceReferences(
+  rootPath: string,
+  sourceId: string,
+  opts: MineReferencesOptions = {},
+): Promise<ParsedReference[]> {
+  const bodyPath = path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md');
+  let body: string;
+  try {
+    body = await fs.readFile(bodyPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Source has no body.md to mine: ${sourceId}`, { cause: err });
+    }
+    throw err;
+  }
+
+  const section = extractReferenceSection(body);
+  if (!section) {
+    throw new Error('No "References" / "Bibliography" / "Works Cited" section found in body.md');
+  }
+  const entries = splitReferenceEntries(section);
+  if (entries.length === 0) {
+    throw new Error('Reference section found but no individual entries could be split out.');
+  }
+
+  const llm = opts.llmComplete ?? complete;
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const results: ParsedReference[] = [];
+  for (let i = 0; i < entries.length; i += batchSize) {
+    const batch = entries.slice(i, i + batchSize);
+    const parsed = await parseBatchWithLLM(batch, llm);
+    for (const p of parsed) {
+      if (p.title.trim()) results.push(p);
+    }
+  }
+  return results;
+}
+
+// ── Section + entry extraction ───────────────────────────────────────────
+
+const REF_HEADING_RE = /^(#{1,6})\s+(References|Bibliography|Works\s+Cited|Literature\s+Cited|Cited\s+Works|Citations)\s*$/im;
+
+/**
+ * Return the body of the first "References" section, or null. We grab
+ * from the line *after* the heading up to (but not including) the
+ * next heading at the same or shallower depth.
+ *
+ * Exposed for tests.
+ */
+export function extractReferenceSection(body: string): string | null {
+  const m = body.match(REF_HEADING_RE);
+  if (!m) return null;
+  const headingMarker = m[1];
+  const headingDepth = headingMarker.length;
+  // Index of the line right after the heading.
+  const startIdx = (m.index ?? 0) + m[0].length;
+  // Scan forward for the next heading of equal-or-shallower depth.
+  const rest = body.slice(startIdx);
+  const nextHeadingRe = new RegExp(`^(#{1,${headingDepth}})\\s+\\S`, 'm');
+  const nextMatch = rest.match(nextHeadingRe);
+  const section = nextMatch
+    ? rest.slice(0, nextMatch.index ?? rest.length)
+    : rest;
+  const trimmed = section.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Split a references-section blob into per-entry raw strings.
+ * Strategies tried in order:
+ *   1. Numbered lines:   `1.` / `1)` / `[1]` at the start of a line.
+ *   2. Bulleted lines:   `-` / `*` / `•` at the start.
+ *   3. Blank-line separated paragraphs.
+ *
+ * The first strategy that yields >1 entry wins. Falling back to
+ * paragraph split catches the most common "References:\n\nSmith…
+ * \n\nJones…" style.
+ *
+ * Exposed for tests.
+ */
+export function splitReferenceEntries(section: string): string[] {
+  // Strategy 1: numbered / bracketed prefixes.
+  const numbered = splitOnLeadingMarker(section, /^\s*(?:\[\d+\]|\(\d+\)|\d+[.)])\s+/m);
+  if (numbered.length > 1) return numbered.map(stripWhitespace).filter(Boolean);
+
+  // Strategy 2: bullets.
+  const bulleted = splitOnLeadingMarker(section, /^\s*[-*•]\s+/m);
+  if (bulleted.length > 1) return bulleted.map(stripWhitespace).filter(Boolean);
+
+  // Strategy 3: blank-line paragraphs.
+  return section.split(/\n\s*\n+/).map(stripWhitespace).filter(Boolean);
+}
+
+function splitOnLeadingMarker(text: string, marker: RegExp): string[] {
+  // Find all marker positions; split between them.
+  const positions: number[] = [];
+  const g = new RegExp(marker.source, marker.flags.includes('g') ? marker.flags : `${marker.flags}g`);
+  let m: RegExpExecArray | null;
+  while ((m = g.exec(text)) !== null) {
+    positions.push(m.index);
+    // Avoid infinite loop on zero-width matches.
+    if (m.index === g.lastIndex) g.lastIndex++;
+  }
+  if (positions.length === 0) return [text];
+  const out: string[] = [];
+  for (let i = 0; i < positions.length; i++) {
+    const start = positions[i];
+    const end = i + 1 < positions.length ? positions[i + 1] : text.length;
+    let chunk = text.slice(start, end);
+    // Drop the marker prefix so the LLM doesn't have to chew on it.
+    chunk = chunk.replace(marker, '');
+    out.push(chunk);
+  }
+  return out;
+}
+
+function stripWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+// ── LLM-assisted entry parsing ───────────────────────────────────────────
+
+const SYSTEM_PROMPT_HEADER = `You are parsing a reference list from an academic paper.
+For each raw citation, extract the bibliographic fields you can recognise.
+Return a JSON array — one object per input citation, in the same order.
+
+Each object has these fields. Use null when a field isn't determinable.
+
+  {
+    "raw": "<verbatim input citation>",
+    "title": "<paper / book / chapter title>",
+    "authors": ["Last, F.", "..."],
+    "year": "2023",
+    "containerTitle": "<journal / book / proceedings>",
+    "doi": "10.NNNN/...",
+    "arxiv": "2301.12345",
+    "pubmed": "12345678",
+    "isbn": "978-...",
+    "url": "https://...",
+    "subtype": "Article" | "Book" | "Preprint" | "Report" | "Source"
+  }
+
+Output ONLY the JSON array — no prose, no markdown fence, no comments.`;
+
+async function parseBatchWithLLM(
+  entries: string[],
+  llm: (prompt: string) => Promise<string>,
+): Promise<ParsedReference[]> {
+  const numbered = entries.map((e, i) => `${i + 1}. ${e}`).join('\n\n');
+  const prompt = `${SYSTEM_PROMPT_HEADER}\n\nCitations to parse:\n\n${numbered}`;
+  const response = await llm(prompt);
+  return parseLLMResponse(response, entries);
+}
+
+/**
+ * Parse the LLM's response into ParsedReference records. Tolerant of
+ * code-fence wrappers (`\`\`\`json … \`\`\``) and stray prefix prose.
+ *
+ * Exposed for tests.
+ */
+export function parseLLMResponse(text: string, originals: string[]): ParsedReference[] {
+  const stripped = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```$/i, '')
+    .trim();
+  let parsed: unknown;
+  try { parsed = JSON.parse(stripped); }
+  catch (err) {
+    throw new Error(
+      `LLM returned non-JSON: ${err instanceof Error ? err.message : String(err)}\n${text.slice(0, 200)}`,
+      { cause: err },
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('LLM response was not a JSON array.');
+  }
+  const out: ParsedReference[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    const r = parsed[i] as Record<string, unknown>;
+    if (!r || typeof r !== 'object') continue;
+    const title = typeof r.title === 'string' ? r.title.trim() : '';
+    if (!title) continue;
+    out.push({
+      raw: typeof r.raw === 'string' && r.raw.trim() ? r.raw : (originals[i] ?? ''),
+      title,
+      authors: Array.isArray(r.authors)
+        ? r.authors.filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
+        : [],
+      year: typeof r.year === 'string' && /^\d{4}$/.test(r.year) ? r.year : null,
+      containerTitle: typeof r.containerTitle === 'string' && r.containerTitle.trim() ? r.containerTitle.trim() : null,
+      doi: typeof r.doi === 'string' && r.doi.trim() ? r.doi.trim() : null,
+      arxiv: typeof r.arxiv === 'string' && r.arxiv.trim() ? r.arxiv.trim() : null,
+      pubmed: typeof r.pubmed === 'string' && r.pubmed.trim() ? r.pubmed.trim() : null,
+      isbn: typeof r.isbn === 'string' && r.isbn.trim() ? r.isbn.trim() : null,
+      url: typeof r.url === 'string' && r.url.trim() ? r.url.trim() : null,
+      subtype: isValidSubtype(r.subtype) ? r.subtype : 'Source',
+    });
+  }
+  return out;
+}
+
+function isValidSubtype(v: unknown): v is ParsedReference['subtype'] {
+  return v === 'Article' || v === 'Book' || v === 'Preprint' || v === 'Report' || v === 'Source';
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -270,6 +270,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.INGEST_SET_SETTINGS, settings),
     ingestSmart: (rawInput: string) =>
       ipcRenderer.invoke(Channels.SOURCES_INGEST_SMART, rawInput),
+    mineReferences: (sourceId: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_MINE_REFERENCES, sourceId),
+    createReferenceStubs: (sourceId: string, refs: unknown[]) =>
+      ipcRenderer.invoke(Channels.SOURCES_CREATE_REFERENCE_STUBS, { sourceId, refs }),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -23,6 +23,7 @@
   } from '../shared/refactor/auto-tag';
   import { getEditorStore } from './lib/stores/editor.svelte';
   import PromptDialog from './lib/components/PromptDialog.svelte';
+  import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import OpenTargetDialog from './lib/components/OpenTargetDialog.svelte';
@@ -1779,6 +1780,66 @@
   }
 
   /**
+   * Right-click a source → "Mine references…" (#106). Runs the LLM
+   * mining call, opens a review dialog. User checks the candidates
+   * they want, clicks Approve → backend writes the stub files and
+   * adds `minerva:references` edges from the parent.
+   */
+  let mineReviewState = $state<{
+    parentId: string;
+    parentTitle: string;
+    refs: import('../shared/mine-references').ParsedReference[];
+  } | null>(null);
+
+  async function handleMineReferences(source: import('../shared/types').SourceMetadata): Promise<void> {
+    try {
+      const refs = await withBusy('Mining references…', () =>
+        api.sources.mineReferences(source.sourceId),
+      );
+      if (refs.length === 0) {
+        await showConfirm(
+          'No references the LLM could parse. The body.md may not have a References section, or its formatting is too irregular for first-pass extraction.',
+          CONFIRM_KEYS.mineReferencesEmpty,
+          'OK',
+        );
+        return;
+      }
+      mineReviewState = {
+        parentId: source.sourceId,
+        parentTitle: source.title ?? source.sourceId,
+        refs,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn't mine references: ${msg}`, CONFIRM_KEYS.mineReferencesFailed, 'OK');
+    }
+  }
+
+  async function handleMineReferencesApply(
+    accepted: import('../shared/mine-references').ParsedReference[],
+  ): Promise<void> {
+    const state = mineReviewState;
+    mineReviewState = null;
+    if (!state) return;
+    try {
+      const result = await withBusy('Creating stubs…', () =>
+        api.sources.createReferenceStubs(state.parentId, accepted),
+      );
+      await refreshSourcesCache();
+      const lines: string[] = [];
+      if (result.created.length > 0) lines.push(`Created ${result.created.length} new stub${result.created.length === 1 ? '' : 's'}.`);
+      if (result.matchedExisting.length > 0) lines.push(`${result.matchedExisting.length} matched existing sources.`);
+      if (result.skipped.length > 0) lines.push(`${result.skipped.length} skipped (id collision).`);
+      if (lines.length > 0) {
+        await showConfirm(lines.join(' '), CONFIRM_KEYS.mineReferencesResult, 'OK');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn't create stubs: ${msg}`, CONFIRM_KEYS.mineReferencesFailed, 'OK');
+    }
+  }
+
+  /**
    * Click on a bare-DOI link inside the markdown preview (#473).
    * If the DOI already maps to an ingested source, open it. Otherwise
    * offer to ingest — dismissable, keyed so the user can suppress
@@ -2417,6 +2478,7 @@
           onSourceDeleted={handleSourceDeleted}
           onShowConfirm={showConfirm}
           onShowPrompt={showPrompt}
+          onMineReferences={handleMineReferences}
           onTableClick={(name) => editor.openQuery(`SELECT * FROM ${name}`, 'sql')}
           onOpenCsv={(rel) => handleFileSelect(rel)}
           onExternalDrop={handleExternalDrop}
@@ -2622,6 +2684,7 @@
               onShowConfirm={showConfirm}
               onDeleted={handleSourceDeleted}
               onCreateAboutNote={handleNewAboutSourceNote}
+              onOpenReference={handleOpenSource}
             />
           {/key}
         {:else}
@@ -2745,6 +2808,14 @@
       initial={promptDialog.initial ?? ''}
       onConfirm={handlePromptConfirm}
       onCancel={handlePromptCancel}
+    />
+  {/if}
+  {#if mineReviewState}
+    <MineReferencesDialog
+      parentTitle={mineReviewState.parentTitle}
+      refs={mineReviewState.refs}
+      onApply={handleMineReferencesApply}
+      onCancel={() => { mineReviewState = null; }}
     />
   {/if}
   {#if confirmDialog}

--- a/src/renderer/lib/components/MineReferencesDialog.svelte
+++ b/src/renderer/lib/components/MineReferencesDialog.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+  /**
+   * Review the LLM-parsed references before any stubs land on disk
+   * (#106). Per CLAUDE.md trust principle, the LLM proposes,
+   * the human confirms — this dialog is that confirmation step.
+   *
+   * Each row is selected by default; user can uncheck individual
+   * entries before Approve. The mining call already happened so
+   * we render the results immediately; the dialog never re-fetches.
+   */
+  import type { ParsedReference } from '../../../shared/mine-references';
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    /** Parent source the references will be linked from. Used only
+     *  for the dialog header. */
+    parentTitle: string;
+    refs: ParsedReference[];
+    onApply: (accepted: ParsedReference[]) => Promise<void>;
+    onCancel: () => void;
+  }
+
+  let { parentTitle, refs, onApply, onCancel }: Props = $props();
+
+  let selected = $state<boolean[]>(refs.map(() => true));
+  let saving = $state(false);
+
+  const selectedCount = $derived(selected.filter(Boolean).length);
+
+  function toggleAll(value: boolean) {
+    selected = refs.map(() => value);
+  }
+
+  async function apply() {
+    if (saving) return;
+    const accepted = refs.filter((_, i) => selected[i]);
+    if (accepted.length === 0) return;
+    saving = true;
+    try {
+      await onApply(accepted);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+    else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void apply();
+  }
+
+  function bylineOf(ref: ParsedReference): string {
+    const who = ref.authors.length === 0 ? ''
+      : ref.authors.length === 1 ? ref.authors[0]
+      : ref.authors.length === 2 ? `${ref.authors[0]} and ${ref.authors[1]}`
+      : `${ref.authors[0]} et al.`;
+    if (who && ref.year) return `${who} (${ref.year})`;
+    return who || (ref.year ?? '');
+  }
+
+  /** Compact "found identifier" chip list — DOI / arXiv / PMID / ISBN /
+   *  URL — so the user can see at a glance whether each row will land
+   *  with a structured identifier or as a content-hash stub. */
+  function idChips(ref: ParsedReference): { kind: string; value: string }[] {
+    const out: { kind: string; value: string }[] = [];
+    if (ref.doi) out.push({ kind: 'DOI', value: ref.doi });
+    if (ref.arxiv) out.push({ kind: 'arXiv', value: ref.arxiv });
+    if (ref.pubmed) out.push({ kind: 'PMID', value: ref.pubmed });
+    if (ref.isbn) out.push({ kind: 'ISBN', value: ref.isbn });
+    if (ref.url) out.push({ kind: 'URL', value: ref.url });
+    return out;
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Review references">
+    <header class="card-header">
+      <div class="eyebrow">REVIEW REFERENCES · {refs.length} {refs.length === 1 ? 'candidate' : 'candidates'}</div>
+      <h2 class="title">Mine references from "{parentTitle}"</h2>
+      <p class="sub">
+        Each accepted reference becomes a stub source linked from
+        this paper. Stubs can be promoted to full sources later with
+        Resolve.
+      </p>
+    </header>
+
+    {#if refs.length === 0}
+      <div class="body">
+        <div class="empty">
+          The LLM didn't find any references it could parse. If the
+          paper has a References section, the formatting may be too
+          irregular for first-pass extraction.
+        </div>
+      </div>
+    {:else}
+      <div class="body">
+        <div class="bulk-row">
+          <span class="bulk-count">{selectedCount} of {refs.length} selected</span>
+          <span class="bulk-spacer"></span>
+          <button class="bulk-btn" onclick={() => toggleAll(true)}>Select all</button>
+          <button class="bulk-btn" onclick={() => toggleAll(false)}>Select none</button>
+        </div>
+        <div class="list">
+          {#each refs as ref, i (i)}
+            <label class="row" class:selected={selected[i]}>
+              <input type="checkbox" bind:checked={selected[i]} />
+              <div class="details">
+                <div class="title-line">
+                  <span class="rtitle">{ref.title}</span>
+                  <span class="subtype">{ref.subtype}</span>
+                </div>
+                {#if ref.authors.length || ref.year}
+                  <div class="byline">{bylineOf(ref)}</div>
+                {/if}
+                {#if ref.containerTitle}
+                  <div class="container">{ref.containerTitle}</div>
+                {/if}
+                {#each idChips(ref) as chip}
+                  <span class="id-chip">{chip.kind} · <span class="mono">{chip.value}</span></span>
+                {/each}
+                <div class="raw" title="Verbatim citation text">{ref.raw}</div>
+              </div>
+            </label>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ⌘↵ approve</span>
+      <span class="footer-actions">
+        <button class="btn ghost" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={selectedCount === 0 || saving} onclick={apply}>
+          <Icon name="plus" size={11} />
+          {saving ? 'Creating…' : `Create ${selectedCount} stub${selectedCount === 1 ? '' : 's'}`}
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 720px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+  .card-header {
+    padding: 20px 24px 8px;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+  .sub {
+    margin: 6px 0 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+  .body {
+    padding: 12px 24px 18px;
+    overflow: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .empty {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    padding: 24px 0;
+    text-align: center;
+    font-style: italic;
+  }
+  .bulk-row { display: flex; align-items: center; gap: 12px; }
+  .bulk-count { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
+  .bulk-spacer { flex: 1; }
+  .bulk-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 3px 9px;
+    border-radius: 5px;
+    font-family: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .bulk-btn:hover { color: var(--text); border-color: var(--border-strong); }
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    cursor: pointer;
+  }
+  .row:hover { border-color: var(--border-strong); }
+  .row.selected {
+    border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+    background: color-mix(in oklch, var(--accent) 8%, var(--bg));
+  }
+  .row input[type='checkbox'] {
+    margin-top: 3px;
+    flex-shrink: 0;
+    accent-color: var(--accent);
+  }
+  .details {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .title-line {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .rtitle {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+  .subtype {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    background: var(--bg-button);
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .byline {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .container {
+    font-size: 11.5px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .id-chip {
+    display: inline-block;
+    margin-right: 6px;
+    font-size: 11px;
+    color: var(--accent);
+  }
+  .mono { font-family: var(--font-mono); }
+  .raw {
+    font-size: 11px;
+    color: var(--text-faint);
+    line-height: 1.4;
+    margin-top: 3px;
+    padding: 5px 9px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    word-break: break-word;
+  }
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .footer-actions { display: inline-flex; gap: 8px; }
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .btn.ghost { background: transparent; color: var(--text-muted); }
+  .btn.ghost:hover { color: var(--text); border-color: var(--border-strong); }
+  .btn.primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .btn.primary:hover:not(:disabled) { opacity: 0.92; }
+  .btn:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -62,13 +62,14 @@
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
     onShowPrompt?: (message: string, initial?: string) => Promise<string | null>;
+    onMineReferences?: (source: import('../../../shared/types').SourceMetadata) => Promise<void>;
     onTableClick?: (tableName: string) => void;
     onOpenCsv?: (relativePath: string) => void;
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -575,7 +576,7 @@
       {/if}
     {:else if activePanel === 'sites'}
       {#if onSourceSelect && onShowConfirm && onShowPrompt}
-        <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} {onShowPrompt} onSourceOpened={onSourceSelect} />
+        <SourcesPanel bind:this={sourcesPanel} {onSourceSelect} {onSourceDeleted} {onShowConfirm} {onShowPrompt} {onMineReferences} onSourceOpened={onSourceSelect} />
       {/if}
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {onSourceSelect} />

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -21,9 +21,12 @@
      *  `about: [[sources/<id>]]`, open it for editing, and refresh
      *  this detail view so the new note shows under Notes (#474). */
     onCreateAboutNote?: (sourceId: string) => Promise<string | null>;
+    /** Open another source — used by the References section to
+     *  navigate to a referenced source (or stub) (#106). */
+    onOpenReference?: (sourceId: string) => void;
   }
 
-  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted, onCreateAboutNote }: Props = $props();
+  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted, onCreateAboutNote, onOpenReference }: Props = $props();
 
   async function handleDelete() {
     if (!detail) return;
@@ -259,8 +262,10 @@
       </p>
     </div>
   {:else}
-    <header>
-      <div class="subtype">{detail.metadata.subtype ?? 'Source'}</div>
+    <header class:stub={detail.metadata.stubStatus === 'unresolved'}>
+      <div class="subtype">
+        {detail.metadata.subtype ?? 'Source'}{#if detail.metadata.stubStatus === 'unresolved'} · STUB{/if}
+      </div>
       <h1>{@html renderInlineWithMath(detail.metadata.title ?? sourceId)}</h1>
       {#if detail.metadata.creators.length || detail.metadata.year}
         <div class="byline">{formatByline(detail.metadata.creators, detail.metadata.year)}</div>
@@ -445,6 +450,23 @@
         </ul>
       {/if}
     </section>
+
+    {#if detail.references.length > 0}
+      <section>
+        <h2>References ({detail.references.length})</h2>
+        <ul class="about-list">
+          {#each detail.references as ref (ref.sourceId)}
+            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <li onclick={() => onOpenReference?.(ref.sourceId)} class:stub-row={ref.stubStatus === 'unresolved'}>
+              <span class="about-title">{ref.title}</span>
+              {#if ref.stubStatus === 'unresolved'}
+                <span class="stub-badge">stub</span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
 
     <section>
       <h2>Referenced from ({detail.backlinks.length})</h2>
@@ -887,6 +909,32 @@
     font-size: 11px;
     color: var(--text-faint);
   }
+
+  /* Stub source from reference mining (#106): italic title, dimmed
+     for visual distinction from fully-ingested sources. */
+  .about-list li.stub-row .about-title {
+    font-family: var(--font-display);
+    font-style: italic;
+    color: color-mix(in oklch, var(--accent) 60%, var(--text-muted));
+  }
+  .stub-badge {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    color: var(--text-faint);
+    background: var(--bg-button);
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  /* Stub markers in the source-detail header: italicise the title +
+     dim the byline so it reads as "partial record" at a glance. */
+  header.stub h1 {
+    font-style: italic;
+    color: color-mix(in oklch, var(--text) 75%, transparent);
+  }
+  header.stub .byline { color: var(--text-faint); }
 
   code {
     background: var(--bg-button);

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -30,9 +30,12 @@
      *  the "+" button's smart-paste path lands the user on the new
      *  source without an extra click. (#473) */
     onSourceOpened?: (sourceId: string) => void;
+    /** Mine the source's References section into stub Source nodes
+     *  (#106). Host orchestrates the LLM call + review dialog. */
+    onMineReferences?: (source: SourceMetadata) => Promise<void>;
   }
 
-  let { onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onSourceOpened }: Props = $props();
+  let { onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onSourceOpened, onMineReferences }: Props = $props();
 
   let sources = $state<SourceMetadata[]>([]);
   let filter = $state('');
@@ -395,6 +398,12 @@
     } catch (err) {
       console.error('[minerva] Strip upstream tags failed:', err);
     }
+  }
+
+  async function handleMineReferences(source: SourceMetadata): Promise<void> {
+    contextMenu = null;
+    if (!onMineReferences) return;
+    await onMineReferences(source);
   }
 
   let adding = $state(false);
@@ -819,6 +828,9 @@
         <button onclick={() => handleCopyDoi(contextMenu!.source, 'url')}>Copy DOI URL</button>
       {/if}
       <div class="context-divider"></div>
+      {#if onMineReferences}
+        <button onclick={() => handleMineReferences(contextMenu!.source)}>Mine references…</button>
+      {/if}
       <button onclick={() => handleStripUpstreamTags(contextMenu!.source)}>Strip upstream tags</button>
       <button onclick={() => handleMergeStart(contextMenu!.source)}>Merge into…</button>
       <button onclick={() => handleDelete(contextMenu!.source)}>Delete Source</button>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -40,6 +40,12 @@ export const CONFIRM_KEYS = {
   /** DOI clicked in the preview that doesn't match an existing source
    *  yet (#473). User confirms before we hit CrossRef. */
   ingestDoiFromBody: 'ingest-doi-from-body',
+  /** Reference mining produced no candidates (#106). */
+  mineReferencesEmpty: 'mine-references-empty',
+  /** Reference mining or stub-materialisation failed (#106). */
+  mineReferencesFailed: 'mine-references-failed',
+  /** Per-stub creation summary after reference-mining approval (#106). */
+  mineReferencesResult: 'mine-references-result',
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
@@ -222,6 +228,24 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Ingest DOI from body',
     description:
       'Shown when you click a bare DOI in the preview that doesn\'t match an existing source — confirms before fetching CrossRef.',
+  },
+  {
+    key: CONFIRM_KEYS.mineReferencesEmpty,
+    title: 'Mine references: nothing parsed',
+    description:
+      'Shown when reference mining finishes with zero candidates — typically because the body.md has no References section, or the formatting is too irregular for the first-pass extractor.',
+  },
+  {
+    key: CONFIRM_KEYS.mineReferencesFailed,
+    title: 'Mine references: error',
+    description:
+      'Shown when reference mining or stub creation fails outright (network error, LLM returned non-JSON, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.mineReferencesResult,
+    title: 'Mine references: summary',
+    description:
+      'Shown after approved references are materialised, summarising how many became new stubs vs matched existing sources vs were skipped.',
   },
   {
     key: CONFIRM_KEYS.dropImportRejected,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -700,6 +700,17 @@ export interface SourcesApi {
     title: string;
     route: 'identifier' | 'url';
   }>;
+  /** Mine a source's References section via the LLM. Returns the
+   *  parsed candidates for user approval; no stubs are written until
+   *  `createReferenceStubs` is called. (#106) */
+  mineReferences(sourceId: string): Promise<import('../../../shared/mine-references').ParsedReference[]>;
+  /** Materialise approved references as stub sources + add
+   *  `minerva:references` edges from the parent (#106). */
+  createReferenceStubs(sourceId: string, refs: import('../../../shared/mine-references').ParsedReference[]): Promise<{
+    created: { sourceId: string; title: string }[];
+    matchedExisting: { sourceId: string; title: string }[];
+    skipped: { reason: string; raw: string }[];
+  }>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -251,6 +251,12 @@ export const Channels = {
    *  the "+" button, detects whether it's a DOI / arXiv id / PMID /
    *  URL, and dispatches to the matching ingest path (#473). */
   SOURCES_INGEST_SMART: 'sources:ingestSmart',
+  /** Mine a source's References section via the LLM and return the
+   *  parsed candidates for user approval (#106). */
+  SOURCES_MINE_REFERENCES: 'sources:mineReferences',
+  /** Materialise approved reference candidates as stub Source nodes
+   *  + add `minerva:references` edges from the parent (#106). */
+  SOURCES_CREATE_REFERENCE_STUBS: 'sources:createReferenceStubs',
 
   // Collections (#470)
   /** Read `.minerva/collections.json` as a CollectionsFile. */

--- a/src/shared/mine-references.ts
+++ b/src/shared/mine-references.ts
@@ -1,0 +1,18 @@
+/**
+ * Wire shape shared between the renderer (approval dialog) and the
+ * main process (LLM mining + stub materialisation). One JS object
+ * per parsed reference. (#106)
+ */
+export interface ParsedReference {
+  raw: string;
+  title: string;
+  authors: string[];
+  year: string | null;
+  containerTitle: string | null;
+  doi: string | null;
+  arxiv: string | null;
+  pubmed: string | null;
+  isbn: string | null;
+  url: string | null;
+  subtype: 'Article' | 'Book' | 'Preprint' | 'Report' | 'Source';
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -120,6 +120,10 @@ export interface SourceMetadata {
   readStatus: ReadStatus | null;
   /** ISO date by which the user wants to have finished this. */
   readDueBy: string | null;
+  /** `thought:stubStatus` literal. `"unresolved"` indicates a source
+   *  created by reference-mining (#106) — partial metadata, no body,
+   *  resolvable later via #107. `null` for fully-ingested sources. */
+  stubStatus: string | null;
 }
 
 export interface SourceExcerpt {
@@ -164,12 +168,25 @@ export interface SourceAboutNote {
   title: string;
 }
 
+/** One outgoing reference edge (`minerva:references`) from this
+ *  source to another (typically a stub). (#106) */
+export interface SourceReference {
+  sourceId: string;
+  title: string;
+  /** When the target is a stub (`thought:stubStatus "unresolved"`),
+   *  the UI styles the row in italic / low-contrast. */
+  stubStatus: string | null;
+}
+
 export interface SourceDetail {
   metadata: SourceMetadata;
   excerpts: SourceExcerpt[];
   backlinks: SourceBacklink[];
   /** Notes whose frontmatter declares them as *about* this source. */
   aboutNotes: SourceAboutNote[];
+  /** Outgoing `minerva:references` edges — typically populated by
+   *  reference mining (#106). */
+  references: SourceReference[];
 }
 
 /** Manually-curated source collection (#470 phase 1). Sources can

--- a/tests/main/sources/create-reference-stubs.test.ts
+++ b/tests/main/sources/create-reference-stubs.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Materialising approved reference candidates as stub Source nodes
+ * (#106). Writes meta.ttl per accepted reference + adds
+ * `minerva:references` edges from the parent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initGraph,
+  indexSource,
+  getSourceDetail,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import {
+  createReferenceStubs,
+  appendReferencesEdges,
+} from '../../../src/main/sources/create-reference-stubs';
+import type { ParsedReference } from '../../../src/shared/mine-references';
+
+const PARENT_TTL = `this: a thought:Article ;
+    dc:title "Parent paper" ;
+    bibo:doi "10.1/parent" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+function makeRef(overrides: Partial<ParsedReference>): ParsedReference {
+  return {
+    raw: 'Smith, J. (2024). Foo bar. Journal X, 12(3), 45-67.',
+    title: 'Foo bar',
+    authors: ['Smith, J.'],
+    year: '2024',
+    containerTitle: 'Journal X',
+    doi: null,
+    arxiv: null,
+    pubmed: null,
+    isbn: null,
+    url: null,
+    subtype: 'Article',
+    ...overrides,
+  };
+}
+
+describe('appendReferencesEdges', () => {
+  it('inserts one minerva:references line per id before the final dot', () => {
+    const out = appendReferencesEdges(PARENT_TTL, ['stub-a', 'stub-b']);
+    expect(out).toContain('minerva:references sources:stub-a ;');
+    expect(out).toContain('minerva:references sources:stub-b ;');
+    // Order preserves the parent's final accessedAt as the .-terminated line.
+    expect(out.indexOf('minerva:references')).toBeLessThan(out.indexOf('thought:accessedAt'));
+  });
+
+  it('dedupes against existing references already on the parent', () => {
+    const withOne = appendReferencesEdges(PARENT_TTL, ['stub-a']);
+    const again = appendReferencesEdges(withOne, ['stub-a', 'stub-b']);
+    // Single occurrence of stub-a, fresh occurrence of stub-b.
+    expect((again.match(/sources:stub-a/g) ?? []).length).toBe(1);
+    expect(again).toContain('sources:stub-b');
+  });
+
+  it('is a no-op when every input is already present', () => {
+    const withBoth = appendReferencesEdges(PARENT_TTL, ['a', 'b']);
+    expect(appendReferencesEdges(withBoth, ['a', 'b'])).toBe(withBoth);
+  });
+});
+
+describe('createReferenceStubs', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const parentId = 'doi-10.1_parent';
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-stubs-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    const parentDir = path.join(root, '.minerva', 'sources', parentId);
+    fs.mkdirSync(parentDir, { recursive: true });
+    fs.writeFileSync(path.join(parentDir, 'meta.ttl'), PARENT_TTL);
+    indexSource(ctx, parentId, PARENT_TTL);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('creates a stub source folder per accepted reference and links from parent', async () => {
+    const refs: ParsedReference[] = [
+      makeRef({ title: 'Ref one' }),
+      makeRef({ title: 'Ref two', authors: ['Jones, K.'], year: '2023' }),
+    ];
+    const result = await createReferenceStubs(root, parentId, refs);
+
+    expect(result.created).toHaveLength(2);
+    expect(result.matchedExisting).toEqual([]);
+    expect(result.skipped).toEqual([]);
+
+    // Stub meta.ttl files exist on disk.
+    for (const c of result.created) {
+      const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', c.sourceId, 'meta.ttl'), 'utf-8');
+      expect(ttl).toContain('thought:stubStatus "unresolved"');
+      expect(ttl).toContain('thought:rawReference');
+    }
+
+    // Parent's references edges land in the graph.
+    const detail = getSourceDetail(ctx, parentId);
+    const refTitles = detail!.references.map((r) => r.title).sort();
+    expect(refTitles).toEqual(['Ref one', 'Ref two']);
+    expect(detail!.references.every((r) => r.stubStatus === 'unresolved')).toBe(true);
+  });
+
+  it('matchedExisting when a stub already lives at the canonical id', async () => {
+    const ref = makeRef({ title: 'Already here', doi: '10.1/already' });
+    // Pre-create at the canonical id.
+    const { canonicalSourceId } = await import('../../../src/main/sources/source-id');
+    const { id } = canonicalSourceId({ doi: ref.doi! });
+    const dir = path.join(root, '.minerva', 'sources', id);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), `this: a thought:Article ; dc:title "Existing" .\n`);
+    indexSource(ctx, id, `this: a thought:Article ; dc:title "Existing" .\n`);
+
+    const result = await createReferenceStubs(root, parentId, [ref]);
+    expect(result.created).toEqual([]);
+    expect(result.matchedExisting).toHaveLength(1);
+
+    // Parent still gets the edge.
+    const detail = getSourceDetail(ctx, parentId);
+    expect(detail!.references).toHaveLength(1);
+    // Existing source's title is preserved (not the stub's would-be title).
+    expect(detail!.references[0].title).toBe('Existing');
+  });
+
+  it('uses DOI for canonical id when present', async () => {
+    const ref = makeRef({ doi: '10.1/foo' });
+    const result = await createReferenceStubs(root, parentId, [ref]);
+    expect(result.created[0].sourceId).toBe('doi-10.1_foo');
+  });
+
+  it('falls back to a content-hash id when no identifier was extracted', async () => {
+    const ref = makeRef({ doi: null, arxiv: null, pubmed: null, isbn: null, url: null });
+    const result = await createReferenceStubs(root, parentId, [ref]);
+    expect(result.created[0].sourceId).toMatch(/^sha-[a-f0-9]+$/);
+  });
+
+  it('dedupes within a single batch when two refs hash to the same id', async () => {
+    const ref = makeRef({ title: 'Same title', authors: ['Same'], year: '2024' });
+    const result = await createReferenceStubs(root, parentId, [ref, ref]);
+    // Second occurrence matches the just-created stub.
+    expect(result.created).toHaveLength(1);
+    expect(result.matchedExisting).toHaveLength(1);
+    // Only one references edge on the parent (dedupe in append).
+    const detail = getSourceDetail(ctx, parentId);
+    expect(detail!.references).toHaveLength(1);
+  });
+});

--- a/tests/main/sources/mine-references.test.ts
+++ b/tests/main/sources/mine-references.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Reference mining helpers (#106) — pure-function tests for the
+ * section detector, the entry splitter, and the LLM-response
+ * parser. The end-to-end mineSourceReferences orchestrator is
+ * exercised in the IPC tests with a stubbed LLM.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractReferenceSection,
+  splitReferenceEntries,
+  parseLLMResponse,
+} from '../../../src/main/sources/mine-references';
+
+describe('extractReferenceSection', () => {
+  it('finds a level-2 References heading and returns its body', () => {
+    const body = `# Introduction
+
+Some prose.
+
+## References
+
+Smith, J. (2024). Foo bar.
+
+Jones, K. (2023). Baz quux.`;
+    expect(extractReferenceSection(body)).toBe(
+      'Smith, J. (2024). Foo bar.\n\nJones, K. (2023). Baz quux.',
+    );
+  });
+
+  it('finds "Bibliography" too', () => {
+    const body = `# Body\n\n## Bibliography\n\nentry one\n\nentry two`;
+    expect(extractReferenceSection(body)).toBe('entry one\n\nentry two');
+  });
+
+  it('finds "Works Cited" (case-insensitive)', () => {
+    const body = `# Body\n\n### WORKS CITED\n\nentry`;
+    expect(extractReferenceSection(body)).toBe('entry');
+  });
+
+  it('stops at the next equal-or-shallower heading', () => {
+    const body = `# A\n\n## References\n\nentry one\n\nentry two\n\n## Appendix\n\nnot a ref`;
+    expect(extractReferenceSection(body)).toBe('entry one\n\nentry two');
+  });
+
+  it('continues past deeper subheadings', () => {
+    const body = `## References\n\nentry one\n\n### Secondary\n\nentry two\n\n## Appendix`;
+    const section = extractReferenceSection(body);
+    expect(section).toContain('entry one');
+    expect(section).toContain('entry two');
+    expect(section).not.toContain('Appendix');
+  });
+
+  it('returns null when no References-like heading exists', () => {
+    expect(extractReferenceSection('# Just a body\n\nno refs here')).toBeNull();
+  });
+
+  it('returns null for an empty section', () => {
+    expect(extractReferenceSection('# A\n\n## References\n\n   \n')).toBeNull();
+  });
+});
+
+describe('splitReferenceEntries', () => {
+  it('splits on numbered list prefixes', () => {
+    const section = `1. Smith, J. (2024). Foo bar.
+2. Jones, K. (2023). Baz quux.
+3. Lin, R. (2022). Title here.`;
+    const entries = splitReferenceEntries(section);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toContain('Smith, J.');
+    expect(entries[2]).toContain('Lin, R.');
+    // Numbered prefix stripped.
+    expect(entries[0]).not.toMatch(/^1\./);
+  });
+
+  it('splits on bracket-style numbering', () => {
+    const section = `[1] Smith 2024.\n[2] Jones 2023.`;
+    expect(splitReferenceEntries(section)).toHaveLength(2);
+  });
+
+  it('splits on bullets', () => {
+    const section = `- Smith 2024.\n- Jones 2023.\n- Lin 2022.`;
+    expect(splitReferenceEntries(section)).toHaveLength(3);
+  });
+
+  it('falls back to paragraph splitting', () => {
+    const section = `Smith, J. (2024). Foo.\n\nJones, K. (2023). Bar.\n\nLin (2022). Baz.`;
+    expect(splitReferenceEntries(section)).toHaveLength(3);
+  });
+
+  it('returns a single entry when no separator works', () => {
+    expect(splitReferenceEntries('one line only')).toEqual(['one line only']);
+  });
+});
+
+describe('parseLLMResponse', () => {
+  const ORIGINALS = ['Smith 2024 raw', 'Jones 2023 raw'];
+
+  it('parses a clean JSON array', () => {
+    const out = parseLLMResponse(
+      JSON.stringify([
+        { raw: 'Smith 2024 raw', title: 'Foo', authors: ['Smith, J.'], year: '2024', doi: '10.1/foo', subtype: 'Article' },
+        { raw: 'Jones 2023 raw', title: 'Bar', authors: ['Jones, K.'], year: '2023', subtype: 'Book' },
+      ]),
+      ORIGINALS,
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0].title).toBe('Foo');
+    expect(out[0].doi).toBe('10.1/foo');
+    expect(out[0].subtype).toBe('Article');
+    expect(out[1].subtype).toBe('Book');
+  });
+
+  it('strips a leading ```json fence', () => {
+    const fenced = '```json\n' + JSON.stringify([{ raw: 'r', title: 'T', authors: [], year: null, subtype: 'Article' }]) + '\n```';
+    const out = parseLLMResponse(fenced, ['r']);
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('T');
+  });
+
+  it('drops entries with no title (LLM said "nothing useful here")', () => {
+    const out = parseLLMResponse(JSON.stringify([
+      { raw: 'r1', title: '', subtype: 'Article' },
+      { raw: 'r2', title: 'Real', subtype: 'Article' },
+    ]), ['r1', 'r2']);
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('Real');
+  });
+
+  it('defaults missing scalar fields to null', () => {
+    const out = parseLLMResponse(JSON.stringify([{ raw: 'r', title: 'T', subtype: 'Article' }]), ['r']);
+    expect(out[0].year).toBeNull();
+    expect(out[0].doi).toBeNull();
+    expect(out[0].containerTitle).toBeNull();
+    expect(out[0].authors).toEqual([]);
+  });
+
+  it('rejects an invalid subtype by falling back to Source', () => {
+    const out = parseLLMResponse(JSON.stringify([{ raw: 'r', title: 'T', subtype: 'Periodical' }]), ['r']);
+    expect(out[0].subtype).toBe('Source');
+  });
+
+  it('falls back to the original entry text when raw is missing', () => {
+    const out = parseLLMResponse(JSON.stringify([{ title: 'T', subtype: 'Article' }]), ['original-text']);
+    expect(out[0].raw).toBe('original-text');
+  });
+
+  it('throws on non-JSON', () => {
+    expect(() => parseLLMResponse('plain prose, no json', [])).toThrow(/non-JSON/);
+  });
+
+  it('throws when the response is not an array', () => {
+    expect(() => parseLLMResponse(JSON.stringify({ title: 'T' }), [])).toThrow(/not a JSON array/);
+  });
+
+  it('coerces malformed year values to null', () => {
+    const out = parseLLMResponse(JSON.stringify([{ raw: 'r', title: 'T', year: 'not-a-year', subtype: 'Article' }]), ['r']);
+    expect(out[0].year).toBeNull();
+  });
+});


### PR DESCRIPTION
First half of the research-library flywheel. Right-click a source with a body.md → **Mine references…** → LLM parses the References section into structured candidates → review dialog → user approves N → backend writes stub Source nodes linked back via \`minerva:references\`.

## Pipeline

1. **Section detection** (\`extractReferenceSection\`) — scan body.md for a \`References\` / \`Bibliography\` / \`Works Cited\` / \`Literature Cited\` / \`Cited Works\` / \`Citations\` heading at any depth. Take everything until the next heading of equal-or-shallower depth.
2. **Entry splitting** (\`splitReferenceEntries\`) — try numbered list (\`1.\` / \`[1]\` / \`(1)\`), then bullets (\`-\` / \`*\` / \`•\`), then blank-line paragraphs. First strategy yielding >1 entry wins.
3. **LLM parse** — batched (default 30 per call) JSON-output prompt asks the model to extract title, authors, year, container, DOI, arXiv id, PMID, ISBN, URL, subtype per entry. Fence-stripping tolerated; missing fields default to null; bad subtypes fall back to \`Source\`.
4. **Review** — \`MineReferencesDialog.svelte\` shows each candidate with its identifier chips + raw citation. Each row is selected by default; user unchecks the ones they don't want, then **Create N stubs**. Per CLAUDE.md trust principle: the LLM proposes, the human confirms.
5. **Materialise** — \`createReferenceStubs\` writes a \`meta.ttl\` per accepted reference with \`thought:stubStatus "unresolved"\` + \`thought:rawReference\` markers, and adds \`minerva:references sources:<stub-id>\` edges from the parent source.

## Schema additions
- New \`thought:stubStatus\` literal predicate (e.g. \`"unresolved"\`).
- New \`thought:rawReference\` literal — kept so #107 resolve can re-parse if needed.
- New \`minerva:references\` edge from parent source to stub.

\`SourceMetadata.stubStatus\` surfaces in the source detail header (italic title + "STUB" badge) and the new References list (italic + dimmed row + "stub" badge).

## Dedup
Each candidate gets a canonical id from \`canonicalSourceId\` — DOI / arXiv / PMID / ISBN / URL / content-hash fallback. If the id already exists, no overwrite: the parent still gets the edge, the existing source's title is preserved.

## Tests
- \`mine-references.test.ts\` (21): section detection across heading depths, entry splitting strategies, LLM-response parsing with malformed shapes / bad subtypes / missing fields.
- \`create-reference-stubs.test.ts\` (8): per-stub disk write, \`minerva:references\` edge appending + dedup, content-hash fallback when no identifier, within-batch dedup.

Full suite **2372 / 2372** (+29 new).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Ingest a paper that has a Bibliography (any CrossRef DOI for a paper with an open-access PDF works; the readability path embeds the references section in body.md).
  2. Right-click the source in the Sources panel → "Mine references…" → busy spinner → review dialog opens listing N candidates with title / authors / year / identifier chips / raw citation.
  3. Uncheck a couple, leave the rest. Click "Create N stubs".
  4. Source detail now shows a "References (N)" section with italic-dimmed rows.
  5. Click a stub row → source detail opens with "Article · STUB" header + italic title.
  6. Mine again from the same paper → previously-created stubs return as `matchedExisting`, no duplicates.

## Out of scope (next, #107)
- "Resolve stub" command — promote a stub to a full source via CrossRef title search.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)