### PR TITLE
Decompose App.svelte: note-ops test + extract source-ops (#670, increment 5)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -24,7 +24,9 @@
   import { getEditorStore } from './lib/stores/editor.svelte';
   import { getBusyStore } from './lib/stores/busy.svelte';
   import { getClipboardStore } from './lib/stores/clipboard.svelte';
+  import { getSourceFlowStore } from './lib/stores/source-flow.svelte';
   import { createNoteOps, type NoteOpsCtx } from './lib/app/note-ops';
+  import { createSourceOps, type SourceOpsCtx } from './lib/app/source-ops';
   import DialogHost from './lib/components/DialogHost.svelte';
   import { getDialogStore } from './lib/stores/dialogs.svelte';
   import { substituteTemplate } from '../shared/templates';
@@ -35,8 +37,6 @@
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
   import type { SafeDeleteBlocker } from '../shared/types';
-  import { displaySourceTitle } from '../shared/source-display';
-  import { RESOLVE_AUTO_THRESHOLD } from '../shared/resolve-stub';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
@@ -100,6 +100,7 @@
   const notebase = getNotebaseStore();
   const editor = getEditorStore();
   const busy = getBusyStore();
+  const sourceFlow = getSourceFlowStore();
   const clipboard = getClipboardStore();
   /** Last note tab the user was on. Used by the SourceDetail "Append
    *  to current note" action (#101) — when the user is viewing a
@@ -490,8 +491,6 @@
     onCancel: () => void;
   } | null>(null);
   let findInNotesMode = $state<'find' | 'replace' | null>(null);
-  let ocrSession = $state<{ sourceId: string; title: string; pageCount: number } | null>(null);
-  let ocrPdfBytes = $state<Uint8Array | null>(null);
 
   async function handleFileSelect(relativePath: string, searchQuery?: string) {
     recordCurrentPosition();
@@ -1335,148 +1334,6 @@
   }
 
   /**
-   * Shared completion for "Ingest URL/File as Source". A URL or file can resolve
-   * to a web page, a PDF (possibly needing OCR), or a text doc — branch on the
-   * result the same way regardless of where it came from.
-   */
-  async function handleIngestedSourceResult(
-    result: { sourceId: string; title: string; duplicate: boolean; needsOcr?: boolean; pageCount?: number },
-  ) {
-    if (result.duplicate) {
-      setTimeout(() => handleOpenSource(result.sourceId), 150);
-      await showConfirm(
-        `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
-        CONFIRM_KEYS.ingestDuplicate,
-        'OK',
-      );
-      return;
-    }
-    if (result.needsOcr) {
-      // Scanned PDF (from a file or a URL) — meta.ttl + original.pdf are
-      // persisted but body.md is empty until OCR runs (#95). Defer opening the
-      // tab until OCR finishes / is skipped so the user isn't staring at a blank body.
-      ocrSession = { sourceId: result.sourceId, title: result.title, pageCount: result.pageCount ?? 0 };
-      ocrPdfBytes = await api.sources.readPdf(result.sourceId);
-      return;
-    }
-    // Wait a beat so the file watcher's indexSource pass finishes before we
-    // open the source tab — otherwise the detail panel's graph query returns
-    // empty and the tab renders as "unknown source."
-    setTimeout(() => handleOpenSource(result.sourceId), 150);
-  }
-
-  async function handleIngestUrlAsSource() {
-    if (!notebase.meta) return;
-    const raw = await showPrompt('URL to ingest as a source:');
-    if (!raw) return;
-    const url = raw.trim();
-    if (!url) return;
-    try {
-      const result = await busy.withBusy('Fetching…', () => api.sources.ingestUrl(url));
-      await handleIngestedSourceResult(result);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
-
-  async function handleExternalDrop(destFolder: string, files: FileList) {
-    if (!notebase.meta) return;
-    const localPaths: string[] = [];
-    for (const f of files) {
-      // Electron 32+: `webUtils.getPathForFile` is the supported accessor;
-      // `File.path` was deprecated and is removed in Electron 34.
-      const p = api.files.getPathForFile(f);
-      if (p) localPaths.push(p);
-    }
-    if (localPaths.length === 0) return;
-    try {
-      const result = await busy.withBusy('Importing…', () =>
-        api.files.dropImport(destFolder, localPaths),
-      );
-      // Open the first newly-ingested PDF source tab, matching the menu-
-      // triggered Ingest PDF flow. setTimeout waits for the watcher to
-      // finish reindexing the source so the detail panel has data.
-      const openablePdf = result.ingestedPdfs.find((p) => !p.duplicate) ?? result.ingestedPdfs[0];
-      if (openablePdf) {
-        setTimeout(() => handleOpenSource(openablePdf.sourceId), 150);
-      }
-      if (result.rejected.length > 0) {
-        const lines = result.rejected
-          .map((r) => `• ${r.localPath.split('/').pop()} — ${r.reason}`)
-          .join('\n');
-        await showConfirm(
-          `Some files were skipped:\n${lines}`,
-          CONFIRM_KEYS.dropImportRejected,
-          'OK',
-        );
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
-
-  async function handleImportBibtex() {
-    if (!notebase.meta) return;
-    try {
-      const result = await busy.withBusy('Importing BibTeX…', () => api.sources.importBibtex());
-      if (!result) return; // user cancelled the picker
-      // Refresh the Sources panel so the new entries are immediately visible.
-      sidebar?.refreshSources();
-      await refreshSourcesCache();
-      const parts: string[] = [
-        `Imported: ${result.imported.length}`,
-        `Duplicate (skipped): ${result.duplicate.length}`,
-      ];
-      if (result.failed.length > 0) parts.push(`Failed: ${result.failed.length}`);
-      if (result.parseErrors > 0) parts.push(`Parse errors: ${result.parseErrors}`);
-      let message = `BibTeX import complete.\n\n${parts.join('\n')}`;
-      if (result.failed.length > 0) {
-        const preview = result.failed
-          .slice(0, 5)
-          .map((f) => `  • ${f.key}: ${f.reason}`)
-          .join('\n');
-        const more = result.failed.length > 5 ? `\n  …and ${result.failed.length - 5} more` : '';
-        message += `\n\nFirst failures:\n${preview}${more}`;
-      }
-      await showConfirm(message, CONFIRM_KEYS.bibtexImportComplete, 'OK');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`BibTeX import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
-
-  async function handleImportZoteroRdf() {
-    if (!notebase.meta) return;
-    try {
-      const result = await busy.withBusy('Importing Zotero RDF…', () => api.sources.importZoteroRdf());
-      if (!result) return;
-      sidebar?.refreshSources();
-      await refreshSourcesCache();
-      const pdfsLifted = result.imported.filter((i) => i.pdfAttached).length;
-      const parts: string[] = [
-        `Imported: ${result.imported.length}` + (pdfsLifted > 0 ? ` (${pdfsLifted} with PDF)` : ''),
-        `Duplicate (skipped): ${result.duplicate.length}`,
-      ];
-      if (result.failed.length > 0) parts.push(`Failed: ${result.failed.length}`);
-      let message = `Zotero RDF import complete.\n\n${parts.join('\n')}`;
-      if (result.failed.length > 0) {
-        const preview = result.failed
-          .slice(0, 5)
-          .map((f) => `  • ${f.subject}: ${f.reason}`)
-          .join('\n');
-        const more = result.failed.length > 5 ? `\n  …and ${result.failed.length - 5} more` : '';
-        message += `\n\nFirst failures:\n${preview}${more}`;
-      }
-      await showConfirm(message, CONFIRM_KEYS.zoteroRdfImportComplete, 'OK');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Zotero RDF import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
-
-  /**
    * Three-way prompt ("This Window" / "New Window" / "Cancel") wrapped
    * in a promise. Returns 'this' without prompting when no thoughtbase
    * is currently open — same-window is the obviously-right choice for
@@ -1615,117 +1472,6 @@
       await showConfirm(`Save cell output failed: ${msg}`, CONFIRM_KEYS.saveCellOutputFailed, 'OK');
     }
   }
-
-  async function handleIngestFileAsSource() {
-    if (!notebase.meta) return;
-    try {
-      const result = await busy.withBusy('Ingesting…', () => api.sources.ingestFile());
-      if (!result) return; // user cancelled the picker
-      await handleIngestedSourceResult(result);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
-
-  async function handleOcrDone(pages: string[]) {
-    if (!ocrSession) return;
-    const { sourceId } = ocrSession;
-    ocrSession = null;
-    ocrPdfBytes = null;
-    try {
-      await api.sources.finishPdfOcr(sourceId, pages);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`OCR save failed: ${msg}`, CONFIRM_KEYS.ingestPdfFailed, 'OK');
-      return;
-    }
-    setTimeout(() => handleOpenSource(sourceId), 150);
-  }
-
-  function handleOcrCancel() {
-    // Source + original.pdf stay on disk; body.md is the "OCR pending"
-    // placeholder. User can delete the source if they want it gone.
-    if (!ocrSession) return;
-    const { sourceId } = ocrSession;
-    ocrSession = null;
-    ocrPdfBytes = null;
-    setTimeout(() => handleOpenSource(sourceId), 150);
-  }
-
-  /**
-   * Right-click a source → "Mine references…" (#106). Runs the LLM
-   * mining call, opens a review dialog. User checks the candidates
-   * they want, clicks Approve → backend writes the stub files and
-   * adds `minerva:references` edges from the parent.
-   */
-  let mineReviewState = $state<{
-    parentId: string;
-    parentTitle: string;
-    refs: import('../shared/mine-references').ParsedReference[];
-  } | null>(null);
-
-  async function handleMineReferences(source: import('../shared/types').SourceMetadata): Promise<void> {
-    try {
-      const refs = await busy.withBusy('Mining references…', () =>
-        api.sources.mineReferences(source.sourceId),
-      );
-      if (refs.length === 0) {
-        await showConfirm(
-          'No references the LLM could parse. The body.md may not have a References section, or its formatting is too irregular for first-pass extraction.',
-          CONFIRM_KEYS.mineReferencesEmpty,
-          'OK',
-        );
-        return;
-      }
-      mineReviewState = {
-        parentId: source.sourceId,
-        parentTitle: source.title ?? source.sourceId,
-        refs,
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Couldn't mine references: ${msg}`, CONFIRM_KEYS.mineReferencesFailed, 'OK');
-    }
-  }
-
-  async function handleMineReferencesApply(
-    accepted: import('../shared/mine-references').ParsedReference[],
-  ): Promise<void> {
-    const state = mineReviewState;
-    mineReviewState = null;
-    if (!state) return;
-    try {
-      const result = await busy.withBusy('Creating stubs…', () =>
-        api.sources.createReferenceStubs(state.parentId, accepted),
-      );
-      await refreshSourcesCache();
-      const lines: string[] = [];
-      if (result.created.length > 0) lines.push(`Created ${result.created.length} new stub${result.created.length === 1 ? '' : 's'}.`);
-      if (result.matchedExisting.length > 0) lines.push(`${result.matchedExisting.length} matched existing sources.`);
-      if (result.skipped.length > 0) lines.push(`${result.skipped.length} skipped (id collision).`);
-      if (lines.length > 0) {
-        await showConfirm(lines.join(' '), CONFIRM_KEYS.mineReferencesResult, 'OK');
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Couldn't create stubs: ${msg}`, CONFIRM_KEYS.mineReferencesFailed, 'OK');
-    }
-  }
-
-  /**
-   * Resolve a stub source by searching CrossRef (#107). Two paths:
-   * - Top candidate's confidence ≥ `RESOLVE_AUTO_THRESHOLD` → apply
-   *   automatically, no picker. The user can still undo via git
-   *   if they disagree.
-   * - Otherwise → open the disambiguation picker with the top 3.
-   */
-  let resolveStubState = $state<{
-    sourceId: string;
-    stubTitle: string;
-    candidates: import('../shared/resolve-stub').ResolveCandidate[];
-  } | null>(null);
-
   /**
    * Safe-delete blocker dialog state (#429). `proceed` is the
    * "Delete anyway" closure — calling it runs the existing batch
@@ -1757,123 +1503,24 @@
     handleRename, handleCopyWithPrompt, handleMoveWithPrompt,
   } = createNoteOps(noteOpsCtx);
 
-  async function handleResolveStub(sourceId: string): Promise<void> {
-    if (!notebase.meta) return;
-    let candidates: import('../shared/resolve-stub').ResolveCandidate[];
-    try {
-      candidates = await busy.withBusy('Searching CrossRef…', () =>
-        api.sources.resolveStub(sourceId),
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Resolve failed: ${msg}`, CONFIRM_KEYS.resolveStubFailed, 'OK');
-      return;
-    }
-    if (candidates.length === 0) {
-      await showConfirm(
-        'CrossRef returned no matches. Refine the stub’s title or authors, or ingest the DOI directly.',
-        CONFIRM_KEYS.resolveStubEmpty,
-        'OK',
-      );
-      return;
-    }
-    const top = candidates[0];
-    if (top.confidence >= RESOLVE_AUTO_THRESHOLD) {
-      await applyResolution(sourceId, top.doi, top.title);
-      return;
-    }
-    // Below threshold — let the user pick.
-    const detail = await api.graph.sourceDetail(sourceId);
-    resolveStubState = {
-      sourceId,
-      stubTitle: detail ? displaySourceTitle(detail.metadata) : sourceId,
-      candidates,
-    };
-  }
-
-  async function handleResolveStubApply(doi: string): Promise<void> {
-    const state = resolveStubState;
-    resolveStubState = null;
-    if (!state) return;
-    const picked = state.candidates.find((c) => c.doi === doi);
-    await applyResolution(state.sourceId, doi, picked?.title ?? state.stubTitle);
-  }
-
-  async function applyResolution(sourceId: string, doi: string, newTitle: string): Promise<void> {
-    try {
-      await busy.withBusy('Applying resolution…', () =>
-        api.sources.applyStubResolution(sourceId, doi),
-      );
-      await refreshSourcesCache();
-      await showConfirm(
-        `Resolved to "${newTitle}". The source's metadata now reflects the CrossRef record; the source id stays the same so existing citations keep resolving.`,
-        CONFIRM_KEYS.resolveStubApplied,
-        'OK',
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Couldn’t apply resolution: ${msg}`, CONFIRM_KEYS.resolveStubFailed, 'OK');
-    }
-  }
-
-  /**
-   * Click on a bare-DOI link inside the markdown preview (#473).
-   * If the DOI already maps to an ingested source, open it. Otherwise
-   * offer to ingest — dismissable, keyed so the user can suppress
-   * the prompt project-wide once they've made up their mind.
-   */
-  async function handleDoiClick(doi: string): Promise<void> {
-    if (!notebase.meta) return;
-    // Normalise — sources store DOIs case-folded; user input might
-    // have mixed case from the rendered link text.
-    const target = doi.toLowerCase();
-    const existing = sourcesCache.find((s) => (s.doi ?? '').toLowerCase() === target);
-    if (existing) {
-      handleOpenSource(existing.sourceId);
-      return;
-    }
-    const confirmed = await showConfirm(
-      `Ingest this DOI as a new source?\n\n${doi}`,
-      CONFIRM_KEYS.ingestDoiFromBody,
-      'Ingest',
-    );
-    if (!confirmed) return;
-    try {
-      const result = await busy.withBusy('Looking up…', () => api.sources.ingestIdentifier(doi));
-      setTimeout(() => handleOpenSource(result.sourceId), 150);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
-
-  async function handleIngestIdentifier() {
-    if (!notebase.meta) return;
-    const raw = await showPrompt('DOI, arXiv id, or PubMed id:');
-    if (!raw) return;
-    const identifier = raw.trim();
-    if (!identifier) return;
-    try {
-      const result = await busy.withBusy('Looking up…', () => api.sources.ingestIdentifier(identifier));
-      setTimeout(() => handleOpenSource(result.sourceId), 150);
-      if (result.duplicate) {
-        await showConfirm(
-          `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
-          CONFIRM_KEYS.ingestDuplicate,
-          'OK',
-        );
-      } else if (result.pdfError) {
-        await showConfirm(
-          `Ingested "${result.title}", but the open-access PDF fetch failed: ${result.pdfError}. The source's bibo:uri points at the canonical record so you can still grab it by hand.`,
-          CONFIRM_KEYS.ingestPdfFailed,
-          'OK',
-        );
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
-    }
-  }
+  // Source-ops handler cluster (#670): source ingest (URL / file / identifier /
+  // external drop / DOI-click), OCR (#95), reference mining (#106), stub
+  // resolution (#107). Lives in ./lib/app/source-ops.ts; in-flight feature-dialog
+  // state lives in the source-flow store; destructured into the same names so
+  // every call site reads unchanged. The source *view* handlers (handleOpenSource
+  // etc.) stay in App — source-ops reaches them via ctx getters.
+  const sourceOpsCtx: SourceOpsCtx = {
+    openSource: (id, hi) => handleOpenSource(id, hi),
+    getSidebar: () => sidebar,
+    refreshSourcesCache: () => refreshSourcesCache(),
+    findSourceByDoi: (target) => sourcesCache.find((s) => (s.doi ?? '').toLowerCase() === target),
+  };
+  const {
+    handleIngestUrlAsSource, handleIngestFileAsSource,
+    handleIngestIdentifier, handleOcrDone, handleOcrCancel, handleMineReferences,
+    handleMineReferencesApply, handleResolveStub, handleResolveStubApply, handleDoiClick,
+    handleImportBibtex, handleImportZoteroRdf, handleExternalDrop,
+  } = createSourceOps(sourceOpsCtx);
 
   async function handleDecompose(_relativePath: string) {
     if (!notebase.meta) return;
@@ -2698,11 +2345,11 @@
       onCancel={saveQueryRequest.onCancel}
     />
   {/if}
-  {#if ocrSession && ocrPdfBytes}
+  {#if sourceFlow.ocrSession && sourceFlow.ocrPdfBytes}
     <OcrProgressDialog
-      pdfBytes={ocrPdfBytes}
-      pageCount={ocrSession.pageCount}
-      title={ocrSession.title}
+      pdfBytes={sourceFlow.ocrPdfBytes}
+      pageCount={sourceFlow.ocrSession.pageCount}
+      title={sourceFlow.ocrSession.title}
       onDone={handleOcrDone}
       onCancel={handleOcrCancel}
     />
@@ -2718,20 +2365,20 @@
     />
   {/if}
   <DialogHost />
-  {#if mineReviewState}
+  {#if sourceFlow.mineReview}
     <MineReferencesDialog
-      parentTitle={mineReviewState.parentTitle}
-      refs={mineReviewState.refs}
+      parentTitle={sourceFlow.mineReview.parentTitle}
+      refs={sourceFlow.mineReview.refs}
       onApply={handleMineReferencesApply}
-      onCancel={() => { mineReviewState = null; }}
+      onCancel={() => sourceFlow.setMineReview(null)}
     />
   {/if}
-  {#if resolveStubState}
+  {#if sourceFlow.resolveStub}
     <ResolveStubDialog
-      stubTitle={resolveStubState.stubTitle}
-      candidates={resolveStubState.candidates}
+      stubTitle={sourceFlow.resolveStub.stubTitle}
+      candidates={sourceFlow.resolveStub.candidates}
       onApply={handleResolveStubApply}
-      onCancel={() => { resolveStubState = null; }}
+      onCancel={() => sourceFlow.setResolveStub(null)}
     />
   {/if}
   {#if safeDeleteDialogState}

--- a/src/renderer/lib/app/source-ops.ts
+++ b/src/renderer/lib/app/source-ops.ts
@@ -1,0 +1,392 @@
+/**
+ * Source-ops handler cluster extracted from App.svelte (#670). Source ingest
+ * (URL / file / identifier / external drop / DOI-click), the OCR flow (#95),
+ * reference mining (#106), and stub resolution (#107). Bodies are verbatim
+ * from App.svelte; the only changes are the store / ctx substitutions for the
+ * pieces that used to be inline component refs, local `$state`, or sibling
+ * function declarations that stay in App (the source *view* handlers).
+ */
+import { api } from '../ipc/client';
+import { getNotebaseStore } from '../stores/notebase.svelte';
+import { getDialogStore } from '../stores/dialogs.svelte';
+import { getBusyStore } from '../stores/busy.svelte';
+import { getSourceFlowStore } from '../stores/source-flow.svelte';
+import { displaySourceTitle } from '../../../shared/source-display';
+import { RESOLVE_AUTO_THRESHOLD } from '../../../shared/resolve-stub';
+import { CONFIRM_KEYS } from '../confirm-keys';
+import type { ParsedReference } from '../../../shared/mine-references';
+import type { ResolveCandidate } from '../../../shared/resolve-stub';
+import type { SourceMetadata } from '../../../shared/types';
+
+export interface SourceOpsCtx {
+  openSource: (sourceId: string, highlightExcerptId?: string) => void;
+  getSidebar: () => { refreshSources: () => void } | undefined;
+  refreshSourcesCache: () => Promise<void>;
+  findSourceByDoi: (doiLower: string) => { sourceId: string } | undefined;
+}
+
+export function createSourceOps(ctx: SourceOpsCtx) {
+  const notebase = getNotebaseStore();
+  const dialogs = getDialogStore();
+  const busy = getBusyStore();
+  const flow = getSourceFlowStore();
+  const { showPrompt, showConfirm } = dialogs;
+
+  /**
+   * Shared completion for "Ingest URL/File as Source". A URL or file can resolve
+   * to a web page, a PDF (possibly needing OCR), or a text doc — branch on the
+   * result the same way regardless of where it came from.
+   */
+  async function handleIngestedSourceResult(
+    result: { sourceId: string; title: string; duplicate: boolean; needsOcr?: boolean; pageCount?: number },
+  ) {
+    if (result.duplicate) {
+      setTimeout(() => ctx.openSource(result.sourceId), 150);
+      await showConfirm(
+        `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
+        CONFIRM_KEYS.ingestDuplicate,
+        'OK',
+      );
+      return;
+    }
+    if (result.needsOcr) {
+      // Scanned PDF (from a file or a URL) — meta.ttl + original.pdf are
+      // persisted but body.md is empty until OCR runs (#95). Defer opening the
+      // tab until OCR finishes / is skipped so the user isn't staring at a blank body.
+      flow.setOcrSession({ sourceId: result.sourceId, title: result.title, pageCount: result.pageCount ?? 0 });
+      flow.setOcrPdfBytes(await api.sources.readPdf(result.sourceId));
+      return;
+    }
+    // Wait a beat so the file watcher's indexSource pass finishes before we
+    // open the source tab — otherwise the detail panel's graph query returns
+    // empty and the tab renders as "unknown source."
+    setTimeout(() => ctx.openSource(result.sourceId), 150);
+  }
+
+  async function handleIngestUrlAsSource() {
+    if (!notebase.meta) return;
+    const raw = await showPrompt('URL to ingest as a source:');
+    if (!raw) return;
+    const url = raw.trim();
+    if (!url) return;
+    try {
+      const result = await busy.withBusy('Fetching…', () => api.sources.ingestUrl(url));
+      await handleIngestedSourceResult(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  async function handleExternalDrop(destFolder: string, files: FileList) {
+    if (!notebase.meta) return;
+    const localPaths: string[] = [];
+    for (const f of files) {
+      // Electron 32+: `webUtils.getPathForFile` is the supported accessor;
+      // `File.path` was deprecated and is removed in Electron 34.
+      const p = api.files.getPathForFile(f);
+      if (p) localPaths.push(p);
+    }
+    if (localPaths.length === 0) return;
+    try {
+      const result = await busy.withBusy('Importing…', () =>
+        api.files.dropImport(destFolder, localPaths),
+      );
+      // Open the first newly-ingested PDF source tab, matching the menu-
+      // triggered Ingest PDF flow. setTimeout waits for the watcher to
+      // finish reindexing the source so the detail panel has data.
+      const openablePdf = result.ingestedPdfs.find((p) => !p.duplicate) ?? result.ingestedPdfs[0];
+      if (openablePdf) {
+        setTimeout(() => ctx.openSource(openablePdf.sourceId), 150);
+      }
+      if (result.rejected.length > 0) {
+        const lines = result.rejected
+          .map((r) => `• ${r.localPath.split('/').pop()} — ${r.reason}`)
+          .join('\n');
+        await showConfirm(
+          `Some files were skipped:\n${lines}`,
+          CONFIRM_KEYS.dropImportRejected,
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  async function handleImportBibtex() {
+    if (!notebase.meta) return;
+    try {
+      const result = await busy.withBusy('Importing BibTeX…', () => api.sources.importBibtex());
+      if (!result) return; // user cancelled the picker
+      // Refresh the Sources panel so the new entries are immediately visible.
+      ctx.getSidebar()?.refreshSources();
+      await ctx.refreshSourcesCache();
+      const parts: string[] = [
+        `Imported: ${result.imported.length}`,
+        `Duplicate (skipped): ${result.duplicate.length}`,
+      ];
+      if (result.failed.length > 0) parts.push(`Failed: ${result.failed.length}`);
+      if (result.parseErrors > 0) parts.push(`Parse errors: ${result.parseErrors}`);
+      let message = `BibTeX import complete.\n\n${parts.join('\n')}`;
+      if (result.failed.length > 0) {
+        const preview = result.failed
+          .slice(0, 5)
+          .map((f) => `  • ${f.key}: ${f.reason}`)
+          .join('\n');
+        const more = result.failed.length > 5 ? `\n  …and ${result.failed.length - 5} more` : '';
+        message += `\n\nFirst failures:\n${preview}${more}`;
+      }
+      await showConfirm(message, CONFIRM_KEYS.bibtexImportComplete, 'OK');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`BibTeX import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  async function handleImportZoteroRdf() {
+    if (!notebase.meta) return;
+    try {
+      const result = await busy.withBusy('Importing Zotero RDF…', () => api.sources.importZoteroRdf());
+      if (!result) return;
+      ctx.getSidebar()?.refreshSources();
+      await ctx.refreshSourcesCache();
+      const pdfsLifted = result.imported.filter((i) => i.pdfAttached).length;
+      const parts: string[] = [
+        `Imported: ${result.imported.length}` + (pdfsLifted > 0 ? ` (${pdfsLifted} with PDF)` : ''),
+        `Duplicate (skipped): ${result.duplicate.length}`,
+      ];
+      if (result.failed.length > 0) parts.push(`Failed: ${result.failed.length}`);
+      let message = `Zotero RDF import complete.\n\n${parts.join('\n')}`;
+      if (result.failed.length > 0) {
+        const preview = result.failed
+          .slice(0, 5)
+          .map((f) => `  • ${f.subject}: ${f.reason}`)
+          .join('\n');
+        const more = result.failed.length > 5 ? `\n  …and ${result.failed.length - 5} more` : '';
+        message += `\n\nFirst failures:\n${preview}${more}`;
+      }
+      await showConfirm(message, CONFIRM_KEYS.zoteroRdfImportComplete, 'OK');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Zotero RDF import failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  async function handleIngestFileAsSource() {
+    if (!notebase.meta) return;
+    try {
+      const result = await busy.withBusy('Ingesting…', () => api.sources.ingestFile());
+      if (!result) return; // user cancelled the picker
+      await handleIngestedSourceResult(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  async function handleOcrDone(pages: string[]) {
+    if (!flow.ocrSession) return;
+    const { sourceId } = flow.ocrSession;
+    flow.setOcrSession(null);
+    flow.setOcrPdfBytes(null);
+    try {
+      await api.sources.finishPdfOcr(sourceId, pages);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`OCR save failed: ${msg}`, CONFIRM_KEYS.ingestPdfFailed, 'OK');
+      return;
+    }
+    setTimeout(() => ctx.openSource(sourceId), 150);
+  }
+
+  function handleOcrCancel() {
+    // Source + original.pdf stay on disk; body.md is the "OCR pending"
+    // placeholder. User can delete the source if they want it gone.
+    if (!flow.ocrSession) return;
+    const { sourceId } = flow.ocrSession;
+    flow.setOcrSession(null);
+    flow.setOcrPdfBytes(null);
+    setTimeout(() => ctx.openSource(sourceId), 150);
+  }
+
+  /**
+   * Right-click a source → "Mine references…" (#106). Runs the LLM
+   * mining call, opens a review dialog. User checks the candidates
+   * they want, clicks Approve → backend writes the stub files and
+   * adds `minerva:references` edges from the parent.
+   */
+  async function handleMineReferences(source: SourceMetadata): Promise<void> {
+    try {
+      const refs = await busy.withBusy('Mining references…', () =>
+        api.sources.mineReferences(source.sourceId),
+      );
+      if (refs.length === 0) {
+        await showConfirm(
+          'No references the LLM could parse. The body.md may not have a References section, or its formatting is too irregular for first-pass extraction.',
+          CONFIRM_KEYS.mineReferencesEmpty,
+          'OK',
+        );
+        return;
+      }
+      flow.setMineReview({
+        parentId: source.sourceId,
+        parentTitle: source.title ?? source.sourceId,
+        refs,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn't mine references: ${msg}`, CONFIRM_KEYS.mineReferencesFailed, 'OK');
+    }
+  }
+
+  async function handleMineReferencesApply(
+    accepted: ParsedReference[],
+  ): Promise<void> {
+    const state = flow.mineReview;
+    flow.setMineReview(null);
+    if (!state) return;
+    try {
+      const result = await busy.withBusy('Creating stubs…', () =>
+        api.sources.createReferenceStubs(state.parentId, accepted),
+      );
+      await ctx.refreshSourcesCache();
+      const lines: string[] = [];
+      if (result.created.length > 0) lines.push(`Created ${result.created.length} new stub${result.created.length === 1 ? '' : 's'}.`);
+      if (result.matchedExisting.length > 0) lines.push(`${result.matchedExisting.length} matched existing sources.`);
+      if (result.skipped.length > 0) lines.push(`${result.skipped.length} skipped (id collision).`);
+      if (lines.length > 0) {
+        await showConfirm(lines.join(' '), CONFIRM_KEYS.mineReferencesResult, 'OK');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn't create stubs: ${msg}`, CONFIRM_KEYS.mineReferencesFailed, 'OK');
+    }
+  }
+
+  async function handleResolveStub(sourceId: string): Promise<void> {
+    if (!notebase.meta) return;
+    let candidates: ResolveCandidate[];
+    try {
+      candidates = await busy.withBusy('Searching CrossRef…', () =>
+        api.sources.resolveStub(sourceId),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Resolve failed: ${msg}`, CONFIRM_KEYS.resolveStubFailed, 'OK');
+      return;
+    }
+    if (candidates.length === 0) {
+      await showConfirm(
+        'CrossRef returned no matches. Refine the stub’s title or authors, or ingest the DOI directly.',
+        CONFIRM_KEYS.resolveStubEmpty,
+        'OK',
+      );
+      return;
+    }
+    const top = candidates[0];
+    if (top.confidence >= RESOLVE_AUTO_THRESHOLD) {
+      await applyResolution(sourceId, top.doi, top.title);
+      return;
+    }
+    // Below threshold — let the user pick.
+    const detail = await api.graph.sourceDetail(sourceId);
+    flow.setResolveStub({
+      sourceId,
+      stubTitle: detail ? displaySourceTitle(detail.metadata) : sourceId,
+      candidates,
+    });
+  }
+
+  async function handleResolveStubApply(doi: string): Promise<void> {
+    const state = flow.resolveStub;
+    flow.setResolveStub(null);
+    if (!state) return;
+    const picked = state.candidates.find((c) => c.doi === doi);
+    await applyResolution(state.sourceId, doi, picked?.title ?? state.stubTitle);
+  }
+
+  async function applyResolution(sourceId: string, doi: string, newTitle: string): Promise<void> {
+    try {
+      await busy.withBusy('Applying resolution…', () =>
+        api.sources.applyStubResolution(sourceId, doi),
+      );
+      await ctx.refreshSourcesCache();
+      await showConfirm(
+        `Resolved to "${newTitle}". The source's metadata now reflects the CrossRef record; the source id stays the same so existing citations keep resolving.`,
+        CONFIRM_KEYS.resolveStubApplied,
+        'OK',
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn’t apply resolution: ${msg}`, CONFIRM_KEYS.resolveStubFailed, 'OK');
+    }
+  }
+
+  /**
+   * Click on a bare-DOI link inside the markdown preview (#473).
+   * If the DOI already maps to an ingested source, open it. Otherwise
+   * offer to ingest — dismissable, keyed so the user can suppress
+   * the prompt project-wide once they've made up their mind.
+   */
+  async function handleDoiClick(doi: string): Promise<void> {
+    if (!notebase.meta) return;
+    // Normalise — sources store DOIs case-folded; user input might
+    // have mixed case from the rendered link text.
+    const target = doi.toLowerCase();
+    const existing = ctx.findSourceByDoi(target);
+    if (existing) {
+      ctx.openSource(existing.sourceId);
+      return;
+    }
+    const confirmed = await showConfirm(
+      `Ingest this DOI as a new source?\n\n${doi}`,
+      CONFIRM_KEYS.ingestDoiFromBody,
+      'Ingest',
+    );
+    if (!confirmed) return;
+    try {
+      const result = await busy.withBusy('Looking up…', () => api.sources.ingestIdentifier(doi));
+      setTimeout(() => ctx.openSource(result.sourceId), 150);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  async function handleIngestIdentifier() {
+    if (!notebase.meta) return;
+    const raw = await showPrompt('DOI, arXiv id, or PubMed id:');
+    if (!raw) return;
+    const identifier = raw.trim();
+    if (!identifier) return;
+    try {
+      const result = await busy.withBusy('Looking up…', () => api.sources.ingestIdentifier(identifier));
+      setTimeout(() => ctx.openSource(result.sourceId), 150);
+      if (result.duplicate) {
+        await showConfirm(
+          `Already ingested: "${result.title || result.sourceId}". Opened the existing source.`,
+          CONFIRM_KEYS.ingestDuplicate,
+          'OK',
+        );
+      } else if (result.pdfError) {
+        await showConfirm(
+          `Ingested "${result.title}", but the open-access PDF fetch failed: ${result.pdfError}. The source's bibo:uri points at the canonical record so you can still grab it by hand.`,
+          CONFIRM_KEYS.ingestPdfFailed,
+          'OK',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Ingest failed: ${msg}`, CONFIRM_KEYS.ingestFailed, 'OK');
+    }
+  }
+
+  return {
+    handleIngestedSourceResult, handleIngestUrlAsSource, handleIngestFileAsSource,
+    handleIngestIdentifier, handleOcrDone, handleOcrCancel, handleMineReferences,
+    handleMineReferencesApply, handleResolveStub, handleResolveStubApply, handleDoiClick,
+    handleImportBibtex, handleImportZoteroRdf, handleExternalDrop,
+  };
+}

--- a/src/renderer/lib/stores/source-flow.svelte.ts
+++ b/src/renderer/lib/stores/source-flow.svelte.ts
@@ -1,0 +1,48 @@
+/**
+ * Source-flow feature-dialog state (#670). Three multi-step source flows keep
+ * their in-flight state here so the source-ops handler cluster can drive them
+ * and App's template can render the paired dialogs without a prop fan-out:
+ *
+ * - Mine references (#106): right-click a source → mine its References section
+ *   with the LLM, review the parsed candidates, approve → backend writes stubs.
+ * - Resolve stub (#107): search CrossRef for a stub source; below the
+ *   auto-apply threshold the disambiguation picker opens with the top
+ *   candidates.
+ * - OCR (#95): a scanned PDF is persisted but its body.md is empty until OCR
+ *   runs; the OCR dialog reads the PDF bytes + page count from here and the
+ *   source tab is deferred until OCR finishes / is skipped.
+ */
+import type { ParsedReference } from '../../../shared/mine-references';
+import type { ResolveCandidate } from '../../../shared/resolve-stub';
+
+export interface OcrSession {
+  sourceId: string;
+  title: string;
+  pageCount: number;
+}
+
+export interface MineReview {
+  parentId: string;
+  parentTitle: string;
+  refs: ParsedReference[];
+}
+
+export interface ResolveStub {
+  sourceId: string;
+  stubTitle: string;
+  candidates: ResolveCandidate[];
+}
+
+let ocrSession = $state<OcrSession | null>(null);
+let ocrPdfBytes = $state<Uint8Array | null>(null);
+let mineReview = $state<MineReview | null>(null);
+let resolveStub = $state<ResolveStub | null>(null);
+
+export function getSourceFlowStore() {
+  return {
+    get ocrSession() { return ocrSession; }, setOcrSession(s: OcrSession | null) { ocrSession = s; },
+    get ocrPdfBytes() { return ocrPdfBytes; }, setOcrPdfBytes(b: Uint8Array | null) { ocrPdfBytes = b; },
+    get mineReview() { return mineReview; }, setMineReview(s: MineReview | null) { mineReview = s; },
+    get resolveStub() { return resolveStub; }, setResolveStub(s: ResolveStub | null) { resolveStub = s; },
+  };
+}

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Behavioral net for the note-ops handlers extracted from App.svelte (#670).
+ * Mocks the api client + notebase/editor/dialog stores; uses the real
+ * busy/clipboard runes stores. Verifies the moved handler bodies, not just
+ * that the command palette / keymap reach them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NoteFile } from '../../../src/shared/types';
+
+const h = vi.hoisted(() => {
+  const api = {
+    notebase: {
+      createFile: vi.fn(), writeFile: vi.fn(), rename: vi.fn(), copy: vi.fn(),
+      deleteFile: vi.fn(), deleteFolder: vi.fn(), createFolder: vi.fn(),
+      readFile: vi.fn(), mergePreview: vi.fn(), merge: vi.fn(),
+    },
+    links: { externalInbound: vi.fn() },
+    templates: { get: vi.fn() },
+  };
+  const notebase = { meta: { rootPath: '/p', name: 'p' } as unknown, files: [] as NoteFile[], refresh: vi.fn() };
+  const editor = { openFile: vi.fn(), tabs: [] as unknown[], closeTabsForDeletedPath: vi.fn(), flushAutoSave: vi.fn() };
+  const dialog = {
+    showPrompt: vi.fn(), showConfirm: vi.fn(), showNewNoteDialog: vi.fn(), showSnippetPicker: vi.fn(),
+  };
+  return { api, notebase, editor, dialog };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogStore: () => h.dialog }));
+
+import { createNoteOps, type NoteOpsCtx } from '../../../src/renderer/lib/app/note-ops';
+import { getClipboardStore } from '../../../src/renderer/lib/stores/clipboard.svelte';
+
+function dir(name: string, children: NoteFile[]): NoteFile {
+  return { name, relativePath: name, isDirectory: true, children };
+}
+function file(relativePath: string): NoteFile {
+  return { name: relativePath.split('/').pop()!, relativePath, isDirectory: false };
+}
+
+const sidebar = { getSelectionPaths: vi.fn(() => [] as string[]), refreshTags: vi.fn(), clearSelection: vi.fn() };
+let ctx: NoteOpsCtx;
+let ops: ReturnType<typeof createNoteOps>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.notebase.meta = { rootPath: '/p', name: 'p' };
+  h.notebase.files = [];
+  h.editor.tabs = [];
+  sidebar.getSelectionPaths.mockReturnValue([]);
+  getClipboardStore().clear();
+  ctx = {
+    getSidebar: () => sidebar,
+    getEditorComponent: () => undefined,
+    setSafeDeleteState: vi.fn(),
+    setMergePickerSource: vi.fn(),
+  };
+  ops = createNoteOps(ctx);
+});
+
+describe('handleRename', () => {
+  it('preserves the original extension when the user omits one', async () => {
+    h.dialog.showPrompt.mockResolvedValue('renamed');
+    await ops.handleRename('notes/foo.md');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('notes/foo.md', 'notes/renamed.md');
+    expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('respects an explicit extension the user types', async () => {
+    h.dialog.showPrompt.mockResolvedValue('renamed.ttl');
+    await ops.handleRename('foo.md');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('foo.md', 'renamed.ttl');
+  });
+
+  it('does nothing on cancel or an unchanged name', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleRename('foo.md');
+    h.dialog.showPrompt.mockResolvedValue('foo.md');
+    await ops.handleRename('foo.md');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNewNote', () => {
+  it('creates the file in the target directory and opens it', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md' });
+    await ops.handleNewNote('folder');
+    expect(h.api.notebase.createFile).toHaveBeenCalledWith('folder/fresh.md');
+    expect(h.notebase.refresh).toHaveBeenCalled();
+    expect(h.editor.openFile).toHaveBeenCalledWith('folder/fresh.md');
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+  });
+
+  it('does nothing when the dialog is cancelled', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue(null);
+    await ops.handleNewNote();
+    expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleDelete', () => {
+  it('confirms then deletes when there are no inbound-link blockers', async () => {
+    h.dialog.showConfirm.mockResolvedValue(true);
+    await ops.handleDelete('notes/x.md', false);
+    expect(ctx.setSafeDeleteState).not.toHaveBeenCalled();
+    expect(h.api.notebase.deleteFile).toHaveBeenCalledWith('notes/x.md');
+    expect(h.editor.closeTabsForDeletedPath).toHaveBeenCalledWith('notes/x.md');
+    expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('does not delete when the user cancels the confirm', async () => {
+    h.dialog.showConfirm.mockResolvedValue(false);
+    await ops.handleDelete('notes/x.md', false);
+    expect(h.api.notebase.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('shows the safe-delete blocker dialog instead of deleting when external links exist', async () => {
+    h.notebase.files = [dir('notes', [file('notes/x.md')])];
+    sidebar.getSelectionPaths.mockReturnValue(['notes/x.md']);
+    h.api.links.externalInbound.mockResolvedValue([
+      { source: 'notes/y.md', target: 'notes/x.md', occurrences: 1 },
+    ]);
+    await ops.handleDelete('notes/x.md', false);
+    expect(ctx.setSafeDeleteState).toHaveBeenCalledTimes(1);
+    expect(h.api.notebase.deleteFile).not.toHaveBeenCalled();
+    expect(h.dialog.showConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('handlePaste', () => {
+  it('cut: renames each item into the destination and clears the clipboard', async () => {
+    getClipboardStore().set({ items: [{ relativePath: 'a.md', isDirectory: false }], mode: 'cut' });
+    await ops.handlePaste('dest');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
+    expect(getClipboardStore().current).toBeNull();
+  });
+
+  it('copy: copies each item and leaves the clipboard intact', async () => {
+    getClipboardStore().set({ items: [{ relativePath: 'a.md', isDirectory: false }], mode: 'copy' });
+    await ops.handlePaste('dest');
+    expect(h.api.notebase.copy).toHaveBeenCalledWith('a.md', 'dest/a.md');
+    expect(getClipboardStore().current).not.toBeNull();
+  });
+
+  it('does nothing with an empty clipboard', async () => {
+    await ops.handlePaste('dest');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+    expect(h.api.notebase.copy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCopyWithPrompt', () => {
+  it('copies to the prompted name (extension preserved) when no collision', async () => {
+    h.dialog.showPrompt.mockResolvedValue('dup');
+    h.api.notebase.readFile.mockRejectedValue(new Error('ENOENT')); // dest does not exist
+    await ops.handleCopyWithPrompt('a.md');
+    expect(h.api.notebase.copy).toHaveBeenCalledWith('a.md', 'dup.md');
+  });
+
+  it('aborts with a notice when the destination already exists', async () => {
+    h.dialog.showPrompt.mockResolvedValue('dup');
+    h.api.notebase.readFile.mockResolvedValue('existing content'); // dest exists → collision
+    await ops.handleCopyWithPrompt('a.md');
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(h.api.notebase.copy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/renderer/app/source-ops.test.ts
+++ b/tests/renderer/app/source-ops.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Behavioral net for the source-ops handlers extracted from App.svelte (#670).
+ * Mocks the api client + notebase/dialog stores; uses the real busy +
+ * source-flow runes stores. Verifies the moved handler bodies (ingest, OCR,
+ * reference mining, stub resolution), not just that menus reach them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const api = {
+    sources: {
+      ingestUrl: vi.fn(), ingestFile: vi.fn(), ingestIdentifier: vi.fn(),
+      readPdf: vi.fn(), finishPdfOcr: vi.fn(), mineReferences: vi.fn(),
+      createReferenceStubs: vi.fn(), resolveStub: vi.fn(), applyStubResolution: vi.fn(),
+      importBibtex: vi.fn(), importZoteroRdf: vi.fn(),
+    },
+    files: { getPathForFile: vi.fn(), dropImport: vi.fn() },
+    graph: { sourceDetail: vi.fn() },
+  };
+  const notebase = { meta: { rootPath: '/p', name: 'p' } as unknown };
+  const dialog = { showPrompt: vi.fn(), showConfirm: vi.fn() };
+  return { api, notebase, dialog };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogStore: () => h.dialog }));
+
+import { createSourceOps, type SourceOpsCtx } from '../../../src/renderer/lib/app/source-ops';
+import { getSourceFlowStore } from '../../../src/renderer/lib/stores/source-flow.svelte';
+
+const flow = getSourceFlowStore();
+const sidebar = { refreshSources: vi.fn() };
+let ctx: SourceOpsCtx;
+let ops: ReturnType<typeof createSourceOps>;
+
+function resetFlow() {
+  flow.setOcrSession(null);
+  flow.setOcrPdfBytes(null);
+  flow.setMineReview(null);
+  flow.setResolveStub(null);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.notebase.meta = { rootPath: '/p', name: 'p' };
+  resetFlow();
+  ctx = {
+    openSource: vi.fn(),
+    getSidebar: () => sidebar,
+    refreshSourcesCache: vi.fn().mockResolvedValue(undefined),
+    findSourceByDoi: vi.fn(() => undefined),
+  };
+  ops = createSourceOps(ctx);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('handleIngestUrlAsSource', () => {
+  it('ingests the prompted URL and routes a plain result to openSource', async () => {
+    vi.useFakeTimers();
+    h.dialog.showPrompt.mockResolvedValue('https://example.com/x');
+    h.api.sources.ingestUrl.mockResolvedValue({
+      sourceId: 's1', title: 'X', duplicate: false,
+    });
+    await ops.handleIngestUrlAsSource();
+    expect(h.api.sources.ingestUrl).toHaveBeenCalledWith('https://example.com/x');
+    expect(flow.ocrSession).toBeNull();
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('s1');
+  });
+
+  it('does nothing on an empty prompt', async () => {
+    h.dialog.showPrompt.mockResolvedValue('');
+    await ops.handleIngestUrlAsSource();
+    expect(h.api.sources.ingestUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleIngestedSourceResult', () => {
+  it('needsOcr opens the OCR session and loads the PDF bytes instead of the tab', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    h.api.sources.readPdf.mockResolvedValue(bytes);
+    await ops.handleIngestedSourceResult({
+      sourceId: 's2', title: 'Scan', duplicate: false, needsOcr: true, pageCount: 4,
+    });
+    expect(flow.ocrSession).toEqual({ sourceId: 's2', title: 'Scan', pageCount: 4 });
+    expect(flow.ocrPdfBytes).toBe(bytes);
+    expect(h.api.sources.readPdf).toHaveBeenCalledWith('s2');
+    expect(ctx.openSource).not.toHaveBeenCalled();
+  });
+
+  it('duplicate result confirms (and does not open OCR)', async () => {
+    await ops.handleIngestedSourceResult({ sourceId: 's3', title: 'Dup', duplicate: true });
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(flow.ocrSession).toBeNull();
+  });
+});
+
+describe('handleOcrDone', () => {
+  it('finishes OCR for the active session and clears it', async () => {
+    vi.useFakeTimers();
+    flow.setOcrSession({ sourceId: 's4', title: 'T', pageCount: 1 });
+    flow.setOcrPdfBytes(new Uint8Array());
+    await ops.handleOcrDone(['page one']);
+    expect(h.api.sources.finishPdfOcr).toHaveBeenCalledWith('s4', ['page one']);
+    expect(flow.ocrSession).toBeNull();
+    expect(flow.ocrPdfBytes).toBeNull();
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('s4');
+  });
+});
+
+describe('handleMineReferences', () => {
+  it('sets the review state when refs come back', async () => {
+    h.api.sources.mineReferences.mockResolvedValue([{ raw: 'a' }, { raw: 'b' }]);
+    await ops.handleMineReferences({ sourceId: 'p1', title: 'Parent' } as never);
+    expect(flow.mineReview).toEqual({
+      parentId: 'p1', parentTitle: 'Parent', refs: [{ raw: 'a' }, { raw: 'b' }],
+    });
+  });
+
+  it('shows a notice and leaves review state null when no refs parse', async () => {
+    h.api.sources.mineReferences.mockResolvedValue([]);
+    await ops.handleMineReferences({ sourceId: 'p2', title: 'Parent' } as never);
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(flow.mineReview).toBeNull();
+  });
+});
+
+describe('handleResolveStub', () => {
+  it('auto-applies when the top candidate clears the confidence threshold', async () => {
+    h.api.sources.resolveStub.mockResolvedValue([
+      { doi: '10.1/x', title: 'Match', confidence: 0.95 },
+    ]);
+    await ops.handleResolveStub('stub1');
+    expect(h.api.sources.applyStubResolution).toHaveBeenCalledWith('stub1', '10.1/x');
+    expect(flow.resolveStub).toBeNull();
+  });
+
+  it('opens the picker when the top candidate is below threshold', async () => {
+    h.api.sources.resolveStub.mockResolvedValue([
+      { doi: '10.1/y', title: 'Maybe', confidence: 0.5 },
+    ]);
+    h.api.graph.sourceDetail.mockResolvedValue({ metadata: { title: 'Stub' } });
+    await ops.handleResolveStub('stub2');
+    expect(h.api.sources.applyStubResolution).not.toHaveBeenCalled();
+    expect(flow.resolveStub?.sourceId).toBe('stub2');
+    expect(flow.resolveStub?.candidates).toHaveLength(1);
+  });
+});
+
+describe('handleImportBibtex', () => {
+  it('does nothing more when the picker is cancelled', async () => {
+    h.api.sources.importBibtex.mockResolvedValue(null);
+    await ops.handleImportBibtex();
+    expect(ctx.refreshSourcesCache).not.toHaveBeenCalled();
+    expect(sidebar.refreshSources).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and reports on a successful import', async () => {
+    h.api.sources.importBibtex.mockResolvedValue({
+      imported: [{}], duplicate: [], failed: [], parseErrors: 0,
+    });
+    await ops.handleImportBibtex();
+    expect(sidebar.refreshSources).toHaveBeenCalled();
+    expect(ctx.refreshSourcesCache).toHaveBeenCalled();
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Fifth increment of the App.svelte decomposition (#670), following the "pair a behavioral test with each handler-group move" plan.

Partially addresses #670.

### 1. Backfill the note-ops behavioral net
`tests/renderer/app/note-ops.test.ts` (13 tests) mocks the api client + notebase/editor/dialog stores (real busy/clipboard stores) and exercises the increment-4 bodies directly: rename extension-preservation, new-note create+open, the **safe-delete blocker branch vs confirm+delete**, clipboard cut-clears / copy-keeps, and copy-with-prompt collision. This nets those handlers beyond the command/keymap *dispatch* tests.

### 2. Extract source-ops
- **`lib/stores/source-flow.svelte.ts`** — `getSourceFlowStore()`: the OCR (#95) / mine-references (#106) / resolve-stub (#107) in-flight feature-dialog state (was four App `$state` decls), read reactively by both the handlers and the template's paired dialogs.
- **`lib/app/source-ops.ts`** — `createSourceOps(ctx)` houses **15 handlers moved verbatim**: ingest (URL / file / identifier / external-drop / DOI-click), OCR done/cancel, reference mining + apply, stub resolve + apply, BibTeX + Zotero RDF import. Substitutions only: `handleOpenSource`→`ctx.openSource`, `sidebar`→`ctx.getSidebar`, `refreshSourcesCache`→`ctx`, the DOI cache lookup→`ctx.findSourceByDoi`, busy via the busy store, the four feature-state reads/writes via the source-flow store.
- App builds the ctx and destructures the handlers back into the same names; the OCR/mine/resolve dialogs now read `sourceFlow.*` (the OCR guard stays `… && ocrPdfBytes`, verbatim). Source **view** handlers (`handleOpenSource` etc.) stay in App and are reached via ctx.
- **`tests/renderer/app/source-ops.test.ts`** (11 tests): ingest-url dispatch + empty-prompt no-op, `handleIngestedSourceResult` OCR/duplicate branches, mine empty-vs-found, resolve auto-apply-vs-picker, bibtex cancel-vs-success.

## Result
`App.svelte`: **2,965 → 2,612** (cumulative across #696–#699 + this: **3,764 → 2,612**, −1,152).

## Reactivity (reviewed by hand — no component test catches it)
- `source-flow.svelte.ts` is a runes store; ctx refs are getters (`() => sidebar`); template reads `{#if sourceFlow.ocrSession && sourceFlow.ocrPdfBytes}` etc. through reactive getters. OCR `setTimeout(…, 150)` open-deferral preserved.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2802 passed** (incl. the #676 flake this run).
- `pnpm test:e2e` — boot smoke passes.

## Remaining (#670)
refactor-ops (auto-link/auto-tag/extract/split/format/bibliography), nav-ops, the source-view + template/excerpt ops — toward <1,000, each paired with a behavioral test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)