### PR TITLE
fix: reorganize editor right-click submenus (Highlight / Link / Paragraph / Elements)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -24,9 +24,10 @@
   import { sortLines, selectionTracker } from '../editor/commands';
   import {
     toggleBold, toggleItalic, toggleCode, toggleStrikethrough, toggleHighlight,
-    toggleH1, toggleH2, toggleH3, toggleQuote, toggleBulletList, toggleNumberedList, toggleTaskList,
+    toggleH1, toggleH2, toggleH3, toggleQuote, toggleBulletList, toggleNumberedList,
     insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage,
-    insertWikiLink, insertTypedLinks,
+    insertWikiLink, insertTypedLinks, insertCallouts,
+    insertSparqlQuery, insertSqlQuery, insertPythonScript, insertMermaidDiagram,
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
@@ -994,7 +995,7 @@
           </div>
         </div>
         <div class="submenu-separator"></div>
-        <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
+        <button onclick={() => runCmd(insertFootnote)}>Footnote</button>
       </div>
     </div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
@@ -1003,6 +1004,17 @@
         <button onclick={() => runCmd(toggleH1)}>Heading 1</button>
         <button onclick={() => runCmd(toggleH2)}>Heading 2</button>
         <button onclick={() => runCmd(toggleH3)}>Heading 3</button>
+        <div class="submenu-separator"></div>
+        <button onclick={() => runCmd(toggleQuote)}>Quote</button>
+        <div class="submenu-item" onmouseenter={adjustSubmenu}>
+          <span class="submenu-trigger">Callout...<Icon name="chevronRight" size={10} /></span>
+          <div class="submenu">
+            {#each insertCallouts as { label, command }}
+              <button onclick={() => runCmd(command)}>{label}</button>
+            {/each}
+          </div>
+        </div>
+        <button onclick={() => runCmd(insertHorizontalRule)}>Horizontal Rule</button>
       </div>
     </div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
@@ -1012,10 +1024,18 @@
         <button onclick={() => runCmd(insertImage)}>Image</button>
         <button onclick={() => runCmd(toggleBulletList)}>Bulleted List</button>
         <button onclick={() => runCmd(toggleNumberedList)}>Numbered List</button>
-        <button onclick={() => runCmd(toggleTaskList)}>Task List</button>
-        <button onclick={() => runCmd(toggleQuote)}>Quote</button>
-        <button onclick={() => runCmd(insertHorizontalRule)}>Horizontal Rule</button>
-        <button onclick={() => runCmd(insertFootnote)}>Footnote</button>
+        <div class="submenu-separator"></div>
+        <div class="submenu-item" onmouseenter={adjustSubmenu}>
+          <span class="submenu-trigger">Query...<Icon name="chevronRight" size={10} /></span>
+          <div class="submenu">
+            <button onclick={() => runCmd(insertSqlQuery)}>SQL</button>
+            <button onclick={() => runCmd(insertSparqlQuery)}>SPARQL</button>
+          </div>
+        </div>
+        <button onclick={() => runCmd(insertPythonScript)}>Python Script</button>
+        <button onclick={() => runCmd(insertMermaidDiagram)}>Mermaid Diagram</button>
+        <div class="submenu-separator"></div>
+        <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
       </div>
     </div>
     {#if onToolInvoke && toolMenus.length > 0}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -968,37 +968,20 @@
     {/if}
     <div class="separator"></div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Format<Icon name="chevronRight" size={10} /></span>
+      <span class="submenu-trigger">Highlight<Icon name="chevronRight" size={10} /></span>
       <div class="submenu">
+        <button onclick={() => runCmd(toggleHighlight)}>Colored Highlight</button>
         <button onclick={() => runCmd(toggleBold)}>Bold</button>
         <button onclick={() => runCmd(toggleItalic)}>Italic</button>
         <button onclick={() => runCmd(toggleCode)}>Code</button>
         <button onclick={() => runCmd(toggleStrikethrough)}>Strikethrough</button>
-        <button onclick={() => runCmd(toggleHighlight)}>Highlight</button>
       </div>
     </div>
     <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Paragraph<Icon name="chevronRight" size={10} /></span>
-      <div class="submenu">
-        <button onclick={() => runCmd(toggleH1)}>Heading 1</button>
-        <button onclick={() => runCmd(toggleH2)}>Heading 2</button>
-        <button onclick={() => runCmd(toggleH3)}>Heading 3</button>
-        <button onclick={() => runCmd(toggleQuote)}>Quote</button>
-        <button onclick={() => runCmd(toggleBulletList)}>Bulleted List</button>
-        <button onclick={() => runCmd(toggleNumberedList)}>Numbered List</button>
-        <button onclick={() => runCmd(toggleTaskList)}>Task List</button>
-      </div>
-    </div>
-    <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Insert<Icon name="chevronRight" size={10} /></span>
+      <span class="submenu-trigger">Link<Icon name="chevronRight" size={10} /></span>
       <div class="submenu">
         <button onclick={() => runCmd(insertWikiLink)}>Wiki Link</button>
         <button onclick={() => runCmd(insertLink)}>URL Link</button>
-        <button onclick={() => runCmd(insertImage)}>Image</button>
-        <button onclick={() => runCmd(insertTable)}>Table</button>
-        <button onclick={() => runCmd(insertHorizontalRule)}>Horizontal Rule</button>
-        <button onclick={() => runCmd(insertFootnote)}>Footnote</button>
-        <div class="submenu-separator"></div>
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
           <span class="submenu-trigger">Typed Link...<Icon name="chevronRight" size={10} /></span>
           <div class="submenu">
@@ -1012,6 +995,27 @@
         </div>
         <div class="submenu-separator"></div>
         <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
+      </div>
+    </div>
+    <div class="submenu-item" onmouseenter={adjustSubmenu}>
+      <span class="submenu-trigger">Paragraph<Icon name="chevronRight" size={10} /></span>
+      <div class="submenu">
+        <button onclick={() => runCmd(toggleH1)}>Heading 1</button>
+        <button onclick={() => runCmd(toggleH2)}>Heading 2</button>
+        <button onclick={() => runCmd(toggleH3)}>Heading 3</button>
+      </div>
+    </div>
+    <div class="submenu-item" onmouseenter={adjustSubmenu}>
+      <span class="submenu-trigger">Elements<Icon name="chevronRight" size={10} /></span>
+      <div class="submenu">
+        <button onclick={() => runCmd(insertTable)}>Table</button>
+        <button onclick={() => runCmd(insertImage)}>Image</button>
+        <button onclick={() => runCmd(toggleBulletList)}>Bulleted List</button>
+        <button onclick={() => runCmd(toggleNumberedList)}>Numbered List</button>
+        <button onclick={() => runCmd(toggleTaskList)}>Task List</button>
+        <button onclick={() => runCmd(toggleQuote)}>Quote</button>
+        <button onclick={() => runCmd(insertHorizontalRule)}>Horizontal Rule</button>
+        <button onclick={() => runCmd(insertFootnote)}>Footnote</button>
       </div>
     </div>
     {#if onToolInvoke && toolMenus.length > 0}

--- a/src/renderer/lib/editor/formatting.ts
+++ b/src/renderer/lib/editor/formatting.ts
@@ -373,3 +373,70 @@ export const insertWikiLink: Command = (view: EditorView) => {
   }
   return true;
 };
+
+// ── Fenced block + diagram inserts ─────────────────────────────────────────
+
+/** Insert a fenced block in `lang` with the cursor on its empty body line.
+ *  Adds a leading newline when not already at the start of a line. */
+function makeInsertFence(lang: string): Command {
+  return (view: EditorView) => {
+    const pos = view.state.selection.main.head;
+    const line = view.state.doc.lineAt(pos);
+    const prefix = pos === line.from ? '' : '\n';
+    const open = `${prefix}\`\`\`${lang}\n`;
+    view.dispatch({
+      changes: { from: pos, insert: `${open}\n\`\`\`\n` },
+      selection: { anchor: pos + open.length }, // empty line inside the fence
+    });
+    return true;
+  };
+}
+
+export const insertSparqlQuery: Command = makeInsertFence('sparql');
+export const insertSqlQuery: Command = makeInsertFence('sql');
+export const insertPythonScript: Command = makeInsertFence('python');
+export const insertMermaidDiagram: Command = makeInsertFence('mermaid');
+
+// ── Callout inserts ────────────────────────────────────────────────────────
+
+/** Callout types supported by the preview's callout plugin, in a sensible
+ *  menu order. */
+const CALLOUT_TYPES: { type: string; label: string }[] = [
+  { type: 'note', label: 'Note' },
+  { type: 'abstract', label: 'Abstract' },
+  { type: 'info', label: 'Info' },
+  { type: 'tip', label: 'Tip' },
+  { type: 'success', label: 'Success' },
+  { type: 'question', label: 'Question' },
+  { type: 'warning', label: 'Warning' },
+  { type: 'failure', label: 'Failure' },
+  { type: 'danger', label: 'Danger' },
+  { type: 'bug', label: 'Bug' },
+  { type: 'example', label: 'Example' },
+  { type: 'quote', label: 'Quote' },
+  { type: 'todo', label: 'Todo' },
+];
+
+function makeInsertCallout(type: string): Command {
+  return (view: EditorView) => {
+    const { state } = view;
+    const { from, to } = state.selection.main;
+    const selected = state.sliceDoc(from, to);
+    const line = state.doc.lineAt(from);
+    const prefix = from === line.from ? '' : '\n';
+    if (selected) {
+      // Wrap the selection as the callout body.
+      const body = selected.split('\n').map((l) => `> ${l}`).join('\n');
+      const insert = `${prefix}> [!${type}]\n${body}\n`;
+      view.dispatch({ changes: { from, to, insert }, selection: { anchor: from + insert.length } });
+    } else {
+      const head = `${prefix}> [!${type}]\n> `;
+      view.dispatch({ changes: { from, insert: head }, selection: { anchor: from + head.length } });
+    }
+    return true;
+  };
+}
+
+/** Pre-built insert commands per callout type, for the editor menu. */
+export const insertCallouts: { type: string; label: string; command: Command }[] =
+  CALLOUT_TYPES.map((c) => ({ ...c, command: makeInsertCallout(c.type) }));

--- a/tests/renderer/editor/insert-commands.test.ts
+++ b/tests/renderer/editor/insert-commands.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Fenced-block (Query / Python / Mermaid) and Callout insert commands added
+ * to the editor right-click menu. They're full CodeMirror commands, so we
+ * stand up a detached EditorView and assert the resulting doc + cursor.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import {
+  insertSqlQuery,
+  insertSparqlQuery,
+  insertPythonScript,
+  insertMermaidDiagram,
+  insertCallouts,
+} from '../../../src/renderer/lib/editor/formatting';
+
+let view: EditorView;
+afterEach(() => view?.destroy());
+
+function mk(doc: string, pos = doc.length): EditorView {
+  view = new EditorView({ state: EditorState.create({ doc, selection: { anchor: pos } }) });
+  return view;
+}
+
+describe('fenced-block inserts', () => {
+  it('insertSqlQuery inserts a ```sql fence with the cursor on the body line', () => {
+    const v = mk('');
+    insertSqlQuery(v);
+    expect(v.state.doc.toString()).toBe('```sql\n\n```\n');
+    expect(v.state.selection.main.head).toBe('```sql\n'.length); // empty body line
+  });
+
+  it('insertSparqlQuery / insertPythonScript / insertMermaidDiagram use the right language', () => {
+    expect((insertSparqlQuery(mk('')), view.state.doc.toString())).toBe('```sparql\n\n```\n');
+    expect((insertPythonScript(mk('')), view.state.doc.toString())).toBe('```python\n\n```\n');
+    expect((insertMermaidDiagram(mk('')), view.state.doc.toString())).toBe('```mermaid\n\n```\n');
+  });
+
+  it('adds a leading newline when not at the start of a line', () => {
+    const v = mk('text', 4);
+    insertSqlQuery(v);
+    expect(v.state.doc.toString()).toBe('text\n```sql\n\n```\n');
+  });
+});
+
+describe('callout inserts', () => {
+  it('exposes all 13 supported callout types', () => {
+    expect(insertCallouts.map((c) => c.type)).toEqual([
+      'note', 'abstract', 'info', 'tip', 'success', 'question',
+      'warning', 'failure', 'danger', 'bug', 'example', 'quote', 'todo',
+    ]);
+  });
+
+  it('inserts a `> [!type]` callout with the cursor on the body line', () => {
+    const note = insertCallouts.find((c) => c.type === 'note')!;
+    const v = mk('');
+    note.command(v);
+    expect(v.state.doc.toString()).toBe('> [!note]\n> ');
+    expect(v.state.selection.main.head).toBe('> [!note]\n> '.length);
+  });
+
+  it('wraps a selection as the callout body', () => {
+    const warn = insertCallouts.find((c) => c.type === 'warning')!;
+    const v = mk('line one\nline two', 0);
+    v.dispatch({ selection: { anchor: 0, head: v.state.doc.length } });
+    warn.command(v);
+    expect(v.state.doc.toString()).toBe('> [!warning]\n> line one\n> line two\n');
+  });
+});


### PR DESCRIPTION
The **Format / Paragraph / Insert** submenus in the editor right-click menu had drifted into a grab-bag. Regroup into four clearer submenus, in order:

| New submenu | Contents |
|---|---|
| **Highlight** | was "Format" — **Colored Highlight** (renamed from "Highlight", moved first), Bold, Italic, Code, Strikethrough |
| **Link** | the linking inserts: Wiki Link, URL Link, **Typed Link...** (submenu), Link List for Tag… |
| **Paragraph** | just the heading levels — Heading 1 / 2 / 3 |
| **Elements** | the block elements: Table, Image, Bulleted/Numbered/Task List, Quote, Horizontal Rule, Footnote |

So lists + Quote move out of Paragraph, and Table / Image / Horizontal Rule / Footnote move out of Insert — both into Elements. No commands were added or removed; this is pure regrouping + the one rename.

`pnpm lint` clean. Markup-only change.