### PR TITLE
Add unsigned macOS release pipeline (#660)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+# Release pipeline for Minerva (#660).
+#
+# Builds the macOS distributables (DMG + ZIP) via electron-forge make and
+# publishes them. Two triggers:
+#   - push a `v*` tag  → build + attach to a DRAFT GitHub Release for review
+#   - workflow_dispatch → build + upload artifacts only (test the make path
+#     without cutting a release)
+#
+# This closes the two gaps from build review B-H1: the `make` path was never
+# exercised by CI (a maker regression stayed invisible until release day), and
+# there was no tag→downloadable-build flow.
+#
+# NOTE: builds are currently UNSIGNED + un-notarized — Gatekeeper will quarantine
+# them on other Macs. Code signing + notarization is #661 (blocked on Apple
+# Developer Program enrollment); it layers onto this pipeline once a Developer ID
+# certificate exists.
+
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+# The release job needs to create a Release and upload assets.
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      # electron-forge package OOMs on the default heap when bundling the
+      # renderer + native deps — match build:e2e (#373).
+      NODE_OPTIONS: --max-old-space-size=4096
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build distributables (electron-forge make)
+        run: pnpm build
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p dist-artifacts
+          find out/make -type f \( -name '*.dmg' -o -name '*.zip' \) -exec cp {} dist-artifacts/ \;
+          echo "Collected:"
+          ls -la dist-artifacts
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: minerva-macos-${{ runner.arch }}
+          path: dist-artifacts/*
+          if-no-files-found: error
+
+      # Tag pushes additionally publish a DRAFT release — review the assets,
+      # then hit "Publish" by hand. Flip `draft: false` once the pipeline is
+      # trusted (and signing has landed).
+      - name: Publish draft GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist-artifacts/*
+          draft: true
+          generate_release_notes: true


### PR DESCRIPTION
## What

Closes #660. Adds **`.github/workflows/release.yml`** — the first tag→build→publish flow.

- **Push a `v*` tag** → runs `electron-forge make` (DMG + ZIP) and attaches them to a **draft** GitHub Release (auto-generated notes).
- **`workflow_dispatch`** → builds + uploads artifacts only, so the `make` path can be exercised on demand without cutting a release.

Reuses ci.yml's setup verbatim (pnpm 10, Node via `.nvmrc`, `--frozen-lockfile`) and the `build:e2e` heap bump (`NODE_OPTIONS=--max-old-space-size=4096`).

## Why it matters
The two gaps from build review B-H1: the **`make` path was never run by CI** (a maker regression stayed invisible until release day — and the DMG maker pulls in native helpers like `macos-alias`/`appdmg` that the `package`-only e2e job never exercised), and there was **no tag→downloadable-build flow**. This closes both cheaply.

## Unsigned — on purpose
Builds are **unsigned + un-notarized**, so Gatekeeper will quarantine them on other Macs. Code signing + notarization is **#661**, currently blocked on Apple Developer Program enrollment (in progress). It layers onto this pipeline once a Developer ID certificate exists — at which point we flip `draft: true` → `false`. Until then the draft release means **nothing ships unreviewed**.

## Verification
Ran the full `pnpm build` locally (had to rebuild `macos-alias` for the local Node first — a dev-machine ABI quirk that doesn't affect CI, where install + build share one `.nvmrc` Node). It completed the make and produced:
- `out/make/Minerva-0.1.0-arm64.dmg`
- `out/make/zip/darwin/arm64/Minerva-darwin-arm64-0.1.0.zip`

— exactly the paths the workflow's collection step globs (`find out/make -name '*.dmg' -o -name '*.zip'`).

## Note for reviewers
After merge, you can smoke-test it with **Actions → Release → Run workflow** (the `workflow_dispatch` path) — it'll build and upload the artifacts without needing a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)