### PR TITLE
Document the cross-process tool registry + self-approving compute write (#675, #667)

### DIFF
--- a/src/main/compute/proposal-helpers.ts
+++ b/src/main/compute/proposal-helpers.ts
@@ -71,8 +71,31 @@ function formatTableCell(value: unknown): string {
 
 /**
  * Write the ComputeProposal triples into the graph. Called from the RUN handler
- * so every executed cell leaves an audit-trail record — the integrity stock
- * query verifies the LLM hasn't snuck a cell past review.
+ * so every executed cell leaves an audit-trail record.
+ *
+ * Trust-model note (#667): this writes `thought:proposalStatus thought:approved`
+ * directly via `graph.parseIntoStore`, bypassing the approval engine
+ * (`proposeWrite` → user review → `approveProposal`). That is intentional and is
+ * NOT a Trust-Principle violation:
+ *
+ *  - It is not an LLM *claim* about the knowledge graph (the kind that must be
+ *    reviewed). It is an audit record of a compute cell the user ALREADY
+ *    confirmed by clicking Run — the approval already happened, in the UI, at
+ *    run time. There is nothing left to review, so routing it back through the
+ *    pending-proposal queue would be busywork that asks the user to approve
+ *    something they just triggered.
+ *  - It records the proposal *as* approved precisely so it doubles as its own
+ *    provenance: who proposed it (`llm:propose_compute`), the exact code that
+ *    ran, and when.
+ *
+ * It is, however, exactly the shape the dev-time write guard
+ * (`graph/write-guard`) flags — a direct `parseIntoStore` from a near-LLM path.
+ * If a guard warning ever points here, this is the carve-out: a warning is
+ * expected and benign. The integrity stock query (CLAUDE.md) looks for
+ * `thought:Component` nodes attributed to an LLM that LACK an approved proposal;
+ * a `thought:ComputeProposal` that already carries `thought:proposalStatus
+ * thought:approved` is its own approval record, so it does not (and must not) be
+ * mistaken for an unreviewed bypass.
  */
 export function recordComputeProposalRun(
   ctx: ProjectContext,

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -1,5 +1,28 @@
 import type { ThinkingToolDef, ThinkingToolInfo, ToolCategory } from './types';
 
+/**
+ * Cross-process tool registry (#675).
+ *
+ * `tools` below is module-global mutable state. An ES module is a singleton
+ * *per process*, and main and renderer are separate processes — so each gets
+ * its OWN independent copy of this Map. That duplication is by design:
+ *
+ *  - **Main** populates it from compiled skills (`skills/register.ts`) with full
+ *    `ThinkingToolDef`s, including the prompt bodies the executor needs.
+ *  - **Renderer** populates ITS copy (`renderer/lib/tools/tool-registry.ts`)
+ *    from `api.skills.list()` — serializable `SkillInfo` only. The renderer
+ *    never receives prompt bodies (see CLAUDE.md "Tools for Thought"); its
+ *    registry exists so menus / the command palette / right-click can list and
+ *    dispatch tools without a round-trip.
+ *
+ * The two copies are populated from different sources and never share state at
+ * runtime; "register once in each process at startup" is the contract.
+ *
+ * Caveat for tests: because the Map is process-global, a test that registers
+ * tools mutates a singleton shared with every other test in the same worker —
+ * register into a clean state and clear up front (`unregisterTool` / re-register)
+ * rather than assuming an empty registry.
+ */
 const tools = new Map<string, ThinkingToolDef>();
 
 export function registerTool(tool: ThinkingToolDef): void {


### PR DESCRIPTION
## What

The two documentation issues — both subtle-but-intentional patterns the architecture review flagged as surprising without a comment. **Docs only, no behavior change.**

### #675 — `shared/tools/registry.ts`
The module-global `tools` Map is a **per-process singleton** (ES module semantics), loaded independently in:
- **main** — full `ThinkingToolDef`s incl. prompt bodies (from compiled skills);
- **renderer** — serializable `SkillInfo` only (the renderer never sees prompt bodies).

Added a header explaining the dual-instantiation design + the test caveat (it's process-global mutable state, so tests share the singleton within a worker).

### #667 — `recordComputeProposalRun` (now in `compute/proposal-helpers.ts`, moved there in #676)
Expanded the doc to spell out **why writing `thought:proposalStatus thought:approved` directly via `parseIntoStore` is NOT a Trust-Principle bypass**: it's an audit record of a compute cell the user *already* confirmed by clicking Run — the approval happened in the UI at run time — recorded as approved so it doubles as provenance. Names it explicitly as the expected **carve-out** for both the dev-time write-guard warning and the integrity stock query (an approved `ComputeProposal` is its own approval record, not an unreviewed `Component`).

## Verification
- `pnpm lint` — 0 errors.

Closes #675, closes #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)