### PR TITLE
Split Preview.svelte: extract pure helpers into lib/preview/* + tests (#672, increment 1)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -25,12 +25,15 @@
   import { normalizeSqlRows } from '../editor/sql-result';
   import { clampSubmenu } from '../utils/menuClamp';
   import { renderChart, type ChartHandle, type ChartConfig, type ChartSeries } from '../charts';
-  import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
   import { getToolInfosByCategory } from '../tools/tool-registry';
   import mdFootnote from 'markdown-it-footnote';
   import { planOutputEdit } from '../editor/output-block';
   import { findRunnableFences, codeOf } from '../../../shared/compute/fences';
   import type { CellResult } from '../ipc/client';
+  import { escapeHtml, escapeAttr, stripFrontmatter, countFrontmatterLines } from '../preview/text';
+  import { resolveRelativeImagePath, mimeFromPath } from '../preview/image-paths';
+  import { type CiteMeta, type QuoteMeta, collapseCiteRows, buildCiteTooltip, buildQuoteTooltip, buildFootnoteTooltip } from '../preview/cite-meta';
+  import { findSourceFenceBefore, renderComputeOutput, tableToCsv, outputToMarkdownClipboard } from '../preview/compute-output-render';
 
   interface Props {
     content: string;
@@ -141,22 +144,6 @@
   const queryCache = new Map<string, { results: unknown[]; error?: string }>();
 
   // Cite/quote metadata caches: id → resolved bundle (survives re-renders)
-  interface CiteMeta {
-    title?: string;
-    creators: string[];
-    year?: string;
-    doi?: string;
-    uri?: string;
-  }
-  interface QuoteMeta {
-    citedText?: string;
-    sourceTitle?: string;
-    sourceCreator?: string;
-    sourceYear?: string;
-    page?: string;
-    pageRange?: string;
-    locationText?: string;
-  }
   const citeMetaCache = new Map<string, CiteMeta>();
   const quoteMetaCache = new Map<string, QuoteMeta>();
 
@@ -462,63 +449,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
   };
 
   /**
-   * Walk backwards from the output fence token to find the executable
-   * fence that produced it. Returns null when anything other than
-   * whitespace sits between the two — a loose sanity check that keeps
-   * us from wiring a Save-as-note action to the wrong source when users
-   * paste an isolated output block.
-   */
-  function findSourceFenceBefore(tokens: Token[], idx: number): { language: string; code: string } | null {
-    const RUNNABLE = new Set(['sparql', 'sql', 'python']);
-    for (let i = idx - 1; i >= 0; i--) {
-      const t = tokens[i];
-      if (t.type === 'fence') {
-        const lang = (t.info ?? '').trim().split(/\s+/)[0]?.toLowerCase() ?? '';
-        if (RUNNABLE.has(lang)) {
-          return { language: lang, code: (t.content ?? '').replace(/\n$/, '') };
-        }
-        return null;
-      }
-      // Any heading / paragraph / blockquote between the two fences means
-      // the output block isn't adjacent to a runnable source — bail.
-      if (t.type === 'paragraph_open' || t.type === 'heading_open' ||
-          t.type === 'blockquote_open' || t.type === 'bullet_list_open' ||
-          t.type === 'ordered_list_open') {
-        return null;
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Resolve a relative `![](src)` reference against the note's
-   * directory and normalise so `..` segments collapse. Returns a
-   * project-rooted relative path (no leading `/`).
-   */
-  function resolveRelativeImagePath(src: string, fromNote: string | null | undefined): string {
-    // Split off the note's parent directory. The regex form
-    // `/\/[^/]*$/` would silently fall back to the full string when
-    // there's no slash — i.e. for a project-root note like
-    // `graph.md`, `noteDir` would become `graph.md` and downstream
-    // resolution would treat the file itself as a directory (the
-    // ENOTDIR symptom). Use a guarded lastIndexOf instead.
-    const lastSlash = fromNote ? fromNote.lastIndexOf('/') : -1;
-    const noteDir = lastSlash > 0 && fromNote ? fromNote.slice(0, lastSlash) : '';
-    const baseSegments = noteDir ? noteDir.split('/') : [];
-    const srcSegments = src.split('/');
-    const out: string[] = [...baseSegments];
-    for (const seg of srcSegments) {
-      if (seg === '' || seg === '.') continue;
-      if (seg === '..') {
-        if (out.length > 0) out.pop();
-        continue;
-      }
-      out.push(seg);
-    }
-    return out.join('/');
-  }
-
-  /**
    * Cache of {projectRelPath → data URL} for images referenced from
    * the rendered note. Survives re-renders so panning around a long
    * doc doesn't keep refetching the same `<img>` over and over.
@@ -526,18 +456,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
    * project-scoped automatically since paths include the note dir).
    */
   const imageDataUrlCache = new Map<string, string>();
-
-  /** MIME guess from a relative-path extension; data URLs need it explicit. */
-  function mimeFromPath(rel: string): string {
-    const ext = rel.toLowerCase().match(/\.([^./\\]+)$/)?.[1] ?? '';
-    if (ext === 'png') return 'image/png';
-    if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
-    if (ext === 'gif') return 'image/gif';
-    if (ext === 'webp') return 'image/webp';
-    if (ext === 'svg') return 'image/svg+xml';
-    if (ext === 'avif') return 'image/avif';
-    return 'application/octet-stream';
-  }
 
   /**
    * Post-render hydration: walk every `.local-image[data-rel]`
@@ -582,91 +500,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         img.classList.add('local-image-broken');
       }
     }));
-  }
-
-  function renderComputeOutput(content: string, source: { language: string; code: string } | null): string {
-    let payload: unknown;
-    try {
-      payload = JSON.parse(content.trim());
-    } catch {
-      return `<pre class="compute-output compute-output-raw">${escapeHtml(content)}</pre>`;
-    }
-    const p = payload as { type?: string } & Record<string, unknown>;
-    let inner: string;
-    let saveable = false;
-    if (!p || typeof p !== 'object' || typeof p.type !== 'string') {
-      inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
-    } else if (p.type === 'error') {
-      const message = typeof p.message === 'string' ? p.message : JSON.stringify(p.message);
-      inner = `<div class="compute-output compute-output-error">${escapeHtml(message)}</div>`;
-      // Errors aren't worth saving as notes; skip the overflow menu.
-    } else if (p.type === 'text') {
-      const value = typeof p.value === 'string' ? p.value : JSON.stringify(p.value);
-      inner = `<pre class="compute-output compute-output-text">${escapeHtml(value)}</pre>`;
-      saveable = true;
-    } else if (p.type === 'table' && Array.isArray(p.columns) && Array.isArray(p.rows)) {
-      const columns = p.columns as string[];
-      const rows = p.rows as Array<Array<string | number | boolean | null>>;
-      const totalRows = typeof p.totalRows === 'number' ? p.totalRows : null;
-      const truncated = p.truncated === true;
-      const headers = columns.map((c) => `<th>${escapeHtml(c)}</th>`).join('');
-      const body = rows.map((r) => {
-        const cells = r.map((v) => `<td>${escapeHtml(v == null ? '' : String(v))}</td>`).join('');
-        return `<tr>${cells}</tr>`;
-      }).join('');
-      // Truncation footer (#243): when the kernel capped rows, surface
-      // the gap so the user knows there's more data than they can see
-      // and can re-run with `df.tail(...)` / `.iloc[]` if they need it.
-      const footer = truncated && totalRows
-        ? `<p class="compute-output-truncation">Showing ${rows.length} of ${totalRows} rows · ${totalRows - rows.length} more hidden</p>`
-        : '';
-      inner = `<div class="compute-output-table-wrap"><table class="compute-output compute-output-table"><thead><tr>${headers}</tr></thead><tbody>${body}</tbody></table>${footer}</div>`;
-      saveable = true;
-    } else if (p.type === 'json') {
-      inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(p.value, null, 2))}</pre>`;
-      saveable = true;
-    } else if (p.type === 'image' && (p.mime === 'image/png' || p.mime === 'image/svg+xml')) {
-      // Inline image (#243). PNG → data URL with base64 payload; SVG →
-      // raw markup wrapped in a div so the host stylesheet can scope it.
-      // Click-to-zoom toggles a `.zoomed` class via the global compute
-      // output click handler (App.svelte) — same affordance as save-as-note.
-      const data = typeof p.data === 'string' ? p.data : '';
-      if (p.mime === 'image/png') {
-        inner = `<img class="compute-output compute-output-image" src="data:image/png;base64,${escapeAttr(data)}" alt="cell output" />`;
-      } else {
-        // SVG: insert raw markup. SVG is rendered inline, so any embedded
-        // <script> would execute. Sanitize with the same DOMPurify config
-        // the html branch uses.
-        const safe = sanitizeComputeOutputHtml(data);
-        inner = `<div class="compute-output compute-output-svg">${safe}</div>`;
-      }
-      saveable = true;
-    } else if (p.type === 'html' && typeof p.html === 'string') {
-      // _repr_html_ output (Seaborn styled tables, IPython.display.HTML, …).
-      // DOMPurify with a strict allowlist — no <script>, no <iframe>,
-      // no event handlers — so a malformed _repr_html_ from a user-side
-      // library can't escape the output container.
-      const safe = sanitizeComputeOutputHtml(p.html);
-      inner = `<div class="compute-output compute-output-html">${safe}</div>`;
-      saveable = true;
-    } else {
-      // Unknown type — show the raw JSON so the user can tell what came back.
-      inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
-    }
-
-    // Wrap the rendered output with a ⋯ overflow-menu button when we have
-    // enough context to offer save/copy actions — the output payload
-    // parses cleanly, its type is saveable, and we found the source
-    // fence it came from (so we know what cell to attribute back).
-    if (saveable && source) {
-      const outputB64 = btoa(unescape(encodeURIComponent(JSON.stringify(payload))));
-      const codeB64 = btoa(unescape(encodeURIComponent(source.code)));
-      return `<div class="compute-output-wrap" data-source-language="${escapeAttr(source.language)}" data-source-code-b64="${outputB64.length > 0 ? codeB64 : ''}" data-output-b64="${outputB64}">
-        <button class="compute-output-menu-btn" type="button" title="Output options">⋯</button>
-        ${inner}
-      </div>`;
-    }
-    return inner;
   }
 
   // Query directive plugin: :::query-list ... :::
@@ -735,24 +568,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     const configJson = Object.keys(config).length > 0 ? escapeAttr(JSON.stringify(config)) : '';
     return `<div class="query-block" data-type="${escapeAttr(type)}" data-query="${escapeAttr(query)}"${configJson ? ` data-config="${configJson}"` : ''}><span class="query-loading">Loading...</span></div>`;
   };
-
-  function escapeHtml(str: string): string {
-    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function escapeAttr(str: string): string {
-    return escapeHtml(str).replace(/"/g, '&quot;');
-  }
-
-  function stripFrontmatter(text: string): string {
-    return text.replace(/^---\n[\s\S]*?\n---\n?/, '');
-  }
-
-  function countFrontmatterLines(text: string): number {
-    const m = text.match(/^---\n[\s\S]*?\n---\n?/);
-    if (!m) return 0;
-    return (m[0].match(/\n/g) ?? []).length;
-  }
 
   // Re-rendering markdown + KaTeX + highlight.js + citeproc on every
   // keystroke felt as typing lag in split-view once notes pass a few
@@ -982,22 +797,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     } catch {
       // Fall back to the source-id already rendered.
     }
-  }
-
-  function collapseCiteRows(rows: Array<Record<string, string>>): CiteMeta {
-    const meta: CiteMeta = { creators: [] };
-    const creatorSet = new Set<string>();
-    for (const row of rows) {
-      if (row.title && !meta.title) meta.title = row.title;
-      if (row.creator && !creatorSet.has(row.creator)) {
-        creatorSet.add(row.creator);
-        meta.creators.push(row.creator);
-      }
-      if (row.issued && !meta.year) meta.year = row.issued.slice(0, 4);
-      if (row.doi && !meta.doi) meta.doi = row.doi;
-      if (row.uri && !meta.uri) meta.uri = row.uri;
-    }
-    return meta;
   }
 
   function applyCiteMeta(el: HTMLElement, _displayEl: HTMLSpanElement, _sourceId: string, meta: CiteMeta) {
@@ -1532,43 +1331,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     outputMenu = null;
   }
 
-  /**
-   * RFC-4180-ish CSV: quote fields containing commas, quotes, or
-   * newlines; double internal quotes; CRLF row terminator. Pasted into
-   * Excel / Numbers / Sheets it parses back to the original table.
-   */
-  function tableToCsv(
-    columns: string[],
-    rows: Array<Array<string | number | boolean | null>>,
-  ): string {
-    const escape = (v: string | number | boolean | null): string => {
-      if (v == null) return '';
-      const s = String(v);
-      if (/[",\r\n]/.test(s)) {
-        return '"' + s.replace(/"/g, '""') + '"';
-      }
-      return s;
-    };
-    const lines = [columns.map(escape).join(','), ...rows.map((r) => r.map(escape).join(','))];
-    return lines.join('\r\n');
-  }
-
-  function outputToMarkdownClipboard(output: import('../../../shared/compute/types').CellOutput): string {
-    if (output.type === 'table') {
-      if (output.columns.length === 0) return '*(empty result)*';
-      const esc = (s: string) => s.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
-      const header = `| ${output.columns.map(esc).join(' | ')} |`;
-      const divider = `| ${output.columns.map(() => '---').join(' | ')} |`;
-      const body = output.rows.map((r) =>
-        `| ${r.map((v) => esc(v == null ? '' : String(v))).join(' | ')} |`,
-      );
-      return [header, divider, ...body].join('\n');
-    }
-    if (output.type === 'text') return '```\n' + output.value.replace(/\n$/, '') + '\n```';
-    if (output.type === 'json') return '```json\n' + JSON.stringify(output.value, null, 2) + '\n```';
-    return '```\n' + JSON.stringify(output) + '\n```';
-  }
-
   let tooltipVisible = $state(false);
   let tooltipHtml = $state('');
   let tooltipStyle = $state('');
@@ -1618,21 +1380,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     tooltipVisible = false;
   }
 
-  /**
-   * Clone the footnote-body `<li>` minus its back-arrow anchor and the
-   * surrounding `<p>` wrapper, leaving the bare body text. markdown-it-
-   * footnote always wraps the body in one or more `<p>` elements with
-   * a trailing `<a class="footnote-backref">↩</a>`; stripping the
-   * backref and reusing the cleaned innerHTML keeps the tooltip a faithful
-   * mini-render of the footnote prose (links, emphasis, code spans
-   * all preserved).
-   */
-  function buildFootnoteTooltip(body: HTMLElement): string {
-    const clone = body.cloneNode(true) as HTMLElement;
-    for (const bk of clone.querySelectorAll('.footnote-backref')) bk.remove();
-    return `<div class="tt-footnote">${clone.innerHTML.trim()}</div>`;
-  }
-
   function positionTooltip(anchor: HTMLElement) {
     if (!previewEl) return;
     const anchorRect = anchor.getBoundingClientRect();
@@ -1645,42 +1392,6 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     tooltipStyle = `top:${top}px;left:${Math.min(left, Math.max(8, maxLeft))}px`;
   }
 
-  function buildCiteTooltip(meta: CiteMeta): string {
-    const parts: string[] = [];
-    if (meta.title) parts.push(`<div class="tt-title">${escapeHtml(meta.title)}</div>`);
-    const byline = formatFullByline(meta.creators, meta.year);
-    if (byline) parts.push(`<div class="tt-byline">${escapeHtml(byline)}</div>`);
-    if (meta.doi) parts.push(`<div class="tt-meta">DOI: ${escapeHtml(meta.doi)}</div>`);
-    else if (meta.uri) parts.push(`<div class="tt-meta">${escapeHtml(meta.uri)}</div>`);
-    return parts.join('') || `<div class="tt-meta">No metadata available</div>`;
-  }
-
-  function buildQuoteTooltip(meta: QuoteMeta): string {
-    const parts: string[] = [];
-    if (meta.citedText) {
-      parts.push(`<div class="tt-quote">“${escapeHtml(meta.citedText)}”</div>`);
-    }
-    const src = meta.sourceTitle;
-    const creator = meta.sourceCreator;
-    const year = meta.sourceYear;
-    const byline = [src, creator && year ? `${creator} (${year})` : creator || (year ? `(${year})` : '')]
-      .filter(Boolean).join(' — ');
-    if (byline) parts.push(`<div class="tt-byline">— ${escapeHtml(byline)}</div>`);
-    const loc = meta.pageRange ? `pp. ${meta.pageRange}`
-      : meta.page ? `p. ${meta.page}`
-      : meta.locationText ? meta.locationText
-      : '';
-    if (loc) parts.push(`<div class="tt-meta">${escapeHtml(loc)}</div>`);
-    return parts.join('') || `<div class="tt-meta">No excerpt metadata available</div>`;
-  }
-
-  function formatFullByline(creators: string[], year?: string): string {
-    const who = creators.length === 0 ? ''
-      : creators.length <= 3 ? creators.join(', ')
-      : `${creators.slice(0, 3).join(', ')}, …`;
-    if (who && year) return `${who} · ${year}`;
-    return who || (year ?? '');
-  }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->

--- a/src/renderer/lib/preview/cite-meta.ts
+++ b/src/renderer/lib/preview/cite-meta.ts
@@ -1,0 +1,93 @@
+/**
+ * Cite / quote / footnote metadata helpers extracted from Preview.svelte
+ * (#672, #110 citations). `collapseCiteRows` / `formatFullByline` and the
+ * tooltip builders are pure; `buildFootnoteTooltip` is a pure DOM→string
+ * transform over a passed-in element. No stores, no reactivity.
+ */
+import { escapeHtml } from './text';
+
+// Cite/quote metadata bundles: id → resolved bundle.
+export interface CiteMeta {
+  title?: string;
+  creators: string[];
+  year?: string;
+  doi?: string;
+  uri?: string;
+}
+export interface QuoteMeta {
+  citedText?: string;
+  sourceTitle?: string;
+  sourceCreator?: string;
+  sourceYear?: string;
+  page?: string;
+  pageRange?: string;
+  locationText?: string;
+}
+
+export function collapseCiteRows(rows: Array<Record<string, string>>): CiteMeta {
+  const meta: CiteMeta = { creators: [] };
+  const creatorSet = new Set<string>();
+  for (const row of rows) {
+    if (row.title && !meta.title) meta.title = row.title;
+    if (row.creator && !creatorSet.has(row.creator)) {
+      creatorSet.add(row.creator);
+      meta.creators.push(row.creator);
+    }
+    if (row.issued && !meta.year) meta.year = row.issued.slice(0, 4);
+    if (row.doi && !meta.doi) meta.doi = row.doi;
+    if (row.uri && !meta.uri) meta.uri = row.uri;
+  }
+  return meta;
+}
+
+/**
+ * Clone the footnote-body `<li>` minus its back-arrow anchor and the
+ * surrounding `<p>` wrapper, leaving the bare body text. markdown-it-
+ * footnote always wraps the body in one or more `<p>` elements with
+ * a trailing `<a class="footnote-backref">↩</a>`; stripping the
+ * backref and reusing the cleaned innerHTML keeps the tooltip a faithful
+ * mini-render of the footnote prose (links, emphasis, code spans
+ * all preserved).
+ */
+export function buildFootnoteTooltip(body: HTMLElement): string {
+  const clone = body.cloneNode(true) as HTMLElement;
+  for (const bk of clone.querySelectorAll('.footnote-backref')) bk.remove();
+  return `<div class="tt-footnote">${clone.innerHTML.trim()}</div>`;
+}
+
+export function buildCiteTooltip(meta: CiteMeta): string {
+  const parts: string[] = [];
+  if (meta.title) parts.push(`<div class="tt-title">${escapeHtml(meta.title)}</div>`);
+  const byline = formatFullByline(meta.creators, meta.year);
+  if (byline) parts.push(`<div class="tt-byline">${escapeHtml(byline)}</div>`);
+  if (meta.doi) parts.push(`<div class="tt-meta">DOI: ${escapeHtml(meta.doi)}</div>`);
+  else if (meta.uri) parts.push(`<div class="tt-meta">${escapeHtml(meta.uri)}</div>`);
+  return parts.join('') || `<div class="tt-meta">No metadata available</div>`;
+}
+
+export function buildQuoteTooltip(meta: QuoteMeta): string {
+  const parts: string[] = [];
+  if (meta.citedText) {
+    parts.push(`<div class="tt-quote">“${escapeHtml(meta.citedText)}”</div>`);
+  }
+  const src = meta.sourceTitle;
+  const creator = meta.sourceCreator;
+  const year = meta.sourceYear;
+  const byline = [src, creator && year ? `${creator} (${year})` : creator || (year ? `(${year})` : '')]
+    .filter(Boolean).join(' — ');
+  if (byline) parts.push(`<div class="tt-byline">— ${escapeHtml(byline)}</div>`);
+  const loc = meta.pageRange ? `pp. ${meta.pageRange}`
+    : meta.page ? `p. ${meta.page}`
+    : meta.locationText ? meta.locationText
+    : '';
+  if (loc) parts.push(`<div class="tt-meta">${escapeHtml(loc)}</div>`);
+  return parts.join('') || `<div class="tt-meta">No excerpt metadata available</div>`;
+}
+
+export function formatFullByline(creators: string[], year?: string): string {
+  const who = creators.length === 0 ? ''
+    : creators.length <= 3 ? creators.join(', ')
+    : `${creators.slice(0, 3).join(', ')}, …`;
+  if (who && year) return `${who} · ${year}`;
+  return who || (year ?? '');
+}

--- a/src/renderer/lib/preview/compute-output-render.ts
+++ b/src/renderer/lib/preview/compute-output-render.ts
@@ -1,0 +1,164 @@
+/**
+ * Compute-output rendering + clipboard helpers extracted from
+ * Preview.svelte (#672, #238/#243/#244). `renderComputeOutput` produces
+ * the shape-specific HTML for a ```output fence; `findSourceFenceBefore`
+ * locates the runnable fence that produced it; `tableToCsv` /
+ * `outputToMarkdownClipboard` back the overflow-menu copy actions. Pure —
+ * `renderComputeOutput` uses the browser `btoa`/`unescape`/
+ * `encodeURIComponent` globals, which are available in the renderer.
+ */
+import type Token from 'markdown-it/lib/token.mjs';
+import { escapeHtml, escapeAttr } from './text';
+import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
+import type { CellOutput } from '../../../shared/compute/types';
+
+/**
+ * Walk backwards from the output fence token to find the executable
+ * fence that produced it. Returns null when anything other than
+ * whitespace sits between the two — a loose sanity check that keeps
+ * us from wiring a Save-as-note action to the wrong source when users
+ * paste an isolated output block.
+ */
+export function findSourceFenceBefore(tokens: Token[], idx: number): { language: string; code: string } | null {
+  const RUNNABLE = new Set(['sparql', 'sql', 'python']);
+  for (let i = idx - 1; i >= 0; i--) {
+    const t = tokens[i];
+    if (t.type === 'fence') {
+      const lang = (t.info ?? '').trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+      if (RUNNABLE.has(lang)) {
+        return { language: lang, code: (t.content ?? '').replace(/\n$/, '') };
+      }
+      return null;
+    }
+    // Any heading / paragraph / blockquote between the two fences means
+    // the output block isn't adjacent to a runnable source — bail.
+    if (t.type === 'paragraph_open' || t.type === 'heading_open' ||
+        t.type === 'blockquote_open' || t.type === 'bullet_list_open' ||
+        t.type === 'ordered_list_open') {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function renderComputeOutput(content: string, source: { language: string; code: string } | null): string {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(content.trim());
+  } catch {
+    return `<pre class="compute-output compute-output-raw">${escapeHtml(content)}</pre>`;
+  }
+  const p = payload as { type?: string } & Record<string, unknown>;
+  let inner: string;
+  let saveable = false;
+  if (!p || typeof p !== 'object' || typeof p.type !== 'string') {
+    inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+  } else if (p.type === 'error') {
+    const message = typeof p.message === 'string' ? p.message : JSON.stringify(p.message);
+    inner = `<div class="compute-output compute-output-error">${escapeHtml(message)}</div>`;
+    // Errors aren't worth saving as notes; skip the overflow menu.
+  } else if (p.type === 'text') {
+    const value = typeof p.value === 'string' ? p.value : JSON.stringify(p.value);
+    inner = `<pre class="compute-output compute-output-text">${escapeHtml(value)}</pre>`;
+    saveable = true;
+  } else if (p.type === 'table' && Array.isArray(p.columns) && Array.isArray(p.rows)) {
+    const columns = p.columns as string[];
+    const rows = p.rows as Array<Array<string | number | boolean | null>>;
+    const totalRows = typeof p.totalRows === 'number' ? p.totalRows : null;
+    const truncated = p.truncated === true;
+    const headers = columns.map((c) => `<th>${escapeHtml(c)}</th>`).join('');
+    const body = rows.map((r) => {
+      const cells = r.map((v) => `<td>${escapeHtml(v == null ? '' : String(v))}</td>`).join('');
+      return `<tr>${cells}</tr>`;
+    }).join('');
+    // Truncation footer (#243): when the kernel capped rows, surface
+    // the gap so the user knows there's more data than they can see
+    // and can re-run with `df.tail(...)` / `.iloc[]` if they need it.
+    const footer = truncated && totalRows
+      ? `<p class="compute-output-truncation">Showing ${rows.length} of ${totalRows} rows · ${totalRows - rows.length} more hidden</p>`
+      : '';
+    inner = `<div class="compute-output-table-wrap"><table class="compute-output compute-output-table"><thead><tr>${headers}</tr></thead><tbody>${body}</tbody></table>${footer}</div>`;
+    saveable = true;
+  } else if (p.type === 'json') {
+    inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(p.value, null, 2))}</pre>`;
+    saveable = true;
+  } else if (p.type === 'image' && (p.mime === 'image/png' || p.mime === 'image/svg+xml')) {
+    // Inline image (#243). PNG → data URL with base64 payload; SVG →
+    // raw markup wrapped in a div so the host stylesheet can scope it.
+    // Click-to-zoom toggles a `.zoomed` class via the global compute
+    // output click handler (App.svelte) — same affordance as save-as-note.
+    const data = typeof p.data === 'string' ? p.data : '';
+    if (p.mime === 'image/png') {
+      inner = `<img class="compute-output compute-output-image" src="data:image/png;base64,${escapeAttr(data)}" alt="cell output" />`;
+    } else {
+      // SVG: insert raw markup. SVG is rendered inline, so any embedded
+      // <script> would execute. Sanitize with the same DOMPurify config
+      // the html branch uses.
+      const safe = sanitizeComputeOutputHtml(data);
+      inner = `<div class="compute-output compute-output-svg">${safe}</div>`;
+    }
+    saveable = true;
+  } else if (p.type === 'html' && typeof p.html === 'string') {
+    // _repr_html_ output (Seaborn styled tables, IPython.display.HTML, …).
+    // DOMPurify with a strict allowlist — no <script>, no <iframe>,
+    // no event handlers — so a malformed _repr_html_ from a user-side
+    // library can't escape the output container.
+    const safe = sanitizeComputeOutputHtml(p.html);
+    inner = `<div class="compute-output compute-output-html">${safe}</div>`;
+    saveable = true;
+  } else {
+    // Unknown type — show the raw JSON so the user can tell what came back.
+    inner = `<pre class="compute-output compute-output-json">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+  }
+
+  // Wrap the rendered output with a ⋯ overflow-menu button when we have
+  // enough context to offer save/copy actions — the output payload
+  // parses cleanly, its type is saveable, and we found the source
+  // fence it came from (so we know what cell to attribute back).
+  if (saveable && source) {
+    const outputB64 = btoa(unescape(encodeURIComponent(JSON.stringify(payload))));
+    const codeB64 = btoa(unescape(encodeURIComponent(source.code)));
+    return `<div class="compute-output-wrap" data-source-language="${escapeAttr(source.language)}" data-source-code-b64="${outputB64.length > 0 ? codeB64 : ''}" data-output-b64="${outputB64}">
+        <button class="compute-output-menu-btn" type="button" title="Output options">⋯</button>
+        ${inner}
+      </div>`;
+  }
+  return inner;
+}
+
+/**
+ * RFC-4180-ish CSV: quote fields containing commas, quotes, or
+ * newlines; double internal quotes; CRLF row terminator. Pasted into
+ * Excel / Numbers / Sheets it parses back to the original table.
+ */
+export function tableToCsv(
+  columns: string[],
+  rows: Array<Array<string | number | boolean | null>>,
+): string {
+  const escape = (v: string | number | boolean | null): string => {
+    if (v == null) return '';
+    const s = String(v);
+    if (/[",\r\n]/.test(s)) {
+      return '"' + s.replace(/"/g, '""') + '"';
+    }
+    return s;
+  };
+  const lines = [columns.map(escape).join(','), ...rows.map((r) => r.map(escape).join(','))];
+  return lines.join('\r\n');
+}
+
+export function outputToMarkdownClipboard(output: CellOutput): string {
+  if (output.type === 'table') {
+    if (output.columns.length === 0) return '*(empty result)*';
+    const esc = (s: string) => s.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+    const header = `| ${output.columns.map(esc).join(' | ')} |`;
+    const divider = `| ${output.columns.map(() => '---').join(' | ')} |`;
+    const body = output.rows.map((r) =>
+      `| ${r.map((v) => esc(v == null ? '' : String(v))).join(' | ')} |`,
+    );
+    return [header, divider, ...body].join('\n');
+  }
+  if (output.type === 'text') return '```\n' + output.value.replace(/\n$/, '') + '\n```';
+  if (output.type === 'json') return '```json\n' + JSON.stringify(output.value, null, 2) + '\n```';
+  return '```\n' + JSON.stringify(output) + '\n```';
+}

--- a/src/renderer/lib/preview/image-paths.ts
+++ b/src/renderer/lib/preview/image-paths.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure relative-image-path resolution + MIME guessing extracted from
+ * Preview.svelte (#672, #244 image rendering). No DOM, no reactivity.
+ */
+
+/**
+ * Resolve a relative `![](src)` reference against the note's
+ * directory and normalise so `..` segments collapse. Returns a
+ * project-rooted relative path (no leading `/`).
+ */
+export function resolveRelativeImagePath(src: string, fromNote: string | null | undefined): string {
+  // Split off the note's parent directory. The regex form
+  // `/\/[^/]*$/` would silently fall back to the full string when
+  // there's no slash — i.e. for a project-root note like
+  // `graph.md`, `noteDir` would become `graph.md` and downstream
+  // resolution would treat the file itself as a directory (the
+  // ENOTDIR symptom). Use a guarded lastIndexOf instead.
+  const lastSlash = fromNote ? fromNote.lastIndexOf('/') : -1;
+  const noteDir = lastSlash > 0 && fromNote ? fromNote.slice(0, lastSlash) : '';
+  const baseSegments = noteDir ? noteDir.split('/') : [];
+  const srcSegments = src.split('/');
+  const out: string[] = [...baseSegments];
+  for (const seg of srcSegments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length > 0) out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
+}
+
+/** MIME guess from a relative-path extension; data URLs need it explicit. */
+export function mimeFromPath(rel: string): string {
+  const ext = rel.toLowerCase().match(/\.([^./\\]+)$/)?.[1] ?? '';
+  if (ext === 'png') return 'image/png';
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
+  if (ext === 'gif') return 'image/gif';
+  if (ext === 'webp') return 'image/webp';
+  if (ext === 'svg') return 'image/svg+xml';
+  if (ext === 'avif') return 'image/avif';
+  return 'application/octet-stream';
+}

--- a/src/renderer/lib/preview/text.ts
+++ b/src/renderer/lib/preview/text.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure HTML/text-escaping + frontmatter helpers extracted from
+ * Preview.svelte (#672). No DOM, no reactivity — just string transforms,
+ * so they're trivially unit-testable and shared by the other preview
+ * modules.
+ */
+
+export function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function escapeAttr(str: string): string {
+  return escapeHtml(str).replace(/"/g, '&quot;');
+}
+
+export function stripFrontmatter(text: string): string {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, '');
+}
+
+export function countFrontmatterLines(text: string): number {
+  const m = text.match(/^---\n[\s\S]*?\n---\n?/);
+  if (!m) return 0;
+  return (m[0].match(/\n/g) ?? []).length;
+}

--- a/tests/renderer/preview/cite-meta.test.ts
+++ b/tests/renderer/preview/cite-meta.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+/**
+ * Cite / quote / footnote metadata helpers (#672).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  collapseCiteRows,
+  formatFullByline,
+  buildCiteTooltip,
+  buildQuoteTooltip,
+  buildFootnoteTooltip,
+  type CiteMeta,
+} from '../../../src/renderer/lib/preview/cite-meta';
+
+describe('collapseCiteRows', () => {
+  it('dedups creators, takes first title / year-from-issued / doi / uri', () => {
+    const meta = collapseCiteRows([
+      { title: 'First Title', creator: 'Ada', issued: '2001-05-01', doi: '10.1/x', uri: 'http://a' },
+      { title: 'Ignored Title', creator: 'Ada', issued: '1999', doi: '10.2/y', uri: 'http://b' },
+      { creator: 'Babbage' },
+    ]);
+    expect(meta).toEqual({
+      title: 'First Title',
+      creators: ['Ada', 'Babbage'],
+      year: '2001',
+      doi: '10.1/x',
+      uri: 'http://a',
+    });
+  });
+  it('returns an empty creators array for no rows', () => {
+    expect(collapseCiteRows([])).toEqual({ creators: [] });
+  });
+});
+
+describe('formatFullByline', () => {
+  it('returns empty for no creators and no year', () => {
+    expect(formatFullByline([])).toBe('');
+  });
+  it('joins 1-3 creators', () => {
+    expect(formatFullByline(['Ada', 'Babbage', 'Lovelace'])).toBe('Ada, Babbage, Lovelace');
+  });
+  it('truncates more than 3 creators with an ellipsis', () => {
+    expect(formatFullByline(['A', 'B', 'C', 'D'])).toBe('A, B, C, …');
+  });
+  it('appends the year with a separator when present', () => {
+    expect(formatFullByline(['Ada'], '2001')).toBe('Ada · 2001');
+  });
+  it('returns just the year when there are no creators', () => {
+    expect(formatFullByline([], '2001')).toBe('2001');
+  });
+});
+
+describe('buildCiteTooltip', () => {
+  it('renders title, byline, and DOI with escaped fields', () => {
+    const meta: CiteMeta = { title: 'A & B', creators: ['Ada'], year: '2001', doi: '10.1/<x>' };
+    const html = buildCiteTooltip(meta);
+    expect(html).toContain('A &amp; B');
+    expect(html).toContain('Ada · 2001');
+    expect(html).toContain('DOI: 10.1/&lt;x&gt;');
+  });
+  it('falls back to the uri when there is no doi', () => {
+    const html = buildCiteTooltip({ creators: [], uri: 'http://example.com' });
+    expect(html).toContain('http://example.com');
+  });
+  it('shows a fallback when there is no metadata', () => {
+    expect(buildCiteTooltip({ creators: [] })).toContain('No metadata available');
+  });
+});
+
+describe('buildQuoteTooltip', () => {
+  it('renders cited text, byline, and page location with escaping', () => {
+    const html = buildQuoteTooltip({
+      citedText: 'a < b',
+      sourceTitle: 'Title',
+      sourceCreator: 'Ada',
+      sourceYear: '2001',
+      page: '42',
+    });
+    expect(html).toContain('a &lt; b');
+    expect(html).toContain('Title — Ada (2001)');
+    expect(html).toContain('p. 42');
+  });
+  it('prefers a page range over a single page', () => {
+    const html = buildQuoteTooltip({ pageRange: '10-12', page: '10' });
+    expect(html).toContain('pp. 10-12');
+  });
+  it('shows a fallback when there is no excerpt metadata', () => {
+    expect(buildQuoteTooltip({})).toContain('No excerpt metadata available');
+  });
+});
+
+describe('buildFootnoteTooltip', () => {
+  it('strips the backref and keeps the body text', () => {
+    const li = document.createElement('li');
+    li.innerHTML = '<p>body text <a class="footnote-backref" href="#fnref1">↩</a></p>';
+    const html = buildFootnoteTooltip(li);
+    expect(html).toContain('body text');
+    expect(html).not.toContain('footnote-backref');
+    expect(html).not.toContain('↩');
+    expect(html.startsWith('<div class="tt-footnote">')).toBe(true);
+  });
+});

--- a/tests/renderer/preview/compute-output-render.test.ts
+++ b/tests/renderer/preview/compute-output-render.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+/**
+ * Compute-output rendering + clipboard helpers (#672).
+ */
+import { describe, it, expect } from 'vitest';
+import type Token from 'markdown-it/lib/token.mjs';
+import {
+  findSourceFenceBefore,
+  renderComputeOutput,
+  tableToCsv,
+  outputToMarkdownClipboard,
+} from '../../../src/renderer/lib/preview/compute-output-render';
+import type { CellOutput } from '../../../src/shared/compute/types';
+
+function tok(type: string, info = '', content = ''): Token {
+  return { type, info, content } as unknown as Token;
+}
+
+describe('renderComputeOutput', () => {
+  it('renders a text payload', () => {
+    const html = renderComputeOutput(JSON.stringify({ type: 'text', value: 'hi <b>' }), null);
+    expect(html).toContain('compute-output-text');
+    expect(html).toContain('hi &lt;b&gt;');
+  });
+  it('renders a table payload', () => {
+    const html = renderComputeOutput(
+      JSON.stringify({ type: 'table', columns: ['a', 'b'], rows: [[1, 2]] }),
+      null,
+    );
+    expect(html).toContain('compute-output-table');
+    expect(html).toContain('<th>a</th>');
+    expect(html).toContain('<td>1</td>');
+  });
+  it('renders a json payload', () => {
+    const html = renderComputeOutput(JSON.stringify({ type: 'json', value: { k: 1 } }), null);
+    expect(html).toContain('compute-output-json');
+    expect(html).toContain('"k": 1');
+  });
+  it('renders an error payload without a wrap menu', () => {
+    const html = renderComputeOutput(
+      JSON.stringify({ type: 'error', message: 'boom' }),
+      { language: 'python', code: 'x' },
+    );
+    expect(html).toContain('compute-output-error');
+    expect(html).toContain('boom');
+    expect(html).not.toContain('compute-output-wrap');
+  });
+  it('renders unparseable content as a raw pre', () => {
+    const html = renderComputeOutput('not json {', null);
+    expect(html).toContain('compute-output-raw');
+    expect(html).toContain('not json {');
+  });
+  it('wraps a saveable result with a source in the overflow menu', () => {
+    const html = renderComputeOutput(
+      JSON.stringify({ type: 'text', value: 'hi' }),
+      { language: 'python', code: 'print(1)' },
+    );
+    expect(html).toContain('compute-output-wrap');
+    expect(html).toContain('compute-output-menu-btn');
+    expect(html).toContain('⋯');
+  });
+  it('does not wrap a saveable result when there is no source', () => {
+    const html = renderComputeOutput(JSON.stringify({ type: 'text', value: 'hi' }), null);
+    expect(html).not.toContain('compute-output-wrap');
+  });
+});
+
+describe('tableToCsv', () => {
+  it('quotes cells with comma / quote / newline and doubles inner quotes', () => {
+    const csv = tableToCsv(['a', 'b'], [['x,y', 'he said "hi"'], ['line1\nline2', 'plain']]);
+    expect(csv).toBe('a,b\r\n"x,y","he said ""hi"""\r\n"line1\nline2",plain');
+  });
+});
+
+describe('outputToMarkdownClipboard', () => {
+  it('renders a table as a markdown pipe table', () => {
+    const out: CellOutput = { type: 'table', columns: ['a', 'b'], rows: [['1', '2']] };
+    expect(outputToMarkdownClipboard(out)).toBe('| a | b |\n| --- | --- |\n| 1 | 2 |');
+  });
+  it('renders an empty table as the empty marker', () => {
+    const out: CellOutput = { type: 'table', columns: [], rows: [] };
+    expect(outputToMarkdownClipboard(out)).toBe('*(empty result)*');
+  });
+  it('renders text as a fenced block', () => {
+    const out: CellOutput = { type: 'text', value: 'hello\n' };
+    expect(outputToMarkdownClipboard(out)).toBe('```\nhello\n```');
+  });
+});
+
+describe('findSourceFenceBefore', () => {
+  it('returns the nearest preceding runnable fence', () => {
+    const tokens = [
+      tok('fence', 'sparql', 'SELECT * WHERE {}\n'),
+      tok('fence', 'output', '{}'),
+    ];
+    expect(findSourceFenceBefore(tokens, 1)).toEqual({
+      language: 'sparql',
+      code: 'SELECT * WHERE {}',
+    });
+  });
+  it('returns null when a heading intervenes', () => {
+    const tokens = [
+      tok('fence', 'python', 'print(1)\n'),
+      tok('heading_open', 'h2'),
+      tok('fence', 'output', '{}'),
+    ];
+    expect(findSourceFenceBefore(tokens, 2)).toBeNull();
+  });
+  it('returns null when a paragraph intervenes', () => {
+    const tokens = [
+      tok('fence', 'sql', 'SELECT 1\n'),
+      tok('paragraph_open'),
+      tok('fence', 'output', '{}'),
+    ];
+    expect(findSourceFenceBefore(tokens, 2)).toBeNull();
+  });
+  it('returns null when there is no preceding fence', () => {
+    const tokens = [tok('fence', 'output', '{}')];
+    expect(findSourceFenceBefore(tokens, 0)).toBeNull();
+  });
+  it('returns null when the preceding fence is not runnable', () => {
+    const tokens = [
+      tok('fence', 'text', 'hi\n'),
+      tok('fence', 'output', '{}'),
+    ];
+    expect(findSourceFenceBefore(tokens, 1)).toBeNull();
+  });
+});

--- a/tests/renderer/preview/image-paths.test.ts
+++ b/tests/renderer/preview/image-paths.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Relative-image-path resolution + MIME guessing (#672).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRelativeImagePath,
+  mimeFromPath,
+} from '../../../src/renderer/lib/preview/image-paths';
+
+describe('resolveRelativeImagePath', () => {
+  it('resolves against a nested note directory', () => {
+    expect(resolveRelativeImagePath('img.png', 'notes/sub/post.md')).toBe('notes/sub/img.png');
+  });
+  it('collapses .. segments relative to the note dir', () => {
+    expect(resolveRelativeImagePath('../assets/img.png', 'notes/sub/post.md'))
+      .toBe('notes/assets/img.png');
+  });
+  it('strips a leading ./', () => {
+    expect(resolveRelativeImagePath('./img.png', 'notes/post.md')).toBe('notes/img.png');
+  });
+  it('treats a root-level note (graph.md) as having no dir prefix', () => {
+    expect(resolveRelativeImagePath('img.png', 'graph.md')).toBe('img.png');
+  });
+  it('handles a null note path', () => {
+    expect(resolveRelativeImagePath('img.png', null)).toBe('img.png');
+  });
+});
+
+describe('mimeFromPath', () => {
+  it('maps known extensions', () => {
+    expect(mimeFromPath('a.png')).toBe('image/png');
+    expect(mimeFromPath('a.jpg')).toBe('image/jpeg');
+    expect(mimeFromPath('a.jpeg')).toBe('image/jpeg');
+    expect(mimeFromPath('a.gif')).toBe('image/gif');
+    expect(mimeFromPath('a.webp')).toBe('image/webp');
+    expect(mimeFromPath('a.svg')).toBe('image/svg+xml');
+    expect(mimeFromPath('a.avif')).toBe('image/avif');
+  });
+  it('falls back to octet-stream for unknown / extensionless', () => {
+    expect(mimeFromPath('a.bmp')).toBe('application/octet-stream');
+    expect(mimeFromPath('noext')).toBe('application/octet-stream');
+  });
+});

--- a/tests/renderer/preview/text.test.ts
+++ b/tests/renderer/preview/text.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure text/frontmatter helpers extracted from Preview.svelte (#672).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  escapeHtml,
+  escapeAttr,
+  stripFrontmatter,
+  countFrontmatterLines,
+} from '../../../src/renderer/lib/preview/text';
+
+describe('escapeHtml', () => {
+  it('escapes &, <, >', () => {
+    expect(escapeHtml('a & b < c > d')).toBe('a &amp; b &lt; c &gt; d');
+  });
+  it('escapes & first so entities are not double-encoded', () => {
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+  });
+});
+
+describe('escapeAttr', () => {
+  it('escapes html plus double quotes', () => {
+    expect(escapeAttr('say "<hi>"')).toBe('say &quot;&lt;hi&gt;&quot;');
+  });
+});
+
+describe('stripFrontmatter', () => {
+  it('removes a leading --- … --- block', () => {
+    const text = '---\ntitle: X\ntags: [a]\n---\nbody here';
+    expect(stripFrontmatter(text)).toBe('body here');
+  });
+  it('leaves content without frontmatter untouched', () => {
+    expect(stripFrontmatter('# Heading\nbody')).toBe('# Heading\nbody');
+  });
+});
+
+describe('countFrontmatterLines', () => {
+  it('counts the newlines in the frontmatter block', () => {
+    const text = '---\ntitle: X\ntags: [a]\n---\nbody';
+    expect(countFrontmatterLines(text)).toBe(4);
+  });
+  it('returns 0 when there is no frontmatter', () => {
+    expect(countFrontmatterLines('# Heading\nbody')).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

First increment of the oversized-component split (#672), starting with the highest-value, lowest-risk target. Preview.svelte's bulk is in its ~1,684-line **script**, not markup — so this is a **logic extraction** (the App.svelte pattern), not the riskier markup-splitting. The markdown-it `md` instance, renderer rules, DOM handlers, `$state`, and template/style are untouched.

Partially addresses #672.

### New modules (`src/renderer/lib/preview/`)
- **`text.ts`** — `escapeHtml`, `escapeAttr`, `stripFrontmatter`, `countFrontmatterLines`
- **`image-paths.ts`** — `resolveRelativeImagePath`, `mimeFromPath`
- **`cite-meta.ts`** — `CiteMeta`/`QuoteMeta` types + `collapseCiteRows`, `formatFullByline`, `buildCiteTooltip`, `buildQuoteTooltip`, `buildFootnoteTooltip`
- **`compute-output-render.ts`** — `findSourceFenceBefore`, `renderComputeOutput`, `tableToCsv`, `outputToMarkdownClipboard`

Bodies moved **verbatim**; Preview imports them back.

### Tests (44, `tests/renderer/preview/`)
Escaping/frontmatter helpers; image-path `..`-collapse + root-note + mime guessing; cite/quote/footnote tooltip building (incl. the footnote-backref strip); the compute-output renderer (every output type + the `saveable && source` ⋯-menu wrap, and the non-saveable/error cases that don't wrap); `tableToCsv` quoting/escaping; `outputToMarkdownClipboard` table/text/empty; `findSourceFenceBefore` adjacency rules.

## Result
`Preview.svelte`: **2,586 → 2,297 lines**. Now ~250 lines of formerly-inline pure logic are in tested modules.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2889 passed** (+44).
- `pnpm test:e2e` — boot smoke passes.

## Note on scope
This is logic-only, by design — these components have no component tests, so I'm deliberately **not** splitting the declarative template/markup (prop-drilling/binding risk) until #673 (renderer component tests) provides a net. Remaining Preview logic that's more component-coupled (the markdown-it factory, query-block rendering, DOM handlers) could be a further increment; the other oversized components (SettingsDialog/ConversationsPanel are markup/CSS-heavy) are better deferred to post-#673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)