### PR TITLE
Ship unbundleable native/dynamic deps in the packaged app + e2e guard (#691 follow-up)

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -2,6 +2,68 @@ import type { ForgeConfig } from '@electron-forge/shared-types';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDMG } from '@electron-forge/maker-dmg';
+import path from 'node:path';
+import fs from 'node:fs';
+
+// @electron-forge/plugin-vite bundles the main process and ships NO node_modules
+// in the package. That's fine for everything Rollup can bundle — but a few deps
+// it CAN'T (native `.node` binaries, dynamic `require()`s) get externalized and
+// then have nowhere to resolve at runtime. The packaged app died at first use of
+// each: "cannot find @duckdb/node-bindings" (DuckDB's native binary), then
+// "cannot find @mixmark-io/domino" (turndown's DOM impl, required eagerly so it
+// crashed at launch). Rather than chase them one by one, we ship the *transitive
+// closure* of the known unbundleable roots. The packaged-app e2e (tests/e2e)
+// opens a real project and so fails loudly if this list ever goes stale again.
+//
+// `afterPrune` runs after the plugin strips node_modules, so the copies survive.
+//
+// Roots = the bundle's external `require()`s that aren't Node built-ins, minus
+// `canvas` (not installed; linkedom intentionally falls back to a shim). The
+// DuckDB platform binary is an *optional* dep of @duckdb/node-bindings (not in
+// its `dependencies`), so it's named explicitly.
+const EXTERNAL_DEP_ROOTS = [
+  '@duckdb/node-bindings',
+  `@duckdb/node-bindings-${process.platform}-${process.arch}`,
+  '@mixmark-io/domino',
+  'encoding', // node-fetch's optional charset path → require('encoding') → iconv-lite
+];
+
+/** BFS the `dependencies` graph from each root; skips absent optionals. */
+function depClosure(roots: string[]): Set<string> {
+  const root = process.cwd();
+  const seen = new Set<string>();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const name = queue.shift() as string;
+    if (seen.has(name)) continue;
+    const pkgJson = path.join(root, 'node_modules', name, 'package.json');
+    if (!fs.existsSync(pkgJson)) continue; // optional/peer not installed
+    seen.add(name);
+    const pkg = JSON.parse(fs.readFileSync(pkgJson, 'utf-8')) as { dependencies?: Record<string, string> };
+    queue.push(...Object.keys(pkg.dependencies ?? {}));
+  }
+  return seen;
+}
+
+function copyExternalDeps(buildPath: string): void {
+  const root = process.cwd();
+  const closure = depClosure(EXTERNAL_DEP_ROOTS);
+  // The required roots must resolve — a missing native binding is a broken
+  // build, not an optional we can shrug off.
+  for (const required of ['@duckdb/node-bindings', `@duckdb/node-bindings-${process.platform}-${process.arch}`, '@mixmark-io/domino']) {
+    if (!closure.has(required)) {
+      throw new Error(`[forge] required external dep not installed: ${required}`);
+    }
+  }
+  for (const dep of closure) {
+    fs.mkdirSync(path.dirname(path.join(buildPath, 'node_modules', dep)), { recursive: true });
+    fs.cpSync(
+      path.join(root, 'node_modules', dep),
+      path.join(buildPath, 'node_modules', dep),
+      { recursive: true, dereference: true },
+    );
+  }
+}
 
 const config: ForgeConfig = {
   packagerConfig: {
@@ -10,6 +72,16 @@ const config: ForgeConfig = {
     // we drop under `resources/`) next to the main bundle in the
     // packaged app, so process.resourcesPath finds it (#241).
     extraResource: ['resources'],
+    afterPrune: [
+      (buildPath, _electronVersion, _platform, _arch, done) => {
+        try {
+          copyExternalDeps(buildPath);
+          done();
+        } catch (err) {
+          done(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    ],
   },
   makers: [
     new MakerZIP({}, ['darwin', 'linux', 'win32']),

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -29,11 +29,28 @@
 
 import { test, expect, _electron as electron, type ConsoleMessage, type Page } from '@playwright/test';
 import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
 
 // Playwright transpiles tests as CJS (no `"type": "module"` in
 // package.json), so __dirname is available — using import.meta.url
 // would force ESM and trip Playwright's loader.
 const projectRoot = path.resolve(__dirname, '..', '..');
+
+/** Path to the packaged app binary, or null if it hasn't been built. */
+function packagedBinary(): string | null {
+  if (process.platform !== 'darwin') return null; // only darwin .app layout handled
+  const p = path.join(
+    projectRoot,
+    'out',
+    `Minerva-${process.platform}-${process.arch}`,
+    'Minerva.app',
+    'Contents',
+    'MacOS',
+    'Minerva',
+  );
+  return fs.existsSync(p) ? p : null;
+}
 
 test('app launches, renderer mounts, no thrown errors', async () => {
   // page.on('pageerror') captures synchronous renderer-side throws
@@ -115,4 +132,70 @@ test('app launches, renderer mounts, no thrown errors', async () => {
   expect(rendererErrors, `renderer threw: ${rendererErrors.map((e) => e.message).join('; ')}`)
     .toHaveLength(0);
   expect(meaningful, `renderer console errors: ${meaningful.join('; ')}`).toHaveLength(0);
+});
+
+/**
+ * Packaging regression: the *packaged* app opens a project that uses DuckDB
+ * tables (#691 follow-up). The test above boots `.vite/build/main.js` against
+ * the repo, so it uses the dev `node_modules` and never exercises what actually
+ * shipped. @electron-forge/plugin-vite bundles the main process and ships no
+ * node_modules, so the externalized `@duckdb/node-bindings` native binary has to
+ * be copied in by forge.config's `afterPrune` hook — and if it isn't, the app
+ * dies at first DuckDB use with "cannot find @duckdb/node-bindings".
+ *
+ * We launch the packaged binary against a seeded session that restores a
+ * CSV-bearing fixture, so `registerAllCsvs` runs DuckDB on launch. A copy of the
+ * fixture is used so the run can't dirty the git-tracked one.
+ */
+test('packaged app opens a DuckDB-backed project (native binding shipped)', async () => {
+  const appBinary = packagedBinary();
+  test.skip(appBinary === null, 'packaged app not built — run `pnpm build:e2e` first');
+
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-userdata-'));
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-project-'));
+  // Copy the fixture (it has newData.csv → registerAllCsvs → DuckDB) so the
+  // launch can't mutate the tracked fixture (search-index persist, etc.).
+  fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataDir, 'session.json'),
+    JSON.stringify([{ x: 80, y: 80, width: 1000, height: 700, rootPath: projectDir }]),
+  );
+
+  const mainOut: string[] = [];
+  const app = await electron.launch({
+    executablePath: appBinary as string,
+    args: [`--user-data-dir=${userDataDir}`],
+    timeout: 60_000,
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
+  });
+  app.process().stderr?.on('data', (chunk: Buffer) => mainOut.push(chunk.toString()));
+  app.process().stdout?.on('data', (chunk: Buffer) => mainOut.push(chunk.toString()));
+
+  let openedProject = false;
+  try {
+    const win: Page = await app.firstWindow({ timeout: 20_000 });
+    await win.waitForLoadState('domcontentloaded');
+    // Session restore opens the project in `did-finish-load` → acquireProject →
+    // registerAllCsvs (DuckDB). On success the welcome screen is replaced by the
+    // workspace, so the "Open Thoughtbase" button disappears; on a missing
+    // binding, registerAllCsvs throws, the project never opens, and the error
+    // lands on the main stream. Poll for the workspace, tolerating the failure
+    // case so the clearer stderr assertion below runs.
+    try {
+      await expect(win.getByRole('button', { name: 'Open Thoughtbase' }))
+        .toHaveCount(0, { timeout: 25_000 });
+      openedProject = true;
+    } catch { /* fall through to the stream assertion for a clearer message */ }
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+
+  const out = mainOut.join('');
+  expect(
+    /cannot find.*duckdb|@duckdb\/node-bindings/i.test(out),
+    `DuckDB native binding failed to load in the packaged app:\n${out}`,
+  ).toBe(false);
+  expect(openedProject, 'the restored project never opened (workspace never replaced the welcome screen)').toBe(true);
 });

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -3,18 +3,14 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     rollupOptions: {
-      // linkedom has an optional `canvas` integration: it tries
-      // `require('canvas')` and falls back to an internal shim when the
-      // native module isn't installed. Bundling both branches eagerly
-      // collapses the try/catch — rollup emits a synthetic throw for
-      // the unresolvable `canvas` and the app crashes at load. Mark
-      // `canvas` external so the `require` stays runtime and the
-      // fallback branch actually runs.
-      //
-      // DuckDB ships a platform-specific `.node` binary per arch via
-      // `require('@duckdb/node-bindings-<platform>-<arch>/duckdb.node')`.
-      // Rollup can't resolve `.node` files — keep the whole bindings
-      // family external so the require stays runtime.
+      // Kept as runtime `require`s rather than bundled:
+      // - `canvas`: linkedom's optional canvas integration tries
+      //   `require('canvas')` and falls back to an internal shim when it's
+      //   absent. Bundling both branches collapses the try/catch into a
+      //   synthetic throw, crashing at load — keep the require runtime.
+      // - DuckDB bindings: Rollup can't bundle the `.node` binary. The plugin
+      //   ships no node_modules, so forge.config's `afterPrune` hook copies the
+      //   binding's runtime closure into the packaged app.
       external: [
         'canvas',
         /^@duckdb\/node-bindings/,


### PR DESCRIPTION
## What

The packaged `Minerva.app` was **broken for real use.** `@electron-forge/plugin-vite` bundles the main process and ships **no `node_modules`** — so every dependency Rollup can't bundle (native `.node` binaries, dynamic `require()`s) was simply missing. The app died at first use of each, a cascade:

1. **`cannot find @duckdb/node-bindings`** — DuckDB's native binary, at first table use (this is what you hit opening a project).
2. **`cannot find @mixmark-io/domino`** — turndown's DOM impl, imported eagerly in `ingest.ts`, so it crashed the app **at launch** (no window at all).

And the e2e smoke never caught any of it: it boots `.vite/build/main.js` against the repo (**dev** `node_modules`) and never opens a project.

## Fix — ship the transitive closure, don't whack moles

`forge.config.ts` `afterPrune` hook (runs after the plugin strips `node_modules`, so copies survive) ships the **transitive closure** of the unbundleable roots:

- **Roots** = the main bundle's external `require()`s that aren't Node built-ins: `@duckdb/node-bindings` (+ the platform `.node` package — an *optional* dep, named explicitly), `@mixmark-io/domino`, `encoding` (node-fetch's charset path). **`canvas` excluded** — not installed; linkedom intentionally shims its absence.
- A **BFS over `dependencies`** pulls the rest (`detect-libc`, `iconv-lite`, `safer-buffer`).
- Required roots **throw** if absent — a missing native binding is a broken build, not a silent ship.

## Regression guard — the part that matters

New e2e test launches the **packaged binary** against a seeded session that restores a CSV-bearing fixture (a **temp copy**, so it can't dirty the tracked fixture). That exercises *both* failure modes:
- **startup crash** → no window (catches the domino class);
- **project-open failure** → workspace never replaces the welcome screen (catches the duckdb class).

If the dep list ever goes stale again, this fails loudly instead of shipping a broken app.

## Verification
- `pnpm lint` — 0 errors.
- `electron-forge package` ships the full closure: `@duckdb/*` (incl. `duckdb.node`), `@mixmark-io/domino`, `encoding`/`iconv-lite`/`safer-buffer`.
- **Both e2e tests pass against the packaged app** — and the packaged app opens a DuckDB-backed project in ~3.5s, confirming packaged startup is nothing like the 9s dev-toolchain cost.

## Context
Found while investigating slow `pnpm dev` startup (#691) — which turned out to be dev-toolchain only (Vite re-bundling ~85MB of main deps each start), *not* user-facing. Chasing that surfaced this genuinely user-facing packaging bug, which a distribution build (#725) would have shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)