### PR TITLE
Extract BibliographySettings panel from SettingsDialog (#672)

### DIFF
--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  /**
+   * AI settings panel (default model + Anthropic API key + per-tool model
+   * overrides, extracted from SettingsDialog for #672).
+   *
+   * Unlike the other settings panels, the AI settings are persisted by the
+   * dialog's Done handler (so the key + model + overrides apply together), not
+   * on each edit. So this panel is presentational: the dialog owns the state
+   * and the save, and binds it here via `$bindable` props. `apiKeyStatus` is
+   * read-only (reflects what's already stored).
+   */
+  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+  import { getAllToolInfos } from '../tools/tool-registry';
+  import type { ThinkingToolInfo } from '../../../shared/tools/types';
+
+  interface Props {
+    model: string;
+    apiKeyInput: string;
+    clearApiKey: boolean;
+    toolModelOverrides: Record<string, string>;
+    apiKeyStatus: 'unknown' | 'set' | 'unset';
+  }
+
+  let {
+    model = $bindable(),
+    apiKeyInput = $bindable(),
+    clearApiKey = $bindable(),
+    toolModelOverrides = $bindable(),
+    apiKeyStatus,
+  }: Props = $props();
+
+  const allTools: ThinkingToolInfo[] = getAllToolInfos();
+
+  function setToolOverride(toolId: string, value: string): void {
+    const next = { ...toolModelOverrides };
+    if (value) next[toolId] = value;
+    else delete next[toolId];
+    toolModelOverrides = next;
+  }
+</script>
+
+<div class="field">
+  <label for="model">Default model</label>
+  <select id="model" bind:value={model}>
+    {#each MODEL_OPTIONS as m}
+      <option value={m.value}>{m.label}</option>
+    {/each}
+  </select>
+</div>
+<div class="field">
+  <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>
+    {#if apiKeyStatus === 'unknown'}
+      Loading…
+    {:else if clearApiKey}
+      API key will be cleared on save
+    {:else if apiKeyStatus === 'set'}
+      ✓ API key saved
+    {:else}
+      No API key set
+    {/if}
+  </div>
+  <label for="api-key">
+    Anthropic API key
+  </label>
+  <input
+    id="api-key"
+    type="password"
+    bind:value={apiKeyInput}
+    placeholder={apiKeyStatus === 'set' ? 'Type to replace existing key' : 'Enter Anthropic API key'}
+    autocomplete="off"
+    spellcheck="false"
+    autocapitalize="off"
+    oncopy={(e) => e.preventDefault()}
+    oncut={(e) => e.preventDefault()}
+    oncontextmenu={(e) => e.preventDefault()}
+    disabled={clearApiKey}
+  />
+  <p class="hint">
+    Keys are stored in your user data directory. The saved value is never displayed back.
+    You can also set <code>ANTHROPIC_API_KEY</code> as an environment variable.
+  </p>
+  {#if apiKeyStatus === 'set' && !clearApiKey}
+    <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
+      Clear saved key
+    </button>
+  {:else if clearApiKey}
+    <button class="link-btn" onclick={() => { clearApiKey = false; }}>
+      Cancel clear
+    </button>
+  {/if}
+</div>
+<div class="field">
+  <label>Tool model overrides</label>
+  <p class="hint">
+    Each tool's author may suggest a preferred model. You can override that
+    per tool. Empty override → use the tool's preference; no preference →
+    fall back to the default model above.
+  </p>
+  {#if allTools.length === 0}
+    <p class="hint">No tools registered.</p>
+  {:else}
+    <table class="tool-models">
+      <thead>
+        <tr>
+          <th>Tool</th>
+          <th>Tool preference</th>
+          <th>Your override</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each allTools as t}
+          <tr>
+            <td>{t.name}</td>
+            <td class="muted">{t.preferredModel ? modelLabel(t.preferredModel) : '—'}</td>
+            <td>
+              <select
+                value={toolModelOverrides[t.id] ?? ''}
+                onchange={(e) => setToolOverride(t.id, e.currentTarget.value)}
+              >
+                <option value="">Use tool preference</option>
+                {#each MODEL_OPTIONS as m}
+                  <option value={m.value}>{m.label}</option>
+                {/each}
+              </select>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</div>
+
+<style>
+  /* Shared form vocabulary, scoped to this panel (app's per-dialog convention). */
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label { color: var(--text); }
+  .field input[type="password"],
+  .field select {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .field input[type="password"]:focus,
+  .field select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .link-btn {
+    align-self: flex-start;
+    margin-top: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .link-btn:hover { color: var(--text); }
+
+  /* AI panel — API key status + tool-override table. */
+  .api-key-status {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+  }
+  .api-key-status.saved {
+    color: var(--accent);
+  }
+  .tool-models {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  .tool-models th,
+  .tool-models td {
+    text-align: left;
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .tool-models th {
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+  .tool-models td.muted {
+    color: var(--text-muted);
+  }
+  .tool-models select {
+    padding: 3px 6px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    max-width: 170px;
+  }
+</style>

--- a/src/renderer/lib/components/BibliographySettings.svelte
+++ b/src/renderer/lib/components/BibliographySettings.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+  /**
+   * Bibliography settings panel (CSL citation style + imported styles/locales,
+   * #302, extracted from SettingsDialog for #672).
+   *
+   * Self-contained: owns the active style + the user-imported CSL asset lists,
+   * loads on mount, and drives api.bibliography.* / api.csl.*. The active style
+   * is per-project; imported assets live under .minerva/.
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+
+  let bibliographyStyles = $state<{ id: string; label: string; isUser?: boolean }[]>([]);
+  let bibliographyStyleId = $state('apa');
+  let userStyles = $state<{ id: string; label: string; filePath: string }[]>([]);
+  let userLocales = $state<{ id: string; filePath: string }[]>([]);
+  let cslImportError = $state<string | null>(null);
+  let cslImporting = $state(false);
+
+  async function loadBibliographySettings(): Promise<void> {
+    try {
+      const [styles, current, uStyles, uLocales] = await Promise.all([
+        api.bibliography.listStyles(),
+        api.bibliography.getStyle(),
+        api.csl.listUserStyles(),
+        api.csl.listUserLocales(),
+      ]);
+      bibliographyStyles = styles;
+      bibliographyStyleId = current;
+      userStyles = uStyles;
+      userLocales = uLocales;
+    } catch (e) {
+      console.error('[settings] failed to load bibliography settings:', e);
+    }
+  }
+
+  async function setBibliographyStyle(next: string): Promise<void> {
+    bibliographyStyleId = next;
+    try {
+      await api.bibliography.setStyle(next);
+    } catch (e) {
+      console.error('[settings] failed to save bibliography style:', e);
+    }
+  }
+
+  async function importUserStyle(): Promise<void> {
+    cslImportError = null;
+    cslImporting = true;
+    try {
+      const result = await api.csl.importStyle();
+      if (result) await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    } finally {
+      cslImporting = false;
+    }
+  }
+
+  async function importUserLocale(): Promise<void> {
+    cslImportError = null;
+    cslImporting = true;
+    try {
+      const result = await api.csl.importLocale();
+      if (result) await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    } finally {
+      cslImporting = false;
+    }
+  }
+
+  async function removeUserStyle(id: string): Promise<void> {
+    cslImportError = null;
+    try {
+      await api.csl.removeStyle(id);
+      await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function removeUserLocale(id: string): Promise<void> {
+    cslImportError = null;
+    try {
+      await api.csl.removeLocale(id);
+      await loadBibliographySettings();
+    } catch (e) {
+      cslImportError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  onMount(loadBibliographySettings);
+</script>
+
+<div class="field">
+  <label for="csl-style">Citation style</label>
+  <select
+    id="csl-style"
+    value={bibliographyStyleId}
+    onchange={(e) => { void setBibliographyStyle(e.currentTarget.value); }}
+  >
+    {#each bibliographyStyles as style (style.id)}
+      <option value={style.id}>
+        {style.label}{style.isUser ? ' (imported)' : ''}
+      </option>
+    {/each}
+  </select>
+  <p class="hint">
+    Used by Refactor → Insert/Update Bibliography. Stored per-project
+    in <code>.minerva/config.json</code>, so different thoughtbases can
+    follow different style guides.
+  </p>
+</div>
+
+<div class="field">
+  <label>Imported styles</label>
+  <p class="hint">
+    Drop additional <code>.csl</code> files into your project under
+    <code>.minerva/csl-styles/</code> — they show up in the picker above and
+    in the Export dialog. The Zotero Style Repository at
+    <code>zotero.org/styles</code> publishes 10,000+ open styles.
+  </p>
+  {#if userStyles.length === 0}
+    <p class="hint empty">No imported styles yet.</p>
+  {:else}
+    <ul class="csl-list">
+      {#each userStyles as s (s.id)}
+        <li>
+          <span class="csl-label">{s.label}</span>
+          <span class="csl-id">{s.id}</span>
+          <button class="link-btn" onclick={() => { void removeUserStyle(s.id); }}>
+            Remove
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+  <button
+    class="action-btn"
+    onclick={() => { void importUserStyle(); }}
+    disabled={cslImporting}
+  >
+    Import .csl style…
+  </button>
+</div>
+
+<div class="field">
+  <label>Imported locales</label>
+  <p class="hint">
+    Optional. Bundled locale is en-US; import additional CSL
+    locale XML to render bibliographies in another language.
+  </p>
+  {#if userLocales.length === 0}
+    <p class="hint empty">No imported locales yet.</p>
+  {:else}
+    <ul class="csl-list">
+      {#each userLocales as l (l.id)}
+        <li>
+          <span class="csl-label">{l.id}</span>
+          <button class="link-btn" onclick={() => { void removeUserLocale(l.id); }}>
+            Remove
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+  <button
+    class="action-btn"
+    onclick={() => { void importUserLocale(); }}
+    disabled={cslImporting}
+  >
+    Import locale .xml…
+  </button>
+</div>
+
+{#if cslImportError}
+  <div class="csl-error">{cslImportError}</div>
+{/if}
+
+<style>
+  /* Shared form vocabulary, scoped to this panel (app's per-dialog convention). */
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label { color: var(--text); }
+  .field select {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .field select:focus { outline: none; border-color: var(--accent); }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .hint.empty {
+    font-style: italic;
+    margin: 0 0 8px 0;
+  }
+  .action-btn {
+    align-self: flex-start;
+    padding: 4px 12px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .action-btn:hover:not(:disabled) { background: var(--bg-button-hover); }
+  .action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .link-btn {
+    align-self: flex-start;
+    margin-top: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .link-btn:hover { color: var(--text); }
+  .csl-error {
+    margin-top: 8px;
+    padding: 6px 10px;
+    border-left: 3px solid var(--accent);
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    white-space: pre-wrap;
+  }
+
+  /* User-imported CSL assets list (#302). */
+  .csl-list {
+    list-style: none;
+    margin: 0 0 8px 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .csl-list li {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-button);
+    font-size: 12px;
+  }
+  .csl-list .csl-label {
+    flex: 1;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .csl-list .csl-id {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .csl-list .link-btn {
+    align-self: auto;
+    margin-top: 0;
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -44,6 +44,7 @@
   import SitesSettings from './SitesSettings.svelte';
   import ComputeSettings from './ComputeSettings.svelte';
   import SkillsSettings from './SkillsSettings.svelte';
+  import BibliographySettings from './BibliographySettings.svelte';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -226,88 +227,8 @@
     }
   }
 
-  // Bibliography style (per-project, persisted in .minerva/config.json).
-  let bibliographyStyles = $state<{ id: string; label: string; isUser?: boolean }[]>([]);
-  let bibliographyStyleId = $state('apa');
-  // User-imported CSL assets (#302) — project-scoped under .minerva/.
-  let userStyles = $state<{ id: string; label: string; filePath: string }[]>([]);
-  let userLocales = $state<{ id: string; filePath: string }[]>([]);
-  let cslImportError = $state<string | null>(null);
-  let cslImporting = $state(false);
-
-  async function loadBibliographySettings(): Promise<void> {
-    try {
-      const [styles, current, uStyles, uLocales] = await Promise.all([
-        api.bibliography.listStyles(),
-        api.bibliography.getStyle(),
-        api.csl.listUserStyles(),
-        api.csl.listUserLocales(),
-      ]);
-      bibliographyStyles = styles;
-      bibliographyStyleId = current;
-      userStyles = uStyles;
-      userLocales = uLocales;
-    } catch (e) {
-      console.error('[settings] failed to load bibliography settings:', e);
-    }
-  }
-
-  async function setBibliographyStyle(next: string): Promise<void> {
-    bibliographyStyleId = next;
-    try {
-      await api.bibliography.setStyle(next);
-    } catch (e) {
-      console.error('[settings] failed to save bibliography style:', e);
-    }
-  }
-
-  async function importUserStyle(): Promise<void> {
-    cslImportError = null;
-    cslImporting = true;
-    try {
-      const result = await api.csl.importStyle();
-      if (result) await loadBibliographySettings();
-    } catch (e) {
-      cslImportError = e instanceof Error ? e.message : String(e);
-    } finally {
-      cslImporting = false;
-    }
-  }
-
-  async function importUserLocale(): Promise<void> {
-    cslImportError = null;
-    cslImporting = true;
-    try {
-      const result = await api.csl.importLocale();
-      if (result) await loadBibliographySettings();
-    } catch (e) {
-      cslImportError = e instanceof Error ? e.message : String(e);
-    } finally {
-      cslImporting = false;
-    }
-  }
-
-  // Skills (#629, menu config #630) now live in SkillsSettings.svelte.
-
-  async function removeUserStyle(id: string): Promise<void> {
-    cslImportError = null;
-    try {
-      await api.csl.removeStyle(id);
-      await loadBibliographySettings();
-    } catch (e) {
-      cslImportError = e instanceof Error ? e.message : String(e);
-    }
-  }
-
-  async function removeUserLocale(id: string): Promise<void> {
-    cslImportError = null;
-    try {
-      await api.csl.removeLocale(id);
-      await loadBibliographySettings();
-    } catch (e) {
-      cslImportError = e instanceof Error ? e.message : String(e);
-    }
-  }
+  // Bibliography (#302) + Skills (#629) now live in their own panel components
+  // (BibliographySettings.svelte / SkillsSettings.svelte).
 
   // Web + AI settings (async-loaded from main process)
   let webEnabled = $state(true);
@@ -342,7 +263,6 @@
     } catch (e) {
       console.error('[settings] failed to load LLM settings:', e);
     }
-    await loadBibliographySettings();
     await loadExcerptSettings();
     try {
       const ingest = await api.sources.getIngestSettings();
@@ -807,90 +727,7 @@
           <SitesSettings />
 
         {:else if activeTab === 'bibliography'}
-          <div class="field">
-            <label for="csl-style">Citation style</label>
-            <select
-              id="csl-style"
-              value={bibliographyStyleId}
-              onchange={(e) => { void setBibliographyStyle(e.currentTarget.value); }}
-            >
-              {#each bibliographyStyles as style (style.id)}
-                <option value={style.id}>
-                  {style.label}{style.isUser ? ' (imported)' : ''}
-                </option>
-              {/each}
-            </select>
-            <p class="hint">
-              Used by Refactor → Insert/Update Bibliography. Stored per-project
-              in <code>.minerva/config.json</code>, so different thoughtbases can
-              follow different style guides.
-            </p>
-          </div>
-
-          <div class="field">
-            <label>Imported styles</label>
-            <p class="hint">
-              Drop additional <code>.csl</code> files into your project under
-              <code>.minerva/csl-styles/</code> — they show up in the picker above and
-              in the Export dialog. The Zotero Style Repository at
-              <code>zotero.org/styles</code> publishes 10,000+ open styles.
-            </p>
-            {#if userStyles.length === 0}
-              <p class="hint empty">No imported styles yet.</p>
-            {:else}
-              <ul class="csl-list">
-                {#each userStyles as s (s.id)}
-                  <li>
-                    <span class="csl-label">{s.label}</span>
-                    <span class="csl-id">{s.id}</span>
-                    <button class="link-btn" onclick={() => { void removeUserStyle(s.id); }}>
-                      Remove
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            {/if}
-            <button
-              class="action-btn"
-              onclick={() => { void importUserStyle(); }}
-              disabled={cslImporting}
-            >
-              Import .csl style…
-            </button>
-          </div>
-
-          <div class="field">
-            <label>Imported locales</label>
-            <p class="hint">
-              Optional. Bundled locale is en-US; import additional CSL
-              locale XML to render bibliographies in another language.
-            </p>
-            {#if userLocales.length === 0}
-              <p class="hint empty">No imported locales yet.</p>
-            {:else}
-              <ul class="csl-list">
-                {#each userLocales as l (l.id)}
-                  <li>
-                    <span class="csl-label">{l.id}</span>
-                    <button class="link-btn" onclick={() => { void removeUserLocale(l.id); }}>
-                      Remove
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            {/if}
-            <button
-              class="action-btn"
-              onclick={() => { void importUserLocale(); }}
-              disabled={cslImporting}
-            >
-              Import locale .xml…
-            </button>
-          </div>
-
-          {#if cslImportError}
-            <div class="csl-error">{cslImportError}</div>
-          {/if}
+          <BibliographySettings />
 
         {:else if activeTab === 'skills'}
           <SkillsSettings />
@@ -1392,46 +1229,6 @@
     margin: 0 0 16px 0;
   }
 
-  /* User-imported CSL assets list (#302). Mirrors the privileged-sites
-     style — each row shows a label, id, and a Remove action. */
-  .csl-list {
-    list-style: none;
-    margin: 0 0 8px 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-  .csl-list li {
-    display: flex;
-    align-items: baseline;
-    gap: 10px;
-    padding: 4px 8px;
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    background: var(--bg-button);
-    font-size: 12px;
-  }
-  .csl-list .csl-label {
-    flex: 1;
-    color: var(--text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .csl-list .csl-id {
-    font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: 11px;
-    color: var(--text-muted);
-  }
-  .csl-list .link-btn {
-    align-self: auto;
-    margin-top: 0;
-  }
-  .hint.empty {
-    font-style: italic;
-    margin: 0 0 8px 0;
-  }
   .action-btn {
     align-self: flex-start;
     padding: 4px 12px;
@@ -1448,16 +1245,6 @@
   .action-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-  .csl-error {
-    margin-top: 8px;
-    padding: 6px 10px;
-    border-left: 3px solid var(--accent);
-    background: var(--bg-button);
-    color: var(--text);
-    font-size: 12px;
-    font-family: var(--font-mono, ui-monospace, monospace);
-    white-space: pre-wrap;
   }
 
   .section-intro code {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -38,13 +38,11 @@
   } from '../../../shared/formatter/registry';
   import '../../../shared/formatter/rules/index';
   import type { FormatSettings } from '../../../shared/formatter/engine';
-  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
-  import { getAllToolInfos } from '../tools/tool-registry';
-  import type { ThinkingToolInfo } from '../../../shared/tools/types';
   import SitesSettings from './SitesSettings.svelte';
   import ComputeSettings from './ComputeSettings.svelte';
   import SkillsSettings from './SkillsSettings.svelte';
   import BibliographySettings from './BibliographySettings.svelte';
+  import AiSettings from './AiSettings.svelte';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -244,7 +242,6 @@
   // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
   let loadedLlm: LLMSettings | null = null;
   let toolModelOverrides = $state<Record<string, string>>({});
-  const allTools: ThinkingToolInfo[] = getAllToolInfos();
 
   // Compute (#374): the Python-interpreter panel now lives in
   // ComputeSettings.svelte (self-contained).
@@ -272,12 +269,6 @@
     }
   });
 
-  function setToolOverride(toolId: string, value: string) {
-    const next = { ...toolModelOverrides };
-    if (value) next[toolId] = value;
-    else delete next[toolId];
-    toolModelOverrides = next;
-  }
 
   function parseDomains(text: string): string[] {
     return text
@@ -753,96 +744,13 @@
           <ComputeSettings />
 
         {:else if activeTab === 'ai'}
-          <div class="field">
-            <label for="model">Default model</label>
-            <select id="model" bind:value={model}>
-              {#each MODEL_OPTIONS as m}
-                <option value={m.value}>{m.label}</option>
-              {/each}
-            </select>
-          </div>
-          <div class="field">
-            <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>
-              {#if apiKeyStatus === 'unknown'}
-                Loading…
-              {:else if clearApiKey}
-                API key will be cleared on save
-              {:else if apiKeyStatus === 'set'}
-                ✓ API key saved
-              {:else}
-                No API key set
-              {/if}
-            </div>
-            <label for="api-key">
-              Anthropic API key
-            </label>
-            <input
-              id="api-key"
-              type="password"
-              bind:value={apiKeyInput}
-              placeholder={apiKeyStatus === 'set' ? 'Type to replace existing key' : 'Enter Anthropic API key'}
-              autocomplete="off"
-              spellcheck="false"
-              autocapitalize="off"
-              oncopy={(e) => e.preventDefault()}
-              oncut={(e) => e.preventDefault()}
-              oncontextmenu={(e) => e.preventDefault()}
-              disabled={clearApiKey}
-            />
-            <p class="hint">
-              Keys are stored in your user data directory. The saved value is never displayed back.
-              You can also set <code>ANTHROPIC_API_KEY</code> as an environment variable.
-            </p>
-            {#if apiKeyStatus === 'set' && !clearApiKey}
-              <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
-                Clear saved key
-              </button>
-            {:else if clearApiKey}
-              <button class="link-btn" onclick={() => { clearApiKey = false; }}>
-                Cancel clear
-              </button>
-            {/if}
-          </div>
-          <div class="field">
-            <label>Tool model overrides</label>
-            <p class="hint">
-              Each tool's author may suggest a preferred model. You can override that
-              per tool. Empty override → use the tool's preference; no preference →
-              fall back to the default model above.
-            </p>
-            {#if allTools.length === 0}
-              <p class="hint">No tools registered.</p>
-            {:else}
-              <table class="tool-models">
-                <thead>
-                  <tr>
-                    <th>Tool</th>
-                    <th>Tool preference</th>
-                    <th>Your override</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each allTools as t}
-                    <tr>
-                      <td>{t.name}</td>
-                      <td class="muted">{t.preferredModel ? modelLabel(t.preferredModel) : '—'}</td>
-                      <td>
-                        <select
-                          value={toolModelOverrides[t.id] ?? ''}
-                          onchange={(e) => setToolOverride(t.id, e.currentTarget.value)}
-                        >
-                          <option value="">Use tool preference</option>
-                          {#each MODEL_OPTIONS as m}
-                            <option value={m.value}>{m.label}</option>
-                          {/each}
-                        </select>
-                      </td>
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-            {/if}
-          </div>
+          <AiSettings
+            bind:model
+            bind:apiKeyInput
+            bind:clearApiKey
+            bind:toolModelOverrides
+            {apiKeyStatus}
+          />
         {/if}
       </section>
     </div>
@@ -1161,65 +1069,6 @@
   .btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-
-  .tool-models {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 12px;
-  }
-
-  .tool-models th,
-  .tool-models td {
-    text-align: left;
-    padding: 5px 8px;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .tool-models th {
-    font-weight: 600;
-    color: var(--text-muted);
-    font-size: 11px;
-  }
-
-  .tool-models td.muted {
-    color: var(--text-muted);
-  }
-
-  .tool-models select {
-    padding: 3px 6px;
-    background: var(--bg);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
-    max-width: 170px;
-  }
-
-  .api-key-status {
-    font-size: 11px;
-    color: var(--text-muted);
-    margin-bottom: 4px;
-  }
-
-  .api-key-status.saved {
-    color: var(--accent);
-  }
-
-  .link-btn {
-    align-self: flex-start;
-    margin-top: 4px;
-    padding: 0;
-    border: none;
-    background: none;
-    color: var(--text-muted);
-    font-size: 11px;
-    text-decoration: underline;
-    cursor: pointer;
-  }
-
-  .link-btn:hover {
-    color: var(--text);
   }
 
   .section-intro {

--- a/tests/renderer/components/AiSettings.test.ts
+++ b/tests/renderer/components/AiSettings.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for AiSettings (#672) — the model / API-key / tool-override
+ * panel extracted from SettingsDialog. The dialog owns persistence (save-on-
+ * Done) and binds the state in; this pins the presentational behavior: the API-
+ * key status states + the clear/cancel toggle, the model select, and the tool-
+ * override table (getAllToolInfos mocked; modelLabel runs for real).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const { getAllToolInfosMock } = vi.hoisted(() => ({ getAllToolInfosMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({
+  getAllToolInfos: getAllToolInfosMock,
+}));
+
+import AiSettings from '../../../src/renderer/lib/components/AiSettings.svelte';
+
+function props(over: Partial<{
+  model: string; apiKeyInput: string; clearApiKey: boolean;
+  toolModelOverrides: Record<string, string>; apiKeyStatus: 'unknown' | 'set' | 'unset';
+}> = {}) {
+  return {
+    model: 'claude-sonnet-4-6',
+    apiKeyInput: '',
+    clearApiKey: false,
+    toolModelOverrides: {},
+    apiKeyStatus: 'set' as const,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  getAllToolInfosMock.mockReset();
+});
+
+describe('AiSettings (#672)', () => {
+  it('renders the API-key status for each state', () => {
+    getAllToolInfosMock.mockReturnValue([]);
+    expect(render(AiSettings, props({ apiKeyStatus: 'set' })).getByText('✓ API key saved')).toBeTruthy();
+    cleanup();
+    expect(render(AiSettings, props({ apiKeyStatus: 'unset' })).getByText('No API key set')).toBeTruthy();
+    cleanup();
+    expect(render(AiSettings, props({ apiKeyStatus: 'unknown' })).getByText('Loading…')).toBeTruthy();
+  });
+
+  it('Clear saved key flips to the cleared state and disables the input; Cancel clear restores it', async () => {
+    getAllToolInfosMock.mockReturnValue([]);
+    const { getByText, getByLabelText, queryByText } = render(AiSettings, props({ apiKeyStatus: 'set' }));
+
+    await fireEvent.click(getByText('Clear saved key'));
+    expect(getByText('API key will be cleared on save')).toBeTruthy();
+    expect((getByLabelText('Anthropic API key') as HTMLInputElement).disabled).toBe(true);
+    expect(queryByText('✓ API key saved')).toBeNull();
+
+    await fireEvent.click(getByText('Cancel clear'));
+    expect(getByText('✓ API key saved')).toBeTruthy();
+  });
+
+  it('renders the tool-override table with each tool, its preference, and an override select', () => {
+    getAllToolInfosMock.mockReturnValue([
+      { id: 'summarize', name: 'Summarize', preferredModel: 'claude-haiku-4-5-20251001' },
+      { id: 'analyze', name: 'Analyze', preferredModel: undefined },
+    ]);
+    const { getByText, getAllByRole } = render(AiSettings, props());
+    expect(getByText('Summarize')).toBeTruthy();
+    expect(getByText('Analyze')).toBeTruthy();
+    // No-preference tool shows the em-dash.
+    expect(getByText('—')).toBeTruthy();
+    // model select + one override select per tool.
+    expect(getAllByRole('combobox').length).toBe(3);
+  });
+
+  it('shows the empty state when no tools are registered', () => {
+    getAllToolInfosMock.mockReturnValue([]);
+    expect(render(AiSettings, props()).getByText('No tools registered.')).toBeTruthy();
+  });
+
+  it('changing a tool override updates that select to the chosen model', async () => {
+    getAllToolInfosMock.mockReturnValue([
+      { id: 'summarize', name: 'Summarize', preferredModel: undefined },
+    ]);
+    const { getAllByRole } = render(AiSettings, props());
+    // [0] = default-model select, [1] = the tool override select.
+    const overrideSelect = getAllByRole('combobox')[1] as HTMLSelectElement;
+    expect(overrideSelect.value).toBe(''); // "Use tool preference"
+
+    await fireEvent.change(overrideSelect, { target: { value: 'claude-opus-4-7' } });
+    expect(overrideSelect.value).toBe('claude-opus-4-7');
+  });
+});

--- a/tests/renderer/components/BibliographySettings.test.ts
+++ b/tests/renderer/components/BibliographySettings.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for BibliographySettings (#672) — the CSL citation-style /
+ * imported-assets panel extracted from SettingsDialog. Mocks api.bibliography
+ * + api.csl and pins the on-mount load, the style change, the imported lists +
+ * empty states, import/remove flows, and the import-error banner.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+const {
+  listStylesMock, getStyleMock, setStyleMock,
+  listUserStylesMock, listUserLocalesMock,
+  importStyleMock, importLocaleMock, removeStyleMock, removeLocaleMock,
+} = vi.hoisted(() => ({
+  listStylesMock: vi.fn(),
+  getStyleMock: vi.fn(),
+  setStyleMock: vi.fn(),
+  listUserStylesMock: vi.fn(),
+  listUserLocalesMock: vi.fn(),
+  importStyleMock: vi.fn(),
+  importLocaleMock: vi.fn(),
+  removeStyleMock: vi.fn(),
+  removeLocaleMock: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    bibliography: { listStyles: listStylesMock, getStyle: getStyleMock, setStyle: setStyleMock },
+    csl: {
+      listUserStyles: listUserStylesMock,
+      listUserLocales: listUserLocalesMock,
+      importStyle: importStyleMock,
+      importLocale: importLocaleMock,
+      removeStyle: removeStyleMock,
+      removeLocale: removeLocaleMock,
+    },
+  },
+}));
+
+import BibliographySettings from '../../../src/renderer/lib/components/BibliographySettings.svelte';
+
+function setup(over: {
+  styles?: { id: string; label: string; isUser?: boolean }[];
+  current?: string;
+  userStyles?: { id: string; label: string; filePath: string }[];
+  userLocales?: { id: string; filePath: string }[];
+} = {}) {
+  listStylesMock.mockResolvedValue(over.styles ?? [
+    { id: 'apa', label: 'APA' },
+    { id: 'chicago', label: 'Chicago' },
+  ]);
+  getStyleMock.mockResolvedValue(over.current ?? 'apa');
+  listUserStylesMock.mockResolvedValue(over.userStyles ?? []);
+  listUserLocalesMock.mockResolvedValue(over.userLocales ?? []);
+}
+
+afterEach(() => {
+  cleanup();
+  [listStylesMock, getStyleMock, setStyleMock, listUserStylesMock, listUserLocalesMock,
+    importStyleMock, importLocaleMock, removeStyleMock, removeLocaleMock].forEach((m) => m.mockReset());
+});
+
+describe('BibliographySettings (#672)', () => {
+  it('loads styles on mount and selects the current one', async () => {
+    setup({ current: 'chicago' });
+    const { findByDisplayValue } = render(BibliographySettings, {});
+    // The select shows the current style's option label.
+    expect(await findByDisplayValue('Chicago')).toBeTruthy();
+  });
+
+  it('shows empty states when no user styles / locales are imported', async () => {
+    setup({ userStyles: [], userLocales: [] });
+    const { findByText, getByText } = render(BibliographySettings, {});
+    expect(await findByText('No imported styles yet.')).toBeTruthy();
+    expect(getByText('No imported locales yet.')).toBeTruthy();
+  });
+
+  it('changing the style select persists via api.bibliography.setStyle', async () => {
+    setup();
+    setStyleMock.mockResolvedValue(undefined);
+    const { findByDisplayValue, getByRole } = render(BibliographySettings, {});
+    await findByDisplayValue('APA');
+
+    await fireEvent.change(getByRole('combobox'), { target: { value: 'chicago' } });
+    expect(setStyleMock).toHaveBeenCalledWith('chicago');
+  });
+
+  it('renders imported styles + locales with a Remove action', async () => {
+    setup({
+      userStyles: [{ id: 'my-style', label: 'My Journal', filePath: '/x/my.csl' }],
+      userLocales: [{ id: 'de-DE', filePath: '/x/de.xml' }],
+    });
+    const { findByText, getByText } = render(BibliographySettings, {});
+    expect(await findByText('My Journal')).toBeTruthy();
+    expect(getByText('my-style')).toBeTruthy();
+    expect(getByText('de-DE')).toBeTruthy();
+  });
+
+  it('Import .csl style calls api.csl.importStyle then refreshes', async () => {
+    setup();
+    importStyleMock.mockResolvedValue(true);
+    const { findByText, getByText } = render(BibliographySettings, {});
+    await findByText('No imported styles yet.');
+
+    listStylesMock.mockClear();
+    await fireEvent.click(getByText('Import .csl style…'));
+    await waitFor(() => expect(importStyleMock).toHaveBeenCalled());
+    await waitFor(() => expect(listStylesMock).toHaveBeenCalled()); // reloaded
+  });
+
+  it('Remove style calls api.csl.removeStyle with the id', async () => {
+    setup({ userStyles: [{ id: 'my-style', label: 'My Journal', filePath: '/x/my.csl' }] });
+    removeStyleMock.mockResolvedValue(undefined);
+    const { findByText, getByText } = render(BibliographySettings, {});
+    await findByText('My Journal');
+
+    await fireEvent.click(getByText('Remove'));
+    await waitFor(() => expect(removeStyleMock).toHaveBeenCalledWith('my-style'));
+  });
+
+  it('surfaces an import error in the banner', async () => {
+    setup();
+    importLocaleMock.mockRejectedValue(new Error('not valid CSL locale XML'));
+    const { findByText, getByText } = render(BibliographySettings, {});
+    await findByText('No imported locales yet.');
+
+    await fireEvent.click(getByText('Import locale .xml…'));
+    expect(await findByText('not valid CSL locale XML')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Fourth per-tab panel split of SettingsDialog (after sites #720, compute #721, skills #722). The **bibliography tab** (#302) — the CSL citation-style picker plus the imported user styles/locales lists with import/remove — is self-contained on `api.bibliography.*` / `api.csl.*`, so it lifts whole into **`BibliographySettings.svelte`**. **SettingsDialog 1,640 → 1,363.**

With both skills (#722) and bibliography now extracted, the dialog also sheds the orphaned `.csl-*` / `.hint.empty` / `.csl-error` CSS (svelte-check confirmed unused).

## Tests (7)
`components/BibliographySettings.test.ts` mocks `api.bibliography` + `api.csl` and pins: the on-mount load + current-style selection, the empty states, the style change → `setStyle`, the imported lists render, Import → `importStyle` + reload, Remove → `removeStyle(id)`, and the import-error banner.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3005 passed** (+7).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

_The **ai** tab follows in a stacked PR (branched off this one, since both touch SettingsDialog)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)