### PR TITLE
ui: split Bookmarks — project-wide admin moves to left sidebar, right sidebar shows active note only

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -3121,7 +3121,6 @@
           onFileSelect={handleFileSelect}
           onNavigate={handleNavigate}
           onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
-          onShowPrompt={showPrompt}
           onOpenConversation={(msg) => { void openConversationWithMessage(msg); }}
           onOpenQuery={(sql) => editor.openQuery(sql, 'sql')}
           onOpenSource={handleOpenSource}

--- a/src/renderer/lib/components/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/BookmarksPanel.svelte
@@ -1,0 +1,330 @@
+<script lang="ts">
+  import { getBookmarksStore } from '../stores/bookmarks.svelte';
+  import type { BookmarkNode } from '../../../shared/types';
+  import Ribbon from './right-sidebar/Ribbon.svelte';
+  import Icon from './Icon.svelte';
+  import { clampMenuToViewport } from '../utils/menuClamp';
+
+  interface Props {
+    onFileSelect: (relativePath: string) => void;
+    onShowPrompt: (message: string) => Promise<string | null>;
+  }
+
+  let { onFileSelect, onShowPrompt }: Props = $props();
+
+  const bookmarks = getBookmarksStore();
+  let expanded = $state<Record<string, boolean>>({});
+  let search = $state('');
+  let contextMenu = $state<{ x: number; y: number; nodeId: string; nodeType: 'bookmark' | 'folder' } | null>(null);
+  let contextMenuEl = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    if (!contextMenu || !contextMenuEl) return;
+    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      contextMenu = { ...contextMenu, ...next };
+    }
+  });
+
+  function collectFolderIds(nodes: BookmarkNode[], out: string[] = []): string[] {
+    for (const n of nodes) {
+      if (n.type === 'folder') {
+        out.push(n.id);
+        collectFolderIds(n.children, out);
+      }
+    }
+    return out;
+  }
+
+  function expandAll() {
+    const next: Record<string, boolean> = {};
+    for (const id of collectFolderIds(bookmarks.tree)) next[id] = true;
+    expanded = next;
+  }
+
+  function collapseAll() {
+    expanded = {};
+  }
+
+  // When a search is active, hide branches whose entire subtree has no
+  // matching bookmark. Folders whose name matches also stay visible even
+  // if their children don't — lets the user find folders by name.
+  function matchesSearch(node: BookmarkNode): boolean {
+    const q = search.trim().toLowerCase();
+    if (!q) return true;
+    if (node.name.toLowerCase().includes(q)) return true;
+    if (node.type === 'folder') {
+      return node.children.some(matchesSearch);
+    }
+    return false;
+  }
+
+  function toggleFolder(id: string) {
+    expanded[id] = !expanded[id];
+  }
+
+  function handleClick(node: BookmarkNode) {
+    if (node.type === 'bookmark') {
+      onFileSelect(node.relativePath);
+    } else {
+      toggleFolder(node.id);
+    }
+  }
+
+  function showContextMenu(e: MouseEvent, node: BookmarkNode) {
+    e.preventDefault();
+    contextMenu = { x: e.clientX, y: e.clientY, nodeId: node.id, nodeType: node.type };
+    const close = () => { contextMenu = null; window.removeEventListener('click', close); };
+    setTimeout(() => window.addEventListener('click', close), 0);
+  }
+
+  async function handleRename(id: string) {
+    const name = await onShowPrompt('New name:');
+    if (name) bookmarks.rename(id, name);
+    contextMenu = null;
+  }
+
+  async function handleNewFolder() {
+    const name = await onShowPrompt('Folder name:');
+    if (name) bookmarks.addFolder(name);
+  }
+
+  function handleDragStart(e: DragEvent, id: string) {
+    e.dataTransfer!.setData('text/bookmark-id', id);
+    e.dataTransfer!.effectAllowed = 'move';
+  }
+
+  function handleDrop(e: DragEvent, targetFolderId: string | null) {
+    e.preventDefault();
+    const id = e.dataTransfer!.getData('text/bookmark-id');
+    if (id && id !== targetFolderId) {
+      bookmarks.move(id, targetFolderId);
+    }
+  }
+
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    e.dataTransfer!.dropEffect = 'move';
+  }
+</script>
+
+<div class="bookmarks-panel">
+  <Ribbon
+    {search}
+    onSearch={(q: string) => { search = q; }}
+    searchPlaceholder="Find bookmark…"
+    onExpandAll={expandAll}
+    onCollapseAll={collapseAll}
+  />
+  <div class="panel-header">
+    <button class="new-folder-btn" onclick={handleNewFolder} title="New Folder">+ Folder</button>
+  </div>
+
+  {#if bookmarks.tree.length === 0}
+    <p class="empty">No bookmarks yet</p>
+  {:else}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="bookmark-tree"
+      ondragover={handleDragOver}
+      ondrop={(e) => handleDrop(e, null)}
+    >
+      {#each bookmarks.tree as node}
+        {#if matchesSearch(node)}
+          {@render bookmarkNode(node, 0)}
+        {/if}
+      {/each}
+    </div>
+  {/if}
+
+  {#if contextMenu}
+    <div class="context-menu" bind:this={contextMenuEl} style:left="{contextMenu.x}px" style:top="{contextMenu.y}px">
+      <button onclick={() => handleRename(contextMenu!.nodeId)}>Rename</button>
+      <button onclick={() => { bookmarks.remove(contextMenu!.nodeId); contextMenu = null; }}>Delete</button>
+    </div>
+  {/if}
+</div>
+
+{#snippet bookmarkNode(node: BookmarkNode, depth: number)}
+  {#if node.type === 'folder'}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="bm-item folder"
+      style:padding-left="{8 + depth * 14}px"
+      onclick={() => toggleFolder(node.id)}
+      oncontextmenu={(e) => showContextMenu(e, node)}
+      ondragover={handleDragOver}
+      ondrop={(e) => { e.stopPropagation(); handleDrop(e, node.id); }}
+    >
+      <span class="chev"><Icon name={expanded[node.id] ? 'chevronDown' : 'chevronRight'} size={11} color="var(--text-faint)" /></span>
+      <Icon name={expanded[node.id] ? 'folderOpen' : 'folder'} size={14} color="var(--text-muted)" />
+      <span class="bm-name">{node.name}</span>
+      <span class="folder-count">{node.children.length}</span>
+    </div>
+    {#if expanded[node.id] || search.trim()}
+      {#each node.children as child}
+        {#if matchesSearch(child)}
+          {@render bookmarkNode(child, depth + 1)}
+        {/if}
+      {/each}
+    {/if}
+  {:else}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="bm-item bookmark"
+      style:padding-left="{8 + depth * 14}px"
+      onclick={() => handleClick(node)}
+      oncontextmenu={(e) => showContextMenu(e, node)}
+      draggable={true}
+      ondragstart={(e) => handleDragStart(e, node.id)}
+    >
+      <span class="chev"></span>
+      <Icon name="bookmark" size={13} color="var(--text-faint)" />
+      <span class="bm-body">
+        <span class="bm-name">{node.name}</span>
+        <span class="bm-path">{node.relativePath}</span>
+      </span>
+    </div>
+  {/if}
+{/snippet}
+
+<style>
+  .bookmarks-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .panel-header {
+    display: flex;
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .new-folder-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 9px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--bg);
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+
+  .new-folder-btn:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+
+  .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    text-align: center;
+    padding: 16px 0;
+  }
+
+  .bookmark-tree {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 0;
+  }
+
+  .bm-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 12px;
+    border-left: 2px solid transparent;
+    cursor: pointer;
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    color: var(--text);
+  }
+  .bm-item:hover {
+    background: color-mix(in oklch, var(--text) 4%, transparent);
+    border-left-color: var(--accent);
+  }
+
+  /* Fixed-width chevron slot so folder/bookmark icons align in a column */
+  .chev {
+    width: 11px;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .bm-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .bm-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* Sub-line: source path in mono-faint (§13.7). Lives in the body
+     column so it tucks under the bookmark name. */
+  .bm-path {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Folder row: count chip on the right; folder title slightly heavier. */
+  .folder {
+    color: var(--text);
+  }
+  .folder .bm-name {
+    font-weight: 500;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .folder-count {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 120px;
+  }
+
+  .context-menu button {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .context-menu button:hover { background: var(--bg-button); }
+</style>

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -92,7 +92,6 @@
      *  how the target is written. */
     onNavigate?: (target: string) => void | Promise<void>;
     onScrollToLine: (line: number) => void;
-    onShowPrompt: (message: string) => Promise<string | null>;
     onOpenConversation?: (message: string) => void;
     onOpenQuery: (sql: string) => void;
     onOpenSource: (sourceId: string) => void;
@@ -101,7 +100,7 @@
   }
 
   let {
-    activeFilePath, content, onFileSelect, onNavigate, onScrollToLine, onShowPrompt,
+    activeFilePath, content, onFileSelect, onNavigate, onScrollToLine,
     onOpenConversation, onOpenQuery, onOpenSource, onOpenExcerpt,
     onContentChange,
   }: Props = $props();
@@ -234,7 +233,7 @@
     {:else if activePanel === 'citations'}
       <CitationsPanel {activeFilePath} {content} {revision} {onOpenSource} {onOpenExcerpt} />
     {:else if activePanel === 'bookmarks'}
-      <BookmarksPanel {onFileSelect} {onShowPrompt} />
+      <BookmarksPanel {activeFilePath} {onFileSelect} />
     {:else if activePanel === 'inspections'}
       <InspectionsPanel {revision} {onOpenConversation} />
     {:else if activePanel === 'proposals'}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -4,6 +4,7 @@
   import TagPanel from './TagPanel.svelte';
   import SourcesPanel from './SourcesPanel.svelte';
   import TablesPanel from './TablesPanel.svelte';
+  import BookmarksPanel from './BookmarksPanel.svelte';
   import Icon from './Icon.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { getSidebarSelectionStore } from '../stores/sidebar-selection.svelte';
@@ -11,15 +12,16 @@
   import { getSidebarSettings, setSidebarSettings } from '../sidebar/settings';
   import { tick } from 'svelte';
 
-  type PanelType = 'notes' | 'sites' | 'tags' | 'tables';
+  type PanelType = 'notes' | 'sites' | 'tags' | 'tables' | 'bookmarks';
 
   /** Hybrid icon-rail definition: the active tab shows the label, the
    *  others are icon-only. Per IMPLEMENTATION.md §5.1. */
-  const PANELS: ReadonlyArray<{ id: PanelType; label: string; icon: 'notes' | 'sites' | 'tags' | 'tables' }> = [
-    { id: 'notes',  label: 'Notes',  icon: 'notes' },
-    { id: 'sites',  label: 'Sources',  icon: 'sites' },
-    { id: 'tags',   label: 'Tags',   icon: 'tags' },
-    { id: 'tables', label: 'Tables', icon: 'tables' },
+  const PANELS: ReadonlyArray<{ id: PanelType; label: string; icon: 'notes' | 'sites' | 'tags' | 'tables' | 'bookmark' }> = [
+    { id: 'notes',     label: 'Notes',     icon: 'notes' },
+    { id: 'sites',     label: 'Sources',   icon: 'sites' },
+    { id: 'tags',      label: 'Tags',      icon: 'tags' },
+    { id: 'tables',    label: 'Tables',    icon: 'tables' },
+    { id: 'bookmarks', label: 'Bookmarks', icon: 'bookmark' },
   ];
 
   /** Recursively count files (not folders) in the tree — drives the
@@ -583,6 +585,10 @@
     {:else if activePanel === 'tables'}
       {#if onTableClick && onOpenCsv}
         <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} />
+      {/if}
+    {:else if activePanel === 'bookmarks'}
+      {#if onShowPrompt}
+        <BookmarksPanel {onFileSelect} {onShowPrompt} />
       {/if}
     {/if}
   </div>

--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -1,192 +1,67 @@
 <script lang="ts">
   import { getBookmarksStore } from '../../stores/bookmarks.svelte';
-  import type { BookmarkNode } from '../../../../shared/types';
-  import Ribbon from './Ribbon.svelte';
+  import type { Bookmark, BookmarkNode } from '../../../../shared/types';
   import Icon from '../Icon.svelte';
-  import { clampMenuToViewport } from '../../utils/menuClamp';
 
   interface Props {
+    activeFilePath: string | null;
     onFileSelect: (relativePath: string) => void;
-    onShowPrompt: (message: string) => Promise<string | null>;
   }
 
-  let { onFileSelect, onShowPrompt }: Props = $props();
+  let { activeFilePath, onFileSelect }: Props = $props();
 
   const bookmarks = getBookmarksStore();
-  let expanded = $state<Record<string, boolean>>({});
-  let search = $state('');
-  let contextMenu = $state<{ x: number; y: number; nodeId: string; nodeType: 'bookmark' | 'folder' } | null>(null);
-  let contextMenuEl = $state<HTMLDivElement | undefined>();
 
-  $effect(() => {
-    if (!contextMenu || !contextMenuEl) return;
-    const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
-    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
-      contextMenu = { ...contextMenu, ...next };
-    }
-  });
-
-  function collectFolderIds(nodes: BookmarkNode[], out: string[] = []): string[] {
+  /** Walk the bookmarks tree and collect every bookmark whose
+   *  `relativePath` matches the active note. The project-wide tree's
+   *  folder structure is purely organisational, so we flatten it. */
+  function flatten(nodes: BookmarkNode[], out: Bookmark[] = []): Bookmark[] {
     for (const n of nodes) {
-      if (n.type === 'folder') {
-        out.push(n.id);
-        collectFolderIds(n.children, out);
-      }
+      if (n.type === 'folder') flatten(n.children, out);
+      else out.push(n);
     }
     return out;
   }
 
-  function expandAll() {
-    const next: Record<string, boolean> = {};
-    for (const id of collectFolderIds(bookmarks.tree)) next[id] = true;
-    expanded = next;
-  }
-
-  function collapseAll() {
-    expanded = {};
-  }
-
-  // When a search is active, hide branches whose entire subtree has no
-  // matching bookmark. Folders whose name matches also stay visible even
-  // if their children don't — lets the user find folders by name.
-  function matchesSearch(node: BookmarkNode): boolean {
-    const q = search.trim().toLowerCase();
-    if (!q) return true;
-    if (node.name.toLowerCase().includes(q)) return true;
-    if (node.type === 'folder') {
-      return node.children.some(matchesSearch);
-    }
-    return false;
-  }
-
-  function toggleFolder(id: string) {
-    expanded[id] = !expanded[id];
-  }
-
-  function handleClick(node: BookmarkNode) {
-    if (node.type === 'bookmark') {
-      onFileSelect(node.relativePath);
-    } else {
-      toggleFolder(node.id);
-    }
-  }
-
-  function showContextMenu(e: MouseEvent, node: BookmarkNode) {
-    e.preventDefault();
-    contextMenu = { x: e.clientX, y: e.clientY, nodeId: node.id, nodeType: node.type };
-    const close = () => { contextMenu = null; window.removeEventListener('click', close); };
-    setTimeout(() => window.addEventListener('click', close), 0);
-  }
-
-  async function handleRename(id: string) {
-    const name = await onShowPrompt('New name:');
-    if (name) bookmarks.rename(id, name);
-    contextMenu = null;
-  }
-
-  async function handleNewFolder() {
-    const name = await onShowPrompt('Folder name:');
-    if (name) bookmarks.addFolder(name);
-  }
-
-  function handleDragStart(e: DragEvent, id: string) {
-    e.dataTransfer!.setData('text/bookmark-id', id);
-    e.dataTransfer!.effectAllowed = 'move';
-  }
-
-  function handleDrop(e: DragEvent, targetFolderId: string | null) {
-    e.preventDefault();
-    const id = e.dataTransfer!.getData('text/bookmark-id');
-    if (id && id !== targetFolderId) {
-      bookmarks.move(id, targetFolderId);
-    }
-  }
-
-  function handleDragOver(e: DragEvent) {
-    e.preventDefault();
-    e.dataTransfer!.dropEffect = 'move';
-  }
+  const forActiveNote = $derived<Bookmark[]>(
+    activeFilePath
+      ? flatten(bookmarks.tree).filter((b) => b.relativePath === activeFilePath)
+      : [],
+  );
 </script>
 
 <div class="bookmarks-panel">
-  <Ribbon
-    {search}
-    onSearch={(q: string) => { search = q; }}
-    searchPlaceholder="Find bookmark…"
-    onExpandAll={expandAll}
-    onCollapseAll={collapseAll}
-  />
-  <div class="panel-header">
-    <button class="new-folder-btn" onclick={handleNewFolder} title="New Folder">+ Folder</button>
-  </div>
-
-  {#if bookmarks.tree.length === 0}
-    <p class="empty">No bookmarks yet</p>
+  {#if !activeFilePath}
+    <p class="empty">No active note</p>
+  {:else if forActiveNote.length === 0}
+    <p class="empty">No bookmarks for this note</p>
   {:else}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="bookmark-tree"
-      ondragover={handleDragOver}
-      ondrop={(e) => handleDrop(e, null)}
-    >
-      {#each bookmarks.tree as node}
-        {#if matchesSearch(node)}
-          {@render bookmarkNode(node, 0)}
-        {/if}
+    <div class="bookmark-list">
+      {#each forActiveNote as bm (bm.id)}
+        <div class="bm-item">
+          <button
+            type="button"
+            class="bm-open"
+            onclick={() => onFileSelect(bm.relativePath)}
+            title={bm.name}
+          >
+            <Icon name="bookmark" size={13} color="var(--text-faint)" />
+            <span class="bm-name">{bm.name}</span>
+          </button>
+          <button
+            type="button"
+            class="bm-delete"
+            onclick={() => bookmarks.remove(bm.id)}
+            title="Delete bookmark"
+            aria-label="Delete bookmark"
+          >
+            <Icon name="close" size={12} color="currentColor" />
+          </button>
+        </div>
       {/each}
-    </div>
-  {/if}
-
-  {#if contextMenu}
-    <div class="context-menu" bind:this={contextMenuEl} style:left="{contextMenu.x}px" style:top="{contextMenu.y}px">
-      <button onclick={() => handleRename(contextMenu!.nodeId)}>Rename</button>
-      <button onclick={() => { bookmarks.remove(contextMenu!.nodeId); contextMenu = null; }}>Delete</button>
     </div>
   {/if}
 </div>
-
-{#snippet bookmarkNode(node: BookmarkNode, depth: number)}
-  {#if node.type === 'folder'}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="bm-item folder"
-      style:padding-left="{8 + depth * 14}px"
-      onclick={() => toggleFolder(node.id)}
-      oncontextmenu={(e) => showContextMenu(e, node)}
-      ondragover={handleDragOver}
-      ondrop={(e) => { e.stopPropagation(); handleDrop(e, node.id); }}
-    >
-      <span class="chev"><Icon name={expanded[node.id] ? 'chevronDown' : 'chevronRight'} size={11} color="var(--text-faint)" /></span>
-      <Icon name={expanded[node.id] ? 'folderOpen' : 'folder'} size={14} color="var(--text-muted)" />
-      <span class="bm-name">{node.name}</span>
-      <span class="folder-count">{node.children.length}</span>
-    </div>
-    {#if expanded[node.id] || search.trim()}
-      {#each node.children as child}
-        {#if matchesSearch(child)}
-          {@render bookmarkNode(child, depth + 1)}
-        {/if}
-      {/each}
-    {/if}
-  {:else}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="bm-item bookmark"
-      style:padding-left="{8 + depth * 14}px"
-      onclick={() => handleClick(node)}
-      oncontextmenu={(e) => showContextMenu(e, node)}
-      draggable={true}
-      ondragstart={(e) => handleDragStart(e, node.id)}
-    >
-      <span class="chev"></span>
-      <Icon name="bookmark" size={13} color="var(--text-faint)" />
-      <span class="bm-body">
-        <span class="bm-name">{node.name}</span>
-        <span class="bm-path">{node.relativePath}</span>
-      </span>
-    </div>
-  {/if}
-{/snippet}
 
 <style>
   .bookmarks-panel {
@@ -196,40 +71,14 @@
     overflow: hidden;
   }
 
-  .panel-header {
-    display: flex;
-    padding: 6px 12px;
-    border-bottom: 1px solid var(--border);
-    flex-shrink: 0;
-  }
-
-  .new-folder-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 3px 9px;
-    border: 1px solid var(--border);
-    border-radius: 5px;
-    background: var(--bg);
-    color: var(--text-muted);
-    font-family: var(--font-sans);
-    font-size: 11.5px;
-    cursor: pointer;
-  }
-
-  .new-folder-btn:hover {
-    color: var(--text);
-    border-color: var(--border-strong);
-  }
-
   .empty {
     color: var(--text-muted);
     font-size: 12px;
     text-align: center;
-    padding: 16px 0;
+    padding: 16px 12px;
   }
 
-  .bookmark-tree {
+  .bookmark-list {
     flex: 1;
     overflow-y: auto;
     padding: 4px 0;
@@ -238,93 +87,48 @@
   .bm-item {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 5px 12px;
     border-left: 2px solid transparent;
-    cursor: pointer;
-    font-family: var(--font-sans);
-    font-size: 12.5px;
-    color: var(--text);
   }
   .bm-item:hover {
     background: color-mix(in oklch, var(--text) 4%, transparent);
     border-left-color: var(--accent);
   }
 
-  /* Fixed-width chevron slot so folder/bookmark icons align in a column */
-  .chev {
-    width: 11px;
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .bm-body {
+  .bm-open {
     flex: 1;
     min-width: 0;
     display: flex;
-    flex-direction: column;
-    gap: 1px;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 6px 5px 10px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    cursor: pointer;
+    text-align: left;
   }
   .bm-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  /* Sub-line: source path in mono-faint (§13.7). Lives in the body
-     column so it tucks under the bookmark name. */
-  .bm-path {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* Folder row: count chip on the right; folder title slightly heavier. */
-  .folder {
-    color: var(--text);
-  }
-  .folder .bm-name {
-    font-weight: 500;
     flex: 1;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .folder-count {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    font-variant-numeric: tabular-nums;
+
+  /* Delete affordance: muted by default, picks up the row's hover
+     state and only lights up on its own hover. Sized to read as
+     "small action" rather than "danger." */
+  .bm-delete {
     flex-shrink: 0;
-  }
-
-  .context-menu {
-    position: fixed;
-    z-index: 1000;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 4px 0;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    min-width: 120px;
-  }
-
-  .context-menu button {
-    display: block;
-    width: 100%;
-    padding: 6px 12px;
+    padding: 4px 10px;
     border: none;
     background: none;
-    color: var(--text);
-    font-size: 12px;
+    color: var(--text-faint);
     cursor: pointer;
-    text-align: left;
+    opacity: 0;
   }
-
-  .context-menu button:hover { background: var(--bg-button); }
+  .bm-item:hover .bm-delete { opacity: 1; }
+  .bm-delete:hover { color: var(--text); }
 </style>


### PR DESCRIPTION
## Summary

The right-sidebar Bookmarks panel was showing the entire project bookmark tree with rename / new-folder / drag-reorder / search affordances. That's an administrative surface — it belongs in the left sidebar next to Notes / Sources / Tags / Tables, alongside the other project-wide explorers. The right sidebar should stay focused on the active note.

- The existing full Bookmarks panel moves to `components/BookmarksPanel.svelte` and gets a new "Bookmarks" tab in the left Sidebar — the project-wide view is still one click away.
- `right-sidebar/BookmarksPanel.svelte` is rewritten as a minimal view: a flat list of bookmarks whose `relativePath` matches the active note, click to open, hover reveals a small delete affordance, "No bookmarks for this note" empty state when none match. No folder/rename/drag UI.
- `onShowPrompt` removed from `RightSidebar`'s props — nothing inside the right sidebar needs to prompt for anything anymore.

## Test plan

- [ ] Open the left sidebar, switch to the Bookmarks tab, and confirm the full project-wide bookmark tree with rename / new-folder / search / drag-reorder behavior is intact.
- [ ] In the right sidebar, switch to the Bookmarks panel and verify it shows only bookmarks for the active note. Hover a row → delete button appears; click it and the bookmark disappears.
- [ ] Click a bookmark row in the right sidebar and confirm the note opens / stays open.
- [ ] Open a note with no bookmarks and confirm the right-sidebar panel reads "No bookmarks for this note."
- [ ] Switch to a different note and confirm the right-sidebar bookmark list updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)