### PR TITLE
Extract AiSettings panel from SettingsDialog (#672)

### DIFF
--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  /**
+   * AI settings panel (default model + Anthropic API key + per-tool model
+   * overrides, extracted from SettingsDialog for #672).
+   *
+   * Unlike the other settings panels, the AI settings are persisted by the
+   * dialog's Done handler (so the key + model + overrides apply together), not
+   * on each edit. So this panel is presentational: the dialog owns the state
+   * and the save, and binds it here via `$bindable` props. `apiKeyStatus` is
+   * read-only (reflects what's already stored).
+   */
+  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+  import { getAllToolInfos } from '../tools/tool-registry';
+  import type { ThinkingToolInfo } from '../../../shared/tools/types';
+
+  interface Props {
+    model: string;
+    apiKeyInput: string;
+    clearApiKey: boolean;
+    toolModelOverrides: Record<string, string>;
+    apiKeyStatus: 'unknown' | 'set' | 'unset';
+  }
+
+  let {
+    model = $bindable(),
+    apiKeyInput = $bindable(),
+    clearApiKey = $bindable(),
+    toolModelOverrides = $bindable(),
+    apiKeyStatus,
+  }: Props = $props();
+
+  const allTools: ThinkingToolInfo[] = getAllToolInfos();
+
+  function setToolOverride(toolId: string, value: string): void {
+    const next = { ...toolModelOverrides };
+    if (value) next[toolId] = value;
+    else delete next[toolId];
+    toolModelOverrides = next;
+  }
+</script>
+
+<div class="field">
+  <label for="model">Default model</label>
+  <select id="model" bind:value={model}>
+    {#each MODEL_OPTIONS as m}
+      <option value={m.value}>{m.label}</option>
+    {/each}
+  </select>
+</div>
+<div class="field">
+  <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>
+    {#if apiKeyStatus === 'unknown'}
+      Loading…
+    {:else if clearApiKey}
+      API key will be cleared on save
+    {:else if apiKeyStatus === 'set'}
+      ✓ API key saved
+    {:else}
+      No API key set
+    {/if}
+  </div>
+  <label for="api-key">
+    Anthropic API key
+  </label>
+  <input
+    id="api-key"
+    type="password"
+    bind:value={apiKeyInput}
+    placeholder={apiKeyStatus === 'set' ? 'Type to replace existing key' : 'Enter Anthropic API key'}
+    autocomplete="off"
+    spellcheck="false"
+    autocapitalize="off"
+    oncopy={(e) => e.preventDefault()}
+    oncut={(e) => e.preventDefault()}
+    oncontextmenu={(e) => e.preventDefault()}
+    disabled={clearApiKey}
+  />
+  <p class="hint">
+    Keys are stored in your user data directory. The saved value is never displayed back.
+    You can also set <code>ANTHROPIC_API_KEY</code> as an environment variable.
+  </p>
+  {#if apiKeyStatus === 'set' && !clearApiKey}
+    <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
+      Clear saved key
+    </button>
+  {:else if clearApiKey}
+    <button class="link-btn" onclick={() => { clearApiKey = false; }}>
+      Cancel clear
+    </button>
+  {/if}
+</div>
+<div class="field">
+  <label>Tool model overrides</label>
+  <p class="hint">
+    Each tool's author may suggest a preferred model. You can override that
+    per tool. Empty override → use the tool's preference; no preference →
+    fall back to the default model above.
+  </p>
+  {#if allTools.length === 0}
+    <p class="hint">No tools registered.</p>
+  {:else}
+    <table class="tool-models">
+      <thead>
+        <tr>
+          <th>Tool</th>
+          <th>Tool preference</th>
+          <th>Your override</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each allTools as t}
+          <tr>
+            <td>{t.name}</td>
+            <td class="muted">{t.preferredModel ? modelLabel(t.preferredModel) : '—'}</td>
+            <td>
+              <select
+                value={toolModelOverrides[t.id] ?? ''}
+                onchange={(e) => setToolOverride(t.id, e.currentTarget.value)}
+              >
+                <option value="">Use tool preference</option>
+                {#each MODEL_OPTIONS as m}
+                  <option value={m.value}>{m.label}</option>
+                {/each}
+              </select>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</div>
+
+<style>
+  /* Shared form vocabulary, scoped to this panel (app's per-dialog convention). */
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label { color: var(--text); }
+  .field input[type="password"],
+  .field select {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .field input[type="password"]:focus,
+  .field select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .link-btn {
+    align-self: flex-start;
+    margin-top: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .link-btn:hover { color: var(--text); }
+
+  /* AI panel — API key status + tool-override table. */
+  .api-key-status {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+  }
+  .api-key-status.saved {
+    color: var(--accent);
+  }
+  .tool-models {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  .tool-models th,
+  .tool-models td {
+    text-align: left;
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .tool-models th {
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+  .tool-models td.muted {
+    color: var(--text-muted);
+  }
+  .tool-models select {
+    padding: 3px 6px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    max-width: 170px;
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -38,13 +38,11 @@
   } from '../../../shared/formatter/registry';
   import '../../../shared/formatter/rules/index';
   import type { FormatSettings } from '../../../shared/formatter/engine';
-  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
-  import { getAllToolInfos } from '../tools/tool-registry';
-  import type { ThinkingToolInfo } from '../../../shared/tools/types';
   import SitesSettings from './SitesSettings.svelte';
   import ComputeSettings from './ComputeSettings.svelte';
   import SkillsSettings from './SkillsSettings.svelte';
   import BibliographySettings from './BibliographySettings.svelte';
+  import AiSettings from './AiSettings.svelte';
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -244,7 +242,6 @@
   // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
   let loadedLlm: LLMSettings | null = null;
   let toolModelOverrides = $state<Record<string, string>>({});
-  const allTools: ThinkingToolInfo[] = getAllToolInfos();
 
   // Compute (#374): the Python-interpreter panel now lives in
   // ComputeSettings.svelte (self-contained).
@@ -272,12 +269,6 @@
     }
   });
 
-  function setToolOverride(toolId: string, value: string) {
-    const next = { ...toolModelOverrides };
-    if (value) next[toolId] = value;
-    else delete next[toolId];
-    toolModelOverrides = next;
-  }
 
   function parseDomains(text: string): string[] {
     return text
@@ -753,96 +744,13 @@
           <ComputeSettings />
 
         {:else if activeTab === 'ai'}
-          <div class="field">
-            <label for="model">Default model</label>
-            <select id="model" bind:value={model}>
-              {#each MODEL_OPTIONS as m}
-                <option value={m.value}>{m.label}</option>
-              {/each}
-            </select>
-          </div>
-          <div class="field">
-            <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>
-              {#if apiKeyStatus === 'unknown'}
-                Loading…
-              {:else if clearApiKey}
-                API key will be cleared on save
-              {:else if apiKeyStatus === 'set'}
-                ✓ API key saved
-              {:else}
-                No API key set
-              {/if}
-            </div>
-            <label for="api-key">
-              Anthropic API key
-            </label>
-            <input
-              id="api-key"
-              type="password"
-              bind:value={apiKeyInput}
-              placeholder={apiKeyStatus === 'set' ? 'Type to replace existing key' : 'Enter Anthropic API key'}
-              autocomplete="off"
-              spellcheck="false"
-              autocapitalize="off"
-              oncopy={(e) => e.preventDefault()}
-              oncut={(e) => e.preventDefault()}
-              oncontextmenu={(e) => e.preventDefault()}
-              disabled={clearApiKey}
-            />
-            <p class="hint">
-              Keys are stored in your user data directory. The saved value is never displayed back.
-              You can also set <code>ANTHROPIC_API_KEY</code> as an environment variable.
-            </p>
-            {#if apiKeyStatus === 'set' && !clearApiKey}
-              <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
-                Clear saved key
-              </button>
-            {:else if clearApiKey}
-              <button class="link-btn" onclick={() => { clearApiKey = false; }}>
-                Cancel clear
-              </button>
-            {/if}
-          </div>
-          <div class="field">
-            <label>Tool model overrides</label>
-            <p class="hint">
-              Each tool's author may suggest a preferred model. You can override that
-              per tool. Empty override → use the tool's preference; no preference →
-              fall back to the default model above.
-            </p>
-            {#if allTools.length === 0}
-              <p class="hint">No tools registered.</p>
-            {:else}
-              <table class="tool-models">
-                <thead>
-                  <tr>
-                    <th>Tool</th>
-                    <th>Tool preference</th>
-                    <th>Your override</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each allTools as t}
-                    <tr>
-                      <td>{t.name}</td>
-                      <td class="muted">{t.preferredModel ? modelLabel(t.preferredModel) : '—'}</td>
-                      <td>
-                        <select
-                          value={toolModelOverrides[t.id] ?? ''}
-                          onchange={(e) => setToolOverride(t.id, e.currentTarget.value)}
-                        >
-                          <option value="">Use tool preference</option>
-                          {#each MODEL_OPTIONS as m}
-                            <option value={m.value}>{m.label}</option>
-                          {/each}
-                        </select>
-                      </td>
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-            {/if}
-          </div>
+          <AiSettings
+            bind:model
+            bind:apiKeyInput
+            bind:clearApiKey
+            bind:toolModelOverrides
+            {apiKeyStatus}
+          />
         {/if}
       </section>
     </div>
@@ -1161,65 +1069,6 @@
   .btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-
-  .tool-models {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 12px;
-  }
-
-  .tool-models th,
-  .tool-models td {
-    text-align: left;
-    padding: 5px 8px;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .tool-models th {
-    font-weight: 600;
-    color: var(--text-muted);
-    font-size: 11px;
-  }
-
-  .tool-models td.muted {
-    color: var(--text-muted);
-  }
-
-  .tool-models select {
-    padding: 3px 6px;
-    background: var(--bg);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
-    max-width: 170px;
-  }
-
-  .api-key-status {
-    font-size: 11px;
-    color: var(--text-muted);
-    margin-bottom: 4px;
-  }
-
-  .api-key-status.saved {
-    color: var(--accent);
-  }
-
-  .link-btn {
-    align-self: flex-start;
-    margin-top: 4px;
-    padding: 0;
-    border: none;
-    background: none;
-    color: var(--text-muted);
-    font-size: 11px;
-    text-decoration: underline;
-    cursor: pointer;
-  }
-
-  .link-btn:hover {
-    color: var(--text);
   }
 
   .section-intro {

--- a/tests/renderer/components/AiSettings.test.ts
+++ b/tests/renderer/components/AiSettings.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render coverage for AiSettings (#672) — the model / API-key / tool-override
+ * panel extracted from SettingsDialog. The dialog owns persistence (save-on-
+ * Done) and binds the state in; this pins the presentational behavior: the API-
+ * key status states + the clear/cancel toggle, the model select, and the tool-
+ * override table (getAllToolInfos mocked; modelLabel runs for real).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const { getAllToolInfosMock } = vi.hoisted(() => ({ getAllToolInfosMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({
+  getAllToolInfos: getAllToolInfosMock,
+}));
+
+import AiSettings from '../../../src/renderer/lib/components/AiSettings.svelte';
+
+function props(over: Partial<{
+  model: string; apiKeyInput: string; clearApiKey: boolean;
+  toolModelOverrides: Record<string, string>; apiKeyStatus: 'unknown' | 'set' | 'unset';
+}> = {}) {
+  return {
+    model: 'claude-sonnet-4-6',
+    apiKeyInput: '',
+    clearApiKey: false,
+    toolModelOverrides: {},
+    apiKeyStatus: 'set' as const,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  getAllToolInfosMock.mockReset();
+});
+
+describe('AiSettings (#672)', () => {
+  it('renders the API-key status for each state', () => {
+    getAllToolInfosMock.mockReturnValue([]);
+    expect(render(AiSettings, props({ apiKeyStatus: 'set' })).getByText('✓ API key saved')).toBeTruthy();
+    cleanup();
+    expect(render(AiSettings, props({ apiKeyStatus: 'unset' })).getByText('No API key set')).toBeTruthy();
+    cleanup();
+    expect(render(AiSettings, props({ apiKeyStatus: 'unknown' })).getByText('Loading…')).toBeTruthy();
+  });
+
+  it('Clear saved key flips to the cleared state and disables the input; Cancel clear restores it', async () => {
+    getAllToolInfosMock.mockReturnValue([]);
+    const { getByText, getByLabelText, queryByText } = render(AiSettings, props({ apiKeyStatus: 'set' }));
+
+    await fireEvent.click(getByText('Clear saved key'));
+    expect(getByText('API key will be cleared on save')).toBeTruthy();
+    expect((getByLabelText('Anthropic API key') as HTMLInputElement).disabled).toBe(true);
+    expect(queryByText('✓ API key saved')).toBeNull();
+
+    await fireEvent.click(getByText('Cancel clear'));
+    expect(getByText('✓ API key saved')).toBeTruthy();
+  });
+
+  it('renders the tool-override table with each tool, its preference, and an override select', () => {
+    getAllToolInfosMock.mockReturnValue([
+      { id: 'summarize', name: 'Summarize', preferredModel: 'claude-haiku-4-5-20251001' },
+      { id: 'analyze', name: 'Analyze', preferredModel: undefined },
+    ]);
+    const { getByText, getAllByRole } = render(AiSettings, props());
+    expect(getByText('Summarize')).toBeTruthy();
+    expect(getByText('Analyze')).toBeTruthy();
+    // No-preference tool shows the em-dash.
+    expect(getByText('—')).toBeTruthy();
+    // model select + one override select per tool.
+    expect(getAllByRole('combobox').length).toBe(3);
+  });
+
+  it('shows the empty state when no tools are registered', () => {
+    getAllToolInfosMock.mockReturnValue([]);
+    expect(render(AiSettings, props()).getByText('No tools registered.')).toBeTruthy();
+  });
+
+  it('changing a tool override updates that select to the chosen model', async () => {
+    getAllToolInfosMock.mockReturnValue([
+      { id: 'summarize', name: 'Summarize', preferredModel: undefined },
+    ]);
+    const { getAllByRole } = render(AiSettings, props());
+    // [0] = default-model select, [1] = the tool override select.
+    const overrideSelect = getAllByRole('combobox')[1] as HTMLSelectElement;
+    expect(overrideSelect.value).toBe(''); // "Use tool preference"
+
+    await fireEvent.change(overrideSelect, { target: { value: 'claude-opus-4-7' } });
+    expect(overrideSelect.value).toBe('claude-opus-4-7');
+  });
+});


### PR DESCRIPTION
## What

Fifth per-tab panel split of SettingsDialog, and the last big one. The **ai tab** — default model + Anthropic API key + per-tool model overrides — moves into **`AiSettings.svelte`**. **SettingsDialog 1,363 → 1,162.**

> **Stacked on #723** (bibliography) — both touch SettingsDialog. Merge #723 first; this targets that branch so the diff is just the ai changes.

## Why this one is different (presentational, not self-contained)
Unlike sites/compute/skills/bibliography (which save on each edit), the **ai settings persist on the dialog's Done handler** — so the key + model + overrides apply together. Changing that would be a real behavior change, so I kept it: the dialog keeps the state + `handleDone` and binds it into the child via **`$bindable` props** (`model` / `apiKeyInput` / `clearApiKey` / `toolModelOverrides`), with `apiKeyStatus` read-only. **Save-on-Done is unchanged.**

The dialog sheds its now-unused `MODEL_OPTIONS` / `modelLabel` / `getAllToolInfos` / `allTools` / `setToolOverride` and the `.tool-models` / `.api-key-status` / `.link-btn` CSS (svelte-check confirmed unused).

## Tests (5)
`components/AiSettings.test.ts` mocks `getAllToolInfos` and pins: the API-key status states, the **Clear saved key → cleared (input disabled) → Cancel clear** round trip, the tool-override table (name + preference + per-tool select), the no-tools empty state, and an override select reflecting the chosen model.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3010 passed** (+5).
- `pnpm test:e2e` — electron-forge build + boot smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)