### PR TITLE
fix: keep context menus off the top edge of the viewport

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -36,7 +36,7 @@
   import { footnoteDecorations } from '../editor/footnote-decorations';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
-  import { clampMenuToViewport } from '../utils/menuClamp';
+  import { clampMenuToViewport, clampSubmenu } from '../utils/menuClamp';
   import { extractClaimUri } from '../../../shared/refactor/find-arguments';
 
   export interface CursorInfo {
@@ -467,34 +467,8 @@
     closeMenu();
   }
 
-  // Flip a submenu up/left if its default position (right of + below the parent
-  // item) would extend past the viewport. Called on submenu-item hover.
   function adjustSubmenu(event: MouseEvent) {
-    const item = event.currentTarget as HTMLElement;
-    const submenu = item.querySelector<HTMLElement>(':scope > .submenu');
-    if (!submenu) return;
-
-    // Reset any prior inline overrides so we measure the default CSS position.
-    submenu.style.top = '';
-    submenu.style.bottom = '';
-    submenu.style.left = '';
-    submenu.style.right = '';
-
-    requestAnimationFrame(() => {
-      const rect = submenu.getBoundingClientRect();
-      const vh = window.innerHeight;
-      const vw = window.innerWidth;
-      const MARGIN = 8;
-
-      if (rect.bottom > vh - MARGIN) {
-        submenu.style.top = 'auto';
-        submenu.style.bottom = '-4px';
-      }
-      if (rect.right > vw - MARGIN) {
-        submenu.style.left = 'auto';
-        submenu.style.right = '100%';
-      }
-    });
+    clampSubmenu(event.currentTarget as HTMLElement);
   }
 
   const initSettings = getEditorSettings();

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -23,6 +23,7 @@
   import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
   import { normalizeSqlRows } from '../editor/sql-result';
+  import { clampSubmenu } from '../utils/menuClamp';
   import { renderChart, type ChartHandle, type ChartConfig, type ChartSeries } from '../charts';
   import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
   import { getToolInfosByCategory } from '../tools/tool-registry';
@@ -1446,30 +1447,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   }
 
   function adjustNoteSubmenu(event: MouseEvent): void {
-    // Flip a submenu up/left if its default position (right of + below
-    // the parent item) would extend past the viewport. Mirrors
-    // Editor.svelte's adjustSubmenu.
-    const item = event.currentTarget as HTMLElement;
-    const submenu = item.querySelector<HTMLElement>(':scope > .submenu');
-    if (!submenu) return;
-    submenu.style.top = '';
-    submenu.style.bottom = '';
-    submenu.style.left = '';
-    submenu.style.right = '';
-    requestAnimationFrame(() => {
-      const rect = submenu.getBoundingClientRect();
-      const vh = window.innerHeight;
-      const vw = window.innerWidth;
-      const MARGIN = 8;
-      if (rect.bottom > vh - MARGIN) {
-        submenu.style.top = 'auto';
-        submenu.style.bottom = '-4px';
-      }
-      if (rect.right > vw - MARGIN) {
-        submenu.style.left = 'auto';
-        submenu.style.right = '100%';
-      }
-    });
+    clampSubmenu(event.currentTarget as HTMLElement);
   }
 
   // ── Compute-output overflow menu state (#244) ──────────────────────────────

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -2,7 +2,7 @@
   import { api } from '../ipc/client';
   import type { SourceMetadata, Collection, SmartCollection, SmartCollectionPredicate, ReadStatus } from '../../../shared/types';
   import { displaySourceTitle } from '../../../shared/source-display';
-  import { clampMenuToViewport } from '../utils/menuClamp';
+  import { clampMenuToViewport, clampSubmenu } from '../utils/menuClamp';
   import SourcePickerDialog from './SourcePickerDialog.svelte';
   import CollectionPickerDialog from './CollectionPickerDialog.svelte';
   import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
@@ -125,24 +125,8 @@
     try { localStorage.setItem(QUEUE_EXPANDED_KEY, String(queueExpanded)); } catch { /* ok */ }
   }
 
-  /** Reposition a submenu so it doesn't clip the viewport — same
-   *  helper Editor.svelte uses for its right-click submenus. */
   function adjustSubmenu(event: MouseEvent) {
-    const item = event.currentTarget as HTMLElement;
-    const submenu = item.querySelector<HTMLElement>(':scope > .submenu');
-    if (!submenu) return;
-    submenu.style.top = '';
-    submenu.style.bottom = '';
-    submenu.style.left = '';
-    submenu.style.right = '';
-    requestAnimationFrame(() => {
-      const rect = submenu.getBoundingClientRect();
-      const vh = window.innerHeight;
-      const vw = window.innerWidth;
-      const MARGIN = 8;
-      if (rect.bottom > vh - MARGIN) { submenu.style.top = 'auto'; submenu.style.bottom = '-4px'; }
-      if (rect.right  > vw - MARGIN) { submenu.style.left = 'auto'; submenu.style.right = '100%'; }
-    });
+    clampSubmenu(event.currentTarget as HTMLElement);
   }
 
   $effect(() => {

--- a/src/renderer/lib/utils/menuClamp.ts
+++ b/src/renderer/lib/utils/menuClamp.ts
@@ -1,14 +1,21 @@
 /**
- * Keep a floating context menu inside the viewport.
+ * Keep floating context menus inside the viewport.
  *
  * The Electron title-bar menus are native and the OS handles edge
  * avoidance. Our in-app menus (sidebar file tree, tab right-click,
  * tables, bookmarks, editor content + gutter) are custom HTML divs —
- * so clicking near the bottom-right corner of the window will run them
- * off-screen unless we nudge them back. Each call site drives a
- * $effect that measures the menu's bounding box and clamps the
- * originating pointer coordinates to keep the menu in-bounds with an
- * 8px margin.
+ * so clicking near any window edge will run them off-screen unless we
+ * nudge them back.
+ *
+ * Two helpers:
+ *   - `clampMenuToViewport(x, y, el)` for the top-level menu opened at
+ *     pointer coordinates. Caller drives it from a $effect that
+ *     measures the rendered menu and pushes back the originating
+ *     coordinates if any edge overflows.
+ *   - `clampSubmenu(itemEl)` for hover-opened submenus. Submenus
+ *     default to opening down + right of the parent item; this flips
+ *     them up / left when they'd overflow, and falls back to clamping
+ *     to the viewport edge if a flip would clip the opposite edge too.
  *
  * Usage:
  *   $effect(() => {
@@ -18,7 +25,11 @@
  *       contextMenu = { ...contextMenu, ...next };
  *     }
  *   });
+ *
+ *   <div class="submenu-item" onmouseenter={(e) => clampSubmenu(e.currentTarget)}>
  */
+const MARGIN = 8;
+
 export function clampMenuToViewport(
   x: number,
   y: number,
@@ -27,7 +38,6 @@ export function clampMenuToViewport(
   const rect = el.getBoundingClientRect();
   const vh = window.innerHeight;
   const vw = window.innerWidth;
-  const MARGIN = 8;
   let nextX = x;
   let nextY = y;
   if (rect.bottom > vh - MARGIN) {
@@ -36,5 +46,68 @@ export function clampMenuToViewport(
   if (rect.right > vw - MARGIN) {
     nextX = Math.max(MARGIN, vw - rect.width - MARGIN);
   }
+  // Top / left clamps run after the bottom / right ones so a tall menu
+  // anchored to a low click pins to the top edge rather than the
+  // bottom — the user is much more likely to want the first items
+  // visible than the last.
+  if (rect.top < MARGIN) {
+    nextY = MARGIN;
+  }
+  if (rect.left < MARGIN) {
+    nextX = MARGIN;
+  }
   return { x: nextX, y: nextY };
+}
+
+/**
+ * Reposition a hover-opened `.submenu` inside the given `.submenu-item`
+ * so it stays in the viewport. Resets prior overrides first so the
+ * default CSS position (right + below the parent) is measured cleanly,
+ * then flips / clamps as needed. The submenu is `position: absolute`
+ * inside the item — `top` / `bottom` styles are interpreted relative
+ * to the item, so we convert viewport-target positions to item-local
+ * offsets where needed.
+ */
+export function clampSubmenu(item: HTMLElement): void {
+  const submenu = item.querySelector<HTMLElement>(':scope > .submenu');
+  if (!submenu) return;
+
+  submenu.style.top = '';
+  submenu.style.bottom = '';
+  submenu.style.left = '';
+  submenu.style.right = '';
+
+  requestAnimationFrame(() => {
+    const subRect = submenu.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    const vh = window.innerHeight;
+    const vw = window.innerWidth;
+
+    // Vertical: prefer down (default), else flip up, else clamp to top
+    // edge. The flipped position has the submenu's bottom 4px below the
+    // item's bottom — its top would be at `itemRect.bottom + 4 - height`.
+    if (subRect.bottom > vh - MARGIN) {
+      const flippedTop = itemRect.bottom + 4 - subRect.height;
+      if (flippedTop >= MARGIN) {
+        submenu.style.top = 'auto';
+        submenu.style.bottom = '-4px';
+      } else {
+        // Neither down nor up fits cleanly — pin the submenu top to
+        // MARGIN so the first items are visible. CSS `top` is relative
+        // to the item, so this offsets it to land at viewport MARGIN.
+        submenu.style.top = `${MARGIN - itemRect.top}px`;
+        submenu.style.bottom = 'auto';
+      }
+    } else if (subRect.top < MARGIN) {
+      // Default-down position already clips the top — happens when the
+      // parent item sits near the top of the viewport.
+      submenu.style.top = `${MARGIN - itemRect.top}px`;
+      submenu.style.bottom = 'auto';
+    }
+
+    if (subRect.right > vw - MARGIN) {
+      submenu.style.left = 'auto';
+      submenu.style.right = '100%';
+    }
+  });
 }


### PR DESCRIPTION
## Summary

Right-click menus and hover submenus already nudged themselves away from the bottom and right edges, but neither helper handled top / left clipping — and the submenu helper, when flipping upward to avoid the bottom edge, could land its own top above the viewport when the parent item sat near the bottom of a tall menu.

- `clampMenuToViewport`: top + left clamps added, complementing the existing bottom + right ones. Top-edge clicks no longer leave the first item tucked behind the title bar.
- New `clampSubmenu(item)` helper in `menuClamp.ts`: factors the previously-duplicated submenu adjust logic (Editor / Preview / SourcesPanel) into one place. It tries the default down-right position, flips up / left when that overflows, and as a last resort clamps the submenu top to MARGIN — so when neither down nor up fits cleanly, the first items are visible rather than the last.
- Editor, Preview, and SourcesPanel each replace their local `adjustSubmenu` / `adjustNoteSubmenu` copy with a one-liner that calls the shared helper.

## Test plan

- [ ] Resize the window very short, then right-click in the editor near the bottom edge and verify the context menu sits inside the viewport with the standard margin (existing behavior).
- [ ] Right-click in the editor near the top edge and verify the menu's top sits at the standard margin rather than touching / clipping above the title bar.
- [ ] Open Format → highlight color submenu (or any tall submenu in Editor / Preview / SourcesPanel) from a parent item near the bottom edge — verify the submenu flips up.
- [ ] Open the same submenu from a parent item near the top edge — verify it stays in the viewport rather than running off the top.
- [ ] Use the SourcesPanel right-click submenu in a similar low / high position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)