### PR TITLE
a11y: keyboard access for clickable rows — bookmarks, tabs, right-sidebar panels (#761)

### DIFF
--- a/src/renderer/lib/components/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/BookmarksPanel.svelte
@@ -147,11 +147,13 @@
 
 {#snippet bookmarkNode(node: BookmarkNode, depth: number)}
   {#if node.type === 'folder'}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="bm-item folder"
       style:padding-left="{8 + depth * 14}px"
+      role="button"
+      tabindex="0"
       onclick={() => toggleFolder(node.id)}
+      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleFolder(node.id); } }}
       oncontextmenu={(e) => showContextMenu(e, node)}
       ondragover={handleDragOver}
       ondrop={(e) => { e.stopPropagation(); handleDrop(e, node.id); }}
@@ -169,11 +171,13 @@
       {/each}
     {/if}
   {:else}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="bm-item bookmark"
       style:padding-left="{8 + depth * 14}px"
+      role="button"
+      tabindex="0"
       onclick={() => handleClick(node)}
+      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(node); } }}
       oncontextmenu={(e) => showContextMenu(e, node)}
       draggable={true}
       ondragstart={(e) => handleDragStart(e, node.id)}
@@ -249,6 +253,10 @@
   .bm-item:hover {
     background: color-mix(in oklch, var(--text) 4%, transparent);
     border-left-color: var(--accent);
+  }
+  .bm-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
   }
 
   /* Fixed-width chevron slot so folder/bookmark icons align in a column */

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -80,6 +80,7 @@
       class:active={i === activeIndex}
       class:dirty
       onclick={() => onSwitch(i)}
+      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSwitch(i); } }}
       onauxclick={(e) => handleMiddleClick(e, i)}
       oncontextmenu={(e) => handleContextMenu(e, i)}
       title={tab.type === 'note'

--- a/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
@@ -85,8 +85,13 @@
         {@const collapsed = !!collapsedGroups[type]}
         <div class="type-group">
           {#if type !== ''}
-            <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-            <div class="type-header" onclick={() => toggleGroup(type)}>
+            <div
+              class="type-header"
+              role="button"
+              tabindex="0"
+              onclick={() => toggleGroup(type)}
+              onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroup(type); } }}
+            >
               <Icon name={collapsed ? 'chevronRight' : 'chevronDown'} size={11} color="var(--text-faint)" />
               <span class="type-square" style:background={typeLinks[0].linkColor} aria-hidden="true"></span>
               <span class="type-label">{typeLinks[0].linkLabel}</span>
@@ -143,6 +148,10 @@
     align-items: center;
     gap: 8px;
     color: var(--text);
+  }
+  .type-header:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
   }
   .type-header:hover {
     background: color-mix(in oklch, var(--text) 4%, transparent);

--- a/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
@@ -88,8 +88,13 @@
         {@const collapsed = !!collapsedGroups[type]}
         <div class="type-group">
           {#if type !== ''}
-            <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-            <div class="type-header" onclick={() => toggleGroup(type)}>
+            <div
+              class="type-header"
+              role="button"
+              tabindex="0"
+              onclick={() => toggleGroup(type)}
+              onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroup(type); } }}
+            >
               <Icon name={collapsed ? 'chevronRight' : 'chevronDown'} size={11} color="var(--text-faint)" />
               <span class="type-square" style:background={typeLinks[0].linkColor} aria-hidden="true"></span>
               <span class="type-label">{typeLinks[0].linkLabel}</span>
@@ -151,6 +156,10 @@
     align-items: center;
     gap: 8px;
     color: var(--text);
+  }
+  .type-header:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
   }
   .type-header:hover {
     background: color-mix(in oklch, var(--text) 4%, transparent);

--- a/src/renderer/lib/components/right-sidebar/OutlinePanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutlinePanel.svelte
@@ -67,23 +67,28 @@
         {#each headings as heading, i}
           {#if isVisible(i)}
             <li>
-              <button
+              <!-- A div, not a button: it carries the inner collapse-toggle
+                   button, and a button can't contain a button. -->
+              <div
                 class="outline-item"
+                role="button"
+                tabindex="0"
                 style:padding-left="{(heading.level - 1) * 14 + 8}px"
                 onclick={() => onScrollToLine(heading.line)}
+                onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onScrollToLine(heading.line); } }}
               >
                 {#if hasChildren(i) && !search.trim()}
-                  <span
+                  <button
+                    type="button"
                     class="collapse-toggle"
                     onclick={(e) => { e.stopPropagation(); toggleCollapse(i); }}
-                    role="button"
-                    tabindex="-1"
-                  >{collapsed[i] ? '▸' : '▾'}</span>
+                    title={collapsed[i] ? 'Expand' : 'Collapse'}
+                  >{collapsed[i] ? '▸' : '▾'}</button>
                 {:else}
                   <span class="collapse-spacer"></span>
                 {/if}
                 <span class="heading-text">{heading.text}</span>
-              </button>
+              </div>
             </li>
           {/if}
         {/each}
@@ -125,12 +130,19 @@
     text-align: left;
     border-radius: 3px;
   }
+  .outline-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
 
   .outline-item:hover {
     background: var(--bg-button);
   }
 
   .collapse-toggle {
+    border: none;
+    background: none;
+    padding: 0;
     font-size: 10px;
     width: 12px;
     text-align: center;


### PR DESCRIPTION
Keyboard activation for clickable rows you couldn't reach by keyboard, on a keyboard-first tool. Part of the a11y sweep (#761). Mouse behavior unchanged throughout; pure keyboard parity. **Boot a11y warnings 55 → 49.**

## BookmarksPanel
Folder + bookmark rows were click-only `<div>`s (role warning suppressed). Now `role="button" tabindex="0"` + `onkeydown` mirroring the click (Enter/Space → toggle folder / open bookmark) + `:focus-visible` ring.

## TabBar
Tabs already had `role="tab" + tabindex="0"` but no keyboard handler — added `onkeydown` (Enter/Space → switch tab).

## OutgoingLinksPanel + BacklinksPanel
The collapsible type-group headers were click-only `<div>`s with a non-working `svelte-ignore`. Now `role="button" tabindex="0"` + `onkeydown` (toggle group) + focus ring; dead suppression removed.

## OutlinePanel
Same nested-interactive shape as the tables-row bug (#760): the `outline-item` `<button>` held an inner collapse-toggle `<span role="button">`. Made the row a `<div role="button">` with keyboard activation (Enter/Space → scroll to heading) and turned the toggle into a real `<button>` (valid in a div, keyboard-native).

## Deferred to follow-up slices of #761
The Settings section `<label>`s (need per-component CSS), and the static-element role warnings (Preview, SourceDetail, App drag overlays, ExcerptDensityGutter).

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3090 passed. `pnpm test:e2e` — 4 passed.