### PR TITLE
feat: source health-check inspections (#119)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -39,6 +39,10 @@ export async function runAllChecks(ctx: ProjectContext): Promise<Inspection[]> {
       checkEvidenceGaps(ctx),
       checkContradictions(ctx),
       checkInvalidDois(ctx),
+      checkSourcesMissingMetadata(ctx),
+      checkLongUnresolvedStubs(ctx, 30), // 30 days
+      checkCitedUnreadSources(ctx),
+      checkDuplicateSources(ctx),
     ]);
     const flat = results.flat();
     lastResultsByProject.set(ctx.rootPath, flat);
@@ -213,6 +217,191 @@ async function checkContradictions(ctx: ProjectContext): Promise<Inspection[]> {
     message: `Established claim "${r.aLabel}" contradicts established claim "${r.bLabel}"`,
     suggestedAction: 'Review both claims — at least one needs to be revised or its status changed',
   }));
+}
+
+/**
+ * Sources missing the bibliographic minimum — no dc:title OR no
+ * dc:creator (#119). Stubs are intentionally partial; filter them
+ * out so the inspections panel surfaces only sources that should
+ * have been populated but weren't.
+ */
+async function checkSourcesMissingMetadata(ctx: ProjectContext): Promise<Inspection[]> {
+  const results = await queryGraph(ctx, `
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    PREFIX dc: <http://purl.org/dc/terms/>
+    SELECT ?source ?sourceId ?title (GROUP_CONCAT(?creator; SEPARATOR=", ") AS ?creators) WHERE {
+      ?source minerva:sourceId ?sourceId .
+      OPTIONAL { ?source dc:title ?title }
+      OPTIONAL { ?source dc:creator ?creator }
+      FILTER NOT EXISTS { ?source thought:stubStatus ?_stub }
+      FILTER(!BOUND(?title) || !BOUND(?creator))
+    }
+    GROUP BY ?source ?sourceId ?title
+    LIMIT 50
+  `);
+
+  return (results.results as Record<string, string>[]).map((r, i) => {
+    const label = r.title || r.sourceId;
+    const missing: string[] = [];
+    if (!r.title) missing.push('title');
+    if (!r.creators) missing.push('authors');
+    return {
+      id: `source-missing-metadata-${i}`,
+      type: 'source_missing_metadata',
+      severity: 'info' as const,
+      nodeUri: r.source,
+      nodeLabel: label,
+      message: `Source "${label}" is missing ${missing.join(' and ')}.`,
+      suggestedAction: missing.includes('title')
+        ? 'Open meta.ttl and set dc:title.'
+        : 'Open meta.ttl and add dc:creator entries.',
+    };
+  });
+}
+
+/**
+ * Reference stubs (#106) that have lingered unresolved for more
+ * than `thresholdDays` days (#119). Soft prompt to run Resolve
+ * (#107) or hand-fix the stub.
+ */
+async function checkLongUnresolvedStubs(ctx: ProjectContext, thresholdDays: number): Promise<Inspection[]> {
+  const cutoff = new Date(Date.now() - thresholdDays * 86400000).toISOString();
+  const results = await queryGraph(ctx, `
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    PREFIX dc: <http://purl.org/dc/terms/>
+    SELECT ?source ?sourceId ?title ?modified WHERE {
+      ?source minerva:sourceId ?sourceId .
+      ?source thought:stubStatus "unresolved" .
+      ?source dc:modified ?modified .
+      OPTIONAL { ?source dc:title ?title }
+      FILTER(?modified < "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+    }
+    ORDER BY ?modified
+    LIMIT 50
+  `);
+
+  return (results.results as Record<string, string>[]).map((r, i) => {
+    const label = r.title || r.sourceId;
+    return {
+      id: `stub-aged-${i}`,
+      type: 'stub_aged',
+      severity: 'info' as const,
+      nodeUri: r.source,
+      nodeLabel: label,
+      message: `Stub "${label}" has been unresolved since ${r.modified.split('T')[0]}.`,
+      suggestedAction: 'Right-click the source and run "Resolve to full source", or hand-edit meta.ttl.',
+    };
+  });
+}
+
+/**
+ * Sources cited by at least one note whose readStatus is unset or
+ * explicitly "unread" (#119). Soft nudge — "you cited this; have
+ * you read it?"
+ */
+async function checkCitedUnreadSources(ctx: ProjectContext): Promise<Inspection[]> {
+  const results = await queryGraph(ctx, `
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    PREFIX dc: <http://purl.org/dc/terms/>
+    SELECT ?source ?sourceId ?title (COUNT(DISTINCT ?note) AS ?cites) WHERE {
+      ?source minerva:sourceId ?sourceId .
+      ?note thought:cites ?source .
+      OPTIONAL { ?source dc:title ?title }
+      OPTIONAL { ?source minerva:readStatus ?status }
+      FILTER(!BOUND(?status) || ?status = "unread")
+      FILTER NOT EXISTS { ?source thought:stubStatus ?_stub }
+    }
+    GROUP BY ?source ?sourceId ?title
+    ORDER BY DESC(?cites)
+    LIMIT 25
+  `);
+
+  return (results.results as Record<string, string>[]).map((r, i) => {
+    const label = r.title || r.sourceId;
+    const count = Number(r.cites ?? 0) || 0;
+    return {
+      id: `source-cited-unread-${i}`,
+      type: 'source_cited_unread',
+      severity: 'info' as const,
+      nodeUri: r.source,
+      nodeLabel: label,
+      message: `"${label}" is cited ${count === 1 ? 'once' : `${count} times`} but you haven't marked it Reading or Read.`,
+      suggestedAction: 'Open the source and set its reading status, or right-click → Mark reading.',
+    };
+  });
+}
+
+/**
+ * Sources sharing the same DOI or URL (#119). After the canonical-id
+ * rules (#90) this shouldn't happen — but if a user hand-creates a
+ * source folder, or two ingests raced before the dedupe landed,
+ * the safety net flags the duplicates so they can be merged via
+ * #90 part 2.
+ */
+async function checkDuplicateSources(ctx: ProjectContext): Promise<Inspection[]> {
+  const inspections: Inspection[] = [];
+
+  // Duplicate DOIs (lowercased).
+  const dupDois = await queryGraph(ctx, `
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    PREFIX bibo: <http://purl.org/ontology/bibo/>
+    PREFIX dc: <http://purl.org/dc/terms/>
+    SELECT ?keyDoi (GROUP_CONCAT(DISTINCT ?source; SEPARATOR=" || ") AS ?sources)
+           (GROUP_CONCAT(DISTINCT ?sourceId; SEPARATOR=" || ") AS ?ids) WHERE {
+      ?source minerva:sourceId ?sourceId .
+      ?source bibo:doi ?doi .
+      BIND(LCASE(?doi) AS ?keyDoi)
+    }
+    GROUP BY ?keyDoi
+    HAVING (COUNT(DISTINCT ?source) > 1)
+    LIMIT 25
+  `);
+  for (const [i, r] of (dupDois.results as Record<string, string>[]).entries()) {
+    const ids = (r.ids ?? '').split(' || ').filter(Boolean);
+    const firstSource = (r.sources ?? '').split(' || ')[0] ?? '';
+    inspections.push({
+      id: `dup-doi-${i}`,
+      type: 'source_duplicate_doi',
+      severity: 'warning',
+      nodeUri: firstSource,
+      nodeLabel: ids[0] ?? r.keyDoi,
+      message: `Duplicate DOI ${r.keyDoi}: ${ids.length} sources (${ids.join(', ')}).`,
+      suggestedAction: 'Right-click one and choose "Merge into…" to consolidate.',
+    });
+  }
+
+  // Duplicate URIs (lowercased, trailing slash normalised).
+  const dupUris = await queryGraph(ctx, `
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    PREFIX bibo: <http://purl.org/ontology/bibo/>
+    SELECT ?keyUri (GROUP_CONCAT(DISTINCT ?source; SEPARATOR=" || ") AS ?sources)
+           (GROUP_CONCAT(DISTINCT ?sourceId; SEPARATOR=" || ") AS ?ids) WHERE {
+      ?source minerva:sourceId ?sourceId .
+      ?source bibo:uri ?uri .
+      BIND(LCASE(REPLACE(STR(?uri), "/$", "")) AS ?keyUri)
+    }
+    GROUP BY ?keyUri
+    HAVING (COUNT(DISTINCT ?source) > 1)
+    LIMIT 25
+  `);
+  for (const [i, r] of (dupUris.results as Record<string, string>[]).entries()) {
+    const ids = (r.ids ?? '').split(' || ').filter(Boolean);
+    const firstSource = (r.sources ?? '').split(' || ')[0] ?? '';
+    inspections.push({
+      id: `dup-uri-${i}`,
+      type: 'source_duplicate_uri',
+      severity: 'warning',
+      nodeUri: firstSource,
+      nodeLabel: ids[0] ?? r.keyUri,
+      message: `Duplicate URL ${r.keyUri}: ${ids.length} sources (${ids.join(', ')}).`,
+      suggestedAction: 'Right-click one and choose "Merge into…" to consolidate.',
+    });
+  }
+
+  return inspections;
 }
 
 // ── Timer ──────────────────────────────────────────────────────────────────

--- a/tests/main/graph/source-health-checks.test.ts
+++ b/tests/main/graph/source-health-checks.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Source-related inspections (#119). Each check is shape-only —
+ * no network — so the tests build a real graph state and run the
+ * pass.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexSource, indexNote } from '../../../src/main/graph/index';
+import { runAllChecks } from '../../../src/main/graph/health-checks';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function buildMeta(extra = '', subtype = 'Article'): string {
+  return `this: a thought:${subtype} ;
+${extra}    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+}
+
+function makeSourceOnDisk(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl);
+}
+
+describe('source health checks (#119)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-src-health-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  // ─── missing metadata ───────────────────────────────────────────────────
+
+  it('flags sources missing dc:title', async () => {
+    const ttl = buildMeta('    dc:creator "Alice" ;\n');
+    makeSourceOnDisk(root, 'no-title', ttl);
+    indexSource(ctx, 'no-title', ttl);
+    const inspections = await runAllChecks(ctx);
+    const missing = inspections.filter((i) => i.type === 'source_missing_metadata');
+    expect(missing).toHaveLength(1);
+    expect(missing[0].message).toContain('title');
+  });
+
+  it('flags sources missing dc:creator', async () => {
+    const ttl = buildMeta('    dc:title "Solo author piece" ;\n');
+    makeSourceOnDisk(root, 'no-author', ttl);
+    indexSource(ctx, 'no-author', ttl);
+    const inspections = await runAllChecks(ctx);
+    const missing = inspections.filter((i) => i.type === 'source_missing_metadata');
+    expect(missing).toHaveLength(1);
+    expect(missing[0].message).toContain('authors');
+  });
+
+  it('does not flag a fully-populated source', async () => {
+    const ttl = buildMeta('    dc:title "Complete" ;\n    dc:creator "Smith" ;\n');
+    makeSourceOnDisk(root, 'ok', ttl);
+    indexSource(ctx, 'ok', ttl);
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'source_missing_metadata')).toBe(false);
+  });
+
+  it('does not flag stubs for missing metadata (they\'re intentionally partial)', async () => {
+    const ttl = buildMeta('    thought:stubStatus "unresolved" ;\n');
+    makeSourceOnDisk(root, 'stub-1', ttl);
+    indexSource(ctx, 'stub-1', ttl);
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'source_missing_metadata')).toBe(false);
+  });
+
+  // ─── long-unresolved stubs ──────────────────────────────────────────────
+
+  it('flags stubs older than 30 days', async () => {
+    const ttl = buildMeta('    dc:title "Aged stub" ;\n    thought:stubStatus "unresolved" ;\n');
+    makeSourceOnDisk(root, 'aged-stub', ttl);
+    indexSource(ctx, 'aged-stub', ttl);
+    // dc:modified is sourced from the file's mtime; backdate so the
+    // staleness check fires.
+    const old = new Date(Date.now() - 45 * 86400000);
+    fs.utimesSync(path.join(root, '.minerva', 'sources', 'aged-stub', 'meta.ttl'), old, old);
+    indexSource(ctx, 'aged-stub', ttl);
+    const inspections = await runAllChecks(ctx);
+    const aged = inspections.filter((i) => i.type === 'stub_aged');
+    expect(aged).toHaveLength(1);
+    expect(aged[0].message).toContain('Aged stub');
+  });
+
+  it('does not flag freshly-created stubs', async () => {
+    const ttl = buildMeta('    dc:title "Fresh stub" ;\n    thought:stubStatus "unresolved" ;\n');
+    makeSourceOnDisk(root, 'fresh-stub', ttl);
+    indexSource(ctx, 'fresh-stub', ttl);
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'stub_aged')).toBe(false);
+  });
+
+  // ─── cited but unread ───────────────────────────────────────────────────
+
+  it('flags a source that\'s cited but has no readStatus', async () => {
+    const ttl = buildMeta('    dc:title "Cited paper" ;\n    dc:creator "Smith" ;\n');
+    makeSourceOnDisk(root, 'cited-paper', ttl);
+    indexSource(ctx, 'cited-paper', ttl);
+    await indexNote(ctx, 'note.md', '# Note\n\nSee [[cite::cited-paper]] for context.\n');
+    const inspections = await runAllChecks(ctx);
+    const flagged = inspections.filter((i) => i.type === 'source_cited_unread');
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].nodeLabel).toBe('Cited paper');
+  });
+
+  it('does not flag a cited source that\'s marked reading', async () => {
+    const ttl = buildMeta('    dc:title "Cited paper" ;\n    dc:creator "Smith" ;\n    minerva:readStatus "reading" ;\n');
+    makeSourceOnDisk(root, 'cited-paper', ttl);
+    indexSource(ctx, 'cited-paper', ttl);
+    await indexNote(ctx, 'note.md', '[[cite::cited-paper]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'source_cited_unread')).toBe(false);
+  });
+
+  it('flags a cited source that\'s explicitly "unread"', async () => {
+    const ttl = buildMeta('    dc:title "Cited paper" ;\n    dc:creator "Smith" ;\n    minerva:readStatus "unread" ;\n');
+    makeSourceOnDisk(root, 'cited-paper', ttl);
+    indexSource(ctx, 'cited-paper', ttl);
+    await indexNote(ctx, 'note.md', '[[cite::cited-paper]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'source_cited_unread')).toBe(true);
+  });
+
+  // ─── duplicate DOI / URI ────────────────────────────────────────────────
+
+  it('flags two sources sharing the same DOI (case-insensitive)', async () => {
+    const a = buildMeta('    dc:title "A" ;\n    bibo:doi "10.1145/Foo" ;\n');
+    const b = buildMeta('    dc:title "B" ;\n    bibo:doi "10.1145/foo" ;\n');
+    makeSourceOnDisk(root, 'dup-a', a);
+    makeSourceOnDisk(root, 'dup-b', b);
+    indexSource(ctx, 'dup-a', a);
+    indexSource(ctx, 'dup-b', b);
+    const inspections = await runAllChecks(ctx);
+    const dup = inspections.filter((i) => i.type === 'source_duplicate_doi');
+    expect(dup).toHaveLength(1);
+    expect(dup[0].message).toContain('dup-a');
+    expect(dup[0].message).toContain('dup-b');
+  });
+
+  it('flags two sources sharing the same URL (trailing-slash normalised)', async () => {
+    const a = buildMeta('    dc:title "A" ;\n    bibo:uri "https://example.com/x" ;\n');
+    const b = buildMeta('    dc:title "B" ;\n    bibo:uri "https://example.com/x/" ;\n');
+    makeSourceOnDisk(root, 'url-a', a);
+    makeSourceOnDisk(root, 'url-b', b);
+    indexSource(ctx, 'url-a', a);
+    indexSource(ctx, 'url-b', b);
+    const inspections = await runAllChecks(ctx);
+    const dup = inspections.filter((i) => i.type === 'source_duplicate_uri');
+    expect(dup).toHaveLength(1);
+  });
+
+  it('does not flag a single source with a unique DOI', async () => {
+    const ttl = buildMeta('    dc:title "Solo" ;\n    dc:creator "Smith" ;\n    bibo:doi "10.1145/unique" ;\n');
+    makeSourceOnDisk(root, 'solo', ttl);
+    indexSource(ctx, 'solo', ttl);
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'source_duplicate_doi')).toBe(false);
+  });
+});


### PR DESCRIPTION
Four new checks running through the existing ambient-intelligence inspections pipeline so the right-sidebar panel surfaces data-quality issues on sources without the user having to go looking.

## Checks

- **\`source_missing_metadata\`** (info) — sources without \`dc:title\` OR \`dc:creator\`. Stubs are excluded; they're intentionally partial. Surfaces as "Source 'X' is missing title / authors."
- **\`stub_aged\`** (info) — reference stubs (#106) that have lingered unresolved for >30 days. Suggests Resolve (#107) or a hand-edit.
- **\`source_cited_unread\`** (info) — a source cited from at least one note where readStatus is unset or "unread". Soft nudge — "you cited this; have you read it?" Excludes stubs.
- **\`source_duplicate_doi\`** + **\`source_duplicate_uri\`** (warning) — safety net against canonical-id (#90) bypass: two sources sharing the same lower-cased DOI or trailing-slash-normalised URL. Suggested action is the merge-sources command (#90 part 2).

## Tests
12 cases in \`source-health-checks.test.ts\`:
- missing-title / missing-author / fully-populated / stub-excluded
- aged stub (mtime backdated 45d) vs fresh stub
- cited-unread vs cited-reading vs cited-explicitly-unread
- duplicate DOI (case-insensitive) vs duplicate URL (trailing-slash normalised) vs unique

Full suite **2429 / 2429** (+12 new).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**: Inspections panel shows the new rows on a project with stubs / cited-unread / hand-authored partial sources.

Closes #119.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)