### PR TITLE
feat: per-machine skill menu config — enable / reassign / reorder (#630)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,9 +23,11 @@ import { rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, getRootPath, markPathHandled, windowsForProject } from './window-manager';
 import { executeTool, prepareConversationTool } from './tools/executor';
 import { getSkillCatalog } from './skills/loader';
-import { reloadAndRegisterSkills } from './skills/register';
+import { reloadAndRegisterSkills, reapplyMenuConfig } from './skills/register';
 import { pickAndImportSkill, removeUserSkill, revealSkillsFolder, type ImportedSkill } from './skills/manage';
+import { getMenuConfig, saveMenuConfig } from './skills/menu-config-store';
 import { toSkillInfo, type SkillCatalogInfo } from '../shared/skills/types';
+import type { MenuConfig } from '../shared/skills/menu-config';
 import { runAutoTag } from './llm/auto-tag';
 import {
   suggestLinksTo,
@@ -1262,14 +1264,23 @@ export function registerIpcHandlers(): void {
   // main and are rendered at prepare/execute time (Phase 3).
   ipcMain.handle(Channels.SKILLS_LIST, async (): Promise<SkillCatalogInfo> => {
     const cat = await getSkillCatalog();
-    return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
+    return { skills: cat.skills.map(toSkillInfo), errors: cat.errors, config: getMenuConfig() };
   });
   ipcMain.handle(Channels.SKILLS_RELOAD, async (): Promise<SkillCatalogInfo> => {
     // Re-scan files, re-sync the registry, and rebuild the menu so newly
     // added/removed skills appear without a restart.
     const cat = await reloadAndRegisterSkills();
     rebuildMenu();
-    return { skills: cat.skills.map(toSkillInfo), errors: cat.errors };
+    return { skills: cat.skills.map(toSkillInfo), errors: cat.errors, config: getMenuConfig() };
+  });
+  ipcMain.handle(Channels.SKILLS_MENU_CONFIG_SET, async (_e, config: MenuConfig): Promise<MenuConfig> => {
+    // Persist, re-sync the registry under the new config (disabled skills
+    // drop out, overrides re-home, order changes), then rebuild the native
+    // menu. The renderer re-applies the same config to its own registry.
+    const saved = await saveMenuConfig(config);
+    reapplyMenuConfig(await getSkillCatalog());
+    rebuildMenu();
+    return saved;
   });
   ipcMain.handle(Channels.SKILLS_IMPORT, async (e): Promise<ImportedSkill | null> => {
     const win = winFromEvent(e);

--- a/src/main/skills/menu-config-store.ts
+++ b/src/main/skills/menu-config-store.ts
@@ -1,0 +1,58 @@
+/**
+ * Persistence for the per-machine skill menu config (#630).
+ *
+ * Stored as `~/.minerva/menu-config.json`. Loaded once at startup into a module
+ * cache so the (synchronous) menu builder and registry sync can read it without
+ * awaiting; mutations go through `saveMenuConfig`, which rewrites the file and
+ * refreshes the cache. `file` is injectable for tests.
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  type MenuConfig,
+  emptyMenuConfig,
+  normalizeMenuConfig,
+} from '../../shared/skills/menu-config';
+
+export function menuConfigPath(): string {
+  return path.join(os.homedir(), '.minerva', 'menu-config.json');
+}
+
+let cached: MenuConfig = emptyMenuConfig();
+
+/** Synchronous accessor for the last-loaded config (menu.ts / register.ts). */
+export function getMenuConfig(): MenuConfig {
+  return cached;
+}
+
+/** Read and cache the config. Missing file → empty (the all-defaults case). */
+export async function loadMenuConfig(file: string = menuConfigPath()): Promise<MenuConfig> {
+  try {
+    const raw = await fs.readFile(file, 'utf-8');
+    cached = normalizeMenuConfig(JSON.parse(raw));
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      cached = emptyMenuConfig();
+    } else {
+      // Corrupt JSON or unreadable file: fall back to defaults rather than
+      // crashing startup. The user can re-save from Settings to repair it.
+      console.warn('[skills] failed to read menu-config.json; using defaults:', e);
+      cached = emptyMenuConfig();
+    }
+  }
+  return cached;
+}
+
+/** Validate, persist, and cache a new config. */
+export async function saveMenuConfig(
+  config: MenuConfig,
+  file: string = menuConfigPath(),
+): Promise<MenuConfig> {
+  const normalized = normalizeMenuConfig(config);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(normalized, null, 2) + '\n', 'utf-8');
+  cached = normalized;
+  return normalized;
+}

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -65,7 +65,14 @@ function normalizeParameters(raw: unknown, errors: string[]): ToolParameter[] {
     if (obj.placeholder !== undefined) param.placeholder = asString(obj.placeholder);
     // `default` (friendly) or `defaultValue`
     const dflt = obj.default ?? obj.defaultValue;
-    if (dflt !== undefined) param.defaultValue = String(dflt);
+    if (dflt !== undefined) {
+      param.defaultValue =
+        typeof dflt === 'string'
+          ? dflt
+          : typeof dflt === 'number' || typeof dflt === 'boolean'
+            ? String(dflt)
+            : JSON.stringify(dflt);
+    }
     if (obj.required !== undefined) param.required = Boolean(obj.required);
     if (type === 'select') {
       const opts = obj.options;
@@ -109,7 +116,7 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
 
   let fm: Record<string, unknown>;
   try {
-    const parsed = YAML.parse(m[1]);
+    const parsed: unknown = YAML.parse(m[1]);
     if (typeof parsed !== 'object' || parsed === null) {
       return { errors: ['frontmatter is not a YAML mapping'], label: fallbackLabel };
     }

--- a/src/main/skills/register.ts
+++ b/src/main/skills/register.ts
@@ -9,6 +9,8 @@ import { registerTool, unregisterTool } from '../../shared/tools/registry';
 import { compileSkill } from './compile';
 import { getSkillCatalog, reloadSkillCatalog } from './loader';
 import type { SkillCatalog } from '../../shared/skills/types';
+import { applyMenuConfig } from '../../shared/skills/menu-config';
+import { getMenuConfig, loadMenuConfig } from './menu-config-store';
 
 const registeredSkillIds = new Set<string>();
 
@@ -17,7 +19,11 @@ function applyCatalog(catalog: SkillCatalog): void {
   // the fresh set. Safe to run repeatedly.
   for (const id of registeredSkillIds) unregisterTool(id);
   registeredSkillIds.clear();
-  for (const skill of catalog.skills) {
+  // Honor the per-machine menu config: disabled skills are skipped entirely
+  // (off the menu, palette and slash), menu overrides change their category,
+  // and the configured order becomes the registration order.
+  const live = applyMenuConfig(catalog.skills, getMenuConfig());
+  for (const skill of live) {
     registerTool(compileSkill(skill));
     registeredSkillIds.add(skill.id);
   }
@@ -31,9 +37,16 @@ function applyCatalog(catalog: SkillCatalog): void {
 /** Load (cached) and register skills. Call once during app startup, before
  *  menus are built. */
 export async function registerSkillsAtStartup(): Promise<SkillCatalog> {
+  await loadMenuConfig();
   const catalog = await getSkillCatalog();
   applyCatalog(catalog);
   return catalog;
+}
+
+/** Re-apply the current catalog with the current (already-loaded) menu config.
+ *  Call after the config changes so the registry and menus reflect it. */
+export function reapplyMenuConfig(catalog: SkillCatalog): void {
+  applyCatalog(catalog);
 }
 
 /** Re-scan skill files and re-sync the registry. Returns the fresh catalog so

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -357,6 +357,7 @@ contextBridge.exposeInMainWorld('api', {
     import: () => ipcRenderer.invoke(Channels.SKILLS_IMPORT),
     remove: (id: string) => ipcRenderer.invoke(Channels.SKILLS_REMOVE, id),
     revealFolder: () => ipcRenderer.invoke(Channels.SKILLS_REVEAL),
+    setMenuConfig: (config: unknown) => ipcRenderer.invoke(Channels.SKILLS_MENU_CONFIG_SET, config),
   },
   sites: {
     list: () => ipcRenderer.invoke(Channels.SITES_LIST),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -89,6 +89,7 @@
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
   import { gatherContext } from './lib/tools/context';
   import { getAllToolInfos, registerSkillInfos } from './lib/tools/tool-registry';
+  import { applyMenuConfig } from '../shared/skills/menu-config';
   import type { ToolContext } from '../shared/tools/types';
 
   type ViewMode = 'source' | 'preview' | 'split';
@@ -2875,7 +2876,9 @@
     void (async () => {
       try {
         const cat = await api.skills.list();
-        registerSkillInfos(cat.skills);
+        // Apply the per-machine menu config (#630): only enabled skills, in
+        // their effective menu and configured order, reach the palette / slash.
+        registerSkillInfos(applyMenuConfig(cat.skills, cat.config));
       } catch (err) {
         console.warn('[skills] failed to load skill list:', err);
       }

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -42,6 +42,15 @@
   import { getAllToolInfos, registerSkillInfos } from '../tools/tool-registry';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
   import type { SkillInfo, SkillMenu, SkillLoadError } from '../../../shared/skills/types';
+  import {
+    applyMenuConfig,
+    effectiveMenu,
+    isSkillEnabled,
+    skillsForMenu as orderedSkillsForMenu,
+    emptyMenuConfig,
+    type MenuConfig,
+  } from '../../../shared/skills/menu-config';
+  import { SKILL_MENUS } from '../../../shared/skills/types';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -337,14 +346,69 @@
     }
   }
 
-  // ---- Skills (#629) ----
-  let skillCatalog = $state<{ skills: SkillInfo[]; errors: SkillLoadError[] }>({ skills: [], errors: [] });
+  // ---- Skills (#629, menu config #630) ----
+  let skillCatalog = $state<{ skills: SkillInfo[]; errors: SkillLoadError[]; config: MenuConfig }>({
+    skills: [],
+    errors: [],
+    config: emptyMenuConfig(),
+  });
   let skillsBusy = $state(false);
   let skillsError = $state<string | null>(null);
-  const SKILL_MENU_ORDER: readonly SkillMenu[] = ['Learning', 'Research', 'Analysis'];
+  const SKILL_MENU_ORDER: readonly SkillMenu[] = SKILL_MENUS;
 
+  /** Skills shown under a menu in Settings — includes disabled ones (you need
+   *  to see a skill to turn it back on), in configured order, effective menu. */
   function skillsForMenu(menu: SkillMenu): SkillInfo[] {
-    return skillCatalog.skills.filter((s) => s.menu === menu);
+    return orderedSkillsForMenu(skillCatalog.skills, skillCatalog.config, menu, true);
+  }
+
+  function skillEnabled(s: SkillInfo): boolean {
+    return isSkillEnabled(s.id, skillCatalog.config);
+  }
+
+  /** Re-sync the renderer registry (palette / slash) from a config + persist it
+   *  to main (which rebuilds the native menu). Optimistic: the UI updates first. */
+  async function commitConfig(next: MenuConfig): Promise<void> {
+    skillsError = null;
+    skillCatalog = { ...skillCatalog, config: next };
+    registerSkillInfos(applyMenuConfig(skillCatalog.skills, next));
+    try {
+      const saved = await api.skills.setMenuConfig($state.snapshot(next));
+      skillCatalog = { ...skillCatalog, config: saved };
+      registerSkillInfos(applyMenuConfig(skillCatalog.skills, saved));
+    } catch (e) {
+      skillsError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  function toggleSkillEnabled(s: SkillInfo): void {
+    const cfg = skillCatalog.config;
+    void commitConfig({
+      skills: {
+        ...cfg.skills,
+        [s.id]: { enabled: !skillEnabled(s), menu: effectiveMenu(s, cfg) },
+      },
+      order: cfg.order,
+    });
+  }
+
+  function reassignSkill(s: SkillInfo, menu: SkillMenu): void {
+    const cfg = skillCatalog.config;
+    if (effectiveMenu(s, cfg) === menu) return;
+    void commitConfig({
+      skills: { ...cfg.skills, [s.id]: { enabled: skillEnabled(s), menu } },
+      order: cfg.order,
+    });
+  }
+
+  function moveSkill(s: SkillInfo, menu: SkillMenu, dir: -1 | 1): void {
+    const ids = skillsForMenu(menu).map((x) => x.id);
+    const i = ids.indexOf(s.id);
+    const j = i + dir;
+    if (i === -1 || j < 0 || j >= ids.length) return;
+    [ids[i], ids[j]] = [ids[j], ids[i]];
+    const cfg = skillCatalog.config;
+    void commitConfig({ skills: cfg.skills, order: { ...cfg.order, [menu]: ids } });
   }
 
   /** Refresh the catalog and re-sync the renderer registry so the command
@@ -353,7 +417,7 @@
     try {
       const cat = await api.skills.list();
       skillCatalog = cat;
-      registerSkillInfos(cat.skills);
+      registerSkillInfos(applyMenuConfig(cat.skills, cat.config));
     } catch (e) {
       console.error('[settings] failed to load skills:', e);
     }
@@ -391,7 +455,7 @@
     try {
       const cat = await api.skills.reload();
       skillCatalog = cat;
-      registerSkillInfos(cat.skills);
+      registerSkillInfos(applyMenuConfig(cat.skills, cat.config));
     } catch (e) {
       skillsError = e instanceof Error ? e.message : String(e);
     } finally {
@@ -1166,6 +1230,12 @@
             </div>
           {/if}
 
+          <p class="hint">
+            Turn skills off, move them between menus, or reorder them — per
+            machine. Changes apply to the menu bar, command palette, and slash
+            commands immediately.
+          </p>
+
           {#each SKILL_MENU_ORDER as menu (menu)}
             {@const items = skillsForMenu(menu)}
             <div class="field">
@@ -1174,16 +1244,47 @@
                 <p class="hint empty">No skills in this menu.</p>
               {:else}
                 <ul class="skill-list">
-                  {#each items as s (s.id)}
-                    <li>
+                  {#each items as s, i (s.id)}
+                    <li class:disabled={!skillEnabled(s)}>
                       <div class="skill-row">
+                        <input
+                          type="checkbox"
+                          class="skill-toggle"
+                          checked={skillEnabled(s)}
+                          title={skillEnabled(s) ? 'Enabled — click to hide' : 'Hidden — click to enable'}
+                          onchange={() => toggleSkillEnabled(s)}
+                        />
                         <span class="skill-name">{s.name}</span>
                         <span class="skill-src" class:user={s.source === 'user'}>{s.source}</span>
-                        {#if s.source === 'user'}
-                          <button class="link-btn" onclick={() => { void removeSkill(s.id); }} disabled={skillsBusy}>
-                            Remove
-                          </button>
-                        {/if}
+                        <div class="skill-controls">
+                          <button
+                            class="reorder-btn"
+                            title="Move up"
+                            disabled={i === 0}
+                            onclick={() => moveSkill(s, menu, -1)}
+                          >↑</button>
+                          <button
+                            class="reorder-btn"
+                            title="Move down"
+                            disabled={i === items.length - 1}
+                            onclick={() => moveSkill(s, menu, 1)}
+                          >↓</button>
+                          <select
+                            class="skill-menu-select"
+                            title="Move to menu"
+                            value={menu}
+                            onchange={(e) => reassignSkill(s, e.currentTarget.value as SkillMenu)}
+                          >
+                            {#each SKILL_MENU_ORDER as m (m)}
+                              <option value={m}>{m}</option>
+                            {/each}
+                          </select>
+                          {#if s.source === 'user'}
+                            <button class="link-btn" onclick={() => { void removeSkill(s.id); }} disabled={skillsBusy}>
+                              Remove
+                            </button>
+                          {/if}
+                        </div>
                       </div>
                       <span class="skill-desc">{s.description}</span>
                     </li>
@@ -1865,8 +1966,50 @@
   }
   .skill-row {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 8px;
+  }
+  .skill-list li.disabled .skill-name,
+  .skill-list li.disabled .skill-desc {
+    opacity: 0.45;
+  }
+  .skill-toggle {
+    flex: none;
+    margin: 0;
+    cursor: pointer;
+  }
+  .skill-controls {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .reorder-btn {
+    flex: none;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    line-height: 1;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    cursor: pointer;
+  }
+  .reorder-btn:hover:not(:disabled) {
+    border-color: var(--accent);
+  }
+  .reorder-btn:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+  .skill-menu-select {
+    font-size: 12px;
+    padding: 2px 4px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
   }
   .skill-name {
     font-weight: 600;
@@ -1882,9 +2025,6 @@
   .skill-src.user {
     color: var(--accent);
     opacity: 1;
-  }
-  .skill-row .link-btn {
-    margin-left: auto;
   }
   .skill-desc {
     font-size: 12px;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -512,6 +512,10 @@ export interface SkillsApi {
   import(): Promise<{ id: string; name: string } | null>;
   remove(id: string): Promise<void>;
   revealFolder(): Promise<void>;
+  /** Persist the per-machine menu config; returns the normalized config. */
+  setMenuConfig(
+    config: import('../../../shared/skills/menu-config').MenuConfig,
+  ): Promise<import('../../../shared/skills/menu-config').MenuConfig>;
 }
 
 export interface MenuApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -355,6 +355,8 @@ export const Channels = {
   SKILLS_REMOVE: 'skills:remove',
   /** Reveal the user skills folder (~/.minerva/skills/) in the OS file manager. */
   SKILLS_REVEAL: 'skills:reveal',
+  /** Persist the per-machine menu config (enabled / menu override / order). */
+  SKILLS_MENU_CONFIG_SET: 'skills:menuConfig:set',
 
   // Proposals
   PROPOSAL_LIST: 'proposal:list',

--- a/src/shared/skills/menu-config.ts
+++ b/src/shared/skills/menu-config.ts
@@ -1,0 +1,142 @@
+/**
+ * Per-machine menu configuration (#630, part of #622).
+ *
+ * Skills declare a home menu (Learning / Research / Analysis) in their
+ * frontmatter, but the user can, per machine, override three things:
+ *
+ *   - **enabled**: hide a skill from every surface (menu, palette, slash)
+ *     without deleting its file. Stock skills can't be removed, so this is
+ *     how you turn one off.
+ *   - **menu**: move a skill into a different one of the fixed three.
+ *   - **order**: arrange skills within a menu.
+ *
+ * The config is persisted as `~/.minerva/menu-config.json` (load/save live in
+ * the main process — see src/main/skills/menu-config-store.ts). Everything in
+ * this module is pure so both main (native menu + registry) and the renderer
+ * (palette / slash / settings UI) apply identical rules.
+ *
+ * Defaults are implicit: a skill with no entry is enabled, in its declared
+ * menu, appended after any explicitly-ordered skills. So a fresh install needs
+ * no config file, and newly-added skills slot in sensibly.
+ */
+
+import { type SkillMenu, SKILL_MENUS } from './types';
+
+/** Per-skill override. Both fields are explicit once the user touches a skill. */
+export interface SkillSetting {
+  enabled: boolean;
+  menu: SkillMenu;
+}
+
+export interface MenuConfig {
+  /** id → override. Absent id = enabled, declared menu. */
+  skills: Record<string, SkillSetting>;
+  /** menu → ordered skill ids. Ids absent from the array sort last (appended). */
+  order: Record<SkillMenu, string[]>;
+}
+
+/** Minimal item shape the ordering functions need (SkillDef and SkillInfo both fit). */
+export interface MenuItemLike {
+  id: string;
+  menu: SkillMenu;
+}
+
+export function emptyMenuConfig(): MenuConfig {
+  return {
+    skills: {},
+    order: { Learning: [], Research: [], Analysis: [] },
+  };
+}
+
+/** Coerce arbitrary parsed JSON into a valid MenuConfig, dropping junk. */
+export function normalizeMenuConfig(raw: unknown): MenuConfig {
+  const out = emptyMenuConfig();
+  if (!raw || typeof raw !== 'object') return out;
+  const r = raw as Record<string, unknown>;
+
+  if (r.skills && typeof r.skills === 'object') {
+    for (const [id, v] of Object.entries(r.skills as Record<string, unknown>)) {
+      if (!v || typeof v !== 'object') continue;
+      const s = v as Record<string, unknown>;
+      const menu = SKILL_MENUS.includes(s.menu as SkillMenu) ? (s.menu as SkillMenu) : undefined;
+      // A setting is meaningful only if it carries an enabled flag or a valid
+      // menu override; otherwise it's noise and the defaults already cover it.
+      if (typeof s.enabled !== 'boolean' && !menu) continue;
+      out.skills[id] = {
+        enabled: typeof s.enabled === 'boolean' ? s.enabled : true,
+        menu: menu ?? 'Learning',
+      };
+      // If no valid menu was given, leave the override off by reusing the
+      // declared menu at apply time — represented by deleting the menu hint.
+      if (!menu) delete (out.skills[id] as Partial<SkillSetting>).menu;
+    }
+  }
+
+  if (r.order && typeof r.order === 'object') {
+    const ord = r.order as Record<string, unknown>;
+    for (const menu of SKILL_MENUS) {
+      const arr = ord[menu];
+      if (Array.isArray(arr)) {
+        out.order[menu] = arr.filter((x): x is string => typeof x === 'string');
+      }
+    }
+  }
+
+  return out;
+}
+
+export function isSkillEnabled(id: string, config: MenuConfig): boolean {
+  return config.skills[id]?.enabled ?? true;
+}
+
+/** The menu a skill effectively lives in, honoring any override. */
+export function effectiveMenu(item: MenuItemLike, config: MenuConfig): SkillMenu {
+  return config.skills[item.id]?.menu ?? item.menu;
+}
+
+/**
+ * All items whose effective menu is `menu`, in configured order, with their
+ * `menu` field rewritten to the effective value. Pass `includeDisabled` for the
+ * settings UI (which must show toggled-off skills); leave it false for the
+ * functional surfaces (menu / palette / slash).
+ *
+ * Order: explicitly-ordered ids first (by their array position), then the
+ * menu's *native* unlisted skills (declared here, catalog order), then skills
+ * *moved in* via an override (appended, per #630's default). Ties preserve
+ * catalog order — JS sort is stable.
+ */
+export function skillsForMenu<T extends MenuItemLike>(
+  items: T[],
+  config: MenuConfig,
+  menu: SkillMenu,
+  includeDisabled = false,
+): T[] {
+  const order = config.order[menu] ?? [];
+  const matched = items.filter(
+    (it) =>
+      effectiveMenu(it, config) === menu &&
+      (includeDisabled || isSkillEnabled(it.id, config)),
+  );
+  // rank tuple: [tier, sub] — lower sorts first.
+  const rank = (it: MenuItemLike): [number, number] => {
+    const i = order.indexOf(it.id);
+    if (i !== -1) return [0, i]; // user placed it explicitly
+    return [1, it.menu === menu ? 0 : 1]; // native before moved-in
+  };
+  return [...matched]
+    .sort((a, b) => {
+      const ra = rank(a);
+      const rb = rank(b);
+      return ra[0] - rb[0] || ra[1] - rb[1];
+    })
+    .map((it) => ({ ...it, menu }));
+}
+
+/**
+ * Flat list of enabled skills across all three menus, each with its effective
+ * menu, grouped Learning → Research → Analysis and ordered within. This is the
+ * registration order for both the main and renderer tool registries.
+ */
+export function applyMenuConfig<T extends MenuItemLike>(items: T[], config: MenuConfig): T[] {
+  return SKILL_MENUS.flatMap((menu) => skillsForMenu(items, config, menu, false));
+}

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -14,6 +14,7 @@ import type {
   ToolCategory,
   ToolParameter,
 } from '../tools/types';
+import type { MenuConfig } from './menu-config';
 
 export type SkillMenu = 'Learning' | 'Research' | 'Analysis';
 
@@ -97,6 +98,8 @@ export interface SkillCatalog {
 export interface SkillCatalogInfo {
   skills: SkillInfo[];
   errors: SkillLoadError[];
+  /** The per-machine menu config (#630) the renderer applies + edits. */
+  config: MenuConfig;
 }
 
 export function toSkillInfo(s: SkillDef): SkillInfo {

--- a/tests/main/skills-analysis.test.ts
+++ b/tests/main/skills-analysis.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import path from 'node:path';
 import { loadSkillCatalog } from '../../src/main/skills/loader';
 import { compileSkill } from '../../src/main/skills/compile';
-import { buildConversationPayload } from '../../src/main/tools/executor';
 import type { ThinkingToolDef } from '../../src/shared/tools/types';
 import type { SkillDef } from '../../src/shared/skills/types';
 

--- a/tests/main/skills-menu-config-store.test.ts
+++ b/tests/main/skills-menu-config-store.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  loadMenuConfig,
+  saveMenuConfig,
+  getMenuConfig,
+} from '../../src/main/skills/menu-config-store';
+import { emptyMenuConfig, type MenuConfig } from '../../src/shared/skills/menu-config';
+
+let dir: string;
+let file: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-menucfg-'));
+  file = path.join(dir, 'sub', 'menu-config.json');
+});
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('loadMenuConfig', () => {
+  it('returns defaults when the file is missing', async () => {
+    const cfg = await loadMenuConfig(file);
+    expect(cfg).toEqual(emptyMenuConfig());
+    expect(getMenuConfig()).toEqual(emptyMenuConfig());
+  });
+
+  it('returns defaults on corrupt JSON rather than throwing', async () => {
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, '{ not json', 'utf-8');
+    const cfg = await loadMenuConfig(file);
+    expect(cfg).toEqual(emptyMenuConfig());
+  });
+});
+
+describe('saveMenuConfig', () => {
+  it('creates the directory, persists, normalizes, and caches', async () => {
+    const cfg: MenuConfig = {
+      skills: { 'learning.a': { enabled: false, menu: 'Research' } },
+      order: { Learning: ['learning.b'], Research: [], Analysis: [] },
+    };
+    const saved = await saveMenuConfig(cfg, file);
+    expect(saved.skills['learning.a']).toEqual({ enabled: false, menu: 'Research' });
+    expect(getMenuConfig()).toEqual(saved);
+
+    // Round-trips through disk.
+    const reloaded = await loadMenuConfig(file);
+    expect(reloaded).toEqual(saved);
+  });
+
+  it('strips junk before writing', async () => {
+    await saveMenuConfig(
+      { skills: { x: { enabled: true, menu: 'Bogus' as never } }, order: {} as never },
+      file,
+    );
+    const onDisk = JSON.parse(await fs.readFile(file, 'utf-8'));
+    // invalid menu → enabled-only override; missing order keys filled in
+    expect(onDisk.skills.x).toEqual({ enabled: true });
+    expect(onDisk.order).toEqual(emptyMenuConfig().order);
+  });
+});

--- a/tests/shared/skills-menu-config.test.ts
+++ b/tests/shared/skills-menu-config.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyMenuConfig,
+  normalizeMenuConfig,
+  isSkillEnabled,
+  effectiveMenu,
+  skillsForMenu,
+  applyMenuConfig,
+  type MenuConfig,
+  type MenuItemLike,
+} from '../../src/shared/skills/menu-config';
+
+const item = (id: string, menu: MenuItemLike['menu']): MenuItemLike => ({ id, menu });
+
+const items: MenuItemLike[] = [
+  item('learning.a', 'Learning'),
+  item('learning.b', 'Learning'),
+  item('learning.c', 'Learning'),
+  item('research.x', 'Research'),
+  item('analysis.z', 'Analysis'),
+];
+
+describe('defaults (no config)', () => {
+  const cfg = emptyMenuConfig();
+
+  it('treats every skill as enabled in its declared menu', () => {
+    expect(isSkillEnabled('learning.a', cfg)).toBe(true);
+    expect(effectiveMenu(item('learning.a', 'Learning'), cfg)).toBe('Learning');
+  });
+
+  it('keeps catalog order within a menu', () => {
+    expect(skillsForMenu(items, cfg, 'Learning').map((s) => s.id)).toEqual([
+      'learning.a',
+      'learning.b',
+      'learning.c',
+    ]);
+  });
+
+  it('applyMenuConfig groups Learning → Research → Analysis', () => {
+    expect(applyMenuConfig(items, cfg).map((s) => s.id)).toEqual([
+      'learning.a',
+      'learning.b',
+      'learning.c',
+      'research.x',
+      'analysis.z',
+    ]);
+  });
+});
+
+describe('enabled flag', () => {
+  it('filters disabled skills out of the functional surfaces', () => {
+    const cfg: MenuConfig = {
+      skills: { 'learning.b': { enabled: false, menu: 'Learning' } },
+      order: emptyMenuConfig().order,
+    };
+    expect(isSkillEnabled('learning.b', cfg)).toBe(false);
+    expect(skillsForMenu(items, cfg, 'Learning').map((s) => s.id)).toEqual([
+      'learning.a',
+      'learning.c',
+    ]);
+    expect(applyMenuConfig(items, cfg).map((s) => s.id)).not.toContain('learning.b');
+  });
+
+  it('still shows disabled skills when includeDisabled is set (settings UI)', () => {
+    const cfg: MenuConfig = {
+      skills: { 'learning.b': { enabled: false, menu: 'Learning' } },
+      order: emptyMenuConfig().order,
+    };
+    expect(skillsForMenu(items, cfg, 'Learning', true).map((s) => s.id)).toEqual([
+      'learning.a',
+      'learning.b',
+      'learning.c',
+    ]);
+  });
+});
+
+describe('menu override', () => {
+  it('re-homes a skill and rewrites its menu field', () => {
+    const cfg: MenuConfig = {
+      skills: { 'learning.b': { enabled: true, menu: 'Analysis' } },
+      order: emptyMenuConfig().order,
+    };
+    expect(effectiveMenu(item('learning.b', 'Learning'), cfg)).toBe('Analysis');
+    expect(skillsForMenu(items, cfg, 'Learning').map((s) => s.id)).toEqual([
+      'learning.a',
+      'learning.c',
+    ]);
+    const moved = skillsForMenu(items, cfg, 'Analysis');
+    expect(moved.map((s) => s.id)).toEqual(['analysis.z', 'learning.b']);
+    expect(moved.find((s) => s.id === 'learning.b')?.menu).toBe('Analysis');
+  });
+});
+
+describe('ordering', () => {
+  it('honors an explicit order, appending unlisted skills', () => {
+    const cfg: MenuConfig = {
+      skills: {},
+      order: { Learning: ['learning.c', 'learning.a'], Research: [], Analysis: [] },
+    };
+    expect(skillsForMenu(items, cfg, 'Learning').map((s) => s.id)).toEqual([
+      'learning.c',
+      'learning.a',
+      'learning.b', // unlisted → appended, catalog order
+    ]);
+  });
+});
+
+describe('normalizeMenuConfig', () => {
+  it('returns defaults for junk input', () => {
+    expect(normalizeMenuConfig(null)).toEqual(emptyMenuConfig());
+    expect(normalizeMenuConfig('nope')).toEqual(emptyMenuConfig());
+    expect(normalizeMenuConfig(42)).toEqual(emptyMenuConfig());
+  });
+
+  it('drops invalid menus and non-string order entries', () => {
+    const out = normalizeMenuConfig({
+      skills: {
+        good: { enabled: false, menu: 'Research' },
+        badMenu: { enabled: true, menu: 'Nonsense' },
+        empty: {},
+      },
+      order: { Learning: ['a', 5, 'b'], Bogus: ['x'] },
+    });
+    expect(out.skills.good).toEqual({ enabled: false, menu: 'Research' });
+    // invalid menu is kept as an enabled-only override (declared menu used at apply time)
+    expect(out.skills.badMenu).toEqual({ enabled: true });
+    expect(out.skills.empty).toBeUndefined();
+    expect(out.order.Learning).toEqual(['a', 'b']);
+    expect((out.order as Record<string, unknown>).Bogus).toBeUndefined();
+  });
+
+  it('an enabled-only override leaves the declared menu intact', () => {
+    const out = normalizeMenuConfig({ skills: { 'x.y': { enabled: false } } });
+    expect(out.skills['x.y']).toEqual({ enabled: false });
+    expect(effectiveMenu(item('x.y', 'Learning'), out)).toBe('Learning');
+  });
+});


### PR DESCRIPTION
Phase 8 of 9 in the skills epic (#622). Closes #630.

Per-machine configuration of which skills show where, persisted to `~/.minerva/menu-config.json`.

## What
Skills declare a home menu (Learning / Research / Analysis) in frontmatter. The user can now override three things, **per machine**:

- **enabled** — hide a skill from the menu bar, command palette, and slash commands without deleting its file. Since stock skills can't be removed, this is how you turn one off.
- **menu** — move a skill into a different one of the fixed three.
- **order** — arrange skills within a menu (↑/↓).

## How
- `src/shared/skills/menu-config.ts` — pure config types + `applyMenuConfig` / `skillsForMenu` / `effectiveMenu` / `isSkillEnabled` / `normalizeMenuConfig`. Shared so the native menu, renderer registry, and Settings UI apply identical rules.
- `src/main/skills/menu-config-store.ts` — load/save the JSON (cached; corrupt/missing → defaults).
- `register.ts` applies the config when compiling skills into the main registry (disabled skipped, `menu`→`category` overridden, configured order = registration order) — so `menu.ts` needs **no change**; it reads the already-filtered registry.
- `App.svelte` / `SettingsDialog` register the **effective** set into the renderer registry. The Skills tab gains a per-skill enable checkbox, a menu dropdown, and reorder buttons — applied optimistically and persisted via a new `skills:menuConfig:set` IPC channel (which re-syncs the registry + rebuilds the native menu).

**Defaults are implicit:** an untouched or newly-added skill is enabled, in its declared menu, appended after any explicitly-ordered skills. A fresh install needs no config file.

Also fixes three pre-existing eslint errors in earlier-phase skill files (parse.ts `default` stringification + an `any` assignment, an unused test import) that were blocking the lint gate.

## Tests
- `tests/shared/skills-menu-config.test.ts` — defaults, enabled filter, menu override + re-home append, explicit ordering, `normalizeMenuConfig` junk-handling.
- `tests/main/skills-menu-config-store.test.ts` — missing/corrupt → defaults, save→normalize→cache→round-trip.
- Full suite green: 245 files, 2632 tests. `tsc` + `svelte-check` + `eslint` clean.

## Acceptance
- ✅ Disabling a skill removes it from menu + palette.
- ✅ Reassigning moves it between menus.
- ✅ Reordering persists across restart (JSON round-trip).
- ✅ Config is per-machine (`~/.minerva/menu-config.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)