### PR TITLE
feat: Highlight in right-click → Format submenu

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -23,7 +23,7 @@
   } from '../editor/image-upload';
   import { sortLines, selectionTracker } from '../editor/commands';
   import {
-    toggleBold, toggleItalic, toggleCode, toggleStrikethrough,
+    toggleBold, toggleItalic, toggleCode, toggleStrikethrough, toggleHighlight,
     toggleH1, toggleH2, toggleH3, toggleQuote, toggleBulletList, toggleNumberedList, toggleTaskList,
     insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage,
     insertWikiLink, insertTypedLinks,
@@ -992,6 +992,7 @@
         <button onclick={() => runCmd(toggleItalic)}>Italic</button>
         <button onclick={() => runCmd(toggleCode)}>Code</button>
         <button onclick={() => runCmd(toggleStrikethrough)}>Strikethrough</button>
+        <button onclick={() => runCmd(toggleHighlight)}>Highlight</button>
       </div>
     </div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>


### PR DESCRIPTION
## Summary
Adds a **Highlight** entry to the editor's right-click → Format submenu, alongside Bold / Italic / Code / Strikethrough. Runs the same `toggleHighlight` command bound to ⌘⇧Y — first click wraps with `==yellow:…==`, repeat clicks cycle yellow → green → blue → pink → orange → unwrap.

## Test plan
- [x] `pnpm lint` clean
- [ ] Manual: select text → right-click → Format → Highlight → yellow tint applied. Right-click again → Format → Highlight → cycles green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)