### PR TITLE
Decompose App.svelte: extract pure text/tree helpers (#670, increment 3)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -59,7 +59,15 @@
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
   import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
-  import { slugify } from '../shared/slug';
+  import {
+    slugifyForPath,
+    findAnchorOffset,
+    offsetToLineCol,
+    flattenNotePaths,
+    countNotes,
+    describeDeleteNoun,
+    describeDeleteMessage,
+  } from './lib/app/text-helpers';
   import { initAppearance } from './lib/appearance/settings';
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationsStore } from './lib/stores/conversations.svelte';
@@ -324,11 +332,6 @@
     return { systemPrompt, firstMessage };
   }
 
-  /** Cheap slug for path placeholders in the system prompt. The agent
-   *  may override these paths; this is just a sensible default. */
-  function slugifyForPath(s: string): string {
-    return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'overview';
-  }
 
   async function handleOnboardingAccept(answers: OnboardingAnswers, dontAskAgain: boolean) {
     showOnboarding = false;
@@ -541,22 +544,6 @@
    * Locate a heading (by slug) or block-id inside raw markdown and return
    * the character offset of its line. Shared between source and split modes.
    */
-  function findAnchorOffset(text: string, anchor: string): number | null {
-    const isBlockId = anchor.startsWith('^');
-    const lines = text.split('\n');
-    let offset = 0;
-    for (const line of lines) {
-      if (isBlockId) {
-        if (line.trimEnd().endsWith(anchor)) return offset;
-      } else {
-        const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
-        if (m && slugify(m[2]) === anchor) return offset;
-      }
-      offset += line.length + 1;
-    }
-    return null;
-  }
-
   function handleSourceDeleted(sourceId: string) {
     // Close every tab bound to this source — the detail view AND any PDF
     // viewer — so the user isn't left staring at a ghost viewer that then
@@ -610,18 +597,6 @@
   }
 
   /** Flatten the sidebar file tree to a list of indexable relative paths. */
-  function flattenNotePaths(files: import('../shared/types').NoteFile[]): string[] {
-    const out: string[] = [];
-    const walk = (xs: import('../shared/types').NoteFile[]) => {
-      for (const f of xs) {
-        if (f.isDirectory) walk(f.children ?? []);
-        else if (/\.(md|ttl|csv)$/.test(f.relativePath)) out.push(f.relativePath);
-      }
-    };
-    walk(files);
-    return out;
-  }
-
   function handleTagSelect(tag: string) {
     sidebar?.refreshTags();
     setTimeout(() => sidebar?.selectTag(tag), 50);
@@ -1077,27 +1052,6 @@
     await executeDeletes(targets);
   }
 
-  function describeDeleteNoun(targets: Array<{ isDirectory: boolean }>): string {
-    if (targets.length === 1) return targets[0].isDirectory ? 'folder' : 'note';
-    const allDirs = targets.every((t) => t.isDirectory);
-    const allFiles = targets.every((t) => !t.isDirectory);
-    if (allDirs) return 'folders';
-    if (allFiles) return 'notes';
-    return 'items';
-  }
-
-  function describeDeleteMessage(
-    targets: Array<{ relativePath: string; isDirectory: boolean }>,
-    noun: string,
-  ): string {
-    if (targets.length === 1) {
-      const name = targets[0].relativePath.split('/').pop();
-      return `Delete ${noun} "${name}"?`;
-    }
-    const sample = targets.slice(0, 3).map((t) => t.relativePath).join(', ');
-    const more = targets.length > 3 ? ', …' : '';
-    return `Delete ${targets.length} ${noun} (${sample}${more})?`;
-  }
 
   async function executeDeletes(
     targets: Array<{ relativePath: string; isDirectory: boolean }>,
@@ -1161,15 +1115,6 @@
       // File may have been deleted/moved between the dialog popping
       // and the click — opening alone is enough.
     }
-  }
-
-  function offsetToLineCol(text: string, offset: number): { line: number; col: number } {
-    let line = 1;
-    let col = 0;
-    for (let i = 0; i < offset && i < text.length; i++) {
-      if (text[i] === '\n') { line++; col = 0; } else { col++; }
-    }
-    return { line, col };
   }
 
   // ── Sidebar clipboard ──────────────────────────────────────────────────
@@ -2870,14 +2815,6 @@
   /** Count .md notes anywhere in the tree (recursive over folder
    *  children). The onboarding trigger uses this to decide whether
    *  the thoughtbase is "empty" — folders alone don't disqualify. */
-  function countNotes(files: import('../shared/types').NoteFile[]): number {
-    let n = 0;
-    for (const f of files) {
-      if (!f.isDirectory && f.name.endsWith('.md')) n++;
-      else if (f.isDirectory && f.children) n += countNotes(f.children);
-    }
-    return n;
-  }
 </script>
 
 <svelte:window onkeydown={(e) => handleKeydown(e, keymapDeps)} />

--- a/src/renderer/lib/app/text-helpers.ts
+++ b/src/renderer/lib/app/text-helpers.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure text / note-tree helpers extracted from App.svelte (#670). No stores,
+ * no DOM, no reactivity — just string and NoteFile-tree functions, so they're
+ * trivially unit-testable and don't belong inline in the root component.
+ */
+import { slugify } from '../../../shared/slug';
+import type { NoteFile } from '../../../shared/types';
+
+/** Cheap slug for path placeholders (e.g. onboarding system-prompt paths).
+ *  Callers may override; this is just a sensible default. */
+export function slugifyForPath(s: string): string {
+  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'overview';
+}
+
+/** Byte offset of the heading/block-id anchor within `text`, or null.
+ *  `^id` matches a trailing block id; otherwise matches a heading whose
+ *  slug equals `anchor`. */
+export function findAnchorOffset(text: string, anchor: string): number | null {
+  const isBlockId = anchor.startsWith('^');
+  const lines = text.split('\n');
+  let offset = 0;
+  for (const line of lines) {
+    if (isBlockId) {
+      if (line.trimEnd().endsWith(anchor)) return offset;
+    } else {
+      const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+      if (m && slugify(m[2]) === anchor) return offset;
+    }
+    offset += line.length + 1;
+  }
+  return null;
+}
+
+/** 1-based line + 0-based column for a byte offset into `text`. */
+export function offsetToLineCol(text: string, offset: number): { line: number; col: number } {
+  let line = 1;
+  let col = 0;
+  for (let i = 0; i < offset && i < text.length; i++) {
+    if (text[i] === '\n') { line++; col = 0; } else { col++; }
+  }
+  return { line, col };
+}
+
+/** Flatten a NoteFile tree to the relative paths of indexable leaf files. */
+export function flattenNotePaths(files: NoteFile[]): string[] {
+  const out: string[] = [];
+  const walk = (xs: NoteFile[]) => {
+    for (const f of xs) {
+      if (f.isDirectory) walk(f.children ?? []);
+      else if (/\.(md|ttl|csv)$/.test(f.relativePath)) out.push(f.relativePath);
+    }
+  };
+  walk(files);
+  return out;
+}
+
+/** Recursive count of `.md` notes in a NoteFile tree (folders don't count). */
+export function countNotes(files: NoteFile[]): number {
+  let n = 0;
+  for (const f of files) {
+    if (!f.isDirectory && f.name.endsWith('.md')) n++;
+    else if (f.isDirectory && f.children) n += countNotes(f.children);
+  }
+  return n;
+}
+
+/** Singular/plural noun for a delete confirmation over a set of targets. */
+export function describeDeleteNoun(targets: Array<{ isDirectory: boolean }>): string {
+  if (targets.length === 1) return targets[0].isDirectory ? 'folder' : 'note';
+  const allDirs = targets.every((t) => t.isDirectory);
+  const allFiles = targets.every((t) => !t.isDirectory);
+  if (allDirs) return 'folders';
+  if (allFiles) return 'notes';
+  return 'items';
+}
+
+/** Human-readable delete confirmation message for one or more targets. */
+export function describeDeleteMessage(
+  targets: Array<{ relativePath: string; isDirectory: boolean }>,
+  noun: string,
+): string {
+  if (targets.length === 1) {
+    const name = targets[0].relativePath.split('/').pop();
+    return `Delete ${noun} "${name}"?`;
+  }
+  const sample = targets.slice(0, 3).map((t) => t.relativePath).join(', ');
+  const more = targets.length > 3 ? ', …' : '';
+  return `Delete ${targets.length} ${noun} (${sample}${more})?`;
+}

--- a/tests/renderer/app/text-helpers.test.ts
+++ b/tests/renderer/app/text-helpers.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure text / note-tree helpers extracted from App.svelte (#670).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  slugifyForPath,
+  findAnchorOffset,
+  offsetToLineCol,
+  flattenNotePaths,
+  countNotes,
+  describeDeleteNoun,
+  describeDeleteMessage,
+} from '../../../src/renderer/lib/app/text-helpers';
+import type { NoteFile } from '../../../src/shared/types';
+
+function dir(name: string, children: NoteFile[]): NoteFile {
+  return { name, relativePath: name, isDirectory: true, children };
+}
+function file(relativePath: string): NoteFile {
+  const name = relativePath.split('/').pop()!;
+  return { name, relativePath, isDirectory: false };
+}
+
+describe('slugifyForPath', () => {
+  it('lowercases, dashes runs of non-alphanumerics, trims dashes', () => {
+    expect(slugifyForPath('Hello, World!')).toBe('hello-world');
+    expect(slugifyForPath('  Spaced  Out  ')).toBe('spaced-out');
+  });
+  it('caps length at 40 chars', () => {
+    expect(slugifyForPath('a'.repeat(60)).length).toBe(40);
+  });
+  it('falls back to "overview" when nothing survives', () => {
+    expect(slugifyForPath('!!!')).toBe('overview');
+    expect(slugifyForPath('')).toBe('overview');
+  });
+});
+
+describe('findAnchorOffset', () => {
+  it('finds a heading by slug and returns its byte offset', () => {
+    const text = '# Intro\n\n## My Section\n\nbody';
+    const off = findAnchorOffset(text, 'my-section');
+    expect(off).toBe(text.indexOf('## My Section'));
+  });
+  it('finds a trailing block id', () => {
+    const text = 'a paragraph ^abc123\nnext';
+    expect(findAnchorOffset(text, '^abc123')).toBe(0);
+  });
+  it('returns null when the anchor is absent', () => {
+    expect(findAnchorOffset('# Intro\nbody', 'missing')).toBeNull();
+  });
+});
+
+describe('offsetToLineCol', () => {
+  it('maps offsets to 1-based line / 0-based col', () => {
+    const text = 'abc\nde\nf';
+    expect(offsetToLineCol(text, 0)).toEqual({ line: 1, col: 0 });
+    expect(offsetToLineCol(text, 2)).toEqual({ line: 1, col: 2 });
+    expect(offsetToLineCol(text, 4)).toEqual({ line: 2, col: 0 });
+    expect(offsetToLineCol(text, 7)).toEqual({ line: 3, col: 0 });
+  });
+});
+
+describe('flattenNotePaths', () => {
+  it('collects md/ttl/csv leaves recursively, skipping other files', () => {
+    const tree = [
+      file('a.md'),
+      file('ignore.png'),
+      dir('sub', [file('sub/b.ttl'), file('sub/c.csv'), file('sub/d.txt')]),
+    ];
+    expect(flattenNotePaths(tree)).toEqual(['a.md', 'sub/b.ttl', 'sub/c.csv']);
+  });
+});
+
+describe('countNotes', () => {
+  it('counts .md files recursively, not folders or other files', () => {
+    const tree = [
+      file('a.md'),
+      file('b.csv'),
+      dir('sub', [file('sub/c.md'), dir('deep', [file('sub/deep/e.md')])]),
+    ];
+    expect(countNotes(tree)).toBe(3);
+  });
+});
+
+describe('describeDeleteNoun', () => {
+  it('singular/plural by target makeup', () => {
+    expect(describeDeleteNoun([{ isDirectory: false }])).toBe('note');
+    expect(describeDeleteNoun([{ isDirectory: true }])).toBe('folder');
+    expect(describeDeleteNoun([{ isDirectory: false }, { isDirectory: false }])).toBe('notes');
+    expect(describeDeleteNoun([{ isDirectory: true }, { isDirectory: true }])).toBe('folders');
+    expect(describeDeleteNoun([{ isDirectory: true }, { isDirectory: false }])).toBe('items');
+  });
+});
+
+describe('describeDeleteMessage', () => {
+  it('names a single target', () => {
+    expect(describeDeleteMessage([{ relativePath: 'a/b.md', isDirectory: false }], 'note'))
+      .toBe('Delete note "b.md"?');
+  });
+  it('summarizes multiple with a sample and overflow', () => {
+    const targets = ['a.md', 'b.md', 'c.md', 'd.md'].map((p) => ({ relativePath: p, isDirectory: false }));
+    expect(describeDeleteMessage(targets, 'notes')).toBe('Delete 4 notes (a.md, b.md, c.md, …)?');
+  });
+});


### PR DESCRIPTION
## What

Third increment of the App.svelte decomposition (#670). Extracts seven pure, dependency-free helpers into `lib/app/text-helpers.ts`:

`slugifyForPath`, `findAnchorOffset`, `offsetToLineCol`, `flattenNotePaths`, `countNotes`, `describeDeleteNoun`, `describeDeleteMessage`.

No stores, no DOM, no reactivity — just string / NoteFile-tree functions, so they belong in a testable module rather than inline in the root component. App's direct `slugify` import is dropped (only `findAnchorOffset` used it; now internal to the helpers module).

Partially addresses #670.

### Net
`tests/renderer/app/text-helpers.test.ts` (12 tests): slug capping/fallback, heading-slug + block-id offset finding, line/col mapping, tree flatten/count, and the delete-confirmation noun/message phrasing.

## Result
`App.svelte`: **3,514 → 3,451** (cumulative: 3,764 → 3,451).

## Note on menu-wiring
I floated menu-event wiring for this increment, but on inspection it's **net-neutral boilerplate** — a ~50-field handler interface mirroring the `api.menu.on*` calls, with per-binding guards that differ subtly from the command registry (e.g. menu `onGotoLine` guards on `editor.activeTab`), so it can't reuse `commandDeps`. Deferred in favor of the handler-group extraction, which is what actually reduces App.svelte toward <1,000.

## Remaining (follow-ups to #670)
- handler-group extraction (note-ops / source-ops / refactor-ops / nav-ops) into action modules — the main remaining bulk
- menu-event wiring (if still worthwhile after the handler groups move)

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2777 passed**; the one full-run failure is the documented #676 citeproc flake (`tree-markdown` Chicago), which passes in isolation (confirmed) and is unrelated to this change.
- `pnpm test:e2e` — boot smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)