### PR TITLE
Validate proposal payload kind at creation + tier store-effect tests (#665, #666)

### DIFF
--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -177,6 +177,31 @@ async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<
   return r.results.length > 0;
 }
 
+/** Payload kinds that `dispatchApply` actually knows how to apply. Keep in
+ *  sync with the `switch` in dispatchApply — the `source` / `saved-query`
+ *  kinds are defined on the type but not yet wired to a dispatcher. */
+const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt']);
+
+/**
+ * Reject a bundle containing a payload kind that has no apply dispatcher (#665).
+ * Without this, an un-wired kind (`source` / `saved-query`) could be filed as a
+ * pending proposal and only blow up — with NotImplementedError — when the user
+ * clicks Approve. Fail fast at creation instead, so a skill emitting an
+ * unsupported kind surfaces the bug immediately rather than at the user's
+ * approve click.
+ */
+function assertWiredPayloads(payloads: ProposalPayload[]): void {
+  for (const p of payloads) {
+    if (!WIRED_PAYLOAD_KINDS.has(p.kind)) {
+      throw new Error(
+        `proposeWrite: payload kind "${p.kind}" has no apply dispatcher yet — ` +
+        `filing this proposal would fail at approval time. ` +
+        `Wired kinds: ${[...WIRED_PAYLOAD_KINDS].join(', ')}.`,
+      );
+    }
+  }
+}
+
 /**
  * Submit a proposed bundle. Based on the operation's approval tier:
  * - requires_approval: persists a pending Proposal, returns it.
@@ -185,6 +210,7 @@ async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<
  * - autonomous: applies the bundle immediately, no proposal record.
  */
 export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal | null> {
+  assertWiredPayloads(write.payloads);
   let tier = getApprovalTier(write.operationType);
   const now = new Date().toISOString();
   const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * 86400000).toISOString();

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -246,3 +246,125 @@ describe('established-node escalation (#656)', () => {
     expect(await statusOf(proposal!.uri)).toEqual(['pending']);
   });
 });
+
+describe('payload-kind validation at proposeWrite time (#665)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-payload-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+  });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  it('rejects a saved-query payload at creation (would throw at apply otherwise)', async () => {
+    await expect(proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{
+        kind: 'saved-query',
+        scope: 'project',
+        name: 'watch',
+        description: 'd',
+        query: 'SELECT * WHERE { ?s ?p ?o }',
+        language: 'sparql',
+      }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    })).rejects.toThrow(/saved-query.*no apply dispatcher/);
+  });
+
+  it('rejects a source payload at creation', async () => {
+    await expect(proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{ kind: 'source', sourceId: 's1', metaTtl: '' }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    })).rejects.toThrow(/source.*no apply dispatcher/);
+  });
+
+  it('rejects when an un-wired kind is mixed into an otherwise-valid bundle', async () => {
+    await expect(proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [
+        { kind: 'graph-triples', turtle: '<https://ex.example/z> a <https://ex.example/Claim> .', affectsNodeUris: ['https://ex.example/z'] },
+        { kind: 'saved-query', scope: 'global', name: 'w', description: 'd', query: 'x', language: 'sql' },
+      ],
+      note: 'test',
+      proposedBy: 'unit-test',
+    })).rejects.toThrow(/no apply dispatcher/);
+  });
+
+  it('accepts the wired kinds (graph-triples)', async () => {
+    const p = await proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{ kind: 'graph-triples', turtle: '<https://ex.example/ok> a <https://ex.example/Claim> .', affectsNodeUris: ['https://ex.example/ok'] }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    });
+    expect(p).not.toBeNull();
+  });
+});
+
+describe('tier store effects (#666)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const TAG = 'https://minerva.dev/ontology#tag';
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-tier-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+  });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  /** Number of `<node> <TAG> ?o` triples currently in the store. */
+  async function tagCount(node: string): Promise<number> {
+    const r = await queryGraph(ctx, `SELECT ?o WHERE { <${node}> <${TAG}> ?o . }`);
+    return r.results.length;
+  }
+
+  function write(op: OperationType, node: string) {
+    return {
+      operationType: op,
+      payloads: [{ kind: 'graph-triples' as const, turtle: `<${node}> <${TAG}> "x" .`, affectsNodeUris: [node] }],
+      note: 'test',
+      proposedBy: 'unit-test',
+    };
+  }
+
+  it('autonomous: the write lands in the store immediately, with no proposal record', async () => {
+    const node = 'https://ex.example/auto';
+    const proposal = await proposeWrite(ctx, write('tag_addition', node));
+    expect(proposal).toBeNull();
+    expect(await tagCount(node)).toBe(1);
+  });
+
+  it('notify_only: the write lands immediately AND an approved proposal is recorded', async () => {
+    const node = 'https://ex.example/notify';
+    const proposal = await proposeWrite(ctx, write('confidence_update', node));
+    expect(proposal).not.toBeNull();
+    expect(await tagCount(node)).toBe(1); // applied immediately
+    const r = await queryGraph(ctx, `SELECT ?s WHERE { <${proposal!.uri}> thought:proposalStatus ?s . }`);
+    expect((r.results as Array<{ s: string }>)[0].s).toBe('https://minerva.dev/ontology/thought#approved');
+  });
+
+  it('requires_approval: the write is ABSENT until approved, then present', async () => {
+    const node = 'https://ex.example/gated';
+    const proposal = await proposeWrite(ctx, write('new_claim', node));
+    expect(proposal).not.toBeNull();
+    expect(await tagCount(node)).toBe(0); // not applied yet
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect(await tagCount(node)).toBe(1); // applied on approval
+  });
+
+  it('requires_approval rejected: the write never lands', async () => {
+    const node = 'https://ex.example/rejected';
+    const proposal = await proposeWrite(ctx, write('new_claim', node));
+    expect(await tagCount(node)).toBe(0);
+    expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);
+    expect(await tagCount(node)).toBe(0); // still absent
+  });
+});

--- a/tests/main/llm/proposal-bundle.test.ts
+++ b/tests/main/llm/proposal-bundle.test.ts
@@ -229,12 +229,13 @@ describe('ProposalBundle apply + rollback (#418)', () => {
     }
   });
 
-  it('un-wired payload kinds (source / excerpt / saved-query) throw NotImplementedError on apply', async () => {
-    // The type accepts these kinds (the Research-tools tickets that
-    // need them are filed under #414/#415/follow-ups). The runtime
-    // behaviour is "fail loudly" until each is wired in its own PR.
+  it('un-wired payload kinds (source / saved-query) are rejected at proposeWrite time (#665)', async () => {
+    // The type accepts these kinds (the Research-tools tickets that need them
+    // are filed under #414/#415/follow-ups), but they have no apply dispatcher
+    // yet. Rather than file a proposal that explodes at the user's Approve
+    // click, proposeWrite rejects an un-wired kind at creation (#665).
     setPolicy('component_creation', 'requires_approval');
-    const proposal = await proposeWrite(ctx, {
+    await expect(proposeWrite(ctx, {
       operationType: 'component_creation',
       payloads: [{
         kind: 'saved-query',
@@ -246,8 +247,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       }],
       note: 'unwired kind',
       proposedBy: 'unit-test',
-    });
-    await expect(approveProposal(ctx, proposal!.uri))
-      .rejects.toThrow(/not yet wired/);
+    })).rejects.toThrow(/no apply dispatcher/);
   });
 });


### PR DESCRIPTION
## What

Closes #665. Closes #666. The last two trust-path correctness items from the QA review.

### #665 — fail fast on un-wired payload kinds
The `ProposalPayload` type has five kinds, but only `graph-triples` / `note` / `excerpt` have an apply dispatcher — `source` / `saved-query` threw `NotImplementedError` at **apply** time. So a skill emitting one could file a `thought:pending` proposal that only blew up when the **user clicked Approve**.

`proposeWrite` now validates payload kinds **at creation** (`assertWiredPayloads` against `WIRED_PAYLOAD_KINDS`) and rejects an un-wired kind immediately, with a message naming the kind + the wired set. The apply-time `switch` throw stays as defense-in-depth.

Updated the existing `proposal-bundle.test.ts` case (which asserted the apply-time throw — and was stale: it listed `excerpt` as un-wired, but excerpt was wired in #104) to assert the new creation-time rejection.

### #666 — tier store-effect tests
The tier→operation mapping was tested, but not what actually **lands in the graph** per tier. Added tests asserting:
- `autonomous` → the write is present in the store immediately, no proposal recorded
- `notify_only` → present immediately **and** an `approved` proposal is recorded
- `requires_approval` → **absent until** `approveProposal`, present after
- `requires_approval` rejected → never lands

## Tests
+4 (#665 creation validation) +4 (#666 store effects) in `approval.test.ts`; 1 updated in `proposal-bundle.test.ts`. Verified no production code constructs the un-wired kinds (they're reserved for future Research tools), so the validation breaks nothing.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2902 passed**.
- `pnpm test:e2e` — boot smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)