### PR TITLE
feat: skill file format, parser & loader + skills.list() IPC (#624)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -22,6 +22,8 @@ import { clearRecentProjects } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool, prepareConversationTool } from './tools/executor';
+import { getSkillCatalog, reloadSkillCatalog } from './skills/loader';
+import { toSkillInfo, type SkillCatalogInfo } from '../shared/skills/types';
 import { runAutoTag } from './llm/auto-tag';
 import {
   suggestLinksTo,
@@ -1253,6 +1255,17 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(Channels.TOOL_PREPARE_CONVERSATION, (_e, request: ToolExecutionRequest) =>
     prepareConversationTool(request));
+
+  // Skills (#622). Returns serializable metadata only — prompt bodies stay in
+  // main and are rendered at prepare/execute time (Phase 3).
+  ipcMain.handle(Channels.SKILLS_LIST, async (): Promise<SkillCatalogInfo> => {
+    const cat = await getSkillCatalog();
+    return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
+  });
+  ipcMain.handle(Channels.SKILLS_RELOAD, async (): Promise<SkillCatalogInfo> => {
+    const cat = await reloadSkillCatalog();
+    return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
+  });
 
   ipcMain.handle(Channels.REFACTOR_AUTO_TAG, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/main/skills/loader.ts
+++ b/src/main/skills/loader.ts
@@ -1,0 +1,132 @@
+/**
+ * Skill loader (#624). Assembles the skill catalog from two sources:
+ *
+ *   - **stock**: read-only `*.md` files bundled in `./stock/`, embedded at
+ *     build time via Vite's `import.meta.glob` (no filesystem packaging).
+ *   - **user**: `~/.minerva/skills/` — either bare `*.md` files or folders
+ *     containing `SKILL.md` (Claude-style), read at runtime via fs.
+ *
+ * User skills are additive only: a user skill whose id collides with a stock
+ * skill is rejected (it can't shadow stock) — to change a stock skill you
+ * disable it and author your own (later phases). Parse failures are isolated
+ * per file so one bad skill never breaks the catalog.
+ *
+ * No menu/registry/UI wiring here — that's Phase 3. This module only loads and
+ * exposes the catalog (consumed by the `skills:list` IPC handler).
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  type SkillCatalog,
+  type SkillDef,
+  type SkillLoadError,
+} from '../../shared/skills/types';
+import { parseSkill } from './parse';
+
+// Embedded stock skills. Empty until phases 4–6 migrate the hardcoded tools.
+const STOCK_RAW = import.meta.glob('./stock/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+export function userSkillsDir(): string {
+  return path.join(os.homedir(), '.minerva', 'skills');
+}
+
+function loadStock(): { skills: SkillDef[]; errors: SkillLoadError[] } {
+  const skills: SkillDef[] = [];
+  const errors: SkillLoadError[] = [];
+  for (const [key, content] of Object.entries(STOCK_RAW)) {
+    const r = parseSkill(content, 'stock', key);
+    if (r.skill) skills.push(r.skill);
+    else for (const message of r.errors) errors.push({ source: 'stock', filePath: key, label: r.label, message });
+  }
+  return { skills, errors };
+}
+
+async function readSkillFiles(dir: string): Promise<{ filePath: string; content: string }[]> {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw e;
+  }
+  const out: { filePath: string; content: string }[] = [];
+  for (const ent of entries) {
+    if (ent.name.startsWith('.')) continue;
+    if (ent.isFile() && ent.name.toLowerCase().endsWith('.md')) {
+      const fp = path.join(dir, ent.name);
+      out.push({ filePath: fp, content: await fs.readFile(fp, 'utf-8') });
+    } else if (ent.isDirectory()) {
+      // Claude-style: a folder containing SKILL.md (+ optional assets).
+      const fp = path.join(dir, ent.name, 'SKILL.md');
+      try {
+        out.push({ filePath: fp, content: await fs.readFile(fp, 'utf-8') });
+      } catch { /* folder without a SKILL.md — not a skill */ }
+    }
+  }
+  return out;
+}
+
+async function loadUser(dir: string): Promise<{ skills: SkillDef[]; errors: SkillLoadError[] }> {
+  const skills: SkillDef[] = [];
+  const errors: SkillLoadError[] = [];
+  for (const { filePath, content } of await readSkillFiles(dir)) {
+    const r = parseSkill(content, 'user', filePath);
+    if (r.skill) skills.push(r.skill);
+    else for (const message of r.errors) errors.push({ source: 'user', filePath, label: r.label, message });
+  }
+  return { skills, errors };
+}
+
+/**
+ * Build the catalog. Stock loads first and wins id collisions; a user skill
+ * colliding with stock (or an earlier user skill) is rejected with an error.
+ * `dir` is injectable for tests; defaults to `~/.minerva/skills/`.
+ */
+export async function loadSkillCatalog(dir: string = userSkillsDir()): Promise<SkillCatalog> {
+  const stock = loadStock();
+  const user = await loadUser(dir);
+
+  const byId = new Map<string, SkillDef>();
+  const errors: SkillLoadError[] = [...stock.errors, ...user.errors];
+
+  for (const s of stock.skills) {
+    if (byId.has(s.id)) {
+      errors.push({ source: 'stock', filePath: s.filePath, label: s.name, message: `duplicate stock skill id "${s.id}"` });
+      continue;
+    }
+    byId.set(s.id, s);
+  }
+  for (const s of user.skills) {
+    const existing = byId.get(s.id);
+    if (existing) {
+      const clash = existing.source === 'stock'
+        ? `id "${s.id}" is already a stock skill; user skills can't override stock`
+        : `duplicate user skill id "${s.id}"`;
+      errors.push({ source: 'user', filePath: s.filePath, label: s.name, message: clash });
+      continue;
+    }
+    byId.set(s.id, s);
+  }
+
+  return { skills: [...byId.values()], errors };
+}
+
+// --- Cached singleton for the running app ------------------------------------
+
+let cached: SkillCatalog | null = null;
+
+export async function getSkillCatalog(): Promise<SkillCatalog> {
+  if (!cached) cached = await loadSkillCatalog();
+  return cached;
+}
+
+export async function reloadSkillCatalog(): Promise<SkillCatalog> {
+  cached = await loadSkillCatalog();
+  return cached;
+}

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -1,0 +1,189 @@
+/**
+ * Skill file parser (#624). Splits YAML frontmatter from the markdown body,
+ * validates every field, and normalizes friendly authoring shorthands into the
+ * canonical SkillDef. Never throws on content problems — returns collected
+ * errors so one malformed skill can't break the rest of the catalog.
+ */
+
+import YAML from 'yaml';
+import type { ContextRequirement, OutputMode, ToolParameter } from '../../shared/tools/types';
+import {
+  SKILL_MENUS,
+  type SkillDef,
+  type SkillMenu,
+  type SkillSource,
+} from '../../shared/skills/types';
+import { validateTemplate } from './template';
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+const CONTEXT_REQUIREMENTS: readonly ContextRequirement[] = [
+  'selectedText', 'fullNote', 'relatedNotes', 'taggedNotes', 'claimUnderCursor', 'selectionRange',
+];
+const OUTPUT_MODES: readonly OutputMode[] = [
+  'newNote', 'appendToNote', 'replaceSelection', 'insertAtCursor', 'multipleNotes', 'openConversation',
+];
+const PARAM_TYPES = ['text', 'textarea', 'select', 'number'] as const;
+
+export interface ParseResult {
+  skill?: SkillDef;
+  errors: string[];
+  /** Best-effort label for error reporting even when the skill is rejected. */
+  label: string;
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function normalizeParameters(raw: unknown, errors: string[]): ToolParameter[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    errors.push('`parameters` must be a list');
+    return [];
+  }
+  const out: ToolParameter[] = [];
+  raw.forEach((p, i) => {
+    if (typeof p !== 'object' || p === null) {
+      errors.push(`parameter #${i + 1} must be a mapping`);
+      return;
+    }
+    const obj = p as Record<string, unknown>;
+    const id = asString(obj.id);
+    const label = asString(obj.label) ?? id;
+    const type = asString(obj.type) ?? 'text';
+    if (!id) { errors.push(`parameter #${i + 1} is missing \`id\``); return; }
+    if (!(PARAM_TYPES as readonly string[]).includes(type)) {
+      errors.push(`parameter "${id}" has invalid type "${type}"`);
+      return;
+    }
+    const param: ToolParameter = { id, label: label ?? id, type: type as ToolParameter['type'] };
+    if (obj.placeholder !== undefined) param.placeholder = asString(obj.placeholder);
+    // `default` (friendly) or `defaultValue`
+    const dflt = obj.default ?? obj.defaultValue;
+    if (dflt !== undefined) param.defaultValue = String(dflt);
+    if (obj.required !== undefined) param.required = Boolean(obj.required);
+    if (type === 'select') {
+      const opts = obj.options;
+      if (!Array.isArray(opts) || opts.length === 0) {
+        errors.push(`select parameter "${id}" needs a non-empty \`options\` list`);
+        return;
+      }
+      param.options = opts.map((o) =>
+        typeof o === 'object' && o !== null
+          ? { label: String((o as Record<string, unknown>).label ?? (o as Record<string, unknown>).value), value: String((o as Record<string, unknown>).value) }
+          : { label: String(o), value: String(o) },
+      );
+    }
+    out.push(param);
+  });
+  return out;
+}
+
+function normalizeStringArray(raw: unknown, field: string, allowed: readonly string[] | null, errors: string[]): string[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) { errors.push(`\`${field}\` must be a list`); return []; }
+  const out: string[] = [];
+  for (const item of raw) {
+    const s = asString(item);
+    if (s === undefined) { errors.push(`\`${field}\` entries must be strings`); continue; }
+    if (allowed && !allowed.includes(s)) { errors.push(`\`${field}\` has invalid value "${s}"`); continue; }
+    out.push(s);
+  }
+  return out;
+}
+
+export function parseSkill(content: string, source: SkillSource, filePath: string): ParseResult {
+  const errors: string[] = [];
+  const fallbackLabel = filePath.replace(/\/SKILL\.md$/i, '').split('/').pop() || filePath;
+
+  const m = FRONTMATTER_RE.exec(content);
+  if (!m) {
+    return { errors: ['missing YAML frontmatter (file must start with `---`)'], label: fallbackLabel };
+  }
+  const body = content.slice(m[0].length).trim();
+
+  let fm: Record<string, unknown>;
+  try {
+    const parsed = YAML.parse(m[1]);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { errors: ['frontmatter is not a YAML mapping'], label: fallbackLabel };
+    }
+    fm = parsed as Record<string, unknown>;
+  } catch (e) {
+    return { errors: [`invalid YAML frontmatter: ${(e as Error).message}`], label: fallbackLabel };
+  }
+
+  const name = asString(fm.name);
+  const label = name ?? fallbackLabel;
+
+  // Required fields
+  if (!name) errors.push('`name` is required');
+  const description = asString(fm.description);
+  if (!description) errors.push('`description` is required');
+
+  const menuRaw = asString(fm.menu);
+  if (!menuRaw) errors.push('`menu` is required');
+  else if (!(SKILL_MENUS as readonly string[]).includes(menuRaw)) {
+    errors.push(`\`menu\` must be one of ${SKILL_MENUS.join(', ')} (got "${menuRaw}")`);
+  }
+
+  const outputModeRaw = asString(fm.outputMode);
+  if (!outputModeRaw) errors.push('`outputMode` is required');
+  else if (!(OUTPUT_MODES as readonly string[]).includes(outputModeRaw)) {
+    errors.push(`\`outputMode\` is invalid (got "${outputModeRaw}")`);
+  }
+
+  if (!body) errors.push('skill body (the prompt) is empty');
+
+  // Optional / normalized fields
+  const context = normalizeStringArray(fm.context, 'context', CONTEXT_REQUIREMENTS, errors) as ContextRequirement[];
+  const parameters = normalizeParameters(fm.parameters, errors);
+  const tools = normalizeStringArray(fm.tools, 'tools', null, errors);
+  const web = fm.web === undefined ? false : Boolean(fm.web);
+  const model = asString(fm.model);
+  const requiresSelection = Boolean(fm.requiresSelection);
+  const outputNotePrefix = asString(fm.outputNotePrefix);
+  const firstMessage = asString(fm.firstMessage) ?? '';
+  const longDescription = asString(fm.longDescription) ?? description ?? '';
+
+  let slashCommand = asString(fm.slashCommand);
+  if (slashCommand && !slashCommand.startsWith('/')) slashCommand = `/${slashCommand}`;
+
+  // Template validation (context-independent): catch typos / unbalanced blocks.
+  for (const err of validateTemplate(body)) errors.push(`body: ${err}`);
+  if (firstMessage) {
+    for (const err of validateTemplate(firstMessage)) errors.push(`firstMessage: ${err}`);
+  }
+
+  if (errors.length > 0) return { errors, label };
+
+  const id = asString(fm.id) ?? slugify(name!);
+  if (!id) return { errors: ['could not derive an `id` (provide one explicitly)'], label };
+
+  const skill: SkillDef = {
+    id,
+    name: name!,
+    description: description!,
+    longDescription,
+    menu: menuRaw as SkillMenu,
+    outputMode: outputModeRaw as OutputMode,
+    context,
+    parameters,
+    tools,
+    web,
+    model,
+    slashCommand,
+    outputNotePrefix,
+    requiresSelection,
+    firstMessage,
+    body,
+    source,
+    filePath,
+  };
+  return { skill, errors: [], label };
+}

--- a/src/main/skills/stock/README.txt
+++ b/src/main/skills/stock/README.txt
@@ -1,0 +1,4 @@
+# Stock skills
+
+Migrated stock skills land here as `*.md` files (phases 4–6). Loaded read-only
+via `import.meta.glob` — see `../loader.ts`. This file is ignored by the glob.

--- a/src/main/skills/template.ts
+++ b/src/main/skills/template.ts
@@ -274,3 +274,42 @@ export function renderTemplateDiagnostic(
 export function renderTemplate(template: string, ctx: SkillRenderContext): string {
   return renderTemplateDiagnostic(template, ctx).text;
 }
+
+const KNOWN_VAR_PATHS = new Set([
+  'selection', 'note', 'note.content', 'note.title', 'note.path',
+  'claim', 'claim.uri', 'claim.label', 'claim.sourceText',
+]);
+
+function isKnownPath(path: string): boolean {
+  if (KNOWN_VAR_PATHS.has(path)) return true;
+  return path.startsWith('param.') && path.length > 'param.'.length;
+}
+
+/**
+ * Context-independent validation for skill authoring (#624). Checks block
+ * balance and that every variable path and filter is known — catching typos
+ * like `{{note.body}}` or `{{x | blockqote}}` that lenient rendering would
+ * silently swallow. Returns a list of human-readable problems (empty = valid).
+ */
+export function validateTemplate(template: string): string[] {
+  const errors: string[] = [];
+  let tokens: Token[];
+  try {
+    tokens = tokenize(template);
+    parse(tokens); // structural check (balanced #if/else//if)
+  } catch (e) {
+    errors.push((e as Error).message);
+    return errors;
+  }
+  for (const tk of tokens) {
+    if (tk.t === 'var') {
+      if (!isKnownPath(tk.path)) errors.push(`unknown variable "${tk.path}"`);
+      for (const f of tk.filters) {
+        if (!FILTERS[f]) errors.push(`unknown filter "${f}"`);
+      }
+    } else if (tk.t === 'if') {
+      if (!isKnownPath(tk.path)) errors.push(`unknown condition "${tk.path}"`);
+    }
+  }
+  return errors;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -351,6 +351,10 @@ contextBridge.exposeInMainWorld('api', {
     setSettings: (settings: unknown) => ipcRenderer.invoke(Channels.TOOL_SET_SETTINGS, settings),
     onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
   },
+  skills: {
+    list: () => ipcRenderer.invoke(Channels.SKILLS_LIST),
+    reload: () => ipcRenderer.invoke(Channels.SKILLS_RELOAD),
+  },
   sites: {
     list: () => ipcRenderer.invoke(Channels.SITES_LIST),
     add: (domain: string, label?: string) =>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -505,6 +505,11 @@ export interface ToolsApi {
   onInvoke(cb: (toolId: string) => void): void;
 }
 
+export interface SkillsApi {
+  list(): Promise<import('../../../shared/skills/types').SkillCatalogInfo>;
+  reload(): Promise<import('../../../shared/skills/types').SkillCatalogInfo>;
+}
+
 export interface MenuApi {
   onNewNote(cb: () => void): void;
   onSave(cb: () => void): void;
@@ -580,6 +585,7 @@ export interface IdeApi {
   proposals: ProposalsApi;
   tabs: TabsApi;
   tools: ToolsApi;
+  skills: SkillsApi;
   refactor: RefactorApi;
   formatter: FormatterApi;
   sources: SourcesApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -344,6 +344,12 @@ export const Channels = {
   /** Prepare the system prompt + first message + model for a conversational tool. */
   TOOL_PREPARE_CONVERSATION: 'tool:prepareConversation',
 
+  // Skills (markdown skill files — #622)
+  /** List the loaded skill catalog (metadata + load errors). */
+  SKILLS_LIST: 'skills:list',
+  /** Re-scan stock + user skill files and return the refreshed catalog. */
+  SKILLS_RELOAD: 'skills:reload',
+
   // Proposals
   PROPOSAL_LIST: 'proposal:list',
   PROPOSAL_DETAIL: 'proposal:detail',

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Skill file format (#624, part of #622).
+ *
+ * A skill is a markdown file (or a folder with SKILL.md) whose YAML
+ * frontmatter declares metadata and whose body is the prompt template (system
+ * prompt for `openConversation` skills; the one-shot prompt for `newNote`).
+ * `firstMessage` lives in frontmatter. These types are the parsed/compiled
+ * shapes shared across processes; rendering of the templates happens in main.
+ */
+
+import type {
+  ContextRequirement,
+  OutputMode,
+  ToolParameter,
+} from '../tools/types';
+
+export type SkillMenu = 'Learning' | 'Research' | 'Analysis';
+
+export const SKILL_MENUS: readonly SkillMenu[] = ['Learning', 'Research', 'Analysis'];
+
+/** Where a skill was loaded from. User skills can only add, never shadow stock. */
+export type SkillSource = 'stock' | 'user';
+
+/**
+ * A validated, loaded skill. `body` and `firstMessage` are template strings
+ * (see src/main/skills/template.ts) rendered in main at prepare/execute time.
+ */
+export interface SkillDef {
+  id: string;
+  name: string;
+  description: string;
+  longDescription: string;
+  menu: SkillMenu;
+  outputMode: OutputMode;
+  context: ContextRequirement[];
+  parameters: ToolParameter[];
+  /** Conversation tools the skill advertises. Empty/omitted = default set. */
+  tools: string[];
+  /** Web access default for conversational skills. */
+  web: boolean;
+  /** Tool author's preferred model; falls back to the global default. */
+  model?: string;
+  slashCommand?: string;
+  outputNotePrefix?: string;
+  requiresSelection: boolean;
+  /** Auto-fired first user message (template). Empty = let the user start. */
+  firstMessage: string;
+  /** Prompt body (template) — system prompt or one-shot prompt. */
+  body: string;
+  source: SkillSource;
+  /** Absolute path for user skills; the glob key for stock skills. */
+  filePath: string;
+}
+
+/** Serializable metadata sent to the renderer over IPC — no template bodies. */
+export interface SkillInfo {
+  id: string;
+  name: string;
+  description: string;
+  longDescription: string;
+  menu: SkillMenu;
+  outputMode: OutputMode;
+  context: ContextRequirement[];
+  parameters: ToolParameter[];
+  model?: string;
+  web: boolean;
+  slashCommand?: string;
+  outputNotePrefix?: string;
+  requiresSelection: boolean;
+  source: SkillSource;
+}
+
+export interface SkillLoadError {
+  source: SkillSource;
+  /** File path or glob key the error came from. */
+  filePath: string;
+  /** Best-effort skill name/id if it parsed far enough; else the filename. */
+  label: string;
+  message: string;
+}
+
+export interface SkillCatalog {
+  skills: SkillDef[];
+  errors: SkillLoadError[];
+}
+
+export interface SkillCatalogInfo {
+  skills: SkillInfo[];
+  errors: SkillLoadError[];
+}
+
+export function toSkillInfo(s: SkillDef): SkillInfo {
+  return {
+    id: s.id,
+    name: s.name,
+    description: s.description,
+    longDescription: s.longDescription,
+    menu: s.menu,
+    outputMode: s.outputMode,
+    context: s.context,
+    parameters: s.parameters,
+    model: s.model,
+    web: s.web,
+    slashCommand: s.slashCommand,
+    outputNotePrefix: s.outputNotePrefix,
+    requiresSelection: s.requiresSelection,
+    source: s.source,
+  };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -18,3 +18,13 @@ declare module '*?url' {
   const url: string;
   export default url;
 }
+
+// Minimal typing for Vite's `import.meta.glob` (used by the skill loader to
+// embed stock skill files, #622). We don't pull all of `vite/client` here so
+// the rest of `import.meta` in the main process keeps its default typing.
+interface ImportMeta {
+  glob(
+    pattern: string,
+    options?: { query?: string; import?: string; eager?: boolean },
+  ): Record<string, unknown>;
+}

--- a/tests/main/skills-loader.test.ts
+++ b/tests/main/skills-loader.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+let dir: string;
+
+const skillFile = (name: string, menu = 'Learning') => `---
+name: ${name}
+description: desc for ${name}
+menu: ${menu}
+outputMode: openConversation
+---
+Body for ${name}.`;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-skills-'));
+});
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('loadSkillCatalog', () => {
+  it('returns empty (no errors) when the user dir is missing', async () => {
+    const cat = await loadSkillCatalog(path.join(dir, 'does-not-exist'));
+    expect(cat.skills).toEqual([]);
+    expect(cat.errors).toEqual([]);
+  });
+
+  it('loads bare .md files from the user dir', async () => {
+    await fs.writeFile(path.join(dir, 'alpha.md'), skillFile('Alpha'));
+    await fs.writeFile(path.join(dir, 'beta.md'), skillFile('Beta', 'Analysis'));
+    const cat = await loadSkillCatalog(dir);
+    expect(cat.errors).toEqual([]);
+    expect(cat.skills.map((s) => s.name).sort()).toEqual(['Alpha', 'Beta']);
+    expect(cat.skills.every((s) => s.source === 'user')).toBe(true);
+  });
+
+  it('loads a Claude-style folder with SKILL.md', async () => {
+    const sub = path.join(dir, 'gamma');
+    await fs.mkdir(sub);
+    await fs.writeFile(path.join(sub, 'SKILL.md'), skillFile('Gamma'));
+    await fs.writeFile(path.join(sub, 'notes.txt'), 'ignored asset');
+    const cat = await loadSkillCatalog(dir);
+    expect(cat.skills.map((s) => s.name)).toEqual(['Gamma']);
+    expect(cat.skills[0].filePath.endsWith('SKILL.md')).toBe(true);
+  });
+
+  it('ignores dotfiles and folders without SKILL.md', async () => {
+    await fs.writeFile(path.join(dir, '.hidden.md'), skillFile('Hidden'));
+    await fs.mkdir(path.join(dir, 'empty-folder'));
+    const cat = await loadSkillCatalog(dir);
+    expect(cat.skills).toEqual([]);
+    expect(cat.errors).toEqual([]);
+  });
+
+  it('isolates a bad skill without dropping the good ones', async () => {
+    await fs.writeFile(path.join(dir, 'good.md'), skillFile('Good'));
+    await fs.writeFile(path.join(dir, 'bad.md'), '---\nname: Bad\n---\nbody'); // missing menu/outputMode/desc
+    const cat = await loadSkillCatalog(dir);
+    expect(cat.skills.map((s) => s.name)).toEqual(['Good']);
+    expect(cat.errors.length).toBeGreaterThan(0);
+    expect(cat.errors[0].source).toBe('user');
+    expect(cat.errors[0].label).toBe('Bad');
+  });
+
+  it('rejects a duplicate user skill id with an error', async () => {
+    await fs.writeFile(path.join(dir, 'one.md'), skillFile('Dup'));
+    await fs.writeFile(path.join(dir, 'two.md'), skillFile('Dup'));
+    const cat = await loadSkillCatalog(dir);
+    expect(cat.skills.length).toBe(1);
+    expect(cat.errors.some((e) => /duplicate user skill id/.test(e.message))).toBe(true);
+  });
+});

--- a/tests/main/skills-parse.test.ts
+++ b/tests/main/skills-parse.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { parseSkill } from '../../src/main/skills/parse';
+
+const VALID = `---
+name: Summarize
+description: Summarize the active note
+menu: Learning
+outputMode: openConversation
+context: [fullNote]
+web: true
+model: claude-sonnet-4-6
+slashCommand: summarize
+firstMessage: "Summarize."
+---
+You summarize the note.
+{{#if note}}
+## Note
+{{note.content}}
+{{/if}}`;
+
+describe('parseSkill — valid', () => {
+  it('parses a complete skill and derives fields', () => {
+    const { skill, errors } = parseSkill(VALID, 'stock', 'stock/summarize.md');
+    expect(errors).toEqual([]);
+    expect(skill).toBeDefined();
+    expect(skill!.id).toBe('summarize'); // slug of name
+    expect(skill!.menu).toBe('Learning');
+    expect(skill!.outputMode).toBe('openConversation');
+    expect(skill!.context).toEqual(['fullNote']);
+    expect(skill!.web).toBe(true);
+    expect(skill!.model).toBe('claude-sonnet-4-6');
+    expect(skill!.slashCommand).toBe('/summarize'); // normalized leading slash
+    expect(skill!.firstMessage).toBe('Summarize.');
+    expect(skill!.body.startsWith('You summarize the note.')).toBe(true);
+    expect(skill!.source).toBe('stock');
+  });
+
+  it('defaults longDescription to description and web to false', () => {
+    const c = `---
+name: Taboo
+description: Restate without a banned word
+menu: Analysis
+outputMode: newNote
+---
+Body here {{selection}}`;
+    const { skill } = parseSkill(c, 'user', '/u/taboo.md');
+    expect(skill!.longDescription).toBe('Restate without a banned word');
+    expect(skill!.web).toBe(false);
+    expect(skill!.context).toEqual([]);
+  });
+
+  it('honors an explicit id', () => {
+    const c = `---
+id: learning.summarize
+name: Summarize
+description: d
+menu: Learning
+outputMode: openConversation
+---
+body`;
+    expect(parseSkill(c, 'stock', 'x.md').skill!.id).toBe('learning.summarize');
+  });
+});
+
+describe('parseSkill — parameters', () => {
+  it('normalizes select options (string and object forms) and default', () => {
+    const c = `---
+name: ELI
+description: d
+menu: Learning
+outputMode: openConversation
+parameters:
+  - id: audience
+    label: Audience
+    type: select
+    default: undergrad
+    options:
+      - { label: "Child", value: "a curious 8-year-old" }
+      - undergrad
+---
+body {{param.audience}}`;
+    const { skill, errors } = parseSkill(c, 'stock', 'x.md');
+    expect(errors).toEqual([]);
+    const p = skill!.parameters[0];
+    expect(p.defaultValue).toBe('undergrad');
+    expect(p.options).toEqual([
+      { label: 'Child', value: 'a curious 8-year-old' },
+      { label: 'undergrad', value: 'undergrad' },
+    ]);
+  });
+
+  it('rejects a select without options', () => {
+    const c = `---
+name: X
+description: d
+menu: Learning
+outputMode: openConversation
+parameters:
+  - id: a
+    type: select
+---
+body`;
+    const { skill, errors } = parseSkill(c, 'stock', 'x.md');
+    expect(skill).toBeUndefined();
+    expect(errors.join(' ')).toMatch(/needs a non-empty `options`/);
+  });
+});
+
+describe('parseSkill — validation failures', () => {
+  it('flags missing frontmatter', () => {
+    expect(parseSkill('no frontmatter here', 'user', 'x.md').errors[0]).toMatch(/frontmatter/);
+  });
+
+  it('collects all missing required fields', () => {
+    const { skill, errors } = parseSkill(`---\nfoo: bar\n---\n`, 'user', 'x.md');
+    expect(skill).toBeUndefined();
+    const joined = errors.join(' ');
+    expect(joined).toMatch(/`name` is required/);
+    expect(joined).toMatch(/`description` is required/);
+    expect(joined).toMatch(/`menu` is required/);
+    expect(joined).toMatch(/`outputMode` is required/);
+    expect(joined).toMatch(/body .* is empty/);
+  });
+
+  it('rejects invalid enum values', () => {
+    const c = `---
+name: X
+description: d
+menu: Wisdom
+outputMode: telepathy
+context: [moonPhase]
+---
+body`;
+    const errors = parseSkill(c, 'user', 'x.md').errors.join(' ');
+    expect(errors).toMatch(/`menu` must be one of/);
+    expect(errors).toMatch(/`outputMode` is invalid/);
+    expect(errors).toMatch(/`context` has invalid value "moonPhase"/);
+  });
+
+  it('catches template typos in body and firstMessage', () => {
+    const c = `---
+name: X
+description: d
+menu: Learning
+outputMode: openConversation
+firstMessage: "Go {{param}}"
+---
+Body {{note.body}} and {{selection | blockqote}}`;
+    const errors = parseSkill(c, 'user', 'x.md').errors.join(' ');
+    expect(errors).toMatch(/body: unknown variable "note.body"/);
+    expect(errors).toMatch(/body: unknown filter "blockqote"/);
+    expect(errors).toMatch(/firstMessage: unknown variable "param"/);
+  });
+
+  it('catches unbalanced template blocks', () => {
+    const c = `---
+name: X
+description: d
+menu: Learning
+outputMode: openConversation
+---
+{{#if note}}unclosed`;
+    expect(parseSkill(c, 'user', 'x.md').errors.join(' ')).toMatch(/body:.*unclosed/);
+  });
+});


### PR DESCRIPTION
**Phase 2 of 9** of the conversational skills system (#622). Closes #624. Depends on #623 (template engine, merged).

Loads skills into the main process. No menu/registry/UI wiring yet — that's Phase 3.

## Format
A skill is a markdown file (or a folder with `SKILL.md` + optional assets) whose YAML frontmatter declares metadata and whose body is the prompt template. Shared types in `src/shared/skills/types.ts` (`SkillDef`, serializable `SkillInfo`, `SkillCatalog`, errors).

```markdown
---
name: Summarize
description: Summarize the active note
menu: Learning
outputMode: openConversation
context: [fullNote]
web: true
model: claude-sonnet-4-6
slashCommand: summarize
firstMessage: "Summarize."
---
You summarize the note.
{{#if note}}
## Note
{{note.content}}
{{/if}}
```

## Parser (`src/main/skills/parse.ts`)
Splits frontmatter from body; validates required fields + enums (menu/outputMode/context/param types); normalizes friendly shorthands (select options as bare strings **or** `{label,value}`; `default` → `defaultValue`; `slashCommand` gets a leading slash); derives `id` from `name` when absent; validates body + `firstMessage` templates via the engine's new context-independent `validateTemplate` (catches typos like `{{note.body}}` / `{{x | blockqote}}` and unbalanced blocks). Never throws on content problems — collects per-skill errors.

## Loader (`src/main/skills/loader.ts`)
- **stock**: embedded via `import.meta.glob('./stock/*.md', { query:'?raw', eager })` — empty until phases 4–6; no fs packaging.
- **user**: `~/.minerva/skills/` via fs — bare `.md` or folder/`SKILL.md`.
- User skills are **additive**: an id colliding with stock (or another user skill) is rejected. A bad skill is isolated, never dropping the rest. Cached catalog + reload.

## IPC
`skills.list()` / `skills.reload()` return serializable metadata (`SkillInfo` — no prompt bodies) plus load errors.

Also: `validateTemplate()` added to the engine; a minimal `ImportMeta.glob` typing added to `vite-env.d.ts` (avoids pulling all of `vite/client` into main).

## Tests
16 new (parser + loader): valid parse, every validation failure, parameter normalization (both option forms), folder form, dotfile/empty-folder skipping, error isolation, duplicate-id rejection. `tsc` + `svelte-check` clean; full suite 2586 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)