### PR TITLE
Add optional pre-push lint hook (#690)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pre-push lint gate (#690).
+#
+# Runs the fast `pnpm lint` (tsc + svelte-check + eslint, ~30s) before a push so
+# an obvious type/template/lint failure is caught locally instead of burning a
+# slow macos-latest CI run. Pre-push (not pre-commit) keeps commits frictionless.
+#
+# Escape hatches: `git push --no-verify`, or `SKIP_HOOKS=1 git push`.
+# Activated by the `prepare` script (sets core.hooksPath to .githooks on install).
+
+if [ "$SKIP_HOOKS" = "1" ]; then
+  exit 0
+fi
+
+echo "→ pre-push: pnpm lint (skip with --no-verify)…"
+if ! pnpm lint; then
+  echo "✗ pre-push: lint failed — push aborted. Fix it, or bypass with: git push --no-verify" >&2
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@ Minerva is a desktop markdown IDE built with Electron + Svelte 5 + TypeScript. I
 - `pnpm test` — Run tests once (vitest run). Use `pnpm test:watch` for the file-watcher loop.
 - `pnpm build` — Build distributable (electron-forge make)
 
+A **pre-push hook** (`.githooks/pre-push`, activated by the `prepare` script's
+`core.hooksPath` on `pnpm install`) runs `pnpm lint` before each push so an
+obvious failure is caught locally instead of in CI (#690). Bypass a single push
+with `git push --no-verify` (or `SKIP_HOOKS=1 git push`).
+
 ## Architecture
 
 Three-process Electron app with strict context isolation:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "description": "Minerva — an integrated knowledge management environment",
   "main": ".vite/build/main.js",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "dev": "electron-forge start",
     "build": "electron-forge make",
     "package": "electron-forge package",


### PR DESCRIPTION
## What

Closes #690. PR-per-change against a slow `macos-latest` CI means a trivial lint failure costs a full CI round-trip to discover. A **pre-push** hook running the fast `pnpm lint` (~30s) catches it locally first. Pre-push (not pre-commit) keeps commits frictionless.

## Implementation — zero new dependency
Native git hooks, no husky / lint-staged (the project had neither, and minimalism fits its philosophy):
- **`.githooks/pre-push`** runs `pnpm lint`; non-zero blocks the push.
- **`prepare`** script sets `core.hooksPath .githooks` on `pnpm install` (guarded with `|| true` so it no-ops outside a git checkout, e.g. CI / tarball installs).

## Deliberately escapable
Per CLAUDE.md's "stay out of the way":
- `git push --no-verify` bypasses a single push.
- `SKIP_HOOKS=1 git push` does the same via env.
- Documented in CLAUDE.md.

## Verified live
**This PR's own push exercised the hook end-to-end** — the lint run (`COMPLETED 1812 FILES 0 ERRORS`) printed before the push completed. Also confirmed: the skip path (`SKIP_HOOKS=1` → exit 0) and that git records the `100755` executable bit.

## Note
Activation is per-clone (git config is local), set by `prepare` on the next `pnpm install`. A reviewer who pulls this branch gets the hook after their next install; bypass anytime with `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)