### PR TITLE
fix: right-sidebar Tags panel now includes frontmatter tags

### DIFF
--- a/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TagsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { TagInfo, TaggedNote, TaggedSource } from '../../../../shared/types';
   import { api } from '../../ipc/client';
+  import { extractTagsFromContent } from '../../../../shared/refactor/auto-tag';
   import Ribbon from './Ribbon.svelte';
   import Icon from '../Icon.svelte';
   import {
@@ -93,17 +94,22 @@
     allTags = await api.tags.list();
   }
 
-  /** Tags written literally in the active note (no ancestors yet). */
+  /** Tags written literally in the active note — both body `#hashtag`
+   *  syntax and YAML frontmatter `tags:` lists. Many notes carry tags
+   *  only in frontmatter, so missing those left the panel blank. */
   const ACTIVE_TAG_RE = /(?:^|\s)#([a-zA-Z][\w/-]*)/g;
   const CODE_RE = /```[\s\S]*?```|`[^`\n]+`/g;
   const tagsInActiveNote = $derived.by<Set<string>>(() => {
-    const stripped = content.replace(CODE_RE, '');
     const found = new Set<string>();
+    const stripped = content.replace(CODE_RE, '');
     ACTIVE_TAG_RE.lastIndex = 0;
     let m;
     while ((m = ACTIVE_TAG_RE.exec(stripped)) !== null) {
       const cleaned = m[1].replace(/\/+$/, '');
       if (cleaned) found.add(cleaned);
+    }
+    for (const t of extractTagsFromContent(content)) {
+      if (t) found.add(t);
     }
     return found;
   });


### PR DESCRIPTION
## Summary

Follow-up to #609. After scoping the right-sidebar Tags panel to the active note's tags, notes that carry tags only in YAML frontmatter started showing an empty panel — the panel's body extraction only matched `#hashtag` syntax. This change unions body extraction with `extractTagsFromContent` (the existing frontmatter parser) so both sources populate the active-note tag set.

## Test plan

- [ ] Open a note whose tags live only in YAML frontmatter (`tags: [foo, bar]`) and verify the right-sidebar Tags panel lists them.
- [ ] Open a note with tags in both frontmatter and body (`#baz`) and verify the union appears.
- [ ] Open a note with tags only in `#hashtag` body syntax and verify behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)