### PR TITLE
Add PdfViewer coverage + extract its pure logic (#672, unblocks #689 pdfjs)

### DIFF
--- a/src/renderer/lib/components/PdfViewer.svelte
+++ b/src/renderer/lib/components/PdfViewer.svelte
@@ -18,6 +18,12 @@
   import type { SourceExcerpt } from '../../../shared/types';
   import { getEditorStore } from '../stores/editor.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import {
+    MIN_SCALE, MAX_SCALE, DEFAULT_SCALE,
+    zoomInScale, zoomOutScale,
+    itemPosition, findExcerptRects,
+    type TextLayerItem,
+  } from '../pdf/text-layer';
   // Worker URL has to be a *static* import — Vite's `?url` suffix is
   // resolved at build time. Inside `await import(...)` it falls
   // through to a regular ES module load and `.default` is undefined,
@@ -56,10 +62,7 @@
 
   let page = $state(initialPage);
   let numPages = $state(0);
-  let scale = $state(1.2);
-  const MIN_SCALE = 0.5;
-  const MAX_SCALE = 3.0;
-  const SCALE_STEP = 0.15;
+  let scale = $state(DEFAULT_SCALE);
 
   let canvasEl = $state<HTMLCanvasElement>();
   let textLayerEl = $state<HTMLDivElement>();
@@ -199,24 +202,6 @@
     }
   }
 
-  function itemPosition(
-    item: { transform: number[]; width: number; height: number },
-    viewport: { width: number; height: number; transform: number[] },
-  ): { left: number; top: number; fontSize: number } {
-    // pdfjs page coordinates have origin at bottom-left; viewport
-    // transform flips Y and applies the user scale. Compose item's
-    // text matrix with the viewport transform to land in CSS pixels.
-    const t = item.transform;
-    const v = viewport.transform;
-    // Affine compose: out = v ∘ t
-    const a = v[0] * t[0] + v[2] * t[1];
-    const b = v[1] * t[0] + v[3] * t[1];
-    const e = v[0] * t[4] + v[2] * t[5] + v[4];
-    const f = v[1] * t[4] + v[3] * t[5] + v[5];
-    const fontSize = Math.hypot(a, b);
-    return { left: e, top: f - fontSize, fontSize };
-  }
-
   // ── Excerpt highlight overlay ─────────────────────────────────────────────
 
   function paintExcerptHighlights(
@@ -228,77 +213,24 @@
     highlightLayerEl.style.height = `${viewport.height}px`;
     highlightLayerEl.replaceChildren();
 
-    // Build a flat string of the page text plus a parallel
-    // index-of-each-character → text-item map so we can map a match
-    // range back to spans and their bounding boxes.
-    const pageText: string[] = [];
-    const charToItem: number[] = [];
-    text.items.forEach((it, idx) => {
-      if (!('str' in it)) return;
-      const s = (it as TextItem & { str: string }).str;
-      for (const ch of s) {
-        pageText.push(ch);
-        charToItem.push(idx);
-      }
-      // Trailing space to keep word boundaries when items are
-      // adjacent without intervening whitespace.
-      pageText.push(' ');
-      charToItem.push(idx);
-    });
-    const haystack = pageText.join('');
-    const haystackNorm = normalizeForMatch(haystack);
-
-    for (const e of excerpts) {
-      // Page constraint: if the excerpt knows its page, skip when
-      // it's not the current one. No page hint → still try matching.
-      // `page` from SourceExcerpt is the TTL-serialised string form;
-      // an int compare needs a parse first.
-      if (e.page != null) {
-        const ep = parseInt(e.page, 10);
-        if (Number.isFinite(ep) && ep !== page) continue;
-      }
-      if (!e.citedText) continue;
-      const needle = normalizeForMatch(e.citedText);
-      if (!needle) continue;
-      const start = haystackNorm.indexOf(needle);
-      if (start < 0) continue;
-      const end = start + needle.length;
-
-      // Resolve back to the set of text-content items the match spans
-      // and compute their union bounding box. itemRects gives us each
-      // contributing item's box; for a single-item match this is one
-      // rectangle, for multi-line we get a stacked set.
-      const itemSet = new Set<number>();
-      for (let i = start; i < end && i < charToItem.length; i++) {
-        itemSet.add(charToItem[i]);
-      }
-      for (const idx of itemSet) {
-        const it = text.items[idx] as TextItem & { transform: number[]; width: number; height: number };
-        if (!('str' in it)) continue;
-        const { left, top, fontSize } = itemPosition(it, viewport);
-        const width = it.width * scale;
-        const hl = document.createElement('div');
-        hl.className = 'pdf-excerpt-hl';
-        hl.style.left = `${left}px`;
-        hl.style.top = `${top}px`;
-        hl.style.width = `${width}px`;
-        hl.style.height = `${fontSize * 1.15}px`;
-        hl.title = `Excerpt ${e.excerptId}`;
-        highlightLayerEl.appendChild(hl);
-      }
+    // Matching + geometry is pure (text-layer.ts); paint the resulting rects.
+    const rects = findExcerptRects(
+      text.items as unknown as TextLayerItem[],
+      excerpts,
+      viewport,
+      scale,
+      page,
+    );
+    for (const r of rects) {
+      const hl = document.createElement('div');
+      hl.className = 'pdf-excerpt-hl';
+      hl.style.left = `${r.left}px`;
+      hl.style.top = `${r.top}px`;
+      hl.style.width = `${r.width}px`;
+      hl.style.height = `${r.height}px`;
+      hl.title = `Excerpt ${r.excerptId}`;
+      highlightLayerEl.appendChild(hl);
     }
-  }
-
-  /** Normalize whitespace + zero-width chars so the search is robust
-   *  against PDF's hyphenation / soft-line-break noise. Soft hyphen
-   *  (U+00AD), zero-width space (U+200B), zero-width non-joiner
-   *  (U+200C) get stripped — they're invisible noise that PDFs love. */
-  function normalizeForMatch(s: string): string {
-    return s
-      .replace(/\s+/g, ' ')
-      .replace(/[\u00AD\u200B\u200C]/g, '')
-      .trim()
-      .toLowerCase();
   }
 
   // ── Selection → Save as Excerpt ───────────────────────────────────────────
@@ -339,9 +271,9 @@
 
   function prevPage(): void { if (page > 1) page--; }
   function nextPage(): void { if (page < numPages) page++; }
-  function zoomIn(): void { scale = Math.min(MAX_SCALE, +(scale + SCALE_STEP).toFixed(2)); }
-  function zoomOut(): void { scale = Math.max(MIN_SCALE, +(scale - SCALE_STEP).toFixed(2)); }
-  function zoomReset(): void { scale = 1.2; }
+  function zoomIn(): void { scale = zoomInScale(scale); }
+  function zoomOut(): void { scale = zoomOutScale(scale); }
+  function zoomReset(): void { scale = DEFAULT_SCALE; }
 
   function handleKey(e: KeyboardEvent): void {
     // Ignore when typing into a text field — page jump input belongs to itself.

--- a/src/renderer/lib/pdf/text-layer.ts
+++ b/src/renderer/lib/pdf/text-layer.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure geometry + text-matching helpers behind the PDF viewer's text layer and
+ * excerpt-highlight overlay (#100, extracted from PdfViewer.svelte for #672 —
+ * and so the viewer's pdfjs-coupled logic is unit-tested ahead of the pdfjs 6
+ * bump, #689).
+ *
+ * DOM-free: these compute positions / rectangles from the pdfjs text-content
+ * items + viewport, and the component does the actual span/div painting from
+ * what they return. That keeps the fiddly affine math + citedText matching
+ * testable without a canvas or a live pdfjs document.
+ */
+
+/** The slice of a pdfjs TextContent item we read. */
+export interface TextLayerItem {
+  str?: string;
+  transform: number[];
+  width: number;
+  height: number;
+}
+
+/** The slice of a pdfjs viewport we read: dimensions + page→viewport affine. */
+export interface ViewportLike {
+  width: number;
+  height: number;
+  transform: number[];
+}
+
+export interface ItemBox {
+  left: number;
+  top: number;
+  fontSize: number;
+}
+
+// Zoom bounds — shared by the toolbar buttons, keyboard shortcuts, and reset.
+export const MIN_SCALE = 0.5;
+export const MAX_SCALE = 3.0;
+export const SCALE_STEP = 0.15;
+export const DEFAULT_SCALE = 1.2;
+
+export function clampScale(scale: number): number {
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
+}
+
+/** One zoom-in step, clamped to MAX and rounded to 2dp (float-drift guard). */
+export function zoomInScale(scale: number): number {
+  return Math.min(MAX_SCALE, +(scale + SCALE_STEP).toFixed(2));
+}
+
+/** One zoom-out step, clamped to MIN and rounded to 2dp. */
+export function zoomOutScale(scale: number): number {
+  return Math.max(MIN_SCALE, +(scale - SCALE_STEP).toFixed(2));
+}
+
+/**
+ * Project a text item into CSS pixels by composing its text matrix with the
+ * viewport transform. pdfjs page coords are bottom-left origin; the viewport
+ * transform flips Y and applies the user scale, so `out = viewport ∘ item`.
+ * Returns the span's top-left corner + font size.
+ */
+export function itemPosition(item: { transform: number[] }, viewport: ViewportLike): ItemBox {
+  const t = item.transform;
+  const v = viewport.transform;
+  const a = v[0] * t[0] + v[2] * t[1];
+  const b = v[1] * t[0] + v[3] * t[1];
+  const e = v[0] * t[4] + v[2] * t[5] + v[4];
+  const f = v[1] * t[4] + v[3] * t[5] + v[5];
+  const fontSize = Math.hypot(a, b);
+  return { left: e, top: f - fontSize, fontSize };
+}
+
+/**
+ * Normalize whitespace + zero-width chars so substring search is robust against
+ * PDF hyphenation / soft-line-break noise. Soft hyphen (U+00AD), zero-width
+ * space (U+200B), and zero-width non-joiner (U+200C) are invisible noise PDFs
+ * love; collapse runs of whitespace, drop those, trim, lower-case.
+ */
+export function normalizeForMatch(s: string): string {
+  return s
+    .replace(/\s+/g, ' ')
+    .replace(/[\u00AD\u200B\u200C]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Flatten a page's text items into a single char string plus a parallel
+ * char→item-index map, so a match range can be resolved back to the items (and
+ * thus the bounding boxes) it spans. A trailing space per item preserves word
+ * boundaries between adjacent items.
+ */
+export function buildPageText(items: TextLayerItem[]): { haystack: string; charToItem: number[] } {
+  const chars: string[] = [];
+  const charToItem: number[] = [];
+  items.forEach((it, idx) => {
+    if (typeof it.str !== 'string') return;
+    for (const ch of it.str) {
+      chars.push(ch);
+      charToItem.push(idx);
+    }
+    chars.push(' ');
+    charToItem.push(idx);
+  });
+  return { haystack: chars.join(''), charToItem };
+}
+
+/** The slice of a SourceExcerpt the overlay matches against. */
+export interface ExcerptLike {
+  excerptId: string;
+  citedText: string | null;
+  page: string | null;
+}
+
+export interface HighlightRect {
+  excerptId: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * The highlight rectangles for every excerpt whose cited text is found on the
+ * current page. Page-filtered (an excerpt with a page hint only matches its own
+ * page; no hint → still tried), normalized substring match, resolved back to
+ * the union of text items the match spans — one rect per contributing item, so
+ * a multi-line match yields a stacked set.
+ */
+export function findExcerptRects(
+  items: TextLayerItem[],
+  excerpts: ExcerptLike[],
+  viewport: ViewportLike,
+  scale: number,
+  currentPage: number,
+): HighlightRect[] {
+  const { haystack, charToItem } = buildPageText(items);
+  const haystackNorm = normalizeForMatch(haystack);
+  const rects: HighlightRect[] = [];
+
+  for (const e of excerpts) {
+    if (e.page != null) {
+      const ep = parseInt(e.page, 10);
+      if (Number.isFinite(ep) && ep !== currentPage) continue;
+    }
+    if (!e.citedText) continue;
+    const needle = normalizeForMatch(e.citedText);
+    if (!needle) continue;
+    const start = haystackNorm.indexOf(needle);
+    if (start < 0) continue;
+    const end = start + needle.length;
+
+    const itemSet = new Set<number>();
+    for (let i = start; i < end && i < charToItem.length; i++) {
+      itemSet.add(charToItem[i]);
+    }
+    for (const idx of itemSet) {
+      const it = items[idx];
+      if (typeof it.str !== 'string') continue;
+      const { left, top, fontSize } = itemPosition(it, viewport);
+      rects.push({
+        excerptId: e.excerptId,
+        left,
+        top,
+        width: it.width * scale,
+        height: fontSize * 1.15,
+      });
+    }
+  }
+  return rects;
+}

--- a/tests/renderer/components/PdfViewer.test.ts
+++ b/tests/renderer/components/PdfViewer.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component coverage for the in-app PDF viewer (#100, added for #672/#689 —
+ * the gate the pdfjs 6 bump was waiting on). pdfjs is mocked at the dynamic-
+ * import boundary (real canvas rendering needs a browser) so we can drive the
+ * component's flow: load → toolbar, page navigation + bounds, zoom + bounds,
+ * the page-jump input, "Show extracted", and the load-error path. The pure
+ * geometry / matching is unit-tested in tests/renderer/pdf/text-layer.test.ts.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const { getDocumentMock, readPdfMock, sourceDetailMock, createExcerptMock, onExcerptsChangedMock, setPdfPageMock } =
+  vi.hoisted(() => ({
+    getDocumentMock: vi.fn(),
+    readPdfMock: vi.fn(),
+    sourceDetailMock: vi.fn(),
+    createExcerptMock: vi.fn(),
+    onExcerptsChangedMock: vi.fn(),
+    setPdfPageMock: vi.fn(),
+  }));
+
+vi.mock('pdfjs-dist/legacy/build/pdf.worker.min.mjs?url', () => ({ default: 'stub-worker-url' }));
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: getDocumentMock,
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    sources: { readPdf: readPdfMock, createExcerpt: createExcerptMock, onExcerptsChanged: onExcerptsChangedMock },
+    graph: { sourceDetail: sourceDetailMock },
+  },
+}));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({
+  getEditorStore: () => ({ setPdfPage: setPdfPageMock }),
+}));
+
+import PdfViewer from '../../../src/renderer/lib/components/PdfViewer.svelte';
+
+function fakePage() {
+  return {
+    getViewport: () => ({ width: 600, height: 800, transform: [1, 0, 0, -1, 0, 800] }),
+    render: () => ({ promise: Promise.resolve() }),
+    getTextContent: async () => ({ items: [] }),
+    cleanup: vi.fn(),
+  };
+}
+
+function mockDoc(numPages: number) {
+  getDocumentMock.mockReturnValue({
+    promise: Promise.resolve({
+      numPages,
+      getPage: async () => fakePage(),
+      destroy: vi.fn(),
+    }),
+  });
+}
+
+function renderViewer(over: { initialPage?: number; onShowMarkdown?: (id: string) => void } = {}) {
+  return render(PdfViewer, {
+    sourceId: 'doi-x',
+    initialPage: over.initialPage ?? 1,
+    onShowMarkdown: over.onShowMarkdown ?? vi.fn(),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  [getDocumentMock, readPdfMock, sourceDetailMock, createExcerptMock, onExcerptsChangedMock, setPdfPageMock]
+    .forEach((m) => m.mockReset());
+});
+
+describe('PdfViewer (#100)', () => {
+  it('loads the document on mount and shows the toolbar with the page count', async () => {
+    mockDoc(5);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+
+    const { findByText, getByTitle } = renderViewer();
+    expect(await findByText('/ 5')).toBeTruthy();
+    // Prev is disabled on page 1; next is enabled.
+    expect((getByTitle('Previous page') as HTMLButtonElement).disabled).toBe(true);
+    expect((getByTitle('Next page') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('navigates pages within bounds', async () => {
+    mockDoc(3);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+
+    const { findByText, getByTitle, getByDisplayValue } = renderViewer();
+    await findByText('/ 3');
+
+    await fireEvent.click(getByTitle('Next page'));
+    expect(getByDisplayValue('2')).toBeTruthy();
+    await fireEvent.click(getByTitle('Next page'));
+    expect(getByDisplayValue('3')).toBeTruthy();
+    // At the last page, Next is disabled.
+    expect((getByTitle('Next page') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('zooms in/out and resets, reflecting the percentage label', async () => {
+    mockDoc(2);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+
+    const { findByText, getByTitle, getByText } = renderViewer();
+    await findByText('/ 2');
+    expect(getByText('120%')).toBeTruthy(); // DEFAULT_SCALE
+
+    await fireEvent.click(getByTitle('Zoom in'));
+    expect(getByText('135%')).toBeTruthy();
+    await fireEvent.click(getByTitle('Zoom out'));
+    expect(getByText('120%')).toBeTruthy();
+    await fireEvent.click(getByTitle('Zoom in'));
+    await fireEvent.click(getByTitle('Reset zoom'));
+    expect(getByText('120%')).toBeTruthy();
+  });
+
+  it('jumps to a page via the number input (clamped to range)', async () => {
+    mockDoc(10);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+
+    const { findByText, getByRole, getByTitle } = renderViewer();
+    await findByText('/ 10');
+    const input = getByRole('spinbutton') as HTMLInputElement;
+
+    // A valid in-range jump is accepted.
+    await fireEvent.change(input, { target: { value: '6' } });
+    expect(input.value).toBe('6');
+    // From page 6, Next still works (proves `page` actually moved to 6, not
+    // that the input value alone changed).
+    await fireEvent.click(getByTitle('Next page'));
+    expect(input.value).toBe('7');
+  });
+
+  it('"Show extracted" reports the sourceId to the host', async () => {
+    mockDoc(1);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+    const onShowMarkdown = vi.fn();
+
+    const { findByText, getByText } = renderViewer({ onShowMarkdown });
+    await findByText('/ 1');
+    await fireEvent.click(getByText('Show extracted'));
+    expect(onShowMarkdown).toHaveBeenCalledWith('doi-x');
+  });
+
+  it('surfaces a load error when the PDF bytes cannot be read', async () => {
+    readPdfMock.mockRejectedValue(new Error('source not found'));
+    const { findByText } = renderViewer();
+    expect(await findByText(/Failed to load PDF: source not found/)).toBeTruthy();
+  });
+
+  it('clamps the initial page above the document length down to the last page', async () => {
+    mockDoc(4);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+
+    const { findByText, getByDisplayValue } = renderViewer({ initialPage: 99 });
+    await findByText('/ 4');
+    expect(getByDisplayValue('4')).toBeTruthy();
+  });
+});

--- a/tests/renderer/pdf/text-layer.test.ts
+++ b/tests/renderer/pdf/text-layer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_SCALE, MAX_SCALE, DEFAULT_SCALE,
+  clampScale, zoomInScale, zoomOutScale,
+  itemPosition, normalizeForMatch, buildPageText, findExcerptRects,
+  type TextLayerItem, type ViewportLike, type ExcerptLike,
+} from '../../../src/renderer/lib/pdf/text-layer';
+
+// A pdfjs viewport at scale `s` on a page of height `h` flips Y: [s,0,0,-s,0,h*s].
+const viewport = (s: number, h: number): ViewportLike => ({
+  width: 600, height: h * s, transform: [s, 0, 0, -s, 0, h * s],
+});
+// A text item's matrix: [fontSize,0,0,fontSize,x,y] at bottom-left-origin (x,y).
+const item = (over: Partial<TextLayerItem> & { x?: number; y?: number; fs?: number } = {}): TextLayerItem => ({
+  str: over.str ?? 'text',
+  transform: [over.fs ?? 10, 0, 0, over.fs ?? 10, over.x ?? 0, over.y ?? 0],
+  width: over.width ?? 40,
+  height: over.height ?? 10,
+});
+
+describe('zoom helpers', () => {
+  it('steps in/out and clamps to [MIN, MAX]', () => {
+    expect(zoomInScale(DEFAULT_SCALE)).toBe(1.35); // 1.2 + 0.15
+    expect(zoomOutScale(DEFAULT_SCALE)).toBe(1.05);
+    expect(zoomInScale(2.95)).toBe(MAX_SCALE);   // clamps up
+    expect(zoomOutScale(0.55)).toBe(MIN_SCALE);  // clamps down
+  });
+  it('rounds to 2dp to avoid float drift', () => {
+    expect(zoomInScale(0.5)).toBe(0.65);
+    expect(Number.isInteger(zoomInScale(0.5) * 100)).toBe(true);
+  });
+  it('clampScale bounds arbitrary values', () => {
+    expect(clampScale(10)).toBe(MAX_SCALE);
+    expect(clampScale(0)).toBe(MIN_SCALE);
+    expect(clampScale(1.2)).toBe(1.2);
+  });
+});
+
+describe('normalizeForMatch', () => {
+  it('collapses whitespace, trims, lower-cases', () => {
+    expect(normalizeForMatch('  Hello   World \n ')).toBe('hello world');
+  });
+  it('strips soft-hyphen + zero-width noise PDFs inject', () => {
+    expect(normalizeForMatch('co­oper​ate')).toBe('cooperate');
+  });
+});
+
+describe('itemPosition (affine compose)', () => {
+  it('projects a text item into CSS pixels through the flipped viewport', () => {
+    // s=2, fontSize=10, x=5, y=700, page height 792.
+    const box = itemPosition(item({ x: 5, y: 700, fs: 10 }), viewport(2, 792));
+    expect(box.left).toBe(10);              // s*x
+    expect(box.fontSize).toBe(20);          // s*fontSize
+    expect(box.top).toBe(2 * (792 - 700) - 20); // s*(h-y) - fontSize = 164
+  });
+});
+
+describe('buildPageText', () => {
+  it('flattens items to chars + a parallel char→item map, with item-boundary spaces', () => {
+    const { haystack, charToItem } = buildPageText([item({ str: 'ab' }), item({ str: 'cd' })]);
+    expect(haystack).toBe('ab cd ');
+    expect(charToItem).toEqual([0, 0, 0, 1, 1, 1]); // a,b,<space>→0 ; c,d,<space>→1
+  });
+  it('skips non-text (marked-content) items', () => {
+    const { haystack } = buildPageText([{ transform: [], width: 0, height: 0 }, item({ str: 'x' })]);
+    expect(haystack).toBe('x ');
+  });
+});
+
+describe('findExcerptRects', () => {
+  const vp = viewport(1, 100);
+  const ex = (over: Partial<ExcerptLike>): ExcerptLike => ({ excerptId: 'e1', citedText: null, page: null, ...over });
+
+  it('returns a rect for an excerpt whose cited text is found on the page', () => {
+    const items = [item({ str: 'quantum', x: 10, y: 80, fs: 12, width: 50 })];
+    const rects = findExcerptRects(items, [ex({ citedText: 'Quantum' })], vp, 1, 1);
+    expect(rects).toHaveLength(1);
+    expect(rects[0].excerptId).toBe('e1');
+    expect(rects[0].width).toBe(50);       // item.width * scale
+    expect(rects[0].left).toBe(10);
+  });
+
+  it('skips an excerpt whose page hint is a different page', () => {
+    const items = [item({ str: 'quantum' })];
+    expect(findExcerptRects(items, [ex({ citedText: 'quantum', page: '7' })], vp, 1, 1)).toHaveLength(0);
+    // No page hint → still matched.
+    expect(findExcerptRects(items, [ex({ citedText: 'quantum', page: null })], vp, 1, 1)).toHaveLength(1);
+  });
+
+  it('matches across adjacent items (multi-item span → one rect per item)', () => {
+    const items = [
+      item({ str: 'hello', x: 0, y: 50, width: 30 }),
+      item({ str: 'world', x: 35, y: 50, width: 30 }),
+    ];
+    // "hello world" spans both items (the inter-item space bridges them).
+    const rects = findExcerptRects(items, [ex({ citedText: 'hello world' })], vp, 1, 1);
+    expect(rects).toHaveLength(2);
+  });
+
+  it('returns nothing when the cited text is absent or empty', () => {
+    const items = [item({ str: 'present' })];
+    expect(findExcerptRects(items, [ex({ citedText: 'absent' })], vp, 1, 1)).toHaveLength(0);
+    expect(findExcerptRects(items, [ex({ citedText: '' })], vp, 1, 1)).toHaveLength(0);
+    expect(findExcerptRects(items, [ex({ citedText: null })], vp, 1, 1)).toHaveLength(0);
+  });
+
+  it('scales rect width by the zoom factor', () => {
+    const items = [item({ str: 'zoomed', width: 40 })];
+    const rects = findExcerptRects(items, [ex({ citedText: 'zoomed' })], vp, 2, 1);
+    expect(rects[0].width).toBe(80); // 40 * 2
+  });
+});


### PR DESCRIPTION
## What

`PdfViewer.svelte` was a 582-line **untested** component — and that missing coverage is the exact reason the **pdfjs-dist 5→6** bump was deferred in #689. This adds the coverage that gate requires, in two parts.

### 1. Extract the pdfjs-coupled pure logic → `lib/pdf/text-layer.ts`
DOM-free and unit-testable: the affine **text-item → CSS-pixel** projection (`itemPosition`), the citedText `normalizeForMatch` + page-text flattening (`buildPageText`), the **excerpt-highlight matcher** (`findExcerptRects` — page filter → normalized substring match → resolve back to the items the match spans → rects), and the zoom clamping (`zoomInScale`/`zoomOutScale`/`clampScale`). The component now imports these and only **paints** the rects they return. **PdfViewer 582 → 514.**

### 2. Two test files (20 tests)
- **`tests/renderer/pdf/text-layer.test.ts`** (13) — pins the logic with concrete numbers: the affine math, multi-item matches, page filtering, zoom clamp, zero-width-noise stripping.
- **`tests/renderer/components/PdfViewer.test.ts`** (7) — renders the **real component** against a **mocked pdfjs** (canvas rendering needs a real browser) and drives the flow: load → toolbar + page count, page nav + disabled-at-bounds, zoom + percentage label, the page-jump input, "Show extracted" → host callback, initial-page clamp, and the load-error path.

## How this unblocks pdfjs v6
Between the **render test** (exercises our pdfjs call flow: `getDocument`/`getPage`/`getViewport`/`render`/`getTextContent`/`cleanup`) and **tsc** (which type-checks the real `typeof import('pdfjs-dist')` at the call sites), the v6 bump's risk surface — the API shape + the geometry — is now covered. Only canvas *pixel output* stays manual (inherent: no canvas in jsdom). That satisfies #689's "defer until the viewer has component coverage" gate.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3030 passed** (+20).
- `pnpm test:e2e` — boot smoke passes.

_Follow-up: with this in, the pdfjs-dist 6 bump (#689) can be attempted against this net._

🤖 Generated with [Claude Code](https://claude.com/claude-code)