### PR TITLE
feat: line bookmarks — offset MVP (#756)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -60,6 +60,7 @@
     slugifyForPath,
     flattenNotePaths,
     countNotes,
+    lineBookmarkName,
   } from './lib/app/text-helpers';
   import { initAppearance } from './lib/appearance/settings';
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
@@ -239,6 +240,19 @@
       return;
     }
     bookmarkStore.add(section.text, editor.activeFilePath, { anchor: section.slug });
+  }
+
+  /**
+   * Bookmark the current line — stores the cursor offset so opening jumps
+   * back to it (#756, offset MVP). The offset can go stale if text above is
+   * later edited. A line bookmark is one with a `cursorOffset` and no
+   * `anchor`; the panels render it distinctly and open it via the offset.
+   */
+  function handleBookmarkLine() {
+    if (!editor.activeFilePath) return;
+    const offset = editorComponent?.getOffset() ?? 0;
+    const name = lineBookmarkName(editor.content, offset);
+    bookmarkStore.add(name, editor.activeFilePath, { cursorOffset: offset });
   }
 
   /**
@@ -628,7 +642,7 @@
   // module reads / writes pending search + preview anchor, view mode, and the
   // alias map via ctx — those `$state` decls stay in App.
   const {
-    recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate,
+    recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate, handleOpenAtOffset,
     handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
   } = createNavView({
     getEditorComponent: () => editorComponent,
@@ -1055,6 +1069,7 @@
           activeFilePath={editor.activeFilePath}
           onFileSelect={handleFileSelect}
           onNavigate={handleNavigate}
+          onOpenAtOffset={handleOpenAtOffset}
           onNewNote={handleNewNote}
           onNewFolder={handleNewFolder}
           onDelete={handleDelete}
@@ -1182,8 +1197,9 @@
                     getNotePaths={() => flattenNotePaths(notebase.files)}
                     getSources={() => sourcesCache}
                     getAliases={() => aliasEntries}
-                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath, { cursorOffset: editorComponent?.getOffset() }); }}
+                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath); }}
                     onBookmarkSection={() => { void handleBookmarkSection(); }}
+                    onBookmarkLine={handleBookmarkLine}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
                     onSplitByHeading={handleSplitByHeading}
@@ -1317,6 +1333,7 @@
           content={editor.content}
           onFileSelect={handleFileSelect}
           onNavigate={handleNavigate}
+          onOpenAtOffset={handleOpenAtOffset}
           onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
           onOpenConversation={(msg) => { void openConversationWithMessage(msg); }}
           onOpenQuery={(sql) => editor.openQuery(sql, 'sql')}

--- a/src/renderer/lib/app/nav-view.ts
+++ b/src/renderer/lib/app/nav-view.ts
@@ -81,6 +81,20 @@ export function createNavView(ctx: NavViewCtx) {
   }
 
   /**
+   * Open a note and jump to a stored character offset — line bookmarks
+   * (#756). The offset is honored as-is; it can go stale if the text above
+   * it was edited since the bookmark was made (the offset-MVP tradeoff).
+   * `restorePosition` clamps an out-of-range offset.
+   */
+  async function handleOpenAtOffset(relativePath: string, offset: number) {
+    recordCurrentPosition();
+    await editor.openFile(relativePath);
+    await tick();
+    requestAnimationFrame(() => ctx.getEditorComponent()?.restorePosition(offset));
+    nav.record({ type: 'note', relativePath, offset });
+  }
+
+  /**
    * Locate a heading (by slug) or block-id inside raw markdown and return
    * the character offset of its line. Shared between source and split modes.
    */
@@ -181,6 +195,7 @@ export function createNavView(ctx: NavViewCtx) {
 
   return {
     recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate,
+    handleOpenAtOffset,
     handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
   };
 }

--- a/src/renderer/lib/app/text-helpers.ts
+++ b/src/renderer/lib/app/text-helpers.ts
@@ -41,6 +41,21 @@ export function offsetToLineCol(text: string, offset: number): { line: number; c
   return { line, col };
 }
 
+/**
+ * Display name for a line bookmark (#756): the trimmed text of the line the
+ * offset sits on, truncated, or `Line N` when that line is blank. Gives the
+ * bookmarks panel something legible without storing extra fields.
+ */
+export function lineBookmarkName(text: string, offset: number): string {
+  const clamped = Math.max(0, Math.min(offset, text.length));
+  const start = text.lastIndexOf('\n', clamped - 1) + 1;
+  const endNl = text.indexOf('\n', clamped);
+  const end = endNl === -1 ? text.length : endNl;
+  const line = text.slice(start, end).trim();
+  if (line) return line.length > 60 ? `${line.slice(0, 57)}…` : line;
+  return `Line ${offsetToLineCol(text, clamped).line}`;
+}
+
 /** Flatten a NoteFile tree to the relative paths of indexable leaf files. */
 export function flattenNotePaths(files: NoteFile[]): string[] {
   const out: string[] = [];

--- a/src/renderer/lib/components/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/BookmarksPanel.svelte
@@ -9,10 +9,12 @@
     onFileSelect: (relativePath: string) => void;
     /** Open + scroll to an anchor (`path#slug`) for section bookmarks. */
     onNavigate?: (target: string) => void | Promise<void>;
+    /** Open + jump to a character offset for line bookmarks (#756). */
+    onOpenAtOffset?: (relativePath: string, offset: number) => void | Promise<void>;
     onShowPrompt: (message: string) => Promise<string | null>;
   }
 
-  let { onFileSelect, onNavigate, onShowPrompt }: Props = $props();
+  let { onFileSelect, onNavigate, onOpenAtOffset, onShowPrompt }: Props = $props();
 
   const bookmarks = getBookmarksStore();
   let expanded = $state<Record<string, boolean>>({});
@@ -68,10 +70,18 @@
   function handleClick(node: BookmarkNode) {
     if (node.type === 'bookmark') {
       if (node.anchor && onNavigate) void onNavigate(`${node.relativePath}#${node.anchor}`);
+      else if (node.cursorOffset != null && onOpenAtOffset) void onOpenAtOffset(node.relativePath, node.cursorOffset);
       else onFileSelect(node.relativePath);
     } else {
       toggleFolder(node.id);
     }
+  }
+
+  /** Icon distinguishing the three bookmark kinds. */
+  function bmIcon(node: { anchor?: string; cursorOffset?: number }): 'outline' | 'dot' | 'bookmark' {
+    if (node.anchor) return 'outline';
+    if (node.cursorOffset != null) return 'dot';
+    return 'bookmark';
   }
 
   function showContextMenu(e: MouseEvent, node: BookmarkNode) {
@@ -186,7 +196,7 @@
       ondragstart={(e) => handleDragStart(e, node.id)}
     >
       <span class="chev"></span>
-      <Icon name={node.anchor ? 'outline' : 'bookmark'} size={13} color="var(--text-faint)" />
+      <Icon name={bmIcon(node)} size={13} color="var(--text-faint)" />
       <span class="bm-body">
         <span class="bm-name">{node.name}</span>
         <span class="bm-path">{node.anchor ? `${node.relativePath} › §` : node.relativePath}</span>

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -80,6 +80,9 @@
     /** Bookmark the section (nearest heading at/above the cursor). The
      *  handler reads the cursor via `getOffset()` and resolves the slug. */
     onBookmarkSection?: () => void;
+    /** Bookmark the current line — stores the cursor offset so opening
+     *  jumps back to it (#756). */
+    onBookmarkLine?: () => void;
     onInsertQueryList?: () => void;
     onNavigate?: (target: string) => void;
     /** Click on a `[[cite::source-id]]` in the editor → open the source tab. */
@@ -140,6 +143,7 @@
     onOpenConversation,
     onBookmark,
     onBookmarkSection,
+    onBookmarkLine,
     onInsertQueryList,
     onNavigate,
     onOpenSource,
@@ -1077,6 +1081,9 @@
     <button onclick={() => handleMenuAction(() => onBookmark?.())}>Bookmark This Note</button>
     {#if onBookmarkSection}
       <button onclick={() => handleMenuAction(() => onBookmarkSection?.())}>Bookmark Section</button>
+    {/if}
+    {#if onBookmarkLine}
+      <button onclick={() => handleMenuAction(() => onBookmarkLine?.())}>Bookmark Line</button>
     {/if}
     <div class="separator"></div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -91,6 +91,8 @@
      *  value chip (#489) so clicking opens the right note regardless of
      *  how the target is written. */
     onNavigate?: (target: string) => void | Promise<void>;
+    /** Open a note and jump to a character offset (line bookmarks, #756). */
+    onOpenAtOffset?: (relativePath: string, offset: number) => void | Promise<void>;
     onScrollToLine: (line: number) => void;
     onOpenConversation?: (message: string) => void;
     onOpenQuery: (sql: string) => void;
@@ -100,7 +102,7 @@
   }
 
   let {
-    activeFilePath, content, onFileSelect, onNavigate, onScrollToLine,
+    activeFilePath, content, onFileSelect, onNavigate, onOpenAtOffset, onScrollToLine,
     onOpenConversation, onOpenQuery, onOpenSource, onOpenExcerpt,
     onContentChange,
   }: Props = $props();
@@ -233,7 +235,7 @@
     {:else if activePanel === 'citations'}
       <CitationsPanel {activeFilePath} {content} {revision} {onOpenSource} {onOpenExcerpt} />
     {:else if activePanel === 'bookmarks'}
-      <BookmarksPanel {activeFilePath} {onFileSelect} {onNavigate} />
+      <BookmarksPanel {activeFilePath} {onFileSelect} {onNavigate} {onOpenAtOffset} />
     {:else if activePanel === 'inspections'}
       <InspectionsPanel {revision} {onOpenConversation} />
     {:else if activePanel === 'proposals'}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -48,6 +48,8 @@
     /** Open a note and scroll to an anchor, for `path#slug` targets (e.g.
      *  section bookmarks). Whole-file opens still go through onFileSelect. */
     onNavigate?: (target: string) => void | Promise<void>;
+    /** Open a note and jump to a character offset (line bookmarks). */
+    onOpenAtOffset?: (relativePath: string, offset: number) => void | Promise<void>;
     onNewNote: (directory: string) => void;
     onNewFolder: (directory: string) => void;
     onDelete: (relativePath: string, isDirectory: boolean) => void;
@@ -75,7 +77,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -599,7 +601,7 @@
       {/if}
     {:else if activePanel === 'bookmarks'}
       {#if onShowPrompt}
-        <BookmarksPanel {onFileSelect} {onNavigate} {onShowPrompt} />
+        <BookmarksPanel {onFileSelect} {onNavigate} {onOpenAtOffset} {onShowPrompt} />
       {/if}
     {/if}
   </div>

--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -9,9 +9,26 @@
     /** Open + scroll to an anchor (`path#slug`) for section bookmarks.
      *  Works even when the file is already active (scrolls in place). */
     onNavigate?: (target: string) => void | Promise<void>;
+    /** Open + jump to a character offset for line bookmarks (#756). */
+    onOpenAtOffset?: (relativePath: string, offset: number) => void | Promise<void>;
   }
 
-  let { activeFilePath, onFileSelect, onNavigate }: Props = $props();
+  let { activeFilePath, onFileSelect, onNavigate, onOpenAtOffset }: Props = $props();
+
+  /** Route a bookmark click by kind: section (anchor) → scroll to heading;
+   *  line (cursorOffset) → jump to offset; otherwise open the whole file. */
+  function openBookmark(bm: Bookmark) {
+    if (bm.anchor && onNavigate) void onNavigate(`${bm.relativePath}#${bm.anchor}`);
+    else if (bm.cursorOffset != null && onOpenAtOffset) void onOpenAtOffset(bm.relativePath, bm.cursorOffset);
+    else onFileSelect(bm.relativePath);
+  }
+
+  /** Icon distinguishing the three bookmark kinds. */
+  function bmIcon(bm: Bookmark): 'outline' | 'dot' | 'bookmark' {
+    if (bm.anchor) return 'outline';
+    if (bm.cursorOffset != null) return 'dot';
+    return 'bookmark';
+  }
 
   const bookmarks = getBookmarksStore();
 
@@ -45,10 +62,10 @@
           <button
             type="button"
             class="bm-open"
-            onclick={() => (bm.anchor && onNavigate ? onNavigate(`${bm.relativePath}#${bm.anchor}`) : onFileSelect(bm.relativePath))}
+            onclick={() => openBookmark(bm)}
             title={bm.anchor ? `${bm.relativePath} › ${bm.name}` : bm.name}
           >
-            <Icon name={bm.anchor ? 'outline' : 'bookmark'} size={13} color="var(--text-faint)" />
+            <Icon name={bmIcon(bm)} size={13} color="var(--text-faint)" />
             <span class="bm-name">{bm.name}</span>
           </button>
           <button

--- a/tests/renderer/app/text-helpers.test.ts
+++ b/tests/renderer/app/text-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   slugifyForPath,
   findAnchorOffset,
   offsetToLineCol,
+  lineBookmarkName,
   flattenNotePaths,
   countNotes,
   describeDeleteNoun,
@@ -57,6 +58,32 @@ describe('offsetToLineCol', () => {
     expect(offsetToLineCol(text, 2)).toEqual({ line: 1, col: 2 });
     expect(offsetToLineCol(text, 4)).toEqual({ line: 2, col: 0 });
     expect(offsetToLineCol(text, 7)).toEqual({ line: 3, col: 0 });
+  });
+});
+
+describe('lineBookmarkName (#756)', () => {
+  it('uses the trimmed text of the line the offset sits on', () => {
+    const text = '# Title\n\n  Methods and materials  \nbody';
+    const offset = text.indexOf('Methods') + 3;
+    expect(lineBookmarkName(text, offset)).toBe('Methods and materials');
+  });
+
+  it('falls back to "Line N" on a blank line', () => {
+    const text = 'first\n\nthird';
+    const blank = text.indexOf('\n') + 1; // start of the empty line 2
+    expect(lineBookmarkName(text, blank)).toBe('Line 2');
+  });
+
+  it('truncates long lines with an ellipsis', () => {
+    const long = 'x'.repeat(100);
+    const out = lineBookmarkName(long, 0);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBe(58); // 57 chars + ellipsis
+  });
+
+  it('clamps an out-of-range offset to the last line', () => {
+    const text = 'one\ntwo';
+    expect(lineBookmarkName(text, 9999)).toBe('two');
   });
 });
 

--- a/tests/renderer/components/right-sidebar/BookmarksPanel.test.ts
+++ b/tests/renderer/components/right-sidebar/BookmarksPanel.test.ts
@@ -62,4 +62,36 @@ describe('right-sidebar BookmarksPanel (#755)', () => {
     await fireEvent.click(getByText('Methods'));
     expect(onFileSelect).toHaveBeenCalledWith(ACTIVE);
   });
+
+  it('opens a line bookmark via onOpenAtOffset(path, offset)', async () => {
+    treeRef.current = [
+      { type: 'bookmark', id: 'd', name: 'some line', relativePath: ACTIVE, cursorOffset: 142 },
+    ];
+    const onFileSelect = vi.fn();
+    const onNavigate = vi.fn();
+    const onOpenAtOffset = vi.fn();
+    const { getByText } = render(BookmarksPanel, {
+      activeFilePath: ACTIVE, onFileSelect, onNavigate, onOpenAtOffset,
+    });
+
+    await fireEvent.click(getByText('some line'));
+    expect(onOpenAtOffset).toHaveBeenCalledWith(ACTIVE, 142);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('prefers the section anchor over a stored offset when both are present', async () => {
+    treeRef.current = [
+      { type: 'bookmark', id: 'e', name: 'Methods', relativePath: ACTIVE, anchor: 'methods', cursorOffset: 5 },
+    ];
+    const onNavigate = vi.fn();
+    const onOpenAtOffset = vi.fn();
+    const { getByText } = render(BookmarksPanel, {
+      activeFilePath: ACTIVE, onFileSelect: vi.fn(), onNavigate, onOpenAtOffset,
+    });
+
+    await fireEvent.click(getByText('Methods'));
+    expect(onNavigate).toHaveBeenCalledWith(`${ACTIVE}#methods`);
+    expect(onOpenAtOffset).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Implements **#756** (line/block bookmarks) as the **offset MVP** — the chosen point on the issue's resilience spectrum. Makes the cursor offset that bookmarks already captured real on open. Completes epic **#757** (sub-file bookmarks: whole-file + section #755 + line #756).

## The product call
Per the #756 decision: **offset MVP** — smallest change, **no file mutation**. The stored offset can go stale if text above it is edited later; that's the accepted tradeoff vs. the block-id (mutates the file) and content-rematch (fuzzy) options.

## Changes
- **Model:** a line bookmark is one with `cursorOffset` and **no** `anchor` — reuses the field added in #755, no new field. "Bookmark This Note" no longer captures an offset, so the discriminator stays clean (whole-file = neither; section = `anchor`; line = `cursorOffset`).
- **Create:** a **"Bookmark Line"** item in the source-editor context menu. Auto-names from the line's text (or `Line N` when blank) via the new pure `lineBookmarkName` helper.
- **Open:** new `handleOpenAtOffset` in nav-view opens the note and `restorePosition(offset)` (clamps a stale offset). Threaded to both bookmark panels as `onOpenAtOffset`, alongside the existing section `onNavigate` path.
- **Panel UI:** three distinct icons — `bookmark` (whole file), `outline` (section), `dot` (line).

## Note on legacy data
Older "Bookmark This Note" bookmarks created before this change captured an offset that was stored-but-ignored. They will now be treated as line bookmarks (open at that offset, dot icon). Benign — they restore to where you were — but worth knowing.

## Testing
- `pnpm lint` clean; `pnpm test` green (3131 passing).
- `lineBookmarkName`: line text, blank → `Line N`, truncation, out-of-range clamp.
- Panel routing: line → `onOpenAtOffset(path, offset)`; section anchor wins when both anchor and offset are present.

## Acceptance (#756)
- [x] Can bookmark a line; opening scrolls to it
- [x] Whole-file + section bookmarks unchanged
- [ ] Robust-across-edits — out of scope by design (offset MVP); block-id / content-rematch remain a future option

🤖 Generated with [Claude Code](https://claude.com/claude-code)