### PR TITLE
Implement the established-node escalation in the approval engine (#656)

### DIFF
--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -157,6 +157,27 @@ function collectAffectsNodes(ctx: ProjectContext, payloads: ProposalPayload[]): 
 }
 
 /**
+ * The Trust Principle's established-node escalation (#656): a write that
+ * touches any human-vetted (`thought:hasStatus thought:established`) node
+ * escalates to `requires_approval` regardless of its operation type — so the
+ * LLM can't silently re-tag, flag, or otherwise mutate an established claim
+ * via an `autonomous`/`notify_only` op. Returns true if any of `uris` is
+ * established.
+ */
+async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<boolean> {
+  if (uris.length === 0) return false;
+  const values = uris.map((u) => `<${u}>`).join(' ');
+  const r = await graph.queryGraph(ctx, `
+    PREFIX thought: <${THOUGHT}>
+    SELECT ?n WHERE {
+      VALUES ?n { ${values} }
+      ?n thought:hasStatus thought:established .
+    } LIMIT 1
+  `);
+  return r.results.length > 0;
+}
+
+/**
  * Submit a proposed bundle. Based on the operation's approval tier:
  * - requires_approval: persists a pending Proposal, returns it.
  * - notify_only: applies the bundle immediately, persists an approved
@@ -164,9 +185,19 @@ function collectAffectsNodes(ctx: ProjectContext, payloads: ProposalPayload[]): 
  * - autonomous: applies the bundle immediately, no proposal record.
  */
 export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal | null> {
-  const tier = getApprovalTier(write.operationType);
+  let tier = getApprovalTier(write.operationType);
   const now = new Date().toISOString();
   const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * 86400000).toISOString();
+
+  // Established-node escalation (#656). Computed before the tier dispatch so it
+  // can pull an autonomous/notify_only write up to requires_approval when it
+  // touches a human-vetted node — the Trust Principle invariant CLAUDE.md
+  // documents. Collected here (not after the autonomous return) so the check
+  // covers autonomous ops too.
+  const affectsNodeUris = collectAffectsNodes(ctx, write.payloads);
+  if (tier !== 'requires_approval' && await anyNodeEstablished(ctx, affectsNodeUris)) {
+    tier = 'requires_approval';
+  }
 
   if (tier === 'autonomous') {
     await applyBundle(ctx, write.payloads);
@@ -174,7 +205,6 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
   }
 
   const uri = proposalUri();
-  const affectsNodeUris = collectAffectsNodes(ctx, write.payloads);
   const proposal: Proposal = {
     uri,
     status: tier === 'notify_only' ? 'approved' : 'pending',

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -13,7 +13,7 @@ import {
   type OperationType,
   type ApprovalTier,
 } from '../../../src/main/llm/approval';
-import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { initGraph, queryGraph, parseIntoStore } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 describe('approval policy', () => {
@@ -144,4 +144,105 @@ describe('approval tiers cover all default operations', () => {
       expect(getApprovalTier(op)).toBe(tier);
     });
   }
+});
+
+describe('established-node escalation (#656)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  const THOUGHT = 'https://minerva.dev/ontology/thought#';
+  const ESTABLISHED = 'https://ex.example/established-claim';
+  const TENTATIVE = 'https://ex.example/tentative-claim';
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-escalation-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+    // Seed one human-vetted (established) node and one ordinary node.
+    parseIntoStore(ctx, `<${ESTABLISHED}> <${THOUGHT}hasStatus> <${THOUGHT}established> .`);
+    parseIntoStore(ctx, `<${TENTATIVE}> <${THOUGHT}hasStatus> <${THOUGHT}proposed> .`);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function statusOf(uri: string): Promise<string[]> {
+    const r = await queryGraph(ctx, `SELECT ?s WHERE { <${uri}> thought:proposalStatus ?s . }`);
+    return (r.results as Array<{ s: string }>).map((row) => row.s.replace(THOUGHT, ''));
+  }
+
+  function tagWrite(nodeUri: string) {
+    return {
+      operationType: 'tag_addition' as OperationType,
+      payloads: [{
+        kind: 'graph-triples' as const,
+        turtle: `<${nodeUri}> <https://minerva.dev/ontology#tag> "auto" .`,
+        affectsNodeUris: [nodeUri],
+      }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    };
+  }
+
+  it('an autonomous op on a NON-established node still applies silently (no proposal)', async () => {
+    const proposal = await proposeWrite(ctx, tagWrite(TENTATIVE));
+    expect(proposal).toBeNull();
+  });
+
+  it('escalates an autonomous op on an established node to a pending proposal', async () => {
+    const proposal = await proposeWrite(ctx, tagWrite(ESTABLISHED));
+    expect(proposal).not.toBeNull();
+    expect(await statusOf(proposal!.uri)).toEqual(['pending']);
+    // The write must NOT have been applied — escalation means it awaits approval.
+    const applied = await queryGraph(ctx,
+      `SELECT ?o WHERE { <${ESTABLISHED}> <https://minerva.dev/ontology#tag> ?o . }`);
+    expect(applied.results.length).toBe(0);
+  });
+
+  it('escalates a notify_only op on an established node to pending (not auto-applied)', async () => {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'confidence_update',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: `<${ESTABLISHED}> <${THOUGHT}confidenceValue> "0.9" .`,
+        affectsNodeUris: [ESTABLISHED],
+      }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await statusOf(proposal!.uri)).toEqual(['pending']);
+  });
+
+  it('a notify_only op on a non-established node stays notify_only (approved + applied)', async () => {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'confidence_update',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: `<${TENTATIVE}> <${THOUGHT}confidenceValue> "0.5" .`,
+        affectsNodeUris: [TENTATIVE],
+      }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await statusOf(proposal!.uri)).toEqual(['approved']);
+  });
+
+  it('does not escalate a requires_approval op differently (still pending, unaffected)', async () => {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: `<${ESTABLISHED}> a <https://ex.example/Claim> .`,
+        affectsNodeUris: [ESTABLISHED],
+      }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    });
+    expect(proposal).not.toBeNull();
+    expect(await statusOf(proposal!.uri)).toEqual(['pending']);
+  });
 });


### PR DESCRIPTION
## What

Closes #656.

CLAUDE.md documents — as a **Trust Principle invariant** — that *"Nodes with `thought:hasStatus thought:established` automatically escalate to `requires_approval` regardless of operation type."* Investigation confirmed that rule existed **only in the docs**: `proposeWrite` computed the tier purely from `operationType` (no `established` reference anywhere in `src/main/llm/`), so an LLM `autonomous` op (`tag_addition`/`staleness_flag`) or `notify_only` op (`confidence_update`/`status_change`) on a human-vetted established claim was applied **silently**. (QA review Q-C2 — rated the top correctness gap — / architecture review #6.)

`thought:established` is a real ontology status (one of proposed/explored/established/challenged/revised/abandoned) and established nodes occur in practice (health-checks already query for them), so per the issue's decision point I **implemented** the rule rather than deleting the doc.

## How

`proposeWrite` now collects the affected node URIs **before** the tier dispatch and, via a new `anyNodeEstablished()` SPARQL check, overrides the tier to `requires_approval` when any affected node is `thought:established`. The write then becomes a **pending proposal** the user must approve, instead of applying silently. `requires_approval` ops are unaffected; the lookup is skipped when there are no affected nodes (so non-graph writes pay nothing).

The implementation matches the documented wording exactly, so CLAUDE.md needs no change — the claim is now true *and* tested.

## Tests (5)
- autonomous op on a **non**-established node → still applies silently (returns `null`, no proposal)
- autonomous op on an **established** node → escalates to a **pending** proposal, and the triple is **not** applied (awaits approval)
- notify_only op on an established node → escalates to **pending** (not auto-approved/applied)
- notify_only op on a non-established node → stays **approved** + applied
- a `requires_approval` op is unchanged (still pending)

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2894 passed** (+5).
- `pnpm test:e2e` — boot smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)