### PR TITLE
feat: safe-by-default delete with external-reference pre-flight (#429)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1921,7 +1921,7 @@ export function allTags(ctx: ProjectContext): string[] {
 
 // ── Link queries ────────────────────────────────────────────────────────────
 
-import type { OutgoingLink, Backlink } from '../../shared/types';
+import type { OutgoingLink, Backlink, SafeDeleteBlocker } from '../../shared/types';
 import { LINK_TYPES } from '../../shared/link-types';
 
 export function outgoingLinks(ctx: ProjectContext, relativePath: string): OutgoingLink[] {
@@ -2082,6 +2082,112 @@ export function backlinks(ctx: ProjectContext, relativePath: string): Backlink[]
   }
 
   return results;
+}
+
+/**
+ * Safe-delete pre-flight (#429). Given the set of notes about to be
+ * deleted, return every inbound edge whose source is *not* itself in
+ * the set — i.e. the edges that would become broken links if the
+ * delete proceeded. Records are deduped per (target, source) and
+ * carry a count + a representative typed link-label when available.
+ *
+ * Selection-internal edges (where source ∈ paths) are filtered out so
+ * the "closed loop" case (A↔B both in the set) proceeds silently.
+ * Self-statements about the target node (its own type / title / path
+ * triples) are ignored — they aren't *inbound from another note*.
+ *
+ * Non-.md paths and unknown paths are skipped without error.
+ */
+export function findExternalInboundLinks(
+  ctx: ProjectContext,
+  paths: string[],
+): SafeDeleteBlocker[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  const targetSet = new Set(paths.filter((p) => p.endsWith('.md')));
+  if (targetSet.size === 0) return [];
+
+  // Build (path → noteUri) once and a reverse map (uriValue → path) so
+  // pass-A (anchored typed links) can identify which target a given
+  // object IRI points at without re-walking the set per statement.
+  const targetUris = new Map<string, $rdf.NamedNode>();
+  const uriToPath = new Map<string, string>();
+  for (const p of targetSet) {
+    const u = noteUri(state, p);
+    targetUris.set(p, u);
+    uriToPath.set(u.value, p);
+  }
+
+  // Predicate IRIs we consider "typed" — used both to label rows and
+  // to skip those predicates in the untyped sweep below (since we'll
+  // have already counted them with a richer label).
+  const typedPredByIri = new Map<string, LinkType>();
+  for (const lt of LINK_TYPES) {
+    if (lt.targetKind && lt.targetKind !== 'note') continue;
+    typedPredByIri.set(linkPredicate(lt).value, lt);
+  }
+
+  type Row = SafeDeleteBlocker;
+  const byKey = new Map<string, Row>();
+  const ensureRow = (target: string, sourceNode: $rdf.NamedNode): Row | null => {
+    const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
+    const sourcePath = pathStmts[0]?.object.value;
+    if (!sourcePath || !sourcePath.endsWith('.md')) return null;
+    if (targetSet.has(sourcePath)) return null;
+    const key = `${target} ${sourcePath}`;
+    let row = byKey.get(key);
+    if (!row) {
+      const titleStmts = store.statementsMatching(sourceNode, DC('title'), undefined);
+      row = {
+        target,
+        source: sourcePath,
+        sourceTitle: titleStmts[0]?.object.value ?? sourcePath,
+        linkLabel: null,
+        linkCount: 0,
+      };
+      byKey.set(key, row);
+    }
+    return row;
+  };
+
+  // Pass A — typed link predicates. Match both exact target IRI and
+  // anchored variants (`#heading`). This pass owns the linkLabel.
+  for (const lt of LINK_TYPES) {
+    if (lt.targetKind && lt.targetKind !== 'note') continue;
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
+    for (const st of stmts) {
+      const objValue = st.object.value;
+      const hashIdx = objValue.indexOf('#');
+      const baseValue = hashIdx === -1 ? objValue : objValue.slice(0, hashIdx);
+      const target = uriToPath.get(baseValue);
+      if (!target) continue;
+      const row = ensureRow(target, st.subject as $rdf.NamedNode);
+      if (!row) continue;
+      row.linkCount += 1;
+      if (!row.linkLabel) row.linkLabel = lt.label;
+    }
+  }
+
+  // Pass B — untyped sweep. Catches frontmatter wiki-links that
+  // materialise as `prov:wasDerivedFrom`, `thought:decomposes`, plain
+  // `[[…]]` → `minerva:linksTo`, etc. Skip predicates already covered
+  // by pass A so we don't double-count, and skip self-statements.
+  for (const [target, targetSym] of targetUris) {
+    for (const st of store.statementsMatching(undefined, undefined, targetSym)) {
+      if (typedPredByIri.has(st.predicate.value)) continue;
+      if (st.subject.equals(targetSym)) continue;
+      const row = ensureRow(target, st.subject as $rdf.NamedNode);
+      if (!row) continue;
+      row.linkCount += 1;
+    }
+  }
+
+  // Order for stable display: by target, then source.
+  return [...byKey.values()].sort((a, b) =>
+    a.target.localeCompare(b.target) || a.source.localeCompare(b.source),
+  );
 }
 
 // ── Source detail queries ───────────────────────────────────────────────────

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -761,6 +761,12 @@ export function registerIpcHandlers(): void {
     },
   );
 
+  ipcMain.handle(Channels.LINKS_EXTERNAL_INBOUND, (e, paths: string[]) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return graph.findExternalInboundLinks(projectContext(rootPath), paths);
+  });
+
   // Saved queries
   ipcMain.handle(Channels.QUERIES_LIST, (e) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -83,6 +83,8 @@ contextBridge.exposeInMainWorld('api', {
     bundle: (relativePath: string) => ipcRenderer.invoke(Channels.LINKS_BUNDLE, relativePath),
     citationsForNote: (relativePath: string, content?: string) =>
       ipcRenderer.invoke(Channels.LINKS_CITATIONS_FOR_NOTE, relativePath, content),
+    externalInbound: (paths: string[]) =>
+      ipcRenderer.invoke(Channels.LINKS_EXTERNAL_INBOUND, paths),
   },
   queries: {
     list: () => ipcRenderer.invoke(Channels.QUERIES_LIST),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -25,6 +25,8 @@
   import PromptDialog from './lib/components/PromptDialog.svelte';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
+  import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
+  import type { SafeDeleteBlocker } from '../shared/types';
   import { RESOLVE_AUTO_THRESHOLD } from '../shared/resolve-stub';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
@@ -955,6 +957,14 @@
    * (relativePath, isDirectory) args are kept for the legacy callback
    * signature but ignored when a selection exists.
    *
+   * Safe by default (#429): before the standard confirm, expand the
+   * selection to its set of .md descendants and query the graph for
+   * inbound links from notes outside that set. If any exist, show
+   * the blocker dialog instead — the user can Cancel, Open the first
+   * reference to fix it, or Delete anyway. The "Delete anyway" path
+   * skips the second confirm; the blocker dialog already established
+   * intent.
+   *
    * Best-effort across all targets: failures are collected and
    * reported in one summary dialog rather than aborting the batch.
    * `closeTabsForDeletedPath` runs per successful target so a folder
@@ -969,28 +979,68 @@
       : [{ relativePath, isDirectory }];
     if (targets.length === 0) return;
 
-    const noun = (() => {
-      if (targets.length === 1) return targets[0].isDirectory ? 'folder' : 'note';
-      const allDirs = targets.every((t) => t.isDirectory);
-      const allFiles = targets.every((t) => !t.isDirectory);
-      if (allDirs) return 'folders';
-      if (allFiles) return 'notes';
-      return 'items';
-    })();
+    // Build the .md set S that the pre-flight reference check needs.
+    // expandSelectionToNoteFiles takes whatever paths the user picked
+    // (folders or files) and yields the .md leaves underneath.
+    const inputPaths = new Set(targets.map((t) => t.relativePath));
+    const mdSet = expandSelectionToNoteFiles(inputPaths, notebase.files);
 
-    let message: string;
-    if (targets.length === 1) {
-      const name = targets[0].relativePath.split('/').pop();
-      message = `Delete ${noun} "${name}"?`;
-    } else {
-      const sample = targets.slice(0, 3).map((t) => t.relativePath).join(', ');
-      const more = targets.length > 3 ? ', …' : '';
-      message = `Delete ${targets.length} ${noun} (${sample}${more})?`;
+    let blockers: SafeDeleteBlocker[] = [];
+    if (mdSet.length > 0) {
+      try {
+        blockers = await api.links.externalInbound(mdSet);
+      } catch {
+        // Graph unreachable or transient: fail open (preserve old
+        // behaviour rather than block deletes on an indexing hiccup).
+        blockers = [];
+      }
     }
 
-    const confirmed = await showConfirm(message, CONFIRM_KEYS.delete, 'Delete');
-    if (!confirmed) return;
+    if (blockers.length > 0) {
+      safeDeleteDialogState = {
+        selectionCount: targets.length,
+        targets: mdSet,
+        blockers,
+        proceed: () => executeDeletes(targets),
+      };
+      return;
+    }
 
+    const noun = describeDeleteNoun(targets);
+    const confirmed = await showConfirm(
+      describeDeleteMessage(targets, noun),
+      CONFIRM_KEYS.delete,
+      'Delete',
+    );
+    if (!confirmed) return;
+    await executeDeletes(targets);
+  }
+
+  function describeDeleteNoun(targets: Array<{ isDirectory: boolean }>): string {
+    if (targets.length === 1) return targets[0].isDirectory ? 'folder' : 'note';
+    const allDirs = targets.every((t) => t.isDirectory);
+    const allFiles = targets.every((t) => !t.isDirectory);
+    if (allDirs) return 'folders';
+    if (allFiles) return 'notes';
+    return 'items';
+  }
+
+  function describeDeleteMessage(
+    targets: Array<{ relativePath: string; isDirectory: boolean }>,
+    noun: string,
+  ): string {
+    if (targets.length === 1) {
+      const name = targets[0].relativePath.split('/').pop();
+      return `Delete ${noun} "${name}"?`;
+    }
+    const sample = targets.slice(0, 3).map((t) => t.relativePath).join(', ');
+    const more = targets.length > 3 ? ', …' : '';
+    return `Delete ${targets.length} ${noun} (${sample}${more})?`;
+  }
+
+  async function executeDeletes(
+    targets: Array<{ relativePath: string; isDirectory: boolean }>,
+  ): Promise<void> {
     const failures: Array<{ path: string; error: string }> = [];
     for (const t of targets) {
       try {
@@ -1021,6 +1071,44 @@
         'OK',
       );
     }
+  }
+
+  /**
+   * Open the first linking note from the safe-delete blocker dialog
+   * and jump to the link site. We scan the source's content for the
+   * first `[[…<basename>…]]` occurrence — typed and untyped wiki-link
+   * forms both start with `[[`, and the target basename is enough to
+   * disambiguate within a single source. On no match we still open
+   * the note (offset 0) so the user lands somewhere useful.
+   */
+  async function openFirstReferenceFromSafeDelete(source: string, target: string): Promise<void> {
+    safeDeleteDialogState = null;
+    await editor.openFile(source);
+    try {
+      const content = await api.notebase.readFile(source);
+      const basename = target.replace(/\.md$/, '').split('/').pop() ?? '';
+      // Match `[[…basename]]`, `[[…basename|alias]]`, `[[…basename#anchor]]`
+      // — anchor allowed since #140's broken-link inspection considers anchor
+      // links as references too.
+      const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`\\[\\[[^\\]]*${escaped}[^\\]]*\\]\\]`);
+      const m = re.exec(content);
+      const offset = m?.index ?? 0;
+      const { line, col } = offsetToLineCol(content, offset);
+      requestAnimationFrame(() => editorComponent?.gotoLineColumn(line, col + 1));
+    } catch {
+      // File may have been deleted/moved between the dialog popping
+      // and the click — opening alone is enough.
+    }
+  }
+
+  function offsetToLineCol(text: string, offset: number): { line: number; col: number } {
+    let line = 1;
+    let col = 0;
+    for (let i = 0; i < offset && i < text.length; i++) {
+      if (text[i] === '\n') { line++; col = 0; } else { col++; }
+    }
+    return { line, col };
   }
 
   // ── Sidebar clipboard ──────────────────────────────────────────────────
@@ -2067,6 +2155,20 @@
     sourceId: string;
     stubTitle: string;
     candidates: import('../shared/resolve-stub').ResolveCandidate[];
+  } | null>(null);
+
+  /**
+   * Safe-delete blocker dialog state (#429). `proceed` is the
+   * "Delete anyway" closure — calling it runs the existing batch
+   * delete against the same `targets` snapshot the dialog was
+   * computed from. Cleared when the user picks any of the three
+   * exits or the dialog is dismissed.
+   */
+  let safeDeleteDialogState = $state<{
+    selectionCount: number;
+    targets: string[];
+    blockers: SafeDeleteBlocker[];
+    proceed: () => Promise<void>;
   } | null>(null);
 
   async function handleResolveStub(sourceId: string): Promise<void> {
@@ -3143,6 +3245,22 @@
       candidates={resolveStubState.candidates}
       onApply={handleResolveStubApply}
       onCancel={() => { resolveStubState = null; }}
+    />
+  {/if}
+  {#if safeDeleteDialogState}
+    {@const st = safeDeleteDialogState}
+    <SafeDeleteBlockerDialog
+      selectionCount={st.selectionCount}
+      targets={st.targets}
+      blockers={st.blockers}
+      onCancel={() => { safeDeleteDialogState = null; }}
+      onDeleteAnyway={async () => {
+        safeDeleteDialogState = null;
+        await st.proceed();
+      }}
+      onOpenFirstReference={(source, target) => {
+        void openFirstReferenceFromSafeDelete(source, target);
+      }}
     />
   {/if}
   {#if showCommandPalette}

--- a/src/renderer/lib/components/SafeDeleteBlockerDialog.svelte
+++ b/src/renderer/lib/components/SafeDeleteBlockerDialog.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+  /**
+   * Pre-flight block (#429) for Safe Delete. Shown when at least one
+   * selected note has an inbound link from outside the delete set —
+   * deleting would silently break that link.
+   *
+   * Three exits:
+   *   Cancel               — close, do nothing.
+   *   Delete anyway        — bypass to the original delete path.
+   *   Open first reference — open the first linking note so the user
+   *                          can fix the reference and retry.
+   *
+   * No "Don't ask again" — every delete with external blockers should
+   * surface; that's the whole point of safe-by-default. The earlier
+   * "Delete N notes?" confirm still has its own suppression for the
+   * no-blocker case.
+   */
+  import type { SafeDeleteBlocker } from '../../../shared/types';
+
+  interface Props {
+    /** Number of items the user originally selected (folders count once). */
+    selectionCount: number;
+    /** All `.md` paths in the delete set. Used to report "N of M blocked". */
+    targets: string[];
+    /** External inbound rows from `findExternalInboundLinks`. */
+    blockers: SafeDeleteBlocker[];
+    onCancel: () => void;
+    onDeleteAnyway: () => void;
+    /** Source + target of the first row, for "Open first reference". */
+    onOpenFirstReference: (source: string, target: string) => void;
+  }
+
+  let { selectionCount, targets, blockers, onCancel, onDeleteAnyway, onOpenFirstReference }: Props = $props();
+
+  // Group blockers by target for the display.
+  const grouped = $derived.by(() => {
+    const m = new Map<string, SafeDeleteBlocker[]>();
+    for (const b of blockers) {
+      const arr = m.get(b.target) ?? [];
+      arr.push(b);
+      m.set(b.target, arr);
+    }
+    return [...m.entries()];
+  });
+
+  const blockedTargetCount = $derived(grouped.length);
+  const totalLinks = $derived(blockers.reduce((n, b) => n + b.linkCount, 0));
+  const firstBlocker = $derived(blockers[0] ?? null);
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Safe Delete — external references found">
+    <header class="card-header">
+      <div class="eyebrow">SAFE DELETE · {blockedTargetCount} of {targets.length} blocked</div>
+      <h2 class="title">
+        {#if blockedTargetCount === 1}
+          1 note has external references
+        {:else}
+          {blockedTargetCount} notes have external references
+        {/if}
+      </h2>
+      <p class="sub">
+        {totalLinks} inbound link{totalLinks === 1 ? '' : 's'} from
+        {selectionCount === 1 ? 'this selection' : 'outside the selection'}
+        would become broken. Fix or remove the reference{totalLinks === 1 ? '' : 's'}, then retry —
+        or override with <em>Delete anyway</em>.
+      </p>
+    </header>
+
+    <div class="body">
+      <div class="list">
+        {#each grouped as [target, rows] (target)}
+          <div class="group">
+            <div class="group-head">{target}</div>
+            <div class="group-sub">referenced by:</div>
+            <ul class="refs">
+              {#each rows as r (r.source)}
+                <li>
+                  <span class="src">{r.source}</span>
+                  <span class="meta">
+                    {#if r.linkLabel}
+                      <span class="label">{r.linkLabel}</span> ·
+                    {/if}
+                    {r.linkCount} link{r.linkCount === 1 ? '' : 's'}
+                  </span>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel</span>
+      <span class="footer-actions">
+        <button class="btn ghost" onclick={onCancel}>Cancel</button>
+        <button
+          class="btn ghost"
+          disabled={!firstBlocker}
+          onclick={() => firstBlocker && onOpenFirstReference(firstBlocker.source, firstBlocker.target)}
+        >
+          Open first reference
+        </button>
+        <button class="btn primary" onclick={onDeleteAnyway}>Delete anyway</button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 640px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+  .card-header {
+    padding: 20px 24px 8px;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+  .sub {
+    margin: 6px 0 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+  .body {
+    padding: 12px 24px 18px;
+    overflow: auto;
+    flex: 1;
+  }
+  .list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .group {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg);
+  }
+  .group-head {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--text);
+    word-break: break-all;
+  }
+  .group-sub {
+    font-size: 11px;
+    color: var(--text-faint);
+    margin: 2px 0 6px;
+  }
+  .refs {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .refs li {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    font-size: 12.5px;
+  }
+  .src {
+    font-family: var(--font-mono);
+    color: var(--text);
+    word-break: break-all;
+  }
+  .meta {
+    color: var(--text-faint);
+    font-size: 11.5px;
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .label {
+    color: var(--text-muted);
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-actions {
+    display: inline-flex;
+    gap: 8px;
+  }
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .ghost {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .ghost:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .ghost:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  /* "primary" per CLAUDE.md — destructive verbs stay on accent, not red. */
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover {
+    opacity: 0.92;
+  }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -111,6 +111,10 @@ export interface LinksApi {
     relativePath: string,
     content?: string,
   ): Promise<import('../../../shared/types').CitationGroup[]>;
+  /** Safe-delete pre-flight (#429): inbound edges from outside `paths`. */
+  externalInbound(
+    paths: string[],
+  ): Promise<import('../../../shared/types').SafeDeleteBlocker[]>;
 }
 
 export interface QueriesApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -61,6 +61,9 @@ export const Channels = {
    * deduplicates triples.
    */
   LINKS_CITATIONS_FOR_NOTE: 'links:citationsForNote',
+  /** Safe-delete pre-flight (#429): given a set of .md paths slated
+   *  for deletion, return every inbound edge from outside that set. */
+  LINKS_EXTERNAL_INBOUND: 'links:externalInbound',
 
   // Saved queries
   QUERIES_LIST: 'queries:list',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -244,6 +244,23 @@ export interface CsvTableCollision {
   attemptedPath: string;
 }
 
+/** One inbound edge from outside the delete set into a note slated
+ *  for deletion (#429 Safe Delete). The renderer groups rows by
+ *  `target` to render the blocker dialog. */
+export interface SafeDeleteBlocker {
+  /** Note in the deletion set that has an external inbound edge. */
+  target: string;
+  /** Note outside the set that links into `target`. */
+  source: string;
+  /** Title of the linking note, falling back to its path. */
+  sourceTitle: string;
+  /** Human label for the most-specific link type that linked source →
+   *  target. `null` when only an untyped/frontmatter predicate hit. */
+  linkLabel: string | null;
+  /** Total inbound edges from source → target, across predicates. */
+  linkCount: number;
+}
+
 // ── Bookmarks ────────────────────────────────────────────────────────────
 
 export interface Bookmark {

--- a/tests/main/graph/safe-delete-preflight.test.ts
+++ b/tests/main/graph/safe-delete-preflight.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Pre-flight reference check for Safe Delete (#429). All cases use
+ * the live indexer + the real `findExternalInboundLinks` query —
+ * no mocking — so any future change to LINK_TYPES, predicate
+ * namespaces, or anchor handling continues to be exercised here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, findExternalInboundLinks } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('safe-delete pre-flight (#429)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-safe-delete-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  // ─── acceptance: standalone note with no inbound links ─────────────────
+
+  it('returns no blockers when nothing links into the selection', async () => {
+    await indexNote(ctx, 'orphan.md', '# Orphan\n\nNo one cites me.\n');
+    const blockers = await findExternalInboundLinks(ctx, ['orphan.md']);
+    expect(blockers).toEqual([]);
+  });
+
+  // ─── acceptance: external linker blocks delete ─────────────────────────
+
+  it('flags an external note that wiki-links into the selection', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n');
+    await indexNote(ctx, 'other.md', '# Other\n\nSee [[target]] for context.\n');
+    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].target).toBe('target.md');
+    expect(blockers[0].source).toBe('other.md');
+    expect(blockers[0].sourceTitle).toBe('Other');
+    expect(blockers[0].linkCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('captures the typed link-label when the inbound edge is typed', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n');
+    await indexNote(ctx, 'other.md', '# Other\n\n[[supports::target]]\n');
+    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].linkLabel).toBe('Supports');
+  });
+
+  // ─── acceptance: closed loop within the selection deletes silently ────
+
+  it('does not block when two notes only link to each other (closed loop)', async () => {
+    await indexNote(ctx, 'a.md', '# A\n\nSee [[b]].\n');
+    await indexNote(ctx, 'b.md', '# B\n\nSee [[a]].\n');
+    const blockers = await findExternalInboundLinks(ctx, ['a.md', 'b.md']);
+    expect(blockers).toEqual([]);
+  });
+
+  it('still flags when only one of a pair points outward', async () => {
+    await indexNote(ctx, 'a.md', '# A\n\nSee [[b]].\n');
+    await indexNote(ctx, 'b.md', '# B\n\nNo outgoing.\n');
+    await indexNote(ctx, 'outside.md', '# Outside\n\nSee [[a]].\n');
+    const blockers = await findExternalInboundLinks(ctx, ['a.md', 'b.md']);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].source).toBe('outside.md');
+    expect(blockers[0].target).toBe('a.md');
+  });
+
+  // ─── acceptance: folder bundle with only-internal references deletes ──
+
+  it('treats internal-only references inside a folder bundle as safe', async () => {
+    await indexNote(ctx, 'topic/intro.md', '# Intro\n\nSee [[topic/details|details]].\n');
+    await indexNote(ctx, 'topic/details.md', '# Details\n\nSee [[topic/intro]].\n');
+    const blockers = await findExternalInboundLinks(ctx, [
+      'topic/intro.md',
+      'topic/details.md',
+    ]);
+    expect(blockers).toEqual([]);
+  });
+
+  it('reports only the children that have outside referrers, not the whole folder', async () => {
+    await indexNote(ctx, 'topic/intro.md', '# Intro\n');
+    await indexNote(ctx, 'topic/details.md', '# Details\n');
+    await indexNote(ctx, 'outside.md', '# Outside\n\nSee [[topic/details]].\n');
+    const blockers = await findExternalInboundLinks(ctx, [
+      'topic/intro.md',
+      'topic/details.md',
+    ]);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].target).toBe('topic/details.md');
+    expect(blockers[0].source).toBe('outside.md');
+  });
+
+  // ─── multi-edge dedup ─────────────────────────────────────────────────
+
+  it('dedupes multiple edges between the same source/target into one row with linkCount', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n');
+    await indexNote(
+      ctx,
+      'other.md',
+      '# Other\n\n[[target]] and again [[supports::target]] and once more [[target]].\n',
+    );
+    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].linkCount).toBeGreaterThanOrEqual(2);
+    // A typed predicate landed in pass A so the label should be preserved
+    // (either `References` from the untyped [[target]] form or `Supports`
+    // from the explicit `[[supports::target]]` — both are typed wiki-links;
+    // first one through LINK_TYPES wins).
+    expect(['References', 'Supports']).toContain(blockers[0].linkLabel);
+  });
+
+  // ─── anchored links ──────────────────────────────────────────────────
+
+  it('flags anchored wiki-links (`[[target#heading]]`) as inbound references too', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n\n## Section\n');
+    await indexNote(ctx, 'other.md', '# Other\n\n[[supports::target#section]]\n');
+    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].source).toBe('other.md');
+  });
+
+  // ─── ignores non-.md and unknown paths ───────────────────────────────
+
+  it('skips non-.md paths in the input set', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n');
+    await indexNote(ctx, 'other.md', '# Other\n\n[[target]]\n');
+    // Pass a non-.md path alongside — it should be ignored, not throw.
+    const blockers = await findExternalInboundLinks(ctx, ['target.md', 'pics/diagram.png']);
+    expect(blockers).toHaveLength(1);
+  });
+
+  it('returns empty when called with no paths', async () => {
+    await indexNote(ctx, 'target.md', '# Target\n');
+    await indexNote(ctx, 'other.md', '# Other\n\n[[target]]\n');
+    expect(await findExternalInboundLinks(ctx, [])).toEqual([]);
+  });
+
+  // ─── order ──────────────────────────────────────────────────────────
+
+  it('orders rows by (target, source) for stable rendering', async () => {
+    await indexNote(ctx, 'b.md', '# B\n');
+    await indexNote(ctx, 'a.md', '# A\n');
+    await indexNote(ctx, 'z.md', '# Z\n\n[[a]] [[b]]\n');
+    await indexNote(ctx, 'x.md', '# X\n\n[[a]]\n');
+    const blockers = await findExternalInboundLinks(ctx, ['a.md', 'b.md']);
+    // Expect a.md rows before b.md rows; within a.md, x then z.
+    expect(blockers.map((b) => `${b.target} ← ${b.source}`)).toEqual([
+      'a.md ← x.md',
+      'a.md ← z.md',
+      'b.md ← z.md',
+    ]);
+  });
+});

--- a/tests/main/graph/safe-delete-preflight.test.ts
+++ b/tests/main/graph/safe-delete-preflight.test.ts
@@ -30,7 +30,7 @@ describe('safe-delete pre-flight (#429)', () => {
 
   it('returns no blockers when nothing links into the selection', async () => {
     await indexNote(ctx, 'orphan.md', '# Orphan\n\nNo one cites me.\n');
-    const blockers = await findExternalInboundLinks(ctx, ['orphan.md']);
+    const blockers = findExternalInboundLinks(ctx, ['orphan.md']);
     expect(blockers).toEqual([]);
   });
 
@@ -39,7 +39,7 @@ describe('safe-delete pre-flight (#429)', () => {
   it('flags an external note that wiki-links into the selection', async () => {
     await indexNote(ctx, 'target.md', '# Target\n');
     await indexNote(ctx, 'other.md', '# Other\n\nSee [[target]] for context.\n');
-    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    const blockers = findExternalInboundLinks(ctx, ['target.md']);
     expect(blockers).toHaveLength(1);
     expect(blockers[0].target).toBe('target.md');
     expect(blockers[0].source).toBe('other.md');
@@ -50,7 +50,7 @@ describe('safe-delete pre-flight (#429)', () => {
   it('captures the typed link-label when the inbound edge is typed', async () => {
     await indexNote(ctx, 'target.md', '# Target\n');
     await indexNote(ctx, 'other.md', '# Other\n\n[[supports::target]]\n');
-    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    const blockers = findExternalInboundLinks(ctx, ['target.md']);
     expect(blockers).toHaveLength(1);
     expect(blockers[0].linkLabel).toBe('Supports');
   });
@@ -60,7 +60,7 @@ describe('safe-delete pre-flight (#429)', () => {
   it('does not block when two notes only link to each other (closed loop)', async () => {
     await indexNote(ctx, 'a.md', '# A\n\nSee [[b]].\n');
     await indexNote(ctx, 'b.md', '# B\n\nSee [[a]].\n');
-    const blockers = await findExternalInboundLinks(ctx, ['a.md', 'b.md']);
+    const blockers = findExternalInboundLinks(ctx, ['a.md', 'b.md']);
     expect(blockers).toEqual([]);
   });
 
@@ -68,7 +68,7 @@ describe('safe-delete pre-flight (#429)', () => {
     await indexNote(ctx, 'a.md', '# A\n\nSee [[b]].\n');
     await indexNote(ctx, 'b.md', '# B\n\nNo outgoing.\n');
     await indexNote(ctx, 'outside.md', '# Outside\n\nSee [[a]].\n');
-    const blockers = await findExternalInboundLinks(ctx, ['a.md', 'b.md']);
+    const blockers = findExternalInboundLinks(ctx, ['a.md', 'b.md']);
     expect(blockers).toHaveLength(1);
     expect(blockers[0].source).toBe('outside.md');
     expect(blockers[0].target).toBe('a.md');
@@ -79,7 +79,7 @@ describe('safe-delete pre-flight (#429)', () => {
   it('treats internal-only references inside a folder bundle as safe', async () => {
     await indexNote(ctx, 'topic/intro.md', '# Intro\n\nSee [[topic/details|details]].\n');
     await indexNote(ctx, 'topic/details.md', '# Details\n\nSee [[topic/intro]].\n');
-    const blockers = await findExternalInboundLinks(ctx, [
+    const blockers = findExternalInboundLinks(ctx, [
       'topic/intro.md',
       'topic/details.md',
     ]);
@@ -90,7 +90,7 @@ describe('safe-delete pre-flight (#429)', () => {
     await indexNote(ctx, 'topic/intro.md', '# Intro\n');
     await indexNote(ctx, 'topic/details.md', '# Details\n');
     await indexNote(ctx, 'outside.md', '# Outside\n\nSee [[topic/details]].\n');
-    const blockers = await findExternalInboundLinks(ctx, [
+    const blockers = findExternalInboundLinks(ctx, [
       'topic/intro.md',
       'topic/details.md',
     ]);
@@ -108,7 +108,7 @@ describe('safe-delete pre-flight (#429)', () => {
       'other.md',
       '# Other\n\n[[target]] and again [[supports::target]] and once more [[target]].\n',
     );
-    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    const blockers = findExternalInboundLinks(ctx, ['target.md']);
     expect(blockers).toHaveLength(1);
     expect(blockers[0].linkCount).toBeGreaterThanOrEqual(2);
     // A typed predicate landed in pass A so the label should be preserved
@@ -123,7 +123,7 @@ describe('safe-delete pre-flight (#429)', () => {
   it('flags anchored wiki-links (`[[target#heading]]`) as inbound references too', async () => {
     await indexNote(ctx, 'target.md', '# Target\n\n## Section\n');
     await indexNote(ctx, 'other.md', '# Other\n\n[[supports::target#section]]\n');
-    const blockers = await findExternalInboundLinks(ctx, ['target.md']);
+    const blockers = findExternalInboundLinks(ctx, ['target.md']);
     expect(blockers).toHaveLength(1);
     expect(blockers[0].source).toBe('other.md');
   });
@@ -134,14 +134,14 @@ describe('safe-delete pre-flight (#429)', () => {
     await indexNote(ctx, 'target.md', '# Target\n');
     await indexNote(ctx, 'other.md', '# Other\n\n[[target]]\n');
     // Pass a non-.md path alongside — it should be ignored, not throw.
-    const blockers = await findExternalInboundLinks(ctx, ['target.md', 'pics/diagram.png']);
+    const blockers = findExternalInboundLinks(ctx, ['target.md', 'pics/diagram.png']);
     expect(blockers).toHaveLength(1);
   });
 
   it('returns empty when called with no paths', async () => {
     await indexNote(ctx, 'target.md', '# Target\n');
     await indexNote(ctx, 'other.md', '# Other\n\n[[target]]\n');
-    expect(await findExternalInboundLinks(ctx, [])).toEqual([]);
+    expect(findExternalInboundLinks(ctx, [])).toEqual([]);
   });
 
   // ─── order ──────────────────────────────────────────────────────────
@@ -151,7 +151,7 @@ describe('safe-delete pre-flight (#429)', () => {
     await indexNote(ctx, 'a.md', '# A\n');
     await indexNote(ctx, 'z.md', '# Z\n\n[[a]] [[b]]\n');
     await indexNote(ctx, 'x.md', '# X\n\n[[a]]\n');
-    const blockers = await findExternalInboundLinks(ctx, ['a.md', 'b.md']);
+    const blockers = findExternalInboundLinks(ctx, ['a.md', 'b.md']);
     // Expect a.md rows before b.md rows; within a.md, x then z.
     expect(blockers.map((b) => `${b.target} ← ${b.source}`)).toEqual([
       'a.md ← x.md',


### PR DESCRIPTION
## Summary
- Delete is now safe by default: a graph pre-flight checks every selected `.md` path for inbound wiki-links from notes *outside* the delete set. If any exist, a blocker dialog intercepts with Cancel / Open first reference / Delete anyway.
- Closed-loop selections (notes that only link to each other within the bundle) delete silently — the user gets the existing confirm and nothing else.
- Folder selections expand to their `.md` children; only the children with outside referrers are reported, not the whole folder.
- "Open first reference" opens the linking note and jumps the cursor to the first `[[…<basename>…]]` site so the user can rewrite or remove the link before retrying.

The pre-flight reuses the same `LINK_TYPES` registry + URI helpers as `backlinks()` / `findNotesLinkingTo()`, so any new link type added to `src/shared/link-types.ts` will continue to be enforced automatically. Untyped object-IRI hits (e.g. `prov:wasDerivedFrom` from `derived_from:` frontmatter) are covered by a second sweep.

Per CLAUDE.md the override stays on the accent color, not red — Delete is a normal operation backed by git, the dialog is just informational. No "Don't ask again" on the blocker dialog: surfacing externally-broken refs is the whole point.

Closes #429

## Test plan
- [x] `pnpm test` — 2451 tests pass (12 new in `tests/main/graph/safe-delete-preflight.test.ts` covering all #429 acceptance criteria)
- [x] `pnpm lint` clean
- [ ] Manual smoke: delete orphan → no dialog, confirm only. Delete linked-from-outside note → blocker dialog. Delete two notes that only link to each other → no dialog. "Open first reference" jumps to the link site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)