### PR TITLE
fix: frontmatter fold arrow no longer jumps between lines 1 and 2

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -9,7 +9,7 @@
   import { oneDark } from '@codemirror/theme-one-dark';
   import { getEffectiveTheme, getThemeMode } from '../theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
-  import { indentUnit, foldEffect, unfoldEffect, foldedRanges } from '@codemirror/language';
+  import { indentUnit, foldEffect, unfoldEffect, foldedRanges, foldService } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
   import { search, openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
   import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
@@ -502,6 +502,26 @@
   const extensions = [
     basicSetup,
     markdown({ codeLanguages: languages }),
+    // Pin the frontmatter fold's gutter arrow to line 1 by claiming the
+    // foldable range there ourselves. Without this, the markdown
+    // language's syntactic fold detection picks line 2 for the YAML
+    // body, so toggling the fold makes the arrow jump between lines —
+    // and a click-to-collapse from the expanded state leaves line 1 of
+    // the YAML visible.
+    foldService.of((state, lineStart) => {
+      if (lineStart !== 0) return null;
+      const doc = state.doc;
+      if (doc.lines < 2) return null;
+      const first = doc.line(1);
+      if (first.text.trim() !== '---') return null;
+      for (let i = 2; i <= doc.lines; i++) {
+        const line = doc.line(i);
+        if (line.text.trim() === '---') {
+          return { from: first.to, to: line.to };
+        }
+      }
+      return null;
+    }),
     themeCompartment.of(cmTheme()),
     minervaEditorTheme(),
     search({


### PR DESCRIPTION
## Summary

The manual frontmatter fold's range starts at end-of-line-1, so when initially folded the gutter arrow sits on line 1 — but as soon as you expand it, the markdown language's syntactic fold detection takes over and chooses line 2 (the start of the YAML body) as the foldable owner. The arrow visibly jumps down a line, and a click-to-collapse from the expanded state uses the line-2-rooted range, which leaves the first YAML line visible alongside the collapsed indicator.

Register a `foldService` for line 1 that returns the same `firstLine.to .. closingFence.to` range used by the existing `findFrontmatterRange`. The arrow now stays on line 1 in both states, and click-to-collapse from any state hides the YAML body cleanly.

## Test plan

- [ ] Open a note that has YAML frontmatter with the default "always collapse frontmatter" setting on; verify the fold arrow is on line 1.
- [ ] Click the arrow to expand; verify the arrow stays on line 1 (no jump).
- [ ] Click the arrow to collapse again; verify only the `---` fence is shown plus the collapsed indicator — not the first YAML line.
- [ ] Toggle "always collapse frontmatter" off and reopen a note; verify expanding/collapsing behavior remains consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)