### PR TITLE
Add axe-core a11y smoke for dialogs + command palette (and fix what it found) (#681)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     }
   },
   "devDependencies": {
+    "axe-core": "^4.10.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
+      axe-core:
+        specifier: ^4.10.3
+        version: 4.12.1
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -2837,6 +2840,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -10981,6 +10988,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 

--- a/src/renderer/lib/components/ConfirmDialog.svelte
+++ b/src/renderer/lib/components/ConfirmDialog.svelte
@@ -41,10 +41,10 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true">
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
     <header class="card-header">
       <div class="eyebrow">Confirm action</div>
-      <h2 class="title">{message}</h2>
+      <h2 class="title" id="confirm-dialog-title">{message}</h2>
     </header>
 
     {#if !hideDontAskAgain}

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -41,10 +41,10 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true">
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="prompt-dialog-title">
     <header class="card-header">
       <div class="eyebrow">Input</div>
-      <h2 class="title">{message}</h2>
+      <h2 class="title" id="prompt-dialog-title">{message}</h2>
     </header>
 
     <div class="body">
@@ -53,6 +53,7 @@
         bind:value
         type="text"
         class="input"
+        aria-labelledby="prompt-dialog-title"
         list={suggestions.length > 0 ? listId : undefined}
         autocomplete="off"
       />

--- a/tests/helpers/axe.ts
+++ b/tests/helpers/axe.ts
@@ -1,0 +1,27 @@
+/**
+ * axe-core a11y assertion for component tests (#681).
+ *
+ * Runs axe against rendered DOM and fails with a readable list of violations.
+ * color-contrast is disabled: jsdom doesn't compute layout/colours, so that
+ * check is unreliable here — it belongs to a real-browser / manual pass, not
+ * this ARIA/role/label/keyboard smoke.
+ */
+import axe from 'axe-core';
+import { expect } from 'vitest';
+
+export async function expectNoA11yViolations(root: Element = document.body): Promise<void> {
+  const results = await axe.run(root, {
+    rules: { 'color-contrast': { enabled: false } },
+  });
+  if (results.violations.length > 0) {
+    const detail = results.violations
+      .map((v) =>
+        `  • [${v.impact ?? 'n/a'}] ${v.id} — ${v.help}\n` +
+        v.nodes.map((n) => `      ${n.html}`).join('\n'),
+      )
+      .join('\n');
+    expect.fail(
+      `axe-core found ${results.violations.length} accessibility violation(s):\n${detail}`,
+    );
+  }
+}

--- a/tests/renderer/a11y/dialogs.test.ts
+++ b/tests/renderer/a11y/dialogs.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Accessibility smoke for the app's modal surfaces (#681 / QA Q-M4). Minerva is
+ * a keyboard-first tool, but svelte-check's a11y warnings are non-fatal and
+ * nothing gated ARIA / role / label correctness. These render each dialog and
+ * run axe-core, so a focus-trap / mislabelled-control / nameless-dialog
+ * regression fails CI instead of shipping silently.
+ */
+
+import { describe, it, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { expectNoA11yViolations } from '../../helpers/axe';
+import ConfirmDialog from '../../../src/renderer/lib/components/ConfirmDialog.svelte';
+import PromptDialog from '../../../src/renderer/lib/components/PromptDialog.svelte';
+
+// Keep the command palette's recent-list deterministic (localStorage-backed).
+vi.mock('../../../src/renderer/lib/command-palette/recent', () => ({
+  loadRecent: () => [] as string[],
+  recordRecent: vi.fn(),
+}));
+import CommandPaletteDialog from '../../../src/renderer/lib/components/CommandPaletteDialog.svelte';
+
+afterEach(cleanup);
+
+describe('dialog accessibility smoke (#681)', () => {
+  it('ConfirmDialog is axe-clean (with and without the don\'t-ask-again checkbox)', async () => {
+    render(ConfirmDialog, {
+      message: 'Delete this note?',
+      confirmLabel: 'Delete',
+      onConfirm: () => {},
+      onCancel: () => {},
+    });
+    await expectNoA11yViolations();
+  });
+
+  it('ConfirmDialog is axe-clean when the checkbox is hidden', async () => {
+    render(ConfirmDialog, {
+      message: 'Apply changes?',
+      hideDontAskAgain: true,
+      onConfirm: () => {},
+      onCancel: () => {},
+    });
+    await expectNoA11yViolations();
+  });
+
+  it('PromptDialog is axe-clean', async () => {
+    render(PromptDialog, {
+      message: 'Name the new note',
+      onConfirm: () => {},
+      onCancel: () => {},
+    });
+    await expectNoA11yViolations();
+  });
+
+  it('PromptDialog with suggestions is axe-clean', async () => {
+    render(PromptDialog, {
+      message: 'Move to folder',
+      suggestions: ['notes/', 'notes/sources/'],
+      initial: 'notes/',
+      onConfirm: () => {},
+      onCancel: () => {},
+    });
+    await expectNoA11yViolations();
+  });
+
+  it('CommandPaletteDialog is axe-clean', async () => {
+    render(CommandPaletteDialog, {
+      commands: [
+        { id: 'settings', title: 'Open Settings', category: 'App', enabled: true, run: () => {} },
+        { id: 'note', title: 'New Note', category: 'File', enabled: true, run: () => {} },
+      ],
+      onClose: () => {},
+    });
+    await expectNoA11yViolations();
+  });
+});


### PR DESCRIPTION
## What

Closes #681. Minerva is keyboard-first, but **nothing gated ARIA / role / label correctness** — svelte-check's a11y warnings are explicitly non-fatal. Adds `axe-core` + a render-and-run smoke for the modal surfaces (`ConfirmDialog`, `PromptDialog`, `CommandPaletteDialog`).

## The smoke found 3 real violations — fixed in this PR
The point of the test is to catch these, and it did immediately:

| Component | axe rule | Fix |
|---|---|---|
| ConfirmDialog | `aria-dialog-name` (serious) — `role="dialog"` with no accessible name | `aria-labelledby` → the title `<h2>` (now id'd) |
| PromptDialog | `aria-dialog-name` (serious) | same |
| PromptDialog | **`label` (critical)** — text input has no accessible name | labelled it via the title (`aria-labelledby`), so a screen reader announces what to type |

The dialog edits are **aria attributes only** — no behaviour change.

## Helper + env notes
- `tests/helpers/axe.ts` — `expectNoA11yViolations(root?)` runs axe and fails with a readable violation list.
- **`color-contrast` is disabled**: jsdom/happy-dom don't compute layout/colours, so contrast is unreliable here — it belongs to a real-browser / manual pass, not this ARIA/role/label/keyboard smoke. (Documented inline.)
- Runs under **happy-dom**: jsdom throws on the palette's `scrollIntoView` effect; happy-dom stubs it. (Debugged this — it was an env quirk presenting as a false `aria-dialog-name` failure, not a real palette bug; the palette's existing `aria-label` is correct.)

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3059 passed** (+5).
- `pnpm test:e2e` — electron-forge build + boot smoke.

_Future: this helper makes it cheap to add an a11y assertion to any new dialog/panel — worth wiring into the other modal surfaces opportunistically._

🤖 Generated with [Claude Code](https://claude.com/claude-code)