### PR TITLE
Add shared temp-project test fixtures + migrate opportunistically (#678)

### DIFF
--- a/tests/helpers/temp-project.ts
+++ b/tests/helpers/temp-project.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared temp-project test fixtures (#678).
+ *
+ * ~90 main-process test files repeat the same `fs.mkdtempSync(...) →
+ * projectContext → initGraph → afterEach rm` boilerplate. The team deliberately
+ * tolerated that duplication until fixtures were warranted (see CLAUDE.md feedback);
+ * at this many repetitions the threshold is crossed. These helpers collapse the
+ * boilerplate to one line and give a single place to harden teardown — afterEach
+ * always runs, so a tmpdir can't leak even if a test or a beforeEach throws after
+ * the dir is created.
+ *
+ * Three shapes, pick what fits:
+ *  - `useGraphProject()` / `useTempDir()` — register the per-test lifecycle for
+ *    you and return a live handle (`.root` / `.ctx` track the current test).
+ *    The least boilerplate; preferred for new describe blocks.
+ *  - `makeGraphProject()` — returns `{ root, ctx, cleanup }` so a test can wire
+ *    it into its own beforeEach/afterEach when it needs extra setup alongside.
+ *  - `withTempProject(fn)` — a one-shot temp dir for the duration of `fn`.
+ */
+
+import { beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph } from '../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../src/main/project-context-types';
+
+const DEFAULT_PREFIX = 'minerva-test-';
+
+function freshTempDir(prefix = DEFAULT_PREFIX): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+async function removeDir(dir: string): Promise<void> {
+  if (dir) await fsp.rm(dir, { recursive: true, force: true });
+}
+
+/** A created temp project + its graph, plus a teardown. */
+export interface GraphProject {
+  root: string;
+  ctx: ProjectContext;
+  /** Remove the temp dir. Safe to call more than once. */
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Create a fresh temp dir, bind a ProjectContext, and initialize its graph.
+ * The caller owns teardown via the returned `cleanup()` — wire it into an
+ * afterEach (or a try/finally).
+ */
+export async function makeGraphProject(prefix = DEFAULT_PREFIX): Promise<GraphProject> {
+  const root = freshTempDir(prefix);
+  const ctx = projectContext(root);
+  await initGraph(ctx);
+  return { root, ctx, cleanup: () => removeDir(root) };
+}
+
+/** A live handle whose `.root` / `.ctx` point at the current test's project. */
+export interface ProjectHandle {
+  readonly root: string;
+  readonly ctx: ProjectContext;
+}
+
+/**
+ * Register a fresh temp project + graph for every test in the enclosing
+ * describe, with automatic teardown. Returns a live handle — read `.root` /
+ * `.ctx` inside each `it`.
+ *
+ *   const project = useGraphProject();
+ *   it('…', () => { parseIntoStore(project.ctx, …); });
+ */
+export function useGraphProject(prefix = DEFAULT_PREFIX): ProjectHandle {
+  let project: GraphProject | undefined;
+  beforeEach(async () => { project = await makeGraphProject(prefix); });
+  afterEach(async () => { await project?.cleanup(); });
+  return {
+    get root() { return project?.root ?? ''; },
+    get ctx() {
+      if (!project) throw new Error('useGraphProject: accessed ctx outside a test');
+      return project.ctx;
+    },
+  };
+}
+
+/**
+ * Register a fresh temp dir (no graph) for every test in the enclosing
+ * describe, with automatic teardown. For fs-level tests.
+ */
+export function useTempDir(prefix = DEFAULT_PREFIX): { readonly root: string } {
+  let root = '';
+  beforeEach(() => { root = freshTempDir(prefix); });
+  afterEach(async () => { await removeDir(root); });
+  return { get root() { return root; } };
+}
+
+/**
+ * Run `fn` with a one-shot temp dir, removed afterward — even if `fn` throws.
+ * For a single isolated case that doesn't need the describe-wide lifecycle.
+ */
+export async function withTempProject<T>(
+  fn: (root: string) => T | Promise<T>,
+  prefix = DEFAULT_PREFIX,
+): Promise<T> {
+  const root = freshTempDir(prefix);
+  try {
+    return await fn(root);
+  } finally {
+    await removeDir(root);
+  }
+}

--- a/tests/main/compute/proposal-helpers.test.ts
+++ b/tests/main/compute/proposal-helpers.test.ts
@@ -6,18 +6,14 @@
  * provenance comes from `buildComputeProposalNoteBlock`.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs';
-import fsp from 'node:fs/promises';
-import path from 'node:path';
-import os from 'node:os';
+import { describe, it, expect } from 'vitest';
 import {
   formatComputeResultAsContext,
   buildComputeProposalNoteBlock,
   recordComputeProposalRun,
 } from '../../../src/main/compute/proposal-helpers';
-import { initGraph, queryGraph } from '../../../src/main/graph/index';
-import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { queryGraph } from '../../../src/main/graph/index';
+import { useGraphProject } from '../../helpers/temp-project';
 import type { ConversationComputeDraft } from '../../../src/shared/conversation-compute-drafts';
 import type { CellResult } from '../../../src/shared/compute/types';
 
@@ -105,19 +101,10 @@ describe('buildComputeProposalNoteBlock', () => {
 });
 
 describe('recordComputeProposalRun (graph audit trail)', () => {
-  let root: string;
-  let ctx: ProjectContext;
-
-  beforeEach(async () => {
-    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-compute-rec-'));
-    ctx = projectContext(root);
-    await initGraph(ctx);
-  });
-  afterEach(async () => {
-    await fsp.rm(root, { recursive: true, force: true });
-  });
+  const project = useGraphProject('minerva-compute-rec-');
 
   it('writes an approved+executed ComputeProposal node the integrity query can find', async () => {
+    const ctx = project.ctx;
     recordComputeProposalRun(ctx, draft({ draftId: 'run-1', code: 'print(2+2)' }), 'print(2+2)');
 
     const uri = 'https://minerva.dev/ontology/thought#proposal/run-1';
@@ -138,6 +125,7 @@ describe('recordComputeProposalRun (graph audit trail)', () => {
 
   it('escapes quotes/newlines in the recorded code so the turtle stays valid', async () => {
     // A naive (unescaped) build would produce broken turtle and write nothing.
+    const ctx = project.ctx;
     recordComputeProposalRun(ctx, draft({ draftId: 'run-2' }), 'print("a\nb")');
 
     const uri = 'https://minerva.dev/ontology/thought#proposal/run-2';

--- a/tests/main/graph/csv-table-indexing.test.ts
+++ b/tests/main/graph/csv-table-indexing.test.ts
@@ -1,27 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
-import { initGraph, indexCsvTable, unindexCsvTable, unindexAllCsvTables, queryGraph } from '../../../src/main/graph/index';
-import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
-
-function mkTempProject(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-csv-table-test-'));
-}
+import { describe, it, expect, beforeEach } from 'vitest';
+import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, queryGraph } from '../../../src/main/graph/index';
+import { type ProjectContext } from '../../../src/main/project-context-types';
+import { useGraphProject } from '../../helpers/temp-project';
 
 describe('indexCsvTable — DuckDB table shape in the graph', () => {
-  let root: string;
+  const project = useGraphProject('minerva-csv-table-test-');
   let ctx: ProjectContext;
-
-  beforeEach(async () => {
-    root = mkTempProject();
-    ctx = projectContext(root);
-    await initGraph(ctx);
-  });
-
-  afterEach(() => {
-    fs.rmSync(root, { recursive: true, force: true });
-  });
+  beforeEach(() => { ctx = project.ctx; });
 
   it('emits the table as csvw:Table and owl:Class', async () => {
     indexCsvTable(ctx, {

--- a/tests/main/graph/write-guard-wired.test.ts
+++ b/tests/main/graph/write-guard-wired.test.ts
@@ -14,11 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs';
-import fsp from 'node:fs/promises';
-import path from 'node:path';
-import os from 'node:os';
-import { initGraph, parseIntoStore, removeMatchingTriples, queryGraph } from '../../../src/main/graph/index';
+import { parseIntoStore, removeMatchingTriples, queryGraph } from '../../../src/main/graph/index';
 import {
   enterLLMContext,
   exitLLMContext,
@@ -26,7 +22,8 @@ import {
   exitTrustedContext,
   __resetWriteGuardForTests,
 } from '../../../src/main/graph/write-guard';
-import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { type ProjectContext } from '../../../src/main/project-context-types';
+import { useGraphProject } from '../../helpers/temp-project';
 
 const S = 'https://minerva.dev/c/guard-test';
 const P = 'https://minerva.dev/ontology/thought#label';
@@ -38,22 +35,19 @@ async function objectsOf(ctx: ProjectContext): Promise<string[]> {
 }
 
 describe('LLM write guard wired into the graph write path (#657)', () => {
-  let root: string;
+  const project = useGraphProject('minerva-guard-wired-');
   let ctx: ProjectContext;
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(async () => {
-    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-guard-wired-'));
-    ctx = projectContext(root);
-    await initGraph(ctx);
+  beforeEach(() => {
+    ctx = project.ctx; // fresh per test (useGraphProject's beforeEach ran first)
     __resetWriteGuardForTests();
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     warnSpy.mockRestore();
     __resetWriteGuardForTests();
-    await fsp.rm(root, { recursive: true, force: true });
   });
 
   it('a direct parseIntoStore in LLM context (bypassing approval) trips the guard', () => {

--- a/tests/main/project-config.test.ts
+++ b/tests/main/project-config.test.ts
@@ -3,11 +3,9 @@
  * including the new Python trust slice (#373).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import fs from 'node:fs';
-import fsp from 'node:fs/promises';
 import path from 'node:path';
-import os from 'node:os';
 import {
   readProjectConfig,
   patchProjectConfig,
@@ -16,16 +14,11 @@ import {
   getPythonTrust,
   setPythonTrust,
 } from '../../src/main/project-config';
+import { useTempDir } from '../helpers/temp-project';
 
+const project = useTempDir('minerva-config-test-');
 let root: string;
-
-beforeEach(() => {
-  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-config-test-'));
-});
-
-afterEach(async () => {
-  await fsp.rm(root, { recursive: true, force: true });
-});
+beforeEach(() => { root = project.root; });
 
 describe('readProjectConfig (#373)', () => {
   it('returns {} when the file is missing', () => {


### PR DESCRIPTION
## What

Closes #678. ~90 main-process test files repeat the same `fs.mkdtempSync(...) → projectContext → initGraph → afterEach rm` boilerplate. The team deliberately tolerated that duplication *until fixtures were warranted* (per CLAUDE.md feedback) — at this many copies the threshold is crossed, exactly as the issue argues.

### New `tests/helpers/temp-project.ts` — three shapes
- **`useGraphProject()` / `useTempDir()`** — register the per-test lifecycle *for you* and return a live handle (`.root` / `.ctx` track the current test). Least boilerplate; preferred for new describe blocks.
- **`makeGraphProject()`** → `{ root, ctx, cleanup }` — for tests that wire it into their own `beforeEach` alongside extra setup.
- **`withTempProject(fn)`** — a one-shot temp dir for a single isolated case.

### Hardened teardown (the leak the issue flagged)
There's no global safety-net sweep today, so a throw in `beforeEach` after the dir is created leaks a tmpdir. Centralizing here fixes it: the `afterEach` (or the `finally` in `withTempProject`) always runs, so the dir is always removed.

### Migrated 4 files — opportunistically, not big-bang
To exercise the helpers across graph + fs subsystems without a risky mass rewrite:
- `proposal-helpers`, `write-guard-wired`, `csv-table-indexing` → `useGraphProject` (the latter two keep a thin extra hook for the warnSpy / a `ctx` alias so test bodies are unchanged).
- `project-config` → `useTempDir`.

`useGraphProject` is built on `makeGraphProject`, so that primitive is covered too. (`withTempProject` is provided as the documented one-shot primitive the issue names — future migrations will reach for it.)

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3054 passed** (migrations preserve behavior — test count unchanged). Test-only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)