### PR TITLE
Fix nested <button> in tables panel + sweep dead CSS selectors

### DIFF
--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -431,9 +431,6 @@
     align-items: center;
     cursor: pointer;
   }
-  .radio-group input:disabled + * {
-    color: var(--text-muted);
-  }
   select {
     background: var(--bg-button);
     color: var(--text);
@@ -534,8 +531,7 @@
     flex-basis: 100%;
   }
   .audit-section li > .row-check ~ .title,
-  .audit-section li > .row-check ~ .path,
-  .audit-section li > .row-check ~ .reason {
+  .audit-section li > .row-check ~ .path {
     flex-basis: calc(100% - 22px);
   }
 

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -953,7 +953,6 @@
     font-size: 12px;
   }
 
-  .field input[type="password"],
   .field input[type="text"],
   .field select,
   .field textarea {
@@ -966,7 +965,6 @@
     font-family: inherit;
   }
 
-  .field input[type="password"]:focus,
   .field input[type="text"]:focus,
   .field select:focus,
   .field textarea:focus {
@@ -1078,23 +1076,6 @@
     margin: 0 0 16px 0;
   }
 
-  .action-btn {
-    align-self: flex-start;
-    padding: 4px 12px;
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    background: var(--bg-button);
-    color: var(--text);
-    font-size: 12px;
-    cursor: pointer;
-  }
-  .action-btn:hover:not(:disabled) {
-    background: var(--bg-button-hover);
-  }
-  .action-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
 
   .section-intro code {
     font-size: 11px;

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1183,12 +1183,6 @@
   .submenu-item:hover > .submenu {
     display: block;
   }
-  .submenu-separator {
-    height: 1px;
-    background: var(--border);
-    margin: 4px 0;
-  }
-
   /* Reading-due-date modal — popped out of the context-menu "Set due
      date" item. Owns its own dismissal (Escape / overlay click /
      Cancel / Save) so the native date picker can open without the

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -923,20 +923,6 @@
     width: 14px;
     flex-shrink: 0;
   }
-  .key-input {
-    flex: 1;
-    background: var(--bg-inset);
-    border: 1px solid transparent;
-    border-radius: 4px;
-    padding: 4px 8px;
-    color: var(--text);
-    font-family: var(--font-mono);
-    font-size: 12px;
-  }
-  .key-input:focus {
-    border-color: var(--accent);
-    outline: none;
-  }
   .add-btn {
     background: var(--bg);
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TablesPanel.svelte
@@ -86,10 +86,16 @@
       {#each tables() as name}
         {@const info = registeredTables.get(name)}
         {@const known = info !== undefined}
-        <button
+        <!-- A div, not a button: the row carries an inner "SELECT *" button, and
+             a button can't contain a button. role/tabindex/onkeydown keep it
+             keyboard-accessible. -->
+        <div
           class="row"
           class:dead={!known}
+          role="button"
+          tabindex="0"
           onclick={() => onOpenQuery(`SELECT * FROM ${name}`)}
+          onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenQuery(`SELECT * FROM ${name}`); } }}
           title={known ? `${name} · ${info.rowCount} × ${info.columns.length}` : `${name} (not registered)`}
         >
           {#if known}
@@ -112,7 +118,7 @@
               title="SELECT * FROM {name}"
             >SELECT *</button>
           {/if}
-        </button>
+        </div>
       {/each}
     {/if}
   </div>
@@ -159,6 +165,10 @@
   .row:hover {
     background: color-mix(in oklch, var(--text) 4%, transparent);
     border-left-color: var(--accent);
+  }
+  .row:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
   }
   .row.dead {
     cursor: default;


### PR DESCRIPTION
The actionable subset of the boot-time svelte-check warnings (the rest are the intentional dialog state-snapshot idiom, or the a11y sweep tracked in #761).

## Real bug — nested `<button>` (right-sidebar TablesPanel)
Each table row was a `<button>` containing an inner **"SELECT *"** `<button>`. A button can't contain a button — the browser reconstructs the DOM (`node_invalid_placement_ssr`), making the inner button's behavior unreliable. Both did the same thing (open `SELECT * FROM <name>`; the inner just `stopPropagation`'d).

Fix: converted the row to a `<div role="button" tabindex="0">` with `onclick` + `onkeydown` (Enter/Space) so the inner button is valid HTML **and** the row stays keyboard-accessible; added a `:focus-visible` ring to replace the native button one.

## Dead CSS (`css_unused_selector`)
Removed: SettingsDialog `.action-btn*` (orphaned by the #672 split) + the `input[type=password]` arms of two multi-selectors; SourcesPanel `.submenu-separator`; PropertiesPanel `.key-input` + `:focus`; ExportDialog `.radio-group input:disabled + *` and the `.reason` arm of an audit-row multi-selector. (Multi-selector rules: only the dead arm trimmed, used arms kept.)

**Boot warnings 66 → 55.**

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3090 passed. `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)