### PR TITLE
Extract ComputeSettings panel from SettingsDialog (#672)

### DIFF
--- a/src/renderer/lib/components/ComputeSettings.svelte
+++ b/src/renderer/lib/components/ComputeSettings.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+  /**
+   * Compute settings panel (#374, extracted from SettingsDialog for #672).
+   *
+   * Self-contained: owns the per-machine Python interpreter override + the live
+   * probe state, loads on mount, and drives everything through api.compute.*.
+   * The dialog just mounts it for the "compute" tab.
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+
+  let pythonPathInput = $state('');
+  /** What's saved to disk; used to detect dirty state. */
+  let pythonPathSaved = $state('');
+  let pythonProbe = $state<{ ok: boolean; path: string; version?: string; error?: string } | null>(null);
+  let pythonProbing = $state(false);
+
+  async function loadComputeSettings(): Promise<void> {
+    try {
+      const s = await api.compute.getPythonSettings();
+      pythonPathInput = s.pythonPath;
+      pythonPathSaved = s.pythonPath;
+      // Probe whatever the resolver would currently pick so the status line
+      // reflects the live state, not just the override.
+      await refreshPythonProbe();
+    } catch (e) {
+      console.error('[settings] failed to load python settings:', e);
+    }
+  }
+
+  async function refreshPythonProbe(): Promise<void> {
+    pythonProbing = true;
+    try {
+      // Empty `pythonPathInput` → probe the resolver's active pick (env var or
+      // `python3`). Non-empty → probe the input directly so the status line
+      // shows whether the candidate would work.
+      pythonProbe = await api.compute.probePython(pythonPathInput.trim() || undefined);
+    } catch (e) {
+      pythonProbe = { ok: false, path: pythonPathInput, error: e instanceof Error ? e.message : String(e) };
+    } finally {
+      pythonProbing = false;
+    }
+  }
+
+  async function browsePythonInterpreter(): Promise<void> {
+    const picked = await api.compute.browsePython();
+    if (!picked) return;
+    pythonPathInput = picked;
+    // Probe immediately so the user gets instant feedback on whether the
+    // picked file is actually a runnable Python.
+    await refreshPythonProbe();
+  }
+
+  async function savePythonPath(): Promise<void> {
+    try {
+      await api.compute.setPythonSettings({ pythonPath: pythonPathInput.trim() });
+      pythonPathSaved = pythonPathInput.trim();
+      await refreshPythonProbe();
+    } catch (e) {
+      pythonProbe = { ok: false, path: pythonPathInput, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  async function restartPythonKernelFromSettings(): Promise<void> {
+    try {
+      await api.compute.restartPythonKernel();
+    } catch (e) {
+      console.error('[settings] failed to restart python kernel:', e);
+    }
+  }
+
+  onMount(loadComputeSettings);
+</script>
+
+<div class="field">
+  <label for="python-path">Python interpreter</label>
+  <p class="hint">
+    Path to the Python executable Minerva should use for cell
+    execution. Leave empty to fall back to the
+    <code>MINERVA_PYTHON</code> environment variable, then to
+    <code>python3</code> on <code>$PATH</code>. Stored
+    per-machine — different projects on this machine share the
+    same interpreter.
+  </p>
+  <div class="path-row">
+    <input
+      id="python-path"
+      type="text"
+      bind:value={pythonPathInput}
+      placeholder="/Users/you/.minerva-venv/bin/python"
+      spellcheck="false"
+      autocomplete="off"
+      autocapitalize="off"
+    />
+    <button
+      class="action-btn"
+      onclick={() => { void browsePythonInterpreter(); }}
+      disabled={pythonProbing}
+    >
+      Browse…
+    </button>
+    <button
+      class="action-btn"
+      onclick={() => { void refreshPythonProbe(); }}
+      disabled={pythonProbing}
+      title="Test the interpreter — runs `python --version`"
+    >
+      {pythonProbing ? 'Probing…' : 'Probe'}
+    </button>
+  </div>
+
+  {#if pythonProbe}
+    <div class="probe-result" class:probe-ok={pythonProbe.ok} class:probe-error={!pythonProbe.ok}>
+      {#if pythonProbe.ok}
+        <strong>{pythonProbe.version}</strong>
+        <span class="probe-path">at <code>{pythonProbe.path}</code></span>
+      {:else}
+        <strong>Couldn't run interpreter:</strong>
+        <span class="probe-path">{pythonProbe.error}</span>
+      {/if}
+    </div>
+  {/if}
+
+  <div class="action-row">
+    <button
+      class="action-btn primary"
+      onclick={() => { void savePythonPath(); }}
+      disabled={pythonProbing || pythonPathInput.trim() === pythonPathSaved}
+    >
+      Save
+    </button>
+    <button
+      class="action-btn"
+      onclick={() => { void restartPythonKernelFromSettings(); }}
+      title="Apply the new interpreter to a fresh kernel — wipes namespace state"
+    >
+      Save &amp; Restart Kernel
+    </button>
+    {#if pythonPathSaved}
+      <button
+        class="link-btn"
+        onclick={() => { pythonPathInput = ''; void savePythonPath(); }}
+      >
+        Clear override
+      </button>
+    {/if}
+  </div>
+
+  <p class="hint">
+    Tip: a venv at <code>~/.minerva-venv/bin/python</code> with
+    <code>pandas</code>, <code>matplotlib</code>, and
+    <code>pillow</code> installed gives you the full rich-output
+    pipeline. After changing the interpreter, click
+    <em>Save &amp; Restart Kernel</em> so the next cell runs
+    against the new env.
+  </p>
+</div>
+
+<style>
+  /* Shared form vocabulary, scoped to this panel (the app's per-dialog
+     convention — each component carries its own .field / .hint / button CSS). */
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label { color: var(--text); }
+  .field input[type="text"] {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .field input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .action-btn {
+    align-self: flex-start;
+    padding: 4px 12px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .action-btn:hover:not(:disabled) { background: var(--bg-button-hover); }
+  .action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .action-btn.primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+    font-weight: 500;
+  }
+  .action-btn.primary:hover:not(:disabled) { filter: brightness(1.1); }
+  .link-btn {
+    align-self: flex-start;
+    margin-top: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .link-btn:hover { color: var(--text); }
+
+  /* Compute-specific. */
+  .path-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    margin: 6px 0;
+  }
+  .path-row input[type="text"] {
+    flex: 1;
+    min-width: 0;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 12px;
+  }
+  .probe-result {
+    padding: 6px 10px;
+    border-left: 3px solid var(--border);
+    background: var(--bg-button);
+    font-size: 12px;
+    margin: 6px 0;
+    border-radius: 0 3px 3px 0;
+  }
+  .probe-result.probe-ok { border-left-color: var(--accent); }
+  .probe-result.probe-error { border-left-color: var(--accent); }
+  .probe-result strong { display: block; margin-bottom: 2px; }
+  .probe-result .probe-path {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+  .probe-result code {
+    font-size: 11px;
+    background: var(--bg);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+  .action-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    margin: 8px 0;
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -52,6 +52,7 @@
   } from '../../../shared/skills/menu-config';
   import { SKILL_MENUS } from '../../../shared/skills/types';
   import SitesSettings from './SitesSettings.svelte';
+  import ComputeSettings from './ComputeSettings.svelte';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -456,66 +457,8 @@
   let toolModelOverrides = $state<Record<string, string>>({});
   const allTools: ThinkingToolInfo[] = getAllToolInfos();
 
-  // Compute (#374): per-machine Python interpreter override.
-  let pythonPathInput = $state('');
-  /** What's saved to disk; used to detect dirty state. */
-  let pythonPathSaved = $state('');
-  let pythonProbe = $state<{ ok: boolean; path: string; version?: string; error?: string } | null>(null);
-  let pythonProbing = $state(false);
-
-  async function loadComputeSettings(): Promise<void> {
-    try {
-      const s = await api.compute.getPythonSettings();
-      pythonPathInput = s.pythonPath;
-      pythonPathSaved = s.pythonPath;
-      // Probe whatever the resolver would currently pick so the
-      // status line reflects the live state, not just the override.
-      await refreshPythonProbe();
-    } catch (e) {
-      console.error('[settings] failed to load python settings:', e);
-    }
-  }
-
-  async function refreshPythonProbe(): Promise<void> {
-    pythonProbing = true;
-    try {
-      // Empty `pythonPathInput` → probe the resolver's active pick
-      // (env var or `python3`). Non-empty → probe the input directly
-      // so the status line shows whether the candidate would work.
-      pythonProbe = await api.compute.probePython(pythonPathInput.trim() || undefined);
-    } catch (e) {
-      pythonProbe = { ok: false, path: pythonPathInput, error: e instanceof Error ? e.message : String(e) };
-    } finally {
-      pythonProbing = false;
-    }
-  }
-
-  async function browsePythonInterpreter(): Promise<void> {
-    const picked = await api.compute.browsePython();
-    if (!picked) return;
-    pythonPathInput = picked;
-    // Probe immediately so the user gets instant feedback on whether
-    // the picked file is actually a runnable Python.
-    await refreshPythonProbe();
-  }
-
-  async function savePythonPath(): Promise<void> {
-    try {
-      await api.compute.setPythonSettings({ pythonPath: pythonPathInput.trim() });
-      pythonPathSaved = pythonPathInput.trim();
-      await refreshPythonProbe();
-    } catch (e) {
-      pythonProbe = { ok: false, path: pythonPathInput, error: e instanceof Error ? e.message : String(e) };
-    }
-  }
-
-  async function restartPythonKernelFromSettings(): Promise<void> {
-    try {
-      await api.compute.restartPythonKernel();
-    } catch (e) {
-      console.error('[settings] failed to restart python kernel:', e);
-    }
-  }
+  // Compute (#374): the Python-interpreter panel now lives in
+  // ComputeSettings.svelte (self-contained).
 
   onMount(async () => {
     try {
@@ -533,7 +476,6 @@
     }
     await loadBibliographySettings();
     await loadExcerptSettings();
-    await loadComputeSettings();
     await loadSkills();
     try {
       const ingest = await api.sources.getIngestSettings();
@@ -1203,89 +1145,7 @@
           </div>
 
         {:else if activeTab === 'compute'}
-          <div class="field">
-            <label for="python-path">Python interpreter</label>
-            <p class="hint">
-              Path to the Python executable Minerva should use for cell
-              execution. Leave empty to fall back to the
-              <code>MINERVA_PYTHON</code> environment variable, then to
-              <code>python3</code> on <code>$PATH</code>. Stored
-              per-machine — different projects on this machine share the
-              same interpreter.
-            </p>
-            <div class="path-row">
-              <input
-                id="python-path"
-                type="text"
-                bind:value={pythonPathInput}
-                placeholder="/Users/you/.minerva-venv/bin/python"
-                spellcheck="false"
-                autocomplete="off"
-                autocapitalize="off"
-              />
-              <button
-                class="action-btn"
-                onclick={() => { void browsePythonInterpreter(); }}
-                disabled={pythonProbing}
-              >
-                Browse…
-              </button>
-              <button
-                class="action-btn"
-                onclick={() => { void refreshPythonProbe(); }}
-                disabled={pythonProbing}
-                title="Test the interpreter — runs `python --version`"
-              >
-                {pythonProbing ? 'Probing…' : 'Probe'}
-              </button>
-            </div>
-
-            {#if pythonProbe}
-              <div class="probe-result" class:probe-ok={pythonProbe.ok} class:probe-error={!pythonProbe.ok}>
-                {#if pythonProbe.ok}
-                  <strong>{pythonProbe.version}</strong>
-                  <span class="probe-path">at <code>{pythonProbe.path}</code></span>
-                {:else}
-                  <strong>Couldn't run interpreter:</strong>
-                  <span class="probe-path">{pythonProbe.error}</span>
-                {/if}
-              </div>
-            {/if}
-
-            <div class="action-row">
-              <button
-                class="action-btn primary"
-                onclick={() => { void savePythonPath(); }}
-                disabled={pythonProbing || pythonPathInput.trim() === pythonPathSaved}
-              >
-                Save
-              </button>
-              <button
-                class="action-btn"
-                onclick={() => { void restartPythonKernelFromSettings(); }}
-                title="Apply the new interpreter to a fresh kernel — wipes namespace state"
-              >
-                Save &amp; Restart Kernel
-              </button>
-              {#if pythonPathSaved}
-                <button
-                  class="link-btn"
-                  onclick={() => { pythonPathInput = ''; void savePythonPath(); }}
-                >
-                  Clear override
-                </button>
-              {/if}
-            </div>
-
-            <p class="hint">
-              Tip: a venv at <code>~/.minerva-venv/bin/python</code> with
-              <code>pandas</code>, <code>matplotlib</code>, and
-              <code>pillow</code> installed gives you the full rich-output
-              pipeline. After changing the interpreter, click
-              <em>Save &amp; Restart Kernel</em> so the next cell runs
-              against the new env.
-            </p>
-          </div>
+          <ComputeSettings />
 
         {:else if activeTab === 'ai'}
           <div class="field">
@@ -1934,56 +1794,6 @@
   }
   .skill-err-label {
     font-weight: 600;
-  }
-
-  /* Compute panel — Python interpreter row + probe status (#374). */
-  .path-row {
-    display: flex;
-    gap: 6px;
-    align-items: center;
-    margin: 6px 0;
-  }
-  .path-row input[type="text"] {
-    flex: 1;
-    min-width: 0;
-    font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: 12px;
-  }
-  .probe-result {
-    padding: 6px 10px;
-    border-left: 3px solid var(--border);
-    background: var(--bg-button);
-    font-size: 12px;
-    margin: 6px 0;
-    border-radius: 0 3px 3px 0;
-  }
-  .probe-result.probe-ok { border-left-color: var(--accent); }
-  .probe-result.probe-error { border-left-color: var(--accent); }
-  .probe-result strong { display: block; margin-bottom: 2px; }
-  .probe-result .probe-path {
-    color: var(--text-muted);
-    font-size: 11px;
-  }
-  .probe-result code {
-    font-size: 11px;
-    background: var(--bg);
-    padding: 1px 4px;
-    border-radius: 2px;
-  }
-  .action-row {
-    display: flex;
-    gap: 6px;
-    align-items: center;
-    margin: 8px 0;
-  }
-  .action-btn.primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
-    font-weight: 500;
-  }
-  .action-btn.primary:hover:not(:disabled) {
-    filter: brightness(1.1);
   }
 
   .section-intro code {

--- a/tests/renderer/components/ComputeSettings.test.ts
+++ b/tests/renderer/components/ComputeSettings.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for ComputeSettings (#672) — the Python-interpreter panel
+ * extracted from SettingsDialog. Self-contained: loads on mount and drives
+ * api.compute.*. These tests mock that boundary and pin the probe-on-mount, the
+ * probe status line, Browse, Save (with dirty-state gating), and Clear override.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+const {
+  getPythonSettingsMock, probePythonMock, browsePythonMock,
+  setPythonSettingsMock, restartKernelMock,
+} = vi.hoisted(() => ({
+  getPythonSettingsMock: vi.fn(),
+  probePythonMock: vi.fn(),
+  browsePythonMock: vi.fn(),
+  setPythonSettingsMock: vi.fn(),
+  restartKernelMock: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    compute: {
+      getPythonSettings: getPythonSettingsMock,
+      probePython: probePythonMock,
+      browsePython: browsePythonMock,
+      setPythonSettings: setPythonSettingsMock,
+      restartPythonKernel: restartKernelMock,
+    },
+  },
+}));
+
+import ComputeSettings from '../../../src/renderer/lib/components/ComputeSettings.svelte';
+
+afterEach(() => {
+  cleanup();
+  [getPythonSettingsMock, probePythonMock, browsePythonMock, setPythonSettingsMock, restartKernelMock]
+    .forEach((m) => m.mockReset());
+});
+
+describe('ComputeSettings (#672)', () => {
+  it('loads the saved path on mount and probes, showing the version', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3' });
+    probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12.1' });
+    const { findByText, getByDisplayValue } = render(ComputeSettings, {});
+
+    expect(await findByText('Python 3.12.1')).toBeTruthy();
+    expect(getByDisplayValue('/usr/bin/python3')).toBeTruthy();
+    // It probed the resolver's pick (input was non-empty → probes that path).
+    expect(probePythonMock).toHaveBeenCalledWith('/usr/bin/python3');
+  });
+
+  it('shows the error state when the probe fails', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/bad/python' });
+    probePythonMock.mockResolvedValue({ ok: false, path: '/bad/python', error: 'not executable' });
+    const { findByText } = render(ComputeSettings, {});
+    expect(await findByText(/Couldn't run interpreter/)).toBeTruthy();
+    expect(await findByText('not executable')).toBeTruthy();
+  });
+
+  it('Browse sets the picked path and re-probes', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '' });
+    probePythonMock.mockResolvedValue({ ok: true, path: 'x', version: 'Python 3.12' });
+    browsePythonMock.mockResolvedValue('/opt/py/bin/python');
+    const { findByText, getByText, getByDisplayValue } = render(ComputeSettings, {});
+    await findByText('Python 3.12');
+
+    await fireEvent.click(getByText('Browse…'));
+    await waitFor(() => expect(getByDisplayValue('/opt/py/bin/python')).toBeTruthy());
+    expect(browsePythonMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Save is gated on dirty state and persists via api.compute.setPythonSettings', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3' });
+    probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12' });
+    setPythonSettingsMock.mockResolvedValue(undefined);
+    const { findByText, getByText, getByDisplayValue } = render(ComputeSettings, {});
+    await findByText('Python 3.12');
+
+    // Pristine → Save disabled.
+    expect(getByText('Save').closest('button')!.disabled).toBe(true);
+
+    await fireEvent.input(getByDisplayValue('/usr/bin/python3'), { target: { value: '/new/python' } });
+    expect(getByText('Save').closest('button')!.disabled).toBe(false);
+
+    await fireEvent.click(getByText('Save'));
+    expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '/new/python' });
+  });
+
+  it('Clear override blanks the path and saves', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3' });
+    probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12' });
+    setPythonSettingsMock.mockResolvedValue(undefined);
+    const { findByText, getByText } = render(ComputeSettings, {});
+    await findByText('Python 3.12');
+
+    await fireEvent.click(getByText('Clear override'));
+    await waitFor(() => expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '' }));
+  });
+});


### PR DESCRIPTION
## What

Second per-tab panel split of SettingsDialog (after SitesSettings in #720). The **compute tab** (#374) — the per-machine Python interpreter override + live probe — is self-contained (its state and handlers only touch `api.compute.*`), so it lifts whole into **`ComputeSettings.svelte`** that owns its state, loads on mount, and is mounted by the dialog for the "compute" tab. **SettingsDialog 2,052 → 1,912.**

## CSS handling
Compute-specific rules (`.path-row` / `.probe-*` / `.action-row` / the compute-only `.action-btn.primary`) moved into the child and were **deleted from the dialog** (svelte-check confirmed they're now unused). The shared `.action-btn` / `.link-btn` / `.field` / `.hint` rules stay (other panels use them); the child carries its own scoped copies, per the app's per-dialog convention.

## Behavior note
Like the sites panel, the interpreter settings now load lazily when the compute tab is opened (the child's `onMount`) rather than eagerly on dialog open — equivalent (the panel is the only place they render) and leaner.

## Tests (5)
`components/ComputeSettings.test.ts` mocks `api.compute` and pins: the probe-on-mount + version line, the probe **error** state, Browse → set-path + re-probe, **Save gated on dirty state** → `setPythonSettings`, and Clear override → save with an empty path.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **2990 passed** (+5).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)