### PR TITLE
feat: "Create note" from conversation (#177)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -66,6 +66,10 @@
     todayDateString,
   } from './lib/refactor/extract';
   import { planSplitByHeading } from './lib/refactor/split-by-heading';
+  import {
+    planCreateFromConversation,
+    suggestConversationNoteTitle,
+  } from './lib/refactor/create-from-conversation';
   import { getRefactorSettings } from './lib/refactor/settings';
   import { getFormatSettings, loadFormatSettings } from './lib/formatter/settings';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
@@ -602,6 +606,70 @@
     const derived = deriveProposedTitle(body);
     if (derived) return derived;
     return showPrompt('New note name:');
+  }
+
+  /**
+   * "Create note" from the active conversation (#177). Body comes
+   * from the user's selection in the conversation pane if any;
+   * otherwise the most recent assistant message. The new note's
+   * frontmatter records the source note + conversation id for
+   * traceability.
+   *
+   * Lands in the same folder as the conversation's origin note
+   * (when there is one), or at the thoughtbase root for freeform
+   * conversations. Honours the Refactoring settings tab's
+   * destination + filename-prefix templates.
+   */
+  async function handleCreateNoteFromConversation(args: {
+    conversation: import('../shared/types').Conversation;
+    selectionText: string;
+    fallbackText: string;
+  }): Promise<void> {
+    if (!notebase.meta) return;
+    const body = args.selectionText.trim() || args.fallbackText.trim();
+    if (!body) {
+      await showConfirm(
+        'Nothing to create from — the conversation has no assistant text yet.',
+        CONFIRM_KEYS.createNoteFromConvEmpty,
+        'OK',
+      );
+      return;
+    }
+    const suggested = suggestConversationNoteTitle(body);
+    const title = suggested ?? await showPrompt('New note name:');
+    if (!title) return;
+
+    const sourceRelativePath = args.conversation.contextBundle.notePath ?? null;
+    const plan = planCreateFromConversation({
+      title,
+      body,
+      sourceRelativePath,
+      conversationId: args.conversation.id,
+      today: new Date().toISOString().slice(0, 10),
+      settings: getRefactorSettings(),
+    });
+
+    try {
+      // Loop on collision so the second-of-the-same-title doesn't
+      // clobber the first. Existing extract / split-here paths
+      // accept clobbers, but conversation-source notes are likely
+      // to land repeatedly off the same prompts.
+      let path = plan.newNotePath;
+      for (let attempt = 2; attempt < 20; attempt++) {
+        if (!(await api.notebase.fileExists(path))) break;
+        const dot = plan.newNotePath.lastIndexOf('.md');
+        path = dot > 0
+          ? `${plan.newNotePath.slice(0, dot)}-${attempt}.md`
+          : `${plan.newNotePath}-${attempt}`;
+      }
+      await api.notebase.writeFile(path, plan.newNoteContent);
+      await notebase.refresh();
+      await editor.openFile(path);
+      sidebar?.refreshTags();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn't create note: ${msg}`, CONFIRM_KEYS.createNoteFromConvFailed, 'OK');
+    }
   }
 
   async function handleExtractSelection() {
@@ -2795,7 +2863,10 @@
 
   {#if notebase.meta}
     {#key notebase.meta.rootPath}
-      <ConversationsPanel currentNotePath={editor.activeFilePath ?? null} />
+      <ConversationsPanel
+        currentNotePath={editor.activeFilePath ?? null}
+        onCreateNoteFromConversation={handleCreateNoteFromConversation}
+      />
     {/key}
   {/if}
 

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -38,9 +38,18 @@
      *  against whatever the user is looking at, even if it differs from
      *  the conversation's origin. */
     currentNotePath: string | null;
+    /** Host implementation of "Create note from this conversation"
+     *  (#177). Receives the conversation, the selected text (or
+     *  empty when no selection lives inside the conversation pane),
+     *  and the latest assistant message's content as a fallback. */
+    onCreateNoteFromConversation?: (args: {
+      conversation: import('../../../shared/types').Conversation;
+      selectionText: string;
+      fallbackText: string;
+    }) => Promise<void>;
   }
 
-  let { currentNotePath }: Props = $props();
+  let { currentNotePath, onCreateNoteFromConversation }: Props = $props();
 
   const store = getConversationsStore();
   const editor = getEditorStore();
@@ -63,6 +72,50 @@
       const s = await api.tools.getSettings();
       defaultModel = s.model ?? null;
     } catch { /* settings unavailable; picker still works without the label */ }
+  });
+
+  /**
+   * "Create note" from the active conversation (#177). Pulls the
+   * current selection if it sits inside the conversation pane;
+   * otherwise the host's fallback (last assistant message) wins.
+   */
+  let creatingNote = $state(false);
+  async function handleCreateNote(): Promise<void> {
+    if (!onCreateNoteFromConversation || creatingNote) return;
+    const tab = store.activeTab;
+    if (!tab || tab.conversation.messages.filter((m) => m.role === 'assistant').length === 0) return;
+    creatingNote = true;
+    try {
+      const sel = window.getSelection();
+      let selectionText = '';
+      if (sel && scrollEl && !sel.isCollapsed) {
+        // Only honour the selection when it lives inside the
+        // conversation pane — otherwise users could trigger from
+        // editor selections by accident.
+        if (scrollEl.contains(sel.anchorNode) && scrollEl.contains(sel.focusNode)) {
+          selectionText = sel.toString().trim();
+        }
+      }
+      const lastAssistant = [...tab.conversation.messages]
+        .reverse()
+        .find((m) => m.role === 'assistant');
+      const fallbackText = lastAssistant?.content ?? '';
+      await onCreateNoteFromConversation({
+        conversation: tab.conversation,
+        selectionText,
+        fallbackText,
+      });
+    } finally {
+      creatingNote = false;
+    }
+  }
+
+  /** Whether the "Create note" affordance is enabled. Requires at
+   *  least one assistant message in the active conversation. */
+  const canCreateNote = $derived.by(() => {
+    const tab = store.activeTab;
+    if (!tab) return false;
+    return tab.conversation.messages.some((m) => m.role === 'assistant');
   });
 
   async function handleModelChange(tabId: string, e: Event) {
@@ -480,6 +533,17 @@
               <option value={m.value}>{m.label}</option>
             {/each}
           </select>
+          {#if onCreateNoteFromConversation}
+            <button
+              type="button"
+              class="rail-action"
+              disabled={!canCreateNote || creatingNote}
+              onclick={handleCreateNote}
+              title="Create a new note from the selection (or last assistant message) — #177"
+            >
+              {creatingNote ? 'Creating…' : 'Create note'}
+            </button>
+          {/if}
         </div>
 
         {#snippet messageBlock(msg: ConversationMessage)}
@@ -1126,6 +1190,24 @@
     max-width: 200px;
     flex-shrink: 0;
   }
+  /* "Create note" rail button (#177). Sits next to the model picker
+     and follows the same chrome — keeps the rail visually contained. */
+  .rail-action {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .rail-action:hover:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .rail-action:disabled { opacity: 0.45; cursor: default; }
 
   .messages {
     flex: 1;

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -50,6 +50,9 @@ export const CONFIRM_KEYS = {
   resolveStubEmpty: 'resolve-stub-empty',
   resolveStubFailed: 'resolve-stub-failed',
   resolveStubApplied: 'resolve-stub-applied',
+  /** "Create note from conversation" outcomes (#177). */
+  createNoteFromConvEmpty: 'create-note-from-conv-empty',
+  createNoteFromConvFailed: 'create-note-from-conv-failed',
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
@@ -268,6 +271,18 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Resolve stub: applied',
     description:
       'Shown after the chosen DOI is applied to a stub, confirming the new title and that existing citations to the old id still resolve.',
+  },
+  {
+    key: CONFIRM_KEYS.createNoteFromConvEmpty,
+    title: 'Create note from conversation: nothing to create',
+    description:
+      'Shown when "Create note" is triggered on a conversation that has no assistant text and no selection.',
+  },
+  {
+    key: CONFIRM_KEYS.createNoteFromConvFailed,
+    title: 'Create note from conversation: error',
+    description:
+      'Shown when the file write for a conversation-derived note fails (permissions, disk full, etc).',
   },
   {
     key: CONFIRM_KEYS.dropImportRejected,

--- a/src/renderer/lib/refactor/create-from-conversation.ts
+++ b/src/renderer/lib/refactor/create-from-conversation.ts
@@ -1,0 +1,117 @@
+/**
+ * Plan a "Create note from conversation" operation (#177).
+ *
+ * Distinct from extract / split:
+ *   - The source content isn't being rewritten; we're not splitting
+ *     a note. We just write a new note with the given body.
+ *   - Provenance lives in frontmatter (`source:` + `conversation:`)
+ *     rather than as a wiki-link back-edit in the source note.
+ *
+ * Reuses the refactor settings (destination folder, filename
+ * prefix) so the new note lands consistently with extract /
+ * split-here output. When the conversation has no origin note, the
+ * destination falls back to `root`.
+ */
+
+import {
+  deriveProposedTitle,
+  resolveDestinationFolder,
+  renderFilenamePrefix,
+  sanitizeFilename,
+} from './extract';
+import type { RefactorSettings } from './settings';
+import { DEFAULT_REFACTOR_SETTINGS } from './settings';
+
+export interface PlanCreateFromConversationOptions {
+  /** Pre-resolved title for the new note (caller may have prompted). */
+  title: string;
+  /** Body text to land in the note — selection or last-assistant text. */
+  body: string;
+  /** Origin-note relativePath when the conversation has one; null
+   *  for freeform conversations. Drives the destination folder via
+   *  `same-folder` settings + the frontmatter `source:` field. */
+  sourceRelativePath: string | null;
+  /** Conversation id, recorded in frontmatter for traceability. */
+  conversationId: string;
+  /** YYYY-MM-DD for the frontmatter `created:` line. */
+  today: string;
+  settings?: RefactorSettings;
+  now?: Date;
+}
+
+export interface CreateFromConversationPlan {
+  newNotePath: string;
+  newNoteContent: string;
+}
+
+export function planCreateFromConversation(opts: PlanCreateFromConversationOptions): CreateFromConversationPlan {
+  const settings = opts.settings ?? DEFAULT_REFACTOR_SETTINGS;
+  // Freeform conversations have no source — fall back to root
+  // regardless of the destination setting, since `same-folder` has
+  // no folder to copy from.
+  const sourcePath = opts.sourceRelativePath ?? '';
+  const dir = sourcePath
+    ? resolveDestinationFolder(sourcePath, settings, opts.now)
+    : '';
+  const prefix = sourcePath ? renderFilenamePrefix(sourcePath, settings, opts.now) : '';
+  const stem = `${prefix}${sanitizeFilename(opts.title) || `note-${Date.now()}`}`;
+  const newNotePath = dir ? `${dir}/${stem}.md` : `${stem}.md`;
+
+  const frontmatter = buildFrontmatter({
+    title: opts.title,
+    today: opts.today,
+    sourceRelativePath: opts.sourceRelativePath,
+    conversationId: opts.conversationId,
+  });
+  const trimmedBody = opts.body.replace(/^\s+|\s+$/g, '');
+  const newNoteContent = `${frontmatter}${trimmedBody}\n`;
+  return { newNotePath, newNoteContent };
+}
+
+interface FrontmatterArgs {
+  title: string;
+  today: string;
+  sourceRelativePath: string | null;
+  conversationId: string;
+}
+
+function buildFrontmatter(args: FrontmatterArgs): string {
+  const lines = ['---'];
+  lines.push(`title: ${yamlScalar(args.title)}`);
+  lines.push(`created: ${args.today}`);
+  if (args.sourceRelativePath) {
+    lines.push(`source: ${yamlScalar(args.sourceRelativePath)}`);
+  }
+  lines.push(`conversation: ${yamlScalar(args.conversationId)}`);
+  lines.push('---', '');
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Quote-and-escape a YAML scalar when it would otherwise be parsed
+ * as something else (numbers, dates, booleans, anything with
+ * special punctuation). Plain alphanumerics + a handful of safe
+ * punctuation chars round-trip unquoted.
+ */
+export function yamlScalar(s: string): string {
+  if (s === '') return '""';
+  // Conservative: any character outside this set forces quoting.
+  if (/^[A-Za-z0-9 _.\-/]+$/.test(s) && !/^(true|false|null|yes|no|on|off|~)$/i.test(s) && !/^[+-]?\d+$/.test(s) && !/^\d{4}-\d{2}-\d{2}$/.test(s)) {
+    return s;
+  }
+  // Double-quoted with the standard JSON-escape set is safe.
+  return JSON.stringify(s);
+}
+
+/**
+ * Pick a default title for the new note. If the body has a leading
+ * heading or a short first line, use that. Otherwise return null so
+ * the host can prompt the user.
+ *
+ * Re-uses the existing `deriveProposedTitle` heuristic so titles
+ * across extract / split-here / create-from-conversation stay
+ * consistent.
+ */
+export function suggestConversationNoteTitle(body: string): string | null {
+  return deriveProposedTitle(body);
+}

--- a/tests/renderer/create-from-conversation.test.ts
+++ b/tests/renderer/create-from-conversation.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Plan "create note from conversation" (#177). Pure-function tests
+ * — the host wires writeFile / openFile around the plan.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  planCreateFromConversation,
+  suggestConversationNoteTitle,
+  yamlScalar,
+} from '../../src/renderer/lib/refactor/create-from-conversation';
+import { DEFAULT_REFACTOR_SETTINGS } from '../../src/renderer/lib/refactor/settings';
+
+const BASE = {
+  title: 'My new note',
+  body: 'Hello world.\nA second line.',
+  conversationId: 'conv-1775415007888-pizewg',
+  today: '2026-05-27',
+  settings: DEFAULT_REFACTOR_SETTINGS,
+};
+
+describe('planCreateFromConversation', () => {
+  it('writes frontmatter with title / created / source / conversation', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      sourceRelativePath: 'notes/origin.md',
+    });
+    expect(plan.newNoteContent).toContain('title: My new note');
+    expect(plan.newNoteContent).toContain('created: 2026-05-27');
+    expect(plan.newNoteContent).toContain('source: notes/origin.md');
+    expect(plan.newNoteContent).toContain('conversation: conv-1775415007888-pizewg');
+    expect(plan.newNoteContent).toContain('Hello world.');
+  });
+
+  it('omits the source field for a freeform conversation', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      sourceRelativePath: null,
+    });
+    expect(plan.newNoteContent).not.toContain('source:');
+    // Other fields still present.
+    expect(plan.newNoteContent).toContain('conversation:');
+    expect(plan.newNoteContent).toContain('title:');
+  });
+
+  it('lands in the source note\'s folder by default', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      sourceRelativePath: 'reading/papers/origin.md',
+    });
+    expect(plan.newNotePath).toBe('reading/papers/my-new-note.md');
+  });
+
+  it('falls back to root for freeform conversations regardless of destination setting', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      sourceRelativePath: null,
+      settings: { ...DEFAULT_REFACTOR_SETTINGS, destination: 'same-folder' },
+    });
+    expect(plan.newNotePath).toBe('my-new-note.md');
+  });
+
+  it('honours the custom destination template when the source path is present', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      sourceRelativePath: 'reading/origin.md',
+      settings: { ...DEFAULT_REFACTOR_SETTINGS, destination: 'custom', destinationTemplate: 'derived/{{source}}' },
+    });
+    expect(plan.newNotePath.startsWith('derived/reading/origin.md/')).toBe(true);
+  });
+
+  it('trims surrounding whitespace from the body', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      body: '\n\n  body with leading whitespace  \n\n',
+      sourceRelativePath: 'a.md',
+    });
+    expect(plan.newNoteContent).toMatch(/---\n\nbody with leading whitespace\n$/);
+  });
+
+  it('quotes path-shaped titles so YAML doesn\'t mis-parse them', () => {
+    // Titles containing colons / brackets / lone dashes need quoting.
+    const plan = planCreateFromConversation({
+      ...BASE,
+      title: 'Notes: 2026-05-27 thoughts',
+      sourceRelativePath: null,
+    });
+    expect(plan.newNoteContent).toContain('title: "Notes: 2026-05-27 thoughts"');
+  });
+
+  it('falls back to a default stem when the title sanitises to empty', () => {
+    const plan = planCreateFromConversation({
+      ...BASE,
+      title: '!!!',
+      sourceRelativePath: 'a.md',
+    });
+    expect(plan.newNotePath).toMatch(/^note-\d+\.md$/);
+  });
+});
+
+describe('suggestConversationNoteTitle', () => {
+  it('uses the first markdown heading when present', () => {
+    expect(suggestConversationNoteTitle('# A bold claim\n\nbody here')).toBe('A bold claim');
+  });
+
+  it('uses the first short line when no heading', () => {
+    expect(suggestConversationNoteTitle('A summary in one line\n\nlonger body follows')).toBe('A summary in one line');
+  });
+
+  it('returns null when the body opens with a long paragraph', () => {
+    const long = 'This is a much longer opening paragraph that would not make a sensible note title and should fall through to the host prompt.';
+    expect(suggestConversationNoteTitle(long)).toBeNull();
+  });
+});
+
+describe('yamlScalar', () => {
+  it('passes plain words through unquoted', () => {
+    expect(yamlScalar('hello-world')).toBe('hello-world');
+    expect(yamlScalar('Plain Words')).toBe('Plain Words');
+  });
+  it('quotes values that look like dates / booleans / numbers', () => {
+    expect(yamlScalar('2026-05-27')).toBe('"2026-05-27"');
+    expect(yamlScalar('true')).toBe('"true"');
+    expect(yamlScalar('42')).toBe('"42"');
+  });
+  it('quotes anything with punctuation YAML cares about', () => {
+    expect(yamlScalar('Notes: hi')).toBe('"Notes: hi"');
+    expect(yamlScalar('a "quote" inside')).toBe('"a \\"quote\\" inside"');
+  });
+});


### PR DESCRIPTION
Promote a conversation's content into a standalone note. Distinct from **File Selection** (crystallises text as thought components) and **Resolve** (files the whole conversation as a \`thought:Source\`) — this lands a plain note the user can edit, link, and extend freely.

## Entry point
"Create note" button in the conversation context rail, next to the model picker. Enabled whenever the conversation has at least one assistant message.

## Body selection
- If text is selected inside the conversation pane → use the selection. Scoped to the messages container so an editor-side selection can't accidentally bleed in.
- Otherwise → most recent assistant message's content.

## Frontmatter
\`\`\`yaml
---
title: <derived or prompted>
created: <YYYY-MM-DD>
source: <origin note's relativePath>  # omitted for freeform
conversation: <conv-id>
---
\`\`\`

\`yamlScalar\` quotes values that would otherwise mis-parse as dates / booleans / numbers / contain punctuation.

## Destination
\`planCreateFromConversation\` reuses the refactor settings (\`destination\` mode + \`destinationTemplate\` + \`filenamePrefix\`) so output lands consistently with extract / split-here. Freeform conversations (no origin note) fall back to the thoughtbase root regardless of the setting.

## Collision handling
If the resolved filename already exists, append \`-2\`, \`-3\`, … until a free slot is found (up to 20). Mirrors the smart-paste duplicate handling without overwriting.

## Title heuristic
\`suggestConversationNoteTitle\` re-exports \`deriveProposedTitle\` from the existing extract helpers — first markdown heading, then first short line, else null (host prompts).

## Tests
14 cases in \`create-from-conversation.test.ts\`:
- Frontmatter shape with / without source path
- Destination resolution: same-folder / root / custom template / freeform fallback
- Body whitespace trim
- Title-scalar quoting for punctuation-containing values
- Stem fallback when sanitisation yields nothing
- Title-suggestion heuristic across body shapes
- \`yamlScalar\` edge cases

Full suite **2393 / 2393** (+14 new).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Open the conversations panel from any note.
  2. Send a prompt; assistant replies. **Create note** button activates.
  3. Click it (no selection) → derived/prompted title → new note opens with the assistant text as body and frontmatter (\`title\`, \`created\`, \`source: <origin>\`, \`conversation: <id>\`).
  4. Select a paragraph in an earlier message; click Create note → new note's body is the selection, not the most recent message.
  5. Start a freeform conversation (no origin note) → Create note → no \`source:\` field, file lands at root.

Closes #177.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)