### PR TITLE
Decompose App.svelte: extract global keymap (#670, increment 2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -135,6 +135,10 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
+      // vitest spy assertions (`expect(deps.fn).toHaveBeenCalled()`)
+      // necessarily reference mock functions unbound; there's no real
+      // `this`-binding hazard with vi.fn() mocks, so the rule is noise here.
+      '@typescript-eslint/unbound-method': 'off',
     },
   },
   {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -37,6 +37,7 @@
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
+  import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import GotoLineDialog from './lib/components/GotoLineDialog.svelte';
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
@@ -2632,71 +2633,25 @@
     else viewMode = 'source';
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    // ⌘K (or Ctrl+K) opens the command palette (#463). ⌘⇧P is
-    // already bound to cycle view mode, so we use the Linear / VS
-    // Code convention instead of Obsidian's ⌘P (which is our quick-
-    // open).
-    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === 'k') {
-      if (notebase.meta) {
-        e.preventDefault();
-        showCommandPalette = !showCommandPalette;
-        return;
-      }
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === '[') {
-      e.preventDefault();
-      void handleNavBack();
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === ']') {
-      e.preventDefault();
-      void handleNavForward();
-    }
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'p') {
-      e.preventDefault();
-      cycleViewMode();
-    }
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'b') {
-      e.preventDefault();
-      rightSidebarVisible = !rightSidebarVisible;
-    }
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 't') {
-      e.preventDefault();
-      handleCycleTheme();
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
-      e.preventDefault();
-      void handleNewNote();
-    }
-    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'w') {
-      if (editor.activeIndex >= 0) {
-        e.preventDefault();
-        editor.closeTab(editor.activeIndex);
-      }
-    }
-    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'p') {
-      if (notebase.meta) {
-        e.preventDefault();
-        showGotoNote = !showGotoNote;
-      }
-    }
-    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'g') {
-      if (editor.activeTab) {
-        e.preventDefault();
-        showGotoLine = true;
-      }
-    }
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'q') {
-      if (notebase.meta) {
-        e.preventDefault();
-        editor.openQuery();
-      }
-    }
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'i') {
-      e.preventDefault();
-      void openConversation();
-    }
-  }
+  // Global keyboard shortcuts live in lib/keymap/handle-keydown.ts (#670);
+  // this object injects the state predicates + actions they dispatch to.
+  const keymapDeps: KeymapDeps = {
+    hasProject: () => !!notebase.meta,
+    hasActiveTab: () => !!editor.activeTab,
+    hasActiveIndex: () => editor.activeIndex >= 0,
+    toggleCommandPalette: () => { showCommandPalette = !showCommandPalette; },
+    navBack: () => { void handleNavBack(); },
+    navForward: () => { void handleNavForward(); },
+    cyclePreview: () => cycleViewMode(),
+    toggleRightSidebar: () => { rightSidebarVisible = !rightSidebarVisible; },
+    cycleTheme: () => handleCycleTheme(),
+    newNote: () => { void handleNewNote(); },
+    closeActiveTab: () => { editor.closeTab(editor.activeIndex); },
+    toggleQuickOpen: () => { showGotoNote = !showGotoNote; },
+    openGotoLine: () => { showGotoLine = true; },
+    newQuery: () => editor.openQuery(),
+    openConversation: () => { void openConversation(); },
+  };
 
   onMount(() => {
     initTheme();
@@ -2925,7 +2880,7 @@
   }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
+<svelte:window onkeydown={(e) => handleKeydown(e, keymapDeps)} />
 
 <div class="app">
   <TitleBar

--- a/src/renderer/lib/keymap/handle-keydown.ts
+++ b/src/renderer/lib/keymap/handle-keydown.ts
@@ -1,0 +1,96 @@
+/**
+ * Global keyboard shortcuts (#463 / extracted from App.svelte in #670).
+ *
+ * `handleKeydown(e, deps)` is the window-level keymap, moved out of App.svelte
+ * as a pure function of an injected `KeymapDeps`. It runs at event time (not
+ * reactively), so the predicates read current state when a key is pressed.
+ * Keeping it dependency-injected makes the key→action dispatch unit-testable
+ * without mounting the app — part of the App.svelte decomposition safety net.
+ *
+ * Behaviour preserved verbatim, including which combos guard on state before
+ * calling `preventDefault()` (so an unhandled combo with no project open still
+ * falls through to the browser / editor).
+ */
+export interface KeymapDeps {
+  hasProject: () => boolean;
+  hasActiveTab: () => boolean;
+  hasActiveIndex: () => boolean;
+  toggleCommandPalette: () => void;
+  navBack: () => void;
+  navForward: () => void;
+  cyclePreview: () => void;
+  toggleRightSidebar: () => void;
+  cycleTheme: () => void;
+  newNote: () => void;
+  closeActiveTab: () => void;
+  toggleQuickOpen: () => void;
+  openGotoLine: () => void;
+  newQuery: () => void;
+  openConversation: () => void;
+}
+
+export function handleKeydown(e: KeyboardEvent, deps: KeymapDeps): void {
+  const mod = e.metaKey || e.ctrlKey;
+  // ⌘K (or Ctrl+K) opens the command palette (#463). ⌘⇧P is already bound to
+  // cycle view mode, so we use the Linear / VS Code convention instead of
+  // Obsidian's ⌘P (which is our quick-open).
+  if (mod && !e.shiftKey && !e.altKey && e.key === 'k') {
+    if (deps.hasProject()) {
+      e.preventDefault();
+      deps.toggleCommandPalette();
+      return;
+    }
+  }
+  if (mod && e.key === '[') {
+    e.preventDefault();
+    deps.navBack();
+  }
+  if (mod && e.key === ']') {
+    e.preventDefault();
+    deps.navForward();
+  }
+  if (mod && e.shiftKey && e.key === 'p') {
+    e.preventDefault();
+    deps.cyclePreview();
+  }
+  if (mod && e.shiftKey && e.key === 'b') {
+    e.preventDefault();
+    deps.toggleRightSidebar();
+  }
+  if (mod && e.shiftKey && e.key === 't') {
+    e.preventDefault();
+    deps.cycleTheme();
+  }
+  if (mod && e.key === 'n') {
+    e.preventDefault();
+    deps.newNote();
+  }
+  if (mod && !e.shiftKey && e.key === 'w') {
+    if (deps.hasActiveIndex()) {
+      e.preventDefault();
+      deps.closeActiveTab();
+    }
+  }
+  if (mod && !e.shiftKey && e.key === 'p') {
+    if (deps.hasProject()) {
+      e.preventDefault();
+      deps.toggleQuickOpen();
+    }
+  }
+  if (mod && !e.shiftKey && e.key === 'g') {
+    if (deps.hasActiveTab()) {
+      e.preventDefault();
+      deps.openGotoLine();
+    }
+  }
+  if (mod && e.shiftKey && e.key === 'q') {
+    if (deps.hasProject()) {
+      e.preventDefault();
+      deps.newQuery();
+    }
+  }
+  if (mod && e.shiftKey && e.key === 'i') {
+    e.preventDefault();
+    deps.openConversation();
+  }
+}

--- a/tests/renderer/keymap/handle-keydown.test.ts
+++ b/tests/renderer/keymap/handle-keydown.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Global keymap (#463 / extracted in #670) — safety net for keyboard dispatch.
+ * Verifies each shortcut routes to the right action, that combos guard on
+ * state before preventDefault, and that unmatched keys are ignored.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { handleKeydown, type KeymapDeps } from '../../../src/renderer/lib/keymap/handle-keydown';
+
+function makeDeps(overrides: Partial<KeymapDeps> = {}): KeymapDeps {
+  const actions = [
+    'toggleCommandPalette', 'navBack', 'navForward', 'cyclePreview',
+    'toggleRightSidebar', 'cycleTheme', 'newNote', 'closeActiveTab',
+    'toggleQuickOpen', 'openGotoLine', 'newQuery', 'openConversation',
+  ] as const;
+  const deps = {
+    hasProject: () => true,
+    hasActiveTab: () => true,
+    hasActiveIndex: () => true,
+  } as Record<string, unknown>;
+  for (const a of actions) deps[a] = vi.fn();
+  return { ...deps, ...overrides } as KeymapDeps;
+}
+
+function press(
+  key: string,
+  mods: { meta?: boolean; ctrl?: boolean; shift?: boolean; alt?: boolean } = {},
+): KeyboardEvent {
+  return {
+    key,
+    metaKey: mods.meta ?? true, // default to ⌘ held
+    ctrlKey: mods.ctrl ?? false,
+    shiftKey: mods.shift ?? false,
+    altKey: mods.alt ?? false,
+    preventDefault: vi.fn(),
+  } as unknown as KeyboardEvent;
+}
+
+describe('handleKeydown — dispatch', () => {
+  const cases: Array<[string, { shift?: boolean }, keyof KeymapDeps]> = [
+    ['k', {}, 'toggleCommandPalette'],
+    ['[', {}, 'navBack'],
+    [']', {}, 'navForward'],
+    ['p', { shift: true }, 'cyclePreview'],
+    ['b', { shift: true }, 'toggleRightSidebar'],
+    ['t', { shift: true }, 'cycleTheme'],
+    ['n', {}, 'newNote'],
+    ['w', {}, 'closeActiveTab'],
+    ['p', {}, 'toggleQuickOpen'],
+    ['g', {}, 'openGotoLine'],
+    ['q', { shift: true }, 'newQuery'],
+    ['i', { shift: true }, 'openConversation'],
+  ];
+
+  for (const [key, mods, action] of cases) {
+    it(`${mods.shift ? '⌘⇧' : '⌘'}${key} → ${action}`, () => {
+      const deps = makeDeps();
+      const e = press(key, mods);
+      handleKeydown(e, deps);
+      expect(deps[action]).toHaveBeenCalledTimes(1);
+      expect(e.preventDefault).toHaveBeenCalled();
+    });
+  }
+
+  it('works with Ctrl as the modifier too', () => {
+    const deps = makeDeps();
+    handleKeydown(press('n', { meta: false, ctrl: true }), deps);
+    expect(deps.newNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores keys pressed without a modifier', () => {
+    const deps = makeDeps();
+    const e = press('k', { meta: false, ctrl: false });
+    handleKeydown(e, deps);
+    expect(deps.toggleCommandPalette).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleKeydown — state guards', () => {
+  it('⌘K does nothing (no preventDefault) with no project open', () => {
+    const deps = makeDeps({ hasProject: () => false });
+    const e = press('k');
+    handleKeydown(e, deps);
+    expect(deps.toggleCommandPalette).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('⌘W does nothing with no active tab index', () => {
+    const deps = makeDeps({ hasActiveIndex: () => false });
+    const e = press('w');
+    handleKeydown(e, deps);
+    expect(deps.closeActiveTab).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('⌘P quick-open does nothing with no project', () => {
+    const deps = makeDeps({ hasProject: () => false });
+    const e = press('p');
+    handleKeydown(e, deps);
+    expect(deps.toggleQuickOpen).not.toHaveBeenCalled();
+  });
+
+  it('⌘G does nothing with no active tab', () => {
+    const deps = makeDeps({ hasActiveTab: () => false });
+    const e = press('g');
+    handleKeydown(e, deps);
+    expect(deps.openGotoLine).not.toHaveBeenCalled();
+  });
+
+  it('⌘⇧Q does nothing with no project', () => {
+    const deps = makeDeps({ hasProject: () => false });
+    handleKeydown(press('q', { shift: true }), deps);
+    expect(deps.newQuery).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Second increment of the App.svelte decomposition (#670). Extracts the window-level keyboard shortcut handler.

Partially addresses #670 (stays open for the remaining handler-group extraction).

- `handleKeydown` → `lib/keymap/handle-keydown.ts` as a pure function of an injected `KeymapDeps`. It runs at **event time, not reactively**, so the state predicates read current values when a key is pressed — no reactivity subtlety. Behaviour is preserved verbatim, including exactly which combos guard on state *before* calling `preventDefault()` (so an unhandled combo with no project open still falls through).
- App builds the deps object and binds `onkeydown={(e) => handleKeydown(e, keymapDeps)}`.

### Net (widened to keyboard dispatch)
`tests/renderer/keymap/handle-keydown.test.ts` (19 tests): each shortcut → its action, Ctrl-as-modifier, no-modifier keys ignored, and the project / active-tab / active-index guards (⌘K, ⌘W, ⌘P, ⌘G, ⌘⇧Q).

### eslint
Disabled `@typescript-eslint/unbound-method` in the **tests override only** — vitest spy assertions (`expect(deps.fn).toHaveBeenCalled()`) inherently reference mock functions unbound, and there's no real `this`-binding hazard with `vi.fn()` mocks. Consistent with the other test-ergonomics rules already disabled there.

## Result

`App.svelte`: **3,559 → 3,514 lines** (cumulative with #696: 3,764 → 3,514).

## Remaining (follow-ups to #670)
- menu-event wiring (`api.menu.on*` effect) → module
- pure text helpers → module
- handler-group extraction (note-ops / source-ops / refactor-ops / nav-ops) toward the <1,000 target

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2766 passed** (+19).
- `pnpm test:e2e` — boot smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)