### PR TITLE
feat: Extract Key Claims from a source (#104)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,9 @@ no longer a `definitions/` tool registry; do not add one.
   `sourceBody` context (`{{source.*}}`). Source skills write back via the
   approval-gated `propose_source_properties` tool → `meta.ttl` upsert
   (`sources/source-meta-write.ts`). Worked example: `propose-source-summary.md`.
+  Claim mining (#104): `propose_claims` files `thought:Claim` notes + anchored
+  `thought:Excerpt` nodes (the approval engine's `excerpt` payload kind is now
+  wired) via `extract-key-claims.md`.
 - Authoring reference: `docs/authoring-skills.md`. To change a stock skill,
   disable it and author your own — don't edit bundled files.
 

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -188,11 +188,17 @@ menu (and is kept out of the note menus + editor right-click). Pair it with
 - `{{#if source}}` / `{{#if source.body}}` — branch when no source / no body.
 
 To write back to a source through the approval engine, a conversational
-source skill calls `propose_source_properties` with the `sourceId` plus a
-proposed `abstract` (`dc:abstract`) and/or `tldr` (`thought:tldr`). Like every
-LLM write, it's a *proposal*: the user approves an inline card before anything
-lands on the source's metadata. The stock **Propose Summary**
-(`research.propose-source-summary`) is the worked example.
+source skill calls one of the source-filing tools — each emits a reviewable
+card and writes nothing until the user approves:
+
+- `propose_source_properties` — a proposed `abstract` (`dc:abstract`) and/or
+  `tldr` (`thought:tldr`) on the source. Worked example: **Propose Summary**
+  (`research.propose-source-summary`).
+- `propose_claims` — key claims mined from the body, each `{ text, kind, quote,
+  confidence }`. On approval each becomes a `thought:Claim` note citing a
+  `thought:Excerpt` anchored into `body.md` (the evidence edge), with its
+  confidence. Worked example: **Extract Key Claims**
+  (`research.extract-key-claims`).
 
 ## Parameters
 

--- a/src/main/graph/frontmatter-predicates.ts
+++ b/src/main/graph/frontmatter-predicates.ts
@@ -83,6 +83,11 @@ const MAP: Record<string, FrontmatterPredicate> = {
   // Parent decomposition note → source note. Lets queries surface
   // every decomposition the user has filed for a given passage.
   decomposes: THOUGHT('decomposes'),
+  // Per-claim confidence (#104). A claim note's `confidence: 0.0–1.0`
+  // materialises as thought:confidenceValue. The predicate already exists
+  // in the ontology (xsd:decimal).
+  confidence: THOUGHT('confidenceValue'),
+  confidenceValue: THOUGHT('confidenceValue'),
 
   // prov:* (provenance — #244 derived notes)
   derived_from: PROV('wasDerivedFrom'),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -120,7 +120,8 @@ import {
 } from './compute/python-settings';
 import { saveCellOutput, type SaveCellOutputInput } from './compute/save-cell-output';
 import * as publish from './publish';
-import { createExcerpt } from './sources/create-excerpt';
+import { createExcerpt, buildExcerptTtl } from './sources/create-excerpt';
+import { slugify } from '../shared/slug';
 import type { FormatSettings } from '../shared/formatter/engine';
 import type { AutoLinkSuggestion } from '../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../shared/refactor/auto-link-inbound';
@@ -205,6 +206,39 @@ function buildConversationSystemPrompt(
 function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null {
   const win = winFromEvent(e);
   return getRootPath(win.id);
+}
+
+/** Build a thought:Claim note from an extracted claim (#104). Mirrors the
+ *  child-note shape of the Decompose-into-Claims skill: claim metadata in
+ *  frontmatter (materialised as thought:* by the indexer), a blockquote of the
+ *  supporting passage, a `[[quote::id]]` edge to the excerpt, and a turtle
+ *  block declaring rdf:type. */
+function buildClaimNoteContent(
+  claim: import('../shared/conversation-claims-drafts').DraftClaim,
+  sourceId: string,
+): string {
+  const y = (s: string): string => JSON.stringify(s); // valid double-quoted YAML scalar
+  return [
+    '---',
+    `title: ${y(claim.text)}`,
+    `claim-kind: ${claim.kind}`,
+    `source-text: ${y(claim.quote)}`,
+    `confidence: ${claim.confidence}`,
+    `extracted-from: "[[sources/${sourceId}]]"`,
+    'extracted-by: llm:extract-key-claims',
+    '---',
+    '',
+    `# ${claim.text}`,
+    '',
+    ...claim.quote.split(/\r?\n/).map((l) => `> ${l}`),
+    '',
+    `[[quote::${claim.excerptId}]]`,
+    '',
+    '```turtle',
+    'this: a thought:Claim .',
+    '```',
+    '',
+  ].join('\n');
 }
 
 async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
@@ -2094,6 +2128,11 @@ export function registerIpcHandlers(): void {
             win.webContents.send(Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT, draft);
           }
         },
+        onClaimsDraft: (draft: import('../shared/conversation-claims-drafts').ConversationClaimsDraft) => {
+          if (!win.isDestroyed()) {
+            win.webContents.send(Channels.CONVERSATION_CLAIMS_DRAFT, draft);
+          }
+        },
         onComputeDraft: (draft: import('../shared/conversation-compute-drafts').ConversationComputeDraft) => {
           if (!win.isDestroyed()) {
             win.webContents.send(Channels.CONVERSATION_COMPUTE_DRAFT, draft);
@@ -2250,6 +2289,84 @@ export function registerIpcHandlers(): void {
         applied: true,
         filedPaths,
       };
+    },
+  );
+
+  // Counterpart to CONVERSATION_FILE_DRAFT for the propose_claims tool (#104).
+  // Files, through the approval engine, one bundle per source: a thought:Excerpt
+  // node per supporting quote (anchored by char offsets) + a thought:Claim note
+  // per claim that quotes its excerpt and carries its confidence. Excerpt
+  // payloads go first so the node exists before the note's quotes edge resolves.
+  ipcMain.handle(
+    Channels.CONVERSATION_FILE_CLAIMS_DRAFT,
+    async (
+      e,
+      draft: import('../shared/conversation-claims-drafts').ConversationClaimsDraft,
+    ): Promise<import('../shared/conversation-claims-drafts').FileClaimsDraftResult> => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      const sourceId = draft?.sourceId;
+      if (!sourceId || !Array.isArray(draft.claims) || draft.claims.length === 0) {
+        throw new Error(
+          `FILE_CLAIMS_DRAFT: draft has no sourceId/claims (received ${JSON.stringify(draft).slice(0, 200)}). ` +
+          `If this came from a Svelte 5 $state value, snapshot it before sending across IPC.`,
+        );
+      }
+      const ctx = projectContext(rootPath);
+      try {
+        const payloads: import('./llm/approval').ProposalPayload[] = [];
+        const seenExcerpts = new Set<string>();
+        const claimPaths: string[] = [];
+        const excerptIds: string[] = [];
+
+        draft.claims.forEach((claim, i) => {
+          // Excerpt payload (dedupe — two claims may share a quote).
+          if (!seenExcerpts.has(claim.excerptId)) {
+            seenExcerpts.add(claim.excerptId);
+            excerptIds.push(claim.excerptId);
+            payloads.push({
+              kind: 'excerpt',
+              excerptId: claim.excerptId,
+              excerptTtl: buildExcerptTtl({
+                sourceId,
+                citedText: claim.quote,
+                charStart: claim.charStart ?? null,
+                charEnd: claim.charEnd ?? null,
+              }),
+            });
+          }
+          // Claim note payload.
+          const slug = slugify(claim.text).slice(0, 48) || 'claim';
+          const relativePath = `notes/claims/${sourceId}-${i + 1}-${slug}.md`;
+          claimPaths.push(relativePath);
+          payloads.push({
+            kind: 'note',
+            relativePath,
+            content: buildClaimNoteContent(claim, sourceId),
+          });
+        });
+
+        const proposal = await approval.proposeWrite(ctx, {
+          operationType: 'component_creation',
+          payloads,
+          note: draft.note,
+          conversationUri: `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`,
+          proposedBy: `llm:conversation:${draft.conversationId}`,
+        });
+        if (proposal) await approval.approveProposal(ctx, proposal.uri);
+
+        return { outcome: { sourceId, claimPaths, excerptIds } };
+      } catch (err) {
+        console.warn('[conv] FILE_CLAIMS_DRAFT failed for', sourceId, err);
+        return {
+          outcome: {
+            sourceId,
+            claimPaths: [],
+            excerptIds: [],
+            error: err instanceof Error ? err.message : String(err),
+          },
+        };
+      }
     },
   );
 

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -459,8 +459,18 @@ async function dispatchApply(ctx: ProjectContext, p: ProposalPayload): Promise<u
       }
       return { resolvedPath: finalPath };
     }
+    case 'excerpt': {
+      // #104: file a thought:Excerpt node so claim-extraction can anchor its
+      // evidence. Mirrors the `note` case — write the .ttl then index directly
+      // (rather than waiting on the chokidar watcher) so the graph reflects it
+      // immediately for the claim notes' `[[quote::id]]` edges in the same bundle.
+      const relativePath = `.minerva/excerpts/${p.excerptId}.ttl`;
+      await notebaseFs.createFile(ctx.rootPath, relativePath);
+      await notebaseFs.writeFile(ctx.rootPath, relativePath, p.excerptTtl);
+      graph.indexExcerpt(ctx, p.excerptId, p.excerptTtl);
+      return { excerptPath: relativePath };
+    }
     case 'source':
-    case 'excerpt':
     case 'saved-query':
       throw new Error(
         `Approval payload kind "${p.kind}" not yet wired (#418 ships graph-triples + note; later kinds land as needed).`,
@@ -482,8 +492,15 @@ async function dispatchRollback(ctx: ProjectContext, a: AppliedRecord): Promise<
       graph.removeNote(ctx, data.resolvedPath);
       return;
     }
+    case 'excerpt': {
+      const data = a.rollbackData as { excerptPath: string };
+      try { await notebaseFs.deleteFile(ctx.rootPath, data.excerptPath); }
+      catch { /* file may already be gone */ }
+      // No graph.removeExcerpt today; rollback is best-effort and a reindex
+      // reconciles any drift (same posture as the triples-last convention).
+      return;
+    }
     case 'source':
-    case 'excerpt':
     case 'saved-query':
       // Never reached today — apply throws before recording an
       // applied entry for these kinds.

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -14,6 +14,7 @@ import type { ConversationSourceDraft } from '../../shared/conversation-source-d
 import type { ConversationPropertyDraft } from '../../shared/conversation-property-drafts';
 import type { ConversationComputeDraft } from '../../shared/conversation-compute-drafts';
 import type { ConversationSourcePropertyDraft } from '../../shared/conversation-source-property-drafts';
+import type { ConversationClaimsDraft } from '../../shared/conversation-claims-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { formatToolCall } from './format-tool-call';
 
@@ -45,6 +46,12 @@ export interface StreamCallbacks {
    * without it, the tool fails with a "no UI surface" error.
    */
   onSourcePropertyDraft?: (draft: ConversationSourcePropertyDraft) => void;
+  /**
+   * Counterpart to `onDraft` for the propose_claims tool (#104). Forwarded via
+   * Channels.CONVERSATION_CLAIMS_DRAFT; without it the tool fails with a "no UI
+   * surface" error.
+   */
+  onClaimsDraft?: (draft: ConversationClaimsDraft) => void;
   /**
    * Counterpart to `onDraft` for the propose_compute tool (#245).
    * Forwarded via Channels.CONVERSATION_COMPUTE_DRAFT; without it,
@@ -353,6 +360,9 @@ export async function completeWithTools(
       }
       if (callbacks?.onSourcePropertyDraft) {
         toolCallbacks.onSourcePropertyDraft = callbacks.onSourcePropertyDraft;
+      }
+      if (callbacks?.onClaimsDraft) {
+        toolCallbacks.onClaimsDraft = callbacks.onClaimsDraft;
       }
       if (callbacks?.onComputeDraft) {
         toolCallbacks.onComputeDraft = callbacks.onComputeDraft;

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -36,6 +36,14 @@ import { readFrontmatterProperties } from '../../shared/refactor/frontmatter-pat
 import type { PropertyPatch, PropertyValue } from '../../shared/refactor/frontmatter-patch';
 import { detectIdentifier } from '../sources/ingest-identifier';
 import { normalizeUrl } from '../sources/source-id';
+import { excerptIdFor } from '../sources/create-excerpt';
+import {
+  CLAIM_KINDS,
+  type ClaimKind,
+  type ConversationClaimsDraft,
+  type DraftClaim,
+  type ProposeClaimsInput,
+} from '../../shared/conversation-claims-drafts';
 
 export interface ToolContext {
   rootPath: string;
@@ -69,6 +77,10 @@ export interface ToolCallbacks {
    *  tool (#103). Forwards a source's proposed abstract / TL;DR to the
    *  renderer for inline review before anything touches the meta.ttl. */
   onSourcePropertyDraft?: (draft: ConversationSourcePropertyDraft) => void;
+  /** Counterpart to `onDraft` for the `propose_claims` tool (#104). Forwards a
+   *  source's extracted key claims (each with a supporting excerpt) to the
+   *  renderer for inline review before any node is filed. */
+  onClaimsDraft?: (draft: ConversationClaimsDraft) => void;
   /** Counterpart to `onDraft` for the `propose_compute` tool (#245).
    *  Forwards SPARQL / SQL / Python cell drafts to the renderer for
    *  inline review. The user clicks Run / Insert / Discard. */
@@ -426,6 +438,65 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
     },
   },
   {
+    name: 'propose_claims',
+    description:
+      'Propose the key claims a SOURCE makes, each anchored to a supporting ' +
+      'excerpt. Use this when asked to extract / mine claims from a source. ' +
+      'The user reviews the list as an inline card; on Approve, each claim is ' +
+      'filed as a thought:Claim note that cites a thought:Excerpt (anchored ' +
+      'into the body) and carries its confidence. On Discard nothing is ' +
+      'written.\n' +
+      '\n' +
+      'For each claim, the `quote` MUST be copied **verbatim** from the source ' +
+      'body — it is used to locate and anchor the excerpt; a paraphrase will ' +
+      'still file but loses the character-range anchor. Extract the *key* ' +
+      'claims, not every atom. The `sourceId` is given in the conversation ' +
+      'context; pass it through verbatim. Submit ONE call.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        note: {
+          type: 'string',
+          description:
+            'A short sentence describing what you are proposing. Surfaced to ' +
+            'the user on the inline review card.',
+        },
+        sourceId: {
+          type: 'string',
+          description: 'Id of the source the claims come from (from context).',
+        },
+        claims: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 64,
+          items: {
+            type: 'object',
+            properties: {
+              text: { type: 'string', description: 'The claim as a concise assertion.' },
+              kind: {
+                type: 'string',
+                enum: ['factual', 'evaluative', 'definitional', 'predictive'],
+                description: 'factual (a state of the world), evaluative (a value judgment), definitional (what a term means), or predictive (what will happen).',
+              },
+              quote: {
+                type: 'string',
+                description: 'A verbatim passage from the source body that supports the claim.',
+              },
+              confidence: {
+                type: 'number',
+                minimum: 0,
+                maximum: 1,
+                description: 'Your confidence (0–1) that the source actually makes this claim.',
+              },
+            },
+            required: ['text', 'kind', 'quote', 'confidence'],
+          },
+        },
+      },
+      required: ['note', 'sourceId', 'claims'],
+    },
+  },
+  {
     name: 'propose_compute',
     description:
       'Propose a code cell (SPARQL, SQL, or Python) for the user to review and run. ' +
@@ -657,6 +728,8 @@ export async function executeNotebaseTool(
         return runSetProperties(ctx, input, callbacks);
       case 'propose_source_properties':
         return runProposeSourceProperties(ctx, input, callbacks);
+      case 'propose_claims':
+        return runProposeClaims(ctx, input, callbacks);
       case 'propose_compute':
         return runProposeCompute(ctx, input, callbacks);
       case 'ask_user':
@@ -1268,6 +1341,114 @@ function parseProposeSourcePropertiesInput(
   if (abstract) out.abstract = abstract;
   if (tldr) out.tldr = tldr;
   return out;
+}
+
+/**
+ * Trust-principle parity with the other draft tools (#104):
+ * `propose_claims` does NOT write. It reads the source body, resolves each
+ * quote to an excerpt id + char range, emits a `ConversationClaimsDraft` for
+ * inline review, and returns "drafted." The
+ * `CONVERSATION_FILE_CLAIMS_DRAFT` handler files claim notes + excerpt nodes
+ * through the approval engine once the user approves.
+ */
+async function runProposeClaims(
+  ctx: ToolContext,
+  input: unknown,
+  callbacks: ToolCallbacks,
+): Promise<{ content: string; isError: boolean }> {
+  if (!callbacks.onClaimsDraft) {
+    return { content: 'propose_claims is only available in conversation contexts.', isError: true };
+  }
+  if (!ctx.conversationId) {
+    return { content: 'propose_claims requires a bound conversation id.', isError: true };
+  }
+  const parsed = parseProposeClaimsInput(input);
+  if ('error' in parsed) {
+    return { content: parsed.error, isError: true };
+  }
+
+  // Read the source body so each quote can be anchored by char range. A
+  // missing body isn't fatal — claims still file, just quote-anchored.
+  let body = '';
+  try {
+    body = await fs.readFile(ctx.rootPath, `.minerva/sources/${parsed.sourceId}/body.md`);
+  } catch { /* no body.md — offsets stay unset */ }
+
+  const claims: DraftClaim[] = parsed.claims.map((c) => {
+    const quote = c.quote.trim();
+    const idx = body ? body.indexOf(quote) : -1;
+    const found = idx >= 0;
+    return {
+      text: c.text.trim(),
+      kind: c.kind,
+      quote,
+      confidence: c.confidence,
+      excerptId: excerptIdFor(parsed.sourceId, quote),
+      quoteFound: found,
+      ...(found ? { charStart: idx, charEnd: idx + quote.length } : {}),
+    };
+  });
+
+  const draft: ConversationClaimsDraft = {
+    draftId: `claimsdraft-${randomUUID()}`,
+    conversationId: ctx.conversationId,
+    note: parsed.note,
+    sourceId: parsed.sourceId,
+    claims,
+    createdAt: new Date().toISOString(),
+  };
+  callbacks.onClaimsDraft(draft);
+
+  const approx = claims.filter((c) => !c.quoteFound).length;
+  return {
+    content: JSON.stringify({
+      status: 'drafted',
+      draftId: draft.draftId,
+      sourceId: parsed.sourceId,
+      claimCount: claims.length,
+      quotesNotAnchored: approx,
+      hint:
+        'STOP. The claims have been queued for user review. End this turn with ' +
+        'ONE short acknowledgement sentence and DO NOT call propose_claims ' +
+        'again. DO NOT call any other tool. DO NOT repeat the claims inline.',
+    }) + `\n\n(queued ${claims.length} claim(s) for ${parsed.sourceId}${approx ? `, ${approx} quote(s) not verbatim` : ''})`,
+    isError: false,
+  };
+}
+
+function parseProposeClaimsInput(
+  input: unknown,
+): ProposeClaimsInput | { error: string } {
+  if (!input || typeof input !== 'object') {
+    return { error: 'propose_claims input must be an object.' };
+  }
+  const obj = input as Record<string, unknown>;
+  const note = typeof obj.note === 'string' ? obj.note.trim() : '';
+  if (!note) return { error: '`note` is required and must be a non-empty string.' };
+  const sourceId = typeof obj.sourceId === 'string' ? obj.sourceId.trim() : '';
+  if (!sourceId) return { error: '`sourceId` is required and must be a non-empty string.' };
+  if (!Array.isArray(obj.claims) || obj.claims.length === 0) {
+    return { error: '`claims` must be a non-empty array.' };
+  }
+  const claims: ProposeClaimsInput['claims'] = [];
+  for (const raw of obj.claims) {
+    if (!raw || typeof raw !== 'object') return { error: 'Each claim must be an object.' };
+    const c = raw as Record<string, unknown>;
+    const text = typeof c.text === 'string' ? c.text.trim() : '';
+    if (!text) return { error: 'Each claim needs a non-empty `text`.' };
+    const quote = typeof c.quote === 'string' ? c.quote.trim() : '';
+    if (!quote) return { error: `claim "${text.slice(0, 40)}": a non-empty \`quote\` is required.` };
+    const kind = typeof c.kind === 'string' ? c.kind : '';
+    if (!(CLAIM_KINDS as readonly string[]).includes(kind)) {
+      return { error: `claim "${text.slice(0, 40)}": \`kind\` must be one of ${CLAIM_KINDS.join(', ')}.` };
+    }
+    const confidence = typeof c.confidence === 'number' ? c.confidence : NaN;
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+      return { error: `claim "${text.slice(0, 40)}": \`confidence\` must be a number in [0, 1].` };
+    }
+    claims.push({ text, kind: kind as ClaimKind, quote, confidence });
+  }
+  return { note, sourceId, claims };
 }
 
 function isPropertyValue(v: unknown): v is PropertyValue {

--- a/src/main/skills/stock/extract-key-claims.md
+++ b/src/main/skills/stock/extract-key-claims.md
@@ -1,0 +1,53 @@
+---
+id: research.extract-key-claims
+name: Extract Key Claims
+description: Mine the central claims a source makes, each with a supporting excerpt
+menu: Research
+group: Mining
+scope: source
+outputMode: openConversation
+context: [sourceMetadata, sourceBody]
+model: claude-opus-4-7
+firstMessage: |-
+  {{#if source}}{{#if source.body}}Extract the key claims from "{{source.title}}" — each with a verbatim supporting quote and a confidence — for my review.{{else}}This source has no extracted body text to mine yet — ingest or add its body.md first.{{/if}}{{else}}Open a source first, then run Extract Key Claims from its Tools menu.{{/if}}
+longDescription: >-
+  Reads this source's body and identifies the central claims it makes — not every atom, the load-bearing
+  ones. For each it proposes the claim, its kind, a verbatim supporting quote, and a confidence. On
+  approval each claim is filed as a thought:Claim note that cites a thought:Excerpt anchored into the body
+  (the evidence link), carrying its confidence. Nothing is written until you approve. Source-scoped sibling
+  of Decompose into Claims (#104).
+---
+You are mining the **key claims** a source makes, with evidence. You read the source, propose claims for review, and only file them when the user approves — you never write directly.
+
+{{#if source.body}}
+## What counts as a key claim
+
+A claim is one distinct assertion presented as true. Extract the **central, load-bearing** claims — the ones the source's argument rests on — not every incidental statement. Each claim gets a kind:
+
+- **factual** — asserts something is the case ("X causes Y", "the rate fell in 2020")
+- **evaluative** — a value judgment ("this approach is superior", "the policy failed")
+- **definitional** — what a term means ("a heuristic is a rule of thumb")
+- **predictive** — what will happen ("adoption will accelerate")
+
+## Process
+
+1. Read the source body below. Identify its key claims.
+2. For each, draft: the claim text, its kind, a **verbatim** supporting quote copied exactly from the body, and a confidence (0–1) that the source actually makes the claim.
+3. Show the user a concise list (claim · kind · confidence, with the quote). Iterate — they may merge, split, drop, re-kind, or adjust confidence.
+
+**Quotes must be copied verbatim** from the body — they're used to locate and anchor the excerpt. A paraphrase still files but loses the exact character anchor, so prefer an exact substring.
+
+## Filing the result
+
+When the user is satisfied, call `propose_claims` exactly once with `{ sourceId: {{source.id}}, claims: [{ text, kind, quote, confidence }, …] }`. Each claim becomes a `thought:Claim` note citing a `thought:Excerpt` (its evidence) with its confidence — after the user approves the inline card. Do not paste the claims as prose instead of calling the tool; the tool is what makes them reviewable and filable.
+
+## Anti-flattery
+
+If the source makes no strong claims — it's purely descriptive, or only raises questions — say so and file nothing. Do not invent claims to look thorough. Reserve high confidence for claims the source plainly asserts.
+
+## Source: {{source.title}}
+
+{{source.body}}
+{{else}}
+This source has no readable body text, so there's nothing to mine. Ask the user to ingest the source's full text (or add a `body.md`) and try again.
+{{/if}}

--- a/src/main/sources/create-excerpt.ts
+++ b/src/main/sources/create-excerpt.ts
@@ -23,6 +23,11 @@ export interface CreateExcerptParams {
   page?: number | null;
   pageRange?: string | null;
   locationText?: string | null;
+  /** Optional 0-based character offsets of the cited text within the source's
+   *  extracted body.md (#104). When supplied, emitted as thought:charStart /
+   *  thought:charEnd so the excerpt is anchored, not just quote-matched. */
+  charStart?: number | null;
+  charEnd?: number | null;
 }
 
 export interface CreateExcerptResult {
@@ -40,7 +45,7 @@ export async function createExcerpt(
   if (!cited) throw new Error('Empty selection; nothing to excerpt.');
   if (!params.sourceId) throw new Error('Missing sourceId.');
 
-  const excerptId = `${params.sourceId}-${shortHash(cited)}`;
+  const excerptId = excerptIdFor(params.sourceId, cited);
   const relativePath = `.minerva/excerpts/${excerptId}.ttl`;
   const absPath = path.join(rootPath, relativePath);
 
@@ -73,8 +78,19 @@ export function buildExcerptTtl(params: CreateExcerptParams): string {
   if (params.locationText) {
     lines.push(`    thought:locationText ${ttlString(params.locationText)} ;`);
   }
+  if (params.charStart != null && params.charEnd != null) {
+    lines.push(`    thought:charStart ${params.charStart} ;`);
+    lines.push(`    thought:charEnd ${params.charEnd} ;`);
+  }
   lines.push(`    prov:generatedAtTime ${ttlString(new Date().toISOString())}^^xsd:dateTime .`);
   return lines.join('\n') + '\n';
+}
+
+/** Deterministic excerpt id for a (source, citedText) pair. Exposed so callers
+ *  that need the id before/without writing the file (e.g. the claim-extraction
+ *  draft, #104) compute the same id `createExcerpt` would. */
+export function excerptIdFor(sourceId: string, citedText: string): string {
+  return `${sourceId}-${shortHash(citedText.trim())}`;
 }
 
 function ttlString(s: string): string {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -219,6 +219,10 @@ contextBridge.exposeInMainWorld('api', {
       subscribeIpc(Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT, cb),
     fileSourcePropertyDraft: (draft: unknown) =>
       ipcRenderer.invoke(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, draft),
+    onClaimsDraft: (cb: (draft: unknown) => void) =>
+      subscribeIpc(Channels.CONVERSATION_CLAIMS_DRAFT, cb),
+    fileClaimsDraft: (draft: unknown) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_FILE_CLAIMS_DRAFT, draft),
     onComputeDraft: (cb: (draft: unknown) => void) =>
       subscribeIpc(Channels.CONVERSATION_COMPUTE_DRAFT, cb),
     runComputeDraft: (input: unknown) =>

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -20,6 +20,10 @@
     SourcePropertyOutcome,
   } from '../../../shared/conversation-source-property-drafts';
   import type {
+    ConversationClaimsDraft,
+    ClaimsOutcome,
+  } from '../../../shared/conversation-claims-drafts';
+  import type {
     ConversationComputeDraft,
   } from '../../../shared/conversation-compute-drafts';
   import type { CellOutput } from '../../../shared/compute/types';
@@ -322,6 +326,18 @@
     store.discardSourcePropertyDraft(tabId, draftId);
   }
 
+  async function handleApproveClaims(tabId: string, draft: ConversationClaimsDraft) {
+    try {
+      await store.approveClaimsDraft(tabId, draft);
+    } catch (e) {
+      console.error('[conv-panel] approve claims failed:', e);
+    }
+  }
+
+  function handleDiscardClaims(tabId: string, draftId: string) {
+    store.discardClaimsDraft(tabId, draftId);
+  }
+
   // ── propose_compute card state (#245) ─────────────────────────────
   //
   // Per-draft editor buffer (when the user clicks Edit) and a flag for
@@ -493,6 +509,14 @@
       ([, entry]) => entry.afterMessageIndex === i,
     );
   }
+  function claimsDraftsAt(tab: TabT, i: number) {
+    return tab.claimsDrafts.filter((d) => d.afterMessageIndex === i);
+  }
+  function claimsResultsAt(tab: TabT, i: number) {
+    return Object.entries(tab.claimsDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex === i,
+    );
+  }
   function computeDraftsAt(tab: TabT, i: number) {
     return tab.computeDrafts.filter((d) => d.afterMessageIndex === i);
   }
@@ -533,6 +557,16 @@
   function orphanSourcePropertyResults(tab: TabT) {
     const max = tab.conversation.messages.length;
     return Object.entries(tab.sourcePropertyDraftResults).filter(
+      ([, entry]) => entry.afterMessageIndex >= max,
+    );
+  }
+  function orphanClaimsDrafts(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return tab.claimsDrafts.filter((d) => d.afterMessageIndex >= max);
+  }
+  function orphanClaimsResults(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return Object.entries(tab.claimsDraftResults).filter(
       ([, entry]) => entry.afterMessageIndex >= max,
     );
   }
@@ -842,6 +876,50 @@
           </div>
         {/snippet}
 
+        {#snippet claimsDraftCardBlock(draft: ConversationClaimsDraft)}
+          <!-- propose_claims review card (#104). Each claim shows its kind,
+               confidence, and the supporting quote; Approve files claim notes +
+               excerpt nodes through the approval engine. -->
+          <div class="draft-card">
+            <div class="draft-summary">
+              <strong>🧩 {draft.claims.length} claim{draft.claims.length === 1 ? '' : 's'}</strong>
+              <span class="draft-note">{draft.note}</span>
+            </div>
+            <ul class="claims-list">
+              {#each draft.claims as c, ci (ci)}
+                <li class="claim-item">
+                  <div class="claim-head">
+                    <span class="claim-kind">{c.kind}</span>
+                    <span class="claim-conf">conf {c.confidence.toFixed(2)}</span>
+                    {#if !c.quoteFound}<span class="claim-approx" title="Quote wasn't a verbatim substring of the body — excerpt files without a character anchor">approx</span>{/if}
+                  </div>
+                  <div class="claim-text">{c.text}</div>
+                  <div class="claim-quote">{c.quote}</div>
+                </li>
+              {/each}
+            </ul>
+            <div class="draft-actions">
+              <button type="button" class="draft-btn primary" onclick={() => handleApproveClaims(tab.id, draft)}>Approve &amp; file</button>
+              <button type="button" class="draft-btn" onclick={() => handleDiscardClaims(tab.id, draft.draftId)}>Discard</button>
+            </div>
+          </div>
+        {/snippet}
+
+        {#snippet claimsResultLine(_draftId: string, outcome: ClaimsOutcome)}
+          <div class="filed-line">
+            <span class="filed-prefix">🧩 Filed:</span>
+            {#if outcome.error}
+              <span class="filed-error" title={outcome.error}>⚠ {outcome.sourceId}</span>
+            {:else}
+              {#each outcome.claimPaths as p, pi (p)}
+                {#if pi > 0}<span class="filed-sep">·</span>{/if}
+                <button type="button" class="filed-link" title={p} onclick={() => openFiledNote(p)}>{basename(p)}</button>
+              {/each}
+              <span class="filed-dup"> · {outcome.excerptIds.length} excerpt{outcome.excerptIds.length === 1 ? '' : 's'}</span>
+            {/if}
+          </div>
+        {/snippet}
+
         {#snippet computeOutputBlock(output: CellOutput)}
           {#if output.type === 'text'}
             <pre class="compute-output-text">{output.value}</pre>
@@ -1031,6 +1109,12 @@
             {#each sourcePropertyResultsAt(tab, i) as [draftId, entry] (draftId)}
               {@render sourcePropertyResultLine(draftId, entry.outcome)}
             {/each}
+            {#each claimsDraftsAt(tab, i) as draft (draft.draftId)}
+              {@render claimsDraftCardBlock(draft)}
+            {/each}
+            {#each claimsResultsAt(tab, i) as [draftId, entry] (draftId)}
+              {@render claimsResultLine(draftId, entry.outcome)}
+            {/each}
             {#each computeDraftsAt(tab, i) as draft (draft.draftId)}
               {@render computeDraftCardBlock(draft)}
             {/each}
@@ -1117,6 +1201,12 @@
           {/each}
           {#each orphanSourcePropertyResults(tab) as [draftId, entry] (draftId)}
             {@render sourcePropertyResultLine(draftId, entry.outcome)}
+          {/each}
+          {#each orphanClaimsDrafts(tab) as draft (draft.draftId)}
+            {@render claimsDraftCardBlock(draft)}
+          {/each}
+          {#each orphanClaimsResults(tab) as [draftId, entry] (draftId)}
+            {@render claimsResultLine(draftId, entry.outcome)}
           {/each}
           {#each orphanComputeDrafts(tab) as draft (draft.draftId)}
             {@render computeDraftCardBlock(draft)}
@@ -1645,6 +1735,47 @@
     font-size: 12px;
     line-height: 1.5;
     color: var(--text);
+    white-space: pre-wrap;
+  }
+  /* propose_claims card (#104). */
+  .claims-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .claim-item {
+    border-left: 2px solid var(--border);
+    padding-left: 8px;
+  }
+  .claim-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 10px;
+    margin-bottom: 2px;
+  }
+  .claim-kind {
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+  }
+  .claim-conf { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+  .claim-approx {
+    color: var(--bg);
+    background: var(--text-muted);
+    border-radius: 3px;
+    padding: 0 4px;
+  }
+  .claim-text { font-size: 13px; color: var(--text); }
+  .claim-quote {
+    font-size: 11px;
+    color: var(--text-muted);
+    border-left: 2px solid var(--border);
+    padding-left: 6px;
+    margin-top: 2px;
     white-space: pre-wrap;
   }
   .property-kv-list {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -431,6 +431,14 @@ export interface ConversationsApi {
   fileSourcePropertyDraft(
     draft: import('../../../shared/conversation-source-property-drafts').ConversationSourcePropertyDraft,
   ): Promise<import('../../../shared/conversation-source-property-drafts').FileSourcePropertyDraftResult>;
+  /** Subscribe to key-claim drafts produced by the propose_claims tool (#104). */
+  onClaimsDraft(
+    cb: (draft: import('../../../shared/conversation-claims-drafts').ConversationClaimsDraft) => void,
+  ): void;
+  /** Apply an approved claims draft (file claim notes + excerpt nodes via approval). */
+  fileClaimsDraft(
+    draft: import('../../../shared/conversation-claims-drafts').ConversationClaimsDraft,
+  ): Promise<import('../../../shared/conversation-claims-drafts').FileClaimsDraftResult>;
   /** Subscribe to code-cell drafts produced by the propose_compute tool (#245). */
   onComputeDraft(
     cb: (draft: import('../../../shared/conversation-compute-drafts').ConversationComputeDraft) => void,

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -20,6 +20,10 @@ import type {
   ConversationSourcePropertyDraft,
   SourcePropertyOutcome,
 } from '../../../shared/conversation-source-property-drafts';
+import type {
+  ConversationClaimsDraft,
+  ClaimsOutcome,
+} from '../../../shared/conversation-claims-drafts';
 import type { CellResult } from '../../../shared/compute/types';
 import type {
   AskUserRequest,
@@ -57,6 +61,7 @@ type AnchoredDraft = ConversationDraft & { afterMessageIndex: number };
 type AnchoredSourceDraft = ConversationSourceDraft & { afterMessageIndex: number };
 type AnchoredPropertyDraft = ConversationPropertyDraft & { afterMessageIndex: number };
 type AnchoredSourcePropertyDraft = ConversationSourcePropertyDraft & { afterMessageIndex: number };
+type AnchoredClaimsDraft = ConversationClaimsDraft & { afterMessageIndex: number };
 interface SourceDraftResultEntry {
   outcomes: SourceIngestOutcome[];
   afterMessageIndex: number;
@@ -67,6 +72,10 @@ interface PropertyDraftResultEntry {
 }
 interface SourcePropertyDraftResultEntry {
   outcome: SourcePropertyOutcome;
+  afterMessageIndex: number;
+}
+interface ClaimsDraftResultEntry {
+  outcome: ClaimsOutcome;
   afterMessageIndex: number;
 }
 /** Post-Approve summary for a propose_notes draft. Persists in the
@@ -124,6 +133,11 @@ interface TabRuntime {
   /** Per-draft outcome after Approve on a source-property draft — renders
    *  the post-Approve "Updated:" line in place of the card. */
   sourcePropertyDraftResults: Record<string, SourcePropertyDraftResultEntry>;
+  /** propose_claims drafts awaiting Approve/Discard (#104). */
+  claimsDrafts: AnchoredClaimsDraft[];
+  /** Per-draft outcome after Approve on a claims draft — renders the
+   *  post-Approve "Filed:" line in place of the card. */
+  claimsDraftResults: Record<string, ClaimsDraftResultEntry>;
   /** propose_compute drafts awaiting Run / Insert / Discard. */
   computeDrafts: AnchoredComputeDraft[];
   /** Per-draft Run / Insert state. Stays alive after Run so the user
@@ -167,6 +181,7 @@ let draftSubscribed = false;
 let sourceDraftSubscribed = false;
 let propertyDraftSubscribed = false;
 let sourcePropertyDraftSubscribed = false;
+let claimsDraftSubscribed = false;
 let computeDraftSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
@@ -241,6 +256,15 @@ function ensureSubscriptions(): void {
     });
     sourcePropertyDraftSubscribed = true;
   }
+  if (!claimsDraftSubscribed) {
+    api.conversations.onClaimsDraft((draft) => {
+      const t = tabs.find((tab) => tab.id === draft.conversationId);
+      if (!t) return;
+      const afterMessageIndex = t.conversation.messages.length;
+      t.claimsDrafts = [...t.claimsDrafts, { ...draft, afterMessageIndex }];
+    });
+    claimsDraftSubscribed = true;
+  }
   if (!computeDraftSubscribed) {
     api.conversations.onComputeDraft((draft) => {
       const t = tabs.find((tab) => tab.id === draft.conversationId);
@@ -305,6 +329,8 @@ async function init(): Promise<void> {
       propertyDraftResults: {},
       sourcePropertyDrafts: [],
       sourcePropertyDraftResults: {},
+      claimsDrafts: [],
+      claimsDraftResults: {},
       computeDrafts: [],
       computeDraftState: {},
       pendingQuestion: null,
@@ -396,6 +422,8 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     propertyDraftResults: {},
     sourcePropertyDrafts: [],
     sourcePropertyDraftResults: {},
+    claimsDrafts: [],
+    claimsDraftResults: {},
     computeDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
@@ -454,6 +482,8 @@ async function openConversationTab(opts: {
     propertyDraftResults: {},
     sourcePropertyDrafts: [],
     sourcePropertyDraftResults: {},
+    claimsDrafts: [],
+    claimsDraftResults: {},
     computeDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
@@ -689,6 +719,31 @@ function discardSourcePropertyDraft(tabId: string, draftId: string): void {
   tab.sourcePropertyDrafts = tab.sourcePropertyDrafts.filter((d) => d.draftId !== draftId);
 }
 
+async function approveClaimsDraft(
+  tabId: string,
+  draft: ConversationClaimsDraft,
+): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  const anchored = tab.claimsDrafts.find((d) => d.draftId === draft.draftId);
+  const afterMessageIndex = anchored?.afterMessageIndex ?? tab.conversation.messages.length;
+  // JSON round-trip to shed any $state Proxy before IPC structured-clone —
+  // the claims array is nested, so this is the safe snapshot (#104).
+  const plain = JSON.parse(JSON.stringify(draft)) as ConversationClaimsDraft;
+  const result = await api.conversations.fileClaimsDraft(plain);
+  tab.claimsDrafts = tab.claimsDrafts.filter((d) => d.draftId !== draft.draftId);
+  tab.claimsDraftResults = {
+    ...tab.claimsDraftResults,
+    [draft.draftId]: { outcome: result.outcome, afterMessageIndex },
+  };
+}
+
+function discardClaimsDraft(tabId: string, draftId: string): void {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  tab.claimsDrafts = tab.claimsDrafts.filter((d) => d.draftId !== draftId);
+}
+
 async function runComputeDraft(
   tabId: string,
   draft: ConversationComputeDraft,
@@ -825,6 +880,8 @@ export function getConversationsStore() {
     discardPropertyDraft,
     approveSourcePropertyDraft,
     discardSourcePropertyDraft,
+    approveClaimsDraft,
+    discardClaimsDraft,
     runComputeDraft,
     insertComputeDraft,
     discardComputeDraft,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -391,6 +391,10 @@ export const Channels = {
   CONVERSATION_SOURCE_PROPERTY_DRAFT: 'conversation:sourcePropertyDraft',
   /** renderer → main: user approved a source-property draft; upsert dc:abstract / thought:tldr into the source's meta.ttl and reindex. */
   CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT: 'conversation:fileSourcePropertyDraft',
+  /** main → renderer: a propose_claims tool call produced a key-claims draft for review (#104). Payload is ConversationClaimsDraft. */
+  CONVERSATION_CLAIMS_DRAFT: 'conversation:claimsDraft',
+  /** renderer → main: user approved a claims draft; file claim notes + excerpt nodes through the approval engine. */
+  CONVERSATION_FILE_CLAIMS_DRAFT: 'conversation:fileClaimsDraft',
   /** main → renderer: a propose_compute tool call produced a code-cell draft for review (#245). Payload is ConversationComputeDraft. */
   CONVERSATION_COMPUTE_DRAFT: 'conversation:computeDraft',
   /** renderer → main: user clicked Run on a compute draft. Executes via the existing compute registry and appends the result to the conversation log. */

--- a/src/shared/conversation-claims-drafts.ts
+++ b/src/shared/conversation-claims-drafts.ts
@@ -1,0 +1,78 @@
+/**
+ * Conversation claim-extraction drafts (the `propose_claims` tool path, #104).
+ *
+ * Counterpart to `conversation-source-property-drafts.ts`. The LLM, reading a
+ * Source's body, calls `propose_claims` with the key claims it found — each a
+ * `{ text, kind, quote, confidence }`. The tool (server side) does NOT write:
+ * it locates each quote in `body.md`, computes the excerpt id + char offsets,
+ * and emits a `ConversationClaimsDraft` for inline review
+ * (`Channels.CONVERSATION_CLAIMS_DRAFT`).
+ *
+ * On Approve the renderer hands the draft back via
+ * `Channels.CONVERSATION_FILE_CLAIMS_DRAFT`; that handler files, through the
+ * approval engine, one bundle per source: a `thought:Excerpt` node per quote
+ * (anchored by char offsets into body.md) and a `thought:Claim` note per claim
+ * that quotes its excerpt (`[[quote::id]]` → `thought:quotes`) and carries its
+ * confidence. Trust principle: the card click is the human-confirm gate.
+ *
+ * Drafts live in renderer memory and drop when the tab closes.
+ */
+
+export type ClaimKind = 'factual' | 'evaluative' | 'definitional' | 'predictive';
+
+export const CLAIM_KINDS: readonly ClaimKind[] = [
+  'factual', 'evaluative', 'definitional', 'predictive',
+];
+
+/** One proposed claim + its supporting excerpt, resolved against body.md. */
+export interface DraftClaim {
+  /** The claim, as a concise assertion. */
+  text: string;
+  kind: ClaimKind;
+  /** Verbatim supporting passage copied from the source body. */
+  quote: string;
+  /** 0–1 confidence the model assigns to the claim. */
+  confidence: number;
+  /** Deterministic excerpt id for (sourceId, quote) — computed server side. */
+  excerptId: string;
+  /** 0-based char offsets of the quote in body.md, when it matched verbatim. */
+  charStart?: number;
+  charEnd?: number;
+  /** False when the quote was not a verbatim substring of the body — the
+   *  excerpt still files (quote-anchored) but without offsets; the card flags it. */
+  quoteFound: boolean;
+}
+
+export interface ConversationClaimsDraft {
+  /** Stable id used to wire Approve/Discard back to the cached bundle. */
+  draftId: string;
+  conversationId: string;
+  /** Bundle-level "why I'm proposing these" note from the LLM. */
+  note: string;
+  /** The source the claims were extracted from. */
+  sourceId: string;
+  claims: DraftClaim[];
+  createdAt: string;
+}
+
+/** Result returned by `CONVERSATION_FILE_CLAIMS_DRAFT`. */
+export interface ClaimsOutcome {
+  sourceId: string;
+  /** Project-relative paths of the filed claim notes. */
+  claimPaths: string[];
+  /** Excerpt ids filed (or already present). */
+  excerptIds: string[];
+  /** Error message when the bundle failed to apply. */
+  error?: string;
+}
+
+export interface FileClaimsDraftResult {
+  outcome: ClaimsOutcome;
+}
+
+/** Input shape for the `propose_claims` tool. */
+export interface ProposeClaimsInput {
+  note: string;
+  sourceId: string;
+  claims: Array<{ text: string; kind: ClaimKind; quote: string; confidence: number }>;
+}

--- a/tests/main/llm/claims-bundle.test.ts
+++ b/tests/main/llm/claims-bundle.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #104 — the approval engine's `excerpt` payload (newly wired) and the
+ * claim-note + excerpt bundle that "Extract Key Claims" files. Verifies a mixed
+ * note+excerpt bundle lands both, the Claim→Excerpt `thought:quotes` edge
+ * resolves, confidence indexes as `thought:confidenceValue`, the excerpt carries
+ * its char anchor, and a later-payload failure rolls the excerpt file back.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  proposeWrite,
+  approveProposal,
+  resetPolicy,
+  setPolicy,
+  type ProposalPayload,
+} from '../../../src/main/llm/approval';
+import { buildExcerptTtl } from '../../../src/main/sources/create-excerpt';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-claims-bundle-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+  resetPolicy();
+  setPolicy('component_creation', 'requires_approval');
+});
+afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+const SOURCE_ID = 'paper-1';
+const EXCERPT_ID = `${SOURCE_ID}-abc123def456`;
+
+function claimNote(): string {
+  return [
+    '---',
+    'title: "The sky is blue due to Rayleigh scattering"',
+    'claim-kind: factual',
+    'source-text: "The sky is blue because of Rayleigh scattering."',
+    'confidence: 0.9',
+    `extracted-from: "[[sources/${SOURCE_ID}]]"`,
+    'extracted-by: llm:extract-key-claims',
+    '---',
+    '',
+    '# The sky is blue due to Rayleigh scattering',
+    '',
+    '> The sky is blue because of Rayleigh scattering.',
+    '',
+    `[[quote::${EXCERPT_ID}]]`,
+    '',
+    '```turtle',
+    'this: a thought:Claim .',
+    '```',
+    '',
+  ].join('\n');
+}
+
+function bundle(): ProposalPayload[] {
+  return [
+    {
+      kind: 'excerpt',
+      excerptId: EXCERPT_ID,
+      excerptTtl: buildExcerptTtl({
+        sourceId: SOURCE_ID,
+        citedText: 'The sky is blue because of Rayleigh scattering.',
+        charStart: 8,
+        charEnd: 55,
+      }),
+    },
+    { kind: 'note', relativePath: 'notes/claims/paper-1-1-sky.md', content: claimNote() },
+  ];
+}
+
+describe('claims bundle (#104)', () => {
+  it('files the excerpt node + claim note and links them', async () => {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation', payloads: bundle(), note: 'claims', proposedBy: 'unit-test',
+    });
+    expect(proposal).not.toBeNull();
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+
+    // Excerpt .ttl on disk.
+    expect(fs.existsSync(path.join(root, '.minerva', 'excerpts', `${EXCERPT_ID}.ttl`))).toBe(true);
+    // Claim note on disk.
+    expect(fs.existsSync(path.join(root, 'notes', 'claims', 'paper-1-1-sky.md'))).toBe(true);
+
+    // Claim → Excerpt evidence edge + confidence, queryable.
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?claim ?excerpt ?conf WHERE {
+        ?claim a thought:Claim ;
+               thought:quotes ?excerpt ;
+               thought:confidenceValue ?conf .
+      }
+    `);
+    const rows = r.results as Array<{ claim: string; excerpt: string; conf: string }>;
+    expect(rows.length).toBe(1);
+    expect(rows[0].excerpt).toContain(EXCERPT_ID);
+    expect(Number(rows[0].conf)).toBeCloseTo(0.9);
+
+    // Excerpt carries its char anchor.
+    const ex = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?start WHERE { ?e a thought:Excerpt ; thought:charStart ?start . }
+    `);
+    expect((ex.results as Array<{ start: string }>).map((x) => Number(x.start))).toContain(8);
+  });
+
+  it('rolls the excerpt file back when a later payload throws', async () => {
+    const payloads: ProposalPayload[] = [
+      bundle()[0], // excerpt (applies first)
+      // A graph-triples payload with malformed turtle → apply throws after the excerpt landed.
+      { kind: 'graph-triples', turtle: 'this is not valid turtle <<<', affectsNodeUris: [] },
+    ];
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'component_creation', payloads, note: 'rollback', proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx, proposal!.uri)).rejects.toBeTruthy();
+    // The excerpt .ttl written by the first payload must be rolled back.
+    expect(fs.existsSync(path.join(root, '.minerva', 'excerpts', `${EXCERPT_ID}.ttl`))).toBe(false);
+  });
+});

--- a/tests/main/llm/propose-claims-tool.test.ts
+++ b/tests/main/llm/propose-claims-tool.test.ts
@@ -1,0 +1,112 @@
+/**
+ * propose_claims tool (#104) — server-side execution contract.
+ *
+ * Guarantees: the tool never writes (emits a draft for review), resolves each
+ * quote to an excerpt id + char offsets against the source body, validates the
+ * claim shapes, and flags quotes that aren't verbatim substrings.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool, type ToolContext } from '../../../src/main/llm/tools';
+import { excerptIdFor } from '../../../src/main/sources/create-excerpt';
+import type { ConversationClaimsDraft } from '../../../src/shared/conversation-claims-drafts';
+
+let root: string;
+const SOURCE_ID = 'smith-2024';
+const BODY = '# Paper\n\nThe sky is blue because of Rayleigh scattering. Adoption will accelerate next year.\n';
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-claims-tool-'));
+  await fsp.mkdir(path.join(root, '.minerva', 'sources', SOURCE_ID), { recursive: true });
+  await fsp.writeFile(path.join(root, '.minerva', 'sources', SOURCE_ID, 'body.md'), BODY, 'utf-8');
+});
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+function ctx(): ToolContext {
+  return { rootPath: root, conversationId: 'conv-1' };
+}
+
+describe('propose_claims tool execution', () => {
+  it('emits a draft with excerpt ids + char offsets for verbatim quotes', async () => {
+    const onClaimsDraft = vi.fn();
+    const quote = 'The sky is blue because of Rayleigh scattering.';
+    const out = await executeNotebaseTool(
+      ctx(),
+      'propose_claims',
+      {
+        note: 'Key claims from the paper',
+        sourceId: SOURCE_ID,
+        claims: [{ text: 'The sky is blue due to Rayleigh scattering', kind: 'factual', quote, confidence: 0.9 }],
+      },
+      { onClaimsDraft },
+    );
+    expect(out.isError).toBe(false);
+    expect(onClaimsDraft).toHaveBeenCalledTimes(1);
+    const draft = onClaimsDraft.mock.calls[0][0] as ConversationClaimsDraft;
+    expect(draft.draftId).toMatch(/^claimsdraft-/);
+    expect(draft.sourceId).toBe(SOURCE_ID);
+    const c = draft.claims[0];
+    expect(c.excerptId).toBe(excerptIdFor(SOURCE_ID, quote));
+    expect(c.quoteFound).toBe(true);
+    expect(c.charStart).toBe(BODY.indexOf(quote));
+    expect(c.charEnd).toBe(BODY.indexOf(quote) + quote.length);
+  });
+
+  it('flags a quote that is not a verbatim substring (no offsets)', async () => {
+    const onClaimsDraft = vi.fn();
+    await executeNotebaseTool(
+      ctx(),
+      'propose_claims',
+      {
+        note: 'n',
+        sourceId: SOURCE_ID,
+        claims: [{ text: 'paraphrased', kind: 'factual', quote: 'the sky is azure (paraphrase)', confidence: 0.5 }],
+      },
+      { onClaimsDraft },
+    );
+    const draft = onClaimsDraft.mock.calls[0][0] as ConversationClaimsDraft;
+    expect(draft.claims[0].quoteFound).toBe(false);
+    expect(draft.claims[0].charStart).toBeUndefined();
+  });
+
+  it('rejects an invalid kind', async () => {
+    const onClaimsDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      ctx(),
+      'propose_claims',
+      { note: 'n', sourceId: SOURCE_ID, claims: [{ text: 't', kind: 'opinion', quote: 'q', confidence: 0.5 }] },
+      { onClaimsDraft },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('kind');
+    expect(onClaimsDraft).not.toHaveBeenCalled();
+  });
+
+  it('rejects confidence outside [0,1] and empty claim lists', async () => {
+    const bad = await executeNotebaseTool(
+      ctx(), 'propose_claims',
+      { note: 'n', sourceId: SOURCE_ID, claims: [{ text: 't', kind: 'factual', quote: 'q', confidence: 2 }] },
+      { onClaimsDraft: vi.fn() },
+    );
+    expect(bad.isError).toBe(true);
+    const empty = await executeNotebaseTool(
+      ctx(), 'propose_claims',
+      { note: 'n', sourceId: SOURCE_ID, claims: [] },
+      { onClaimsDraft: vi.fn() },
+    );
+    expect(empty.isError).toBe(true);
+  });
+
+  it('errors with a clear message when no UI surface is wired', async () => {
+    const out = await executeNotebaseTool(
+      ctx(), 'propose_claims',
+      { note: 'n', sourceId: SOURCE_ID, claims: [{ text: 't', kind: 'factual', quote: 'q', confidence: 0.5 }] },
+      {},
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('only available in conversation contexts');
+  });
+});

--- a/tests/main/skills-extract-key-claims.test.ts
+++ b/tests/main/skills-extract-key-claims.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Extract Key Claims (#104) — source-scoped claim-mining skill. Pins that it
+ * loads with `scope: source`, gathers source context, and instructs the model
+ * to file via `propose_claims`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+import { compileSkill } from '../../src/main/skills/compile';
+import type { ThinkingToolDef } from '../../src/shared/tools/types';
+
+let def: ThinkingToolDef;
+
+beforeAll(async () => {
+  const cat = await loadSkillCatalog(path.join(__dirname, '__no_user_skills__'));
+  expect(cat.errors).toEqual([]);
+  const skill = cat.skills.find((s) => s.id === 'research.extract-key-claims');
+  expect(skill).toBeDefined();
+  def = compileSkill(skill!);
+});
+
+describe('extract-key-claims skill', () => {
+  it('is a source-scoped Research conversation skill', () => {
+    expect(def.scope).toBe('source');
+    expect(def.category).toBe('research');
+    expect(def.group).toBe('Mining');
+    expect(def.outputMode).toBe('openConversation');
+  });
+
+  it('requests source metadata + body context', () => {
+    expect(def.context).toContain('sourceMetadata');
+    expect(def.context).toContain('sourceBody');
+  });
+
+  it('threads the body into the system prompt and instructs propose_claims', () => {
+    const sys = def.buildSystemPrompt!({
+      sourceId: 'src-1',
+      sourceTitle: 'A Paper',
+      sourceBody: 'body-text-zzz',
+    });
+    expect(sys).toContain('body-text-zzz');
+    expect(sys).toContain('A Paper');
+    expect(sys).toContain('src-1'); // sourceId passed to the tool call
+    expect(sys).toContain('propose_claims');
+    expect(sys).toContain('verbatim');
+  });
+
+  it('degrades gracefully when the source has no body', () => {
+    const sys = def.buildSystemPrompt!({ sourceId: 's', sourceTitle: 'Empty', sourceBody: '' });
+    expect(sys).toContain('no readable body');
+  });
+});

--- a/tests/main/sources/create-excerpt.test.ts
+++ b/tests/main/sources/create-excerpt.test.ts
@@ -39,6 +39,18 @@ describe('buildExcerptTtl (#224)', () => {
     expect(ttl).not.toContain('thought:page');
     expect(ttl).not.toContain('thought:pageRange');
     expect(ttl).not.toContain('thought:locationText');
+    expect(ttl).not.toContain('thought:charStart');
+  });
+
+  it('emits charStart/charEnd when both offsets are supplied (#104)', () => {
+    const ttl = buildExcerptTtl({ sourceId: 's', citedText: 'x', charStart: 10, charEnd: 11 });
+    expect(ttl).toContain('thought:charStart 10');
+    expect(ttl).toContain('thought:charEnd 11');
+  });
+
+  it('omits char offsets unless both are present', () => {
+    const ttl = buildExcerptTtl({ sourceId: 's', citedText: 'x', charStart: 10, charEnd: null });
+    expect(ttl).not.toContain('thought:charStart');
   });
 
   it('escapes quotes and backslashes in the cited text', () => {


### PR DESCRIPTION
Closes #104.

## What

A source-scoped conversational skill — **Extract Key Claims** (Source viewer ▸ Tools ▸ Mining) — that reads a Source's `body.md`, identifies the central claims it makes, and on approval files each as a `thought:Claim` note backed by a `thought:Excerpt` anchored into the body (the evidence link), with a per-claim confidence.

It's the source-scoped sibling of **Decompose into Claims**, built on the #103 source-tool framework. Claims are filed **as notes** (consistent with Decompose — editable, linkable, in the sidebar); excerpts are graph nodes.

## Pipeline

1. **Skill** `extract-key-claims.md` (`scope: source`, `context: [sourceMetadata, sourceBody]`) reads `{{source.body}}` and proposes claims as `{ text, kind, quote, confidence }`, iterating with the user.
2. **`propose_claims` tool** validates and emits a `ConversationClaimsDraft` — resolving each **verbatim** quote to a deterministic excerpt id + char offsets via `body.indexOf` (graceful "approx" flag when a quote isn't an exact substring). Writes nothing (trust principle), mirroring `propose_notes` / `propose_source_properties`.
3. **On approve**, `CONVERSATION_FILE_CLAIMS_DRAFT` builds one bundle — an `excerpt` payload (anchored) + a claim-note payload per claim — and files it via `proposeWrite` + `approveProposal`: **gated, atomic, rollback-safe, with a Proposal audit record**. Each claim note carries `confidence` frontmatter and a `[[quote::excerptId]]` edge → `thought:quotes` Claim→Excerpt.

## Enabling infrastructure

- **Wired the approval engine's `excerpt` payload kind** (was a `NotImplementedError` stub): write `.minerva/excerpts/<id>.ttl` + `graph.indexExcerpt`, with best-effort file-delete rollback. This is what lets excerpts ride the same gate as the claim notes, in one bundle.
- `buildExcerptTtl` gains optional `charStart`/`charEnd` (`thought:charStart`/`charEnd`, already in the ontology); `excerptIdFor` exported for deterministic ids without writing.
- `confidence` → `thought:confidenceValue` frontmatter mapping (predicate already existed; just wasn't mapped).

## Renderer

A claims review card (each claim: kind chip · confidence · quoted excerpt, with an "approx" marker when the quote didn't anchor) + a post-approve "Filed:" line. Store / preload / client wiring mirrors the #103 source-property draft path (subscription, approve/discard, interleave + orphan rendering).

## Design notes

- **Claims as notes** (confirmed): consistent with Decompose, and the `[[quote::id]]` edge already models the Claim→Excerpt evidence link, so no new predicate was needed (the issue's `thought:supportedBy` → `thought:quotes`).
- **Verbatim quotes** are required for char anchoring; a paraphrase still files (citedText-anchored) but loses offsets, and the card flags it so the user sees it before approving.

## Tests

`charStart/charEnd` emission; `propose_claims` validation + quote anchoring + approx flag + no-UI-surface error; the newly-wired excerpt-payload apply + a **mixed note+excerpt bundle end-to-end** (queries the `thought:quotes` Claim→Excerpt edge, `thought:confidenceValue`, and the char anchor through the graph) + bundle rollback; skill load. Full suite green (260 files, 2711 tests); `pnpm lint` clean.

## Try it
1. Open a Source with a body → **Tools ▾ → Extract Key Claims**.
2. The conversation lists candidate claims (kind · confidence · quote); refine.
3. Approve → claim notes under `notes/claims/`, each citing a new excerpt; the density gutter (#102) shows them.
4. `SELECT ?c ?e WHERE { ?c a thought:Claim ; thought:quotes ?e }` returns the links; claims carry `thought:confidenceValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)