### PR TITLE
Rename a source (#765)

### DIFF
--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -12,6 +12,7 @@ import { ingestFile } from '../sources/ingest-file';
 import { deleteSource } from '../sources/delete-source';
 import { mergeSources, MergeSourcesError } from '../sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from '../sources/read-status';
+import { setSourceTitle } from '../sources/source-meta-write';
 import { stripUpstreamTags } from '../sources/strip-upstream-tags';
 import { getIngestSettings, saveIngestSettings, type IngestSettings } from '../sources/ingest-settings';
 import { ingestSmart } from '../sources/ingest-smart';
@@ -257,6 +258,15 @@ export function registerSources(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     await setSourceReadStatus(rootPath, params.sourceId, params.status);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
+  ipcMain.handle(Channels.SOURCES_SET_TITLE, async (e, params: { sourceId: string; title: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await setSourceTitle(rootPath, params.sourceId, params.title);
     await persistIndexes(rootPath);
     const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);

--- a/src/main/sources/source-meta-write.ts
+++ b/src/main/sources/source-meta-write.ts
@@ -154,3 +154,23 @@ export async function setSourceProperties(
   }
   return changed;
 }
+
+/**
+ * Rename a source by upserting its `dc:title` (#765). A source's display name
+ * is its `dc:title`; `displaySourceTitle` falls back to URI/DOI/"Untitled" only
+ * when it's absent, so renaming is just a single-predicate upsert + reindex —
+ * the same direct-write path as read-status (a user action, not an LLM
+ * proposal, so it does not go through the approval engine). Empty/whitespace
+ * titles are rejected so a rename can't blank the name into the fallback.
+ */
+export async function setSourceTitle(
+  rootPath: string,
+  sourceId: string,
+  title: string,
+): Promise<void> {
+  const trimmed = title.trim();
+  if (!trimmed) throw new Error('Source title cannot be empty.');
+  await setSourceProperties(rootPath, sourceId, [
+    { predicate: 'dc:title', value: ttlString(trimmed) },
+  ]);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -282,6 +282,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SOURCES_MERGE, { srcId, destId }),
     setReadStatus: (sourceId: string, status: 'unread' | 'reading' | 'read' | 'skipped' | null) =>
       ipcRenderer.invoke(Channels.SOURCES_SET_READ_STATUS, { sourceId, status }),
+    setTitle: (sourceId: string, title: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_SET_TITLE, { sourceId, title }),
     setReadDueBy: (sourceId: string, dueBy: string | null) =>
       ipcRenderer.invoke(Channels.SOURCES_SET_READ_DUE_BY, { sourceId, dueBy }),
     queueMembers: (view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished') =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1252,6 +1252,7 @@
               highlightExcerptId={editor.activeTab.highlightExcerptId}
               onNavigate={handleNavigate}
               onShowConfirm={showConfirm}
+              onShowPrompt={showPrompt}
               onDeleted={handleSourceDeleted}
               onCreateAboutNote={handleNewAboutSourceNote}
               onOpenReference={handleOpenSource}

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -23,6 +23,8 @@
     highlightExcerptId?: string;
     onNavigate: (target: string) => void;
     onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
+    /** Prompt for text (rename). Host supplies App.svelte's showPrompt. */
+    onShowPrompt: (message: string, initial?: string) => Promise<string | null>;
     onDeleted?: (sourceId: string) => void;
     /** Create a Zotero-style child note pre-populated with
      *  `about: [[sources/<id>]]`, open it for editing, and refresh
@@ -64,7 +66,7 @@
   }
 
   let {
-    sourceId, highlightExcerptId, onNavigate, onShowConfirm, onDeleted,
+    sourceId, highlightExcerptId, onNavigate, onShowConfirm, onShowPrompt, onDeleted,
     onCreateAboutNote, onOpenReference, onResolveStub, onOpenPdf,
     onCreateNoteFromExcerpt, onAppendExcerptToCurrent, canAppendToCurrent = false,
     onInvokeTool,
@@ -110,6 +112,19 @@
   $effect(() => {
     void api.sources.hasPdf(sourceId).then((r) => { hasPdf = r; });
   });
+
+  async function handleRename() {
+    if (!detail) return;
+    const current = displaySourceTitle(detail.metadata);
+    const name = await onShowPrompt('Rename source:', current);
+    if (!name || name.trim() === current) return;
+    try {
+      await api.sources.setTitle(sourceId, name.trim());
+      await load(sourceId);
+    } catch (err) {
+      console.error('[minerva] Rename source failed:', err);
+    }
+  }
 
   async function handleDelete() {
     if (!detail) return;
@@ -458,6 +473,7 @@
         {#if hasPdf && onOpenPdf}
           <button class="action-btn" onclick={() => onOpenPdf(sourceId)}>Open original PDF</button>
         {/if}
+        <button class="action-btn" onclick={handleRename}>Rename source</button>
         <button class="action-btn" onclick={handleDelete}>Delete source</button>
       </div>
     </section>

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -211,6 +211,19 @@
     await refresh();
   }
 
+  async function handleRenameSource(source: SourceMetadata): Promise<void> {
+    contextMenu = null;
+    const current = displaySourceTitle(source);
+    const name = await onShowPrompt('Rename source:', current);
+    if (!name || name.trim() === current) return;
+    try {
+      await api.sources.setTitle(source.sourceId, name.trim());
+      // setTitle broadcasts SOURCES_CHANGED → host refreshes the sidebar.
+    } catch (err) {
+      console.error('[minerva] Rename source failed:', err);
+    }
+  }
+
   function handleMergeStart(source: SourceMetadata) {
     contextMenu = null;
     mergeSrc = source;
@@ -749,6 +762,8 @@
       style:left="{contextMenu.x}px"
       style:top="{contextMenu.y}px"
     >
+      <button onclick={() => handleRenameSource(contextMenu!.source)}>Rename…</button>
+      <div class="context-divider"></div>
       <button onclick={() => handleAddToCollection(contextMenu!.source)}>Add to collection…</button>
       {#if activeCollectionId && !activeIsSmart}
         <button onclick={() => handleRemoveFromActiveCollection(contextMenu!.source)}>Remove from collection</button>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -753,6 +753,8 @@ export interface SourcesApi {
   }>;
   /** Set / change / clear a source's reading-queue status (#116). */
   setReadStatus(sourceId: string, status: import('../../../shared/types').ReadStatus | null): Promise<void>;
+  /** Rename a source (upsert dc:title) (#765). */
+  setTitle(sourceId: string, title: string): Promise<void>;
   /** Set / change / clear a source's due-by date (ISO YYYY-MM-DD). */
   setReadDueBy(sourceId: string, dueBy: string | null): Promise<void>;
   /** Resolve a built-in Reading Queue view against the live graph. */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -277,6 +277,8 @@ export const Channels = {
   SOURCES_MERGE: 'sources:merge',
   /** Set/clear a source's reading-queue status (#116). */
   SOURCES_SET_READ_STATUS: 'sources:setReadStatus',
+  /** Rename a source (upsert dc:title) (#765). */
+  SOURCES_SET_TITLE: 'sources:setTitle',
   /** Set/clear a source's due-by date (#116). */
   SOURCES_SET_READ_DUE_BY: 'sources:setReadDueBy',
   /** Resolve a built-in Reading Queue view (unread / reading /

--- a/tests/main/sources/source-meta-write.test.ts
+++ b/tests/main/sources/source-meta-write.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   upsertSingleValuedPredicate,
   ttlString,
+  setSourceTitle,
 } from '../../../src/main/sources/source-meta-write';
 
 const META = `this: a thought:Article ;
@@ -49,6 +50,26 @@ describe('source summary predicates', () => {
     expect(ttl.trimEnd().endsWith('.')).toBe(true);
     expect(ttl).toContain('dc:abstract "A." ;');
     expect(ttl).toContain('thought:tldr "T." ;');
+  });
+});
+
+describe('setSourceTitle (rename, #765)', () => {
+  it('replaces dc:title in place — no duplicate line, old title gone', () => {
+    const out = upsertSingleValuedPredicate(META, 'dc:title', ttlString('Renamed paper'));
+    expect(out).toContain('dc:title "Renamed paper" ;');
+    expect(out).not.toContain('"Test paper"');
+    expect((out.match(/dc:title/g) ?? []).length).toBe(1);
+  });
+
+  it('inserts dc:title when a source has none yet', () => {
+    const noTitle = `this: a thought:Article ;\n    dc:creator "Alice" .\n`;
+    const out = upsertSingleValuedPredicate(noTitle, 'dc:title', ttlString('Fresh'));
+    expect(out).toContain('dc:title "Fresh" ;');
+    expect(out.trimEnd().endsWith('.')).toBe(true);
+  });
+
+  it('rejects an empty/whitespace title before touching disk', async () => {
+    await expect(setSourceTitle('/nonexistent/root', 'src-x', '   ')).rejects.toThrow(/cannot be empty/);
   });
 });
 

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -289,6 +289,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "setIngestSettings",
     "setReadDueBy",
     "setReadStatus",
+    "setTitle",
     "stripUpstreamTags",
   ],
   "tables": [


### PR DESCRIPTION
## Yes — the model supports it

A source's display name is its `dc:title` in `meta.ttl` (`displaySourceTitle` only falls back to URI / DOI / "Untitled" when it's absent). The write path also already existed — `source-meta-write.ts`'s line-oriented single-predicate upsert + reindex, the same one read-status uses. The only thing missing was an affordance to set the title after ingest. Added one.

## Backend
- `setSourceTitle(rootPath, sourceId, title)` upserts `dc:title` via `setSourceProperties`; rejects empty/whitespace so a rename can't blank the name into the fallback.
- `SOURCES_SET_TITLE` wired through `register-sources` (persist + broadcast `SOURCES_CHANGED`, mirroring `setReadStatus`), preload, and the client API.
- This is a **direct user write, not an LLM proposal**, so it bypasses the approval engine — same precedent as read-status.

## Affordances (the two obvious spots)
- **Sources sidebar** → right-click → **"Rename…"** (mirrors the existing collection rename). The `SOURCES_CHANGED` broadcast refreshes the list automatically.
- **Source detail view** → **"Rename source"** button beside "Delete source"; reloads the detail so the heading updates.

Both prompt with the current display title pre-filled and no-op on empty/unchanged.

## Tests
- `dc:title` upsert replaces in place (no dup, old title gone) / inserts when a source has none.
- `setSourceTitle` rejects an empty title before touching disk.
- Updated the preload contract snapshot for the new `setTitle` method.

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3093 passed. `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)