### PR TITLE
Decompose App.svelte: command registry + dialog store (#670, increment 1)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -22,12 +22,9 @@
     extractTagsFromContent,
   } from '../shared/refactor/auto-tag';
   import { getEditorStore } from './lib/stores/editor.svelte';
-  import PromptDialog from './lib/components/PromptDialog.svelte';
-  import NewNoteDialog from './lib/components/NewNoteDialog.svelte';
-  import type { NoteExt, NewNoteResult } from './lib/components/new-note-dialog-types';
-  import SnippetPickerDialog from './lib/components/SnippetPickerDialog.svelte';
+  import DialogHost from './lib/components/DialogHost.svelte';
+  import { getDialogStore } from './lib/stores/dialogs.svelte';
   import { substituteTemplate } from '../shared/templates';
-  import type { TemplateInfo } from './lib/ipc/client';
   import PdfViewer from './lib/components/PdfViewer.svelte';
   import { getPreferredSourceView, setPreferredSourceView } from './lib/source-view-preference';
   import { buildExcerptNoteContent, buildExcerptAppendBlock } from '../shared/excerpt-note';
@@ -39,10 +36,8 @@
   import { RESOLVE_AUTO_THRESHOLD } from '../shared/resolve-stub';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
-  import { formatAccelerator } from './lib/command-palette/format-accelerator';
-  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
   import ExportDialog from './lib/components/ExportDialog.svelte';
-  import OpenTargetDialog from './lib/components/OpenTargetDialog.svelte';
   import GotoLineDialog from './lib/components/GotoLineDialog.svelte';
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
   import SaveQueryDialog from './lib/components/SaveQueryDialog.svelte';
@@ -68,7 +63,6 @@
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationsStore } from './lib/stores/conversations.svelte';
   import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
-  import { getConfirmSuppressionStore } from './lib/stores/confirm-suppression.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
@@ -243,84 +237,12 @@
   }
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
-  let promptDialog = $state<{ message: string; suggestions?: string[]; initial?: string; resolve: (value: string | null) => void } | null>(null);
-  let newNoteDialog = $state<{
-    initialExt: NoteExt;
-    resolve: (value: NewNoteResult | null) => void;
-  } | null>(null);
-  let snippetPicker = $state<{
-    templates: TemplateInfo[];
-    resolve: (value: TemplateInfo | null) => void;
-  } | null>(null);
-  let confirmDialog = $state<{ message: string; confirmLabel: string; key: string; hideDontAskAgain?: boolean; resolve: (value: boolean) => void } | null>(null);
+  // Generic modal dialogs (prompt / confirm / new-note / snippet / open-target)
+  // live in the dialog store (#670); destructure the imperative `show*` helpers
+  // so the many call sites read unchanged. <DialogHost> renders the state.
+  const dialogs = getDialogStore();
+  const { showPrompt, showConfirm, showNewNoteDialog, showSnippetPicker } = dialogs;
   let exportDialogFor = $state<string | null>(null);
-  /**
-   * Three-way prompt for opening / creating a thoughtbase when the
-   * current window already holds one. `null` means no dialog open.
-   */
-  let openTargetDialog = $state<{
-    message: string;
-    resolve: (choice: 'this' | 'new' | 'cancel') => void;
-  } | null>(null);
-  const confirmSuppression = getConfirmSuppressionStore();
-
-  function showPrompt(
-    message: string,
-    initialOrOptions?: string | { suggestions?: string[]; initial?: string },
-  ): Promise<string | null> {
-    // Two overloads to keep call sites readable. New callers pass
-    // (message, "current name") for Rename-style flows; existing
-    // callers can keep their {suggestions} object.
-    const opts = typeof initialOrOptions === 'string'
-      ? { initial: initialOrOptions }
-      : (initialOrOptions ?? {});
-    return new Promise((resolve) => {
-      promptDialog = { message, suggestions: opts.suggestions, initial: opts.initial, resolve };
-    });
-  }
-
-  function showNewNoteDialog(
-    initialExt: NoteExt = '.md',
-  ): Promise<NewNoteResult | null> {
-    return new Promise((resolve) => {
-      newNoteDialog = { initialExt, resolve };
-    });
-  }
-
-  function showConfirm(
-    message: string,
-    key: string,
-    confirmLabel = 'OK',
-    options: { hideDontAskAgain?: boolean } = {},
-  ): Promise<boolean> {
-    if (confirmSuppression.isSuppressed(key)) return Promise.resolve(true);
-    return new Promise((resolve) => {
-      confirmDialog = { message, confirmLabel, key, hideDontAskAgain: options.hideDontAskAgain, resolve };
-    });
-  }
-
-  function handlePromptConfirm(value: string) {
-    promptDialog?.resolve(value);
-    promptDialog = null;
-  }
-
-  function handlePromptCancel() {
-    promptDialog?.resolve(null);
-    promptDialog = null;
-  }
-
-  function handleConfirmOk(dontAskAgain: boolean) {
-    if (dontAskAgain && confirmDialog) {
-      confirmSuppression.suppress(confirmDialog.key);
-    }
-    confirmDialog?.resolve(true);
-    confirmDialog = null;
-  }
-
-  function handleConfirmCancel() {
-    confirmDialog?.resolve(false);
-    confirmDialog = null;
-  }
 
   /**
    * Surfaced when any LLM-backed action fails because the user hasn't
@@ -499,145 +421,59 @@
    *  menu still lives in `src/main/menu.ts` — moving menus to read
    *  from this registry is a separate follow-up.
    */
-  const commands = $derived<Command[]>(buildCommandRegistry());
-
-  function buildCommandRegistry(): Command[] {
-    const hasProject = !!notebase.meta;
-    const hasNote = !!editor.activeFilePath;
-    const hasActiveNoteTab = editor.activeTab?.type === 'note';
-    const list: Command[] = [
-      // ── File ──
-      { id: 'file.newNote', title: 'New Note', category: 'File',
-        keybinding: formatAccelerator('CmdOrCtrl+N'),
-        enabled: hasProject, run: () => handleNewNote() },
-      { id: 'file.save', title: 'Save', category: 'File',
-        keybinding: formatAccelerator('CmdOrCtrl+S'),
-        enabled: hasNote, run: () => handleSave() },
-      { id: 'file.openProject', title: 'Open Thoughtbase…', category: 'File',
-        keybinding: formatAccelerator('CmdOrCtrl+O'),
-        enabled: true, run: () => handleOpenThoughtbase() },
-      { id: 'file.newProject', title: 'New Thoughtbase…', category: 'File',
-        keybinding: null, enabled: true, run: () => handleNewThoughtbase() },
-      { id: 'file.closeProject', title: 'Close Thoughtbase', category: 'File',
-        keybinding: formatAccelerator('CmdOrCtrl+Shift+W'),
-        enabled: hasProject, run: () => { notebase.close(); editor.clear(); } },
-      { id: 'file.print', title: 'Print…', category: 'File',
-        keybinding: null, enabled: hasNote, run: () => window.print() },
-      { id: 'file.saveAsTemplate', title: 'Save as Template…', category: 'File',
-        keybinding: null, enabled: hasActiveNoteTab,
-        run: () => { void handleSaveAsTemplate(); } },
-      { id: 'edit.insertTemplate', title: 'Insert Template…', category: 'Edit',
-        keybinding: null, enabled: hasActiveNoteTab,
-        run: () => { void handleInsertTemplate(); } },
-      // ── Edit / search ──
-      { id: 'edit.find', title: 'Find', category: 'Edit',
-        keybinding: formatAccelerator('CmdOrCtrl+F'),
-        enabled: hasNote, run: () => editorComponent?.openFind() },
-      { id: 'edit.findReplace', title: 'Find and Replace', category: 'Edit',
-        keybinding: formatAccelerator('CmdOrCtrl+H'),
-        enabled: hasNote, run: () => editorComponent?.openFindReplace() },
-      { id: 'edit.findInNotes', title: 'Find in Notes…', category: 'Edit',
-        keybinding: formatAccelerator('CmdOrCtrl+Shift+F'),
-        enabled: hasProject, run: () => { findInNotesMode = 'find'; } },
-      { id: 'edit.replaceInNotes', title: 'Replace in Notes…', category: 'Edit',
-        keybinding: formatAccelerator('CmdOrCtrl+Shift+H'),
-        enabled: hasProject, run: () => { findInNotesMode = 'replace'; } },
-      { id: 'edit.gotoLine', title: 'Go to Line…', category: 'Edit',
-        keybinding: null, enabled: hasNote, run: () => { showGotoLine = true; } },
-      { id: 'edit.sortLines', title: 'Sort Lines', category: 'Edit',
-        keybinding: null, enabled: hasNote, run: () => editorComponent?.runSortLines() },
-      // ── View ──
-      { id: 'view.toggleSidebar', title: 'Toggle Left Sidebar', category: 'View',
-        keybinding: null, enabled: true, run: () => { sidebarVisible = !sidebarVisible; } },
-      { id: 'view.toggleRightSidebar', title: 'Toggle Right Sidebar', category: 'View',
-        keybinding: null, enabled: true, run: () => { rightSidebarVisible = !rightSidebarVisible; } },
-      { id: 'view.togglePreview', title: 'Toggle Preview Mode', category: 'View',
-        keybinding: null, enabled: hasNote, run: () => cycleViewMode() },
-      { id: 'view.toggleConversations', title: 'Toggle Conversations', category: 'View',
-        keybinding: null, enabled: true, run: () => conversationsStore.toggle() },
-      { id: 'view.cycleTheme', title: 'Cycle Theme', category: 'View',
-        keybinding: null, enabled: true, run: () => handleCycleTheme() },
-      { id: 'view.fontIncrease', title: 'Increase Font Size', category: 'View',
-        keybinding: null, enabled: true,
-        run: () => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; } },
-      { id: 'view.fontDecrease', title: 'Decrease Font Size', category: 'View',
-        keybinding: null, enabled: true,
-        run: () => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; } },
-      { id: 'view.fontReset', title: 'Reset Font Size', category: 'View',
-        keybinding: null, enabled: true,
-        run: () => { editorComponent?.resetFontSize(); editorFontSize = 14; } },
-      // ── Navigate ──
-      { id: 'nav.quickOpen', title: 'Go to…', category: 'Navigate',
-        keybinding: formatAccelerator('CmdOrCtrl+P'),
-        enabled: hasProject,
-        run: () => {
-          void refreshSourcesCache();
-          void refreshSavedQueriesCache();
-          showGotoNote = true;
-        } },
-      { id: 'nav.back', title: 'Navigate Back', category: 'Navigate',
-        keybinding: formatAccelerator('CmdOrCtrl+['),
-        enabled: nav.canGoBack, run: () => handleNavBack() },
-      { id: 'nav.forward', title: 'Navigate Forward', category: 'Navigate',
-        keybinding: formatAccelerator('CmdOrCtrl+]'),
-        enabled: nav.canGoForward, run: () => handleNavForward() },
-      // ── Refactor ──
-      { id: 'refactor.rename', title: 'Rename Note…', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); } },
-      { id: 'refactor.move', title: 'Move Note…', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); } },
-      { id: 'refactor.copy', title: 'Copy Note…', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); } },
-      { id: 'refactor.extract', title: 'Extract Selection to New Note', category: 'Refactor',
-        keybinding: null, enabled: hasActiveNoteTab, run: () => handleExtractSelection() },
-      { id: 'refactor.splitHere', title: 'Split Here', category: 'Refactor',
-        keybinding: null, enabled: hasActiveNoteTab, run: () => handleSplitHere() },
-      { id: 'refactor.splitByHeading', title: 'Split by Heading…', category: 'Refactor',
-        keybinding: null, enabled: hasActiveNoteTab, run: () => handleSplitByHeading() },
-      { id: 'refactor.autoTag', title: 'Auto-tag Note', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); } },
-      { id: 'refactor.autoLink', title: 'Auto-link Outbound', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); } },
-      { id: 'refactor.autoLinkInbound', title: 'Auto-link Inbound', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); } },
-      { id: 'refactor.decompose', title: 'Decompose into Claims', category: 'Refactor',
-        keybinding: null, enabled: hasNote,
-        run: () => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); } },
-      { id: 'refactor.format', title: 'Format', category: 'Refactor',
-        keybinding: null, enabled: hasNote, run: () => handleFormat() },
-      // ── Research ──
-      { id: 'research.ingestUrl', title: 'Ingest URL as Source…', category: 'Research',
-        keybinding: formatAccelerator('CmdOrCtrl+Shift+I'),
-        enabled: hasProject, run: () => handleIngestUrlAsSource() },
-      { id: 'research.ingestIdentifier', title: 'Ingest Identifier…', category: 'Research',
-        keybinding: formatAccelerator('CmdOrCtrl+Shift+D'),
-        enabled: hasProject, run: () => handleIngestIdentifier() },
-      { id: 'research.ingestFile', title: 'Ingest File as Source…', category: 'Research',
-        keybinding: null, enabled: hasProject, run: () => handleIngestFileAsSource() },
-      { id: 'research.importBibtex', title: 'Import BibTeX…', category: 'Research',
-        keybinding: null, enabled: hasProject, run: () => handleImportBibtex() },
-      { id: 'research.importZoteroRdf', title: 'Import Zotero RDF…', category: 'Research',
-        keybinding: null, enabled: hasProject, run: () => handleImportZoteroRdf() },
-      { id: 'research.bibliography', title: 'Insert/Update Bibliography', category: 'Research',
-        keybinding: null, enabled: hasNote, run: () => { void handleBibliography(); } },
-      // ── Query ──
-      { id: 'query.new', title: 'New Query', category: 'Query',
-        keybinding: null, enabled: hasProject, run: () => editor.openQuery() },
-      { id: 'query.editSaved', title: 'Edit Saved Queries…', category: 'Query',
-        keybinding: null, enabled: hasProject, run: () => { showEditSavedQueries = true; } },
-      // ── Settings / app ──
-      { id: 'app.settings', title: 'Settings…', category: 'App',
-        keybinding: formatAccelerator('CmdOrCtrl+,'),
-        enabled: true, run: () => { showSettings = true; } },
-    ];
-    return list;
-  }
+  const commandDeps: CommandDeps = {
+    hasProject: () => !!notebase.meta,
+    hasNote: () => !!editor.activeFilePath,
+    hasActiveNoteTab: () => editor.activeTab?.type === 'note',
+    canGoBack: () => nav.canGoBack,
+    canGoForward: () => nav.canGoForward,
+    newNote: () => { void handleNewNote(); },
+    save: () => { void handleSave(); },
+    openProject: () => { void handleOpenThoughtbase(); },
+    newProject: () => { void handleNewThoughtbase(); },
+    closeProject: () => { notebase.close(); editor.clear(); },
+    print: () => window.print(),
+    saveAsTemplate: () => { void handleSaveAsTemplate(); },
+    insertTemplate: () => { void handleInsertTemplate(); },
+    find: () => editorComponent?.openFind(),
+    findReplace: () => editorComponent?.openFindReplace(),
+    findInNotes: () => { findInNotesMode = 'find'; },
+    replaceInNotes: () => { findInNotesMode = 'replace'; },
+    gotoLine: () => { showGotoLine = true; },
+    sortLines: () => editorComponent?.runSortLines(),
+    toggleSidebar: () => { sidebarVisible = !sidebarVisible; },
+    toggleRightSidebar: () => { rightSidebarVisible = !rightSidebarVisible; },
+    togglePreview: () => cycleViewMode(),
+    toggleConversations: () => conversationsStore.toggle(),
+    cycleTheme: () => handleCycleTheme(),
+    fontIncrease: () => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; },
+    fontDecrease: () => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; },
+    fontReset: () => { editorComponent?.resetFontSize(); editorFontSize = 14; },
+    quickOpen: () => { void refreshSourcesCache(); void refreshSavedQueriesCache(); showGotoNote = true; },
+    navBack: () => { void handleNavBack(); },
+    navForward: () => { void handleNavForward(); },
+    renameActive: () => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); },
+    moveActive: () => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); },
+    copyActive: () => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); },
+    extractSelection: () => { void handleExtractSelection(); },
+    splitHere: () => { void handleSplitHere(); },
+    splitByHeading: () => { void handleSplitByHeading(); },
+    autoTagActive: () => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); },
+    autoLinkActive: () => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); },
+    autoLinkInboundActive: () => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); },
+    decomposeActive: () => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); },
+    format: () => { void handleFormat(); },
+    ingestUrl: () => { void handleIngestUrlAsSource(); },
+    ingestIdentifier: () => { void handleIngestIdentifier(); },
+    ingestFile: () => { void handleIngestFileAsSource(); },
+    importBibtex: () => { void handleImportBibtex(); },
+    importZoteroRdf: () => { void handleImportZoteroRdf(); },
+    bibliography: () => { void handleBibliography(); },
+    newQuery: () => editor.openQuery(),
+    editSavedQueries: () => { showEditSavedQueries = true; },
+    openSettings: () => { showSettings = true; },
+  };
+  const commands = $derived<Command[]>(buildCommandRegistry(commandDeps));
   /** When non-null, the merge-target picker is shown. Holds the source
    *  note path; the picker filters the source out of its candidates. */
   let mergePickerSource = $state<string | null>(null);
@@ -1032,9 +868,6 @@
 
   /** Show the snippet picker (#475). Resolves with the chosen
    *  template or `null` when the user cancels. */
-  function showSnippetPicker(templates: TemplateInfo[]): Promise<TemplateInfo | null> {
-    return new Promise((resolve) => { snippetPicker = { templates, resolve }; });
-  }
 
   /** Insert a template's substituted body at the editor caret
    *  (replacing the current selection if any). `{{selection}}`
@@ -2140,10 +1973,11 @@
    * a blank entry screen.
    */
   function askOpenTarget(message: string): Promise<'this' | 'new' | 'cancel'> {
+    // App-level shortcut: with no project open there's nothing to open "in a
+    // new window vs this one", so skip the prompt. The dialog primitive lives
+    // in the dialog store (#670).
     if (!notebase.meta) return Promise.resolve('this');
-    return new Promise((resolve) => {
-      openTargetDialog = { message, resolve };
-    });
+    return dialogs.askOpenTarget(message);
   }
 
   async function handleOpenThoughtbase(): Promise<void> {
@@ -3477,29 +3311,7 @@
       onClose={() => { findInNotesMode = null; }}
     />
   {/if}
-  {#if promptDialog}
-    <PromptDialog
-      message={promptDialog.message}
-      suggestions={promptDialog.suggestions ?? []}
-      initial={promptDialog.initial ?? ''}
-      onConfirm={handlePromptConfirm}
-      onCancel={handlePromptCancel}
-    />
-  {/if}
-  {#if newNoteDialog}
-    <NewNoteDialog
-      initialExt={newNoteDialog.initialExt}
-      onConfirm={(value) => { const r = newNoteDialog!.resolve; newNoteDialog = null; r(value); }}
-      onCancel={() => { const r = newNoteDialog!.resolve; newNoteDialog = null; r(null); }}
-    />
-  {/if}
-  {#if snippetPicker}
-    <SnippetPickerDialog
-      templates={snippetPicker.templates}
-      onPick={(t) => { const r = snippetPicker!.resolve; snippetPicker = null; r(t); }}
-      onCancel={() => { const r = snippetPicker!.resolve; snippetPicker = null; r(null); }}
-    />
-  {/if}
+  <DialogHost />
   {#if mineReviewState}
     <MineReferencesDialog
       parentTitle={mineReviewState.parentTitle}
@@ -3536,23 +3348,6 @@
     <CommandPaletteDialog
       {commands}
       onClose={() => { showCommandPalette = false; }}
-    />
-  {/if}
-  {#if confirmDialog}
-    <ConfirmDialog
-      message={confirmDialog.message}
-      confirmLabel={confirmDialog.confirmLabel}
-      hideDontAskAgain={confirmDialog.hideDontAskAgain}
-      onConfirm={handleConfirmOk}
-      onCancel={handleConfirmCancel}
-    />
-  {/if}
-  {#if openTargetDialog}
-    <OpenTargetDialog
-      message={openTargetDialog.message}
-      onThisWindow={() => { const r = openTargetDialog!.resolve; openTargetDialog = null; r('this'); }}
-      onNewWindow={() => { const r = openTargetDialog!.resolve; openTargetDialog = null; r('new'); }}
-      onCancel={() => { const r = openTargetDialog!.resolve; openTargetDialog = null; r('cancel'); }}
     />
   {/if}
   {#if exportDialogFor}

--- a/src/renderer/lib/command-palette/registry.ts
+++ b/src/renderer/lib/command-palette/registry.ts
@@ -1,0 +1,205 @@
+/**
+ * Command-palette registry (#463, extracted from App.svelte in #670).
+ *
+ * `buildCommandRegistry(deps)` is a pure mapping from injected dependencies
+ * to the `Command[]` the palette (and, later, a custom-keybinding UI) draws
+ * from. App.svelte calls it inside a `$derived`, so the `enabled` predicates
+ * are passed as GETTER FUNCTIONS rather than plain booleans — the derived
+ * re-tracks them on each recompute, keeping the palette from ever offering an
+ * action that would silently no-op. The `run` callbacks fire later, on user
+ * action, so they're plain thunks.
+ *
+ * Keeping this a pure function of `deps` (no store/component imports) makes the
+ * command set and its dispatch unit-testable without mounting the app — the
+ * safety net the #670 decomposition is built against.
+ *
+ * Adding a command: append a row here and a matching field to `CommandDeps`.
+ * The Electron menu still lives in `src/main/menu.ts`.
+ */
+import type { Command } from './types';
+import { formatAccelerator } from './format-accelerator';
+
+/** Dependencies the command registry needs from the host component. */
+export interface CommandDeps {
+  // ── reactive state predicates (read inside App's $derived) ──
+  hasProject(): boolean;
+  hasNote(): boolean;
+  hasActiveNoteTab(): boolean;
+  canGoBack(): boolean;
+  canGoForward(): boolean;
+  // ── File ──
+  newNote(): void;
+  save(): void;
+  openProject(): void;
+  newProject(): void;
+  closeProject(): void;
+  print(): void;
+  saveAsTemplate(): void;
+  // ── Edit ──
+  insertTemplate(): void;
+  find(): void;
+  findReplace(): void;
+  findInNotes(): void;
+  replaceInNotes(): void;
+  gotoLine(): void;
+  sortLines(): void;
+  // ── View ──
+  toggleSidebar(): void;
+  toggleRightSidebar(): void;
+  togglePreview(): void;
+  toggleConversations(): void;
+  cycleTheme(): void;
+  fontIncrease(): void;
+  fontDecrease(): void;
+  fontReset(): void;
+  // ── Navigate ──
+  quickOpen(): void;
+  navBack(): void;
+  navForward(): void;
+  // ── Refactor (operate on the active note) ──
+  renameActive(): void;
+  moveActive(): void;
+  copyActive(): void;
+  extractSelection(): void;
+  splitHere(): void;
+  splitByHeading(): void;
+  autoTagActive(): void;
+  autoLinkActive(): void;
+  autoLinkInboundActive(): void;
+  decomposeActive(): void;
+  format(): void;
+  // ── Research ──
+  ingestUrl(): void;
+  ingestIdentifier(): void;
+  ingestFile(): void;
+  importBibtex(): void;
+  importZoteroRdf(): void;
+  bibliography(): void;
+  // ── Query ──
+  newQuery(): void;
+  editSavedQueries(): void;
+  // ── App ──
+  openSettings(): void;
+}
+
+export function buildCommandRegistry(deps: CommandDeps): Command[] {
+  const hasProject = deps.hasProject();
+  const hasNote = deps.hasNote();
+  const hasActiveNoteTab = deps.hasActiveNoteTab();
+  return [
+    // ── File ──
+    { id: 'file.newNote', title: 'New Note', category: 'File',
+      keybinding: formatAccelerator('CmdOrCtrl+N'),
+      enabled: hasProject, run: () => deps.newNote() },
+    { id: 'file.save', title: 'Save', category: 'File',
+      keybinding: formatAccelerator('CmdOrCtrl+S'),
+      enabled: hasNote, run: () => deps.save() },
+    { id: 'file.openProject', title: 'Open Thoughtbase…', category: 'File',
+      keybinding: formatAccelerator('CmdOrCtrl+O'),
+      enabled: true, run: () => deps.openProject() },
+    { id: 'file.newProject', title: 'New Thoughtbase…', category: 'File',
+      keybinding: null, enabled: true, run: () => deps.newProject() },
+    { id: 'file.closeProject', title: 'Close Thoughtbase', category: 'File',
+      keybinding: formatAccelerator('CmdOrCtrl+Shift+W'),
+      enabled: hasProject, run: () => deps.closeProject() },
+    { id: 'file.print', title: 'Print…', category: 'File',
+      keybinding: null, enabled: hasNote, run: () => deps.print() },
+    { id: 'file.saveAsTemplate', title: 'Save as Template…', category: 'File',
+      keybinding: null, enabled: hasActiveNoteTab,
+      run: () => deps.saveAsTemplate() },
+    { id: 'edit.insertTemplate', title: 'Insert Template…', category: 'Edit',
+      keybinding: null, enabled: hasActiveNoteTab,
+      run: () => deps.insertTemplate() },
+    // ── Edit / search ──
+    { id: 'edit.find', title: 'Find', category: 'Edit',
+      keybinding: formatAccelerator('CmdOrCtrl+F'),
+      enabled: hasNote, run: () => deps.find() },
+    { id: 'edit.findReplace', title: 'Find and Replace', category: 'Edit',
+      keybinding: formatAccelerator('CmdOrCtrl+H'),
+      enabled: hasNote, run: () => deps.findReplace() },
+    { id: 'edit.findInNotes', title: 'Find in Notes…', category: 'Edit',
+      keybinding: formatAccelerator('CmdOrCtrl+Shift+F'),
+      enabled: hasProject, run: () => deps.findInNotes() },
+    { id: 'edit.replaceInNotes', title: 'Replace in Notes…', category: 'Edit',
+      keybinding: formatAccelerator('CmdOrCtrl+Shift+H'),
+      enabled: hasProject, run: () => deps.replaceInNotes() },
+    { id: 'edit.gotoLine', title: 'Go to Line…', category: 'Edit',
+      keybinding: null, enabled: hasNote, run: () => deps.gotoLine() },
+    { id: 'edit.sortLines', title: 'Sort Lines', category: 'Edit',
+      keybinding: null, enabled: hasNote, run: () => deps.sortLines() },
+    // ── View ──
+    { id: 'view.toggleSidebar', title: 'Toggle Left Sidebar', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.toggleSidebar() },
+    { id: 'view.toggleRightSidebar', title: 'Toggle Right Sidebar', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.toggleRightSidebar() },
+    { id: 'view.togglePreview', title: 'Toggle Preview Mode', category: 'View',
+      keybinding: null, enabled: hasNote, run: () => deps.togglePreview() },
+    { id: 'view.toggleConversations', title: 'Toggle Conversations', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.toggleConversations() },
+    { id: 'view.cycleTheme', title: 'Cycle Theme', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.cycleTheme() },
+    { id: 'view.fontIncrease', title: 'Increase Font Size', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.fontIncrease() },
+    { id: 'view.fontDecrease', title: 'Decrease Font Size', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.fontDecrease() },
+    { id: 'view.fontReset', title: 'Reset Font Size', category: 'View',
+      keybinding: null, enabled: true, run: () => deps.fontReset() },
+    // ── Navigate ──
+    { id: 'nav.quickOpen', title: 'Go to…', category: 'Navigate',
+      keybinding: formatAccelerator('CmdOrCtrl+P'),
+      enabled: hasProject, run: () => deps.quickOpen() },
+    { id: 'nav.back', title: 'Navigate Back', category: 'Navigate',
+      keybinding: formatAccelerator('CmdOrCtrl+['),
+      enabled: deps.canGoBack(), run: () => deps.navBack() },
+    { id: 'nav.forward', title: 'Navigate Forward', category: 'Navigate',
+      keybinding: formatAccelerator('CmdOrCtrl+]'),
+      enabled: deps.canGoForward(), run: () => deps.navForward() },
+    // ── Refactor ──
+    { id: 'refactor.rename', title: 'Rename Note…', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.renameActive() },
+    { id: 'refactor.move', title: 'Move Note…', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.moveActive() },
+    { id: 'refactor.copy', title: 'Copy Note…', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.copyActive() },
+    { id: 'refactor.extract', title: 'Extract Selection to New Note', category: 'Refactor',
+      keybinding: null, enabled: hasActiveNoteTab, run: () => deps.extractSelection() },
+    { id: 'refactor.splitHere', title: 'Split Here', category: 'Refactor',
+      keybinding: null, enabled: hasActiveNoteTab, run: () => deps.splitHere() },
+    { id: 'refactor.splitByHeading', title: 'Split by Heading…', category: 'Refactor',
+      keybinding: null, enabled: hasActiveNoteTab, run: () => deps.splitByHeading() },
+    { id: 'refactor.autoTag', title: 'Auto-tag Note', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.autoTagActive() },
+    { id: 'refactor.autoLink', title: 'Auto-link Outbound', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.autoLinkActive() },
+    { id: 'refactor.autoLinkInbound', title: 'Auto-link Inbound', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.autoLinkInboundActive() },
+    { id: 'refactor.decompose', title: 'Decompose into Claims', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.decomposeActive() },
+    { id: 'refactor.format', title: 'Format', category: 'Refactor',
+      keybinding: null, enabled: hasNote, run: () => deps.format() },
+    // ── Research ──
+    { id: 'research.ingestUrl', title: 'Ingest URL as Source…', category: 'Research',
+      keybinding: formatAccelerator('CmdOrCtrl+Shift+I'),
+      enabled: hasProject, run: () => deps.ingestUrl() },
+    { id: 'research.ingestIdentifier', title: 'Ingest Identifier…', category: 'Research',
+      keybinding: formatAccelerator('CmdOrCtrl+Shift+D'),
+      enabled: hasProject, run: () => deps.ingestIdentifier() },
+    { id: 'research.ingestFile', title: 'Ingest File as Source…', category: 'Research',
+      keybinding: null, enabled: hasProject, run: () => deps.ingestFile() },
+    { id: 'research.importBibtex', title: 'Import BibTeX…', category: 'Research',
+      keybinding: null, enabled: hasProject, run: () => deps.importBibtex() },
+    { id: 'research.importZoteroRdf', title: 'Import Zotero RDF…', category: 'Research',
+      keybinding: null, enabled: hasProject, run: () => deps.importZoteroRdf() },
+    { id: 'research.bibliography', title: 'Insert/Update Bibliography', category: 'Research',
+      keybinding: null, enabled: hasNote, run: () => deps.bibliography() },
+    // ── Query ──
+    { id: 'query.new', title: 'New Query', category: 'Query',
+      keybinding: null, enabled: hasProject, run: () => deps.newQuery() },
+    { id: 'query.editSaved', title: 'Edit Saved Queries…', category: 'Query',
+      keybinding: null, enabled: hasProject, run: () => deps.editSavedQueries() },
+    // ── Settings / app ──
+    { id: 'app.settings', title: 'Settings…', category: 'App',
+      keybinding: formatAccelerator('CmdOrCtrl+,'),
+      enabled: true, run: () => deps.openSettings() },
+  ];
+}

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  /**
+   * Renders the generic modal dialogs held by the dialog store (#670).
+   * Mounted once near the root of App.svelte; each `show*` call on the store
+   * pops the corresponding dialog here. Keeps the imperative prompt/confirm
+   * plumbing out of App.svelte's template.
+   */
+  import PromptDialog from './PromptDialog.svelte';
+  import NewNoteDialog from './NewNoteDialog.svelte';
+  import SnippetPickerDialog from './SnippetPickerDialog.svelte';
+  import ConfirmDialog from './ConfirmDialog.svelte';
+  import OpenTargetDialog from './OpenTargetDialog.svelte';
+  import { getDialogStore } from '../stores/dialogs.svelte';
+
+  const dialogs = getDialogStore();
+</script>
+
+{#if dialogs.prompt}
+  <PromptDialog
+    message={dialogs.prompt.message}
+    suggestions={dialogs.prompt.suggestions ?? []}
+    initial={dialogs.prompt.initial ?? ''}
+    onConfirm={(v) => dialogs.confirmPrompt(v)}
+    onCancel={() => dialogs.cancelPrompt()}
+  />
+{/if}
+
+{#if dialogs.newNote}
+  <NewNoteDialog
+    initialExt={dialogs.newNote.initialExt}
+    onConfirm={(v) => dialogs.confirmNewNote(v)}
+    onCancel={() => dialogs.cancelNewNote()}
+  />
+{/if}
+
+{#if dialogs.snippet}
+  <SnippetPickerDialog
+    templates={dialogs.snippet.templates}
+    onPick={(t) => dialogs.pickSnippet(t)}
+    onCancel={() => dialogs.cancelSnippet()}
+  />
+{/if}
+
+{#if dialogs.confirm}
+  <ConfirmDialog
+    message={dialogs.confirm.message}
+    confirmLabel={dialogs.confirm.confirmLabel}
+    hideDontAskAgain={dialogs.confirm.hideDontAskAgain}
+    onConfirm={(dontAskAgain) => dialogs.confirmConfirm(dontAskAgain)}
+    onCancel={() => dialogs.cancelConfirm()}
+  />
+{/if}
+
+{#if dialogs.openTarget}
+  <OpenTargetDialog
+    message={dialogs.openTarget.message}
+    onThisWindow={() => dialogs.resolveOpenTarget('this')}
+    onNewWindow={() => dialogs.resolveOpenTarget('new')}
+    onCancel={() => dialogs.resolveOpenTarget('cancel')}
+  />
+{/if}

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -1,0 +1,150 @@
+/**
+ * Generic modal-dialog store (#670, extracted from App.svelte).
+ *
+ * Owns the imperative prompt/confirm/new-note/snippet/open-target dialogs that
+ * App.svelte used to manage inline. Each `show*` returns a Promise that
+ * resolves when the user acts, so callers read like `const name = await
+ * showPrompt(...)`. `<DialogHost>` renders the state held here; the resolve/
+ * cancel methods are what the host's buttons call.
+ *
+ * Feature-specific dialogs (mine-references, resolve-stub, safe-delete, export,
+ * command palette) stay in App.svelte — they close over feature handlers and
+ * aren't general primitives.
+ *
+ * Runes work in `.svelte.ts`, so the state stays reactive after the move.
+ */
+import { getConfirmSuppressionStore } from './confirm-suppression.svelte';
+import type { NoteExt, NewNoteResult } from '../components/new-note-dialog-types';
+import type { TemplateInfo } from '../ipc/client';
+
+export interface PromptState {
+  message: string;
+  suggestions?: string[];
+  initial?: string;
+  resolve: (value: string | null) => void;
+}
+export interface NewNoteState {
+  initialExt: NoteExt;
+  resolve: (value: NewNoteResult | null) => void;
+}
+export interface SnippetPickerState {
+  templates: TemplateInfo[];
+  resolve: (value: TemplateInfo | null) => void;
+}
+export interface ConfirmState {
+  message: string;
+  confirmLabel: string;
+  key: string;
+  hideDontAskAgain?: boolean;
+  resolve: (value: boolean) => void;
+}
+export type OpenTargetChoice = 'this' | 'new' | 'cancel';
+export interface OpenTargetState {
+  message: string;
+  resolve: (value: OpenTargetChoice) => void;
+}
+
+let prompt = $state<PromptState | null>(null);
+let newNote = $state<NewNoteState | null>(null);
+let snippet = $state<SnippetPickerState | null>(null);
+let confirm = $state<ConfirmState | null>(null);
+let openTarget = $state<OpenTargetState | null>(null);
+
+export function getDialogStore() {
+  const confirmSuppression = getConfirmSuppressionStore();
+
+  function showPrompt(
+    message: string,
+    initialOrOptions?: string | { suggestions?: string[]; initial?: string },
+  ): Promise<string | null> {
+    // Two overloads to keep call sites readable. New callers pass
+    // (message, "current name") for Rename-style flows; existing
+    // callers can keep their {suggestions} object.
+    const opts = typeof initialOrOptions === 'string'
+      ? { initial: initialOrOptions }
+      : (initialOrOptions ?? {});
+    return new Promise((resolve) => {
+      prompt = { message, suggestions: opts.suggestions, initial: opts.initial, resolve };
+    });
+  }
+
+  function showNewNoteDialog(initialExt: NoteExt = '.md'): Promise<NewNoteResult | null> {
+    return new Promise((resolve) => {
+      newNote = { initialExt, resolve };
+    });
+  }
+
+  function showConfirm(
+    message: string,
+    key: string,
+    confirmLabel = 'OK',
+    options: { hideDontAskAgain?: boolean } = {},
+  ): Promise<boolean> {
+    if (confirmSuppression.isSuppressed(key)) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      confirm = { message, confirmLabel, key, hideDontAskAgain: options.hideDontAskAgain, resolve };
+    });
+  }
+
+  function showSnippetPicker(templates: TemplateInfo[]): Promise<TemplateInfo | null> {
+    return new Promise((resolve) => { snippet = { templates, resolve }; });
+  }
+
+  /** Pure open-target prompt — always shows. App.svelte wraps this with the
+   *  "no project open → 'this'" shortcut, which is app logic, not dialog logic. */
+  function askOpenTarget(message: string): Promise<OpenTargetChoice> {
+    return new Promise((resolve) => { openTarget = { message, resolve }; });
+  }
+
+  // ── resolve/cancel — called by DialogHost's child-component callbacks ──
+  function confirmPrompt(value: string) { prompt?.resolve(value); prompt = null; }
+  function cancelPrompt() { prompt?.resolve(null); prompt = null; }
+
+  function confirmNewNote(value: NewNoteResult) { const r = newNote?.resolve; newNote = null; r?.(value); }
+  function cancelNewNote() { const r = newNote?.resolve; newNote = null; r?.(null); }
+
+  function pickSnippet(t: TemplateInfo) { const r = snippet?.resolve; snippet = null; r?.(t); }
+  function cancelSnippet() { const r = snippet?.resolve; snippet = null; r?.(null); }
+
+  function confirmConfirm(dontAskAgain: boolean) {
+    if (dontAskAgain && confirm) confirmSuppression.suppress(confirm.key);
+    confirm?.resolve(true);
+    confirm = null;
+  }
+  function cancelConfirm() { confirm?.resolve(false); confirm = null; }
+
+  function resolveOpenTarget(choice: OpenTargetChoice) {
+    const r = openTarget?.resolve; openTarget = null; r?.(choice);
+  }
+
+  return {
+    get prompt() { return prompt; },
+    get newNote() { return newNote; },
+    get snippet() { return snippet; },
+    get confirm() { return confirm; },
+    get openTarget() { return openTarget; },
+    showPrompt,
+    showNewNoteDialog,
+    showConfirm,
+    showSnippetPicker,
+    askOpenTarget,
+    confirmPrompt,
+    cancelPrompt,
+    confirmNewNote,
+    cancelNewNote,
+    pickSnippet,
+    cancelSnippet,
+    confirmConfirm,
+    cancelConfirm,
+    resolveOpenTarget,
+  };
+}
+
+// Test-only: clear any in-flight dialog state between cases.
+export function __resetDialogsForTests(): void {
+  prompt = null;
+  newNote = null;
+  snippet = null;
+  confirm = null;
+  openTarget = null;
+}

--- a/tests/renderer/command-palette/registry.test.ts
+++ b/tests/renderer/command-palette/registry.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Command-palette registry (#463 / extracted in #670).
+ *
+ * This is the behavioral safety net for the App.svelte decomposition: it
+ * pins the command set, the `enabled` predicate wiring, and — crucially —
+ * that each command's `run()` dispatches to the right injected dependency.
+ * A future refactor that re-points a command at the wrong handler, drops a
+ * command, or breaks an `enabled` predicate fails here.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { buildCommandRegistry, type CommandDeps } from '../../../src/renderer/lib/command-palette/registry';
+
+// Every CommandDeps method, as a spy. Predicates default to true so every
+// command is enabled unless a test overrides them.
+function makeDeps(overrides: Partial<CommandDeps> = {}): CommandDeps {
+  const actionNames = [
+    'newNote', 'save', 'openProject', 'newProject', 'closeProject', 'print',
+    'saveAsTemplate', 'insertTemplate', 'find', 'findReplace', 'findInNotes',
+    'replaceInNotes', 'gotoLine', 'sortLines', 'toggleSidebar', 'toggleRightSidebar',
+    'togglePreview', 'toggleConversations', 'cycleTheme', 'fontIncrease', 'fontDecrease',
+    'fontReset', 'quickOpen', 'navBack', 'navForward', 'renameActive', 'moveActive',
+    'copyActive', 'extractSelection', 'splitHere', 'splitByHeading', 'autoTagActive',
+    'autoLinkActive', 'autoLinkInboundActive', 'decomposeActive', 'format', 'ingestUrl',
+    'ingestIdentifier', 'ingestFile', 'importBibtex', 'importZoteroRdf', 'bibliography',
+    'newQuery', 'editSavedQueries', 'openSettings',
+  ] as const;
+  const deps = {
+    hasProject: () => true,
+    hasNote: () => true,
+    hasActiveNoteTab: () => true,
+    canGoBack: () => true,
+    canGoForward: () => true,
+  } as Record<string, unknown>;
+  for (const name of actionNames) deps[name] = vi.fn();
+  return { ...deps, ...overrides } as CommandDeps;
+}
+
+describe('buildCommandRegistry', () => {
+  it('returns the full command set with stable ids', () => {
+    const ids = buildCommandRegistry(makeDeps()).map((c) => c.id);
+    expect(ids).toEqual([
+      'file.newNote', 'file.save', 'file.openProject', 'file.newProject',
+      'file.closeProject', 'file.print', 'file.saveAsTemplate', 'edit.insertTemplate',
+      'edit.find', 'edit.findReplace', 'edit.findInNotes', 'edit.replaceInNotes',
+      'edit.gotoLine', 'edit.sortLines', 'view.toggleSidebar', 'view.toggleRightSidebar',
+      'view.togglePreview', 'view.toggleConversations', 'view.cycleTheme',
+      'view.fontIncrease', 'view.fontDecrease', 'view.fontReset', 'nav.quickOpen',
+      'nav.back', 'nav.forward', 'refactor.rename', 'refactor.move', 'refactor.copy',
+      'refactor.extract', 'refactor.splitHere', 'refactor.splitByHeading',
+      'refactor.autoTag', 'refactor.autoLink', 'refactor.autoLinkInbound',
+      'refactor.decompose', 'refactor.format', 'research.ingestUrl',
+      'research.ingestIdentifier', 'research.ingestFile', 'research.importBibtex',
+      'research.importZoteroRdf', 'research.bibliography', 'query.new',
+      'query.editSaved', 'app.settings',
+    ]);
+  });
+
+  it('every command has a category and a run thunk', () => {
+    for (const cmd of buildCommandRegistry(makeDeps())) {
+      expect(cmd.category).toBeTruthy();
+      expect(typeof cmd.run).toBe('function');
+    }
+  });
+
+  it('gates project-scoped commands on hasProject()', () => {
+    const cmds = buildCommandRegistry(makeDeps({ hasProject: () => false }));
+    const byId = (id: string) => cmds.find((c) => c.id === id)!;
+    expect(byId('file.newNote').enabled).toBe(false);
+    expect(byId('edit.findInNotes').enabled).toBe(false);
+    expect(byId('nav.quickOpen').enabled).toBe(false);
+    expect(byId('research.ingestUrl').enabled).toBe(false);
+    expect(byId('query.new').enabled).toBe(false);
+    // Project-independent commands stay enabled.
+    expect(byId('file.openProject').enabled).toBe(true);
+    expect(byId('app.settings').enabled).toBe(true);
+    expect(byId('view.toggleSidebar').enabled).toBe(true);
+  });
+
+  it('gates note-scoped commands on hasNote()', () => {
+    const cmds = buildCommandRegistry(makeDeps({ hasNote: () => false }));
+    const byId = (id: string) => cmds.find((c) => c.id === id)!;
+    expect(byId('file.save').enabled).toBe(false);
+    expect(byId('edit.find').enabled).toBe(false);
+    expect(byId('refactor.rename').enabled).toBe(false);
+    expect(byId('refactor.format').enabled).toBe(false);
+    expect(byId('research.bibliography').enabled).toBe(false);
+  });
+
+  it('gates active-note-tab commands on hasActiveNoteTab()', () => {
+    const cmds = buildCommandRegistry(makeDeps({ hasActiveNoteTab: () => false }));
+    const byId = (id: string) => cmds.find((c) => c.id === id)!;
+    expect(byId('file.saveAsTemplate').enabled).toBe(false);
+    expect(byId('edit.insertTemplate').enabled).toBe(false);
+    expect(byId('refactor.extract').enabled).toBe(false);
+    expect(byId('refactor.splitHere').enabled).toBe(false);
+    expect(byId('refactor.splitByHeading').enabled).toBe(false);
+  });
+
+  it('gates nav commands on canGoBack()/canGoForward()', () => {
+    const cmds = buildCommandRegistry(makeDeps({ canGoBack: () => false, canGoForward: () => true }));
+    expect(cmds.find((c) => c.id === 'nav.back')!.enabled).toBe(false);
+    expect(cmds.find((c) => c.id === 'nav.forward')!.enabled).toBe(true);
+  });
+
+  it('dispatches each command run() to its corresponding dependency', () => {
+    // Map of command id → the dep method it must call.
+    const wiring: Record<string, keyof CommandDeps> = {
+      'file.newNote': 'newNote', 'file.save': 'save', 'file.openProject': 'openProject',
+      'file.newProject': 'newProject', 'file.closeProject': 'closeProject',
+      'file.print': 'print', 'file.saveAsTemplate': 'saveAsTemplate',
+      'edit.insertTemplate': 'insertTemplate', 'edit.find': 'find',
+      'edit.findReplace': 'findReplace', 'edit.findInNotes': 'findInNotes',
+      'edit.replaceInNotes': 'replaceInNotes', 'edit.gotoLine': 'gotoLine',
+      'edit.sortLines': 'sortLines', 'view.toggleSidebar': 'toggleSidebar',
+      'view.toggleRightSidebar': 'toggleRightSidebar', 'view.togglePreview': 'togglePreview',
+      'view.toggleConversations': 'toggleConversations', 'view.cycleTheme': 'cycleTheme',
+      'view.fontIncrease': 'fontIncrease', 'view.fontDecrease': 'fontDecrease',
+      'view.fontReset': 'fontReset', 'nav.quickOpen': 'quickOpen', 'nav.back': 'navBack',
+      'nav.forward': 'navForward', 'refactor.rename': 'renameActive',
+      'refactor.move': 'moveActive', 'refactor.copy': 'copyActive',
+      'refactor.extract': 'extractSelection', 'refactor.splitHere': 'splitHere',
+      'refactor.splitByHeading': 'splitByHeading', 'refactor.autoTag': 'autoTagActive',
+      'refactor.autoLink': 'autoLinkActive', 'refactor.autoLinkInbound': 'autoLinkInboundActive',
+      'refactor.decompose': 'decomposeActive', 'refactor.format': 'format',
+      'research.ingestUrl': 'ingestUrl', 'research.ingestIdentifier': 'ingestIdentifier',
+      'research.ingestFile': 'ingestFile', 'research.importBibtex': 'importBibtex',
+      'research.importZoteroRdf': 'importZoteroRdf', 'research.bibliography': 'bibliography',
+      'query.new': 'newQuery', 'query.editSaved': 'editSavedQueries',
+      'app.settings': 'openSettings',
+    };
+    const deps = makeDeps();
+    const cmds = buildCommandRegistry(deps);
+    // Every command must appear in the wiring map (catches a new command
+    // that forgot a dispatch assertion).
+    expect(new Set(cmds.map((c) => c.id))).toEqual(new Set(Object.keys(wiring)));
+    for (const cmd of cmds) {
+      cmd.run();
+      const depMethod = deps[wiring[cmd.id]] as ReturnType<typeof vi.fn>;
+      expect(depMethod, `command ${cmd.id} should call deps.${wiring[cmd.id]}`).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/tests/renderer/stores/dialogs.test.ts
+++ b/tests/renderer/stores/dialogs.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Dialog store (#670) — the behavioral safety net for the prompt/confirm
+ * primitives extracted from App.svelte. Verifies each `show*` resolves on the
+ * matching resolve/cancel method, and that confirm-suppression short-circuits.
+ * jsdom is needed only for the confirm-suppression store's localStorage.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getDialogStore, __resetDialogsForTests } from '../../../src/renderer/lib/stores/dialogs.svelte';
+import { getConfirmSuppressionStore } from '../../../src/renderer/lib/stores/confirm-suppression.svelte';
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => store.clear(),
+      get length() { return store.size; },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+beforeEach(() => {
+  localStorage.clear();
+  getConfirmSuppressionStore().clearAll();
+  __resetDialogsForTests();
+});
+
+describe('dialog store — prompt', () => {
+  it('shows a prompt and resolves with the confirmed value', async () => {
+    const d = getDialogStore();
+    const p = d.showPrompt('Rename to?', 'old-name');
+    expect(d.prompt).not.toBeNull();
+    expect(d.prompt!.message).toBe('Rename to?');
+    expect(d.prompt!.initial).toBe('old-name');
+    d.confirmPrompt('new-name');
+    expect(await p).toBe('new-name');
+    expect(d.prompt).toBeNull();
+  });
+
+  it('resolves null on cancel', async () => {
+    const d = getDialogStore();
+    const p = d.showPrompt('Name?', { suggestions: ['a', 'b'] });
+    expect(d.prompt!.suggestions).toEqual(['a', 'b']);
+    d.cancelPrompt();
+    expect(await p).toBeNull();
+    expect(d.prompt).toBeNull();
+  });
+});
+
+describe('dialog store — confirm', () => {
+  it('resolves true on confirm, false on cancel', async () => {
+    const d = getDialogStore();
+    const p1 = d.showConfirm('Delete it?', 'delete-note', 'Delete');
+    expect(d.confirm!.confirmLabel).toBe('Delete');
+    d.confirmConfirm(false);
+    expect(await p1).toBe(true);
+
+    const p2 = d.showConfirm('Delete it?', 'delete-note', 'Delete');
+    d.cancelConfirm();
+    expect(await p2).toBe(false);
+  });
+
+  it('short-circuits to true (no dialog) when the key is suppressed', async () => {
+    const d = getDialogStore();
+    // First confirm with "don't ask again" suppresses the key.
+    const p = d.showConfirm('Delete it?', 'delete-note', 'Delete');
+    d.confirmConfirm(true);
+    expect(await p).toBe(true);
+    // Second call resolves immediately without opening a dialog.
+    const p2 = d.showConfirm('Delete it?', 'delete-note', 'Delete');
+    expect(d.confirm).toBeNull();
+    expect(await p2).toBe(true);
+  });
+
+  it('does not suppress when "don\'t ask again" is unchecked', async () => {
+    const d = getDialogStore();
+    const p = d.showConfirm('Delete it?', 'delete-note', 'Delete');
+    d.confirmConfirm(false);
+    await p;
+    const p2 = d.showConfirm('Delete it?', 'delete-note', 'Delete');
+    expect(d.confirm).not.toBeNull(); // dialog shown again
+    d.cancelConfirm();
+    await p2;
+  });
+});
+
+describe('dialog store — snippet picker & open-target', () => {
+  it('snippet picker resolves with the picked template, null on cancel', async () => {
+    const d = getDialogStore();
+    const tpl = { name: 'Daily', path: 'templates/daily.md' } as never;
+    const p = d.showSnippetPicker([tpl]);
+    expect(d.snippet!.templates).toHaveLength(1);
+    d.pickSnippet(tpl);
+    expect(await p).toBe(tpl);
+
+    const p2 = d.showSnippetPicker([tpl]);
+    d.cancelSnippet();
+    expect(await p2).toBeNull();
+  });
+
+  it('open-target resolves with each choice', async () => {
+    const d = getDialogStore();
+    for (const choice of ['this', 'new', 'cancel'] as const) {
+      const p = d.askOpenTarget('Open where?');
+      expect(d.openTarget).not.toBeNull();
+      d.resolveOpenTarget(choice);
+      expect(await p).toBe(choice);
+      expect(d.openTarget).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## What

First increment of the App.svelte decomposition (#670). Extracts the two subsystems with the **safety net built first**, since App.svelte has no component test and the e2e smoke only verifies boot — reactivity regressions in extracted UI would otherwise pass CI silently.

Partially addresses #670 (does not close it — see Remaining below).

### Command palette
- `buildCommandRegistry` → `lib/command-palette/registry.ts` as a **pure function of an injected `CommandDeps`**. The `enabled` predicates are passed as **getter functions** so App's `$derived` still tracks reactive state on each recompute; `run` callbacks are plain thunks. App builds the deps object and keeps the `$derived`.
- **Net:** `tests/renderer/command-palette/registry.test.ts` (7 tests) pins the full command set + stable ids, the `hasProject`/`hasNote`/`hasActiveNoteTab`/nav `enabled` gating, and that **every command's `run()` dispatches to the right dependency** (a wiring map asserts 1:1 coverage, so a mis-pointed or dropped command fails here).

### Dialogs
- The generic **prompt / confirm / new-note / snippet / open-target** dialogs → `lib/stores/dialogs.svelte.ts` (runes store) + `DialogHost.svelte` to render them. App destructures the `show*` helpers so the ~dozens of call sites read unchanged; `askOpenTarget` keeps its no-project shortcut and delegates to the store. Feature dialogs (mine-references, resolve-stub, safe-delete, export, command palette) stay in App.
- **Net:** `tests/renderer/stores/dialogs.test.ts` (7 tests) — each `show*` resolves on confirm/cancel, and confirm-suppression short-circuits.

## Result

`App.svelte`: **3,764 → 3,559 lines** (−271 / +66). Reactivity preserved (getter-injected predicates; runes store).

## Remaining (follow-ups to #670, against this net)

Reaching the issue's <1,000 target needs relocating the ~100 handler bodies, which the dispatch/dialog net doesn't cover — so per the safety-first plan these land as separate, independently-reviewable PRs:
- keymap (`handleKeydown`) → module + dispatch test
- menu-event wiring (`api.menu.on*` effect) → module
- pure text helpers → module
- handler-group extraction (note-ops / source-ops / refactor-ops / nav-ops) into action modules

## Verification

- `pnpm lint` — **0 errors**.
- `pnpm test` — **2747 passed** (+14 new).
- `pnpm test:e2e` — boot smoke passes (App mounts with `DialogHost` + injected registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)