### PR TITLE
feat: Ingest URL as Source / Ingest File as Source

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -78,7 +78,8 @@ import {
   USER_LOCALES_DIR,
 } from './publish/csl/user-assets';
 import { renderInlineCitations, type InlineCiteRequest } from './citations/render-inline';
-import { ingestPdf, finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
+import { finishPdfOcrIngest, readOriginalPdf } from './sources/ingest-pdf';
+import { ingestFile } from './sources/ingest-file';
 import { deleteSource } from './sources/delete-source';
 import { mergeSources, MergeSourcesError } from './sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from './sources/read-status';
@@ -1688,18 +1689,21 @@ export function registerIpcHandlers(): void {
     });
   });
 
-  ipcMain.handle(Channels.SOURCES_INGEST_PDF, async (e) => {
+  ipcMain.handle(Channels.SOURCES_INGEST_FILE, async (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     const win = winFromEvent(e);
     const result = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
-      filters: [{ name: 'PDF', extensions: ['pdf'] }],
-      title: 'Ingest PDF',
+      filters: [
+        { name: 'Documents', extensions: ['pdf', 'html', 'htm', 'md', 'markdown', 'txt', 'text'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+      title: 'Ingest File as Source',
       buttonLabel: 'Ingest',
     });
     if (result.canceled || result.filePaths.length === 0) return null;
-    const ingested = await ingestPdf(rootPath, result.filePaths[0]);
+    const ingested = await ingestFile(rootPath, result.filePaths[0]);
     // Re-index the new source so it shows up in the sidebar + graph.
     await reindexFile(rootPath, `.minerva/sources/${ingested.sourceId}/meta.ttl`);
     await persistIndexes(rootPath);

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -137,7 +137,7 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
 
         // Ingest / Import — bringing external things in.
         gate({
-          label: 'Ingest URL…',
+          label: 'Ingest URL as Source…',
           accelerator: 'CmdOrCtrl+Shift+I',
           click: () => send(Channels.MENU_INGEST_URL),
         }),
@@ -147,8 +147,8 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           click: () => send(Channels.MENU_INGEST_IDENTIFIER),
         }),
         gate({
-          label: 'Ingest PDF…',
-          click: () => send(Channels.MENU_INGEST_PDF),
+          label: 'Ingest File as Source…',
+          click: () => send(Channels.MENU_INGEST_FILE),
         }),
         gate({
           label: 'Import BibTeX…',

--- a/src/main/sources/ingest-file.ts
+++ b/src/main/sources/ingest-file.ts
@@ -1,0 +1,114 @@
+/**
+ * Local-file ingestion → Source (the "Ingest File as Source" command).
+ *
+ * Dispatches by file type:
+ *   - PDF              → the PDF pipeline (text extraction + OCR fallback)
+ *   - HTML             → the same Readability/structured extraction as URL ingest
+ *   - text / Markdown  → a thought:Document whose body.md is the file content
+ *
+ * Other types are rejected with a clear message. All three share the Source
+ * layout under `.minerva/sources/<id>/` and dedupe on a content hash so the same
+ * file ingested twice collapses to one Source.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { canonicalSourceId } from './source-id';
+import { ingestPdfBuffer } from './ingest-pdf';
+import { ingestHtmlString, type IngestResult } from './ingest';
+
+const HTML_EXTS = new Set(['.html', '.htm']);
+const TEXT_EXTS = new Set(['.md', '.markdown', '.txt', '.text']);
+
+export async function ingestFile(rootPath: string, absPath: string): Promise<IngestResult> {
+  const ext = path.extname(absPath).toLowerCase();
+  const base = path.basename(absPath);
+
+  if (ext === '.pdf') {
+    const buf = await fs.readFile(absPath);
+    const pdf = await ingestPdfBuffer(rootPath, buf, { originalFilename: base });
+    return {
+      sourceId: pdf.sourceId,
+      relativePath: pdf.relativePath,
+      duplicate: pdf.duplicate,
+      title: pdf.title,
+      kind: 'pdf',
+      pageCount: pdf.pageCount,
+      needsOcr: pdf.needsOcr,
+    };
+  }
+
+  if (HTML_EXTS.has(ext)) {
+    const html = await fs.readFile(absPath, 'utf-8');
+    // No URL for a local file → content-hash id, no bibo:uri; filename is the
+    // title fallback when the page has no <title>.
+    return ingestHtmlString(rootPath, html, { titleFallback: stripExt(base) });
+  }
+
+  if (TEXT_EXTS.has(ext)) {
+    const content = await fs.readFile(absPath, 'utf-8');
+    return ingestTextDocument(rootPath, content, base);
+  }
+
+  throw new Error(
+    `Can't ingest *${ext || ' (no extension)'} as a source yet — PDF, HTML, text, and Markdown are supported.`,
+  );
+}
+
+/** A plain-text / Markdown file as a thought:Document source. */
+async function ingestTextDocument(
+  rootPath: string,
+  content: string,
+  filename: string,
+): Promise<IngestResult> {
+  const { id: sourceId } = canonicalSourceId({}, content);
+  const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
+  const relativePath = `.minerva/sources/${sourceId}/meta.ttl`;
+  const title = firstMarkdownHeading(content) ?? stripExt(filename);
+
+  // Dedupe: same content → same id. Leave the existing Source untouched.
+  try {
+    await fs.access(path.join(sourceDir, 'meta.ttl'));
+    return { sourceId, relativePath, duplicate: true, title, kind: 'text' };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  await fs.mkdir(sourceDir, { recursive: true });
+  await fs.writeFile(path.join(sourceDir, 'body.md'), content.endsWith('\n') ? content : `${content}\n`, 'utf-8');
+  await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildTextMetaTtl(title), 'utf-8');
+  return { sourceId, relativePath, duplicate: false, title, kind: 'text' };
+}
+
+function buildTextMetaTtl(title: string): string {
+  return [
+    'this: a thought:Document ;',
+    `    dc:title ${ttlString(title)} ;`,
+    `    thought:accessedAt ${ttlString(new Date().toISOString())}^^xsd:dateTime .`,
+    '',
+  ].join('\n');
+}
+
+/** First `# H1` heading in a Markdown document, if any. */
+function firstMarkdownHeading(content: string): string | null {
+  for (const line of content.split(/\r?\n/)) {
+    const m = /^#\s+(.+?)\s*$/.exec(line);
+    if (m) return m[1];
+    if (line.trim().length > 0) break; // stop at the first non-blank, non-heading line
+  }
+  return null;
+}
+
+function stripExt(filename: string): string {
+  return filename.replace(/\.[^.]+$/, '');
+}
+
+function ttlString(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}

--- a/src/main/sources/ingest-pdf.ts
+++ b/src/main/sources/ingest-pdf.ts
@@ -45,6 +45,21 @@ export async function ingestPdf(
   pdfAbsolutePath: string,
 ): Promise<PdfIngestResult> {
   const buf = await fs.readFile(pdfAbsolutePath);
+  return ingestPdfBuffer(rootPath, buf, { originalFilename: path.basename(pdfAbsolutePath) });
+}
+
+/**
+ * Ingest a PDF from an in-memory buffer (#94). The buffer source can be a local
+ * file (`ingestPdf`) or a PDF downloaded from a URL (`ingestUrl`). `originalFilename`
+ * is the title/filename fallback and is recorded in meta.ttl as provenance — for a
+ * URL it's the last path segment.
+ */
+export async function ingestPdfBuffer(
+  rootPath: string,
+  buf: Buffer,
+  opts: { originalFilename: string },
+): Promise<PdfIngestResult> {
+  const { originalFilename } = opts;
   // pdfjs transfers the underlying ArrayBuffer when we hand it a Uint8Array,
   // so every pdfjs call needs a fresh copy and we compute the content hash
   // up front from the untouched Node Buffer.
@@ -73,7 +88,7 @@ export async function ingestPdf(
       sourceId,
       relativePath,
       duplicate: true,
-      title: meta.title ?? path.basename(pdfAbsolutePath),
+      title: meta.title ?? originalFilename,
       pageCount: 0,
       needsOcr: false,
     };
@@ -87,7 +102,7 @@ export async function ingestPdf(
 
   await fs.mkdir(sourceDir, { recursive: true });
   await fs.writeFile(path.join(sourceDir, 'original.pdf'), buf);
-  const title = meta.title ?? path.basename(pdfAbsolutePath);
+  const title = meta.title ?? originalFilename;
   await fs.writeFile(
     path.join(sourceDir, 'body.md'),
     needsOcr
@@ -98,7 +113,7 @@ export async function ingestPdf(
   await fs.writeFile(
     path.join(sourceDir, 'meta.ttl'),
     buildMetaTtl(meta, {
-      originalFilename: path.basename(pdfAbsolutePath),
+      originalFilename,
       pageCount: totalPages,
       extractionMethod: needsOcr ? null : 'text-layer',
     }),

--- a/src/main/sources/ingest.ts
+++ b/src/main/sources/ingest.ts
@@ -17,6 +17,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { Buffer } from 'node:buffer';
 import { parseHTML } from 'linkedom';
 import { Readability } from '@mozilla/readability';
 import TurndownService from 'turndown';
@@ -24,6 +25,7 @@ import { canonicalSourceId, normalizeUrl } from './source-id';
 import { mergeMetaTtl } from './source-merge';
 import { extractStructured, structuredToArticleMetadata } from './site-handlers';
 import { buildMetaTtl as buildArticleMetaTtl } from './ingest-identifier';
+import { ingestPdfBuffer } from './ingest-pdf';
 
 export interface IngestResult {
   sourceId: string;
@@ -32,6 +34,15 @@ export interface IngestResult {
   duplicate: boolean;
   /** The `<title>`-derived title, for the caller to surface in a toast. */
   title: string;
+  /** What was ingested. `'web'` for an HTML page, `'pdf'` when a URL/file served
+   *  a PDF (routed to the PDF pipeline), `'text'` for a plain-text/Markdown file.
+   *  Absent on legacy callers that don't set it. */
+  kind?: 'web' | 'pdf' | 'text';
+  /** PDF page count — only set when `kind === 'pdf'`. */
+  pageCount?: number;
+  /** True when a PDF (from a URL) had no text layer and needs OCR — only set
+   *  when `kind === 'pdf'`. The renderer runs the same OCR flow as a file PDF. */
+  needsOcr?: boolean;
 }
 
 export interface IngestOptions {
@@ -47,30 +58,62 @@ export async function ingestUrl(
   const normalized = normalizeUrl(rawUrl);
   if (!normalized) throw new Error(`Not a valid URL: ${rawUrl}`);
 
-  // Structured-metadata extraction (#221) needs the DOM, so we have to
-  // fetch before we can decide on a canonical id. That means dedupe has
-  // to happen after fetch, not before — an extra network round-trip in
-  // the duplicate case, but scholarly sites dedupe straight to their
-  // identifier-based folder (arxiv-<id>, doi-<id>) which is what we want.
-  const html = await fetchHtml(normalized, opts.fetchImpl ?? globalThis.fetch);
+  // A URL can resolve to HTML or to a PDF (e.g. an arXiv /pdf/ link). Fetch
+  // once, then branch on the content: a PDF goes through the PDF pipeline so
+  // "Ingest URL as Source" handles papers-by-link, not just web pages.
+  const fetched = await fetchForIngest(normalized, opts.fetchImpl ?? globalThis.fetch);
+  if (fetched.kind === 'pdf') {
+    const pdf = await ingestPdfBuffer(rootPath, Buffer.from(fetched.bytes), {
+      originalFilename: pdfFilenameFromUrl(normalized),
+    });
+    return {
+      sourceId: pdf.sourceId,
+      relativePath: pdf.relativePath,
+      duplicate: pdf.duplicate,
+      title: pdf.title,
+      kind: 'pdf',
+      pageCount: pdf.pageCount,
+      needsOcr: pdf.needsOcr,
+    };
+  }
+  return ingestHtmlString(rootPath, fetched.text, { url: normalized });
+}
+
+/**
+ * Persist a web Source from an HTML string. Shared by URL ingest (with a `url`,
+ * which enables site-handler structured metadata + a bibo:uri) and local-file
+ * ingest (no `url` — id falls back to a content hash, no bibo:uri). Returns the
+ * same shape as `ingestUrl`'s HTML path.
+ */
+export async function ingestHtmlString(
+  rootPath: string,
+  html: string,
+  opts: { url?: string; titleFallback?: string } = {},
+): Promise<IngestResult> {
+  const url = opts.url ?? null;
   const { document } = parseHTML(html);
-  Object.defineProperty(document, 'documentURI', { value: normalized, configurable: true });
-  Object.defineProperty(document, 'baseURI', { value: normalized, configurable: true });
+  if (url) {
+    Object.defineProperty(document, 'documentURI', { value: url, configurable: true });
+    Object.defineProperty(document, 'baseURI', { value: url, configurable: true });
+  }
 
-  const urlObj = new URL(normalized);
-  const structured = extractStructured(document, urlObj);
+  const structured = url ? extractStructured(document, new URL(url)) : null;
 
-  const { id: sourceId } = canonicalSourceId({
-    doi: structured?.doi ?? undefined,
-    arxiv: structured?.arxiv ?? undefined,
-    pubmed: structured?.pubmed ?? undefined,
-    isbn: structured?.isbn ?? undefined,
-    url: normalized,
-  });
+  const { id: sourceId } = canonicalSourceId(
+    {
+      doi: structured?.doi ?? undefined,
+      arxiv: structured?.arxiv ?? undefined,
+      pubmed: structured?.pubmed ?? undefined,
+      isbn: structured?.isbn ?? undefined,
+      url: url ?? undefined,
+    },
+    // No URL/identifier (local file) → seed the id off the content.
+    url ? undefined : html,
+  );
   const sourceDir = path.join(rootPath, '.minerva', 'sources', sourceId);
   const relativePath = `.minerva/sources/${sourceId}/meta.ttl`;
 
-  const extracted = extractReadableFromDoc(document, normalized);
+  const extracted = extractReadableFromDoc(document, url ?? '', opts.titleFallback);
 
   // Dedupe: if meta.ttl already exists, MERGE new metadata into it
   // rather than overwrite or skip (#90). body.md and other files are
@@ -81,7 +124,7 @@ export async function ingestUrl(
       ? {
           doi: structured.doi ?? null,
           isbn: structured.isbn ?? null,
-          uri: normalized,
+          uri: url,
           // Structured handlers may supply richer metadata — fold it in
           // via structuredToArticleMetadata so the field shapes line up.
           ...(() => {
@@ -91,7 +134,7 @@ export async function ingestUrl(
               abstract: extracted.excerpt,
               issued: extracted.publishedTime,
               publisher: extracted.siteName,
-              uri: normalized,
+              uri: url,
             });
             return {
               issued: m.issued,
@@ -103,7 +146,7 @@ export async function ingestUrl(
           })(),
         }
       : {
-          uri: normalized,
+          uri: url,
           publisher: extracted.siteName,
           abstract: extracted.excerpt,
           issued: extracted.publishedTime,
@@ -114,7 +157,7 @@ export async function ingestUrl(
       await fs.writeFile(path.join(sourceDir, 'meta.ttl'), merged, 'utf-8');
     }
     const existingTitle = await readExistingTitle(sourceDir).catch(() => '');
-    return { sourceId, relativePath, duplicate: true, title: existingTitle || extracted.title };
+    return { sourceId, relativePath, duplicate: true, title: existingTitle || extracted.title, kind: 'web' };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
     // Not found — proceed to fresh ingest.
@@ -136,27 +179,36 @@ export async function ingestUrl(
       abstract: extracted.excerpt,
       issued: extracted.publishedTime,
       publisher: extracted.siteName,
-      uri: normalized,
+      uri: url,
     });
     await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildArticleMetaTtl(metadata), 'utf-8');
     title = metadata.title;
   } else {
     // No site handler matched — Readability-only fallback writes a
     // thought:WebPage meta.ttl with a single byline.
-    await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildMetaTtl(extracted, normalized), 'utf-8');
+    await fs.writeFile(path.join(sourceDir, 'meta.ttl'), buildMetaTtl(extracted, url), 'utf-8');
     title = extracted.title;
   }
 
-  return { sourceId, relativePath, duplicate: false, title };
+  return { sourceId, relativePath, duplicate: false, title, kind: 'web' };
 }
 
-// ── HTML fetch ──────────────────────────────────────────────────────────
+// ── Fetch + content-type routing ─────────────────────────────────────────
 
-async function fetchHtml(url: string, f: typeof fetch): Promise<string> {
+type FetchedContent =
+  | { kind: 'html'; text: string }
+  | { kind: 'pdf'; bytes: ArrayBuffer };
+
+/**
+ * Fetch a URL and classify it as HTML or PDF. A PDF is recognised by its
+ * Content-Type (`application/pdf`) or, when the server is vague, by a `.pdf`
+ * URL path. Anything else that isn't HTML/XML is rejected as before.
+ */
+async function fetchForIngest(url: string, f: typeof fetch): Promise<FetchedContent> {
   const res = await f(url, {
-    // Respect the server's content negotiation while preferring HTML.
     headers: {
-      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      // Accept both HTML and PDF; prefer HTML for content negotiation.
+      'Accept': 'text/html,application/xhtml+xml,application/pdf;q=0.9,application/xml;q=0.8,*/*;q=0.7',
       // Some sites gate on UA; pretend to be a browser.
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36',
     },
@@ -166,10 +218,26 @@ async function fetchHtml(url: string, f: typeof fetch): Promise<string> {
     throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
   }
   const ct = (res.headers.get('content-type') ?? '').toLowerCase();
+  const looksPdfByUrl = /\.pdf(?:[?#]|$)/i.test(url);
+  if (ct.includes('pdf') || (looksPdfByUrl && (ct.includes('octet-stream') || ct.length === 0))) {
+    return { kind: 'pdf', bytes: await res.arrayBuffer() };
+  }
   if (!ct.includes('html') && !ct.includes('xml') && ct.length > 0) {
     throw new Error(`Unsupported content-type for ingest: ${ct}`);
   }
-  return await res.text();
+  return { kind: 'html', text: await res.text() };
+}
+
+/** Best-effort filename for a PDF fetched from a URL — the last path segment,
+ *  or the host. Used as the PDF title/provenance fallback. */
+function pdfFilenameFromUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split('/').filter(Boolean).pop();
+    return last && /\.pdf$/i.test(last) ? last : (last ?? u.hostname);
+  } catch {
+    return url;
+  }
 }
 
 // ── Readability extraction ──────────────────────────────────────────────
@@ -203,7 +271,7 @@ export function extractReadable(html: string, url: string): ExtractedArticle {
  * parsing the HTML twice. The `documentURI` / `baseURI` setup is the
  * caller's responsibility.
  */
-export function extractReadableFromDoc(document: Document, _url: string): ExtractedArticle {
+export function extractReadableFromDoc(document: Document, _url: string, titleFallback?: string): ExtractedArticle {
   const reader = new Readability(document);
   const article = reader.parse();
   if (!article) throw new Error('Readability could not extract content from this page');
@@ -215,7 +283,7 @@ export function extractReadableFromDoc(document: Document, _url: string): Extrac
   const lang = article.lang?.trim() || null;
 
   return {
-    title: article.title?.trim() || '(untitled)',
+    title: article.title?.trim() || titleFallback?.trim() || '(untitled)',
     byline,
     siteName,
     excerpt,
@@ -243,12 +311,12 @@ export function buildBodyMarkdown(article: ExtractedArticle): string {
 
 // ── Turtle meta ─────────────────────────────────────────────────────────
 
-export function buildMetaTtl(article: ExtractedArticle, url: string): string {
+export function buildMetaTtl(article: ExtractedArticle, url: string | null): string {
   const lines: string[] = [
     'this: a thought:WebPage ;',
     `    dc:title ${ttlString(article.title)} ;`,
-    `    bibo:uri ${ttlString(url)} ;`,
   ];
+  if (url) lines.push(`    bibo:uri ${ttlString(url)} ;`);
   if (article.byline) lines.push(`    dc:creator ${ttlString(article.byline)} ;`);
   if (article.siteName) lines.push(`    dc:publisher ${ttlString(article.siteName)} ;`);
   if (article.excerpt) lines.push(`    dc:abstract ${ttlString(article.excerpt)} ;`);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -262,7 +262,7 @@ contextBridge.exposeInMainWorld('api', {
     ingestUrl: (url: string) => ipcRenderer.invoke(Channels.SOURCES_INGEST_URL, url),
     ingestIdentifier: (identifier: string) =>
       ipcRenderer.invoke(Channels.SOURCES_INGEST_IDENTIFIER, identifier),
-    ingestPdf: () => ipcRenderer.invoke(Channels.SOURCES_INGEST_PDF),
+    ingestFile: () => ipcRenderer.invoke(Channels.SOURCES_INGEST_FILE),
     readPdf: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_READ_PDF, sourceId),
     hasPdf: (sourceId: string) => ipcRenderer.invoke(Channels.SOURCES_HAS_PDF, sourceId),
     getExcerptNoteFolder: () => ipcRenderer.invoke(Channels.EXCERPT_GET_NOTE_FOLDER),
@@ -534,8 +534,8 @@ contextBridge.exposeInMainWorld('api', {
     onIngestIdentifier: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_INGEST_IDENTIFIER, () => cb());
     },
-    onIngestPdf: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_INGEST_PDF, () => cb());
+    onIngestFile: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_INGEST_FILE, () => cb());
     },
     onExport: (cb: (exporterId: string) => void) => subscribeIpc(Channels.MENU_EXPORT, cb),
     onImportBibtex: (cb: () => void) => {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -612,14 +612,14 @@
       { id: 'refactor.format', title: 'Format', category: 'Refactor',
         keybinding: null, enabled: hasNote, run: () => handleFormat() },
       // ── Research ──
-      { id: 'research.ingestUrl', title: 'Ingest URL…', category: 'Research',
+      { id: 'research.ingestUrl', title: 'Ingest URL as Source…', category: 'Research',
         keybinding: formatAccelerator('CmdOrCtrl+Shift+I'),
-        enabled: hasProject, run: () => handleIngestUrl() },
+        enabled: hasProject, run: () => handleIngestUrlAsSource() },
       { id: 'research.ingestIdentifier', title: 'Ingest Identifier…', category: 'Research',
         keybinding: formatAccelerator('CmdOrCtrl+Shift+D'),
         enabled: hasProject, run: () => handleIngestIdentifier() },
-      { id: 'research.ingestPdf', title: 'Ingest PDF…', category: 'Research',
-        keybinding: null, enabled: hasProject, run: () => handleIngestPdf() },
+      { id: 'research.ingestFile', title: 'Ingest File as Source…', category: 'Research',
+        keybinding: null, enabled: hasProject, run: () => handleIngestFileAsSource() },
       { id: 'research.importBibtex', title: 'Import BibTeX…', category: 'Research',
         keybinding: null, enabled: hasProject, run: () => handleImportBibtex() },
       { id: 'research.importZoteroRdf', title: 'Import Zotero RDF…', category: 'Research',
@@ -1991,25 +1991,46 @@
     }
   }
 
-  async function handleIngestUrl() {
+  /**
+   * Shared completion for "Ingest URL/File as Source". A URL or file can resolve
+   * to a web page, a PDF (possibly needing OCR), or a text doc — branch on the
+   * result the same way regardless of where it came from.
+   */
+  async function handleIngestedSourceResult(
+    result: { sourceId: string; title: string; duplicate: boolean; needsOcr?: boolean; pageCount?: number },
+  ) {
+    if (result.duplicate) {
+      setTimeout(() => handleOpenSource(result.sourceId), 150);
+      await showConfirm(
+        `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
+        CONFIRM_KEYS.ingestDuplicate,
+        'OK',
+      );
+      return;
+    }
+    if (result.needsOcr) {
+      // Scanned PDF (from a file or a URL) — meta.ttl + original.pdf are
+      // persisted but body.md is empty until OCR runs (#95). Defer opening the
+      // tab until OCR finishes / is skipped so the user isn't staring at a blank body.
+      ocrSession = { sourceId: result.sourceId, title: result.title, pageCount: result.pageCount ?? 0 };
+      ocrPdfBytes = await api.sources.readPdf(result.sourceId);
+      return;
+    }
+    // Wait a beat so the file watcher's indexSource pass finishes before we
+    // open the source tab — otherwise the detail panel's graph query returns
+    // empty and the tab renders as "unknown source."
+    setTimeout(() => handleOpenSource(result.sourceId), 150);
+  }
+
+  async function handleIngestUrlAsSource() {
     if (!notebase.meta) return;
-    const raw = await showPrompt('URL to ingest:');
+    const raw = await showPrompt('URL to ingest as a source:');
     if (!raw) return;
     const url = raw.trim();
     if (!url) return;
     try {
       const result = await withBusy('Fetching…', () => api.sources.ingestUrl(url));
-      // Wait a beat so the file watcher's indexSource pass finishes before
-      // we try to open the source tab — otherwise the detail panel's graph
-      // query returns empty and the tab renders as "unknown source."
-      setTimeout(() => handleOpenSource(result.sourceId), 150);
-      if (result.duplicate) {
-        await showConfirm(
-          `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
-          CONFIRM_KEYS.ingestDuplicate,
-          'OK',
-        );
-      }
+      await handleIngestedSourceResult(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
@@ -2251,35 +2272,12 @@
     }
   }
 
-  async function handleIngestPdf() {
+  async function handleIngestFileAsSource() {
     if (!notebase.meta) return;
     try {
-      const result = await withBusy('Extracting PDF…', () => api.sources.ingestPdf());
+      const result = await withBusy('Ingesting…', () => api.sources.ingestFile());
       if (!result) return; // user cancelled the picker
-      if (result.duplicate) {
-        setTimeout(() => handleOpenSource(result.sourceId), 150);
-        await showConfirm(
-          `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
-          CONFIRM_KEYS.ingestDuplicate,
-          'OK',
-        );
-        return;
-      }
-      if (result.needsOcr) {
-        // Scanned PDF — meta.ttl + original.pdf are persisted but
-        // body.md is empty until the renderer OCRs (#95). Hold off on
-        // opening the source tab until OCR finishes / is skipped, so
-        // the user isn't staring at a blank body.
-        ocrSession = {
-          sourceId: result.sourceId,
-          title: result.title,
-          pageCount: result.pageCount,
-        };
-        const bytes = await api.sources.readPdf(result.sourceId);
-        ocrPdfBytes = bytes;
-        return;
-      }
-      setTimeout(() => handleOpenSource(result.sourceId), 150);
+      await handleIngestedSourceResult(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
@@ -2968,9 +2966,9 @@
     api.menu.onBibliography(() => { void handleBibliography(); });
 
     // Ingest URL (#93)
-    api.menu.onIngestUrl(() => handleIngestUrl());
+    api.menu.onIngestUrl(() => handleIngestUrlAsSource());
     api.menu.onIngestIdentifier(() => handleIngestIdentifier());
-    api.menu.onIngestPdf(() => handleIngestPdf());
+    api.menu.onIngestFile(() => handleIngestFileAsSource());
     api.menu.onImportBibtex(() => handleImportBibtex());
     api.menu.onImportZoteroRdf(() => handleImportZoteroRdf());
     api.menu.onExport((id) => { exportDialogFor = id; });

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -721,10 +721,10 @@
   }
 
   function handleSourceDeleted(sourceId: string) {
-    // Close any open tab for this source so the user isn't staring at
-    // a ghost viewer after delete.
-    const idx = editor.tabs.findIndex((t) => t.type === 'source' && t.sourceId === sourceId);
-    if (idx !== -1) editor.closeTab(idx);
+    // Close every tab bound to this source — the detail view AND any PDF
+    // viewer — so the user isn't left staring at a ghost viewer that then
+    // fails to load the deleted original.pdf.
+    editor.closeTabsForSource(sourceId);
   }
 
   function handleOpenSource(sourceId: string, highlightExcerptId?: string) {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -583,7 +583,7 @@ export interface MenuApi {
   onBibliography(cb: () => void): void;
   onIngestUrl(cb: () => void): void;
   onIngestIdentifier(cb: () => void): void;
-  onIngestPdf(cb: () => void): void;
+  onIngestFile(cb: () => void): void;
   onExport(cb: (exporterId: string) => void): void;
   onImportBibtex(cb: () => void): void;
   onImportZoteroRdf(cb: () => void): void;
@@ -674,6 +674,13 @@ export interface SourcesApi {
     relativePath: string;
     duplicate: boolean;
     title: string;
+    /** 'web' for an HTML page; 'pdf' when the URL served a PDF (routed to the
+     *  PDF pipeline). */
+    kind?: 'web' | 'pdf' | 'text';
+    /** Page count when kind === 'pdf'. */
+    pageCount?: number;
+    /** True when a PDF URL had no text layer and needs OCR. */
+    needsOcr?: boolean;
   }>;
   /** Ingest a DOI / arXiv id / PubMed id via the matching bibliographic API. */
   ingestIdentifier(identifier: string): Promise<{
@@ -685,15 +692,18 @@ export interface SourcesApi {
     pdfSaved: boolean;
     pdfError: string | null;
   }>;
-  /** Open an OS file picker and ingest the selected PDF (#94). Returns null if cancelled. */
-  ingestPdf(): Promise<{
+  /** Open an OS file picker and ingest the selected file as a source — PDF, HTML,
+   *  or text/Markdown. Returns null if cancelled. */
+  ingestFile(): Promise<{
     sourceId: string;
     relativePath: string;
     duplicate: boolean;
     title: string;
-    pageCount: number;
-    /** True if the PDF has no text layer; caller should run OCR via readPdf + finishPdfOcr. */
-    needsOcr: boolean;
+    kind?: 'web' | 'pdf' | 'text';
+    /** Page count when kind === 'pdf'. */
+    pageCount?: number;
+    /** True if a PDF has no text layer; caller should run OCR via readPdf + finishPdfOcr. */
+    needsOcr?: boolean;
   } | null>;
   /** Read raw bytes of a persisted source's original.pdf (#95). */
   readPdf(sourceId: string): Promise<Uint8Array>;

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -500,6 +500,30 @@ export function getEditorStore() {
     return closed;
   }
 
+  /** Close every tab bound to a source — both its detail view and its PDF
+   *  viewer — e.g. when the source is deleted, so neither is left pointing at
+   *  files that no longer exist. */
+  function closeTabsForSource(sourceId: string): number {
+    let closed = 0;
+    for (let i = tabs.length - 1; i >= 0; i--) {
+      const t = tabs[i];
+      if ((isSource(t) || isPdf(t)) && t.sourceId === sourceId) {
+        tabs.splice(i, 1);
+        if (i === activeIndex) {
+          activeIndex = -1;
+        } else if (i < activeIndex) {
+          activeIndex--;
+        }
+        closed++;
+      }
+    }
+    if (activeIndex < 0 && tabs.length > 0) {
+      activeIndex = Math.min(tabs.length - 1, Math.max(0, activeIndex));
+    }
+    if (closed > 0) schedulePersistTabs();
+    return closed;
+  }
+
   function switchTab(index: number) {
     if (index >= 0 && index < tabs.length) {
       flushAutoSave();
@@ -536,6 +560,7 @@ export function getEditorStore() {
     save,
     isPathDirty,
     closeTabsForDeletedPath,
+    closeTabsForSource,
     applyRenameTransitions,
     reloadTabFromDisk,
     setContent,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -210,8 +210,9 @@ export const Channels = {
   SOURCES_INGEST_URL: 'sources:ingestUrl',
   /** Ingest a DOI / arXiv id / PubMed id (#96). Hits CrossRef / arXiv / PubMed. */
   SOURCES_INGEST_IDENTIFIER: 'sources:ingestIdentifier',
-  /** Ingest a local PDF (#94). Main opens a file picker and extracts text via unpdf. */
-  SOURCES_INGEST_PDF: 'sources:ingestPdf',
+  /** Ingest a local file as a source. Main opens a file picker; dispatches by
+   *  type — PDF (text+OCR), HTML (Readability), text/Markdown (verbatim body). */
+  SOURCES_INGEST_FILE: 'sources:ingestFile',
   /** Read raw PDF bytes of a persisted source, used by the OCR worker (#95). */
   SOURCES_READ_PDF: 'sources:readPdf',
   /** Cheap check used by the source detail UI to decide whether to
@@ -240,8 +241,8 @@ export const Channels = {
   MENU_INGEST_URL: 'menu:ingestUrl',
   /** Menu → "Ingest identifier…" — prompts the renderer for a DOI/arXiv/PMID. */
   MENU_INGEST_IDENTIFIER: 'menu:ingestIdentifier',
-  /** Menu → "Ingest PDF…" — opens a file picker in main and extracts the text layer. */
-  MENU_INGEST_PDF: 'menu:ingestPdf',
+  /** Menu → "Ingest File as Source…" — opens a file picker in main and ingests it. */
+  MENU_INGEST_FILE: 'menu:ingestFile',
   /** Menu → "Import BibTeX…" — opens a .bib picker and imports each entry as a Source. */
   MENU_IMPORT_BIBTEX: 'menu:importBibtex',
   /** Menu → "Import Zotero RDF…" — opens a .rdf picker; lifts attached PDFs when present. */

--- a/src/shared/ontology-thought.ttl
+++ b/src/shared/ontology-thought.ttl
@@ -179,6 +179,11 @@ thought:PDFSource a owl:Class ;
     rdfs:label "PDF Source" ;
     rdfs:comment "Catch-all for a source distributed as a PDF that does not fit another subtype. Most scholarly PDFs should be classified as thought:Article / thought:Preprint / thought:Book instead; this class exists for the long tail." .
 
+thought:Document a owl:Class ;
+    rdfs:subClassOf thought:Source ;
+    rdfs:label "Document" ;
+    rdfs:comment "A plain-text or Markdown document ingested as a source (#: ingest file as source). Its body is the file content verbatim, with no extraction step." .
+
 # ── Source Metadata ───────────────────────────────────────────────────────
 # Predicates expected on Source instances. We reuse standard vocabularies
 # (Dublin Core Terms, BIBO, schema.org/ScholarlyArticle) directly rather

--- a/tests/main/sources/ingest-file.test.ts
+++ b/tests/main/sources/ingest-file.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `ingestFile` — dispatch a local file to the right Source pipeline by type:
+ * PDF → PDF pipeline, HTML → Readability, text/Markdown → verbatim Document.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { ingestFile } from '../../../src/main/sources/ingest-file';
+
+const FIXTURE_PDF = path.resolve(
+  __dirname, '..', '..', 'fixtures', 'sample-project', '.minerva', 'sources', 'arxiv-2604.18522', 'original.pdf',
+);
+
+const SAMPLE_HTML = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Saved Article</title></head>
+<body><article><h1>Saved Article</h1>
+<p>This is the lede paragraph, long enough for Readability to score it as real content with enough words and punctuation to clear the bar.</p>
+<p>A second paragraph adds weight so the article passes the extraction threshold, which is stricter on sparse pages.</p>
+<p>A third paragraph for good measure, since Readability is fussy.</p></article></body></html>`;
+
+describe('ingestFile dispatch', () => {
+  let root: string;
+  let scratch: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-ingest-file-'));
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-ingest-file-src-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  async function write(name: string, content: string): Promise<string> {
+    const p = path.join(scratch, name);
+    await fsp.writeFile(p, content, 'utf-8');
+    return p;
+  }
+
+  it('routes a .pdf file to the PDF pipeline', async () => {
+    const result = await ingestFile(root, FIXTURE_PDF);
+    expect(result.kind).toBe('pdf');
+    expect(result.pageCount).toBeGreaterThan(0);
+    const dir = path.join(root, '.minerva', 'sources', result.sourceId);
+    expect(fs.existsSync(path.join(dir, 'original.pdf'))).toBe(true);
+  });
+
+  it('routes a .html file through Readability into a web Source', async () => {
+    const result = await ingestFile(root, await write('article.html', SAMPLE_HTML));
+    expect(result.kind).toBe('web');
+    expect(result.title).toBe('Saved Article');
+    const dir = path.join(root, '.minerva', 'sources', result.sourceId);
+    const meta = await fsp.readFile(path.join(dir, 'meta.ttl'), 'utf-8');
+    expect(meta).toContain('thought:WebPage');
+    // Local file → no bibo:uri.
+    expect(meta).not.toContain('bibo:uri');
+    const body = await fsp.readFile(path.join(dir, 'body.md'), 'utf-8');
+    expect(body).toMatch(/lede paragraph/);
+  });
+
+  it('ingests a Markdown file as a Document, title from the first heading', async () => {
+    const md = '# My Notes\n\nSome body text here.\n';
+    const result = await ingestFile(root, await write('notes.md', md));
+    expect(result.kind).toBe('text');
+    expect(result.title).toBe('My Notes');
+    const dir = path.join(root, '.minerva', 'sources', result.sourceId);
+    const meta = await fsp.readFile(path.join(dir, 'meta.ttl'), 'utf-8');
+    expect(meta).toContain('thought:Document');
+    expect(meta).toContain('dc:title "My Notes"');
+    const body = await fsp.readFile(path.join(dir, 'body.md'), 'utf-8');
+    expect(body).toBe(md); // verbatim
+  });
+
+  it('ingests a .txt file as a Document, title from the filename', async () => {
+    const result = await ingestFile(root, await write('plain-notes.txt', 'just some text, no heading'));
+    expect(result.kind).toBe('text');
+    expect(result.title).toBe('plain-notes');
+  });
+
+  it('dedupes identical text content to one Source', async () => {
+    const a = await ingestFile(root, await write('a.md', '# Same\n\nidentical body'));
+    const b = await ingestFile(root, await write('b.md', '# Same\n\nidentical body'));
+    expect(b.sourceId).toBe(a.sourceId);
+    expect(b.duplicate).toBe(true);
+  });
+
+  it('rejects an unsupported file type with a clear message', async () => {
+    await expect(ingestFile(root, await write('report.docx', 'binary-ish')))
+      .rejects.toThrow(/can't ingest .*docx.*PDF, HTML, text, and Markdown/i);
+  });
+});

--- a/tests/main/sources/ingest.test.ts
+++ b/tests/main/sources/ingest.test.ts
@@ -298,10 +298,12 @@ describe('ingestUrl (#93)', () => {
     ).rejects.toThrow(/404/);
   });
 
-  it('rejects non-HTML content types', async () => {
+  it('rejects content types that are neither HTML nor PDF', async () => {
+    // PDFs are now routed to the PDF pipeline (see the PDF-URL describe block);
+    // other binary types (e.g. images) are still rejected up front.
     await expect(
-      ingestUrl(root, 'https://example.com/doc.pdf', {
-        fetchImpl: mockFetch('%PDF-1.4...', { contentType: 'application/pdf' }),
+      ingestUrl(root, 'https://example.com/photo.png', {
+        fetchImpl: mockFetch('\x89PNG...', { contentType: 'image/png' }),
       }),
     ).rejects.toThrow(/unsupported content-type/i);
   });
@@ -369,5 +371,50 @@ describe('ingestUrl (#93)', () => {
       'utf-8',
     );
     expect(meta).toContain('thought:WebPage');
+  });
+
+  it('tags an HTML result with kind "web"', async () => {
+    const result = await ingestUrl(root, 'https://example.com/foo', {
+      fetchImpl: mockFetch(samplePageHtml()),
+    });
+    expect(result.kind).toBe('web');
+  });
+});
+
+// A URL can resolve to a PDF (e.g. an arXiv /pdf/ link). "Ingest URL as Source"
+// must route those through the PDF pipeline rather than rejecting them.
+describe('ingestUrl — PDF URLs (#: ingest url as source)', () => {
+  let root: string;
+  const FIXTURE_PDF = path.resolve(
+    __dirname, '..', '..', 'fixtures', 'sample-project', '.minerva', 'sources', 'arxiv-2604.18522', 'original.pdf',
+  );
+
+  beforeEach(() => { root = mkTempProject(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  function mockPdfFetch(bytes: Buffer, contentType: string): typeof fetch {
+    return async () => new Response(bytes, { status: 200, headers: { 'content-type': contentType } });
+  }
+
+  it('routes an application/pdf response to the PDF pipeline', async () => {
+    const bytes = fs.readFileSync(FIXTURE_PDF);
+    const result = await ingestUrl(root, 'https://example.com/paper', {
+      fetchImpl: mockPdfFetch(bytes, 'application/pdf'),
+    });
+    expect(result.kind).toBe('pdf');
+    expect(result.pageCount).toBeGreaterThan(0);
+    const dir = path.join(root, '.minerva', 'sources', result.sourceId);
+    expect(fs.existsSync(path.join(dir, 'original.pdf'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'body.md'))).toBe(true);
+    const meta = await fsp.readFile(path.join(dir, 'meta.ttl'), 'utf-8');
+    expect(meta).toContain('thought:PDFSource');
+  });
+
+  it('treats a .pdf URL served as octet-stream as a PDF', async () => {
+    const bytes = fs.readFileSync(FIXTURE_PDF);
+    const result = await ingestUrl(root, 'https://example.com/files/paper.pdf', {
+      fetchImpl: mockPdfFetch(bytes, 'application/octet-stream'),
+    });
+    expect(result.kind).toBe('pdf');
   });
 });


### PR DESCRIPTION
## What

Renames the import commands for their *outcome* (both make a **Source**) and broadens them so the names are honest:

| Before | After | New behavior |
|---|---|---|
| Ingest URL… | **Ingest URL as Source…** | Also handles a URL that serves a **PDF** (e.g. an arXiv `/pdf/…` link) — downloads it and runs the PDF pipeline instead of erroring. |
| Ingest PDF… | **Ingest File as Source…** | Accepts **PDF, HTML, and text/Markdown** files, not just PDF. |
| Ingest Identifier… | *(unchanged)* | |

Confirmed scope: PDF (existing text+OCR pipeline), HTML (same Readability/structured extraction as URL ingest → a web Source), text/Markdown (a `thought:Document` whose `body.md` is the file verbatim). Other binary types (docx, epub, …) are rejected with a clear message.

## How

- **`ingestPdfBuffer`** factored out of `ingestPdf` — a buffer core shared by the file picker and the URL-PDF download. Dedupe stays content-hash based, so the same paper ingested by file *or* URL collapses to one Source.
- **`ingestHtmlString`** factored out of `ingestUrl` — shared by URL ingest (with a `url` → structured metadata + `bibo:uri`) and local-HTML ingest (no `url` → content-hash id, no `bibo:uri`).
- **`ingestUrl`** now content-type-sniffs: `application/pdf` (or a `.pdf` URL served as `octet-stream`) → PDF pipeline; HTML/XML → web pipeline; other types still rejected.
- **`IngestResult`** gains optional `kind` (`'web' | 'pdf' | 'text'`) + `pageCount`/`needsOcr`. This keeps the shape backward-compatible, so `ingestSmart` and the `propose_sources` conversation path transparently gain PDF-URL handling, and the renderer routes a scanned PDF (from a file *or* a URL) into the **same existing OCR flow**.
- **`ingestFile`** (new module) dispatches by extension; the OS picker's filters broaden to `pdf, html, htm, md, markdown, txt, text` + All Files.
- New **`thought:Document`** source subclass for text/Markdown.
- Renames: channels `SOURCES_INGEST_PDF`→`FILE`, `MENU_INGEST_PDF`→`FILE`; `api.sources.ingestPdf`→`ingestFile`; menu + command-palette labels.
- Drag-drop `dropImport` left as-is (already routes PDFs) — out of scope.

## Tests

- `ingest-file`: dispatch for `.pdf` / `.html` / `.md` / `.txt`, content dedupe, and unsupported `.docx` throwing the clear message; local HTML produces a `thought:WebPage` with no `bibo:uri`; Markdown title from the first `# heading`, body verbatim.
- `ingest`: a `application/pdf` response and a `.pdf`-as-octet-stream URL both route to the PDF pipeline (`kind:'pdf'`, pageCount, `thought:PDFSource`); HTML tagged `kind:'web'`. Updated the old "rejects PDF content-type" test (PDFs are now accepted) to assert a still-rejected type (image/png).

Full suite green (2733); lint clean.

## Try it
1. Research ▸ **Ingest URL as Source…** on an HTML article (web Source) and on a direct PDF link (PDF Source, text extracted; scanned PDF → OCR prompt).
2. Research ▸ **Ingest File as Source…** → picker shows PDF/HTML/MD/TXT; ingest one of each; pick a `.docx` → clear "not supported" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)