### PR TITLE
Upgrade pdfjs-dist 5→6 (#689)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mermaid": "^11.15.0",
     "minisearch": "^7.2.0",
     "n3": "^2.0.3",
-    "pdfjs-dist": "^5.6.205",
+    "pdfjs-dist": "^6.0.227",
     "rdflib": "^2.3.9",
     "sql-formatter": "^15.8.1",
     "tesseract.js": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       pdfjs-dist:
-        specifier: ^5.6.205
-        version: 5.6.205
+        specifier: ^6.0.227
+        version: 6.0.227
       rdflib:
         specifier: ^2.3.9
         version: 2.3.9(encoding@0.1.13)
@@ -1838,8 +1838,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    resolution: {integrity: sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
   '@napi-rs/canvas-darwin-arm64@0.1.99':
     resolution: {integrity: sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1850,14 +1862,33 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.99':
     resolution: {integrity: sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
   '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
     resolution: {integrity: sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1870,8 +1901,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
     resolution: {integrity: sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    resolution: {integrity: sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
@@ -1884,8 +1929,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@napi-rs/canvas-linux-x64-musl@0.1.99':
     resolution: {integrity: sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1897,14 +1956,30 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@napi-rs/canvas-win32-x64-msvc@0.1.99':
     resolution: {integrity: sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/canvas@0.1.99':
     resolution: {integrity: sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/canvas@1.0.0':
+    resolution: {integrity: sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==}
     engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4556,9 +4631,6 @@ packages:
       encoding:
         optional: true
 
-  node-readable-to-web-readable-stream@0.4.2:
-    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
-
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
@@ -4749,9 +4821,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pdfjs-dist@5.6.205:
-    resolution: {integrity: sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==}
-    engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
+  pdfjs-dist@6.0.227:
+    resolution: {integrity: sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   pe-library@1.0.1:
     resolution: {integrity: sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==}
@@ -9858,34 +9930,67 @@ snapshots:
   '@napi-rs/canvas-android-arm64@0.1.99':
     optional: true
 
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    optional: true
+
   '@napi-rs/canvas-darwin-arm64@0.1.99':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
     optional: true
 
   '@napi-rs/canvas-darwin-x64@0.1.99':
     optional: true
 
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    optional: true
+
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.99':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
     optional: true
 
   '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
     optional: true
 
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    optional: true
+
   '@napi-rs/canvas-linux-arm64-musl@0.1.99':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
     optional: true
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
     optional: true
 
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    optional: true
+
   '@napi-rs/canvas-linux-x64-gnu@0.1.99':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
     optional: true
 
   '@napi-rs/canvas-linux-x64-musl@0.1.99':
     optional: true
 
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    optional: true
+
   '@napi-rs/canvas-win32-arm64-msvc@0.1.99':
     optional: true
 
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    optional: true
+
   '@napi-rs/canvas-win32-x64-msvc@0.1.99':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
     optional: true
 
   '@napi-rs/canvas@0.1.99':
@@ -9901,6 +10006,21 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.99
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.99
       '@napi-rs/canvas-win32-x64-msvc': 0.1.99
+    optional: true
+
+  '@napi-rs/canvas@1.0.0':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-x64': 1.0.0
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.0
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.0
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-musl': 1.0.0
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.0
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.0
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -12863,9 +12983,6 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
-  node-readable-to-web-readable-stream@0.4.2:
-    optional: true
-
   node-releases@2.0.36: {}
 
   node-status-codes@1.0.0: {}
@@ -13048,10 +13165,9 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pdfjs-dist@5.6.205:
+  pdfjs-dist@6.0.227:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.99
-      node-readable-to-web-readable-stream: 0.4.2
+      '@napi-rs/canvas': 1.0.0
 
   pe-library@1.0.1: {}
 

--- a/src/renderer/lib/components/PdfViewer.svelte
+++ b/src/renderer/lib/components/PdfViewer.svelte
@@ -37,6 +37,7 @@
   // the call sites here and the dynamic import doesn't give us
   // namespaces. The API we touch is small and stable.
   type PdfjsModule = typeof import('pdfjs-dist');
+  type PdfLoadingTask = ReturnType<PdfjsModule['getDocument']>;
   type PdfDocumentProxy = Awaited<ReturnType<PdfjsModule['getDocument']>['promise']>;
   type PdfPageProxy = Awaited<ReturnType<PdfDocumentProxy['getPage']>>;
   type TextContent = Awaited<ReturnType<PdfPageProxy['getTextContent']>>;
@@ -57,6 +58,9 @@
 
   let pdfjs = $state<PdfjsModule | null>(null);
   let doc = $state<PdfDocumentProxy | null>(null);
+  /** The current document's loading task — pdfjs 6 hangs `destroy()` here, not
+   *  on the proxy. Held so a reload (or unmount) can tear the old doc down. */
+  let loadingTask: PdfLoadingTask | null = null;
   let loadError = $state<string | null>(null);
   let loading = $state(true);
 
@@ -114,8 +118,10 @@
         pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
       }
       const bytes = await api.sources.readPdf(id);
-      const newDoc = await pdfjs.getDocument({ data: bytes }).promise;
-      if (doc) void doc.destroy();
+      const newTask = pdfjs.getDocument({ data: bytes });
+      const newDoc = await newTask.promise;
+      if (loadingTask) void loadingTask.destroy();
+      loadingTask = newTask;
       doc = newDoc;
       numPages = newDoc.numPages;
       if (page > numPages) page = numPages;

--- a/src/renderer/lib/ocr/run-ocr.ts
+++ b/src/renderer/lib/ocr/run-ocr.ts
@@ -39,7 +39,11 @@ export async function runOcr(
   onProgress: (p: OcrProgress) => void,
   signal?: AbortSignal,
 ): Promise<string[]> {
-  const doc = await pdfjs.getDocument({ data: pdfBytes }).promise;
+  // pdfjs 6 moved full teardown from the document proxy to the loading task —
+  // `PDFDocumentProxy` now only exposes `cleanup()`; `destroy()` lives on the
+  // task returned by `getDocument()`. Hold the task so we can tear it down.
+  const loadingTask = pdfjs.getDocument({ data: pdfBytes });
+  const doc = await loadingTask.promise;
   const totalPages = doc.numPages;
 
   const worker = await createTesseractWorker();
@@ -63,7 +67,7 @@ export async function runOcr(
   } finally {
     await worker.terminate();
     await doc.cleanup();
-    await doc.destroy();
+    await loadingTask.destroy();
   }
 }
 

--- a/tests/renderer/ocr/run-ocr.test.ts
+++ b/tests/renderer/ocr/run-ocr.test.ts
@@ -47,7 +47,9 @@ import { runOcr, type OcrProgress } from '../../../src/renderer/lib/ocr/run-ocr'
 function stubPdf(numPages: number, opts: { onPageRender?: (n: number) => void } = {}) {
   const pageCleanup = vi.fn();
   const docCleanup = vi.fn();
-  const docDestroy = vi.fn();
+  // pdfjs 6: full teardown is `loadingTask.destroy()` (the getDocument() return),
+  // not `doc.destroy()`. The doc proxy only exposes cleanup().
+  const taskDestroy = vi.fn();
   const getPage = vi.fn(async (n: number) => ({
     getViewport: () => ({ width: 100, height: 200 }),
     render: () => ({
@@ -57,12 +59,14 @@ function stubPdf(numPages: number, opts: { onPageRender?: (n: number) => void } 
     }),
     cleanup: pageCleanup,
   }));
+  const doc = { numPages, getPage, cleanup: docCleanup };
   return {
-    doc: { numPages, getPage, cleanup: docCleanup, destroy: docDestroy },
+    doc,
+    loadingTask: { promise: Promise.resolve(doc), destroy: taskDestroy },
     getPage,
     pageCleanup,
     docCleanup,
-    docDestroy,
+    taskDestroy,
   };
 }
 
@@ -83,8 +87,8 @@ afterEach(() => {
 
 describe('runOcr() (#343)', () => {
   it('returns one extracted text per page in order', async () => {
-    const { doc } = stubPdf(3);
-    getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+    const { loadingTask } = stubPdf(3);
+    getDocumentMock.mockReturnValue(loadingTask);
     recognizeMock
       .mockResolvedValueOnce({ data: { text: 'page-1-text' } })
       .mockResolvedValueOnce({ data: { text: 'page-2-text' } })
@@ -96,8 +100,8 @@ describe('runOcr() (#343)', () => {
   });
 
   it('fires onProgress at start, mid, and end of each page in order', async () => {
-    const { doc } = stubPdf(3);
-    getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+    const { loadingTask } = stubPdf(3);
+    getDocumentMock.mockReturnValue(loadingTask);
     recognizeMock.mockResolvedValue({ data: { text: 'x' } });
     createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
 
@@ -118,21 +122,21 @@ describe('runOcr() (#343)', () => {
   });
 
   it('always tears down the worker and the doc, even on error', async () => {
-    const { doc, docCleanup, docDestroy } = stubPdf(1);
-    getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+    const { loadingTask, docCleanup, taskDestroy } = stubPdf(1);
+    getDocumentMock.mockReturnValue(loadingTask);
     recognizeMock.mockRejectedValueOnce(new Error('tesseract bombed'));
     createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
 
     await expect(runOcr(new Uint8Array(), () => undefined)).rejects.toThrow('tesseract bombed');
     expect(terminateMock).toHaveBeenCalledTimes(1);
     expect(docCleanup).toHaveBeenCalledTimes(1);
-    expect(docDestroy).toHaveBeenCalledTimes(1);
+    expect(taskDestroy).toHaveBeenCalledTimes(1);
   });
 
   describe('AbortSignal', () => {
     it('rejects with AbortError when aborted before the first page', async () => {
-      const { doc, getPage } = stubPdf(3);
-      getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+      const { loadingTask, getPage } = stubPdf(3);
+      getDocumentMock.mockReturnValue(loadingTask);
       recognizeMock.mockResolvedValue({ data: { text: 'x' } });
       createWorkerMock.mockResolvedValue({ recognize: recognizeMock, terminate: terminateMock });
 
@@ -152,8 +156,8 @@ describe('runOcr() (#343)', () => {
     it('mid-run abort skips remaining pages and still tears down', async () => {
       // Abort after page 2 finishes — page 3 must never be processed.
       const ctrl = new AbortController();
-      const { doc, getPage, docDestroy } = stubPdf(3);
-      getDocumentMock.mockReturnValue({ promise: Promise.resolve(doc) });
+      const { loadingTask, getPage, taskDestroy } = stubPdf(3);
+      getDocumentMock.mockReturnValue(loadingTask);
       recognizeMock.mockImplementation(async () => {
         // Trigger abort once page 2's recognize resolves; the loop will
         // see the signal at the top of iteration 3.
@@ -171,7 +175,7 @@ describe('runOcr() (#343)', () => {
       expect(getPage).toHaveBeenCalledTimes(2);
       expect(recognizeMock).toHaveBeenCalledTimes(2);
       expect(terminateMock).toHaveBeenCalledTimes(1);
-      expect(docDestroy).toHaveBeenCalledTimes(1);
+      expect(taskDestroy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## What

The pdfjs bump #689 was waiting on — now doable because the viewer got coverage in #728. **pdfjs-dist 5.6 → 6.0.**

## The net worked exactly as intended
The **one** real v6 API change was caught immediately by **tsc** against the real `typeof import('pdfjs-dist')` types — no guesswork:

> `PDFDocumentProxy.destroy()` is gone. Full teardown moved to the **loading task** (`getDocument()`'s return, a `PDFDocumentLoadingTask`); the document proxy now keeps only `cleanup()`.

Both consumers migrated to hold the loading task and call `loadingTask.destroy()`:
- **`run-ocr.ts`** — capture the task; `doc.cleanup()` + `loadingTask.destroy()` in `finally`.
- **`PdfViewer.svelte`** — track the task alongside `doc`, destroy the prior one on reload.
- **`run-ocr.test.ts`** — the stub now models the task/proxy split (destroy on the task, cleanup on the doc).

Our import paths (`legacy/build/pdf.mjs` + the worker `?url`, plus run-ocr's `build/*`) all still exist in v6 — verified on disk before touching code.

## Verification
- `pnpm lint` — **0 errors** (tsc + svelte-check against real v6 types).
- `pnpm test` — **3030 passed** (the #728 PdfViewer + text-layer tests and the run-ocr test exercise the flow on the v6-shaped API).
- `pnpm test:e2e` — the **electron-forge production build bundles pdfjs 6 (legacy build) and the app boots clean**.

## Residual gap (unchanged, inherent)
Actual canvas PDF *rendering* isn't covered in CI (no canvas in jsdom). Worth a one-minute manual check — open a PDF source in `pnpm dev`, confirm it renders + text selects + an excerpt highlights — before the next release. Everything around it (API shape, our call flow, the production bundle, boot) is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)