### PR TITLE
Decompose App.svelte: extract template-ops + conversation-ops (#670, increment 8 — final handler cluster)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -23,11 +23,11 @@
   import { createSourceOps, type SourceOpsCtx } from './lib/app/source-ops';
   import { createNavView, type NavViewCtx } from './lib/app/nav-view';
   import { createRefactorOps, type RefactorOpsCtx } from './lib/app/refactor-ops.svelte';
+  import { createTemplateOps, type TemplateOpsCtx } from './lib/app/template-ops';
+  import { createConversationOps, type ConversationOpsCtx } from './lib/app/conversation-ops';
   import DialogHost from './lib/components/DialogHost.svelte';
   import { getDialogStore } from './lib/stores/dialogs.svelte';
-  import { substituteTemplate } from '../shared/templates';
   import PdfViewer from './lib/components/PdfViewer.svelte';
-  import { buildExcerptNoteContent, buildExcerptAppendBlock } from '../shared/excerpt-note';
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
@@ -68,17 +68,10 @@
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
-  import {
-    planCreateFromConversation,
-    suggestConversationNoteTitle,
-  } from './lib/refactor/create-from-conversation';
-  import { getRefactorSettings } from './lib/refactor/settings';
   import { loadFormatSettings } from './lib/formatter/settings';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
-  import { gatherContext } from './lib/tools/context';
-  import { getAllToolInfos, registerSkillInfos } from './lib/tools/tool-registry';
+  import { registerSkillInfos } from './lib/tools/tool-registry';
   import { applyMenuConfig } from '../shared/skills/menu-config';
-  import type { ToolContext } from '../shared/tools/types';
 
   type ViewMode = 'source' | 'preview' | 'split';
 
@@ -222,7 +215,7 @@
   // live in the dialog store (#670); destructure the imperative `show*` helpers
   // so the many call sites read unchanged. <DialogHost> renders the state.
   const dialogs = getDialogStore();
-  const { showPrompt, showConfirm, showSnippetPicker } = dialogs;
+  const { showPrompt, showConfirm } = dialogs;
   let exportDialogFor = $state<string | null>(null);
 
   /**
@@ -505,207 +498,6 @@
     tab.title = result.name;
   }
 
-  // ── Note refactoring: extract / split ──────────────────────────────────
-
-  /**
-   * "Create note" from the active conversation (#177). Body comes
-   * from the user's selection in the conversation pane if any;
-   * otherwise the most recent assistant message. The new note's
-   * frontmatter records the source note + conversation id for
-   * traceability.
-   *
-   * Lands in the same folder as the conversation's origin note
-   * (when there is one), or at the thoughtbase root for freeform
-   * conversations. Honours the Refactoring settings tab's
-   * destination + filename-prefix templates.
-   */
-  async function handleCreateNoteFromConversation(args: {
-    conversation: import('../shared/types').Conversation;
-    selectionText: string;
-    fallbackText: string;
-  }): Promise<void> {
-    if (!notebase.meta) return;
-    const body = args.selectionText.trim() || args.fallbackText.trim();
-    if (!body) {
-      await showConfirm(
-        'Nothing to create from — the conversation has no assistant text yet.',
-        CONFIRM_KEYS.createNoteFromConvEmpty,
-        'OK',
-      );
-      return;
-    }
-    const suggested = suggestConversationNoteTitle(body);
-    const title = suggested ?? await showPrompt('New note name:');
-    if (!title) return;
-
-    const sourceRelativePath = args.conversation.contextBundle.notePath ?? null;
-    const plan = planCreateFromConversation({
-      title,
-      body,
-      sourceRelativePath,
-      conversationId: args.conversation.id,
-      today: new Date().toISOString().slice(0, 10),
-      settings: getRefactorSettings(),
-    });
-
-    try {
-      // Loop on collision so the second-of-the-same-title doesn't
-      // clobber the first. Existing extract / split-here paths
-      // accept clobbers, but conversation-source notes are likely
-      // to land repeatedly off the same prompts.
-      let path = plan.newNotePath;
-      for (let attempt = 2; attempt < 20; attempt++) {
-        if (!(await api.notebase.fileExists(path))) break;
-        const dot = plan.newNotePath.lastIndexOf('.md');
-        path = dot > 0
-          ? `${plan.newNotePath.slice(0, dot)}-${attempt}.md`
-          : `${plan.newNotePath}-${attempt}`;
-      }
-      await api.notebase.writeFile(path, plan.newNoteContent);
-      await notebase.refresh();
-      await editor.openFile(path);
-      sidebar?.refreshTags();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Couldn't create note: ${msg}`, CONFIRM_KEYS.createNoteFromConvFailed, 'OK');
-    }
-  }
-
-  /** Show the snippet picker (#475). Resolves with the chosen
-   *  template or `null` when the user cancels. */
-
-  /** Insert a template's substituted body at the editor caret
-   *  (replacing the current selection if any). `{{selection}}`
-   *  picks up the selected text; `{{cursor}}` becomes the post-
-   *  insert caret position; `{{prompt:Label}}` pauses for input
-   *  via the existing showPrompt dialog. (#475) */
-  async function handleInsertTemplate(): Promise<void> {
-    if (!notebase.meta) return;
-    if (editor.activeTab?.type !== 'note') return;
-    const list = await api.templates.list();
-    if (list.length === 0) return;
-    const picked = await showSnippetPicker(list);
-    if (!picked) return;
-    const body = await api.templates.get(picked.filename);
-    if (body === null) return;
-    const selection = editorComponent?.getSelectedText() ?? '';
-    const titleFromPath = (editor.activeFilePath?.split('/').pop() ?? '')
-      .replace(/\.(md|ttl|csv|py)$/i, '');
-    const sub = await substituteTemplate(body, {
-      title: titleFromPath,
-      selection,
-      prompt: (label: string) => showPrompt(`${label}:`),
-    });
-    if (sub.cancelled) return;
-    editorComponent?.insertText(sub.content, sub.cursorOffset);
-  }
-
-  /** Save the active note's body as a template under
-   *  `.minerva/templates/<name>.md` (#475). The body is copied
-   *  verbatim — placeholders the user typed (`{{title}}` etc.) live
-   *  in the source and get resolved when the template is *used*.
-   *  Existing template files at the same name are overwritten;
-   *  showPrompt is light-weight enough that the user can just retype
-   *  if they meant a different name. */
-  async function handleSaveAsTemplate(): Promise<void> {
-    if (!notebase.meta) return;
-    const tab = editor.activeTab;
-    if (!tab || tab.type !== 'note') return;
-    const suggested = (tab.relativePath.split('/').pop() ?? '')
-      .replace(/\.(md|ttl|csv|py)$/i, '');
-    const name = await showPrompt('Template name:', suggested);
-    if (!name) return;
-    try {
-      await api.templates.saveAs(name, tab.content);
-    } catch (err) {
-      console.error('[templates] saveAs failed', err);
-    }
-  }
-
-  /** Zotero-style "New note about this source" (#474). Creates a note
-   *  pre-populated with `about: [[sources/<id>]]` frontmatter so it
-   *  immediately surfaces under the source's Notes section. */
-  async function handleNewAboutSourceNote(sourceId: string): Promise<string | null> {
-    if (!notebase.meta) return null;
-    const name = await showPrompt('Note name:');
-    if (!name) return null;
-    const filename = name.endsWith('.md') ? name : `${name}.md`;
-    const relativePath = filename;
-    const titleStem = name.replace(/\.md$/, '');
-    const initialContent = `---\nabout: [[sources/${sourceId}]]\n---\n\n# ${titleStem}\n\n`;
-    await api.notebase.writeFile(relativePath, initialContent);
-    await notebase.refresh();
-    await editor.openFile(relativePath);
-    sidebar?.refreshTags();
-    return relativePath;
-  }
-
-  /** Create a new note seeded from an excerpt (#101). Prompts for
-   *  the title with a sensible default ("Note on <displayTitle>"),
-   *  builds the markdown via `buildExcerptNoteContent`, writes to
-   *  the configured excerpt-note folder (project-config), and
-   *  opens the result. Returns the new note's relative path so
-   *  callers can highlight or further-navigate. */
-  async function handleCreateNoteFromExcerpt(
-    sourceId: string,
-    excerpt: import('../shared/types').SourceExcerpt,
-  ): Promise<string | null> {
-    if (!notebase.meta) return null;
-    const detail = await api.graph.sourceDetail(sourceId);
-    const built = buildExcerptNoteContent({
-      sourceId,
-      excerpt,
-      source: detail?.metadata,
-    });
-    const name = await showPrompt('Note name:', built.suggestedTitle);
-    if (!name) return null;
-    const folder = await api.sources.getExcerptNoteFolder();
-    const stem = name.replace(/\.md$/, '');
-    const filename = `${stem}.md`;
-    const relativePath = folder ? `${folder}/${filename}` : filename;
-    // Re-build with the user's chosen title so the H1 matches.
-    const finalContent = buildExcerptNoteContent({
-      sourceId,
-      excerpt,
-      source: detail?.metadata,
-      titleOverride: stem,
-    }).content;
-    await api.notebase.writeFile(relativePath, finalContent);
-    await notebase.refresh();
-    await editor.openFile(relativePath);
-    sidebar?.refreshTags();
-    return relativePath;
-  }
-
-  /** Append an excerpt's quote (with a [[quote::id]] link) to the
-   *  user's "current" note (#101). When the user is on the
-   *  source-detail tab, "current" is the most-recent note tab —
-   *  tracked via `lastNotePath`. Returns true when the append
-   *  happened so the SourceDetail can flash a brief "Appended ✓"
-   *  affordance. */
-  function handleAppendExcerptToCurrent(
-    excerpt: import('../shared/types').SourceExcerpt,
-  ): boolean {
-    const block = buildExcerptAppendBlock(excerpt);
-    const active = editor.activeNoteTab;
-    if (active) {
-      editor.setContent(active.content + block);
-      return true;
-    }
-    if (!lastNotePath) return false;
-    const idx = editor.tabs.findIndex(
-      (t) => t.type === 'note' && t.relativePath === lastNotePath,
-    );
-    if (idx === -1) return false;
-    editor.switchTab(idx);
-    // setContent operates on the active tab — switchTab already
-    // flipped activeIndex so this targets the right buffer.
-    const target = editor.tabs[idx];
-    if (target.type !== 'note') return false;
-    editor.setContent(target.content + block);
-    return true;
-  }
-
   /**
    * Three-way prompt ("This Window" / "New Window" / "Cancel") wrapped
    * in a promise. Returns 'this' without prompting when no thoughtbase
@@ -772,79 +564,6 @@
     }
   }
 
-  async function handleSaveCellOutput(payload: {
-    cellLanguage: string;
-    cellCode: string;
-    output: import('../shared/compute/types').CellOutput;
-    /** Pin to notebook (#244). When true, the saver looks up an
-     *  existing derived note for this cell and overwrites it rather
-     *  than prompting for a new destination; sets `pin=true` on the
-     *  source cell's fence on first pin so subsequent saves reuse
-     *  the same destination automatically. */
-    pin?: boolean;
-  }): Promise<void> {
-    if (!notebase.meta) return;
-    const sourcePath = editor.activeFilePath;
-    if (!sourcePath) return;
-    // For a non-pinned "Save as note", prompt for a destination. Pin
-    // saves skip the prompt — the backend resolves the destination
-    // from the graph (existing derived note for this cell). When the
-    // cell is being pinned for the first time AND no derived note
-    // exists yet, the backend falls back to the default path.
-    let destPath: string | undefined;
-    if (!payload.pin) {
-      const dest = await showPrompt(
-        `Save cell output as note. Path (default: notes/derived/):`,
-      );
-      if (dest === null) return; // user cancelled
-      let trimmed = dest.trim();
-      // Add `.md` if the user typed a bare path. The pipeline writes a
-      // markdown note unconditionally, so a missing extension would
-      // produce a file that `Open` doesn't recognise as a note.
-      if (trimmed.length > 0 && !/\.md$/i.test(trimmed)) {
-        trimmed += '.md';
-      }
-      destPath = trimmed.length > 0 ? trimmed : undefined;
-    }
-    try {
-      let result = await api.compute.saveCellOutput({
-        sourcePath,
-        cellLanguage: payload.cellLanguage,
-        cellCode: payload.cellCode,
-        output: payload.output,
-        destPath,
-        pin: payload.pin,
-      });
-      // Confirm-on-diff (#244): the destination exists with different
-      // content. Ask the user before overwriting; on yes, retry with
-      // `forceOverwrite: true`. The dialog is intentionally compact
-      // — a full diff view is a future polish item.
-      if (result.status === 'needs-confirm') {
-        const ok = await showConfirm(
-          `"${result.derivedPath}" already exists with different content. Overwrite it?`,
-          CONFIRM_KEYS.saveCellOutputFailed,
-          'Overwrite',
-        );
-        if (!ok) return;
-        result = await api.compute.saveCellOutput({
-          sourcePath,
-          cellLanguage: payload.cellLanguage,
-          cellCode: payload.cellCode,
-          output: payload.output,
-          destPath: result.derivedPath,
-          pin: payload.pin,
-          forceOverwrite: true,
-        });
-        if (result.status !== 'written') return;
-      }
-      // Refresh the file tree so the new note is selectable, then open it.
-      await notebase.refresh();
-      setTimeout(() => handleFileSelect(result.derivedPath), 100);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showConfirm(`Save cell output failed: ${msg}`, CONFIRM_KEYS.saveCellOutputFailed, 'OK');
-    }
-  }
   /**
    * Safe-delete blocker dialog state (#429). `proceed` is the
    * "Delete anyway" closure — calling it runs the existing batch
@@ -932,22 +651,35 @@
     handleFormat, handleBibliography, handleAutoTag,
   } = createRefactorOps(refactorOpsCtx);
 
-  async function handleDecompose(_relativePath: string) {
-    if (!notebase.meta) return;
-    // Both decompose and crystallize are ThinkingTools (#515), so the
-    // editor right-click menu routes through the same tool-prep flow
-    // the ToolPanel uses. The `_relativePath` arg is preserved for
-    // API symmetry with the other right-click handlers, but the tool
-    // gathers its own `fullNote` context against the active editor.
-    const ctx = await gatherContext(['fullNote'], editorComponent?.getView());
-    await handleOpenConversationFromTool({ toolId: 'research.decompose', context: ctx });
-  }
+  // Template / note-creation handler cluster (#670): new-note-from-conversation
+  // (#177), Insert / Save-as Template (#475), new-note-about-source (#474), and
+  // the excerpt → note / append flows (#101). Lives in ./lib/app/template-ops.ts;
+  // no feature-state store. Destructured into the same names so every call site
+  // reads unchanged. Reads the sidebar / editor component and lastNotePath via ctx.
+  const {
+    handleCreateNoteFromConversation, handleInsertTemplate, handleSaveAsTemplate,
+    handleNewAboutSourceNote, handleCreateNoteFromExcerpt, handleAppendExcerptToCurrent,
+  } = createTemplateOps({
+    getSidebar: () => sidebar,
+    getEditorComponent: () => editorComponent,
+    getLastNotePath: () => lastNotePath,
+  } satisfies TemplateOpsCtx);
 
-  async function handleCrystallize(_relativePath: string) {
-    if (!notebase.meta) return;
-    const ctx = await gatherContext(['fullNote'], editorComponent?.getView());
-    await handleOpenConversationFromTool({ toolId: 'research.crystallize', context: ctx });
-  }
+  // Conversation / tool-invocation handler cluster (#670): save-cell-output
+  // (#244), decompose / crystallize (#515), the freeform / message / from-tool
+  // conversation openers, and generic tool invocation. Lives in
+  // ./lib/app/conversation-ops.ts. Placed after createNavView so handleFileSelect
+  // is in scope for the openFileSelect getter; reaches the editor view + tool-
+  // panel component via ctx. The conversationsStore / toolPanel store handles
+  // stay in App (onMount streaming still uses them).
+  const {
+    handleSaveCellOutput, handleDecompose, handleCrystallize,
+    openConversation, openConversationWithMessage, handleOpenConversationFromTool, handleToolInvoke,
+  } = createConversationOps({
+    getEditorView: () => editorComponent?.getView(),
+    getToolPanelComponent: () => toolPanelComponent,
+    openFileSelect: (p) => { void handleFileSelect(p); },
+  } satisfies ConversationOpsCtx);
 
   function handleCycleTheme() {
     themeLabel = cycleTheme();
@@ -975,59 +707,6 @@
       nav.record({ type: 'query', tabId: targetTab.id });
     } else {
       editor.switchTab(index);
-    }
-  }
-
-  async function openConversationWithMessage(message: string) {
-    await conversationsStore.openConversationTab({
-      notePath: editor.activeFilePath ?? undefined,
-      initialMessage: message,
-    });
-  }
-
-  async function openConversation() {
-    await conversationsStore.openFreeform(editor.activeFilePath ?? undefined);
-  }
-
-  async function handleOpenConversationFromTool(invocation: { toolId: string; context: ToolContext }) {
-    let prep;
-    try {
-      prep = await api.tools.prepareConversation({
-        toolId: invocation.toolId,
-        context: invocation.context,
-      });
-    } catch (err) {
-      // The tool's `buildSystemPrompt` may throw with a user-facing
-      // explanation (e.g. find-arguments throws "right-click on a
-      // claim line first" when no URI was extracted from the cursor).
-      // Surface that message as a dialog rather than logging it
-      // silently to console.
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error('[tool] prepareConversation failed:', err);
-      await showConfirm(msg, CONFIRM_KEYS.toolPrepareFailed, 'OK');
-      return;
-    }
-
-    const notePath = invocation.context.fullNotePath ?? editor.activeFilePath ?? undefined;
-    await conversationsStore.openConversationTab({
-      notePath,
-      systemPrompt: prep.systemPrompt,
-      ...(prep.model ? { model: prep.model } : {}),
-      ...(prep.firstMessage ? { initialMessage: prep.firstMessage } : {}),
-      ...(prep.requiresTools && prep.requiresTools.length > 0
-        ? { extraTools: prep.requiresTools }
-        : {}),
-    });
-  }
-
-  async function handleToolInvoke(toolId: string) {
-    const allTools = getAllToolInfos();
-    const toolInfo = allTools.find(t => t.id === toolId);
-    if (!toolInfo) return;
-    const ctx = await gatherContext(toolInfo.context, editorComponent?.getView());
-    toolPanel.open(toolInfo, ctx);
-    if (!toolInfo.parameters || toolInfo.parameters.length === 0) {
-      requestAnimationFrame(() => toolPanelComponent?.startExecution());
     }
   }
 

--- a/src/renderer/lib/app/conversation-ops.ts
+++ b/src/renderer/lib/app/conversation-ops.ts
@@ -1,0 +1,188 @@
+/**
+ * Conversation / tool-invocation handler cluster extracted from App.svelte
+ * (#670). Save-cell-output (#244), decompose / crystallize (#515), the
+ * freeform / message / from-tool conversation openers, and generic tool
+ * invocation. Bodies are verbatim from App.svelte; the only changes are the
+ * ctx getter substitutions for the pieces that used to be inline component
+ * refs (editor view, tool-panel component) or a sibling App function
+ * (handleFileSelect, from the nav-view cluster).
+ */
+import { api } from '../ipc/client';
+import { getNotebaseStore } from '../stores/notebase.svelte';
+import { getEditorStore } from '../stores/editor.svelte';
+import { getDialogStore } from '../stores/dialogs.svelte';
+import { getConversationsStore } from '../stores/conversations.svelte';
+import { getToolPanelStore } from '../stores/tool-panel.svelte';
+import { gatherContext } from '../tools/context';
+import { getAllToolInfos } from '../tools/tool-registry';
+import { CONFIRM_KEYS } from '../confirm-keys';
+import type { ToolContext } from '../../../shared/tools/types';
+
+export interface ConversationOpsCtx {
+  getEditorView: () => Parameters<typeof gatherContext>[1];
+  getToolPanelComponent: () => { startExecution: () => void } | undefined;
+  openFileSelect: (relativePath: string) => void;
+}
+
+export function createConversationOps(ctx: ConversationOpsCtx) {
+  const notebase = getNotebaseStore();
+  const editor = getEditorStore();
+  const dialogs = getDialogStore();
+  const conversationsStore = getConversationsStore();
+  const toolPanel = getToolPanelStore();
+  const { showPrompt, showConfirm } = dialogs;
+
+  async function handleSaveCellOutput(payload: {
+    cellLanguage: string;
+    cellCode: string;
+    output: import('../../../shared/compute/types').CellOutput;
+    /** Pin to notebook (#244). When true, the saver looks up an
+     *  existing derived note for this cell and overwrites it rather
+     *  than prompting for a new destination; sets `pin=true` on the
+     *  source cell's fence on first pin so subsequent saves reuse
+     *  the same destination automatically. */
+    pin?: boolean;
+  }): Promise<void> {
+    if (!notebase.meta) return;
+    const sourcePath = editor.activeFilePath;
+    if (!sourcePath) return;
+    // For a non-pinned "Save as note", prompt for a destination. Pin
+    // saves skip the prompt — the backend resolves the destination
+    // from the graph (existing derived note for this cell). When the
+    // cell is being pinned for the first time AND no derived note
+    // exists yet, the backend falls back to the default path.
+    let destPath: string | undefined;
+    if (!payload.pin) {
+      const dest = await showPrompt(
+        `Save cell output as note. Path (default: notes/derived/):`,
+      );
+      if (dest === null) return; // user cancelled
+      let trimmed = dest.trim();
+      // Add `.md` if the user typed a bare path. The pipeline writes a
+      // markdown note unconditionally, so a missing extension would
+      // produce a file that `Open` doesn't recognise as a note.
+      if (trimmed.length > 0 && !/\.md$/i.test(trimmed)) {
+        trimmed += '.md';
+      }
+      destPath = trimmed.length > 0 ? trimmed : undefined;
+    }
+    try {
+      let result = await api.compute.saveCellOutput({
+        sourcePath,
+        cellLanguage: payload.cellLanguage,
+        cellCode: payload.cellCode,
+        output: payload.output,
+        destPath,
+        pin: payload.pin,
+      });
+      // Confirm-on-diff (#244): the destination exists with different
+      // content. Ask the user before overwriting; on yes, retry with
+      // `forceOverwrite: true`. The dialog is intentionally compact
+      // — a full diff view is a future polish item.
+      if (result.status === 'needs-confirm') {
+        const ok = await showConfirm(
+          `"${result.derivedPath}" already exists with different content. Overwrite it?`,
+          CONFIRM_KEYS.saveCellOutputFailed,
+          'Overwrite',
+        );
+        if (!ok) return;
+        result = await api.compute.saveCellOutput({
+          sourcePath,
+          cellLanguage: payload.cellLanguage,
+          cellCode: payload.cellCode,
+          output: payload.output,
+          destPath: result.derivedPath,
+          pin: payload.pin,
+          forceOverwrite: true,
+        });
+        if (result.status !== 'written') return;
+      }
+      // Refresh the file tree so the new note is selectable, then open it.
+      await notebase.refresh();
+      setTimeout(() => ctx.openFileSelect(result.derivedPath), 100);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Save cell output failed: ${msg}`, CONFIRM_KEYS.saveCellOutputFailed, 'OK');
+    }
+  }
+
+  async function handleDecompose(_relativePath: string) {
+    if (!notebase.meta) return;
+    // Both decompose and crystallize are ThinkingTools (#515), so the
+    // editor right-click menu routes through the same tool-prep flow
+    // the ToolPanel uses. The `_relativePath` arg is preserved for
+    // API symmetry with the other right-click handlers, but the tool
+    // gathers its own `fullNote` context against the active editor.
+    const toolCtx = await gatherContext(['fullNote'], ctx.getEditorView());
+    await handleOpenConversationFromTool({ toolId: 'research.decompose', context: toolCtx });
+  }
+
+  async function handleCrystallize(_relativePath: string) {
+    if (!notebase.meta) return;
+    const toolCtx = await gatherContext(['fullNote'], ctx.getEditorView());
+    await handleOpenConversationFromTool({ toolId: 'research.crystallize', context: toolCtx });
+  }
+
+  async function openConversationWithMessage(message: string) {
+    await conversationsStore.openConversationTab({
+      notePath: editor.activeFilePath ?? undefined,
+      initialMessage: message,
+    });
+  }
+
+  async function openConversation() {
+    await conversationsStore.openFreeform(editor.activeFilePath ?? undefined);
+  }
+
+  async function handleOpenConversationFromTool(invocation: { toolId: string; context: ToolContext }) {
+    let prep;
+    try {
+      prep = await api.tools.prepareConversation({
+        toolId: invocation.toolId,
+        context: invocation.context,
+      });
+    } catch (err) {
+      // The tool's `buildSystemPrompt` may throw with a user-facing
+      // explanation (e.g. find-arguments throws "right-click on a
+      // claim line first" when no URI was extracted from the cursor).
+      // Surface that message as a dialog rather than logging it
+      // silently to console.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[tool] prepareConversation failed:', err);
+      await showConfirm(msg, CONFIRM_KEYS.toolPrepareFailed, 'OK');
+      return;
+    }
+
+    const notePath = invocation.context.fullNotePath ?? editor.activeFilePath ?? undefined;
+    await conversationsStore.openConversationTab({
+      notePath,
+      systemPrompt: prep.systemPrompt,
+      ...(prep.model ? { model: prep.model } : {}),
+      ...(prep.firstMessage ? { initialMessage: prep.firstMessage } : {}),
+      ...(prep.requiresTools && prep.requiresTools.length > 0
+        ? { extraTools: prep.requiresTools }
+        : {}),
+    });
+  }
+
+  async function handleToolInvoke(toolId: string) {
+    const allTools = getAllToolInfos();
+    const toolInfo = allTools.find(t => t.id === toolId);
+    if (!toolInfo) return;
+    const toolCtx = await gatherContext(toolInfo.context, ctx.getEditorView());
+    toolPanel.open(toolInfo, toolCtx);
+    if (!toolInfo.parameters || toolInfo.parameters.length === 0) {
+      requestAnimationFrame(() => ctx.getToolPanelComponent()?.startExecution());
+    }
+  }
+
+  return {
+    handleSaveCellOutput,
+    handleDecompose,
+    handleCrystallize,
+    openConversation,
+    openConversationWithMessage,
+    handleOpenConversationFromTool,
+    handleToolInvoke,
+  };
+}

--- a/src/renderer/lib/app/template-ops.ts
+++ b/src/renderer/lib/app/template-ops.ts
@@ -1,0 +1,237 @@
+/**
+ * Template / note-creation handler cluster extracted from App.svelte (#670).
+ * New-note-from-conversation (#475), Insert / Save-as Template (#475),
+ * new-note-about-source (#474), and the excerpt → note / append flows (#101).
+ * Bodies are verbatim from App.svelte; the only changes are the ctx getter
+ * substitutions for the pieces that used to be inline component refs (editor
+ * component, sidebar) or local `$state` (lastNotePath). No feature-state store —
+ * this cluster has none.
+ */
+import { api } from '../ipc/client';
+import { getNotebaseStore } from '../stores/notebase.svelte';
+import { getEditorStore } from '../stores/editor.svelte';
+import { getDialogStore } from '../stores/dialogs.svelte';
+import { substituteTemplate } from '../../../shared/templates';
+import { buildExcerptNoteContent, buildExcerptAppendBlock } from '../../../shared/excerpt-note';
+import {
+  suggestConversationNoteTitle,
+  planCreateFromConversation,
+} from '../refactor/create-from-conversation';
+import { getRefactorSettings } from '../refactor/settings';
+import { CONFIRM_KEYS } from '../confirm-keys';
+import type { Conversation, SourceExcerpt } from '../../../shared/types';
+
+interface EditorRef {
+  getSelectedText: () => string;
+  insertText: (s: string, offset?: number | null) => void;
+}
+interface SidebarRef {
+  refreshTags: () => void;
+}
+
+export interface TemplateOpsCtx {
+  getSidebar: () => SidebarRef | undefined;
+  getEditorComponent: () => EditorRef | undefined;
+  getLastNotePath: () => string | null;
+}
+
+export function createTemplateOps(ctx: TemplateOpsCtx) {
+  const notebase = getNotebaseStore();
+  const editor = getEditorStore();
+  const dialogs = getDialogStore();
+  const { showPrompt, showConfirm, showSnippetPicker } = dialogs;
+
+  async function handleCreateNoteFromConversation(args: {
+    conversation: Conversation;
+    selectionText: string;
+    fallbackText: string;
+  }): Promise<void> {
+    if (!notebase.meta) return;
+    const body = args.selectionText.trim() || args.fallbackText.trim();
+    if (!body) {
+      await showConfirm(
+        'Nothing to create from — the conversation has no assistant text yet.',
+        CONFIRM_KEYS.createNoteFromConvEmpty,
+        'OK',
+      );
+      return;
+    }
+    const suggested = suggestConversationNoteTitle(body);
+    const title = suggested ?? await showPrompt('New note name:');
+    if (!title) return;
+
+    const sourceRelativePath = args.conversation.contextBundle.notePath ?? null;
+    const plan = planCreateFromConversation({
+      title,
+      body,
+      sourceRelativePath,
+      conversationId: args.conversation.id,
+      today: new Date().toISOString().slice(0, 10),
+      settings: getRefactorSettings(),
+    });
+
+    try {
+      // Loop on collision so the second-of-the-same-title doesn't
+      // clobber the first. Existing extract / split-here paths
+      // accept clobbers, but conversation-source notes are likely
+      // to land repeatedly off the same prompts.
+      let path = plan.newNotePath;
+      for (let attempt = 2; attempt < 20; attempt++) {
+        if (!(await api.notebase.fileExists(path))) break;
+        const dot = plan.newNotePath.lastIndexOf('.md');
+        path = dot > 0
+          ? `${plan.newNotePath.slice(0, dot)}-${attempt}.md`
+          : `${plan.newNotePath}-${attempt}`;
+      }
+      await api.notebase.writeFile(path, plan.newNoteContent);
+      await notebase.refresh();
+      await editor.openFile(path);
+      ctx.getSidebar()?.refreshTags();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Couldn't create note: ${msg}`, CONFIRM_KEYS.createNoteFromConvFailed, 'OK');
+    }
+  }
+
+  /** Insert a template's substituted body at the editor caret
+   *  (replacing the current selection if any). `{{selection}}`
+   *  picks up the selected text; `{{cursor}}` becomes the post-
+   *  insert caret position; `{{prompt:Label}}` pauses for input
+   *  via the existing showPrompt dialog. (#475) */
+  async function handleInsertTemplate(): Promise<void> {
+    if (!notebase.meta) return;
+    if (editor.activeTab?.type !== 'note') return;
+    const list = await api.templates.list();
+    if (list.length === 0) return;
+    const picked = await showSnippetPicker(list);
+    if (!picked) return;
+    const body = await api.templates.get(picked.filename);
+    if (body === null) return;
+    const selection = ctx.getEditorComponent()?.getSelectedText() ?? '';
+    const titleFromPath = (editor.activeFilePath?.split('/').pop() ?? '')
+      .replace(/\.(md|ttl|csv|py)$/i, '');
+    const sub = await substituteTemplate(body, {
+      title: titleFromPath,
+      selection,
+      prompt: (label: string) => showPrompt(`${label}:`),
+    });
+    if (sub.cancelled) return;
+    ctx.getEditorComponent()?.insertText(sub.content, sub.cursorOffset);
+  }
+
+  /** Save the active note's body as a template under
+   *  `.minerva/templates/<name>.md` (#475). The body is copied
+   *  verbatim — placeholders the user typed (`{{title}}` etc.) live
+   *  in the source and get resolved when the template is *used*.
+   *  Existing template files at the same name are overwritten;
+   *  showPrompt is light-weight enough that the user can just retype
+   *  if they meant a different name. */
+  async function handleSaveAsTemplate(): Promise<void> {
+    if (!notebase.meta) return;
+    const tab = editor.activeTab;
+    if (!tab || tab.type !== 'note') return;
+    const suggested = (tab.relativePath.split('/').pop() ?? '')
+      .replace(/\.(md|ttl|csv|py)$/i, '');
+    const name = await showPrompt('Template name:', suggested);
+    if (!name) return;
+    try {
+      await api.templates.saveAs(name, tab.content);
+    } catch (err) {
+      console.error('[templates] saveAs failed', err);
+    }
+  }
+
+  /** Zotero-style "New note about this source" (#474). Creates a note
+   *  pre-populated with `about: [[sources/<id>]]` frontmatter so it
+   *  immediately surfaces under the source's Notes section. */
+  async function handleNewAboutSourceNote(sourceId: string): Promise<string | null> {
+    if (!notebase.meta) return null;
+    const name = await showPrompt('Note name:');
+    if (!name) return null;
+    const filename = name.endsWith('.md') ? name : `${name}.md`;
+    const relativePath = filename;
+    const titleStem = name.replace(/\.md$/, '');
+    const initialContent = `---\nabout: [[sources/${sourceId}]]\n---\n\n# ${titleStem}\n\n`;
+    await api.notebase.writeFile(relativePath, initialContent);
+    await notebase.refresh();
+    await editor.openFile(relativePath);
+    ctx.getSidebar()?.refreshTags();
+    return relativePath;
+  }
+
+  /** Create a new note seeded from an excerpt (#101). Prompts for
+   *  the title with a sensible default ("Note on <displayTitle>"),
+   *  builds the markdown via `buildExcerptNoteContent`, writes to
+   *  the configured excerpt-note folder (project-config), and
+   *  opens the result. Returns the new note's relative path so
+   *  callers can highlight or further-navigate. */
+  async function handleCreateNoteFromExcerpt(
+    sourceId: string,
+    excerpt: SourceExcerpt,
+  ): Promise<string | null> {
+    if (!notebase.meta) return null;
+    const detail = await api.graph.sourceDetail(sourceId);
+    const built = buildExcerptNoteContent({
+      sourceId,
+      excerpt,
+      source: detail?.metadata,
+    });
+    const name = await showPrompt('Note name:', built.suggestedTitle);
+    if (!name) return null;
+    const folder = await api.sources.getExcerptNoteFolder();
+    const stem = name.replace(/\.md$/, '');
+    const filename = `${stem}.md`;
+    const relativePath = folder ? `${folder}/${filename}` : filename;
+    // Re-build with the user's chosen title so the H1 matches.
+    const finalContent = buildExcerptNoteContent({
+      sourceId,
+      excerpt,
+      source: detail?.metadata,
+      titleOverride: stem,
+    }).content;
+    await api.notebase.writeFile(relativePath, finalContent);
+    await notebase.refresh();
+    await editor.openFile(relativePath);
+    ctx.getSidebar()?.refreshTags();
+    return relativePath;
+  }
+
+  /** Append an excerpt's quote (with a [[quote::id]] link) to the
+   *  user's "current" note (#101). When the user is on the
+   *  source-detail tab, "current" is the most-recent note tab —
+   *  tracked via `lastNotePath`. Returns true when the append
+   *  happened so the SourceDetail can flash a brief "Appended ✓"
+   *  affordance. */
+  function handleAppendExcerptToCurrent(
+    excerpt: SourceExcerpt,
+  ): boolean {
+    const block = buildExcerptAppendBlock(excerpt);
+    const active = editor.activeNoteTab;
+    if (active) {
+      editor.setContent(active.content + block);
+      return true;
+    }
+    const lastNotePath = ctx.getLastNotePath();
+    if (!lastNotePath) return false;
+    const idx = editor.tabs.findIndex(
+      (t) => t.type === 'note' && t.relativePath === lastNotePath,
+    );
+    if (idx === -1) return false;
+    editor.switchTab(idx);
+    // setContent operates on the active tab — switchTab already
+    // flipped activeIndex so this targets the right buffer.
+    const target = editor.tabs[idx];
+    if (target.type !== 'note') return false;
+    editor.setContent(target.content + block);
+    return true;
+  }
+
+  return {
+    handleCreateNoteFromConversation,
+    handleInsertTemplate,
+    handleSaveAsTemplate,
+    handleNewAboutSourceNote,
+    handleCreateNoteFromExcerpt,
+    handleAppendExcerptToCurrent,
+  };
+}

--- a/tests/renderer/app/conversation-ops.test.ts
+++ b/tests/renderer/app/conversation-ops.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Behavioral net for the conversation / tool-invocation handlers extracted from
+ * App.svelte (#670). Mocks the api client + notebase / editor / dialog /
+ * conversations / tool-panel stores, plus the tool registry + context gatherer.
+ * Verifies the moved handler bodies (open conversation, from-tool prep,
+ * generic tool invoke, save-cell-output), not just that menus reach them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const api = {
+    tools: { prepareConversation: vi.fn() },
+    compute: { saveCellOutput: vi.fn() },
+  };
+  const notebase = {
+    meta: { rootPath: '/p', name: 'p' } as unknown,
+    refresh: vi.fn().mockResolvedValue(undefined),
+  };
+  const editor = {
+    activeFilePath: null as string | null,
+    activeTab: undefined as unknown,
+  };
+  const dialog = { showPrompt: vi.fn(), showConfirm: vi.fn() };
+  const conversationsStore = { openFreeform: vi.fn(), openConversationTab: vi.fn() };
+  const toolPanel = { open: vi.fn() };
+  const registry = { getAllToolInfos: vi.fn(() => [] as unknown[]) };
+  const tools = { gatherContext: vi.fn().mockResolvedValue({}) };
+  return { api, notebase, editor, dialog, conversationsStore, toolPanel, registry, tools };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogStore: () => h.dialog }));
+vi.mock('../../../src/renderer/lib/stores/conversations.svelte', () => ({ getConversationsStore: () => h.conversationsStore }));
+vi.mock('../../../src/renderer/lib/stores/tool-panel.svelte', () => ({ getToolPanelStore: () => h.toolPanel }));
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({ getAllToolInfos: h.registry.getAllToolInfos }));
+vi.mock('../../../src/renderer/lib/tools/context', () => ({ gatherContext: h.tools.gatherContext }));
+
+import { createConversationOps, type ConversationOpsCtx } from '../../../src/renderer/lib/app/conversation-ops';
+
+const toolPanelComponent = { startExecution: vi.fn() };
+const openFileSelect = vi.fn();
+let ctx: ConversationOpsCtx;
+let ops: ReturnType<typeof createConversationOps>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.notebase.meta = { rootPath: '/p', name: 'p' };
+  h.editor.activeFilePath = null;
+  h.editor.activeTab = undefined;
+  h.registry.getAllToolInfos.mockReturnValue([]);
+  h.tools.gatherContext.mockResolvedValue({});
+  ctx = {
+    getEditorView: () => undefined,
+    getToolPanelComponent: () => toolPanelComponent,
+    openFileSelect,
+  };
+  ops = createConversationOps(ctx);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('openConversation', () => {
+  it('opens a freeform conversation rooted at the active note', async () => {
+    h.editor.activeFilePath = 'a.md';
+    await ops.openConversation();
+    expect(h.conversationsStore.openFreeform).toHaveBeenCalledWith('a.md');
+  });
+});
+
+describe('openConversationWithMessage', () => {
+  it('opens a conversation tab seeded with the message', async () => {
+    h.editor.activeFilePath = 'a.md';
+    await ops.openConversationWithMessage('hello');
+    expect(h.conversationsStore.openConversationTab).toHaveBeenCalledWith({
+      notePath: 'a.md',
+      initialMessage: 'hello',
+    });
+  });
+});
+
+describe('handleOpenConversationFromTool', () => {
+  it('opens a tab with the prepared system prompt on success', async () => {
+    h.api.tools.prepareConversation.mockResolvedValue({
+      systemPrompt: 'SYS', firstMessage: 'FIRST', requiresTools: [],
+    });
+    await ops.handleOpenConversationFromTool({ toolId: 't.x', context: { fullNotePath: 'n.md' } });
+    expect(h.conversationsStore.openConversationTab).toHaveBeenCalledWith(
+      expect.objectContaining({ notePath: 'n.md', systemPrompt: 'SYS', initialMessage: 'FIRST' }),
+    );
+  });
+
+  it('surfaces a confirm dialog (and opens nothing) when prep throws', async () => {
+    h.api.tools.prepareConversation.mockRejectedValue(new Error('right-click a claim first'));
+    await ops.handleOpenConversationFromTool({ toolId: 't.y', context: {} });
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(h.conversationsStore.openConversationTab).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleToolInvoke', () => {
+  it('does nothing for an unknown tool id', async () => {
+    h.registry.getAllToolInfos.mockReturnValue([{ id: 'known', context: [], parameters: [] }]);
+    await ops.handleToolInvoke('unknown');
+    expect(h.toolPanel.open).not.toHaveBeenCalled();
+  });
+
+  it('opens the panel and auto-starts a no-parameter tool via rAF', async () => {
+    // The auto-start defers through requestAnimationFrame — run the callback
+    // synchronously so we can assert startExecution fired on the ctx component.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0; });
+    const toolInfo = { id: 'go', context: ['fullNote'], parameters: [] };
+    h.registry.getAllToolInfos.mockReturnValue([toolInfo]);
+    await ops.handleToolInvoke('go');
+    expect(h.toolPanel.open).toHaveBeenCalledWith(toolInfo, expect.anything());
+    expect(toolPanelComponent.startExecution).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('handleSaveCellOutput', () => {
+  const payload = {
+    cellLanguage: 'python',
+    cellCode: 'print(1)',
+    output: { kind: 'text', text: '1' } as never,
+  };
+
+  it('does not save when the destination prompt is cancelled', async () => {
+    h.editor.activeFilePath = 'nb.md';
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleSaveCellOutput(payload);
+    expect(h.api.compute.saveCellOutput).not.toHaveBeenCalled();
+  });
+
+  it('saves the cell output and opens the derived note via ctx', async () => {
+    vi.useFakeTimers();
+    h.editor.activeFilePath = 'nb.md';
+    h.dialog.showPrompt.mockResolvedValue('derived/out');
+    h.api.compute.saveCellOutput.mockResolvedValue({ status: 'written', derivedPath: 'derived/out.md' });
+    await ops.handleSaveCellOutput(payload);
+    expect(h.api.compute.saveCellOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ sourcePath: 'nb.md', destPath: 'derived/out.md' }),
+    );
+    expect(h.notebase.refresh).toHaveBeenCalled();
+    // The open is deferred behind a setTimeout — advance fake timers to fire it.
+    vi.advanceTimersByTime(200);
+    expect(openFileSelect).toHaveBeenCalledWith('derived/out.md');
+  });
+});

--- a/tests/renderer/app/template-ops.test.ts
+++ b/tests/renderer/app/template-ops.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Behavioral net for the template / note-creation handlers extracted from
+ * App.svelte (#670). Mocks the api client + notebase / editor / dialog stores,
+ * and the refactor template-planning helpers (create-from-conversation /
+ * settings). Verifies the moved handler bodies (save-as / insert template,
+ * new-about-source note, excerpt append, create-from-conversation collision
+ * loop), not just that menus reach them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const api = {
+    templates: { list: vi.fn(), get: vi.fn(), saveAs: vi.fn() },
+    graph: { sourceDetail: vi.fn() },
+    sources: { getExcerptNoteFolder: vi.fn() },
+    notebase: { fileExists: vi.fn(), writeFile: vi.fn() },
+  };
+  const notebase = {
+    meta: { rootPath: '/p', name: 'p' } as unknown,
+    refresh: vi.fn().mockResolvedValue(undefined),
+  };
+  const editor = {
+    openFile: vi.fn(),
+    setContent: vi.fn(),
+    switchTab: vi.fn(),
+    activeTab: undefined as unknown,
+    activeFilePath: null as string | null,
+    activeNoteTab: undefined as unknown,
+    tabs: [] as unknown[],
+  };
+  const dialog = { showPrompt: vi.fn(), showConfirm: vi.fn(), showSnippetPicker: vi.fn() };
+  return { api, notebase, editor, dialog };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogStore: () => h.dialog }));
+
+import { createTemplateOps, type TemplateOpsCtx } from '../../../src/renderer/lib/app/template-ops';
+
+const sidebar = { refreshTags: vi.fn() };
+const editorComponent = { getSelectedText: vi.fn(() => ''), insertText: vi.fn() };
+let lastNotePath: string | null = null;
+let ctx: TemplateOpsCtx;
+let ops: ReturnType<typeof createTemplateOps>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.notebase.meta = { rootPath: '/p', name: 'p' };
+  h.editor.activeTab = undefined;
+  h.editor.activeFilePath = null;
+  h.editor.activeNoteTab = undefined;
+  h.editor.tabs = [];
+  lastNotePath = null;
+  ctx = {
+    getSidebar: () => sidebar,
+    getEditorComponent: () => editorComponent,
+    getLastNotePath: () => lastNotePath,
+  };
+  ops = createTemplateOps(ctx);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('handleSaveAsTemplate', () => {
+  it('prompts for a name and saves the active note body', async () => {
+    h.editor.activeTab = { type: 'note', relativePath: 'foo/bar.md', content: '# body' };
+    h.dialog.showPrompt.mockResolvedValue('my-template');
+    await ops.handleSaveAsTemplate();
+    expect(h.api.templates.saveAs).toHaveBeenCalledWith('my-template', '# body');
+  });
+
+  it('does nothing when the prompt is cancelled', async () => {
+    h.editor.activeTab = { type: 'note', relativePath: 'a.md', content: 'x' };
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleSaveAsTemplate();
+    expect(h.api.templates.saveAs).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleInsertTemplate', () => {
+  it('does nothing when there are no templates', async () => {
+    h.editor.activeTab = { type: 'note', relativePath: 'a.md', content: '' };
+    h.api.templates.list.mockResolvedValue([]);
+    await ops.handleInsertTemplate();
+    expect(h.dialog.showSnippetPicker).not.toHaveBeenCalled();
+    expect(editorComponent.insertText).not.toHaveBeenCalled();
+  });
+
+  it('inserts the picked template body via the ctx editor component', async () => {
+    h.editor.activeTab = { type: 'note', relativePath: 'a.md', content: '' };
+    h.editor.activeFilePath = 'a.md';
+    h.api.templates.list.mockResolvedValue([{ filename: 't.md', name: 't' }]);
+    h.dialog.showSnippetPicker.mockResolvedValue({ filename: 't.md', name: 't' });
+    h.api.templates.get.mockResolvedValue('hello body');
+    await ops.handleInsertTemplate();
+    expect(editorComponent.insertText).toHaveBeenCalled();
+    expect(editorComponent.insertText.mock.calls[0][0]).toContain('hello body');
+  });
+});
+
+describe('handleNewAboutSourceNote', () => {
+  it('writes an about: frontmatter note and opens it', async () => {
+    h.dialog.showPrompt.mockResolvedValue('On Raft');
+    const result = await ops.handleNewAboutSourceNote('src-1');
+    expect(result).toBe('On Raft.md');
+    expect(h.api.notebase.writeFile).toHaveBeenCalledWith(
+      'On Raft.md',
+      expect.stringContaining('about: [[sources/src-1]]'),
+    );
+    expect(h.editor.openFile).toHaveBeenCalledWith('On Raft.md');
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+  });
+
+  it('returns null when the prompt is cancelled', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    const result = await ops.handleNewAboutSourceNote('src-1');
+    expect(result).toBeNull();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAppendExcerptToCurrent', () => {
+  const excerpt = { excerptId: 'e1', text: 'quote', sourceId: 's1' } as never;
+
+  it('appends to the active note tab via editor.setContent', () => {
+    h.editor.activeNoteTab = { type: 'note', relativePath: 'cur.md', content: 'existing' };
+    const ok = ops.handleAppendExcerptToCurrent(excerpt);
+    expect(ok).toBe(true);
+    expect(h.editor.setContent).toHaveBeenCalledWith(expect.stringContaining('existing'));
+  });
+
+  it('with no active note, switches to lastNotePath (via ctx) then appends', () => {
+    h.editor.activeNoteTab = undefined;
+    lastNotePath = 'prev.md';
+    h.editor.tabs = [{ type: 'note', relativePath: 'prev.md', content: 'prev body' }];
+    const ok = ops.handleAppendExcerptToCurrent(excerpt);
+    expect(ok).toBe(true);
+    expect(h.editor.switchTab).toHaveBeenCalledWith(0);
+    expect(h.editor.setContent).toHaveBeenCalledWith(expect.stringContaining('prev body'));
+  });
+
+  it('returns false with no active note and no lastNotePath', () => {
+    h.editor.activeNoteTab = undefined;
+    lastNotePath = null;
+    const ok = ops.handleAppendExcerptToCurrent(excerpt);
+    expect(ok).toBe(false);
+    expect(h.editor.setContent).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCreateNoteFromConversation', () => {
+  const conversation = {
+    id: 'conv-1',
+    contextBundle: { notePath: 'notes/origin.md' },
+  } as never;
+
+  it('confirms (and creates nothing) when there is no body text', async () => {
+    await ops.handleCreateNoteFromConversation({
+      conversation,
+      selectionText: '   ',
+      fallbackText: '',
+    });
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('writes + opens the note, bumping the name on collision', async () => {
+    h.dialog.showPrompt.mockResolvedValue('My Note');
+    // First candidate path exists, second does not — exercises the bump loop.
+    h.api.notebase.fileExists
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    await ops.handleCreateNoteFromConversation({
+      conversation,
+      selectionText: 'some assistant prose to file away',
+      fallbackText: '',
+    });
+    expect(h.api.notebase.writeFile).toHaveBeenCalledTimes(1);
+    const writtenPath = h.api.notebase.writeFile.mock.calls[0][0] as string;
+    // The bumped name carries the `-2` collision suffix before `.md`.
+    expect(writtenPath).toMatch(/-2\.md$/);
+    expect(h.editor.openFile).toHaveBeenCalledWith(writtenPath);
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Final handler-extraction increment of #670. Moves the last two clusters out of App.svelte.

Partially addresses #670 (see the template-split assessment in the thread for the remaining gap to <1,000).

- **`lib/app/template-ops.ts`** — `createTemplateOps(ctx)`: the 6 note-creation handlers (insert/save template, new-about-source, create-from-excerpt, append-excerpt, create-from-conversation). ctx getters for sidebar / editorComponent / lastNotePath.
- **`lib/app/conversation-ops.ts`** — `createConversationOps(ctx)`: the 7 conversation/tool handlers (save-cell-output, decompose, crystallize, open-conversation [+ with-message], open-conversation-from-tool, tool-invoke). ctx getters for the editor view / tool-panel component, plus `openFileSelect` (→ nav-view's `handleFileSelect`, which save-cell-output opens the derived note through).

Bodies moved verbatim; substitutions only. Two notes:
- forced local rename `const ctx` → `toolCtx` inside decompose/crystallize/tool-invoke to avoid shadowing the ctx parameter (behavior-identical local rename).
- `getNotebaseStore` is imported in conversation-ops (save-cell-output/decompose/crystallize guard on `notebase.meta` + `refresh`) — the spec missed it; added to keep bodies verbatim.

App destructures both into the same names; `lastNotePath` / `toolPanelComponent` `$state` and the `conversationsStore` / `toolPanel` handles stay in App (onMount still uses them).

### Tests
`template-ops.test.ts` (11) + `conversation-ops.test.ts` (8): template insert/save, about-note frontmatter, excerpt append, create-from-conv collision-loop, open-conversation variants, tool-prep success/throw, tool-invoke auto-start, save-cell-output prompt/save.

## Result
`App.svelte`: **1,956 → 1,635** (cumulative **3,764 → 1,635, −2,129 / ~57%**).

Every handler group is now in a focused, behaviorally-netted module; App.svelte is a composition root (state + lifecycle + module-wiring + layout template).

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2841 passed**.
- `pnpm test:e2e` — boot smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)