### PR TITLE
fix: move highlight shortcut off ⌘⇧H (collided with Replace in Notes)

### DIFF
--- a/src/renderer/lib/editor/command-registry.ts
+++ b/src/renderer/lib/editor/command-registry.ts
@@ -30,7 +30,10 @@ export const COMMAND_REGISTRY: CommandEntry[] = [
   { id: 'editor.toggleItalic', label: 'Italic', defaultKey: 'Mod-i', command: toggleItalic },
   { id: 'editor.toggleCode', label: 'Code', defaultKey: 'Mod-e', command: toggleCode },
   { id: 'editor.toggleStrikethrough', label: 'Strikethrough', defaultKey: 'Mod-Shift-x', command: toggleStrikethrough },
-  { id: 'editor.toggleHighlight', label: 'Highlight (cycle color)', defaultKey: 'Mod-Shift-h', command: toggleHighlight },
+  // `Mod-Shift-h` would collide with the menu's "Replace in Notes…"
+  // accelerator (matches VS Code's Replace-in-Files). Y → yellow, the
+  // default highlight color, gives the shortcut a mnemonic anchor.
+  { id: 'editor.toggleHighlight', label: 'Highlight (cycle color)', defaultKey: 'Mod-Shift-y', command: toggleHighlight },
 
   // Paragraph
   { id: 'editor.toggleH1', label: 'Heading 1', defaultKey: '', command: toggleH1 },


### PR DESCRIPTION
## Summary
The highlight shortcut I added in #601 was being shadowed by the menu's existing "Replace in Notes…" accelerator on ⌘⇧H. Reassigned to **⌘⇧Y** — Y for yellow (the default highlight color), no other handler claims that key.

Per discussion: kept Replace-in-Notes where it is (matches VS Code) rather than cascading three menu renames.

## Test plan
- [x] `pnpm lint` clean
- [ ] Manual: select a word, press ⌘⇧Y — yellow tint appears, preview matches. Press again — cycles green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)