### PR TITLE
Extract SitesSettings panel from SettingsDialog (#672)

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -51,6 +51,7 @@
     type MenuConfig,
   } from '../../../shared/skills/menu-config';
   import { SKILL_MENUS } from '../../../shared/skills/types';
+  import SitesSettings from './SitesSettings.svelte';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -211,59 +212,7 @@
     { value: 'system', label: 'System' },
   ];
 
-  // Privileged sites (#NEW). Loaded from main, mutated via api.sites.*.
-  let sites = $state<import('../../../shared/types').PrivilegedSite[]>([]);
-  let newSiteDomain = $state('');
-  let newSiteLabel = $state('');
-  let siteBusyId = $state<string | null>(null);
-
-  async function reloadSites(): Promise<void> {
-    try {
-      sites = await api.sites.list();
-    } catch (e) {
-      console.error('[settings] failed to load sites:', e);
-    }
-  }
-
-  async function addSite(): Promise<void> {
-    const domain = newSiteDomain.trim();
-    if (!domain) return;
-    try {
-      await api.sites.add(domain, newSiteLabel.trim() || undefined);
-      newSiteDomain = '';
-      newSiteLabel = '';
-      await reloadSites();
-    } catch (e) {
-      console.error('[settings] addSite failed:', e);
-    }
-  }
-
-  async function loginSite(id: string): Promise<void> {
-    siteBusyId = id;
-    try {
-      await api.sites.login(id);
-      await reloadSites();
-    } finally {
-      siteBusyId = null;
-    }
-  }
-
-  async function logoutSite(id: string): Promise<void> {
-    await api.sites.logout(id);
-    await reloadSites();
-  }
-
-  async function removeSite(id: string): Promise<void> {
-    await api.sites.remove(id);
-    await reloadSites();
-  }
-
-  function formatLastLogin(iso: string | null): string {
-    if (!iso) return 'never';
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return iso;
-    return d.toLocaleString();
-  }
+  // Privileged sites now live in SitesSettings.svelte (self-contained panel).
 
   // Excerpt → Note default folder (#101). Empty string = project root.
   let excerptNoteFolder = $state('');
@@ -582,7 +531,6 @@
     } catch (e) {
       console.error('[settings] failed to load LLM settings:', e);
     }
-    await reloadSites();
     await loadBibliographySettings();
     await loadExcerptSettings();
     await loadComputeSettings();
@@ -1047,64 +995,7 @@
           </div>
 
         {:else if activeTab === 'sites'}
-          <div class="field">
-            <p class="hint">
-              Add sites you have a login for (institutional access, paid
-              subscriptions, etc.). Minerva will route ingest fetches to those
-              domains through your in-app browser session, so the response
-              reflects what you can see when logged in.
-            </p>
-          </div>
-          <div class="field">
-            <label for="new-site-domain">Add site</label>
-            <div class="site-add-row">
-              <input
-                id="new-site-domain"
-                type="text"
-                bind:value={newSiteDomain}
-                placeholder="arxiv.org"
-              />
-              <input
-                type="text"
-                bind:value={newSiteLabel}
-                placeholder="Label (optional)"
-              />
-              <button onclick={addSite} disabled={!newSiteDomain.trim()}>Add</button>
-            </div>
-          </div>
-          <div class="field">
-            {#if sites.length === 0}
-              <p class="hint">No sites configured.</p>
-            {:else}
-              <ul class="sites-list">
-                {#each sites as site (site.id)}
-                  <li class="site-row">
-                    <div class="site-info">
-                      <div class="site-label">{site.label}</div>
-                      <div class="site-meta">
-                        {site.domain} · last login: {formatLastLogin(site.lastLoginAt)}
-                      </div>
-                    </div>
-                    <div class="site-actions">
-                      <button
-                        onclick={() => loginSite(site.id)}
-                        disabled={siteBusyId === site.id}
-                        title="Open a browser window for this domain so you can log in"
-                      >Login</button>
-                      <button
-                        onclick={() => logoutSite(site.id)}
-                        title="Clear cookies for this site"
-                      >Logout</button>
-                      <button
-                        onclick={() => removeSite(site.id)}
-                        title="Remove site and clear its cookies"
-                      >Remove</button>
-                    </div>
-                  </li>
-                {/each}
-              </ul>
-            {/if}
-          </div>
+          <SitesSettings />
 
         {:else if activeTab === 'bibliography'}
           <div class="field">
@@ -2157,49 +2048,5 @@
 
   .primary:hover {
     opacity: 0.9;
-  }
-
-  .site-add-row {
-    display: flex;
-    gap: 6px;
-  }
-  .site-add-row input {
-    flex: 1;
-    min-width: 0;
-  }
-  .sites-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .site-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 8px 10px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-  }
-  .site-info {
-    flex: 1;
-    min-width: 0;
-  }
-  .site-label {
-    font-size: 13px;
-    color: var(--text);
-  }
-  .site-meta {
-    font-size: 11px;
-    color: var(--text-muted);
-    margin-top: 2px;
-  }
-  .site-actions {
-    display: flex;
-    gap: 4px;
-    flex-shrink: 0;
   }
 </style>

--- a/src/renderer/lib/components/SitesSettings.svelte
+++ b/src/renderer/lib/components/SitesSettings.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  /**
+   * Privileged-sites settings panel (extracted from SettingsDialog for #672).
+   *
+   * Self-contained: it owns the site list + the add-form fields, loads on
+   * mount, and drives everything through `api.sites.*`. Used to route ingest
+   * fetches for domains the user has a login for (institutional / paid access)
+   * through the in-app browser session. The dialog just mounts it for the
+   * "sites" tab.
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+  import type { PrivilegedSite } from '../../../shared/types';
+
+  let sites = $state<PrivilegedSite[]>([]);
+  let newSiteDomain = $state('');
+  let newSiteLabel = $state('');
+  let siteBusyId = $state<string | null>(null);
+
+  async function reloadSites(): Promise<void> {
+    try {
+      sites = await api.sites.list();
+    } catch (e) {
+      console.error('[settings] failed to load sites:', e);
+    }
+  }
+
+  async function addSite(): Promise<void> {
+    const domain = newSiteDomain.trim();
+    if (!domain) return;
+    try {
+      await api.sites.add(domain, newSiteLabel.trim() || undefined);
+      newSiteDomain = '';
+      newSiteLabel = '';
+      await reloadSites();
+    } catch (e) {
+      console.error('[settings] addSite failed:', e);
+    }
+  }
+
+  async function loginSite(id: string): Promise<void> {
+    siteBusyId = id;
+    try {
+      await api.sites.login(id);
+      await reloadSites();
+    } finally {
+      siteBusyId = null;
+    }
+  }
+
+  async function logoutSite(id: string): Promise<void> {
+    await api.sites.logout(id);
+    await reloadSites();
+  }
+
+  async function removeSite(id: string): Promise<void> {
+    await api.sites.remove(id);
+    await reloadSites();
+  }
+
+  function formatLastLogin(iso: string | null): string {
+    if (!iso) return 'never';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString();
+  }
+
+  onMount(reloadSites);
+</script>
+
+<div class="field">
+  <p class="hint">
+    Add sites you have a login for (institutional access, paid
+    subscriptions, etc.). Minerva will route ingest fetches to those
+    domains through your in-app browser session, so the response
+    reflects what you can see when logged in.
+  </p>
+</div>
+<div class="field">
+  <label for="new-site-domain">Add site</label>
+  <div class="site-add-row">
+    <input
+      id="new-site-domain"
+      type="text"
+      bind:value={newSiteDomain}
+      placeholder="arxiv.org"
+    />
+    <input
+      type="text"
+      bind:value={newSiteLabel}
+      placeholder="Label (optional)"
+    />
+    <button onclick={addSite} disabled={!newSiteDomain.trim()}>Add</button>
+  </div>
+</div>
+<div class="field">
+  {#if sites.length === 0}
+    <p class="hint">No sites configured.</p>
+  {:else}
+    <ul class="sites-list">
+      {#each sites as site (site.id)}
+        <li class="site-row">
+          <div class="site-info">
+            <div class="site-label">{site.label}</div>
+            <div class="site-meta">
+              {site.domain} · last login: {formatLastLogin(site.lastLoginAt)}
+            </div>
+          </div>
+          <div class="site-actions">
+            <button
+              onclick={() => loginSite(site.id)}
+              disabled={siteBusyId === site.id}
+              title="Open a browser window for this domain so you can log in"
+            >Login</button>
+            <button
+              onclick={() => logoutSite(site.id)}
+              title="Clear cookies for this site"
+            >Logout</button>
+            <button
+              onclick={() => removeSite(site.id)}
+              title="Remove site and clear its cookies"
+            >Remove</button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  /* Form vocabulary, scoped to this panel — same convention every dialog in
+     the app follows (each carries its own .field / .hint rules). */
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label { color: var(--text); }
+  .field input[type="text"] {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .field input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .site-add-row {
+    display: flex;
+    gap: 6px;
+  }
+  .site-add-row input {
+    flex: 1;
+    min-width: 0;
+  }
+  .sites-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .site-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+  }
+  .site-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .site-label {
+    font-size: 13px;
+    color: var(--text);
+  }
+  .site-meta {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+  .site-actions {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+</style>

--- a/tests/renderer/components/SitesSettings.test.ts
+++ b/tests/renderer/components/SitesSettings.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for SitesSettings (#672) — the privileged-sites panel
+ * extracted from SettingsDialog. Self-contained: it loads on mount and drives
+ * api.sites.*. These tests mock that boundary and pin the list render, the
+ * add-form gating, and that each action reaches the right IPC call.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+const { listMock, addMock, loginMock, logoutMock, removeMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  addMock: vi.fn(),
+  loginMock: vi.fn(),
+  logoutMock: vi.fn(),
+  removeMock: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { sites: { list: listMock, add: addMock, login: loginMock, logout: logoutMock, remove: removeMock } },
+}));
+
+import SitesSettings from '../../../src/renderer/lib/components/SitesSettings.svelte';
+
+const site = (over = {}) => ({
+  id: 's1', label: 'arXiv', domain: 'arxiv.org', lastLoginAt: null, ...over,
+});
+
+afterEach(() => {
+  cleanup();
+  [listMock, addMock, loginMock, logoutMock, removeMock].forEach((m) => m.mockReset());
+});
+
+describe('SitesSettings (#672)', () => {
+  it('loads sites on mount and renders the list with last-login "never"', async () => {
+    listMock.mockResolvedValue([site({ label: 'arXiv', domain: 'arxiv.org', lastLoginAt: null })]);
+    const { findByText, getByText } = render(SitesSettings, {});
+    expect(await findByText('arXiv')).toBeTruthy();
+    expect(getByText(/arxiv\.org · last login: never/)).toBeTruthy();
+  });
+
+  it('shows the empty state when no sites are configured', async () => {
+    listMock.mockResolvedValue([]);
+    const { findByText } = render(SitesSettings, {});
+    expect(await findByText('No sites configured.')).toBeTruthy();
+  });
+
+  it('Add is disabled until a domain is typed, then calls api.sites.add', async () => {
+    listMock.mockResolvedValue([]);
+    addMock.mockResolvedValue(undefined);
+    const { findByText, getByPlaceholderText } = render(SitesSettings, {});
+    await findByText('No sites configured.');
+
+    const addBtn = (await findByText('Add')).closest('button')!;
+    expect(addBtn.disabled).toBe(true);
+
+    await fireEvent.input(getByPlaceholderText('arxiv.org'), { target: { value: 'nature.com' } });
+    await fireEvent.input(getByPlaceholderText('Label (optional)'), { target: { value: 'Nature' } });
+    expect(addBtn.disabled).toBe(false);
+
+    await fireEvent.click(addBtn);
+    expect(addMock).toHaveBeenCalledWith('nature.com', 'Nature');
+  });
+
+  it('Login / Logout / Remove reach the matching api.sites call with the site id', async () => {
+    listMock.mockResolvedValue([site({ id: 's7' })]);
+    loginMock.mockResolvedValue(undefined);
+    logoutMock.mockResolvedValue(undefined);
+    removeMock.mockResolvedValue(undefined);
+    const { findByText, getByText } = render(SitesSettings, {});
+    await findByText('arXiv');
+
+    await fireEvent.click(getByText('Login'));
+    await waitFor(() => expect(loginMock).toHaveBeenCalledWith('s7'));
+
+    await fireEvent.click(getByText('Logout'));
+    await waitFor(() => expect(logoutMock).toHaveBeenCalledWith('s7'));
+
+    await fireEvent.click(getByText('Remove'));
+    await waitFor(() => expect(removeMock).toHaveBeenCalledWith('s7'));
+  });
+
+  it('formats a real last-login timestamp instead of "never"', async () => {
+    listMock.mockResolvedValue([site({ lastLoginAt: '2026-01-02T03:04:05Z' })]);
+    const { findByText, queryByText } = render(SitesSettings, {});
+    await findByText('arXiv');
+    expect(queryByText(/last login: never/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

First split of the last oversized component. SettingsDialog is a **13-tab dialog** where each tab is a self-contained panel — so the natural decomposition is **one component per tab**. The privileged-sites tab is the cleanest starting point: its state (site list + add-form fields) and handlers only ever touch `api.sites.*`, so it lifts whole into a self-contained **`SitesSettings.svelte`** that owns its state, loads on mount, and is just mounted by the dialog for the "sites" tab. **SettingsDialog 2,205 → 2,052.**

## On the form CSS
The panel carries its own scoped `.field` / `.hint` / input styles. That's **not** duplication smell here — it's the convention every dialog in this app already follows (~20 components each scope their own `.field`/`.hint`, since those are generic names that can't be safely globalized). The dialog keeps those rules for its other twelve panels.

## Behavior note
Sites now load when the user opens the **Sites tab** (the child's `onMount`) rather than eagerly on dialog open. Equivalent from the user's view — the list only ever renders in that panel — and slightly leaner (no fetch unless you look at it). The dialog still owns the tab nav + routing.

## Tests (5)
`components/SitesSettings.test.ts` mocks `api.sites` and pins: the on-mount list render (with "last login: never"), the empty state, the add-form gating + `api.sites.add(domain, label)` call, Login / Logout / Remove → matching IPC with the site id, and the real-timestamp format.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2985 passed** (+5).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

_Increment, not the whole dialog: this establishes the per-tab-panel pattern. The other heavy tabs (compute / bibliography / skills / ai) are the same shape and can follow as their own PRs._

🤖 Generated with [Claude Code](https://claude.com/claude-code)