### PR TITLE
fix: never surface canonical source ids (`url-<hash>`) to the user

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -27,6 +27,7 @@
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
   import type { SafeDeleteBlocker } from '../shared/types';
+  import { displaySourceTitle } from '../shared/source-display';
   import { RESOLVE_AUTO_THRESHOLD } from '../shared/resolve-stub';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
@@ -2200,7 +2201,7 @@
     const detail = await api.graph.sourceDetail(sourceId);
     resolveStubState = {
       sourceId,
-      stubTitle: detail?.metadata.title ?? sourceId,
+      stubTitle: detail ? displaySourceTitle(detail.metadata) : sourceId,
       candidates,
     };
   }
@@ -2928,6 +2929,7 @@
           <TabBar
             tabs={editor.tabs}
             activeIndex={editor.activeIndex}
+            sources={sourcesCache}
             onSwitch={handleSwitchTab}
             onClose={editor.closeTab}
             onCloseOthers={editor.closeOthers}

--- a/src/renderer/lib/components/GotoNoteDialog.svelte
+++ b/src/renderer/lib/components/GotoNoteDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { NoteFile, SourceMetadata, SavedQuery } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
   import Icon from './Icon.svelte';
   import type { IconName } from './icons/registry';
   import { formatRelativeTime } from '../utils/format-relative-time';
@@ -141,7 +142,7 @@
     const mkNote = (n: { name: string; relativePath: string; mtimeMs?: number }, score: number): NoteItem =>
       ({ kind: 'note', name: n.name, relativePath: n.relativePath, mtimeMs: n.mtimeMs, score });
     const mkSource = (s: SourceMetadata, score: number): SourceItem =>
-      ({ kind: 'source', name: s.title ?? s.sourceId, sourceId: s.sourceId, byline: formatByline(s), score });
+      ({ kind: 'source', name: displaySourceTitle(s), sourceId: s.sourceId, byline: formatByline(s), score });
     const mkQuery = (qy: SavedQuery, score: number): QueryItem =>
       ({ kind: 'query', name: qy.name, query: qy, score });
 
@@ -156,7 +157,7 @@
 
     const sourceItems: SourceItem[] = (scope === 'all' || scope === 'sources')
       ? allSources.flatMap((s) => {
-        const name = s.title ?? s.sourceId;
+        const name = displaySourceTitle(s);
         if (!q) return [mkSource(s, 0)];
         if (regex) return regex.test(name) || regex.test(s.sourceId) ? [mkSource(s, 1)] : [];
         const score = scoreMatch(name, formatByline(s) ?? s.sourceId, q);

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -3,6 +3,7 @@
   import Preview from './Preview.svelte';
   import { renderInlineWithMath } from '../markdown/inline-math';
   import type { SourceDetail, SourceExcerpt, SourceBacklink, ReadStatus } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
 
   const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
     { value: 'unread', label: 'Unread' },
@@ -35,7 +36,7 @@
 
   async function handleDelete() {
     if (!detail) return;
-    const label = detail.metadata.title ?? sourceId;
+    const label = displaySourceTitle(detail.metadata);
     const confirmed = await onShowConfirm(
       `Delete source "${label}"? Any excerpts from this source will also be removed.`,
       'delete-source',
@@ -271,7 +272,7 @@
       <div class="subtype">
         {detail.metadata.subtype ?? 'Source'}{#if detail.metadata.stubStatus === 'unresolved'} · STUB{/if}
       </div>
-      <h1>{@html renderInlineWithMath(detail.metadata.title ?? sourceId)}</h1>
+      <h1>{@html renderInlineWithMath(displaySourceTitle(detail.metadata))}</h1>
       {#if detail.metadata.creators.length || detail.metadata.year}
         <div class="byline">{formatByline(detail.metadata.creators, detail.metadata.year)}</div>
       {/if}

--- a/src/renderer/lib/components/SourcePickerDialog.svelte
+++ b/src/renderer/lib/components/SourcePickerDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SourceMetadata } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
   import Icon from './Icon.svelte';
 
   interface Props {
@@ -29,7 +30,7 @@
     const q = query.trim().toLowerCase();
     if (!q) return candidates;
     return candidates.filter((s) => {
-      const title = (s.title ?? s.sourceId).toLowerCase();
+      const title = displaySourceTitle(s).toLowerCase();
       const byline = s.creators.join(' ').toLowerCase();
       const year = s.year ?? '';
       return title.includes(q) || byline.includes(q) || year.includes(q) || s.sourceId.toLowerCase().includes(q);
@@ -96,7 +97,7 @@
             >
               <Icon name="sites" size={13} color={i === selectedIndex ? 'var(--accent)' : 'var(--text-faint)'} />
               <span class="result-body">
-                <span class="result-title">{s.title ?? s.sourceId}</span>
+                <span class="result-title">{displaySourceTitle(s)}</span>
                 {#if who || s.year}
                   <span class="result-byline">
                     {#if who}{who}{/if}{#if who && s.year} · {/if}{#if s.year}<span class="year">{s.year}</span>{/if}

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { api } from '../ipc/client';
   import type { SourceMetadata, Collection, SmartCollection, SmartCollectionPredicate, ReadStatus } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import SourcePickerDialog from './SourcePickerDialog.svelte';
   import CollectionPickerDialog from './CollectionPickerDialog.svelte';
@@ -205,7 +206,7 @@
 
   async function handleDelete(source: SourceMetadata) {
     contextMenu = null;
-    const label = source.title ?? source.sourceId;
+    const label = displaySourceTitle(source);
     const confirmed = await onShowConfirm(
       `Delete source "${label}"? Any excerpts from this source will also be removed.`,
       'delete-source',
@@ -347,7 +348,7 @@
     const q = filter.trim().toLowerCase();
     if (!q) return base;
     return base.filter((s) => {
-      const title = (s.title ?? s.sourceId).toLowerCase();
+      const title = displaySourceTitle(s).toLowerCase();
       const byline = s.creators.join(' ').toLowerCase();
       const year = s.year ?? '';
       return title.includes(q) || byline.includes(q) || year.includes(q) || s.sourceId.includes(q);
@@ -881,7 +882,7 @@
                 aria-label={statusTitle(s.readStatus)}
               >{statusGlyph(s.readStatus)}</span>
             {/if}
-            {s.title ?? s.sourceId}
+            {displaySourceTitle(s)}
           </div>
           {#if s.creators.length > 0 || s.year || s.readDueBy}
             {@const who = formatCreators(s.creators)}
@@ -1041,7 +1042,7 @@
     <div class="due-dialog" role="dialog" aria-modal="true" aria-label="Reading due date">
       <header class="due-dialog-header">
         <div class="due-dialog-eyebrow">READING DUE DATE</div>
-        <h2 class="due-dialog-title">{m.source.title ?? m.source.sourceId}</h2>
+        <h2 class="due-dialog-title">{displaySourceTitle(m.source)}</h2>
       </header>
       <div class="due-dialog-body">
         <!-- svelte-ignore a11y_autofocus -->

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { Tab } from '../stores/editor.svelte';
+  import type { SourceMetadata } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import Icon from './Icon.svelte';
@@ -7,6 +9,10 @@
   interface Props {
     tabs: Tab[];
     activeIndex: number;
+    /** Project's full source list. Used to resolve a human-readable
+     *  label for source tabs (the canonical id like `url-abc123` is
+     *  filesystem-only and must never reach the user). */
+    sources?: SourceMetadata[];
     onSwitch: (index: number) => void;
     onClose: (index: number) => void;
     onCloseOthers: (index: number) => void;
@@ -18,7 +24,23 @@
     onNewTab?: () => void;
   }
 
-  let { tabs, activeIndex, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark, onNewTab }: Props = $props();
+  let { tabs, activeIndex, sources, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark, onNewTab }: Props = $props();
+
+  /** Map sourceId → metadata for label lookups. Rebuilds whenever the
+   *  parent's `sources` array changes. */
+  const sourcesById = $derived(() => {
+    const m = new Map<string, SourceMetadata>();
+    for (const s of sources ?? []) m.set(s.sourceId, s);
+    return m;
+  });
+
+  /** Best-effort display label for a source tab. When the metadata
+   *  hasn't loaded yet, fall back to "Source" (still better than the
+   *  raw canonical id). */
+  function sourceTabLabel(sourceId: string): string {
+    const meta = sourcesById().get(sourceId);
+    return meta ? displaySourceTitle(meta) : 'Source';
+  }
 
   let contextMenu = $state<{ x: number; y: number; index: number } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
@@ -60,7 +82,7 @@
       onclick={() => onSwitch(i)}
       onauxclick={(e) => handleMiddleClick(e, i)}
       oncontextmenu={(e) => handleContextMenu(e, i)}
-      title={tab.type === 'note' ? tab.relativePath : tab.type === 'query' ? tab.title : `Source: ${tab.sourceId}`}
+      title={tab.type === 'note' ? tab.relativePath : tab.type === 'query' ? tab.title : `Source: ${sourceTabLabel(tab.sourceId)}`}
       role="tab"
       tabindex="0"
     >
@@ -80,7 +102,7 @@
       <span class="tab-name">
         {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
         {:else if tab.type === 'query'}{tab.title}
-        {:else}{tab.sourceId}{/if}
+        {:else}{sourceTabLabel(tab.sourceId)}{/if}
       </span>
       <button
         class="close-btn"

--- a/src/renderer/lib/editor/link-autocomplete.ts
+++ b/src/renderer/lib/editor/link-autocomplete.ts
@@ -1,6 +1,7 @@
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { LINK_TYPES } from '../../../shared/link-types';
 import type { SourceMetadata } from '../../../shared/types';
+import { displaySourceTitle } from '../../../shared/source-display';
 import { extractAnchors } from './note-anchors';
 
 // ── Phase detection (pure) ─────────────────────────────────────────────────
@@ -131,7 +132,7 @@ export function aliasOptions(entries: readonly { alias: string; relativePath: st
 
 export function sourceOptions(sources: readonly SourceMetadata[]): Completion[] {
   return sources.map((s) => {
-    const title = s.title ?? s.sourceId;
+    const title = displaySourceTitle(s);
     const creators = s.creators.length > 0
       ? (s.creators.length === 1 ? s.creators[0]
         : s.creators.length === 2 ? `${s.creators[0]} and ${s.creators[1]}`

--- a/src/shared/source-display.ts
+++ b/src/shared/source-display.ts
@@ -1,0 +1,48 @@
+/**
+ * User-facing display label for a Source.
+ *
+ * Source ids on disk follow a canonical format (`url-<hash>`,
+ * `doi-10.xxxx_yyyy`, `sha-<hash>`, …) chosen for filesystem
+ * stability — never for human reading. Anywhere a source's name
+ * shows up in the UI (tab heading, sidebar row, picker, etc.) should
+ * route through this helper so a raw `url-abc123def456` never reaches
+ * the user.
+ *
+ * Priority:
+ *   1. `meta.title`        (the usual case after a successful ingest)
+ *   2. cleaned `meta.uri`  (hostname + path — readable, identifies
+ *                          the page even when the fetch didn't get
+ *                          a title)
+ *   3. `DOI 10.xxxx/yyyy`  (for sources that have a DOI but no title)
+ *   4. `"Untitled source"` (the honest fallback — better than exposing
+ *                          the canonical id, which is not addressable
+ *                          information for the user)
+ */
+export interface SourceTitleSource {
+  title: string | null;
+  uri: string | null;
+  doi: string | null;
+}
+
+export function displaySourceTitle(meta: SourceTitleSource): string {
+  if (meta.title && meta.title.trim().length > 0) return meta.title.trim();
+  if (meta.uri) return cleanUrlForDisplay(meta.uri);
+  if (meta.doi) return `DOI ${meta.doi}`;
+  return 'Untitled source';
+}
+
+/**
+ * Strip the scheme + leading `www.` and the query string from a URL,
+ * leaving a compact identifier the user can recognise. Falls back to
+ * the raw string when the URL doesn't parse.
+ */
+function cleanUrlForDisplay(uri: string): string {
+  try {
+    const u = new URL(uri);
+    const host = u.hostname.replace(/^www\./, '');
+    const path = u.pathname && u.pathname !== '/' ? u.pathname.replace(/\/$/, '') : '';
+    return host + path;
+  } catch {
+    return uri;
+  }
+}

--- a/tests/shared/source-display.test.ts
+++ b/tests/shared/source-display.test.ts
@@ -1,0 +1,72 @@
+/**
+ * displaySourceTitle — central helper for picking a user-facing label
+ * for a Source. Canonical ids (`url-<hash>`, `sha-<hash>`, …) are
+ * filesystem-only and must never reach the UI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { displaySourceTitle } from '../../src/shared/source-display';
+
+describe('displaySourceTitle', () => {
+  it('uses the title when present', () => {
+    expect(displaySourceTitle({ title: 'On the dangers of stochastic parrots', uri: null, doi: null }))
+      .toBe('On the dangers of stochastic parrots');
+  });
+
+  it('trims whitespace from the title', () => {
+    expect(displaySourceTitle({ title: '  Title with padding  ', uri: null, doi: null }))
+      .toBe('Title with padding');
+  });
+
+  it('treats an empty-string title as missing and falls back', () => {
+    expect(displaySourceTitle({ title: '', uri: 'https://example.com/paper', doi: null }))
+      .toBe('example.com/paper');
+  });
+
+  it('treats whitespace-only title as missing', () => {
+    expect(displaySourceTitle({ title: '   ', uri: 'https://example.com/x', doi: null }))
+      .toBe('example.com/x');
+  });
+
+  it('cleans a URL — strips scheme and leading www', () => {
+    expect(displaySourceTitle({ title: null, uri: 'https://www.example.com/papers/2026', doi: null }))
+      .toBe('example.com/papers/2026');
+  });
+
+  it('drops a trailing slash from the cleaned URL', () => {
+    expect(displaySourceTitle({ title: null, uri: 'https://example.com/papers/', doi: null }))
+      .toBe('example.com/papers');
+  });
+
+  it('hides the empty pathname for a bare hostname', () => {
+    expect(displaySourceTitle({ title: null, uri: 'https://example.com', doi: null }))
+      .toBe('example.com');
+  });
+
+  it('falls back to the raw string for non-URL URIs', () => {
+    expect(displaySourceTitle({ title: null, uri: 'not-a-url', doi: null }))
+      .toBe('not-a-url');
+  });
+
+  it('uses the DOI when title and URI are missing', () => {
+    expect(displaySourceTitle({ title: null, uri: null, doi: '10.1145/3678002' }))
+      .toBe('DOI 10.1145/3678002');
+  });
+
+  it('prefers title > URI > DOI > Untitled', () => {
+    expect(displaySourceTitle({ title: 'T', uri: 'https://u', doi: '10.1/x' })).toBe('T');
+    expect(displaySourceTitle({ title: null, uri: 'https://u', doi: '10.1/x' })).toBe('u');
+    expect(displaySourceTitle({ title: null, uri: null, doi: '10.1/x' })).toBe('DOI 10.1/x');
+    expect(displaySourceTitle({ title: null, uri: null, doi: null })).toBe('Untitled source');
+  });
+
+  it('never returns a canonical-id-style string for the no-metadata case', () => {
+    // The whole point of the helper: nothing it returns should look
+    // like `url-<hash>` / `sha-<hash>` / etc. — those are filesystem
+    // ids and must never reach the UI.
+    const out = displaySourceTitle({ title: null, uri: null, doi: null });
+    expect(out).not.toMatch(/^url-/);
+    expect(out).not.toMatch(/^sha-/);
+    expect(out).not.toMatch(/^doi-/);
+  });
+});


### PR DESCRIPTION
## Summary
Sources are stored under \`.minerva/sources/<id>/\` with a canonical id chosen for filesystem stability — \`doi-10.1145_3678002\`, \`url-<hash>\`, \`sha-<hash>\`. Every UI site that needed a label fell back to \`s.title ?? s.sourceId\` and would print the raw \`url-abc123def456\` whenever an ingest didn't recover a title.

Centralised a single helper \`displaySourceTitle()\` and routed every fallback through it:

1. **title** if set
2. otherwise **cleaned URL** (hostname + path, scheme + leading \`www\` stripped)
3. otherwise **\`DOI 10.xxxx/yyyy\`**
4. otherwise **\"Untitled source\"**

So a URL-ingested page with no extracted title shows up as \`example.com/papers/2026\` everywhere, instead of \`url-abc123def456\`.

## Wired through
- Source tab heading + label (\`SourceDetail.svelte\`)
- Sidebar source row + filter (\`SourcesPanel.svelte\`)
- Source picker, GotoNote / command palette, link autocomplete
- Resolve-stub dialog (\`App.svelte\`)
- Delete-confirmation label
- **\`TabBar.svelte\`** now takes the source list as a prop so the tab label can resolve through the helper rather than printing \`tab.sourceId\` raw

## Test plan
- [x] \`pnpm test\` — 2504 pass (11 new for the helper)
- [x] \`pnpm lint\` clean
- [ ] Manual: open a source with no title — heading + tab + sidebar row all show the cleaned URL, not \`url-<hash>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)