### PR TITLE
Extract ComputeDraftCard from ConversationsPanel (#672)

### DIFF
--- a/src/renderer/lib/components/ComputeDraftCard.svelte
+++ b/src/renderer/lib/components/ComputeDraftCard.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  /**
+   * The propose_compute review card (#245, extracted from ConversationsPanel
+   * for #672). Shows the proposed cell — language pill, rationale, safety
+   * flags, code (with an inline editor), Run / Edit / Insert / Discard actions,
+   * and the run output (text / json / table / image / html).
+   *
+   * The card owns its ephemeral UI state — edit buffer, edit mode, and the
+   * "risky → click Run twice" acknowledgement — since those are per-card view
+   * concerns. The panel keeps the run state (running / result / insertedAt,
+   * which live in the conversation store) and the actions that touch the store
+   * (Run / Insert / Discard) and the editor (open-inserted), passed in as
+   * callbacks. So the Trust boundary is unchanged: this card only proposes;
+   * the store/approval path still does the work.
+   */
+  import type { ConversationComputeDraft } from '../../../shared/conversation-compute-drafts';
+  import type { CellOutput, CellResult } from '../../../shared/compute/types';
+  import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
+
+  interface RunState {
+    running: boolean;
+    result: CellResult | null;
+    insertedAt: string | null;
+  }
+
+  interface Props {
+    draft: ConversationComputeDraft;
+    /** Run state from the conversation store, or undefined before first Run. */
+    runState: RunState | undefined;
+    /** edited === undefined when the cell was never edited (run the original). */
+    onRun: (draft: ConversationComputeDraft, edited: string | undefined) => void;
+    onInsert: (draft: ConversationComputeDraft, edited: string | undefined) => void;
+    onDiscard: (draft: ConversationComputeDraft) => void;
+    onOpenInserted: (path: string) => void;
+  }
+
+  let { draft, runState, onRun, onInsert, onDiscard, onOpenInserted }: Props = $props();
+
+  // Per-card ephemeral state. `editBuffer === null` means "never edited".
+  let editing = $state(false);
+  let editBuffer = $state<string | null>(null);
+  let armedRisky = $state(false);
+
+  const code = $derived(editBuffer ?? draft.code);
+  const running = $derived(runState?.running === true);
+  const result = $derived(runState?.result ?? null);
+  const insertedAt = $derived(runState?.insertedAt ?? null);
+
+  function langLabel(lang: 'sparql' | 'sql' | 'python'): string {
+    return lang === 'sparql' ? 'SPARQL' : lang === 'sql' ? 'SQL' : 'Python';
+  }
+
+  /** Last path segment for the "filed as a cell in X" link. */
+  function basename(p: string): string {
+    const slash = p.lastIndexOf('/');
+    return slash >= 0 ? p.slice(slash + 1) : p;
+  }
+
+  /** Format a single table cell — wide values truncate; bigints show plain. */
+  function formatComputeCell(value: unknown): string {
+    if (value == null) return '';
+    if (typeof value === 'bigint') return value.toString();
+    if (typeof value === 'string') return value.length > 200 ? value.slice(0, 200) + '…' : value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    try { return JSON.stringify(value); } catch { return ''; }
+  }
+
+  function startEdit(): void {
+    editBuffer = draft.code;
+    editing = true;
+  }
+  function cancelEdit(): void {
+    editBuffer = null;
+    editing = false;
+  }
+  function commitEdit(): void {
+    // Keep the buffer; just exit edit mode. The edited code folds into the
+    // Run / Insert payloads when those fire.
+    editing = false;
+  }
+
+  function run(): void {
+    if (draft.safetyFlags.length > 0 && !armedRisky) {
+      // First click on a flagged cell just arms; a second Run executes.
+      armedRisky = true;
+      return;
+    }
+    onRun(draft, editBuffer ?? undefined);
+  }
+</script>
+
+<div class="draft-card compute-card">
+  <div class="compute-header">
+    <span class="compute-lang">{langLabel(draft.language)}</span>
+    <span class="draft-note">{draft.rationale}</span>
+  </div>
+  {#if draft.safetyFlags.length > 0}
+    <div class="compute-safety" role="alert">
+      <strong>⚠ Risky patterns detected:</strong>
+      <ul>
+        {#each draft.safetyFlags as f (f.id)}
+          <li>{@html f.message}</li>
+        {/each}
+      </ul>
+      {#if armedRisky}
+        <span class="compute-safety-armed">Click Run again to confirm execution.</span>
+      {/if}
+    </div>
+  {/if}
+  {#if editing}
+    <textarea
+      class="compute-edit"
+      value={code}
+      spellcheck="false"
+      oninput={(e) => { editBuffer = e.currentTarget.value; }}
+      rows={Math.max(4, Math.min(20, code.split('\n').length))}
+    ></textarea>
+    <div class="compute-edit-actions">
+      <button type="button" class="draft-btn" onclick={cancelEdit}>Cancel</button>
+      <button type="button" class="draft-btn primary" onclick={commitEdit}>Done</button>
+    </div>
+  {:else}
+    <pre class="compute-code"><code>{code}</code></pre>
+  {/if}
+  <div class="draft-actions">
+    <button
+      type="button"
+      class="draft-btn primary"
+      disabled={running || editing}
+      onclick={run}
+    >{running ? 'Running…' : armedRisky ? 'Run anyway' : 'Run'}</button>
+    {#if !editing}
+      <button type="button" class="draft-btn" onclick={startEdit}>Edit</button>
+    {/if}
+    <button
+      type="button"
+      class="draft-btn"
+      disabled={running || editing}
+      onclick={() => onInsert(draft, editBuffer ?? undefined)}
+    >Insert into notebook</button>
+    <button type="button" class="draft-btn" onclick={() => onDiscard(draft)}>Discard</button>
+  </div>
+  {#if insertedAt}
+    <div class="compute-inserted">
+      Filed as a cell in
+      <button
+        type="button"
+        class="filed-link"
+        title={insertedAt}
+        onclick={() => onOpenInserted(insertedAt)}
+      >{basename(insertedAt)}</button>
+    </div>
+  {/if}
+  {#if result}
+    <div class="compute-output">
+      {#if !result.ok}
+        <div class="compute-output-error">
+          <strong>Error:</strong> {result.error}
+        </div>
+      {:else}
+        {@render outputBlock(result.output)}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+{#snippet outputBlock(output: CellOutput)}
+  {#if output.type === 'text'}
+    <pre class="compute-output-text">{output.value}</pre>
+  {:else if output.type === 'json'}
+    <pre class="compute-output-text">{JSON.stringify(output.value, null, 2)}</pre>
+  {:else if output.type === 'table'}
+    <div class="compute-output-table">
+      <table>
+        <thead>
+          <tr>{#each output.columns as col (col)}<th>{col}</th>{/each}</tr>
+        </thead>
+        <tbody>
+          {#each output.rows.slice(0, 50) as row, ri (ri)}
+            <tr>{#each row as cell, ci (ci)}<td>{formatComputeCell(cell)}</td>{/each}</tr>
+          {/each}
+        </tbody>
+      </table>
+      {#if output.truncated || output.rows.length > 50}
+        <div class="compute-output-trailer">
+          Showing {Math.min(output.rows.length, 50)} of {output.totalRows ?? output.rows.length} rows
+        </div>
+      {/if}
+    </div>
+  {:else if output.type === 'image'}
+    {#if output.mime === 'image/png'}
+      <!-- Base64 PNG bytes from matplotlib / PIL. -->
+      <img class="compute-output-image" alt="compute output" src={`data:image/png;base64,${output.data}`} />
+    {:else}
+      <!-- SVG markup — sanitized for the same reasons as html. -->
+      <div class="compute-output-image">{@html sanitizeComputeOutputHtml(output.data)}</div>
+    {/if}
+  {:else if output.type === 'html'}
+    <div class="compute-output-html">{@html sanitizeComputeOutputHtml(output.html)}</div>
+  {/if}
+{/snippet}
+
+<style>
+  /* Card chrome shared in spirit with DraftCard.svelte; the compute card's
+     mid-card actions + output don't fit that shell, so it carries its own. */
+  .draft-card {
+    border: 1px solid color-mix(in oklch, var(--accent) 28%, transparent);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: color-mix(in oklch, var(--accent) 5%, var(--bg));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .draft-note { color: var(--text-muted); font-size: 12px; }
+  .draft-actions { display: flex; gap: 6px; justify-content: flex-end; }
+  .draft-btn {
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: none;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .draft-btn:hover:not(:disabled) { background: var(--bg, var(--bg-sidebar)); }
+  .draft-btn.primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+  .draft-btn.primary:hover:not(:disabled) {
+    background: var(--accent);
+    opacity: 0.9;
+  }
+  .draft-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+  .compute-card { gap: 6px; }
+  .compute-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .compute-lang {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 3px;
+    background: var(--accent);
+    color: var(--bg);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    flex-shrink: 0;
+  }
+  .compute-code {
+    margin: 0;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: var(--text);
+    white-space: pre;
+    overflow-x: auto;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .compute-code code {
+    background: transparent;
+    padding: 0;
+    font-family: inherit;
+  }
+  .compute-edit {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: var(--text);
+    resize: vertical;
+    box-sizing: border-box;
+  }
+  .compute-edit:focus { outline: none; border-color: var(--accent); }
+  .compute-edit-actions {
+    display: flex;
+    gap: 6px;
+    justify-content: flex-end;
+  }
+  .compute-safety {
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: 3px;
+    padding: 6px 10px;
+    font-size: 11px;
+    background: var(--bg-button);
+    color: var(--text);
+  }
+  .compute-safety ul {
+    margin: 4px 0 0 0;
+    padding-left: 18px;
+    color: var(--text-muted);
+  }
+  .compute-safety-armed {
+    display: block;
+    margin-top: 4px;
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .compute-output {
+    margin-top: 4px;
+    padding: 8px 10px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+  }
+  .compute-output-error {
+    color: var(--text);
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .compute-output-text {
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--text);
+    white-space: pre-wrap;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+  .compute-output-table {
+    overflow-x: auto;
+    max-height: 280px;
+    overflow-y: auto;
+  }
+  .compute-output-table table {
+    border-collapse: collapse;
+    font-size: 11px;
+    color: var(--text);
+  }
+  .compute-output-table th,
+  .compute-output-table td {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    text-align: left;
+    white-space: nowrap;
+  }
+  .compute-output-table th {
+    background: var(--bg-button);
+    font-weight: 600;
+  }
+  .compute-output-trailer {
+    font-size: 10px;
+    color: var(--text-muted);
+    padding-top: 4px;
+  }
+  .compute-output-image {
+    max-width: 100%;
+    height: auto;
+  }
+  .compute-output-html {
+    font-size: 12px;
+    color: var(--text);
+  }
+  .compute-inserted {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding: 2px 4px;
+  }
+  .filed-link {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: var(--accent);
+    font: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+  .filed-link:hover { text-decoration-color: var(--accent); }
+</style>

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -26,14 +26,13 @@
   import type {
     ConversationComputeDraft,
   } from '../../../shared/conversation-compute-drafts';
-  import type { CellOutput } from '../../../shared/compute/types';
-  import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
   import type { ConversationMessage, Citation } from '../../../shared/types';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
   import { insertCitationMarker } from '../conversations/cite-from-conversation';
   import { type CiteStatus } from '../conversations/citations';
   import MessageCitations from './MessageCitations.svelte';
   import DraftCard from './DraftCard.svelte';
+  import ComputeDraftCard from './ComputeDraftCard.svelte';
   import { getSlashCommands } from '../tools/tool-registry';
   import { slashQueryFromComposer, filterSlashCommands } from '../conversations/slash-commands';
 
@@ -396,83 +395,31 @@
     store.discardClaimsDraft(tabId, draftId);
   }
 
-  // ── propose_compute card state (#245) ─────────────────────────────
+  // ── propose_compute card actions (#245) ───────────────────────────
   //
-  // Per-draft editor buffer (when the user clicks Edit) and a flag for
-  // "I see the safety warnings, run anyway". Keyed by draftId so two
-  // compute drafts in the same conversation are independent. Edit
-  // buffers are dropped when the draft is discarded.
-  let computeEdits = $state<Record<string, string>>({});
-  let computeEditing = $state<Record<string, boolean>>({});
-  let computeRiskyAck = $state<Record<string, boolean>>({});
-
-  function startEditCompute(draft: ConversationComputeDraft): void {
-    computeEdits[draft.draftId] = draft.code;
-    computeEditing[draft.draftId] = true;
-  }
-
-  function cancelEditCompute(draftId: string): void {
-    delete computeEdits[draftId];
-    computeEditing[draftId] = false;
-  }
-
-  function commitEditCompute(draftId: string): void {
-    // No persistence here — the edited code is folded into Run /
-    // Insert payloads when the user actually fires those actions.
-    // This just exits edit mode while preserving the buffer.
-    computeEditing[draftId] = false;
-  }
-
-  function effectiveComputeCode(draft: ConversationComputeDraft): string {
-    const edited = computeEdits[draft.draftId];
-    return edited !== undefined ? edited : draft.code;
-  }
-
-  async function handleRunCompute(draft: ConversationComputeDraft): Promise<void> {
-    if (draft.safetyFlags.length > 0 && !computeRiskyAck[draft.draftId]) {
-      // First click on a flagged cell just arms the acknowledgement;
-      // the user has to click Run a second time to actually execute.
-      computeRiskyAck[draft.draftId] = true;
-      return;
-    }
-    const edited = computeEdits[draft.draftId];
+  // The edit buffer / edit mode / risky-ack now live inside ComputeDraftCard
+  // (per-card view state); the panel only forwards the three store actions and
+  // the run state. `edited` is undefined when the cell was never edited.
+  function onRunCompute(draft: ConversationComputeDraft, edited: string | undefined): void {
     const tab = store.activeTab;
     if (!tab) return;
-    await store.runComputeDraft(tab.id, draft, edited);
+    void store.runComputeDraft(tab.id, draft, edited);
   }
 
-  async function handleInsertCompute(draft: ConversationComputeDraft): Promise<void> {
+  function onInsertCompute(draft: ConversationComputeDraft, edited: string | undefined): void {
     const tab = store.activeTab;
     if (!tab) return;
-    const edited = computeEdits[draft.draftId];
-    await store.insertComputeDraft(tab.id, draft, edited);
+    void store.insertComputeDraft(tab.id, draft, edited);
   }
 
-  function handleDiscardCompute(draft: ConversationComputeDraft): void {
+  function onDiscardCompute(draft: ConversationComputeDraft): void {
     const tab = store.activeTab;
     if (!tab) return;
-    delete computeEdits[draft.draftId];
-    delete computeEditing[draft.draftId];
-    delete computeRiskyAck[draft.draftId];
     store.discardComputeDraft(tab.id, draft.draftId);
-  }
-
-  function languagePillLabel(lang: 'sparql' | 'sql' | 'python'): string {
-    return lang === 'sparql' ? 'SPARQL' : lang === 'sql' ? 'SQL' : 'Python';
   }
 
   function openInsertedNote(path: string): void {
     void editor.openFile(path);
-  }
-
-  /** Format a single table cell for inline rendering. Wide values
-   *  get truncated; bigints are shown as plain numbers (no `n` suffix). */
-  function formatComputeCell(value: unknown): string {
-    if (value == null) return '';
-    if (typeof value === 'bigint') return value.toString();
-    if (typeof value === 'string') return value.length > 200 ? value.slice(0, 200) + '…' : value;
-    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-    try { return JSON.stringify(value); } catch { return ''; }
   }
 
   /** Render a frontmatter value for inline display on the review card.
@@ -945,126 +892,6 @@
           </div>
         {/snippet}
 
-        {#snippet computeOutputBlock(output: CellOutput)}
-          {#if output.type === 'text'}
-            <pre class="compute-output-text">{output.value}</pre>
-          {:else if output.type === 'json'}
-            <pre class="compute-output-text">{JSON.stringify(output.value, null, 2)}</pre>
-          {:else if output.type === 'table'}
-            <div class="compute-output-table">
-              <table>
-                <thead>
-                  <tr>{#each output.columns as col (col)}<th>{col}</th>{/each}</tr>
-                </thead>
-                <tbody>
-                  {#each output.rows.slice(0, 50) as row, ri (ri)}
-                    <tr>{#each row as cell, ci (ci)}<td>{formatComputeCell(cell)}</td>{/each}</tr>
-                  {/each}
-                </tbody>
-              </table>
-              {#if output.truncated || output.rows.length > 50}
-                <div class="compute-output-trailer">
-                  Showing {Math.min(output.rows.length, 50)} of {output.totalRows ?? output.rows.length} rows
-                </div>
-              {/if}
-            </div>
-          {:else if output.type === 'image'}
-            {#if output.mime === 'image/png'}
-              <!-- Base64 PNG bytes from matplotlib / PIL. -->
-              <img class="compute-output-image" alt="compute output" src={`data:image/png;base64,${output.data}`} />
-            {:else}
-              <!-- SVG markup — sanitized for the same reasons as html. -->
-              <div class="compute-output-image">{@html sanitizeComputeOutputHtml(output.data)}</div>
-            {/if}
-          {:else if output.type === 'html'}
-            <div class="compute-output-html">{@html sanitizeComputeOutputHtml(output.html)}</div>
-          {/if}
-        {/snippet}
-
-        {#snippet computeDraftCardBlock(draft: ConversationComputeDraft)}
-          {@const state = tab.computeDraftState[draft.draftId]}
-          {@const editing = computeEditing[draft.draftId] === true}
-          {@const code = effectiveComputeCode(draft)}
-          {@const result = state?.result ?? null}
-          {@const running = state?.running === true}
-          {@const insertedAt = state?.insertedAt ?? null}
-          {@const armedRisky = computeRiskyAck[draft.draftId] === true}
-          <div class="draft-card compute-card">
-            <div class="compute-header">
-              <span class="compute-lang">{languagePillLabel(draft.language)}</span>
-              <span class="draft-note">{draft.rationale}</span>
-            </div>
-            {#if draft.safetyFlags.length > 0}
-              <div class="compute-safety" role="alert">
-                <strong>⚠ Risky patterns detected:</strong>
-                <ul>
-                  {#each draft.safetyFlags as f (f.id)}
-                    <li>{@html f.message}</li>
-                  {/each}
-                </ul>
-                {#if armedRisky}
-                  <span class="compute-safety-armed">Click Run again to confirm execution.</span>
-                {/if}
-              </div>
-            {/if}
-            {#if editing}
-              <textarea
-                class="compute-edit"
-                value={code}
-                spellcheck="false"
-                oninput={(e) => { computeEdits[draft.draftId] = e.currentTarget.value; }}
-                rows={Math.max(4, Math.min(20, code.split('\n').length))}
-              ></textarea>
-              <div class="compute-edit-actions">
-                <button type="button" class="draft-btn" onclick={() => cancelEditCompute(draft.draftId)}>Cancel</button>
-                <button type="button" class="draft-btn primary" onclick={() => commitEditCompute(draft.draftId)}>Done</button>
-              </div>
-            {:else}
-              <pre class="compute-code"><code>{code}</code></pre>
-            {/if}
-            <div class="draft-actions">
-              <button
-                type="button"
-                class="draft-btn primary"
-                disabled={running || editing}
-                onclick={() => { void handleRunCompute(draft); }}
-              >{running ? 'Running…' : armedRisky ? 'Run anyway' : 'Run'}</button>
-              {#if !editing}
-                <button type="button" class="draft-btn" onclick={() => startEditCompute(draft)}>Edit</button>
-              {/if}
-              <button
-                type="button"
-                class="draft-btn"
-                disabled={running || editing}
-                onclick={() => { void handleInsertCompute(draft); }}
-              >Insert into notebook</button>
-              <button type="button" class="draft-btn" onclick={() => handleDiscardCompute(draft)}>Discard</button>
-            </div>
-            {#if insertedAt}
-              <div class="compute-inserted">
-                Filed as a cell in
-                <button
-                  type="button"
-                  class="filed-link"
-                  title={insertedAt}
-                  onclick={() => openInsertedNote(insertedAt)}
-                >{basename(insertedAt)}</button>
-              </div>
-            {/if}
-            {#if result}
-              <div class="compute-output">
-                {#if !result.ok}
-                  <div class="compute-output-error">
-                    <strong>Error:</strong> {result.error}
-                  </div>
-                {:else}
-                  {@render computeOutputBlock(result.output)}
-                {/if}
-              </div>
-            {/if}
-          </div>
-        {/snippet}
-
         {#snippet propertyResultLine(_draftId: string, outcomes: PropertyUpdateOutcome[])}
           <!-- Compact "Updated:" line that replaces the propose-property
                card after Approve. Each successfully-patched path is a
@@ -1141,7 +968,14 @@
               {@render claimsResultLine(draftId, entry.outcome)}
             {/each}
             {#each computeDraftsAt(tab, i) as draft (draft.draftId)}
-              {@render computeDraftCardBlock(draft)}
+              <ComputeDraftCard
+                {draft}
+                runState={tab.computeDraftState[draft.draftId]}
+                onRun={onRunCompute}
+                onInsert={onInsertCompute}
+                onDiscard={onDiscardCompute}
+                onOpenInserted={openInsertedNote}
+              />
             {/each}
           {/each}
 
@@ -1234,7 +1068,14 @@
             {@render claimsResultLine(draftId, entry.outcome)}
           {/each}
           {#each orphanComputeDrafts(tab) as draft (draft.draftId)}
-            {@render computeDraftCardBlock(draft)}
+            <ComputeDraftCard
+              {draft}
+              runState={tab.computeDraftState[draft.draftId]}
+              onRun={onRunCompute}
+              onInsert={onInsertCompute}
+              onDiscard={onDiscardCompute}
+              onOpenInserted={openInsertedNote}
+            />
           {/each}
         </div>
 
@@ -1624,20 +1465,10 @@
   /* Proposal / draft card (§9.2) — accent-tinted bordered card so a
      proposal pops out of the message stream as something the user is
      about to decide on. Uses oklch color-mix so it tracks palette swaps. */
-  /* The five simple draft cards now render via DraftCard.svelte (which carries
-     its own copy of this chrome). These rules remain only for the still-inline
-     compute card (.draft-card.compute-card + its .draft-note / .draft-actions /
-     .draft-btn); they go away when the compute card is extracted too. */
-  .draft-card {
-    border: 1px solid color-mix(in oklch, var(--accent) 28%, transparent);
-    border-radius: 8px;
-    padding: 10px 12px;
-    background: color-mix(in oklch, var(--accent) 5%, var(--bg));
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .draft-note { color: var(--text-muted); font-size: 12px; }
+  /* Draft-card chrome (.draft-card / .draft-note / .draft-actions / .draft-btn)
+     now lives in DraftCard.svelte and ComputeDraftCard.svelte. Only the
+     card-body styles below (.draft-paths, source/property/claims lists) remain
+     here — they render as DraftCard children, so they keep the panel's scope. */
   .draft-paths { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
   .draft-path-btn {
     width: 100%;
@@ -1667,7 +1498,6 @@
     overflow-x: auto;
     max-height: 280px;
   }
-  .draft-actions { display: flex; gap: 6px; justify-content: flex-end; }
 
   /* propose_sources cards. Same outer chrome as note draft cards;
      interior shows a flat list of url/identifier pills rather than the
@@ -1813,149 +1643,6 @@
     text-decoration-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
   }
 
-  /* propose_compute card (#245). Two-column header with the language
-     pill on the left and the LLM's one-line rationale on the right.
-     Code uses a monospace pre block; edit mode swaps in a textarea.
-     Risky-Python flags surface above the code in a muted alert box,
-     and the Run button label changes to "Run anyway" after the first
-     click so the second click is the explicit confirmation. */
-  .compute-card { gap: 6px; }
-  .compute-header {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-  }
-  .compute-lang {
-    display: inline-block;
-    padding: 1px 8px;
-    border-radius: 3px;
-    background: var(--accent);
-    color: var(--bg);
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    flex-shrink: 0;
-  }
-  .compute-code {
-    margin: 0;
-    padding: 8px 10px;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 12px;
-    color: var(--text);
-    white-space: pre;
-    overflow-x: auto;
-    max-height: 360px;
-    overflow-y: auto;
-  }
-  .compute-code code {
-    background: transparent;
-    padding: 0;
-    font-family: inherit;
-  }
-  .compute-edit {
-    width: 100%;
-    padding: 8px 10px;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 12px;
-    color: var(--text);
-    resize: vertical;
-    box-sizing: border-box;
-  }
-  .compute-edit:focus { outline: none; border-color: var(--accent); }
-  .compute-edit-actions {
-    display: flex;
-    gap: 6px;
-    justify-content: flex-end;
-  }
-  .compute-safety {
-    border: 1px solid var(--border);
-    border-left: 3px solid var(--accent);
-    border-radius: 3px;
-    padding: 6px 10px;
-    font-size: 11px;
-    background: var(--bg-button);
-    color: var(--text);
-  }
-  .compute-safety ul {
-    margin: 4px 0 0 0;
-    padding-left: 18px;
-    color: var(--text-muted);
-  }
-  .compute-safety-armed {
-    display: block;
-    margin-top: 4px;
-    color: var(--accent);
-    font-weight: 600;
-  }
-  .compute-output {
-    margin-top: 4px;
-    padding: 8px 10px;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-  }
-  .compute-output-error {
-    color: var(--text);
-    font-size: 12px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  }
-  .compute-output-text {
-    margin: 0;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 11px;
-    color: var(--text);
-    white-space: pre-wrap;
-    max-height: 240px;
-    overflow-y: auto;
-  }
-  .compute-output-table {
-    overflow-x: auto;
-    max-height: 280px;
-    overflow-y: auto;
-  }
-  .compute-output-table table {
-    border-collapse: collapse;
-    font-size: 11px;
-    color: var(--text);
-  }
-  .compute-output-table th,
-  .compute-output-table td {
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    text-align: left;
-    white-space: nowrap;
-  }
-  .compute-output-table th {
-    background: var(--bg-button);
-    font-weight: 600;
-  }
-  .compute-output-trailer {
-    font-size: 10px;
-    color: var(--text-muted);
-    padding-top: 4px;
-  }
-  .compute-output-image img,
-  .compute-output-image {
-    max-width: 100%;
-    height: auto;
-  }
-  .compute-output-html {
-    font-size: 12px;
-    color: var(--text);
-  }
-  .compute-inserted {
-    font-size: 11px;
-    color: var(--text-muted);
-    padding: 2px 4px;
-  }
-
   /* Post-Approve summary line — replaces the inline draft card for
      both propose_notes and propose_sources. Single-line, no chrome,
      clickable filenames/titles. Persistent (no dismiss) so the user
@@ -1989,31 +1676,6 @@
   .filed-link:hover { text-decoration-color: var(--accent); }
   .filed-dup { color: var(--text-muted); text-decoration: none; }
   .filed-error { color: var(--text-muted); }
-  .draft-btn {
-    padding: 4px 10px;
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    background: none;
-    color: var(--text);
-    cursor: pointer;
-    font-size: 12px;
-  }
-  .draft-btn:hover:not(:disabled) { background: var(--bg, var(--bg-sidebar)); }
-  .draft-btn.primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
-  }
-  /* Primary buttons set `color: var(--bg)` for dark-text-on-accent.
-     The shared `.draft-btn:hover` rule above sets background to
-     var(--bg), which on a primary button collapses text and background
-     to the same color — invisible label. Keep the accent background on
-     hover and just dim slightly, matching `.send-btn:hover`. */
-  .draft-btn.primary:hover:not(:disabled) {
-    background: var(--accent);
-    opacity: 0.9;
-  }
-  .draft-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 
   .composer {
     display: flex;

--- a/tests/renderer/components/ComputeDraftCard.test.ts
+++ b/tests/renderer/components/ComputeDraftCard.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for ComputeDraftCard (#672) — the propose_compute review
+ * card extracted from ConversationsPanel. Pins the card's behavior: it renders
+ * the proposal, enforces the risky-Python "click Run twice" confirmation, folds
+ * edited code into Run, and routes Run / Insert / Discard / open-inserted back
+ * to the panel. The run state (running / result / insertedAt) is passed in.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { ConversationComputeDraft } from '../../../src/shared/conversation-compute-drafts';
+import type { CellResult } from '../../../src/shared/compute/types';
+import ComputeDraftCard from '../../../src/renderer/lib/components/ComputeDraftCard.svelte';
+
+function draft(over: Partial<ConversationComputeDraft> = {}): ConversationComputeDraft {
+  return {
+    draftId: 'd1',
+    conversationId: 'c1',
+    language: 'python',
+    code: 'print(1 + 1)',
+    rationale: 'Compute the answer',
+    safetyFlags: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+function renderCard(over: {
+  draft?: ConversationComputeDraft;
+  runState?: { running: boolean; result: CellResult | null; insertedAt: string | null };
+  onRun?: (d: ConversationComputeDraft, edited: string | undefined) => void;
+  onInsert?: (d: ConversationComputeDraft, edited: string | undefined) => void;
+  onDiscard?: (d: ConversationComputeDraft) => void;
+  onOpenInserted?: (p: string) => void;
+} = {}) {
+  return render(ComputeDraftCard, {
+    draft: over.draft ?? draft(),
+    runState: over.runState,
+    onRun: over.onRun ?? vi.fn(),
+    onInsert: over.onInsert ?? vi.fn(),
+    onDiscard: over.onDiscard ?? vi.fn(),
+    onOpenInserted: over.onOpenInserted ?? vi.fn(),
+  });
+}
+
+afterEach(cleanup);
+
+describe('ComputeDraftCard (#672)', () => {
+  it('renders the language pill, rationale, and code', () => {
+    const { getByText } = renderCard();
+    expect(getByText('Python')).toBeTruthy();
+    expect(getByText('Compute the answer')).toBeTruthy();
+    expect(getByText('print(1 + 1)')).toBeTruthy();
+  });
+
+  it('Run executes immediately when there are no safety flags', async () => {
+    const onRun = vi.fn();
+    const d = draft({ safetyFlags: [] });
+    const { getByText } = renderCard({ draft: d, onRun });
+    await fireEvent.click(getByText('Run'));
+    expect(onRun).toHaveBeenCalledWith(d, undefined);
+  });
+
+  it('a risky cell arms on the first Run click and only executes on the second', async () => {
+    const onRun = vi.fn();
+    const d = draft({ safetyFlags: [{ id: 'f1', message: 'uses os.system' }] });
+    const { getByText } = renderCard({ draft: d, onRun });
+
+    await fireEvent.click(getByText('Run'));
+    expect(onRun).not.toHaveBeenCalled();             // armed, not run
+    expect(getByText('Run anyway')).toBeTruthy();
+    expect(getByText(/Click Run again to confirm/)).toBeTruthy();
+
+    await fireEvent.click(getByText('Run anyway'));
+    expect(onRun).toHaveBeenCalledWith(d, undefined); // second click executes
+  });
+
+  it('Edit folds the edited code into the next Run', async () => {
+    const onRun = vi.fn();
+    const d = draft({ code: 'print(1)' });
+    const { getByText, getByRole } = renderCard({ draft: d, onRun });
+
+    await fireEvent.click(getByText('Edit'));
+    await fireEvent.input(getByRole('textbox'), { target: { value: 'print(2)' } });
+    await fireEvent.click(getByText('Done'));
+    await fireEvent.click(getByText('Run'));
+
+    expect(onRun).toHaveBeenCalledWith(d, 'print(2)');
+  });
+
+  it('Insert reports onInsert and Discard reports onDiscard', async () => {
+    const onInsert = vi.fn();
+    const onDiscard = vi.fn();
+    const d = draft();
+    const { getByText } = renderCard({ draft: d, onInsert, onDiscard });
+
+    await fireEvent.click(getByText('Insert into notebook'));
+    expect(onInsert).toHaveBeenCalledWith(d, undefined);
+
+    await fireEvent.click(getByText('Discard'));
+    expect(onDiscard).toHaveBeenCalledWith(d);
+  });
+
+  it('disables Run and shows "Running…" while a run is in flight', () => {
+    const { getByText } = renderCard({ runState: { running: true, result: null, insertedAt: null } });
+    const btn = getByText('Running…').closest('button')!;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('renders an error result', () => {
+    const { getByText } = renderCard({
+      runState: { running: false, result: { ok: false, error: 'NameError: x' }, insertedAt: null },
+    });
+    expect(getByText(/NameError: x/)).toBeTruthy();
+  });
+
+  it('renders a table result via formatComputeCell', () => {
+    const result: CellResult = {
+      ok: true,
+      output: { type: 'table', columns: ['a', 'b'], rows: [[1, 'x']], truncated: false, totalRows: 1 },
+    };
+    const { getByText } = renderCard({ runState: { running: false, result, insertedAt: null } });
+    expect(getByText('a')).toBeTruthy();
+    expect(getByText('x')).toBeTruthy();
+  });
+
+  it('shows the "filed as a cell" link and opens it', async () => {
+    const onOpenInserted = vi.fn();
+    const { getByText } = renderCard({
+      runState: { running: false, result: null, insertedAt: 'notes/sub/analysis.md' },
+      onOpenInserted,
+    });
+    const link = getByText('analysis.md'); // basename of the inserted path
+    await fireEvent.click(link);
+    expect(onOpenInserted).toHaveBeenCalledWith('notes/sub/analysis.md');
+  });
+});


### PR DESCRIPTION
## What

Pulls the **propose_compute review card** (#245) — the richest of the draft cards: language pill, rationale, safety flags, an inline code editor, **Run / Edit / Insert / Discard**, and the run output (text / json / table / image / html) — into its own **`ComputeDraftCard.svelte`**. **ConversationsPanel 2,162 → 1,824** (−338).

## Clears the duplication debt from #718
The DraftCard PR left a temporary copy of `.draft-card` / `.draft-note` / `.draft-actions` / `.draft-btn` in the panel for the still-inline compute card. With the compute card now gone, the panel renders **none** of that chrome — so all of it (plus the entire `.compute-*` block) is **deleted** from ConversationsPanel. Only the simple cards' *body* styles (`.draft-paths`, source/property/claims lists) remain — those render as `DraftCard` children, in the panel's scope.

## Design — keeps the Trust boundary intact
The card owns its **ephemeral view state** — edit buffer, edit mode, and the risky-Python "click Run twice" acknowledgement — because those are per-card UI concerns. The panel keeps the **run state** (running / result / insertedAt, which live in the conversation store) and the three store actions (Run / Insert / Discard) + open-inserted, passed in as callbacks. So the card only *proposes*; the store/approval path still does the work.

## Tests (9)
`components/ComputeDraftCard.test.ts` pins: the render, the **risky two-click confirmation** (first Run arms → "Run anyway", second executes), edited-code-folds-into-Run, Insert/Discard routing, the running/disabled state, error + table output, and the filed-cell link → open-inserted.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2980 passed** (+9).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)