### PR TITLE
feat: snippet / fragment templates — Insert Template at the caret (#475)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -297,6 +297,10 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           accelerator: 'CmdOrCtrl+Shift+U',
           click: () => send(Channels.MENU_TOGGLE_CASE),
         }),
+        gate({
+          label: 'Insert Template…',
+          click: () => send(Channels.MENU_INSERT_TEMPLATE),
+        }),
         { type: 'separator' },
         gate({
           label: 'Extend Selection',

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -385,6 +385,9 @@ contextBridge.exposeInMainWorld('api', {
     onSaveAsTemplate: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SAVE_AS_TEMPLATE, () => cb());
     },
+    onInsertTemplate: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_INSERT_TEMPLATE, () => cb());
+    },
     onToggleSidebar: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_TOGGLE_SIDEBAR, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -25,7 +25,9 @@
   import PromptDialog from './lib/components/PromptDialog.svelte';
   import NewNoteDialog from './lib/components/NewNoteDialog.svelte';
   import type { NoteExt, NewNoteResult } from './lib/components/new-note-dialog-types';
+  import SnippetPickerDialog from './lib/components/SnippetPickerDialog.svelte';
   import { substituteTemplate } from '../shared/templates';
+  import type { TemplateInfo } from './lib/ipc/client';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
@@ -231,6 +233,10 @@
   let newNoteDialog = $state<{
     initialExt: NoteExt;
     resolve: (value: NewNoteResult | null) => void;
+  } | null>(null);
+  let snippetPicker = $state<{
+    templates: TemplateInfo[];
+    resolve: (value: TemplateInfo | null) => void;
   } | null>(null);
   let confirmDialog = $state<{ message: string; confirmLabel: string; key: string; hideDontAskAgain?: boolean; resolve: (value: boolean) => void } | null>(null);
   let exportDialogFor = $state<string | null>(null);
@@ -506,6 +512,9 @@
       { id: 'file.saveAsTemplate', title: 'Save as Template…', category: 'File',
         keybinding: null, enabled: hasActiveNoteTab,
         run: () => { void handleSaveAsTemplate(); } },
+      { id: 'edit.insertTemplate', title: 'Insert Template…', category: 'Edit',
+        keybinding: null, enabled: hasActiveNoteTab,
+        run: () => { void handleInsertTemplate(); } },
       // ── Edit / search ──
       { id: 'edit.find', title: 'Find', category: 'Edit',
         keybinding: formatAccelerator('CmdOrCtrl+F'),
@@ -972,6 +981,38 @@
       requestAnimationFrame(() => editorComponent?.restorePosition(offset, 0));
     }
     sidebar?.refreshTags();
+  }
+
+  /** Show the snippet picker (#475). Resolves with the chosen
+   *  template or `null` when the user cancels. */
+  function showSnippetPicker(templates: TemplateInfo[]): Promise<TemplateInfo | null> {
+    return new Promise((resolve) => { snippetPicker = { templates, resolve }; });
+  }
+
+  /** Insert a template's substituted body at the editor caret
+   *  (replacing the current selection if any). `{{selection}}`
+   *  picks up the selected text; `{{cursor}}` becomes the post-
+   *  insert caret position; `{{prompt:Label}}` pauses for input
+   *  via the existing showPrompt dialog. (#475) */
+  async function handleInsertTemplate(): Promise<void> {
+    if (!notebase.meta) return;
+    if (editor.activeTab?.type !== 'note') return;
+    const list = await api.templates.list();
+    if (list.length === 0) return;
+    const picked = await showSnippetPicker(list);
+    if (!picked) return;
+    const body = await api.templates.get(picked.filename);
+    if (body === null) return;
+    const selection = editorComponent?.getSelectedText() ?? '';
+    const titleFromPath = (editor.activeFilePath?.split('/').pop() ?? '')
+      .replace(/\.(md|ttl|csv|py)$/i, '');
+    const sub = await substituteTemplate(body, {
+      title: titleFromPath,
+      selection,
+      prompt: (label: string) => showPrompt(`${label}:`),
+    });
+    if (sub.cancelled) return;
+    editorComponent?.insertText(sub.content, sub.cursorOffset);
   }
 
   /** Save the active note's body as a template under
@@ -2741,6 +2782,7 @@
     api.menu.onNewNote(() => handleNewNote());
     api.menu.onSave(() => handleSave());
     api.menu.onSaveAsTemplate(() => { void handleSaveAsTemplate(); });
+    api.menu.onInsertTemplate(() => { void handleInsertTemplate(); });
     api.menu.onCycleTheme(() => handleCycleTheme());
     api.menu.onFontIncrease(() => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
     api.menu.onFontDecrease(() => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
@@ -3310,6 +3352,13 @@
       initialExt={newNoteDialog.initialExt}
       onConfirm={(value) => { const r = newNoteDialog!.resolve; newNoteDialog = null; r(value); }}
       onCancel={() => { const r = newNoteDialog!.resolve; newNoteDialog = null; r(null); }}
+    />
+  {/if}
+  {#if snippetPicker}
+    <SnippetPickerDialog
+      templates={snippetPicker.templates}
+      onPick={(t) => { const r = snippetPicker!.resolve; snippetPicker = null; r(t); }}
+      onCancel={() => { const r = snippetPicker!.resolve; snippetPicker = null; r(null); }}
     />
   {/if}
   {#if mineReviewState}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -747,6 +747,38 @@
     return { from: main.from, to: main.to };
   }
 
+  /** Selected text (empty string if no selection). Used by the
+   *  snippet flow (#475) so a `{{selection}}` placeholder picks up
+   *  whatever the user had highlighted at the trigger moment. */
+  export function getSelectedText(): string {
+    if (!view) return '';
+    const main = view.state.selection.main;
+    if (main.from === main.to) return '';
+    return view.state.doc.sliceString(main.from, main.to);
+  }
+
+  /**
+   * Replace the current selection (or insert at the caret if there
+   * is no selection) with `text`. If `caretWithin` is non-null, the
+   * cursor lands at that offset inside the inserted text — used by
+   * the snippet flow to honour a `{{cursor}}` marker. Returns true
+   * if an edit was applied.
+   */
+  export function insertText(text: string, caretWithin: number | null = null): boolean {
+    if (!view) return false;
+    const main = view.state.selection.main;
+    const insertPos = main.from;
+    const finalCaret = caretWithin !== null
+      ? insertPos + caretWithin
+      : insertPos + text.length;
+    view.dispatch({
+      changes: { from: main.from, to: main.to, insert: text },
+      selection: { anchor: finalCaret },
+    });
+    view.focus();
+    return true;
+  }
+
   /**
    * Resolve a thought:Claim URI from the active selection, then the
    * line under the cursor. Returns null when nothing matches. Used by
@@ -774,16 +806,6 @@
     view.dispatch({
       selection: { anchor: clamped },
       effects: EditorView.scrollIntoView(clamped, { y: 'center' }),
-    });
-    view.focus();
-  }
-
-  export function insertText(text: string) {
-    if (!view) return;
-    const pos = view.state.selection.main.head;
-    view.dispatch({
-      changes: { from: pos, insert: text },
-      selection: { anchor: pos + text.length },
     });
     view.focus();
   }

--- a/src/renderer/lib/components/SnippetPickerDialog.svelte
+++ b/src/renderer/lib/components/SnippetPickerDialog.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  /**
+   * Snippet / fragment template picker (#475 second half). Pulls from
+   * the same `.minerva/templates/` folder as the note-creation flow,
+   * but instead of seeding a new file, inserts the substituted body
+   * at the editor caret (optionally wrapping the current selection
+   * via `{{selection}}`).
+   *
+   * UI is a lightweight typeahead — text input at the top, filtered
+   * list below, Enter to choose, Esc to cancel. Modeled on the
+   * command palette but without the recency / scoring layer; the
+   * template list is short enough that substring filter is enough.
+   */
+  import type { TemplateInfo } from '../ipc/client';
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    templates: TemplateInfo[];
+    onPick: (template: TemplateInfo) => void;
+    onCancel: () => void;
+  }
+
+  let { templates, onPick, onCancel }: Props = $props();
+
+  let query = $state('');
+  let selectedIndex = $state(0);
+  let inputEl = $state<HTMLInputElement>();
+
+  const results = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return templates;
+    return templates.filter((t) => t.name.toLowerCase().includes(q));
+  });
+
+  $effect(() => {
+    // Reset selection when the result set changes — keeps the
+    // highlight on the first match as the user narrows.
+    results;
+    selectedIndex = 0;
+  });
+
+  $effect(() => { inputEl?.focus(); });
+  $effect(() => {
+    const el = document.querySelector('.sp-results .selected');
+    el?.scrollIntoView({ block: 'nearest' });
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (results.length > 0) selectedIndex = (selectedIndex + 1) % results.length;
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (results.length > 0) selectedIndex = (selectedIndex - 1 + results.length) % results.length;
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const pick = results[selectedIndex];
+      if (pick) onPick(pick);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Insert</div>
+      <h2 class="title">Insert Template</h2>
+    </header>
+
+    <div class="body">
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        type="text"
+        class="input"
+        placeholder="Filter templates…"
+        autocomplete="off"
+      />
+
+      {#if templates.length === 0}
+        <div class="empty">No templates in this project yet.</div>
+      {:else if results.length === 0}
+        <div class="empty">No matches.</div>
+      {:else}
+        <div class="sp-results" role="listbox">
+          {#each results as t, i (t.filename)}
+            {@const selected = i === selectedIndex}
+            <button
+              type="button"
+              class="sp-row"
+              class:selected
+              role="option"
+              aria-selected={selected}
+              onmousemove={() => { selectedIndex = i; }}
+              onclick={() => onPick(t)}
+            >
+              <Icon name="notes" size={13} color={selected ? 'var(--accent)' : 'var(--text-faint)'} />
+              <span class="sp-name">{t.name}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↑↓ · ↵ insert</span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 460px;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+    color: var(--text);
+  }
+
+  .body {
+    padding: 14px 24px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .input {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+    box-sizing: border-box;
+  }
+
+  .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    text-align: center;
+    padding: 16px 0;
+  }
+
+  .sp-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    max-height: 280px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px;
+    background: var(--bg-inset);
+  }
+  .sp-row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 6px 9px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 12.5px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .sp-row.selected {
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--accent);
+  }
+  .sp-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -509,6 +509,7 @@ export interface MenuApi {
   onNewNote(cb: () => void): void;
   onSave(cb: () => void): void;
   onSaveAsTemplate(cb: () => void): void;
+  onInsertTemplate(cb: () => void): void;
   onToggleSidebar(cb: () => void): void;
   onTogglePreview(cb: () => void): void;
   onQuickOpen(cb: () => void): void;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -118,6 +118,7 @@ export const Channels = {
   // Menu → renderer events (main sends, renderer listens)
   MENU_NEW_NOTE: 'menu:newNote',
   MENU_SAVE_AS_TEMPLATE: 'menu:saveAsTemplate',
+  MENU_INSERT_TEMPLATE: 'menu:insertTemplate',
   MENU_SAVE: 'menu:save',
   MENU_TOGGLE_SIDEBAR: 'menu:toggleSidebar',
   MENU_TOGGLE_PREVIEW: 'menu:togglePreview',

--- a/src/shared/templates.ts
+++ b/src/shared/templates.ts
@@ -39,6 +39,10 @@ export interface SubstitutionContext {
   title: string;
   /** Used for `{{date}}` / `{{time}}` substitution. Defaults to `new Date()`. */
   now?: Date;
+  /** Currently-selected text in the host editor, substituted for
+   *  `{{selection}}`. Only meaningful in the snippet-insertion flow
+   *  (#475). Empty string when nothing is selected. */
+  selection?: string;
   /** Resolver for `{{prompt:Label}}`. Returns `null` if the user cancels;
    *  the engine then aborts substitution and returns `cancelled: true`. */
   prompt?: (label: string) => Promise<string | null>;
@@ -156,6 +160,7 @@ async function resolvePlaceholder(
   now: Date,
 ): Promise<PlaceholderResolution> {
   if (expr === 'title') return { kind: 'text', text: ctx.title };
+  if (expr === 'selection') return { kind: 'text', text: ctx.selection ?? '' };
   if (expr === 'cursor') return { kind: 'cursor' };
   if (expr === 'date') return { kind: 'text', text: formatDateTime('YYYY-MM-DD', now) };
   if (expr === 'time') return { kind: 'text', text: formatDateTime('HH:mm', now) };

--- a/tests/shared/templates.test.ts
+++ b/tests/shared/templates.test.ts
@@ -78,6 +78,19 @@ describe('substituteTemplate (#475)', () => {
     expect(r.content).toBe('A  B');
   });
 
+  it('substitutes {{selection}} with the supplied text', async () => {
+    const r = await substituteTemplate(
+      '> [!note]\n> {{selection}}\n',
+      { title: '', now: FIXED, selection: 'The quick brown fox' },
+    );
+    expect(r.content).toBe('> [!note]\n> The quick brown fox\n');
+  });
+
+  it('substitutes {{selection}} with empty when none supplied', async () => {
+    const r = await substituteTemplate('[{{selection}}]', { title: '', now: FIXED });
+    expect(r.content).toBe('[]');
+  });
+
   it('falls back to a labelled placeholder when no prompt resolver is supplied', async () => {
     const r = await substituteTemplate('{{prompt:Topic}}', { title: '', now: FIXED });
     expect(r.content).toBe('{{Topic}}');


### PR DESCRIPTION
## Summary

Second half of #475. Any template under `.minerva/templates/` can now be inserted at the caret in an open note, with the current selection folded in via a new `{{selection}}` variable. Same substitution engine, same template folder, same Save-as-Template flow — just a different entry point.

- `substituteTemplate` gains a `selection` field in its context and resolves the `{{selection}}` placeholder. Empty string when nothing was selected.
- New `SnippetPickerDialog`: lightweight typeahead over the project's templates, ↑↓ to navigate, ↵ to insert, esc to cancel.
- Editor surface: `getSelectedText()` returns the active selection (or empty string), and `insertText(text, caretWithin?)` replaces the current selection with `text` and positions the caret at `caretWithin` if a `{{cursor}}` marker was present. The previous one-arg `insertText` (LLM query-list flow) keeps working — the old single-purpose impl is removed and the new one subsumes it.
- `handleInsertTemplate` wires it together: read editor selection, show picker, fetch body, substitute (with `selection` + `showPrompt` for any `{{prompt:Label}}` placeholders), insert. Cancelling a prompt cancels the whole insertion.
- **Insert Template…** appears in the command palette under Edit and in the native Edit menu.

## Test plan

- [ ] Select some text in a note, run "Insert Template…" from the command palette → pick a template that uses `{{selection}}` (write one as `> [!note]\n> {{selection}}` first) → verify the selected text is replaced with the substituted block.
- [ ] No selection: caret-only insert → verify the template appears at the caret, no replacement.
- [ ] Template with `{{cursor}}` → caret lands at the marker, not after the inserted block.
- [ ] Template with `{{prompt:Subject}}` → showPrompt fires; cancelling leaves the document untouched.
- [ ] Native Edit menu → Insert Template… opens the same picker.
- [ ] Verify the LLM query-list "insert" flow (the queryList drag handler / button) still works — that path was the only existing caller of `insertText`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)