### PR TITLE
feat: compile + register skills into the tool registry (#625)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -22,7 +22,8 @@ import { clearRecentProjects } from './recent-projects';
 import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool, prepareConversationTool } from './tools/executor';
-import { getSkillCatalog, reloadSkillCatalog } from './skills/loader';
+import { getSkillCatalog } from './skills/loader';
+import { reloadAndRegisterSkills } from './skills/register';
 import { toSkillInfo, type SkillCatalogInfo } from '../shared/skills/types';
 import { runAutoTag } from './llm/auto-tag';
 import {
@@ -1263,7 +1264,10 @@ export function registerIpcHandlers(): void {
     return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
   });
   ipcMain.handle(Channels.SKILLS_RELOAD, async (): Promise<SkillCatalogInfo> => {
-    const cat = await reloadSkillCatalog();
+    // Re-scan files, re-sync the registry, and rebuild the menu so newly
+    // added/removed skills appear without a restart.
+    const cat = await reloadAndRegisterSkills();
+    rebuildMenu();
     return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
   });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import { registerBuiltinExporters } from './publish';
 import { installCsp } from './security';
 import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
+import { registerSkillsAtStartup } from './skills/register';
 
 app.setName('Minerva');
 
@@ -23,7 +24,7 @@ function boot(label: string): void {
 
 boot('main module loaded');
 
-void app.whenReady().then(() => {
+void app.whenReady().then(async () => {
   boot('app ready');
   installCsp();
   boot('csp installed');
@@ -33,6 +34,13 @@ void app.whenReady().then(() => {
   boot('executors registered');
   registerBuiltinExporters();
   boot('exporters registered');
+
+  // Load + register skill files (#625) before any menu is built, so the
+  // dynamic Learning/Analysis menus include them on first paint. Failure to
+  // load a skill is isolated per-file inside the loader; a total failure here
+  // shouldn't block startup.
+  await registerSkillsAtStartup().catch((err) => console.warn('[skills] startup load failed:', err));
+  boot('skills registered');
 
   const session = loadSession().filter((s) => {
     try { return fs.statSync(s.rootPath).isDirectory(); } catch { return false; }

--- a/src/main/skills/compile.ts
+++ b/src/main/skills/compile.ts
@@ -1,0 +1,52 @@
+/**
+ * Compile a loaded SkillDef into a runtime ThinkingToolDef (#625).
+ *
+ * The executor and the menu already speak ThinkingToolDef — compiling skills
+ * into that shape means `getTool(id)` finds them and the conversation /
+ * newNote pipelines run them with no changes. The build* closures render the
+ * skill's templates through the engine at prepare/execute time, exactly where
+ * the old hardcoded builders ran.
+ */
+
+import type { ThinkingToolDef, ToolContext } from '../../shared/tools/types';
+import { menuToCategory, type SkillDef } from '../../shared/skills/types';
+import type { ConversationToolKey } from '../../shared/conversation-tools';
+import { renderTemplate, toRenderContext } from './template';
+
+const CONVERSATION_TOOL_KEYS: readonly ConversationToolKey[] = ['ask_user'];
+
+export function compileSkill(skill: SkillDef): ThinkingToolDef {
+  const render = (template: string, ctx: ToolContext): string =>
+    renderTemplate(template, toRenderContext(ctx));
+
+  // `tools:` is, for now, the set of opt-in conversation tools the skill wants
+  // on top of the default set (only `ask_user` exists today). Unknown entries
+  // are dropped — full per-skill tool restriction is a later concern, and the
+  // non-regression default (omit = full default set) holds.
+  const requiresTools = skill.tools.filter(
+    (t): t is ConversationToolKey => (CONVERSATION_TOOL_KEYS as readonly string[]).includes(t),
+  );
+
+  const def: ThinkingToolDef = {
+    id: skill.id,
+    name: skill.name,
+    category: menuToCategory(skill.menu),
+    description: skill.description,
+    longDescription: skill.longDescription,
+    context: skill.context,
+    parameters: skill.parameters,
+    outputMode: skill.outputMode,
+    buildPrompt: (ctx) => render(skill.body, ctx),
+    requiresSelection: skill.requiresSelection,
+    web: { defaultEnabled: skill.web },
+  };
+  if (skill.outputMode === 'openConversation') {
+    def.buildSystemPrompt = (ctx) => render(skill.body, ctx);
+    def.buildFirstMessage = (ctx) => render(skill.firstMessage, ctx);
+  }
+  if (skill.model) def.preferredModel = skill.model;
+  if (skill.slashCommand) def.slashCommand = skill.slashCommand;
+  if (skill.outputNotePrefix) def.outputNotePrefix = skill.outputNotePrefix;
+  if (requiresTools.length > 0) def.requiresTools = requiresTools;
+  return def;
+}

--- a/src/main/skills/register.ts
+++ b/src/main/skills/register.ts
@@ -1,0 +1,45 @@
+/**
+ * Registers compiled skills into the shared tool registry in the main process
+ * (#625), so the executor (`getTool`) and the dynamic menus pick them up
+ * alongside the hardcoded tools. Tracks which ids it added so a reload can
+ * cleanly replace the previous set without disturbing hardcoded tools.
+ */
+
+import { registerTool, unregisterTool } from '../../shared/tools/registry';
+import { compileSkill } from './compile';
+import { getSkillCatalog, reloadSkillCatalog } from './loader';
+import type { SkillCatalog } from '../../shared/skills/types';
+
+const registeredSkillIds = new Set<string>();
+
+function applyCatalog(catalog: SkillCatalog): void {
+  // Drop the previously-registered skills (never hardcoded tools), then add
+  // the fresh set. Safe to run repeatedly.
+  for (const id of registeredSkillIds) unregisterTool(id);
+  registeredSkillIds.clear();
+  for (const skill of catalog.skills) {
+    registerTool(compileSkill(skill));
+    registeredSkillIds.add(skill.id);
+  }
+  if (catalog.errors.length > 0) {
+    for (const err of catalog.errors) {
+      console.warn(`[skills] ${err.source}:${err.label} — ${err.message} (${err.filePath})`);
+    }
+  }
+}
+
+/** Load (cached) and register skills. Call once during app startup, before
+ *  menus are built. */
+export async function registerSkillsAtStartup(): Promise<SkillCatalog> {
+  const catalog = await getSkillCatalog();
+  applyCatalog(catalog);
+  return catalog;
+}
+
+/** Re-scan skill files and re-sync the registry. Returns the fresh catalog so
+ *  the caller can rebuild the menu. */
+export async function reloadAndRegisterSkills(): Promise<SkillCatalog> {
+  const catalog = await reloadSkillCatalog();
+  applyCatalog(catalog);
+  return catalog;
+}

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -88,7 +88,7 @@
   import { getFormatSettings, loadFormatSettings } from './lib/formatter/settings';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
   import { gatherContext } from './lib/tools/context';
-  import { getAllToolInfos } from './lib/tools/tool-registry';
+  import { getAllToolInfos, registerSkillInfos } from './lib/tools/tool-registry';
   import type { ToolContext } from '../shared/tools/types';
 
   type ViewMode = 'source' | 'preview' | 'split';
@@ -2868,6 +2868,18 @@
   onMount(() => {
     initTheme();
     initAppearance();
+
+    // Pull skill metadata loaded by main (#625) into the renderer registry so
+    // the tool panel / command palette / slash commands see skills alongside
+    // hardcoded tools. Fire-and-forget — skills enrich the menus when ready.
+    void (async () => {
+      try {
+        const cat = await api.skills.list();
+        registerSkillInfos(cat.skills);
+      } catch (err) {
+        console.warn('[skills] failed to load skill list:', err);
+      }
+    })();
 
     // Auto-save
     editor.onAutoSaved = () => {

--- a/src/renderer/lib/tools/tool-registry.ts
+++ b/src/renderer/lib/tools/tool-registry.ts
@@ -1,5 +1,47 @@
 // Import all tool definitions so they register with the registry
 import '../../../shared/tools/definitions/index';
+import { registerTool, unregisterTool } from '../../../shared/tools/registry';
+import { menuToCategory, type SkillInfo } from '../../../shared/skills/types';
+import type { ThinkingToolDef } from '../../../shared/tools/types';
 
 // Re-export registry functions for renderer use
 export { getAllToolInfos, getToolInfosByCategory, getTool, getSlashCommands } from '../../../shared/tools/registry';
+
+/**
+ * Skills are loaded from disk in the main process (#625). The renderer learns
+ * about them via `api.skills.list()` and registers their metadata here so the
+ * tool panel, command palette and slash commands treat them like any other
+ * tool. The build* closures live in main and run at prepare/execute time — the
+ * renderer never invokes them, so these stubs are never called.
+ */
+export function skillInfoToToolDef(info: SkillInfo): ThinkingToolDef {
+  return {
+    id: info.id,
+    name: info.name,
+    category: menuToCategory(info.menu),
+    description: info.description,
+    longDescription: info.longDescription,
+    context: info.context,
+    parameters: info.parameters,
+    outputMode: info.outputMode,
+    outputNotePrefix: info.outputNotePrefix,
+    slashCommand: info.slashCommand,
+    preferredModel: info.model,
+    web: { defaultEnabled: info.web },
+    requiresSelection: info.requiresSelection,
+    buildPrompt: () => '', // never invoked in the renderer
+  };
+}
+
+const registeredSkillIds = new Set<string>();
+
+/** Replace the previously-registered skill infos with a fresh set. Hardcoded
+ *  tools (registered via the static import above) are left untouched. */
+export function registerSkillInfos(infos: SkillInfo[]): void {
+  for (const id of registeredSkillIds) unregisterTool(id);
+  registeredSkillIds.clear();
+  for (const info of infos) {
+    registerTool(skillInfoToToolDef(info));
+    registeredSkillIds.add(info.id);
+  }
+}

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -11,12 +11,22 @@
 import type {
   ContextRequirement,
   OutputMode,
+  ToolCategory,
   ToolParameter,
 } from '../tools/types';
 
 export type SkillMenu = 'Learning' | 'Research' | 'Analysis';
 
 export const SKILL_MENUS: readonly SkillMenu[] = ['Learning', 'Research', 'Analysis'];
+
+/** Skill `menu:` (display-cased) ↔ the registry's lowercase ToolCategory. */
+export function menuToCategory(menu: SkillMenu): ToolCategory {
+  return menu.toLowerCase() as ToolCategory;
+}
+
+export function categoryToMenu(category: ToolCategory): SkillMenu {
+  return (category.charAt(0).toUpperCase() + category.slice(1)) as SkillMenu;
+}
 
 /** Where a skill was loaded from. User skills can only add, never shadow stock. */
 export type SkillSource = 'stock' | 'user';

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -6,6 +6,11 @@ export function registerTool(tool: ThinkingToolDef): void {
   tools.set(tool.id, tool);
 }
 
+/** Remove a registered tool. Used to re-sync compiled skills on reload (#625). */
+export function unregisterTool(id: string): void {
+  tools.delete(id);
+}
+
 export function getTool(id: string): ThinkingToolDef | undefined {
   return tools.get(id);
 }

--- a/tests/main/skills-compile.test.ts
+++ b/tests/main/skills-compile.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { compileSkill } from '../../src/main/skills/compile';
+import { buildConversationPayload } from '../../src/main/tools/executor';
+import { getTool, registerTool, unregisterTool } from '../../src/shared/tools/registry';
+import type { SkillDef } from '../../src/shared/skills/types';
+
+function skill(overrides: Partial<SkillDef> = {}): SkillDef {
+  return {
+    id: 'learning.sample',
+    name: 'Sample',
+    description: 'a sample',
+    longDescription: 'a longer description',
+    menu: 'Learning',
+    outputMode: 'openConversation',
+    context: ['fullNote'],
+    parameters: [],
+    tools: [],
+    web: false,
+    requiresSelection: false,
+    firstMessage: '',
+    body: '',
+    source: 'stock',
+    filePath: 'stock/sample.md',
+    ...overrides,
+  };
+}
+
+describe('compileSkill', () => {
+  it('maps a conversation skill and renders its templates', () => {
+    const def = compileSkill(skill({
+      body: 'You help. {{#if note}}Note: {{note.content}}{{/if}}',
+      firstMessage: 'Go on {{note.title}}',
+      web: true,
+      model: 'claude-opus-4-8',
+      slashCommand: '/sample',
+      tools: ['ask_user', 'bogus'],
+    }));
+
+    expect(def.category).toBe('learning');
+    expect(def.outputMode).toBe('openConversation');
+    expect(def.web).toEqual({ defaultEnabled: true });
+    expect(def.preferredModel).toBe('claude-opus-4-8');
+    expect(def.requiresTools).toEqual(['ask_user']); // unknown "bogus" dropped
+
+    const ctx = { fullNoteContent: 'BODY', fullNoteTitle: 'TITLE' };
+    expect(def.buildSystemPrompt!(ctx)).toBe('You help. Note: BODY');
+    expect(def.buildFirstMessage!(ctx)).toBe('Go on TITLE');
+    // No note → conditional collapses.
+    expect(def.buildSystemPrompt!({})).toBe('You help. ');
+  });
+
+  it('maps a one-shot newNote skill to buildPrompt only', () => {
+    const def = compileSkill(skill({
+      menu: 'Analysis',
+      outputMode: 'newNote',
+      outputNotePrefix: 'steelman',
+      body: 'Steelman: {{selection}}',
+    }));
+    expect(def.category).toBe('analysis');
+    expect(def.outputNotePrefix).toBe('steelman');
+    expect(def.buildSystemPrompt).toBeUndefined();
+    expect(def.buildFirstMessage).toBeUndefined();
+    expect(def.buildPrompt({ selectedText: 'X' })).toBe('Steelman: X');
+  });
+});
+
+describe('compiled skill through the conversation payload builder', () => {
+  it('produces the same payload shape as a hardcoded conversational tool', () => {
+    const def = compileSkill(skill({
+      body: 'SYS {{note.content}}',
+      firstMessage: 'FIRST {{note.title}}',
+      web: true,
+      model: 'claude-opus-4-8',
+    }));
+    const payload = buildConversationPayload(
+      def,
+      { model: 'claude-sonnet-4-6', toolModelOverrides: {} },
+      { context: { fullNoteContent: 'C', fullNoteTitle: 'T' } },
+    );
+    expect(payload).toEqual({
+      toolId: 'learning.sample',
+      systemPrompt: 'SYS C',
+      firstMessage: 'FIRST T',
+      model: 'claude-opus-4-8', // differs from default → pinned
+      webEnabled: true,
+    });
+  });
+
+  it('omits model when it equals the global default', () => {
+    const def = compileSkill(skill({ body: 'b', model: 'claude-sonnet-4-6' }));
+    const payload = buildConversationPayload(
+      def,
+      { model: 'claude-sonnet-4-6', toolModelOverrides: {} },
+      { context: {} },
+    );
+    expect(payload.model).toBeUndefined();
+  });
+});
+
+describe('registry round-trip (coexistence with hardcoded tools)', () => {
+  it('registers a compiled skill so getTool finds it', () => {
+    const def = compileSkill(skill({ id: 'learning.roundtrip', body: 'b' }));
+    registerTool(def);
+    try {
+      expect(getTool('learning.roundtrip')).toBe(def);
+      // A hardcoded tool registered via static import is still present.
+      expect(getTool('learning.summarize')).toBeDefined();
+    } finally {
+      unregisterTool('learning.roundtrip');
+    }
+    expect(getTool('learning.roundtrip')).toBeUndefined();
+  });
+});

--- a/tests/renderer/skills-registry.test.ts
+++ b/tests/renderer/skills-registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  skillInfoToToolDef,
+  registerSkillInfos,
+  getAllToolInfos,
+} from '../../src/renderer/lib/tools/tool-registry';
+import type { SkillInfo } from '../../src/shared/skills/types';
+
+function info(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: 'research.sample',
+    name: 'Sample',
+    description: 'desc',
+    longDescription: 'long desc',
+    menu: 'Research',
+    outputMode: 'openConversation',
+    context: ['claimUnderCursor'],
+    parameters: [],
+    web: true,
+    model: 'claude-opus-4-8',
+    slashCommand: '/sample',
+    requiresSelection: false,
+    source: 'user',
+    ...overrides,
+  };
+}
+
+describe('skillInfoToToolDef', () => {
+  it('maps a SkillInfo into a renderer tool def with category from menu', () => {
+    const def = skillInfoToToolDef(info());
+    expect(def.category).toBe('research');
+    expect(def.context).toEqual(['claimUnderCursor']);
+    expect(def.web).toEqual({ defaultEnabled: true });
+    expect(def.preferredModel).toBe('claude-opus-4-8');
+    expect(def.outputMode).toBe('openConversation');
+    expect(def.buildPrompt({})).toBe(''); // stub — never invoked in renderer
+  });
+});
+
+describe('registerSkillInfos', () => {
+  it('adds skills to the registry and replaces them on re-sync', () => {
+    registerSkillInfos([info({ id: 'analysis.s1', name: 'S1', menu: 'Analysis' })]);
+    expect(getAllToolInfos().find((t) => t.id === 'analysis.s1')?.category).toBe('analysis');
+
+    // Re-sync with a different set drops the previous skill.
+    registerSkillInfos([info({ id: 'learning.s2', name: 'S2', menu: 'Learning' })]);
+    const ids = getAllToolInfos().map((t) => t.id);
+    expect(ids).toContain('learning.s2');
+    expect(ids).not.toContain('analysis.s1');
+
+    // Hardcoded tools are never touched by skill sync.
+    expect(ids).toContain('learning.summarize');
+
+    // Clear skills.
+    registerSkillInfos([]);
+    expect(getAllToolInfos().some((t) => t.id === 'learning.s2')).toBe(false);
+  });
+});


### PR DESCRIPTION
**Phase 3 of 9** of the conversational skills system (#622). Closes #625. Depends on #623, #624 (merged).

Wires loaded skills into the running app on both sides of the IPC boundary — **with no executor changes**.

## Main
- `compileSkill()` turns a `SkillDef` into a `ThinkingToolDef` whose `build*` closures render the skill's `body`/`firstMessage` templates through the engine at prepare/execute time. So `getTool(id)` finds skills and the existing conversation (`buildConversationPayload`) and one-shot (`executeTool`) paths run them **unchanged**.
- `register.ts` syncs compiled skills into the shared registry, tracking their ids so a reload cleanly replaces them without touching hardcoded tools.
- `registerSkillsAtStartup()` runs in `main.ts` before any menu is built (the already-dynamic Learning/Analysis menus pick skills up). `skills:reload` re-syncs and rebuilds the menu.

## Renderer
- `registerSkillInfos()` converts `SkillInfo` metadata from `api.skills.list()` into registry entries (stub `build*` — never invoked in the renderer; prompts render in main) so the tool panel, command palette and slash commands treat skills like any other tool.
- `App.svelte` fetches the list on mount.

Also: `unregisterTool()` added to the shared registry; `menuToCategory`/`categoryToMenu` helpers (skill `menu:` is display-cased; the registry keys on lowercase `ToolCategory`).

## No-regression
With no stock skills yet and an empty `~/.minerva/skills/`, the catalog is empty at runtime, so existing tools are untouched. The compile→register→executor path and the renderer info conversion are covered by **7 new tests**. `tsc` + `svelte-check` clean; full suite **2593** pass.

## Try it live
Drop a `.md` skill into `~/.minerva/skills/` and it appears in the Learning/Analysis menu (and command palette / slash commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)