### PR TITLE
fix: title-bar Quick Open button — correct label + shortcut

### DIFF
--- a/src/renderer/lib/components/TitleBar.svelte
+++ b/src/renderer/lib/components/TitleBar.svelte
@@ -14,8 +14,9 @@
     canGoForward: boolean;
     onNavBack: () => void;
     onNavForward: () => void;
-    /** Opens the cmd-K Goto Note palette. Triggered by the search
-     *  affordance in the right cluster. */
+    /** Opens the Quick Open palette — fuzzy match across notes,
+     *  sources, and saved queries. Bound to Cmd+P (matches the
+     *  Navigate › Quick Open menu entry). */
     onOpenGotoNote: () => void;
     /** Opens Settings. Triggered by the cog button at the far right. */
     onOpenSettings: () => void;
@@ -76,10 +77,10 @@
   </div>
 
   <div class="right-cluster">
-    <button class="search-box" onclick={onOpenGotoNote} title="Goto Note (Cmd+K)">
+    <button class="search-box" onclick={onOpenGotoNote} title="Quick Open (Cmd+P) — fuzzy-match notes, sources, queries">
       <Icon name="search" size={13} color="var(--text-muted)" />
-      <span class="search-placeholder">Find…</span>
-      <span class="search-kbd">⌘ K</span>
+      <span class="search-placeholder">Quick Open…</span>
+      <span class="search-kbd">⌘ P</span>
     </button>
     <button class="icon-btn" onclick={onOpenSettings} title="Settings">
       <Icon name="settings" size={15} color="var(--text-muted)" />


### PR DESCRIPTION
## Summary
The search button in the title bar said \"Find… ⌘ K\" — wrong on both counts. The button opens the Goto Note / Quick Open palette (fuzzy match across notes, sources, saved queries), which is bound to **⌘P**. ⌘K opens the command palette, a different surface.

Relabelled the button \"Quick Open… ⌘ P\" so it matches the **Navigate › Quick Open** menu entry that's already wired in `main/menu.ts`. (No menu change was needed — the entry was already there; only the title-bar label was misleading users into thinking it was missing.)

## Test plan
- [x] `pnpm lint` clean
- [ ] Manual: click the title-bar button → Quick Open palette opens; ⌘P does the same; Navigate › Quick Open does the same; ⌘K opens the command palette (separate surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)