### PR TITLE
fix: group typed links under a "Typed Link..." submenu in Insert

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -999,12 +999,17 @@
         <button onclick={() => runCmd(insertHorizontalRule)}>Horizontal Rule</button>
         <button onclick={() => runCmd(insertFootnote)}>Footnote</button>
         <div class="submenu-separator"></div>
-        {#each insertTypedLinks as { linkType, command }}
-          <button onclick={() => runCmd(command)}>
-            <span class="typed-link-dot" style:background={linkType.color}></span>
-            {linkType.label} Link
-          </button>
-        {/each}
+        <div class="submenu-item" onmouseenter={adjustSubmenu}>
+          <span class="submenu-trigger">Typed Link...<Icon name="chevronRight" size={10} /></span>
+          <div class="submenu">
+            {#each insertTypedLinks as { linkType, command }}
+              <button onclick={() => runCmd(command)}>
+                <span class="typed-link-dot" style:background={linkType.color}></span>
+                {linkType.label} Link
+              </button>
+            {/each}
+          </div>
+        </div>
         <div class="submenu-separator"></div>
         <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
       </div>


### PR DESCRIPTION
The colored typed-link entries (`supports`, `rebuts`, `cite`, etc.) were a flat block in the editor right-click **Insert** submenu. Move them into a nested **Typed Link...** submenu so Insert stays scannable:

```
Insert ▸
  Wiki Link
  URL Link
  Image
  Table
  Horizontal Rule
  Footnote
  ──────────
  Typed Link... ▸
    ● supports Link
    ● rebuts Link
    ● … (all typed links, with their colored dots)
  ──────────
  Link List for Tag...
```

Same entries and colored dots, just nested one level. Uses the existing recursive `> .submenu` CSS (no styling changes).

`pnpm lint` clean. Markup-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)