### PR TITLE
Lazy-load PdfViewer + OcrProgressDialog — defer pdfjs/tesseract off startup (#691)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -27,7 +27,9 @@
   import { createConversationOps, type ConversationOpsCtx } from './lib/app/conversation-ops';
   import DialogHost from './lib/components/DialogHost.svelte';
   import { getDialogStore } from './lib/stores/dialogs.svelte';
-  import PdfViewer from './lib/components/PdfViewer.svelte';
+  // PdfViewer + OcrProgressDialog are loaded lazily at their render sites
+  // (`{#await import()}`) so pdfjs-dist + tesseract.js stay out of the eager
+  // startup graph (#691).
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
@@ -41,7 +43,6 @@
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
   import SaveQueryDialog from './lib/components/SaveQueryDialog.svelte';
   import FindInNotesDialog from './lib/components/FindInNotesDialog.svelte';
-  import OcrProgressDialog from './lib/components/OcrProgressDialog.svelte';
   import GotoNoteDialog from './lib/components/GotoNoteDialog.svelte';
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationsPanel from './lib/components/ConversationsPanel.svelte';
@@ -1264,11 +1265,15 @@
           {/key}
         {:else if editor.activeTab?.type === 'pdf'}
           {#key editor.activeTab.sourceId}
-            <PdfViewer
-              sourceId={editor.activeTab.sourceId}
-              initialPage={editor.activeTab.page}
-              onShowMarkdown={handleShowMarkdownFromPdf}
-            />
+            <!-- Lazy: pdfjs-dist only loads when a PDF tab is opened, keeping it
+                 out of the eager startup graph (#691). -->
+            {#await import('./lib/components/PdfViewer.svelte') then { default: PdfViewer }}
+              <PdfViewer
+                sourceId={editor.activeTab.sourceId}
+                initialPage={editor.activeTab.page}
+                onShowMarkdown={handleShowMarkdownFromPdf}
+              />
+            {/await}
           {/key}
         {:else}
           <div class="no-file">
@@ -1369,13 +1374,17 @@
     />
   {/if}
   {#if sourceFlow.ocrSession && sourceFlow.ocrPdfBytes}
-    <OcrProgressDialog
-      pdfBytes={sourceFlow.ocrPdfBytes}
-      pageCount={sourceFlow.ocrSession.pageCount}
-      title={sourceFlow.ocrSession.title}
-      onDone={handleOcrDone}
-      onCancel={handleOcrCancel}
-    />
+    <!-- Lazy: tesseract.js (multi-MB WASM) + pdfjs only load when OCR actually
+         runs, keeping them out of the eager startup graph (#691). -->
+    {#await import('./lib/components/OcrProgressDialog.svelte') then { default: OcrProgressDialog }}
+      <OcrProgressDialog
+        pdfBytes={sourceFlow.ocrPdfBytes}
+        pageCount={sourceFlow.ocrSession.pageCount}
+        title={sourceFlow.ocrSession.title}
+        onDone={handleOcrDone}
+        onCancel={handleOcrCancel}
+      />
+    {/await}
   {/if}
   {#if findInNotesMode}
     <FindInNotesDialog


### PR DESCRIPTION
## Context

Reported symptom: `pnpm dev` → app-available is ~9s. This is the **code-splitting half of #691** — its bundle-size framing undersells a real *startup* cost.

## Root cause

`App.svelte` *statically* imported `PdfViewer` (→ **pdfjs-dist**) and `OcrProgressDialog` (→ `run-ocr` → **pdfjs + tesseract.js**, multi-MB WASM). Both render only conditionally (PDF tab open / OCR running), but a static import loads the module at launch regardless — so **every** session, including ones that never touch a PDF, loaded and (in dev) pre-bundled two of the heaviest deps in the tree.

## Fix

Converted both render sites to `{#await import('…') then { default: X }}`, so the modules load only when their condition first becomes true. The import graph confirms this fully evicts pdfjs + tesseract from the eager graph (`run-ocr` is imported only by `OcrProgressDialog`; pdfjs only by `run-ocr` + `PdfViewer`).

### Build evidence (renderer chunks)
| Chunk | Size | Before → After |
|---|---|---|
| `pdf-*.js` | 475K | now a **lazy** chunk |
| `pdf.worker.min` | 1.2M ×2 | off the startup path |
| `OcrProgressDialog-*.js` (tesseract) | 435K | now a **lazy** chunk |
| `PdfViewer-*.js` | 7.8K | lazy |

~900K of JS + the 1.2M workers leave the eager `index`. (mermaid/wardley/cytoscape/katex were already split.)

## Honest scope + expectations
- This targets the **clearly deferrable** heavy deps. The eager `index` is still ~3.2M, **dominated by CodeMirror** — but that's the *primary* editor view, so lazy-loading it would relocate the wait, not remove it. Left as-is.
- A fixed **electron-forge + Vite + Electron boot floor** remains that no code-splitting touches. This won't take the 9s to zero.
- **Please measure** `pnpm dev` startup before/after on your machine — run it twice (the first run rebuilds Vite's `optimizeDeps` cache, the second is the steady-state number).

## No behaviour change
The components appear exactly when they did, one async tick later — imperceptible next to the actual PDF render / OCR work.

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3061 passed. `pnpm test:e2e` — build + boot smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)