### PR TITLE
Decompose graph/index.ts: extract LLM write guard + real test (#671, increment 1)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -226,56 +226,19 @@ export function noteUriFor(ctx: ProjectContext, relativePath: string): string | 
   return noteUri(state, relativePath).value;
 }
 
-// ── LLM Write Guard ───────────────────────────────────────────────────────
-// Tracks whether the current call path originates from an LLM operation.
-// Direct graph writes from LLM context that bypass the approval engine
-// are logged as warnings during development. Approval engine wraps its
-// own writes in the *trusted* counter so its in-LLM-context writes don't
-// trigger the warning.
-
-let llmContextDepth = 0;
-let trustedContextDepth = 0;
-
-/** Mark the start of an LLM-originated operation. Nest-safe. */
-export function enterLLMContext(): void {
-  llmContextDepth++;
-}
-
-/** Mark the end of an LLM-originated operation. */
-export function exitLLMContext(): void {
-  if (llmContextDepth > 0) llmContextDepth--;
-}
-
-/** Returns true if currently in an LLM call path. */
-export function isInLLMContext(): boolean {
-  return llmContextDepth > 0;
-}
-
-/**
- * Mark the start of a trusted graph mutation — i.e. one going through the
- * approval engine. Used by approval.ts to wrap its own parseIntoStore /
- * removeMatchingTriples calls so the write guard doesn't flag them.
- */
-export function enterTrustedContext(): void {
-  trustedContextDepth++;
-}
-
-export function exitTrustedContext(): void {
-  if (trustedContextDepth > 0) trustedContextDepth--;
-}
-
-/** Dev-time guard. Logs once per offending call when an LLM-originated
- *  call path mutates the graph without going through the approval engine.
- *  No-op in trusted context (proposeWrite / approveProposal / approval-only
- *  mutators) and outside LLM context. */
-function checkLLMWriteGuard(operation: string): void {
-  if (!isInLLMContext()) return;
-  if (trustedContextDepth > 0) return;
-  console.warn(
-    `[trust-guard] ${operation} called from LLM context outside the approval engine. ` +
-    `LLM-originated writes must go through proposeWrite()/approveProposal().`,
-  );
-}
+// ── LLM Write Guard (#671) ────────────────────────────────────────────────
+// Extracted into ./write-guard.ts so it can be unit-tested in isolation. The
+// public enter/exit/is helpers are re-exported here so existing
+// `graph.enterLLMContext()` call sites (approval.ts, auto-link/auto-tag, ipc)
+// are unchanged; the indexers below call `checkLLMWriteGuard` directly.
+export {
+  enterLLMContext,
+  exitLLMContext,
+  isInLLMContext,
+  enterTrustedContext,
+  exitTrustedContext,
+} from './write-guard';
+import { checkLLMWriteGuard } from './write-guard';
 
 // ── Project config (persisted in .minerva/config.json) ─────────────────────
 

--- a/src/main/graph/write-guard.ts
+++ b/src/main/graph/write-guard.ts
@@ -1,0 +1,71 @@
+/**
+ * LLM write guard (#671, extracted from graph/index.ts).
+ *
+ * Tracks whether the current call path originates from an LLM operation.
+ * Direct graph writes from LLM context that bypass the approval engine are
+ * logged as warnings during development. The approval engine wraps its own
+ * writes in the *trusted* counter so its in-LLM-context writes don't trigger
+ * the warning.
+ *
+ * This is a development-time guardrail, not a runtime security boundary — the
+ * goal is to catch accidental approval-engine bypasses during development. It
+ * lives in its own module (with no dependency on GraphState) so it can be
+ * unit-tested in isolation; the graph indexers import `checkLLMWriteGuard`,
+ * and the public enter/exit/is helpers are re-exported from graph/index.ts so
+ * existing `graph.enterLLMContext()` call sites are unchanged.
+ */
+
+let llmContextDepth = 0;
+let trustedContextDepth = 0;
+
+/** Mark the start of an LLM-originated operation. Nest-safe. */
+export function enterLLMContext(): void {
+  llmContextDepth++;
+}
+
+/** Mark the end of an LLM-originated operation. */
+export function exitLLMContext(): void {
+  if (llmContextDepth > 0) llmContextDepth--;
+}
+
+/** Returns true if currently in an LLM call path. */
+export function isInLLMContext(): boolean {
+  return llmContextDepth > 0;
+}
+
+/**
+ * Mark the start of a trusted graph mutation — i.e. one going through the
+ * approval engine. Used by approval.ts to wrap its own parseIntoStore /
+ * removeMatchingTriples calls so the write guard doesn't flag them.
+ */
+export function enterTrustedContext(): void {
+  trustedContextDepth++;
+}
+
+export function exitTrustedContext(): void {
+  if (trustedContextDepth > 0) trustedContextDepth--;
+}
+
+/** True while inside an approval-engine (trusted) mutation. */
+export function isInTrustedContext(): boolean {
+  return trustedContextDepth > 0;
+}
+
+/** Dev-time guard. Logs once per offending call when an LLM-originated
+ *  call path mutates the graph without going through the approval engine.
+ *  No-op in trusted context (proposeWrite / approveProposal / approval-only
+ *  mutators) and outside LLM context. */
+export function checkLLMWriteGuard(operation: string): void {
+  if (!isInLLMContext()) return;
+  if (trustedContextDepth > 0) return;
+  console.warn(
+    `[trust-guard] ${operation} called from LLM context outside the approval engine. ` +
+    `LLM-originated writes must go through proposeWrite()/approveProposal().`,
+  );
+}
+
+/** Test-only: reset both counters between cases. */
+export function __resetWriteGuardForTests(): void {
+  llmContextDepth = 0;
+  trustedContextDepth = 0;
+}

--- a/tests/main/graph/write-guard.test.ts
+++ b/tests/main/graph/write-guard.test.ts
@@ -1,12 +1,24 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { enterLLMContext, exitLLMContext, isInLLMContext } from '../../../src/main/graph/index';
+/**
+ * LLM write guard (#671) — now tested in isolation against the extracted
+ * write-guard module, including the actual guard *behaviour* (does it warn?),
+ * which the previous version only gestured at (QA #657 / Q-C1).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  enterLLMContext,
+  exitLLMContext,
+  isInLLMContext,
+  enterTrustedContext,
+  exitTrustedContext,
+  isInTrustedContext,
+  checkLLMWriteGuard,
+  __resetWriteGuardForTests,
+} from '../../../src/main/graph/write-guard';
 
-describe('LLM write guard', () => {
-  afterEach(() => {
-    // Clean up any leftover context
-    while (isInLLMContext()) exitLLMContext();
-  });
+beforeEach(() => __resetWriteGuardForTests());
+afterEach(() => __resetWriteGuardForTests());
 
+describe('LLM context counter', () => {
   it('starts outside LLM context', () => {
     expect(isInLLMContext()).toBe(false);
   });
@@ -18,10 +30,9 @@ describe('LLM write guard', () => {
     expect(isInLLMContext()).toBe(false);
   });
 
-  it('supports nested LLM context', () => {
+  it('is nest-safe — inner exit keeps the outer context open', () => {
     enterLLMContext();
     enterLLMContext();
-    expect(isInLLMContext()).toBe(true);
     exitLLMContext();
     expect(isInLLMContext()).toBe(true);
     exitLLMContext();
@@ -34,19 +45,56 @@ describe('LLM write guard', () => {
     expect(isInLLMContext()).toBe(false);
     enterLLMContext();
     expect(isInLLMContext()).toBe(true);
-    exitLLMContext();
-    expect(isInLLMContext()).toBe(false);
+  });
+});
+
+describe('trusted context counter', () => {
+  it('tracks enter/exit and is nest-safe', () => {
+    expect(isInTrustedContext()).toBe(false);
+    enterTrustedContext();
+    enterTrustedContext();
+    expect(isInTrustedContext()).toBe(true);
+    exitTrustedContext();
+    expect(isInTrustedContext()).toBe(true);
+    exitTrustedContext();
+    expect(isInTrustedContext()).toBe(false);
+  });
+});
+
+describe('checkLLMWriteGuard behaviour', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => { warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => warnSpy.mockRestore());
+
+  it('stays silent outside LLM context', () => {
+    checkLLMWriteGuard('indexNote');
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('logs warning when direct write attempted in LLM context', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('WARNS when a graph write happens in LLM context outside the approval engine', () => {
     enterLLMContext();
+    checkLLMWriteGuard('indexNote');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0][0]);
+    expect(msg).toContain('[trust-guard]');
+    expect(msg).toContain('indexNote');
+    expect(msg).toContain('proposeWrite');
+  });
 
-    // The guardedAdd function is internal, but we can verify the context flag
-    // is correctly set, which is what guardedAdd checks
-    expect(isInLLMContext()).toBe(true);
+  it('stays silent in LLM context when the write is inside a trusted (approval-engine) context', () => {
+    enterLLMContext();
+    enterTrustedContext();
+    checkLLMWriteGuard('indexSource');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 
-    exitLLMContext();
-    warnSpy.mockRestore();
+  it('re-warns once the trusted context is exited but LLM context remains', () => {
+    enterLLMContext();
+    enterTrustedContext();
+    checkLLMWriteGuard('indexSource');
+    expect(warnSpy).not.toHaveBeenCalled();
+    exitTrustedContext();
+    checkLLMWriteGuard('indexSource');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What

First increment of the graph/index.ts decomposition (#671), doing the issue's **explicit "in particular" priority**: pull the LLM write guard into its own module so it can be unit-tested in isolation — which also resolves the no-op test QA flagged (#657 / Q-C1).

Partially addresses #671.

- **`src/main/graph/write-guard.ts`** — the llm/trusted context counters + `enterLLMContext`/`exitLLMContext`/`isInLLMContext` + `enterTrustedContext`/`exitTrustedContext` + `checkLLMWriteGuard`, plus a new `isInTrustedContext()` and a test-only reset. No `GraphState` dependency, so it's trivially testable in isolation.
- **`graph/index.ts`** re-exports the public enter/exit/is helpers (so external callers — `approval.ts`, `auto-link`/`auto-tag`, `ipc` — are unchanged; verified by tsc) and imports `checkLLMWriteGuard` for the 9 indexer call sites.
- **`tests/main/graph/write-guard.test.ts`** — replaced the previous test (whose "logs warning" case asserted *nothing*) with one that asserts the **actual guard behaviour**: WARNS on an LLM-context write outside the approval engine; stays silent outside LLM context and inside a trusted context; re-warns after the trusted context exits. Plus counter nest-safety.

## Result
`graph/index.ts`: **2,717 → 2,680 lines**. Small by line count, but it's the issue's named priority and it closes the QA trust-test gap.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2845 passed**.
- `pnpm test:e2e` — boot smoke passes.

## Remaining (gated follow-ups)
graph/index.ts is the **core RDF engine** (heavy shared `states` map, ~36 graph tests). The two big remaining chunks each warrant their own staged PR against that test net:
1. **Read/query layer** (~970 lines, `queryGraph` + `schemaForCompletion` + `listTags`/`notesByTag*`/`backlinks`/`outgoingLinks`/`getSourceDetail`/`citationsForNote`/reading-queue/…) → `graph/queries.ts`, after extracting a shared `graph/state.ts` core (the `states` map + `getState` + `GraphState` + namespaces/rdf-helpers).
2. **Indexers** (~900 lines, `indexNote`/`indexSource`/`indexExcerpt`/`indexCsv*`/`remove*`/`indexAllNotes`) → `graph/indexers.ts`, optionally with the registered-indexer (OCP) pattern the issue mentions.

These are cycle-sensitive (the shared-state core must come first) and touch engine correctness, so I've kept them out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)