### PR TITLE
chore: add elapsed-ms to the boot trace + mark the project-open phase

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,9 +18,11 @@ app.setName('Minerva');
 // Boot-trace: stderr-tagged so the e2e smoke test (#394) can recover them
 // from the captured main-process stream when launch hangs on CI (#518).
 // In normal runs these are a few lines and harmless; on a hang they tell
-// us which step never returned.
+// us which step never returned — and the elapsed-ms makes them a cheap
+// startup profile (which phase owns the time).
+const BOOT_T0 = Date.now();
 function boot(label: string): void {
-  console.error(`[boot] ${label}`);
+  console.error(`[boot +${Date.now() - BOOT_T0}ms] ${label}`);
 }
 
 boot('main module loaded');
@@ -53,7 +55,9 @@ void app.whenReady().then(async () => {
       const win = createWindow({ x: state.x, y: state.y, width: state.width, height: state.height });
       buildMenu(win);
       win.webContents.once('did-finish-load', async () => {
+        boot(`renderer loaded — opening project ${path.basename(state.rootPath)}`);
         await openProjectInWindow(win, state.rootPath);
+        boot(`project indexed ${path.basename(state.rootPath)}`);
         win.webContents.send(Channels.PROJECT_OPENED, {
           rootPath: state.rootPath,
           name: path.basename(state.rootPath),


### PR DESCRIPTION
The [boot] trace logged phase labels but no timing, so it couldn't say which phase owned startup. Adds `+Nms` since module load to each line, and marks the session-restore project-open path (renderer-loaded → project-indexed) which previously had no boot line at all — that's where graph indexAllNotes runs, the most likely startup cost on a real project.

Diagnostic for the ~9s `pnpm dev` startup: the gaps between lines locate it — e.g. a large jump on "project indexed" means re-indexing dominates; a large "app ready" baseline means it's electron-forge/Vite/Electron boot (toolchain overhead, before app code runs at all).