### PR TITLE
a11y: settings section headings are spans, not orphan labels (#761)

### DIFF
--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -90,7 +90,7 @@
   {/if}
 </div>
 <div class="field">
-  <label>Tool model overrides</label>
+  <span class="field-label">Tool model overrides</span>
   <p class="hint">
     Each tool's author may suggest a preferred model. You can override that
     per tool. Empty override → use the tool's preference; no preference →

--- a/src/renderer/lib/components/BibliographySettings.svelte
+++ b/src/renderer/lib/components/BibliographySettings.svelte
@@ -113,7 +113,7 @@
 </div>
 
 <div class="field">
-  <label>Imported styles</label>
+  <span class="field-label">Imported styles</span>
   <p class="hint">
     Drop additional <code>.csl</code> files into your project under
     <code>.minerva/csl-styles/</code> — they show up in the picker above and
@@ -145,7 +145,7 @@
 </div>
 
 <div class="field">
-  <label>Imported locales</label>
+  <span class="field-label">Imported locales</span>
   <p class="hint">
     Optional. Bundled locale is en-US; import additional CSL
     locale XML to render bibliographies in another language.

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -178,7 +178,7 @@
     </h2>
 
     <div class="option-row">
-      <label>Scope</label>
+      <span class="field-label">Scope</span>
       <div class="radio-group">
         {#if canScopeProject}
           <label>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -465,7 +465,7 @@
             </p>
           </div>
           <div class="field">
-            <label>Don't-ask-again confirmations</label>
+            <span class="field-label">Don't-ask-again confirmations</span>
             <p class="hint">
               Dialogs you've muted via "Don't ask again." Re-enable a row to see its
               prompt next time the action occurs.

--- a/src/renderer/lib/components/SkillsSettings.svelte
+++ b/src/renderer/lib/components/SkillsSettings.svelte
@@ -151,7 +151,7 @@
 </script>
 
 <div class="field">
-  <label>Skills</label>
+  <span class="field-label">Skills</span>
   <p class="hint">
     Skills are markdown files that drive the Learning, Research, and
     Analysis menus. Built-in skills ship with Minerva; your own live in
@@ -178,7 +178,7 @@
 
 {#if skillCatalog.errors.length > 0}
   <div class="field">
-    <label>Skills that failed to load</label>
+    <span class="field-label">Skills that failed to load</span>
     <ul class="skill-errs">
       {#each skillCatalog.errors as err (err.filePath + err.message)}
         <li><span class="skill-err-label">{err.label}</span> — {err.message}</li>
@@ -196,7 +196,7 @@
 {#each SKILL_MENU_ORDER as menu (menu)}
   {@const items = skillsForMenu(menu)}
   <div class="field">
-    <label>{menu}</label>
+    <span class="field-label">{menu}</span>
     {#if items.length === 0}
       <p class="hint empty">No skills in this menu.</p>
     {:else}
@@ -260,7 +260,7 @@
     color: var(--text);
     font-size: 12px;
   }
-  .field label { color: var(--text); }
+  .field-label { color: var(--text); }
   .field select {
     padding: 5px 8px;
     background: var(--bg);


### PR DESCRIPTION
Part of the a11y sweep (#761). Companion to the keyboard-rows PR (#762) — disjoint file set.

## Problem
Several Settings / Export sub-panels used `<label>` for a **section heading** — "Tool model overrides", "Skills", "Imported styles", "Imported locales", "Don't-ask-again confirmations", "Scope", and per-menu group titles. A `<label>` with no associated control is meaningless to a screen reader (`a11y_label_has_associated_control`).

## Fix
These don't label a single control — they title a group/description. Changed them to `<span class="field-label">`. **Visually identical**: `.field` is a column flex and the headings carried no distinct styling (just inherited color), so the span renders the same. The genuine control-`<label>`s in those panels are untouched.

SkillsSettings had all three of its `<label>`s converted, which orphaned its `.field label { color }` rule — retargeted to `.field-label` so it stays used.

**Boot a11y warnings 49 → 41.**

Files: AiSettings, SkillsSettings (×3), BibliographySettings (×2), SettingsDialog, ExportDialog.

## Note for later
The "Scope" heading labels a radio-group; a fuller fix would add `role="radiogroup" aria-labelledby` for programmatic grouping. Left minimal here (warning cleared, visual intact) — noted on #761.

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3090 passed. `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)