### PR TITLE
Add / remove tags on sources (#766)

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -924,6 +924,19 @@ export function indexSource(ctx: ProjectContext, sourceId: string, metaTtl: stri
     store.add(subject, MINERVA('hasTag'), tagNode, graph);
   }
 
+  // User-added tags (#766). Each `minerva:tag "..."` literal becomes a
+  // hasTag edge too, so a tag added via the source's add/remove affordance
+  // looks identical to an upstream or body tag in the tag panel + smart
+  // collections. Distinct predicate from upstreamTag so "Strip upstream
+  // tags" leaves the user's own tags alone.
+  for (const st of store.statementsMatching(subject, MINERVA('tag'), undefined, graph)) {
+    const name = st.object.value;
+    if (!name) continue;
+    const tagNode = tagUri(state, name);
+    ensureTag(state, tagNode, name);
+    store.add(subject, MINERVA('hasTag'), tagNode, graph);
+  }
+
   if (bodyMd) indexSourceBody(state, sourceId, bodyMd, subject, graph);
 }
 

--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -819,6 +819,18 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
   const readStatus = rawReadStatus && READ_STATUS_VALUES.has(rawReadStatus as ReadStatus)
     ? rawReadStatus as ReadStatus
     : null;
+
+  // Tag names: resolve each hasTag edge to its tagName literal (falling back
+  // to the URI tail). Deduped + sorted for a stable display order.
+  const tags: string[] = [];
+  for (const st of store.statementsMatching(subject, MINERVA('hasTag'), undefined)) {
+    const tagNode = st.object as $rdf.NamedNode;
+    const nameStmts = store.statementsMatching(tagNode, MINERVA('tagName'), undefined);
+    const name = nameStmts[0]?.object.value ?? tagNode.value;
+    if (name && !tags.includes(name)) tags.push(name);
+  }
+  tags.sort((a, b) => a.localeCompare(b));
+
   return {
     sourceId,
     subtype,
@@ -832,6 +844,7 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
     readStatus,
     readDueBy: first(MINERVA('readDueBy')),
     stubStatus: first(THOUGHT('stubStatus')),
+    tags,
   };
 }
 

--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -12,7 +12,7 @@ import { ingestFile } from '../sources/ingest-file';
 import { deleteSource } from '../sources/delete-source';
 import { mergeSources, MergeSourcesError } from '../sources/merge-sources';
 import { setSourceReadStatus, setSourceReadDueBy } from '../sources/read-status';
-import { setSourceTitle } from '../sources/source-meta-write';
+import { setSourceTitle, addSourceTag, removeSourceTag } from '../sources/source-meta-write';
 import { stripUpstreamTags } from '../sources/strip-upstream-tags';
 import { getIngestSettings, saveIngestSettings, type IngestSettings } from '../sources/ingest-settings';
 import { ingestSmart } from '../sources/ingest-smart';
@@ -267,6 +267,24 @@ export function registerSources(): void {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     await setSourceTitle(rootPath, params.sourceId, params.title);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
+  ipcMain.handle(Channels.SOURCES_ADD_TAG, async (e, params: { sourceId: string; tag: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await addSourceTag(rootPath, params.sourceId, params.tag);
+    await persistIndexes(rootPath);
+    const win = winFromEvent(e);
+    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+  });
+
+  ipcMain.handle(Channels.SOURCES_REMOVE_TAG, async (e, params: { sourceId: string; tag: string }) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    await removeSourceTag(rootPath, params.sourceId, params.tag);
     await persistIndexes(rootPath);
     const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);

--- a/src/main/sources/source-meta-write.ts
+++ b/src/main/sources/source-meta-write.ts
@@ -121,6 +121,76 @@ export function ttlString(s: string): string {
   return `"${escaped}"`;
 }
 
+/**
+ * Add a user tag to a source (#766): insert a `minerva:tag "tag"` line unless
+ * the source already carries that tag as a user (`minerva:tag`) or upstream
+ * (`minerva:upstreamTag`) literal. Returns true if a line was added. The
+ * indexer maps `minerva:tag` → `minerva:hasTag`, so the new tag immediately
+ * joins the tag tree + smart collections. (A user write, not an LLM proposal —
+ * no approval engine, same as read-status / rename.)
+ */
+export async function addSourceTag(
+  rootPath: string,
+  sourceId: string,
+  tag: string,
+): Promise<boolean> {
+  const t = tag.trim();
+  if (!t) throw new Error('Tag cannot be empty.');
+  const metaPath = sourceMetaPath(rootPath, sourceId);
+  const { ttl, added } = addTagLine(await readMeta(metaPath), t);
+  if (!added) return false;
+  await fs.writeFile(metaPath, ttl, 'utf-8');
+  await reindexSource(rootPath, sourceId);
+  return true;
+}
+
+/**
+ * Pure: insert a `minerva:tag "tag"` line unless the source already carries
+ * that tag as a user (`minerva:tag`) or upstream (`minerva:upstreamTag`)
+ * literal. Exposed for tests.
+ */
+export function addTagLine(ttl: string, tag: string): { ttl: string; added: boolean } {
+  const litEsc = ttlString(tag).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (new RegExp(`^[ \\t]*minerva:(tag|upstreamTag)\\s+${litEsc}\\s*;`, 'm').test(ttl)) {
+    return { ttl, added: false };
+  }
+  return { ttl: insertBeforeFinalDot(ttl, `    minerva:tag ${ttlString(tag)} ;`), added: true };
+}
+
+/**
+ * Remove a tag from a source (#766): drop any `minerva:tag "tag"` and
+ * `minerva:upstreamTag "tag"` line. Body-hashtag-derived tags are NOT removable
+ * here (they live in body.md and re-derive on index) — callers should surface
+ * that the tag must be removed from the source body. Returns true if a line was
+ * removed.
+ */
+export async function removeSourceTag(
+  rootPath: string,
+  sourceId: string,
+  tag: string,
+): Promise<boolean> {
+  const t = tag.trim();
+  if (!t) return false;
+  const metaPath = sourceMetaPath(rootPath, sourceId);
+  const { ttl, removed } = removeTagLines(await readMeta(metaPath), t);
+  if (!removed) return false;
+  await fs.writeFile(metaPath, ttl, 'utf-8');
+  await reindexSource(rootPath, sourceId);
+  return true;
+}
+
+/**
+ * Pure: drop every `minerva:tag "tag"` / `minerva:upstreamTag "tag"` line.
+ * Body-hashtag-derived tags re-derive on index and are not removable here.
+ * Exposed for tests.
+ */
+export function removeTagLines(ttl: string, tag: string): { ttl: string; removed: boolean } {
+  const litEsc = ttlString(tag).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`^[ \\t]*minerva:(tag|upstreamTag)\\s+${litEsc}\\s*;?[ \\t]*\\n?`, 'gm');
+  if (!re.test(ttl)) return { ttl, removed: false };
+  return { ttl: normaliseTrailingSeparator(ttl.replace(re, '')), removed: true };
+}
+
 /** One predicate to upsert. `value` is the raw TTL object (already a quoted
  *  literal / typed literal), or `null` to delete the predicate. */
 export interface SourceMetaUpdate {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -286,6 +286,10 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.SOURCES_SET_TITLE, { sourceId, title }),
     setReadDueBy: (sourceId: string, dueBy: string | null) =>
       ipcRenderer.invoke(Channels.SOURCES_SET_READ_DUE_BY, { sourceId, dueBy }),
+    addTag: (sourceId: string, tag: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_ADD_TAG, { sourceId, tag }),
+    removeTag: (sourceId: string, tag: string) =>
+      ipcRenderer.invoke(Channels.SOURCES_REMOVE_TAG, { sourceId, tag }),
     queueMembers: (view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished') =>
       ipcRenderer.invoke(Channels.SOURCES_QUEUE_MEMBERS, view),
     stripUpstreamTags: (sourceId: string) =>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -63,7 +63,7 @@
     onSourceSelect?: (sourceId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
-    onShowPrompt?: (message: string, initial?: string) => Promise<string | null>;
+    onShowPrompt?: (message: string, initialOrOptions?: string | { suggestions?: string[]; initial?: string }) => Promise<string | null>;
     onMineReferences?: (source: import('../../../shared/types').SourceMetadata) => Promise<void>;
     onTableClick?: (tableName: string) => void;
     onOpenCsv?: (relativePath: string) => void;

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -146,9 +146,24 @@
   /** Focus the inline tag input the moment it mounts. */
   function autofocus(node: HTMLInputElement) { node.focus(); }
 
+  /** Project tag vocabulary for the inline add-tag autocomplete, minus tags
+   *  this source already carries. Loaded fresh each time the input opens. */
+  let tagVocab = $state<string[]>([]);
+  const tagListId = 'source-tag-suggestions';
+
   function startAddTag() {
     newTagText = '';
     addingTag = true;
+    void loadTagVocab();
+  }
+
+  async function loadTagVocab() {
+    try {
+      const have = new Set(detail?.metadata.tags ?? []);
+      tagVocab = (await api.tags.list()).map((t) => t.tag).filter((t) => !have.has(t));
+    } catch {
+      tagVocab = [];
+    }
   }
 
   async function commitAddTag() {
@@ -451,12 +466,18 @@
         {#if addingTag}
           <input
             class="tag-input"
+            list={tagListId}
             bind:value={newTagText}
             use:autofocus
             onkeydown={tagInputKeydown}
             onblur={() => { addingTag = false; newTagText = ''; }}
             placeholder="tag…"
           />
+          <datalist id={tagListId}>
+            {#each tagVocab as t (t)}
+              <option value={t}></option>
+            {/each}
+          </datalist>
         {:else}
           <button class="add-tag-btn" onclick={startAddTag}>+ tag</button>
         {/if}

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -139,6 +139,45 @@
     onDeleted?.(sourceId);
   }
 
+  // ── Tags (#766) ──────────────────────────────────────────────────────────
+  let addingTag = $state(false);
+  let newTagText = $state('');
+
+  /** Focus the inline tag input the moment it mounts. */
+  function autofocus(node: HTMLInputElement) { node.focus(); }
+
+  function startAddTag() {
+    newTagText = '';
+    addingTag = true;
+  }
+
+  async function commitAddTag() {
+    const t = newTagText.trim();
+    addingTag = false;
+    newTagText = '';
+    if (!t) return;
+    try {
+      await api.sources.addTag(sourceId, t);
+      await load(sourceId);
+    } catch (err) {
+      console.error('[minerva] add source tag failed:', err);
+    }
+  }
+
+  function tagInputKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') { e.preventDefault(); void commitAddTag(); }
+    else if (e.key === 'Escape') { addingTag = false; newTagText = ''; }
+  }
+
+  async function handleRemoveTag(tag: string) {
+    try {
+      await api.sources.removeTag(sourceId, tag);
+      await load(sourceId);
+    } catch (err) {
+      console.error('[minerva] remove source tag failed:', err);
+    }
+  }
+
   let detail = $state<SourceDetail | null>(null);
   let loading = $state(true);
   let loadedId = $state<string | null>(null);
@@ -402,6 +441,26 @@
       {#if detail.metadata.creators.length || detail.metadata.year}
         <div class="byline">{formatByline(detail.metadata.creators, detail.metadata.year)}</div>
       {/if}
+      <div class="source-tags">
+        {#each detail.metadata.tags as tag (tag)}
+          <span class="tag-chip">
+            #{tag}
+            <button class="tag-remove" title="Remove tag" onclick={() => handleRemoveTag(tag)}>×</button>
+          </span>
+        {/each}
+        {#if addingTag}
+          <input
+            class="tag-input"
+            bind:value={newTagText}
+            use:autofocus
+            onkeydown={tagInputKeydown}
+            onblur={() => { addingTag = false; newTagText = ''; }}
+            placeholder="tag…"
+          />
+        {:else}
+          <button class="add-tag-btn" onclick={startAddTag}>+ tag</button>
+        {/if}
+      </div>
       {#if detail.metadata.stubStatus === 'unresolved' && onResolveStub}
         <button
           class="resolve-stub-btn"
@@ -780,6 +839,56 @@
     color: var(--text-muted);
     font-size: 14px;
   }
+
+  /* Tag editor (#766) */
+  .source-tags {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+  }
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 1px 4px 1px 7px;
+    border-radius: 10px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-size: 12px;
+  }
+  .tag-remove {
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
+    padding: 0 2px;
+  }
+  .tag-remove:hover { color: var(--text); }
+  .add-tag-btn {
+    border: 1px dashed var(--border);
+    background: none;
+    color: var(--text-muted);
+    border-radius: 10px;
+    font-size: 12px;
+    padding: 1px 8px;
+    cursor: pointer;
+  }
+  .add-tag-btn:hover { color: var(--text); border-color: var(--text-muted); }
+  .tag-input {
+    border: 1px solid var(--accent);
+    background: var(--bg);
+    color: var(--text);
+    border-radius: 10px;
+    font-size: 12px;
+    padding: 1px 8px;
+    width: 100px;
+    font-family: inherit;
+  }
+  .tag-input:focus { outline: none; }
 
   section {
     margin-bottom: 12px;

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -35,7 +35,7 @@
     onSourceSelect: (sourceId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm: (message: string, key: string, label?: string) => Promise<boolean>;
-    onShowPrompt: (message: string, initial?: string) => Promise<string | null>;
+    onShowPrompt: (message: string, initialOrOptions?: string | { suggestions?: string[]; initial?: string }) => Promise<string | null>;
     /** Open a freshly-ingested source in a tab. Wired by the host so
      *  the "+" button's smart-paste path lands the user on the new
      *  source without an extra click. (#473) */
@@ -226,7 +226,14 @@
 
   async function handleAddTag(source: SourceMetadata): Promise<void> {
     contextMenu = null;
-    const tag = await onShowPrompt('Add tag to source:');
+    // Offer the project tag vocabulary (minus what this source already has) as
+    // autocomplete, so tags get reused rather than re-spelled.
+    let suggestions: string[] = [];
+    try {
+      const have = new Set(source.tags);
+      suggestions = (await api.tags.list()).map((t) => t.tag).filter((t) => !have.has(t));
+    } catch { /* fall back to a plain prompt */ }
+    const tag = await onShowPrompt('Add tag to source:', { suggestions });
     if (!tag || !tag.trim()) return;
     try {
       await api.sources.addTag(source.sourceId, tag.trim());

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -224,6 +224,18 @@
     }
   }
 
+  async function handleAddTag(source: SourceMetadata): Promise<void> {
+    contextMenu = null;
+    const tag = await onShowPrompt('Add tag to source:');
+    if (!tag || !tag.trim()) return;
+    try {
+      await api.sources.addTag(source.sourceId, tag.trim());
+      // addTag broadcasts SOURCES_CHANGED → host refreshes the sidebar.
+    } catch (err) {
+      console.error('[minerva] Add source tag failed:', err);
+    }
+  }
+
   function handleMergeStart(source: SourceMetadata) {
     contextMenu = null;
     mergeSrc = source;
@@ -763,6 +775,7 @@
       style:top="{contextMenu.y}px"
     >
       <button onclick={() => handleRenameSource(contextMenu!.source)}>Rename…</button>
+      <button onclick={() => handleAddTag(contextMenu!.source)}>Add tag…</button>
       <div class="context-divider"></div>
       <button onclick={() => handleAddToCollection(contextMenu!.source)}>Add to collection…</button>
       {#if activeCollectionId && !activeIsSmart}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -757,6 +757,10 @@ export interface SourcesApi {
   setTitle(sourceId: string, title: string): Promise<void>;
   /** Set / change / clear a source's due-by date (ISO YYYY-MM-DD). */
   setReadDueBy(sourceId: string, dueBy: string | null): Promise<void>;
+  /** Add a user tag to a source (#766). */
+  addTag(sourceId: string, tag: string): Promise<void>;
+  /** Remove a tag from a source (#766). */
+  removeTag(sourceId: string, tag: string): Promise<void>;
   /** Resolve a built-in Reading Queue view against the live graph. */
   queueMembers(view: 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished'):
     Promise<import('../../../shared/types').SourceMetadata[]>;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -281,6 +281,10 @@ export const Channels = {
   SOURCES_SET_TITLE: 'sources:setTitle',
   /** Set/clear a source's due-by date (#116). */
   SOURCES_SET_READ_DUE_BY: 'sources:setReadDueBy',
+  /** Add a user tag to a source (#766). */
+  SOURCES_ADD_TAG: 'sources:addTag',
+  /** Remove a tag from a source (#766). */
+  SOURCES_REMOVE_TAG: 'sources:removeTag',
   /** Resolve a built-in Reading Queue view (unread / reading /
    *  dueThisWeek / recentlyFinished) against the live graph (#116). */
   SOURCES_QUEUE_MEMBERS: 'sources:queueMembers',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,6 +131,10 @@ export interface SourceMetadata {
    *  created by reference-mining (#106) — partial metadata, no body,
    *  resolvable later via #107. `null` for fully-ingested sources. */
   stubStatus: string | null;
+  /** Tag names attached to this source — the union of its `minerva:hasTag`
+   *  edges (user `minerva:tag`, upstream subject tags, body hashtags),
+   *  sorted. Editable via add/remove (#766). */
+  tags: string[];
 }
 
 export interface SourceExcerpt {

--- a/tests/main/sources/source-meta-write.test.ts
+++ b/tests/main/sources/source-meta-write.test.ts
@@ -8,6 +8,9 @@ import {
   upsertSingleValuedPredicate,
   ttlString,
   setSourceTitle,
+  addTagLine,
+  removeTagLines,
+  addSourceTag,
 } from '../../../src/main/sources/source-meta-write';
 
 const META = `this: a thought:Article ;
@@ -70,6 +73,47 @@ describe('setSourceTitle (rename, #765)', () => {
 
   it('rejects an empty/whitespace title before touching disk', async () => {
     await expect(setSourceTitle('/nonexistent/root', 'src-x', '   ')).rejects.toThrow(/cannot be empty/);
+  });
+});
+
+describe('source tags (#766)', () => {
+  it('adds a minerva:tag line before the closing dot', () => {
+    const { ttl, added } = addTagLine(META, 'methods');
+    expect(added).toBe(true);
+    expect(ttl).toContain('minerva:tag "methods" ;');
+    expect(ttl.indexOf('minerva:tag')).toBeLessThan(ttl.indexOf('thought:accessedAt'));
+    expect(ttl.trimEnd().endsWith('.')).toBe(true);
+  });
+
+  it('does not duplicate a tag already present as a user OR upstream tag', () => {
+    const withUser = addTagLine(META, 'ml').ttl;
+    expect(addTagLine(withUser, 'ml').added).toBe(false);
+    const upstream = `this: a thought:Article ;\n    minerva:upstreamTag "ml" ;\n    dc:title "X" .\n`;
+    expect(addTagLine(upstream, 'ml').added).toBe(false);
+  });
+
+  it('removes both user (minerva:tag) and upstream (minerva:upstreamTag) lines', () => {
+    const ttl = `this: a thought:Article ;\n    minerva:tag "ml" ;\n    minerva:upstreamTag "ml" ;\n    dc:title "X" .\n`;
+    const { ttl: out, removed } = removeTagLines(ttl, 'ml');
+    expect(removed).toBe(true);
+    expect(out).not.toContain('"ml"');
+    expect(out).toContain('dc:title "X"');
+    expect(out.trimEnd().endsWith('.')).toBe(true);
+  });
+
+  it('removing a tag that is the last predicate keeps the TTL well-formed', () => {
+    const ttl = `this: a thought:Article ;\n    minerva:tag "only" .\n`;
+    const { ttl: out } = removeTagLines(ttl, 'only');
+    expect(out).not.toContain('minerva:tag');
+    expect(out.trimEnd().endsWith('.')).toBe(true);
+  });
+
+  it('removeTagLines is a no-op for an absent tag', () => {
+    expect(removeTagLines(META, 'nope').removed).toBe(false);
+  });
+
+  it('addSourceTag rejects an empty tag before touching disk', async () => {
+    await expect(addSourceTag('/nonexistent/root', 'src-x', '  ')).rejects.toThrow(/cannot be empty/);
   });
 });
 

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -261,6 +261,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "setMenuConfig",
   ],
   "sources": [
+    "addTag",
     "applyStubResolution",
     "createExcerpt",
     "createReferenceStubs",
@@ -284,6 +285,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onImportZoteroRdfProgress",
     "queueMembers",
     "readPdf",
+    "removeTag",
     "resolveStub",
     "setExcerptNoteFolder",
     "setIngestSettings",


### PR DESCRIPTION
Sources could already *carry* tags (upstream subject tags from ingest, body.md hashtags) — smart collections and the tag tree filter by them — but there was **no affordance to add or remove one**, and tags weren't even surfaced to the detail view. This adds proper user tagging.

## Model
A new user-tag predicate **`minerva:tag "name"`** in a source's `meta.ttl`. The indexer maps it to a `minerva:hasTag` edge (mirroring the existing upstream/body pipelines), so a user tag participates in the tag tree + smart collections identically. Distinct from `minerva:upstreamTag` so **"Strip upstream tags" leaves user tags alone**. Direct user write — no approval engine (same precedent as read-status / rename).

- `addSourceTag` / `removeSourceTag`, built on pure, tested `addTagLine` / `removeTagLines` helpers (the `strip-upstream-tags` pattern):
  - **add** inserts a `minerva:tag` line unless the tag is already a user or upstream tag (dedup — `hasTag` is a set);
  - **remove** drops matching `minerva:tag` *and* `minerva:upstreamTag` lines. Body-hashtag-derived tags re-derive on index and aren't removable here (they live in the body).
- `SourceMetadata.tags` now carries the source's `hasTag` names (sorted), populated in `collectSourceMetadata`.
- `SOURCES_ADD_TAG` / `SOURCES_REMOVE_TAG` wired through register-sources (persist + `SOURCES_CHANGED`), preload, client.

## Affordances
- **Source detail** — an inline tag editor under the byline: chips with `×` to remove, **"+ tag"** → inline input (Enter commits, Esc cancels). Reloads after.
- **Sources sidebar** — right-click → **"Add tag…"**.

## Tests
`addTagLine` inserts / dedupes against user+upstream; `removeTagLines` drops both user+upstream and stays well-formed when removing the last predicate; `addSourceTag` rejects empty before disk. Updated the preload contract snapshot for `addTag`/`removeTag`.

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3096 passed. `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** added **tag-vocabulary autocomplete** to the source add-tag affordances, matching notes (which already autocomplete via `showPrompt({ suggestions })`). The sidebar "Add tag…" prompt and the detail-view inline input both suggest existing project tags (minus tags the source already has). Removal stays chip-based (× on the visible tag).