### PR TITLE
Upgrade Electron 35 → 42 + sandbox the main window (#659, #684)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/turndown": "^5.0.6",
     "@vitest/coverage-v8": "^2.1.9",
     "codemirror": "^6.0.1",
-    "electron": "^35.7.5",
+    "electron": "^42.4.0",
     "eslint": "^10.2.1",
     "eslint-plugin-svelte": "^3.17.1",
     "globals": "^17.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.2
       electron:
-        specifier: ^35.7.5
-        version: 35.7.5
+        specifier: ^42.4.0
+        version: 42.4.0
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -1397,18 +1397,22 @@ packages:
     resolution: {integrity: sha512-tiB6cglVQFcSw9N8GRwVwZUeB9u0DOx2Mj7aFXBUsFLUYQapvVGv51tUSy/UAW5lvmubGscYIILuVko+II3+NA==}
     engines: {node: '>= 14.17.5'}
 
+  '@electron-internal/extract-zip@1.0.2':
+    resolution: {integrity: sha512-VJuNETNPEhrmQEZezeTZO5TZMV+dobBRyJ7zHjGJWIhMS7m7W1UeClt69u4hkUxv9ZZVxuli/E9Yvc4gDNHGsg==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
-
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
+
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
     resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
@@ -2525,6 +2529,9 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -3515,9 +3522,9 @@ packages:
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
-  electron@35.7.5:
-    resolution: {integrity: sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==}
-    engines: {node: '>= 12.20.55'}
+  electron@42.4.0:
+    resolution: {integrity: sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emoji-regex@8.0.0:
@@ -3557,6 +3564,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -9381,13 +9392,15 @@ snapshots:
     dependencies:
       chrome-trace-event: 1.0.4
 
+  '@electron-internal/extract-zip@1.0.2': {}
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
       glob: 7.2.3
       minimatch: 3.1.5
 
-  '@electron/get@2.0.3':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -9401,17 +9414,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0':
+  '@electron/get@5.0.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.7.4
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.25.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10494,7 +10506,7 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/n3@1.26.1':
     dependencies:
@@ -10508,6 +10520,10 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/node@25.5.0':
     dependencies:
@@ -11648,11 +11664,11 @@ snapshots:
 
   electron-to-chromium@1.5.328: {}
 
-  electron@35.7.5:
+  electron@42.4.0:
     dependencies:
-      '@electron/get': 2.0.3
-      '@types/node': 22.19.15
-      extract-zip: 2.0.1
+      '@electron-internal/extract-zip': 1.0.2
+      '@electron/get': 5.0.0
+      '@types/node': 24.13.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11686,6 +11702,8 @@ snapshots:
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   err-code@2.0.3: {}
 

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -69,6 +69,10 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      // The preload imports only `electron` + the pure `shared/channels`
+      // module (no Node builtins), so the renderer never needs Node — run it
+      // sandboxed, matching the privileged-site and PDF-render windows (#684).
+      sandbox: true,
     },
   });
 


### PR DESCRIPTION
## What

- Bump **Electron `^35.7.5` → `^42.4.0`** (resolved 42.4.0).
- Enable **`sandbox: true`** on the main window in `window-manager.ts`.

Closes #659. Closes #684.

## Why

Electron 35 is **past its security-support window** — Electron only backports Chromium CVEs to the latest three stable majors (~40–42). For an app that renders fetched/remote content (in-app PDF viewer, privileged-site windows for web ingestion, Readability/turndown/linkedom over fetched HTML), running an unpatched Chromium was the one dependency finding with genuine security weight (modernization review M-C1).

The main window was the only `BrowserWindow` not already sandboxed; the privileged-site and PDF-render windows set `sandbox: true` already. The preload imports only `electron` + the pure `shared/channels` module (**no Node builtins**), so the renderer never needs Node — folding the sandbox hardening (M-C1 Phase 1.5 / #684) in here while touching the Electron surface.

## No source changes needed

The Electron APIs in use — `printToPDF`, `session.fromPartition`, `session.clearStorageData`, `webRequest.onHeadersReceived`, `contextBridge`, `webUtils`, navigation guards — are all stable through Electron 42. No deprecated/removed-API usage surfaced.

## Verification

- `pnpm lint` — **0 errors** (tsc + svelte-check + eslint).
- `pnpm test` — **2733 passed** (263 files), including the off-screen `printToPDF` PDF-export tests.
- `pnpm test:e2e` — packaged app **builds with native deps** (DuckDB / fs-xattr / macos-alias prepared cleanly) and the **Playwright Electron smoke boots clean under sandbox** (app launches, renderer mounts, no thrown errors).

## Notes / follow-ups (separate issues)

- Remaining toolchain majors (Vite 6→8, Vitest 2→4, TS 5→6) are deferred to #678/#679/#680.
- Consumer-coupled native/major bumps (`@duckdb/node-api` patch, etc.) tracked in #692.
- This bumps the **bundled Node** that ships with Electron; the dev/CI build-Node pin is a separate hygiene item (#682).

🤖 Generated with [Claude Code](https://claude.com/claude-code)