### PR TITLE
Upgrade chokidar 4→5 (#689)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/markdown-it-footnote": "^3.0.4",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",
-    "chokidar": "^4.0.0",
+    "chokidar": "^5.0.0",
     "citeproc": "^2.4.63",
     "date-fns": "^4.4.0",
     "dompurify": "^3.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0(chart.js@4.5.1)(date-fns@4.4.0)
       chokidar:
-        specifier: ^4.0.0
-        version: 4.0.3
+        specifier: ^5.0.0
+        version: 5.0.0
       citeproc:
         specifier: ^2.4.63
         version: 2.4.63
@@ -2897,6 +2897,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
@@ -5020,6 +5024,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -10998,6 +11006,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@2.0.0: {}
 
   chrome-trace-event@1.0.4: {}
@@ -13363,6 +13375,8 @@ snapshots:
       string_decoder: 1.3.0
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   rechoir@0.8.0:
     dependencies:


### PR DESCRIPTION
## What

Part of #689 (the deferred consumer-coupled majors). Bumps **chokidar 4→5** — the file watcher (`src/main/notebase/watcher.ts`) is its only consumer.

chokidar 5 requires **Node ≥ 20.19** (we pin 24 via `.nvmrc`) and keeps the options we pass (`ignored` regex/strings, `persistent`, `ignoreInitial`) and the `watch()` / `FSWatcher` API unchanged — tsc + the tests confirm. No code changes needed.

## Why this is the one I took
The issue gated chokidar on "the **smoke + watcher tests green**" — and unlike the other two #689 majors, chokidar actually *has* that coverage:
- `tests/main/notebase/watcher.test.ts` wires up **real chokidar** against a temp dir and asserts add/change/delete events (not mocked).
- `tests/main/notebase/path-dedup.test.ts` covers the IPC↔watcher dedup window (#345).
- The macOS-pinned e2e smoke (the documented reason CI exercises fsevents) boots the real app.

All green on v5.

## Verification
- `pnpm lint` — **0 errors**.
- watcher + dedup suites — **24 passed** (real chokidar v5).
- `pnpm test` — **3010 passed**.
- `pnpm test:e2e` — boot smoke passes.

## The other two #689 majors are deferred (details in an issue comment)
- **@retorquere/bibtex-parser 10** — 10.0.0 ships **with no type declarations** (its `types`/`exports.types` point at a `dist/types/` that isn't in the tarball). Bumping would force losing type safety on the entry-mapping code. Upstream-broken; staying on v9.
- **pdfjs-dist 6** — the in-app `PdfViewer.svelte` still has no component coverage and the smoke doesn't render a PDF, so a v6 rendering/worker regression would ship unverified — exactly the gate the issue set ("defer until the viewer has component coverage"). Deferred until that coverage exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)