### PR TITLE
Extract a shared DraftCard shell from ConversationsPanel (#672)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -33,6 +33,7 @@
   import { insertCitationMarker } from '../conversations/cite-from-conversation';
   import { type CiteStatus } from '../conversations/citations';
   import MessageCitations from './MessageCitations.svelte';
+  import DraftCard from './DraftCard.svelte';
   import { getSlashCommands } from '../tools/tool-registry';
   import { slashQueryFromComposer, filterSlashCommands } from '../conversations/slash-commands';
 
@@ -738,11 +739,13 @@
         {/snippet}
 
         {#snippet noteDraftCard(draft: ConversationDraft)}
-          <div class="draft-card">
-            <div class="draft-summary">
-              <strong>{draft.payloads.length} note{draft.payloads.length === 1 ? '' : 's'}</strong>
-              <span class="draft-note">{draft.note}</span>
-            </div>
+          <DraftCard
+            headline={`${draft.payloads.length} note${draft.payloads.length === 1 ? '' : 's'}`}
+            note={draft.note}
+            approveLabel="Approve & file"
+            onApprove={() => handleApprove(tab.id, draft)}
+            onDiscard={() => handleDiscard(tab.id, draft.draftId)}
+          >
             <ul class="draft-paths">
               {#each draft.payloads as p}
                 {@const key = draft.draftId + ':' + p.relativePath}
@@ -757,19 +760,17 @@
                 </li>
               {/each}
             </ul>
-            <div class="draft-actions">
-              <button type="button" class="draft-btn primary" onclick={() => handleApprove(tab.id, draft)}>Approve &amp; file</button>
-              <button type="button" class="draft-btn" onclick={() => handleDiscard(tab.id, draft.draftId)}>Discard</button>
-            </div>
-          </div>
+          </DraftCard>
         {/snippet}
 
         {#snippet sourceDraftCardBlock(draft: ConversationSourceDraft)}
-          <div class="draft-card">
-            <div class="draft-summary">
-              <strong>📚 {draft.sources.length} source{draft.sources.length === 1 ? '' : 's'}</strong>
-              <span class="draft-note">{draft.note}</span>
-            </div>
+          <DraftCard
+            headline={`📚 ${draft.sources.length} source${draft.sources.length === 1 ? '' : 's'}`}
+            note={draft.note}
+            approveLabel="Approve & ingest"
+            onApprove={() => handleApproveSource(tab.id, draft)}
+            onDiscard={() => handleDiscardSource(tab.id, draft.draftId)}
+          >
             <ul class="source-list">
               {#each draft.sources as s, si (si)}
                 <li>
@@ -778,11 +779,7 @@
                 </li>
               {/each}
             </ul>
-            <div class="draft-actions">
-              <button type="button" class="draft-btn primary" onclick={() => handleApproveSource(tab.id, draft)}>Approve &amp; ingest</button>
-              <button type="button" class="draft-btn" onclick={() => handleDiscardSource(tab.id, draft.draftId)}>Discard</button>
-            </div>
-          </div>
+          </DraftCard>
         {/snippet}
 
         {#snippet sourceResultLine(_draftId: string, outcomes: SourceIngestOutcome[])}
@@ -841,11 +838,13 @@
                instead of a flat list. Each value renders with its key
                so the user can eyeball the diff without clicking
                through to the file. -->
-          <div class="draft-card">
-            <div class="draft-summary">
-              <strong>🔑 {draft.updates.length} note{draft.updates.length === 1 ? '' : 's'}</strong>
-              <span class="draft-note">{draft.note}</span>
-            </div>
+          <DraftCard
+            headline={`🔑 ${draft.updates.length} note${draft.updates.length === 1 ? '' : 's'}`}
+            note={draft.note}
+            approveLabel="Approve & apply"
+            onApprove={() => handleApproveProperty(tab.id, draft)}
+            onDiscard={() => handleDiscardProperty(tab.id, draft.draftId)}
+          >
             <ul class="property-update-list">
               {#each draft.updates as u, ui (ui)}
                 <li class="property-update">
@@ -861,22 +860,20 @@
                 </li>
               {/each}
             </ul>
-            <div class="draft-actions">
-              <button type="button" class="draft-btn primary" onclick={() => handleApproveProperty(tab.id, draft)}>Approve &amp; apply</button>
-              <button type="button" class="draft-btn" onclick={() => handleDiscardProperty(tab.id, draft.draftId)}>Discard</button>
-            </div>
-          </div>
+          </DraftCard>
         {/snippet}
 
         {#snippet sourcePropertyDraftCardBlock(draft: ConversationSourcePropertyDraft)}
           <!-- propose_source_properties review card (#103). Shows the proposed
                abstract / TL;DR for one source; Approve upserts dc:abstract /
                thought:tldr into its meta.ttl. -->
-          <div class="draft-card">
-            <div class="draft-summary">
-              <strong>📄 Source summary</strong>
-              <span class="draft-note">{draft.note}</span>
-            </div>
+          <DraftCard
+            headline="📄 Source summary"
+            note={draft.note}
+            approveLabel="Approve & apply"
+            onApprove={() => handleApproveSourceProperty(tab.id, draft)}
+            onDiscard={() => handleDiscardSourceProperty(tab.id, draft.draftId)}
+          >
             <div class="property-update-path">{draft.sourceId}</div>
             {#if draft.abstract}
               <div class="source-prop-block">
@@ -890,11 +887,7 @@
                 <div class="source-prop-text">{draft.tldr}</div>
               </div>
             {/if}
-            <div class="draft-actions">
-              <button type="button" class="draft-btn primary" onclick={() => handleApproveSourceProperty(tab.id, draft)}>Approve &amp; apply</button>
-              <button type="button" class="draft-btn" onclick={() => handleDiscardSourceProperty(tab.id, draft.draftId)}>Discard</button>
-            </div>
-          </div>
+          </DraftCard>
         {/snippet}
 
         {#snippet sourcePropertyResultLine(_draftId: string, outcome: SourcePropertyOutcome)}
@@ -914,11 +907,13 @@
           <!-- propose_claims review card (#104). Each claim shows its kind,
                confidence, and the supporting quote; Approve files claim notes +
                excerpt nodes through the approval engine. -->
-          <div class="draft-card">
-            <div class="draft-summary">
-              <strong>🧩 {draft.claims.length} claim{draft.claims.length === 1 ? '' : 's'}</strong>
-              <span class="draft-note">{draft.note}</span>
-            </div>
+          <DraftCard
+            headline={`🧩 ${draft.claims.length} claim${draft.claims.length === 1 ? '' : 's'}`}
+            note={draft.note}
+            approveLabel="Approve & file"
+            onApprove={() => handleApproveClaims(tab.id, draft)}
+            onDiscard={() => handleDiscardClaims(tab.id, draft.draftId)}
+          >
             <ul class="claims-list">
               {#each draft.claims as c, ci (ci)}
                 <li class="claim-item">
@@ -932,11 +927,7 @@
                 </li>
               {/each}
             </ul>
-            <div class="draft-actions">
-              <button type="button" class="draft-btn primary" onclick={() => handleApproveClaims(tab.id, draft)}>Approve &amp; file</button>
-              <button type="button" class="draft-btn" onclick={() => handleDiscardClaims(tab.id, draft.draftId)}>Discard</button>
-            </div>
-          </div>
+          </DraftCard>
         {/snippet}
 
         {#snippet claimsResultLine(_draftId: string, outcome: ClaimsOutcome)}
@@ -1633,6 +1624,10 @@
   /* Proposal / draft card (§9.2) — accent-tinted bordered card so a
      proposal pops out of the message stream as something the user is
      about to decide on. Uses oklch color-mix so it tracks palette swaps. */
+  /* The five simple draft cards now render via DraftCard.svelte (which carries
+     its own copy of this chrome). These rules remain only for the still-inline
+     compute card (.draft-card.compute-card + its .draft-note / .draft-actions /
+     .draft-btn); they go away when the compute card is extracted too. */
   .draft-card {
     border: 1px solid color-mix(in oklch, var(--accent) 28%, transparent);
     border-radius: 8px;
@@ -1642,7 +1637,6 @@
     flex-direction: column;
     gap: 8px;
   }
-  .draft-summary { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
   .draft-note { color: var(--text-muted); font-size: 12px; }
   .draft-paths { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
   .draft-path-btn {

--- a/src/renderer/lib/components/DraftCard.svelte
+++ b/src/renderer/lib/components/DraftCard.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  /**
+   * Shared chrome for a conversation draft-approval card (#672, extracted from
+   * ConversationsPanel). The five simple draft cards (note / source / property /
+   * source-property / claims) all share this shell — a summary headline + note,
+   * a card-specific body, and an Approve / Discard action row. Each call site
+   * passes its own body as children and wires the two callbacks; the panel
+   * keeps owning the drafts and the approval orchestration.
+   *
+   * (The richer compute card has mid-card actions + output and stays inline in
+   * ConversationsPanel for now, so the `.draft-*` chrome is briefly defined in
+   * both places — consolidated once the compute card is extracted too.)
+   */
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    /** Bold summary headline, e.g. "📚 2 sources" (emoji included by caller). */
+    headline: string;
+    /** The draft's one-line rationale/note. */
+    note: string;
+    /** Primary button label, e.g. "Approve & file" / "Approve & ingest". */
+    approveLabel: string;
+    onApprove: () => void;
+    onDiscard: () => void;
+    /** Card-specific body (the payload list / diff / claims, etc.). */
+    children: Snippet;
+  }
+
+  let { headline, note, approveLabel, onApprove, onDiscard, children }: Props = $props();
+</script>
+
+<div class="draft-card">
+  <div class="draft-summary">
+    <strong>{headline}</strong>
+    <span class="draft-note">{note}</span>
+  </div>
+  {@render children()}
+  <div class="draft-actions">
+    <button type="button" class="draft-btn primary" onclick={onApprove}>{approveLabel}</button>
+    <button type="button" class="draft-btn" onclick={onDiscard}>Discard</button>
+  </div>
+</div>
+
+<style>
+  .draft-card {
+    border: 1px solid color-mix(in oklch, var(--accent) 28%, transparent);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: color-mix(in oklch, var(--accent) 5%, var(--bg));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .draft-summary { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .draft-note { color: var(--text-muted); font-size: 12px; }
+  .draft-actions { display: flex; gap: 6px; justify-content: flex-end; }
+  .draft-btn {
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: none;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .draft-btn:hover:not(:disabled) { background: var(--bg, var(--bg-sidebar)); }
+  .draft-btn.primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+  /* Primary buttons set `color: var(--bg)` for dark-text-on-accent. The shared
+     `.draft-btn:hover` rule sets background to var(--bg), which on a primary
+     button would collapse text and background to the same color — keep the
+     accent background on hover and just dim. */
+  .draft-btn.primary:hover:not(:disabled) {
+    background: var(--accent);
+    opacity: 0.9;
+  }
+  .draft-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+</style>

--- a/tests/renderer/components/DraftCard.test.ts
+++ b/tests/renderer/components/DraftCard.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for DraftCard (#672) — the shared shell behind the five
+ * simple conversation draft-approval cards (note / source / property /
+ * source-property / claims). Pins the chrome and the Trust action row: the
+ * headline + note render, the card body is projected, and the Approve / Discard
+ * buttons report back to the panel.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import DraftCard from '../../../src/renderer/lib/components/DraftCard.svelte';
+
+const body = createRawSnippet(() => ({
+  render: () => '<div data-testid="card-body">body content</div>',
+}));
+
+function renderCard(over: { onApprove?: () => void; onDiscard?: () => void; approveLabel?: string } = {}) {
+  return render(DraftCard, {
+    headline: '📚 2 sources',
+    note: 'Found two papers to file',
+    approveLabel: over.approveLabel ?? 'Approve & ingest',
+    onApprove: over.onApprove ?? vi.fn(),
+    onDiscard: over.onDiscard ?? vi.fn(),
+    children: body,
+  });
+}
+
+afterEach(cleanup);
+
+describe('DraftCard (#672)', () => {
+  it('renders the headline, note, and the projected body', () => {
+    const { getByText, getByTestId } = renderCard();
+    expect(getByText('📚 2 sources')).toBeTruthy();
+    expect(getByText('Found two papers to file')).toBeTruthy();
+    expect(getByTestId('card-body').textContent).toBe('body content');
+  });
+
+  it('uses the caller-supplied approve label', () => {
+    const { getByText } = renderCard({ approveLabel: 'Approve & file' });
+    expect(getByText('Approve & file')).toBeTruthy();
+  });
+
+  it('Approve fires onApprove', async () => {
+    const onApprove = vi.fn();
+    const { getByText } = renderCard({ onApprove, approveLabel: 'Approve & apply' });
+    await fireEvent.click(getByText('Approve & apply'));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it('Discard fires onDiscard', async () => {
+    const onDiscard = vi.fn();
+    const { getByText } = renderCard({ onDiscard });
+    await fireEvent.click(getByText('Discard'));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Continues #672 behind the component-test net (#680). The five **simple** conversation draft-approval cards — note / source / property / source-property / claims — each hand-rolled the *same* chrome: a summary headline + note, a card-specific body, and an **Approve / Discard** action row. That's the Trust human-confirm step for conversation drafts, duplicated five ways (markup **and** CSS).

Pulled the chrome into one **`DraftCard.svelte`** shell. Each card now passes its `headline`, `approveLabel`, the two callbacks, and its distinct body (as children) — keeping only the part that differs.

## Honest note on impact
This is a **de-duplication**, not a line-count win: ConversationsPanel barely shrinks (2,168 → 2,162) because the per-card prop lines replace the removed chrome roughly 1:1. The value is that the summary + action-row chrome (and its CSS) now lives in **one** place instead of five, and that shared shell is unit-tested.

The panel still owns the drafts and the approval orchestration — `DraftCard` is pure presentation.

## Compute card
The richer compute card (mid-card actions, edit mode, output rendering) doesn't fit the simple shell, so it **stays inline** for now. Its `.draft-*` chrome is briefly defined in both places (commented in the parent) — to be consolidated when the compute card is extracted as its own follow-up.

## Tests (4)
`components/DraftCard.test.ts` renders the shell and pins the headline / note / projected body and the `Approve → onApprove` / `Discard → onDiscard` actions (body passed via `createRawSnippet`).

## Verification
- `pnpm lint` — **0 errors** (svelte-check confirms no orphaned CSS / scoping issues).
- `pnpm test` — **2971 passed** (+4).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)