### PR TITLE
Cache node_modules across CI jobs, keyed on the lockfile (#663)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,20 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      # node-linker=hoisted → node_modules is a self-contained flat tree (no
+      # store symlinks), so caching it directly is safe. Keyed on the lockfile
+      # + Node + OS/arch, so a dep or Node bump busts it. The `cache: pnpm`
+      # store cache above still speeds the miss path. Bump v1 if a runner-image
+      # change ever stales the native binaries baked into the tree (#663).
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-v1-${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('.nvmrc') }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Lint (tsc + svelte-check + eslint)
@@ -73,7 +86,17 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      # See lint-and-test for the rationale; same key so both jobs share the
+      # cached tree across runs (#663).
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-v1-${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('.nvmrc') }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: E2E (electron-forge package + Playwright)


### PR DESCRIPTION
## What

Closes #663. Both jobs (`lint-and-test`, `e2e`) run `pnpm install --frozen-lockfile`. The pnpm **store** is cached (`cache: pnpm`), so downloads dedupe — but the **link step** (a ~1.6 GB `node_modules` tree) runs fully in every job, every run. This adds an `actions/cache` on `node_modules` so a warm run **skips install entirely**.

## Why it's safe to cache node_modules directly
`node-linker=hoisted` (`.npmrc`) means `node_modules` is a **self-contained flat tree** — no symlinks into a separate pnpm store — so caching it standalone is clean. The key is `lockfile + Node + OS/arch`, so any dependency or Node bump busts it; `install` only runs on a cache **miss** (and the existing `cache: pnpm` store cache still speeds that path).

- **Jobs stay separate** — parallelism is correct, exactly as the issue asks. They share one key, so the cache warms across runs (most PRs push more than once).
- The key carries a **`v1` prefix** to bump if a `macos-latest` image change ever stales the native binaries (electron/duckdb/canvas) baked into the cached tree — the one accepted tradeoff of node_modules caching, documented inline and self-healing.

## Verification
- Workflow YAML validated (parses; both jobs gain the cache step before a now-`cache-hit`-gated install).
- Functional behavior is unchanged on a cache miss (normal `--frozen-lockfile` install); the speedup is the cache-hit path. The real timing win shows on CI itself once a base cache exists — can't be exercised on a local runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)