### PR TITLE
Refresh open editor tabs after sidebar Add/Remove Tag

### DIFF
--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -58,6 +58,28 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
   const flow = getRefactorFlowStore();
   const { showPrompt, showConfirm } = dialogs;
 
+  /**
+   * After a renderer-initiated bulk write (tag add/remove, entrypoint toggle),
+   * sync any affected OPEN note tabs to disk so the visible page reflects the
+   * change. `api.notebase.writeFile` suppresses the `rewritten` broadcast that
+   * normally drives this (it assumes the writer is the editor saving its own
+   * buffer) — so the writer refreshes the views itself, mirroring App's
+   * onRewritten flow including the unsaved-edits prompt.
+   */
+  async function syncOpenTabsToDisk(paths: string[]): Promise<void> {
+    for (const path of paths) {
+      if (editor.isPathDirty(path)) {
+        const keepDisk = await showConfirm(
+          `"${path}" is open with unsaved edits. Discard them and load the updated version?`,
+          CONFIRM_KEYS.rewriteConflict,
+          'Load disk',
+        );
+        if (!keepDisk) continue;
+      }
+      await editor.reloadTabFromDisk(path);
+    }
+  }
+
   async function resolveTitle(body: string): Promise<string | null> {
     const derived = deriveProposedTitle(body);
     if (derived) return derived;
@@ -308,7 +330,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     const tag = raw.trim().toLowerCase();
     if (!tag) return;
 
-    let changed = 0;
+    const changedPaths: string[] = [];
     const failures: Array<{ path: string; error: string }> = [];
     for (const path of targets) {
       try {
@@ -316,7 +338,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
         const { content: next, addedTags } = mergeTagsIntoContent(content, [tag]);
         if (addedTags.length > 0) {
           await api.notebase.writeFile(path, next);
-          changed++;
+          changedPaths.push(path);
         }
       } catch (err) {
         failures.push({ path, error: err instanceof Error ? err.message : String(err) });
@@ -324,7 +346,8 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     }
 
     ctx.getSidebar()?.refreshTags();
-    await reportBulkTagSummary('Add', tag, targets.length, changed, failures);
+    await syncOpenTabsToDisk(changedPaths);
+    await reportBulkTagSummary('Add', tag, targets.length, changedPaths.length, failures);
   }
 
   /**
@@ -377,7 +400,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     const tag = raw.trim().toLowerCase();
     if (!tag) return;
 
-    let changed = 0;
+    const changedPaths: string[] = [];
     const failures: Array<{ path: string; error: string }> = [...readFailures];
     for (const path of targets) {
       // Skip files that already errored on read — we don't have
@@ -388,7 +411,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
         const { content: next, removedTags } = removeTagsFromContent(content, [tag]);
         if (removedTags.length > 0) {
           await api.notebase.writeFile(path, next);
-          changed++;
+          changedPaths.push(path);
         }
       } catch (err) {
         failures.push({ path, error: err instanceof Error ? err.message : String(err) });
@@ -396,7 +419,8 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     }
 
     ctx.getSidebar()?.refreshTags();
-    await reportBulkTagSummary('Remove', tag, targets.length, changed, failures);
+    await syncOpenTabsToDisk(changedPaths);
+    await reportBulkTagSummary('Remove', tag, targets.length, changedPaths.length, failures);
   }
 
   /**
@@ -414,14 +438,16 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
       const content = await api.notebase.readFile(relativePath);
       const hasIt = extractTagsFromContent(content)
         .some((t) => t.toLowerCase() === ENTRYPOINT_TAG);
+      let wrote = false;
       if (hasIt) {
         const { content: next, removedTags } = removeTagsFromContent(content, [ENTRYPOINT_TAG]);
-        if (removedTags.length > 0) await api.notebase.writeFile(relativePath, next);
+        if (removedTags.length > 0) { await api.notebase.writeFile(relativePath, next); wrote = true; }
       } else {
         const { content: next, addedTags } = mergeTagsIntoContent(content, [ENTRYPOINT_TAG]);
-        if (addedTags.length > 0) await api.notebase.writeFile(relativePath, next);
+        if (addedTags.length > 0) { await api.notebase.writeFile(relativePath, next); wrote = true; }
       }
       ctx.getSidebar()?.refreshTags();
+      if (wrote) await syncOpenTabsToDisk([relativePath]);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Toggle entrypoint failed: ${msg}`, CONFIRM_KEYS.bulkTagFailed, 'OK');

--- a/tests/renderer/app/refactor-ops.test.ts
+++ b/tests/renderer/app/refactor-ops.test.ts
@@ -32,6 +32,7 @@ const h = vi.hoisted(() => {
     flushAutoSave: vi.fn(),
     save: vi.fn().mockResolvedValue(undefined),
     reloadTabFromDisk: vi.fn().mockResolvedValue(undefined),
+    isPathDirty: vi.fn(() => false),
     openFile: vi.fn().mockResolvedValue(undefined),
     setContent: vi.fn(),
   };
@@ -153,6 +154,28 @@ describe('handleAddTag', () => {
     const [path] = h.api.notebase.writeFile.mock.calls[0];
     expect(path).toBe('note.md');
     expect(sidebar.refreshTags).toHaveBeenCalled();
+  });
+
+  it('syncs an open tab to disk after tagging so the page updates (regression)', async () => {
+    h.api.tags.list.mockResolvedValue([]);
+    h.dialog.showPrompt.mockResolvedValue('bar');
+    h.api.notebase.readFile.mockResolvedValue('body');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleAddTag('note.md', false);
+    // The whole point: the changed note's open editor buffer is reloaded.
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+  });
+
+  it('prompts before clobbering unsaved edits in an open tab, and skips reload if declined', async () => {
+    h.api.tags.list.mockResolvedValue([]);
+    h.dialog.showPrompt.mockResolvedValue('bar');
+    h.api.notebase.readFile.mockResolvedValue('body');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    h.editor.isPathDirty.mockReturnValue(true);
+    h.dialog.showConfirm.mockResolvedValue(false); // keep my edits
+    await ops.handleAddTag('note.md', false);
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(h.editor.reloadTabFromDisk).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Bug (manual smoke)

Bulk **Add Tag** / **Remove Tag** from the left sidebar wrote the tag to disk and reindexed it (the Tags panel updated), but a note **already open in an editor tab** kept showing its stale buffer — the tag was in the file but not on the open page.

## Cause

These ops write via `api.notebase.writeFile`, which **suppresses the `rewritten` broadcast** that normally drives App's `onRewritten` tab-reload. That suppression assumes the writer is the editor saving its own buffer (true for a normal save) — but here we're writing to *other* notes' tabs, so nothing told them to refresh.

## Fix

The writer refreshes the views itself. A new `syncOpenTabsToDisk(paths)` helper mirrors the `onRewritten` flow: reload each changed note's open tab from disk, **prompting before discarding unsaved edits** (same `rewriteConflict` gate). Wired into all three affected handlers — `handleAddTag`, `handleRemoveTag`, and `handleToggleEntrypoint` (entrypoint toggle had the same bug). Each now collects the paths it actually changed and syncs only those.

## Tests

Extended `refactor-ops.test.ts` (+ `isPathDirty` on the editor mock):
- `reloadTabFromDisk` fires for the tagged note (the regression).
- A dirty open tab prompts and **skips** the reload when the user keeps their edits.

## Verification
- `pnpm lint` — 0 errors.
- `pnpm test` — 3089 passed (+2).
- `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)