### PR TITLE
feat: broken-link inspection (#140)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -1,5 +1,6 @@
-import { queryGraph } from './index';
+import { queryGraph, headingsFor } from './index';
 import type { ProjectContext } from '../project-context-types';
+import { LINK_TYPES } from '../../shared/link-types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -43,6 +44,7 @@ export async function runAllChecks(ctx: ProjectContext): Promise<Inspection[]> {
       checkLongUnresolvedStubs(ctx, 30), // 30 days
       checkCitedUnreadSources(ctx),
       checkDuplicateSources(ctx),
+      checkBrokenLinks(ctx),
     ]);
     const flat = results.flat();
     lastResultsByProject.set(ctx.rootPath, flat);
@@ -402,6 +404,197 @@ async function checkDuplicateSources(ctx: ProjectContext): Promise<Inspection[]>
   }
 
   return inspections;
+}
+
+/**
+ * Walk every typed wiki-link triple in the graph and flag the ones
+ * whose target doesn't exist (#140). Three kinds of breakage:
+ *
+ *   - **broken_note_link** — `[[missing-note]]` or any typed link to
+ *     a note relativePath that isn't in the project.
+ *   - **broken_anchor_link** — `[[note#heading]]` where the note
+ *     exists but no heading slugifies to the fragment. (Block-id
+ *     anchors `#^id` are intentionally skipped — they don't live in
+ *     the graph; checking them would need a full body re-scan.)
+ *   - **broken_cite_quote** — `[[cite::id]]` / `[[quote::id]]` where
+ *     no source / excerpt exists with that id.
+ *
+ * Severity is `warning`: broken links are often intentional WIP
+ * stubs, not data-corruption. The inspection reports; the user
+ * fixes (no auto-fix per scope note).
+ */
+async function checkBrokenLinks(ctx: ProjectContext): Promise<Inspection[]> {
+  // Build the IN-list of link predicates from the typed-link
+  // registry so adding a new link type elsewhere automatically
+  // extends the check.
+  const predicateIris = LINK_TYPES.map((lt) => {
+    const ns = lt.predicateNamespace === 'thought'
+      ? 'https://minerva.dev/ontology/thought#'
+      : 'https://minerva.dev/ontology#';
+    return `<${ns}${lt.predicate}>`;
+  });
+  const valuesClause = predicateIris.join(' ');
+
+  // Pre-fetch the valid-target sets so per-row lookups are O(1).
+  const [notesRes, sourcesRes, excerptsRes] = await Promise.all([
+    queryGraph(ctx, `
+      PREFIX minerva: <https://minerva.dev/ontology#>
+      SELECT ?path WHERE { ?n minerva:relativePath ?path . ?n a minerva:Note }
+    `),
+    queryGraph(ctx, `
+      PREFIX minerva: <https://minerva.dev/ontology#>
+      SELECT ?id WHERE { ?s minerva:sourceId ?id }
+    `),
+    queryGraph(ctx, `
+      PREFIX minerva: <https://minerva.dev/ontology#>
+      SELECT ?id WHERE { ?e minerva:excerptId ?id }
+    `),
+  ]);
+  const validNotes = new Set((notesRes.results as { path: string }[]).map((r) => r.path));
+  const validSources = new Set((sourcesRes.results as { id: string }[]).map((r) => r.id));
+  const validExcerpts = new Set((excerptsRes.results as { id: string }[]).map((r) => r.id));
+
+  // Walk every link triple — across every typed-link predicate.
+  const linksRes = await queryGraph(ctx, `
+    PREFIX minerva: <https://minerva.dev/ontology#>
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    SELECT ?source ?sourcePath ?predicate ?target WHERE {
+      ?source minerva:relativePath ?sourcePath .
+      ?source ?predicate ?target .
+      VALUES ?predicate { ${valuesClause} }
+    }
+    LIMIT 1000
+  `);
+
+  const inspections: Inspection[] = [];
+  let counter = 0;
+  for (const row of linksRes.results as { source: string; sourcePath: string; predicate: string; target: string }[]) {
+    const classified = classifyTarget(row.target);
+    if (!classified) continue;
+    const ins = inspectionForBrokenLink(ctx, row, classified, validNotes, validSources, validExcerpts, counter);
+    if (ins) {
+      inspections.push(ins);
+      counter++;
+    }
+    if (inspections.length >= 50) break; // soft cap so we don't drown the panel
+  }
+  return inspections;
+}
+
+/** A wiki-link target IRI parsed into kind + base + optional fragment. */
+interface ClassifiedTarget {
+  kind: 'note' | 'source' | 'excerpt' | null;
+  /** The identifier portion — relativePath for notes (with `.md`),
+   *  sourceId / excerptId for the others. URL-decoded. */
+  id: string;
+  /** Fragment after `#`, decoded; null when none. */
+  anchor: string | null;
+}
+
+function classifyTarget(iri: string): ClassifiedTarget | null {
+  // Strip the fragment first so we can match against the base form.
+  const hashIdx = iri.lastIndexOf('#');
+  const base = hashIdx >= 0 ? iri.slice(0, hashIdx) : iri;
+  const anchor = hashIdx >= 0 ? decode(iri.slice(hashIdx + 1)) : null;
+
+  // Match the segment after the last `note/` / `source/` / `excerpt/`.
+  const noteIdx = base.lastIndexOf('/note/');
+  if (noteIdx >= 0) {
+    const id = decodeSegmented(base.slice(noteIdx + '/note/'.length));
+    // Note URIs in the indexer carry a `.md` suffix on the path
+    // string (e.g. `path/foo.md`); add it for matching.
+    return { kind: 'note', id: id.endsWith('.md') ? id : `${id}.md`, anchor };
+  }
+  const sourceIdx = base.lastIndexOf('/source/');
+  if (sourceIdx >= 0) {
+    return { kind: 'source', id: decode(base.slice(sourceIdx + '/source/'.length)), anchor };
+  }
+  const excerptIdx = base.lastIndexOf('/excerpt/');
+  if (excerptIdx >= 0) {
+    return { kind: 'excerpt', id: decode(base.slice(excerptIdx + '/excerpt/'.length)), anchor };
+  }
+  return null; // external URI or unknown shape — not our concern.
+}
+
+function decode(s: string): string {
+  try { return decodeURIComponent(s); }
+  catch { return s; }
+}
+
+/** Decode a `note/` path that's been segment-encoded so slashes survive. */
+function decodeSegmented(s: string): string {
+  return s.split('/').map(decode).join('/');
+}
+
+function inspectionForBrokenLink(
+  ctx: ProjectContext,
+  row: { source: string; sourcePath: string; predicate: string; target: string },
+  classified: ClassifiedTarget,
+  validNotes: Set<string>,
+  validSources: Set<string>,
+  validExcerpts: Set<string>,
+  index: number,
+): Inspection | null {
+  if (classified.kind === 'source') {
+    if (validSources.has(classified.id)) return null;
+    return {
+      id: `broken-cite-${index}`,
+      type: 'broken_cite_quote',
+      severity: 'warning',
+      nodeUri: row.source,
+      nodeLabel: row.sourcePath,
+      message: `Note "${row.sourcePath}" cites an unknown source: ${classified.id}`,
+      suggestedAction: 'Ingest the source via Ingest Identifier… or fix the `[[cite::id]]` target.',
+    };
+  }
+  if (classified.kind === 'excerpt') {
+    if (validExcerpts.has(classified.id)) return null;
+    return {
+      id: `broken-quote-${index}`,
+      type: 'broken_cite_quote',
+      severity: 'warning',
+      nodeUri: row.source,
+      nodeLabel: row.sourcePath,
+      message: `Note "${row.sourcePath}" quotes an unknown excerpt: ${classified.id}`,
+      suggestedAction: 'Create the excerpt from the source viewer, or fix the `[[quote::id]]` target.',
+    };
+  }
+  if (classified.kind === 'note') {
+    if (!validNotes.has(classified.id)) {
+      const linkText = classified.anchor
+        ? `${classified.id.replace(/\.md$/, '')}#${classified.anchor}`
+        : classified.id.replace(/\.md$/, '');
+      return {
+        id: `broken-note-${index}`,
+        type: 'broken_note_link',
+        severity: 'warning',
+        nodeUri: row.source,
+        nodeLabel: row.sourcePath,
+        message: `Note "${row.sourcePath}" links to a missing note: [[${linkText}]]`,
+        suggestedAction: 'Create the target note, fix the spelling, or remove the link.',
+      };
+    }
+    // Note exists. Check anchor when one was specified.
+    // Block-id anchors (`#^id`) intentionally skipped — they're
+    // scattered through the note body, not stored as triples.
+    if (classified.anchor && !classified.anchor.startsWith('^')) {
+      const headings = headingsFor(ctx, classified.id);
+      const found = headings.some((h) => h.slug === classified.anchor);
+      if (!found) {
+        const stem = classified.id.replace(/\.md$/, '');
+        return {
+          id: `broken-anchor-${index}`,
+          type: 'broken_anchor_link',
+          severity: 'warning',
+          nodeUri: row.source,
+          nodeLabel: row.sourcePath,
+          message: `Note "${row.sourcePath}" links to a missing heading: [[${stem}#${classified.anchor}]]`,
+          suggestedAction: 'Add the heading to the target note, fix the anchor slug, or remove the `#…` part.',
+        };
+      }
+    }
+  }
+  return null;
 }
 
 // ── Timer ──────────────────────────────────────────────────────────────────

--- a/tests/main/graph/broken-link-inspection.test.ts
+++ b/tests/main/graph/broken-link-inspection.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Broken-link inspection (#140). Three flavours: missing note,
+ * missing anchor, unknown cite/quote id.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, indexSource, indexExcerpt } from '../../../src/main/graph/index';
+import { runAllChecks } from '../../../src/main/graph/health-checks';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const SOURCE_META = `this: a thought:Article ;
+    dc:title "A paper" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+const EXCERPT_TTL = `this: a thought:Excerpt ;
+    thought:fromSource sources:smith-2023 ;
+    thought:citedText "..." .
+`;
+
+function writeSource(root: string, id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl);
+}
+
+describe('broken-link inspection (#140)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-broken-links-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  // ─── broken note link ───────────────────────────────────────────────────
+
+  it('flags a [[missing-note]] wiki-link', async () => {
+    await indexNote(ctx, 'a.md', '# A\n\nLinks to [[missing-note]] for context.\n');
+    const inspections = await runAllChecks(ctx);
+    const broken = inspections.filter((i) => i.type === 'broken_note_link');
+    expect(broken).toHaveLength(1);
+    expect(broken[0].message).toContain('missing-note');
+    expect(broken[0].nodeLabel).toBe('a.md');
+    expect(broken[0].severity).toBe('warning');
+  });
+
+  it('does not flag a link to an existing note', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n');
+    await indexNote(ctx, 'source.md', '# S\n\n[[target]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(false);
+  });
+
+  it('flags a typed broken link too (`[[supports::missing]]`)', async () => {
+    await indexNote(ctx, 'a.md', '[[supports::missing-note]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(true);
+  });
+
+  // ─── broken anchor link ─────────────────────────────────────────────────
+
+  it('flags a [[note#missing-heading]] when the note exists but the heading does not', async () => {
+    await indexNote(ctx, 'target.md', '# Real heading\n\nbody\n');
+    await indexNote(ctx, 'source.md', '# S\n\nSee [[target#missing-heading]]\n');
+    const inspections = await runAllChecks(ctx);
+    const broken = inspections.filter((i) => i.type === 'broken_anchor_link');
+    expect(broken).toHaveLength(1);
+    expect(broken[0].message).toContain('missing-heading');
+  });
+
+  it('does not flag [[note#real-heading]] when the heading exists', async () => {
+    await indexNote(ctx, 'target.md', '# Real heading\n\nbody\n');
+    await indexNote(ctx, 'source.md', '[[target#real-heading]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_anchor_link')).toBe(false);
+  });
+
+  it('does not flag block-id anchors (`#^id`) — they\'re not in the graph', async () => {
+    // Even if no `^id` exists in target.md, the inspection should
+    // skip rather than false-flag.
+    await indexNote(ctx, 'target.md', '# T\n\nplain body\n');
+    await indexNote(ctx, 'source.md', '[[target#^somewhere]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_anchor_link')).toBe(false);
+  });
+
+  // ─── broken cite / quote ────────────────────────────────────────────────
+
+  it('flags [[cite::unknown-source]]', async () => {
+    await indexNote(ctx, 'a.md', '# A\n\nAs [[cite::unknown-source]] shows.\n');
+    const inspections = await runAllChecks(ctx);
+    const broken = inspections.filter((i) => i.type === 'broken_cite_quote');
+    expect(broken).toHaveLength(1);
+    expect(broken[0].message).toContain('unknown-source');
+  });
+
+  it('does not flag [[cite::known]] for a real source', async () => {
+    writeSource(root, 'smith-2023', SOURCE_META);
+    indexSource(ctx, 'smith-2023', SOURCE_META);
+    await indexNote(ctx, 'a.md', '[[cite::smith-2023]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_cite_quote')).toBe(false);
+  });
+
+  it('flags [[quote::unknown-excerpt]]', async () => {
+    await indexNote(ctx, 'a.md', '[[quote::unknown-excerpt]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_cite_quote')).toBe(true);
+  });
+
+  it('does not flag [[quote::known]] for a real excerpt', async () => {
+    writeSource(root, 'smith-2023', SOURCE_META);
+    indexSource(ctx, 'smith-2023', SOURCE_META);
+    indexExcerpt(ctx, 'p42-graphs', EXCERPT_TTL);
+    await indexNote(ctx, 'a.md', '[[quote::p42-graphs]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_cite_quote')).toBe(false);
+  });
+});


### PR DESCRIPTION
New health-check pass that walks every typed wiki-link triple in the graph and flags three flavours of breakage:

- **\`broken_note_link\`** — \`[[missing-note]]\` (or any typed link) whose target relativePath isn't in the project.
- **\`broken_anchor_link\`** — \`[[note#heading]]\` where the note exists but no heading slugifies to the fragment. Block-id anchors (\`#^id\`) are intentionally skipped — they're scattered through the note body, not stored as triples.
- **\`broken_cite_quote\`** — \`[[cite::id]]\` / \`[[quote::id]]\` where no source / excerpt exists with that id.

Severity \`warning\` per the issue's note that broken links are often intentional WIP stubs; the inspection reports, the user fixes (no auto-fix).

## Implementation
- Predicate IN-list built dynamically from \`LINK_TYPES\` so adding a new typed link automatically extends the check.
- Pre-fetches valid-target sets (note paths, source ids, excerpt ids) once so per-row lookups are O(1).
- Single SPARQL pass over all link triples (LIMIT 1000), 50-row soft cap on emitted inspections so we never drown the panel.
- Anchor validation uses the existing in-memory \`headingsFor\` helper (heading slugs aren't in the graph — they live in \`state.headingsPerNote\`).

## Tests
10 cases in \`broken-link-inspection.test.ts\`:
- missing-note: bare \`[[x]]\` + typed \`[[supports::x]]\`
- present note → no flag
- missing heading vs present heading
- block-id anchors skipped (no false-flag)
- broken cite vs known cite
- broken quote vs known quote

Full suite **2439 / 2439** (+10).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` passes
- [x] \`pnpm dev\` boots clean
- [ ] **UI verification**: Inspections panel shows the three new rows on a thoughtbase with deliberately-broken links.

Closes #140.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)