### PR TITLE
fix: keep always-unbound columns in SPARQL SELECT results

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1738,20 +1738,36 @@ export function schemaForCompletion(ctx: ProjectContext): GraphSchema {
   };
 }
 
-export async function queryGraph(ctx: ProjectContext, sparql: string): Promise<{ results: unknown[]; error?: string }> {
+export async function queryGraph(
+  ctx: ProjectContext,
+  sparql: string,
+): Promise<{ results: unknown[]; columns: string[]; error?: string }> {
   const state = getState(ctx);
-  if (!state || !engine) return { results: [] };
+  if (!state || !engine) return { results: [], columns: [] };
   const { store } = state;
 
   try {
     if (!state.n3Cache) state.n3Cache = buildN3Store(store);
     const n3Store = state.n3Cache;
     const prefixed = injectSparqlPrefixes(sparql);
-    const bindingsStream = await engine.queryBindings(prefixed, {
-      sources: [n3Store],
-    });
-    const bindings = await bindingsStream.toArray();
 
+    // Use the full query() API (not queryBindings) so we can read the result
+    // metadata: the SELECT projection — in order, including variables that end
+    // up unbound in every row. Deriving columns from the bindings alone would
+    // silently drop an always-unbound column.
+    const result = await engine.query(prefixed, { sources: [n3Store] });
+    if (result.resultType !== 'bindings') {
+      return { results: [], columns: [] };
+    }
+    const metadata = await result.metadata();
+    // Comunica's runtime shape for `variables` has drifted from its types: some
+    // versions expose `RDF.Variable[]` (the element IS the variable), others
+    // `{ variable: RDF.Variable }[]`. Handle both so the column list is robust.
+    const vars = metadata.variables as unknown as Array<{ value?: string; variable?: { value: string } }>;
+    let columns = vars.map((v) => v.variable?.value ?? v.value ?? '').filter(Boolean);
+
+    const bindingsStream = await result.execute();
+    const bindings = await bindingsStream.toArray();
     const results = bindings.map((binding) => {
       const obj: Record<string, string> = {};
       for (const [variable, term] of binding) {
@@ -1760,9 +1776,16 @@ export async function queryGraph(ctx: ProjectContext, sparql: string): Promise<{
       return obj;
     });
 
-    return { results };
+    if (columns.length === 0) {
+      // Fallback (e.g. metadata unavailable): union of keys across all rows.
+      const seen = new Set<string>();
+      for (const row of results) for (const k of Object.keys(row)) seen.add(k);
+      columns = [...seen];
+    }
+
+    return { results, columns };
   } catch (e) {
-    return { results: [], error: String(e) };
+    return { results: [], columns: [], error: String(e) };
   }
 }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -140,7 +140,7 @@ export interface GitApi {
 }
 
 export interface GraphApi {
-  query(sparql: string): Promise<{ results: unknown[]; error?: string }>;
+  query(sparql: string): Promise<{ results: unknown[]; columns: string[]; error?: string }>;
   groundCheck(claimText: string): Promise<{ node: string; label: string; type: string }[]>;
   inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
   runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -418,12 +418,12 @@ export function getEditorStore() {
         tab.executionTime = Math.round(performance.now() - start);
         if (response.error) {
           tab.error = response.error;
-        } else if (response.results.length > 0) {
-          tab.columns = Object.keys(response.results[0] as Record<string, string>);
-          tab.results = response.results as Record<string, string>[];
         } else {
-          tab.columns = [];
-          tab.results = [];
+          // Columns come from the SELECT projection (via the query engine's
+          // metadata), so a variable that's unbound in every row still shows
+          // as an (empty) column rather than vanishing.
+          tab.columns = response.columns;
+          tab.results = response.results as Record<string, string>[];
         }
       }
     } catch (e) {

--- a/tests/main/graph/query-unbound-columns.test.ts
+++ b/tests/main/graph/query-unbound-columns.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A SELECT variable that ends up unbound in every row must still appear as a
+ * column (from the projection), rather than vanishing from the results. Earlier
+ * the columns were derived from the bindings alone, so an always-unbound
+ * variable was dropped entirely.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('queryGraph projected columns', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-query-cols-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    await indexNote(ctx, 'a.md', '---\ntitle: Note A\n---\n# Note A\n');
+    await indexNote(ctx, 'b.md', '---\ntitle: Note B\n---\n# Note B\n');
+  });
+
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  it('keeps a column that is unbound in every row', async () => {
+    // ?missing is projected but never bound — no note has dc:description here.
+    const { results, columns } = await queryGraph(ctx, `
+      SELECT ?title ?missing WHERE {
+        ?note rdf:type minerva:Note .
+        ?note dc:title ?title .
+        OPTIONAL { ?note dc:description ?missing }
+      }
+      ORDER BY ?title`);
+
+    expect(columns).toEqual(['title', 'missing']); // projection order preserved
+    expect(results.length).toBe(2);
+    // The rows have a title but no `missing` key.
+    expect((results as Record<string, string>[]).map((r) => r.title)).toEqual(['Note A', 'Note B']);
+    expect((results[0] as Record<string, string>).missing).toBeUndefined();
+  });
+
+  it('reports projected columns even when there are zero rows', async () => {
+    const { results, columns } = await queryGraph(ctx, `
+      SELECT ?title ?nope WHERE {
+        ?note rdf:type minerva:Note .
+        ?note dc:title ?title .
+        ?note minerva:nonexistentPredicate ?nope .
+      }`);
+    expect(results.length).toBe(0);
+    expect(columns).toEqual(['title', 'nope']);
+  });
+
+  it('preserves all bound columns in projection order', async () => {
+    const { columns } = await queryGraph(ctx, `
+      SELECT ?path ?title WHERE {
+        ?note rdf:type minerva:Note .
+        ?note dc:title ?title .
+        ?note minerva:relativePath ?path .
+      }`);
+    expect(columns).toEqual(['path', 'title']);
+  });
+});


### PR DESCRIPTION
## Problem

If a column in a SPARQL `SELECT` was unbound in **every** row, it disappeared from the results table entirely — e.g. `SELECT ?title ?note WHERE { … OPTIONAL { … ?note } }` showed only a `title` column when nothing ever bound `?note`.

Two causes:
1. `queryGraph` built each row solely from a binding's *present* variables and returned no column list — an always-unbound variable never appears in any binding, so it was unrecoverable downstream.
2. The renderer then derived columns from `Object.keys(results[0])` — only the **first row's** bound keys (also wrong for a var bound in some rows but not the first).

## Fix

`queryGraph` now uses the full `engine.query()` API so it can read the result **metadata** and return `columns` = the `SELECT` projection, in order, *including* variables unbound in every row. The renderer uses `response.columns` directly (mirroring the SQL path), and the results table already renders `row[col] ?? ''` — so an always-unbound variable now shows as an empty column instead of vanishing. Falls back to the union of row keys if metadata is somehow unavailable.

Heads-up for reviewers: Comunica's **runtime** shape for `metadata.variables` has drifted from its published `.d.ts` (some versions expose `RDF.Variable[]`, where each element *is* the variable; others `{ variable: RDF.Variable }[]`). I confirmed 5.1.3 returns the former and the mapping handles both.

## Test

`tests/main/graph/query-unbound-columns.test.ts` drives the real `queryGraph` against an indexed project:
- an always-unbound projected variable keeps its column (rows have no key for it);
- columns are reported even with zero result rows;
- projection order is preserved.

Full suite green (2723 tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)