### PR TITLE
Decompose App.svelte: extract nav-ops + source-view ops (#670, increment 7)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -14,7 +14,6 @@
   import SourceDetail from './lib/components/SourceDetail.svelte';
   import { onMount, tick } from 'svelte';
   import { getNotebaseStore } from './lib/stores/notebase.svelte';
-  import { flattenNoteFiles, resolveWikiLinkTarget } from './lib/wiki-link-resolver';
   import { getEditorStore } from './lib/stores/editor.svelte';
   import { getBusyStore } from './lib/stores/busy.svelte';
   import { getClipboardStore } from './lib/stores/clipboard.svelte';
@@ -22,12 +21,12 @@
   import { getRefactorFlowStore } from './lib/stores/refactor-flow.svelte';
   import { createNoteOps, type NoteOpsCtx } from './lib/app/note-ops';
   import { createSourceOps, type SourceOpsCtx } from './lib/app/source-ops';
+  import { createNavView, type NavViewCtx } from './lib/app/nav-view';
   import { createRefactorOps, type RefactorOpsCtx } from './lib/app/refactor-ops.svelte';
   import DialogHost from './lib/components/DialogHost.svelte';
   import { getDialogStore } from './lib/stores/dialogs.svelte';
   import { substituteTemplate } from '../shared/templates';
   import PdfViewer from './lib/components/PdfViewer.svelte';
-  import { getPreferredSourceView, setPreferredSourceView } from './lib/source-view-preference';
   import { buildExcerptNoteContent, buildExcerptAppendBlock } from '../shared/excerpt-note';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
@@ -58,7 +57,6 @@
   import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
   import {
     slugifyForPath,
-    findAnchorOffset,
     flattenNotePaths,
     countNotes,
   } from './lib/app/text-helpers';
@@ -465,108 +463,7 @@
   } | null>(null);
   let findInNotesMode = $state<'find' | 'replace' | null>(null);
 
-  async function handleFileSelect(relativePath: string, searchQuery?: string) {
-    recordCurrentPosition();
-    const existingTab = editor.tabs.find((t) => t.type === 'note' && t.relativePath === relativePath) as import('./lib/stores/editor.svelte').NoteTab | undefined;
-    const savedOffset = existingTab?.cursorOffset;
-    const savedScroll = existingTab?.scrollTop;
-    pendingSearchQuery = searchQuery ?? null;
-    await editor.openFile(relativePath);
-    if (!searchQuery && savedOffset != null) {
-      await tick();
-      requestAnimationFrame(() => {
-        editorComponent?.restorePosition(savedOffset, savedScroll);
-      });
-      nav.record({ type: 'note', relativePath, offset: savedOffset });
-    } else {
-      nav.record({ type: 'note', relativePath, offset: 0 });
-    }
-  }
-
   let pendingPreviewAnchor = $state<string | null>(null);
-
-  async function handleNavigate(target: string) {
-    recordCurrentPosition();
-    const hashIdx = target.indexOf('#');
-    const pathPart = hashIdx >= 0 ? target.slice(0, hashIdx) : target;
-    const anchor = hashIdx >= 0 ? target.slice(hashIdx + 1) : null;
-    // Resolve against the actual note tree before falling back to a
-    // naive `${target}.md`. Lets short-form wiki-links like [[raft]],
-    // [[Sets, Functions]], or [[journey/raft]] open the correct file
-    // regardless of how deeply nested it is.
-    const flat = flattenNoteFiles(notebase.files);
-    const resolved = resolveWikiLinkTarget(pathPart, flat, aliasMap);
-    const notePath = resolved ?? (pathPart.endsWith('.md') ? pathPart : `${pathPart}.md`);
-    await editor.openFile(notePath);
-    // Route anchors: preview scrolls by element id; editor jumps by doc offset.
-    if (anchor) {
-      pendingPreviewAnchor = anchor;
-      if (viewMode === 'source' || viewMode === 'split') {
-        const content = editor.content;
-        const offset = findAnchorOffset(content, anchor);
-        if (offset !== null) {
-          requestAnimationFrame(() => editorComponent?.gotoOffset(offset));
-        }
-      }
-    }
-    nav.record({ type: 'note', relativePath: notePath, offset: 0 });
-  }
-
-  /**
-   * Locate a heading (by slug) or block-id inside raw markdown and return
-   * the character offset of its line. Shared between source and split modes.
-   */
-  function handleSourceDeleted(sourceId: string) {
-    // Close every tab bound to this source — the detail view AND any PDF
-    // viewer — so the user isn't left staring at a ghost viewer that then
-    // fails to load the deleted original.pdf.
-    editor.closeTabsForSource(sourceId);
-  }
-
-  function handleOpenSource(sourceId: string, highlightExcerptId?: string) {
-    recordCurrentPosition();
-    // If the user last viewed this source as a PDF (and the file is
-    // still there), route them back to the PDF tab rather than the
-    // extracted-text detail. An explicit excerpt highlight wins —
-    // jumping to an excerpt is a markdown-view affordance until the
-    // PDF viewer's highlight click-to-navigate is wired up. (#100)
-    if (!highlightExcerptId && getPreferredSourceView(sourceId) === 'pdf') {
-      void api.sources.hasPdf(sourceId).then((ok) => {
-        if (ok) {
-          editor.openPdf(sourceId);
-          nav.record({ type: 'source', sourceId });
-        } else {
-          editor.openSource(sourceId);
-          nav.record({ type: 'source', sourceId });
-        }
-      });
-      return;
-    }
-    editor.openSource(sourceId, { highlightExcerptId });
-    nav.record({ type: 'source', sourceId, highlightExcerptId });
-  }
-
-  /** Open the PDF view for a source; remember the choice so the next
-   *  click on this source from the sidebar / search / quick-open
-   *  routes here directly. */
-  function handleOpenPdf(sourceId: string) {
-    recordCurrentPosition();
-    setPreferredSourceView(sourceId, 'pdf');
-    editor.openPdf(sourceId);
-    nav.record({ type: 'source', sourceId });
-  }
-
-  /** Switch back to the extracted-markdown view from a PDF tab. */
-  function handleShowMarkdownFromPdf(sourceId: string) {
-    setPreferredSourceView(sourceId, 'markdown');
-    editor.openSource(sourceId);
-  }
-
-  async function handleOpenExcerpt(excerptId: string) {
-    const result = await api.graph.excerptSource(excerptId);
-    if (!result) return;
-    handleOpenSource(result.sourceId, excerptId);
-  }
 
   /** Flatten the sidebar file tree to a list of indexable relative paths. */
   function handleTagSelect(tag: string) {
@@ -979,6 +876,25 @@
     handleRename, handleCopyWithPrompt, handleMoveWithPrompt,
   } = createNoteOps(noteOpsCtx);
 
+  // Nav-ops + source-view-ops handler cluster (#670): position history
+  // (back/forward), file / wiki-link navigation, and the source *view* handlers
+  // (open source / PDF / excerpt, show-markdown, source-deleted). Lives in
+  // ./lib/app/nav-view.ts; no feature-state store. Destructured into the same
+  // names so every call site reads unchanged. Placed before createSourceOps so
+  // handleOpenSource is in scope for the sourceOpsCtx.openSource getter. The
+  // module reads / writes pending search + preview anchor, view mode, and the
+  // alias map via ctx — those `$state` decls stay in App.
+  const {
+    recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate,
+    handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
+  } = createNavView({
+    getEditorComponent: () => editorComponent,
+    setPendingSearchQuery: (s) => { pendingSearchQuery = s; },
+    setPendingPreviewAnchor: (s) => { pendingPreviewAnchor = s; },
+    getViewMode: () => viewMode,
+    getAliasMap: () => aliasMap,
+  } satisfies NavViewCtx);
+
   // Source-ops handler cluster (#670): source ingest (URL / file / identifier /
   // external drop / DOI-click), OCR (#95), reference mining (#106), stub
   // resolution (#107). Lives in ./lib/app/source-ops.ts; in-flight feature-dialog
@@ -1031,49 +947,6 @@
     if (!notebase.meta) return;
     const ctx = await gatherContext(['fullNote'], editorComponent?.getView());
     await handleOpenConversationFromTool({ toolId: 'research.crystallize', context: ctx });
-  }
-
-  function recordCurrentPosition() {
-    const activeTab = editor.activeTab;
-    if (!activeTab) return;
-    if (activeTab.type === 'note' && editor.activeFilePath) {
-      nav.record({ type: 'note', relativePath: editor.activeFilePath, offset: editorComponent?.getOffset() ?? 0 });
-    } else if (activeTab.type === 'query') {
-      nav.record({ type: 'query', tabId: activeTab.id });
-    }
-  }
-
-  async function navigateToPosition(pos: import('./lib/stores/navigation.svelte').NavPosition) {
-    if (pos.type === 'note') {
-      await editor.openFile(pos.relativePath);
-      requestAnimationFrame(() => {
-        editorComponent?.gotoOffset(pos.offset);
-        nav.doneNavigating();
-      });
-    } else if (pos.type === 'source') {
-      editor.openSource(pos.sourceId, { highlightExcerptId: pos.highlightExcerptId });
-      nav.doneNavigating();
-    } else {
-      const idx = editor.tabs.findIndex((t) => t.type === 'query' && t.id === pos.tabId);
-      if (idx >= 0) {
-        editor.switchTab(idx);
-      }
-      nav.doneNavigating();
-    }
-  }
-
-  async function handleNavBack() {
-    recordCurrentPosition();
-    const pos = nav.goBack();
-    if (!pos) return;
-    await navigateToPosition(pos);
-  }
-
-  async function handleNavForward() {
-    recordCurrentPosition();
-    const pos = nav.goForward();
-    if (!pos) return;
-    await navigateToPosition(pos);
   }
 
   function handleCycleTheme() {

--- a/src/renderer/lib/app/nav-view.ts
+++ b/src/renderer/lib/app/nav-view.ts
@@ -1,0 +1,186 @@
+/**
+ * Nav-ops + source-view-ops handler cluster extracted from App.svelte (#670).
+ * Position history (back/forward), file/wiki-link navigation, and the source
+ * *view* handlers (open source / PDF / excerpt, show-markdown, source-deleted).
+ * Bodies are verbatim from App.svelte; the only changes are the ctx getter /
+ * setter substitutions for the pieces that used to be inline component refs or
+ * local `$state` (editor component, pending search / preview anchor, view mode,
+ * alias map). No feature-state store — this cluster has none.
+ */
+import { api } from '../ipc/client';
+import { getEditorStore } from '../stores/editor.svelte';
+import { getNotebaseStore } from '../stores/notebase.svelte';
+import { getNavigationStore, type NavPosition } from '../stores/navigation.svelte';
+import { flattenNoteFiles, resolveWikiLinkTarget } from '../wiki-link-resolver';
+import { findAnchorOffset } from './text-helpers';
+import { getPreferredSourceView, setPreferredSourceView } from '../source-view-preference';
+import { tick } from 'svelte';
+
+interface EditorRef {
+  getOffset: () => number;
+  gotoOffset: (offset: number) => void;
+  restorePosition: (offset: number, scrollTop?: number) => void;
+}
+
+export interface NavViewCtx {
+  getEditorComponent: () => EditorRef | undefined;
+  setPendingSearchQuery: (s: string | null) => void;
+  setPendingPreviewAnchor: (s: string | null) => void;
+  getViewMode: () => 'source' | 'preview' | 'split';
+  getAliasMap: () => Record<string, string>;
+}
+
+export function createNavView(ctx: NavViewCtx) {
+  const editor = getEditorStore();
+  const notebase = getNotebaseStore();
+  const nav = getNavigationStore();
+
+  async function handleFileSelect(relativePath: string, searchQuery?: string) {
+    recordCurrentPosition();
+    const existingTab = editor.tabs.find((t) => t.type === 'note' && t.relativePath === relativePath) as import('../stores/editor.svelte').NoteTab | undefined;
+    const savedOffset = existingTab?.cursorOffset;
+    const savedScroll = existingTab?.scrollTop;
+    ctx.setPendingSearchQuery(searchQuery ?? null);
+    await editor.openFile(relativePath);
+    if (!searchQuery && savedOffset != null) {
+      await tick();
+      requestAnimationFrame(() => {
+        ctx.getEditorComponent()?.restorePosition(savedOffset, savedScroll);
+      });
+      nav.record({ type: 'note', relativePath, offset: savedOffset });
+    } else {
+      nav.record({ type: 'note', relativePath, offset: 0 });
+    }
+  }
+
+  async function handleNavigate(target: string) {
+    recordCurrentPosition();
+    const hashIdx = target.indexOf('#');
+    const pathPart = hashIdx >= 0 ? target.slice(0, hashIdx) : target;
+    const anchor = hashIdx >= 0 ? target.slice(hashIdx + 1) : null;
+    // Resolve against the actual note tree before falling back to a
+    // naive `${target}.md`. Lets short-form wiki-links like [[raft]],
+    // [[Sets, Functions]], or [[journey/raft]] open the correct file
+    // regardless of how deeply nested it is.
+    const flat = flattenNoteFiles(notebase.files);
+    const resolved = resolveWikiLinkTarget(pathPart, flat, ctx.getAliasMap());
+    const notePath = resolved ?? (pathPart.endsWith('.md') ? pathPart : `${pathPart}.md`);
+    await editor.openFile(notePath);
+    // Route anchors: preview scrolls by element id; editor jumps by doc offset.
+    if (anchor) {
+      ctx.setPendingPreviewAnchor(anchor);
+      if (ctx.getViewMode() === 'source' || ctx.getViewMode() === 'split') {
+        const content = editor.content;
+        const offset = findAnchorOffset(content, anchor);
+        if (offset !== null) {
+          requestAnimationFrame(() => ctx.getEditorComponent()?.gotoOffset(offset));
+        }
+      }
+    }
+    nav.record({ type: 'note', relativePath: notePath, offset: 0 });
+  }
+
+  /**
+   * Locate a heading (by slug) or block-id inside raw markdown and return
+   * the character offset of its line. Shared between source and split modes.
+   */
+  function handleSourceDeleted(sourceId: string) {
+    // Close every tab bound to this source — the detail view AND any PDF
+    // viewer — so the user isn't left staring at a ghost viewer that then
+    // fails to load the deleted original.pdf.
+    editor.closeTabsForSource(sourceId);
+  }
+
+  function handleOpenSource(sourceId: string, highlightExcerptId?: string) {
+    recordCurrentPosition();
+    // If the user last viewed this source as a PDF (and the file is
+    // still there), route them back to the PDF tab rather than the
+    // extracted-text detail. An explicit excerpt highlight wins —
+    // jumping to an excerpt is a markdown-view affordance until the
+    // PDF viewer's highlight click-to-navigate is wired up. (#100)
+    if (!highlightExcerptId && getPreferredSourceView(sourceId) === 'pdf') {
+      void api.sources.hasPdf(sourceId).then((ok) => {
+        if (ok) {
+          editor.openPdf(sourceId);
+          nav.record({ type: 'source', sourceId });
+        } else {
+          editor.openSource(sourceId);
+          nav.record({ type: 'source', sourceId });
+        }
+      });
+      return;
+    }
+    editor.openSource(sourceId, { highlightExcerptId });
+    nav.record({ type: 'source', sourceId, highlightExcerptId });
+  }
+
+  /** Open the PDF view for a source; remember the choice so the next
+   *  click on this source from the sidebar / search / quick-open
+   *  routes here directly. */
+  function handleOpenPdf(sourceId: string) {
+    recordCurrentPosition();
+    setPreferredSourceView(sourceId, 'pdf');
+    editor.openPdf(sourceId);
+    nav.record({ type: 'source', sourceId });
+  }
+
+  /** Switch back to the extracted-markdown view from a PDF tab. */
+  function handleShowMarkdownFromPdf(sourceId: string) {
+    setPreferredSourceView(sourceId, 'markdown');
+    editor.openSource(sourceId);
+  }
+
+  async function handleOpenExcerpt(excerptId: string) {
+    const result = await api.graph.excerptSource(excerptId);
+    if (!result) return;
+    handleOpenSource(result.sourceId, excerptId);
+  }
+
+  function recordCurrentPosition() {
+    const activeTab = editor.activeTab;
+    if (!activeTab) return;
+    if (activeTab.type === 'note' && editor.activeFilePath) {
+      nav.record({ type: 'note', relativePath: editor.activeFilePath, offset: ctx.getEditorComponent()?.getOffset() ?? 0 });
+    } else if (activeTab.type === 'query') {
+      nav.record({ type: 'query', tabId: activeTab.id });
+    }
+  }
+
+  async function navigateToPosition(pos: NavPosition) {
+    if (pos.type === 'note') {
+      await editor.openFile(pos.relativePath);
+      requestAnimationFrame(() => {
+        ctx.getEditorComponent()?.gotoOffset(pos.offset);
+        nav.doneNavigating();
+      });
+    } else if (pos.type === 'source') {
+      editor.openSource(pos.sourceId, { highlightExcerptId: pos.highlightExcerptId });
+      nav.doneNavigating();
+    } else {
+      const idx = editor.tabs.findIndex((t) => t.type === 'query' && t.id === pos.tabId);
+      if (idx >= 0) {
+        editor.switchTab(idx);
+      }
+      nav.doneNavigating();
+    }
+  }
+
+  async function handleNavBack() {
+    recordCurrentPosition();
+    const pos = nav.goBack();
+    if (!pos) return;
+    await navigateToPosition(pos);
+  }
+
+  async function handleNavForward() {
+    recordCurrentPosition();
+    const pos = nav.goForward();
+    if (!pos) return;
+    await navigateToPosition(pos);
+  }
+
+  return {
+    recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate,
+    handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
+  };
+}

--- a/tests/renderer/app/nav-view.test.ts
+++ b/tests/renderer/app/nav-view.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Behavioral net for the nav-ops + source-view-ops handlers extracted from
+ * App.svelte (#670). Mocks the api client, the editor / navigation / notebase
+ * stores, and the source-view-preference module (to avoid localStorage).
+ * Verifies the moved handler bodies (open source / PDF / excerpt, show-markdown,
+ * source-deleted, back nav), not just that menus reach them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const api = {
+    graph: { excerptSource: vi.fn() },
+    sources: { hasPdf: vi.fn() },
+  };
+  const editor = {
+    openFile: vi.fn(),
+    openPdf: vi.fn(),
+    openSource: vi.fn(),
+    closeTabsForSource: vi.fn(),
+    switchTab: vi.fn(),
+    tabs: [] as unknown[],
+    activeTab: undefined as unknown,
+    activeFilePath: null as string | null,
+    content: '',
+  };
+  const nav = {
+    record: vi.fn(),
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    doneNavigating: vi.fn(),
+  };
+  const notebase = { files: [] as unknown[] };
+  const pref = { getPreferredSourceView: vi.fn(), setPreferredSourceView: vi.fn() };
+  return { api, editor, nav, notebase, pref };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/navigation.svelte', () => ({ getNavigationStore: () => h.nav }));
+vi.mock('../../../src/renderer/lib/source-view-preference', () => ({
+  getPreferredSourceView: h.pref.getPreferredSourceView,
+  setPreferredSourceView: h.pref.setPreferredSourceView,
+}));
+
+import { createNavView, type NavViewCtx } from '../../../src/renderer/lib/app/nav-view';
+
+let ctx: NavViewCtx;
+let view: ReturnType<typeof createNavView>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // navigateToPosition (note branch) defers gotoOffset via requestAnimationFrame,
+  // which isn't defined under the node test env — stub it as a no-op scheduler.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { void cb; return 0; });
+  h.editor.tabs = [];
+  h.editor.activeTab = undefined;
+  h.editor.activeFilePath = null;
+  h.editor.content = '';
+  h.pref.getPreferredSourceView.mockReturnValue(null);
+  ctx = {
+    getEditorComponent: () => undefined,
+    setPendingSearchQuery: vi.fn(),
+    setPendingPreviewAnchor: vi.fn(),
+    getViewMode: () => 'source',
+    getAliasMap: () => ({}),
+  };
+  view = createNavView(ctx);
+});
+
+describe('handleOpenPdf', () => {
+  it('remembers the pdf preference, opens the pdf, and records nav', () => {
+    view.handleOpenPdf('s1');
+    expect(h.pref.setPreferredSourceView).toHaveBeenCalledWith('s1', 'pdf');
+    expect(h.editor.openPdf).toHaveBeenCalledWith('s1');
+    expect(h.nav.record).toHaveBeenCalledWith({ type: 'source', sourceId: 's1' });
+  });
+});
+
+describe('handleShowMarkdownFromPdf', () => {
+  it('remembers the markdown preference and opens the extracted source', () => {
+    view.handleShowMarkdownFromPdf('s2');
+    expect(h.pref.setPreferredSourceView).toHaveBeenCalledWith('s2', 'markdown');
+    expect(h.editor.openSource).toHaveBeenCalledWith('s2');
+  });
+});
+
+describe('handleSourceDeleted', () => {
+  it('closes every tab bound to the deleted source', () => {
+    view.handleSourceDeleted('s3');
+    expect(h.editor.closeTabsForSource).toHaveBeenCalledWith('s3');
+  });
+});
+
+describe('handleOpenSource', () => {
+  it('routes to the pdf view when preferred and a pdf exists', async () => {
+    h.pref.getPreferredSourceView.mockReturnValue('pdf');
+    h.api.sources.hasPdf.mockResolvedValue(true);
+    view.handleOpenSource('s4');
+    // The pdf branch fires `void hasPdf(...).then(...)` — let the microtask run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.api.sources.hasPdf).toHaveBeenCalledWith('s4');
+    expect(h.editor.openPdf).toHaveBeenCalledWith('s4');
+    expect(h.editor.openSource).not.toHaveBeenCalled();
+  });
+
+  it('opens the extracted source with the highlight when an excerpt is requested', () => {
+    h.pref.getPreferredSourceView.mockReturnValue('markdown');
+    view.handleOpenSource('s5', 'ex1');
+    expect(h.api.sources.hasPdf).not.toHaveBeenCalled();
+    expect(h.editor.openSource).toHaveBeenCalledWith('s5', { highlightExcerptId: 'ex1' });
+    expect(h.nav.record).toHaveBeenCalledWith({ type: 'source', sourceId: 's5', highlightExcerptId: 'ex1' });
+  });
+});
+
+describe('handleOpenExcerpt', () => {
+  it('resolves the excerpt to its source and opens it with the highlight', async () => {
+    h.api.graph.excerptSource.mockResolvedValue({ sourceId: 's6' });
+    h.pref.getPreferredSourceView.mockReturnValue('markdown');
+    await view.handleOpenExcerpt('ex2');
+    expect(h.api.graph.excerptSource).toHaveBeenCalledWith('ex2');
+    expect(h.editor.openSource).toHaveBeenCalledWith('s6', { highlightExcerptId: 'ex2' });
+  });
+
+  it('does nothing when the excerpt has no source', async () => {
+    h.api.graph.excerptSource.mockResolvedValue(null);
+    await view.handleOpenExcerpt('ex3');
+    expect(h.editor.openSource).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNavBack', () => {
+  it('opens the note position returned by goBack', async () => {
+    h.nav.goBack.mockReturnValue({ type: 'note', relativePath: 'a.md', offset: 5 });
+    await view.handleNavBack();
+    expect(h.editor.openFile).toHaveBeenCalledWith('a.md');
+  });
+
+  it('opens nothing when goBack returns null', async () => {
+    h.nav.goBack.mockReturnValue(null);
+    await view.handleNavBack();
+    expect(h.editor.openFile).not.toHaveBeenCalled();
+    expect(h.editor.openSource).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Seventh increment of the App.svelte decomposition (#670). Moves the navigation-history + source-view-open cluster into `lib/app/nav-view.ts` (plain `.ts` — no runes, no feature-state store needed).

Partially addresses #670.

`createNavView(ctx)` houses **11 functions moved verbatim**: `recordCurrentPosition`, `navigateToPosition` (internal), `handleNavBack`/`handleNavForward`, `handleFileSelect`, `handleNavigate`, `handleSourceDeleted`, `handleOpenSource`, `handleOpenPdf`, `handleShowMarkdownFromPdf`, `handleOpenExcerpt`.

Substitutions only: `editorComponent` via ctx getter; `pendingSearchQuery` / `pendingPreviewAnchor` writes via ctx setters; `viewMode` / `aliasMap` reads via ctx getters (those `$state` decls stay in App — they're read by the editor/preview components).

**Cross-wiring:** `recordCurrentPosition` and `handleOpenSource` are returned because App-resident code uses them (`handleSwitchTab` + the Go-to-Line dialog call `recordCurrentPosition`; the source-ops ctx + several template props call `handleOpenSource`). The `createNavView` destructure is placed **before** `createSourceOps`, so `sourceOpsCtx.openSource` resolves the new `handleOpenSource` (verified: createNavView@890, createSourceOps@915).

`tests/renderer/app/nav-view.test.ts` (9 tests): open-pdf / show-markdown preference writes, source-deleted tab close, open-source pdf-exists vs markdown+highlight branches, open-excerpt hit/null, nav-back note-pos vs null. (The pdf branch's `void hasPdf().then()` microtask + the `requestAnimationFrame` in `navigateToPosition` are handled in the harness.)

## Result
`App.svelte`: **2,083 → 1,956** (cumulative across #696–#701 + this: **3,764 → 1,956, −1,808**, ~48% smaller).

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2822 passed**.
- `pnpm test:e2e` — boot smoke passes.

## Remaining (#670)
template/excerpt-note ops (insert/save template, new-about-source, create-from-excerpt, append-excerpt) and the conversation/tool-routing handlers (open-conversation, tool-invoke, decompose/crystallize, save-cell-output, create-note-from-conversation) — the last cluster toward <1,000, paired with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)