### PR TITLE
Prove the LLM write guard is wired into the graph write path (#657)

### DIFF
--- a/tests/main/graph/write-guard-wired.test.ts
+++ b/tests/main/graph/write-guard-wired.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration coverage for the LLM write guard (#657 / QA Q-C1).
+ *
+ * write-guard.test.ts unit-tests the guard primitive (checkLLMWriteGuard). This
+ * file proves the guard is actually WIRED INTO the real graph write path: it
+ * drives the genuine `parseIntoStore` / `removeMatchingTriples` and asserts that
+ *   - a direct write in LLM context (i.e. bypassing the approval engine) is
+ *     caught (warned), and
+ *   - the same write inside the approval engine's *trusted* context is exempt.
+ *
+ * That's the "verify the approval gate cannot be skipped" check CLAUDE.md's
+ * LLM/Graph checklist asks for — the previous test only exercised the counter
+ * and never touched a real write.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, parseIntoStore, removeMatchingTriples, queryGraph } from '../../../src/main/graph/index';
+import {
+  enterLLMContext,
+  exitLLMContext,
+  enterTrustedContext,
+  exitTrustedContext,
+  __resetWriteGuardForTests,
+} from '../../../src/main/graph/write-guard';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const S = 'https://minerva.dev/c/guard-test';
+const P = 'https://minerva.dev/ontology/thought#label';
+const TRIPLE = `<${S}> <${P}> "guarded" .`;
+
+async function objectsOf(ctx: ProjectContext): Promise<string[]> {
+  const r = await queryGraph(ctx, `SELECT ?o WHERE { <${S}> <${P}> ?o }`);
+  return (r.results as Array<{ o: string }>).map((x) => x.o);
+}
+
+describe('LLM write guard wired into the graph write path (#657)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-guard-wired-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    __resetWriteGuardForTests();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    __resetWriteGuardForTests();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('a direct parseIntoStore in LLM context (bypassing approval) trips the guard', () => {
+    enterLLMContext();
+    parseIntoStore(ctx, TRIPLE);
+    exitLLMContext();
+
+    expect(warnSpy).toHaveBeenCalled();
+    const msg = String(warnSpy.mock.calls[0][0]);
+    expect(msg).toContain('[trust-guard]');
+    expect(msg).toContain('parseIntoStore');
+    expect(msg).toContain('proposeWrite'); // the message tells you the right path
+  });
+
+  it('the SAME write inside the approval engine\'s trusted context is exempt', async () => {
+    // This is how the approval engine applies an approved proposal: an LLM-
+    // originated path, but wrapped in the trusted context so its writes are
+    // legitimate.
+    enterLLMContext();
+    enterTrustedContext();
+    parseIntoStore(ctx, TRIPLE);
+    exitTrustedContext();
+    exitLLMContext();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(await objectsOf(ctx)).toContain('guarded'); // and it actually landed
+  });
+
+  it('a normal write outside any LLM context is silent', async () => {
+    parseIntoStore(ctx, TRIPLE);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(await objectsOf(ctx)).toContain('guarded');
+  });
+
+  it('removeMatchingTriples is guarded on the same path', () => {
+    parseIntoStore(ctx, TRIPLE); // seed outside LLM context
+    warnSpy.mockClear();
+
+    enterLLMContext();
+    removeMatchingTriples(ctx, S, P);
+    exitLLMContext();
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(String(warnSpy.mock.calls[0][0])).toContain('removeMatchingTriples');
+  });
+
+  it('warns but does NOT block — a dev guardrail, not a hard gate (per CLAUDE.md)', async () => {
+    // The guard's documented contract: it surfaces a bypass, it doesn't reject
+    // the write. Pinning that so a future "make it throw" is a conscious change,
+    // not an accidental one.
+    enterLLMContext();
+    parseIntoStore(ctx, TRIPLE);
+    exitLLMContext();
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(await objectsOf(ctx)).toContain('guarded');
+  });
+});


### PR DESCRIPTION
## What

Closes #657. The Trust-Principle write guard was the issue's concern: the original `write-guard.test.ts` was 5 green tests that only checked the `enter/exitLLMContext` counter and never asserted a warning.

Two things the issue asked for, and where they stand:
1. **Extract the guard** into `src/main/graph/write-guard.ts` — **already done in #671** (the graph decomposition), and `write-guard.test.ts` now unit-tests the primitive (`checkLLMWriteGuard`), *including* the warning assertion the original lacked.
2. **Add a real bypass test** — this PR. The piece still missing: a green primitive test proves the guard *works*, but not that the *real graph writes actually route through it*. "The gate can't be skipped" needs a write-path test.

## The new test
`tests/main/graph/write-guard-wired.test.ts` drives the **genuine** `parseIntoStore` / `removeMatchingTriples` against a real initialized graph and asserts:
- a **direct write in LLM context** (bypassing the approval engine) trips the guard — the `[trust-guard] … parseIntoStore … proposeWrite()` warning fires;
- the **same write inside the approval engine's trusted context** is exempt **and lands** (the legit path isn't flagged);
- a normal write outside LLM context is silent and lands;
- `removeMatchingTriples` is guarded on the same path;
- the guard **warns but does not block** — pinning the documented dev-guardrail contract (per CLAUDE.md) so a future "make it throw" is a conscious change.

That's the "verify the approval gate cannot be skipped" check from CLAUDE.md's LLM/Graph checklist — exercised against the real write functions, not the primitive in isolation.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3035 passed** (+5). Test-only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)