### PR TITLE
feat: Enter-accept eats the half-typed word tail (#206)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -13,6 +13,7 @@
   import { highlightWhitespace } from '@codemirror/view';
   import { search, openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
   import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
+  import { acceptCompletionEatTail, completionKeymapNoEnter } from '../editor/accept-completion-eat-tail';
   import { historyField } from '@codemirror/commands';
   import { api } from '../ipc/client';
   import {
@@ -833,6 +834,13 @@
       // when no completion panel is open, so Tab-for-indent still works
       // everywhere else.
       { key: 'Tab', run: acceptCompletion },
+      // Enter accepts the active completion and eats the half-typed word tail
+      // (#206) — only word chars, so `[[No|te]]` → `[[Notebook]]` keeps its
+      // brackets. Returns false with no popup open, so Enter stays a newline /
+      // list-continuation. completionKeymapNoEnter restores arrow-nav and
+      // Escape that defaultKeymap:false (below) removes.
+      { key: 'Enter', run: acceptCompletionEatTail },
+      ...completionKeymapNoEnter,
       ...resolved.map(({ key: k, command: run }) => ({ key: k, run })),
     ]));
 
@@ -868,6 +876,9 @@
       override: [tagCompletion, linkCompletion],
       activateOnTyping: true,
       closeOnBlur: true,
+      // Our Enter binding (acceptCompletionEatTail) owns accept-on-Enter; the
+      // built-in one would win the tie otherwise (#206).
+      defaultKeymap: false,
     });
 
     const allExtensions = [...extensions, appKeymap, updateListener, completion];

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -21,6 +21,7 @@
   import { formatSql } from '../../../shared/sql-format';
   import { autocompletion, acceptCompletion } from '@codemirror/autocomplete';
   import { createSparqlCompletionSource, type SparqlSchema } from '../editor/sparql-autocomplete';
+  import { acceptCompletionEatTail, completionKeymapNoEnter } from '../editor/accept-completion-eat-tail';
 
   function toCsv(columns: string[], rows: Record<string, string>[]): string {
     const escape = (s: string) => {
@@ -156,10 +157,14 @@
   }
 
   function completionFor(lang: QueryLanguage): Extension {
+    // `defaultKeymap: false` drops the built-in completion keybindings so our
+    // own Enter (accept + eat tail, #206) owns that key — the default Enter
+    // won the precedence tie otherwise. Nav/Escape are re-added via
+    // `completionKeymapNoEnter` in the keymap block below.
     // lang-sql bundles its own completion source via the `schema` option;
     // we only need to override for SPARQL.
-    if (lang === 'sql') return autocompletion();
-    return autocompletion({ override: [createSparqlCompletionSource(() => schema)] });
+    if (lang === 'sql') return autocompletion({ defaultKeymap: false });
+    return autocompletion({ defaultKeymap: false, override: [createSparqlCompletionSource(() => schema)] });
   }
 
   function isDark(): boolean {
@@ -247,6 +252,12 @@
           { key: 'Mod-s', run: () => { if (!isEmpty) onSave(); return true; } },
           { key: 'Shift-Alt-f', run: () => { if (isEmpty) return true; return reformat(); } },
           { key: 'Tab', run: acceptCompletion },
+          // Enter accepts the active completion and eats the half-typed word
+          // tail (#206); returns false with no popup open so Enter is a
+          // newline as usual. completionKeymapNoEnter restores arrow-nav and
+          // Escape that defaultKeymap:false removed.
+          { key: 'Enter', run: acceptCompletionEatTail },
+          ...completionKeymapNoEnter,
         ])),
         keymap.of([
           indentWithTab,

--- a/src/renderer/lib/editor/accept-completion-eat-tail.ts
+++ b/src/renderer/lib/editor/accept-completion-eat-tail.ts
@@ -1,0 +1,73 @@
+import type { Command, KeyBinding } from '@codemirror/view';
+import {
+  acceptCompletion,
+  closeCompletion,
+  completionKeymap,
+  selectedCompletion,
+} from '@codemirror/autocomplete';
+
+/**
+ * Enter-accept that also eats the half-typed word tail after the cursor (#206).
+ *
+ * Tab and the default Enter both accept the active completion by replacing
+ * only what's between the completion's `from` and the cursor — anything the
+ * user had typed *after* the cursor stays put. So Enter-accepting `SELECT`
+ * from the middle of `SEL|stuff` leaves `SELECTstuff`. This command instead
+ * lands you on `SELECT`.
+ *
+ * It eats only the contiguous run of *word* characters (`\w`) after the
+ * cursor, not all non-whitespace. That's the difference that makes it safe in
+ * the markdown editor too: editing the middle of `[[No|te]]` and accepting a
+ * note stops the eat at the `]`, yielding `[[Notebook]]` rather than swallowing
+ * the closing brackets. Same for `#fo|o, rest` — the `,` halts the eat.
+ *
+ * Returns false when no completion is selected so Enter falls through to its
+ * normal job (newline, list continuation, …). Pair with
+ * {@link completionKeymapNoEnter} and `autocompletion({ defaultKeymap: false })`
+ * so the built-in Enter binding doesn't win the precedence tie — at any
+ * precedence the built-in beat a sibling Enter entry, which is why earlier
+ * attempts in #206's PR never fired.
+ */
+export const acceptCompletionEatTail: Command = (view) => {
+  if (!selectedCompletion(view.state)) return false;
+  if (!acceptCompletion(view)) return false;
+
+  // acceptCompletion dispatches synchronously, so `view.state` here is the
+  // post-accept doc with the cursor sitting just before any leftover tail.
+  const { state } = view;
+  const changes: { from: number; to: number }[] = [];
+  for (const range of state.selection.ranges) {
+    const head = range.head;
+    const line = state.doc.lineAt(head);
+    const end = line.from + wordTailEnd(line.text, head - line.from);
+    if (end > head) changes.push({ from: head, to: end });
+  }
+  if (changes.length > 0) {
+    view.dispatch({ changes, scrollIntoView: true });
+  }
+  // Deleting the tail can re-trigger activate-on-typing; the user just
+  // committed a choice, so keep the popup shut.
+  closeCompletion(view);
+  return true;
+};
+
+/**
+ * Index just past the contiguous run of word characters (`\w`) starting at
+ * `from` in `text`. Stops at the first non-word char (whitespace, `]`, `)`,
+ * `,`, `.`, …) or end of string — that boundary is what keeps the eat from
+ * swallowing `]]` in `[[link]]` or the `,` after a `#tag`. Exported for tests.
+ */
+export function wordTailEnd(text: string, from: number): number {
+  let to = from;
+  while (to < text.length && /\w/.test(text[to])) to++;
+  return to;
+}
+
+/**
+ * The default completion keymap with its Enter binding removed, so a custom
+ * Enter command (e.g. {@link acceptCompletionEatTail}) can own that key.
+ * Install this alongside `autocompletion({ defaultKeymap: false })` to keep
+ * arrow-navigation / Escape-to-close while replacing only Enter.
+ */
+export const completionKeymapNoEnter: readonly KeyBinding[] =
+  completionKeymap.filter((b) => b.key !== 'Enter');

--- a/tests/renderer/accept-completion-eat-tail.test.ts
+++ b/tests/renderer/accept-completion-eat-tail.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  wordTailEnd,
+  completionKeymapNoEnter,
+} from '../../src/renderer/lib/editor/accept-completion-eat-tail';
+
+// The tail-eat (#206) deletes from the cursor to wordTailEnd(...). These cases
+// pin the boundary that makes the behavior safe in both editors: it stops at
+// the first non-word char, so brackets/punctuation around a completion survive.
+describe('wordTailEnd', () => {
+  it('eats a plain word tail (the SPARQL keyword case)', () => {
+    // `SEL|stuff` after accepting `SELECT` becomes `SELECT|stuff`; eat `stuff`.
+    expect(wordTailEnd('stuff', 0)).toBe(5);
+  });
+
+  it('stops at a closing bracket so wiki-links keep their `]]`', () => {
+    // Post-accept doc line `[[Notebook]]` with cursor after `Notebook`.
+    const line = '[[Notebook]]';
+    const head = '[[Notebook'.length;
+    expect(wordTailEnd(line, head)).toBe(head); // nothing to eat — next char is `]`
+  });
+
+  it('eats a mid-word remnant but halts at the `]`', () => {
+    // `[[No|te]]`, accept `Notebook` → `[[Notebookte]]`, cursor after `Notebook`.
+    const line = '[[Notebookte]]';
+    const head = '[[Notebook'.length;
+    expect(wordTailEnd(line, head)).toBe('[[Notebookte'.length); // eats `te`, stops at `]`
+  });
+
+  it('stops at a comma after a tag', () => {
+    // `#foo, rest` with cursor after `#foo`.
+    expect(wordTailEnd('#foo, rest', 4)).toBe(4);
+  });
+
+  it('stops at whitespace', () => {
+    expect(wordTailEnd('SELECT distinct', 6)).toBe(6);
+  });
+
+  it('treats `_` and digits as word chars', () => {
+    expect(wordTailEnd('foo_bar2)', 0)).toBe('foo_bar2'.length); // stops at `)`
+  });
+
+  it('handles an empty remnant at end of line', () => {
+    expect(wordTailEnd('SELECT', 6)).toBe(6);
+  });
+});
+
+describe('completionKeymapNoEnter', () => {
+  it('drops the Enter binding so a custom Enter can own the key', () => {
+    expect(completionKeymapNoEnter.some((b) => b.key === 'Enter')).toBe(false);
+  });
+
+  it('keeps navigation/escape bindings', () => {
+    const keys = completionKeymapNoEnter.map((b) => b.key);
+    expect(keys).toContain('ArrowDown');
+    expect(keys).toContain('ArrowUp');
+    expect(keys).toContain('Escape');
+  });
+});


### PR DESCRIPTION
Closes #206.

## What

When the completion popup is open, **Enter** now accepts the active completion *and* eats the leftover half-typed word after the cursor. Enter-accepting `SELECT` from the middle of `SEL|stuff` now lands you on `SELECT` instead of `SELECTstuff`.

## Why the earlier attempts didn't stick

The PR notes on #206 found that the built-in completion `Enter` binding won the precedence tie even at `Prec.highest`, so a sibling `Enter` entry never fired. This fixes it deterministically: `autocompletion({ defaultKeymap: false })` removes the built-in completion keys, then we re-install accept / arrow-nav / Escape via `completionKeymapNoEnter` and add our own `Enter` (`acceptCompletionEatTail`) — so our binding is the only `Enter` touching completion.

## Scope: both panels

The issue scoped the markdown editor out, but @dgriffith asked to include it. Two things make that safe:

1. The eat is bounded to **word characters** (`\w`), not all non-whitespace. It stops at the first delimiter, so `[[No|te]]` → `[[Notebook]]` keeps its closing brackets, and the `,` after a `#tag` survives.
2. Enter already accepted completions in the markdown editor (it used the default completion keymap), so this only refines existing behavior — with no popup open, Enter still returns false and falls through to newline / list-continuation.

## Implementation

- New shared helper `src/renderer/lib/editor/accept-completion-eat-tail.ts`:
  - `acceptCompletionEatTail` — the custom Enter command (accept → delete word tail → close popup).
  - `completionKeymapNoEnter` — the default completion keymap minus its Enter binding.
  - `wordTailEnd` — pure boundary helper (where the eat stops), unit-tested.
- Wired into `QueryPanel.svelte` (SPARQL) and `Editor.svelte` (markdown).

## Testing

- New unit tests for `wordTailEnd` boundary cases (bracket / comma / whitespace / underscore-digit) and the keymap filter — 9 tests.
- `tsc --noEmit` clean, `svelte-check` 0 errors, full suite 2545 tests pass.
- The CodeMirror command itself isn't driven end-to-end (autocomplete is async + needs layout — flaky under jsdom, and no existing test constructs an `EditorView`); the custom boundary logic it relies on is covered by the pure-function tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)