### PR TITLE
Renderer bundle-size guardrail — finish #691

### DIFF
--- a/tests/e2e/bundle-budget.spec.ts
+++ b/tests/e2e/bundle-budget.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Renderer bundle-size guardrail (#691).
+ *
+ * #744 moved the heavy renderer deps (PDF.js, Tesseract) out of the eager
+ * startup graph into lazy chunks. Nothing stopped that from silently regressing
+ * — a single static `import PdfViewer from …` at the top of App.svelte would
+ * pull pdfjs (~0.5M + 1.2M workers) straight back into the entry chunk, and no
+ * test would notice. This locks it in.
+ *
+ * Runs in the e2e job (after `pnpm build:e2e` has produced the renderer build);
+ * it's a pure build-artifact assertion, no Electron needed.
+ *
+ * KaTeX is deliberately NOT expected to be lazy: `shared/markdown/math-plugin`
+ * is shared with the static-HTML publish exporters, which must render math
+ * synchronously to a string (there's no DOM to hydrate at export time). So katex
+ * stays eagerly imported — that's an architectural constraint, documented on #691,
+ * not a regression.
+ */
+
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const ASSETS = path.resolve(__dirname, '..', '..', '.vite', 'renderer', 'main_window', 'assets');
+
+// The eager entry chunk is ~3.33MB today, dominated by CodeMirror (the editor —
+// the primary view, intentionally eager). The budget sits ~370KB above that:
+// enough headroom for ordinary growth, but below the smallest heavy lazy dep
+// (Tesseract/OCR ~0.45M, PDF.js ~0.49M, Mermaid ~0.58M), so any of them merging
+// back into the entry trips it. Bump it *deliberately* if honest growth trips it.
+const MAX_ENTRY_BYTES = 3_700_000;
+
+function assets(): string[] {
+  return fs.readdirSync(ASSETS);
+}
+
+test('renderer entry chunk stays under budget (heavy deps stay code-split)', () => {
+  test.skip(!fs.existsSync(ASSETS), 'renderer not built — run `pnpm build:e2e` first');
+
+  const entries = assets()
+    .filter((f) => /^index-.*\.js$/.test(f))
+    .map((f) => ({ f, size: fs.statSync(path.join(ASSETS, f)).size }))
+    .sort((a, b) => b.size - a.size);
+
+  expect(entries[0], 'no index-*.js entry chunk found in the renderer build').toBeTruthy();
+  const { f, size } = entries[0];
+  expect(
+    size,
+    `entry chunk ${f} is ${(size / 1e6).toFixed(2)}MB, over the ${(MAX_ENTRY_BYTES / 1e6).toFixed(2)}MB budget — ` +
+      `a heavy dependency likely merged back into the eager startup graph (see #691/#744).`,
+  ).toBeLessThan(MAX_ENTRY_BYTES);
+});
+
+test('PDF.js and Tesseract/OCR ship as separate lazy chunks', () => {
+  test.skip(!fs.existsSync(ASSETS), 'renderer not built — run `pnpm build:e2e` first');
+
+  const files = assets();
+  expect(files.some((f) => /^pdf-.*\.js$/.test(f)), 'expected a separate pdfjs (`pdf-*.js`) chunk').toBe(true);
+  expect(
+    files.some((f) => /^OcrProgressDialog-.*\.js$/.test(f)),
+    'expected a separate OCR (`OcrProgressDialog-*.js`, carries tesseract.js) chunk',
+  ).toBe(true);
+});


### PR DESCRIPTION
## What

The last piece of #691. #744 code-split the heavy renderer deps; this **locks that in** with the size guardrail the issue asked for, so the work can't silently regress.

`tests/e2e/bundle-budget.spec.ts` (pure build-artifact assertions, runs in the e2e job after `pnpm build:e2e`):
- **Entry chunk < 3.7MB.** It's ~3.33MB today (CodeMirror-dominated — the editor is the primary view, intentionally eager). The budget sits below the smallest heavy lazy dep (~0.45M), so any of pdfjs (0.49M) / tesseract (0.45M) / mermaid (0.58M) merging back into the eager graph trips it.
- **pdfjs + OCR ship as separate chunks** (`pdf-*.js`, `OcrProgressDialog-*.js`).

The concrete regression it catches: someone re-adding a static `import PdfViewer` at the top of `App.svelte` — exactly what #744 removed.

## #691 final accounting

| Deliverable | Status |
|---|---|
| Bundle audit | ✅ done (numbers below) |
| PDF.js / Tesseract dynamic-import | ✅ #744 |
| Mermaid dynamic-import | ✅ already was |
| **KaTeX** dynamic-import | ⚠️ **intentional exception** (see below) |
| Size guardrail | ✅ this PR |

### Audit (renderer chunks, current build)
- Eager entry `index-*.js`: **3.33MB** (CodeMirror + Svelte + app shell)
- Lazy: wardley 0.61M, mermaid.core 0.58M, **pdf 0.49M** (+ 1.2M×2 workers), **OcrProgressDialog/tesseract 0.45M**, cytoscape 0.44M, katex 0.26M

### Why KaTeX stays eager
`shared/markdown/math-plugin` is shared between the live preview **and the static-HTML publish exporters**. The exporters must render math **synchronously to a string** — there's no DOM to hydrate at export time — so katex can't be deferred via async hydration without forking the plugin (and adding a FOUC regression to preview) for ~0.26M. Documented in the spec + here.

## Verification
- `pnpm lint` — 0 errors.
- Full e2e — **4 passed** (2 budget + 2 smoke).

Closes #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)