### PR TITLE
fix: remove Decompose Note + Crystallize from the editor right-click menu

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -704,14 +704,14 @@
   } satisfies TemplateOpsCtx);
 
   // Conversation / tool-invocation handler cluster (#670): save-cell-output
-  // (#244), decompose / crystallize (#515), the freeform / message / from-tool
+  // (#244), decompose (#515), the freeform / message / from-tool
   // conversation openers, and generic tool invocation. Lives in
   // ./lib/app/conversation-ops.ts. Placed after createNavView so handleFileSelect
   // is in scope for the openFileSelect getter; reaches the editor view + tool-
   // panel component via ctx. The conversationsStore / toolPanel store handles
   // stay in App (onMount streaming still uses them).
   const {
-    handleSaveCellOutput, handleDecompose, handleCrystallize,
+    handleSaveCellOutput, handleDecompose,
     openConversation, newConversation, openConversationWithMessage, handleOpenConversationFromTool, handleToolInvoke,
   } = createConversationOps({
     getEditorView: () => editorComponent?.getView(),
@@ -1216,8 +1216,6 @@
                     onAutoTag={() => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); }}
                     onAutoLink={() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); }}
                     onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
-                    onDecompose={() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); }}
-                    onCrystallize={() => { if (editor.activeFilePath) void handleCrystallize(editor.activeFilePath); }}
                     onFormatCurrentNote={() => handleFormat()}
                     onUploadError={(message) => {
                       // Image-upload rejection (#455). Surface via the

--- a/src/renderer/lib/app/conversation-ops.ts
+++ b/src/renderer/lib/app/conversation-ops.ts
@@ -1,6 +1,6 @@
 /**
  * Conversation / tool-invocation handler cluster extracted from App.svelte
- * (#670). Save-cell-output (#244), decompose / crystallize (#515), the
+ * (#670). Save-cell-output (#244), decompose (#515), the
  * freeform / message / from-tool conversation openers, and generic tool
  * invocation. Bodies are verbatim from App.svelte; the only changes are the
  * ctx getter substitutions for the pieces that used to be inline component
@@ -108,19 +108,13 @@ export function createConversationOps(ctx: ConversationOpsCtx) {
 
   async function handleDecompose(_relativePath: string) {
     if (!notebase.meta) return;
-    // Both decompose and crystallize are ThinkingTools (#515), so the
-    // editor right-click menu routes through the same tool-prep flow
-    // the ToolPanel uses. The `_relativePath` arg is preserved for
-    // API symmetry with the other right-click handlers, but the tool
-    // gathers its own `fullNote` context against the active editor.
+    // Decompose is a ThinkingTool (#515), so the Refactor ▸ Decompose Note
+    // menu item (and the command palette) routes through the same tool-prep
+    // flow the ToolPanel uses. The `_relativePath` arg is preserved for API
+    // symmetry with the other handlers, but the tool gathers its own
+    // `fullNote` context against the active editor.
     const toolCtx = await gatherContext(['fullNote'], ctx.getEditorView());
     await handleOpenConversationFromTool({ toolId: 'research.decompose', context: toolCtx });
-  }
-
-  async function handleCrystallize(_relativePath: string) {
-    if (!notebase.meta) return;
-    const toolCtx = await gatherContext(['fullNote'], ctx.getEditorView());
-    await handleOpenConversationFromTool({ toolId: 'research.crystallize', context: toolCtx });
   }
 
   async function openConversationWithMessage(message: string) {
@@ -189,7 +183,6 @@ export function createConversationOps(ctx: ConversationOpsCtx) {
   return {
     handleSaveCellOutput,
     handleDecompose,
-    handleCrystallize,
     openConversation,
     newConversation,
     openConversationWithMessage,

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -103,8 +103,6 @@
     onAutoTag?: () => void;
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
-    onDecompose?: () => void;
-    onCrystallize?: () => void;
     onFormatCurrentNote?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
@@ -162,8 +160,6 @@
     onAutoTag,
     onAutoLink,
     onAutoLinkInbound,
-    onDecompose,
-    onCrystallize,
     onFormatCurrentNote,
     getNotePaths,
     getSources,
@@ -1036,7 +1032,7 @@
       {/each}
     {/if}
     <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onMerge || onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose || onCrystallize}
+    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onMerge || onAutoTag || onAutoLink || onAutoLinkInbound}
       <div class="submenu-item" onmouseenter={adjustSubmenu}>
         <span class="submenu-trigger">Refactor<Icon name="chevronRight" size={10} /></span>
         <div class="submenu">
@@ -1067,7 +1063,7 @@
           {#if onSplitByHeading}
             <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
           {/if}
-          {#if onAutoTag || onAutoLink || onAutoLinkInbound || onDecompose || onCrystallize}
+          {#if onAutoTag || onAutoLink || onAutoLinkInbound}
             {#if onExtractSelection || onSplitHere || onSplitByHeading}
               <div class="separator"></div>
             {/if}
@@ -1079,12 +1075,6 @@
             {/if}
             {#if onAutoLinkInbound}
               <button onclick={() => handleMenuAction(() => onAutoLinkInbound?.())}>Auto-link inbound&hellip;</button>
-            {/if}
-            {#if onDecompose}
-              <button onclick={() => handleMenuAction(() => onDecompose?.())}>Decompose Note&hellip;</button>
-            {/if}
-            {#if onCrystallize}
-              <button onclick={() => handleMenuAction(() => onCrystallize?.())}>Crystallize as Components&hellip;</button>
             {/if}
           {/if}
           {#if onFormatCurrentNote}


### PR DESCRIPTION
Both **Decompose Note…** and **Crystallize as Components…** are obsoleted by the data-driven Tools ▸ Research entries that now appear in the right-click menu (`research.decompose`, `research.crystallize` skills), so the dedicated Refactor items were redundant.

## Changes
- Removed the two buttons from the editor context menu and the `onDecompose` / `onCrystallize` Editor props (+ the App.svelte wiring).
- **Kept `handleDecompose`** — still used by the native **Refactor ▸ Decompose Note** menu item and the command palette. Only the right-click entry is gone.
- `handleCrystallize`'s only entry point was this menu, so removed the now-orphaned wrapper from `conversation-ops.ts`. Crystallization remains available via the **`research.crystallize`** skill under Tools ▸ Research.

## Testing
- `pnpm lint` clean; `pnpm test` green (3182 passing). No tests referenced the removed wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)