### PR TITLE
feat: Settings → Skills tab with import / remove / reveal (#629)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -24,6 +24,7 @@ import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, m
 import { executeTool, prepareConversationTool } from './tools/executor';
 import { getSkillCatalog } from './skills/loader';
 import { reloadAndRegisterSkills } from './skills/register';
+import { pickAndImportSkill, removeUserSkill, revealSkillsFolder, type ImportedSkill } from './skills/manage';
 import { toSkillInfo, type SkillCatalogInfo } from '../shared/skills/types';
 import { runAutoTag } from './llm/auto-tag';
 import {
@@ -1269,6 +1270,23 @@ export function registerIpcHandlers(): void {
     const cat = await reloadAndRegisterSkills();
     rebuildMenu();
     return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
+  });
+  ipcMain.handle(Channels.SKILLS_IMPORT, async (e): Promise<ImportedSkill | null> => {
+    const win = winFromEvent(e);
+    const imported = await pickAndImportSkill(win);
+    if (imported) {
+      await reloadAndRegisterSkills();
+      rebuildMenu();
+    }
+    return imported;
+  });
+  ipcMain.handle(Channels.SKILLS_REMOVE, async (_e, id: string): Promise<void> => {
+    await removeUserSkill(id);
+    await reloadAndRegisterSkills();
+    rebuildMenu();
+  });
+  ipcMain.handle(Channels.SKILLS_REVEAL, async (): Promise<void> => {
+    await revealSkillsFolder();
   });
 
   ipcMain.handle(Channels.REFACTOR_AUTO_TAG, async (e, relativePath: string) => {

--- a/src/main/skills/manage.ts
+++ b/src/main/skills/manage.ts
@@ -1,0 +1,108 @@
+/**
+ * User-skill management (#629): import a `.md` file or a Claude-style skill
+ * folder into ~/.minerva/skills/, remove a user skill, and reveal the folder.
+ * Validation reuses the parser so a bad file is rejected with a clear message
+ * before anything is copied. Modeled on the CSL-import flow.
+ */
+
+import { dialog, shell, type BrowserWindow } from 'electron';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { userSkillsDir, loadSkillCatalog } from './loader';
+import { parseSkill } from './parse';
+
+export interface ImportedSkill {
+  id: string;
+  name: string;
+}
+
+/** Validate + copy a skill from an arbitrary path into the user skills dir.
+ *  `dir` is injectable for tests; defaults to ~/.minerva/skills/. */
+export async function importSkillFromPath(src: string, dir: string = userSkillsDir()): Promise<ImportedSkill> {
+  const stat = await fs.stat(src);
+  const isFolder = stat.isDirectory();
+
+  let content: string;
+  let destName: string;
+  if (isFolder) {
+    destName = path.basename(src);
+    const skillMd = path.join(src, 'SKILL.md');
+    try {
+      content = await fs.readFile(skillMd, 'utf-8');
+    } catch {
+      throw new Error('That folder has no SKILL.md — pick a skill folder or a single .md file.');
+    }
+  } else {
+    if (!src.toLowerCase().endsWith('.md')) {
+      throw new Error('Pick a .md file or a folder containing SKILL.md.');
+    }
+    destName = path.basename(src);
+    content = await fs.readFile(src, 'utf-8');
+  }
+
+  // Validate before copying.
+  const parsed = parseSkill(content, 'user', isFolder ? path.join(src, 'SKILL.md') : src);
+  if (!parsed.skill) {
+    throw new Error(`This file isn't a valid skill:\n• ${parsed.errors.join('\n• ')}`);
+  }
+
+  // Additive only — can't shadow stock or duplicate an existing skill.
+  const catalog = await loadSkillCatalog(dir);
+  const clash = catalog.skills.find((s) => s.id === parsed.skill!.id);
+  if (clash) {
+    throw new Error(
+      clash.source === 'stock'
+        ? `A built-in skill already uses the id "${parsed.skill.id}". User skills can't override stock — disable it and give yours a different id.`
+        : `You already have a skill with the id "${parsed.skill.id}".`,
+    );
+  }
+
+  await fs.mkdir(dir, { recursive: true });
+  const dest = path.join(dir, destName);
+  try {
+    await fs.access(dest);
+    throw new Error(`A skill named "${destName}" already exists in your skills folder.`);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e; // re-throw the "already exists" Error
+  }
+
+  if (isFolder) {
+    await fs.cp(src, dest, { recursive: true });
+  } else {
+    await fs.copyFile(src, dest);
+  }
+  return { id: parsed.skill.id, name: parsed.skill.name };
+}
+
+/** Show the open dialog and import the chosen skill. Returns null on cancel. */
+export async function pickAndImportSkill(win: BrowserWindow): Promise<ImportedSkill | null> {
+  const result = await dialog.showOpenDialog(win, {
+    title: 'Import skill',
+    buttonLabel: 'Import',
+    // macOS lets a single dialog accept either a file or a folder.
+    properties: ['openFile', 'openDirectory'],
+    filters: [{ name: 'Skill', extensions: ['md'] }],
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return importSkillFromPath(result.filePaths[0]);
+}
+
+/** Delete a user skill by id (the bare .md file, or the folder for SKILL.md).
+ *  `dir` is injectable for tests; defaults to ~/.minerva/skills/. */
+export async function removeUserSkill(id: string, dir: string = userSkillsDir()): Promise<void> {
+  const catalog = await loadSkillCatalog(dir);
+  const skill = catalog.skills.find((s) => s.id === id && s.source === 'user');
+  if (!skill) throw new Error(`No user skill with id "${id}".`);
+  if (/[/\\]SKILL\.md$/i.test(skill.filePath)) {
+    await fs.rm(path.dirname(skill.filePath), { recursive: true, force: true });
+  } else {
+    await fs.rm(skill.filePath, { force: true });
+  }
+}
+
+/** Reveal ~/.minerva/skills/ in the OS file manager, creating it if needed. */
+export async function revealSkillsFolder(): Promise<void> {
+  const dir = userSkillsDir();
+  await fs.mkdir(dir, { recursive: true });
+  await shell.openPath(dir);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -354,6 +354,9 @@ contextBridge.exposeInMainWorld('api', {
   skills: {
     list: () => ipcRenderer.invoke(Channels.SKILLS_LIST),
     reload: () => ipcRenderer.invoke(Channels.SKILLS_RELOAD),
+    import: () => ipcRenderer.invoke(Channels.SKILLS_IMPORT),
+    remove: (id: string) => ipcRenderer.invoke(Channels.SKILLS_REMOVE, id),
+    revealFolder: () => ipcRenderer.invoke(Channels.SKILLS_REVEAL),
   },
   sites: {
     list: () => ipcRenderer.invoke(Channels.SITES_LIST),

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -39,8 +39,9 @@
   import '../../../shared/formatter/rules/index';
   import type { FormatSettings } from '../../../shared/formatter/engine';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
-  import { getAllToolInfos } from '../tools/tool-registry';
+  import { getAllToolInfos, registerSkillInfos } from '../tools/tool-registry';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
+  import type { SkillInfo, SkillMenu, SkillLoadError } from '../../../shared/skills/types';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -54,7 +55,7 @@
 
   let { onApplyEditor, onThemeChanged, onClose, initialTab }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'ingest' | 'sites' | 'bibliography' | 'excerpts' | 'compute' | 'ai';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'refactoring' | 'formatter' | 'web' | 'ingest' | 'sites' | 'bibliography' | 'excerpts' | 'compute' | 'ai' | 'skills';
 
   /** Restructure per IMPLEMENTATION.md §10.4 — 10 flat tabs become 4
    *  semantic groups. Group labels render in mono-uppercase above each
@@ -99,6 +100,7 @@
       label: 'AI',
       items: [
         { id: 'ai', label: 'AI', sub: 'Model · API key · tool prefs' },
+        { id: 'skills', label: 'Skills', sub: 'Conversation skills · import' },
       ],
     },
   ];
@@ -335,6 +337,76 @@
     }
   }
 
+  // ---- Skills (#629) ----
+  let skillCatalog = $state<{ skills: SkillInfo[]; errors: SkillLoadError[] }>({ skills: [], errors: [] });
+  let skillsBusy = $state(false);
+  let skillsError = $state<string | null>(null);
+  const SKILL_MENU_ORDER: readonly SkillMenu[] = ['Learning', 'Research', 'Analysis'];
+
+  function skillsForMenu(menu: SkillMenu): SkillInfo[] {
+    return skillCatalog.skills.filter((s) => s.menu === menu);
+  }
+
+  /** Refresh the catalog and re-sync the renderer registry so the command
+   *  palette / slash commands track imports & removals too. */
+  async function loadSkills(): Promise<void> {
+    try {
+      const cat = await api.skills.list();
+      skillCatalog = cat;
+      registerSkillInfos(cat.skills);
+    } catch (e) {
+      console.error('[settings] failed to load skills:', e);
+    }
+  }
+
+  async function importSkill(): Promise<void> {
+    skillsError = null;
+    skillsBusy = true;
+    try {
+      const res = await api.skills.import();
+      if (res) await loadSkills();
+    } catch (e) {
+      skillsError = e instanceof Error ? e.message : String(e);
+    } finally {
+      skillsBusy = false;
+    }
+  }
+
+  async function removeSkill(id: string): Promise<void> {
+    skillsError = null;
+    skillsBusy = true;
+    try {
+      await api.skills.remove(id);
+      await loadSkills();
+    } catch (e) {
+      skillsError = e instanceof Error ? e.message : String(e);
+    } finally {
+      skillsBusy = false;
+    }
+  }
+
+  async function reloadSkills(): Promise<void> {
+    skillsError = null;
+    skillsBusy = true;
+    try {
+      const cat = await api.skills.reload();
+      skillCatalog = cat;
+      registerSkillInfos(cat.skills);
+    } catch (e) {
+      skillsError = e instanceof Error ? e.message : String(e);
+    } finally {
+      skillsBusy = false;
+    }
+  }
+
+  async function revealSkills(): Promise<void> {
+    try {
+      await api.skills.revealFolder();
+    } catch (e) {
+      skillsError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
   async function removeUserStyle(id: string): Promise<void> {
     cslImportError = null;
     try {
@@ -450,6 +522,7 @@
     await loadBibliographySettings();
     await loadExcerptSettings();
     await loadComputeSettings();
+    await loadSkills();
     try {
       const ingest = await api.sources.getIngestSettings();
       importUpstreamTags = ingest.importUpstreamTags;
@@ -1054,6 +1127,71 @@
           {#if cslImportError}
             <div class="csl-error">{cslImportError}</div>
           {/if}
+
+        {:else if activeTab === 'skills'}
+          <div class="field">
+            <label>Skills</label>
+            <p class="hint">
+              Skills are markdown files that drive the Learning, Research, and
+              Analysis menus. Built-in skills ship with Minerva; your own live in
+              <code>~/.minerva/skills/</code> and apply across every thoughtbase.
+              A skill is a single <code>.md</code> file (or a folder with a
+              <code>SKILL.md</code>) — YAML frontmatter plus a prompt body.
+            </p>
+            <div class="skill-actions">
+              <button class="action-btn" onclick={() => { void importSkill(); }} disabled={skillsBusy}>
+                Import skill…
+              </button>
+              <button class="action-btn" onclick={() => { void revealSkills(); }}>
+                Reveal skills folder
+              </button>
+              <button class="action-btn" onclick={() => { void reloadSkills(); }} disabled={skillsBusy}>
+                Reload
+              </button>
+            </div>
+          </div>
+
+          {#if skillsError}
+            <div class="csl-error">{skillsError}</div>
+          {/if}
+
+          {#if skillCatalog.errors.length > 0}
+            <div class="field">
+              <label>Skills that failed to load</label>
+              <ul class="skill-errs">
+                {#each skillCatalog.errors as err (err.filePath + err.message)}
+                  <li><span class="skill-err-label">{err.label}</span> — {err.message}</li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#each SKILL_MENU_ORDER as menu (menu)}
+            {@const items = skillsForMenu(menu)}
+            <div class="field">
+              <label>{menu}</label>
+              {#if items.length === 0}
+                <p class="hint empty">No skills in this menu.</p>
+              {:else}
+                <ul class="skill-list">
+                  {#each items as s (s.id)}
+                    <li>
+                      <div class="skill-row">
+                        <span class="skill-name">{s.name}</span>
+                        <span class="skill-src" class:user={s.source === 'user'}>{s.source}</span>
+                        {#if s.source === 'user'}
+                          <button class="link-btn" onclick={() => { void removeSkill(s.id); }} disabled={skillsBusy}>
+                            Remove
+                          </button>
+                        {/if}
+                      </div>
+                      <span class="skill-desc">{s.description}</span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+          {/each}
 
         {:else if activeTab === 'excerpts'}
           <div class="field">
@@ -1700,6 +1838,71 @@
     font-size: 12px;
     font-family: var(--font-mono, ui-monospace, monospace);
     white-space: pre-wrap;
+  }
+
+  /* Skills panel (#629). */
+  .skill-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+  }
+  .skill-list {
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .skill-list li {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 10px;
+    background: var(--bg-button);
+    border-radius: 4px;
+  }
+  .skill-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .skill-name {
+    font-weight: 600;
+    font-size: 13px;
+  }
+  .skill-src {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted, var(--text));
+    opacity: 0.6;
+  }
+  .skill-src.user {
+    color: var(--accent);
+    opacity: 1;
+  }
+  .skill-row .link-btn {
+    margin-left: auto;
+  }
+  .skill-desc {
+    font-size: 12px;
+    color: var(--text-muted, var(--text));
+    opacity: 0.8;
+  }
+  .skill-errs {
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 0;
+    font-size: 12px;
+  }
+  .skill-errs li {
+    padding: 4px 0;
+    color: var(--text);
+  }
+  .skill-err-label {
+    font-weight: 600;
   }
 
   /* Compute panel — Python interpreter row + probe status (#374). */

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -508,6 +508,10 @@ export interface ToolsApi {
 export interface SkillsApi {
   list(): Promise<import('../../../shared/skills/types').SkillCatalogInfo>;
   reload(): Promise<import('../../../shared/skills/types').SkillCatalogInfo>;
+  /** Pick a .md file or skill folder and import it. Returns null on cancel. */
+  import(): Promise<{ id: string; name: string } | null>;
+  remove(id: string): Promise<void>;
+  revealFolder(): Promise<void>;
 }
 
 export interface MenuApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -349,6 +349,12 @@ export const Channels = {
   SKILLS_LIST: 'skills:list',
   /** Re-scan stock + user skill files and return the refreshed catalog. */
   SKILLS_RELOAD: 'skills:reload',
+  /** Pick a .md file or skill folder and import it into ~/.minerva/skills/. */
+  SKILLS_IMPORT: 'skills:import',
+  /** Delete a user skill by id. */
+  SKILLS_REMOVE: 'skills:remove',
+  /** Reveal the user skills folder (~/.minerva/skills/) in the OS file manager. */
+  SKILLS_REVEAL: 'skills:reveal',
 
   // Proposals
   PROPOSAL_LIST: 'proposal:list',

--- a/tests/main/skills-manage.test.ts
+++ b/tests/main/skills-manage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { importSkillFromPath, removeUserSkill } from '../../src/main/skills/manage';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+let userDir: string;
+let srcDir: string;
+
+const skillFile = (name: string, extra = '') => `---
+name: ${name}
+description: desc for ${name}
+menu: Analysis
+outputMode: openConversation
+${extra}---
+Body for ${name}. {{#if note}}{{note.content}}{{/if}}`;
+
+beforeEach(async () => {
+  userDir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-uskills-'));
+  srcDir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-src-'));
+});
+afterEach(async () => {
+  await fs.rm(userDir, { recursive: true, force: true });
+  await fs.rm(srcDir, { recursive: true, force: true });
+});
+
+describe('importSkillFromPath', () => {
+  it('imports a valid .md file into the user dir', async () => {
+    const src = path.join(srcDir, 'my-skill.md');
+    await fs.writeFile(src, skillFile('My Skill'));
+    const res = await importSkillFromPath(src, userDir);
+    expect(res).toEqual({ id: 'my-skill', name: 'My Skill' });
+    expect(await fs.readFile(path.join(userDir, 'my-skill.md'), 'utf-8')).toContain('My Skill');
+
+    const cat = await loadSkillCatalog(userDir);
+    expect(cat.skills.find((s) => s.id === 'my-skill')?.source).toBe('user');
+  });
+
+  it('imports a folder containing SKILL.md', async () => {
+    const folder = path.join(srcDir, 'fancy');
+    await fs.mkdir(folder);
+    await fs.writeFile(path.join(folder, 'SKILL.md'), skillFile('Fancy'));
+    await fs.writeFile(path.join(folder, 'asset.txt'), 'bundled');
+    const res = await importSkillFromPath(folder, userDir);
+    expect(res.name).toBe('Fancy');
+    expect(await fs.readFile(path.join(userDir, 'fancy', 'SKILL.md'), 'utf-8')).toContain('Fancy');
+    expect(await fs.readFile(path.join(userDir, 'fancy', 'asset.txt'), 'utf-8')).toBe('bundled');
+  });
+
+  it('rejects an invalid skill with a descriptive error', async () => {
+    const src = path.join(srcDir, 'bad.md');
+    await fs.writeFile(src, '---\nname: Bad\n---\nbody'); // missing menu/outputMode/desc
+    await expect(importSkillFromPath(src, userDir)).rejects.toThrow(/isn't a valid skill/);
+  });
+
+  it('rejects a non-markdown file', async () => {
+    const src = path.join(srcDir, 'notes.txt');
+    await fs.writeFile(src, 'hello');
+    await expect(importSkillFromPath(src, userDir)).rejects.toThrow(/\.md file or a folder/);
+  });
+
+  it('rejects a folder without SKILL.md', async () => {
+    const folder = path.join(srcDir, 'empty');
+    await fs.mkdir(folder);
+    await expect(importSkillFromPath(folder, userDir)).rejects.toThrow(/no SKILL\.md/);
+  });
+
+  it('rejects an id that collides with a stock skill', async () => {
+    const src = path.join(srcDir, 'dup.md');
+    await fs.writeFile(src, skillFile('Summarize Clone', 'id: learning.summarize\n'));
+    await expect(importSkillFromPath(src, userDir)).rejects.toThrow(/built-in skill/);
+  });
+
+  it('rejects a duplicate of an already-imported user skill', async () => {
+    const a = path.join(srcDir, 'a.md');
+    await fs.writeFile(a, skillFile('Dup', 'id: my.dup\n'));
+    await importSkillFromPath(a, userDir);
+    const b = path.join(srcDir, 'b.md');
+    await fs.writeFile(b, skillFile('Dup Two', 'id: my.dup\n'));
+    await expect(importSkillFromPath(b, userDir)).rejects.toThrow(/already have a skill/);
+  });
+
+  it('rejects when a file of the same name already exists', async () => {
+    const a = path.join(srcDir, 'same.md');
+    await fs.writeFile(a, skillFile('First', 'id: my.first\n'));
+    await importSkillFromPath(a, userDir);
+    // A different source file with the SAME basename but a different id.
+    const a2 = path.join(srcDir, 'sub', 'same.md');
+    await fs.mkdir(path.dirname(a2));
+    await fs.writeFile(a2, skillFile('Second', 'id: my.second\n'));
+    await expect(importSkillFromPath(a2, userDir)).rejects.toThrow(/already exists/);
+  });
+});
+
+describe('removeUserSkill', () => {
+  it('removes a bare .md user skill', async () => {
+    const src = path.join(srcDir, 'gone.md');
+    await fs.writeFile(src, skillFile('Gone', 'id: my.gone\n'));
+    await importSkillFromPath(src, userDir);
+    await removeUserSkill('my.gone', userDir);
+    await expect(fs.access(path.join(userDir, 'gone.md'))).rejects.toThrow();
+    expect((await loadSkillCatalog(userDir)).skills.find((s) => s.id === 'my.gone')).toBeUndefined();
+  });
+
+  it('removes a folder-form user skill (deletes the whole folder)', async () => {
+    const folder = path.join(srcDir, 'foldy');
+    await fs.mkdir(folder);
+    await fs.writeFile(path.join(folder, 'SKILL.md'), skillFile('Foldy', 'id: my.foldy\n'));
+    await importSkillFromPath(folder, userDir);
+    await removeUserSkill('my.foldy', userDir);
+    await expect(fs.access(path.join(userDir, 'foldy'))).rejects.toThrow();
+  });
+
+  it('refuses to remove a stock skill', async () => {
+    await expect(removeUserSkill('learning.summarize', userDir)).rejects.toThrow(/No user skill/);
+  });
+
+  it('errors on an unknown id', async () => {
+    await expect(removeUserSkill('nope.nope', userDir)).rejects.toThrow(/No user skill/);
+  });
+});


### PR DESCRIPTION
**Phase 7 of 9** of the conversational skills system (#622). Closes #629.

Adds a **Skills tab** to Settings (under the AI group) for managing skills, plus the IPC + main-process plumbing behind it.

## Main (`src/main/skills/manage.ts`)
- **importSkillFromPath**: validate (via the parser) then copy a `.md` file *or* a Claude-style folder (with `SKILL.md`) into `~/.minerva/skills/`. Additive only — rejects ids that collide with stock or an existing user skill, and refuses to overwrite a same-named file. Modeled on the CSL-import flow.
- **pickAndImportSkill**: `showOpenDialog` (file or folder) → import.
- **removeUserSkill**: delete the bare `.md` or the whole folder; refuses stock.
- **revealSkillsFolder**: `shell.openPath(~/.minerva/skills)`, creating it on demand.

The import/remove IPC handlers re-sync the registry and rebuild the native menu so changes take effect without a restart. The target dir is injectable so tests never touch the real home dir.

## IPC
`skills.import` / `skills.remove` / `skills.revealFolder` (+ existing `list`/`reload`).

## Renderer
The Skills panel lists skills grouped by menu with **stock/user** badges, a Remove action on user skills, a load-error section, and **Import / Reveal folder / Reload** buttons. After any change it re-lists and calls `registerSkillInfos`, so the command palette and slash commands track imports/removals too.

## Tests
12 new for `manage.ts` (valid file + folder import, every rejection path, bare/folder removal, stock-refusal). **Full suite 2618 pass**; `tsc` + `svelte-check` clean (the new a11y label warnings match the existing section-label pattern in this dialog).

## Try it live
Settings → AI → **Skills**: import a hand-authored `.md`, watch it appear in its menu, then remove it. "Reveal skills folder" opens `~/.minerva/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)