### PR TITLE
Lock layer boundaries: move fence parsing to shared + eslint rules (#668)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -175,4 +175,45 @@ export default tseslint.config(
       // selectively as the project standardizes on rules we want.
     },
   },
+  // ── Layer-boundary enforcement (#668) ──────────────────────────────────
+  // The four-layer topology (pure `shared`, `main`, `preload`, `renderer`)
+  // was previously maintained by convention alone — and one main→renderer
+  // import had already slipped through. These rules freeze it. The
+  // type-aware `no-restricted-imports` also catches `import type` crossings,
+  // which the base rule misses. In-repo cross-layer imports are always
+  // relative (`../main/…`, `../../renderer/…`); external packages are bare
+  // specifiers, so the path globs don't catch them.
+  {
+    files: ['src/shared/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['**/main/**', '**/renderer/**', '**/preload/**', 'node:*'],
+          message: 'src/shared must stay pure — no imports from main, renderer, preload, or Node builtins (#668).',
+        }],
+      }],
+    },
+  },
+  {
+    files: ['src/main/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['**/renderer/**'],
+          message: 'main must not import renderer code — move shared logic to src/shared (#668).',
+        }],
+      }],
+    },
+  },
+  {
+    files: ['src/renderer/**/*.ts', 'src/renderer/**/*.svelte'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['**/main/**'],
+          message: 'renderer must not import main-process code — go through the IPC bridge (#668).',
+        }],
+      }],
+    },
+  },
 );

--- a/src/main/compute/save-cell-output.ts
+++ b/src/main/compute/save-cell-output.ts
@@ -15,7 +15,7 @@ import {
   findRunnableFences,
   codeOf,
   type FenceRange,
-} from '../../renderer/lib/editor/output-block';
+} from '../../shared/compute/fences';
 import {
   ensureCellId,
   rewriteFenceInfo,

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -28,7 +28,8 @@
   import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
   import { getToolInfosByCategory } from '../tools/tool-registry';
   import mdFootnote from 'markdown-it-footnote';
-  import { findRunnableFences, planOutputEdit, codeOf } from '../editor/output-block';
+  import { planOutputEdit } from '../editor/output-block';
+  import { findRunnableFences, codeOf } from '../../../shared/compute/fences';
   import type { CellResult } from '../ipc/client';
 
   interface Props {

--- a/src/renderer/lib/editor/compute-cells.ts
+++ b/src/renderer/lib/editor/compute-cells.ts
@@ -17,12 +17,12 @@
 import { EditorView, keymap, gutter, GutterMarker } from '@codemirror/view';
 import { StateEffect, StateField, Prec } from '@codemirror/state';
 import type { Extension } from '@codemirror/state';
+import { planOutputEdit } from './output-block';
 import {
   findRunnableFences,
-  planOutputEdit,
   codeOf,
   type FenceRange,
-} from './output-block';
+} from '../../../shared/compute/fences';
 import type { CellResult } from '../ipc/client';
 
 // ── Running state ──────────────────────────────────────────────────────────

--- a/src/renderer/lib/editor/output-block.ts
+++ b/src/renderer/lib/editor/output-block.ts
@@ -17,20 +17,18 @@
  * yet) or replaces the existing one in place. These helpers operate on
  * raw strings so they're trivial to unit-test without spinning up a
  * CodeMirror view.
+ *
+ * The language-agnostic fence *scanning* primitives (`findRunnableFences`,
+ * `codeOf`, `FenceRange`) live in `shared/compute/fences` so the main process
+ * can reuse them without importing renderer code (#668); the editing helpers
+ * below are renderer-only.
  */
+
+import type { FenceRange } from '../../../shared/compute/fences';
 
 export type CellResultLike =
   | { ok: true; output: unknown }
   | { ok: false; error: string };
-
-export interface FenceRange {
-  /** Byte offset where the opening triple-backtick line begins. */
-  startOffset: number;
-  /** Byte offset of the character just after the closing triple-backtick newline. */
-  endOffset: number;
-  /** Fence language (case as written in the doc). */
-  language: string;
-}
 
 export interface OutputEdit {
   /** Absolute range in the doc to replace. */
@@ -132,77 +130,4 @@ export function resultToJson(result: CellResultLike): string {
     return JSON.stringify(result.output);
   }
   return JSON.stringify({ type: 'error', message: result.error });
-}
-
-/**
- * Walk the doc for executable fences whose language is in `allowed`.
- * Line positions are 1-based (matches CodeMirror's line numbering) to
- * keep the consumer boring. Pure so the CM-less tests can exercise it.
- */
-export function findRunnableFences(
-  doc: string,
-  allowed: ReadonlySet<string>,
-): Array<FenceRange & { openingLine: number; closingLine: number }> {
-  const out: Array<FenceRange & { openingLine: number; closingLine: number }> = [];
-  const lines = doc.split('\n');
-  // Running byte offsets per line start.
-  const lineOffsets: number[] = [0];
-  for (let i = 0; i < lines.length; i++) {
-    lineOffsets.push(lineOffsets[i] + lines[i].length + 1);
-  }
-
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
-    // Accept optional post-language info (e.g. `sparql {id=abc}`), but
-    // require *some* language tag — an unlabeled ``` is a plain code
-    // block the compute shell leaves alone.
-    const open = line.match(/^```(\w+)(\s.*)?$/);
-    if (!open) { i++; continue; }
-    const language = open[1];
-    // Find the closing fence.
-    let close = -1;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (lines[j] === '```') { close = j; break; }
-    }
-    if (close < 0) break; // unclosed fence; stop scanning
-    if (allowed.has(language.toLowerCase())) {
-      const startOffset = lineOffsets[i];
-      // endOffset: position just after the closing ```. When the closing
-      // line is followed by more content (`close < lines.length - 1`),
-      // a `\n` sits between the closing ``` and the next line, so we
-      // skip past it. When the fence is the last thing in the doc —
-      // no trailing newline — endOffset stops at doc.length. Without
-      // this the offset ran one past the end, which made subsequent
-      // `view.dispatch({ changes: { from: endOffset } })` calls silently
-      // no-op in CodeMirror, breaking output-block writes for any note
-      // that ended with an executable fence.
-      const hasTrailingNewline = close < lines.length - 1;
-      const endOffset = lineOffsets[close] + lines[close].length + (hasTrailingNewline ? 1 : 0);
-      out.push({
-        startOffset,
-        endOffset,
-        language,
-        openingLine: i + 1,
-        closingLine: close + 1,
-      });
-    }
-    i = close + 1;
-  }
-  return out;
-}
-
-/**
- * Extract the inner code of a fence range from the doc (everything
- * between the opening and closing fence lines, with no trailing newline).
- */
-export function codeOf(doc: string, fence: FenceRange): string {
-  const body = doc.slice(fence.startOffset, fence.endOffset);
-  const nl = body.indexOf('\n');
-  if (nl < 0) return '';
-  // Drop the opening ```lang line.
-  const withoutOpen = body.slice(nl + 1);
-  // Drop the closing ``` (with or without trailing newline).
-  const withoutClose = withoutOpen.replace(/```(\n|$)[\s\S]*$/, '');
-  return withoutClose.replace(/\n$/, '');
 }

--- a/src/shared/compute/fences.ts
+++ b/src/shared/compute/fences.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure fence-parsing primitives shared by the renderer (CodeMirror compute
+ * cells) and the main process (`save-cell-output` derived-note writer).
+ *
+ * These used to live in `renderer/lib/editor/output-block.ts`, but the main
+ * process needs `findRunnableFences` / `codeOf` / `FenceRange` to locate and
+ * read executable fences when saving a cell's output as a note (#244). Main
+ * must not import renderer code, so the language-agnostic fence scanning lives
+ * here in `shared/` while the renderer-only output-block *editing* helpers
+ * (`planOutputEdit`, `findAdjacentOutputBlock`, …) stay in the editor module.
+ *
+ * Operating on raw strings keeps them trivially unit-testable without a
+ * CodeMirror view.
+ */
+
+export interface FenceRange {
+  /** Byte offset where the opening triple-backtick line begins. */
+  startOffset: number;
+  /** Byte offset of the character just after the closing triple-backtick newline. */
+  endOffset: number;
+  /** Fence language (case as written in the doc). */
+  language: string;
+}
+
+/**
+ * Walk the doc for executable fences whose language is in `allowed`.
+ * Line positions are 1-based (matches CodeMirror's line numbering) to
+ * keep the consumer boring. Pure so the CM-less tests can exercise it.
+ */
+export function findRunnableFences(
+  doc: string,
+  allowed: ReadonlySet<string>,
+): Array<FenceRange & { openingLine: number; closingLine: number }> {
+  const out: Array<FenceRange & { openingLine: number; closingLine: number }> = [];
+  const lines = doc.split('\n');
+  // Running byte offsets per line start.
+  const lineOffsets: number[] = [0];
+  for (let i = 0; i < lines.length; i++) {
+    lineOffsets.push(lineOffsets[i] + lines[i].length + 1);
+  }
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    // Accept optional post-language info (e.g. `sparql {id=abc}`), but
+    // require *some* language tag — an unlabeled ``` is a plain code
+    // block the compute shell leaves alone.
+    const open = line.match(/^```(\w+)(\s.*)?$/);
+    if (!open) { i++; continue; }
+    const language = open[1];
+    // Find the closing fence.
+    let close = -1;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j] === '```') { close = j; break; }
+    }
+    if (close < 0) break; // unclosed fence; stop scanning
+    if (allowed.has(language.toLowerCase())) {
+      const startOffset = lineOffsets[i];
+      // endOffset: position just after the closing ```. When the closing
+      // line is followed by more content (`close < lines.length - 1`),
+      // a `\n` sits between the closing ``` and the next line, so we
+      // skip past it. When the fence is the last thing in the doc —
+      // no trailing newline — endOffset stops at doc.length. Without
+      // this the offset ran one past the end, which made subsequent
+      // `view.dispatch({ changes: { from: endOffset } })` calls silently
+      // no-op in CodeMirror, breaking output-block writes for any note
+      // that ended with an executable fence.
+      const hasTrailingNewline = close < lines.length - 1;
+      const endOffset = lineOffsets[close] + lines[close].length + (hasTrailingNewline ? 1 : 0);
+      out.push({
+        startOffset,
+        endOffset,
+        language,
+        openingLine: i + 1,
+        closingLine: close + 1,
+      });
+    }
+    i = close + 1;
+  }
+  return out;
+}
+
+/**
+ * Extract the inner code of a fence range from the doc (everything
+ * between the opening and closing fence lines, with no trailing newline).
+ */
+export function codeOf(doc: string, fence: FenceRange): string {
+  const body = doc.slice(fence.startOffset, fence.endOffset);
+  const nl = body.indexOf('\n');
+  if (nl < 0) return '';
+  // Drop the opening ```lang line.
+  const withoutOpen = body.slice(nl + 1);
+  // Drop the closing ``` (with or without trailing newline).
+  const withoutClose = withoutOpen.replace(/```(\n|$)[\s\S]*$/, '');
+  return withoutClose.replace(/\n$/, '');
+}

--- a/tests/renderer/editor/output-block.test.ts
+++ b/tests/renderer/editor/output-block.test.ts
@@ -2,71 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   planOutputEdit,
   findAdjacentOutputBlock,
-  findRunnableFences,
-  codeOf,
   resultToJson,
 } from '../../../src/renderer/lib/editor/output-block';
+// findRunnableFences moved to shared (#668); imported here only to locate
+// fences for the output-block editing tests below.
+import { findRunnableFences } from '../../../src/shared/compute/fences';
 
 const ALLOWED = new Set(['sparql', 'sql', 'python']);
-
-describe('findRunnableFences (#238)', () => {
-  it('finds fences whose language is in the allow-list', () => {
-    const doc = [
-      '# Note',
-      '',
-      '```sparql',
-      'SELECT ?n WHERE { ?n a :Note }',
-      '```',
-      '',
-      'prose',
-      '',
-      '```js',
-      'console.log("ignored")',
-      '```',
-      '',
-      '```sql',
-      'SELECT 1',
-      '```',
-      '',
-    ].join('\n');
-    const fences = findRunnableFences(doc, ALLOWED);
-    expect(fences.map((f) => f.language)).toEqual(['sparql', 'sql']);
-    expect(fences[0].openingLine).toBe(3);
-    expect(fences[0].closingLine).toBe(5);
-  });
-
-  it('extracts the inner code via codeOf', () => {
-    const doc = '```sparql\nSELECT 1\nSELECT 2\n```\n';
-    const [fence] = findRunnableFences(doc, ALLOWED);
-    expect(codeOf(doc, fence)).toBe('SELECT 1\nSELECT 2');
-  });
-
-  it('skips unclosed fences rather than crashing', () => {
-    const doc = '```sparql\nSELECT 1\n\n(no close)\n';
-    expect(findRunnableFences(doc, ALLOWED)).toEqual([]);
-  });
-
-  it('is case-insensitive on the language tag', () => {
-    const fences = findRunnableFences('```SPARQL\nx\n```\n', ALLOWED);
-    expect(fences).toHaveLength(1);
-    expect(fences[0].language).toBe('SPARQL');
-  });
-
-  it('endOffset stops at doc.length when the fence is the last line (no trailing newline)', () => {
-    // Regression: running a fence that ended with no trailing \n set
-    // endOffset past the doc end, and view.dispatch silently no-op'd.
-    const doc = '# Title\n\n```sparql\nSELECT 1\n```';
-    const [fence] = findRunnableFences(doc, ALLOWED);
-    expect(fence.endOffset).toBe(doc.length);
-  });
-
-  it('endOffset includes the trailing newline when one is present', () => {
-    const doc = '```sparql\nSELECT 1\n```\n';
-    const [fence] = findRunnableFences(doc, ALLOWED);
-    expect(fence.endOffset).toBe(doc.length);
-    expect(doc[fence.endOffset - 1]).toBe('\n');
-  });
-});
 
 describe('findAdjacentOutputBlock', () => {
   it('finds an output fence on the very next line', () => {

--- a/tests/shared/compute/fences.test.ts
+++ b/tests/shared/compute/fences.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { findRunnableFences, codeOf } from '../../../src/shared/compute/fences';
+
+const ALLOWED = new Set(['sparql', 'sql', 'python']);
+
+describe('findRunnableFences (#238)', () => {
+  it('finds fences whose language is in the allow-list', () => {
+    const doc = [
+      '# Note',
+      '',
+      '```sparql',
+      'SELECT ?n WHERE { ?n a :Note }',
+      '```',
+      '',
+      'prose',
+      '',
+      '```js',
+      'console.log("ignored")',
+      '```',
+      '',
+      '```sql',
+      'SELECT 1',
+      '```',
+      '',
+    ].join('\n');
+    const fences = findRunnableFences(doc, ALLOWED);
+    expect(fences.map((f) => f.language)).toEqual(['sparql', 'sql']);
+    expect(fences[0].openingLine).toBe(3);
+    expect(fences[0].closingLine).toBe(5);
+  });
+
+  it('extracts the inner code via codeOf', () => {
+    const doc = '```sparql\nSELECT 1\nSELECT 2\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(codeOf(doc, fence)).toBe('SELECT 1\nSELECT 2');
+  });
+
+  it('skips unclosed fences rather than crashing', () => {
+    const doc = '```sparql\nSELECT 1\n\n(no close)\n';
+    expect(findRunnableFences(doc, ALLOWED)).toEqual([]);
+  });
+
+  it('is case-insensitive on the language tag', () => {
+    const fences = findRunnableFences('```SPARQL\nx\n```\n', ALLOWED);
+    expect(fences).toHaveLength(1);
+    expect(fences[0].language).toBe('SPARQL');
+  });
+
+  it('endOffset stops at doc.length when the fence is the last line (no trailing newline)', () => {
+    // Regression: running a fence that ended with no trailing \n set
+    // endOffset past the doc end, and view.dispatch silently no-op'd.
+    const doc = '# Title\n\n```sparql\nSELECT 1\n```';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(fence.endOffset).toBe(doc.length);
+  });
+
+  it('endOffset includes the trailing newline when one is present', () => {
+    const doc = '```sparql\nSELECT 1\n```\n';
+    const [fence] = findRunnableFences(doc, ALLOWED);
+    expect(fence.endOffset).toBe(doc.length);
+    expect(doc[fence.endOffset - 1]).toBe('\n');
+  });
+});


### PR DESCRIPTION
## What

Closes #668.

1. **Fix the one existing layer violation.** `src/main/compute/save-cell-output.ts` imported `findRunnableFences` / `codeOf` / `FenceRange` from `src/renderer/lib/editor/output-block` — main depending on renderer.
2. **Add eslint boundary rules** so the topology can't erode again.

## How

### Move the shared primitives
The language-agnostic fence-*scanning* helpers (`findRunnableFences`, `codeOf`, `FenceRange`) move to a new **`src/shared/compute/fences.ts`**. The renderer-only output-block *editing* helpers (`planOutputEdit`, `findAdjacentOutputBlock`, `resultToJson`) stay in `output-block.ts`. Consumers updated:

- `main/compute/save-cell-output.ts` → imports from `shared/compute/fences` (no more renderer import)
- `renderer/lib/editor/compute-cells.ts`, `renderer/lib/components/Preview.svelte` → import the primitives from shared, editing helpers from `output-block`
- Tests for the moved primitives move to `tests/shared/compute/fences.test.ts` (matching the new home + the `src/shared` coverage floor); the renderer test keeps the output-block editing cases.

### Enforce the boundaries
Three type-aware `@typescript-eslint/no-restricted-imports` configs in `eslint.config.mjs`:

| Layer | May not import |
|-------|---------------|
| `src/shared/**` | main, renderer, preload, **node builtins** (`node:*`) |
| `src/main/**` | renderer |
| `src/renderer/**` (+ `.svelte`) | main |

The type-aware variant also catches `import type` crossings the base rule misses. In-repo cross-layer imports are always relative, so the path globs don't snag bare external-package specifiers.

## Verification

- `pnpm lint` — **0 errors** (confirmed clean *before* adding the move, so the rules only had the one C3 violation to catch; verified the rule actually fires via a probe import — main→renderer reported with the custom message).
- `pnpm test` — **2733 passed** (264 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)