### PR TITLE
fix: query panel renders columns even when projection is absent

### DIFF
--- a/src/renderer/lib/editor/sql-result.ts
+++ b/src/renderer/lib/editor/sql-result.ts
@@ -30,3 +30,22 @@ export function normalizeSqlRows(
     return out;
   });
 }
+
+/**
+ * Derive a column list from the union of keys across all result rows, in
+ * first-seen order. Fallback for the SPARQL path when the engine's projection
+ * metadata is unavailable — strictly better than reading only the first row's
+ * keys (which misses a variable bound in some rows but not the first). Cannot
+ * recover a variable that is unbound in every row; that's what the projection
+ * metadata is for.
+ */
+export function unionColumns(rows: Record<string, unknown>[]): string[] {
+  const cols: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) { seen.add(k); cols.push(k); }
+    }
+  }
+  return cols;
+}

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -1,6 +1,6 @@
 import { api } from '../ipc/client';
 import type { TabSession, SavedTab } from '../../../shared/types';
-import { normalizeSqlRows } from '../editor/sql-result';
+import { normalizeSqlRows, unionColumns } from '../editor/sql-result';
 
 // ── Tab types ───────────────────────────────────────────────────────────────
 
@@ -419,11 +419,16 @@ export function getEditorStore() {
         if (response.error) {
           tab.error = response.error;
         } else {
-          // Columns come from the SELECT projection (via the query engine's
-          // metadata), so a variable that's unbound in every row still shows
-          // as an (empty) column rather than vanishing.
-          tab.columns = response.columns;
-          tab.results = response.results as Record<string, string>[];
+          const rows = response.results as Record<string, string>[];
+          // Prefer the SELECT projection (from the engine metadata) — it keeps a
+          // variable that's unbound in every row as an empty column. Fall back
+          // to the union of keys across all rows when the projection is absent
+          // (e.g. an older main process that predates the columns field), so the
+          // panel never renders header-less / cell-less.
+          tab.columns = response.columns?.length
+            ? response.columns
+            : unionColumns(rows);
+          tab.results = rows;
         }
       }
     } catch (e) {

--- a/tests/renderer/editor/sql-result.test.ts
+++ b/tests/renderer/editor/sql-result.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeSqlRows } from '../../../src/renderer/lib/editor/sql-result';
+import { normalizeSqlRows, unionColumns } from '../../../src/renderer/lib/editor/sql-result';
 
 describe('normalizeSqlRows (#234)', () => {
   it('stringifies bigints', () => {
@@ -39,5 +39,21 @@ describe('normalizeSqlRows (#234)', () => {
   it('tolerates columns missing from a row', () => {
     const rows = normalizeSqlRows(['a', 'b'], [{ a: 'x' }]);
     expect(rows).toEqual([{ a: 'x', b: '' }]);
+  });
+});
+
+describe('unionColumns (SPARQL fallback)', () => {
+  it('collects keys across all rows in first-seen order', () => {
+    const cols = unionColumns([{ a: '1', b: '2' }, { a: '3', c: '4' }]);
+    expect(cols).toEqual(['a', 'b', 'c']);
+  });
+
+  it('catches a key absent from the first row (the old first-row bug)', () => {
+    const cols = unionColumns([{ a: '1' }, { a: '2', b: '3' }]);
+    expect(cols).toEqual(['a', 'b']);
+  });
+
+  it('returns [] for no rows', () => {
+    expect(unionColumns([])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem (regression from #651)

After #651, the SPARQL results panel showed a correct **row count** but **no columns and no cells**.

#651 changed the renderer to `tab.columns = response.columns`. That's correct when the main process returns the new `columns` field — but in a dev session, editing `src/main/graph/index.ts` hot-reloads the *renderer* (Vite) while the Electron *main* process keeps running the old `queryGraph` that returns only `{ results }`. So `response.columns` is `undefined`, `{#each tab.columns}` renders nothing, and only the row count (from `tab.results`) survives.

A full app restart picks up the new main and fixes it — but the renderer shouldn't blank out just because `columns` is missing.

## Fix

Defensive column resolution in the SPARQL branch of `executeQuery`:

```ts
tab.columns = response.columns?.length ? response.columns : unionColumns(rows);
```

- **Projection present** (current main): use it — keeps an always-unbound variable as an empty column (the #651 behavior).
- **Projection absent** (older main / any gap): fall back to the union of keys across *all* rows. This is also strictly better than the pre-#651 `Object.keys(results[0])`, which missed a variable bound in some rows but not the first.

`unionColumns` is extracted into `sql-result.ts` with unit tests (first-seen order, catches a key absent from the first row, empty input).

Full suite green (2726); lint clean.

> Note for anyone hitting this live: restart `pnpm dev` so the main process reloads — main-process changes don't hot-reload. This patch just makes the panel resilient if that hasn't happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)