### PR TITLE
feat: highlight syntax (==text== / ==color:text==) — edit + preview (#468)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -30,6 +30,7 @@
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
+  import { highlightDecorations } from '../editor/highlight-decorations';
   import { computeCellsExtension } from '../editor/compute-cells';
   import { footnotePreview } from '../editor/footnote-preview';
   import { footnoteDecorations } from '../editor/footnote-decorations';
@@ -538,6 +539,7 @@
     }),
     footnotePreview(),
     footnoteDecorations(),
+    highlightDecorations(),
     EditorView.domEventHandlers({
       // Snapshot the selection at the very start of a right-click, before
       // any built-in handling can collapse it. Then, when the click is

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -16,6 +16,7 @@
   import 'katex/dist/katex.min.css';
   import { installMath } from '../../../shared/markdown/math-plugin';
   import { installDoiAutolink } from '../../../shared/markdown/doi-plugin';
+  import { installHighlight } from '../../../shared/markdown/highlight-plugin';
   import { installCallouts } from '../markdown/callout-plugin';
   import { hydrateMermaidBlocks, invalidateMermaidTheme } from '../markdown/mermaid-renderer';
   import { getLinkType } from '../../../shared/link-types';
@@ -183,6 +184,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   installMath(md);
   installCallouts(md);
   installDoiAutolink(md);
+  installHighlight(md);
   // Footnotes — markdown-it-footnote renders `[^id]` as a numbered
   // superscript anchored to a back-of-note `<section class="footnotes">`,
   // and each footnote body links back to the ref. Both jumps fire

--- a/src/renderer/lib/editor/highlight-decorations.ts
+++ b/src/renderer/lib/editor/highlight-decorations.ts
@@ -1,0 +1,78 @@
+/**
+ * Source-mode rendering for `==text==` / `==color:text==` (#468).
+ *
+ * The preview already lights up these spans via the markdown-it
+ * plugin; this extension paints the same tint in the editor itself so
+ * the highlight is visible while typing. We don't hide the `==`
+ * delimiters — keeping them visible is the convention for inline
+ * markup (matches the `*…*` and `~~…~~` story); the user can see
+ * exactly what they wrote.
+ *
+ * Scanner is shared with the preview plugin (`scanHighlights`) so the
+ * two surfaces agree on which substrings count as highlights.
+ */
+
+import {
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  Decoration,
+  type DecorationSet,
+} from '@codemirror/view';
+import { RangeSetBuilder } from '@codemirror/state';
+import { scanHighlights } from '../../../shared/markdown/highlight-plugin';
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const { from, to } of view.visibleRanges) {
+    const text = view.state.doc.sliceString(from, to);
+    const matches = scanHighlights(text, from);
+    // RangeSetBuilder demands sorted, non-overlapping ranges. The
+    // scanner already returns them in left-to-right order with no
+    // overlap (it advances past each closing `==`).
+    for (const m of matches) {
+      builder.add(
+        m.from,
+        m.to,
+        Decoration.mark({
+          class: m.color ? `cm-highlight cm-highlight-${m.color}` : 'cm-highlight',
+          attributes: m.color ? { 'data-hl-color': m.color } : undefined,
+        }),
+      );
+    }
+  }
+  return builder.finish();
+}
+
+const highlightTheme = EditorView.theme({
+  // Base colors live in global.css so theme swaps (Honey / Light /
+  // Contrast) flow through. The tint percentages match the preview's
+  // `mark.hl-*` rules so the two surfaces look the same intensity.
+  '.cm-highlight': {
+    background: 'color-mix(in oklch, var(--accent) 22%, transparent)',
+    borderRadius: '2px',
+  },
+  '.cm-highlight-yellow': { background: 'color-mix(in oklch, var(--hl-yellow) 30%, transparent)' },
+  '.cm-highlight-green':  { background: 'color-mix(in oklch, var(--hl-green) 30%, transparent)' },
+  '.cm-highlight-blue':   { background: 'color-mix(in oklch, var(--hl-blue) 30%, transparent)' },
+  '.cm-highlight-pink':   { background: 'color-mix(in oklch, var(--hl-pink) 30%, transparent)' },
+  '.cm-highlight-orange': { background: 'color-mix(in oklch, var(--hl-orange) 30%, transparent)' },
+});
+
+export function highlightDecorations() {
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      constructor(view: EditorView) {
+        this.decorations = buildDecorations(view);
+      }
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged) {
+          this.decorations = buildDecorations(update.view);
+        }
+      }
+    },
+    { decorations: (v) => v.decorations },
+  );
+  return [plugin, highlightTheme];
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -16,6 +16,15 @@
   --rust:         oklch(0.665 0.105 38);
   --iris:         oklch(0.700 0.080 280);
 
+  /* Highlight palette (#468) — `==color:text==` tint backgrounds.
+     Chroma is high enough to read as colored over the dark paper, the
+     `color-mix` in the rule mutes it to "highlighter pen" intensity. */
+  --hl-yellow:    oklch(0.835 0.165 92);
+  --hl-green:     oklch(0.795 0.150 148);
+  --hl-blue:      oklch(0.755 0.135 245);
+  --hl-pink:      oklch(0.795 0.135 350);
+  --hl-orange:    oklch(0.775 0.150 50);
+
   /* Backwards-compat aliases — kept until every component migrates to
      the new tokens above. Components that haven't been touched yet
      still resolve through these. */
@@ -53,6 +62,13 @@
   --sage:         oklch(0.460 0.060 148);
   --rust:         oklch(0.520 0.115 38);
   --iris:         oklch(0.500 0.090 280);
+
+  /* Highlight palette (#468) — darker chroma to read on light paper. */
+  --hl-yellow:    oklch(0.720 0.170 90);
+  --hl-green:     oklch(0.620 0.155 148);
+  --hl-blue:      oklch(0.580 0.150 245);
+  --hl-pink:      oklch(0.640 0.150 350);
+  --hl-orange:    oklch(0.660 0.165 50);
 }
 
 [data-theme="contrast"] {
@@ -77,6 +93,13 @@
   --bg-tabbar:             var(--bg-elev);
   --bg-toolbar:            var(--bg-elev);
   --bg-code:               #eaeaef;
+
+  /* Highlight palette (#468) — AA-passable colors over the white body. */
+  --hl-yellow:    oklch(0.700 0.180 90);
+  --hl-green:     oklch(0.560 0.165 148);
+  --hl-blue:      oklch(0.520 0.165 245);
+  --hl-pink:      oklch(0.600 0.165 350);
+  --hl-orange:    oklch(0.640 0.180 50);
 }
 
 /* ── Density ─────────────────────────────────────────────────────────
@@ -243,6 +266,24 @@ details.callout[open] > summary.callout-title::after {
 .callout-abstract .callout-icon::before { content: '\2630'; }
 .callout-todo .callout-icon::before     { content: '\2610'; }
 .callout-unknown .callout-icon::before  { content: '\25CF'; }
+
+/* Highlights (#468). `==text==` and `==color:text==` from the markdown-it
+   plugin render here as `<mark class="hl hl-{color}?">`. Lives in
+   global.css (not Preview's scoped CSS) so @html-rendered children
+   match — same reason as callouts above. Tint percentages mirror the
+   CodeMirror theme in highlight-decorations.ts so source mode and
+   preview mode look the same intensity. */
+mark.hl {
+  background: color-mix(in oklch, var(--accent) 22%, transparent);
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+mark.hl-yellow { background: color-mix(in oklch, var(--hl-yellow) 30%, transparent); }
+mark.hl-green  { background: color-mix(in oklch, var(--hl-green)  30%, transparent); }
+mark.hl-blue   { background: color-mix(in oklch, var(--hl-blue)   30%, transparent); }
+mark.hl-pink   { background: color-mix(in oklch, var(--hl-pink)   30%, transparent); }
+mark.hl-orange { background: color-mix(in oklch, var(--hl-orange) 30%, transparent); }
 
 /* Mermaid diagram blocks (#467). Centered SVG with subtle bordered
    panel; error renders inline so a single broken diagram can't brick

--- a/src/shared/markdown/highlight-plugin.ts
+++ b/src/shared/markdown/highlight-plugin.ts
@@ -1,0 +1,194 @@
+/**
+ * Markdown-it plugin: `==text==` and `==color:text==` highlights (#468).
+ *
+ * Renders as `<mark class="hl">…</mark>` (default) or
+ * `<mark class="hl hl-{color}">…</mark>` for a recognised palette color
+ * (yellow, green, blue, pink, orange). Unrecognised prefixes fall
+ * through as part of the body, so `==Pythagorean: a²+b²==` highlights
+ * the whole thing rather than guessing at a color.
+ *
+ * Tokenisation is recursive: the body re-enters the inline parser so
+ * `==**bold**==` and `==[[wiki-link]]==` work as expected. We register
+ * before `emphasis` so `**==X==**` resolves outermost-emphasis ↦
+ * inner-highlight without delimiter races.
+ *
+ * Rejects, following Pandoc convention:
+ *   - `===` runs (three or more equals — heading-rule territory)
+ *   - empty bodies
+ *   - newlines inside the body (inline-only)
+ *   - whitespace immediately after the opening `==` or before the
+ *     closing `==` (matches strong/em — keeps `== test ==` in prose
+ *     from accidentally highlighting)
+ */
+
+import type MarkdownIt from 'markdown-it';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
+
+export const HIGHLIGHT_PALETTE = ['yellow', 'green', 'blue', 'pink', 'orange'] as const;
+export type HighlightColor = typeof HIGHLIGHT_PALETTE[number];
+const PALETTE_SET = new Set<string>(HIGHLIGHT_PALETTE);
+
+const COLOR_PREFIX_RE = /^([a-z]+):/;
+
+export interface HighlightMatch {
+  /** Offset of the opening `==` in the input. */
+  from: number;
+  /** Offset just past the closing `==` in the input. */
+  to: number;
+  /** Palette color, or null for the uncolored default. */
+  color: HighlightColor | null;
+}
+
+/**
+ * Scan flat text for `==…==` highlights and return their absolute
+ * offsets + color. Used by the CodeMirror source-mode decoration
+ * (#468) so the editor and the preview agree about what counts as a
+ * highlight. The plugin uses the parser-state form; this helper mirrors
+ * the same rejection rules:
+ *
+ *   - `===` runs are not delimiters (forward OR backward)
+ *   - empty bodies are not delimiters
+ *   - newlines inside the body end the match
+ *   - whitespace adjacent to either delimiter rejects (matches strong/em)
+ *
+ * `offset` is added to each result so the caller can pass a slice of
+ * the editor document and recover absolute positions.
+ */
+export function scanHighlights(text: string, offset = 0): HighlightMatch[] {
+  const out: HighlightMatch[] = [];
+  let i = 0;
+  while (i < text.length - 1) {
+    if (text.charCodeAt(i) !== 0x3d || text.charCodeAt(i + 1) !== 0x3d) { i++; continue; }
+    if (text.charCodeAt(i + 2) === 0x3d) { i++; continue; }
+    if (i > 0 && text.charCodeAt(i - 1) === 0x3d) { i++; continue; }
+    const afterOpen = text.charCodeAt(i + 2);
+    if (afterOpen === 0x20 || afterOpen === 0x09 || afterOpen === 0x0a) { i++; continue; }
+
+    // Scan for the closing `==`, rejecting at newlines so highlights
+    // stay strictly inline (the preview plugin does the same).
+    let j = i + 2;
+    let closing = -1;
+    while (j < text.length - 1) {
+      const c = text.charCodeAt(j);
+      if (c === 0x0a) break;
+      if (
+        c === 0x3d &&
+        text.charCodeAt(j + 1) === 0x3d &&
+        text.charCodeAt(j + 2) !== 0x3d
+      ) {
+        closing = j;
+        break;
+      }
+      j++;
+    }
+    if (closing === -1) { i++; continue; }
+    if (closing === i + 2) { i++; continue; }
+    const beforeClose = text.charCodeAt(closing - 1);
+    if (beforeClose === 0x20 || beforeClose === 0x09) { i++; continue; }
+
+    const content = text.slice(i + 2, closing);
+    const colorMatch = COLOR_PREFIX_RE.exec(content);
+    let color: HighlightColor | null = null;
+    if (colorMatch && PALETTE_SET.has(colorMatch[1])) {
+      // Match the plugin's "color prefix with empty body" guard
+      // (`==yellow:==` falls back to uncolored).
+      if (colorMatch[0].length < content.length) {
+        color = colorMatch[1] as HighlightColor;
+      }
+    }
+    out.push({ from: offset + i, to: offset + closing + 2, color });
+    i = closing + 2;
+  }
+  return out;
+}
+
+export function installHighlight(md: MarkdownIt): void {
+  md.inline.ruler.before('emphasis', 'highlight', highlightInline);
+  // No render override: markdown-it's default emits `<mark>…</mark>`
+  // (driven by the tokens' `tag = 'mark'`) and flows every attrSet
+  // attribute through automatically — including `data-hl-color`.
+}
+
+function highlightInline(state: StateInline, silent: boolean): boolean {
+  if (state.src.charCodeAt(state.pos) !== 0x3d /* = */) return false;
+  if (state.src.charCodeAt(state.pos + 1) !== 0x3d) return false;
+  // Three or more `=` in a row aren't a highlight delimiter — most
+  // commonly seen as ASCII rules or table-of-contents formatting. We
+  // reject both forward (`===` starting here) and backward (the `==`
+  // we're at is itself the tail of a longer run, e.g. mid-`===`).
+  if (state.src.charCodeAt(state.pos + 2) === 0x3d) return false;
+  if (state.pos > 0 && state.src.charCodeAt(state.pos - 1) === 0x3d) return false;
+
+  const bodyStart = state.pos + 2;
+  // Whitespace immediately after opening — matches the strong/em rule
+  // ("== text ==" is prose, not a highlight).
+  const afterOpen = state.src.charCodeAt(bodyStart);
+  if (afterOpen === 0x20 || afterOpen === 0x09 || afterOpen === 0x0a) return false;
+
+  // Scan forward for the closing `==` that isn't itself part of `===`.
+  let scan = bodyStart;
+  let closingPos = -1;
+  while (scan < state.posMax - 1) {
+    const c = state.src.charCodeAt(scan);
+    if (c === 0x0a) return false;
+    if (
+      c === 0x3d &&
+      state.src.charCodeAt(scan + 1) === 0x3d &&
+      state.src.charCodeAt(scan + 2) !== 0x3d
+    ) {
+      closingPos = scan;
+      break;
+    }
+    scan++;
+  }
+  if (closingPos === -1) return false;
+  if (closingPos === bodyStart) return false;
+  // Whitespace immediately before the closing — same rule.
+  const beforeClose = state.src.charCodeAt(closingPos - 1);
+  if (beforeClose === 0x20 || beforeClose === 0x09) return false;
+
+  // Parse optional color prefix. Only a known palette entry counts;
+  // anything else stays in the body (`==Pythagorean: a²+b²==`).
+  const content = state.src.slice(bodyStart, closingPos);
+  const colorMatch = COLOR_PREFIX_RE.exec(content);
+  let color: HighlightColor | null = null;
+  let innerStart = bodyStart;
+  if (colorMatch && PALETTE_SET.has(colorMatch[1])) {
+    color = colorMatch[1] as HighlightColor;
+    innerStart = bodyStart + colorMatch[0].length;
+  }
+  // After stripping a color prefix the body might be empty
+  // (`==yellow:==`) — that's not a real highlight; fall back to
+  // treating the whole content as the body so the user can see what
+  // they wrote.
+  if (innerStart >= closingPos) {
+    color = null;
+    innerStart = bodyStart;
+  }
+
+  if (silent) {
+    state.pos = closingPos + 2;
+    return true;
+  }
+
+  // Push the open token, then recursively tokenise the body so other
+  // inline rules (emphasis, wiki-links, code spans) still run inside.
+  const open = state.push('highlight_open', 'mark', 1);
+  open.markup = '==';
+  open.attrSet('class', color ? `hl hl-${color}` : 'hl');
+  if (color) open.attrSet('data-hl-color', color);
+
+  const savedPos = state.pos;
+  const savedMax = state.posMax;
+  state.pos = innerStart;
+  state.posMax = closingPos;
+  state.md.inline.tokenize(state);
+  state.pos = savedPos;
+  state.posMax = savedMax;
+
+  const close = state.push('highlight_close', 'mark', -1);
+  close.markup = '==';
+
+  state.pos = closingPos + 2;
+  return true;
+}

--- a/tests/shared/markdown/highlight-plugin.test.ts
+++ b/tests/shared/markdown/highlight-plugin.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Markdown-it `==text==` / `==color:text==` highlight plugin (#468).
+ */
+
+import { describe, it, expect } from 'vitest';
+import MarkdownIt from 'markdown-it';
+import { installHighlight, scanHighlights } from '../../../src/shared/markdown/highlight-plugin';
+
+function md(): MarkdownIt {
+  const m = new MarkdownIt({ html: true });
+  installHighlight(m);
+  return m;
+}
+
+describe('highlight plugin (#468)', () => {
+  // ─── baseline ==text== ──────────────────────────────────────────────
+
+  it('renders ==text== as <mark class="hl">', () => {
+    expect(md().render('Hello ==world==!')).toContain('<mark class="hl">world</mark>');
+  });
+
+  it('renders multiple highlights in one paragraph', () => {
+    const html = md().render('==one== then ==two==');
+    expect(html.match(/<mark class="hl">/g)).toHaveLength(2);
+    expect(html).toContain('>one</mark>');
+    expect(html).toContain('>two</mark>');
+  });
+
+  // ─── colored variants ──────────────────────────────────────────────
+
+  it('renders ==yellow:text== with hl-yellow class', () => {
+    const html = md().render('A ==yellow:warning== sign');
+    expect(html).toMatch(/<mark[^>]*class="hl hl-yellow"[^>]*>warning<\/mark>/);
+  });
+
+  it.each(['yellow', 'green', 'blue', 'pink', 'orange'])(
+    'recognises the %s palette color',
+    (color) => {
+      const html = md().render(`==${color}:body==`);
+      expect(html).toMatch(new RegExp(`<mark[^>]*class="hl hl-${color}"[^>]*>body</mark>`));
+    },
+  );
+
+  it('falls back to uncolored when the prefix is not a palette color', () => {
+    // `Pythagorean:` looks like a color prefix but isn't in the palette
+    // — the whole content stays in the body.
+    const html = md().render('==Pythagorean: a²+b²==');
+    expect(html).toContain('<mark class="hl">Pythagorean: a²+b²</mark>');
+    expect(html).not.toContain('hl-');
+  });
+
+  it('keeps a bare palette word as the body when there is no `:`', () => {
+    // `==yellow==` is just the word "yellow" highlighted, not a colored
+    // empty body.
+    expect(md().render('==yellow==')).toContain('<mark class="hl">yellow</mark>');
+  });
+
+  // ─── recursive tokenisation ───────────────────────────────────────
+
+  it('lets emphasis render inside a highlight', () => {
+    const html = md().render('==yellow:**bold** highlight==');
+    expect(html).toMatch(/<mark[^>]*class="hl hl-yellow"/);
+    expect(html).toContain('<strong>bold</strong>');
+  });
+
+  it('does not eat the opening when inline code lives inside', () => {
+    // The body `code spans don't eat ==` should pass through; the
+    // closing `==` after lives in normal text and should still pair
+    // up with the opener.
+    const html = md().render('text ==hl with `code`== end');
+    expect(html).toContain('<mark class="hl">hl with <code>code</code></mark>');
+  });
+
+  // ─── rejection cases ──────────────────────────────────────────────
+
+  it('does not match `=== … ===` (heading-rule territory)', () => {
+    const html = md().render('===not a highlight===');
+    expect(html).not.toContain('<mark');
+  });
+
+  it('does not match across a newline', () => {
+    const html = md().render('==open\nbut not closed on same line==');
+    expect(html).not.toContain('<mark');
+  });
+
+  it('rejects whitespace-padded bodies (== test ==)', () => {
+    // Mirrors strong/em — keeps prose from accidentally highlighting.
+    expect(md().render('== test ==')).not.toContain('<mark');
+  });
+
+  it('rejects empty bodies (====)', () => {
+    expect(md().render('====')).not.toContain('<mark');
+  });
+
+  it('leaves the syntax alone inside a code span', () => {
+    // `` ` `` opens a code span; the `==…==` inside is literal.
+    const html = md().render('Use `==text==` for highlights.');
+    expect(html).toContain('<code>==text==</code>');
+    expect(html).not.toContain('<mark');
+  });
+
+  it('leaves the syntax alone inside a fenced code block', () => {
+    const html = md().render('```\n==in a fence==\n```\n');
+    expect(html).not.toContain('<mark');
+    expect(html).toContain('==in a fence==');
+  });
+
+  // ─── attributes ────────────────────────────────────────────────────
+
+  it('emits a data-hl-color attribute for colored variants', () => {
+    // Useful for the editor's source-mode decoration parity and for
+    // print stylesheets that need to round-trip the color.
+    expect(md().render('==green:passing==')).toContain('data-hl-color="green"');
+  });
+
+  it('omits data-hl-color for the uncolored default', () => {
+    expect(md().render('==default==')).not.toContain('data-hl-color');
+  });
+});
+
+describe('scanHighlights (editor decoration shared scanner)', () => {
+  it('returns one match per ==…== span with absolute offsets', () => {
+    const text = 'Hello ==world== and ==yellow:bye==!';
+    const out = scanHighlights(text);
+    expect(out).toEqual([
+      { from: 6,  to: 15, color: null },
+      { from: 20, to: 34, color: 'yellow' },
+    ]);
+  });
+
+  it('honours the offset argument so callers can pass viewport slices', () => {
+    expect(scanHighlights('==x==', 100)).toEqual([{ from: 100, to: 105, color: null }]);
+  });
+
+  it('skips `===` runs', () => {
+    expect(scanHighlights('===nope=== and ===yep===')).toEqual([]);
+  });
+
+  it('does not cross newlines', () => {
+    expect(scanHighlights('==open\nclose==')).toEqual([]);
+  });
+
+  it('rejects whitespace-padded bodies', () => {
+    expect(scanHighlights('== test ==')).toEqual([]);
+  });
+
+  it('matches every palette color', () => {
+    const colors = ['yellow', 'green', 'blue', 'pink', 'orange'] as const;
+    for (const c of colors) {
+      const r = scanHighlights(`==${c}:b==`);
+      expect(r).toHaveLength(1);
+      expect(r[0].color).toBe(c);
+    }
+  });
+
+  it('falls back to uncolored when prefix is not a palette color', () => {
+    expect(scanHighlights('==Pythagorean: a²+b²==')[0].color).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- `==text==` renders as a yellow-ish default highlight; `==color:text==` for `yellow|green|blue|pink|orange` paints the matching palette tint. Unknown prefixes (e.g. `==Pythagorean: a²+b²==`) fall through as the body.
- Lights up in **both** preview and the editor source view, with the same intensity (shared scanner, same `color-mix` recipe).
- New palette tokens `--hl-yellow` etc. land in all three themes (Honey / Light / Contrast).

## Implementation
- `src/shared/markdown/highlight-plugin.ts` — markdown-it inline rule. Body re-tokenises so **bold**, `code`, and `[[wiki-links]]` still render inside a highlight. Registered before `emphasis` so `**==X==**` nests cleanly. Default `<mark>` rendering handles attributes.
- `src/renderer/lib/editor/highlight-decorations.ts` — CM6 ViewPlugin reusing the same scanner.
- `src/renderer/styles/global.css` — palette + preview `mark.hl-*` rules.

Per CLAUDE.md: tint percentages picked for \"highlighter pen\" intensity without overpowering body text.

Closes #468

## Test plan
- [x] `pnpm test` — 2478 tests pass (27 new for the plugin + shared scanner covering palette colors, recursive tokenisation, code-span safety, rejection rules, edge cases)
- [x] `pnpm lint` clean
- [ ] Manual smoke: type `==yellow:warning==` in a note — yellow tint shows up as you type AND in preview. Same for green/blue/pink/orange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)