### PR TITLE
Extract SourceListItem + display helpers from SourcesPanel (#672)

### DIFF
--- a/src/renderer/lib/components/SourceListItem.svelte
+++ b/src/renderer/lib/components/SourceListItem.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  /**
+   * A single row in the sources list (#672, extracted from SourcesPanel).
+   * Presentational: it renders one source's title, read-status dot, and
+   * author/year/due byline, and reports click / right-click back to the
+   * panel, which owns selection, the context menu, and all IPC.
+   */
+  import type { SourceMetadata } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
+  import {
+    formatCreators,
+    formatDueStamp,
+    isOverdue,
+    statusGlyph,
+    statusTitle,
+  } from '../sources/source-display';
+
+  interface Props {
+    source: SourceMetadata;
+    onSelect: (sourceId: string) => void;
+    onContextMenu: (e: MouseEvent, source: SourceMetadata) => void;
+  }
+
+  let { source, onSelect, onContextMenu }: Props = $props();
+</script>
+
+<button
+  class="source-item"
+  onclick={() => onSelect(source.sourceId)}
+  oncontextmenu={(e) => onContextMenu(e, source)}
+  title={source.sourceId}
+>
+  <div class="source-title">
+    {#if source.readStatus}
+      <span
+        class="status-dot status-{source.readStatus}"
+        title={statusTitle(source.readStatus)}
+        aria-label={statusTitle(source.readStatus)}
+      >{statusGlyph(source.readStatus)}</span>
+    {/if}
+    {displaySourceTitle(source)}
+  </div>
+  {#if source.creators.length > 0 || source.year || source.readDueBy}
+    {@const who = formatCreators(source.creators)}
+    <div class="source-byline">
+      {#if who}{who}{/if}{#if who && source.year} · {/if}{#if source.year}<span class="year">{source.year}</span>{/if}
+      {#if source.readDueBy}
+        {#if who || source.year} · {/if}
+        <span class="due-stamp" class:overdue={isOverdue(source.readDueBy)} title="Reading due {source.readDueBy}">
+          due {formatDueStamp(source.readDueBy)}
+        </span>
+      {/if}
+    </div>
+  {/if}
+</button>
+
+<style>
+  .source-item {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    text-align: left;
+    padding: 10px 16px;
+    background: none;
+    border: none;
+    border-top: 1px solid var(--border);
+    border-left: 2px solid transparent;
+    color: var(--text);
+    cursor: pointer;
+  }
+  .source-item:hover {
+    background: color-mix(in oklch, var(--text) 4%, transparent);
+    border-left-color: var(--accent);
+  }
+
+  .source-title {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .source-byline {
+    font-size: 11px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-top: 2px;
+  }
+  /* The year (and any other mono fragment in the byline) reads as a
+     citation locator — switch to the mono face for tabular feel. */
+  .source-byline :global(.year) {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .status-dot {
+    display: inline-block;
+    width: 1em;
+    text-align: center;
+    margin-right: 4px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1;
+    vertical-align: baseline;
+  }
+  .status-dot.status-reading { color: var(--accent); }
+  .status-dot.status-read { color: color-mix(in oklch, var(--text-muted) 90%, transparent); }
+  .status-dot.status-unread { color: var(--text-faint); }
+  .status-dot.status-skipped { color: var(--text-faint); }
+
+  .due-stamp {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+  }
+  .due-stamp.overdue {
+    color: var(--rust);
+  }
+</style>

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -6,6 +6,8 @@
   import SourcePickerDialog from './SourcePickerDialog.svelte';
   import CollectionPickerDialog from './CollectionPickerDialog.svelte';
   import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
+  import SourceListItem from './SourceListItem.svelte';
+  import { formatDueStamp } from '../sources/source-display';
   import Icon from './Icon.svelte';
 
   type QueueView = 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished';
@@ -676,61 +678,6 @@
     }
   }
 
-  function formatCreators(creators: string[]): string {
-    if (creators.length === 0) return '';
-    if (creators.length === 1) return creators[0];
-    if (creators.length === 2) return `${creators[0]} and ${creators[1]}`;
-    return `${creators[0]} et al.`;
-  }
-
-  /** Compact stamp for the source row's due-by indicator. Shows
-   *  "Jun 15" within the current year, "Jun 15 2027" otherwise. The
-   *  caller adds the leading "due " word so it can be re-styled
-   *  independently. */
-  function formatDueStamp(iso: string): string {
-    const d = new Date(`${iso}T00:00:00`);
-    if (isNaN(d.getTime())) return iso;
-    const now = new Date();
-    const sameYear = d.getFullYear() === now.getFullYear();
-    const opts: Intl.DateTimeFormatOptions = sameYear
-      ? { month: 'short', day: 'numeric' }
-      : { month: 'short', day: 'numeric', year: 'numeric' };
-    return new Intl.DateTimeFormat(undefined, opts).format(d);
-  }
-
-  /** True when the due-by date is strictly before today (local time).
-   *  We highlight overdue items in the list so the user can spot them
-   *  without opening detail. Per CLAUDE.md no-danger-styling: overdue
-   *  uses --rust (a signal color, not red). */
-  function isOverdue(iso: string | null): boolean {
-    if (!iso) return false;
-    const d = new Date(`${iso}T00:00:00`);
-    if (isNaN(d.getTime())) return false;
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return d.getTime() < today.getTime();
-  }
-
-  /** Single character glyph for the status indicator dot. Picked for
-   *  ASCII-safety; users learn the mapping from the title attribute. */
-  function statusGlyph(status: SourceMetadata['readStatus']): string {
-    switch (status) {
-      case 'reading': return '◐';
-      case 'read': return '●';
-      case 'unread': return '○';
-      case 'skipped': return '×';
-      default: return '';
-    }
-  }
-  function statusTitle(status: SourceMetadata['readStatus']): string {
-    switch (status) {
-      case 'reading': return 'Reading';
-      case 'read': return 'Read';
-      case 'unread': return 'Unread';
-      case 'skipped': return 'Skipped';
-      default: return '';
-    }
-  }
 </script>
 
 <div class="sources-panel">
@@ -852,35 +799,7 @@
     </div>
     <div class="source-list">
       {#each visible as s (s.sourceId)}
-        <button
-          class="source-item"
-          onclick={() => onSourceSelect(s.sourceId)}
-          oncontextmenu={(e) => handleContextMenu(e, s)}
-          title={s.sourceId}
-        >
-          <div class="source-title">
-            {#if s.readStatus}
-              <span
-                class="status-dot status-{s.readStatus}"
-                title={statusTitle(s.readStatus)}
-                aria-label={statusTitle(s.readStatus)}
-              >{statusGlyph(s.readStatus)}</span>
-            {/if}
-            {displaySourceTitle(s)}
-          </div>
-          {#if s.creators.length > 0 || s.year || s.readDueBy}
-            {@const who = formatCreators(s.creators)}
-            <div class="source-byline">
-              {#if who}{who}{/if}{#if who && s.year} · {/if}{#if s.year}<span class="year">{s.year}</span>{/if}
-              {#if s.readDueBy}
-                {#if who || s.year} · {/if}
-                <span class="due-stamp" class:overdue={isOverdue(s.readDueBy)} title="Reading due {s.readDueBy}">
-                  due {formatDueStamp(s.readDueBy)}
-                </span>
-              {/if}
-            </div>
-          {/if}
-        </button>
+        <SourceListItem source={s} onSelect={onSourceSelect} onContextMenu={handleContextMenu} />
       {/each}
       {#if visible.length === 0}
         <div class="empty">
@@ -1141,50 +1060,12 @@
      bibliography entry: italic display-serif title, sans+mono byline.
      The 2px accent rail still marks hover/active for parity with the
      file tree. */
-  .source-item {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    text-align: left;
-    padding: 10px 16px;
-    background: none;
-    border: none;
-    border-top: 1px solid var(--border);
-    border-left: 2px solid transparent;
-    color: var(--text);
-    cursor: pointer;
-  }
-  .source-list .source-item:first-child {
+  /* The row itself (border, title, byline, status dot, due stamp) now lives
+     in SourceListItem.svelte. Only the list-level seam stays here: the first
+     row drops its top border so it doesn't double up with the section edge.
+     Targets the child component's root via :global. */
+  .source-list :global(.source-item:first-child) {
     border-top: none;
-  }
-  .source-item:hover {
-    background: color-mix(in oklch, var(--text) 4%, transparent);
-    border-left-color: var(--accent);
-  }
-
-  .source-title {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: 13.5px;
-    color: var(--text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .source-byline {
-    font-size: 11px;
-    color: var(--text-muted);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    margin-top: 2px;
-  }
-  /* The year (and any other mono fragment in the byline) reads as a
-     citation locator — switch to the mono face for tabular feel. */
-  .source-byline :global(.year) {
-    font-family: var(--font-mono);
-    font-variant-numeric: tabular-nums;
   }
 
   /* Collections section sits above the flat source list. Visual
@@ -1287,23 +1168,6 @@
   }
   .smart-row { gap: 6px; }
 
-  /* Reading-queue status dot in the source list (#116). Just a small
-     inline mark in front of the title so the user can scan for "what's
-     reading right now" without leaving the panel. */
-  .status-dot {
-    display: inline-block;
-    width: 1em;
-    text-align: center;
-    margin-right: 4px;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    line-height: 1;
-    vertical-align: baseline;
-  }
-  .status-dot.status-reading { color: var(--accent); }
-  .status-dot.status-read { color: color-mix(in oklch, var(--text-muted) 90%, transparent); }
-  .status-dot.status-unread { color: var(--text-faint); }
-  .status-dot.status-skipped { color: var(--text-faint); }
 
   /* Reading-queue section sits BELOW Collections now, with a
      collapsible header so users who never touch the queue can fold
@@ -1495,15 +1359,4 @@
     font-weight: 600;
   }
   .due-dialog-btn.primary:hover { opacity: 0.92; }
-
-  /* Compact "due Jun 15" stamp on the source row byline. Overdue
-     items shift to --rust (signal color, not red — per CLAUDE.md). */
-  .due-stamp {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-muted);
-  }
-  .due-stamp.overdue {
-    color: var(--rust);
-  }
 </style>

--- a/src/renderer/lib/sources/source-display.ts
+++ b/src/renderer/lib/sources/source-display.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure display helpers for the sources list (#672, extracted from
+ * SourcesPanel.svelte alongside the SourceListItem split).
+ *
+ * These format a source row's byline, due-by stamp, and read-status indicator.
+ * They're pure (modulo "today" for the date helpers) so they can be unit-
+ * tested directly — which covers the render-affecting logic behind the
+ * extracted SourceListItem component. `formatDueStamp` is shared between the
+ * row and the context-menu "Set due date" label, hence its own module.
+ */
+
+import type { SourceMetadata } from '../../../shared/types';
+
+type ReadStatus = SourceMetadata['readStatus'];
+
+/** Byline author rendering: one name, "A and B", or "A et al." for 3+. */
+export function formatCreators(creators: string[]): string {
+  if (creators.length === 0) return '';
+  if (creators.length === 1) return creators[0];
+  if (creators.length === 2) return `${creators[0]} and ${creators[1]}`;
+  return `${creators[0]} et al.`;
+}
+
+/**
+ * Compact stamp for the source row's due-by indicator. Shows "Jun 15" within
+ * the current year, "Jun 15 2027" otherwise. The caller adds the leading
+ * "due " word so it can be re-styled independently. Falls back to the raw ISO
+ * string for an unparseable date.
+ */
+export function formatDueStamp(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`);
+  if (isNaN(d.getTime())) return iso;
+  const now = new Date();
+  const sameYear = d.getFullYear() === now.getFullYear();
+  const opts: Intl.DateTimeFormatOptions = sameYear
+    ? { month: 'short', day: 'numeric' }
+    : { month: 'short', day: 'numeric', year: 'numeric' };
+  return new Intl.DateTimeFormat(undefined, opts).format(d);
+}
+
+/**
+ * True when the due-by date is strictly before today (local time). Overdue
+ * items are highlighted in the list (with --rust, a signal color — not red,
+ * per CLAUDE.md's no-danger-styling rule).
+ */
+export function isOverdue(iso: string | null): boolean {
+  if (!iso) return false;
+  const d = new Date(`${iso}T00:00:00`);
+  if (isNaN(d.getTime())) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return d.getTime() < today.getTime();
+}
+
+/** Single-character glyph for the read-status dot (ASCII-safe; the mapping is
+ *  learned from the title attribute). */
+export function statusGlyph(status: ReadStatus): string {
+  switch (status) {
+    case 'reading': return '◐';
+    case 'read': return '●';
+    case 'unread': return '○';
+    case 'skipped': return '×';
+    default: return '';
+  }
+}
+
+/** Human label for the read-status dot's title/aria. */
+export function statusTitle(status: ReadStatus): string {
+  switch (status) {
+    case 'reading': return 'Reading';
+    case 'read': return 'Read';
+    case 'unread': return 'Unread';
+    case 'skipped': return 'Skipped';
+    default: return '';
+  }
+}

--- a/tests/renderer/components/SourceListItem.test.ts
+++ b/tests/renderer/components/SourceListItem.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for SourceListItem (#672) — the row extracted from
+ * SourcesPanel. Pins the extracted markup: title, read-status dot, the
+ * author/year/due byline, and the click / right-click callbacks the panel
+ * relies on. The pure formatting behind it is unit-tested in
+ * tests/renderer/source-display.test.ts.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { SourceMetadata } from '../../../src/shared/types';
+import SourceListItem from '../../../src/renderer/lib/components/SourceListItem.svelte';
+
+function source(over: Partial<SourceMetadata> = {}): SourceMetadata {
+  return {
+    sourceId: 'doi-10.1234_abc',
+    subtype: null,
+    title: 'On the Origin of Tests',
+    creators: ['Curie', 'Joliot'],
+    year: '1903',
+    publisher: null,
+    doi: '10.1234/abc',
+    uri: null,
+    abstract: null,
+    readStatus: 'reading',
+    readDueBy: null,
+    stubStatus: null,
+    ...over,
+  };
+}
+
+afterEach(cleanup);
+
+describe('SourceListItem (#672)', () => {
+  it('renders the display title, byline authors, and year', () => {
+    const { getByText } = render(SourceListItem, {
+      source: source(),
+      onSelect: vi.fn(),
+      onContextMenu: vi.fn(),
+    });
+    expect(getByText('On the Origin of Tests')).toBeTruthy();
+    expect(getByText(/Curie and Joliot/)).toBeTruthy();
+    expect(getByText('1903')).toBeTruthy();
+  });
+
+  it('renders the read-status dot with a human label', () => {
+    const { getByLabelText } = render(SourceListItem, {
+      source: source({ readStatus: 'reading' }),
+      onSelect: vi.fn(),
+      onContextMenu: vi.fn(),
+    });
+    const dot = getByLabelText('Reading');
+    expect(dot.textContent).toBe('◐');
+  });
+
+  it('omits the byline entirely when there are no creators / year / due date', () => {
+    const { container } = render(SourceListItem, {
+      source: source({ creators: [], year: null, readDueBy: null }),
+      onSelect: vi.fn(),
+      onContextMenu: vi.fn(),
+    });
+    expect(container.querySelector('.source-byline')).toBeNull();
+  });
+
+  it('shows a "due" stamp when a read-due date is set', () => {
+    const { getByText } = render(SourceListItem, {
+      source: source({ readDueBy: '2099-06-15' }),
+      onSelect: vi.fn(),
+      onContextMenu: vi.fn(),
+    });
+    expect(getByText(/due/)).toBeTruthy();
+  });
+
+  it('clicking the row reports the sourceId to onSelect', async () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(SourceListItem, {
+      source: source({ sourceId: 'doi-10.1234_abc' }),
+      onSelect,
+      onContextMenu: vi.fn(),
+    });
+    await fireEvent.click(getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith('doi-10.1234_abc');
+  });
+
+  it('right-clicking reports the event + source to onContextMenu', async () => {
+    const onContextMenu = vi.fn();
+    const src = source();
+    const { getByRole } = render(SourceListItem, {
+      source: src,
+      onSelect: vi.fn(),
+      onContextMenu,
+    });
+    await fireEvent.contextMenu(getByRole('button'));
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+    expect(onContextMenu.mock.calls[0][1]).toBe(src);
+  });
+
+  it('falls back to a readable title when meta.title is null (never the raw id)', () => {
+    const { getByText, queryByText } = render(SourceListItem, {
+      source: source({ title: null, doi: '10.1234/abc', uri: null }),
+      onSelect: vi.fn(),
+      onContextMenu: vi.fn(),
+    });
+    expect(getByText('DOI 10.1234/abc')).toBeTruthy();
+    expect(queryByText(/doi-10\.1234_abc/)).toBeNull();
+  });
+});

--- a/tests/renderer/source-display.test.ts
+++ b/tests/renderer/source-display.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCreators,
+  formatDueStamp,
+  isOverdue,
+  statusGlyph,
+  statusTitle,
+} from '../../src/renderer/lib/sources/source-display';
+
+// Pure display helpers behind the SourceListItem split (#672). The date
+// helpers depend on "today", so those cases use offsets from the current date
+// rather than hard-coded strings.
+
+const isoDaysFromNow = (days: number): string => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+};
+
+describe('formatCreators', () => {
+  it('renders one, two, and many authors', () => {
+    expect(formatCreators([])).toBe('');
+    expect(formatCreators(['Curie'])).toBe('Curie');
+    expect(formatCreators(['Curie', 'Joliot'])).toBe('Curie and Joliot');
+    expect(formatCreators(['Curie', 'Joliot', 'Bohr'])).toBe('Curie et al.');
+  });
+});
+
+describe('statusGlyph / statusTitle', () => {
+  it('maps each read status to a glyph + label', () => {
+    expect(statusGlyph('reading')).toBe('◐');
+    expect(statusGlyph('read')).toBe('●');
+    expect(statusGlyph('unread')).toBe('○');
+    expect(statusGlyph('skipped')).toBe('×');
+    expect(statusTitle('reading')).toBe('Reading');
+    expect(statusTitle('skipped')).toBe('Skipped');
+  });
+
+  it('renders nothing for a null/absent status', () => {
+    expect(statusGlyph(null)).toBe('');
+    expect(statusTitle(null)).toBe('');
+  });
+});
+
+describe('isOverdue', () => {
+  it('is false for null / unparseable', () => {
+    expect(isOverdue(null)).toBe(false);
+    expect(isOverdue('not-a-date')).toBe(false);
+  });
+
+  it('is true strictly before today, false for today and the future', () => {
+    expect(isOverdue(isoDaysFromNow(-1))).toBe(true);
+    expect(isOverdue(isoDaysFromNow(0))).toBe(false); // due today is not overdue
+    expect(isOverdue(isoDaysFromNow(3))).toBe(false);
+  });
+});
+
+describe('formatDueStamp', () => {
+  it('falls back to the raw string for an unparseable date', () => {
+    expect(formatDueStamp('garbage')).toBe('garbage');
+  });
+
+  it('omits the year for an in-current-year date, includes it otherwise', () => {
+    const thisYear = new Date().getFullYear();
+    const inYear = formatDueStamp(`${thisYear}-06-15`);
+    expect(inYear).not.toMatch(String(thisYear)); // "Jun 15", no year
+    const otherYear = formatDueStamp(`${thisYear + 2}-06-15`);
+    expect(otherYear).toMatch(String(thisYear + 2)); // "Jun 15 2027"
+  });
+});


### PR DESCRIPTION
## What

The **first markup-level split** of #672 — done deliberately behind the component-test net just landed in #680. The flat source-list row (title, read-status dot, author/year/due byline) becomes a presentational **`SourceListItem.svelte`** child; SourcesPanel renders one per visible source and keeps owning selection, the context menu, and all IPC. **SourcesPanel 1,509 → 1,362.**

- **`lib/sources/source-display.ts`** — the row's pure formatters (`formatCreators`, `formatDueStamp`, `isOverdue`, `statusGlyph`, `statusTitle`), now unit-tested. `formatDueStamp` is shared — the context-menu "Set due date" label still uses it — so SourcesPanel imports it from here.
- **`SourceListItem.svelte`** — the extracted row markup + its scoped styles. The list-level first-row border seam stays in SourcesPanel, retargeted at the child's root via `.source-list :global(.source-item:first-child)`.

## How I kept it behavior-preserving
The markup + styles moved verbatim into the child (same classes, same CSS), and the one cross-boundary rule (first-row border) is preserved with a `:global` selector. A new **render test pins the extracted markup** so the before/after is asserted, not assumed.

## Tests (14)
- **`source-display.test.ts`** — the pure formatters (date helpers use offsets from *today*, so they're not calendar-fragile).
- **`components/SourceListItem.test.ts`** — renders the row and pins: title / byline / status dot / due stamp, the readable-title fallback (never the raw source id), and the `click → onSelect(sourceId)` / `contextmenu → onContextMenu(e, source)` callbacks SourcesPanel relies on.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2959 passed** (+14).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)