### PR TITLE
feat: thoughtbase-scope context for cross-note formatter rules (#215)

### DIFF
--- a/src/main/formatter/orchestrator.ts
+++ b/src/main/formatter/orchestrator.ts
@@ -5,7 +5,7 @@ import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
 import { formatContent, type FormatSettings } from '../../shared/formatter/engine';
-import type { FormatFileResult } from '../../shared/formatter/types';
+import type { FormatContext, FormatFileResult } from '../../shared/formatter/types';
 import { slugify } from '../../shared/slug';
 import { renameAnchor } from '../notebase/rename-anchor';
 // Side-effect import: populates the rule registry on the main-process side.
@@ -29,11 +29,18 @@ export function formatNoteContent(
   content: string,
   settings: FormatSettings,
   relativePath?: string,
+  rootPath?: string,
 ): string {
   const settingsWithCtx = relativePath
     ? injectFileContext(settings, relativePath)
     : settings;
-  return formatContent(content, settingsWithCtx);
+  // Buffer-mode format (e.g. palette Format on the active note). When we know
+  // the file + project, hand cross-note rules the same context an on-disk
+  // format gets, so behaviour matches between the two paths (#215).
+  const ctx = relativePath && rootPath
+    ? buildFormatContext(rootPath, relativePath)
+    : undefined;
+  return formatContent(content, settingsWithCtx, ctx);
 }
 
 /** Format a single `.md` file on disk + route the write through the standard broadcast pipeline. */
@@ -44,7 +51,7 @@ export async function formatFile(
 ): Promise<FormatFileResult> {
   const before = await notebaseFs.readFile(rootPath, relativePath);
   const settingsWithCtx = injectFileContext(settings, relativePath);
-  const after = formatContent(before, settingsWithCtx);
+  const after = formatContent(before, settingsWithCtx, buildFormatContext(rootPath, relativePath));
   if (after === before) {
     return { relativePath, changed: false, before, after, cascadedPaths: [] };
   }
@@ -174,6 +181,21 @@ function extractHeadingSlugsInOrder(content: string): string[] {
     if (m) out.push(slugify(m[2].trim()));
   }
   return out;
+}
+
+/**
+ * Thoughtbase-scope context for cross-note rules (#215). Backed by the graph
+ * (note list + incoming-anchor links), so it's a main-process concern; the
+ * engine just forwards it to each rule's `apply`.
+ */
+function buildFormatContext(rootPath: string, relativePath: string): FormatContext {
+  const ctx = projectContext(rootPath);
+  return {
+    notePath: relativePath,
+    allNotePaths: graph.allNotePaths(ctx),
+    incomingAnchorLinkCount: (target, slug) =>
+      graph.findNotesLinkingToAnchor(ctx, target, slug).length,
+  };
 }
 
 function injectFileContext(settings: FormatSettings, relativePath: string): FormatSettings {

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -23,7 +23,7 @@ import {
 // external `import * as graph from './graph/index'` callers are unchanged.
 export {
   getAliasMap, getAliasEntries, getAllFrontmatterKeys, noteUriFor, headingsFor,
-  findNotesCitingSource, findNotesQuotingExcerpt, findNotesLinkingToAnchor,
+  findNotesCitingSource, findNotesQuotingExcerpt, findNotesLinkingToAnchor, allNotePaths,
   injectSparqlPrefixes, schemaForCompletion, queryGraph,
   listTags, notesByTagPrefix, notesByTag, sourcesByTag, listAllSources, allTags,
   outgoingLinks, findDerivedNoteForCell, findNotesLinkingTo, backlinks, findExternalInboundLinks,

--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -156,6 +156,14 @@ function collectNotePathsWithPredicate(
   return [...seen];
 }
 
+/** All indexed `.md` note paths in the thoughtbase (#215 — cross-note
+ *  rules use this to reason about which link shortenings are unambiguous). */
+export function allNotePaths(ctx: ProjectContext): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  return [...state.indexedNotePaths].filter((p) => p.endsWith('.md'));
+}
+
 /** Like findNotesLinkingTo, but scoped to links whose anchor is exactly `slug`. */
 export function findNotesLinkingToAnchor(
   ctx: ProjectContext,

--- a/src/main/ipc/register-refactor.ts
+++ b/src/main/ipc/register-refactor.ts
@@ -70,8 +70,8 @@ export function registerRefactor(): void {
   // Formatter (issue #153)
   ipcMain.handle(
     Channels.FORMATTER_FORMAT_CONTENT,
-    (_e, content: string, settings: FormatSettings, relativePath?: string) =>
-      formatNoteContent(content, settings, relativePath),
+    (e, content: string, settings: FormatSettings, relativePath?: string) =>
+      formatNoteContent(content, settings, relativePath, rootPathFromEvent(e) ?? undefined),
   );
 
   // Project-scoped formatter settings (#154). Stored in .minerva/formatter.json

--- a/src/shared/formatter/engine.ts
+++ b/src/shared/formatter/engine.ts
@@ -12,7 +12,7 @@ import { buildParseCache } from './parse-cache';
 import { HOUSE_STYLE_RULE_IDS } from './house-style';
 import { PASTE_SAFE_RULE_IDS } from './paste-safe';
 import { CATEGORY_ORDER, getRule, listAllRules } from './registry';
-import type { EnabledRule, FormatterRule } from './types';
+import type { EnabledRule, FormatContext, FormatterRule } from './types';
 
 export interface FormatSettings {
   /**
@@ -44,14 +44,18 @@ export const DEFAULT_FORMAT_SETTINGS: FormatSettings = {
  * Apply enabled rules to `content`. Returns the rewritten string; equal to
  * `content` when no enabled rule matched.
  */
-export function formatContent(content: string, settings: FormatSettings): string {
+export function formatContent(
+  content: string,
+  settings: FormatSettings,
+  ctx?: FormatContext,
+): string {
   const enabledRules = resolveEnabled(settings);
   if (enabledRules.length === 0) return content;
 
   let current = content;
   for (const { rule, config } of enabledRules) {
     const cache = buildParseCache(current);
-    const next = rule.apply(current, config, cache);
+    const next = rule.apply(current, config, cache, ctx);
     if (next !== current) current = next;
   }
   return current;
@@ -106,10 +110,11 @@ export function formatContentToFixedPoint(
   content: string,
   settings: FormatSettings,
   maxPasses = 3,
+  ctx?: FormatContext,
 ): string {
   let current = content;
   for (let i = 0; i < maxPasses; i++) {
-    const next = formatContent(current, settings);
+    const next = formatContent(current, settings, ctx);
     if (next === current) return current;
     current = next;
   }

--- a/src/shared/formatter/rules/index.ts
+++ b/src/shared/formatter/rules/index.ts
@@ -55,6 +55,7 @@ import './minerva/remove-redundant-wiki-link-display';
 import './minerva/canonicalize-frontmatter-keys';
 import './minerva/unique-block-ids-per-note';
 import './minerva/unique-heading-slugs';
+import './minerva/strip-orphaned-block-ids';
 
 // Footnote (#159) — reference placement, definition ordering, renumbering.
 // `move-footnotes-to-the-bottom` runs before `re-index-footnotes` so the

--- a/src/shared/formatter/rules/minerva/strip-orphaned-block-ids.ts
+++ b/src/shared/formatter/rules/minerva/strip-orphaned-block-ids.ts
@@ -1,0 +1,30 @@
+import { registerRule } from '../../registry';
+import { transformUnprotected } from '../helpers';
+
+/**
+ * A block-id marker is `^id` after one or more spaces, near the end of a line.
+ * Same matcher as `unique-block-ids-per-note`; see `note-anchors.ts` for the
+ * canonical form.
+ */
+const BLOCK_ID_RE = /(\s)\^([\w-]+)(?=\s*(?:\r?\n|$))/g;
+
+registerRule({
+  id: 'strip-orphaned-block-ids',
+  category: 'minerva',
+  title: 'Strip orphaned block-ids',
+  description:
+    'Remove `^block-id` markers that no `[[note#^block-id]]` link anywhere in the thoughtbase points at. Off by default — a block-id you just added but haven’t linked yet counts as orphaned and will be stripped on the next format. Needs thoughtbase context, so it only runs when formatting a saved note or folder, not on paste.',
+  defaultConfig: {},
+  apply(content, _cfg, cache, ctx) {
+    const incoming = ctx?.incomingAnchorLinkCount;
+    const notePath = ctx?.notePath;
+    // No cross-note context (e.g. paste / a buffer with no project) → can't
+    // tell orphans from linked ids, so leave every marker alone.
+    if (!incoming || !notePath) return content;
+    return transformUnprotected(content, cache, (seg) =>
+      seg.replace(BLOCK_ID_RE, (match, _lead: string, id: string) =>
+        incoming(notePath, `^${id}`) === 0 ? '' : match,
+      ),
+    );
+  },
+});

--- a/src/shared/formatter/types.ts
+++ b/src/shared/formatter/types.ts
@@ -39,14 +39,33 @@ export interface ParseCache {
   isProtected(offset: number): boolean;
 }
 
+/**
+ * Thoughtbase-scope context for cross-note rules (#215). Most rules are
+ * purely local and ignore this; a few need to know about *other* notes —
+ * which paths exist, or who links to a given anchor. The orchestrator
+ * populates it on the main side (it has the graph + file list); buffer-mode
+ * formatting (e.g. paste) leaves it undefined, and ctx-dependent rules must
+ * no-op gracefully when a field they need is absent.
+ */
+export interface FormatContext {
+  /** Relative path of the note being formatted. */
+  notePath?: string;
+  /** All `.md` relative paths in the thoughtbase. */
+  allNotePaths?: readonly string[];
+  /** How many notes link to `target#slug` (slug is a heading slug, or a
+   *  `^block-id` including the caret). Backed by the graph. */
+  incomingAnchorLinkCount?: (target: string, slug: string) => number;
+}
+
 export interface FormatterRule<Config = unknown> {
   id: string;
   category: FormatterCategory;
   title: string;
   description: string;
   defaultConfig: Config;
-  /** Pure, idempotent. Must not perform IO or mutate shared state. */
-  apply(content: string, config: Config, cache: ParseCache): string;
+  /** Idempotent, no IO of its own. `ctx` (#215) is the only outside channel:
+   *  cross-note rules read through it; local rules ignore it. */
+  apply(content: string, config: Config, cache: ParseCache, ctx?: FormatContext): string;
 }
 
 /** A rule bound to its user-configured state for a single invocation. */

--- a/tests/main/formatter/orchestrator-cascade.test.ts
+++ b/tests/main/formatter/orchestrator-cascade.test.ts
@@ -101,3 +101,35 @@ describe('formatter orchestrator heading-rename cascade (#156)', () => {
     expect(result.cascadedPaths).toEqual([]);
   });
 });
+
+describe('formatter orchestrator cross-note context (#215)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('strip-orphaned-block-ids drops a block-id nothing links to, keeps a linked one', async () => {
+    writeNote(root, 'notes/foo.md', 'linked para ^kept\n\norphan para ^gone\n');
+    writeNote(root, 'notes/bar.md', 'See [[notes/foo#^kept]].\n');
+
+    await indexNote(ctx, 'notes/foo.md', readNote(root, 'notes/foo.md'));
+    await indexNote(ctx, 'notes/bar.md', readNote(root, 'notes/bar.md'));
+
+    const result = await formatFile(root, 'notes/foo.md', {
+      enabled: { 'strip-orphaned-block-ids': true },
+      configs: {},
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.after).toBe('linked para ^kept\n\norphan para\n');
+    expect(readNote(root, 'notes/foo.md')).toBe('linked para ^kept\n\norphan para\n');
+  });
+});

--- a/tests/shared/formatter/engine.test.ts
+++ b/tests/shared/formatter/engine.test.ts
@@ -157,6 +157,27 @@ describe('house style defaults', () => {
   });
 });
 
+describe('FormatContext threading (#215)', () => {
+  beforeEach(__resetRuleRegistryForTests);
+
+  it('passes the ctx through to rule.apply', () => {
+    registerRule(rule({
+      id: 'ctx-probe',
+      apply: (c, _cfg, _cache, ctx) => (ctx?.notePath ? `${c}[${ctx.notePath}]` : c),
+    }));
+    const out = formatContent('x', { enabled: { 'ctx-probe': true }, configs: {} }, { notePath: 'a.md' });
+    expect(out).toBe('x[a.md]');
+  });
+
+  it('rule sees undefined ctx when none is supplied', () => {
+    registerRule(rule({
+      id: 'ctx-probe',
+      apply: (c, _cfg, _cache, ctx) => (ctx === undefined ? `${c}[NONE]` : c),
+    }));
+    expect(formatContent('x', { enabled: { 'ctx-probe': true }, configs: {} })).toBe('x[NONE]');
+  });
+});
+
 describe('formatPasteSafe (#160)', () => {
   beforeEach(__resetRuleRegistryForTests);
 

--- a/tests/shared/formatter/rules/minerva/strip-orphaned-block-ids.test.ts
+++ b/tests/shared/formatter/rules/minerva/strip-orphaned-block-ids.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import '../../../../../src/shared/formatter/rules/minerva/strip-orphaned-block-ids';
+import { formatContent } from '../../../../../src/shared/formatter/engine';
+import type { FormatContext } from '../../../../../src/shared/formatter/types';
+
+const enabled = { enabled: { 'strip-orphaned-block-ids': true }, configs: {} };
+
+/** ctx where the listed `^id` anchors have incoming links and all else are orphans. */
+function ctx(linked: string[]): FormatContext {
+  return {
+    notePath: 'notes/foo.md',
+    incomingAnchorLinkCount: (_target, slug) => (linked.includes(slug) ? 1 : 0),
+  };
+}
+
+describe('strip-orphaned-block-ids (#215)', () => {
+  it('strips a block-id nothing links to', () => {
+    expect(formatContent('A paragraph ^orphan\n', enabled, ctx([]))).toBe('A paragraph\n');
+  });
+
+  it('keeps a block-id that has incoming links', () => {
+    const src = 'A paragraph ^kept\n';
+    expect(formatContent(src, enabled, ctx(['^kept']))).toBe(src);
+  });
+
+  it('strips only the orphans, keeping the linked ones', () => {
+    expect(formatContent('one ^a\n\ntwo ^b\n', enabled, ctx(['^b']))).toBe('one\n\ntwo ^b\n');
+  });
+
+  it('no-ops without cross-note context (paste / no project)', () => {
+    const src = 'A paragraph ^x\n';
+    expect(formatContent(src, enabled)).toBe(src);                       // no ctx at all
+    expect(formatContent(src, enabled, { notePath: 'notes/foo.md' })).toBe(src); // ctx, no link fn
+  });
+
+  it('ignores `^id`-looking text inside fenced code', () => {
+    const src = '```\ncode ^notid\n```\n';
+    expect(formatContent(src, enabled, ctx([]))).toBe(src);
+  });
+
+  it('is off by default (not in the house style)', () => {
+    expect(formatContent('p ^orphan\n', { enabled: {}, configs: {} }, ctx([]))).toBe('p ^orphan\n');
+  });
+});


### PR DESCRIPTION
Implements **#215**: gives formatter rules an optional `FormatContext` so the few that need cross-note information can reach it, and lands the first consumer.

## Plumbing (the reusable core)
- **`FormatContext`** `{ notePath, allNotePaths, incomingAnchorLinkCount }` in `types.ts`; `apply(content, config, cache, ctx?)`. Back-compat — existing rules just ignore the 4th arg. (I added `notePath` to the issue's sketch since a rule needs to ask "who links to **this** note's anchor.")
- **Engine** — `formatContent` / `formatContentToFixedPoint` thread `ctx` to each rule. The renderer paste path (`formatPasteSafe`, #160) passes no ctx, so ctx-dependent rules no-op there.
- **Orchestrator (main)** builds the ctx — graph-backed: `allNotePaths` from the graph (new `graph.allNotePaths()` accessor), `incomingAnchorLinkCount` over `findNotesLinkingToAnchor`, `notePath` per file. Wired for **both** on-disk (`formatFile`/folder) and **buffer-mode** (`formatNoteContent`, via the IPC handler's `rootPath`) so palette-Format and sidebar-Format behave identically. Generalizes the existing `file-name-heading` config-injection.

## First consumer: `strip-orphaned-block-ids`
Removes `^block-id` markers that no `[[note#^block-id]]` link anywhere in the thoughtbase points at.
- **Off by default** (not in the house style) — per the agreed footgun call: a block-id you just added but haven't linked yet counts as orphaned and would be stripped on the next format.
- No-ops without ctx (paste / no project), and skips `^id`-looking text inside code fences.

## Deferred (follow-up)
`canonical-wiki-link-path-style` — its "shortest-unambiguous" form needs alias-aware resolution, not just `allNotePaths`, so it warrants its own design pass. The plumbing here (`allNotePaths`) is ready for it. Tracked separately.

## Testing
- `pnpm lint` clean; `pnpm test` green (3162 passing).
- ctx threading (rule sees ctx / undefined); the rule (strip / keep-linked / no-ctx no-op / protected-region / off-by-default); **end-to-end via `formatFile` with a real graph** — `^kept` (linked from another note) survives, `^gone` (orphan) is stripped.

Built on #161; part of the formatter epic #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)