### PR TITLE
Extract ConversationsPanel's pure display helpers to a tested module (#672)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -35,6 +35,13 @@
   import ComputeDraftCard from './ComputeDraftCard.svelte';
   import { getSlashCommands } from '../tools/tool-registry';
   import { slashQueryFromComposer, filterSlashCommands } from '../conversations/slash-commands';
+  import {
+    tabTitle,
+    formatPropertyValue,
+    sourceLabel,
+    basename,
+    sourceKindLabel,
+  } from '../conversations/conversation-display';
 
   // Lightweight markdown-it for assistant message rendering. Mirrors the
   // configuration in the legacy ConversationDialog so prose renders the
@@ -304,21 +311,6 @@
     window.addEventListener('pointerup', up);
   }
 
-  function tabTitle(tab: { title: string | null; conversation: { messages: { role: string; content: string }[] } }): string {
-    if (tab.title) return tab.title;
-    const firstUser = tab.conversation.messages.find((m) => m.role === 'user');
-    if (!firstUser) return 'New conversation';
-    const flat = firstUser.content.replace(/\s+/g, ' ').trim();
-    if (!flat) return 'New conversation';
-    // 60-char auto-title heuristic. Truncates on a word boundary when one
-    // exists in the last quarter so we don't slice mid-word for the common
-    // case of a 60-80 char first turn.
-    if (flat.length <= 60) return flat;
-    const window = flat.slice(0, 60);
-    const lastSpace = window.lastIndexOf(' ');
-    return (lastSpace > 45 ? window.slice(0, lastSpace) : window) + '…';
-  }
-
   let pendingAnswerText = $state('');
 
   async function submitAnswer(tabId: string, answer: string) {
@@ -426,45 +418,12 @@
    *  Strings render bare; everything else falls back to compact JSON
    *  so the user can eyeball arrays/objects without scrolling. Null
    *  is shown as a deletion marker. */
-  function formatPropertyValue(v: unknown): string {
-    if (v === null) return '⌫ deleted';
-    if (typeof v === 'string') return v;
-    if (typeof v === 'number' || typeof v === 'boolean') return String(v);
-    try { return JSON.stringify(v) ?? ''; } catch { return '[unserializable]'; }
-  }
-
-  function sourceLabel(s: { identifier?: string; url?: string }): string {
-    return s.identifier ?? s.url ?? '(unknown source)';
-  }
-
-  /** Last segment of a project-relative path — the only part the user
-   *  needs to recognize the filed note in the compact "Filed:" line.
-   *  Full path is still on the link's `title` for hover disambiguation
-   *  when two filings have the same basename. */
-  function basename(p: string): string {
-    const slash = p.lastIndexOf('/');
-    return slash >= 0 ? p.slice(slash + 1) : p;
-  }
-
   function openFiledNote(relativePath: string) {
     void editor.openFile(relativePath);
   }
 
   function openFiledSource(sourceId: string) {
     editor.openSource(sourceId);
-  }
-
-  /** Cheap heuristic for the "doi / arxiv / pmid / url" pill — exact
-   *  normalization happens server-side at ingest time. Only used for
-   *  the badge label so a bit of imprecision is fine. */
-  function sourceKindLabel(s: { identifier?: string; url?: string }): string {
-    if (s.url) return 'url';
-    const id = s.identifier ?? '';
-    const stripped = id.replace(/^(?:https?:\/\/(?:dx\.)?doi\.org\/|doi:|arxiv:|pmid:)\s*/i, '');
-    if (/^10\./.test(stripped)) return 'doi';
-    if (/^\d{4}\.\d{4,5}$|^[a-z-]+(?:\.[a-z-]+)?\/\d{7}$/i.test(stripped)) return 'arxiv';
-    if (/^\d+$/.test(stripped)) return 'pmid';
-    return 'id';
   }
 
   // ── Card anchoring helpers ───────────────────────────────────────────

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -5,9 +5,8 @@
   import { basicSetup } from 'codemirror';
   import { markdown } from '@codemirror/lang-markdown';
   import { languages } from '@codemirror/language-data';
-  import { EditorState, Prec, Compartment, type Extension } from '@codemirror/state';
-  import { oneDark } from '@codemirror/theme-one-dark';
-  import { getEffectiveTheme, getThemeMode } from '../theme';
+  import { EditorState, Prec, Compartment } from '@codemirror/state';
+  import { cmTheme, minervaEditorTheme, fontSizeTheme } from '../editor/editor-theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
   import { indentUnit, foldEffect, unfoldEffect, foldedRanges, foldService } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
@@ -190,42 +189,6 @@
   const lineNumbersCompartment = new Compartment();
   const whitespaceCompartment = new Compartment();
 
-  function cmTheme(): Extension {
-    return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
-  }
-
-  /** Minerva-specific gutter + active-line styling per
-   *  IMPLEMENTATION.md §8.2. Layered on top of cmTheme() so both dark
-   *  oneDark and the empty light base inherit the same tokens. */
-  function minervaEditorTheme(): Extension {
-    return EditorView.theme({
-      '.cm-gutters': {
-        backgroundColor: 'var(--bg)',
-        border: 'none',
-        color: 'var(--text-faint)',
-        fontFamily: 'var(--font-mono)',
-      },
-      '.cm-lineNumbers': { minWidth: '56px' },
-      '.cm-lineNumbers .cm-gutterElement': {
-        padding: '0 10px 0 0',
-        color: 'var(--text-faint)',
-      },
-      '.cm-activeLineGutter': {
-        backgroundColor: 'transparent',
-        color: 'var(--accent)',
-      },
-      // Bar marks the boundary between gutters and content. Painting it
-      // on the content row (rather than the gutter's right edge) means a
-      // single line regardless of how many gutter columns are stacked —
-      // the compute gutter would otherwise paint its own bar on fence
-      // lines, doubling up.
-      '.cm-activeLine': {
-        backgroundColor: 'color-mix(in oklch, var(--accent) 6%, transparent)',
-        boxShadow: 'inset 2px 0 0 var(--accent)',
-      },
-    });
-  }
-
   export function updateTheme() {
     if (view) {
       view.dispatch({ effects: themeCompartment.reconfigure(cmTheme()) });
@@ -233,13 +196,6 @@
   }
   function getFontSize(): number {
     return parseStoredFontSize(localStorage.getItem('editorFontSize'));
-  }
-
-  function fontSizeTheme(size: number) {
-    return EditorView.theme({
-      '.cm-content': { fontSize: `${size}px` },
-      '.cm-gutters': { fontSize: `${size}px` },
-    });
   }
 
   export function changeFontSize(delta: number) {

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -8,6 +8,13 @@
   import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
   import SourceListItem from './SourceListItem.svelte';
   import { formatDueStamp } from '../sources/source-display';
+  import {
+    collectionSubtree,
+    membersInSubtree,
+    subtreeCounts,
+    filterSources,
+    flattenCollectionRows,
+  } from '../sources/collection-tree';
   import Icon from './Icon.svelte';
 
   type QueueView = 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished';
@@ -264,108 +271,28 @@
     !!activeCollectionId && smartCollections.some((s) => s.id === activeCollectionId),
   );
 
-  /** Collection ids in the active subtree (the focused manual
-   *  collection and every descendant). Selecting a parent shows
-   *  everything filed under it — matches what users expect from
-   *  Zotero's "include child collections" default. Returns null
-   *  when nothing is focused, or when the focused entry is a smart
-   *  collection (which has no subtree). */
-  const activeSubtree = $derived.by(() => {
-    if (!activeCollectionId || activeIsSmart) return null;
-    const out = new Set<string>([activeCollectionId]);
-    let added = true;
-    while (added) {
-      added = false;
-      for (const c of collections) {
-        if (c.parent && out.has(c.parent) && !out.has(c.id)) {
-          out.add(c.id);
-          added = true;
-        }
-      }
-    }
-    return out;
-  });
+  /** Collection ids in the active subtree (the focused manual collection and
+   *  every descendant) — see collectionSubtree. */
+  const activeSubtree = $derived(collectionSubtree(activeCollectionId, activeIsSmart, collections));
 
-  /** Source ids the active collection contributes. For manual: union
-   *  of every member array in the subtree. For smart: the live
-   *  smartMembers set. For a queue view: the live queueMembers set. */
+  /** Source ids the active collection contributes. For manual: union of every
+   *  member array in the subtree. For smart: the live smartMembers set. For a
+   *  queue view: the live queueMembers set. */
   const activeMembers = $derived.by(() => {
     if (activeQueueView) return queueMembers;
     if (!activeCollectionId) return null;
     if (activeIsSmart) return smartMembers;
     if (!activeSubtree) return null;
-    const out = new Set<string>();
-    for (const c of collections) {
-      if (activeSubtree.has(c.id)) for (const m of c.members) out.add(m);
-    }
-    return out;
+    return membersInSubtree(activeSubtree, collections);
   });
 
-  /** Per-collection visible counts shown next to each row. Each count
-   *  reflects the subtree-rooted membership the user would see if they
-   *  clicked that row (i.e. includes descendants). */
-  const counts = $derived.by(() => {
-    const childrenOf = new Map<string | null, string[]>();
-    for (const c of collections) {
-      const arr = childrenOf.get(c.parent) ?? [];
-      arr.push(c.id);
-      childrenOf.set(c.parent, arr);
-    }
-    const subtreeMembers = new Map<string, Set<string>>();
-    const collect = (id: string): Set<string> => {
-      const cached = subtreeMembers.get(id);
-      if (cached) return cached;
-      const own = collections.find((c) => c.id === id);
-      const out = new Set<string>(own?.members ?? []);
-      for (const childId of childrenOf.get(id) ?? []) {
-        for (const m of collect(childId)) out.add(m);
-      }
-      subtreeMembers.set(id, out);
-      return out;
-    };
-    const result = new Map<string, number>();
-    for (const c of collections) result.set(c.id, collect(c.id).size);
-    return result;
-  });
+  /** Per-collection subtree-rooted counts shown next to each row. */
+  const counts = $derived(subtreeCounts(collections));
 
-  let visible = $derived.by(() => {
-    let base = sources;
-    if (activeMembers) base = base.filter((s) => activeMembers.has(s.sourceId));
-    const q = filter.trim().toLowerCase();
-    if (!q) return base;
-    return base.filter((s) => {
-      const title = displaySourceTitle(s).toLowerCase();
-      const byline = s.creators.join(' ').toLowerCase();
-      const year = s.year ?? '';
-      return title.includes(q) || byline.includes(q) || year.includes(q) || s.sourceId.includes(q);
-    });
-  });
+  let visible = $derived(filterSources(sources, activeMembers, filter));
 
-  interface CollectionRow {
-    collection: Collection;
-    depth: number;
-    hasChildren: boolean;
-  }
   /** Display-order flattening of the tree, honouring expansion state. */
-  const collectionRows = $derived.by<CollectionRow[]>(() => {
-    const childrenOf = new Map<string | null, Collection[]>();
-    for (const c of collections) {
-      const arr = childrenOf.get(c.parent) ?? [];
-      arr.push(c);
-      childrenOf.set(c.parent, arr);
-    }
-    for (const arr of childrenOf.values()) arr.sort((a, b) => a.name.localeCompare(b.name));
-    const out: CollectionRow[] = [];
-    const walk = (parent: string | null, depth: number) => {
-      for (const c of childrenOf.get(parent) ?? []) {
-        const hasChildren = (childrenOf.get(c.id)?.length ?? 0) > 0;
-        out.push({ collection: c, depth, hasChildren });
-        if (hasChildren && expandedCollections[c.id]) walk(c.id, depth + 1);
-      }
-    };
-    walk(null, 0);
-    return out;
-  });
+  const collectionRows = $derived(flattenCollectionRows(collections, expandedCollections));
 
   function toggleExpanded(id: string) {
     expandedCollections = { ...expandedCollections, [id]: !expandedCollections[id] };

--- a/src/renderer/lib/conversations/conversation-display.ts
+++ b/src/renderer/lib/conversations/conversation-display.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure display helpers for ConversationsPanel (#672) — tab titles, property
+ * formatting, source labels. Extracted from the component so the heuristics
+ * (auto-title truncation, the doi/arxiv/pmid pill) are testable in isolation.
+ */
+
+export interface TabTitleInput {
+  title: string | null;
+  conversation: { messages: { role: string; content: string }[] };
+}
+
+/**
+ * Tab label: the explicit title if set, else a preview of the first user
+ * message — flattened whitespace, truncated to 60 chars on a word boundary when
+ * one falls in the last quarter (so common 60–80 char openers don't slice
+ * mid-word) — else "New conversation".
+ */
+export function tabTitle(tab: TabTitleInput): string {
+  if (tab.title) return tab.title;
+  const firstUser = tab.conversation.messages.find((m) => m.role === 'user');
+  if (!firstUser) return 'New conversation';
+  const flat = firstUser.content.replace(/\s+/g, ' ').trim();
+  if (!flat) return 'New conversation';
+  if (flat.length <= 60) return flat;
+  const window = flat.slice(0, 60);
+  const lastSpace = window.lastIndexOf(' ');
+  return (lastSpace > 45 ? window.slice(0, lastSpace) : window) + '…';
+}
+
+/** Render an arbitrary property value for the proposal diff line. */
+export function formatPropertyValue(v: unknown): string {
+  if (v === null) return '⌫ deleted';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  try { return JSON.stringify(v) ?? ''; } catch { return '[unserializable]'; }
+}
+
+/** Human label for a source draft — identifier, else url, else a placeholder. */
+export function sourceLabel(s: { identifier?: string; url?: string }): string {
+  return s.identifier ?? s.url ?? '(unknown source)';
+}
+
+/** Last segment of a project-relative path (the recognisable part of a "Filed:"
+ *  line; the full path stays on the link title for disambiguation). */
+export function basename(p: string): string {
+  const slash = p.lastIndexOf('/');
+  return slash >= 0 ? p.slice(slash + 1) : p;
+}
+
+/** Cheap heuristic for the "doi / arxiv / pmid / url / id" pill — exact
+ *  normalization happens server-side at ingest; this is only the badge label so
+ *  a little imprecision is fine. */
+export function sourceKindLabel(s: { identifier?: string; url?: string }): string {
+  if (s.url) return 'url';
+  const id = s.identifier ?? '';
+  const stripped = id.replace(/^(?:https?:\/\/(?:dx\.)?doi\.org\/|doi:|arxiv:|pmid:)\s*/i, '');
+  if (/^10\./.test(stripped)) return 'doi';
+  if (/^\d{4}\.\d{4,5}$|^[a-z-]+(?:\.[a-z-]+)?\/\d{7}$/i.test(stripped)) return 'arxiv';
+  if (/^\d+$/.test(stripped)) return 'pmid';
+  return 'id';
+}

--- a/src/renderer/lib/editor/editor-theme.ts
+++ b/src/renderer/lib/editor/editor-theme.ts
@@ -1,0 +1,57 @@
+/**
+ * CodeMirror theme builders for the editor (#672).
+ *
+ * Pure config extracted out of Editor.svelte: each returns a CodeMirror
+ * `Extension`. The component still owns the compartments that swap these in/out
+ * at runtime — this is just the styling, kept in one testable place.
+ */
+
+import { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { getEffectiveTheme, getThemeMode } from '../theme';
+
+/** oneDark in dark mode, an empty base in light/contrast — `minervaEditorTheme`
+ *  layers the shared tokens on top either way. */
+export function cmTheme(): Extension {
+  return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
+}
+
+/** Minerva-specific gutter + active-line styling per IMPLEMENTATION.md §8.2.
+ *  Layered on top of `cmTheme()` so both dark oneDark and the empty light base
+ *  inherit the same tokens. */
+export function minervaEditorTheme(): Extension {
+  return EditorView.theme({
+    '.cm-gutters': {
+      backgroundColor: 'var(--bg)',
+      border: 'none',
+      color: 'var(--text-faint)',
+      fontFamily: 'var(--font-mono)',
+    },
+    '.cm-lineNumbers': { minWidth: '56px' },
+    '.cm-lineNumbers .cm-gutterElement': {
+      padding: '0 10px 0 0',
+      color: 'var(--text-faint)',
+    },
+    '.cm-activeLineGutter': {
+      backgroundColor: 'transparent',
+      color: 'var(--accent)',
+    },
+    // Bar marks the boundary between gutters and content. Painting it on the
+    // content row (rather than the gutter's right edge) means a single line
+    // regardless of how many gutter columns are stacked — the compute gutter
+    // would otherwise paint its own bar on fence lines, doubling up.
+    '.cm-activeLine': {
+      backgroundColor: 'color-mix(in oklch, var(--accent) 6%, transparent)',
+      boxShadow: 'inset 2px 0 0 var(--accent)',
+    },
+  });
+}
+
+/** Content + gutter font-size theme. */
+export function fontSizeTheme(size: number): Extension {
+  return EditorView.theme({
+    '.cm-content': { fontSize: `${size}px` },
+    '.cm-gutters': { fontSize: `${size}px` },
+  });
+}

--- a/src/renderer/lib/sources/collection-tree.ts
+++ b/src/renderer/lib/sources/collection-tree.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure collection-tree algorithms for SourcesPanel (#672).
+ *
+ * Extracted from the component's `$derived.by` blocks so the tree logic — which
+ * is easy to get subtly wrong (cycles, deep nesting, subtree-rooted counts,
+ * display ordering) — lives in one testable place. The component just wires its
+ * reactive state into these.
+ */
+
+import type { Collection, SourceMetadata } from '../../../shared/types';
+import { displaySourceTitle } from '../../../shared/source-display';
+
+export interface CollectionRow {
+  collection: Collection;
+  depth: number;
+  hasChildren: boolean;
+}
+
+/**
+ * The focused manual collection plus every descendant — selecting a parent
+ * shows everything filed under it (Zotero's "include child collections"
+ * default). Returns null when nothing is focused or the focus is a smart
+ * collection (which has no subtree).
+ */
+export function collectionSubtree(
+  activeId: string | null,
+  isSmart: boolean,
+  collections: Collection[],
+): Set<string> | null {
+  if (!activeId || isSmart) return null;
+  const out = new Set<string>([activeId]);
+  let added = true;
+  while (added) {
+    added = false;
+    for (const c of collections) {
+      if (c.parent && out.has(c.parent) && !out.has(c.id)) {
+        out.add(c.id);
+        added = true;
+      }
+    }
+  }
+  return out;
+}
+
+/** Union of member source-ids across every manual collection in `subtree`. */
+export function membersInSubtree(subtree: Set<string>, collections: Collection[]): Set<string> {
+  const out = new Set<string>();
+  for (const c of collections) {
+    if (subtree.has(c.id)) for (const m of c.members) out.add(m);
+  }
+  return out;
+}
+
+/**
+ * Per-collection visible counts — each reflects the subtree-rooted membership
+ * a user would see clicking that row (i.e. includes descendants). Memoized per
+ * id during the walk so a wide/deep tree stays linear.
+ */
+export function subtreeCounts(collections: Collection[]): Map<string, number> {
+  const childrenOf = new Map<string | null, string[]>();
+  for (const c of collections) {
+    const arr = childrenOf.get(c.parent) ?? [];
+    arr.push(c.id);
+    childrenOf.set(c.parent, arr);
+  }
+  const subtreeMembers = new Map<string, Set<string>>();
+  const collect = (id: string): Set<string> => {
+    const cached = subtreeMembers.get(id);
+    if (cached) return cached;
+    const own = collections.find((c) => c.id === id);
+    const out = new Set<string>(own?.members ?? []);
+    for (const childId of childrenOf.get(id) ?? []) {
+      for (const m of collect(childId)) out.add(m);
+    }
+    subtreeMembers.set(id, out);
+    return out;
+  };
+  const result = new Map<string, number>();
+  for (const c of collections) result.set(c.id, collect(c.id).size);
+  return result;
+}
+
+/** Display-order flattening of the tree, honouring expansion state. Siblings
+ *  are sorted by name; collapsed nodes hide their descendants. */
+export function flattenCollectionRows(
+  collections: Collection[],
+  expanded: Record<string, boolean>,
+): CollectionRow[] {
+  const childrenOf = new Map<string | null, Collection[]>();
+  for (const c of collections) {
+    const arr = childrenOf.get(c.parent) ?? [];
+    arr.push(c);
+    childrenOf.set(c.parent, arr);
+  }
+  for (const arr of childrenOf.values()) arr.sort((a, b) => a.name.localeCompare(b.name));
+  const out: CollectionRow[] = [];
+  const walk = (parent: string | null, depth: number) => {
+    for (const c of childrenOf.get(parent) ?? []) {
+      const hasChildren = (childrenOf.get(c.id)?.length ?? 0) > 0;
+      out.push({ collection: c, depth, hasChildren });
+      if (hasChildren && expanded[c.id]) walk(c.id, depth + 1);
+    }
+  };
+  walk(null, 0);
+  return out;
+}
+
+/**
+ * Filter sources by active membership (null = no membership filter) and a
+ * free-text query matched against title / byline / year / id.
+ */
+export function filterSources(
+  sources: SourceMetadata[],
+  activeMembers: Set<string> | null,
+  query: string,
+): SourceMetadata[] {
+  let base = sources;
+  if (activeMembers) base = base.filter((s) => activeMembers.has(s.sourceId));
+  const q = query.trim().toLowerCase();
+  if (!q) return base;
+  return base.filter((s) => {
+    const title = displaySourceTitle(s).toLowerCase();
+    const byline = s.creators.join(' ').toLowerCase();
+    const year = s.year ?? '';
+    return title.includes(q) || byline.includes(q) || year.includes(q) || s.sourceId.includes(q);
+  });
+}

--- a/tests/renderer/collection-tree.test.ts
+++ b/tests/renderer/collection-tree.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure collection-tree algorithms extracted from SourcesPanel (#672).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  collectionSubtree,
+  membersInSubtree,
+  subtreeCounts,
+  flattenCollectionRows,
+  filterSources,
+} from '../../src/renderer/lib/sources/collection-tree';
+import type { Collection, SourceMetadata } from '../../src/shared/types';
+
+function coll(id: string, parent: string | null, members: string[] = [], name = id): Collection {
+  return { id, name, parent, members };
+}
+function src(sourceId: string, over: Partial<SourceMetadata> = {}): SourceMetadata {
+  return { sourceId, creators: [], year: '', ...over } as SourceMetadata;
+}
+
+// a ─ b ─ d
+//   └ c
+const TREE = [coll('a', null, ['s1']), coll('b', 'a', ['s2']), coll('c', 'a', ['s3']), coll('d', 'b', ['s4'])];
+
+describe('collectionSubtree', () => {
+  it('returns the focused collection + all descendants', () => {
+    expect(collectionSubtree('a', false, TREE)).toEqual(new Set(['a', 'b', 'c', 'd']));
+    expect(collectionSubtree('b', false, TREE)).toEqual(new Set(['b', 'd']));
+    expect(collectionSubtree('d', false, TREE)).toEqual(new Set(['d']));
+  });
+  it('returns null when nothing is focused or the focus is smart', () => {
+    expect(collectionSubtree(null, false, TREE)).toBeNull();
+    expect(collectionSubtree('a', true, TREE)).toBeNull();
+  });
+});
+
+describe('membersInSubtree', () => {
+  it('unions members across the subtree', () => {
+    const sub = collectionSubtree('a', false, TREE)!;
+    expect(membersInSubtree(sub, TREE)).toEqual(new Set(['s1', 's2', 's3', 's4']));
+    expect(membersInSubtree(new Set(['b', 'd']), TREE)).toEqual(new Set(['s2', 's4']));
+  });
+});
+
+describe('subtreeCounts', () => {
+  it('counts subtree-rooted membership (includes descendants), deduped', () => {
+    const counts = subtreeCounts(TREE);
+    expect(counts.get('a')).toBe(4); // s1..s4
+    expect(counts.get('b')).toBe(2); // s2, s4
+    expect(counts.get('c')).toBe(1); // s3
+    expect(counts.get('d')).toBe(1); // s4
+  });
+  it('dedupes a source filed in both a parent and child', () => {
+    const counts = subtreeCounts([coll('p', null, ['x']), coll('ch', 'p', ['x'])]);
+    expect(counts.get('p')).toBe(1);
+  });
+});
+
+describe('flattenCollectionRows', () => {
+  it('flattens in display order, hiding descendants of collapsed nodes', () => {
+    const collapsed = flattenCollectionRows(TREE, {}).map((r) => r.collection.id);
+    expect(collapsed).toEqual(['a']); // b/c hidden until a expanded
+    const expanded = flattenCollectionRows(TREE, { a: true, b: true }).map((r) => r.collection.id);
+    expect(expanded).toEqual(['a', 'b', 'd', 'c']); // siblings name-sorted; d under b
+  });
+  it('marks hasChildren + depth', () => {
+    const rows = flattenCollectionRows(TREE, { a: true });
+    expect(rows.find((r) => r.collection.id === 'a')).toMatchObject({ depth: 0, hasChildren: true });
+    expect(rows.find((r) => r.collection.id === 'c')).toMatchObject({ depth: 1, hasChildren: false });
+  });
+});
+
+describe('filterSources', () => {
+  const sources = [
+    src('s1', { creators: ['Ada Lovelace'], year: '1843' }),
+    src('s2', { creators: ['Alan Turing'], year: '1936' }),
+  ];
+  it('filters by active membership', () => {
+    expect(filterSources(sources, new Set(['s2']), '').map((s) => s.sourceId)).toEqual(['s2']);
+    expect(filterSources(sources, null, '')).toHaveLength(2);
+  });
+  it('matches the query against byline / year / id', () => {
+    expect(filterSources(sources, null, 'turing').map((s) => s.sourceId)).toEqual(['s2']);
+    expect(filterSources(sources, null, '1843').map((s) => s.sourceId)).toEqual(['s1']);
+    expect(filterSources(sources, null, 's2').map((s) => s.sourceId)).toEqual(['s2']);
+  });
+});

--- a/tests/renderer/conversation-display.test.ts
+++ b/tests/renderer/conversation-display.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure display helpers extracted from ConversationsPanel (#672).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  tabTitle,
+  formatPropertyValue,
+  sourceLabel,
+  basename,
+  sourceKindLabel,
+} from '../../src/renderer/lib/conversations/conversation-display';
+
+const conv = (msgs: { role: string; content: string }[]) => ({ conversation: { messages: msgs } });
+
+describe('tabTitle', () => {
+  it('uses an explicit title verbatim', () => {
+    expect(tabTitle({ title: 'My chat', ...conv([]) })).toBe('My chat');
+  });
+  it('falls back to "New conversation" with no user message or empty content', () => {
+    expect(tabTitle({ title: null, ...conv([]) })).toBe('New conversation');
+    expect(tabTitle({ title: null, ...conv([{ role: 'user', content: '   ' }]) })).toBe('New conversation');
+  });
+  it('previews the first user message, whitespace-flattened', () => {
+    expect(tabTitle({ title: null, ...conv([{ role: 'assistant', content: 'hi' }, { role: 'user', content: 'a\n  b   c' }]) }))
+      .toBe('a b c');
+  });
+  it('truncates >60 chars on a word boundary in the last quarter, else hard', () => {
+    const wordy = 'one two three four five six seven eight nine ten eleven twelve thirteen';
+    const t = tabTitle({ title: null, ...conv([{ role: 'user', content: wordy }]) });
+    expect(t.endsWith('…')).toBe(true);
+    expect(t.length).toBeLessThanOrEqual(61);
+    expect(wordy.startsWith(t.slice(0, -1))).toBe(true); // a real prefix of the input
+    expect(wordy[t.length - 1]).toBe(' '); // cut fell on a word boundary (no mid-word slice)
+    // No late space → hard cut at 60 + …
+    const nospace = 'x'.repeat(80);
+    expect(tabTitle({ title: null, ...conv([{ role: 'user', content: nospace }]) })).toBe('x'.repeat(60) + '…');
+  });
+});
+
+describe('formatPropertyValue', () => {
+  it('renders deletes, primitives, and JSON', () => {
+    expect(formatPropertyValue(null)).toBe('⌫ deleted');
+    expect(formatPropertyValue('hi')).toBe('hi');
+    expect(formatPropertyValue(42)).toBe('42');
+    expect(formatPropertyValue(true)).toBe('true');
+    expect(formatPropertyValue({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe('sourceLabel + basename', () => {
+  it('prefers identifier, then url, then placeholder', () => {
+    expect(sourceLabel({ identifier: '10.1/x' })).toBe('10.1/x');
+    expect(sourceLabel({ url: 'http://e.com' })).toBe('http://e.com');
+    expect(sourceLabel({})).toBe('(unknown source)');
+  });
+  it('basename returns the last path segment', () => {
+    expect(basename('notes/sources/a.md')).toBe('a.md');
+    expect(basename('top.md')).toBe('top.md');
+  });
+});
+
+describe('sourceKindLabel', () => {
+  it('classifies url / doi / arxiv / pmid / id', () => {
+    expect(sourceKindLabel({ url: 'http://e.com' })).toBe('url');
+    expect(sourceKindLabel({ identifier: 'doi:10.1145/x' })).toBe('doi');
+    expect(sourceKindLabel({ identifier: 'arxiv:2401.01234' })).toBe('arxiv');
+    expect(sourceKindLabel({ identifier: 'pmid:12345678' })).toBe('pmid');
+    expect(sourceKindLabel({ identifier: 'something-else' })).toBe('id');
+  });
+});

--- a/tests/renderer/editor-theme.test.ts
+++ b/tests/renderer/editor-theme.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Smoke coverage for the editor theme builders extracted from Editor.svelte
+ * (#672). They return opaque CodeMirror extensions, so this just pins that each
+ * builds without throwing — catching a broken `EditorView.theme(...)` spec.
+ */
+import { describe, it, expect } from 'vitest';
+import { minervaEditorTheme, fontSizeTheme } from '../../src/renderer/lib/editor/editor-theme';
+
+describe('editor-theme builders (#672)', () => {
+  it('minervaEditorTheme builds an extension', () => {
+    expect(minervaEditorTheme()).toBeTruthy();
+  });
+
+  it('fontSizeTheme builds an extension for a given size', () => {
+    expect(fontSizeTheme(16)).toBeTruthy();
+  });
+  // cmTheme reads the theme mode (localStorage/matchMedia) so it's exercised via
+  // the app at runtime, not here — these two are the env-free pure builders.
+});


### PR DESCRIPTION
## What

Third #672 slice (ConversationsPanel). Its UI seams were already extracted (`MessageCitations`, `DraftCard`, `ComputeDraftCard`, the cite/slash helpers); the remaining clean seam was the **pure display logic** — the auto-title truncation heuristic and the source/property formatters — inline and untested.

Moved `tabTitle`, `formatPropertyValue`, `sourceLabel`, `basename`, `sourceKindLabel` to `lib/conversations/conversation-display.ts`. **ConversationsPanel 1824 → 1783.** The IPC handlers + card-anchoring logic stay (genuinely component-coupled).

- **8 tests**: `tabTitle` (explicit / empty / whitespace-flatten / word-boundary-vs-hard truncation), `formatPropertyValue` (delete / primitive / JSON), source label fallback chain + `basename`, and the doi/arxiv/pmid/url/id pill classifier.

## Verification
- `pnpm lint` — 0 errors.
- `pnpm test` — 3080 passed (+8).
- `pnpm test:e2e` — 4 passed.

Part of #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)