### PR TITLE
Component-test the approval diff UI + command palette (#680)

### DIFF
--- a/tests/renderer/components/CommandPaletteDialog.test.ts
+++ b/tests/renderer/components/CommandPaletteDialog.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component-interaction coverage for the command palette (#680, QA Q-H4).
+ *
+ * Renders the real CommandPaletteDialog and drives it the way a user does —
+ * type to filter, arrow to move, Enter / click to run, Escape to close —
+ * asserting the selected command's run() fires and the dialog closes. The
+ * fuzzy scoring (scoreCommand) runs for real; only the localStorage-backed
+ * recent list is stubbed so results are deterministic.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const { recordRecentMock } = vi.hoisted(() => ({ recordRecentMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/command-palette/recent', () => ({
+  loadRecent: () => [] as string[],
+  recordRecent: recordRecentMock,
+}));
+
+import CommandPaletteDialog from '../../../src/renderer/lib/components/CommandPaletteDialog.svelte';
+
+function makeCommands() {
+  return [
+    { id: 'settings', title: 'Open Settings', category: 'App', enabled: true, run: vi.fn() },
+    { id: 'daily', title: 'Create Daily Note', category: 'File', enabled: true, run: vi.fn() },
+    { id: 'bold', title: 'Toggle Bold', category: 'Format', enabled: false, run: vi.fn() },
+  ];
+}
+
+afterEach(() => {
+  cleanup();
+  recordRecentMock.mockReset();
+});
+
+describe('CommandPaletteDialog (#680)', () => {
+  it('lists every command (alphabetical) when the query is empty', () => {
+    const { getByText } = render(CommandPaletteDialog, { commands: makeCommands(), onClose: vi.fn() });
+    expect(getByText('Open Settings')).toBeTruthy();
+    expect(getByText('Create Daily Note')).toBeTruthy();
+    expect(getByText('Toggle Bold')).toBeTruthy();
+  });
+
+  it('typing filters to fuzzy matches', async () => {
+    const { getByRole, getByText, queryByText } = render(
+      CommandPaletteDialog, { commands: makeCommands(), onClose: vi.fn() },
+    );
+    await fireEvent.input(getByRole('textbox'), { target: { value: 'settings' } });
+    expect(getByText('Open Settings')).toBeTruthy();
+    expect(queryByText('Create Daily Note')).toBeNull();
+  });
+
+  it('Enter runs the selected command, records it as recent, and closes', async () => {
+    const commands = makeCommands();
+    const onClose = vi.fn();
+    const { container } = render(CommandPaletteDialog, { commands, onClose });
+
+    // Empty query → alphabetical: "Create Daily Note" is row 0 (selected).
+    const overlay = container.querySelector('.overlay')!;
+    await fireEvent.keyDown(overlay, { key: 'Enter' });
+
+    expect(commands.find((c) => c.id === 'daily')!.run).toHaveBeenCalledTimes(1);
+    expect(recordRecentMock).toHaveBeenCalledWith('daily');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ArrowDown then Enter runs the next command down', async () => {
+    const commands = makeCommands();
+    const { container } = render(CommandPaletteDialog, { commands, onClose: vi.fn() });
+    const overlay = container.querySelector('.overlay')!;
+
+    await fireEvent.keyDown(overlay, { key: 'ArrowDown' }); // row 0 → row 1 ("Open Settings")
+    await fireEvent.keyDown(overlay, { key: 'Enter' });
+
+    expect(commands.find((c) => c.id === 'settings')!.run).toHaveBeenCalledTimes(1);
+    expect(commands.find((c) => c.id === 'daily')!.run).not.toHaveBeenCalled();
+  });
+
+  it('clicking a result runs that command', async () => {
+    const commands = makeCommands();
+    const onClose = vi.fn();
+    const { getByText } = render(CommandPaletteDialog, { commands, onClose });
+
+    await fireEvent.click(getByText('Open Settings'));
+
+    expect(commands.find((c) => c.id === 'settings')!.run).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a disabled command does not run when clicked', async () => {
+    const commands = makeCommands();
+    const { getByText } = render(CommandPaletteDialog, { commands, onClose: vi.fn() });
+
+    await fireEvent.click(getByText('Toggle Bold'));
+
+    expect(commands.find((c) => c.id === 'bold')!.run).not.toHaveBeenCalled();
+  });
+
+  it('Escape closes without running anything', async () => {
+    const commands = makeCommands();
+    const onClose = vi.fn();
+    const { container } = render(CommandPaletteDialog, { commands, onClose });
+    const overlay = container.querySelector('.overlay')!;
+
+    await fireEvent.keyDown(overlay, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    for (const c of commands) expect(c.run).not.toHaveBeenCalled();
+  });
+
+  it('shows a no-match message when nothing scores', async () => {
+    const { getByRole, getByText } = render(
+      CommandPaletteDialog, { commands: makeCommands(), onClose: vi.fn() },
+    );
+    await fireEvent.input(getByRole('textbox'), { target: { value: 'zzzzqqq' } });
+    expect(getByText(/No commands match/)).toBeTruthy();
+  });
+});

--- a/tests/renderer/components/ProposalsPanel.test.ts
+++ b/tests/renderer/components/ProposalsPanel.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component-interaction coverage for the approval diff UI (#680, QA Q-H4).
+ *
+ * ProposalsPanel is the human-confirm step of the Trust Principle — where the
+ * user actually approves or rejects LLM-originated graph writes. Until now it
+ * was exercised only by the E2E smoke (which never opens a project), so the
+ * in-the-loop interaction was untested. These tests render the real component
+ * against a mocked `api.proposals` boundary and assert that approve / reject —
+ * by button AND by the y/n keystrokes — reach the IPC layer with the right URI.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+const { listMock, approveMock, rejectMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  approveMock: vi.fn(),
+  rejectMock: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { proposals: { list: listMock, approve: approveMock, reject: rejectMock } },
+}));
+
+import ProposalsPanel from '../../../src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte';
+
+interface Payload { kind: string; [k: string]: unknown }
+function pendingProposal(over: Record<string, unknown> = {}) {
+  return {
+    uri: 'urn:proposal:1',
+    status: 'pending',
+    operationType: 'component_creation',
+    note: 'Crystallize claim about photosynthesis',
+    proposedBy: 'llm:test',
+    proposedAt: '2026-01-01T00:00:00Z',
+    payloads: [
+      { kind: 'note', relativePath: 'notes/claim.md', content: '# Claim' },
+      { kind: 'graph-triples', turtle: '<urn:c> a thought:Claim .', affectsNodeUris: ['urn:c'] },
+    ] as Payload[],
+    ...over,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  listMock.mockReset();
+  approveMock.mockReset();
+  rejectMock.mockReset();
+});
+
+/** Render, then wait for the onMount list() to resolve into the DOM. */
+async function renderPanel() {
+  const utils = render(ProposalsPanel, { revision: 0 });
+  await utils.findByText('Crystallize claim about photosynthesis');
+  return utils;
+}
+
+describe('ProposalsPanel — approval diff UI (#680)', () => {
+  it('renders proposals from api.proposals.list with a plain-language effects summary', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    const { getByText } = await renderPanel();
+    // bundleEffectsSummary should read the note + the typed triple, not "2 triples".
+    expect(getByText(/Will create:.*1 note.*1 Claim/)).toBeTruthy();
+  });
+
+  it('selecting a proposal reveals Approve/Reject; Approve reaches IPC and shows the success banner', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    approveMock.mockResolvedValue(true);
+    const { getByText, findByText } = await renderPanel();
+
+    await fireEvent.click(getByText('Crystallize claim about photosynthesis'));
+    await fireEvent.click(getByText('Approve (y)'));
+
+    expect(approveMock).toHaveBeenCalledWith('urn:proposal:1');
+    expect(await findByText(/Approved — landed/)).toBeTruthy();
+  });
+
+  it('Reject button reaches api.proposals.reject with the proposal URI', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    rejectMock.mockResolvedValue(true);
+    const { getByText } = await renderPanel();
+
+    await fireEvent.click(getByText('Crystallize claim about photosynthesis'));
+    await fireEvent.click(getByText('Reject (n)'));
+
+    await waitFor(() => expect(rejectMock).toHaveBeenCalledWith('urn:proposal:1'));
+  });
+
+  it('the "y" keystroke approves the selected proposal (Trust keyboard path)', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    approveMock.mockResolvedValue(true);
+    const { getByText, container } = await renderPanel();
+
+    await fireEvent.click(getByText('Crystallize claim about photosynthesis'));
+    const panel = container.querySelector('.proposals-panel')!;
+    await fireEvent.keyDown(panel, { key: 'y' });
+
+    await waitFor(() => expect(approveMock).toHaveBeenCalledWith('urn:proposal:1'));
+    expect(rejectMock).not.toHaveBeenCalled();
+  });
+
+  it('the "n" keystroke rejects the selected proposal', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    rejectMock.mockResolvedValue(true);
+    const { getByText, container } = await renderPanel();
+
+    await fireEvent.click(getByText('Crystallize claim about photosynthesis'));
+    const panel = container.querySelector('.proposals-panel')!;
+    await fireEvent.keyDown(panel, { key: 'n' });
+
+    await waitFor(() => expect(rejectMock).toHaveBeenCalledWith('urn:proposal:1'));
+    expect(approveMock).not.toHaveBeenCalled();
+  });
+
+  it('a false approve result surfaces the stale/already-resolved error banner (no silent failure)', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    approveMock.mockResolvedValue(false);
+    const { getByText, findByText } = await renderPanel();
+
+    await fireEvent.click(getByText('Crystallize claim about photosynthesis'));
+    await fireEvent.click(getByText('Approve (y)'));
+
+    expect(await findByText(/Approve returned false/)).toBeTruthy();
+  });
+
+  it('clicking the Pending status tab re-queries the list filtered to pending', async () => {
+    listMock.mockResolvedValue([pendingProposal()]);
+    const { getByText } = await renderPanel();
+
+    await fireEvent.click(getByText('Pending'));
+
+    await waitFor(() => expect(listMock).toHaveBeenCalledWith('pending'));
+  });
+});


### PR DESCRIPTION
## What

Closes #680. The repo had 67 `.svelte` files but only 5 renderer tests that actually rendered a component — and critically, the **approval diff UI** (the human-confirm step where the user approves LLM-originated graph writes) was verified only by the E2E smoke, which never opens a project. The Trust Principle's in-the-loop step had **no interaction-level coverage**. This adds it.

Two `@testing-library/svelte` tests rendering the real components against mocked boundaries:

### `ProposalsPanel.test.ts` (8 tests)
Renders proposals from `api.proposals.list`, selects one, and asserts **approve/reject reach IPC with the right URI** — both via the buttons **and via the `y`/`n` keystrokes** (the Trust keyboard path). Also covers:
- the plain-language effects summary ("1 note, 1 Claim", not "2 triples"),
- the false-result error banner (approve returning `false` surfaces, no silent failure),
- the status-tab re-query (`list('pending')`).

### `CommandPaletteDialog.test.ts` (7 tests)
Type-to-filter (real `scoreCommand` fuzzy scoring runs; only the localStorage recent-list is stubbed), Arrow+Enter / click to run the selected command, disabled commands stay inert, Escape closes, no-match message. Asserts the command's `run()` + `recordRecent` + `onClose` fire.

## Why this matters

This establishes the **component-render test net** that the remaining markup-level splits of #672 (ConversationsPanel, SettingsDialog, SourcesPanel — which are template/style-heavy and can't be sliced by pure-logic extraction) should be done behind, so those splits don't change render output blind.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2945 passed** (+15).
- Test-only change — no production code touched, so the forge build / smoke is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)