### PR TITLE
feat: LLM SQL tools — describe_tables + query_sql (#780, #781)

### DIFF
--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -4,6 +4,7 @@ import * as fs from '../notebase/fs';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
+import * as tables from '../sources/tables';
 import ONTOLOGY_TTL from '../../shared/ontology.ttl?raw';
 import THOUGHT_ONTOLOGY_TTL from '../../shared/ontology-thought.ttl?raw';
 import type {
@@ -233,6 +234,42 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
     input_schema: {
       type: 'object',
       properties: {},
+    },
+  },
+  {
+    name: 'describe_tables',
+    description:
+      'List the CSV-backed tables registered in DuckDB, with each table\'s ' +
+      'columns and row count. This is the SQL counterpart to ' +
+      'describe_graph_schema. Call it before writing a `query_sql` query (or ' +
+      'a ```sql compute cell) when you are unsure what tables exist or what ' +
+      'columns they have. Returns "no tables" when the thoughtbase has no ' +
+      'CSV files registered.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'query_sql',
+    description:
+      'Run a read-only SQL query against the thoughtbase\'s DuckDB and get ' +
+      'the rows back. Use this to actually inspect CSV table data (count, ' +
+      'filter, join, aggregate) and reason over the result. This is the SQL ' +
+      'counterpart to query_graph. Read-only: only SELECT / WITH / DESCRIBE ' +
+      '/ SHOW / EXPLAIN / SUMMARIZE queries run; one statement at a time. If ' +
+      'you are unsure about table or column names, call describe_tables ' +
+      'first. (Use propose_compute instead when the user should review and ' +
+      'keep the query as a cell.)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        sql: {
+          type: 'string',
+          description: 'A read-only SQL query (SELECT / WITH / DESCRIBE / SHOW / …).',
+        },
+      },
+      required: ['sql'],
     },
   },
   {
@@ -518,8 +555,9 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
       'Use the standard minerva/thought/dc prefixes; they\'re auto-injected.\n' +
       '  - `sql` — query CSV tables registered in DuckDB. Table names follow the ' +
       'project-relative path with `/` and `.` collapsed to `_` (or the user\'s ' +
-      '`table_name:` override). Call `read_note` on the companion `.md` first if ' +
-      'unsure about a table\'s shape.\n' +
+      '`table_name:` override). Call `describe_tables` to list tables + columns; ' +
+      'use `query_sql` if you just need to see the data yourself rather than ' +
+      'leaving the user a cell.\n' +
       '  - `python` — pandas / numpy / matplotlib analysis. Network calls, ' +
       'subprocess, and file-write APIs are flagged in the UI and require an extra ' +
       'confirmation — avoid them unless genuinely necessary.\n' +
@@ -718,6 +756,10 @@ export async function executeNotebaseTool(
         return runQuery(ctx, input);
       case 'describe_graph_schema':
         return { content: runDescribeSchema(), isError: false };
+      case 'describe_tables':
+        return runDescribeTables(ctx);
+      case 'query_sql':
+        return runQuerySql(ctx, input);
       case 'propose_notes':
         return runProposeNotes(ctx, input, callbacks);
       case 'propose_sources':
@@ -1054,6 +1096,79 @@ function runDescribeSchema(): string {
     '',
     THOUGHT_ONTOLOGY_TTL,
   ].join('\n');
+}
+
+/** describe_tables (#780): list registered DuckDB/CSV tables + their columns. */
+async function runDescribeTables(ctx: ToolContext): Promise<{ content: string; isError: boolean }> {
+  const list = await tables.listTables(projectContext(ctx.rootPath));
+  if (list.length === 0) {
+    return {
+      content:
+        'No CSV tables are registered in this thoughtbase. Add a `.csv` file ' +
+        '(optionally with a companion `.md` carrying a `table_name:` override) ' +
+        'to create one.',
+      isError: false,
+    };
+  }
+  const lines = list.map((t) => {
+    const cols = t.columns.length ? t.columns.join(', ') : '(no columns)';
+    const rows = `${t.rowCount} row${t.rowCount === 1 ? '' : 's'}`;
+    return `- ${t.name} — ${rows}, from ${t.relativePath}\n    columns: ${cols}`;
+  });
+  return {
+    content:
+      'Registered DuckDB tables (query with query_sql or a ```sql cell):\n\n' +
+      lines.join('\n'),
+    isError: false,
+  };
+}
+
+const SQL_READONLY_FIRST_WORDS = new Set([
+  'SELECT', 'WITH', 'DESCRIBE', 'SHOW', 'EXPLAIN', 'SUMMARIZE', 'TABLE', 'FROM', 'VALUES', 'PIVOT', 'UNPIVOT',
+]);
+const QUERY_SQL_ROW_CAP = 200;
+
+/** query_sql (#781): immediate read-only SQL over the project's DuckDB. */
+async function runQuerySql(ctx: ToolContext, input: unknown): Promise<{ content: string; isError: boolean }> {
+  const { sql } = input as { sql: string };
+  if (typeof sql !== 'string' || !sql.trim()) {
+    throw new Error('sql is required');
+  }
+  // Read-only gate: single statement whose leading keyword is a query form.
+  // CSV tables are a read surface; mutations go through propose_compute.
+  const trimmed = sql.trim().replace(/;\s*$/, '');
+  if (/;/.test(trimmed)) {
+    return {
+      content: 'query_sql runs one statement at a time — remove the extra `;`-separated statements.',
+      isError: true,
+    };
+  }
+  const firstWord = trimmed.match(/^\s*(\w+)/)?.[1]?.toUpperCase();
+  if (!firstWord || !SQL_READONLY_FIRST_WORDS.has(firstWord)) {
+    return {
+      content:
+        'query_sql is read-only — start with SELECT / WITH / DESCRIBE / SHOW / EXPLAIN / SUMMARIZE. ' +
+        'Use propose_compute to propose a cell for anything that modifies state.',
+      isError: true,
+    };
+  }
+  const response = await tables.runQuery(projectContext(ctx.rootPath), trimmed);
+  if (!response.ok) {
+    return {
+      content: `SQL error: ${response.error}\n\nCall describe_tables to see available tables and columns.`,
+      isError: true,
+    };
+  }
+  if (response.rows.length === 0) {
+    return { content: 'No rows.', isError: false };
+  }
+  const shown = response.rows.slice(0, QUERY_SQL_ROW_CAP);
+  const body = JSON.stringify(shown, null, 2);
+  const note =
+    response.rows.length > QUERY_SQL_ROW_CAP
+      ? `\n\n(${response.rows.length} rows total; showing the first ${QUERY_SQL_ROW_CAP}. Add LIMIT or aggregate to narrow.)`
+      : '';
+  return { content: body + note, isError: false };
 }
 
 /**

--- a/tests/main/llm/sql-tools.test.ts
+++ b/tests/main/llm/sql-tools.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool } from '../../../src/main/llm/tools';
+import { initTablesDb, registerCsv, disposeProject } from '../../../src/main/sources/tables';
+import { projectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-sql-tools-test-'));
+}
+
+describe('LLM SQL tools — describe_tables (#780) + query_sql (#781)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    await initTablesDb(projectContext(root));
+  });
+
+  afterEach(async () => {
+    disposeProject(projectContext(root));
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function writeCsv(rel: string, content: string): Promise<void> {
+    const abs = path.join(root, rel);
+    await fsp.mkdir(path.dirname(abs), { recursive: true });
+    await fsp.writeFile(abs, content, 'utf-8');
+    await registerCsv(projectContext(root), rel);
+  }
+
+  it('describe_tables lists a registered table with its columns', async () => {
+    await writeCsv('stations.csv', 'id,name,lat\n1,Alpha,0.1\n2,Beta,0.2\n');
+    const res = await executeNotebaseTool({ rootPath: root }, 'describe_tables', {});
+    expect(res.isError).toBe(false);
+    expect(res.content).toContain('stations');
+    expect(res.content).toContain('id, name, lat');
+    expect(res.content).toContain('2 rows');
+  });
+
+  it('describe_tables reports a clear empty state', async () => {
+    const res = await executeNotebaseTool({ rootPath: root }, 'describe_tables', {});
+    expect(res.isError).toBe(false);
+    expect(res.content).toMatch(/no csv tables/i);
+  });
+
+  it('query_sql returns rows for a SELECT', async () => {
+    await writeCsv('stations.csv', 'id,name\n1,Alpha\n2,Beta\n');
+    const res = await executeNotebaseTool({ rootPath: root }, 'query_sql', {
+      sql: 'SELECT name FROM stations ORDER BY id',
+    });
+    expect(res.isError).toBe(false);
+    const rows = JSON.parse(res.content) as Array<{ name: string }>;
+    expect(rows.map((r) => r.name)).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('query_sql rejects non-read-only statements', async () => {
+    await writeCsv('stations.csv', 'id,name\n1,Alpha\n');
+    for (const sql of ['DELETE FROM stations', 'CREATE TABLE x (a int)', 'DROP TABLE stations']) {
+      const res = await executeNotebaseTool({ rootPath: root }, 'query_sql', { sql });
+      expect(res.isError).toBe(true);
+      expect(res.content).toMatch(/read-only/i);
+    }
+  });
+
+  it('query_sql rejects multiple statements', async () => {
+    await writeCsv('stations.csv', 'id\n1\n');
+    const res = await executeNotebaseTool({ rootPath: root }, 'query_sql', {
+      sql: 'SELECT * FROM stations; DROP TABLE stations',
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/one statement/i);
+  });
+
+  it('query_sql error points at describe_tables', async () => {
+    const res = await executeNotebaseTool({ rootPath: root }, 'query_sql', {
+      sql: 'SELECT * FROM does_not_exist',
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/describe_tables/);
+  });
+});


### PR DESCRIPTION
Gives the LLM the two SQL tools it was missing, mirroring what it already has for SPARQL.

**Before:** SPARQL had an immediate executor (`query_graph`) and a schema tool (`describe_graph_schema`). SQL had neither — it was only reachable via `propose_compute` (proposal-gated, results go to the user), and the only schema hint was *"call `read_note` on the companion `.md`."*

## Added
- **`describe_tables`** (#780) — lists the registered DuckDB/CSV tables with columns + row counts (formats the existing `tables.listTables`). Clear empty state. The SQL analog of `describe_graph_schema`.
- **`query_sql`** (#781) — runs a **read-only** SQL query against the project's DuckDB and returns the rows to the model (wraps the existing `tables.runQuery`). The SQL analog of `query_graph`.
  - Read-only gate: single statement, leading keyword must be a query form (`SELECT`/`WITH`/`DESCRIBE`/`SHOW`/`EXPLAIN`/`SUMMARIZE`/`TABLE`/`VALUES`/`PIVOT`); writes are pushed to `propose_compute`.
  - Row cap (200) with a truncation note; errors point at `describe_tables`.
- `propose_compute`'s sql guidance now points at `describe_tables` / `query_sql` instead of "read the companion `.md`."

Both wrap **existing** backend functions — no new query/DB plumbing.

## Testing
- `pnpm lint` clean; `pnpm test` green (3182 passing).
- New `sql-tools.test.ts` (driven through `executeNotebaseTool`): table list + columns + row count, empty state, `SELECT` round-trip, read-only rejections (`DELETE`/`CREATE`/`DROP`), multi-statement rejection, and error → `describe_tables`.

Closes #780, closes #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)