### PR TITLE
feat: annotation density gutter in the source viewer (#102)

### DIFF
--- a/src/renderer/lib/components/ExcerptDensityGutter.svelte
+++ b/src/renderer/lib/components/ExcerptDensityGutter.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  /**
+   * Density heatmap gutter for the source viewer (#102).
+   *
+   * Sits absolute on the right edge of a body container, painting a
+   * tick per excerpt at its proportional vertical position. Hover
+   * surfaces a preview of the citedText; click scrolls the parent
+   * scroller to that excerpt. Excerpts whose citedText isn't found
+   * in the rendered body (user-edited body, OCR mismatch) are
+   * silently skipped.
+   *
+   * `host` is the rendered content element whose excerpts we're
+   * indexing. `scroller` is the actual scrollable ancestor — passing
+   * it explicitly lets the gutter dispatch a scroll on the right
+   * element without having to climb the DOM.
+   */
+  import type { SourceExcerpt } from '../../../shared/types';
+  import { findExcerptRange } from './find-excerpt-range';
+
+  interface Props {
+    host: HTMLElement | null;
+    scroller: HTMLElement | null;
+    excerpts: SourceExcerpt[];
+    /** Bumped by the host whenever the body re-renders so the gutter
+     *  recomputes positions. */
+    revision?: number;
+  }
+
+  let { host, scroller, excerpts, revision = 0 }: Props = $props();
+
+  interface Tick {
+    excerptId: string;
+    topPct: number; // 0..1 within host
+    yPx: number;    // absolute top within host
+    preview: string;
+  }
+
+  let ticks = $state<Tick[]>([]);
+  let hovered = $state<Tick | null>(null);
+  let hoverY = $state(0);
+
+  $effect(() => {
+    // Recompute whenever any input changes. The host's layout may
+    // shift between content load and first paint, so a requestAnimationFrame
+    // gives Preview one tick to settle.
+    revision; host; excerpts;
+    if (!host) { ticks = []; return; }
+    requestAnimationFrame(() => recompute());
+  });
+
+  function recompute(): void {
+    if (!host) return;
+    const total = host.scrollHeight || host.getBoundingClientRect().height;
+    if (total <= 0) { ticks = []; return; }
+    const next: Tick[] = [];
+    const hostRect = host.getBoundingClientRect();
+    for (const e of excerpts) {
+      if (!e.citedText) continue;
+      const range = findExcerptRange(host, e.citedText);
+      if (!range) continue;
+      const r = range.getBoundingClientRect();
+      const y = r.top - hostRect.top + host.scrollTop;
+      next.push({
+        excerptId: e.excerptId,
+        yPx: y,
+        topPct: Math.max(0, Math.min(1, y / total)),
+        preview: previewOf(e.citedText),
+      });
+    }
+    ticks = next;
+  }
+
+  function previewOf(s: string): string {
+    const clean = s.replace(/\s+/g, ' ').trim();
+    return clean.length > 120 ? clean.slice(0, 117) + '…' : clean;
+  }
+
+  function jumpTo(tick: Tick): void {
+    if (!scroller || !host) return;
+    // Scroll the scroller so the excerpt sits roughly a third of the
+    // viewport down — comfortable reading position, leaves context
+    // above visible.
+    const containerRect = scroller.getBoundingClientRect();
+    const targetWithinScroller = tick.yPx + (host.offsetTop - scroller.scrollTop);
+    const desiredTop = scroller.scrollTop + targetWithinScroller - containerRect.height / 3;
+    scroller.scrollTo({ top: Math.max(0, desiredTop), behavior: 'smooth' });
+  }
+
+  function onTickEnter(tick: Tick, e: MouseEvent): void {
+    hovered = tick;
+    hoverY = e.clientY;
+  }
+
+  function onTickLeave(): void { hovered = null; }
+</script>
+
+{#if ticks.length > 0}
+  <div class="excerpt-density-gutter" aria-hidden="true">
+    {#each ticks as t (t.excerptId)}
+      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <div
+        class="tick"
+        style:top="{t.topPct * 100}%"
+        onmouseenter={(e) => onTickEnter(t, e)}
+        onmouseleave={onTickLeave}
+        onclick={() => jumpTo(t)}
+      ></div>
+    {/each}
+  </div>
+{/if}
+
+{#if hovered}
+  <div class="excerpt-tip" style:top="{hoverY}px">
+    {hovered.preview}
+  </div>
+{/if}
+
+<style>
+  .excerpt-density-gutter {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 14px;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .tick {
+    position: absolute;
+    right: 4px;
+    left: 4px;
+    height: 6px;
+    margin-top: -3px;
+    border-radius: 2px;
+    background: color-mix(in oklch, var(--accent) 55%, transparent);
+    pointer-events: auto;
+    cursor: pointer;
+    transition: background 0.1s ease, transform 0.1s ease;
+  }
+  .tick:hover {
+    background: var(--accent);
+    transform: scaleX(1.4);
+  }
+
+  /* Tooltip floats next to the cursor — `position: fixed` so it
+     escapes the body-view's clipping context. */
+  .excerpt-tip {
+    position: fixed;
+    right: 18px;
+    transform: translateY(-50%);
+    max-width: 280px;
+    padding: 6px 10px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    color: var(--text);
+    font-size: 12px;
+    line-height: 1.4;
+    pointer-events: none;
+    z-index: 1000;
+    font-family: var(--font-sans);
+  }
+</style>

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { api } from '../ipc/client';
   import Preview from './Preview.svelte';
+  import ExcerptDensityGutter from './ExcerptDensityGutter.svelte';
   import { renderInlineWithMath } from '../markdown/inline-math';
   import type { SourceDetail, SourceExcerpt, SourceBacklink, ReadStatus } from '../../../shared/types';
   import { displaySourceTitle } from '../../../shared/source-display';
@@ -59,6 +61,21 @@
   }: Props = $props();
   let resolving = $state(false);
   let appendFlashId = $state<string | null>(null);
+
+  // Element refs + bump-on-change revision for the density gutter (#102).
+  let scrollerEl = $state<HTMLDivElement>();
+  let bodyViewEl = $state<HTMLDivElement>();
+  let gutterRevision = $state(0);
+  // Re-index excerpt positions when bodyContent or the excerpt set
+  // changes. The write to gutterRevision is wrapped in `untrack` so
+  // the increment doesn't re-trigger this same effect — without it,
+  // reading + writing gutterRevision spins forever, blocking the
+  // event loop and locking the UI on any tab containing this detail.
+  $effect(() => {
+    void bodyContent;
+    void detail?.excerpts.length;
+    untrack(() => { gutterRevision++; });
+  });
 
   /** True when `.minerva/sources/<id>/original.pdf` exists, so the
    *  "Open original PDF" button can show (#100). Resolved on mount;
@@ -305,7 +322,7 @@
   }
 </script>
 
-<div class="source-detail">
+<div class="source-detail" bind:this={scrollerEl}>
   {#if loading}
     <p class="muted">Loading…</p>
   {:else if !detail}
@@ -433,8 +450,20 @@
           </div>
         {:else if bodyContent !== null}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div class="body-view" oncontextmenu={handleBodyContextMenu}>
+          <div
+            class="body-view"
+            bind:this={bodyViewEl}
+            oncontextmenu={handleBodyContextMenu}
+          >
             <Preview content={bodyContent} onNavigate={onNavigate} />
+            {#if detail && detail.excerpts.length > 0}
+              <ExcerptDensityGutter
+                host={bodyViewEl ?? null}
+                scroller={scrollerEl ?? null}
+                excerpts={detail.excerpts}
+                revision={gutterRevision}
+              />
+            {/if}
           </div>
           {#if recentExcerpt}
             <div class="excerpt-banner" class:duplicate={recentExcerpt.duplicate}>
@@ -768,6 +797,9 @@
      * the source panel's existing padding. */
     margin-left: -48px;
     margin-right: -48px;
+    /* `position: relative` so the density gutter (#102) can absolute-
+     *  position its tick marks against the body's full content height. */
+    position: relative;
   }
   .body-view :global(.preview) {
     padding: 0 48px;

--- a/src/renderer/lib/components/find-excerpt-range.ts
+++ b/src/renderer/lib/components/find-excerpt-range.ts
@@ -1,0 +1,148 @@
+/**
+ * Find an excerpt's `citedText` inside a rendered DOM container (#102).
+ *
+ * Used by the source-viewer density gutter to compute each excerpt's
+ * vertical position within the rendered body. Walks text nodes in
+ * document order, normalises whitespace (so soft line wraps and
+ * paragraph breaks don't defeat substring search), and returns a
+ * Range covering the first match — or null when the text doesn't
+ * appear in the rendered body at all (the user may have edited the
+ * body after creating the excerpt).
+ */
+
+/** Strip soft-hyphen / zero-width chars and collapse runs of
+ *  whitespace, lower-cased — same shape as the PDF viewer's
+ *  highlight matcher so the two surfaces find the same text.
+ *  U+00AD soft hyphen, U+200B zero-width space, U+200C zero-width
+ *  non-joiner are the invisible characters that show up in PDF
+ *  extractions and break naive substring search. */
+export function normalizeForMatch(s: string): string {
+  return s
+    .replace(/\s+/g, ' ')
+    .replace(/[\u00AD\u200B\u200C]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+interface CharIndex {
+  /** Concatenated normalised text of the whole container, separated
+   *  by single spaces at element boundaries so words from adjacent
+   *  blocks don't fuse. */
+  text: string;
+  /** For each character in `text`, the source (node, offsetInNode)
+   *  pair that produced it. Used to map a match back to a Range. */
+  nodes: Array<{ node: Text; offset: number }>;
+}
+
+function buildIndex(container: HTMLElement): CharIndex {
+  const text: string[] = [];
+  const nodes: CharIndex['nodes'] = [];
+
+  // Walk text nodes in document order. TreeWalker is the standard
+  // way; `acceptNode` skips invisible (display:none) subtrees so we
+  // don't index hidden helpers that happen to share text.
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const el = node.parentElement;
+      if (!el) return NodeFilter.FILTER_REJECT;
+      // Skip the gutter and any other excerpt-related chrome we
+      // render inside the container — they're noise for the match.
+      if (el.closest('.excerpt-density-gutter')) return NodeFilter.FILTER_REJECT;
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden') {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  let prevParent: Node | null = null;
+  let cur: Node | null = walker.nextNode();
+  while (cur) {
+    const node = cur as Text;
+    const parent = node.parentNode;
+    // Block boundary: insert a synthetic space between adjacent text
+    // runs whose parent elements differ. Stops "endOfPara" + "Next
+    // line" fusing into "endOfParaNext line".
+    if (prevParent && parent !== prevParent && text.length > 0) {
+      text.push(' ');
+      nodes.push({ node, offset: 0 });
+    }
+    const raw = node.data;
+    for (let i = 0; i < raw.length; i++) {
+      text.push(raw[i]);
+      nodes.push({ node, offset: i });
+    }
+    prevParent = parent;
+    cur = walker.nextNode();
+  }
+
+  return { text: text.join(''), nodes };
+}
+
+/**
+ * Find the first occurrence of `needle` in `container` and return a
+ * DOM Range covering it. Returns null when no match is found.
+ *
+ * The match is normalised on both sides (whitespace collapsed,
+ * soft-hyphens stripped, case-insensitive) so the typical noise that
+ * shows up in PDF / OCR extractions doesn't defeat substring search.
+ */
+export function findExcerptRange(container: HTMLElement, citedText: string): Range | null {
+  const needle = normalizeForMatch(citedText);
+  if (!needle) return null;
+  const idx = buildIndex(container);
+
+  // Map normalised haystack → original-character indices so we can
+  // search in the normalised string and still locate the actual DOM
+  // positions of the start / end. Each char of `normalized` carries
+  // the original-index of the character it derived from; runs of
+  // whitespace collapse to one space whose original-index is the
+  // first whitespace in the run.
+  const normalized: string[] = [];
+  const origAt: number[] = [];
+  let inSpace = false;
+  for (let i = 0; i < idx.text.length; i++) {
+    const ch = idx.text[i];
+    if (/\s/.test(ch)) {
+      if (!inSpace) {
+        normalized.push(' ');
+        origAt.push(i);
+        inSpace = true;
+      }
+    } else if (ch === '\u00AD' || ch === '\u200B' || ch === '\u200C') {
+      continue;
+    } else {
+      normalized.push(ch.toLowerCase());
+      origAt.push(i);
+      inSpace = false;
+    }
+  }
+  const haystack = normalized.join('').trim();
+  if (!haystack) return null;
+  // Offset the trim chopped off the head — preserve so we can map
+  // back. The trim only strips a leading space, which maps to a
+  // single original index; subtract its count.
+  const leadingSpaceCount = normalized.length > 0 && normalized[0] === ' ' ? 1 : 0;
+
+  const hit = haystack.indexOf(needle);
+  if (hit < 0) return null;
+
+  const startOrig = origAt[hit + leadingSpaceCount];
+  const endOrigIncl = origAt[hit + leadingSpaceCount + needle.length - 1];
+  if (startOrig == null || endOrigIncl == null) return null;
+
+  // Build the Range from the original-index → DOM position map.
+  const startInfo = idx.nodes[startOrig];
+  const endInfo = idx.nodes[endOrigIncl];
+  if (!startInfo || !endInfo) return null;
+
+  const range = document.createRange();
+  try {
+    range.setStart(startInfo.node, startInfo.offset);
+    range.setEnd(endInfo.node, Math.min(endInfo.node.data.length, endInfo.offset + 1));
+    return range;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

A thin gutter on the right edge of the source-detail body paints a tick per excerpt at its proportional vertical position. Hover surfaces a 120-char `citedText` preview; click smoothly scrolls the excerpt into view about a third of the way down. Excerpts whose `citedText` doesn't appear in the rendered body (user-edited body, OCR mismatch) are silently skipped — no spurious ticks.

- **`find-excerpt-range.ts`** walks the body's text nodes with `TreeWalker`, builds a char-index that tracks each character's source node + offset, and matches against a normalised needle (whitespace collapsed, soft-hyphen / zero-width chars stripped, case-insensitive). Block boundaries get a synthetic space inserted so "endOfPara" + "Next line" don't fuse during search. Same normalisation shape as the PDF viewer's highlight matcher.
- **`ExcerptDensityGutter.svelte`** takes `host` + `scroller` refs + the excerpts list and paints accent-tinted absolutely-positioned tick marks. Tooltip floats next to the cursor via `position: fixed` so it escapes the body-view's clipping. Re-runs on a `revision` counter the host bumps when `bodyContent` or excerpt count changes.
- **SourceDetail's `.body-view`** gets `position: relative` so the gutter anchors to the body's full content height. The revision-bump effect writes through `untrack` so the increment doesn't re-trigger the same effect and spin forever — a bug caught in testing that locked the renderer event loop and froze any subsequent tab switch.

The PDF-viewer page-distribution variant is intentionally not in this PR — the markdown body view is where the gutter pays off most, and the PDF flow is its own surface that can pick up a sibling pattern later if useful.

## Test plan

- [ ] Open a source with several excerpts in its extracted body. Confirm tick marks appear in the right gutter at the right vertical positions.
- [ ] Hover a tick; verify the tooltip shows the cited text preview.
- [ ] Click a tick; verify the body scrolls so the excerpt lands ~1/3 down the viewport.
- [ ] Save a new excerpt; verify a new tick appears without reload.
- [ ] Open a source that has *zero* excerpts; verify the gutter is absent (no empty column).
- [ ] Switch between a source-detail tab and a PDF tab repeatedly; verify the app stays responsive (the prior `gutterRevision++` spin bug would freeze the renderer here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)