### PR TITLE
chore: remove dead a11y svelte-ignore suppressions (#761)

### DIFF
--- a/src/renderer/lib/components/FindInNotesDialog.svelte
+++ b/src/renderer/lib/components/FindInNotesDialog.svelte
@@ -270,7 +270,6 @@
               <Icon name={collapsedFile ? 'chevronRight' : 'chevronDown'} size={11} color="var(--text-faint)" />
             </span>
             {#if mode === 'replace'}
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
               <input
                 type="checkbox"
                 class="file-check"

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -171,7 +171,7 @@
 </script>
 
 <aside class="right-sidebar" style:width="{width}px">
-  <!-- svelte-ignore a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="resize-handle" class:dragging onmousedown={startResize}></div>
   <!-- Top row: group chips -->
   <div class="group-strip">

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -455,7 +455,7 @@
 <svelte:window onkeydown={handleKeyDown} />
 
 <aside class="sidebar" style:width="{width}px">
-  <!-- svelte-ignore a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="resize-handle" class:dragging onmousedown={startResize}></div>
 
   <div class="panel-tabs">

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -622,7 +622,6 @@
     {/if}
 
     {#if excerptMenu}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="excerpt-menu"

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -789,7 +789,6 @@
         <button onclick={() => handleRemoveFromActiveCollection(contextMenu!.source)}>Remove from collection</button>
       {/if}
       <div class="context-divider"></div>
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="submenu-item" role="menuitem" tabindex="-1" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">
           Mark as…

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -74,7 +74,6 @@
 <div class="tab-bar">
   {#each tabs as tab, i}
     {@const dirty = tab.type === 'note' && tab.content !== tab.savedContent}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="tab"
       class:active={i === activeIndex}


### PR DESCRIPTION
The stale-suppression cleanup from **#761**.

## What I found first
#761's *high-value* items are already in main — `svelte-check` reports **0 `a11y_*` warnings**:
- **Label associations** (the issue's "do first"): all `<label>`s are associated (`for=`/`id` or wrapping their control); the old `field-label` spots are `<span>`s.
- **Keyboard handlers on clickable rows**: OutlinePanel / OutgoingLinksPanel / BacklinksPanel / TabBar / both BookmarksPanels already have `role` + `tabindex` + `onkeydown`.

The reason svelte-check is clean is a mix of those real fixes **plus ~60 `svelte-ignore a11y_*` comments**. This PR audits those comments and removes the dead ones.

## Method
Strip every a11y suppression → run svelte-check → the warnings that reappear are the *live* ones; anything that doesn't reappear was silencing nothing. Six were dead:

| Element | Why the suppression was dead |
|---|---|
| `TabBar` tab `<div>` | already `role="tab"` |
| `SourcesPanel` submenu-item | already `role="menuitem"` |
| `FindInNotesDialog` file checkbox | native `<input>` — keyboard-accessible |
| `SourceDetail` excerpt-menu | already has a `keydown` handler |
| `RightSidebar` resize-handle | `noninteractive_element_interactions` only applies to elements with an implicit ARIA role (`li`/`ul`/…), never a bare `<div>` — kept the live `static_element` rule |
| `Sidebar` resize-handle | same as above |

(One initially-flagged candidate — the SourcesPanel date input — turned out to genuinely use `autofocus`, so its suppression was kept.)

## Result
- **0 a11y warnings, 27 total — unchanged.** Nothing real was unsilenced.
- Comment-only; no behavior change, no test impact. `pnpm lint` clean.

Deliberately **not** in scope (per the #761 triage): the decorative/pointer-only long tail (drag overlays, context-menu divs, Preview hover, density gutter) — those suppressions are load-bearing and intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)