### PR TITLE
feat: source-scoped conversational tools + Propose Summary (#103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ no longer a `definitions/` tool registry; do not add one.
 - **Grouping** (#525): a skill's optional `group:` field renders thematic
   nested submenus within a menu (pure logic in `src/shared/tools/grouping.ts`;
   applied in `menu.ts`). A menu stays flat until one of its skills sets a group.
+- **Source scope** (#103): `scope: source` routes a skill to the Source
+  viewer's Tools menu (excluded from the note menus + editor right-click via
+  `isSourceScoped` in `shared/tools/types.ts`) and feeds it `sourceMetadata` /
+  `sourceBody` context (`{{source.*}}`). Source skills write back via the
+  approval-gated `propose_source_properties` tool → `meta.ttl` upsert
+  (`sources/source-meta-write.ts`). Worked example: `propose-source-summary.md`.
 - Authoring reference: `docs/authoring-skills.md`. To change a stock skill,
   disable it and author your own — don't edit bundled files.
 

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -83,6 +83,7 @@ palette, and the editor right-click menu (because it requests `fullNote`).
 | `id` | string | slug of `name` | Stable identifier used in logs, model overrides, and menu config. **Set it explicitly and never change it once shared** — overrides are pinned by id. Stock ids look like `analysis.steelman`; yours can be anything not already taken. |
 | `longDescription` | string | `description` | 1–3 sentences; the expanded card view. Tell the user what to expect. |
 | `group` | string | — | Thematic sub-group within the menu. When any skill in a menu sets a `group`, that menu renders one nested submenu per group (ungrouped skills fall into **General**, last). Free-form; matched exactly. See [Grouping](#grouping). |
+| `scope` | `note` \| `source` | `note` | Where the skill is invoked and what it operates on. `note` (default) surfaces in the menus + editor right-click and acts on the active note. `source` surfaces in the **Source viewer's Tools menu** and receives the active source's body/metadata. See [Source-scoped skills](#source-scoped-skills). |
 | `context` | string list | `[]` | What to gather before running. See [Context](#context). |
 | `parameters` | list | `[]` | Upfront form fields. See [Parameters](#parameters). |
 | `tools` | string list | default set | Conversation tools to advertise. Currently only `ask_user` is honored as an extra. |
@@ -167,10 +168,31 @@ List what to gather; the matching fields are populated before the body renders.
 | `taggedNotes` | (tag cohort, internal) | Considering notes sharing tags. |
 | `claimUnderCursor` | `{{claim.*}}` | Operating on the `thought:Claim` at the cursor. |
 | `selectionRange` | (offsets, planned) | Edits anchored to the original passage. |
+| `sourceMetadata` | `{{source.id}}`, `{{source.title}}` | Source-scoped skills — id + title of the active source. |
+| `sourceBody` | `{{source.body}}` | Source-scoped skills — the source's extracted `body.md` text. |
 
 Requirements are advisory — your template decides what to do when a field is
 empty. To **hard-require** a selection instead, set `requiresSelection: true`
 (the skill hides without one). To **adapt**, branch with `{{#if note}}`.
+
+## Source-scoped skills
+
+Set `scope: source` to make a skill operate on a **Source** (an ingested
+reference) instead of a note. It then appears in the Source viewer's **Tools**
+menu (and is kept out of the note menus + editor right-click). Pair it with
+`sourceMetadata` / `sourceBody` context to read the active source:
+
+- `{{source.id}}` — the source id (pass it through to source-writing tools).
+- `{{source.title}}` — its title.
+- `{{source.body}}` — its extracted body text (when `sourceBody` is listed).
+- `{{#if source}}` / `{{#if source.body}}` — branch when no source / no body.
+
+To write back to a source through the approval engine, a conversational
+source skill calls `propose_source_properties` with the `sourceId` plus a
+proposed `abstract` (`dc:abstract`) and/or `tldr` (`thought:tldr`). Like every
+LLM write, it's a *proposal*: the user approves an inline card before anything
+lands on the source's metadata. The stock **Propose Summary**
+(`research.propose-source-summary`) is the worked example.
 
 ## Parameters
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -82,6 +82,7 @@ import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest
 import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
+import { setSourceProperties, ttlString } from './sources/source-meta-write';
 import { stripUpstreamTags } from './sources/strip-upstream-tags';
 import { getIngestSettings, saveIngestSettings, type IngestSettings } from './sources/ingest-settings';
 import { ingestSmart } from './sources/ingest-smart';
@@ -2088,6 +2089,11 @@ export function registerIpcHandlers(): void {
             win.webContents.send(Channels.CONVERSATION_PROPERTY_DRAFT, draft);
           }
         },
+        onSourcePropertyDraft: (draft: import('../shared/conversation-source-property-drafts').ConversationSourcePropertyDraft) => {
+          if (!win.isDestroyed()) {
+            win.webContents.send(Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT, draft);
+          }
+        },
         onComputeDraft: (draft: import('../shared/conversation-compute-drafts').ConversationComputeDraft) => {
           if (!win.isDestroyed()) {
             win.webContents.send(Channels.CONVERSATION_COMPUTE_DRAFT, draft);
@@ -2409,6 +2415,56 @@ export function registerIpcHandlers(): void {
       // here — the file watcher's NOTEBASE_FILE_CHANGED event is
       // what the renderer already listens for to refresh views.
       return { outcomes };
+    },
+  );
+
+  // Counterpart to CONVERSATION_FILE_PROPERTY_DRAFT for source summaries
+  // (#103). Upserts the proposed dc:abstract / thought:tldr into the source's
+  // meta.ttl and reindexes — the single human-confirm gate for an
+  // LLM-originated source-metadata write.
+  ipcMain.handle(
+    Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT,
+    async (
+      e,
+      draft: import('../shared/conversation-source-property-drafts').ConversationSourcePropertyDraft,
+    ): Promise<import('../shared/conversation-source-property-drafts').FileSourcePropertyDraftResult> => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      const sourceId = draft?.sourceId;
+      if (!sourceId) {
+        throw new Error(
+          `FILE_SOURCE_PROPERTY_DRAFT: draft has no sourceId (received ${JSON.stringify(draft).slice(0, 200)}). ` +
+          `If this came from a Svelte 5 $state value, snapshot it before sending across IPC.`,
+        );
+      }
+      // Mirror the note handler's defensive check: a payload that arrived
+      // with neither field (e.g. a serialization slip) should surface, not
+      // silently no-op.
+      if (!draft.abstract && !draft.tldr) {
+        return {
+          outcome: {
+            sourceId,
+            changedPredicates: [],
+            error: 'neither abstract nor tldr arrived across IPC — nothing written.',
+          },
+        };
+      }
+      try {
+        const updates: { predicate: string; value: string }[] = [];
+        if (draft.abstract) updates.push({ predicate: 'dc:abstract', value: ttlString(draft.abstract) });
+        if (draft.tldr) updates.push({ predicate: 'thought:tldr', value: ttlString(draft.tldr) });
+        const changedPredicates = await setSourceProperties(rootPath, sourceId, updates);
+        return { outcome: { sourceId, changedPredicates } };
+      } catch (err) {
+        console.warn('[conv] FILE_SOURCE_PROPERTY_DRAFT failed for', sourceId, err);
+        return {
+          outcome: {
+            sourceId,
+            changedPredicates: [],
+            error: err instanceof Error ? err.message : String(err),
+          },
+        };
+      }
     },
   );
 

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -13,6 +13,7 @@ import type { ConversationDraft } from '../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../shared/conversation-source-drafts';
 import type { ConversationPropertyDraft } from '../../shared/conversation-property-drafts';
 import type { ConversationComputeDraft } from '../../shared/conversation-compute-drafts';
+import type { ConversationSourcePropertyDraft } from '../../shared/conversation-source-property-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { formatToolCall } from './format-tool-call';
 
@@ -38,6 +39,12 @@ export interface StreamCallbacks {
    * set_properties calls fail with a "no UI surface" error.
    */
   onPropertyDraft?: (draft: ConversationPropertyDraft) => void;
+  /**
+   * Counterpart to `onPropertyDraft` for the propose_source_properties tool
+   * (#103). Forwarded via Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT;
+   * without it, the tool fails with a "no UI surface" error.
+   */
+  onSourcePropertyDraft?: (draft: ConversationSourcePropertyDraft) => void;
   /**
    * Counterpart to `onDraft` for the propose_compute tool (#245).
    * Forwarded via Channels.CONVERSATION_COMPUTE_DRAFT; without it,
@@ -343,6 +350,9 @@ export async function completeWithTools(
       }
       if (callbacks?.onPropertyDraft) {
         toolCallbacks.onPropertyDraft = callbacks.onPropertyDraft;
+      }
+      if (callbacks?.onSourcePropertyDraft) {
+        toolCallbacks.onSourcePropertyDraft = callbacks.onSourcePropertyDraft;
       }
       if (callbacks?.onComputeDraft) {
         toolCallbacks.onComputeDraft = callbacks.onComputeDraft;

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -25,6 +25,10 @@ import type {
   ConversationComputeDraft,
   ProposeComputeInput,
 } from '../../shared/conversation-compute-drafts';
+import type {
+  ConversationSourcePropertyDraft,
+  ProposeSourcePropertiesInput,
+} from '../../shared/conversation-source-property-drafts';
 import { scanPythonSafety } from '../../shared/python-safety';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { fixupBundleLinks } from '../../shared/refactor/bundle-link-fixup';
@@ -61,6 +65,10 @@ export interface ToolCallbacks {
   /** Counterpart to `onDraft` for the `set_properties` tool. Forwards
    *  frontmatter-patch drafts to the renderer for inline review. */
   onPropertyDraft?: (draft: ConversationPropertyDraft) => void;
+  /** Counterpart to `onPropertyDraft` for the `propose_source_properties`
+   *  tool (#103). Forwards a source's proposed abstract / TL;DR to the
+   *  renderer for inline review before anything touches the meta.ttl. */
+  onSourcePropertyDraft?: (draft: ConversationSourcePropertyDraft) => void;
   /** Counterpart to `onDraft` for the `propose_compute` tool (#245).
    *  Forwards SPARQL / SQL / Python cell drafts to the renderer for
    *  inline review. The user clicks Run / Insert / Discard. */
@@ -373,6 +381,51 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
     },
   },
   {
+    name: 'propose_source_properties',
+    description:
+      'Propose summary metadata for a SOURCE (not a note): a formal ' +
+      '`abstract` and/or a one-paragraph plain-language `tldr`. Use this ' +
+      'when asked to summarize a source. The user reviews the proposal as ' +
+      'an inline card; on Approve, `dc:abstract` / `thought:tldr` are ' +
+      "written to the source's metadata and the graph re-indexed. On " +
+      'Discard nothing is written.\n' +
+      '\n' +
+      'Provide at least one of `abstract` / `tldr`. Submit ONE call for the ' +
+      'source — do not call it repeatedly. The `sourceId` is given to you in ' +
+      'the conversation context; pass it through verbatim.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        note: {
+          type: 'string',
+          description:
+            'A short sentence describing what you are proposing. Surfaced ' +
+            'to the user on the inline review card.',
+        },
+        sourceId: {
+          type: 'string',
+          description:
+            'Id of the source to annotate (provided in the conversation ' +
+            'context). Must match an existing source.',
+        },
+        abstract: {
+          type: 'string',
+          description:
+            'A concise scholarly abstract (1–2 paragraphs), written in the ' +
+            "source's own register. Omit if you are only proposing a TL;DR.",
+        },
+        tldr: {
+          type: 'string',
+          description:
+            'A single plain-language paragraph a non-expert could follow — ' +
+            'the "what is this and why does it matter" gist. Omit if you ' +
+            'are only proposing an abstract.',
+        },
+      },
+      required: ['note', 'sourceId'],
+    },
+  },
+  {
     name: 'propose_compute',
     description:
       'Propose a code cell (SPARQL, SQL, or Python) for the user to review and run. ' +
@@ -602,6 +655,8 @@ export async function executeNotebaseTool(
         return { content: await runFetchProperties(ctx, input), isError: false };
       case 'set_properties':
         return runSetProperties(ctx, input, callbacks);
+      case 'propose_source_properties':
+        return runProposeSourceProperties(ctx, input, callbacks);
       case 'propose_compute':
         return runProposeCompute(ctx, input, callbacks);
       case 'ask_user':
@@ -1131,6 +1186,88 @@ function parseSetPropertiesInput(
     updates.push({ relativePath, properties: sanitized });
   }
   return { note, updates };
+}
+
+/**
+ * Trust-principle parity with `set_properties`, for sources (#103):
+ * `propose_source_properties` does NOT write. It validates the proposal, emits
+ * a `ConversationSourcePropertyDraft` for inline review, and returns "drafted."
+ * The `CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT` handler upserts the predicates
+ * once the user approves.
+ */
+function runProposeSourceProperties(
+  ctx: ToolContext,
+  input: unknown,
+  callbacks: ToolCallbacks,
+): { content: string; isError: boolean } {
+  if (!callbacks.onSourcePropertyDraft) {
+    return {
+      content: 'propose_source_properties is only available in conversation contexts.',
+      isError: true,
+    };
+  }
+  if (!ctx.conversationId) {
+    return {
+      content: 'propose_source_properties requires a bound conversation id.',
+      isError: true,
+    };
+  }
+  const parsed = parseProposeSourcePropertiesInput(input);
+  if ('error' in parsed) {
+    return { content: parsed.error, isError: true };
+  }
+
+  const draft: ConversationSourcePropertyDraft = {
+    draftId: `srcpropdraft-${randomUUID()}`,
+    conversationId: ctx.conversationId,
+    note: parsed.note,
+    sourceId: parsed.sourceId,
+    abstract: parsed.abstract,
+    tldr: parsed.tldr,
+    createdAt: new Date().toISOString(),
+  };
+  callbacks.onSourcePropertyDraft(draft);
+
+  const proposed = [parsed.abstract ? 'abstract' : null, parsed.tldr ? 'tldr' : null]
+    .filter(Boolean)
+    .join(' + ');
+  return {
+    content: JSON.stringify({
+      status: 'drafted',
+      draftId: draft.draftId,
+      sourceId: parsed.sourceId,
+      proposed: { abstract: !!parsed.abstract, tldr: !!parsed.tldr },
+      // Same anti-loop hint as the other draft-emitting tools.
+      hint:
+        'STOP. The source summary has been queued for user review. End this ' +
+        'turn with ONE short acknowledgement sentence and DO NOT call ' +
+        'propose_source_properties again. DO NOT call any other tool. DO NOT ' +
+        'repeat the abstract/tldr text inline.',
+    }) + `\n\n(queued source-property draft for ${parsed.sourceId}: ${proposed})`,
+    isError: false,
+  };
+}
+
+function parseProposeSourcePropertiesInput(
+  input: unknown,
+): ProposeSourcePropertiesInput | { error: string } {
+  if (!input || typeof input !== 'object') {
+    return { error: 'propose_source_properties input must be an object.' };
+  }
+  const obj = input as Record<string, unknown>;
+  const note = typeof obj.note === 'string' ? obj.note.trim() : '';
+  if (!note) return { error: '`note` is required and must be a non-empty string.' };
+  const sourceId = typeof obj.sourceId === 'string' ? obj.sourceId.trim() : '';
+  if (!sourceId) return { error: '`sourceId` is required and must be a non-empty string.' };
+  const abstract = typeof obj.abstract === 'string' ? obj.abstract.trim() : '';
+  const tldr = typeof obj.tldr === 'string' ? obj.tldr.trim() : '';
+  if (!abstract && !tldr) {
+    return { error: 'Provide at least one of `abstract` or `tldr`.' };
+  }
+  const out: ProposeSourcePropertiesInput = { note, sourceId };
+  if (abstract) out.abstract = abstract;
+  if (tldr) out.tldr = tldr;
+  return out;
 }
 
 function isPropertyValue(v: unknown): v is PropertyValue {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -13,6 +13,7 @@ import { restartKernel as restartPythonKernel, interruptKernel as interruptPytho
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
 import { groupToolsByGroup, hasNamedGroups } from '../shared/tools/grouping';
+import { isSourceScoped } from '../shared/tools/types';
 
 function send(channel: string, ...args: unknown[]) {
   const win = BrowserWindow.getFocusedWindow();
@@ -465,9 +466,10 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
     // since #627, Research is data-driven like the others (it used to be a
     // hardcoded block that listed only 4 of the 6 research tools).
     ...(['learning', 'research', 'analysis'] as const)
-      .filter((id) => getToolsByCategory(id).length > 0)
+      // Source-scoped tools (#103) live in the Source viewer, not these menus.
+      .filter((id) => getToolsByCategory(id).some((t) => !isSourceScoped(t)))
       .map((id) => {
-        const tools = getToolsByCategory(id);
+        const tools = getToolsByCategory(id).filter((t) => !isSourceScoped(t));
         const mkItem = (tool: typeof tools[number]) => gate({
           label: tool.name,
           toolTip: tool.description,

--- a/src/main/skills/compile.ts
+++ b/src/main/skills/compile.ts
@@ -45,6 +45,7 @@ export function compileSkill(skill: SkillDef): ThinkingToolDef {
     def.buildFirstMessage = (ctx) => render(skill.firstMessage, ctx);
   }
   if (skill.group) def.group = skill.group;
+  if (skill.scope && skill.scope !== 'note') def.scope = skill.scope;
   if (skill.model) def.preferredModel = skill.model;
   if (skill.slashCommand) def.slashCommand = skill.slashCommand;
   if (skill.outputNotePrefix) def.outputNotePrefix = skill.outputNotePrefix;

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -19,7 +19,9 @@ const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
 
 const CONTEXT_REQUIREMENTS: readonly ContextRequirement[] = [
   'selectedText', 'fullNote', 'relatedNotes', 'taggedNotes', 'claimUnderCursor', 'selectionRange',
+  'sourceMetadata', 'sourceBody',
 ];
+const SCOPES = ['note', 'source'] as const;
 const OUTPUT_MODES: readonly OutputMode[] = [
   'newNote', 'appendToNote', 'replaceSelection', 'insertAtCursor', 'multipleNotes', 'openConversation',
 ];
@@ -156,6 +158,12 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
   const requiresSelection = Boolean(fm.requiresSelection);
   const outputNotePrefix = asString(fm.outputNotePrefix);
   const group = asString(fm.group);
+
+  const scopeRaw = asString(fm.scope);
+  if (scopeRaw !== undefined && !(SCOPES as readonly string[]).includes(scopeRaw)) {
+    errors.push(`\`scope\` must be one of ${SCOPES.join(', ')} (got "${scopeRaw}")`);
+  }
+  const scope = (scopeRaw as SkillDef['scope']) ?? 'note';
   const firstMessage = asString(fm.firstMessage) ?? '';
   const longDescription = asString(fm.longDescription) ?? description ?? '';
 
@@ -180,6 +188,7 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
     longDescription,
     menu: menuRaw as SkillMenu,
     group,
+    scope,
     outputMode: outputModeRaw as OutputMode,
     context,
     parameters,

--- a/src/main/skills/stock/propose-source-summary.md
+++ b/src/main/skills/stock/propose-source-summary.md
@@ -1,0 +1,45 @@
+---
+id: research.propose-source-summary
+name: Propose Summary
+description: Draft an abstract + TL;DR for this source, for your review
+menu: Research
+group: Summarize
+scope: source
+outputMode: openConversation
+context: [sourceMetadata, sourceBody]
+model: claude-opus-4-7
+firstMessage: |-
+  {{#if source}}{{#if source.body}}Summarize "{{source.title}}" — propose an abstract and a one-paragraph TL;DR for my review.{{else}}This source has no extracted body text to summarize yet — ingest or add its body.md first.{{/if}}{{else}}Open a source first, then run Propose Summary from its Tools menu.{{/if}}
+longDescription: >-
+  Reads this source's body and proposes two things for your approval: a concise scholarly
+  `dc:abstract` and a one-paragraph plain-language `thought:tldr`. Nothing is written until you
+  approve the inline card — on approval both land on the source's metadata (the trust principle:
+  the model proposes, you confirm). The first source-scoped skill (#103).
+---
+You are summarizing one of the user's **sources** — an ingested reference document. Read its body and propose summary metadata for the user's review. You never write directly; you propose, the user approves.
+
+{{#if source.body}}
+## Process
+
+1. Read the source body below. Identify its central claim/finding, method or argument, and why it matters.
+2. Draft a **formal abstract** (`dc:abstract`): 1–2 paragraphs in the source's own scholarly register — what it does and concludes, as the author might summarize it.
+3. Draft a **TL;DR** (`thought:tldr`): a single plain-language paragraph a non-expert could follow — the "what is this and why should I care" gist, no jargon.
+4. Keep both grounded in the text. Do not invent findings the source doesn't make; if the body is thin or truncated, say what you can and flag the limitation.
+
+## Filing the result
+
+When the user is satisfied, call `propose_source_properties` exactly once with:
+
+- `note`: a short sentence on what you're proposing.
+- `sourceId`: `{{source.id}}` (pass it through verbatim).
+- `abstract`: your formal abstract.
+- `tldr`: your plain-language TL;DR.
+
+The user reviews an inline card and approves; only then do `dc:abstract` / `thought:tldr` get written to the source. Do not paste the abstract/tldr as prose instead of calling the tool — the tool is what makes them reviewable and filable.
+
+## Source: {{source.title}}
+
+{{source.body}}
+{{else}}
+This source has no readable body text, so there's nothing to summarize. Ask the user to ingest the source's full text (or add a `body.md`) and try again.
+{{/if}}

--- a/src/main/skills/template.ts
+++ b/src/main/skills/template.ts
@@ -31,6 +31,8 @@ export interface SkillRenderContext {
   selection: string;
   note: { content: string; title: string; path: string } | null;
   claim: { uri: string; label: string; sourceText: string } | null;
+  /** Active Source viewer tab (#103). Null when no source is in context. */
+  source: { id: string; title: string; body: string } | null;
   param: Record<string, string>;
 }
 
@@ -49,6 +51,13 @@ export function toRenderContext(tc: ToolContext): SkillRenderContext {
           uri: tc.claimUri,
           label: tc.claimLabel ?? '',
           sourceText: tc.claimSourceText ?? '',
+        }
+      : null,
+    source: tc.sourceId
+      ? {
+          id: tc.sourceId,
+          title: tc.sourceTitle ?? '',
+          body: tc.sourceBody ?? '',
         }
       : null,
     param: tc.parameterValues ?? {},
@@ -203,6 +212,13 @@ function resolve(path: string, ctx: SkillRenderContext): string | object | null 
     if (k === 'uri' || k === 'label' || k === 'sourceText') return ctx.claim[k];
     return undefined;
   }
+  if (path === 'source') return ctx.source;
+  if (path.startsWith('source.')) {
+    const k = path.slice(7);
+    if (!ctx.source) return '';
+    if (k === 'id' || k === 'title' || k === 'body') return ctx.source[k];
+    return undefined;
+  }
   if (path.startsWith('param.')) {
     const k = path.slice(6);
     return ctx.param[k] ?? '';
@@ -281,6 +297,7 @@ export function renderTemplate(template: string, ctx: SkillRenderContext): strin
 const KNOWN_VAR_PATHS = new Set([
   'selection', 'note', 'note.content', 'note.title', 'note.path',
   'claim', 'claim.uri', 'claim.label', 'claim.sourceText',
+  'source', 'source.id', 'source.title', 'source.body',
 ]);
 
 function isKnownPath(path: string): boolean {

--- a/src/main/sources/read-status.ts
+++ b/src/main/sources/read-status.ts
@@ -1,23 +1,14 @@
 /**
  * Reading-queue updates (#116).
  *
- * A source carries an optional `minerva:readStatus` enum and an
- * optional `minerva:readDueBy` date in its `meta.ttl`. Setting either
- * is a small text mutation: drop any existing line for the predicate,
- * insert a fresh one before the closing `.`, then re-index so the
- * graph and SourceMetadata reflect the new value.
- *
- * Same shape as the metadata-merge in #90 part 1 — we control the
- * writer (`buildMetaTtl`) and the predicate is single-valued, so a
- * line-oriented regex pass is reliable for our own output and tolerant
- * of hand edits.
+ * A source carries an optional `minerva:readStatus` enum and an optional
+ * `minerva:readDueBy` date in its `meta.ttl`. Setting either is a single-valued
+ * predicate upsert + re-index, now shared with the source-property approval
+ * path (#103) via `source-meta-write.ts`.
  */
 
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import * as graph from '../graph/index';
-import { projectContext } from '../project-context-types';
 import type { ReadStatus } from '../../shared/types';
+import { setSourceProperties, ttlString } from './source-meta-write';
 
 const VALID: ReadonlySet<ReadStatus> = new Set(['unread', 'reading', 'read', 'skipped']);
 
@@ -35,16 +26,9 @@ export async function setSourceReadStatus(
   if (status !== null && !isReadStatus(status)) {
     throw new Error(`Invalid read status: ${String(status)}`);
   }
-  const metaPath = sourceMetaPath(rootPath, sourceId);
-  const ttl = await readMeta(metaPath);
-  const next = upsertSingleValuedPredicate(
-    ttl,
-    'minerva:readStatus',
-    status === null ? null : `${ttlString(status)}`,
-  );
-  if (next === ttl) return;
-  await fs.writeFile(metaPath, next, 'utf-8');
-  await reindexSource(rootPath, sourceId);
+  await setSourceProperties(rootPath, sourceId, [
+    { predicate: 'minerva:readStatus', value: status === null ? null : ttlString(status) },
+  ]);
 }
 
 /** Set, change, or clear a source's due-by date. ISO date string
@@ -57,145 +41,7 @@ export async function setSourceReadDueBy(
   if (dueBy !== null && !/^\d{4}-\d{2}-\d{2}$/.test(dueBy)) {
     throw new Error(`Invalid ISO date for readDueBy: ${dueBy}`);
   }
-  const metaPath = sourceMetaPath(rootPath, sourceId);
-  const ttl = await readMeta(metaPath);
-  const next = upsertSingleValuedPredicate(
-    ttl,
-    'minerva:readDueBy',
-    dueBy === null ? null : `${ttlString(dueBy)}^^xsd:date`,
-  );
-  if (next === ttl) return;
-  await fs.writeFile(metaPath, next, 'utf-8');
-  await reindexSource(rootPath, sourceId);
-}
-
-function sourceMetaPath(rootPath: string, sourceId: string): string {
-  return path.join(rootPath, '.minerva', 'sources', sourceId, 'meta.ttl');
-}
-
-async function readMeta(metaPath: string): Promise<string> {
-  try {
-    return await fs.readFile(metaPath, 'utf-8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      throw new Error(`Source meta.ttl not found: ${metaPath}`, { cause: err });
-    }
-    throw err;
-  }
-}
-
-async function reindexSource(rootPath: string, sourceId: string): Promise<void> {
-  const ctx = projectContext(rootPath);
-  const ttl = await readMeta(sourceMetaPath(rootPath, sourceId));
-  let body: string | undefined;
-  try {
-    body = await fs.readFile(path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md'), 'utf-8');
-  } catch { /* body optional */ }
-  graph.indexSource(ctx, sourceId, ttl, body);
-}
-
-/**
- * Replace a single-valued predicate's value, or insert a fresh line
- * before the closing `.` when the predicate is absent. Passing
- * `null` for `value` deletes the predicate line entirely.
- *
- * Match scope: a whole TTL line whose first non-whitespace token is
- * the prefixed predicate (`prefix:local`). We don't try to handle
- * comma-continuations because our writer never emits them.
- */
-export function upsertSingleValuedPredicate(
-  ttl: string,
-  predicate: string,
-  value: string | null,
-): string {
-  const escaped = predicate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  // Capture the indentation so we re-emit with the same shape.
-  const re = new RegExp(`^([ \\t]*)${escaped}\\s+[^\\n]*\\n?`, 'm');
-  const hadMatch = re.test(ttl);
-  if (hadMatch) {
-    if (value === null) {
-      // Delete the line. Take care: if the line we delete was the
-      // last predicate, the previous `;` becomes a stray separator.
-      // Cheap fix: after removal, ensure the line above the final
-      // `.` still ends with `;`.
-      const removed = ttl.replace(re, '');
-      return normaliseTrailingSeparator(removed);
-    }
-    return ttl.replace(re, (_match, indent: string) => `${indent}${predicate} ${value} ;\n`);
-  }
-  if (value === null) return ttl; // nothing to delete
-  return insertBeforeFinalDot(ttl, `    ${predicate} ${value} ;`);
-}
-
-/**
- * After deleting a predicate line, the new line that now precedes
- * the final `.` must terminate with `;` (since the deleted line had
- * been the `.`-bearing one, or a middle `;`-terminated line). The
- * existing writer always emits `; ;… .`, so as long as every
- * non-final predicate ends with `;` we're well-formed. This walks
- * back from the final `.` and replaces a stray trailing `;` on the
- * predicate that's now the last with `.`.
- *
- * Concretely: when the writer originally produced
- *   foo ;
- *   readStatus ... ;
- *   bar .
- * and we remove the readStatus line, we get
- *   foo ;
- *   bar .
- * which is already well-formed — every line ending the same as
- * before. So this function is mostly a safety net for the edge
- * case where the predicate we deleted was the bottom-most one.
- */
-function normaliseTrailingSeparator(ttl: string): string {
-  // Find the trailing `.`
-  const trailing = ttl.match(/(\s*\.\s*)$/);
-  if (!trailing) return ttl;
-  const dotIdx = trailing.index ?? ttl.length;
-  // Walk back to the previous newline.
-  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
-  if (lineStart < 0) return ttl;
-  const lineBefore = ttl.slice(lineStart + 1, dotIdx);
-  // If the line before the `.` ends with `;`, switch it to `.` and
-  // drop the dangling `.`.
-  const trimmed = lineBefore.replace(/\s+$/, '');
-  if (trimmed.endsWith(';')) {
-    const fixed = trimmed.slice(0, -1).replace(/\s+$/, '') + ' .';
-    return ttl.slice(0, lineStart + 1) + fixed + '\n';
-  }
-  return ttl;
-}
-
-/**
- * Insert a new predicate line immediately before the closing `.`.
- * The writer always emits `... ;\n    pred value .\n`, so the line
- * preceding the `.` already ends with `;` and we can safely splice
- * a new `;`-terminated predicate before it without rewriting
- * separators.
- *
- * Mirrors the technique in source-merge.ts; kept local because the
- * matching semantics differ slightly (single line, not a batch).
- */
-function insertBeforeFinalDot(ttl: string, newLine: string): string {
-  const trailing = ttl.match(/(\s*\.\s*)$/);
-  if (!trailing) {
-    // Malformed TTL — append + close.
-    return ttl + (ttl.endsWith('\n') ? '' : '\n') + newLine + '\n    .\n';
-  }
-  const dotIdx = trailing.index ?? ttl.length;
-  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
-  if (lineStart < 0) {
-    return ttl.slice(0, dotIdx).replace(/\s+$/, ' ;') + '\n' + newLine + '\n' + ttl.slice(dotIdx);
-  }
-  return ttl.slice(0, lineStart) + '\n' + newLine + ttl.slice(lineStart);
-}
-
-function ttlString(s: string): string {
-  const escaped = s
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
-  return `"${escaped}"`;
+  await setSourceProperties(rootPath, sourceId, [
+    { predicate: 'minerva:readDueBy', value: dueBy === null ? null : `${ttlString(dueBy)}^^xsd:date` },
+  ]);
 }

--- a/src/main/sources/source-meta-write.ts
+++ b/src/main/sources/source-meta-write.ts
@@ -1,0 +1,156 @@
+/**
+ * Single-predicate writers for a source's `meta.ttl` (#103).
+ *
+ * Extracted from `read-status.ts` (#116), which pioneered the line-oriented
+ * upsert: drop any existing line for a single-valued predicate, insert a fresh
+ * one before the closing `.`, then re-index. We control the writer
+ * (`buildMetaTtl`), the predicates are single-valued, and meta.ttl files carry
+ * no `@prefix` block (standard prefixes are injected at index time), so a
+ * line-regex pass is reliable for our own output and tolerant of hand edits.
+ *
+ * `read-status.ts` and the source-property approval path (#103) both build on
+ * these — keep them dependency-free of any one feature's semantics.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+
+export function sourceMetaPath(rootPath: string, sourceId: string): string {
+  return path.join(rootPath, '.minerva', 'sources', sourceId, 'meta.ttl');
+}
+
+export async function readMeta(metaPath: string): Promise<string> {
+  try {
+    return await fs.readFile(metaPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Source meta.ttl not found: ${metaPath}`, { cause: err });
+    }
+    throw err;
+  }
+}
+
+export async function reindexSource(rootPath: string, sourceId: string): Promise<void> {
+  const ctx = projectContext(rootPath);
+  const ttl = await readMeta(sourceMetaPath(rootPath, sourceId));
+  let body: string | undefined;
+  try {
+    body = await fs.readFile(path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md'), 'utf-8');
+  } catch { /* body optional */ }
+  graph.indexSource(ctx, sourceId, ttl, body);
+}
+
+/**
+ * Replace a single-valued predicate's value, or insert a fresh line before the
+ * closing `.` when the predicate is absent. Passing `null` for `value` deletes
+ * the predicate line entirely.
+ *
+ * Match scope: a whole TTL line whose first non-whitespace token is the
+ * prefixed predicate (`prefix:local`). We don't handle comma-continuations
+ * because our writer never emits them.
+ */
+export function upsertSingleValuedPredicate(
+  ttl: string,
+  predicate: string,
+  value: string | null,
+): string {
+  const escaped = predicate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Capture the indentation so we re-emit with the same shape.
+  const re = new RegExp(`^([ \\t]*)${escaped}\\s+[^\\n]*\\n?`, 'm');
+  const hadMatch = re.test(ttl);
+  if (hadMatch) {
+    if (value === null) {
+      const removed = ttl.replace(re, '');
+      return normaliseTrailingSeparator(removed);
+    }
+    return ttl.replace(re, (_match, indent: string) => `${indent}${predicate} ${value} ;\n`);
+  }
+  if (value === null) return ttl; // nothing to delete
+  return insertBeforeFinalDot(ttl, `    ${predicate} ${value} ;`);
+}
+
+/**
+ * After deleting a predicate line, the new line that now precedes the final `.`
+ * must terminate with `;`. The writer always emits `; ;… .`, so as long as
+ * every non-final predicate ends with `;` we're well-formed. This walks back
+ * from the final `.` and fixes a stray trailing `;` on the now-last predicate.
+ */
+function normaliseTrailingSeparator(ttl: string): string {
+  const trailing = ttl.match(/(\s*\.\s*)$/);
+  if (!trailing) return ttl;
+  const dotIdx = trailing.index ?? ttl.length;
+  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
+  if (lineStart < 0) return ttl;
+  const lineBefore = ttl.slice(lineStart + 1, dotIdx);
+  const trimmed = lineBefore.replace(/\s+$/, '');
+  if (trimmed.endsWith(';')) {
+    const fixed = trimmed.slice(0, -1).replace(/\s+$/, '') + ' .';
+    return ttl.slice(0, lineStart + 1) + fixed + '\n';
+  }
+  return ttl;
+}
+
+/**
+ * Insert a new predicate line immediately before the closing `.`. The writer
+ * always emits `... ;\n    pred value .\n`, so the line preceding the `.`
+ * already ends with `;` and we can splice a new `;`-terminated predicate
+ * before it without rewriting separators.
+ */
+function insertBeforeFinalDot(ttl: string, newLine: string): string {
+  const trailing = ttl.match(/(\s*\.\s*)$/);
+  if (!trailing) {
+    return ttl + (ttl.endsWith('\n') ? '' : '\n') + newLine + '\n    .\n';
+  }
+  const dotIdx = trailing.index ?? ttl.length;
+  const lineStart = ttl.lastIndexOf('\n', dotIdx - 1);
+  if (lineStart < 0) {
+    return ttl.slice(0, dotIdx).replace(/\s+$/, ' ;') + '\n' + newLine + '\n' + ttl.slice(dotIdx);
+  }
+  return ttl.slice(0, lineStart) + '\n' + newLine + ttl.slice(lineStart);
+}
+
+export function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+/** One predicate to upsert. `value` is the raw TTL object (already a quoted
+ *  literal / typed literal), or `null` to delete the predicate. */
+export interface SourceMetaUpdate {
+  predicate: string;
+  value: string | null;
+}
+
+/**
+ * Upsert several single-valued predicates into a source's meta.ttl in one pass,
+ * writing + reindexing only if something actually changed. Returns the list of
+ * predicates whose value changed (so callers can report what landed).
+ */
+export async function setSourceProperties(
+  rootPath: string,
+  sourceId: string,
+  updates: SourceMetaUpdate[],
+): Promise<string[]> {
+  const metaPath = sourceMetaPath(rootPath, sourceId);
+  let ttl = await readMeta(metaPath);
+  const changed: string[] = [];
+  for (const u of updates) {
+    const next = upsertSingleValuedPredicate(ttl, u.predicate, u.value);
+    if (next !== ttl) {
+      changed.push(u.predicate);
+      ttl = next;
+    }
+  }
+  if (changed.length > 0) {
+    await fs.writeFile(metaPath, ttl, 'utf-8');
+    await reindexSource(rootPath, sourceId);
+  }
+  return changed;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -215,6 +215,10 @@ contextBridge.exposeInMainWorld('api', {
       subscribeIpc(Channels.CONVERSATION_PROPERTY_DRAFT, cb),
     filePropertyDraft: (draft: unknown) =>
       ipcRenderer.invoke(Channels.CONVERSATION_FILE_PROPERTY_DRAFT, draft),
+    onSourcePropertyDraft: (cb: (draft: unknown) => void) =>
+      subscribeIpc(Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT, cb),
+    fileSourcePropertyDraft: (draft: unknown) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, draft),
     onComputeDraft: (cb: (draft: unknown) => void) =>
       subscribeIpc(Channels.CONVERSATION_COMPUTE_DRAFT, cb),
     runComputeDraft: (input: unknown) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -3351,6 +3351,7 @@
               onCreateNoteFromExcerpt={handleCreateNoteFromExcerpt}
               onAppendExcerptToCurrent={handleAppendExcerptToCurrent}
               canAppendToCurrent={lastNotePath !== null}
+              onInvokeTool={handleToolInvoke}
             />
           {/key}
         {:else if editor.activeTab?.type === 'pdf'}

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -16,6 +16,10 @@
     PropertyUpdateOutcome,
   } from '../../../shared/conversation-property-drafts';
   import type {
+    ConversationSourcePropertyDraft,
+    SourcePropertyOutcome,
+  } from '../../../shared/conversation-source-property-drafts';
+  import type {
     ConversationComputeDraft,
   } from '../../../shared/conversation-compute-drafts';
   import type { CellOutput } from '../../../shared/compute/types';
@@ -306,6 +310,18 @@
     store.discardPropertyDraft(tabId, draftId);
   }
 
+  async function handleApproveSourceProperty(tabId: string, draft: ConversationSourcePropertyDraft) {
+    try {
+      await store.approveSourcePropertyDraft(tabId, draft);
+    } catch (e) {
+      console.error('[conv-panel] approve source property failed:', e);
+    }
+  }
+
+  function handleDiscardSourceProperty(tabId: string, draftId: string) {
+    store.discardSourcePropertyDraft(tabId, draftId);
+  }
+
   // ── propose_compute card state (#245) ─────────────────────────────
   //
   // Per-draft editor buffer (when the user clicks Edit) and a flag for
@@ -469,6 +485,14 @@
       ([, entry]) => entry.afterMessageIndex === i,
     );
   }
+  function sourcePropertyDraftsAt(tab: TabT, i: number) {
+    return tab.sourcePropertyDrafts.filter((d) => d.afterMessageIndex === i);
+  }
+  function sourcePropertyResultsAt(tab: TabT, i: number) {
+    return Object.entries(tab.sourcePropertyDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex === i,
+    );
+  }
   function computeDraftsAt(tab: TabT, i: number) {
     return tab.computeDrafts.filter((d) => d.afterMessageIndex === i);
   }
@@ -499,6 +523,16 @@
   function orphanPropertyResults(tab: TabT) {
     const max = tab.conversation.messages.length;
     return Object.entries(tab.propertyDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex >= max,
+    );
+  }
+  function orphanSourcePropertyDrafts(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return tab.sourcePropertyDrafts.filter((d) => d.afterMessageIndex >= max);
+  }
+  function orphanSourcePropertyResults(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return Object.entries(tab.sourcePropertyDraftResults).filter(
       ([, entry]) => entry.afterMessageIndex >= max,
     );
   }
@@ -766,6 +800,48 @@
           </div>
         {/snippet}
 
+        {#snippet sourcePropertyDraftCardBlock(draft: ConversationSourcePropertyDraft)}
+          <!-- propose_source_properties review card (#103). Shows the proposed
+               abstract / TL;DR for one source; Approve upserts dc:abstract /
+               thought:tldr into its meta.ttl. -->
+          <div class="draft-card">
+            <div class="draft-summary">
+              <strong>📄 Source summary</strong>
+              <span class="draft-note">{draft.note}</span>
+            </div>
+            <div class="property-update-path">{draft.sourceId}</div>
+            {#if draft.abstract}
+              <div class="source-prop-block">
+                <div class="source-prop-label">Abstract</div>
+                <div class="source-prop-text">{draft.abstract}</div>
+              </div>
+            {/if}
+            {#if draft.tldr}
+              <div class="source-prop-block">
+                <div class="source-prop-label">TL;DR</div>
+                <div class="source-prop-text">{draft.tldr}</div>
+              </div>
+            {/if}
+            <div class="draft-actions">
+              <button type="button" class="draft-btn primary" onclick={() => handleApproveSourceProperty(tab.id, draft)}>Approve &amp; apply</button>
+              <button type="button" class="draft-btn" onclick={() => handleDiscardSourceProperty(tab.id, draft.draftId)}>Discard</button>
+            </div>
+          </div>
+        {/snippet}
+
+        {#snippet sourcePropertyResultLine(_draftId: string, outcome: SourcePropertyOutcome)}
+          <div class="filed-line">
+            <span class="filed-prefix">📄 Updated:</span>
+            {#if outcome.error}
+              <span class="filed-error" title={outcome.error}>⚠ {outcome.sourceId}</span>
+            {:else if outcome.changedPredicates.length === 0}
+              <span class="filed-error">{outcome.sourceId} · no change</span>
+            {:else}
+              <span class="filed-link" title={outcome.sourceId}>{outcome.sourceId} · {outcome.changedPredicates.join(', ')}</span>
+            {/if}
+          </div>
+        {/snippet}
+
         {#snippet computeOutputBlock(output: CellOutput)}
           {#if output.type === 'text'}
             <pre class="compute-output-text">{output.value}</pre>
@@ -949,6 +1025,12 @@
             {#each propertyResultsAt(tab, i) as [draftId, entry] (draftId)}
               {@render propertyResultLine(draftId, entry.outcomes)}
             {/each}
+            {#each sourcePropertyDraftsAt(tab, i) as draft (draft.draftId)}
+              {@render sourcePropertyDraftCardBlock(draft)}
+            {/each}
+            {#each sourcePropertyResultsAt(tab, i) as [draftId, entry] (draftId)}
+              {@render sourcePropertyResultLine(draftId, entry.outcome)}
+            {/each}
             {#each computeDraftsAt(tab, i) as draft (draft.draftId)}
               {@render computeDraftCardBlock(draft)}
             {/each}
@@ -1029,6 +1111,12 @@
           {/each}
           {#each orphanPropertyResults(tab) as [draftId, entry] (draftId)}
             {@render propertyResultLine(draftId, entry.outcomes)}
+          {/each}
+          {#each orphanSourcePropertyDrafts(tab) as draft (draft.draftId)}
+            {@render sourcePropertyDraftCardBlock(draft)}
+          {/each}
+          {#each orphanSourcePropertyResults(tab) as [draftId, entry] (draftId)}
+            {@render sourcePropertyResultLine(draftId, entry.outcome)}
           {/each}
           {#each orphanComputeDrafts(tab) as draft (draft.draftId)}
             {@render computeDraftCardBlock(draft)}
@@ -1539,6 +1627,25 @@
     font-size: 12px;
     color: var(--text-muted);
     margin-bottom: 2px;
+  }
+  /* propose_source_properties card (#103). */
+  .source-prop-block {
+    margin: 6px 0;
+    border-left: 2px solid var(--border);
+    padding-left: 8px;
+  }
+  .source-prop-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 2px;
+  }
+  .source-prop-text {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text);
+    white-space: pre-wrap;
   }
   .property-kv-list {
     list-style: none;

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -48,6 +48,7 @@
   }
 
   import { getToolInfosByCategory } from '../tools/tool-registry';
+  import { isSourceScoped } from '../../../shared/tools/types';
 
   interface Props {
     filePath: string;
@@ -157,8 +158,10 @@
     onRunCell,
   }: Props = $props();
 
-  const analysisTools = getToolInfosByCategory('analysis');
-  const learningTools = getToolInfosByCategory('learning');
+  // Source-scoped tools (#103) belong to the Source viewer, never the note
+  // editor's right-click menu.
+  const analysisTools = getToolInfosByCategory('analysis').filter((t) => !isSourceScoped(t));
+  const learningTools = getToolInfosByCategory('learning').filter((t) => !isSourceScoped(t));
 
   let editorContainer: HTMLDivElement;
   let view: EditorView;

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -5,6 +5,10 @@
   import ExcerptDensityGutter from './ExcerptDensityGutter.svelte';
   import { renderInlineWithMath } from '../markdown/inline-math';
   import type { SourceDetail, SourceExcerpt, SourceBacklink, ReadStatus } from '../../../shared/types';
+  import type { ThinkingToolInfo } from '../../../shared/tools/types';
+  import { isSourceScoped } from '../../../shared/tools/types';
+  import { groupToolsByGroup } from '../../../shared/tools/grouping';
+  import { getAllToolInfos } from '../tools/tool-registry';
   import { displaySourceTitle } from '../../../shared/source-display';
 
   const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
@@ -52,15 +56,36 @@
     /** Whether the host currently has an active note tab — used to
      *  enable / disable the Append button. */
     canAppendToCurrent?: boolean;
+    /** Invoke a source-scoped tool (#103) on this source. The host runs
+     *  the same gather-context → tool-panel / conversation flow used by
+     *  the note menus; since this source is the active tab, gatherContext
+     *  picks up its body/metadata. */
+    onInvokeTool?: (toolId: string) => void;
   }
 
   let {
     sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted,
     onCreateAboutNote, onOpenReference, onResolveStub, onOpenPdf,
     onCreateNoteFromExcerpt, onAppendExcerptToCurrent, canAppendToCurrent = false,
+    onInvokeTool,
   }: Props = $props();
   let resolving = $state(false);
   let appendFlashId = $state<string | null>(null);
+
+  // Source-scoped tools (#103) for the header "Tools" menu. Skills register
+  // into the renderer registry during app startup, before any source tab is
+  // opened, so reading the registry here is reliable; the list is grouped by
+  // the skill's optional `group:` for the same thematic submenus the note
+  // menus use (#525).
+  let toolMenuOpen = $state(false);
+  const sourceToolGroups = groupToolsByGroup(
+    getAllToolInfos().filter((t) => isSourceScoped(t)),
+  );
+  const hasSourceTools = sourceToolGroups.some((g) => g.tools.length > 0);
+  function invokeTool(tool: ThinkingToolInfo) {
+    toolMenuOpen = false;
+    onInvokeTool?.(tool.id);
+  }
 
   // Element refs + bump-on-change revision for the density gutter (#102).
   let scrollerEl = $state<HTMLDivElement>();
@@ -335,6 +360,26 @@
     </div>
   {:else}
     <header class:stub={detail.metadata.stubStatus === 'unresolved'}>
+      {#if onInvokeTool && hasSourceTools}
+        <div class="tools-menu">
+          <button class="tools-btn" onclick={() => (toolMenuOpen = !toolMenuOpen)} aria-haspopup="menu" aria-expanded={toolMenuOpen}>
+            Tools <span class="caret">▾</span>
+          </button>
+          {#if toolMenuOpen}
+            <button type="button" class="tools-backdrop" aria-label="Close menu" onclick={() => (toolMenuOpen = false)}></button>
+            <div class="tools-dropdown" role="menu">
+              {#each sourceToolGroups as group, gi (group.label ?? gi)}
+                {#if group.label}<div class="tools-group-label">{group.label}</div>{/if}
+                {#each group.tools as tool (tool.id)}
+                  <button type="button" class="tools-item" role="menuitem" title={tool.description} onclick={() => invokeTool(tool)}>
+                    {tool.name}
+                  </button>
+                {/each}
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
       <div class="subtype">
         {detail.metadata.subtype ?? 'Source'}{#if detail.metadata.stubStatus === 'unresolved'} · STUB{/if}
       </div>
@@ -621,7 +666,67 @@
 
   header {
     margin-bottom: 20px;
+    position: relative;
   }
+
+  /* Source-scoped tools menu (#103) — top-right of the header. */
+  .tools-menu {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+  .tools-btn {
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .tools-btn:hover { background: var(--bg-button-hover); }
+  .tools-btn .caret { color: var(--text-muted); margin-left: 2px; }
+  .tools-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    border: none;
+    background: transparent;
+    cursor: default;
+  }
+  .tools-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 11;
+    min-width: 200px;
+    padding: 4px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .tools-group-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    padding: 6px 8px 2px;
+  }
+  .tools-item {
+    text-align: left;
+    padding: 6px 8px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .tools-item:hover { background: var(--bg-button); }
 
   .subtype {
     display: inline-block;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -423,6 +423,14 @@ export interface ConversationsApi {
   filePropertyDraft(
     draft: import('../../../shared/conversation-property-drafts').ConversationPropertyDraft,
   ): Promise<import('../../../shared/conversation-property-drafts').FilePropertyDraftResult>;
+  /** Subscribe to source-summary drafts produced by propose_source_properties (#103). */
+  onSourcePropertyDraft(
+    cb: (draft: import('../../../shared/conversation-source-property-drafts').ConversationSourcePropertyDraft) => void,
+  ): void;
+  /** Apply an approved source-summary draft (upsert dc:abstract / thought:tldr + reindex). */
+  fileSourcePropertyDraft(
+    draft: import('../../../shared/conversation-source-property-drafts').ConversationSourcePropertyDraft,
+  ): Promise<import('../../../shared/conversation-source-property-drafts').FileSourcePropertyDraftResult>;
   /** Subscribe to code-cell drafts produced by the propose_compute tool (#245). */
   onComputeDraft(
     cb: (draft: import('../../../shared/conversation-compute-drafts').ConversationComputeDraft) => void,

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -16,6 +16,10 @@ import type {
 import type {
   ConversationComputeDraft,
 } from '../../../shared/conversation-compute-drafts';
+import type {
+  ConversationSourcePropertyDraft,
+  SourcePropertyOutcome,
+} from '../../../shared/conversation-source-property-drafts';
 import type { CellResult } from '../../../shared/compute/types';
 import type {
   AskUserRequest,
@@ -52,12 +56,17 @@ import { isMissingApiKeyError } from '../../../shared/llm-errors';
 type AnchoredDraft = ConversationDraft & { afterMessageIndex: number };
 type AnchoredSourceDraft = ConversationSourceDraft & { afterMessageIndex: number };
 type AnchoredPropertyDraft = ConversationPropertyDraft & { afterMessageIndex: number };
+type AnchoredSourcePropertyDraft = ConversationSourcePropertyDraft & { afterMessageIndex: number };
 interface SourceDraftResultEntry {
   outcomes: SourceIngestOutcome[];
   afterMessageIndex: number;
 }
 interface PropertyDraftResultEntry {
   outcomes: PropertyUpdateOutcome[];
+  afterMessageIndex: number;
+}
+interface SourcePropertyDraftResultEntry {
+  outcome: SourcePropertyOutcome;
   afterMessageIndex: number;
 }
 /** Post-Approve summary for a propose_notes draft. Persists in the
@@ -110,6 +119,11 @@ interface TabRuntime {
   /** Per-update outcomes after Approve on a property draft — used to
    *  render the post-Approve "Updated:" line in place of the card. */
   propertyDraftResults: Record<string, PropertyDraftResultEntry>;
+  /** propose_source_properties drafts awaiting Approve/Discard (#103). */
+  sourcePropertyDrafts: AnchoredSourcePropertyDraft[];
+  /** Per-draft outcome after Approve on a source-property draft — renders
+   *  the post-Approve "Updated:" line in place of the card. */
+  sourcePropertyDraftResults: Record<string, SourcePropertyDraftResultEntry>;
   /** propose_compute drafts awaiting Run / Insert / Discard. */
   computeDrafts: AnchoredComputeDraft[];
   /** Per-draft Run / Insert state. Stays alive after Run so the user
@@ -152,6 +166,7 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let draftSubscribed = false;
 let sourceDraftSubscribed = false;
 let propertyDraftSubscribed = false;
+let sourcePropertyDraftSubscribed = false;
 let computeDraftSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
@@ -217,6 +232,15 @@ function ensureSubscriptions(): void {
     });
     propertyDraftSubscribed = true;
   }
+  if (!sourcePropertyDraftSubscribed) {
+    api.conversations.onSourcePropertyDraft((draft) => {
+      const t = tabs.find((tab) => tab.id === draft.conversationId);
+      if (!t) return;
+      const afterMessageIndex = t.conversation.messages.length;
+      t.sourcePropertyDrafts = [...t.sourcePropertyDrafts, { ...draft, afterMessageIndex }];
+    });
+    sourcePropertyDraftSubscribed = true;
+  }
   if (!computeDraftSubscribed) {
     api.conversations.onComputeDraft((draft) => {
       const t = tabs.find((tab) => tab.id === draft.conversationId);
@@ -279,6 +303,8 @@ async function init(): Promise<void> {
       noteDraftResults: {},
       propertyDrafts: [],
       propertyDraftResults: {},
+      sourcePropertyDrafts: [],
+      sourcePropertyDraftResults: {},
       computeDrafts: [],
       computeDraftState: {},
       pendingQuestion: null,
@@ -368,6 +394,8 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     noteDraftResults: {},
     propertyDrafts: [],
     propertyDraftResults: {},
+    sourcePropertyDrafts: [],
+    sourcePropertyDraftResults: {},
     computeDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
@@ -424,6 +452,8 @@ async function openConversationTab(opts: {
     noteDraftResults: {},
     propertyDrafts: [],
     propertyDraftResults: {},
+    sourcePropertyDrafts: [],
+    sourcePropertyDraftResults: {},
     computeDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
@@ -634,6 +664,31 @@ function discardPropertyDraft(tabId: string, draftId: string): void {
   tab.propertyDrafts = tab.propertyDrafts.filter((d) => d.draftId !== draftId);
 }
 
+async function approveSourcePropertyDraft(
+  tabId: string,
+  draft: ConversationSourcePropertyDraft,
+): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  const anchored = tab.sourcePropertyDrafts.find((d) => d.draftId === draft.draftId);
+  const afterMessageIndex = anchored?.afterMessageIndex ?? tab.conversation.messages.length;
+  // JSON round-trip to shed any $state Proxy before IPC structured-clone —
+  // same defensive snapshot the property-draft path uses (#103).
+  const plain = JSON.parse(JSON.stringify(draft)) as ConversationSourcePropertyDraft;
+  const result = await api.conversations.fileSourcePropertyDraft(plain);
+  tab.sourcePropertyDrafts = tab.sourcePropertyDrafts.filter((d) => d.draftId !== draft.draftId);
+  tab.sourcePropertyDraftResults = {
+    ...tab.sourcePropertyDraftResults,
+    [draft.draftId]: { outcome: result.outcome, afterMessageIndex },
+  };
+}
+
+function discardSourcePropertyDraft(tabId: string, draftId: string): void {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  tab.sourcePropertyDrafts = tab.sourcePropertyDrafts.filter((d) => d.draftId !== draftId);
+}
+
 async function runComputeDraft(
   tabId: string,
   draft: ConversationComputeDraft,
@@ -768,6 +823,8 @@ export function getConversationsStore() {
     dismissSourceDraftResult,
     approvePropertyDraft,
     discardPropertyDraft,
+    approveSourcePropertyDraft,
+    discardSourcePropertyDraft,
     runComputeDraft,
     insertComputeDraft,
     discardComputeDraft,

--- a/src/renderer/lib/tools/context.ts
+++ b/src/renderer/lib/tools/context.ts
@@ -138,5 +138,38 @@ export async function gatherContext(
     }
   }
 
+  // Source-scoped context (#103). Read from the active Source viewer tab,
+  // independent of the note editor. `sourceMetadata` fills id/title/metadata;
+  // `sourceBody` additionally reads the extracted body.md (a file read, so it's
+  // gated separately to avoid paying for it when only metadata is wanted).
+  const needsSourceMeta = requirements.includes('sourceMetadata');
+  const needsSourceBody = requirements.includes('sourceBody');
+  if (needsSourceMeta || needsSourceBody) {
+    const sourceTab = editor.activeSourceTab;
+    if (sourceTab) {
+      ctx.sourceId = sourceTab.sourceId;
+      if (needsSourceMeta) {
+        try {
+          const detail = await api.graph.sourceDetail(sourceTab.sourceId);
+          if (detail) {
+            ctx.sourceMetadata = detail.metadata;
+            ctx.sourceTitle = detail.metadata.title ?? '';
+          }
+        } catch {
+          // Graph not initialised / unknown source — leave metadata empty.
+        }
+      }
+      if (needsSourceBody) {
+        try {
+          ctx.sourceBody = await api.notebase.readFile(
+            `.minerva/sources/${sourceTab.sourceId}/body.md`,
+          );
+        } catch {
+          // No body.md (stub, or not yet extracted) — leave body empty.
+        }
+      }
+    }
+  }
+
   return ctx;
 }

--- a/src/renderer/lib/tools/tool-registry.ts
+++ b/src/renderer/lib/tools/tool-registry.ts
@@ -18,6 +18,7 @@ export function skillInfoToToolDef(info: SkillInfo): ThinkingToolDef {
     name: info.name,
     category: menuToCategory(info.menu),
     group: info.group,
+    scope: info.scope,
     description: info.description,
     longDescription: info.longDescription,
     context: info.context,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -387,6 +387,10 @@ export const Channels = {
   CONVERSATION_PROPERTY_DRAFT: 'conversation:propertyDraft',
   /** renderer → main: user approved a property draft; apply each {path, properties} patch and return the per-update outcomes. */
   CONVERSATION_FILE_PROPERTY_DRAFT: 'conversation:filePropertyDraft',
+  /** main → renderer: a propose_source_properties tool call produced a source-meta draft for review (#103). Payload is ConversationSourcePropertyDraft. */
+  CONVERSATION_SOURCE_PROPERTY_DRAFT: 'conversation:sourcePropertyDraft',
+  /** renderer → main: user approved a source-property draft; upsert dc:abstract / thought:tldr into the source's meta.ttl and reindex. */
+  CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT: 'conversation:fileSourcePropertyDraft',
   /** main → renderer: a propose_compute tool call produced a code-cell draft for review (#245). Payload is ConversationComputeDraft. */
   CONVERSATION_COMPUTE_DRAFT: 'conversation:computeDraft',
   /** renderer → main: user clicked Run on a compute draft. Executes via the existing compute registry and appends the result to the conversation log. */

--- a/src/shared/conversation-source-property-drafts.ts
+++ b/src/shared/conversation-source-property-drafts.ts
@@ -1,0 +1,59 @@
+/**
+ * Conversation source-property drafts (the `propose_source_properties` tool
+ * path, #103).
+ *
+ * Counterpart to `conversation-property-drafts.ts`, but the target is a Source's
+ * `meta.ttl` rather than a note's frontmatter. The LLM, summarizing a source,
+ * calls `propose_source_properties` with a proposed `dc:abstract` and/or
+ * `thought:tldr` for one source.
+ *
+ * Trust principle: the tool's server-side execution does NOT write — it emits a
+ * `ConversationSourcePropertyDraft`, forwards it to the renderer via
+ * `Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT`, and returns "queued for
+ * review." The renderer renders an inline card with the proposed abstract /
+ * TL;DR. Approve hands the bundle back through
+ * `Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT`; that handler upserts the
+ * predicates into the source's meta.ttl (`setSourceProperties`) and reindexes.
+ *
+ * Drafts live in renderer memory and are dropped when the conversation tab
+ * closes — same lifecycle as note / source / property drafts.
+ */
+
+export interface ConversationSourcePropertyDraft {
+  /** Stable id used to wire Approve/Discard buttons back to the cached bundle. */
+  draftId: string;
+  /** Conversation that produced the draft. Used by the renderer to bucket. */
+  conversationId: string;
+  /** Bundle-level "why I'm proposing this" note from the LLM. */
+  note: string;
+  /** The source whose meta.ttl is being patched. */
+  sourceId: string;
+  /** Proposed formal abstract (`dc:abstract`). Omitted when not proposed. */
+  abstract?: string;
+  /** Proposed one-paragraph plain-language summary (`thought:tldr`). */
+  tldr?: string;
+  /** ISO timestamp when the draft was created. */
+  createdAt: string;
+}
+
+/** Per-predicate result returned by `CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT`. */
+export interface SourcePropertyOutcome {
+  sourceId: string;
+  /** Predicates actually changed (e.g. `dc:abstract`, `thought:tldr`). Empty
+   *  when every proposed value already matched what was on the source. */
+  changedPredicates: string[];
+  /** Error message when the write failed; the card surfaces it. */
+  error?: string;
+}
+
+export interface FileSourcePropertyDraftResult {
+  outcome: SourcePropertyOutcome;
+}
+
+/** Input shape for the `propose_source_properties` tool. */
+export interface ProposeSourcePropertiesInput {
+  note: string;
+  sourceId: string;
+  abstract?: string;
+  tldr?: string;
+}

--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -221,6 +221,12 @@ dc:abstract a owl:DatatypeProperty ;
     rdfs:domain thought:Source ;
     rdfs:range xsd:string .
 
+thought:tldr a owl:DatatypeProperty ;
+    rdfs:label "TL;DR" ;
+    rdfs:comment "A one-paragraph plain-language summary of a source, distinct from its formal abstract. Typically LLM-proposed and human-approved (#103)." ;
+    rdfs:domain thought:Source ;
+    rdfs:range xsd:string .
+
 bibo:doi a owl:DatatypeProperty ;
     rdfs:label "DOI" ;
     rdfs:comment "Digital Object Identifier. Stored as the bare identifier (no 'doi:' prefix, no URL)." ;

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -13,6 +13,7 @@ import type {
   OutputMode,
   ToolCategory,
   ToolParameter,
+  ToolScope,
 } from '../tools/types';
 import type { MenuConfig } from './menu-config';
 
@@ -44,6 +45,9 @@ export interface SkillDef {
   menu: SkillMenu;
   /** Optional thematic sub-group within the menu (#525). Omit for a flat menu. */
   group?: string;
+  /** Invocation surface + subject (#103). `source` skills live in the Source
+   *  viewer and get source context; absent/`note` is the default. */
+  scope: ToolScope;
   outputMode: OutputMode;
   context: ContextRequirement[];
   parameters: ToolParameter[];
@@ -73,6 +77,7 @@ export interface SkillInfo {
   longDescription: string;
   menu: SkillMenu;
   group?: string;
+  scope: ToolScope;
   outputMode: OutputMode;
   context: ContextRequirement[];
   parameters: ToolParameter[];
@@ -113,6 +118,7 @@ export function toSkillInfo(s: SkillDef): SkillInfo {
     longDescription: s.longDescription,
     menu: s.menu,
     group: s.group,
+    scope: s.scope,
     outputMode: s.outputMode,
     context: s.context,
     parameters: s.parameters,

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -26,7 +26,17 @@ export type ContextRequirement =
    * time; intervening edits between gather and apply may invalidate
    * them, and tools that round-trip should verify.
    */
-  | 'selectionRange';
+  | 'selectionRange'
+  /**
+   * Source-scoped context (#103). Populated from the active Source viewer
+   * tab, not the note editor. `sourceMetadata` fills `sourceId` /
+   * `sourceTitle` / `sourceMetadata`; `sourceBody` additionally reads the
+   * source's extracted `body.md`. A skill that lists either is treated as
+   * source-scoped (see `scope`) and surfaces in the Source viewer rather
+   * than the note menus. Undefined when no source tab is active.
+   */
+  | 'sourceMetadata'
+  | 'sourceBody';
 
 export type OutputMode =
   | 'newNote'
@@ -85,6 +95,17 @@ export interface ToolContext {
   /** 1-based line number of the selection's end (inclusive). */
   selectionEndLine?: number;
   parameterValues?: Record<string, string>;
+  /** Populated by `sourceMetadata`/`sourceBody` (#103). Id of the source in
+   *  the active Source viewer tab. Undefined when no source tab is active. */
+  sourceId?: string;
+  /** thought:title of the active source. */
+  sourceTitle?: string;
+  /** The source's extracted `body.md` text. Populated only by `sourceBody`
+   *  (it's a file read); `sourceMetadata` alone leaves it undefined. */
+  sourceBody?: string;
+  /** Full source metadata (title, creators, year, doi, abstract, …) for the
+   *  active source. Populated by `sourceMetadata`. */
+  sourceMetadata?: import('../types').SourceMetadata;
 }
 
 export interface ToolWebHint {
@@ -92,10 +113,21 @@ export interface ToolWebHint {
   defaultEnabled: boolean;
 }
 
+/**
+ * Where a tool is invoked from and what it operates on (#103). `note`
+ * (default) tools surface in the Learning/Research/Analysis menus + the editor
+ * right-click and act on the active note. `source` tools surface in the Source
+ * viewer's actions menu and receive the active source's body/metadata; they are
+ * kept out of the note surfaces. Absent = `note`.
+ */
+export type ToolScope = 'note' | 'source';
+
 export interface ThinkingToolDef {
   id: string;
   name: string;
   category: ToolCategory;
+  /** Invocation surface + subject (#103). Absent = `note`. */
+  scope?: ToolScope;
   /**
    * Optional thematic sub-grouping within a category (#525). When any tool in
    * a category declares a group, the menu renders one nested submenu per group
@@ -141,6 +173,8 @@ export interface ThinkingToolInfo {
   id: string;
   name: string;
   category: ToolCategory;
+  /** Invocation surface + subject (#103). Absent = `note`. See ThinkingToolDef.scope. */
+  scope?: ToolScope;
   /** Thematic sub-group within the category (#525). See ThinkingToolDef.group. */
   group?: string;
   description: string;
@@ -197,6 +231,13 @@ export interface LLMSettings {
    *   request.modelOverride ?? toolModelOverrides[id] ?? tool.preferredModel ?? model
    */
   toolModelOverrides?: Record<string, string>;
+}
+
+/** Source-scoped tools (#103) live in the Source viewer; everything else is
+ *  note-scoped. Applied identically by the menu, the editor right-click, the
+ *  command palette, and the Source viewer's actions list. */
+export function isSourceScoped(tool: { scope?: ToolScope }): boolean {
+  return tool.scope === 'source';
 }
 
 export const DEFAULT_WEB_SETTINGS: WebSettings = {

--- a/tests/main/graph/source-ontology.test.ts
+++ b/tests/main/graph/source-ontology.test.ts
@@ -67,6 +67,7 @@ describe('Source metadata predicates', () => {
     { ns: SCHEMA, local: 'inContainer', label: 'in container' },
     { ns: THOUGHT, local: 'accessedAt', label: 'accessed at' },
     { ns: THOUGHT, local: 'archivedAt', label: 'archived at' },
+    { ns: THOUGHT, local: 'tldr', label: 'TL;DR' }, // #103
   ];
 
   for (const { ns, local, label: _label } of predicates) {

--- a/tests/main/llm/propose-source-properties-tool.test.ts
+++ b/tests/main/llm/propose-source-properties-tool.test.ts
@@ -1,0 +1,101 @@
+/**
+ * propose_source_properties tool (#103) — server-side execution contract.
+ *
+ * Mirrors propose-sources-tool.test.ts. Guarantees:
+ *  1. The tool MUST NOT write the source. It only emits a draft; the renderer
+ *     triggers the meta.ttl upsert via CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT
+ *     after Approve — the trust-principle gate.
+ *  2. The draft carries the sourceId + proposed abstract/tldr for review.
+ *  3. Validation rejects empty bundles (no abstract and no tldr).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { executeNotebaseTool, type ToolContext } from '../../../src/main/llm/tools';
+import type { ConversationSourcePropertyDraft } from '../../../src/shared/conversation-source-property-drafts';
+
+const baseCtx: ToolContext = { rootPath: '/tmp/never-touched', conversationId: 'conv-test' };
+
+describe('propose_source_properties tool execution', () => {
+  it('emits a draft with the proposed abstract + tldr, writing nothing', async () => {
+    const onSourcePropertyDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_source_properties',
+      {
+        note: 'Summary of the Smith paper',
+        sourceId: 'src-smith-2024',
+        abstract: 'A formal abstract.',
+        tldr: 'The plain-language gist.',
+      },
+      { onSourcePropertyDraft },
+    );
+    expect(out.isError).toBe(false);
+    expect(onSourcePropertyDraft).toHaveBeenCalledTimes(1);
+
+    const draft = onSourcePropertyDraft.mock.calls[0][0] as ConversationSourcePropertyDraft;
+    expect(draft.draftId).toMatch(/^srcpropdraft-/);
+    expect(draft.conversationId).toBe('conv-test');
+    expect(draft.sourceId).toBe('src-smith-2024');
+    expect(draft.abstract).toBe('A formal abstract.');
+    expect(draft.tldr).toBe('The plain-language gist.');
+  });
+
+  it('accepts a tldr-only proposal', async () => {
+    const onSourcePropertyDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_source_properties',
+      { note: 'n', sourceId: 's', tldr: 'just a tldr' },
+      { onSourcePropertyDraft },
+    );
+    expect(out.isError).toBe(false);
+    const draft = onSourcePropertyDraft.mock.calls[0][0] as ConversationSourcePropertyDraft;
+    expect(draft.abstract).toBeUndefined();
+    expect(draft.tldr).toBe('just a tldr');
+  });
+
+  it('rejects a proposal with neither abstract nor tldr', async () => {
+    const onSourcePropertyDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_source_properties',
+      { note: 'n', sourceId: 's' },
+      { onSourcePropertyDraft },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('at least one');
+    expect(onSourcePropertyDraft).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing sourceId', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_source_properties',
+      { note: 'n', abstract: 'a' },
+      { onSourcePropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('sourceId');
+  });
+
+  it('errors with a clear message when no UI surface is wired', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_source_properties',
+      { note: 'n', sourceId: 's', abstract: 'a' },
+      {}, // no onSourcePropertyDraft
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('only available in conversation contexts');
+  });
+
+  it('returns a "do not repeat inline" hint to the model', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_source_properties',
+      { note: 'n', sourceId: 's', abstract: 'a' },
+      { onSourcePropertyDraft: vi.fn() },
+    );
+    expect(out.content).toContain('STOP');
+    expect(out.content).toContain('queued source-property draft');
+  });
+});

--- a/tests/main/skills-parse-scope.test.ts
+++ b/tests/main/skills-parse-scope.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `scope:` frontmatter parsing (#103) and source-context recognition.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseSkill } from '../../src/main/skills/parse';
+
+function mk(extra: string): string {
+  return `---
+name: Test Source Skill
+description: A source skill
+menu: Research
+outputMode: openConversation
+${extra}
+---
+Body referencing {{#if source}}{{source.title}}{{/if}}.`;
+}
+
+describe('parseSkill — scope', () => {
+  it('defaults scope to note when omitted', () => {
+    const { skill, errors } = parseSkill(mk('context: [fullNote]'), 'stock', 'stock/x.md');
+    expect(errors).toEqual([]);
+    expect(skill!.scope).toBe('note');
+  });
+
+  it('parses scope: source', () => {
+    const { skill, errors } = parseSkill(
+      mk('scope: source\ncontext: [sourceMetadata, sourceBody]'),
+      'stock',
+      'stock/x.md',
+    );
+    expect(errors).toEqual([]);
+    expect(skill!.scope).toBe('source');
+    expect(skill!.context).toEqual(['sourceMetadata', 'sourceBody']);
+  });
+
+  it('rejects an invalid scope', () => {
+    const { errors } = parseSkill(mk('scope: planet\ncontext: [fullNote]'), 'stock', 'stock/x.md');
+    expect(errors.some((e) => e.includes('scope'))).toBe(true);
+  });
+
+  it('accepts source context requirements and {{source.*}} template vars', () => {
+    const { skill, errors } = parseSkill(
+      `---
+name: S
+description: d
+menu: Research
+scope: source
+outputMode: openConversation
+context: [sourceBody]
+---
+{{source.id}} / {{source.title}} / {{source.body}}`,
+      'stock',
+      'stock/s.md',
+    );
+    expect(errors).toEqual([]); // no "unknown variable" from the template validator
+    expect(skill).toBeDefined();
+  });
+});

--- a/tests/main/skills-propose-source-summary.test.ts
+++ b/tests/main/skills-propose-source-summary.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Propose Summary (#103) — the first source-scoped stock skill. Pins that it
+ * loads with `scope: source`, gathers source context, and threads the source's
+ * id/title/body into the system prompt with an instruction to file via
+ * `propose_source_properties`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+import { compileSkill } from '../../src/main/skills/compile';
+import type { ThinkingToolDef } from '../../src/shared/tools/types';
+
+let def: ThinkingToolDef;
+
+beforeAll(async () => {
+  const cat = await loadSkillCatalog(path.join(__dirname, '__no_user_skills__'));
+  expect(cat.errors).toEqual([]);
+  const skill = cat.skills.find((s) => s.id === 'research.propose-source-summary');
+  expect(skill).toBeDefined();
+  def = compileSkill(skill!);
+});
+
+describe('propose-source-summary skill', () => {
+  it('is a source-scoped Research conversation skill', () => {
+    expect(def.scope).toBe('source');
+    expect(def.category).toBe('research');
+    expect(def.group).toBe('Summarize');
+    expect(def.outputMode).toBe('openConversation');
+  });
+
+  it('requests source metadata + body context', () => {
+    expect(def.context).toContain('sourceMetadata');
+    expect(def.context).toContain('sourceBody');
+  });
+
+  it('threads the source into the system prompt and instructs the file tool', () => {
+    const sys = def.buildSystemPrompt!({
+      sourceId: 'src-xyz',
+      sourceTitle: 'On Widgets',
+      sourceBody: 'widget-body-zzz',
+    });
+    expect(sys).toContain('widget-body-zzz');
+    expect(sys).toContain('On Widgets');
+    expect(sys).toContain('src-xyz'); // sourceId passed through to the tool call
+    expect(sys).toContain('propose_source_properties');
+    expect(sys).toContain('## Process');
+  });
+
+  it('first message names the source when a body is present', () => {
+    const fm = def.buildFirstMessage!({
+      sourceId: 'src-1',
+      sourceTitle: 'On Widgets',
+      sourceBody: 'body',
+    });
+    expect(fm).toContain('On Widgets');
+  });
+
+  it('degrades gracefully when the source has no body', () => {
+    const sys = def.buildSystemPrompt!({ sourceId: 'src-1', sourceTitle: 'Empty', sourceBody: '' });
+    expect(sys).toContain('no readable body');
+    const fm = def.buildFirstMessage!({ sourceId: 'src-1', sourceTitle: 'Empty', sourceBody: '' });
+    expect(fm).toContain('no extracted body');
+  });
+});

--- a/tests/main/skills-template.test.ts
+++ b/tests/main/skills-template.test.ts
@@ -102,9 +102,9 @@ describe('renderTemplateDiagnostic', () => {
 });
 
 describe('toRenderContext', () => {
-  it('maps ToolContext, nulling absent note/claim', () => {
+  it('maps ToolContext, nulling absent note/claim/source', () => {
     const tc: ToolContext = { selectedText: 's', parameterValues: { a: '1' } };
-    expect(toRenderContext(tc)).toEqual({ selection: 's', note: null, claim: null, param: { a: '1' } });
+    expect(toRenderContext(tc)).toEqual({ selection: 's', note: null, claim: null, source: null, param: { a: '1' } });
   });
 
   it('builds note/claim slots when present', () => {
@@ -115,6 +115,11 @@ describe('toRenderContext', () => {
     const r = toRenderContext(tc);
     expect(r.note).toEqual({ content: 'C', title: 'T', path: 'p.md' });
     expect(r.claim).toEqual({ uri: 'urn:1', label: 'L', sourceText: 'src' });
+  });
+
+  it('builds the source slot when present (#103)', () => {
+    const tc: ToolContext = { sourceId: 's-1', sourceTitle: 'T', sourceBody: 'B' };
+    expect(toRenderContext(tc).source).toEqual({ id: 's-1', title: 'T', body: 'B' });
   });
 });
 

--- a/tests/main/sources/read-status.test.ts
+++ b/tests/main/sources/read-status.test.ts
@@ -11,9 +11,9 @@ import os from 'node:os';
 import {
   setSourceReadStatus,
   setSourceReadDueBy,
-  upsertSingleValuedPredicate,
   isReadStatus,
 } from '../../../src/main/sources/read-status';
+import { upsertSingleValuedPredicate } from '../../../src/main/sources/source-meta-write';
 import {
   initGraph,
   indexSource,

--- a/tests/main/sources/source-meta-write.test.ts
+++ b/tests/main/sources/source-meta-write.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Source meta.ttl single-predicate writers (#103) — extracted from read-status
+ * (#116) and reused by the source-property approval path. Covers the abstract /
+ * TL;DR upserts that "Propose Summary" lands on a source.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  upsertSingleValuedPredicate,
+  ttlString,
+} from '../../../src/main/sources/source-meta-write';
+
+const META = `this: a thought:Article ;
+    dc:title "Test paper" ;
+    dc:creator "Alice" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+describe('source summary predicates', () => {
+  it('inserts dc:abstract before the closing dot', () => {
+    const out = upsertSingleValuedPredicate(META, 'dc:abstract', ttlString('An abstract.'));
+    expect(out).toContain('dc:abstract "An abstract." ;');
+    expect(out.indexOf('dc:abstract')).toBeLessThan(out.indexOf('thought:accessedAt'));
+    expect(out).toContain('dc:title "Test paper"'); // existing predicates survive
+  });
+
+  it('inserts thought:tldr', () => {
+    const out = upsertSingleValuedPredicate(META, 'thought:tldr', ttlString('Plain-language gist.'));
+    expect(out).toContain('thought:tldr "Plain-language gist." ;');
+  });
+
+  it('replaces an existing value in place (no duplicate line)', () => {
+    let ttl = upsertSingleValuedPredicate(META, 'thought:tldr', ttlString('first'));
+    ttl = upsertSingleValuedPredicate(ttl, 'thought:tldr', ttlString('second'));
+    expect(ttl).toContain('thought:tldr "second"');
+    expect(ttl).not.toContain('"first"');
+    expect((ttl.match(/thought:tldr/g) ?? []).length).toBe(1);
+  });
+
+  it('upserting the same value twice is idempotent', () => {
+    const once = upsertSingleValuedPredicate(META, 'dc:abstract', ttlString('stable'));
+    const twice = upsertSingleValuedPredicate(once, 'dc:abstract', ttlString('stable'));
+    expect(twice).toBe(once);
+  });
+
+  it('applying both abstract and tldr keeps the TTL well-formed', () => {
+    let ttl = upsertSingleValuedPredicate(META, 'dc:abstract', ttlString('A.'));
+    ttl = upsertSingleValuedPredicate(ttl, 'thought:tldr', ttlString('T.'));
+    // Exactly one trailing dot, every non-final predicate ends with ';'.
+    expect(ttl.trimEnd().endsWith('.')).toBe(true);
+    expect(ttl).toContain('dc:abstract "A." ;');
+    expect(ttl).toContain('thought:tldr "T." ;');
+  });
+});
+
+describe('ttlString', () => {
+  it('escapes quotes, backslashes, and newlines', () => {
+    expect(ttlString('he said "hi"\nline2')).toBe('"he said \\"hi\\"\\nline2"');
+    expect(ttlString('a\\b')).toBe('"a\\\\b"');
+  });
+});

--- a/tests/shared/source-scope.test.ts
+++ b/tests/shared/source-scope.test.ts
@@ -1,0 +1,27 @@
+/**
+ * `isSourceScoped` (#103) — the single predicate that keeps source tools in the
+ * Source viewer and out of the note menus / editor right-click / palette.
+ */
+import { describe, it, expect } from 'vitest';
+import { isSourceScoped } from '../../src/shared/tools/types';
+
+describe('isSourceScoped', () => {
+  it('is true only for scope: source', () => {
+    expect(isSourceScoped({ scope: 'source' })).toBe(true);
+  });
+
+  it('is false for note scope and for an absent scope (the default)', () => {
+    expect(isSourceScoped({ scope: 'note' })).toBe(false);
+    expect(isSourceScoped({})).toBe(false);
+  });
+
+  it('partitions a mixed tool list — note surfaces keep only note tools', () => {
+    const tools = [
+      { id: 'a', scope: undefined },
+      { id: 'b', scope: 'note' as const },
+      { id: 'c', scope: 'source' as const },
+    ];
+    expect(tools.filter((t) => !isSourceScoped(t)).map((t) => t.id)).toEqual(['a', 'b']);
+    expect(tools.filter((t) => isSourceScoped(t)).map((t) => t.id)).toEqual(['c']);
+  });
+});


### PR DESCRIPTION
Closes #103.

## Why

#103 ("LLM auto-summary + TL;DR for a source") is a conversational tool that only makes sense **on a Source**, not a note. Every skill was note-scoped — surfaced in the Learning/Research/Analysis menus + editor right-click, fed only the active note. So rather than special-case one tool, this adds a **general source-scoped capability** to the skill framework, with #103 as the first consumer.

Two decisions confirmed up front: **one PR** (framework + full #103), and **explicit `scope: source` frontmatter** (not derived from context requirements).

## Part 1 — Framework: source-scoped tools

- **`scope: source`** skill frontmatter (default `note`). Routes a skill to the **Source viewer's Tools menu** and keeps it out of the note menus + editor right-click, via one shared predicate `isSourceScoped` (`shared/tools/types.ts`).
- **New context requirements** `sourceMetadata` / `sourceBody`. `gatherContext` reads the active source tab (`editor.activeSourceTab`) and populates `sourceId` / `sourceTitle` / `sourceBody` / `sourceMetadata`, exposed to templates as `{{source.id|title|body}}` with `{{#if source}}`. Threaded through `parse → compile → tool-registry → template`.
- **SourceDetail** grows a "Tools" dropdown listing source-scoped skills (grouped by `group:` via the existing `groupToolsByGroup`); invocation reuses `handleToolInvoke`, so the active-source context flows through the existing tool-panel → conversation pipeline unchanged.
- The command palette / slash surfaces don't dynamically list tools today, so menu + editor right-click were the only note surfaces needing the filter.

## Part 2 — #103 write path (approval-gated)

A `thought:cites`-style "edge" for summaries: `dc:abstract` (already a meta.ttl predicate) + the new `thought:tldr`, written to the source's `meta.ttl`.

- **`propose_source_properties`** conversation tool — validates and emits a draft, **never writes** (trust principle), exactly mirroring the note `set_properties` flow. The model gets the `sourceId` from context and passes it through.
- **Approval** upserts the predicates into `meta.ttl` and reindexes. The single-predicate writer was extracted from `read-status.ts` into `sources/source-meta-write.ts` (`setSourceProperties` + `upsertSingleValuedPredicate` + `ttlString`), reused by both paths.
- New draft type + 2 channels + IPC apply handler + `ConversationsPanel` review card / "Updated:" filed line + conversations-store wiring (subscription, approve/discard) — all mirroring the property-draft path, including the defensive empty-payload guard.
- **`thought:tldr`** added to the ontology (datatype property on `thought:Source`).
- Stock skill **`propose-source-summary.md`** (Research ▸ Summarize).

## Trust principle

The conversation never writes the graph directly — `propose_source_properties` only drafts; the user approves an inline card before `meta.ttl` is touched. The human-confirm gate CLAUDE.md requires for LLM-originated graph mutations.

## Tests

`scope` parse + validation; `isSourceScoped` partitioning; source-meta upsert (insert / replace / idempotent / both-predicates well-formed); skill load + prompt threading + graceful no-body fallback; tool validation + draft emission + no-UI-surface error; `thought:tldr` ontology predicate. Full suite green (257 files, 2698 tests); `pnpm lint` clean.

## Try it
1. Open a Source with a body → header **Tools ▾ → Propose Summary**.
2. The conversation proposes an abstract + TL;DR and emits a review card.
3. Approve → `dc:abstract` + `thought:tldr` land on the source; its abstract refreshes after reindex.
4. Propose Summary does **not** appear in the note menus or editor right-click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)