### PR TITLE
Drop per-cell triples from indexCsvFile — keep CSVW table + column schema (#337)

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -836,33 +836,22 @@ function indexCsvFile(
   const parsed = parseCsv(content);
   if (parsed.headers.length === 0) return;
 
-  // Columns
-  const colNodes: $rdf.NamedNode[] = [];
+  // Columns — the table's schema (header name + zero-based index). One triple-
+  // cluster per header, so the cost is bounded by column count.
+  //
+  // We deliberately do NOT emit per-cell `csvw:Cell` / `csvw:Row` triples (#337).
+  // A 10k-row × 100-col CSV produced ~4M triples in the in-memory store, and
+  // nothing queried cell *values* over the graph — cell-level querying is the
+  // DuckDB / SQL path's job (`indexCsvTable`, joinable back to this file via
+  // `minerva:fromFile`). Keeping just the Table + column schema is enough for
+  // the sidebar / tag / schema queries that touch CSV files through the graph.
   for (let ci = 0; ci < parsed.headers.length; ci++) {
     const colName = parsed.headers[ci];
     const colUri = $rdf.sym(`${subject.value}/column/${encodeURIComponent(colName)}`);
-    colNodes.push(colUri);
     store.add(colUri, RDF('type'), CSVW('Column'), graph);
     store.add(colUri, CSVW('name'), $rdf.lit(colName), graph);
     store.add(colUri, CSVW('columnIndex'), $rdf.lit(String(ci), undefined, XSD('integer')), graph);
     store.add(subject, CSVW('column'), colUri, graph);
-  }
-
-  // Rows + cells
-  for (let ri = 0; ri < parsed.rows.length; ri++) {
-    const rowUri = $rdf.sym(`${subject.value}/row/${ri}`);
-    store.add(rowUri, RDF('type'), CSVW('Row'), graph);
-    store.add(rowUri, CSVW('rowIndex'), $rdf.lit(String(ri), undefined, XSD('integer')), graph);
-    store.add(subject, CSVW('row'), rowUri, graph);
-
-    for (let ci = 0; ci < parsed.headers.length; ci++) {
-      const value = parsed.rows[ri][ci] ?? '';
-      const cellUri = $rdf.sym(`${rowUri.value}/cell/${encodeURIComponent(parsed.headers[ci])}`);
-      store.add(cellUri, RDF('type'), CSVW('Cell'), graph);
-      store.add(cellUri, CSVW('column'), colNodes[ci], graph);
-      store.add(cellUri, RDF('value'), $rdf.lit(value), graph);
-      store.add(rowUri, CSVW('cell'), cellUri, graph);
-    }
   }
 }
 

--- a/tests/main/graph/csv-indexing.test.ts
+++ b/tests/main/graph/csv-indexing.test.ts
@@ -67,37 +67,54 @@ describe('CSV file indexing (issue #199)', () => {
     ]);
   });
 
-  it('emits one csvw:Row per data row with cells keyed to columns', async () => {
+  it('does NOT emit per-cell csvw:Row / csvw:Cell triples (#337 — cell data is the SQL/DuckDB path)', async () => {
+    // The old behaviour wrote one csvw:Cell per value (~4M triples on a big
+    // CSV). #337 dropped that; only the Table + column schema remain.
     await indexNote(ctx, 'data/m.csv', 'name,count\nalice,3\nbob,5\n');
     const { results } = await queryGraph(ctx, `
-      SELECT ?name ?count WHERE {
-        ?t minerva:relativePath "data/m.csv" ;
-           csvw:row ?r .
-        ?r csvw:cell ?cellName, ?cellCount .
-        ?cellName  csvw:column ?colName  . ?colName  csvw:name "name"  . ?cellName  rdf:value ?name  .
-        ?cellCount csvw:column ?colCount . ?colCount csvw:name "count" . ?cellCount rdf:value ?count .
-      } ORDER BY ?name
+      SELECT ?x WHERE {
+        { ?t minerva:relativePath "data/m.csv" ; csvw:row ?x }
+        UNION
+        { ?x a csvw:Cell }
+      }
     `);
-    expect(results).toEqual([
-      { name: 'alice', count: '3' },
-      { name: 'bob', count: '5' },
-    ]);
+    expect(results).toEqual([]);
   });
 
-  it('re-indexing a CSV replaces the old triples (no stale rows)', async () => {
+  it('re-indexing a CSV replaces the old schema (no stale columns)', async () => {
     await indexNote(ctx, 'data/m.csv', 'name,count\nalice,3\nbob,5\n');
-    await indexNote(ctx, 'data/m.csv', 'name,count\ncarol,7\n');
+    await indexNote(ctx, 'data/m.csv', 'label,score,extra\ncarol,7,x\n');
 
     const { results } = await queryGraph(ctx, `
       SELECT ?name WHERE {
         ?t minerva:relativePath "data/m.csv" ;
-           csvw:row ?r .
-        ?r csvw:cell ?c .
-        ?c csvw:column ?col . ?col csvw:name "name" . ?c rdf:value ?name .
-      }
+           csvw:column ?c .
+        ?c csvw:name ?name .
+      } ORDER BY ?name
     `);
     const names = (results as Array<{ name: string }>).map((r) => r.name);
-    expect(names).toEqual(['carol']);
+    expect(names).toEqual(['extra', 'label', 'score']); // old name/count columns gone
+  });
+
+  it('graph footprint is independent of row count (#337 perf intent)', async () => {
+    // The whole point of #337: indexing a 3-row and a 3000-row CSV with the
+    // same columns must produce the same number of graph triples. Re-adding
+    // per-cell emission would make big.csv balloon and fail this.
+    const csv = (n: number) =>
+      'a,b\n' + Array.from({ length: n }, (_, i) => `r${i},${i}`).join('\n') + '\n';
+    await indexNote(ctx, 'small.csv', csv(3));
+    await indexNote(ctx, 'big.csv', csv(3000));
+
+    const tripleCount = async (p: string) => {
+      const { results } = await queryGraph(ctx, `
+        SELECT (COUNT(*) AS ?n) WHERE {
+          ?t minerva:relativePath "${p}" .
+          GRAPH ?t { ?s ?pred ?o }
+        }
+      `);
+      return Number((results as Array<{ n: string }>)[0].n);
+    };
+    expect(await tripleCount('big.csv')).toBe(await tripleCount('small.csv'));
   });
 
   it('uses the filename stem as dc:title', async () => {


### PR DESCRIPTION
## What

Closes #337. `indexCsvFile` emitted one `csvw:Cell` (+ `rdf:value` + `csvw:column`) plus a `csvw:Row` per row — a **10k-row × 100-col CSV ballooned the in-memory store to ~4M triples** (the P0 perf finding). Nothing queried cell *values* over the graph; cell-level querying is the DuckDB/SQL path's job (`indexCsvTable`, joinable back via `minerva:fromFile`), which has overlapped this since #323.

**Dropped the rows+cells loop. Kept everything cheap and still queried:** the file as `minerva:Note` + `csvw:Table`, `dc:title`/`modified`/`inFolder`, `csvw:inFile`, and the **column schema** (`csvw:Column` + name + zero-based index — bounded by column count, not row count). The graph footprint is now independent of row count.

## Scope boundaries (deliberate)
- **The markdown embedded-table indexer (`indexTable`, `csvw:inNote`) is untouched** — it's a separate path, bounded by note size, and the fixture README query depends on its cells. #337 is only about standalone `.csv` files (`csvw:inFile`).
- The committed `sample-project/.minerva/graph.ttl` still carries `newData.csv`'s old cell triples. It's static fixture *input*, no test asserts those cells, and regenerating a committed fixture by hand is riskier than the inert staleness. Left as-is.
- The `registerAllCsvs` ∥ `indexAllNotes` race noted in the issue *intro* isn't in the `## Scope` list — left as a follow-up rather than scope-creep.

## Tests (`csv-indexing.test.ts`)
- Replaced the row/cell assertions with a **guard that no `csvw:Row`/`csvw:Cell` are emitted**.
- Reworked the re-index test to verify schema replacement **via columns** (old `name`/`count` gone, new headers present).
- Added a **footprint test**: a 3-row and a 3000-row CSV must produce **identical triple counts** — re-adding per-cell emission would fail it. That pins the perf win against regression.

## Verification
- `pnpm lint` — **0 errors**.
- `pnpm test` — **3059 passed**.
- `pnpm test:e2e` — electron-forge build + boot smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)