### PR TITLE
Extract MessageCitations from ConversationsPanel (#672)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -30,7 +30,9 @@
   import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
   import type { ConversationMessage, Citation } from '../../../shared/types';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
-  import { insertCitationMarker, noteBasename } from '../conversations/cite-from-conversation';
+  import { insertCitationMarker } from '../conversations/cite-from-conversation';
+  import { type CiteStatus } from '../conversations/citations';
+  import MessageCitations from './MessageCitations.svelte';
   import { getSlashCommands } from '../tools/tool-registry';
   import { slashQueryFromComposer, filterSlashCommands } from '../conversations/slash-commands';
 
@@ -139,7 +141,6 @@
   // note that anchors the conversation. Per-citation status keyed by
   // `${tabId}:${messageIndex}:${citationIndex}` so each footnote tracks its
   // own running / done / error state independently across tabs.
-  type CiteStatus = { phase: 'running' | 'done' } | { phase: 'error'; message: string };
   let citeState = $state<Record<string, CiteStatus>>({});
 
   function citeKey(tab: TabT, msgIndex: number, ci: number): string {
@@ -518,10 +519,6 @@
     return 'id';
   }
 
-  function hostOf(url: string): string {
-    try { return new URL(url).host.replace(/^www\./, ''); } catch { return url; }
-  }
-
   // ── Card anchoring helpers ───────────────────────────────────────────
   // Each draft / sourceDraft / sourceDraftResult carries an
   // `afterMessageIndex` captured when it arrived (the slot the streaming
@@ -725,32 +722,13 @@
               {#if msg.role === 'assistant'}
                 <div class="msg-content">{@html md.render(msg.content)}</div>
                 {#if msg.citations && msg.citations.length > 0}
-                  {@const target = citeTargetPath(tab)}
-                  <ol class="citations">
-                    {#each msg.citations as cite, ci}
-                      {@const st = citeState[citeKey(tab, msgIndex, ci)]}
-                      <li>
-                        <button type="button" class="citation-link" onclick={() => api.shell.openExternal(cite.url)} title={cite.citedText}>
-                          <span class="citation-num">[{ci + 1}]</span>
-                          <span class="citation-title">{cite.title ?? hostOf(cite.url)}</span>
-                          <span class="citation-host">{hostOf(cite.url)}</span>
-                        </button>
-                        {#if st?.phase === 'done'}
-                          <span class="cite-action done" title="Filed as a source and cited from this note">✓ cited</span>
-                        {:else if st?.phase === 'error'}
-                          <button type="button" class="cite-action error" title={st.message} onclick={() => handleCite(tab, msgIndex, ci, cite)}>retry</button>
-                        {:else}
-                          <button
-                            type="button"
-                            class="cite-action"
-                            disabled={!target || st?.phase === 'running'}
-                            title={target ? `Ingest as a source and cite from ${noteBasename(target)}` : 'No note to cite into — open one in the editor'}
-                            onclick={() => handleCite(tab, msgIndex, ci, cite)}
-                          >{st?.phase === 'running' ? 'citing…' : 'cite'}</button>
-                        {/if}
-                      </li>
-                    {/each}
-                  </ol>
+                  <MessageCitations
+                    citations={msg.citations}
+                    targetPath={citeTargetPath(tab)}
+                    citeStateFor={(ci) => citeState[citeKey(tab, msgIndex, ci)]}
+                    onOpenExternal={(url) => api.shell.openExternal(url)}
+                    onCite={(ci, cite) => handleCite(tab, msgIndex, ci, cite)}
+                  />
                 {/if}
               {:else}
                 <div class="msg-content">{msg.content}</div>
@@ -1598,48 +1576,6 @@
     40%          { opacity: 1;    transform: scale(1.1); }
   }
 
-  .citations {
-    list-style: none;
-    margin: 8px 0 4px 0;
-    padding: 6px 10px;
-    border-left: 2px solid var(--border);
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-  .citation-link {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-    flex: 1;
-    min-width: 0;
-    padding: 2px 0;
-    border: none;
-    background: none;
-    color: var(--text);
-    font-size: 11px;
-    text-align: left;
-    cursor: pointer;
-  }
-  .citation-link:hover .citation-title { text-decoration: underline; }
-  .citation-num { color: var(--text-muted); flex-shrink: 0; font-variant-numeric: tabular-nums; }
-  .citation-title { color: var(--accent); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .citation-host { color: var(--text-muted); font-size: 10px; flex-shrink: 0; margin-left: auto; }
-  .citations li { display: flex; align-items: baseline; gap: 8px; }
-  .cite-action {
-    flex-shrink: 0;
-    border: none;
-    background: none;
-    padding: 2px 4px;
-    font-size: 10px;
-    color: var(--text-muted);
-    cursor: pointer;
-    border-radius: 3px;
-  }
-  .cite-action:hover:not(:disabled) { color: var(--accent); background: var(--bg-button); }
-  .cite-action:disabled { opacity: 0.4; cursor: default; }
-  .cite-action.done { color: var(--accent); cursor: default; }
-  .cite-action.error { color: var(--text); }
 
   .ask-user-card {
     margin-top: 4px;

--- a/src/renderer/lib/components/MessageCitations.svelte
+++ b/src/renderer/lib/components/MessageCitations.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  /**
+   * The numbered citation list under an assistant message (#672, extracted
+   * from ConversationsPanel). Presentational: it renders each citation as an
+   * external link plus a "cite" action whose label tracks the per-citation
+   * progress the panel hands in. The panel owns the cite state and the ingest
+   * orchestration; this child only reports clicks back.
+   */
+  import type { Citation } from '../../../shared/types';
+  import { hostOf, type CiteStatus } from '../conversations/citations';
+  import { noteBasename } from '../conversations/cite-from-conversation';
+
+  interface Props {
+    citations: Citation[];
+    /** Note the citation would be filed into, or null when none is open. */
+    targetPath: string | null;
+    /** Per-citation cite progress, by index within this message. */
+    citeStateFor: (ci: number) => CiteStatus | undefined;
+    onOpenExternal: (url: string) => void;
+    onCite: (ci: number, cite: Citation) => void;
+  }
+
+  let { citations, targetPath, citeStateFor, onOpenExternal, onCite }: Props = $props();
+</script>
+
+<ol class="citations">
+  {#each citations as cite, ci}
+    {@const st = citeStateFor(ci)}
+    <li>
+      <button type="button" class="citation-link" onclick={() => onOpenExternal(cite.url)} title={cite.citedText}>
+        <span class="citation-num">[{ci + 1}]</span>
+        <span class="citation-title">{cite.title ?? hostOf(cite.url)}</span>
+        <span class="citation-host">{hostOf(cite.url)}</span>
+      </button>
+      {#if st?.phase === 'done'}
+        <span class="cite-action done" title="Filed as a source and cited from this note">✓ cited</span>
+      {:else if st?.phase === 'error'}
+        <button type="button" class="cite-action error" title={st.message} onclick={() => onCite(ci, cite)}>retry</button>
+      {:else}
+        <button
+          type="button"
+          class="cite-action"
+          disabled={!targetPath || st?.phase === 'running'}
+          title={targetPath ? `Ingest as a source and cite from ${noteBasename(targetPath)}` : 'No note to cite into — open one in the editor'}
+          onclick={() => onCite(ci, cite)}
+        >{st?.phase === 'running' ? 'citing…' : 'cite'}</button>
+      {/if}
+    </li>
+  {/each}
+</ol>
+
+<style>
+  .citations {
+    list-style: none;
+    margin: 8px 0 4px 0;
+    padding: 6px 10px;
+    border-left: 2px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .citation-link {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    padding: 2px 0;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 11px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .citation-link:hover .citation-title { text-decoration: underline; }
+  .citation-num { color: var(--text-muted); flex-shrink: 0; font-variant-numeric: tabular-nums; }
+  .citation-title { color: var(--accent); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .citation-host { color: var(--text-muted); font-size: 10px; flex-shrink: 0; margin-left: auto; }
+  .citations li { display: flex; align-items: baseline; gap: 8px; }
+  .cite-action {
+    flex-shrink: 0;
+    border: none;
+    background: none;
+    padding: 2px 4px;
+    font-size: 10px;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 3px;
+  }
+  .cite-action:hover:not(:disabled) { color: var(--accent); background: var(--bg-button); }
+  .cite-action:disabled { opacity: 0.4; cursor: default; }
+  .cite-action.done { color: var(--accent); cursor: default; }
+  .cite-action.error { color: var(--text); }
+</style>

--- a/src/renderer/lib/conversations/citations.ts
+++ b/src/renderer/lib/conversations/citations.ts
@@ -1,0 +1,23 @@
+/**
+ * Citation display helpers for the conversation panel (#672, extracted from
+ * ConversationsPanel alongside the MessageCitations split).
+ */
+
+/** Per-citation "cite into note" progress, keyed in the panel by message +
+ *  citation index. Shared by the panel (which owns the state) and the
+ *  MessageCitations child (which renders it). */
+export type CiteStatus =
+  | { phase: 'running' | 'done' }
+  | { phase: 'error'; message: string };
+
+/**
+ * Compact host label for a citation URL — scheme + leading `www.` stripped.
+ * Falls back to the raw string for anything that doesn't parse as a URL.
+ */
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).host.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}

--- a/tests/renderer/components/MessageCitations.test.ts
+++ b/tests/renderer/components/MessageCitations.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for MessageCitations (#672) — the citation list extracted
+ * from ConversationsPanel. Pins the markup (numbered external links + host)
+ * and the cite-action state machine: disabled with no target, "citing…" while
+ * running, "✓ cited" when done, "retry" on error — and the onCite /
+ * onOpenExternal callbacks the panel relies on.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { Citation } from '../../../src/shared/types';
+import type { CiteStatus } from '../../../src/renderer/lib/conversations/citations';
+import MessageCitations from '../../../src/renderer/lib/components/MessageCitations.svelte';
+
+const cites: Citation[] = [
+  { url: 'https://www.nature.com/articles/x', title: 'A Nature paper', citedText: 'quoted bit' },
+  { url: 'https://example.org/blog', title: null, citedText: null },
+];
+
+function renderList(over: {
+  targetPath?: string | null;
+  state?: Record<number, CiteStatus>;
+  onCite?: (ci: number, c: Citation) => void;
+  onOpenExternal?: (url: string) => void;
+} = {}) {
+  const state = over.state ?? {};
+  return render(MessageCitations, {
+    citations: cites,
+    targetPath: 'targetPath' in over ? over.targetPath! : 'notes/active.md',
+    citeStateFor: (ci: number) => state[ci],
+    onOpenExternal: over.onOpenExternal ?? vi.fn(),
+    onCite: over.onCite ?? vi.fn(),
+  });
+}
+
+afterEach(cleanup);
+
+describe('MessageCitations (#672)', () => {
+  it('renders numbered citations with title (or host fallback) and host label', () => {
+    const { getByText } = renderList();
+    expect(getByText('[1]')).toBeTruthy();
+    expect(getByText('A Nature paper')).toBeTruthy();
+    // Second citation has no title → falls back to the host.
+    expect(getByText('[2]')).toBeTruthy();
+    // host label appears for both (nature.com once as host; example.org as both title-fallback and host)
+    expect(getByText('nature.com')).toBeTruthy();
+  });
+
+  it('clicking a citation link opens it externally', async () => {
+    const onOpenExternal = vi.fn();
+    const { getAllByRole } = renderList({ onOpenExternal });
+    // The first button in each <li> is the citation link.
+    await fireEvent.click(getAllByRole('button')[0]);
+    expect(onOpenExternal).toHaveBeenCalledWith('https://www.nature.com/articles/x');
+  });
+
+  it('the cite action is enabled with a target and reports onCite with index + citation', async () => {
+    const onCite = vi.fn();
+    const { getAllByText } = renderList({ targetPath: 'notes/active.md', onCite });
+    await fireEvent.click(getAllByText('cite')[0]);
+    expect(onCite).toHaveBeenCalledWith(0, cites[0]);
+  });
+
+  it('the cite action is disabled when there is no target note', () => {
+    const { getAllByText } = renderList({ targetPath: null });
+    const buttons = getAllByText('cite').map((el) => el.closest('button')!);
+    for (const b of buttons) expect(b.disabled).toBe(true);
+  });
+
+  it('shows "citing…" while running and "✓ cited" when done', () => {
+    const { getByText, getAllByText } = renderList({
+      state: { 0: { phase: 'running' }, 1: { phase: 'done' } },
+    });
+    expect(getAllByText('citing…').length).toBeGreaterThan(0);
+    expect(getByText('✓ cited')).toBeTruthy();
+  });
+
+  it('shows a "retry" action carrying the error message, and retry re-fires onCite', async () => {
+    const onCite = vi.fn();
+    const { getByText, getByTitle } = renderList({
+      state: { 0: { phase: 'error', message: 'ingest failed: 500' } },
+      onCite,
+    });
+    expect(getByTitle('ingest failed: 500')).toBeTruthy();
+    await fireEvent.click(getByText('retry'));
+    expect(onCite).toHaveBeenCalledWith(0, cites[0]);
+  });
+});

--- a/tests/renderer/conversation-citations.test.ts
+++ b/tests/renderer/conversation-citations.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { hostOf } from '../../src/renderer/lib/conversations/citations';
+
+describe('hostOf', () => {
+  it('returns the bare host, stripping scheme and www.', () => {
+    expect(hostOf('https://www.nature.com/articles/x')).toBe('nature.com');
+    expect(hostOf('http://example.org/page?q=1')).toBe('example.org');
+    expect(hostOf('https://sub.domain.io')).toBe('sub.domain.io');
+  });
+
+  it('falls back to the raw string for an unparseable URL', () => {
+    expect(hostOf('not a url')).toBe('not a url');
+    expect(hostOf('')).toBe('');
+  });
+});


### PR DESCRIPTION
## What

Continues the markup-level splits of #672, behind the component-test net from #680. The numbered **citation list** under an assistant message — external links plus the "cite into note" action and its running/done/error states — becomes a presentational **`MessageCitations.svelte`** child. ConversationsPanel keeps the cite state and ingest orchestration and passes per-citation progress in via a closure. **ConversationsPanel 2,232 → 2,168.**

- **`conversations/citations.ts`** — the shared `CiteStatus` type + the pure `hostOf()` URL→host formatter (now unit-tested), used by the child.
- **`MessageCitations.svelte`** — the extracted citation markup + its scoped styles (moved verbatim).

## How I kept it behavior-preserving
Markup + styles moved verbatim. The parent's `citeState` (keyed by message + citation index) stays in the panel; the child receives a `citeStateFor(ci)` closure and reports `onCite(ci, cite)` / `onOpenExternal(url)` back — so the panel still owns all state and IPC. A render test pins the extracted UI.

## Tests (8)
- **`conversation-citations.test.ts`** — `hostOf` (scheme/`www.` stripping, raw fallback).
- **`components/MessageCitations.test.ts`** — renders the list and pins the cite-action **state machine**: enabled-with-target → `onCite(index, citation)`, disabled when no note is open, `citing…` / `✓ cited` / `retry` (the retry button carrying the error message), and the external-open callback.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2967 passed** (+8).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

_Increment, not the whole panel: the citation list is the cleanest self-contained child. The draft-approval cards (6 variants sharing the `.draft-card` shell) and the composer/slash-menu are the next cohesive extractions, each its own PR behind the same test pattern._

🤖 Generated with [Claude Code](https://claude.com/claude-code)