### PR TITLE
feat: resolve stub → full source via CrossRef title search (#107)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -78,6 +78,7 @@ import { getIngestSettings, saveIngestSettings, type IngestSettings } from './so
 import { ingestSmart } from './sources/ingest-smart';
 import { mineSourceReferences, type ParsedReference } from './sources/mine-references';
 import { createReferenceStubs } from './sources/create-reference-stubs';
+import { resolveStub, applyStubResolution } from './sources/resolve-stub';
 import type { ReadStatus } from '../shared/types';
 import type { ReadingQueueView } from './graph/index';
 import {
@@ -1337,6 +1338,22 @@ export function registerIpcHandlers(): void {
     const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
     return result;
+  });
+
+  ipcMain.handle(Channels.SOURCES_RESOLVE_STUB, async (e, sourceId: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await resolveStub(rootPath, sourceId, { fetchImpl: privilegedFetch });
+  });
+
+  ipcMain.handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, async (e, params: { sourceId: string; doi: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    const ok = await applyStubResolution(rootPath, params.sourceId, params.doi, { fetchImpl: privilegedFetch });
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    return { ok };
   });
 
   ipcMain.handle(Channels.INGEST_GET_SETTINGS, () => getIngestSettings());

--- a/src/main/sources/api-adapters/crossref-search.ts
+++ b/src/main/sources/api-adapters/crossref-search.ts
@@ -1,0 +1,55 @@
+/**
+ * CrossRef bibliographic-search adapter (#107).
+ *
+ * Different endpoint than `fetchCrossrefMetadata`: the search API
+ * takes a free-form query and returns a ranked list of `Work`
+ * records. Used by the stub-resolve path to map "Smith, J. (2024).
+ * Foo bar. Journal X." → a DOI.
+ *
+ * Docs: https://api.crossref.org/swagger-ui/index.html#/Works/get_works
+ */
+
+import type { CrossrefWork } from './crossref';
+import { CROSSREF_ENDPOINT } from './crossref';
+
+export interface CrossrefSearchCandidate {
+  /** Raw Work record CrossRef returned. */
+  work: CrossrefWork;
+  /** CrossRef's own relevance score (untransformed). */
+  rawScore: number;
+}
+
+export interface CrossrefSearchOptions {
+  rows?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Run a bibliographic search against CrossRef. `query` is whatever
+ * free-form text identifies the work — typically title + author +
+ * year. CrossRef's relevance ranker handles the rest.
+ *
+ * Returns at most `rows` candidates (default 3, matching the issue's
+ * "show top 3 in a disambiguation UI" intent).
+ */
+export async function searchCrossrefBibliographic(
+  query: string,
+  opts: CrossrefSearchOptions = {},
+): Promise<CrossrefSearchCandidate[]> {
+  const rows = Math.max(1, Math.min(20, opts.rows ?? 3));
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const url = `${CROSSREF_ENDPOINT}?query.bibliographic=${encodeURIComponent(query)}&rows=${rows}`;
+  const res = await fetchImpl(url, {
+    headers: {
+      'Accept': 'application/json',
+      'User-Agent': 'Minerva/1.0 (https://minerva.dev; mailto:ingest@minerva.local)',
+    },
+  });
+  if (!res.ok) throw new Error(`CrossRef search ${res.status}: ${res.statusText}`);
+  const payload = await res.json() as { message?: { items?: (CrossrefWork & { score?: number })[] } };
+  const items = payload.message?.items ?? [];
+  return items.map((item) => ({
+    work: item,
+    rawScore: typeof item.score === 'number' ? item.score : 0,
+  }));
+}

--- a/src/main/sources/resolve-stub.ts
+++ b/src/main/sources/resolve-stub.ts
@@ -1,0 +1,285 @@
+/**
+ * Promote a reference stub (#106) to a fully-resolved source (#107).
+ *
+ *   1. Read the stub's current metadata + raw citation text.
+ *   2. CrossRef bibliographic search → top-N candidates with scores.
+ *   3. Normalise the scores into a 0-1 confidence per candidate
+ *      using title-overlap + author-overlap + year-match heuristics
+ *      on top of CrossRef's own relevance number.
+ *   4. The renderer surfaces the top 3 (or auto-applies the top one
+ *      when its confidence clears the auto-threshold).
+ *   5. On user pick: `applyStubResolution` fetches the full Work
+ *      record via the existing identifier adapter, rewrites the
+ *      stub's meta.ttl with the canonical metadata, and flips
+ *      `thought:stubStatus` to "resolved".
+ *
+ * Scope note: this PR enriches the stub in place. The canonical
+ * source id keeps the stub's content-hash form (`sha-xxx`); a
+ * follow-up will add the rename + cite-link rewrite when the new
+ * DOI implies a better id. The user can rename manually today via
+ * the existing rename-source command.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Parser } from 'n3';
+import { searchCrossrefBibliographic, type CrossrefSearchCandidate } from './api-adapters/crossref-search';
+import { parseCrossrefWork } from './api-adapters/crossref';
+import { fetchCrossrefMetadata } from './api-adapters/crossref';
+import { buildMetaTtl } from './ingest-identifier';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+
+export interface StubMetaSnapshot {
+  title: string;
+  authors: string[];
+  year: string | null;
+  /** Raw citation text — what the LLM extracted from body.md (#106). */
+  rawReference: string | null;
+}
+
+import type { ResolveCandidate } from '../../shared/resolve-stub';
+export type { ResolveCandidate } from '../../shared/resolve-stub';
+
+export interface ResolveOptions {
+  fetchImpl?: typeof fetch;
+  /** Override threshold for "auto-pick the top candidate without
+   *  showing the picker". Default 0.85 (mirrors
+   *  RESOLVE_AUTO_THRESHOLD) — the issue's intent: high-confidence
+   *  matches don't pester the user. */
+  autoThreshold?: number;
+}
+
+const META_TTL_PREAMBLE =
+  '@prefix this: <https://minerva.dev/this/> .\n' +
+  '@prefix dc: <http://purl.org/dc/terms/> .\n' +
+  '@prefix bibo: <http://purl.org/ontology/bibo/> .\n' +
+  '@prefix schema: <http://schema.org/> .\n' +
+  '@prefix thought: <https://minerva.dev/ontology/thought#> .\n' +
+  '@prefix minerva: <https://minerva.dev/ontology#> .\n' +
+  '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n';
+
+const DC = 'http://purl.org/dc/terms/';
+const THOUGHT = 'https://minerva.dev/ontology/thought#';
+
+/**
+ * Read a source's stub fields from its meta.ttl. Used to build the
+ * search query against CrossRef. Exposed for tests.
+ */
+export function parseStubMeta(metaTtl: string): StubMetaSnapshot {
+  const quads = new Parser().parse(META_TTL_PREAMBLE + metaTtl);
+  let title = '';
+  let year: string | null = null;
+  let rawReference: string | null = null;
+  const authors: string[] = [];
+  for (const q of quads) {
+    const p = q.predicate.value;
+    const v = q.object.value;
+    if (p === `${DC}title` && !title) title = v;
+    else if (p === `${DC}creator`) authors.push(v);
+    else if (p === `${DC}issued` && /^\d{4}/.test(v) && !year) year = v.slice(0, 4);
+    else if (p === `${THOUGHT}rawReference` && !rawReference) rawReference = v;
+  }
+  return { title, authors, year, rawReference };
+}
+
+/**
+ * Resolve a stub by issuing a CrossRef bibliographic search and
+ * scoring the candidates. Returns the top-N matches ordered by
+ * confidence desc.
+ */
+export async function resolveStub(
+  rootPath: string,
+  sourceId: string,
+  opts: ResolveOptions = {},
+): Promise<ResolveCandidate[]> {
+  const metaPath = path.join(rootPath, '.minerva', 'sources', sourceId, 'meta.ttl');
+  let metaTtl: string;
+  try {
+    metaTtl = await fs.readFile(metaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Source "${sourceId}" not found.`, { cause: err });
+    }
+    throw err;
+  }
+  const stub = parseStubMeta(metaTtl);
+  if (!stub.title && !stub.rawReference) {
+    throw new Error('Stub has no title or raw citation text to search by.');
+  }
+
+  const query = buildSearchQuery(stub);
+  const raw = await searchCrossrefBibliographic(query, {
+    fetchImpl: opts.fetchImpl,
+    rows: 5,
+  });
+  const candidates = raw
+    .map((c) => scoreCandidate(c, stub))
+    .filter((c): c is ResolveCandidate => c !== null);
+  candidates.sort((a, b) => b.confidence - a.confidence);
+  return candidates.slice(0, 3);
+}
+
+/**
+ * Fetch the chosen DOI's full metadata and rewrite the source's
+ * meta.ttl in place, flipping `thought:stubStatus` from
+ * `"unresolved"` to `"resolved"`. The source id stays the same.
+ *
+ * Returns true on success, false when the DOI fetch failed and no
+ * change was made.
+ */
+export async function applyStubResolution(
+  rootPath: string,
+  sourceId: string,
+  doi: string,
+  opts: ResolveOptions = {},
+): Promise<boolean> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  // Pull full metadata. If this fails, leave the stub untouched.
+  const metadata = await fetchCrossrefMetadata(doi, fetchImpl);
+  // Use the existing builder; mark as resolved.
+  const baseTtl = buildMetaTtl(metadata).replace(
+    /(\s+\.\s*)$/,
+    ` ;\n    thought:stubStatus "resolved" ;\n    thought:resolvedFrom "stub"$1`,
+  );
+
+  const metaPath = path.join(rootPath, '.minerva', 'sources', sourceId, 'meta.ttl');
+  await fs.writeFile(metaPath, baseTtl, 'utf-8');
+
+  // Re-index so the graph picks up the new title / DOI / etc.
+  const ctx = projectContext(rootPath);
+  let body: string | undefined;
+  try { body = await fs.readFile(path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md'), 'utf-8'); } catch { /* ok */ }
+  graph.indexSource(ctx, sourceId, baseTtl, body);
+  return true;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function buildSearchQuery(stub: StubMetaSnapshot): string {
+  // Prefer raw bibliographic text when we have it — CrossRef's own
+  // relevance handles arbitrary citation strings well. Falls back to
+  // the structured fields the LLM extracted.
+  if (stub.rawReference && stub.rawReference.length > 20) {
+    return stub.rawReference.slice(0, 400);
+  }
+  const parts: string[] = [];
+  if (stub.title) parts.push(stub.title);
+  if (stub.authors[0]) parts.push(stub.authors[0]);
+  if (stub.year) parts.push(stub.year);
+  return parts.join(' ');
+}
+
+/**
+ * Convert a CrossRef hit into a `ResolveCandidate` with a 0–1
+ * confidence + plain-English breakdown. Returns null when the hit
+ * has no DOI (we won't surface unrecoverable candidates).
+ *
+ * Scoring uses three signals, weighted:
+ *   - Title overlap: token-set Jaccard between stub.title and
+ *     candidate.title.
+ *   - Author overlap: did the stub's first author surface in the
+ *     candidate's authors?
+ *   - Year match: does the candidate's `issued` year match the
+ *     stub's?
+ *
+ * CrossRef's own `score` is highly variable across queries so we
+ * don't normalise it; we use the *order* it implies (top-N) and
+ * compute our own confidence on top.
+ *
+ * Exposed for tests.
+ */
+export function scoreCandidate(
+  hit: CrossrefSearchCandidate,
+  stub: StubMetaSnapshot,
+): ResolveCandidate | null {
+  if (!hit.work.DOI) return null;
+  const parsed = parseCrossrefWork(hit.work, hit.work.DOI);
+  const reasons: string[] = [];
+
+  // Title overlap (60% weight).
+  const titleScore = stub.title
+    ? titleOverlap(stub.title, parsed.title)
+    : 0;
+  if (titleScore > 0.6) reasons.push('strong title match');
+  else if (titleScore > 0.3) reasons.push('partial title match');
+  else reasons.push('weak title match');
+
+  // Author overlap (25% weight). Compare last-names normalised.
+  const stubAuthorTokens = stub.authors.flatMap(lastNameTokens);
+  const parsedAuthorTokens = new Set(parsed.creators.flatMap(lastNameTokens));
+  const authorOverlap = stubAuthorTokens.length === 0
+    ? 0
+    : stubAuthorTokens.filter((t) => parsedAuthorTokens.has(t)).length / stubAuthorTokens.length;
+  if (authorOverlap >= 1 && stubAuthorTokens.length > 0) reasons.push('every author in common');
+  else if (authorOverlap > 0) reasons.push(`${Math.round(authorOverlap * stubAuthorTokens.length)} author(s) in common`);
+  else if (stubAuthorTokens.length > 0) reasons.push('no shared author names');
+
+  // Year match (15% weight). Hard zero / one.
+  const yearMatch = stub.year && parsed.issued && stub.year === parsed.issued.slice(0, 4) ? 1 : 0;
+  if (stub.year && parsed.issued) {
+    reasons.push(yearMatch === 1 ? 'year match' : `year off (${stub.year} vs ${parsed.issued.slice(0, 4)})`);
+  }
+
+  // Weights: title is the strongest signal, but a year mismatch
+  // should drop below the auto-apply threshold even with a perfect
+  // title + authors (two papers with the same title in different
+  // years are usually distinct works).
+  const confidence = clamp01(
+    0.55 * titleScore +
+    0.20 * authorOverlap +
+    0.25 * yearMatch,
+  );
+
+  return {
+    doi: hit.work.DOI,
+    title: parsed.title,
+    authors: parsed.creators,
+    year: parsed.issued ? parsed.issued.slice(0, 4) : null,
+    containerTitle: parsed.containerTitle,
+    confidence,
+    reasoning: reasons.join(' · '),
+  };
+}
+
+/**
+ * Title-overlap metric: intersection / size-of-shorter-set. Recall
+ * against the shorter side, which is the right question here: the
+ * stub's title is often abbreviated (the LLM extracted a few key
+ * words), while CrossRef stores the full publisher title with
+ * subtitle. A symmetric Jaccard would unfairly penalise that.
+ */
+function titleOverlap(a: string, b: string): number {
+  const aTokens = new Set(tokenise(a));
+  const bTokens = new Set(tokenise(b));
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+  let intersection = 0;
+  for (const t of aTokens) if (bTokens.has(t)) intersection++;
+  return intersection / Math.min(aTokens.size, bTokens.size);
+}
+
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'or', 'of', 'in', 'on', 'for', 'to', 'the',
+  'with', 'from', 'by', 'at', 'as', 'is', 'are',
+]);
+
+function tokenise(text: string): string[] {
+  return text.toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 2 && !STOPWORDS.has(t));
+}
+
+function lastNameTokens(name: string): string[] {
+  // "Smith, J." → "smith"; "Jane Smith" → "smith". Best-effort.
+  const stripped = name.split(',')[0].trim();
+  const last = stripped.split(/\s+/).pop() ?? '';
+  return last ? [last.toLowerCase().replace(/[^a-z]/g, '')] : [];
+}
+
+function clamp01(x: number): number {
+  if (Number.isNaN(x)) return 0;
+  return Math.max(0, Math.min(1, x));
+}
+
+export { RESOLVE_AUTO_THRESHOLD } from '../../shared/resolve-stub';

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -274,6 +274,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SOURCES_MINE_REFERENCES, sourceId),
     createReferenceStubs: (sourceId: string, refs: unknown[]) =>
       ipcRenderer.invoke(Channels.SOURCES_CREATE_REFERENCE_STUBS, { sourceId, refs }),
+    resolveStub: (sourceId: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_RESOLVE_STUB, sourceId),
+    applyStubResolution: (sourceId: string, doi: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_APPLY_STUB_RESOLUTION, { sourceId, doi }),
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -24,6 +24,8 @@
   import { getEditorStore } from './lib/stores/editor.svelte';
   import PromptDialog from './lib/components/PromptDialog.svelte';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
+  import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
+  import { RESOLVE_AUTO_THRESHOLD } from '../shared/resolve-stub';
   import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import OpenTargetDialog from './lib/components/OpenTargetDialog.svelte';
@@ -1840,6 +1842,78 @@
   }
 
   /**
+   * Resolve a stub source by searching CrossRef (#107). Two paths:
+   * - Top candidate's confidence ≥ `RESOLVE_AUTO_THRESHOLD` → apply
+   *   automatically, no picker. The user can still undo via git
+   *   if they disagree.
+   * - Otherwise → open the disambiguation picker with the top 3.
+   */
+  let resolveStubState = $state<{
+    sourceId: string;
+    stubTitle: string;
+    candidates: import('../shared/resolve-stub').ResolveCandidate[];
+  } | null>(null);
+
+  async function handleResolveStub(sourceId: string): Promise<void> {
+    if (!notebase.meta) return;
+    let candidates: import('../shared/resolve-stub').ResolveCandidate[];
+    try {
+      candidates = await withBusy('Searching CrossRef…', () =>
+        api.sources.resolveStub(sourceId),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Resolve failed: ${msg}`, CONFIRM_KEYS.resolveStubFailed, 'OK');
+      return;
+    }
+    if (candidates.length === 0) {
+      await showConfirm(
+        'CrossRef returned no matches. Refine the stub’s title or authors, or ingest the DOI directly.',
+        CONFIRM_KEYS.resolveStubEmpty,
+        'OK',
+      );
+      return;
+    }
+    const top = candidates[0];
+    if (top.confidence >= RESOLVE_AUTO_THRESHOLD) {
+      await applyResolution(sourceId, top.doi, top.title);
+      return;
+    }
+    // Below threshold — let the user pick.
+    const detail = await api.graph.sourceDetail(sourceId);
+    resolveStubState = {
+      sourceId,
+      stubTitle: detail?.metadata.title ?? sourceId,
+      candidates,
+    };
+  }
+
+  async function handleResolveStubApply(doi: string): Promise<void> {
+    const state = resolveStubState;
+    resolveStubState = null;
+    if (!state) return;
+    const picked = state.candidates.find((c) => c.doi === doi);
+    await applyResolution(state.sourceId, doi, picked?.title ?? state.stubTitle);
+  }
+
+  async function applyResolution(sourceId: string, doi: string, newTitle: string): Promise<void> {
+    try {
+      await withBusy('Applying resolution…', () =>
+        api.sources.applyStubResolution(sourceId, doi),
+      );
+      await refreshSourcesCache();
+      await showConfirm(
+        `Resolved to "${newTitle}". The source's metadata now reflects the CrossRef record; the source id stays the same so existing citations keep resolving.`,
+        CONFIRM_KEYS.resolveStubApplied,
+        'OK',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn’t apply resolution: ${msg}`, CONFIRM_KEYS.resolveStubFailed, 'OK');
+    }
+  }
+
+  /**
    * Click on a bare-DOI link inside the markdown preview (#473).
    * If the DOI already maps to an ingested source, open it. Otherwise
    * offer to ingest — dismissable, keyed so the user can suppress
@@ -2685,6 +2759,7 @@
               onDeleted={handleSourceDeleted}
               onCreateAboutNote={handleNewAboutSourceNote}
               onOpenReference={handleOpenSource}
+              onResolveStub={handleResolveStub}
             />
           {/key}
         {:else}
@@ -2816,6 +2891,14 @@
       refs={mineReviewState.refs}
       onApply={handleMineReferencesApply}
       onCancel={() => { mineReviewState = null; }}
+    />
+  {/if}
+  {#if resolveStubState}
+    <ResolveStubDialog
+      stubTitle={resolveStubState.stubTitle}
+      candidates={resolveStubState.candidates}
+      onApply={handleResolveStubApply}
+      onCancel={() => { resolveStubState = null; }}
     />
   {/if}
   {#if confirmDialog}

--- a/src/renderer/lib/components/ResolveStubDialog.svelte
+++ b/src/renderer/lib/components/ResolveStubDialog.svelte
@@ -1,0 +1,290 @@
+<script lang="ts">
+  /**
+   * Disambiguation picker for stub resolution (#107). The CrossRef
+   * search returned >1 plausible candidate (or the top one's
+   * confidence didn't clear the auto-apply threshold). User picks
+   * which DOI to apply.
+   */
+  import type { ResolveCandidate } from '../../../shared/resolve-stub';
+
+  interface Props {
+    stubTitle: string;
+    candidates: ResolveCandidate[];
+    onApply: (doi: string) => Promise<void>;
+    onCancel: () => void;
+  }
+
+  let { stubTitle, candidates, onApply, onCancel }: Props = $props();
+
+  let selectedDoi = $state<string | null>(candidates[0]?.doi ?? null);
+  let applying = $state(false);
+
+  async function apply() {
+    if (!selectedDoi || applying) return;
+    applying = true;
+    try {
+      await onApply(selectedDoi);
+    } finally {
+      applying = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+    else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void apply();
+  }
+
+  function bylineOf(c: ResolveCandidate): string {
+    const who = c.authors.length === 0 ? ''
+      : c.authors.length === 1 ? c.authors[0]
+      : c.authors.length === 2 ? `${c.authors[0]} and ${c.authors[1]}`
+      : `${c.authors[0]} et al.`;
+    if (who && c.year) return `${who} (${c.year})`;
+    return who || (c.year ?? '');
+  }
+
+  function pct(c: number): string {
+    return `${Math.round(c * 100)}%`;
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Resolve stub">
+    <header class="card-header">
+      <div class="eyebrow">RESOLVE STUB · {candidates.length} {candidates.length === 1 ? 'candidate' : 'candidates'}</div>
+      <h2 class="title">Match "{stubTitle}" to a DOI</h2>
+      <p class="sub">
+        Pick the candidate that best matches your stub. The chosen
+        DOI's full metadata replaces the stub's; the source id
+        stays the same.
+      </p>
+    </header>
+
+    {#if candidates.length === 0}
+      <div class="body">
+        <div class="empty">
+          CrossRef returned no matches. Try refining the stub's
+          title or authors and rerun Resolve, or paste the DOI
+          directly via Ingest identifier.
+        </div>
+      </div>
+    {:else}
+      <div class="body">
+        <div class="list">
+          {#each candidates as c (c.doi)}
+            <label class="row" class:selected={selectedDoi === c.doi}>
+              <input
+                type="radio"
+                name="resolve-candidate"
+                value={c.doi}
+                bind:group={selectedDoi}
+              />
+              <div class="details">
+                <div class="title-line">
+                  <span class="rtitle">{c.title}</span>
+                  <span class="confidence" title={c.reasoning}>
+                    <span class="bar" style:--pct="{Math.round(c.confidence * 100)}%"></span>
+                    <span class="num">{pct(c.confidence)}</span>
+                  </span>
+                </div>
+                {#if c.authors.length || c.year}
+                  <div class="byline">{bylineOf(c)}</div>
+                {/if}
+                {#if c.containerTitle}
+                  <div class="container">{c.containerTitle}</div>
+                {/if}
+                <div class="doi mono">{c.doi}</div>
+                <div class="reasoning">{c.reasoning}</div>
+              </div>
+            </label>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ⌘↵ apply</span>
+      <span class="footer-actions">
+        <button class="btn ghost" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={!selectedDoi || applying} onclick={apply}>
+          {applying ? 'Applying…' : 'Apply'}
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 640px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+  .card-header { padding: 20px 24px 8px; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+  .sub {
+    margin: 6px 0 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+  .body {
+    padding: 12px 24px 18px;
+    overflow: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .empty {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    padding: 24px 0;
+    text-align: center;
+    font-style: italic;
+  }
+  .list { display: flex; flex-direction: column; gap: 8px; }
+  .row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    cursor: pointer;
+  }
+  .row:hover { border-color: var(--border-strong); }
+  .row.selected {
+    border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+    background: color-mix(in oklch, var(--accent) 8%, var(--bg));
+  }
+  .row input[type='radio'] { margin-top: 3px; flex-shrink: 0; accent-color: var(--accent); }
+  .details { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+  .title-line {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .rtitle {
+    flex: 1;
+    min-width: 0;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .confidence {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .bar {
+    display: inline-block;
+    height: 5px;
+    width: 70px;
+    background: color-mix(in oklch, var(--accent) 12%, var(--bg-inset));
+    border-radius: 99px;
+    position: relative;
+    overflow: hidden;
+  }
+  .bar::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    width: var(--pct, 0%);
+    background: var(--accent);
+  }
+  .num {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+    min-width: 32px;
+    text-align: right;
+  }
+  .byline { font-size: 12px; color: var(--text-muted); }
+  .container { font-size: 11.5px; color: var(--text-muted); font-style: italic; }
+  .doi {
+    font-size: 11px;
+    color: var(--accent);
+  }
+  .mono { font-family: var(--font-mono); }
+  .reasoning {
+    font-size: 11px;
+    color: var(--text-faint);
+    margin-top: 2px;
+  }
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .footer-actions { display: inline-flex; gap: 8px; }
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .btn.ghost { background: transparent; color: var(--text-muted); }
+  .btn.ghost:hover { color: var(--text); border-color: var(--border-strong); }
+  .btn.primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .btn.primary:hover:not(:disabled) { opacity: 0.92; }
+  .btn:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -24,9 +24,14 @@
     /** Open another source — used by the References section to
      *  navigate to a referenced source (or stub) (#106). */
     onOpenReference?: (sourceId: string) => void;
+    /** Resolve this stub source by searching CrossRef (#107). The
+     *  host runs the search, surfaces a picker if needed, and
+     *  re-loads this detail when the meta.ttl gets rewritten. */
+    onResolveStub?: (sourceId: string) => Promise<void>;
   }
 
-  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted, onCreateAboutNote, onOpenReference }: Props = $props();
+  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted, onCreateAboutNote, onOpenReference, onResolveStub }: Props = $props();
+  let resolving = $state(false);
 
   async function handleDelete() {
     if (!detail) return;
@@ -269,6 +274,15 @@
       <h1>{@html renderInlineWithMath(detail.metadata.title ?? sourceId)}</h1>
       {#if detail.metadata.creators.length || detail.metadata.year}
         <div class="byline">{formatByline(detail.metadata.creators, detail.metadata.year)}</div>
+      {/if}
+      {#if detail.metadata.stubStatus === 'unresolved' && onResolveStub}
+        <button
+          class="resolve-stub-btn"
+          disabled={resolving}
+          onclick={() => onResolveStub?.(sourceId)}
+        >
+          {resolving ? 'Resolving…' : 'Resolve to full source'}
+        </button>
       {/if}
     </header>
 
@@ -935,6 +949,20 @@
     color: color-mix(in oklch, var(--text) 75%, transparent);
   }
   header.stub .byline { color: var(--text-faint); }
+  .resolve-stub-btn {
+    margin-top: 10px;
+    padding: 5px 14px;
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    background: var(--accent);
+    color: var(--accent-ink);
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .resolve-stub-btn:hover:not(:disabled) { opacity: 0.92; }
+  .resolve-stub-btn:disabled { opacity: 0.55; cursor: default; }
 
   code {
     background: var(--bg-button);

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -46,6 +46,10 @@ export const CONFIRM_KEYS = {
   mineReferencesFailed: 'mine-references-failed',
   /** Per-stub creation summary after reference-mining approval (#106). */
   mineReferencesResult: 'mine-references-result',
+  /** Stub-resolve flow signals (#107). */
+  resolveStubEmpty: 'resolve-stub-empty',
+  resolveStubFailed: 'resolve-stub-failed',
+  resolveStubApplied: 'resolve-stub-applied',
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
@@ -246,6 +250,24 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Mine references: summary',
     description:
       'Shown after approved references are materialised, summarising how many became new stubs vs matched existing sources vs were skipped.',
+  },
+  {
+    key: CONFIRM_KEYS.resolveStubEmpty,
+    title: 'Resolve stub: no matches',
+    description:
+      'Shown when CrossRef returned no candidates for a stub-resolve search.',
+  },
+  {
+    key: CONFIRM_KEYS.resolveStubFailed,
+    title: 'Resolve stub: error',
+    description:
+      'Shown when stub resolution or apply step fails (network error, CrossRef 5xx, invalid response, …).',
+  },
+  {
+    key: CONFIRM_KEYS.resolveStubApplied,
+    title: 'Resolve stub: applied',
+    description:
+      'Shown after the chosen DOI is applied to a stub, confirming the new title and that existing citations to the old id still resolve.',
   },
   {
     key: CONFIRM_KEYS.dropImportRejected,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -711,6 +711,13 @@ export interface SourcesApi {
     matchedExisting: { sourceId: string; title: string }[];
     skipped: { reason: string; raw: string }[];
   }>;
+  /** Resolve a stub source by searching CrossRef. Returns top-3
+   *  candidates ranked by confidence (#107). */
+  resolveStub(sourceId: string): Promise<import('../../../shared/resolve-stub').ResolveCandidate[]>;
+  /** Apply the user-picked DOI to a stub source. Rewrites the
+   *  meta.ttl with full CrossRef metadata and flips stubStatus to
+   *  "resolved". (#107) */
+  applyStubResolution(sourceId: string, doi: string): Promise<{ ok: boolean }>;
   /** Fires when a source is added, updated, or removed. */
   onChanged(cb: () => void): void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -257,6 +257,14 @@ export const Channels = {
   /** Materialise approved reference candidates as stub Source nodes
    *  + add `minerva:references` edges from the parent (#106). */
   SOURCES_CREATE_REFERENCE_STUBS: 'sources:createReferenceStubs',
+  /** Resolve a stub source by searching CrossRef. Returns top-3
+   *  candidates with confidence; the renderer surfaces them in a
+   *  picker (or auto-applies the top one when confidence is high).
+   *  (#107) */
+  SOURCES_RESOLVE_STUB: 'sources:resolveStub',
+  /** Apply the user-picked DOI to a stub source: rewrite meta.ttl
+   *  with full CrossRef metadata + flip stubStatus to "resolved". */
+  SOURCES_APPLY_STUB_RESOLUTION: 'sources:applyStubResolution',
 
   // Collections (#470)
   /** Read `.minerva/collections.json` as a CollectionsFile. */

--- a/src/shared/resolve-stub.ts
+++ b/src/shared/resolve-stub.ts
@@ -1,0 +1,22 @@
+/**
+ * Wire shape shared between the renderer (resolve picker) and the
+ * main process (CrossRef search + apply). (#107)
+ */
+export interface ResolveCandidate {
+  doi: string;
+  title: string;
+  authors: string[];
+  year: string | null;
+  containerTitle: string | null;
+  /** Normalised 0–1 confidence used to size the bar + decide
+   *  whether to auto-apply without showing the picker. */
+  confidence: number;
+  /** Plain-text breakdown ("title match", "year match", "1 author
+   *  in common", …). Surfaced as a tooltip / line under the title. */
+  reasoning: string;
+}
+
+/** Default threshold for auto-applying the top candidate without
+ *  showing the picker. Surfaced as a constant so the renderer can
+ *  paint a "Auto-applied" indicator using the same number. */
+export const RESOLVE_AUTO_THRESHOLD = 0.85;

--- a/tests/main/sources/resolve-stub.test.ts
+++ b/tests/main/sources/resolve-stub.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Resolve stub → full source (#107). Pure-function tests for
+ * meta parsing + candidate scoring; the end-to-end flow goes
+ * through the IPC with a mocked CrossRef.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  parseStubMeta,
+  scoreCandidate,
+  applyStubResolution,
+} from '../../../src/main/sources/resolve-stub';
+import {
+  initGraph,
+  indexSource,
+  getSourceDetail,
+} from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import type { CrossrefSearchCandidate } from '../../../src/main/sources/api-adapters/crossref-search';
+
+const STUB_TTL = `this: a thought:Article ;
+    dc:title "Stochastic Parrots: On the Dangers of Bias" ;
+    dc:creator "Bender, Emily M." ;
+    dc:creator "Gebru, Timnit" ;
+    dc:issued "2021"^^xsd:gYear ;
+    thought:stubStatus "unresolved" ;
+    thought:rawReference "Bender, E.M., Gebru, T. (2021). On the dangers of stochastic parrots." .
+`;
+
+describe('parseStubMeta', () => {
+  it('extracts title / authors / year / raw from a stub meta.ttl', () => {
+    const snap = parseStubMeta(STUB_TTL);
+    expect(snap.title).toBe('Stochastic Parrots: On the Dangers of Bias');
+    expect(snap.authors).toEqual(['Bender, Emily M.', 'Gebru, Timnit']);
+    expect(snap.year).toBe('2021');
+    expect(snap.rawReference).toContain('stochastic parrots');
+  });
+
+  it('returns null fields when the predicates are absent', () => {
+    const snap = parseStubMeta(`this: a thought:Source ;\n    thought:stubStatus "unresolved" .\n`);
+    expect(snap.title).toBe('');
+    expect(snap.authors).toEqual([]);
+    expect(snap.year).toBeNull();
+    expect(snap.rawReference).toBeNull();
+  });
+});
+
+function makeHit(work: Partial<CrossrefSearchCandidate['work']> & { DOI: string }, rawScore = 50): CrossrefSearchCandidate {
+  return {
+    work: {
+      DOI: work.DOI,
+      title: work.title ?? ['(untitled)'],
+      author: work.author ?? [],
+      issued: work.issued,
+      'published-print': work['published-print'],
+      'container-title': work['container-title'],
+    },
+    rawScore,
+  };
+}
+
+describe('scoreCandidate', () => {
+  const STUB = {
+    title: 'On the dangers of stochastic parrots',
+    authors: ['Bender, Emily M.', 'Gebru, Timnit'],
+    year: '2021',
+    rawReference: null,
+  };
+
+  it('scores a near-perfect match high', () => {
+    const c = scoreCandidate(
+      makeHit({
+        DOI: '10.1145/3442188.3445922',
+        title: ['On the dangers of stochastic parrots: Can language models be too big?'],
+        author: [{ family: 'Bender' }, { family: 'Gebru' }],
+        issued: { 'date-parts': [[2021]] },
+      }),
+      STUB,
+    );
+    expect(c).not.toBeNull();
+    expect(c!.confidence).toBeGreaterThan(0.85);
+    expect(c!.reasoning).toContain('title match');
+    expect(c!.reasoning).toContain('year match');
+  });
+
+  it('scores a wrong-year same-title match below threshold', () => {
+    const c = scoreCandidate(
+      makeHit({
+        DOI: '10.1/wrong-year',
+        title: ['On the dangers of stochastic parrots: Can language models be too big?'],
+        author: [{ family: 'Bender' }, { family: 'Gebru' }],
+        issued: { 'date-parts': [[2018]] },
+      }),
+      STUB,
+    );
+    expect(c!.confidence).toBeLessThan(0.85);
+    expect(c!.reasoning).toContain('year off');
+  });
+
+  it('scores an unrelated paper near zero', () => {
+    const c = scoreCandidate(
+      makeHit({
+        DOI: '10.1/unrelated',
+        title: ['Quantum chromodynamics in the deep infrared'],
+        author: [{ family: 'Smith' }],
+        issued: { 'date-parts': [[2021]] },
+      }),
+      STUB,
+    );
+    expect(c!.confidence).toBeLessThan(0.3);
+  });
+
+  it('returns null when the candidate has no DOI', () => {
+    // CrossRef can return items without a DOI when searching loosely.
+    const work = { title: ['No DOI'] };
+    const hit = { work, rawScore: 1 } as unknown as CrossrefSearchCandidate;
+    expect(scoreCandidate(hit, STUB)).toBeNull();
+  });
+});
+
+describe('applyStubResolution', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const sourceId = 'sha-stub123';
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-resolve-stub-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    const dir = path.join(root, '.minerva', 'sources', sourceId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), STUB_TTL);
+    indexSource(ctx, sourceId, STUB_TTL);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('rewrites meta.ttl with full metadata and flips stubStatus to resolved', async () => {
+    // Stub fetch — we'd otherwise hit the real CrossRef.
+    const stubFetch = (async () => new Response(JSON.stringify({
+      message: {
+        DOI: '10.1145/3442188.3445922',
+        title: ['On the dangers of stochastic parrots'],
+        author: [
+          { family: 'Bender', given: 'Emily M.' },
+          { family: 'Gebru', given: 'Timnit' },
+        ],
+        issued: { 'date-parts': [[2021]] },
+        publisher: 'ACM',
+        type: 'proceedings-article',
+        URL: 'https://doi.org/10.1145/3442188.3445922',
+      },
+    }), { status: 200 })) as unknown as typeof fetch;
+
+    const ok = await applyStubResolution(root, sourceId, '10.1145/3442188.3445922', { fetchImpl: stubFetch });
+    expect(ok).toBe(true);
+
+    const ttl = fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+    expect(ttl).toContain('bibo:doi "10.1145/3442188.3445922"');
+    expect(ttl).toContain('thought:stubStatus "resolved"');
+    expect(ttl).not.toContain('"unresolved"');
+
+    const detail = getSourceDetail(ctx, sourceId);
+    expect(detail?.metadata.doi).toBe('10.1145/3442188.3445922');
+    expect(detail?.metadata.stubStatus).toBe('resolved');
+  });
+});


### PR DESCRIPTION
Completes the research-library flywheel — stubs created by #106 can now graduate to fully-resolved sources without leaving the app.

## Flow
1. Stub source's detail header shows a **"Resolve to full source"** button (visible whenever \`thought:stubStatus = "unresolved"\`).
2. Click → CrossRef bibliographic search using the stub's title + first author + year (or raw citation text when present).
3. Each hit gets a 0–1 confidence from a weighted blend of:
   - title overlap (recall against the shorter title — CrossRef stores the full publisher title with subtitle, the stub usually has an abbreviated form)
   - author last-name overlap
   - exact year match
4. Top candidate ≥ **0.85** → auto-apply. Otherwise → disambiguation picker (top 3) with confidence bars + plain-English reasoning.
5. Apply path: fetch the picked DOI's full metadata via the existing CrossRef adapter, rewrite \`meta.ttl\` with the canonical record, flip \`thought:stubStatus\` to \`"resolved"\`. **Source id stays the same** so any \`[[cite::]]\` links + \`minerva:references\` edges to the stub keep resolving.

## Files
- \`src/main/sources/api-adapters/crossref-search.ts\` — bibliographic search adapter (separate endpoint from the existing \`fetchCrossrefMetadata\`).
- \`src/main/sources/resolve-stub.ts\` — orchestrator + scorer + meta-ttl rewriter.
- \`src/shared/resolve-stub.ts\` — wire shape + auto-threshold constant shared with the renderer.
- \`src/renderer/lib/components/ResolveStubDialog.svelte\` — picker with confidence bars and a reasoning line per row.
- \`src/renderer/lib/components/SourceDetail.svelte\` — "Resolve to full source" button on stub headers.

## Scoring weights
\`0.55 * titleOverlap + 0.20 * authorOverlap + 0.25 * yearMatch\` — title is the strongest signal but a year mismatch alone drops below the auto-threshold even with perfect title + authors (two papers with the same title in different years are almost always distinct works).

## Tests
\`resolve-stub.test.ts\` (7):
- \`parseStubMeta\` extracts title / authors / year / rawReference.
- \`scoreCandidate\`: perfect match clears the auto-threshold; wrong-year same-title sits below; unrelated paper scores near zero; missing-DOI hit returns null.
- \`applyStubResolution\` rewrites meta.ttl + flips stubStatus (mocked CrossRef).

Full suite **2379 / 2379** (+7 new).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Mine references from a paper (#106), pick one of the resulting stubs.
  2. Open the stub — header shows "STUB" badge + italic title + "Resolve to full source" button.
  3. Click Resolve → busy spinner → if CrossRef has a clear top match, the source is auto-applied (header is now non-italic, "STUB" badge gone, full metadata populated).
  4. For an ambiguous case, the picker shows top 3 with confidence bars and reasoning. Pick one; same outcome.
  5. Try Resolve again on the just-resolved source — it's no longer a stub, so the button is hidden.

## Out of scope (follow-up)
- Renaming the source folder when the resolved DOI implies a new canonical id (\`sha-xxx\` → \`doi-yyy\`). For now the stub keeps its content-hash id; user can rename manually via the existing rename-source flow if they care.

Closes #107.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)