### PR TITLE
Extract Editor's CodeMirror theme builders (#672, Editor)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -5,9 +5,8 @@
   import { basicSetup } from 'codemirror';
   import { markdown } from '@codemirror/lang-markdown';
   import { languages } from '@codemirror/language-data';
-  import { EditorState, Prec, Compartment, type Extension } from '@codemirror/state';
-  import { oneDark } from '@codemirror/theme-one-dark';
-  import { getEffectiveTheme, getThemeMode } from '../theme';
+  import { EditorState, Prec, Compartment } from '@codemirror/state';
+  import { cmTheme, minervaEditorTheme, fontSizeTheme } from '../editor/editor-theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
   import { indentUnit, foldEffect, unfoldEffect, foldedRanges, foldService } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
@@ -190,42 +189,6 @@
   const lineNumbersCompartment = new Compartment();
   const whitespaceCompartment = new Compartment();
 
-  function cmTheme(): Extension {
-    return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
-  }
-
-  /** Minerva-specific gutter + active-line styling per
-   *  IMPLEMENTATION.md §8.2. Layered on top of cmTheme() so both dark
-   *  oneDark and the empty light base inherit the same tokens. */
-  function minervaEditorTheme(): Extension {
-    return EditorView.theme({
-      '.cm-gutters': {
-        backgroundColor: 'var(--bg)',
-        border: 'none',
-        color: 'var(--text-faint)',
-        fontFamily: 'var(--font-mono)',
-      },
-      '.cm-lineNumbers': { minWidth: '56px' },
-      '.cm-lineNumbers .cm-gutterElement': {
-        padding: '0 10px 0 0',
-        color: 'var(--text-faint)',
-      },
-      '.cm-activeLineGutter': {
-        backgroundColor: 'transparent',
-        color: 'var(--accent)',
-      },
-      // Bar marks the boundary between gutters and content. Painting it
-      // on the content row (rather than the gutter's right edge) means a
-      // single line regardless of how many gutter columns are stacked —
-      // the compute gutter would otherwise paint its own bar on fence
-      // lines, doubling up.
-      '.cm-activeLine': {
-        backgroundColor: 'color-mix(in oklch, var(--accent) 6%, transparent)',
-        boxShadow: 'inset 2px 0 0 var(--accent)',
-      },
-    });
-  }
-
   export function updateTheme() {
     if (view) {
       view.dispatch({ effects: themeCompartment.reconfigure(cmTheme()) });
@@ -233,13 +196,6 @@
   }
   function getFontSize(): number {
     return parseStoredFontSize(localStorage.getItem('editorFontSize'));
-  }
-
-  function fontSizeTheme(size: number) {
-    return EditorView.theme({
-      '.cm-content': { fontSize: `${size}px` },
-      '.cm-gutters': { fontSize: `${size}px` },
-    });
   }
 
   export function changeFontSize(delta: number) {

--- a/src/renderer/lib/editor/editor-theme.ts
+++ b/src/renderer/lib/editor/editor-theme.ts
@@ -1,0 +1,57 @@
+/**
+ * CodeMirror theme builders for the editor (#672).
+ *
+ * Pure config extracted out of Editor.svelte: each returns a CodeMirror
+ * `Extension`. The component still owns the compartments that swap these in/out
+ * at runtime — this is just the styling, kept in one testable place.
+ */
+
+import { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { getEffectiveTheme, getThemeMode } from '../theme';
+
+/** oneDark in dark mode, an empty base in light/contrast — `minervaEditorTheme`
+ *  layers the shared tokens on top either way. */
+export function cmTheme(): Extension {
+  return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
+}
+
+/** Minerva-specific gutter + active-line styling per IMPLEMENTATION.md §8.2.
+ *  Layered on top of `cmTheme()` so both dark oneDark and the empty light base
+ *  inherit the same tokens. */
+export function minervaEditorTheme(): Extension {
+  return EditorView.theme({
+    '.cm-gutters': {
+      backgroundColor: 'var(--bg)',
+      border: 'none',
+      color: 'var(--text-faint)',
+      fontFamily: 'var(--font-mono)',
+    },
+    '.cm-lineNumbers': { minWidth: '56px' },
+    '.cm-lineNumbers .cm-gutterElement': {
+      padding: '0 10px 0 0',
+      color: 'var(--text-faint)',
+    },
+    '.cm-activeLineGutter': {
+      backgroundColor: 'transparent',
+      color: 'var(--accent)',
+    },
+    // Bar marks the boundary between gutters and content. Painting it on the
+    // content row (rather than the gutter's right edge) means a single line
+    // regardless of how many gutter columns are stacked — the compute gutter
+    // would otherwise paint its own bar on fence lines, doubling up.
+    '.cm-activeLine': {
+      backgroundColor: 'color-mix(in oklch, var(--accent) 6%, transparent)',
+      boxShadow: 'inset 2px 0 0 var(--accent)',
+    },
+  });
+}
+
+/** Content + gutter font-size theme. */
+export function fontSizeTheme(size: number): Extension {
+  return EditorView.theme({
+    '.cm-content': { fontSize: `${size}px` },
+    '.cm-gutters': { fontSize: `${size}px` },
+  });
+}

--- a/tests/renderer/editor-theme.test.ts
+++ b/tests/renderer/editor-theme.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Smoke coverage for the editor theme builders extracted from Editor.svelte
+ * (#672). They return opaque CodeMirror extensions, so this just pins that each
+ * builds without throwing — catching a broken `EditorView.theme(...)` spec.
+ */
+import { describe, it, expect } from 'vitest';
+import { minervaEditorTheme, fontSizeTheme } from '../../src/renderer/lib/editor/editor-theme';
+
+describe('editor-theme builders (#672)', () => {
+  it('minervaEditorTheme builds an extension', () => {
+    expect(minervaEditorTheme()).toBeTruthy();
+  });
+
+  it('fontSizeTheme builds an extension for a given size', () => {
+    expect(fontSizeTheme(16)).toBeTruthy();
+  });
+  // cmTheme reads the theme mode (localStorage/matchMedia) so it's exercised via
+  // the app at runtime, not here — these two are the env-free pure builders.
+});


### PR DESCRIPTION
## What

First slice of the #672 grind, per the agreed **"genuine seams only"** plan.

**Editor is the cohesive one.** Its bulk is the CodeMirror extensions array + DOM event handlers wired tight to the live `view`, selection state, and image-upload handlers — extracting those would mean a 15-parameter factory that's *worse*, not better. (Decorations, commands, formatting, image-drop/upload, compute-cells, etc. were already pulled into `../editor/*`.)

The one clean seam left is the theme config: `cmTheme` / `minervaEditorTheme` / `fontSizeTheme` are pure `Extension` builders with no component-state coupling. Moved to `../editor/editor-theme.ts`; the component keeps the compartments that swap them at runtime.

- `Editor.svelte` **1276 → 1232**; the `oneDark` / theme-mode imports move to the module.
- Light test on the two env-free builders (opaque CM extensions just need to build without throwing); `cmTheme` reads theme mode so it's exercised via the app.

**This is deliberately the extent of Editor's split** — it stays ~cohesive rather than being force-split for a line target. The bigger genuine seams are in the panels, coming next:
- SourcesPanel — collections/queue sections + modals
- ConversationsPanel — more section components
- Preview — render/hydration helpers → `.ts`

## Verification
- `pnpm lint` — 0 errors.
- `pnpm test` — 3063 passed (+2).
- `pnpm test:e2e` — 4 passed (editor renders at boot).

Part of #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)