### PR TITLE
Smart-collection tag picker offers only tags present on some source

### DIFF
--- a/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
+++ b/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
@@ -53,9 +53,12 @@
   $effect(() => { nameInputEl?.focus(); });
 
   async function loadTags(): Promise<void> {
-    allTags = await api.tags.list();
+    // Smart collections here filter *sources*, so only offer tags that appear
+    // on at least one source (`sourceCount > 0`). The unfiltered vocabulary
+    // includes note-only tags, which can never match a source predicate.
+    allTags = (await api.tags.list()).filter((t) => t.sourceCount > 0);
     // Restore any pre-selected tag that doesn't appear in the live
-    // project vocabulary (e.g. the predicate references a tag that's
+    // source vocabulary (e.g. the predicate references a tag that's
     // since been removed from every source). We still show it so the
     // user can either keep it or uncheck it deliberately.
     for (const t of selectedTags) {

--- a/tests/renderer/smart-collection-tags.test.ts
+++ b/tests/renderer/smart-collection-tags.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Smart SOURCE collections filter sources by tag, so the tag picker must offer
+ * only tags present on some source — not the whole project vocabulary (which
+ * includes note-only tags that can never match a source predicate).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+const { tagsList } = vi.hoisted(() => ({ tagsList: vi.fn() }));
+vi.mock('../../src/renderer/lib/ipc/client', () => ({ api: { tags: { list: tagsList } } }));
+
+import SmartCollectionEditorDialog from '../../src/renderer/lib/components/SmartCollectionEditorDialog.svelte';
+
+afterEach(cleanup);
+
+describe('SmartCollectionEditorDialog tag list', () => {
+  it('offers only tags on some source, hiding note-only tags', async () => {
+    tagsList.mockResolvedValue([
+      { tag: 'note-only', noteCount: 3, sourceCount: 0 },
+      { tag: 'on-sources', noteCount: 0, sourceCount: 2 },
+      { tag: 'on-both', noteCount: 1, sourceCount: 1 },
+    ]);
+
+    const { findByText, queryByText } = render(SmartCollectionEditorDialog, {
+      editing: undefined,
+      onSave: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    // Source tags shown…
+    expect(await findByText('#on-sources')).toBeTruthy();
+    expect(queryByText('#on-both')).toBeTruthy();
+    // …note-only tag hidden.
+    expect(queryByText('#note-only')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Bug (manual smoke)

Creating a **smart source collection**, the tag picker listed the *whole* project vocabulary (`api.tags.list()`) — including **note-only tags**. Those can never match a source predicate, so the picker offered tags that would always produce an empty collection.

## Fix

Filter the list to `sourceCount > 0`. `TagInfo` already carries per-tag `noteCount` / `sourceCount` (`listTags` buckets a tag by whether its subject is a source), so this is a **one-line renderer filter — no new query/IPC**. The existing pre-selected-tag restore is preserved: a previously-picked tag that's since left every source still shows (count 0) so you can keep or uncheck it.

## Test

Render the dialog with mixed `note-only` / `on-sources` / `on-both` tags; assert the source-bearing ones are offered and the note-only one is hidden.

## Verification
- `pnpm lint` — 0 errors.
- `pnpm test` — 3088 passed (+1).
- `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)