### PR TITLE
Extract pure helpers from Editor.svelte (#672)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -37,6 +37,10 @@
   import { footnoteDecorations } from '../editor/footnote-decorations';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
+  import { toHistorySnapshot, canRestoreHistory } from '../editor/history-snapshot';
+  import { DEFAULT_FONT, clampFontSize, parseStoredFontSize } from '../editor/font-size';
+  import { hasImageFiles, imageFilesFromTransfer, imageFilesFromClipboard } from '../editor/image-drop';
+  import { findFrontmatterFoldRange } from '../editor/frontmatter';
   import { clampMenuToViewport, clampSubmenu } from '../utils/menuClamp';
   import { extractClaimUri } from '../../../shared/refactor/find-arguments';
 
@@ -186,19 +190,6 @@
   const lineNumbersCompartment = new Compartment();
   const whitespaceCompartment = new Compartment();
 
-  /**
-   * Sanity-check a stored history snapshot before handing it to
-   * `EditorState.fromJSON`. CM's JSON is an opaque blob to us; we just
-   * need `doc` (string) for the drift check. Anything that doesn't match
-   * that minimum shape is treated as "no snapshot, start fresh."
-   */
-  function toHistorySnapshot(raw: unknown): { doc: string } & Record<string, unknown> | null {
-    if (!raw || typeof raw !== 'object') return null;
-    const obj = raw as Record<string, unknown>;
-    if (typeof obj.doc !== 'string') return null;
-    return obj as { doc: string } & Record<string, unknown>;
-  }
-
   function cmTheme(): Extension {
     return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
   }
@@ -240,12 +231,8 @@
       view.dispatch({ effects: themeCompartment.reconfigure(cmTheme()) });
     }
   }
-  const MIN_FONT = 10;
-  const MAX_FONT = 24;
-  const DEFAULT_FONT = 14;
-
   function getFontSize(): number {
-    return parseInt(localStorage.getItem('editorFontSize') ?? String(DEFAULT_FONT), 10);
+    return parseStoredFontSize(localStorage.getItem('editorFontSize'));
   }
 
   function fontSizeTheme(size: number) {
@@ -257,7 +244,7 @@
 
   export function changeFontSize(delta: number) {
     const current = getFontSize();
-    const next = Math.max(MIN_FONT, Math.min(MAX_FONT, current + delta));
+    const next = clampFontSize(current + delta);
     localStorage.setItem('editorFontSize', String(next));
     if (view) {
       view.dispatch({ effects: fontSizeCompartment.reconfigure(fontSizeTheme(next)) });
@@ -302,19 +289,7 @@
 
   function findFrontmatterRange(): { from: number; to: number } | null {
     if (!view) return null;
-    const doc = view.state.doc;
-    if (doc.lines < 2) return null;
-    const firstLine = doc.line(1);
-    if (firstLine.text.trim() !== '---') return null;
-    for (let i = 2; i <= doc.lines; i++) {
-      const line = doc.line(i);
-      if (line.text.trim() === '---') {
-        // Fold range spans the content between the --- markers, keeping
-        // both fences visible as "---" lines in the gutter-collapsed view.
-        return { from: firstLine.to, to: line.to };
-      }
-    }
-    return null;
+    return findFrontmatterFoldRange(view.state.doc);
   }
 
   function foldFrontmatter() {
@@ -488,17 +463,7 @@
     // the YAML visible.
     foldService.of((state, lineStart) => {
       if (lineStart !== 0) return null;
-      const doc = state.doc;
-      if (doc.lines < 2) return null;
-      const first = doc.line(1);
-      if (first.text.trim() !== '---') return null;
-      for (let i = 2; i <= doc.lines; i++) {
-        const line = doc.line(i);
-        if (line.text.trim() === '---') {
-          return { from: first.to, to: line.to };
-        }
-      }
-      return null;
+      return findFrontmatterFoldRange(state.doc);
     }),
     themeCompartment.of(cmTheme()),
     minervaEditorTheme(),
@@ -600,8 +565,7 @@
         e.preventDefault();
         e.stopPropagation();
         const dropPos = v.posAtCoords({ x: e.clientX, y: e.clientY }) ?? v.state.selection.main.head;
-        const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith('image/'));
-        void handleImageUploads(files, dropPos);
+        void handleImageUploads(imageFilesFromTransfer(e.dataTransfer), dropPos);
         return true;
       },
       // Paste-image upload (#455). Catches the macOS Cmd+Shift+Ctrl+4
@@ -610,13 +574,7 @@
       paste: (e, v) => {
         const items = e.clipboardData?.items;
         if (!items) return false;
-        const files: File[] = [];
-        for (const item of items) {
-          if (item.kind !== 'file') continue;
-          if (!item.type.startsWith('image/')) continue;
-          const f = item.getAsFile();
-          if (f) files.push(f);
-        }
+        const files = imageFilesFromClipboard(items);
         if (files.length === 0) return false;
         e.preventDefault();
         void handleImageUploads(files, v.state.selection.main.head);
@@ -624,25 +582,6 @@
       },
     }),
   ];
-
-  /** True iff the DataTransfer carries at least one image file. Used
-   *  by the dragover gate so a text-drop or internal-CM drop still
-   *  routes through the editor's default handlers. */
-  function hasImageFiles(dt: DataTransfer): boolean {
-    // `items` is the modern API; `files` is the fallback. Either
-    // surface lets us spot an image without consuming the data.
-    if (dt.items) {
-      for (const item of dt.items) {
-        if (item.kind === 'file' && item.type.startsWith('image/')) return true;
-      }
-    }
-    if (dt.files) {
-      for (const f of dt.files) {
-        if (f.type.startsWith('image/')) return true;
-      }
-    }
-    return false;
-  }
 
   /**
    * Run the image-upload pipeline for each file, accumulate the
@@ -893,7 +832,7 @@
     // undoing to a document that no longer matches reality is worse than
     // losing history.
     const snapshot = toHistorySnapshot(initialHistory);
-    const canRestore = snapshot !== null && snapshot.doc === content;
+    const canRestore = canRestoreHistory(snapshot, content);
     const state = canRestore
       ? EditorState.fromJSON(
           snapshot,

--- a/src/renderer/lib/editor/font-size.ts
+++ b/src/renderer/lib/editor/font-size.ts
@@ -1,0 +1,27 @@
+/**
+ * Editor font-size bounds + pure helpers (#672, extracted from Editor.svelte).
+ *
+ * The size is persisted in localStorage under `editorFontSize`; the component
+ * owns that I/O and the CM theme reconfiguration, while these pure helpers own
+ * the clamping and the stored-value parse so they can be unit-tested without a
+ * DOM or a live EditorView.
+ */
+
+export const MIN_FONT = 10;
+export const MAX_FONT = 24;
+export const DEFAULT_FONT = 14;
+
+/** Clamp a font size into the supported [MIN_FONT, MAX_FONT] range. */
+export function clampFontSize(size: number): number {
+  return Math.max(MIN_FONT, Math.min(MAX_FONT, size));
+}
+
+/**
+ * Parse a stored font-size string into a number, falling back to DEFAULT_FONT
+ * when nothing is stored. Mirrors the prior inline `getFontSize()` (a bare
+ * `parseInt(… ?? DEFAULT)`): a present-but-garbage value parses the way
+ * `parseInt` would, and the caller clamps before applying.
+ */
+export function parseStoredFontSize(raw: string | null): number {
+  return parseInt(raw ?? String(DEFAULT_FONT), 10);
+}

--- a/src/renderer/lib/editor/frontmatter.ts
+++ b/src/renderer/lib/editor/frontmatter.ts
@@ -1,0 +1,72 @@
+/**
+ * Locate the YAML frontmatter block's fold range in a markdown document
+ * (#672, extracted from Editor.svelte — the identical scan previously lived
+ * in BOTH `findFrontmatterRange()` and the `foldService`, which could drift).
+ *
+ * Returns CodeMirror-style character offsets: `from` at the end of the
+ * opening `---` line, `to` at the end of the closing `---` line, so the fold
+ * collapses the YAML body while keeping both fence lines visible in the
+ * gutter. Returns null when the doc doesn't open with a `---` fence or has no
+ * closing fence.
+ *
+ * It takes a minimal "line doc" view — line count + a 1-indexed line accessor
+ * exposing `text`/`from`/`to` — which CM's `EditorState.doc` satisfies
+ * structurally, so callers pass `view.state.doc` directly. `docFromText`
+ * builds the same shape from a plain string for non-CM callers and tests.
+ */
+
+export interface FoldRange {
+  from: number;
+  to: number;
+}
+
+export interface DocLine {
+  text: string;
+  from: number;
+  to: number;
+}
+
+export interface LineDoc {
+  /** Total number of lines (1-indexed line space, like CM). */
+  lines: number;
+  /** 1-indexed line accessor. */
+  line(n: number): DocLine;
+}
+
+export function findFrontmatterFoldRange(doc: LineDoc): FoldRange | null {
+  if (doc.lines < 2) return null;
+  const first = doc.line(1);
+  if (first.text.trim() !== '---') return null;
+  for (let i = 2; i <= doc.lines; i++) {
+    const line = doc.line(i);
+    if (line.text.trim() === '---') {
+      // Span the content between the --- markers, keeping both fences
+      // visible as "---" lines in the gutter-collapsed view.
+      return { from: first.to, to: line.to };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a {@link LineDoc} from a raw string, matching CodeMirror's offset
+ * semantics: `from` is the line's start offset, `to` is the position at the
+ * end of the line's text (before the trailing newline).
+ */
+export function docFromText(text: string): LineDoc {
+  const parts = text.split('\n');
+  const starts: number[] = [];
+  let offset = 0;
+  for (const part of parts) {
+    starts.push(offset);
+    offset += part.length + 1; // +1 for the '\n' separator
+  }
+  return {
+    lines: parts.length,
+    line(n: number): DocLine {
+      const i = n - 1;
+      const from = starts[i];
+      return { text: parts[i], from, to: from + parts[i].length };
+    },
+  };
+}

--- a/src/renderer/lib/editor/history-snapshot.ts
+++ b/src/renderer/lib/editor/history-snapshot.ts
@@ -1,0 +1,39 @@
+/**
+ * Restoring a CodeMirror history snapshot across an Editor remount (#672,
+ * extracted from Editor.svelte).
+ *
+ * When a tab is switched away and back, the EditorView is destroyed and
+ * recreated. We persist the serialized CM state (including the undo/redo
+ * stacks) and hand it back on remount. CM's serialized state is an opaque
+ * blob to us; all we validate is that it carries a string `doc`, which powers
+ * the drift check: if the snapshot's document no longer matches the buffer
+ * we're mounting (file reloaded from disk, programmatic rewrite, …), the
+ * stored stacks would let the user undo to a state the file no longer shows,
+ * so we discard them and start from a clean state.
+ */
+
+export type HistorySnapshot = { doc: string } & Record<string, unknown>;
+
+/**
+ * Validate a raw persisted snapshot down to the minimum shape we rely on
+ * (an object with a string `doc`). Anything else → null, meaning "no usable
+ * snapshot, start fresh."
+ */
+export function toHistorySnapshot(raw: unknown): HistorySnapshot | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.doc !== 'string') return null;
+  return obj as HistorySnapshot;
+}
+
+/**
+ * True when `snapshot` can be safely restored against the content we're about
+ * to mount — i.e. its doc still matches, so the undo stack is consistent with
+ * what's shown. A null snapshot (missing / malformed) is never restorable.
+ */
+export function canRestoreHistory(
+  snapshot: HistorySnapshot | null,
+  content: string,
+): boolean {
+  return snapshot !== null && snapshot.doc === content;
+}

--- a/src/renderer/lib/editor/image-drop.ts
+++ b/src/renderer/lib/editor/image-drop.ts
@@ -1,0 +1,48 @@
+/**
+ * Image detection for the editor's drag/drop + paste upload path (#455,
+ * extracted in #672 from Editor.svelte).
+ *
+ * These pure helpers inspect a DataTransfer / clipboard items without
+ * consuming them, so the dragover gate can decide whether to intercept the
+ * drop (image → editor upload) or let it fall through to CodeMirror's default
+ * text-drop handling and App.svelte's project-import drop.
+ */
+
+/**
+ * True iff the DataTransfer carries at least one image file. `items` is the
+ * modern surface; `files` is the fallback — either lets us spot an image
+ * without reading the payload.
+ */
+export function hasImageFiles(dt: DataTransfer): boolean {
+  if (dt.items) {
+    for (const item of dt.items) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) return true;
+    }
+  }
+  if (dt.files) {
+    for (const f of dt.files) {
+      if (f.type.startsWith('image/')) return true;
+    }
+  }
+  return false;
+}
+
+/** The image Files in a drop's DataTransfer.files (the drop handler path). */
+export function imageFilesFromTransfer(dt: DataTransfer): File[] {
+  return Array.from(dt.files).filter((f) => f.type.startsWith('image/'));
+}
+
+/**
+ * The image Files among clipboard items (the paste handler path). Skips
+ * non-file items (text/html) and any item whose `getAsFile()` returns null.
+ */
+export function imageFilesFromClipboard(items: DataTransferItemList): File[] {
+  const files: File[] = [];
+  for (const item of items) {
+    if (item.kind !== 'file') continue;
+    if (!item.type.startsWith('image/')) continue;
+    const f = item.getAsFile();
+    if (f) files.push(f);
+  }
+  return files;
+}

--- a/tests/renderer/editor-font-size.test.ts
+++ b/tests/renderer/editor-font-size.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_FONT,
+  MAX_FONT,
+  DEFAULT_FONT,
+  clampFontSize,
+  parseStoredFontSize,
+} from '../../src/renderer/lib/editor/font-size';
+
+describe('clampFontSize', () => {
+  it('keeps an in-range size unchanged', () => {
+    expect(clampFontSize(14)).toBe(14);
+    expect(clampFontSize(MIN_FONT)).toBe(MIN_FONT);
+    expect(clampFontSize(MAX_FONT)).toBe(MAX_FONT);
+  });
+
+  it('clamps below MIN and above MAX', () => {
+    expect(clampFontSize(MIN_FONT - 5)).toBe(MIN_FONT);
+    expect(clampFontSize(MAX_FONT + 100)).toBe(MAX_FONT);
+  });
+
+  it('models the +/- step behavior at the boundaries', () => {
+    // changeFontSize(delta) does clampFontSize(current + delta).
+    expect(clampFontSize(MAX_FONT + 2)).toBe(MAX_FONT); // can't grow past max
+    expect(clampFontSize(MIN_FONT - 2)).toBe(MIN_FONT); // can't shrink past min
+  });
+});
+
+describe('parseStoredFontSize', () => {
+  it('falls back to DEFAULT_FONT when nothing is stored', () => {
+    expect(parseStoredFontSize(null)).toBe(DEFAULT_FONT);
+  });
+
+  it('parses a stored numeric string', () => {
+    expect(parseStoredFontSize('18')).toBe(18);
+    expect(parseStoredFontSize('10')).toBe(MIN_FONT);
+  });
+
+  it('parses a leading-numeric value the way parseInt does', () => {
+    expect(parseStoredFontSize('16px')).toBe(16);
+  });
+});

--- a/tests/renderer/editor-frontmatter.test.ts
+++ b/tests/renderer/editor-frontmatter.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findFrontmatterFoldRange,
+  docFromText,
+  type LineDoc,
+} from '../../src/renderer/lib/editor/frontmatter';
+
+// findFrontmatterFoldRange replaces a scan that was copied in two places in
+// Editor.svelte. docFromText mirrors CodeMirror's offset semantics so these
+// offsets are exactly what the real `view.state.doc` would yield.
+
+describe('docFromText (CM offset parity)', () => {
+  it('computes from/to offsets with newline separators', () => {
+    const doc = docFromText('a\nbb\nccc');
+    expect(doc.lines).toBe(3);
+    expect(doc.line(1)).toEqual({ text: 'a', from: 0, to: 1 });
+    expect(doc.line(2)).toEqual({ text: 'bb', from: 2, to: 4 });
+    expect(doc.line(3)).toEqual({ text: 'ccc', from: 5, to: 8 });
+  });
+});
+
+describe('findFrontmatterFoldRange', () => {
+  it('spans from the end of the opening fence to the end of the closing fence', () => {
+    // ---\nkey: v\n---\nbody
+    //  opening `---` is line 1 (from 0, to 3); closing `---` is line 3.
+    const text = '---\nkey: v\n---\nbody';
+    const range = findFrontmatterFoldRange(docFromText(text));
+    // from = end of line 1 (3); to = end of closing line 3.
+    // line 3 starts at 4 + 7 = 11, length 3 → to 14.
+    expect(range).toEqual({ from: 3, to: 14 });
+    // Sanity: both fence lines stay visible — the fold begins after the first
+    // `---` and ends at the second `---`'s line end.
+    expect(text.slice(range!.from, range!.to)).toBe('\nkey: v\n---');
+  });
+
+  it('returns null when the doc does not open with a fence', () => {
+    expect(findFrontmatterFoldRange(docFromText('# Title\n\nbody'))).toBeNull();
+  });
+
+  it('returns null when there is no closing fence', () => {
+    expect(findFrontmatterFoldRange(docFromText('---\nkey: v\nno close'))).toBeNull();
+  });
+
+  it('returns null for a doc shorter than two lines', () => {
+    expect(findFrontmatterFoldRange(docFromText('---'))).toBeNull();
+    expect(findFrontmatterFoldRange(docFromText(''))).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace on the fence lines (trim)', () => {
+    const range = findFrontmatterFoldRange(docFromText('---  \nk: v\n  ---\nx'));
+    expect(range).not.toBeNull();
+  });
+
+  it('accepts a CM-shaped doc directly (structural typing)', () => {
+    // Proves the real `view.state.doc` (lines + 1-indexed line()) is accepted.
+    const cmLike: LineDoc = {
+      lines: 3,
+      line: (n) => [
+        { text: '---', from: 0, to: 3 },
+        { text: 'a: 1', from: 4, to: 8 },
+        { text: '---', from: 9, to: 12 },
+      ][n - 1],
+    };
+    expect(findFrontmatterFoldRange(cmLike)).toEqual({ from: 3, to: 12 });
+  });
+});

--- a/tests/renderer/editor-history-snapshot.test.ts
+++ b/tests/renderer/editor-history-snapshot.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toHistorySnapshot,
+  canRestoreHistory,
+  type HistorySnapshot,
+} from '../../src/renderer/lib/editor/history-snapshot';
+
+// The history snapshot guards the tab-switch undo/redo restore (#672). The
+// drift check is the safety-critical part: never restore a stack whose doc no
+// longer matches the buffer being mounted.
+
+describe('toHistorySnapshot', () => {
+  it('accepts an object with a string doc', () => {
+    const snap = toHistorySnapshot({ doc: 'hello', history: { done: [] } });
+    expect(snap).not.toBeNull();
+    expect(snap!.doc).toBe('hello');
+    // Opaque extra fields are preserved for EditorState.fromJSON.
+    expect(snap!.history).toEqual({ done: [] });
+  });
+
+  it('rejects null / undefined / primitives', () => {
+    expect(toHistorySnapshot(null)).toBeNull();
+    expect(toHistorySnapshot(undefined)).toBeNull();
+    expect(toHistorySnapshot('a string')).toBeNull();
+    expect(toHistorySnapshot(42)).toBeNull();
+  });
+
+  it('rejects an object without a string doc', () => {
+    expect(toHistorySnapshot({})).toBeNull();
+    expect(toHistorySnapshot({ doc: 123 })).toBeNull();
+    expect(toHistorySnapshot({ history: {} })).toBeNull();
+  });
+});
+
+describe('canRestoreHistory', () => {
+  const snap = (doc: string): HistorySnapshot => ({ doc });
+
+  it('restores when the snapshot doc matches the content', () => {
+    expect(canRestoreHistory(snap('same'), 'same')).toBe(true);
+  });
+
+  it('refuses when the doc has drifted (file reloaded / rewritten)', () => {
+    expect(canRestoreHistory(snap('old'), 'new')).toBe(false);
+  });
+
+  it('refuses a null snapshot', () => {
+    expect(canRestoreHistory(null, 'anything')).toBe(false);
+  });
+
+  it('treats the empty doc exactly (no falsy short-circuit)', () => {
+    expect(canRestoreHistory(snap(''), '')).toBe(true);
+    expect(canRestoreHistory(snap(''), 'x')).toBe(false);
+  });
+});

--- a/tests/renderer/editor-image-drop.test.ts
+++ b/tests/renderer/editor-image-drop.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasImageFiles,
+  imageFilesFromTransfer,
+  imageFilesFromClipboard,
+} from '../../src/renderer/lib/editor/image-drop';
+
+// Lightweight stand-ins for the DOM transfer surfaces — the helpers only touch
+// `kind` / `type` / `getAsFile()` / iteration, so plain arrays cast to the DOM
+// types exercise the real logic without needing a full jsdom DataTransfer.
+const img = (name = 'shot.png', type = 'image/png') =>
+  new File(['x'], name, { type });
+
+function transfer(opts: { items?: unknown[]; files?: File[] }): DataTransfer {
+  return { items: opts.items ?? [], files: opts.files ?? [] } as unknown as DataTransfer;
+}
+
+function fileItem(file: File) {
+  return { kind: 'file', type: file.type, getAsFile: () => file };
+}
+
+describe('hasImageFiles', () => {
+  it('detects an image via the items surface', () => {
+    const dt = transfer({ items: [fileItem(img())] });
+    expect(hasImageFiles(dt)).toBe(true);
+  });
+
+  it('detects an image via the files fallback', () => {
+    const dt = transfer({ files: [img()] });
+    expect(hasImageFiles(dt)).toBe(true);
+  });
+
+  it('is false for a text drag (string item, no image file)', () => {
+    const dt = transfer({ items: [{ kind: 'string', type: 'text/plain', getAsFile: () => null }] });
+    expect(hasImageFiles(dt)).toBe(false);
+  });
+
+  it('is false for a non-image file', () => {
+    const dt = transfer({ files: [new File(['x'], 'a.pdf', { type: 'application/pdf' })] });
+    expect(hasImageFiles(dt)).toBe(false);
+  });
+
+  it('is false for an empty transfer', () => {
+    expect(hasImageFiles(transfer({}))).toBe(false);
+  });
+});
+
+describe('imageFilesFromTransfer', () => {
+  it('returns only the image files from a mixed drop', () => {
+    const png = img('a.png');
+    const files = [png, new File(['x'], 'b.txt', { type: 'text/plain' })];
+    expect(imageFilesFromTransfer(transfer({ files }))).toEqual([png]);
+  });
+});
+
+describe('imageFilesFromClipboard', () => {
+  it('collects image files, skipping string items and null getAsFile()', () => {
+    const png = img('paste.png');
+    const items = [
+      { kind: 'string', type: 'text/html', getAsFile: () => null },
+      fileItem(png),
+      { kind: 'file', type: 'image/gif', getAsFile: () => null }, // file item but no blob
+    ] as unknown as DataTransferItemList;
+    expect(imageFilesFromClipboard(items)).toEqual([png]);
+  });
+
+  it('returns empty when there are no image items', () => {
+    const items = [
+      { kind: 'string', type: 'text/plain', getAsFile: () => null },
+    ] as unknown as DataTransferItemList;
+    expect(imageFilesFromClipboard(items)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Part of #672 (split oversized Svelte components). Editor.svelte was the most **script-dense** of the targets — 981 of its 1,337 lines were logic — so it's the best ROI for the established "extract pure logic into tested `lib/` modules, import it back" pattern (the same approach as the Preview increment in #707). No behavior change; the logic just gains unit coverage and the component shrinks. **Editor.svelte 1,337 → 1,276.**

## New modules + paired tests (28 tests)
- **`lib/editor/history-snapshot.ts`** — `toHistorySnapshot()` + `canRestoreHistory()`: the tab-switch undo/redo restore guard, including the safety-critical **drift check** (never restore an undo stack whose doc no longer matches the buffer being mounted).
- **`lib/editor/font-size.ts`** — `clampFontSize()` + `parseStoredFontSize()` + the MIN/MAX/DEFAULT bounds: the +/- step clamping and stored-value parse.
- **`lib/editor/image-drop.ts`** — `hasImageFiles()` / `imageFilesFromTransfer()` / `imageFilesFromClipboard()`: the drag-drop + paste image-detection predicates (#455).
- **`lib/editor/frontmatter.ts`** — `findFrontmatterFoldRange()` over a minimal CM-shaped `LineDoc`, plus `docFromText()` for tests. This **de-duplicates** the frontmatter scan that was previously copied verbatim in *both* `findFrontmatterRange()` and the `foldService` (a real drift hazard) — both now delegate to one function. `docFromText` mirrors CM's offset semantics so the tested offsets match what `view.state.doc` yields.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2930 passed** (+28).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

_Increment, not a full split: this is the pure-logic slice. The remaining Editor work (and ConversationsPanel / SettingsDialog / SourcesPanel, which are markup/style-heavy) is better done behind a component-render test net (#680)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)