### PR TITLE
DRY the @shared alias across the vite/vitest configs (#692)

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -10,6 +10,7 @@
     "tests/**/*",
     "*.config.ts",
     "*.config.mts",
+    "vite.shared.ts",
     "eslint.config.mjs"
   ],
   "exclude": ["node_modules", "dist", ".vite", "out", "coverage", "tests/fixtures"]

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig } from 'vite';
+import { sharedAlias } from './vite.shared';
 
 export default defineConfig({
   resolve: {
-    alias: {
-      '@shared': '/src/shared',
-    },
+    alias: sharedAlias,
   },
   build: {
     rollupOptions: {

--- a/vite.preload.config.ts
+++ b/vite.preload.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from 'vite';
+import { sharedAlias } from './vite.shared';
 
 export default defineConfig({
   resolve: {
-    alias: {
-      '@shared': '/src/shared',
-    },
+    alias: sharedAlias,
   },
 });

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -1,11 +1,10 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { sharedAlias } from './vite.shared';
 
 export default defineConfig({
   plugins: [svelte()],
   resolve: {
-    alias: {
-      '@shared': '/src/shared',
-    },
+    alias: sharedAlias,
   },
 });

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared Vite/Vitest config bits (#692).
+ *
+ * The `@shared` path alias was declared independently in all four configs
+ * (main / preload / renderer / vitest) — harmless, but four copies that drift
+ * apart. One source of truth here.
+ */
+
+/** Maps `@shared/*` imports to `src/shared/*`. */
+export const sharedAlias = {
+  '@shared': '/src/shared',
+} as const;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
+import { sharedAlias } from './vite.shared';
 
 export default defineConfig({
   // Svelte + testing-library plugins let vitest transform `.svelte`
@@ -18,9 +19,7 @@ export default defineConfig({
     svelteTesting(),
   ],
   resolve: {
-    alias: {
-      '@shared': '/src/shared',
-    },
+    alias: sharedAlias,
   },
   test: {
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
## What

Closes #692. `vite.main.config.ts`, `vite.preload.config.ts`, `vite.renderer.config.mts`, and `vitest.config.mts` each declared `resolve.alias['@shared'] = '/src/shared'` independently — four copies free to drift. Factored into **`vite.shared.ts`** (`export const sharedAlias`) and imported by all four.

Also added `vite.shared.ts` to `tsconfig.eslint.json`'s `include` so eslint type-checks it as part of the build-config project (the root configs live there, not in the `src`-only `tsc --noEmit` pass).

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3030 passed** (vitest loads `vite.shared` fine).
- `pnpm test:e2e` — electron-forge build + boot smoke; confirms the three vite configs (`.ts` + `.mts` both importing the shared `.ts`) bundle and run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)