### PR TITLE
feat: format-on-paste — reuse formatter rules, no paste flags (#160)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -39,6 +39,9 @@
   import { toHistorySnapshot, canRestoreHistory } from '../editor/history-snapshot';
   import { DEFAULT_FONT, clampFontSize, parseStoredFontSize } from '../editor/font-size';
   import { hasImageFiles, imageFilesFromTransfer, imageFilesFromClipboard } from '../editor/image-drop';
+  import { formatPaste } from '../editor/paste-format';
+  import { getFormatSettings } from '../formatter/settings';
+  import { buildParseCache } from '../../../shared/formatter/parse-cache';
   import { findFrontmatterFoldRange } from '../editor/frontmatter';
   import { clampMenuToViewport, clampSubmenu } from '../utils/menuClamp';
   import { extractClaimUri } from '../../../shared/refactor/find-arguments';
@@ -537,11 +540,31 @@
       // image clipboard contents (text / html) fall through.
       paste: (e, v) => {
         const items = e.clipboardData?.items;
-        if (!items) return false;
-        const files = imageFilesFromClipboard(items);
-        if (files.length === 0) return false;
+        if (items) {
+          const files = imageFilesFromClipboard(items);
+          if (files.length > 0) {
+            e.preventDefault();
+            void handleImageUploads(files, v.state.selection.main.head);
+            return true;
+          }
+        }
+        // Format-on-paste (#160): tidy the pasted text with the user's
+        // enabled paste-safe formatter rules + the always-on paste fixups.
+        const text = e.clipboardData?.getData('text/plain') ?? '';
+        if (!text) return false;
+        const pos = v.state.selection.main.from;
+        // Never reformat content pasted into a code fence / math / inline
+        // code — let the native paste insert it verbatim.
+        if (buildParseCache(v.state.doc.toString()).isProtected(pos)) return false;
+        const line = v.state.doc.lineAt(pos);
+        const lineBeforeCursor = line.text.slice(0, pos - line.from);
+        const out = formatPaste(text, getFormatSettings(), {
+          lineBeforeCursor,
+          inBlockquote: /^\s*>/.test(line.text),
+        });
+        if (out === text) return false; // unchanged → native paste
         e.preventDefault();
-        void handleImageUploads(files, v.state.selection.main.head);
+        v.dispatch(v.state.replaceSelection(out));
         return true;
       },
     }),

--- a/src/renderer/lib/editor/paste-format.ts
+++ b/src/renderer/lib/editor/paste-format.ts
@@ -1,0 +1,103 @@
+/**
+ * Format-on-paste (#160). On every text paste we run two things over the
+ * pasted fragment:
+ *
+ *   1. the **paste-safe subset of the user's enabled formatter rules** —
+ *      paste formatting follows the house style + their toggles, with no
+ *      separate `*-on-paste` settings (`formatPasteSafe`); and
+ *   2. a few **always-on, context-aware paste tidies** that have no
+ *      document-at-rest equivalent: outer-whitespace trim, list/checklist
+ *      marker de-duplication, and (inside a blockquote) footnote-marker
+ *      stripping + `>` continuation indentation.
+ *
+ * The caller (Editor's paste handler) is responsible for skipping this
+ * entirely when the cursor sits inside a protected region (code fence /
+ * math / inline code) — pasted code must not be reformatted.
+ *
+ * Importing this module also registers the formatter rules into the
+ * renderer's registry (the side-effect barrel below), so paste formatting
+ * works without the Settings dialog having been opened.
+ */
+
+import '../../../shared/formatter/rules/index';
+import { formatPasteSafe, type FormatSettings } from '../../../shared/formatter/engine';
+
+export interface PasteContext {
+  /** The cursor line's text up to the insertion point. Carries the leading
+   *  list/checklist marker and blockquote prefix the tidies key off. */
+  lineBeforeCursor: string;
+  /** True when the cursor sits on a blockquote line. */
+  inBlockquote: boolean;
+}
+
+/**
+ * Strip blank (whitespace-only) lines at the start and end of the paste,
+ * but preserve content-line indentation and join-spaces. A single-line
+ * paste is left untouched — so pasting a word to join (`foo` + ` bar`)
+ * keeps its leading space rather than silently producing `foobar`.
+ */
+export function blockTrim(text: string): string {
+  return text.replace(/^(?:[ \t]*\r?\n)+/, '').replace(/(?:\r?\n[ \t]*)+$/, '');
+}
+
+/**
+ * Drop a leading list/checklist marker from the pasted text when the cursor
+ * already sits on an (empty) marker line — otherwise you get `- - item`.
+ * Checklist lines are matched before plain-list lines (more specific).
+ */
+export function dedupeMarker(text: string, ctx: PasteContext): string {
+  const cur = ctx.lineBeforeCursor;
+  const nl = text.indexOf('\n');
+  const first = nl === -1 ? text : text.slice(0, nl);
+  const rest = nl === -1 ? '' : text.slice(nl);
+
+  // Cursor on an empty "- [ ] " checklist item.
+  if (/^\s*[-*+]\s+\[[ xX]\]\s*$/.test(cur)) {
+    const stripped = first.replace(/^\s*[-*+]\s+\[[ xX]\]\s+/, '');
+    return stripped === first ? text : stripped + rest;
+  }
+  // Cursor on an empty "- " / "1. " list item.
+  if (/^\s*([-*+]|\d+[.)])\s*$/.test(cur)) {
+    const stripped = first.replace(/^\s*([-*+]|\d+[.)])\s+/, '');
+    return stripped === first ? text : stripped + rest;
+  }
+  return text;
+}
+
+/** Strip inline footnote references (`[^id]`) from pasted quoted text, while
+ *  leaving footnote *definitions* (`[^id]: …`) intact. */
+export function stripFootnoteRefs(text: string): string {
+  return text.replace(/\[\^[^\]\s]+\](?!:)/g, '');
+}
+
+/**
+ * Keep multi-line content inside the blockquote it's pasted into: prefix
+ * every line after the first with the current line's quote prefix (`> `,
+ * `>> `, …). Lines that already begin a quote are left alone.
+ */
+export function addBlockquoteIndent(text: string, ctx: PasteContext): string {
+  const lines = text.split('\n');
+  if (lines.length < 2) return text;
+  const m = ctx.lineBeforeCursor.match(/^(\s*>+\s?)/);
+  const prefix = m ? m[1] : '> ';
+  for (let i = 1; i < lines.length; i++) {
+    if (!/^\s*>/.test(lines[i])) lines[i] = prefix + lines[i];
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Full paste pipeline. Returns the text to insert; equal to `text` when
+ * nothing changed (the caller then lets the native paste run, preserving
+ * CodeMirror's own undo/scroll behaviour).
+ */
+export function formatPaste(text: string, settings: FormatSettings, ctx: PasteContext): string {
+  let out = blockTrim(text);
+  out = formatPasteSafe(out, settings);
+  out = dedupeMarker(out, ctx);
+  if (ctx.inBlockquote) {
+    out = stripFootnoteRefs(out);
+    out = addBlockquoteIndent(out, ctx);
+  }
+  return out;
+}

--- a/src/shared/formatter/engine.ts
+++ b/src/shared/formatter/engine.ts
@@ -10,6 +10,7 @@
 
 import { buildParseCache } from './parse-cache';
 import { HOUSE_STYLE_RULE_IDS } from './house-style';
+import { PASTE_SAFE_RULE_IDS } from './paste-safe';
 import { CATEGORY_ORDER, getRule, listAllRules } from './registry';
 import type { EnabledRule, FormatterRule } from './types';
 
@@ -49,6 +50,24 @@ export function formatContent(content: string, settings: FormatSettings): string
 
   let current = content;
   for (const { rule, config } of enabledRules) {
+    const cache = buildParseCache(current);
+    const next = rule.apply(current, config, cache);
+    if (next !== current) current = next;
+  }
+  return current;
+}
+
+/**
+ * Apply the user's enabled rules to a *pasted fragment* (#160), restricted
+ * to the fragment-safe subset (`PASTE_SAFE_RULE_IDS`). Same enable/ordering
+ * semantics as `formatContent`, so paste formatting follows the house style
+ * + the user's toggles — there are no separate paste settings. Whole-
+ * document rules are skipped because the fragment isn't the whole document.
+ */
+export function formatPasteSafe(text: string, settings: FormatSettings): string {
+  let current = text;
+  for (const { rule, config } of resolveEnabled(settings)) {
+    if (!PASTE_SAFE_RULE_IDS.has(rule.id)) continue;
     const cache = buildParseCache(current);
     const next = rule.apply(current, config, cache);
     if (next !== current) current = next;

--- a/src/shared/formatter/paste-safe.ts
+++ b/src/shared/formatter/paste-safe.ts
@@ -1,0 +1,56 @@
+/**
+ * The subset of formatter rules that are safe to run over a *pasted
+ * fragment* (#160). Paste auto-formatting reuses the on-demand formatter
+ * rules the user already enabled — there are no separate `*-on-paste`
+ * toggles — but only the fragment-local ones may run, because the pasted
+ * text is not the whole document.
+ *
+ * Excluded by design (would misbehave on a fragment):
+ *   - whole-document rules — `unique-heading-slugs`, `unique-block-ids`,
+ *     footnote re-indexing / relocation, `header-increment`
+ *   - document-edge rules — `line-break-at-document-end`
+ *   - filename/doc-dependent — `file-name-heading`
+ *   - frontmatter (`yaml/*`, `canonicalize-frontmatter-keys`) — a paste
+ *     into the body has no frontmatter to normalise
+ *   - block-separation spacing (`empty-line-around-*`, `heading-blank-lines`)
+ *     — these pad a block with surrounding blank lines, which is a
+ *     whole-document concern, not a paste-range one
+ *
+ * Membership is keyed off the same rule ids the engine uses; a paste-safe
+ * rule still only runs when the user has it enabled (`isRuleEnabled`).
+ */
+
+export const PASTE_SAFE_RULE_IDS: ReadonlySet<string> = new Set([
+  // Inline text normalisations — purely local.
+  'proper-ellipsis',
+  'remove-multiple-spaces',
+  'remove-hyphenated-line-breaks',
+  'no-bare-urls',
+  'quote-style',
+  'emphasis-style',
+  'strong-style',
+  'blockquote-style',
+  'auto-correct-common-misspellings',
+
+  // List tidy — operates within the pasted lines.
+  'remove-empty-list-markers',
+  'remove-consecutive-list-markers',
+  'unordered-list-marker-style',
+  'ordered-list-style',
+
+  // Heading text (not structure/levels) — local to the heading line.
+  'remove-trailing-punctuation-in-heading',
+  'capitalize-headings',
+
+  // Whitespace within the fragment.
+  'trailing-spaces',
+  'consecutive-blank-lines',
+  'space-after-list-marker',
+  'remove-empty-lines-between-list-markers-and-checklists',
+  'remove-link-spacing',
+  'consistent-indentation',
+
+  // Minerva link hygiene — rewrites the link text in place.
+  'canonical-wiki-link-extension',
+  'remove-redundant-wiki-link-display',
+]);

--- a/tests/renderer/editor/paste-format.test.ts
+++ b/tests/renderer/editor/paste-format.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Format-on-paste pipeline (#160). The always-on context tidies are pure
+ * `(text, ctx) → text`; `formatPaste` composes them with the paste-safe
+ * formatter rules. The Editor integration (protected-region guard, CM
+ * dispatch) is covered by manual testing; here we pin the pure logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  blockTrim,
+  dedupeMarker,
+  stripFootnoteRefs,
+  addBlockquoteIndent,
+  formatPaste,
+  type PasteContext,
+} from '../../../src/renderer/lib/editor/paste-format';
+import { DEFAULT_FORMAT_SETTINGS } from '../../../src/shared/formatter/engine';
+
+const ctx = (over: Partial<PasteContext> = {}): PasteContext => ({
+  lineBeforeCursor: '',
+  inBlockquote: false,
+  ...over,
+});
+
+describe('blockTrim', () => {
+  it('strips outer blank lines', () => {
+    expect(blockTrim('\n\nfoo\nbar\n\n')).toBe('foo\nbar');
+    expect(blockTrim('  \n foo\n')).toBe(' foo');
+  });
+
+  it('leaves a single-line paste untouched (preserves join-spaces)', () => {
+    expect(blockTrim(' bar')).toBe(' bar');
+    expect(blockTrim('  hi  ')).toBe('  hi  ');
+  });
+
+  it('preserves first-line indentation of a multi-line paste', () => {
+    expect(blockTrim('\n  - nested\n  - items')).toBe('  - nested\n  - items');
+  });
+});
+
+describe('dedupeMarker', () => {
+  it('drops a leading "- " when the cursor is on an empty list item', () => {
+    expect(dedupeMarker('- foo\n- bar', ctx({ lineBeforeCursor: '- ' }))).toBe('foo\n- bar');
+  });
+
+  it('drops a leading checklist marker when the cursor is on an empty checklist item', () => {
+    expect(dedupeMarker('- [ ] task', ctx({ lineBeforeCursor: '- [ ] ' }))).toBe('task');
+  });
+
+  it('drops an ordered marker when the cursor is on an empty ordered item', () => {
+    expect(dedupeMarker('3. third', ctx({ lineBeforeCursor: '1. ' }))).toBe('third');
+  });
+
+  it('leaves text alone when the cursor line is not an empty marker', () => {
+    expect(dedupeMarker('- foo', ctx({ lineBeforeCursor: 'some text ' }))).toBe('- foo');
+  });
+
+  it('leaves text alone when the pasted line has no marker', () => {
+    expect(dedupeMarker('plain', ctx({ lineBeforeCursor: '- ' }))).toBe('plain');
+  });
+});
+
+describe('stripFootnoteRefs', () => {
+  it('removes inline footnote references', () => {
+    expect(stripFootnoteRefs('A claim[^1] and another[^note].')).toBe('A claim and another.');
+  });
+
+  it('keeps footnote definitions', () => {
+    expect(stripFootnoteRefs('[^1]: the definition')).toBe('[^1]: the definition');
+  });
+});
+
+describe('addBlockquoteIndent', () => {
+  it('prefixes continuation lines with the quote marker', () => {
+    expect(addBlockquoteIndent('line one\nline two', ctx({ lineBeforeCursor: '> ' })))
+      .toBe('line one\n> line two');
+  });
+
+  it('preserves a nested quote prefix', () => {
+    expect(addBlockquoteIndent('a\nb', ctx({ lineBeforeCursor: '>> ' })))
+      .toBe('a\n>> b');
+  });
+
+  it('does not double-prefix lines that already start a quote', () => {
+    expect(addBlockquoteIndent('a\n> b', ctx({ lineBeforeCursor: '> ' })))
+      .toBe('a\n> b');
+  });
+
+  it('leaves single-line pastes unchanged', () => {
+    expect(addBlockquoteIndent('just one', ctx({ lineBeforeCursor: '> ' }))).toBe('just one');
+  });
+});
+
+describe('formatPaste composition', () => {
+  it('trims, then strips footnotes and indents inside a blockquote', () => {
+    const out = formatPaste('\nfirst\nsecond[^1]\n', DEFAULT_FORMAT_SETTINGS, ctx({
+      lineBeforeCursor: '> ',
+      inBlockquote: true,
+    }));
+    expect(out).toBe('first\n> second');
+  });
+
+  it('applies an enabled paste-safe formatter rule', () => {
+    const out = formatPaste('see...', { enabled: { 'proper-ellipsis': true }, configs: {} }, ctx());
+    expect(out).toBe('see…');
+  });
+
+  it('does not touch a marker when the cursor is mid-line (no dedupe)', () => {
+    const out = formatPaste('- item', DEFAULT_FORMAT_SETTINGS, ctx({ lineBeforeCursor: 'text' }));
+    expect(out).toBe('- item');
+  });
+});

--- a/tests/shared/formatter/engine.test.ts
+++ b/tests/shared/formatter/engine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   formatContent,
   formatContentToFixedPoint,
+  formatPasteSafe,
   isRuleEnabled,
   resolveEnabled,
   DEFAULT_FORMAT_SETTINGS,
@@ -153,5 +154,26 @@ describe('house style defaults', () => {
     registerRule(rule({ id: nonHouseId, apply: (c) => c }));
     const enabled = resolveEnabled(DEFAULT_FORMAT_SETTINGS);
     expect(enabled.map((e) => e.rule.id)).toEqual([houseId]);
+  });
+});
+
+describe('formatPasteSafe (#160)', () => {
+  beforeEach(__resetRuleRegistryForTests);
+
+  it('runs an enabled paste-safe rule but skips an enabled non-paste-safe rule', () => {
+    // 'proper-ellipsis' is paste-safe; 'unique-heading-slugs' is not.
+    registerRule(rule({ id: 'proper-ellipsis', apply: (c) => c.replaceAll('...', '…') }));
+    registerRule(rule({ id: 'unique-heading-slugs', apply: (c) => `${c}[WHOLE-DOC]` }));
+    const out = formatPasteSafe('a... b', {
+      enabled: { 'proper-ellipsis': true, 'unique-heading-slugs': true },
+      configs: {},
+    });
+    expect(out).toBe('a… b'); // ellipsis applied; whole-doc rule did not run
+  });
+
+  it('does not run a paste-safe rule the user has disabled', () => {
+    registerRule(rule({ id: 'proper-ellipsis', apply: (c) => c.replaceAll('...', '…') }));
+    const out = formatPasteSafe('a...', { enabled: { 'proper-ellipsis': false }, configs: {} });
+    expect(out).toBe('a...');
   });
 });


### PR DESCRIPTION
Reframes **#160** per the design discussion: drop the parallel `*-on-paste` rules and their toggles. **Paste formatting reuses the formatter rules you already enabled** — no separate "Paste" settings category. If a rule runs in a format pass and is fragment-safe, it just happens on paste too.

## On every text paste (Editor paste handler)
1. **Skip in protected regions.** If the cursor sits in a code fence / math / inline code, fall through to the native paste — pasted code is never reformatted. Reuses the formatter's own `buildParseCache(...).isProtected()`.
2. **Run the paste-safe enabled rules** over the pasted fragment (`formatPasteSafe` + `PASTE_SAFE_RULE_IDS`). Behavior follows the house style + your toggles. Whole-document rules are excluded by design — `unique-*`, footnote reindex/relocation, `yaml/*`, `file-name-heading`, `header-increment`, `line-break-at-document-end`, `empty-line-around-*`/`heading-blank-lines` — they'd misbehave on a fragment.
3. **Always-on, context-aware tidies** (no formatter equivalent, so always on per the agreed scope):
   - outer **blank-line trim** — single-line pastes left untouched so join-spaces and indentation survive (no `foo` + ` bar` → `foobar`)
   - list / checklist **marker de-dup** when the cursor is on an empty marker line (`- ` + paste `- foo` → `foo`)
   - inside a blockquote: **strip inline footnote refs** + prefix continuation lines with the quote marker (`> `)

When the pipeline changes nothing, the **native paste runs unchanged** (preserves CodeMirror undo/scroll). Runs synchronously in the renderer — no IPC per paste.

## Notes / decisions
- **No master on/off toggle.** Paste tidying is always on by design (your call); the formatter portion follows your existing formatter settings, so disabling formatter rules already quiets most of it. Easy to add a kill-switch later if wanted.
- The paste-safe allowlist (`src/shared/formatter/paste-safe.ts`) mirrors the `house-style.ts` pattern — one file, trivial to tweak membership.

## Testing
- `pnpm lint` clean; `pnpm test` green (3153 passing).
- `formatPasteSafe`: runs enabled paste-safe rules, skips enabled whole-doc rules and disabled rules.
- Pure tidies: `blockTrim` (block edges only, single-line/indentation preserved), `dedupeMarker` (list/checklist/ordered/no-op cases), `stripFootnoteRefs` (refs out, definitions kept), `addBlockquoteIndent` (nested prefix, no double-prefix, single-line no-op), and `formatPaste` composition.
- The CM integration (protected-region guard, dispatch) is covered by manual testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)