### PR TITLE
feat: surface CSV table-name collisions as a toast (#354)

### DIFF
--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -127,14 +127,69 @@ async function readCompanionOverride(rootPath: string, relativePath: string): Pr
 }
 
 /**
+ * Information surfaced when two CSVs derive the same table name and
+ * the second is skipped (#354). Callers route this to a renderer
+ * toast so the user can fix the conflict via `table_name:` in a
+ * companion .md.
+ */
+export interface CsvTableCollision {
+  /** Table name both CSVs derived. */
+  tableName: string;
+  /** Path that was registered first and won. */
+  existingPath: string;
+  /** Path that was skipped to avoid the clobber. */
+  attemptedPath: string;
+}
+
+export type RegisterCsvResult =
+  | { ok: true }
+  | { ok: false; reason: 'collision'; collision: CsvTableCollision }
+  | { ok: false; reason: 'inactive' }
+  | { ok: false; reason: 'error'; error: unknown };
+
+/**
+ * Per-project collision-listener registry (#354). Listeners are
+ * attached by window-manager so each window sees collisions for its
+ * own project, including those produced during the init-time
+ * `registerAllCsvs` sweep (when the window-manager isn't yet calling
+ * registerCsv itself).
+ */
+type CollisionListener = (c: CsvTableCollision) => void;
+const collisionListeners = new Map<string, Set<CollisionListener>>();
+
+export function onCsvTableCollision(rootPath: string, listener: CollisionListener): () => void {
+  let set = collisionListeners.get(rootPath);
+  if (!set) { set = new Set(); collisionListeners.set(rootPath, set); }
+  set.add(listener);
+  return () => {
+    const s = collisionListeners.get(rootPath);
+    if (!s) return;
+    s.delete(listener);
+    if (s.size === 0) collisionListeners.delete(rootPath);
+  };
+}
+
+function emitCollision(rootPath: string, c: CsvTableCollision): void {
+  const set = collisionListeners.get(rootPath);
+  if (!set) return;
+  for (const fn of set) {
+    try { fn(c); } catch (err) { console.error('[tables] collision listener threw:', err); }
+  }
+}
+
+/**
  * Register (or re-register) a CSV file as a DuckDB view. The view is lazy —
  * DuckDB re-reads the file on every query — so content changes don't require
  * re-registration. Re-register is called when the file is added or when the
  * companion note's `table_name:` may have changed.
+ *
+ * Returns a result indicating outcome. Callers that own a renderer
+ * window should surface `collision` results as a toast — the
+ * console.warn alone wasn't visible to users (#354).
  */
-export async function registerCsv(ctx: ProjectContext, relativePath: string): Promise<void> {
+export async function registerCsv(ctx: ProjectContext, relativePath: string): Promise<RegisterCsvResult> {
   const state = getState(ctx);
-  if (!state) return;
+  if (!state) return { ok: false, reason: 'inactive' };
   const { rootPath, connection, pathToTable, tableToPath } = state;
   const override = await readCompanionOverride(rootPath, relativePath);
   const tableName = override ?? deriveTableName(relativePath);
@@ -148,7 +203,9 @@ export async function registerCsv(ctx: ProjectContext, relativePath: string): Pr
       `'${existingPath}' and '${relativePath}'. Skipping the second. Use ` +
       `'table_name:' in a companion .md to disambiguate.`,
     );
-    return;
+    const collision = { tableName, existingPath, attemptedPath: relativePath };
+    emitCollision(rootPath, collision);
+    return { ok: false, reason: 'collision', collision };
   }
 
   // If this path was previously registered under a different name (e.g. the
@@ -183,11 +240,13 @@ export async function registerCsv(ctx: ProjectContext, relativePath: string): Pr
     // lets SPARQL consumers ask "what tables do I have?", "what columns
     // does X expose?", and reason about column datatypes.
     await indexCsvTableShape(ctx, relativePath, tableName);
+    return { ok: true };
   } catch (err) {
     console.warn(
       `[tables] Failed to register '${relativePath}' as '${tableName}': ` +
       (err instanceof Error ? err.message : String(err)),
     );
+    return { ok: false, reason: 'error', error: err };
   }
 }
 
@@ -242,16 +301,21 @@ export async function unregisterCsv(ctx: ProjectContext, relativePath: string): 
 /**
  * Scan the thoughtbase on project open and register every `.csv` file under
  * the root. Mirrors graph.indexAllNotes's walker shape.
+ *
+ * Returns the count of successfully-registered CSVs plus any
+ * collisions encountered. Callers route collisions to a renderer
+ * toast (#354).
  */
-export async function registerAllCsvs(ctx: ProjectContext): Promise<number> {
+export async function registerAllCsvs(ctx: ProjectContext): Promise<{ count: number; collisions: CsvTableCollision[] }> {
   const state = getState(ctx);
-  if (!state) return 0;
+  if (!state) return { count: 0, collisions: [] };
   const { rootPath } = state;
   // Wipe stale CSV-table triples up front so CSVs deleted while the app
   // was closed don't linger in the graph after a full rescan. Each
   // registered CSV writes its own triples as it goes.
   unindexAllCsvTables(ctx);
   let count = 0;
+  const collisions: CsvTableCollision[] = [];
   async function walk(dirPath: string) {
     let entries: import('node:fs').Dirent[];
     try {
@@ -266,13 +330,14 @@ export async function registerAllCsvs(ctx: ProjectContext): Promise<number> {
         await walk(fullPath);
       } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.csv')) {
         const rel = path.relative(rootPath, fullPath);
-        await registerCsv(ctx, rel);
-        count++;
+        const result = await registerCsv(ctx, rel);
+        if (result.ok) count++;
+        else if (result.reason === 'collision') collisions.push(result.collision);
       }
     }
   }
   await walk(rootPath);
-  return count;
+  return { count, collisions };
 }
 
 /** Every registered CSV's table name, relative path, column names, and row count. */

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -147,6 +147,16 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   }
 
   ctx.rootPath = rootPath;
+  // Subscribe to CSV table-name collisions BEFORE project init so
+  // the init-time `registerAllCsvs` sweep is also covered (#354).
+  // The console.warn alone wasn't visible to users; this surfaces a
+  // toast pointing at `table_name:` as the fix. Unsub on window
+  // close to avoid leaking listeners across project reopens.
+  const unsubCollision = tables.onCsvTableCollision(rootPath, (collision) => {
+    if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_NAME_COLLISION, collision);
+  });
+  win.once('closed', () => { unsubCollision(); });
+
   const projectCtx: ProjectContext = await acquireProject(rootPath, win.id);
   addRecentProject(rootPath);
   rebuildMenu();
@@ -221,6 +231,8 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     try {
       await tables.registerCsv(projectCtx, csvPath);
       if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+      // Collisions broadcast via the per-project listener attached
+      // before acquireProject — no extra wiring here.
     } catch (err) {
       console.warn(`[tables] sibling re-register failed for ${csvPath} (via ${relativePath}):`, err);
     }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -123,6 +123,9 @@ contextBridge.exposeInMainWorld('api', {
     onChanged: (cb: () => void) => {
       ipcRenderer.on(Channels.TABLES_CHANGED, () => cb());
     },
+    onNameCollision: (cb: (collision: import('../shared/types').CsvTableCollision) => void) => {
+      ipcRenderer.on(Channels.TABLES_NAME_COLLISION, (_e, collision) => cb(collision as import('../shared/types').CsvTableCollision));
+    },
   },
   tags: {
     list: () => ipcRenderer.invoke(Channels.TAGS_LIST),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -2450,6 +2450,21 @@
     sidebar?.refreshTables();
   });
 
+  // CSV table-name collision (#354): two CSVs would land on the
+  // same DuckDB table name; the second was skipped. Show a
+  // suppressible toast pointing at `table_name:` as the fix.
+  api.tables.onNameCollision((collision) => {
+    void showConfirm(
+      `Two CSVs would use the same DuckDB table name "${collision.tableName}":\n\n` +
+      `  • ${collision.existingPath}  (active)\n` +
+      `  • ${collision.attemptedPath}  (skipped)\n\n` +
+      `Add \`table_name: <unique-name>\` to a companion .md alongside one of them to disambiguate.`,
+      CONFIRM_KEYS.tableNameCollision,
+      'OK',
+      { hideDontAskAgain: false },
+    );
+  });
+
   function cycleViewMode() {
     if (viewMode === 'source') viewMode = 'preview';
     else if (viewMode === 'preview') viewMode = 'split';

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -53,6 +53,10 @@ export const CONFIRM_KEYS = {
   /** "Create note from conversation" outcomes (#177). */
   createNoteFromConvEmpty: 'create-note-from-conv-empty',
   createNoteFromConvFailed: 'create-note-from-conv-failed',
+  /** Two CSVs derived the same DuckDB table name; the second was
+   *  skipped (#354). The user can fix by adding `table_name:` to a
+   *  companion .md. */
+  tableNameCollision: 'table-name-collision',
   dropImportRejected: 'drop-import-rejected',
   bibtexImportComplete: 'bibtex-import-complete',
   zoteroRdfImportComplete: 'zotero-rdf-import-complete',
@@ -283,6 +287,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Create note from conversation: error',
     description:
       'Shown when the file write for a conversation-derived note fails (permissions, disk full, etc).',
+  },
+  {
+    key: CONFIRM_KEYS.tableNameCollision,
+    title: 'CSV: table name collision',
+    description:
+      'Shown when two CSVs derive the same DuckDB table name and the second is skipped. Add a `table_name:` line to a companion .md to disambiguate.',
   },
   {
     key: CONFIRM_KEYS.dropImportRejected,

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -174,6 +174,10 @@ export interface TablesApi {
   list(): Promise<TableInfo[]>;
   /** Fires when a CSV is registered/unregistered or the initial scan completes. */
   onChanged(cb: () => void): void;
+  /** Fires when two CSVs derive the same DuckDB table name and the
+   *  second was skipped (#354). Renderer surfaces a suppressible
+   *  toast pointing at `table_name:` as the fix. */
+  onNameCollision(cb: (collision: import('../../../shared/types').CsvTableCollision) => void): void;
 }
 
 export interface TagsApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -294,6 +294,9 @@ export const Channels = {
   TABLES_LIST: 'tables:list',
   /** Broadcast from main when the set of registered DuckDB tables changes (#235). */
   TABLES_CHANGED: 'tables:changed',
+  /** Broadcast from main when a CSV register would clobber an existing
+   *  table name and got skipped (#354). Payload: \`CsvTableCollision\`. */
+  TABLES_NAME_COLLISION: 'tables:nameCollision',
 
   /** Format a single file on disk (#153). Writes through the standard index+broadcast pipeline. */
   FORMATTER_FORMAT_FILE: 'formatter:formatFile',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -232,6 +232,18 @@ export interface CollectionsFile {
   smartCollections?: SmartCollection[];
 }
 
+/** Broadcast payload when two CSVs derive the same DuckDB table
+ *  name and the second is skipped (#354). The renderer surfaces
+ *  this as a suppressible toast pointing at `table_name:` in a
+ *  companion .md as the fix. */
+export interface CsvTableCollision {
+  tableName: string;
+  /** Path that was registered first and won. */
+  existingPath: string;
+  /** Path that was skipped to avoid the clobber. */
+  attemptedPath: string;
+}
+
 // ── Bookmarks ────────────────────────────────────────────────────────────
 
 export interface Bookmark {

--- a/tests/main/sources/tables-csv.test.ts
+++ b/tests/main/sources/tables-csv.test.ts
@@ -12,6 +12,8 @@ import {
   registerAllCsvs,
   listTables,
   deriveTableName,
+  onCsvTableCollision,
+  type CsvTableCollision,
 } from '../../../src/main/sources/tables';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
@@ -278,6 +280,47 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
     expect(b).toEqual({ name: 'nested_b', relativePath: 'nested/b.csv', columns: ['p', 'q', 'r'], rowCount: 1 });
   });
 
+  it('returns a structured collision result when two CSVs derive the same table name (#354)', async () => {
+    // `foo/bar.csv` and `foo_bar.csv` both slug to `foo_bar`.
+    await writeCsv('foo/bar.csv', 'n\n1\n');
+    await writeCsv('foo_bar.csv', 'n\n2\n');
+    const first = await registerCsv(ctx, 'foo/bar.csv');
+    expect(first.ok).toBe(true);
+    const second = await registerCsv(ctx, 'foo_bar.csv');
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.reason).toBe('collision');
+      if (second.reason === 'collision') {
+        expect(second.collision.existingPath).toBe('foo/bar.csv');
+        expect(second.collision.attemptedPath).toBe('foo_bar.csv');
+        expect(second.collision.tableName).toBe('foo_bar');
+      }
+    }
+  });
+
+  it('fires onCsvTableCollision listeners with the project rootPath (#354)', async () => {
+    const seen: CsvTableCollision[] = [];
+    const off = onCsvTableCollision(root, (c) => { seen.push(c); });
+    await writeCsv('foo/bar.csv', 'n\n1\n');
+    await writeCsv('foo_bar.csv', 'n\n2\n');
+    await registerCsv(ctx, 'foo/bar.csv');
+    await registerCsv(ctx, 'foo_bar.csv');
+    off();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ existingPath: 'foo/bar.csv', attemptedPath: 'foo_bar.csv' });
+  });
+
+  it('aggregates collisions in registerAllCsvs return value (#354)', async () => {
+    await writeCsv('foo/bar.csv', 'n\n1\n');
+    await writeCsv('foo_bar.csv', 'n\n2\n');
+    await writeCsv('clean.csv', 'n\n3\n');
+    const { count, collisions } = await registerAllCsvs(ctx);
+    // Two distinct table names landed (foo_bar from one of them, clean).
+    expect(count).toBe(2);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].tableName).toBe('foo_bar');
+  });
+
   it('registerAllCsvs picks up existing CSVs on project open', async () => {
     await writeCsv('top.csv', 'n\n1\n2\n');
     await writeCsv('sub/mid.csv', 'm\nx\n');
@@ -285,8 +328,9 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
     // Hidden dir — should be skipped.
     await writeCsv('.minerva/secret.csv', 'x\n1\n');
 
-    const count = await registerAllCsvs(ctx);
+    const { count, collisions } = await registerAllCsvs(ctx);
     expect(count).toBe(3);
+    expect(collisions).toEqual([]);
 
     const tables = await listTables(ctx);
     expect(tables.map((t) => t.name).sort()).toEqual(['sub_deep_bottom', 'sub_mid', 'top']);


### PR DESCRIPTION
The collision detection at \`tables.ts:144\` already existed but only \`console.warn\`-ed; users never saw it. This routes those collisions to a renderer-visible suppressible toast that points at the \`table_name:\` companion-frontmatter override as the fix.

## Changes
- \`registerCsv\` now returns a structured \`RegisterCsvResult\` (\`ok\` | \`collision\` | \`inactive\` | \`error\`) instead of \`void\`, so callers can branch on outcome.
- \`registerAllCsvs\` returns \`{ count, collisions }\` instead of a bare number.
- New pub/sub: \`onCsvTableCollision(rootPath, listener)\` returning an unsubscriber. Scoped per project so multi-window setups don't cross-talk.
- \`window-manager.ts\` subscribes **before** \`acquireProject\` so init-time collisions are caught (not just file-watcher events later). Listener unwound on \`win.closed\`.
- Renderer: \`api.tables.onNameCollision\` → \`showConfirm\` with a new \`tableNameCollision\` key (suppressible). Message names both paths and tells the user to add \`table_name: <unique-name>\` to a companion .md to fix.

## Tests
3 new cases in \`tables-csv.test.ts\`:
- \`registerCsv\` returns the structured collision result for the second of two CSVs that derive the same table name.
- \`onCsvTableCollision\` listener fires once per collision and receives the right payload.
- \`registerAllCsvs\` aggregates collisions in its return value.

Existing test updated for the new \`{count, collisions}\` shape. Full suite **2417 / 2417** (+3).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**:
  1. Create two CSVs that slug to the same name (e.g. \`foo/bar.csv\` and \`foo_bar.csv\`).
  2. Open the project → toast appears with both paths + the \`table_name:\` hint.
  3. Add \`table_name: bar_unique\` to a companion \`foo/bar.md\`; on save the watcher re-registers and both tables appear.
  4. Tick "Don't ask again" → re-open project, no toast.

Closes #354.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)