### PR TITLE
feat: thematic sub-menus for long tool categories (#525)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,9 @@ no longer a `definitions/` tool registry; do not add one.
   reassign among the three menus, and order. Pure logic in
   `src/shared/skills/menu-config.ts` (`applyMenuConfig`) is applied identically
   by the native menu, the renderer registry, and the Settings → Skills UI.
+- **Grouping** (#525): a skill's optional `group:` field renders thematic
+  nested submenus within a menu (pure logic in `src/shared/tools/grouping.ts`;
+  applied in `menu.ts`). A menu stays flat until one of its skills sets a group.
 - Authoring reference: `docs/authoring-skills.md`. To change a stock skill,
   disable it and author your own — don't edit bundled files.
 

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -82,6 +82,7 @@ palette, and the editor right-click menu (because it requests `fullNote`).
 |---|---|---|---|
 | `id` | string | slug of `name` | Stable identifier used in logs, model overrides, and menu config. **Set it explicitly and never change it once shared** — overrides are pinned by id. Stock ids look like `analysis.steelman`; yours can be anything not already taken. |
 | `longDescription` | string | `description` | 1–3 sentences; the expanded card view. Tell the user what to expect. |
+| `group` | string | — | Thematic sub-group within the menu. When any skill in a menu sets a `group`, that menu renders one nested submenu per group (ungrouped skills fall into **General**, last). Free-form; matched exactly. See [Grouping](#grouping). |
 | `context` | string list | `[]` | What to gather before running. See [Context](#context). |
 | `parameters` | list | `[]` | Upfront form fields. See [Parameters](#parameters). |
 | `tools` | string list | default set | Conversation tools to advertise. Currently only `ask_user` is honored as an extra. |
@@ -238,6 +239,22 @@ Other built-in tools the agent may use freely: `describe_graph_schema` (call it
 before referencing thought-ontology types), the read-only `search_notes` /
 `read_note` / `query_graph`, and `web_search` / `web_fetch` (set `web: true` to
 default them on).
+
+<a name="grouping"></a>
+## Grouping (thematic sub-menus)
+
+A menu with many skills gets hard to scan (the stock **Analysis** menu has 20).
+Give related skills the same `group:` and the menu renders them as nested
+submenus — e.g. `Analysis ▸ Planning ▸ Murphyjitsu`. The stock Analysis skills
+are grouped Disagreement / Planning / Motivation / Semantic / Generation /
+Pattern / Diagnostic.
+
+- Grouping kicks in only when **at least one** skill in a menu has a `group`;
+  otherwise the menu stays a flat list (Learning and Research ship ungrouped).
+- Skills **without** a group in a grouped menu collect under **General**, last.
+- Groups appear in the order their first skill appears — which follows the
+  [menu config](#menu-config) order, so you can influence it by reordering.
+- Grouping affects the menu bar. The editor/preview right-click menus stay flat.
 
 <a name="menu-config"></a>
 ## Menu config (per machine)

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -12,6 +12,7 @@ import { listSavedQueries } from './saved-queries';
 import { restartKernel as restartPythonKernel, interruptKernel as interruptPythonKernel } from './compute/python-kernel';
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
+import { groupToolsByGroup, hasNamedGroups } from '../shared/tools/grouping';
 
 function send(channel: string, ...args: unknown[]) {
   const win = BrowserWindow.getFocusedWindow();
@@ -465,14 +466,29 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
     // hardcoded block that listed only 4 of the 6 research tools).
     ...(['learning', 'research', 'analysis'] as const)
       .filter((id) => getToolsByCategory(id).length > 0)
-      .map((id) => ({
-        label: CATEGORIES.find((c) => c.id === id)!.label,
-        submenu: getToolsByCategory(id).map(tool => gate({
+      .map((id) => {
+        const tools = getToolsByCategory(id);
+        const mkItem = (tool: typeof tools[number]) => gate({
           label: tool.name,
           toolTip: tool.description,
           click: () => send(Channels.TOOL_INVOKE, tool.id),
-        })),
-      })),
+        });
+        // Thematic sub-grouping (#525): when any tool in the category declares
+        // a `group`, render one nested submenu per group (ungrouped → General,
+        // last). Otherwise stay flat — current behavior for ungrouped
+        // categories (Learning, Research).
+        const groups = groupToolsByGroup(tools);
+        const submenu: Electron.MenuItemConstructorOptions[] = hasNamedGroups(groups)
+          ? groups.map((g) => ({
+              label: g.label ?? 'General',
+              submenu: g.tools.map(mkItem),
+            }))
+          : tools.map(mkItem);
+        return {
+          label: CATEGORIES.find((c) => c.id === id)!.label,
+          submenu,
+        };
+      }),
 
     // Query
     {

--- a/src/main/skills/compile.ts
+++ b/src/main/skills/compile.ts
@@ -44,6 +44,7 @@ export function compileSkill(skill: SkillDef): ThinkingToolDef {
     def.buildSystemPrompt = (ctx) => render(skill.body, ctx);
     def.buildFirstMessage = (ctx) => render(skill.firstMessage, ctx);
   }
+  if (skill.group) def.group = skill.group;
   if (skill.model) def.preferredModel = skill.model;
   if (skill.slashCommand) def.slashCommand = skill.slashCommand;
   if (skill.outputNotePrefix) def.outputNotePrefix = skill.outputNotePrefix;

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -155,6 +155,7 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
   const model = asString(fm.model);
   const requiresSelection = Boolean(fm.requiresSelection);
   const outputNotePrefix = asString(fm.outputNotePrefix);
+  const group = asString(fm.group);
   const firstMessage = asString(fm.firstMessage) ?? '';
   const longDescription = asString(fm.longDescription) ?? description ?? '';
 
@@ -178,6 +179,7 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
     description: description!,
     longDescription,
     menu: menuRaw as SkillMenu,
+    group,
     outputMode: outputModeRaw as OutputMode,
     context,
     parameters,

--- a/src/main/skills/stock/antithesize.md
+++ b/src/main/skills/stock/antithesize.md
@@ -3,6 +3,7 @@ id: analysis.antithesize
 name: Antithesize
 description: Generate a standalone opposition — a complete rival worldview
 menu: Analysis
+group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-opus-4-7

--- a/src/main/skills/stock/aversionfactor.md
+++ b/src/main/skills/stock/aversionfactor.md
@@ -3,6 +3,7 @@ id: analysis.aversionfactor
 name: Aversion Factor
 description: Decompose a stated objection into the underlying aversions
 menu: Analysis
+group: Motivation
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/dimensionalize.md
+++ b/src/main/skills/stock/dimensionalize.md
@@ -3,6 +3,7 @@ id: analysis.dimensionalize
 name: Dimensionalize
 description: Reduce a decision to 3-7 measurable dimensions
 menu: Analysis
+group: Semantic
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/doublecrux.md
+++ b/src/main/skills/stock/doublecrux.md
@@ -3,6 +3,7 @@ id: analysis.doublecrux
 name: Double Crux
 description: Find the shared crux that would resolve a disagreement
 menu: Analysis
+group: Disagreement
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-opus-4-7

--- a/src/main/skills/stock/excavate.md
+++ b/src/main/skills/stock/excavate.md
@@ -3,6 +3,7 @@ id: analysis.excavate
 name: Excavate
 description: Surface hidden assumptions underlying arguments
 menu: Analysis
+group: Diagnostic
 outputMode: newNote
 outputNotePrefix: excavate
 slashCommand: /excavate

--- a/src/main/skills/stock/goalfactor.md
+++ b/src/main/skills/stock/goalfactor.md
@@ -3,6 +3,7 @@ id: analysis.goalfactor
 name: Goal Factor
 description: Decompose a goal into the underlying needs it serves
 menu: Analysis
+group: Motivation
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/hamming.md
+++ b/src/main/skills/stock/hamming.md
@@ -3,6 +3,7 @@ id: analysis.hamming
 name: Hamming Question
 description: Surface the most-important problem you are not working on
 menu: Analysis
+group: Planning
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-opus-4-7

--- a/src/main/skills/stock/handlize.md
+++ b/src/main/skills/stock/handlize.md
@@ -3,6 +3,7 @@ id: analysis.handlize
 name: Handlize
 description: Extract operational "handles" — short phrases you can grab and use
 menu: Analysis
+group: Semantic
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/inductify.md
+++ b/src/main/skills/stock/inductify.md
@@ -3,6 +3,7 @@ id: analysis.inductify
 name: Inductify
 description: Cross-example pattern extraction — what underlies these cases?
 menu: Analysis
+group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/innerloop.md
+++ b/src/main/skills/stock/innerloop.md
@@ -3,6 +3,7 @@ id: analysis.innerloop
 name: Inner Loop
 description: Sim the plan from the inside — what would actually happen?
 menu: Analysis
+group: Motivation
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/metaphorize.md
+++ b/src/main/skills/stock/metaphorize.md
@@ -3,6 +3,7 @@ id: analysis.metaphorize
 name: Metaphorize
 description: High-coverage source→target domain mapping
 menu: Analysis
+group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/murphyjitsu.md
+++ b/src/main/skills/stock/murphyjitsu.md
@@ -3,6 +3,7 @@ id: planning.murphyjitsu
 name: Murphyjitsu
 description: Pre-mortem failure analysis for plans and decisions
 menu: Analysis
+group: Planning
 outputMode: newNote
 outputNotePrefix: murphyjitsu
 slashCommand: /murphyjitsu

--- a/src/main/skills/stock/negspace.md
+++ b/src/main/skills/stock/negspace.md
@@ -3,6 +3,7 @@ id: analysis.negspace
 name: Negspace
 description: Detect what is conspicuously absent
 menu: Analysis
+group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/noticing.md
+++ b/src/main/skills/stock/noticing.md
@@ -3,6 +3,7 @@ id: analysis.noticing
 name: Noticing
 description: Surface the felt sense the prose isn't saying out loud
 menu: Analysis
+group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/referenceclass.md
+++ b/src/main/skills/stock/referenceclass.md
@@ -3,6 +3,7 @@ id: analysis.referenceclass
 name: Reference Class
 description: Forecast via base rates from the right outside view
 menu: Analysis
+group: Planning
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/rhetoricize.md
+++ b/src/main/skills/stock/rhetoricize.md
@@ -3,6 +3,7 @@ id: analysis.rhetoricize
 name: Rhetoricize
 description: Map the rhetorical "spin-space" — where could the argument pivot?
 menu: Analysis
+group: Diagnostic
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/rhyme.md
+++ b/src/main/skills/stock/rhyme.md
@@ -3,6 +3,7 @@ id: analysis.rhyme
 name: Rhyme
 description: Fast structural-similarity recognition — what does this echo?
 menu: Analysis
+group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-sonnet-4-6

--- a/src/main/skills/stock/steelman.md
+++ b/src/main/skills/stock/steelman.md
@@ -3,6 +3,7 @@ id: planning.steelman
 name: Steelman
 description: Construct the strongest version of an opposing argument
 menu: Analysis
+group: Disagreement
 outputMode: newNote
 outputNotePrefix: steelman
 slashCommand: /steelman

--- a/src/main/skills/stock/synthesize.md
+++ b/src/main/skills/stock/synthesize.md
@@ -3,6 +3,7 @@ id: analysis.synthesize
 name: Synthesize
 description: Compress thesis + antithesis into a unified frame
 menu: Analysis
+group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
 model: claude-opus-4-7

--- a/src/main/skills/stock/taboo.md
+++ b/src/main/skills/stock/taboo.md
@@ -3,6 +3,7 @@ id: planning.taboo
 name: Taboo
 description: Semantic decomposition by banning a contested term
 menu: Analysis
+group: Semantic
 outputMode: newNote
 outputNotePrefix: taboo
 slashCommand: /taboo

--- a/src/renderer/lib/tools/tool-registry.ts
+++ b/src/renderer/lib/tools/tool-registry.ts
@@ -17,6 +17,7 @@ export function skillInfoToToolDef(info: SkillInfo): ThinkingToolDef {
     id: info.id,
     name: info.name,
     category: menuToCategory(info.menu),
+    group: info.group,
     description: info.description,
     longDescription: info.longDescription,
     context: info.context,

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -42,6 +42,8 @@ export interface SkillDef {
   description: string;
   longDescription: string;
   menu: SkillMenu;
+  /** Optional thematic sub-group within the menu (#525). Omit for a flat menu. */
+  group?: string;
   outputMode: OutputMode;
   context: ContextRequirement[];
   parameters: ToolParameter[];
@@ -70,6 +72,7 @@ export interface SkillInfo {
   description: string;
   longDescription: string;
   menu: SkillMenu;
+  group?: string;
   outputMode: OutputMode;
   context: ContextRequirement[];
   parameters: ToolParameter[];
@@ -109,6 +112,7 @@ export function toSkillInfo(s: SkillDef): SkillInfo {
     description: s.description,
     longDescription: s.longDescription,
     menu: s.menu,
+    group: s.group,
     outputMode: s.outputMode,
     context: s.context,
     parameters: s.parameters,

--- a/src/shared/tools/grouping.ts
+++ b/src/shared/tools/grouping.ts
@@ -1,0 +1,53 @@
+/**
+ * Thematic sub-grouping within a tool category (#525).
+ *
+ * When a category grows long (Analysis ships ~20 skills), a flat list is hard
+ * to scan. Skills can declare an optional `group` (compiled to
+ * `ThinkingToolDef.group`); this helper partitions an already-ordered tool list
+ * into groups for the menu to render as nested submenus.
+ *
+ * Pure and order-preserving: groups appear in first-appearance order (which
+ * follows the menu config's ordering), and ungrouped tools collect into a
+ * trailing bucket (`label: null`, rendered as "General"). If no tool in the
+ * list declares a group, the result is a single null-labelled bucket — the
+ * caller treats that as "render flat", preserving current behavior for
+ * categories nobody has grouped (Learning, Research).
+ */
+
+export interface GroupableTool {
+  group?: string;
+}
+
+export interface ToolGroup<T> {
+  /** The group name, or null for the ungrouped ("General") bucket. */
+  label: string | null;
+  tools: T[];
+}
+
+export function groupToolsByGroup<T extends GroupableTool>(tools: T[]): ToolGroup<T>[] {
+  const named = new Map<string, T[]>(); // insertion order = first appearance
+  const ungrouped: T[] = [];
+
+  for (const tool of tools) {
+    const g = tool.group;
+    if (g) {
+      const bucket = named.get(g);
+      if (bucket) bucket.push(tool);
+      else named.set(g, [tool]);
+    } else {
+      ungrouped.push(tool);
+    }
+  }
+
+  // No named groups → a single flat bucket the caller renders inline.
+  if (named.size === 0) return [{ label: null, tools: ungrouped }];
+
+  const out: ToolGroup<T>[] = [...named].map(([label, ts]) => ({ label, tools: ts }));
+  if (ungrouped.length > 0) out.push({ label: null, tools: ungrouped });
+  return out;
+}
+
+/** True when the partition warrants nested submenus (≥1 named group). */
+export function hasNamedGroups<T>(groups: ToolGroup<T>[]): boolean {
+  return groups.some((g) => g.label !== null);
+}

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -89,6 +89,13 @@ export interface ThinkingToolDef {
   id: string;
   name: string;
   category: ToolCategory;
+  /**
+   * Optional thematic sub-grouping within a category (#525). When any tool in
+   * a category declares a group, the menu renders one nested submenu per group
+   * (ungrouped tools fall into a "General" bucket, last). Free-form string;
+   * matched case-sensitively. Omit for a flat category.
+   */
+  group?: string;
   description: string;
   longDescription: string;
   context: ContextRequirement[];
@@ -127,6 +134,8 @@ export interface ThinkingToolInfo {
   id: string;
   name: string;
   category: ToolCategory;
+  /** Thematic sub-group within the category (#525). See ThinkingToolDef.group. */
+  group?: string;
   description: string;
   longDescription: string;
   context: ContextRequirement[];

--- a/tests/main/skills-analysis.test.ts
+++ b/tests/main/skills-analysis.test.ts
@@ -41,6 +41,16 @@ describe('Analysis skills load + classify', () => {
     }
   });
 
+  it('every Analysis skill declares a thematic group (#525) that survives compile', () => {
+    const GROUPS = new Set(['Disagreement', 'Planning', 'Motivation', 'Semantic', 'Generation', 'Pattern', 'Diagnostic']);
+    for (const id of [...CONVERSATION, ...ONESHOT]) {
+      const s = skills.get(id)!;
+      expect(s.group, id).toBeDefined();
+      expect(GROUPS.has(s.group!), `${id} → ${s.group}`).toBe(true);
+      expect(compileSkill(s).group).toBe(s.group);
+    }
+  });
+
   it.each(CONVERSATION)('%s is a conversation skill with source threading + first message', (id) => {
     const def = defs.get(id)!;
     expect(def.outputMode).toBe('openConversation');

--- a/tests/shared/tool-grouping.test.ts
+++ b/tests/shared/tool-grouping.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { groupToolsByGroup, hasNamedGroups, type GroupableTool } from '../../src/shared/tools/grouping';
+
+const t = (id: string, group?: string): GroupableTool & { id: string } => ({ id, group });
+
+describe('groupToolsByGroup', () => {
+  it('returns a single null bucket when nothing is grouped (flat)', () => {
+    const groups = groupToolsByGroup([t('a'), t('b'), t('c')]);
+    expect(groups).toEqual([{ label: null, tools: [t('a'), t('b'), t('c')] }]);
+    expect(hasNamedGroups(groups)).toBe(false);
+  });
+
+  it('partitions by group in first-appearance order', () => {
+    const groups = groupToolsByGroup([
+      t('a', 'Generation'),
+      t('b', 'Planning'),
+      t('c', 'Generation'),
+      t('d', 'Planning'),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Generation', 'Planning']);
+    expect(groups[0].tools.map((x) => (x as { id: string }).id)).toEqual(['a', 'c']);
+    expect(groups[1].tools.map((x) => (x as { id: string }).id)).toEqual(['b', 'd']);
+    expect(hasNamedGroups(groups)).toBe(true);
+  });
+
+  it('collects ungrouped tools into a trailing null bucket, even if they appear first', () => {
+    const groups = groupToolsByGroup([
+      t('loose1'),
+      t('a', 'Planning'),
+      t('loose2'),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Planning', null]);
+    expect(groups[1].tools.map((x) => (x as { id: string }).id)).toEqual(['loose1', 'loose2']);
+  });
+
+  it('omits the null bucket when every tool is grouped', () => {
+    const groups = groupToolsByGroup([t('a', 'X'), t('b', 'Y')]);
+    expect(groups.map((g) => g.label)).toEqual(['X', 'Y']);
+    expect(groups.every((g) => g.label !== null)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #525.

With the skills epic landing the 20 Analysis tools (the combat-epistemology + FUTURE_TOKENS ports), a flat 20-item submenu is hard to scan. Skills can now declare an optional **`group:`**, and the menu bar renders one nested submenu per group.

```
Analysis ▸
  Disagreement ▸ Double Crux · Steelman
  Planning ▸ Hamming Question · Murphyjitsu · Reference Class
  Motivation ▸ Aversion Factor · Goal Factor · Inner Loop
  Semantic ▸ Dimensionalize · Handlize · Taboo
  Generation ▸ Antithesize · Metaphorize · Synthesize
  Pattern ▸ Inductify · Negspace · Noticing · Rhyme
  Diagnostic ▸ Excavate · Rhetoricize
  General ▸ (any ungrouped skills)
```

## How
- `group?: string` on `ThinkingToolDef`/`ThinkingToolInfo` and `SkillDef`/`SkillInfo`, parsed from frontmatter → compile → renderer registry.
- **Pure, tested helper** `src/shared/tools/grouping.ts`: partitions an ordered tool list into groups in first-appearance order; ungrouped tools collect into a trailing **General** bucket. When no tool has a group it returns one flat bucket, so `menu.ts` renders ungrouped categories (Learning, Research) exactly as before.
- `menu.ts` renders nested submenus when a category has any group, flat otherwise. Editor/Preview right-click menus stay flat (the issue calls flat "probably fine" for the smaller working set).
- The 20 stock Analysis skills tagged with the issue's taxonomy.

Group order follows the existing **menu-config** order (first appearance), so it's user-tunable via reorder — no new config surface.

## Tests
- `tests/shared/tool-grouping.test.ts` — flat fallback, first-appearance order, trailing General bucket, all-grouped case.
- `tests/main/skills-analysis.test.ts` — every Analysis skill declares a valid group that survives compile.
- Full suite green: 246 files, 2637 tests. `tsc` + `svelte-check` + `eslint` clean.

## Notes / out of scope (per issue)
- Grouping is opt-in; Learning (9) and Research (6) stay flat.
- One axis only (no tags); right-click menus stay flat; Settings doesn't edit `group` (it's a frontmatter property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)