### PR TITLE
Auto-reveal active file single-selects it, clearing a stale tree selection

### DIFF
--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -157,6 +157,10 @@
     if (rootName && !rootExpanded) rootExpanded = true;
     expandAncestors(path);
     void scrollPathIntoView(path);
+    // Selection follows the revealed file: single-select it so a stale
+    // selection from before the active file changed (via tab switch, a link,
+    // the command palette, …) doesn't stay highlighted alongside it.
+    selectionStore.setSingle(path);
   });
 
   async function scrollPathIntoView(path: string): Promise<void> {


### PR DESCRIPTION
## Bug (manual smoke)

With **"auto-reveal active file"** on: if something is already selected in the Notes tree and the active file then changes via a **non-tree path** (tab switch, a link, the command palette, breadcrumbs), the sidebar reveals + scrolls to the new file but leaves the previous selection highlighted — **two highlights at once** (old `.selected` + new `.active`).

## Cause

The auto-reveal `$effect` expanded ancestors and scrolled the row into view, but never touched the selection. A plain tree-click already calls `selectionStore.setSingle` (selection follows the click); auto-reveal didn't.

## Fix

Auto-reveal now does the same `setSingle(activeFile)` — selection follows the revealed file, so the stale one clears and you get a single, consistent highlight. 

- Idempotent for the click path (active file == clicked).
- Scoped to the effect, so it only happens when auto-reveal is **on** and the Notes panel is showing.
- ⌘-click multi-select is unaffected — it doesn't change the active file, so the effect doesn't fire (you can still build a multi-selection for bulk ops).

## Verification
- `pnpm lint` — 0 errors; full suite 3089; e2e 4/4.
- Not unit-tested directly (one-line component-effect wiring; `setSingle` itself is covered by `sidebar-selection.test.ts`). Manual confirm of the reveal behavior to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)