### PR TITLE
feat: New Note dialog with type picker + per-project note templates (#475)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,6 +5,7 @@ import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { Channels } from '../shared/channels';
 import * as notebaseFs from './notebase/fs';
+import * as templates from './notebase/templates';
 import { isIndexable } from './notebase/indexable-files';
 import { renameWithLinkRewrites } from './notebase/rename';
 import { mergeNotes, previewMergeNotes } from './notebase/merge';
@@ -922,6 +923,29 @@ export function registerIpcHandlers(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return [];
     return graph.allTags(projectContext(rootPath));
+  });
+
+  // Templates (#475)
+  ipcMain.handle(Channels.TEMPLATES_LIST, async (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return [];
+    return templates.listTemplates(rootPath);
+  });
+
+  ipcMain.handle(Channels.TEMPLATES_GET, async (e, filename: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return null;
+    try {
+      return await templates.readTemplate(rootPath, filename);
+    } catch {
+      return null;
+    }
+  });
+
+  ipcMain.handle(Channels.TEMPLATES_SAVE_AS, async (e, name: string, content: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return await templates.saveTemplate(rootPath, name, content);
   });
 
   // Export

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -128,6 +128,10 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           accelerator: 'CmdOrCtrl+S',
           click: () => send(Channels.MENU_SAVE),
         }),
+        gate({
+          label: 'Save as Template…',
+          click: () => send(Channels.MENU_SAVE_AS_TEMPLATE),
+        }),
         { type: 'separator' },
 
         // Ingest / Import — bringing external things in.

--- a/src/main/notebase/templates.ts
+++ b/src/main/notebase/templates.ts
@@ -1,0 +1,161 @@
+/**
+ * Per-project note templates (#475).
+ *
+ * Templates are plain `.md` files under `.minerva/templates/`. The
+ * filename (sans extension) is the template name. Body is a normal
+ * markdown file with `{{var}}` placeholders that `substituteTemplate`
+ * (shared/templates.ts) resolves at insertion time.
+ *
+ * Listing the folder is the registry — no separate index file, no
+ * config. That keeps templates editable as plain notes once they're
+ * in place.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as notebaseFs from './fs';
+
+const TEMPLATES_DIR = '.minerva/templates';
+
+/** Filenames the stock-seed step writes when the templates folder
+ *  doesn't yet exist. Plain enough to demonstrate variable forms
+ *  without prescribing a workflow. */
+const STOCK_TEMPLATES: ReadonlyArray<{ filename: string; content: string }> = [
+  {
+    filename: 'Daily note.md',
+    content: `# {{date:MMM DD, YYYY}}
+
+## Highlights
+- {{cursor}}
+
+## Notes
+
+## Tomorrow
+`,
+  },
+  {
+    filename: 'Meeting.md',
+    content: `---
+date: {{date}}
+attendees:
+  - {{prompt:Attendees}}
+---
+
+# Meeting with {{prompt:Subject}} — {{date:MMM DD}}
+
+## Agenda
+- {{cursor}}
+
+## Notes
+
+## Action items
+- [ ]
+`,
+  },
+  {
+    filename: 'Decision.md',
+    content: `---
+date: {{date}}
+status: proposed
+---
+
+# Decision: {{title}}
+
+## Context
+{{cursor}}
+
+## Options considered
+1.
+
+## Decision
+
+## Consequences
+`,
+  },
+];
+
+export interface TemplateInfo {
+  /** Template name as the user sees it (the filename without \`.md\`). */
+  name: string;
+  /** Filename on disk including the `.md` extension. */
+  filename: string;
+}
+
+function templatesDirAbs(rootPath: string): string {
+  return path.join(rootPath, TEMPLATES_DIR);
+}
+
+/**
+ * Idempotent: seed the stock templates if the folder doesn't yet
+ * exist. Called on project open so existing projects get them too
+ * without needing a separate migration step.
+ */
+export async function ensureSeeded(rootPath: string): Promise<void> {
+  const dir = templatesDirAbs(rootPath);
+  try {
+    await fs.stat(dir);
+    return; // Already exists — respect whatever the user has done.
+  } catch {
+    // Falls through to seed.
+  }
+  await fs.mkdir(dir, { recursive: true });
+  for (const t of STOCK_TEMPLATES) {
+    const full = path.join(dir, t.filename);
+    await fs.writeFile(full, t.content, 'utf-8');
+  }
+}
+
+/** List the .md files in the templates folder. Returns an empty list
+ *  if the folder doesn't exist (a user could have deleted it). */
+export async function listTemplates(rootPath: string): Promise<TemplateInfo[]> {
+  const dir = templatesDirAbs(rootPath);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: TemplateInfo[] = [];
+  for (const entry of entries) {
+    if (!entry.toLowerCase().endsWith('.md')) continue;
+    if (entry.startsWith('.')) continue;
+    out.push({
+      name: entry.slice(0, -3),
+      filename: entry,
+    });
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/** Read a template body by filename. Throws when the file doesn't
+ *  exist — caller treats that as "user deleted the template
+ *  underneath us" and falls back to an empty note. */
+export async function readTemplate(rootPath: string, filename: string): Promise<string> {
+  if (!filename.toLowerCase().endsWith('.md') || filename.includes('/') || filename.includes('\\')) {
+    throw new Error(`Invalid template filename: ${filename}`);
+  }
+  return await notebaseFs.readFile(rootPath, `${TEMPLATES_DIR}/${filename}`);
+}
+
+/**
+ * Write a template under `.minerva/templates/<name>.md`. The name
+ * argument is sanitised — slashes, backslashes, leading dots, and
+ * the `.md` extension are stripped — so the caller can pass the
+ * user's typed value through without preprocessing.
+ */
+export async function saveTemplate(
+  rootPath: string,
+  rawName: string,
+  content: string,
+): Promise<TemplateInfo> {
+  const cleaned = rawName
+    .trim()
+    .replace(/\.md$/i, '')
+    .replace(/[\\/]/g, '-')
+    .replace(/^\.+/, '');
+  if (!cleaned) throw new Error('Template name is empty');
+  const filename = `${cleaned}.md`;
+  await notebaseFs.writeFile(rootPath, `${TEMPLATES_DIR}/${filename}`, content);
+  return { name: cleaned, filename };
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -6,6 +6,7 @@ import { markPathHandled as markPathHandledImpl, wasHandled } from './notebase/p
 import * as graph from './graph/index';
 import * as search from './search/index';
 import * as notebaseFs from './notebase/fs';
+import * as templates from './notebase/templates';
 import * as tables from './sources/tables';
 import { invalidate as invalidatePythonModules } from './compute/python-kernel';
 import { addRecentProject } from './recent-projects';
@@ -158,6 +159,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   win.once('closed', () => { unsubCollision(); });
 
   const projectCtx: ProjectContext = await acquireProject(rootPath, win.id);
+  // Seed `.minerva/templates/` if absent (#475). Idempotent — existing
+  // projects pick up the stock set the first time they're opened
+  // after this lands; user-curated folders are left untouched.
+  try {
+    await templates.ensureSeeded(rootPath);
+  } catch (err) {
+    console.warn('[window-manager] template seed failed', err);
+  }
   addRecentProject(rootPath);
   rebuildMenu();
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -136,6 +136,12 @@ contextBridge.exposeInMainWorld('api', {
     sourcesByTag: (tag: string) => ipcRenderer.invoke(Channels.TAGS_SOURCES_BY_TAG, tag),
     allNames: () => ipcRenderer.invoke(Channels.TAGS_ALL_NAMES),
   },
+  templates: {
+    list: () => ipcRenderer.invoke(Channels.TEMPLATES_LIST),
+    get: (filename: string) => ipcRenderer.invoke(Channels.TEMPLATES_GET, filename),
+    saveAs: (name: string, content: string) =>
+      ipcRenderer.invoke(Channels.TEMPLATES_SAVE_AS, name, content),
+  },
   export: {
     csv: (csv: string) => ipcRenderer.invoke(Channels.EXPORT_CSV, csv),
   },
@@ -375,6 +381,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onSave: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SAVE, () => cb());
+    },
+    onSaveAsTemplate: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_SAVE_AS_TEMPLATE, () => cb());
     },
     onToggleSidebar: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_TOGGLE_SIDEBAR, () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -23,6 +23,9 @@
   } from '../shared/refactor/auto-tag';
   import { getEditorStore } from './lib/stores/editor.svelte';
   import PromptDialog from './lib/components/PromptDialog.svelte';
+  import NewNoteDialog from './lib/components/NewNoteDialog.svelte';
+  import type { NoteExt, NewNoteResult } from './lib/components/new-note-dialog-types';
+  import { substituteTemplate } from '../shared/templates';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
@@ -225,6 +228,10 @@
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
   let promptDialog = $state<{ message: string; suggestions?: string[]; initial?: string; resolve: (value: string | null) => void } | null>(null);
+  let newNoteDialog = $state<{
+    initialExt: NoteExt;
+    resolve: (value: NewNoteResult | null) => void;
+  } | null>(null);
   let confirmDialog = $state<{ message: string; confirmLabel: string; key: string; hideDontAskAgain?: boolean; resolve: (value: boolean) => void } | null>(null);
   let exportDialogFor = $state<string | null>(null);
   /**
@@ -249,6 +256,14 @@
       : (initialOrOptions ?? {});
     return new Promise((resolve) => {
       promptDialog = { message, suggestions: opts.suggestions, initial: opts.initial, resolve };
+    });
+  }
+
+  function showNewNoteDialog(
+    initialExt: NoteExt = '.md',
+  ): Promise<NewNoteResult | null> {
+    return new Promise((resolve) => {
+      newNoteDialog = { initialExt, resolve };
     });
   }
 
@@ -488,6 +503,9 @@
         enabled: hasProject, run: () => { notebase.close(); editor.clear(); } },
       { id: 'file.print', title: 'Print…', category: 'File',
         keybinding: null, enabled: hasNote, run: () => window.print() },
+      { id: 'file.saveAsTemplate', title: 'Save as Template…', category: 'File',
+        keybinding: null, enabled: hasActiveNoteTab,
+        run: () => { void handleSaveAsTemplate(); } },
       // ── Edit / search ──
       { id: 'edit.find', title: 'Find', category: 'Edit',
         keybinding: formatAccelerator('CmdOrCtrl+F'),
@@ -914,14 +932,68 @@
 
   async function handleNewNote(directory: string = '') {
     if (!notebase.meta) return;
-    const name = await showPrompt('Note name:');
-    if (!name) return;
-    const filename = name.endsWith('.md') ? name : `${name}.md`;
+    const result = await showNewNoteDialog();
+    if (!result) return;
+    const filename = `${result.name}${result.ext}`;
     const relativePath = directory ? `${directory}/${filename}` : filename;
-    await api.notebase.createFile(relativePath);
+
+    // Apply a template if one was chosen — substitution runs in the
+    // renderer with `showPrompt` as the interactive resolver so a
+    // `{{prompt:Label}}` template can pause for input. A null prompt
+    // return cancels: the file isn't written and the flow ends.
+    let initialContent = '';
+    let caretOffset: number | null = null;
+    if (result.templateFilename) {
+      const body = await api.templates.get(result.templateFilename);
+      if (body !== null) {
+        const sub = await substituteTemplate(body, {
+          title: result.name,
+          prompt: (label: string) => showPrompt(`${label}:`),
+        });
+        if (sub.cancelled) return;
+        initialContent = sub.content;
+        caretOffset = sub.cursorOffset;
+      }
+    }
+
+    if (initialContent) {
+      await api.notebase.writeFile(relativePath, initialContent);
+    } else {
+      await api.notebase.createFile(relativePath);
+    }
     await notebase.refresh();
     await editor.openFile(relativePath);
+    if (caretOffset !== null) {
+      // Wait one frame so the editor has mounted the file before we
+      // restore the position — restorePosition is a no-op against an
+      // empty doc otherwise. Capture in a const so TS keeps the
+      // narrowing past the closure boundary.
+      const offset = caretOffset;
+      requestAnimationFrame(() => editorComponent?.restorePosition(offset, 0));
+    }
     sidebar?.refreshTags();
+  }
+
+  /** Save the active note's body as a template under
+   *  `.minerva/templates/<name>.md` (#475). The body is copied
+   *  verbatim — placeholders the user typed (`{{title}}` etc.) live
+   *  in the source and get resolved when the template is *used*.
+   *  Existing template files at the same name are overwritten;
+   *  showPrompt is light-weight enough that the user can just retype
+   *  if they meant a different name. */
+  async function handleSaveAsTemplate(): Promise<void> {
+    if (!notebase.meta) return;
+    const tab = editor.activeTab;
+    if (!tab || tab.type !== 'note') return;
+    const suggested = (tab.relativePath.split('/').pop() ?? '')
+      .replace(/\.(md|ttl|csv|py)$/i, '');
+    const name = await showPrompt('Template name:', suggested);
+    if (!name) return;
+    try {
+      await api.templates.saveAs(name, tab.content);
+    } catch (err) {
+      console.error('[templates] saveAs failed', err);
+    }
   }
 
   /** Zotero-style "New note about this source" (#474). Creates a note
@@ -2668,6 +2740,7 @@
     // Listen for menu events from main process
     api.menu.onNewNote(() => handleNewNote());
     api.menu.onSave(() => handleSave());
+    api.menu.onSaveAsTemplate(() => { void handleSaveAsTemplate(); });
     api.menu.onCycleTheme(() => handleCycleTheme());
     api.menu.onFontIncrease(() => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
     api.menu.onFontDecrease(() => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
@@ -3230,6 +3303,13 @@
       initial={promptDialog.initial ?? ''}
       onConfirm={handlePromptConfirm}
       onCancel={handlePromptCancel}
+    />
+  {/if}
+  {#if newNoteDialog}
+    <NewNoteDialog
+      initialExt={newNoteDialog.initialExt}
+      onConfirm={(value) => { const r = newNoteDialog!.resolve; newNoteDialog = null; r(value); }}
+      onCancel={() => { const r = newNoteDialog!.resolve; newNoteDialog = null; r(null); }}
     />
   {/if}
   {#if mineReviewState}

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -7,6 +7,24 @@
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { extractTagsFromContent } from '../../../shared/refactor/auto-tag';
   import { ENTRYPOINT_TAG } from '../../../shared/entrypoint';
+  import type { IconName } from './icons/registry';
+
+  /** Pick the row icon by extension so the sidebar can disambiguate
+   *  note types at a glance. `.md` stays on the default page icon;
+   *  `.csv`/`.ttl`/`.py` get their own. Unknown extensions fall back
+   *  to `notes` rather than introducing a generic-file icon — the
+   *  notebase is curated, so anything else is almost certainly a
+   *  markdown variant the user wants to read as a note. */
+  function iconForFile(name: string): IconName {
+    const dot = name.lastIndexOf('.');
+    const ext = dot >= 0 ? name.slice(dot).toLowerCase() : '';
+    switch (ext) {
+      case '.csv': return 'tables';
+      case '.ttl': return 'graph';
+      case '.py':  return 'code';
+      default:     return 'notes';
+    }
+  }
 
   interface Props {
     files: NoteFile[];
@@ -223,11 +241,11 @@
         >
           <span class="chev"></span>
           <Icon
-            name="notes"
+            name={iconForFile(file.name)}
             size={13}
             color={activeFilePath === file.relativePath ? 'var(--accent)' : 'var(--text-faint)'}
           />
-          <span class="row-label">{file.name.replace(/\.(md|ttl|csv)$/, '')}</span>
+          <span class="row-label">{file.name.replace(/\.(md|ttl|csv|py)$/, '')}</span>
           {#if file.mtimeMs !== undefined}
             <span class="mtime">{formatRelativeTime(file.mtimeMs)}</span>
           {/if}
@@ -261,7 +279,7 @@
       <div class="separator"></div>
     {/if}
     <button onclick={() => { onNewNote(contextMenu!.dir); contextMenu = null; }}>
-      New Note Here
+      New Note
     </button>
     <button onclick={() => { onNewFolder(contextMenu!.dir); contextMenu = null; }}>
       New Folder

--- a/src/renderer/lib/components/NewNoteDialog.svelte
+++ b/src/renderer/lib/components/NewNoteDialog.svelte
@@ -1,0 +1,444 @@
+<script lang="ts">
+  /**
+   * Two-column New Note dialog (#475 will fill in the template list).
+   *
+   * Left column: note-type picker (Note · Graph · Table · Script).
+   * Right column: name field, with a labeled "Template" slot that's
+   * intentionally reserved for the upcoming templates feature so the
+   * eventual addition doesn't re-lay-out the modal.
+   *
+   * Returns `{ name, ext }` via the host's resolver. The host appends
+   * the extension if the user didn't type one already.
+   */
+  import Icon from './Icon.svelte';
+  import type { IconName } from './icons/registry';
+  import { api, type TemplateInfo } from '../ipc/client';
+  import type { NoteExt, NewNoteResult } from './new-note-dialog-types';
+
+  interface TypeOption {
+    ext: NoteExt;
+    label: string;
+    description: string;
+    icon: IconName;
+  }
+
+  const TYPES: ReadonlyArray<TypeOption> = [
+    { ext: '.md',  label: 'Note',   description: 'Markdown',          icon: 'notes' },
+    { ext: '.ttl', label: 'Graph',  description: 'Turtle / RDF',      icon: 'graph' },
+    { ext: '.csv', label: 'Table',  description: 'Comma-separated',   icon: 'tables' },
+    { ext: '.py',  label: 'Script', description: 'Python',            icon: 'code' },
+  ];
+
+  interface Props {
+    onConfirm: (result: NewNoteResult) => void;
+    onCancel: () => void;
+    /** Default selected type — usually `.md` but a caller could seed
+     *  a different default if invoked from a type-aware surface. */
+    initialExt?: NoteExt;
+  }
+
+  let { onConfirm, onCancel, initialExt = '.md' }: Props = $props();
+
+  let ext = $state<NoteExt>(initialExt);
+  let name = $state('');
+  let inputEl = $state<HTMLInputElement>();
+  let templates = $state<TemplateInfo[]>([]);
+  /** `null` = blank file. Empty string from the select element maps
+   *  to null on read; the select stores filenames. */
+  let templateFilename = $state<string | null>(null);
+
+  $effect(() => { inputEl?.focus(); });
+
+  // Load templates once on mount; the list is small and refreshing
+  // on every keystroke would be wasteful.
+  $effect(() => {
+    void api.templates.list().then((list) => { templates = list; });
+  });
+
+  /** Templates only make sense for markdown notes — substitution
+   *  produces markdown content. Hide the slot for other types so the
+   *  user doesn't pick a template that won't apply. */
+  const templatesApply = $derived(ext === '.md');
+
+  /** Strip the chosen type's extension from the typed name if the
+   *  user typed it explicitly — keeps the on-disk filename clean
+   *  whether they typed "draft" or "draft.py". */
+  function normalize(): NewNoteResult | null {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const lower = trimmed.toLowerCase();
+    const stripped = lower.endsWith(ext)
+      ? trimmed.slice(0, -ext.length)
+      : trimmed;
+    return {
+      name: stripped,
+      ext,
+      templateFilename: templatesApply ? templateFilename : null,
+    };
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      const norm = normalize();
+      if (norm) onConfirm(norm);
+    } else if (e.key === 'Escape') {
+      onCancel();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">New</div>
+      <h2 class="title">New Note</h2>
+    </header>
+
+    <div class="body">
+      <!-- Left: type picker. Vertical list so future additions don't
+           pinch the horizontal layout. -->
+      <div class="type-list" role="radiogroup" aria-label="Note type">
+        {#each TYPES as t (t.ext)}
+          {@const active = ext === t.ext}
+          <button
+            type="button"
+            class="type-row"
+            class:active
+            role="radio"
+            aria-checked={active}
+            onclick={() => { ext = t.ext; inputEl?.focus(); }}
+          >
+            <Icon name={t.icon} size={14} color={active ? 'var(--accent)' : 'currentColor'} />
+            <span class="type-text">
+              <span class="type-label">{t.label}</span>
+              <span class="type-desc">{t.description}</span>
+            </span>
+            <span class="type-ext">{t.ext}</span>
+          </button>
+        {/each}
+      </div>
+
+      <!-- Right: name + reserved Template slot. -->
+      <div class="form">
+        <label class="field">
+          <span class="field-label">Name</span>
+          <input
+            bind:this={inputEl}
+            bind:value={name}
+            type="text"
+            class="input"
+            autocomplete="off"
+            placeholder="My note"
+          />
+        </label>
+
+        {#if templatesApply}
+          <div class="template-slot">
+            <span class="field-label">Template</span>
+            <div class="template-list" role="radiogroup" aria-label="Template">
+              <button
+                type="button"
+                class="template-row"
+                class:active={templateFilename === null}
+                role="radio"
+                aria-checked={templateFilename === null}
+                onclick={() => { templateFilename = null; inputEl?.focus(); }}
+              >
+                <span class="template-name">(none)</span>
+                <span class="template-hint">blank file</span>
+              </button>
+              {#each templates as t (t.filename)}
+                {@const active = templateFilename === t.filename}
+                <button
+                  type="button"
+                  class="template-row"
+                  class:active
+                  role="radio"
+                  aria-checked={active}
+                  onclick={() => { templateFilename = t.filename; inputEl?.focus(); }}
+                >
+                  <span class="template-name">{t.name}</span>
+                </button>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↵ create</span>
+      <span class="footer-actions">
+        <button class="btn secondary" onclick={onCancel}>Cancel</button>
+        <button
+          class="btn primary"
+          disabled={!name.trim()}
+          onclick={() => { const n = normalize(); if (n) onConfirm(n); }}
+        >
+          Create
+          <span class="btn-kbd">↵</span>
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 560px;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+    color: var(--text);
+  }
+
+  .body {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 16px;
+    padding: 16px 24px 18px;
+  }
+
+  /* ── Type list (left column) ───────────────────────────────────── */
+  .type-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 4px;
+    background: var(--bg-inset);
+  }
+  .type-row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 7px 9px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .type-row:hover:not(.active) {
+    background: color-mix(in oklch, var(--text) 4%, transparent);
+    color: var(--text);
+  }
+  .type-row.active {
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--accent);
+  }
+  .type-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .type-label {
+    font-size: 12.5px;
+    font-weight: 500;
+  }
+  .type-desc {
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  .type-row.active .type-desc { color: var(--accent); opacity: 0.7; }
+  .type-ext {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .type-row.active .type-ext { color: var(--accent); opacity: 0.8; }
+
+  /* ── Form (right column) ───────────────────────────────────────── */
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .field-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .input {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+    box-sizing: border-box;
+  }
+
+  /* Template picker (#475). Only rendered for .md, since substitution
+     produces markdown content. (none) row keeps the blank-file path
+     as the default. */
+  .template-slot {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .template-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px;
+    background: var(--bg-inset);
+    max-height: 168px;
+    overflow-y: auto;
+  }
+  .template-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 5px 8px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .template-row:hover:not(.active) {
+    background: color-mix(in oklch, var(--text) 4%, transparent);
+    color: var(--text);
+  }
+  .template-row.active {
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--accent);
+  }
+  .template-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .template-hint {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-faint);
+    flex-shrink: 0;
+  }
+  .template-row.active .template-hint { color: var(--accent); opacity: 0.7; }
+
+  /* ── Footer ────────────────────────────────────────────────────── */
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-actions {
+    display: inline-flex;
+    gap: 8px;
+  }
+
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .secondary {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .secondary:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover:not(:disabled) { opacity: 0.92; }
+  .primary:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .btn-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    opacity: 0.7;
+  }
+</style>

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -112,6 +112,20 @@ export const ICONS = {
     '<path d="m4.5 4.5 1.5 1.5M10 10l1.5 1.5M11.5 4.5 10 6M6 10l-1.5 1.5"/>',
   send: '<path d="M2.5 8 13.5 3 11 13.5 7.5 9.5z"/>',
 
+  // ── Note types (sidebar + New Note picker) ───────────────────────
+  // `notes` (page-with-fold) is the markdown default; `tables` (grid)
+  // already covers CSV. These add the missing two so the FileTree can
+  // disambiguate at a glance.
+  graph:
+    '<circle cx="4" cy="4.5" r="1.4"/>' +
+    '<circle cx="12" cy="4.5" r="1.4"/>' +
+    '<circle cx="8" cy="12" r="1.4"/>' +
+    '<path d="M5.4 4.5h5.2M5 5.8 7.3 10.7M11 5.8 8.7 10.7"/>',
+  code:
+    '<path d="M5.5 5.5 3 8l2.5 2.5"/>' +
+    '<path d="M10.5 5.5 13 8l-2.5 2.5"/>' +
+    '<path d="M9.5 4.5 6.5 11.5"/>',
+
   // ── Brand ─────────────────────────────────────────────────────────
   minervaMark:
     '<circle cx="8" cy="8" r="6"/>' +

--- a/src/renderer/lib/components/new-note-dialog-types.ts
+++ b/src/renderer/lib/components/new-note-dialog-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Types shared between NewNoteDialog.svelte and its host App.svelte
+ * (#475). Lives outside the .svelte file because Svelte 5's instance
+ * script doesn't expose `export type` to other modules — only the
+ * module script does, and adding a `<script context="module">` block
+ * just for two types is heavier than a sibling file.
+ */
+
+export type NoteExt = '.md' | '.ttl' | '.csv' | '.py';
+
+export interface NewNoteResult {
+  name: string;
+  ext: NoteExt;
+  /** Filename of the chosen template (`.md` types only), or null
+   *  for a blank file. */
+  templateFilename: string | null;
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -193,6 +193,20 @@ export interface TagsApi {
   allNames(): Promise<string[]>;
 }
 
+export interface TemplateInfo {
+  /** Template name without the `.md` extension — what the user sees. */
+  name: string;
+  /** Filename on disk (`<name>.md`). */
+  filename: string;
+}
+
+export interface TemplatesApi {
+  list(): Promise<TemplateInfo[]>;
+  /** Returns the template body, or `null` if not found. */
+  get(filename: string): Promise<string | null>;
+  saveAs(name: string, content: string): Promise<TemplateInfo>;
+}
+
 export interface ExportApi {
   csv(csv: string): Promise<void>;
 }
@@ -494,6 +508,7 @@ export interface ToolsApi {
 export interface MenuApi {
   onNewNote(cb: () => void): void;
   onSave(cb: () => void): void;
+  onSaveAsTemplate(cb: () => void): void;
   onToggleSidebar(cb: () => void): void;
   onTogglePreview(cb: () => void): void;
   onQuickOpen(cb: () => void): void;
@@ -553,6 +568,7 @@ export interface IdeApi {
   graph: GraphApi;
   tables: TablesApi;
   tags: TagsApi;
+  templates: TemplatesApi;
   export: ExportApi;
   files: FilesApi;
   compute: ComputeApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -108,8 +108,16 @@ export const Channels = {
   TAGS_SOURCES_BY_TAG: 'tags:sourcesByTag',
   TAGS_ALL_NAMES: 'tags:allNames',
 
+  // Templates (#475) — per-project markdown templates under
+  // `.minerva/templates/`. Listing, reading, and saving go through
+  // these channels; substitution is pure and lives in shared/.
+  TEMPLATES_LIST: 'templates:list',
+  TEMPLATES_GET: 'templates:get',
+  TEMPLATES_SAVE_AS: 'templates:saveAs',
+
   // Menu → renderer events (main sends, renderer listens)
   MENU_NEW_NOTE: 'menu:newNote',
+  MENU_SAVE_AS_TEMPLATE: 'menu:saveAsTemplate',
   MENU_SAVE: 'menu:save',
   MENU_TOGGLE_SIDEBAR: 'menu:toggleSidebar',
   MENU_TOGGLE_PREVIEW: 'menu:togglePreview',

--- a/src/shared/templates.ts
+++ b/src/shared/templates.ts
@@ -1,0 +1,183 @@
+/**
+ * Template variable substitution for note templates (#475).
+ *
+ * Templates are plain markdown with `{{var}}` placeholders that the
+ * engine expands at insertion time. Supported variables:
+ *
+ *   {{title}}           — the new note's title
+ *   {{date}}            — current date, default ISO YYYY-MM-DD
+ *   {{date:FMT}}        — current date, formatted with FMT
+ *   {{time}}            — current time, default HH:mm
+ *   {{time:FMT}}        — current time, formatted with FMT
+ *   {{cursor}}          — placement marker; removed from output, the
+ *                         resulting offset is returned so the caller
+ *                         can position the caret on open
+ *   {{prompt:Label}}    — interactive: the caller's `prompt` resolver
+ *                         is invoked with `Label`; the user's input
+ *                         replaces the placeholder. A `null` return
+ *                         (user cancelled) propagates as
+ *                         `cancelled: true` and substitution stops
+ *
+ * Literal `{{` in template output is written `\{{`; the engine drops
+ * the backslash and emits `{{`. This is the project-wide
+ * `{{`-handling convention — see CLAUDE.md, where the Svelte template
+ * gotcha lives in a different layer but the same character pair.
+ *
+ * Format tokens for `date` / `time` are the conventional subset:
+ *
+ *   YYYY  4-digit year         HH    2-digit hour (24h)
+ *   YY    2-digit year         mm    2-digit minute
+ *   MM    2-digit month        ss    2-digit second
+ *   DD    2-digit day
+ *   MMM   short month name (Jan, Feb…)
+ *
+ * Anything else in FMT is preserved literally.
+ */
+
+export interface SubstitutionContext {
+  /** Title to substitute for `{{title}}`. */
+  title: string;
+  /** Used for `{{date}}` / `{{time}}` substitution. Defaults to `new Date()`. */
+  now?: Date;
+  /** Resolver for `{{prompt:Label}}`. Returns `null` if the user cancels;
+   *  the engine then aborts substitution and returns `cancelled: true`. */
+  prompt?: (label: string) => Promise<string | null>;
+}
+
+export interface SubstitutionResult {
+  /** Final template content with all placeholders resolved. */
+  content: string;
+  /** Character offset of the first `{{cursor}}` marker, or `null` if
+   *  none was present. Offset is into the final `content`. */
+  cursorOffset: number | null;
+  /** True when an interactive `{{prompt:…}}` was cancelled. The
+   *  partially-substituted content is still returned so the caller
+   *  can inspect it, but it's usually discarded. */
+  cancelled: boolean;
+}
+
+const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** Apply the conventional date / time format tokens. Anything unknown
+ *  is preserved verbatim, so `[Day] DD` keeps the `[Day] ` literal. */
+export function formatDateTime(fmt: string, when: Date): string {
+  // Token replacement done in a single pass so longer tokens (`YYYY`,
+  // `MMM`) are matched before their shorter prefixes (`YY`, `MM`).
+  return fmt.replace(/YYYY|YY|MMM|MM|DD|HH|mm|ss/g, (tok) => {
+    switch (tok) {
+      case 'YYYY': return String(when.getFullYear());
+      case 'YY':   return String(when.getFullYear()).slice(-2);
+      case 'MMM':  return SHORT_MONTHS[when.getMonth()];
+      case 'MM':   return pad2(when.getMonth() + 1);
+      case 'DD':   return pad2(when.getDate());
+      case 'HH':   return pad2(when.getHours());
+      case 'mm':   return pad2(when.getMinutes());
+      case 'ss':   return pad2(when.getSeconds());
+      default:     return tok;
+    }
+  });
+}
+
+/**
+ * Substitute variables in `template`. Returns the resolved content,
+ * the cursor offset (if any), and a `cancelled` flag if the user
+ * dismissed an interactive prompt.
+ *
+ * Implementation note: a regex `.replace` doesn't fit because
+ * `{{prompt:…}}` substitution is async. We walk the template once,
+ * emitting resolved chunks into an output array — that also gives us
+ * a natural place to capture the `{{cursor}}` offset (the length of
+ * the joined output at the moment we encounter the marker).
+ */
+export async function substituteTemplate(
+  template: string,
+  ctx: SubstitutionContext,
+): Promise<SubstitutionResult> {
+  const now = ctx.now ?? new Date();
+  const out: string[] = [];
+  let cursorOffset: number | null = null;
+  let cancelled = false;
+
+  let i = 0;
+  while (i < template.length) {
+    // Escape: `\{{` emits a literal `{{` and skips the rest of the
+    // placeholder machinery.
+    if (template[i] === '\\' && template.startsWith('{{', i + 1)) {
+      out.push('{{');
+      i += 3;
+      continue;
+    }
+    if (template.startsWith('{{', i)) {
+      const close = template.indexOf('}}', i + 2);
+      if (close < 0) {
+        // No closing braces — emit the rest verbatim and stop scanning
+        // placeholders so we don't loop forever on a malformed file.
+        out.push(template.slice(i));
+        break;
+      }
+      const expr = template.slice(i + 2, close).trim();
+      const resolved = await resolvePlaceholder(expr, ctx, now);
+      if (resolved.kind === 'cursor') {
+        cursorOffset ??= out.join('').length;
+      } else if (resolved.kind === 'cancelled') {
+        cancelled = true;
+        // Emit nothing for the cancelled prompt and stop — the caller
+        // discards the partial content anyway. Falling through to
+        // emit `{{prompt:…}}` literally would surprise both author
+        // and reader.
+        i = close + 2;
+        out.push(template.slice(i));
+        break;
+      } else {
+        out.push(resolved.text);
+      }
+      i = close + 2;
+      continue;
+    }
+    out.push(template[i]);
+    i++;
+  }
+
+  return { content: out.join(''), cursorOffset, cancelled };
+}
+
+type PlaceholderResolution =
+  | { kind: 'text'; text: string }
+  | { kind: 'cursor' }
+  | { kind: 'cancelled' };
+
+async function resolvePlaceholder(
+  expr: string,
+  ctx: SubstitutionContext,
+  now: Date,
+): Promise<PlaceholderResolution> {
+  if (expr === 'title') return { kind: 'text', text: ctx.title };
+  if (expr === 'cursor') return { kind: 'cursor' };
+  if (expr === 'date') return { kind: 'text', text: formatDateTime('YYYY-MM-DD', now) };
+  if (expr === 'time') return { kind: 'text', text: formatDateTime('HH:mm', now) };
+  if (expr.startsWith('date:')) {
+    return { kind: 'text', text: formatDateTime(expr.slice(5), now) };
+  }
+  if (expr.startsWith('time:')) {
+    return { kind: 'text', text: formatDateTime(expr.slice(5), now) };
+  }
+  if (expr.startsWith('prompt:')) {
+    const label = expr.slice(7).trim() || 'Value';
+    if (!ctx.prompt) {
+      // No prompt resolver was supplied — fall back to emitting the
+      // label so the template author at least sees what was missing
+      // rather than getting a silently-stripped placeholder.
+      return { kind: 'text', text: `{{${label}}}` };
+    }
+    const answer = await ctx.prompt(label);
+    if (answer === null) return { kind: 'cancelled' };
+    return { kind: 'text', text: answer };
+  }
+  // Unknown placeholder — preserve verbatim so the user can see what
+  // didn't resolve rather than ending up with a confusing gap.
+  return { kind: 'text', text: `{{${expr}}}` };
+}

--- a/tests/shared/templates.test.ts
+++ b/tests/shared/templates.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { substituteTemplate, formatDateTime } from '../../src/shared/templates';
+
+describe('substituteTemplate (#475)', () => {
+  const FIXED = new Date(2026, 4, 28, 14, 7, 5); // 2026-05-28 14:07:05
+
+  it('substitutes {{title}}', async () => {
+    const r = await substituteTemplate('# {{title}}\n', { title: 'Hello' });
+    expect(r.content).toBe('# Hello\n');
+    expect(r.cursorOffset).toBeNull();
+    expect(r.cancelled).toBe(false);
+  });
+
+  it('substitutes default {{date}} as YYYY-MM-DD', async () => {
+    const r = await substituteTemplate('{{date}}', { title: '', now: FIXED });
+    expect(r.content).toBe('2026-05-28');
+  });
+
+  it('substitutes default {{time}} as HH:mm', async () => {
+    const r = await substituteTemplate('{{time}}', { title: '', now: FIXED });
+    expect(r.content).toBe('14:07');
+  });
+
+  it('honours date format tokens', async () => {
+    const r = await substituteTemplate('{{date:MMM DD, YYYY}}', { title: '', now: FIXED });
+    expect(r.content).toBe('May 28, 2026');
+  });
+
+  it('honours time format tokens with seconds', async () => {
+    const r = await substituteTemplate('{{time:HH:mm:ss}}', { title: '', now: FIXED });
+    expect(r.content).toBe('14:07:05');
+  });
+
+  it('preserves literal characters inside a format spec', async () => {
+    const r = await substituteTemplate('{{date:[Y]YYYY}}', { title: '', now: FIXED });
+    expect(r.content).toBe('[Y]2026');
+  });
+
+  it('captures {{cursor}} offset and removes the marker', async () => {
+    const r = await substituteTemplate('# {{title}}\n\n{{cursor}}\n\nNotes', {
+      title: 'Hi',
+      now: FIXED,
+    });
+    expect(r.content).toBe('# Hi\n\n\n\nNotes');
+    // After "# Hi\n\n" — six characters
+    expect(r.cursorOffset).toBe(6);
+  });
+
+  it('captures only the first {{cursor}} marker when multiple appear', async () => {
+    const r = await substituteTemplate('A{{cursor}}B{{cursor}}C', { title: '', now: FIXED });
+    expect(r.content).toBe('ABC');
+    expect(r.cursorOffset).toBe(1);
+  });
+
+  it('substitutes {{prompt:Label}} via the resolver', async () => {
+    const r = await substituteTemplate('Hello, {{prompt:Who}}!', {
+      title: '',
+      now: FIXED,
+      prompt: async (label) => {
+        expect(label).toBe('Who');
+        return 'World';
+      },
+    });
+    expect(r.content).toBe('Hello, World!');
+    expect(r.cancelled).toBe(false);
+  });
+
+  it('reports cancelled when the prompt resolver returns null', async () => {
+    const r = await substituteTemplate('A {{prompt:X}} B', {
+      title: '',
+      now: FIXED,
+      prompt: async () => null,
+    });
+    expect(r.cancelled).toBe(true);
+    // Content emits everything up to the cancelled prompt and then
+    // the remaining literal so debugging the partial result is at
+    // least possible.
+    expect(r.content).toBe('A  B');
+  });
+
+  it('falls back to a labelled placeholder when no prompt resolver is supplied', async () => {
+    const r = await substituteTemplate('{{prompt:Topic}}', { title: '', now: FIXED });
+    expect(r.content).toBe('{{Topic}}');
+    expect(r.cancelled).toBe(false);
+  });
+
+  it('preserves unknown placeholders verbatim', async () => {
+    const r = await substituteTemplate('{{nope}}', { title: '', now: FIXED });
+    expect(r.content).toBe('{{nope}}');
+  });
+
+  it('treats \\{{ as a literal {{', async () => {
+    const r = await substituteTemplate('Use \\{{date}} for the date', {
+      title: '',
+      now: FIXED,
+    });
+    expect(r.content).toBe('Use {{date}} for the date');
+  });
+
+  it('handles a template with no placeholders', async () => {
+    const r = await substituteTemplate('Plain text.\nNo vars here.', {
+      title: '',
+      now: FIXED,
+    });
+    expect(r.content).toBe('Plain text.\nNo vars here.');
+    expect(r.cursorOffset).toBeNull();
+  });
+
+  it('tolerates an unterminated `{{` by emitting the rest verbatim', async () => {
+    const r = await substituteTemplate('Before {{title}} and {{never closing', {
+      title: 'X',
+      now: FIXED,
+    });
+    expect(r.content).toBe('Before X and {{never closing');
+  });
+
+  it('trims whitespace inside placeholders', async () => {
+    const r = await substituteTemplate('{{ title }} / {{  date  }}', {
+      title: 'A',
+      now: FIXED,
+    });
+    expect(r.content).toBe('A / 2026-05-28');
+  });
+});
+
+describe('formatDateTime', () => {
+  const D = new Date(2026, 0, 5, 9, 3, 0); // 2026-01-05 09:03:00
+
+  it('pads single-digit components', () => {
+    expect(formatDateTime('YYYY-MM-DD HH:mm:ss', D)).toBe('2026-01-05 09:03:00');
+  });
+
+  it('supports short month names', () => {
+    expect(formatDateTime('MMM YYYY', D)).toBe('Jan 2026');
+  });
+
+  it('preserves untokenised characters', () => {
+    expect(formatDateTime('Today is YYYY/MM/DD.', D)).toBe('Today is 2026/01/05.');
+  });
+});


### PR DESCRIPTION
## Summary

Two related changes that share the new modal.

### Type picker

The old `showPrompt('Note name:')` is replaced with a two-column `NewNoteDialog`. Left column picks the file type — **Note (.md)**, **Graph (.ttl)**, **Table (.csv)**, **Script (.py)** — matching the indexable set. The FileTree picks a row icon per extension (`notes` / `graph` / `tables` / `code`) so the sidebar disambiguates note types at a glance. The right-click "New Note Here" entry loses the redundant "Here."

### Per-project note templates (first half of #475)

- Templates live as plain `.md` files under `.minerva/templates/`; listing the folder is the registry.
- Pure substitution engine in `src/shared/templates.ts` resolves `{{title}}`, `{{date}}`, `{{date:FMT}}`, `{{time}}`, `{{time:FMT}}`, `{{cursor}}`, `{{prompt:Label}}`, plus the `\{{` literal escape. 19 unit tests cover format tokens, multiple cursors, unterminated braces, missing prompt resolver, cancellation, whitespace inside placeholders.
- Right column of the modal becomes a template picker for `.md` types (substitution produces markdown). `(none)` keeps the blank-file default.
- `{{cursor}}` positions the caret on open; `{{prompt:Label}}` pauses the flow to call the existing `showPrompt` dialog. Cancelling there cancels the whole creation.
- **Save as Template…** joins the command palette and the File menu; suggests the current filename (extension stripped) and writes the active note's body verbatim.
- Stock templates (**Daily note**, **Meeting**, **Decision**) seed on project open if the templates folder is missing — idempotent, so existing projects pick them up the first time they reopen after this lands.

The fragment / snippet half of #475 is next up on the follow-up branch.

## Test plan

- [ ] Open a project that hasn't been opened since this lands and verify `.minerva/templates/` is seeded with three `.md` files.
- [ ] Right-click the file tree → New Note. Verify type picker shows the four types with icons + descriptions and the menu label reads "New Note" (no "Here").
- [ ] Pick **Script (.py)** and verify the template picker is hidden, file is created empty with `.py` extension, sidebar shows the code icon.
- [ ] Pick **Note (.md)** + **Daily note** template, type a name, verify the new file opens with `{{date:MMM DD, YYYY}}` substituted and caret positioned at the `{{cursor}}` marker.
- [ ] Pick **Meeting** template, name it; the `showPrompt` dialog should pop for Attendees, then for Subject; cancelling either aborts the whole creation (no file written).
- [ ] Open a note, run "Save as Template…" from command palette → enter a name → re-open New Note and verify the new template appears in the picker.
- [ ] Same flow from the native File → Save as Template… menu item.
- [ ] In the FileTree, verify icons differ for `.md` (notes), `.csv` (tables), `.py` (code), `.ttl` (graph) and the extension strips from the displayed name in all four cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)