### PR TITLE
Rationalize Amazon URLs on ingest + pull categories as tags (#767)

### DIFF
--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -45,7 +45,11 @@ export function registerSources(): void {
   ipcMain.handle(Channels.SOURCES_INGEST_URL, async (e, url: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
-    return await ingestUrl(rootPath, url, { fetchImpl: privilegedFetch });
+    const ingestSettings = await getIngestSettings();
+    return await ingestUrl(rootPath, url, {
+      fetchImpl: privilegedFetch,
+      importUpstreamTags: ingestSettings.importUpstreamTags,
+    });
   });
 
   ipcMain.handle(Channels.SOURCES_INGEST_IDENTIFIER, async (e, identifier: string) => {

--- a/src/main/sources/ingest.ts
+++ b/src/main/sources/ingest.ts
@@ -48,6 +48,10 @@ export interface IngestResult {
 export interface IngestOptions {
   /** Dependency-injection seam for tests; defaults to `globalThis.fetch`. */
   fetchImpl?: typeof fetch;
+  /** When false, page-derived subject tags (e.g. Amazon breadcrumb categories)
+   *  are not written. Mirrors the identifier-ingest setting (#473). Default
+   *  true. */
+  importUpstreamTags?: boolean;
 }
 
 export async function ingestUrl(
@@ -76,7 +80,10 @@ export async function ingestUrl(
       needsOcr: pdf.needsOcr,
     };
   }
-  return ingestHtmlString(rootPath, fetched.text, { url: normalized });
+  return ingestHtmlString(rootPath, fetched.text, {
+    url: normalized,
+    importUpstreamTags: opts.importUpstreamTags,
+  });
 }
 
 /**
@@ -88,7 +95,7 @@ export async function ingestUrl(
 export async function ingestHtmlString(
   rootPath: string,
   html: string,
-  opts: { url?: string; titleFallback?: string } = {},
+  opts: { url?: string; titleFallback?: string; importUpstreamTags?: boolean } = {},
 ): Promise<IngestResult> {
   const url = opts.url ?? null;
   const { document } = parseHTML(html);
@@ -98,6 +105,11 @@ export async function ingestHtmlString(
   }
 
   const structured = url ? extractStructured(document, new URL(url)) : null;
+  // Honor the import-upstream-tags setting (#473): drop page-derived subject
+  // tags before they reach meta.ttl when the user has opted out.
+  if (structured && opts.importUpstreamTags === false) {
+    structured.keywords = [];
+  }
 
   const { id: sourceId } = canonicalSourceId(
     {

--- a/src/main/sources/site-handlers.ts
+++ b/src/main/sources/site-handlers.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ArticleMetadata } from './api-adapters/types';
+import { amazonAsin } from './source-id';
 
 /**
  * Partial metadata derived from site-handler inspection. The ingest
@@ -40,6 +41,10 @@ export interface StructuredExtraction {
   pdfUrl?: string | null;
   /** The site-handler's subtype inference (Article / Preprint / Book …). */
   subtype?: ArticleMetadata['subtype'];
+  /** Subject tags pulled from the page (e.g. Amazon breadcrumb categories).
+   *  Written to meta.ttl as `minerva:upstreamTag` literals, subject to the
+   *  import-upstream-tags setting. */
+  keywords?: string[];
 }
 
 /**
@@ -53,6 +58,10 @@ export interface DocLike {
 }
 interface MetaLike {
   getAttribute(name: string): string | null;
+  /** Present on real elements (linkedom + native); used by handlers that read
+   *  visible text such as breadcrumb categories. Optional so `<meta>`-only
+   *  handlers don't depend on it. */
+  textContent?: string | null;
 }
 
 /**
@@ -61,7 +70,7 @@ interface MetaLike {
  * Returns null when no handler contributed anything.
  */
 export function extractStructured(doc: DocLike, url: URL): StructuredExtraction | null {
-  const handlers = [citationMetaHandler, arxivUrlHandler, pubmedUrlHandler];
+  const handlers = [citationMetaHandler, arxivUrlHandler, pubmedUrlHandler, amazonHandler];
   let out: StructuredExtraction | null = null;
   for (const handler of handlers) {
     const result = handler(doc, url);
@@ -90,6 +99,7 @@ function mergeExtractions(a: StructuredExtraction, b: StructuredExtraction): Str
     isbn: a.isbn ?? b.isbn,
     pdfUrl: a.pdfUrl ?? b.pdfUrl,
     subtype: a.subtype ?? b.subtype,
+    keywords: a.keywords && a.keywords.length > 0 ? a.keywords : b.keywords,
   };
 }
 
@@ -180,7 +190,63 @@ export function pubmedUrlHandler(_doc: DocLike, url: URL): StructuredExtraction 
   return { pubmed: m[1] };
 }
 
+/**
+ * Amazon product pages (#767). Amazon serves the breadcrumb category trail and
+ * og:title in the initial HTML, so for a recognized `/dp/<ASIN>` URL we can pull
+ * a clean title + the category trail as subject tags without rendering JS. The
+ * leading "Books" department label is dropped (too coarse to be a useful tag);
+ * the remaining crumbs ("Science Fiction & Fantasy", "Hard Science Fiction", …)
+ * become `keywords`. We only claim subtype Book when the trail says so, since
+ * Amazon `/dp/` pages are products of every kind. An ISBN-10-shaped ASIN (older
+ * print books) doubles as the ISBN. Everything is best-effort — markup drift
+ * just yields fewer fields, never an error.
+ */
+export function amazonHandler(doc: DocLike, url: URL): StructuredExtraction | null {
+  const asin = amazonAsin(url.hostname, url.pathname);
+  if (!asin) return null;
+
+  const crumbs = elementTexts(doc, '#wayfinding-breadcrumbs_feature_div a')
+    .map((t) => t.replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+  const looksLikeBook = crumbs.some((c) => /^books?$/i.test(c));
+  const keywords = dedupeStrings(crumbs.filter((c) => !/^books?$/i.test(c)));
+
+  const title = metaContent(doc, 'og:title') ?? metaContent(doc, 'title');
+  const isbn = /^\d{9}[\dX]$/i.test(asin) ? asin.toUpperCase() : null;
+
+  return {
+    title: title ?? null,
+    keywords: keywords.length > 0 ? keywords : undefined,
+    isbn,
+    subtype: looksLikeBook || isbn ? 'Book' : undefined,
+  };
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Visible text of every element matching `selector` (trimmed, non-empty). */
+function elementTexts(doc: DocLike, selector: string): string[] {
+  const nodes = doc.querySelectorAll(selector);
+  const out: string[] = [];
+  for (let i = 0; i < nodes.length; i++) {
+    const t = nodes[i].textContent;
+    if (t && t.trim()) out.push(t.trim());
+  }
+  return out;
+}
+
+/** Order-preserving case-insensitive dedupe. */
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const key = v.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(v);
+  }
+  return out;
+}
 
 function metaContent(doc: DocLike, name: string): string | null {
   // Some publishers use `name=`; rarer `property=` (OpenGraph-ish). Try
@@ -308,7 +374,7 @@ export function structuredToArticleMetadata(
     uri: fallback.uri ?? null,
     pdfUrl: structured.pdfUrl ?? null,
     category: null,
-    keywords: [],
+    keywords: structured.keywords ?? [],
   };
 }
 

--- a/src/main/sources/source-id.ts
+++ b/src/main/sources/source-id.ts
@@ -168,7 +168,33 @@ export function normalizeUrl(url: string): string | null {
   if (parsed.pathname.length > 1 && parsed.pathname.endsWith('/')) {
     parsed.pathname = parsed.pathname.slice(0, -1);
   }
+
+  // Amazon product pages bury the ASIN under a title slug and a trailing
+  // `/ref=…` affiliate/section segment, so two links to the same book rarely
+  // match. Collapse a recognized product URL to the canonical `/dp/<ASIN>`
+  // (and drop the query) so the same book dedupes to one source.
+  const asin = amazonAsin(parsed.hostname, parsed.pathname);
+  if (asin) {
+    parsed.pathname = `/dp/${asin}`;
+    parsed.search = '';
+  }
   return parsed.toString();
+}
+
+/**
+ * Extract the 10-char ASIN from an Amazon product URL, or null when the host
+ * isn't Amazon / the path isn't a product page. ASIN appears under several path
+ * shapes (`/dp/`, `/gp/product/`, the legacy `/exec/obidos/…`); we match them
+ * all. `hostname` is expected already-lowercased with `www.` stripped
+ * (normalizeUrl does this), but we tolerate either.
+ */
+export function amazonAsin(hostname: string, pathname: string): string | null {
+  const host = hostname.toLowerCase().replace(/^www\./, '');
+  if (!/(?:^|\.)amazon\.[a-z.]+$/.test(host)) return null;
+  const m = pathname.match(
+    /\/(?:dp|gp\/product|gp\/aw\/d|o|exec\/obidos\/(?:asin|tg\/detail\/-\/[^/]+))\/([A-Z0-9]{10})(?=[/?]|$)/i,
+  );
+  return m ? m[1].toUpperCase() : null;
 }
 
 const TRACKING_PARAMS = new Set([

--- a/tests/main/sources/site-handlers.test.ts
+++ b/tests/main/sources/site-handlers.test.ts
@@ -5,6 +5,7 @@ import {
   citationMetaHandler,
   arxivUrlHandler,
   pubmedUrlHandler,
+  amazonHandler,
   structuredToArticleMetadata,
   normalizeCitationDate,
   type DocLike,
@@ -217,5 +218,48 @@ describe('normalizeCitationDate', () => {
   it('returns null for unparseable inputs', () => {
     expect(normalizeCitationDate('')).toBeNull();
     expect(normalizeCitationDate('no year')).toBeNull();
+  });
+});
+
+describe('amazonHandler (#767)', () => {
+  const html = `<html><head>
+      <meta property="og:title" content="Dune (Hardcover)">
+    </head><body>
+      <div id="wayfinding-breadcrumbs_feature_div">
+        <ul>
+          <li><a href="/books">Books</a></li>
+          <li><a href="/sf">Science Fiction &amp; Fantasy</a></li>
+          <li><a href="/hard-sf">Hard Science Fiction</a></li>
+        </ul>
+      </div>
+    </body></html>`;
+
+  it('pulls title + breadcrumb categories as keywords for a /dp/ page', () => {
+    const out = amazonHandler(docFrom(html), new URL('https://www.amazon.com/Dune/dp/0441013597/ref=sr_1_1'));
+    expect(out).not.toBeNull();
+    expect(out!.title).toBe('Dune (Hardcover)');
+    // "Books" department label is dropped; the specific categories remain.
+    expect(out!.keywords).toEqual(['Science Fiction & Fantasy', 'Hard Science Fiction']);
+    expect(out!.subtype).toBe('Book'); // breadcrumb says Books
+    expect(out!.isbn).toBe('0441013597'); // ISBN-10-shaped ASIN
+  });
+
+  it('returns null for a non-product Amazon URL', () => {
+    expect(amazonHandler(docFrom(html), new URL('https://www.amazon.com/s?k=dune'))).toBeNull();
+  });
+
+  it('returns null off-Amazon', () => {
+    expect(amazonHandler(docFrom(html), new URL('https://example.com/dp/0441013597'))).toBeNull();
+  });
+
+  it('does not claim subtype Book when no Books crumb and ASIN is not ISBN-shaped', () => {
+    const gadget = `<html><head><meta property="og:title" content="USB Cable"></head><body>
+      <div id="wayfinding-breadcrumbs_feature_div"><ul>
+        <li><a href="/e">Electronics</a></li><li><a href="/c">Cables</a></li>
+      </ul></div></body></html>`;
+    const out = amazonHandler(docFrom(gadget), new URL('https://www.amazon.com/dp/B0ABCDEFGH'));
+    expect(out!.subtype).toBeUndefined();
+    expect(out!.isbn).toBeNull();
+    expect(out!.keywords).toEqual(['Electronics', 'Cables']);
   });
 });

--- a/tests/main/sources/source-id.test.ts
+++ b/tests/main/sources/source-id.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeIsbn,
   normalizeUrl,
   shortHash,
+  amazonAsin,
 } from '../../../src/main/sources/source-id';
 
 describe('normalizeDoi (#90)', () => {
@@ -154,6 +155,47 @@ describe('normalizeUrl (#90)', () => {
 
   it('returns null for malformed input', () => {
     expect(normalizeUrl('not a url')).toBeNull();
+  });
+
+  // Amazon product-URL canonicalization (#767).
+  it('collapses a noisy Amazon product URL to /dp/<ASIN>', () => {
+    expect(normalizeUrl('https://www.amazon.com/Some-Book-Title/dp/B0ABCDEFGH/ref=sr_1_1?keywords=foo&qid=999&sr=8-1'))
+      .toBe('https://amazon.com/dp/B0ABCDEFGH');
+  });
+
+  it('handles the /gp/product/ shape too', () => {
+    expect(normalizeUrl('https://www.amazon.co.uk/gp/product/B0ABCDEFGH/ref=ppx_yo_dt_b_asin_title'))
+      .toBe('https://amazon.co.uk/dp/B0ABCDEFGH');
+  });
+
+  it('dedupes two differently-decorated links to the same book', () => {
+    const a = normalizeUrl('https://www.amazon.com/dp/B0ABCDEFGH?tag=aff-20&ref_=nav');
+    const b = normalizeUrl('https://amazon.com/Different-Slug/dp/B0ABCDEFGH/ref=sr_1_3');
+    expect(a).toBe(b);
+  });
+
+  it('leaves non-product Amazon URLs (search, storefront) untouched', () => {
+    expect(normalizeUrl('https://www.amazon.com/s?k=dune'))
+      .toBe('https://amazon.com/s?k=dune');
+  });
+
+  it('does not touch non-Amazon hosts', () => {
+    expect(normalizeUrl('https://example.com/dp/B0ABCDEFGH/ref=x'))
+      .toBe('https://example.com/dp/B0ABCDEFGH/ref=x');
+  });
+});
+
+describe('amazonAsin (#767)', () => {
+  it('extracts the ASIN from common product path shapes', () => {
+    expect(amazonAsin('amazon.com', '/Title/dp/B0ABCDEFGH/ref=x')).toBe('B0ABCDEFGH');
+    expect(amazonAsin('amazon.com', '/gp/product/B0ABCDEFGH')).toBe('B0ABCDEFGH');
+    expect(amazonAsin('www.amazon.co.jp', '/dp/4061099890')).toBe('4061099890');
+  });
+
+  it('returns null off-Amazon or for non-product paths', () => {
+    expect(amazonAsin('example.com', '/dp/B0ABCDEFGH')).toBeNull();
+    expect(amazonAsin('amazon.com', '/s?k=dune')).toBeNull();
+    expect(amazonAsin('notamazon.com', '/dp/B0ABCDEFGH')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Two improvements for the common "ingest an Amazon book link as a Source" flow.

## 1. URL rationalization
Amazon product URLs bury the ASIN under a title slug + a trailing `/ref=…` affiliate/section segment and a pile of query params, so two links to the same book almost never matched → duplicate sources and ugly stored URLs.

`normalizeUrl` (source-id.ts) now collapses a recognized product URL (`/dp/`, `/gp/product/`, legacy `/exec/obidos/…`) to the canonical `https://<host>/dp/<ASIN>` and drops the query:

```
https://www.amazon.com/Some-Book-Title/dp/B0ABCDEFGH/ref=sr_1_1?keywords=foo&qid=999
  → https://amazon.com/dp/B0ABCDEFGH
```

The same book now dedupes to one source however it was linked, and the stored `bibo:uri` is clean. New exported `amazonAsin(host, path)` helper. Generic tracking-param stripping is unchanged and still applies everywhere.

## 2. Tags from the page
Amazon serves the breadcrumb category trail + `og:title` in the initial HTML, so a new `amazonHandler` (site-handlers.ts) gives a `/dp/<ASIN>` page a clean title and its category trail as subject tags:

- "Books" department label dropped; the specific crumbs ("Science Fiction & Fantasy", "Hard Science Fiction", …) become tags.
- subtype **Book** only when the trail says so (Amazon `/dp/` pages are products of every kind).
- an ISBN-10-shaped ASIN doubles as the `bibo:isbn`.

Plumbing: `StructuredExtraction` gained a `keywords` field; `structuredToArticleMetadata` now passes it through (was hardcoded `[]`) → the existing `buildArticleMetaTtl` writes them as `minerva:upstreamTag` literals → `hasTag` edges, so they show in the tag tree + drive smart collections like any other tag. **Gated by the existing import-upstream-tags setting** (threaded through `ingestUrl` → `ingestHtmlString`), same as identifier subject-tags.

Everything is best-effort — Amazon markup drift yields fewer fields, never an error.

## Tests
`normalizeUrl` Amazon canonicalization (path shapes, dedup, non-product + non-Amazon untouched); `amazonAsin`; `amazonHandler` (title + breadcrumb keywords, Book inference, ISBN-shaped ASIN, off-Amazon/non-product nulls, a non-book product).

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3110 passed. `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)