### PR TITLE
feat: section (heading) bookmarks (#755)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -66,6 +66,7 @@
   import { getConversationsStore } from './lib/stores/conversations.svelte';
   import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
+  import { sectionAnchorAt } from './lib/markdown/headings';
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
@@ -218,6 +219,27 @@
   const dialogs = getDialogStore();
   const { showPrompt, showConfirm } = dialogs;
   let exportDialogFor = $state<string | null>(null);
+
+  /**
+   * Bookmark the section the cursor sits in — the nearest heading at/above
+   * it. Stores the heading slug as the bookmark's `anchor` so opening it
+   * scrolls to that heading (#755). Falls back to a dismissible notice when
+   * the cursor is above the note's first heading.
+   */
+  async function handleBookmarkSection() {
+    if (!editor.activeFilePath) return;
+    const offset = editorComponent?.getOffset() ?? 0;
+    const section = sectionAnchorAt(editor.content, offset);
+    if (!section) {
+      await showConfirm(
+        'No section heading above the cursor to bookmark. Place the cursor inside a section first.',
+        CONFIRM_KEYS.bookmarkSectionNoHeading,
+        'OK',
+      );
+      return;
+    }
+    bookmarkStore.add(section.text, editor.activeFilePath, { anchor: section.slug });
+  }
 
   /**
    * Surfaced when any LLM-backed action fails because the user hasn't
@@ -1032,6 +1054,7 @@
           rootName={notebase.meta?.name}
           activeFilePath={editor.activeFilePath}
           onFileSelect={handleFileSelect}
+          onNavigate={handleNavigate}
           onNewNote={handleNewNote}
           onNewFolder={handleNewFolder}
           onDelete={handleDelete}
@@ -1159,7 +1182,8 @@
                     getNotePaths={() => flattenNotePaths(notebase.files)}
                     getSources={() => sourcesCache}
                     getAliases={() => aliasEntries}
-                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath, editorComponent?.getOffset()); }}
+                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath, { cursorOffset: editorComponent?.getOffset() }); }}
+                    onBookmarkSection={() => { void handleBookmarkSection(); }}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
                     onSplitByHeading={handleSplitByHeading}

--- a/src/renderer/lib/components/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/BookmarksPanel.svelte
@@ -7,10 +7,12 @@
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
+    /** Open + scroll to an anchor (`path#slug`) for section bookmarks. */
+    onNavigate?: (target: string) => void | Promise<void>;
     onShowPrompt: (message: string) => Promise<string | null>;
   }
 
-  let { onFileSelect, onShowPrompt }: Props = $props();
+  let { onFileSelect, onNavigate, onShowPrompt }: Props = $props();
 
   const bookmarks = getBookmarksStore();
   let expanded = $state<Record<string, boolean>>({});
@@ -65,7 +67,8 @@
 
   function handleClick(node: BookmarkNode) {
     if (node.type === 'bookmark') {
-      onFileSelect(node.relativePath);
+      if (node.anchor && onNavigate) void onNavigate(`${node.relativePath}#${node.anchor}`);
+      else onFileSelect(node.relativePath);
     } else {
       toggleFolder(node.id);
     }
@@ -183,10 +186,10 @@
       ondragstart={(e) => handleDragStart(e, node.id)}
     >
       <span class="chev"></span>
-      <Icon name="bookmark" size={13} color="var(--text-faint)" />
+      <Icon name={node.anchor ? 'outline' : 'bookmark'} size={13} color="var(--text-faint)" />
       <span class="bm-body">
         <span class="bm-name">{node.name}</span>
-        <span class="bm-path">{node.relativePath}</span>
+        <span class="bm-path">{node.anchor ? `${node.relativePath} › §` : node.relativePath}</span>
       </span>
     </div>
   {/if}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -77,6 +77,9 @@
     onToolInvoke?: (toolId: string) => void;
     onOpenConversation?: () => void;
     onBookmark?: () => void;
+    /** Bookmark the section (nearest heading at/above the cursor). The
+     *  handler reads the cursor via `getOffset()` and resolves the slug. */
+    onBookmarkSection?: () => void;
     onInsertQueryList?: () => void;
     onNavigate?: (target: string) => void;
     /** Click on a `[[cite::source-id]]` in the editor → open the source tab. */
@@ -136,6 +139,7 @@
     onToolInvoke,
     onOpenConversation,
     onBookmark,
+    onBookmarkSection,
     onInsertQueryList,
     onNavigate,
     onOpenSource,
@@ -1071,6 +1075,9 @@
     {/if}
     <button onclick={() => handleMenuAction(() => onOpenConversation?.())}>Ask About This...</button>
     <button onclick={() => handleMenuAction(() => onBookmark?.())}>Bookmark This Note</button>
+    {#if onBookmarkSection}
+      <button onclick={() => handleMenuAction(() => onBookmarkSection?.())}>Bookmark Section</button>
+    {/if}
     <div class="separator"></div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
       <span class="submenu-trigger">Open In<Icon name="chevronRight" size={10} /></span>

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -233,7 +233,7 @@
     {:else if activePanel === 'citations'}
       <CitationsPanel {activeFilePath} {content} {revision} {onOpenSource} {onOpenExcerpt} />
     {:else if activePanel === 'bookmarks'}
-      <BookmarksPanel {activeFilePath} {onFileSelect} />
+      <BookmarksPanel {activeFilePath} {onFileSelect} {onNavigate} />
     {:else if activePanel === 'inspections'}
       <InspectionsPanel {revision} {onOpenConversation} />
     {:else if activePanel === 'proposals'}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -45,6 +45,9 @@
     rootName?: string;
     activeFilePath: string | null;
     onFileSelect: (relativePath: string, searchQuery?: string) => void;
+    /** Open a note and scroll to an anchor, for `path#slug` targets (e.g.
+     *  section bookmarks). Whole-file opens still go through onFileSelect. */
+    onNavigate?: (target: string) => void | Promise<void>;
     onNewNote: (directory: string) => void;
     onNewFolder: (directory: string) => void;
     onDelete: (relativePath: string, isDirectory: boolean) => void;
@@ -72,7 +75,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -596,7 +599,7 @@
       {/if}
     {:else if activePanel === 'bookmarks'}
       {#if onShowPrompt}
-        <BookmarksPanel {onFileSelect} {onShowPrompt} />
+        <BookmarksPanel {onFileSelect} {onNavigate} {onShowPrompt} />
       {/if}
     {/if}
   </div>

--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -6,9 +6,12 @@
   interface Props {
     activeFilePath: string | null;
     onFileSelect: (relativePath: string) => void;
+    /** Open + scroll to an anchor (`path#slug`) for section bookmarks.
+     *  Works even when the file is already active (scrolls in place). */
+    onNavigate?: (target: string) => void | Promise<void>;
   }
 
-  let { activeFilePath, onFileSelect }: Props = $props();
+  let { activeFilePath, onFileSelect, onNavigate }: Props = $props();
 
   const bookmarks = getBookmarksStore();
 
@@ -42,10 +45,10 @@
           <button
             type="button"
             class="bm-open"
-            onclick={() => onFileSelect(bm.relativePath)}
-            title={bm.name}
+            onclick={() => (bm.anchor && onNavigate ? onNavigate(`${bm.relativePath}#${bm.anchor}`) : onFileSelect(bm.relativePath))}
+            title={bm.anchor ? `${bm.relativePath} › ${bm.name}` : bm.name}
           >
-            <Icon name="bookmark" size={13} color="var(--text-faint)" />
+            <Icon name={bm.anchor ? 'outline' : 'bookmark'} size={13} color="var(--text-faint)" />
             <span class="bm-name">{bm.name}</span>
           </button>
           <button

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -14,6 +14,9 @@ export const CONFIRM_KEYS = {
   deleteSource: 'delete-source',
   rewriteConflict: 'confirm-rewrite-conflict',
   headingRenameSuggestion: 'heading-rename-suggestion',
+  /** "Bookmark Section" invoked with the cursor above the first heading —
+   *  there's no section to anchor to. (#755) */
+  bookmarkSectionNoHeading: 'bookmark-section-no-heading',
   moveCollision: 'move-collision',
   copyCollision: 'copy-collision',
   autoTagNoSuggestions: 'auto-tag-no-suggestions',
@@ -119,6 +122,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Update links after heading rename',
     description:
       'Offer to rewrite incoming [[note#heading]] links when a heading edit looks like a rename.',
+  },
+  {
+    key: CONFIRM_KEYS.bookmarkSectionNoHeading,
+    title: 'Bookmark Section: no heading above cursor',
+    description:
+      'Shown when "Bookmark Section" is invoked with the cursor sitting before the note’s first heading, so there is no section to anchor the bookmark to.',
   },
   {
     key: CONFIRM_KEYS.moveCollision,

--- a/src/renderer/lib/markdown/headings.ts
+++ b/src/renderer/lib/markdown/headings.ts
@@ -10,6 +10,8 @@
  * skipping it keeps the parser O(n) per line.
  */
 
+import { slugify } from '../../../shared/slug';
+
 export interface Heading {
   /** ATX level: 1 (`#`) through 6 (`######`). */
   level: number;
@@ -66,4 +68,24 @@ export function activeHeadingChain(headings: readonly Heading[], cursorLine: num
     }
   }
   return chain;
+}
+
+/**
+ * The nearest heading at or above a character offset, as a `{ slug, text }`
+ * suitable for a section bookmark (#755). Returns `null` when the offset sits
+ * before any heading. The slug is computed with the same `slugify` the wiki-
+ * link indexer uses, so `[[note#slug]]` navigation resolves it.
+ */
+export function sectionAnchorAt(
+  content: string,
+  offset: number,
+): { slug: string; text: string } | null {
+  const clamped = Math.max(0, Math.min(offset, content.length));
+  // 1-based line of the cursor — matches `Heading.line`.
+  const cursorLine = content.slice(0, clamped).split('\n').length;
+  const chain = activeHeadingChain(extractHeadings(content), cursorLine);
+  const heading = chain.at(-1);
+  if (!heading) return null;
+  const slug = slugify(heading.text);
+  return slug ? { slug, text: heading.text } : null;
 }

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -22,13 +22,19 @@ export function getBookmarksStore() {
     tree = await api.bookmarks.load();
   }
 
-  function add(name: string, relativePath: string, cursorOffset?: number, parentFolderId?: string) {
+  function add(
+    name: string,
+    relativePath: string,
+    opts: { cursorOffset?: number; anchor?: string; parentFolderId?: string } = {},
+  ) {
+    const { cursorOffset, anchor, parentFolderId } = opts;
     const bookmark: Bookmark = {
       type: 'bookmark',
       id: generateId(),
       name,
       relativePath,
       cursorOffset,
+      anchor,
     };
     if (parentFolderId) {
       const folder = findFolder(tree, parentFolderId);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -280,6 +280,10 @@ export interface Bookmark {
   name: string;
   relativePath: string;
   cursorOffset?: number;
+  /** Optional sub-file anchor. A heading slug (#755 — e.g. `methods`) or a
+   *  `^block-id` (#756). Absent ⇒ the bookmark targets the whole file and
+   *  opens by path, exactly as before. */
+  anchor?: string;
 }
 
 export interface BookmarkFolder {

--- a/tests/renderer/components/right-sidebar/BookmarksPanel.test.ts
+++ b/tests/renderer/components/right-sidebar/BookmarksPanel.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Right-sidebar BookmarksPanel open-routing (#755). Section bookmarks (those
+ * with an `anchor`) open via `onNavigate('path#slug')` so navigation scrolls
+ * to the heading; whole-file bookmarks still open via `onFileSelect(path)`.
+ * The store is mocked so we control the tree without touching IPC.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { BookmarkNode } from '../../../../src/shared/types';
+
+const { treeRef } = vi.hoisted(() => ({ treeRef: { current: [] as BookmarkNode[] } }));
+vi.mock('../../../../src/renderer/lib/stores/bookmarks.svelte', () => ({
+  getBookmarksStore: () => ({
+    get tree() { return treeRef.current; },
+    remove: vi.fn(),
+  }),
+}));
+
+import BookmarksPanel from '../../../../src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte';
+
+afterEach(() => { cleanup(); treeRef.current = []; });
+
+const ACTIVE = 'journey/raft.md';
+
+describe('right-sidebar BookmarksPanel (#755)', () => {
+  it('opens a whole-file bookmark via onFileSelect', async () => {
+    treeRef.current = [
+      { type: 'bookmark', id: 'a', name: 'raft', relativePath: ACTIVE },
+    ];
+    const onFileSelect = vi.fn();
+    const onNavigate = vi.fn();
+    const { getByText } = render(BookmarksPanel, { activeFilePath: ACTIVE, onFileSelect, onNavigate });
+
+    await fireEvent.click(getByText('raft'));
+    expect(onFileSelect).toHaveBeenCalledWith(ACTIVE);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('opens a section bookmark via onNavigate(path#slug)', async () => {
+    treeRef.current = [
+      { type: 'bookmark', id: 'b', name: 'Methods', relativePath: ACTIVE, anchor: 'methods' },
+    ];
+    const onFileSelect = vi.fn();
+    const onNavigate = vi.fn();
+    const { getByText } = render(BookmarksPanel, { activeFilePath: ACTIVE, onFileSelect, onNavigate });
+
+    await fireEvent.click(getByText('Methods'));
+    expect(onNavigate).toHaveBeenCalledWith(`${ACTIVE}#methods`);
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to onFileSelect for a section bookmark when onNavigate is absent', async () => {
+    treeRef.current = [
+      { type: 'bookmark', id: 'c', name: 'Methods', relativePath: ACTIVE, anchor: 'methods' },
+    ];
+    const onFileSelect = vi.fn();
+    const { getByText } = render(BookmarksPanel, { activeFilePath: ACTIVE, onFileSelect });
+
+    await fireEvent.click(getByText('Methods'));
+    expect(onFileSelect).toHaveBeenCalledWith(ACTIVE);
+  });
+});

--- a/tests/renderer/markdown/headings.test.ts
+++ b/tests/renderer/markdown/headings.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { extractHeadings, activeHeadingChain } from '../../../src/renderer/lib/markdown/headings';
+import { extractHeadings, activeHeadingChain, sectionAnchorAt } from '../../../src/renderer/lib/markdown/headings';
 
 describe('extractHeadings', () => {
   it('parses ATX headings at every level (1–6)', () => {
@@ -116,5 +116,44 @@ describe('activeHeadingChain', () => {
     // Build the chain conservatively: take the strictly-shallower
     // ancestors we find. Missing levels are not synthesized.
     expect(chain.map((h) => h.text)).toEqual(['A', 'C']);
+  });
+});
+
+describe('sectionAnchorAt (#755 — section bookmarks)', () => {
+  const doc = [
+    '# Intro',          // line 1, offsets 0..6 (incl newline at 7)
+    'intro body',       // line 2
+    '## Methods',       // line 3
+    'methods body here', // line 4
+  ].join('\n');
+
+  /** Char offset of the start of a 1-based line in `doc`. */
+  function offsetOfLine(line: number): number {
+    return doc.split('\n').slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
+  }
+
+  it('returns the nearest heading at/above the cursor as { slug, text }', () => {
+    const inMethods = offsetOfLine(4) + 3; // inside "methods body here"
+    expect(sectionAnchorAt(doc, inMethods)).toEqual({ slug: 'methods', text: 'Methods' });
+  });
+
+  it('uses the H1 when the cursor sits in the intro body', () => {
+    const inIntro = offsetOfLine(2) + 2;
+    expect(sectionAnchorAt(doc, inIntro)).toEqual({ slug: 'intro', text: 'Intro' });
+  });
+
+  it('returns null when the cursor is above the first heading', () => {
+    const lead = '\n\nprose before any heading\n# Later\n';
+    expect(sectionAnchorAt(lead, 1)).toBeNull();
+  });
+
+  it('slugifies multi-word headings the same way [[note#slug]] links do', () => {
+    const d = '## Prior Work & Notes\nbody';
+    const anchor = sectionAnchorAt(d, d.length - 1);
+    expect(anchor).toEqual({ slug: 'prior-work-notes', text: 'Prior Work & Notes' });
+  });
+
+  it('clamps an out-of-range offset instead of throwing', () => {
+    expect(sectionAnchorAt(doc, 10_000)).toEqual({ slug: 'methods', text: 'Methods' });
   });
 });


### PR DESCRIPTION
Implements **#755** (part of epic **#757** — sub-file bookmarks). Extends bookmarks from whole-file targets to **sections** (headings).

Manually tested ✓.

## Model
- `Bookmark` gains an optional `anchor?: string` (heading slug now; reserved for `^block-id` in #756). Backward-compatible — existing bookmarks have no anchor and open by path exactly as before. Persistence is a JSON pass-through, so no main-process change.

## Create
- A **"Bookmark Section"** item in the source-editor context menu captures the nearest heading at/above the cursor.
- New `sectionAnchorAt(content, offset)` helper composes the existing `extractHeadings` + `activeHeadingChain` + `slugify`, so the stored slug resolves exactly like a `[[note#slug]]` link.
- Falls back to a dismissible notice (new `bookmarkSectionNoHeading` confirm key) when the cursor sits above the note's first heading.

## Navigate
- Both bookmark panels (left-sidebar project-wide tree **and** right-sidebar per-note list) route section bookmarks through the existing `handleNavigate('path#slug')`, which opens-and-scrolls in source and preview and works when the file is already active. Whole-file bookmarks still use `onFileSelect`. No new open-path code.

## Panel UI
- Section bookmarks render with the `outline` icon and a section hint; whole-file rows unchanged.

## Internal
- Bookmark store `add()` switched to an options bag (`{ cursorOffset, anchor, parentFolderId }`) to stay readable as #756 adds more anchor kinds.

## Deferred (agreed scope)
- Heading-rename resilience (cascade slug updates via `renameAnchor`) is a deliberate follow-up. Until then, renaming a heading can orphan a section bookmark — it degrades gracefully (opens the file at top).

## Testing
- `pnpm lint` clean; `pnpm test` green (3125 passing).
- New tests: `sectionAnchorAt` (nearest heading, intro fallback, none-above → null, multi-word slug parity, out-of-range clamp) and a right-sidebar panel test (anchored → `onNavigate('path#slug')`, whole-file → `onFileSelect`, missing-`onNavigate` fallback).

## Acceptance (#755)
- [x] Can bookmark a section; the panel shows it distinctly
- [x] Opening it opens the file and scrolls to the heading
- [x] Whole-file bookmarks unchanged (backward-compatible model)
- [ ] Rename-keeps-valid — explicit follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)