### PR TITLE
Upgrade @duckdb/node-api 1.5.2-r.1 → 1.5.3-r.3 (#689)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/legacy-modes": "^6.5.3",
     "@comunica/query-sparql-rdfjs": "^5.2.3",
-    "@duckdb/node-api": "1.5.2-r.1",
+    "@duckdb/node-api": "1.5.3-r.3",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/ibm-plex-serif": "^5.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^5.2.3
         version: 5.2.3(encoding@0.1.13)
       '@duckdb/node-api':
-        specifier: 1.5.2-r.1
-        version: 1.5.2-r.1
+        specifier: 1.5.3-r.3
+        version: 1.5.3-r.3
       '@fontsource-variable/ibm-plex-sans':
         specifier: ^5.2.8
         version: 5.2.8
@@ -1272,41 +1272,55 @@ packages:
     resolution: {integrity: sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==}
     engines: {node: '>=18.0'}
 
-  '@duckdb/node-api@1.5.2-r.1':
-    resolution: {integrity: sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==}
+  '@duckdb/node-api@1.5.3-r.3':
+    resolution: {integrity: sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA==}
 
-  '@duckdb/node-bindings-darwin-arm64@1.5.2-r.1':
-    resolution: {integrity: sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==}
+  '@duckdb/node-bindings-darwin-arm64@1.5.3-r.3':
+    resolution: {integrity: sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@duckdb/node-bindings-darwin-x64@1.5.2-r.1':
-    resolution: {integrity: sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==}
+  '@duckdb/node-bindings-darwin-x64@1.5.3-r.3':
+    resolution: {integrity: sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg==}
     cpu: [x64]
     os: [darwin]
 
-  '@duckdb/node-bindings-linux-arm64@1.5.2-r.1':
-    resolution: {integrity: sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==}
+  '@duckdb/node-bindings-linux-arm64-musl@1.5.3-r.3':
+    resolution: {integrity: sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@duckdb/node-bindings-linux-x64@1.5.2-r.1':
-    resolution: {integrity: sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==}
+  '@duckdb/node-bindings-linux-arm64@1.5.3-r.3':
+    resolution: {integrity: sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@duckdb/node-bindings-linux-x64-musl@1.5.3-r.3':
+    resolution: {integrity: sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@duckdb/node-bindings-win32-arm64@1.5.2-r.1':
-    resolution: {integrity: sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==}
+  '@duckdb/node-bindings-linux-x64@1.5.3-r.3':
+    resolution: {integrity: sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@duckdb/node-bindings-win32-arm64@1.5.3-r.3':
+    resolution: {integrity: sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug==}
     cpu: [arm64]
     os: [win32]
 
-  '@duckdb/node-bindings-win32-x64@1.5.2-r.1':
-    resolution: {integrity: sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==}
+  '@duckdb/node-bindings-win32-x64@1.5.3-r.3':
+    resolution: {integrity: sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag==}
     cpu: [x64]
     os: [win32]
 
-  '@duckdb/node-bindings@1.5.2-r.1':
-    resolution: {integrity: sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==}
+  '@duckdb/node-bindings@1.5.3-r.3':
+    resolution: {integrity: sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg==}
 
   '@electron-forge/cli@7.11.2':
     resolution: {integrity: sha512-c+C4ndLfHbxwZuCn9G8iT9wD/woLdaVkoSVjAIbj+0nJhi8UmiVsz/+Gxlj4cvhMRTzBMBxudstLU7RocMikfg==}
@@ -9149,36 +9163,46 @@ snapshots:
       ky: 1.14.3
       undici: 6.26.0
 
-  '@duckdb/node-api@1.5.2-r.1':
+  '@duckdb/node-api@1.5.3-r.3':
     dependencies:
-      '@duckdb/node-bindings': 1.5.2-r.1
+      '@duckdb/node-bindings': 1.5.3-r.3
 
-  '@duckdb/node-bindings-darwin-arm64@1.5.2-r.1':
+  '@duckdb/node-bindings-darwin-arm64@1.5.3-r.3':
     optional: true
 
-  '@duckdb/node-bindings-darwin-x64@1.5.2-r.1':
+  '@duckdb/node-bindings-darwin-x64@1.5.3-r.3':
     optional: true
 
-  '@duckdb/node-bindings-linux-arm64@1.5.2-r.1':
+  '@duckdb/node-bindings-linux-arm64-musl@1.5.3-r.3':
     optional: true
 
-  '@duckdb/node-bindings-linux-x64@1.5.2-r.1':
+  '@duckdb/node-bindings-linux-arm64@1.5.3-r.3':
     optional: true
 
-  '@duckdb/node-bindings-win32-arm64@1.5.2-r.1':
+  '@duckdb/node-bindings-linux-x64-musl@1.5.3-r.3':
     optional: true
 
-  '@duckdb/node-bindings-win32-x64@1.5.2-r.1':
+  '@duckdb/node-bindings-linux-x64@1.5.3-r.3':
     optional: true
 
-  '@duckdb/node-bindings@1.5.2-r.1':
+  '@duckdb/node-bindings-win32-arm64@1.5.3-r.3':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.5.3-r.3':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.3-r.3':
+    dependencies:
+      detect-libc: 2.1.2
     optionalDependencies:
-      '@duckdb/node-bindings-darwin-arm64': 1.5.2-r.1
-      '@duckdb/node-bindings-darwin-x64': 1.5.2-r.1
-      '@duckdb/node-bindings-linux-arm64': 1.5.2-r.1
-      '@duckdb/node-bindings-linux-x64': 1.5.2-r.1
-      '@duckdb/node-bindings-win32-arm64': 1.5.2-r.1
-      '@duckdb/node-bindings-win32-x64': 1.5.2-r.1
+      '@duckdb/node-bindings-darwin-arm64': 1.5.3-r.3
+      '@duckdb/node-bindings-darwin-x64': 1.5.3-r.3
+      '@duckdb/node-bindings-linux-arm64': 1.5.3-r.3
+      '@duckdb/node-bindings-linux-arm64-musl': 1.5.3-r.3
+      '@duckdb/node-bindings-linux-x64': 1.5.3-r.3
+      '@duckdb/node-bindings-linux-x64-musl': 1.5.3-r.3
+      '@duckdb/node-bindings-win32-arm64': 1.5.3-r.3
+      '@duckdb/node-bindings-win32-x64': 1.5.3-r.3
 
   '@electron-forge/cli@7.11.2(encoding@0.1.13)':
     dependencies:


### PR DESCRIPTION
## What

The last #689 item — the patch-level **native** bump. CSV-table ingestion (`src/main/sources/tables.ts`) is the only consumer.

Patch-level, but native, so the modernization review flagged "verify the packaged app loads on the target arch" — because nothing automated actually loads the binding (`csv-table-indexing.test.ts` mocks the column shapes; the binding is externalized and loaded at runtime, and the smoke boots without touching it).

## Verified the thing the issue cared about
Loaded the upgraded **arm64** binding directly and ran a query:
```
DuckDBInstance.create(':memory:') → connect() → runAndReadAll("SELECT 42 AS answer, 'ok' AS status")
→ [[42, "ok"]]      PRAGMA version → v1.5.3
```
— exercising the exact API `tables.ts` uses (`create` / `connect` / `runAndReadAll`). And the **electron-forge e2e packages the app** (which bundles `@duckdb/node-bindings-darwin-arm64` via the `vite.main` externalization) and boots clean.

## Verification
- Direct binding **load + query** check on arm64 (above).
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3030 passed**.
- `pnpm test:e2e` — production build + boot smoke.

## #689 status after this
- chokidar 4→5 ✅ (#727) · pdfjs-dist 5→6 ✅ (#729) · @duckdb patch ✅ (this)
- **@retorquere/bibtex-parser 10** stays deferred — upstream-broken (ships no type declarations); reopen when they republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)