### PR TITLE
Open the first filed note when a conversation proposal is approved (#770)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -331,7 +331,9 @@
 
   async function handleApprove(tabId: string, draft: ConversationDraft) {
     try {
-      await store.approveDraft(tabId, draft);
+      const { filedPaths } = await store.approveDraft(tabId, draft);
+      // Open the first filed note so the user lands on what they just approved.
+      if (filedPaths.length > 0) void editor.openFile(filedPaths[0]);
     } catch (e) {
       console.error('[conv-panel] approve failed:', e);
     }

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -588,9 +588,9 @@ async function cancel(): Promise<void> {
   }
 }
 
-async function approveDraft(tabId: string, draft: ConversationDraft): Promise<void> {
+async function approveDraft(tabId: string, draft: ConversationDraft): Promise<{ filedPaths: string[] }> {
   const tab = findTab(tabId);
-  if (!tab) return;
+  if (!tab) return { filedPaths: [] };
   // Inherit the draft's anchor so the result line lands on the same
   // assistant turn the card was attached to.
   const anchored = tab.drafts.find((d) => d.draftId === draft.draftId);
@@ -607,6 +607,7 @@ async function approveDraft(tabId: string, draft: ConversationDraft): Promise<vo
     ...tab.noteDraftResults,
     [draft.draftId]: { filedPaths: result.filedPaths, afterMessageIndex },
   };
+  return { filedPaths: result.filedPaths };
 }
 
 function discardDraft(tabId: string, draftId: string): void {


### PR DESCRIPTION
Approving a `propose_notes` draft wrote the notes and left a "Filed:" summary in the conversation — but didn't open anything, so the user had to go hunt for the new note in the sidebar. Now approval **opens the first filed note** in the editor so they land on what they just created.

## How
`approveDraft` already received the approval engine's post-dedup `filedPaths`; it now **returns** them, and the panel's `handleApprove` opens `filedPaths[0]` (guarded on a non-empty result — a collision-only bundle files nothing). Discard and the other draft kinds (sources, properties, claims) are unchanged.

## Note
No unit test added: the conversations rune store has no existing test harness, and a two-line return-value change doesn't justify building one (lint covers the type wiring). Worth a quick manual confirm on your next smoke pass — approve a multi-note bundle and check the parent note opens.

## Verification
- `pnpm lint` — 0 errors. `pnpm test` — 3110 passed. `pnpm test:e2e` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)