### PR TITLE
feat: prompt template engine for skill files (#623)

### DIFF
--- a/src/main/skills/template.ts
+++ b/src/main/skills/template.ts
@@ -1,0 +1,276 @@
+/**
+ * Prompt template engine for skill files (#623, part of #622).
+ *
+ * Skill bodies and `firstMessage` strings are static markdown that must
+ * reproduce what the old hardcoded `buildSystemPrompt(ctx)` / `buildPrompt(ctx)`
+ * functions composed at runtime: note content, the editor selection, the
+ * claim under the cursor, and parameter values — plus "no-note" variants and
+ * a few text transforms (notably blockquoting a claim's source passage).
+ *
+ * The language is deliberately small and non-executing:
+ *
+ *   - Interpolation:  {{selection}}  {{note.title}}  {{param.audience}}
+ *   - Filters:        {{claim.sourceText | blockquote}}
+ *   - Conditionals:   {{#if note}} … {{else}} … {{/if}}   (nestable, `!` negates)
+ *
+ * Truthiness: an object slot (`note`, `claim`) is truthy when present; a
+ * string slot is truthy when non-empty. Unknown variables render empty in the
+ * default (lenient) mode, or are collected for reporting in strict mode — used
+ * by skill validation, never at render time.
+ *
+ * Whitespace: a block tag that sits alone on its line ("standalone") consumes
+ * that whole line, so authoring `{{#if x}}` on its own line doesn't leave a
+ * blank line behind when the block is taken or skipped — matching Mustache.
+ */
+
+import type { ToolContext } from '../../shared/tools/types';
+
+/** Flattened, render-time view of a ToolContext. `note`/`claim` are null when
+ *  absent so `{{#if note}}` reads naturally. */
+export interface SkillRenderContext {
+  selection: string;
+  note: { content: string; title: string; path: string } | null;
+  claim: { uri: string; label: string; sourceText: string } | null;
+  param: Record<string, string>;
+}
+
+export function toRenderContext(tc: ToolContext): SkillRenderContext {
+  return {
+    selection: tc.selectedText ?? '',
+    note: tc.fullNoteContent
+      ? {
+          content: tc.fullNoteContent,
+          title: tc.fullNoteTitle ?? '',
+          path: tc.fullNotePath ?? '',
+        }
+      : null,
+    claim: tc.claimUri
+      ? {
+          uri: tc.claimUri,
+          label: tc.claimLabel ?? '',
+          sourceText: tc.claimSourceText ?? '',
+        }
+      : null,
+    param: tc.parameterValues ?? {},
+  };
+}
+
+// ---- Filters ----------------------------------------------------------------
+
+type Filter = (input: string) => string;
+
+const FILTERS: Record<string, Filter> = {
+  // Prefix every line with "> " so a multi-line passage renders as one
+  // markdown blockquote. Mirrors the old find-arguments builder.
+  blockquote: (s) => s.split(/\r?\n/).map((l) => `> ${l}`).join('\n'),
+  trim: (s) => s.trim(),
+  upper: (s) => s.toUpperCase(),
+  lower: (s) => s.toLowerCase(),
+};
+
+export const KNOWN_FILTERS: readonly string[] = Object.keys(FILTERS);
+
+// ---- Tokenizer --------------------------------------------------------------
+
+type Token =
+  | { t: 'text'; v: string }
+  | { t: 'var'; path: string; filters: string[]; raw: string }
+  | { t: 'if'; neg: boolean; path: string }
+  | { t: 'else' }
+  | { t: 'endif' };
+
+const MUSTACHE = /\{\{([^}]*)\}\}/g;
+
+function tokenize(template: string): Token[] {
+  const tokens: Token[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  MUSTACHE.lastIndex = 0;
+  while ((m = MUSTACHE.exec(template)) !== null) {
+    if (m.index > last) tokens.push({ t: 'text', v: template.slice(last, m.index) });
+    const inner = m[1].trim();
+    if (inner.startsWith('#if ') || inner.startsWith('#if\t')) {
+      let expr = inner.slice(3).trim();
+      const neg = expr.startsWith('!');
+      if (neg) expr = expr.slice(1).trim();
+      tokens.push({ t: 'if', neg, path: expr });
+    } else if (inner === 'else') {
+      tokens.push({ t: 'else' });
+    } else if (inner === '/if') {
+      tokens.push({ t: 'endif' });
+    } else {
+      const parts = inner.split('|').map((p) => p.trim());
+      const path = parts[0];
+      const filters = parts.slice(1).filter(Boolean);
+      tokens.push({ t: 'var', path, filters, raw: m[1].trim() });
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < template.length) tokens.push({ t: 'text', v: template.slice(last) });
+  return tokens;
+}
+
+/**
+ * Standalone-block whitespace cleanup. When a block tag (if/else/endif) is the
+ * only non-whitespace content on its line, drop the indentation before it and
+ * the single newline after it, so the tag leaves no blank line behind.
+ */
+function trimStandalone(tokens: Token[]): Token[] {
+  const isBlock = (tk: Token) => tk.t === 'if' || tk.t === 'else' || tk.t === 'endif';
+  for (let i = 0; i < tokens.length; i++) {
+    if (!isBlock(tokens[i])) continue;
+    const prev = tokens[i - 1];
+    const next = tokens[i + 1];
+    const prevText = prev && prev.t === 'text' ? prev.v : i === 0 ? '' : null;
+    const nextText = next && next.t === 'text' ? next.v : i === tokens.length - 1 ? '' : null;
+    const prevOk = prevText !== null && (prevText === '' || /(^|\n)[ \t]*$/.test(prevText));
+    const nextOk = nextText !== null && (nextText === '' || /^[ \t]*\r?\n/.test(nextText));
+    if (prevOk && nextOk) {
+      if (prev && prev.t === 'text') prev.v = prev.v.replace(/[ \t]*$/, '');
+      if (next && next.t === 'text') next.v = next.v.replace(/^[ \t]*\r?\n/, '');
+    }
+  }
+  return tokens;
+}
+
+// ---- Parser -----------------------------------------------------------------
+
+type Node =
+  | { t: 'text'; v: string }
+  | { t: 'var'; path: string; filters: string[]; raw: string }
+  | { t: 'if'; neg: boolean; path: string; then: Node[]; else: Node[] };
+
+function parse(tokens: Token[]): Node[] {
+  let pos = 0;
+
+  function parseSeq(stopOnElse: boolean): Node[] {
+    const nodes: Node[] = [];
+    while (pos < tokens.length) {
+      const tk = tokens[pos];
+      if (tk.t === 'endif') return nodes;
+      if (tk.t === 'else' && stopOnElse) return nodes;
+      if (tk.t === 'else') throw new Error('Template: unexpected {{else}} without matching {{#if}}');
+      if (tk.t === 'if') {
+        pos++; // consume the if
+        const thenNodes = parseSeq(true);
+        let elseNodes: Node[] = [];
+        if (tokens[pos] && tokens[pos].t === 'else') {
+          pos++; // consume else
+          elseNodes = parseSeq(false);
+        }
+        if (!tokens[pos] || tokens[pos].t !== 'endif') {
+          throw new Error(`Template: unclosed {{#if ${tk.path}}} (missing {{/if}})`);
+        }
+        pos++; // consume endif
+        nodes.push({ t: 'if', neg: tk.neg, path: tk.path, then: thenNodes, else: elseNodes });
+        continue;
+      }
+      if (tk.t === 'text') nodes.push({ t: 'text', v: tk.v });
+      else if (tk.t === 'var') nodes.push({ t: 'var', path: tk.path, filters: tk.filters, raw: tk.raw });
+      pos++;
+    }
+    return nodes;
+  }
+
+  const out = parseSeq(false);
+  if (pos < tokens.length) {
+    // Only reachable via a stray {{/if}} / {{else}}.
+    throw new Error('Template: unexpected {{/if}} without matching {{#if}}');
+  }
+  return out;
+}
+
+// ---- Resolution -------------------------------------------------------------
+
+/** Resolve a dotted path against the context. Returns string | object | null,
+ *  or `undefined` for an unknown path (so strict mode can flag it). */
+function resolve(path: string, ctx: SkillRenderContext): string | object | null | undefined {
+  if (path === 'selection') return ctx.selection;
+  if (path === 'note') return ctx.note;
+  if (path === 'claim') return ctx.claim;
+  if (path.startsWith('note.')) {
+    const k = path.slice(5);
+    if (!ctx.note) return '';
+    if (k === 'content' || k === 'title' || k === 'path') return ctx.note[k];
+    return undefined;
+  }
+  if (path.startsWith('claim.')) {
+    const k = path.slice(6);
+    if (!ctx.claim) return '';
+    if (k === 'uri' || k === 'label' || k === 'sourceText') return ctx.claim[k];
+    return undefined;
+  }
+  if (path.startsWith('param.')) {
+    const k = path.slice(6);
+    return ctx.param[k] ?? '';
+  }
+  return undefined;
+}
+
+function truthy(value: string | object | null | undefined): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.length > 0;
+  return true; // present object
+}
+
+function applyFilters(value: string, filters: string[], errors: string[]): string {
+  let out = value;
+  for (const f of filters) {
+    const fn = FILTERS[f];
+    if (!fn) {
+      errors.push(`unknown filter "${f}"`);
+      continue;
+    }
+    out = fn(out);
+  }
+  return out;
+}
+
+// ---- Public API -------------------------------------------------------------
+
+export interface RenderResult {
+  text: string;
+  errors: string[];
+}
+
+/** Render with diagnostics — never throws on unknown vars/filters; collects
+ *  them in `errors`. Use for skill validation. */
+export function renderTemplateDiagnostic(
+  template: string,
+  ctx: SkillRenderContext,
+): RenderResult {
+  const errors: string[] = [];
+  const nodes = parse(trimStandalone(tokenize(template)));
+
+  function render(ns: Node[]): string {
+    let out = '';
+    for (const n of ns) {
+      if (n.t === 'text') {
+        out += n.v;
+      } else if (n.t === 'var') {
+        const v = resolve(n.path, ctx);
+        if (v === undefined) {
+          errors.push(`unknown variable "${n.raw}"`);
+          // lenient: render empty
+        } else {
+          const str = typeof v === 'string' ? v : v === null ? '' : '';
+          out += applyFilters(str, n.filters, errors);
+        }
+      } else {
+        const cond = resolve(n.path, ctx);
+        if (cond === undefined) errors.push(`unknown condition "${n.path}"`);
+        const t = truthy(cond);
+        out += render(n.neg ? (t ? n.else : n.then) : t ? n.then : n.else);
+      }
+    }
+    return out;
+  }
+
+  return { text: render(nodes), errors };
+}
+
+/** Render a skill template against a context. Unknown vars/filters render
+ *  empty (lenient). Throws only on structural errors (unbalanced blocks). */
+export function renderTemplate(template: string, ctx: SkillRenderContext): string {
+  return renderTemplateDiagnostic(template, ctx).text;
+}

--- a/tests/main/skills-template.test.ts
+++ b/tests/main/skills-template.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderTemplate,
+  renderTemplateDiagnostic,
+  toRenderContext,
+  type SkillRenderContext,
+} from '../../src/main/skills/template';
+import type { ToolContext } from '../../src/shared/tools/types';
+
+function ctx(partial: Partial<SkillRenderContext> = {}): SkillRenderContext {
+  return {
+    selection: '',
+    note: null,
+    claim: null,
+    param: {},
+    ...partial,
+  };
+}
+
+describe('renderTemplate — interpolation', () => {
+  it('interpolates selection and params', () => {
+    expect(renderTemplate('A {{selection}} B {{param.x}} C', ctx({ selection: 'sel', param: { x: 'PX' } })))
+      .toBe('A sel B PX C');
+  });
+
+  it('renders unknown variables as empty (lenient)', () => {
+    expect(renderTemplate('[{{nope}}]', ctx())).toBe('[]');
+  });
+
+  it('renders dotted note/claim fields, empty when slot absent', () => {
+    expect(renderTemplate('{{note.title}}|{{claim.label}}', ctx())).toBe('|');
+    expect(
+      renderTemplate('{{note.title}}|{{claim.label}}', ctx({
+        note: { content: 'c', title: 'T', path: 'p' },
+        claim: { uri: 'u', label: 'L', sourceText: 's' },
+      })),
+    ).toBe('T|L');
+  });
+});
+
+describe('renderTemplate — filters', () => {
+  it('blockquotes a multi-line passage', () => {
+    expect(renderTemplate('{{claim.sourceText | blockquote}}', ctx({
+      claim: { uri: 'u', label: '', sourceText: 'one\ntwo\nthree' },
+    }))).toBe('> one\n> two\n> three');
+  });
+
+  it('chains trim then upper', () => {
+    expect(renderTemplate('{{selection | trim | upper}}', ctx({ selection: '  hi ' }))).toBe('HI');
+  });
+});
+
+describe('renderTemplate — conditionals', () => {
+  it('takes the then/else branch by object presence', () => {
+    const t = '{{#if note}}has note{{else}}no note{{/if}}';
+    expect(renderTemplate(t, ctx())).toBe('no note');
+    expect(renderTemplate(t, ctx({ note: { content: 'c', title: '', path: '' } }))).toBe('has note');
+  });
+
+  it('treats empty strings as falsy', () => {
+    expect(renderTemplate('{{#if selection}}Y{{else}}N{{/if}}', ctx({ selection: '' }))).toBe('N');
+    expect(renderTemplate('{{#if selection}}Y{{else}}N{{/if}}', ctx({ selection: 'x' }))).toBe('Y');
+  });
+
+  it('supports negation', () => {
+    expect(renderTemplate('{{#if !note}}none{{/if}}', ctx())).toBe('none');
+    expect(renderTemplate('{{#if !note}}none{{/if}}', ctx({ note: { content: 'c', title: '', path: '' } }))).toBe('');
+  });
+
+  it('nests conditionals', () => {
+    const t = '{{#if note}}{{#if note.title}}T:{{note.title}}{{else}}untitled{{/if}}{{/if}}';
+    expect(renderTemplate(t, ctx({ note: { content: 'c', title: 'Hi', path: '' } }))).toBe('T:Hi');
+    expect(renderTemplate(t, ctx({ note: { content: 'c', title: '', path: '' } }))).toBe('untitled');
+  });
+});
+
+describe('renderTemplate — standalone whitespace', () => {
+  it('a block tag alone on its line leaves no blank line behind', () => {
+    const t = 'before\n{{#if note}}\nIN\n{{/if}}\nafter';
+    // note absent → the whole if region collapses cleanly
+    expect(renderTemplate(t, ctx())).toBe('before\nafter');
+    // note present → only IN survives between before/after
+    expect(renderTemplate(t, ctx({ note: { content: 'c', title: '', path: '' } }))).toBe('before\nIN\nafter');
+  });
+
+  it('does not trim inline (non-standalone) tags', () => {
+    expect(renderTemplate('x {{#if selection}}Y{{/if}} z', ctx({ selection: 's' }))).toBe('x Y z');
+  });
+});
+
+describe('renderTemplateDiagnostic', () => {
+  it('collects unknown variables and filters', () => {
+    const r = renderTemplateDiagnostic('{{bogus}} {{selection | nope}}', ctx({ selection: 's' }));
+    expect(r.errors).toContain('unknown variable "bogus"');
+    expect(r.errors).toContain('unknown filter "nope"');
+  });
+
+  it('throws on unbalanced blocks', () => {
+    expect(() => renderTemplate('{{#if note}}x', ctx())).toThrow(/unclosed/);
+    expect(() => renderTemplate('x{{/if}}', ctx())).toThrow(/unexpected/);
+  });
+});
+
+describe('toRenderContext', () => {
+  it('maps ToolContext, nulling absent note/claim', () => {
+    const tc: ToolContext = { selectedText: 's', parameterValues: { a: '1' } };
+    expect(toRenderContext(tc)).toEqual({ selection: 's', note: null, claim: null, param: { a: '1' } });
+  });
+
+  it('builds note/claim slots when present', () => {
+    const tc: ToolContext = {
+      fullNoteContent: 'C', fullNoteTitle: 'T', fullNotePath: 'p.md',
+      claimUri: 'urn:1', claimLabel: 'L', claimSourceText: 'src',
+    };
+    const r = toRenderContext(tc);
+    expect(r.note).toEqual({ content: 'C', title: 'T', path: 'p.md' });
+    expect(r.claim).toEqual({ uri: 'urn:1', label: 'L', sourceText: 'src' });
+  });
+});
+
+// --- Acceptance: reproduce the current hardcoded builders byte-for-byte ------
+// These are the hardest existing prompts (#623). Proving the engine can express
+// them de-risks migrating all 35 tools to skill files.
+
+describe('acceptance: find-arguments first message (support polarity)', () => {
+  // Mirrors buildFindArgumentsFirstMessage('support', ctx) in
+  // research/find-arguments-shared.ts. The migrated find-supporting skill bakes
+  // in the "support" wording (the opposing skill is a separate file).
+  const TMPL =
+    "{{#if claim.label}}Find the strongest arguments that support this claim:\n\n**{{claim.label}}**{{else}}Find the strongest arguments that support the claim under discussion.{{/if}}{{#if claim.sourceText}}\n\n{{claim.sourceText | blockquote}}{{/if}}\n\nUse web search freely. When you're satisfied with the case, ask me to file — I'll review the proposed note before anything lands.";
+
+  const expected = (claimLabel: string, claimSourceText: string): string => {
+    const verb = 'support';
+    const headline = claimLabel
+      ? `Find the strongest arguments that ${verb} this claim:\n\n**${claimLabel}**`
+      : `Find the strongest arguments that ${verb} the claim under discussion.`;
+    const sourceBlock = claimSourceText
+      ? '\n\n' + claimSourceText.split(/\r?\n/).map((l) => `> ${l}`).join('\n')
+      : '';
+    return `${headline}${sourceBlock}\n\nUse web search freely. When you're satisfied with the case, ask me to file — I'll review the proposed note before anything lands.`;
+  };
+
+  it('label + multi-line source', () => {
+    const c = ctx({ claim: { uri: 'u', label: 'AI will plateau', sourceText: 'line one\nline two' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('AI will plateau', 'line one\nline two'));
+  });
+  it('no label, no source', () => {
+    const c = ctx({ claim: { uri: 'u', label: '', sourceText: '' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('', ''));
+  });
+  it('no label, with source', () => {
+    const c = ctx({ claim: { uri: 'u', label: '', sourceText: 'src' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('', 'src'));
+  });
+});
+
+describe('acceptance: find-arguments claim block (system-prompt tail)', () => {
+  // Mirrors the claimBlock built in buildFindArgumentsSystemPrompt.
+  const TMPL =
+    "## Claim\n**URI:** `{{claim.uri}}`{{#if claim.label}}\n**Label:** {{claim.label}}{{/if}}{{#if claim.sourceText}}\n**Source passage:**\n\n{{claim.sourceText | blockquote}}{{/if}}";
+
+  const expected = (uri: string, claimLabel: string, claimSourceText: string): string =>
+    [
+      '## Claim',
+      '',
+      `**URI:** \`${uri}\``,
+      '',
+      claimLabel ? `**Label:** ${claimLabel}` : '',
+      '',
+      claimSourceText
+        ? '**Source passage:**\n\n' + claimSourceText.split(/\r?\n/).map((l) => `> ${l}`).join('\n')
+        : '',
+    ].filter(Boolean).join('\n');
+
+  it('label + source', () => {
+    const c = ctx({ claim: { uri: 'urn:claim:1', label: 'L', sourceText: 'a\nb' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('urn:claim:1', 'L', 'a\nb'));
+  });
+  it('no label, with source', () => {
+    const c = ctx({ claim: { uri: 'urn:claim:1', label: '', sourceText: 'a\nb' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('urn:claim:1', '', 'a\nb'));
+  });
+  it('label, no source', () => {
+    const c = ctx({ claim: { uri: 'urn:claim:1', label: 'L', sourceText: '' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('urn:claim:1', 'L', ''));
+  });
+  it('no label, no source', () => {
+    const c = ctx({ claim: { uri: 'urn:claim:1', label: '', sourceText: '' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('urn:claim:1', '', ''));
+  });
+});
+
+describe('acceptance: explain-like-im note/no-note branches', () => {
+  // Mirrors learning/explain-like-im.ts buildSystemPrompt. Real prompt bodies
+  // stand in as 'W'/'N' here; the audience phrase becomes the param VALUE in
+  // the migrated skill (option value = phrase), so {{param.audience}} is the
+  // phrase directly.
+  const TMPL =
+    '{{#if note}}W\n\nAudience: {{param.audience}}.\n\n## Note{{#if note.title}} — {{note.title}}{{/if}}\n\n{{note.content}}{{else}}N\n\nAudience: {{param.audience}}.{{/if}}';
+
+  const expected = (content: string | null, title: string, phrase: string): string => {
+    if (!content) return `N\n\nAudience: ${phrase}.`;
+    const noteBlock = `\n\n## Note${title ? ` — ${title}` : ''}\n\n${content}`;
+    return `W\n\nAudience: ${phrase}.${noteBlock}`;
+  };
+
+  it('no note → clarifying variant', () => {
+    expect(renderTemplate(TMPL, ctx({ param: { audience: 'a curious 8-year-old' } })))
+      .toBe(expected(null, '', 'a curious 8-year-old'));
+  });
+  it('note with title', () => {
+    const c = ctx({ note: { content: 'BODY', title: 'My Note', path: 'p' }, param: { audience: 'an expert in an adjacent field' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('BODY', 'My Note', 'an expert in an adjacent field'));
+  });
+  it('note without title', () => {
+    const c = ctx({ note: { content: 'BODY', title: '', path: 'p' }, param: { audience: 'a bright high schooler' } });
+    expect(renderTemplate(TMPL, c)).toBe(expected('BODY', '', 'a bright high schooler'));
+  });
+});


### PR DESCRIPTION
**Phase 1 of 9** of the conversational skills system (#622). Closes #623.

Pure, dormant, fully tested — no wiring into menus/registry/UI yet. That comes in later phases.

## Why
Skill files will carry their prompts as static markdown. Today's prompts are *functions* (`buildSystemPrompt(ctx)` / `buildPrompt(ctx)`) that compose note content, the editor selection, the claim under the cursor, parameter values, and "no-note" variants — plus transforms like blockquoting a claim's source passage. A static file needs a template language to reproduce that. This is the linchpin: if a prompt couldn't be expressed as a template, I'd want to know *before* converting 35 tools.

## The language (`src/main/skills/template.ts`)
- **Interpolation:** `{{selection}}` `{{note.title}}` `{{param.audience}}`
- **Filters:** `{{claim.sourceText | blockquote}}` (+ `trim`/`upper`/`lower`)
- **Conditionals:** `{{#if note}} … {{else}} … {{/if}}` — nestable, `!` negates
- **Truthiness:** object slots (`note`, `claim`) truthy when present; strings when non-empty
- **Whitespace:** standalone block tags consume their own line (Mustache-style), so authored conditionals don't leave blank lines
- **Lenient vs diagnostic:** unknown vars/filters render empty by default; `renderTemplateDiagnostic` collects them for skill validation in Phase 2
- `toRenderContext(ToolContext)` flattens to the render view (`note`/`claim` null when absent)

## Tests (25, all passing)
Unit coverage for interpolation, filters, conditionals (else/negation/nesting), standalone whitespace, diagnostics, and structural errors — plus **byte-exact acceptance** reproductions of the three hardest current builders:
- the shared find-arguments **first message** (support polarity),
- the find-arguments **claim block** (including the original's `filter(Boolean)` tight-packing),
- **explain-like-im** note/no-note branching, with the audience phrase folded into the param *value* so `{{param.audience}}` interpolates the phrase directly.

`tsc --noEmit` clean; full suite 2570 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)