### PR TITLE
feat: note-picker parameter type + Find Tensions skill (#516)

### DIFF
--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -193,10 +193,38 @@ parameters:
         value: synthesis
 ```
 
-Types: `text`, `textarea`, `select`, `number`. `select` options may be bare
-strings (label = value) or `{label, value}` pairs. `default` (friendly alias of
-`defaultValue`) seeds the field. Because the template can't map a value to extra
-prose, put any per-option wording directly in the `value`.
+Types: `text`, `textarea`, `select`, `number`, `note`. `select` options may be
+bare strings (label = value) or `{label, value}` pairs. `default` (friendly
+alias of `defaultValue`) seeds the field. Because the template can't map a value
+to extra prose, put any per-option wording directly in the `value`.
+
+### The `note` picker — operating on a second note
+
+A `note` parameter is a fuzzy picker over the project's markdown files. It
+resolves to a **relativePath**, and the picked note's body and title are read
+and exposed to the prompt as companion vars — so a skill can work on a *second*
+note, not just the active one:
+
+| Template var | Value |
+|---|---|
+| `{{param.<id>}}` | the picked note's relativePath |
+| `{{param.<id>.title}}` | its title (basename) |
+| `{{param.<id>.content}}` | its full text |
+
+Guard on the content var — if the picked note was renamed or deleted between
+pick and run, the path and title survive but `{{param.<id>.content}}` is empty:
+
+```markdown
+{{#if param.otherNote.content}}
+Compare the active note against "{{param.otherNote.title}}":
+
+{{param.otherNote.content}}
+{{else}}
+The picked note couldn't be read — ask the user to pick another.
+{{/if}}
+```
+
+The stock **Find Tensions** skill is the worked example.
 
 Parameters cover the **upfront known-decision** case. For ambiguity that only
 appears after the agent reads the source, add `tools: [ask_user]` — the agent

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -23,7 +23,7 @@ const CONTEXT_REQUIREMENTS: readonly ContextRequirement[] = [
 const OUTPUT_MODES: readonly OutputMode[] = [
   'newNote', 'appendToNote', 'replaceSelection', 'insertAtCursor', 'multipleNotes', 'openConversation',
 ];
-const PARAM_TYPES = ['text', 'textarea', 'select', 'number'] as const;
+const PARAM_TYPES = ['text', 'textarea', 'select', 'number', 'note'] as const;
 
 export interface ParseResult {
   skill?: SkillDef;

--- a/src/main/skills/stock/find-tensions.md
+++ b/src/main/skills/stock/find-tensions.md
@@ -1,0 +1,82 @@
+---
+id: analysis.find-tensions
+name: Find Tensions
+description: Surface where this note and another conflict
+menu: Analysis
+group: Disagreement
+outputMode: openConversation
+context: [fullNote]
+slashCommand: /tensions
+model: claude-opus-4-7
+parameters:
+  - id: otherNote
+    label: Compare against
+    type: note
+    required: true
+    placeholder: Pick the note to compare against…
+firstMessage: |-
+  {{#if note}}{{#if param.otherNote.content}}Find the tensions between "{{note.title}}" and "{{param.otherNote.title}}".{{else}}I picked a note to compare against, but its contents couldn't be read — check the path: {{param.otherNote}}{{/if}}{{else}}Open a note first, then pick a second one to compare it against.{{/if}}
+longDescription: >-
+  Reads the active note and a second note you pick, then surfaces where they actually conflict —
+  direct contradictions, clashing unstated assumptions, scope mismatches, and differences of emphasis.
+  This is the first skill that operates on two notes at once. When you're satisfied, ask it to file a
+  Tension note linking both, for review.
+---
+You are a careful analyst comparing two of the user's notes to find where they are in **tension**. Surface real conflicts; don't manufacture them.
+
+{{#if param.otherNote.content}}
+## Process
+
+1. Read both notes below. Identify the positions each takes.
+2. Surface the tensions between them. For each, classify the kind:
+   - **direct contradiction** — both can't be true as stated.
+   - **assumption clash** — they rest on unstated premises that conflict.
+   - **scope mismatch** — they'd agree once you pin down conditions each leaves implicit; name the conditions.
+   - **emphasis** — not a contradiction, but they weight or frame the same thing differently in a way worth noting.
+3. For each tension, quote the conflicting passage from each side. Rank by how load-bearing the conflict is.
+
+## Filing the result
+
+When the user is satisfied, call `propose_notes` with **one** note:
+
+```markdown
+---
+title: Tensions — {{note.title}} vs {{param.otherNote.title}}
+tension-between: ["{{note.title}}", "{{param.otherNote.title}}"]
+---
+
+# Tensions — {{note.title}} vs {{param.otherNote.title}}
+
+Compares [[{{note.title}}]] and [[{{param.otherNote.title}}]].
+
+## Tension 1: <short label>
+
+_kind:_ `direct contradiction | assumption clash | scope mismatch | emphasis`
+
+> <passage from {{note.title}}>
+
+> <passage from {{param.otherNote.title}}>
+
+<one paragraph: what conflicts, and why it matters.>
+
+## Tension 2: …
+
+```turtle
+this: a thought:Tension .
+```
+```
+
+## Anti-flattery
+
+If the two notes are actually consistent — or merely cover different ground without conflicting — **say so and stop**. Do not invent tensions to look thorough; a clean "these don't conflict, here's why" is the honest, useful answer. Reserve "direct contradiction" for genuine ones; downgrade the rest.
+
+## Active note: {{note.title}}
+
+{{note.content}}
+
+## Compared note: {{param.otherNote.title}}
+
+{{param.otherNote.content}}
+{{else}}
+No second note was readable. Ask the user to pick a note to compare the active one against, then re-run.
+{{/if}}

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -5,6 +5,7 @@
   import Icon from './Icon.svelte';
   import type { ToolContext } from '../../../shared/tools/types';
   import { isMissingApiKeyError } from '../../../shared/llm-errors';
+  import { resolveNoteParams, flattenNoteFiles } from '../tools/resolve-note-params';
 
   interface Props {
     onNoteCreated?: () => void;
@@ -23,6 +24,9 @@
   const panel = getToolPanelStore();
   let paramValues = $state<Record<string, string>>({});
   let running = $state(false);
+  // Note-picker (#516) options — flat list of project .md files, loaded lazily
+  // the first time a tool with a `note` parameter is configured.
+  let noteOptions = $state<{ name: string; relativePath: string }[]>([]);
 
   $effect(() => {
     if (panel.panelState === 'configure') {
@@ -33,6 +37,9 @@
         values[p.id] = p.defaultValue ?? '';
       }
       paramValues = values;
+      if (params.some((p) => p.type === 'note') && noteOptions.length === 0) {
+        void api.notebase.listFiles().then((tree) => { noteOptions = flattenNoteFiles(tree); });
+      }
     }
   });
 
@@ -65,12 +72,14 @@
     }
   }
 
-  function handleRunWithParams() {
+  async function handleRunWithParams() {
     const tool = panel.activeTool;
     if (!tool) return;
 
+    // Resolve any note-picker params to the picked note's content/title before
+    // folding them in (#516), so the prompt can reference {{param.x.content}}.
     const snappedParams = Object.keys(paramValues).length > 0
-      ? $state.snapshot(paramValues)
+      ? await resolveNoteParams(tool.parameters, $state.snapshot(paramValues), (p) => api.notebase.readFile(p))
       : undefined;
 
     if (tool.outputMode === 'openConversation') {
@@ -172,6 +181,17 @@
                     placeholder={param.placeholder ?? ''}
                     rows="3"
                   ></textarea>
+                {:else if param.type === 'note'}
+                  <input
+                    list={`notes-${param.id}`}
+                    bind:value={paramValues[param.id]}
+                    placeholder={param.placeholder ?? 'Type to find a note…'}
+                  />
+                  <datalist id={`notes-${param.id}`}>
+                    {#each noteOptions as n (n.relativePath)}
+                      <option value={n.relativePath}>{n.name}</option>
+                    {/each}
+                  </datalist>
                 {:else}
                   <input
                     type={param.type === 'number' ? 'number' : 'text'}
@@ -193,7 +213,7 @@
           </div>
         {/if}
         <div class="actions">
-          <button class="btn primary" onclick={handleRunWithParams}>Run</button>
+          <button class="btn primary" onclick={() => { void handleRunWithParams(); }}>Run</button>
           <button class="btn" onclick={() => panel.close()}>Cancel</button>
         </div>
       </div>

--- a/src/renderer/lib/tools/resolve-note-params.ts
+++ b/src/renderer/lib/tools/resolve-note-params.ts
@@ -1,0 +1,56 @@
+import type { ToolParameter } from '../../../shared/tools/types';
+
+/** Drop a trailing .md; basename as a fallback title for a picked note. */
+function basenameTitle(relativePath: string): string {
+  const base = relativePath.split('/').pop() ?? relativePath;
+  return base.replace(/\.md$/i, '');
+}
+
+/**
+ * Note-picker resolution (#516). For each `note`-type parameter that holds a
+ * picked value (a relativePath), read the note and expose its body + title to
+ * the prompt as the companion template vars `{{param.<id>.content}}` and
+ * `{{param.<id>.title}}`. The picked path itself stays as `{{param.<id>}}`.
+ *
+ * Pure but for the injected `readFile`, so it unit-tests without Electron. A
+ * read failure (the note was renamed/deleted between pick and run) leaves the
+ * path + title in place and just omits the content — the skill prompt decides
+ * how to handle a missing body.
+ */
+export async function resolveNoteParams(
+  params: ToolParameter[] | undefined,
+  values: Record<string, string>,
+  readFile: (relativePath: string) => Promise<string>,
+): Promise<Record<string, string>> {
+  const out = { ...values };
+  for (const p of params ?? []) {
+    if (p.type !== 'note') continue;
+    const rel = out[p.id];
+    if (!rel) continue;
+    out[`${p.id}.title`] = basenameTitle(rel);
+    try {
+      out[`${p.id}.content`] = await readFile(rel);
+    } catch {
+      // Picked note unreadable — keep path + title, omit content.
+    }
+  }
+  return out;
+}
+
+/** Flatten a NoteFile tree to the markdown files, for the picker list. */
+export function flattenNoteFiles(
+  nodes: { name: string; relativePath: string; isDirectory: boolean; children?: unknown[] }[],
+): { name: string; relativePath: string }[] {
+  const out: { name: string; relativePath: string }[] = [];
+  const walk = (ns: typeof nodes): void => {
+    for (const n of ns) {
+      if (n.isDirectory) {
+        if (Array.isArray(n.children)) walk(n.children as typeof nodes);
+      } else if (n.relativePath.toLowerCase().endsWith('.md')) {
+        out.push({ name: n.name, relativePath: n.relativePath });
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -39,7 +39,14 @@ export type OutputMode =
 export interface ToolParameter {
   id: string;
   label: string;
-  type: 'text' | 'textarea' | 'select' | 'number';
+  /**
+   * Input kind. `note` (#516) is a fuzzy note-picker that resolves to a
+   * relativePath; the renderer additionally reads the picked note and exposes
+   * its body + title to the prompt as the companion template vars
+   * `{{param.<id>.content}}` and `{{param.<id>.title}}` — so a skill can
+   * operate on a second note, not just the active one.
+   */
+  type: 'text' | 'textarea' | 'select' | 'number' | 'note';
   placeholder?: string;
   options?: { label: string; value: string }[];
   defaultValue?: string;

--- a/tests/main/skills-find-tensions.test.ts
+++ b/tests/main/skills-find-tensions.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Find Tensions (#516) — the first stock skill that operates on two notes via
+ * a note-picker parameter. Pins that it loads, declares the `note` param, and
+ * threads the picked note's resolved content/title into both the system prompt
+ * and the first message.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+import { compileSkill } from '../../src/main/skills/compile';
+import type { ThinkingToolDef } from '../../src/shared/tools/types';
+
+let def: ThinkingToolDef;
+
+beforeAll(async () => {
+  const cat = await loadSkillCatalog(path.join(__dirname, '__no_user_skills__'));
+  expect(cat.errors).toEqual([]);
+  const skill = cat.skills.find((s) => s.id === 'analysis.find-tensions');
+  expect(skill).toBeDefined();
+  def = compileSkill(skill!);
+});
+
+describe('find-tensions skill', () => {
+  it('declares a required note-picker parameter', () => {
+    const p = def.parameters?.find((x) => x.id === 'otherNote');
+    expect(p?.type).toBe('note');
+    expect(p?.required).toBe(true);
+  });
+
+  it('is an Analysis / Disagreement conversation skill', () => {
+    expect(def.category).toBe('analysis');
+    expect(def.group).toBe('Disagreement');
+    expect(def.outputMode).toBe('openConversation');
+  });
+
+  it('threads both notes into the system prompt when the pick resolves', () => {
+    const sys = def.buildSystemPrompt!({
+      fullNoteTitle: 'Active One',
+      fullNoteContent: 'active-body-aaa',
+      parameterValues: {
+        otherNote: 'ideas/Other.md',
+        'otherNote.title': 'Other Two',
+        'otherNote.content': 'other-body-bbb',
+      },
+    });
+    expect(sys).toContain('active-body-aaa');
+    expect(sys).toContain('other-body-bbb');
+    expect(sys).toContain('Active One');
+    expect(sys).toContain('Other Two');
+    expect(sys).toContain('## Process');
+  });
+
+  it('first message names both notes', () => {
+    const fm = def.buildFirstMessage!({
+      fullNoteTitle: 'Active One',
+      fullNoteContent: 'active-body',
+      parameterValues: { otherNote: 'x.md', 'otherNote.title': 'Other Two', 'otherNote.content': 'b' },
+    });
+    expect(fm).toContain('Active One');
+    expect(fm).toContain('Other Two');
+  });
+
+  it('falls back gracefully when the picked note could not be read', () => {
+    const sys = def.buildSystemPrompt!({
+      fullNoteTitle: 'Active One',
+      fullNoteContent: 'active-body',
+      parameterValues: { otherNote: 'gone.md' }, // no .content
+    });
+    expect(sys).toContain('No second note was readable');
+    const fm = def.buildFirstMessage!({
+      fullNoteTitle: 'Active One',
+      fullNoteContent: 'active-body',
+      parameterValues: { otherNote: 'gone.md' },
+    });
+    expect(fm).toContain("couldn't be read");
+  });
+});

--- a/tests/renderer/resolve-note-params.test.ts
+++ b/tests/renderer/resolve-note-params.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { resolveNoteParams, flattenNoteFiles } from '../../src/renderer/lib/tools/resolve-note-params';
+import type { ToolParameter } from '../../src/shared/tools/types';
+
+const noteParam: ToolParameter = { id: 'otherNote', label: 'Compare against', type: 'note' };
+const textParam: ToolParameter = { id: 'angle', label: 'Angle', type: 'text' };
+
+describe('resolveNoteParams', () => {
+  it('reads a picked note into companion .content / .title vars', async () => {
+    const reader = async (p: string) => (p === 'ideas/Foundations.md' ? '# Foundations\n\nbody text' : '');
+    const out = await resolveNoteParams(
+      [noteParam, textParam],
+      { otherNote: 'ideas/Foundations.md', angle: 'epistemic' },
+      reader,
+    );
+    expect(out.otherNote).toBe('ideas/Foundations.md'); // path preserved
+    expect(out['otherNote.title']).toBe('Foundations'); // basename, .md stripped
+    expect(out['otherNote.content']).toBe('# Foundations\n\nbody text');
+    expect(out.angle).toBe('epistemic'); // non-note params untouched
+  });
+
+  it('leaves path + title but omits content when the note is unreadable', async () => {
+    const reader = async () => { throw new Error('ENOENT'); };
+    const out = await resolveNoteParams([noteParam], { otherNote: 'gone.md' }, reader);
+    expect(out.otherNote).toBe('gone.md');
+    expect(out['otherNote.title']).toBe('gone');
+    expect(out['otherNote.content']).toBeUndefined();
+  });
+
+  it('ignores a note param with no pick and never calls the reader', async () => {
+    let called = false;
+    const reader = async () => { called = true; return ''; };
+    const out = await resolveNoteParams([noteParam], { otherNote: '' }, reader);
+    expect(out['otherNote.content']).toBeUndefined();
+    expect(called).toBe(false);
+  });
+});
+
+describe('flattenNoteFiles', () => {
+  it('flattens the tree to markdown files only', () => {
+    const tree = [
+      { name: 'A.md', relativePath: 'A.md', isDirectory: false },
+      { name: 'img.png', relativePath: 'img.png', isDirectory: false },
+      {
+        name: 'sub', relativePath: 'sub', isDirectory: true, children: [
+          { name: 'B.md', relativePath: 'sub/B.md', isDirectory: false },
+          { name: 'notes', relativePath: 'sub/notes', isDirectory: true, children: [
+            { name: 'C.md', relativePath: 'sub/notes/C.md', isDirectory: false },
+          ] },
+        ],
+      },
+    ];
+    expect(flattenNoteFiles(tree).map((f) => f.relativePath)).toEqual(['A.md', 'sub/B.md', 'sub/notes/C.md']);
+  });
+});


### PR DESCRIPTION
Closes #516 (scoped).

#516 proposed five richer parameter types. Because `{{param.x}}` resolves to a *string*, four of them (toggle-group, slider, tag-picker, multi-select) are cosmetic or overlap existing capability — and the issue's own rule is "implement only the ones that come up during actual ports, not speculatively." The bulk ports needed none of them.

**The exception is `note`** — the only one that removes a hard ceiling. Until now a skill could see the active note, the selection, or the claim under the cursor. It could not reference a *second* note. This adds a fuzzy note-picker, and ships it with a skill that uses it — so it's a capability with a consumer, not infrastructure on spec.

## How
- `ToolParameter.type` gains `'note'` (parser accepts it). ToolPanel renders a native `datalist` fuzzy picker over a flattened `listFiles()`.
- The picked value is a **relativePath**. Before a run the renderer reads the note and exposes companion template vars via dot-keys — **zero template-engine change**:

  | var | value |
  |---|---|
  | `{{param.<id>}}` | relativePath |
  | `{{param.<id>.title}}` | title |
  | `{{param.<id>.content}}` | full body |

- A read failure (note renamed/deleted between pick and run) keeps path + title, omits content; skills guard with `{{#if param.x.content}}`.
- `resolve-note-params.ts` holds resolution + tree-flatten as pure, injected-reader functions — unit-tested without Electron.

## Demo skill — Find Tensions
Analysis ▸ Disagreement. Reads the active note **and** a picked one, surfaces where they conflict (direct contradiction / assumption clash / scope mismatch / emphasis), and files a `thought:Tension` note linking both. The first stock skill operating on two notes at once.

## Deferred (not closed-without-reason — explicitly out of scope)
multi-select (array-valued; a knob, not a capability), tag-picker (overlaps `taggedNotes` + queries), toggle-group and slider (restyle `select`/`number`). Revisit if a concrete skill demands one.

## Tests
- `resolve-note-params.test.ts` — content/title injection, unreadable-note fallback, empty-pick no-op, tree flatten.
- `skills-find-tensions.test.ts` — loads, declares the note param, threads both notes into prompt + first message, graceful fallback.
- Full suite green: 251 files, 2666 tests; `tsc` + `svelte-check` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)