### PR TITLE
a11y: make the static-element svelte-ignore suppressions actually work (#761)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1054,6 +1054,7 @@
           canPaste={clipboard.current !== null}
         />
       {/if}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="editor-pane"
         ondragover={(e) => {

--- a/src/renderer/lib/components/ExcerptDensityGutter.svelte
+++ b/src/renderer/lib/components/ExcerptDensityGutter.svelte
@@ -97,7 +97,8 @@
 {#if ticks.length > 0}
   <div class="excerpt-density-gutter" aria-hidden="true">
     {#each ticks as t (t.excerptId)}
-      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="tick"
         style:top="{t.topPct * 100}%"

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -170,7 +170,8 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="export-dialog-backdrop" onclick={handleBackdropClick}>
   <div class="export-dialog" role="dialog" aria-labelledby="export-dialog-title">
     <h2 id="export-dialog-title">
@@ -296,7 +297,8 @@
             <p class="hint">Click any excluded row to re-include it in this export.</p>
             <ul>
               {#each plan.excluded.slice(0, 40) as ex (ex.relativePath)}
-                <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions -->
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                 <li
                   class="clickable"
                   onclick={() => (

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1335,7 +1335,9 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_mouse_events_have_key_events -->
 <div
   class="preview"
   bind:this={previewEl}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -510,7 +510,8 @@
             <button class="clear-btn" onclick={() => selectionStore.clear()}>clear</button>
           </div>
         {/if}
-        <!-- svelte-ignore a11y_no_static_element_interactions a11y_no_noninteractive_tabindex -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
         <div
           class="file-list"
           class:root-drop-hover={rootDropHover}
@@ -576,6 +577,7 @@
           {/if}
         </div>
       {:else}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div class="empty" oncontextmenu={handleContextMenu}>
           <p>No notes yet</p>
         </div>

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -526,7 +526,8 @@
     {/if}
 
     {#if excerptMenu}
-      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="excerpt-menu"
         style:left="{excerptMenu.x}px"
@@ -601,7 +602,8 @@
       {:else}
         <ul class="about-list">
           {#each detail.aboutNotes as note (note.relativePath)}
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
             <li onclick={() => onNavigate(note.relativePath)}>
               <span class="about-title">{note.title}</span>
               <span class="about-path mono">{note.relativePath}</span>
@@ -616,7 +618,8 @@
         <h2>References ({detail.references.length})</h2>
         <ul class="about-list">
           {#each detail.references as ref (ref.sourceId)}
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
             <li onclick={() => onOpenReference?.(ref.sourceId)} class:stub-row={ref.stubStatus === 'unresolved'}>
               <span class="about-title">{ref.title}</span>
               {#if ref.stubStatus === 'unresolved'}
@@ -635,7 +638,8 @@
       {:else}
         <ul class="backlink-list">
           {#each detail.backlinks as b}
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
             <li onclick={() => onNavigate(b.relativePath)}>
               <span class="backlink-title">{b.title}</span>
               <span class="backlink-meta">

--- a/src/renderer/lib/components/ui/Dialog.svelte
+++ b/src/renderer/lib/components/ui/Dialog.svelte
@@ -53,7 +53,8 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="backdrop"
   style:--scrim={scrim}


### PR DESCRIPTION
Final slice of the a11y sweep (#761).

## Root cause
The entire static-element warning bucket traces to one bug: **Svelte 5 honors only the *first* code in a `<!-- svelte-ignore A B -->` comment.** Every two-code suppression in the codebase was silently half-broken — the second warning leaked to the boot log. The flagged elements were already *deliberately* suppressed by the author (backdrops, resize/drop zones, context-menu containers, the `aria-hidden` density gutter, navigating list items); the comments just weren't taking effect.

## Fix — comment-only, zero behavior/markup change
- **Split** each two-code ignore into one-code-per-comment: ui/Dialog + ExportDialog backdrops, Preview, SourceDetail excerpt-menu, ExcerptDensityGutter, Sidebar file-list.
- **Preview** also emitted `mouseover`/`mouseout` warnings → added `a11y_mouse_events_have_key_events` (hover-preview is a pointer enhancement; the click handler is the real action).
- **Wrong code corrected:** the navigating `<li>`s (SourceDetail about/refs/backlinks, ExportDialog) were suppressed with `a11y_no_static_element_interactions` — but that applies to *non-semantic* elements; a semantic `<li>` needs `a11y_no_noninteractive_element_interactions`. So the real warning had always leaked. Fixed.
- **Added** ignores for two genuinely un-suppressed pointer-only elements: the editor-pane external-file drop zone (App) and the empty-notes contextmenu target (Sidebar).
- **Left alone:** three non-leaking multi-code ignores (resize handles, FindInNotesDialog) — their inert second code fires no warning, and splitting would risk an unused-directive.

## Result
Every **actionable** a11y warning is resolved. Boot warnings **41 → 27**; the remaining 27 are all the intentional `state_referenced_locally` dialog-snapshot idiom (CLAUDE.md: non-fatal, "fixing" them would regress behavior). **Net across the sweep: 66 → 27.**

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3090 passed. `pnpm test:e2e` — 4 passed.

Closes the static-element bucket of #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)