### PR TITLE
feat: annotation → note flow — create / append from any excerpt (#101)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -53,6 +53,8 @@ import {
   setPythonTrust,
   getOnboardingDismissed,
   setOnboardingDismissed,
+  getExcerptNoteFolder,
+  setExcerptNoteFolder,
 } from './project-config';
 import { DEFAULT_STYLE } from './publish/csl/assets';
 import { buildCitationAudit } from './publish/csl/audit';
@@ -1641,6 +1643,18 @@ export function registerIpcHandlers(): void {
     } catch {
       return false;
     }
+  });
+
+  // Excerpt → Note flow defaults (#101).
+  ipcMain.handle(Channels.EXCERPT_GET_NOTE_FOLDER, (e) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return '';
+    return getExcerptNoteFolder(rootPath);
+  });
+  ipcMain.handle(Channels.EXCERPT_SET_NOTE_FOLDER, (e, folder: string) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    setExcerptNoteFolder(rootPath, folder);
   });
 
   // Finalise a scanned-PDF ingest: the renderer has run OCR and hands

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -35,6 +35,12 @@ export interface ProjectConfigShape {
      *  this thoughtbase even if it's reopened while still empty. */
     dismissed?: boolean;
   };
+  /** Excerpt → Note flow defaults (#101). */
+  excerpt?: {
+    /** Project-relative folder where "New note from excerpt" lands.
+     *  Empty string means the project root. */
+    noteFolder?: string;
+  };
 }
 
 function configPath(rootPath: string): string {
@@ -94,4 +100,23 @@ export function getOnboardingDismissed(rootPath: string): boolean {
 export function setOnboardingDismissed(rootPath: string, dismissed: boolean): void {
   const existing = readProjectConfig(rootPath).onboarding ?? {};
   patchProjectConfig(rootPath, { onboarding: { ...existing, dismissed } });
+}
+
+/** Project-relative folder where "New note from excerpt" lands
+ *  (#101). Returns '' when unset, which the renderer treats as
+ *  "project root". */
+export function getExcerptNoteFolder(rootPath: string): string {
+  return readProjectConfig(rootPath).excerpt?.noteFolder ?? '';
+}
+
+export function setExcerptNoteFolder(rootPath: string, folder: string): void {
+  // Normalise: strip leading/trailing slashes and collapse `\` → `/`
+  // so the on-disk config is consistent regardless of how the user
+  // typed it in the settings field.
+  const cleaned = folder
+    .replace(/\\/g, '/')
+    .replace(/^\/+|\/+$/g, '')
+    .trim();
+  const existing = readProjectConfig(rootPath).excerpt ?? {};
+  patchProjectConfig(rootPath, { excerpt: { ...existing, noteFolder: cleaned } });
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -257,6 +257,9 @@ contextBridge.exposeInMainWorld('api', {
     ingestPdf: () => ipcRenderer.invoke(Channels.SOURCES_INGEST_PDF),
     readPdf: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_READ_PDF, sourceId),
     hasPdf: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_HAS_PDF, sourceId),
+    getExcerptNoteFolder: () => ipcRenderer.invoke(Channels.EXCERPT_GET_NOTE_FOLDER),
+    setExcerptNoteFolder: (folder: string) =>
+      ipcRenderer.invoke(Channels.EXCERPT_SET_NOTE_FOLDER, folder),
     finishPdfOcr: (sourceId: string, pages: string[]) =>
       ipcRenderer.invoke(Channels.SOURCES_FINISH_PDF_OCR, sourceId, pages),
     importBibtex: () => ipcRenderer.invoke(Channels.SOURCES_IMPORT_BIBTEX),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -30,6 +30,7 @@
   import type { TemplateInfo } from './lib/ipc/client';
   import PdfViewer from './lib/components/PdfViewer.svelte';
   import { getPreferredSourceView, setPreferredSourceView } from './lib/source-view-preference';
+  import { buildExcerptNoteContent, buildExcerptAppendBlock } from '../shared/excerpt-note';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
@@ -94,6 +95,16 @@
 
   const notebase = getNotebaseStore();
   const editor = getEditorStore();
+  /** Last note tab the user was on. Used by the SourceDetail "Append
+   *  to current note" action (#101) — when the user is viewing a
+   *  source-detail tab the active tab IS the source, so "current"
+   *  means the previously-active note tab. Tracked here rather than
+   *  in the editor store because nothing else cares about it. */
+  let lastNotePath = $state<string | null>(null);
+  $effect(() => {
+    const t = editor.activeNoteTab;
+    if (t) lastNotePath = t.relativePath;
+  });
   const nav = getNavigationStore();
   const toolPanel = getToolPanelStore();
   const conversationsStore = getConversationsStore();
@@ -1088,6 +1099,72 @@
     await editor.openFile(relativePath);
     sidebar?.refreshTags();
     return relativePath;
+  }
+
+  /** Create a new note seeded from an excerpt (#101). Prompts for
+   *  the title with a sensible default ("Note on <displayTitle>"),
+   *  builds the markdown via `buildExcerptNoteContent`, writes to
+   *  the configured excerpt-note folder (project-config), and
+   *  opens the result. Returns the new note's relative path so
+   *  callers can highlight or further-navigate. */
+  async function handleCreateNoteFromExcerpt(
+    sourceId: string,
+    excerpt: import('../shared/types').SourceExcerpt,
+  ): Promise<string | null> {
+    if (!notebase.meta) return null;
+    const detail = await api.graph.sourceDetail(sourceId);
+    const built = buildExcerptNoteContent({
+      sourceId,
+      excerpt,
+      source: detail?.metadata,
+    });
+    const name = await showPrompt('Note name:', built.suggestedTitle);
+    if (!name) return null;
+    const folder = await api.sources.getExcerptNoteFolder();
+    const stem = name.replace(/\.md$/, '');
+    const filename = `${stem}.md`;
+    const relativePath = folder ? `${folder}/${filename}` : filename;
+    // Re-build with the user's chosen title so the H1 matches.
+    const finalContent = buildExcerptNoteContent({
+      sourceId,
+      excerpt,
+      source: detail?.metadata,
+      titleOverride: stem,
+    }).content;
+    await api.notebase.writeFile(relativePath, finalContent);
+    await notebase.refresh();
+    await editor.openFile(relativePath);
+    sidebar?.refreshTags();
+    return relativePath;
+  }
+
+  /** Append an excerpt's quote (with a [[quote::id]] link) to the
+   *  user's "current" note (#101). When the user is on the
+   *  source-detail tab, "current" is the most-recent note tab —
+   *  tracked via `lastNotePath`. Returns true when the append
+   *  happened so the SourceDetail can flash a brief "Appended ✓"
+   *  affordance. */
+  function handleAppendExcerptToCurrent(
+    excerpt: import('../shared/types').SourceExcerpt,
+  ): boolean {
+    const block = buildExcerptAppendBlock(excerpt);
+    const active = editor.activeNoteTab;
+    if (active) {
+      editor.setContent(active.content + block);
+      return true;
+    }
+    if (!lastNotePath) return false;
+    const idx = editor.tabs.findIndex(
+      (t) => t.type === 'note' && t.relativePath === lastNotePath,
+    );
+    if (idx === -1) return false;
+    editor.switchTab(idx);
+    // setContent operates on the active tab — switchTab already
+    // flipped activeIndex so this targets the right buffer.
+    const target = editor.tabs[idx];
+    if (target.type !== 'note') return false;
+    editor.setContent(target.content + block);
+    return true;
   }
 
   async function handleNewFolder(directory: string = '') {
@@ -3256,6 +3333,9 @@
               onOpenReference={handleOpenSource}
               onResolveStub={handleResolveStub}
               onOpenPdf={handleOpenPdf}
+              onCreateNoteFromExcerpt={handleCreateNoteFromExcerpt}
+              onAppendExcerptToCurrent={handleAppendExcerptToCurrent}
+              canAppendToCurrent={lastNotePath !== null}
             />
           {/key}
         {:else if editor.activeTab?.type === 'pdf'}

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -54,7 +54,7 @@
 
   let { onApplyEditor, onThemeChanged, onClose, initialTab }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'ingest' | 'sites' | 'bibliography' | 'compute' | 'ai';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'ingest' | 'sites' | 'bibliography' | 'excerpts' | 'compute' | 'ai';
 
   /** Restructure per IMPLEMENTATION.md §10.4 — 10 flat tabs become 4
    *  semantic groups. Group labels render in mono-uppercase above each
@@ -83,6 +83,7 @@
         { id: 'refactoring',  label: 'Refactoring',  sub: 'Default destination · merge rules' },
         { id: 'formatter',    label: 'Formatter',    sub: 'On-save rules' },
         { id: 'bibliography', label: 'Bibliography', sub: 'Citation style · locale' },
+        { id: 'excerpts',     label: 'Excerpt notes', sub: 'Default destination folder' },
       ],
     },
     {
@@ -251,6 +252,26 @@
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) return iso;
     return d.toLocaleString();
+  }
+
+  // Excerpt → Note default folder (#101). Empty string = project root.
+  let excerptNoteFolder = $state('');
+
+  async function loadExcerptSettings(): Promise<void> {
+    try {
+      excerptNoteFolder = await api.sources.getExcerptNoteFolder();
+    } catch (e) {
+      console.error('[settings] failed to load excerpt settings:', e);
+    }
+  }
+
+  async function commitExcerptNoteFolder(next: string): Promise<void> {
+    excerptNoteFolder = next;
+    try {
+      await api.sources.setExcerptNoteFolder(next);
+    } catch (e) {
+      console.error('[settings] failed to save excerpt folder:', e);
+    }
   }
 
   // Bibliography style (per-project, persisted in .minerva/config.json).
@@ -427,6 +448,7 @@
     }
     await reloadSites();
     await loadBibliographySettings();
+    await loadExcerptSettings();
     await loadComputeSettings();
     try {
       const ingest = await api.sources.getIngestSettings();
@@ -1032,6 +1054,23 @@
           {#if cslImportError}
             <div class="csl-error">{cslImportError}</div>
           {/if}
+
+        {:else if activeTab === 'excerpts'}
+          <div class="field">
+            <label for="excerpt-note-folder">Default destination folder</label>
+            <input
+              id="excerpt-note-folder"
+              type="text"
+              placeholder="(project root)"
+              value={excerptNoteFolder}
+              onchange={(e) => { void commitExcerptNoteFolder(e.currentTarget.value); }}
+            />
+            <p class="hint">
+              Project-relative folder where "New note from excerpt" lands. Empty
+              means the project root. The folder is created on first write.
+              Stored per-project in <code>.minerva/config.json</code>.
+            </p>
+          </div>
 
         {:else if activeTab === 'compute'}
           <div class="field">

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -33,10 +33,32 @@
      *  may also remember the preference per source so the next
      *  open of this source routes to the PDF directly. */
     onOpenPdf?: (sourceId: string) => void;
+    /** Create a new note from an excerpt (#101). Host runs the
+     *  showPrompt for the title, writes the file to the configured
+     *  folder, and opens it. */
+    onCreateNoteFromExcerpt?: (
+      sourceId: string,
+      excerpt: import('../../../shared/types').SourceExcerpt,
+    ) => Promise<string | null>;
+    /** Append the excerpt to the active note tab (#101). Host
+     *  no-ops if there is no active note tab. Boolean tells the
+     *  caller whether the append succeeded so the UI can flash a
+     *  toast. */
+    onAppendExcerptToCurrent?: (
+      excerpt: import('../../../shared/types').SourceExcerpt,
+    ) => boolean;
+    /** Whether the host currently has an active note tab — used to
+     *  enable / disable the Append button. */
+    canAppendToCurrent?: boolean;
   }
 
-  let { sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted, onCreateAboutNote, onOpenReference, onResolveStub, onOpenPdf }: Props = $props();
+  let {
+    sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted,
+    onCreateAboutNote, onOpenReference, onResolveStub, onOpenPdf,
+    onCreateNoteFromExcerpt, onAppendExcerptToCurrent, canAppendToCurrent = false,
+  }: Props = $props();
   let resolving = $state(false);
+  let appendFlashId = $state<string | null>(null);
 
   /** True when `.minerva/sources/<id>/original.pdf` exists, so the
    *  "Open original PDF" button can show (#100). Resolved on mount;
@@ -191,6 +213,20 @@
   api.sources.onExcerptsChanged(() => {
     if (loadedId === sourceId) void load(sourceId);
   });
+
+  async function createNoteFromExcerpt(excerpt: SourceExcerpt): Promise<void> {
+    if (!onCreateNoteFromExcerpt) return;
+    await onCreateNoteFromExcerpt(sourceId, excerpt);
+  }
+
+  function appendExcerptToCurrent(excerpt: SourceExcerpt): void {
+    if (!onAppendExcerptToCurrent) return;
+    const ok = onAppendExcerptToCurrent(excerpt);
+    if (ok) {
+      appendFlashId = excerpt.excerptId;
+      setTimeout(() => { if (appendFlashId === excerpt.excerptId) appendFlashId = null; }, 1500);
+    }
+  }
 
   // After render, if a specific excerpt was highlighted, scroll it into view.
   $effect(() => {
@@ -451,6 +487,25 @@
                   <span class="sep">·</span>
                   <span>{excerptLocation(excerpt)}</span>
                 {/if}
+                <span class="excerpt-actions">
+                  {#if onCreateNoteFromExcerpt}
+                    <button
+                      class="excerpt-action"
+                      onclick={() => { void createNoteFromExcerpt(excerpt); }}
+                      title="Create a new note seeded with this quote"
+                    >New note</button>
+                  {/if}
+                  {#if onAppendExcerptToCurrent}
+                    <button
+                      class="excerpt-action"
+                      disabled={!canAppendToCurrent}
+                      onclick={() => appendExcerptToCurrent(excerpt)}
+                      title={canAppendToCurrent ? 'Append this quote to the active note' : 'No active note tab'}
+                    >
+                      {appendFlashId === excerpt.excerptId ? 'Appended ✓' : 'Append to current'}
+                    </button>
+                  {/if}
+                </span>
               </div>
             </li>
           {/each}
@@ -861,9 +916,36 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    flex-wrap: wrap;
   }
 
   .sep { opacity: 0.5; }
+
+  /* Push the per-excerpt action buttons to the end so the id +
+     location stay left-aligned while the actions cluster right. */
+  .excerpt-actions {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 4px;
+  }
+  .excerpt-action {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .excerpt-action:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .excerpt-action:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
 
   .backlink-list li {
     padding: 8px 10px;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -670,6 +670,10 @@ export interface SourcesApi {
   /** True iff `.minerva/sources/<id>/original.pdf` exists. Used by the
    *  source detail UI to decide whether to show the PDF affordance. */
   hasPdf(sourceId: string): Promise<boolean>;
+  /** Per-project default folder for excerpt-derived notes (#101).
+   *  Returns '' = project root. */
+  getExcerptNoteFolder(): Promise<string>;
+  setExcerptNoteFolder(folder: string): Promise<void>;
   /** Hand per-page OCR'd text back to main; it writes body.md + stamps meta.ttl (#95). */
   finishPdfOcr(sourceId: string, pages: string[]): Promise<void>;
   /** Open a .bib picker and bulk-import every entry (#98). Returns null if cancelled. */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -218,6 +218,10 @@ export const Channels = {
    *  show the "Open original PDF" button. Returns true iff
    *  `.minerva/sources/<id>/original.pdf` exists. */
   SOURCES_HAS_PDF: 'sources:hasPdf',
+  /** Per-project default folder where "New note from excerpt"
+   *  lands (#101). Empty string = project root. */
+  EXCERPT_GET_NOTE_FOLDER: 'excerpt:getNoteFolder',
+  EXCERPT_SET_NOTE_FOLDER: 'excerpt:setNoteFolder',
   /** Renderer returns OCR'd per-page text; main writes body.md + stamps meta.ttl (#95). */
   SOURCES_FINISH_PDF_OCR: 'sources:finishPdfOcr',
   /** Bulk import from a .bib file (#98). Main opens a picker and parses via @retorquere/bibtex-parser. */

--- a/src/shared/excerpt-note.ts
+++ b/src/shared/excerpt-note.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure builders for the Excerpt → Note flow (#101).
+ *
+ * Two surfaces: a brand-new note pre-filled with the quoted passage
+ * (`buildExcerptNoteContent`), and an append-to-current-note block
+ * for the inline reference flow (`buildExcerptAppendBlock`). Both
+ * are pure so the renderer can use them directly and tests don't
+ * need IPC.
+ */
+
+import type { SourceExcerpt, SourceMetadata } from './types';
+import { displaySourceTitle } from './source-display';
+
+export interface ExcerptNoteParams {
+  sourceId: string;
+  /** Excerpt the note is being built from. `citedText` is the only
+   *  field required; everything else is optional and shapes the
+   *  rendered output. */
+  excerpt: Pick<SourceExcerpt, 'excerptId' | 'citedText' | 'page' | 'pageRange' | 'locationText'>;
+  /** Source metadata so the H1 can read "Note on <displayTitle>"
+   *  rather than "Note on <sourceId>". Optional — when omitted the
+   *  builder falls back to the sourceId. */
+  source?: Pick<SourceMetadata, 'title' | 'uri' | 'doi'>;
+  /** When set, used verbatim as the suggested H1 / filename stem
+   *  (the caller has already prompted the user). */
+  titleOverride?: string;
+}
+
+export interface BuiltNote {
+  /** Full markdown body — frontmatter + heading + blockquote + commentary slot. */
+  content: string;
+  /** Suggested title (matches the H1) — caller uses this as the
+   *  filename suggestion when prompting. */
+  suggestedTitle: string;
+}
+
+/** Render the cited text as a markdown blockquote, preserving line
+ *  breaks in the original. Empty lines inside the quote get the
+ *  leading `>` too so the rendered block stays a single quote
+ *  rather than splitting at the first blank line. */
+function blockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => (line ? `> ${line}` : '>'))
+    .join('\n');
+}
+
+function defaultTitle(params: ExcerptNoteParams): string {
+  if (params.titleOverride) return params.titleOverride;
+  const display = params.source ? displaySourceTitle(params.source) : params.sourceId;
+  return `Note on ${display}`;
+}
+
+export function buildExcerptNoteContent(params: ExcerptNoteParams): BuiltNote {
+  const { sourceId, excerpt } = params;
+  const title = defaultTitle(params);
+  const cited = (excerpt.citedText ?? '').trim();
+
+  const frontmatter: string[] = [
+    '---',
+    `about: [[sources/${sourceId}]]`,
+    `quotes: [[quote::${excerpt.excerptId}]]`,
+    '---',
+    '',
+  ];
+
+  const body: string[] = [`# ${title}`, ''];
+  if (cited) {
+    body.push(blockquote(cited));
+    body.push('');
+  }
+  // Page hint sits under the quote so the reader can see where in
+  // the source it came from without opening the excerpt detail.
+  const loc = excerptLocationHint(excerpt);
+  if (loc) {
+    body.push(`*${loc}*`);
+    body.push('');
+  }
+  body.push('## Commentary', '');
+
+  return {
+    content: frontmatter.join('\n') + body.join('\n'),
+    suggestedTitle: title,
+  };
+}
+
+/**
+ * Append form: appends to an existing note. No frontmatter, no
+ * heading — just the quoted passage followed by a `[[quote::id]]`
+ * link the reader can click to jump back to the excerpt detail.
+ * The leading double-newline ensures a clean separation from
+ * whatever ended the existing buffer.
+ */
+export function buildExcerptAppendBlock(
+  excerpt: Pick<SourceExcerpt, 'excerptId' | 'citedText' | 'page' | 'pageRange' | 'locationText'>,
+): string {
+  const cited = (excerpt.citedText ?? '').trim();
+  const lines: string[] = [];
+  if (cited) lines.push(blockquote(cited));
+  const loc = excerptLocationHint(excerpt);
+  if (loc) lines.push(`— [[quote::${excerpt.excerptId}]] · ${loc}`);
+  else lines.push(`— [[quote::${excerpt.excerptId}]]`);
+  return '\n\n' + lines.join('\n') + '\n';
+}
+
+function excerptLocationHint(
+  e: Pick<SourceExcerpt, 'page' | 'pageRange' | 'locationText'>,
+): string {
+  if (e.pageRange) return `pp. ${e.pageRange}`;
+  if (e.page) return `p. ${e.page}`;
+  if (e.locationText) return e.locationText;
+  return '';
+}

--- a/tests/shared/excerpt-note.test.ts
+++ b/tests/shared/excerpt-note.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { buildExcerptNoteContent, buildExcerptAppendBlock } from '../../src/shared/excerpt-note';
+
+describe('buildExcerptNoteContent (#101)', () => {
+  it('renders frontmatter, heading, quote, and commentary slot', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 'toulmin-1958',
+      excerpt: {
+        excerptId: 'toulmin-1958-9a3d4d01e5a6',
+        citedText: 'Arguments in any field of inquiry can usefully be analysed.',
+        page: '12',
+        pageRange: null,
+        locationText: null,
+      },
+      source: {
+        title: 'The Uses of Argument',
+        uri: null,
+        doi: null,
+      },
+    });
+    expect(r.suggestedTitle).toBe('Note on The Uses of Argument');
+    expect(r.content).toContain('about: [[sources/toulmin-1958]]');
+    expect(r.content).toContain('quotes: [[quote::toulmin-1958-9a3d4d01e5a6]]');
+    expect(r.content).toContain('# Note on');
+    expect(r.content).toContain('> Arguments in any field of inquiry');
+    expect(r.content).toContain('*p. 12*');
+    expect(r.content).toContain('## Commentary');
+  });
+
+  it('falls back to sourceId when no source metadata is supplied', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 'abc-123',
+      excerpt: { excerptId: 'abc-123-deadbeef', citedText: 'Hi.', page: null, pageRange: null, locationText: null },
+    });
+    expect(r.suggestedTitle).toBe('Note on abc-123');
+    expect(r.content).toContain('# Note on abc-123');
+  });
+
+  it('respects an explicit titleOverride', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 'abc-123',
+      excerpt: { excerptId: 'abc-123-deadbeef', citedText: 'Hi.', page: null, pageRange: null, locationText: null },
+      titleOverride: 'My weekend reading',
+    });
+    expect(r.suggestedTitle).toBe('My weekend reading');
+    expect(r.content).toContain('# My weekend reading');
+  });
+
+  it('prefers pageRange over page in the location hint', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 's',
+      excerpt: { excerptId: 'e', citedText: 'x', page: '10', pageRange: '10-12', locationText: null },
+    });
+    expect(r.content).toContain('*pp. 10-12*');
+    expect(r.content).not.toContain('*p. 10*');
+  });
+
+  it('falls back to locationText when no page info is present', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 's',
+      excerpt: { excerptId: 'e', citedText: 'x', page: null, pageRange: null, locationText: 'Chapter 3, §4' },
+    });
+    expect(r.content).toContain('*Chapter 3, §4*');
+  });
+
+  it('omits the location line when none of page/pageRange/locationText are set', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 's',
+      excerpt: { excerptId: 'e', citedText: 'x', page: null, pageRange: null, locationText: null },
+    });
+    expect(r.content).not.toMatch(/\*p/);
+    expect(r.content).toContain('## Commentary');
+  });
+
+  it('preserves multi-line quotes as a single blockquote', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 's',
+      excerpt: {
+        excerptId: 'e',
+        citedText: 'first line\n\nthird line',
+        page: null, pageRange: null, locationText: null,
+      },
+    });
+    expect(r.content).toMatch(/> first line\n>\n> third line/);
+  });
+
+  it('handles empty citedText without crashing — the body just has no quote', () => {
+    const r = buildExcerptNoteContent({
+      sourceId: 's',
+      excerpt: { excerptId: 'e', citedText: '', page: null, pageRange: null, locationText: null },
+    });
+    expect(r.content).toContain('## Commentary');
+    expect(r.content).not.toContain('>');
+  });
+});
+
+describe('buildExcerptAppendBlock (#101)', () => {
+  it('appends quote + quote-link + page hint', () => {
+    const b = buildExcerptAppendBlock({
+      excerptId: 'toulmin-1958-deadbeef',
+      citedText: 'A short quote.',
+      page: '12', pageRange: null, locationText: null,
+    });
+    expect(b).toBe('\n\n> A short quote.\n— [[quote::toulmin-1958-deadbeef]] · p. 12\n');
+  });
+
+  it('omits the page hint when there is none', () => {
+    const b = buildExcerptAppendBlock({
+      excerptId: 'e',
+      citedText: 'Quote.',
+      page: null, pageRange: null, locationText: null,
+    });
+    expect(b).toBe('\n\n> Quote.\n— [[quote::e]]\n');
+  });
+
+  it('still produces a usable block when citedText is empty', () => {
+    const b = buildExcerptAppendBlock({
+      excerptId: 'e',
+      citedText: '',
+      page: null, pageRange: null, locationText: null,
+    });
+    expect(b).toContain('[[quote::e]]');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the reading-workflow loop: each excerpt in the SourceDetail excerpts list now has two inline actions.

- **"New note"** prompts for a title (default `"Note on <displayTitle>"`) and writes a markdown file pre-filled with:
  - frontmatter: `about: [[sources/<id>]]` + `quotes: [[quote::<excerptId>]]`
  - an H1 matching the title
  - the citedText as a blockquote
  - an italicised `*p. N*` (or `*pp. 10–12*`, or location text) hint
  - an empty `## Commentary` section
  - Lands in a configurable folder (defaults to project root).
- **"Append to current note"** appends `> <quote>` + `— [[quote::id]] · p. N` to the user's note. When the active tab is the source-detail tab itself, "current" falls back to the most-recently-visited note tab — tracked via `lastNotePath` in App.svelte. Flashes "Appended ✓" briefly on success. Disabled when there's no current note to target.
- New project-config field `excerpt.noteFolder` with `excerpt:getNoteFolder` / `excerpt:setNoteFolder` IPC. Settings dialog gains an "Excerpt notes" item under Authoring with a folder text field.
- Pure content builders in `src/shared/excerpt-note.ts` with 11 unit tests covering multi-line quotes, location-hint precedence (`pageRange > page > locationText`), `titleOverride`, and empty citedText edge cases.

## Test plan

- [ ] Open a source with at least one excerpt; verify "New note" and "Append to current" appear inline on each excerpt.
- [ ] Click "New note", accept the suggested title — verify the file lands at the project root and opens with frontmatter, blockquote, location hint, and `## Commentary` slot.
- [ ] Set `excerpt.noteFolder` to e.g. `Reading/Notes` in Settings → Authoring → Excerpt notes; create another note from an excerpt and verify it lands there.
- [ ] With a note open in another tab, switch to a source-detail tab and click "Append to current" — verify the quote + `[[quote::id]]` line appends to the original note.
- [ ] With no note tab open at all, verify "Append to current" is disabled.
- [ ] Open the new note and confirm the `[[quote::id]]` link resolves and that the source detail now shows the new note under "Notes about this source."

🤖 Generated with [Claude Code](https://claude.com/claude-code)