### PR TITLE
feat: model verification predicates in the ontology + decay-sweep stock queries

### DIFF
--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -552,6 +552,49 @@ thought:connects a owl:ObjectProperty ;
     rdfs:domain thought:Component ;
     rdfs:range thought:Component .
 
+# ── Verification & Currency (research verification cluster, #414–#417) ──────
+# Annotations filed (via the approval engine) by the Check Facts, Find Primary
+# Sources, Date/Scope Check, and Translate the Magnitude research skills. They
+# attach to the thought:Claim that was audited. Stored as literals so a claim
+# carries its latest verdict inline; re-running a tool supersedes the prior
+# value. Pair thought:asOfDate with a status to drive periodic decay sweeps.
+
+thought:verificationStatus a owl:DatatypeProperty ;
+    rdfs:label "verification status" ;
+    rdfs:comment "Result of a web fact-check of this claim, filed by the Check Facts skill: \"corroborated\" (independent sources agree), \"contested\" (credible sources disagree), or \"unverifiable\" (could not confirm either way). \"unverifiable\" is a first-class result, not a failure." ;
+    rdfs:domain thought:Claim ;
+    rdfs:range xsd:string .
+
+thought:currencyStatus a owl:DatatypeProperty ;
+    rdfs:label "currency status" ;
+    rdfs:comment "Result of a date/scope audit of this claim, filed by the Date/Scope Check skill: \"current\" (still true as stated), \"scope-shifted\" (true only under conditions the stated form omits), \"decayed\" (was true, no longer), or \"misstated\" (never held in the form stated)." ;
+    rdfs:domain thought:Claim ;
+    rdfs:range xsd:string .
+
+thought:asOfDate a owl:DatatypeProperty ;
+    rdfs:label "as-of date" ;
+    rdfs:comment "The date a currency/verification check was performed. Load-bearing for decay sweeps: a claim whose most recent as-of date is far in the past is a candidate for re-checking." ;
+    rdfs:domain thought:Claim ;
+    rdfs:range xsd:date .
+
+thought:hasPrimarySource a owl:DatatypeProperty ;
+    rdfs:label "has primary source" ;
+    rdfs:comment "The actual primary source behind this claim (full citation or URL), traced past its citation chain by the Find Primary Sources skill. A literal so it can record a citation even before the source is ingested as a thought:Source node." ;
+    rdfs:domain thought:Claim ;
+    rdfs:range xsd:string .
+
+thought:hasGroundedMagnitude a owl:DatatypeProperty ;
+    rdfs:label "has grounded magnitude" ;
+    rdfs:comment "A quantitative claim's magnitude re-grounded against its base rate, normalisation, and baseline by the Translate the Magnitude skill — the absolute numbers behind a relative or headline framing." ;
+    rdfs:domain thought:Claim ;
+    rdfs:range xsd:string .
+
+thought:verifiedBy a owl:DatatypeProperty ;
+    rdfs:label "verified by" ;
+    rdfs:comment "Provenance for a verification annotation: the agent/tool that produced it, e.g. \"llm:check-facts\". Distinguishes machine verdicts from human-entered ones." ;
+    rdfs:domain thought:Component ;
+    rdfs:range xsd:string .
+
 # ── Grounding (linking back to source text) ───────────────────────────────
 
 thought:groundedIn a owl:ObjectProperty ;

--- a/src/shared/stock-queries.ts
+++ b/src/shared/stock-queries.ts
@@ -235,6 +235,41 @@ SELECT ?sourceId ?title ?creator WHERE {
 ORDER BY ?sourceId`,
   },
   {
+    name: 'Claims: due for a currency re-check (decay sweep)',
+    description: 'Claims whose last currency/fact check predates a cutoff date — the periodic "is my knowledge still current?" sweep. Edit the cutoff for your decay window.',
+    language: 'sparql',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# Edit the cutoff date for your decay window (e.g. five years ago).
+SELECT ?label ?currency ?asOf WHERE {
+  ?claim a thought:Claim .
+  ?claim thought:asOfDate ?asOf .
+  OPTIONAL { ?claim thought:label ?label }
+  OPTIONAL { ?claim thought:currencyStatus ?currency }
+  FILTER(?asOf < "2021-06-01"^^xsd:date)
+}
+ORDER BY ?asOf`,
+  },
+  {
+    name: 'Claims: verification verdicts',
+    description: 'Every claim carrying a fact-check or currency verdict (corroborated / contested / unverifiable / decayed / scope-shifted / misstated) — scan for the contested and unverifiable ones.',
+    language: 'sparql',
+    query: `${PREFIXES}
+PREFIX thought: <https://minerva.dev/ontology/thought#>
+
+SELECT ?label ?verification ?currency ?asOf WHERE {
+  ?claim a thought:Claim .
+  OPTIONAL { ?claim thought:label ?label }
+  OPTIONAL { ?claim thought:verificationStatus ?verification }
+  OPTIONAL { ?claim thought:currencyStatus ?currency }
+  OPTIONAL { ?claim thought:asOfDate ?asOf }
+  FILTER(BOUND(?verification) || BOUND(?currency))
+}
+ORDER BY ?verification ?currency`,
+  },
+  {
     name: 'Compute: derived notes missing their source (#244)',
     description: 'Notes saved via "Save cell output as note" whose source notebook no longer exists — surfaces breakage from a delete/rename that didn\'t fix up the derived note\'s provenance.',
     language: 'sparql',

--- a/tests/main/graph/verification-ontology.test.ts
+++ b/tests/main/graph/verification-ontology.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The verification & currency predicates (#414–#417 follow-up) the research
+ * skills file onto audited claims. Pins that they're declared as datatype
+ * properties on thought:Claim so the ontology documents what the skills emit.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as $rdf from 'rdflib';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
+const RDF = $rdf.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+const RDFS = $rdf.Namespace('http://www.w3.org/2000/01/rdf-schema#');
+const OWL = $rdf.Namespace('http://www.w3.org/2002/07/owl#');
+const XSD = $rdf.Namespace('http://www.w3.org/2001/XMLSchema#');
+
+const ONTOLOGY_TTL = fs.readFileSync(
+  path.join(__dirname, '../../../src/shared/ontology-thought.ttl'),
+  'utf-8',
+);
+
+describe('verification & currency predicates', () => {
+  let store: $rdf.IndexedFormula;
+  beforeAll(() => {
+    store = $rdf.graph();
+    $rdf.parse(ONTOLOGY_TTL, store, THOUGHT('').value, 'text/turtle');
+  });
+
+  const claimProps: Array<[string, string]> = [
+    ['verificationStatus', 'string'],
+    ['currencyStatus', 'string'],
+    ['asOfDate', 'date'],
+    ['hasPrimarySource', 'string'],
+    ['hasGroundedMagnitude', 'string'],
+  ];
+
+  for (const [prop, range] of claimProps) {
+    it(`thought:${prop} is a datatype property on thought:Claim (xsd:${range})`, () => {
+      expect(store.holds(THOUGHT(prop), RDF('type'), OWL('DatatypeProperty'))).toBe(true);
+      expect(store.holds(THOUGHT(prop), RDFS('domain'), THOUGHT('Claim'))).toBe(true);
+      expect(store.holds(THOUGHT(prop), RDFS('range'), XSD(range))).toBe(true);
+    });
+  }
+
+  it('thought:verifiedBy is a datatype property on thought:Component', () => {
+    expect(store.holds(THOUGHT('verifiedBy'), RDF('type'), OWL('DatatypeProperty'))).toBe(true);
+    expect(store.holds(THOUGHT('verifiedBy'), RDFS('domain'), THOUGHT('Component'))).toBe(true);
+    expect(store.holds(THOUGHT('verifiedBy'), RDFS('range'), XSD('string'))).toBe(true);
+  });
+});

--- a/tests/main/stock-queries-claims.test.ts
+++ b/tests/main/stock-queries-claims.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Executes the verification stock queries (#414–#417 follow-up) through the
+ * same SPARQL engine the app uses (Comunica over an N3 store) against a small
+ * claim graph, so a syntax slip or a wrong predicate is caught here rather than
+ * in the Query Panel.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { QueryEngine } from '@comunica/query-sparql-rdfjs';
+import { Store, DataFactory as DF } from 'n3';
+import { STOCK_QUERIES } from '../../src/shared/stock-queries';
+
+const namedNode = (v: string) => DF.namedNode(v);
+const literal = (v: string, dt?: ReturnType<typeof DF.namedNode>) => DF.literal(v, dt);
+const quad = (s: ReturnType<typeof DF.namedNode>, p: ReturnType<typeof DF.namedNode>, o: ReturnType<typeof DF.namedNode> | ReturnType<typeof DF.literal>) => DF.quad(s, p, o);
+const T = (l: string) => namedNode(`https://minerva.dev/ontology/thought#${l}`);
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const XSD_DATE = namedNode('http://www.w3.org/2001/XMLSchema#date');
+
+const queryByName = (name: string): string => {
+  const q = STOCK_QUERIES.find((s) => s.name === name);
+  if (!q) throw new Error(`stock query not found: ${name}`);
+  return q.query;
+};
+
+function store(): Store {
+  const s = new Store();
+  const c1 = namedNode('https://ex/claim/old'); // checked long ago, contested
+  const c2 = namedNode('https://ex/claim/recent'); // checked recently, decayed
+  const c3 = namedNode('https://ex/claim/plain'); // a claim with no verdict
+  s.addQuad(quad(c1, RDF_TYPE, T('Claim')));
+  s.addQuad(quad(c1, T('label'), literal('Coffee cures scurvy')));
+  s.addQuad(quad(c1, T('verificationStatus'), literal('contested')));
+  s.addQuad(quad(c1, T('asOfDate'), literal('2019-03-01', XSD_DATE)));
+  s.addQuad(quad(c2, RDF_TYPE, T('Claim')));
+  s.addQuad(quad(c2, T('label'), literal('The capital is Bonn')));
+  s.addQuad(quad(c2, T('currencyStatus'), literal('decayed')));
+  s.addQuad(quad(c2, T('asOfDate'), literal('2024-09-01', XSD_DATE)));
+  s.addQuad(quad(c3, RDF_TYPE, T('Claim')));
+  s.addQuad(quad(c3, T('label'), literal('Plain unaudited claim')));
+  return s;
+}
+
+async function run(query: string, src: Store): Promise<Record<string, string>[]> {
+  const engine = new QueryEngine();
+  const stream = await engine.queryBindings(query, { sources: [src] });
+  const bindings = await stream.toArray();
+  return bindings.map((b) => {
+    const row: Record<string, string> = {};
+    for (const [k, v] of b) row[k.value] = v.value;
+    return row;
+  });
+}
+
+describe('verification stock queries', () => {
+  let data: Store;
+  beforeAll(() => { data = store(); });
+
+  it('"due for a currency re-check" returns only claims checked before the cutoff', async () => {
+    const rows = await run(queryByName('Claims: due for a currency re-check (decay sweep)'), data);
+    // Cutoff in the shipped query is 2021-06-01: c1 (2019) qualifies, c2 (2024) does not.
+    expect(rows.map((r) => r.label)).toEqual(['Coffee cures scurvy']);
+    expect(rows[0].asOf).toContain('2019-03-01');
+  });
+
+  it('"verification verdicts" lists every claim carrying a verdict, excludes unaudited ones', async () => {
+    const rows = await run(queryByName('Claims: verification verdicts'), data);
+    const labels = rows.map((r) => r.label).sort();
+    expect(labels).toEqual(['Coffee cures scurvy', 'The capital is Bonn']);
+    expect(rows.find((r) => r.label === 'Coffee cures scurvy')?.verification).toBe('contested');
+    expect(rows.find((r) => r.label === 'The capital is Bonn')?.currency).toBe('decayed');
+  });
+});


### PR DESCRIPTION
Follow-up to the research verification cluster (#414–#417): the verdict predicates those skills emit are now first-class in the thought ontology instead of undocumented open-world literals, and two stock queries make the metadata useful — including the decay sweep #416 called for.

## Ontology (`ontology-thought.ttl`)
New **Verification & Currency** section — datatype properties with comments spelling out each verdict's allowed values:

| Predicate | Domain | Range | Values |
|---|---|---|---|
| `thought:verificationStatus` | Claim | xsd:string | corroborated / contested / unverifiable |
| `thought:currencyStatus` | Claim | xsd:string | current / scope-shifted / decayed / misstated |
| `thought:asOfDate` | Claim | xsd:date | date of the check |
| `thought:hasPrimarySource` | Claim | xsd:string | citation/URL of the traced primary |
| `thought:hasGroundedMagnitude` | Claim | xsd:string | absolute numbers behind a framing |
| `thought:verifiedBy` | Component | xsd:string | tool id, e.g. `llm:check-facts` |

## Stock queries (Graph ▸ Stock Queries)
- **Claims: due for a currency re-check (decay sweep)** — claims whose last check predates an editable cutoff date. This is the #416 "claims I haven't re-checked in N years" sweep.
- **Claims: verification verdicts** — every claim carrying a fact-check or currency verdict, so contested / unverifiable ones surface.

## Tests
- `graph/verification-ontology.test.ts` — each predicate is declared with the right type / domain / range.
- `stock-queries-claims.test.ts` — **both queries execute through the real engine (Comunica)** against a claim graph and return the expected rows, including the typed-date cutoff filter.
- Full suite green: 249 files, 2657 tests; `tsc` + `svelte-check` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)