### PR TITLE
De-flake the citeproc publish suites with a scoped timeout (#677)

### DIFF
--- a/tests/main/publish/csl.test.ts
+++ b/tests/main/publish/csl.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -13,6 +13,13 @@ import { loadCitationAssets } from '../../../src/main/publish/csl';
 import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
 import { noteHtmlExporter } from '../../../src/main/publish/exporters/note-html';
 import { parseLocatorAlias } from '../../../src/main/publish/exporters/note-html/render';
+
+// citeproc engine construction (notably Chicago note styles) is CPU-heavy and
+// can blow vitest's 5s default under full-suite parallelism on a contended CI
+// runner, even though it's ~1-2s in isolation (#677). Scope a generous timeout
+// to this file so a genuine hang still fails, without loosening the global
+// default for unrelated suites.
+vi.setConfig({ testTimeout: 30_000 });
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csl-test-'));

--- a/tests/main/publish/tree-html.test.ts
+++ b/tests/main/publish/tree-html.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
 import { treeHtmlExporter } from '../../../src/main/publish/exporters/tree-html';
+
+// citeproc engine construction (notably Chicago note styles) is CPU-heavy and
+// can blow vitest's 5s default under full-suite parallelism on a contended CI
+// runner, even though it's ~1-2s in isolation (#677). Scope a generous timeout
+// to this file so a genuine hang still fails, without loosening the global
+// default for unrelated suites.
+vi.setConfig({ testTimeout: 30_000 });
 
 function mkTempProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tree-html-test-'));

--- a/tests/main/publish/tree-markdown.test.ts
+++ b/tests/main/publish/tree-markdown.test.ts
@@ -6,7 +6,7 @@
  * mirrors how a user actually consumes the export.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -14,6 +14,13 @@ import os from 'node:os';
 import JSZip from 'jszip';
 import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
 import { treeMarkdownExporter } from '../../../src/main/publish/exporters/tree-markdown';
+
+// citeproc engine construction (notably Chicago note styles) is CPU-heavy —
+// ~1.7s for the Chicago case in isolation, but under full-suite parallelism it
+// can blow vitest's 5s default on a contended CI runner (#677). Scope a
+// generous timeout to this file so a genuine hang still fails, without
+// loosening the global default for unrelated suites.
+vi.setConfig({ testTimeout: 30_000 });
 
 function mkProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tree-md-'));

--- a/tests/main/publish/tree-pdf.test.ts
+++ b/tests/main/publish/tree-pdf.test.ts
@@ -8,13 +8,20 @@
  * bibliography.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { resolvePlan } from '../../../src/main/publish/pipeline';
 import { buildTreePdfHtml, treePdfExporter } from '../../../src/main/publish/exporters/tree-pdf';
+
+// citeproc engine construction (notably Chicago note styles) is CPU-heavy and
+// can blow vitest's 5s default under full-suite parallelism on a contended CI
+// runner, even though it's ~1-2s in isolation (#677). Scope a generous timeout
+// to this file so a genuine hang still fails, without loosening the global
+// default for unrelated suites.
+vi.setConfig({ testTimeout: 30_000 });
 
 function mkProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tree-pdf-'));


### PR DESCRIPTION
## What

Closes #677. Kills the flake that just red-CI'd a PR you merged anyway.

The named case — `tree-markdown.test.ts` "Chicago notes & bibliography" — and its siblings in `tree-html` / `tree-pdf` / `csl` all drive citeproc with **note-class styles** (Chicago full-note). Constructing the CSL engine for those styles is CPU-heavy (**~1.7s for the Chicago case in isolation**), and under full-suite parallelism on a contended CI runner it can exceed vitest's **5s default** and time out — even though the same tests pass comfortably in isolation. Classic load-dependent flake.

## Why a timeout (not a refactor or a retry)
- The engine cost is **inherent to citeproc and per-export** — the engine is stateful, so it can't be shared across the independent fixtures these tests need. There's no "make it fast" win to be had.
- `test.retry` would *mask* the slowness (and could mask a real intermittent regression). A generous timeout is the honest call: the test is correct, just slow under contention.

So each of the four citeproc-heavy publish suites gets:
```ts
vi.setConfig({ testTimeout: 30_000 });
```
— **17× the isolated runtime**, so a genuine hang still fails, while the **global 5s default is left intact** for every other suite (real hangs elsewhere still surface fast). `vi.setConfig` is file-scoped and auto-reset, so there's no leak.

## Scope
The issue names `tree-markdown`, but the identical root cause flakes `tree-html` / `tree-pdf` / `csl` too (all four failed together in the earlier coverage-instrumentation run). Fixing only the named one would just move the flake next door, so all four citeproc suites are covered.

## Verification
- The four suites pass (84 tests).
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3010 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)