### PR TITLE
fix: restore open thoughtbase after laptop sleep/wake

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -75,6 +75,27 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
   contexts.set(win.id, { rootPath: null, graphStore: null });
   installNavigationGuards(win.webContents);
 
+  // Re-announce the open project to the renderer on every page load. The
+  // initial open is driven elsewhere (session restore in main.ts, or the
+  // open/new IPC handlers), but a renderer reload — e.g. the Vite HMR client
+  // forcing a full reload when its websocket reconnects after the laptop wakes
+  // from sleep — resets the renderer's in-memory notebase store to the empty
+  // "Open Thoughtbase" view. The project the window still holds in `contexts`
+  // would otherwise be stranded in main with no way back into the UI short of
+  // reopening by hand. Registered before any did-finish-load handler in
+  // main.ts, so on the very first load this no-ops (rootPath still null) and
+  // the session-restore handler does the real open; on later reloads it
+  // rehydrates. Idempotent — no-op until a project is open.
+  win.webContents.on('did-finish-load', () => {
+    const ctx = contexts.get(win.id);
+    if (ctx?.rootPath && !win.isDestroyed()) {
+      win.webContents.send('project:opened', {
+        rootPath: ctx.rootPath,
+        name: path.basename(ctx.rootPath),
+      });
+    }
+  });
+
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     void win.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
   } else {


### PR DESCRIPTION
## Problem

When the laptop sleeps and reopens, the open thoughtbase is replaced by the empty "Open Thoughtbase" welcome view.

## Root cause

The window's open project is tracked in the **main** process (`contexts` map in `window-manager.ts`) and survives sleep/wake fine. But it's announced to the **renderer** exactly once, via `.once('did-finish-load')` in `main.ts`. The renderer stores it in module-level `$state` (`notebase.svelte.ts`), which is purely in-memory.

On wake, the renderer page reloads cleanly (in dev, the Vite HMR client forces a full reload when its websocket reconnects; equivalent reloads happen in other wake scenarios). That reload resets `meta` to `null` → `{#if notebase.meta}` falls through to the welcome screen — and nothing re-sends `project:opened`, because the `.once` handler was already consumed on the original load.

## Fix

Add a persistent `did-finish-load` listener in `createWindow` that re-announces whatever project the window already holds:

- **No-ops on first load** (rootPath still null) — session restore in `main.ts` does the real open.
- **Rehydrates on every subsequent reload** (wake-from-sleep, HMR reconnect, etc.).
- **Covers both** session-restored and manually-opened projects.
- **Idempotent** — `acquireProject` keys acquirers by `winId`, so repeated reloads don't leak references or re-index (init promise is reused).

## Testing

- `tsc --noEmit` passes.
- Manual: open a thoughtbase, close/reopen the laptop lid — project reappears instead of the welcome screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)