### PR TITLE
ui: right-sidebar polish — Bookmarks under Links, scoped Tags, single active-line bar

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -218,10 +218,15 @@
       '.cm-activeLineGutter': {
         backgroundColor: 'transparent',
         color: 'var(--accent)',
-        boxShadow: 'inset -2px 0 0 var(--accent)',
       },
+      // Bar marks the boundary between gutters and content. Painting it
+      // on the content row (rather than the gutter's right edge) means a
+      // single line regardless of how many gutter columns are stacked —
+      // the compute gutter would otherwise paint its own bar on fence
+      // lines, doubling up.
       '.cm-activeLine': {
         backgroundColor: 'color-mix(in oklch, var(--accent) 6%, transparent)',
+        boxShadow: 'inset 2px 0 0 var(--accent)',
       },
     });
   }

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -44,6 +44,12 @@
         { id: 'outline',    label: 'Outline',    icon: 'outline' },
         { id: 'properties', label: 'Properties', icon: 'properties' },
         { id: 'footnotes',  label: 'Footnotes',  icon: 'footnotes' },
+        // Tags and Tables describe what's *inside* the active note's
+        // content, not how it connects to other notes — they sit
+        // alongside Outline / Properties under Note rather than
+        // sharing space with Outgoing / Backlinks under Links.
+        { id: 'tags',       label: 'Tags',       icon: 'tags' },
+        { id: 'tables',     label: 'Tables',     icon: 'tables' },
       ],
     },
     {
@@ -52,9 +58,8 @@
       items: [
         { id: 'outgoing',  label: 'Outgoing',  icon: 'outgoing' },
         { id: 'backlinks', label: 'Backlinks', icon: 'backlinks' },
-        { id: 'tags',      label: 'Tags',      icon: 'tags' },
         { id: 'citations', label: 'Citations', icon: 'citations' },
-        { id: 'tables',    label: 'Tables',    icon: 'tables' },
+        { id: 'bookmarks', label: 'Bookmarks', icon: 'bookmark' },
       ],
     },
     {
@@ -63,7 +68,6 @@
       items: [
         { id: 'inspections', label: 'Inspections', icon: 'inspections' },
         { id: 'proposals',   label: 'Proposals',   icon: 'proposals' },
-        { id: 'bookmarks',   label: 'Bookmarks',   icon: 'bookmark' },
       ],
     },
   ];

--- a/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
@@ -11,8 +11,12 @@
   } from '../../tags';
 
   interface Props {
-    /** Active note's content. Tags from this note are highlighted in
-     *  the tree but the panel shows project-wide tags now (#466). */
+    /** Active note's content. The panel shows only this note's tags
+     *  plus their hierarchical ancestors — the left-sidebar Tags panel
+     *  covers the project-wide view, so duplicating it here adds no
+     *  signal. Ancestors of a tag (e.g. `#foo` for a note tagged
+     *  `#foo/bar/baz`) appear even if no other note uses them; unrelated
+     *  siblings (e.g. `#foo/baz`) do not. */
     content: string;
     onFileSelect: (relativePath: string) => void;
     /** Selecting a source from the tagged-things list opens it in the
@@ -89,10 +93,7 @@
     allTags = await api.tags.list();
   }
 
-  const tree = $derived<TagTreeNode[]>(buildTagTree(allTags));
-
-  /** Tags present in the active note — used to give those rows a
-   *  subtle highlight without filtering the project-wide tree. */
+  /** Tags written literally in the active note (no ancestors yet). */
   const ACTIVE_TAG_RE = /(?:^|\s)#([a-zA-Z][\w/-]*)/g;
   const CODE_RE = /```[\s\S]*?```|`[^`\n]+`/g;
   const tagsInActiveNote = $derived.by<Set<string>>(() => {
@@ -106,6 +107,16 @@
     }
     return found;
   });
+
+  /** Project-wide TagInfo rows for the tags this note actually uses.
+   *  `buildTagTree` will synthesize ancestor nodes from each tag's
+   *  path segments — so `#foo/bar/baz` produces `foo` and `foo/bar`
+   *  in the tree even when no project tag matches them literally. */
+  const tagsForActiveNote = $derived<TagInfo[]>(
+    allTags.filter((t) => tagsInActiveNote.has(t.tag)),
+  );
+
+  const tree = $derived<TagTreeNode[]>(buildTagTree(tagsForActiveNote));
 
   /**
    * Visible nodes after applying the search filter. A subtree-level
@@ -215,8 +226,8 @@
       <span>sources</span>
     </button>
   </div>
-  {#if allTags.length === 0}
-    <div class="empty">No tags in project</div>
+  {#if tagsForActiveNote.length === 0}
+    <div class="empty">No tags in this note</div>
   {:else if visibleRows.length === 0}
     <div class="empty">No matches</div>
   {:else}


### PR DESCRIPTION
## Summary

Three small visual tweaks to the right sidebar and editor chrome:

- **Bookmarks moves from Activity to Links.** The Links group is now Outgoing / Backlinks / Citations / Bookmarks; Activity is back to Inspections / Proposals. Bookmarks are saved references, which sits more naturally next to citations and outgoing/backlinks than under runtime activity.
- **Right-sidebar Tags panel scoped to the current note.** Previously it duplicated the project-wide left-sidebar Tags view. It now shows only tags written in the active note plus their hierarchical ancestors (so a `#foo/bar/baz` tag produces `foo` and `foo/bar` rows even if no other note uses them), but unrelated siblings stay out. Empty-state message updated to "No tags in this note."
- **Active-line accent bar no longer doubles up over the compute gutter.** The bar is now painted on the active content row's left edge rather than each gutter column's right edge, so the visual is a single bar at the gutter/content boundary regardless of how many gutter columns are present.

## Test plan

- [ ] Open a note with mixed tags (some nested, some not) and verify the right-sidebar Tags panel shows only those tags plus their ancestors.
- [ ] Open a note with no tags and verify the empty-state message reads "No tags in this note."
- [ ] Open the right sidebar and confirm Bookmarks appears under Links, after Citations.
- [ ] Open a note containing a runnable fence (`sparql`/`sql`/`python`) and confirm only one accent bar shows on the active line, whether the cursor is on the fence (with execute triangle) or on a regular markdown line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)