### PR TITLE
feat: keep section bookmarks valid across heading renames (#755)

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -513,10 +513,16 @@ export async function indexNote(
 }
 
 /**
- * Offer a rewrite suggestion only for the unambiguous case where exactly
- * one heading slug disappeared AND exactly one appeared AND there are
- * incoming anchored links to the old slug. Anything else (multiple
- * removals, pure deletion, additions without removals) → no prompt.
+ * Detect the unambiguous case where exactly one heading slug disappeared
+ * AND exactly one appeared — i.e. a single heading was renamed in place.
+ * Anything else (multiple removals, pure deletion, additions without
+ * removals) → no candidate.
+ *
+ * `incomingLinkCount` reports how many notes link to the old slug. The
+ * renderer uses it to decide whether to OFFER a link rewrite (only when
+ * > 0), but the candidate fires regardless of link count so the renderer
+ * can also cascade purely-local state — e.g. keep a section bookmark
+ * pointing at the renamed heading (#755), even when nothing links to it.
  */
 function detectHeadingRename(
   state: GraphState,
@@ -533,7 +539,6 @@ function detectHeadingRename(
   const old = removed[0];
   const fresh = added[0];
   const incoming = findNotesLinkingToAnchorImpl(state, relativePath, old.slug).length;
-  if (incoming === 0) return undefined;
 
   return {
     relativePath,

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -970,7 +970,13 @@
     });
 
     api.notebase.onHeadingRenameSuggested(async (candidate) => {
+      // Keep the user's own section bookmarks pointing at the renamed
+      // heading (#755). Local metadata, no content mutation — do it
+      // unconditionally, even when nothing links to the heading.
+      bookmarkStore.retargetSectionAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
+      // Only offer to rewrite OTHER notes' incoming links when some exist.
       const n = candidate.incomingLinkCount;
+      if (n === 0) return;
       const msg =
         `The heading "${candidate.oldText}" in ${candidate.relativePath} looks like it was renamed ` +
         `to "${candidate.newText}". Update ${n} incoming link${n === 1 ? '' : 's'}?`;

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -89,6 +89,28 @@ export function getBookmarksStore() {
     }
   }
 
+  /**
+   * Heading-rename resilience (#755): when a heading in `relativePath` is
+   * renamed (`oldAnchor` slug → `newAnchor`), repoint every section bookmark
+   * that targeted the old slug so it keeps resolving. Returns the number of
+   * bookmarks updated. Pure-local metadata edit — no file mutation.
+   */
+  function retargetSectionAnchor(relativePath: string, oldAnchor: string, newAnchor: string): number {
+    let changed = 0;
+    const walk = (nodes: BookmarkNode[]) => {
+      for (const n of nodes) {
+        if (n.type === 'folder') walk(n.children);
+        else if (n.relativePath === relativePath && n.anchor === oldAnchor) {
+          n.anchor = newAnchor;
+          changed++;
+        }
+      }
+    };
+    walk(tree);
+    if (changed > 0) schedulePersist();
+    return changed;
+  }
+
   function move(id: string, targetFolderId: string | null) {
     const node = findNode(tree, id);
     if (!node) return;
@@ -115,6 +137,7 @@ export function getBookmarksStore() {
     remove,
     move,
     applyRenameTransitions,
+    retargetSectionAnchor,
   };
 }
 

--- a/tests/main/graph/heading-rename.test.ts
+++ b/tests/main/graph/heading-rename.test.ts
@@ -63,10 +63,16 @@ describe('heading snapshots (issue #139)', () => {
     expect(headingRenameCandidate!.incomingLinkCount).toBe(1);
   });
 
-  it('does not flag when there are no incoming links to the old slug', async () => {
+  it('still flags a rename with zero incoming links, reporting incomingLinkCount 0', async () => {
+    // The candidate fires regardless of link count so the renderer can
+    // cascade purely-local state (e.g. section bookmarks, #755); the
+    // link-rewrite dialog is what's gated on incomingLinkCount > 0.
     await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Overview');
     const { headingRenameCandidate } = await indexNote(ctx, 'notes/foo.md', '# Foo\n\n## Summary');
-    expect(headingRenameCandidate).toBeUndefined();
+    expect(headingRenameCandidate).toBeDefined();
+    expect(headingRenameCandidate!.oldSlug).toBe('overview');
+    expect(headingRenameCandidate!.newSlug).toBe('summary');
+    expect(headingRenameCandidate!.incomingLinkCount).toBe(0);
   });
 
   it('does not flag ambiguous cases (multiple removals or additions)', async () => {

--- a/tests/renderer/stores/bookmarks.test.ts
+++ b/tests/renderer/stores/bookmarks.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Bookmark store — heading-rename resilience (#755). `retargetSectionAnchor`
+ * repoints section bookmarks whose heading slug changed, leaving whole-file
+ * bookmarks and other notes' bookmarks alone. IPC persistence is mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { bookmarks: { save: vi.fn(), load: vi.fn() } },
+}));
+
+import { getBookmarksStore } from '../../../src/renderer/lib/stores/bookmarks.svelte';
+
+const store = getBookmarksStore();
+
+/** Remove every top-level bookmark so each test starts from a clean tree
+ *  (the store is a module singleton). */
+function reset() {
+  for (const n of [...store.tree]) store.remove(n.id);
+}
+
+beforeEach(reset);
+
+function bm(name: string) {
+  return store.tree.find((n) => n.type === 'bookmark' && n.name === name);
+}
+
+describe('retargetSectionAnchor (#755)', () => {
+  it('repoints matching section bookmarks and reports the count', () => {
+    store.add('Overview', 'notes/foo.md', { anchor: 'overview' });
+    store.add('foo (whole file)', 'notes/foo.md');               // no anchor
+    store.add('Overview elsewhere', 'notes/bar.md', { anchor: 'overview' });
+
+    const changed = store.retargetSectionAnchor('notes/foo.md', 'overview', 'summary');
+
+    expect(changed).toBe(1);
+    expect(bm('Overview')).toMatchObject({ relativePath: 'notes/foo.md', anchor: 'summary' });
+    // Whole-file bookmark for the same note is untouched.
+    expect(bm('foo (whole file)')).toMatchObject({ anchor: undefined });
+    // Same slug in a different note is untouched.
+    expect(bm('Overview elsewhere')).toMatchObject({ relativePath: 'notes/bar.md', anchor: 'overview' });
+  });
+
+  it('returns 0 and changes nothing when no bookmark matches', () => {
+    store.add('Methods', 'notes/foo.md', { anchor: 'methods' });
+    expect(store.retargetSectionAnchor('notes/foo.md', 'overview', 'summary')).toBe(0);
+    expect(bm('Methods')).toMatchObject({ anchor: 'methods' });
+  });
+
+  it('updates every bookmark pointing at the same renamed heading', () => {
+    store.add('one', 'notes/foo.md', { anchor: 'intro' });
+    store.add('two', 'notes/foo.md', { anchor: 'intro' });
+    expect(store.retargetSectionAnchor('notes/foo.md', 'intro', 'preamble')).toBe(2);
+    expect(bm('one')).toMatchObject({ anchor: 'preamble' });
+    expect(bm('two')).toMatchObject({ anchor: 'preamble' });
+  });
+});


### PR DESCRIPTION
Finishes the deferred resilience item from **#755** (epic **#757**). When you rename a heading, any **section bookmark** pointing at the old slug is repointed to the new one, so it keeps resolving instead of silently opening the file at the top.

## Approach
Bookmark resilience shouldn't depend on whether the heading *also* has incoming `[[note#slug]]` links — people bookmark sections that nothing links to. So:

- **Broadened detection** (`detectHeadingRename`, `indexers.ts`): now fires for *any* unambiguous single-heading rename, carrying `incomingLinkCount` as information rather than a gate. (Previously it suppressed the candidate when no incoming links existed.) The candidate's only consumer is the one renderer handler, and the formatter runs its own separate cascade — so this is contained.
- **Renderer handler** (`App.svelte`): cascades bookmarks **unconditionally** (pure-local metadata, no file mutation), then only shows the "update N incoming links" dialog when `incomingLinkCount > 0`. No new dialog noise for link-less renames.
- **Store**: new `retargetSectionAnchor(relativePath, oldSlug, newSlug)` walks the tree, repoints matching section bookmarks, persists if anything changed.

## Testing
- `pnpm lint` clean; `pnpm test` green (3128 passing).
- Store cascade tests: matching repoint + count, non-match → 0 + no change, multiple bookmarks on the same heading.
- Detection test updated: a zero-incoming-link rename now yields a candidate reporting `incomingLinkCount: 0` (instead of being suppressed). The other no-flag cases (initial index, ambiguous multi-rename, pure deletion, fenced-code) are unchanged.

## Closes the last #755 acceptance box
- [x] Renaming the heading keeps the bookmark valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)