### PR TITLE
feat: reserve room for nested submenus near the right edge

### DIFF
--- a/src/renderer/lib/utils/menuClamp.ts
+++ b/src/renderer/lib/utils/menuClamp.ts
@@ -60,6 +60,36 @@ export function clampMenuToViewport(
 }
 
 /**
+ * Decide which side a submenu should open on (true = left, false = right).
+ * Pure geometry so it's unit-testable.
+ *
+ * Two refinements over a naive "flip left only if the right edge overflows":
+ *   - **Reserve room for a nested level.** When the submenu itself contains
+ *     further submenus (`hasNested`), require room for one more same-width
+ *     level on the chosen side — otherwise a chosen child flyout has nowhere
+ *     to open and clips near the right edge.
+ *   - **Inherit the cascade direction.** Once a chain has opened leftward
+ *     (`inheritLeft`), keep it leftward unless the left genuinely won't fit,
+ *     so descendants don't zig-zag back over their parent.
+ */
+export function chooseSubmenuSide(opts: {
+  itemLeft: number;
+  itemRight: number;
+  submenuWidth: number;
+  viewportWidth: number;
+  inheritLeft: boolean;
+  hasNested: boolean;
+  margin?: number;
+}): boolean {
+  const margin = opts.margin ?? MARGIN;
+  const reserve = opts.hasNested ? opts.submenuWidth : 0;
+  const rightFits = opts.itemRight + opts.submenuWidth + reserve <= opts.viewportWidth - margin;
+  const leftFits = opts.itemLeft - opts.submenuWidth - reserve >= margin;
+  if (opts.inheritLeft) return leftFits || !rightFits;
+  return !rightFits && leftFits;
+}
+
+/**
  * Reposition a hover-opened `.submenu` inside the given `.submenu-item`
  * so it stays in the viewport. Resets prior overrides first so the
  * default CSS position (right + below the parent) is measured cleanly,
@@ -77,11 +107,34 @@ export function clampSubmenu(item: HTMLElement): void {
   submenu.style.left = '';
   submenu.style.right = '';
 
+  // Inherit the open side from the nearest ancestor submenu that already
+  // chose one (recorded via `dataset.openLeft` below).
+  const parentSubmenu = item.closest<HTMLElement>('.submenu');
+  const inheritLeft = parentSubmenu?.dataset.openLeft === 'true';
+
   requestAnimationFrame(() => {
     const subRect = submenu.getBoundingClientRect();
     const itemRect = item.getBoundingClientRect();
     const vh = window.innerHeight;
     const vw = window.innerWidth;
+
+    // Horizontal: pick the side with room — reserving space for one more
+    // level when this submenu has nested submenus, and inheriting the
+    // parent chain's direction. Record the choice so children inherit it.
+    const hasNested = !!submenu.querySelector(':scope > .submenu-item > .submenu');
+    const openLeft = chooseSubmenuSide({
+      itemLeft: itemRect.left,
+      itemRight: itemRect.right,
+      submenuWidth: subRect.width,
+      viewportWidth: vw,
+      inheritLeft,
+      hasNested,
+    });
+    if (openLeft) {
+      submenu.style.left = 'auto';
+      submenu.style.right = '100%';
+    }
+    submenu.dataset.openLeft = String(openLeft);
 
     // Vertical: prefer down (default), else flip up, else clamp to top
     // edge. The flipped position has the submenu's bottom 4px below the
@@ -103,11 +156,6 @@ export function clampSubmenu(item: HTMLElement): void {
       // parent item sits near the top of the viewport.
       submenu.style.top = `${MARGIN - itemRect.top}px`;
       submenu.style.bottom = 'auto';
-    }
-
-    if (subRect.right > vw - MARGIN) {
-      submenu.style.left = 'auto';
-      submenu.style.right = '100%';
     }
   });
 }

--- a/tests/renderer/utils/menuClamp.test.ts
+++ b/tests/renderer/utils/menuClamp.test.ts
@@ -1,0 +1,51 @@
+/**
+ * chooseSubmenuSide — the geometry behind submenu left/right flipping, with
+ * room reserved for a nested level and cascade-direction inheritance so deep
+ * menus near the right edge don't clip or zig-zag.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { chooseSubmenuSide } from '../../../src/renderer/lib/utils/menuClamp';
+
+const base = {
+  itemLeft: 0,
+  itemRight: 0,
+  submenuWidth: 150,
+  viewportWidth: 1000,
+  inheritLeft: false,
+  hasNested: false,
+};
+
+describe('chooseSubmenuSide', () => {
+  it('opens right by default when there is room', () => {
+    expect(chooseSubmenuSide({ ...base, itemLeft: 100, itemRight: 200 })).toBe(false);
+  });
+
+  it('flips left near the right edge when the right overflows and the left fits', () => {
+    expect(chooseSubmenuSide({ ...base, itemLeft: 800, itemRight: 900 })).toBe(true);
+  });
+
+  it('reserves room for a nested level: a leaf opens right but a parent-of-submenu flips left', () => {
+    // Same geometry: the leaf fits on the right, but reserving a second
+    // same-width level pushes a nested-containing submenu to the left.
+    const geom = { ...base, itemLeft: 700, itemRight: 800 };
+    expect(chooseSubmenuSide({ ...geom, hasNested: false })).toBe(false);
+    expect(chooseSubmenuSide({ ...geom, hasNested: true })).toBe(true);
+  });
+
+  it('inherits a leftward cascade: stays left even when the right would fit', () => {
+    expect(chooseSubmenuSide({ ...base, itemLeft: 500, itemRight: 600, inheritLeft: true })).toBe(true);
+  });
+
+  it('an inherited-left chain falls back to right when the left cannot hold it', () => {
+    expect(chooseSubmenuSide({ ...base, itemLeft: 100, itemRight: 200, inheritLeft: true })).toBe(false);
+  });
+
+  it('default chains stay right when the left also cannot fit (clamped elsewhere)', () => {
+    // Cramped viewport: neither side fits; a non-inherited chain keeps the
+    // default right side rather than flipping into an equally-bad left.
+    expect(chooseSubmenuSide({
+      ...base, itemLeft: 80, itemRight: 120, viewportWidth: 200,
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The editor right-click menu now nests up to three levels deep (e.g. **Elements → Query → SQL**, **Paragraph → Callout → types**, **Tools → category → group → items**). Near the right edge of the window, the old submenu clamp flipped each flyout to the left *only* when its own right edge overflowed — judging each level in isolation. Two failure modes followed:

- A leaf submenu would fit and open right, but its chosen child then had no room and clipped off-screen.
- A child that flipped left could zig-zag back *over* its parent on the next level.

## How

Extract the side decision into a pure, unit-testable `chooseSubmenuSide`:

- **Reserve room for one nested level.** When a submenu itself contains further submenus (`hasNested`), require space for one more same-width level on the chosen side before committing to it.
- **Inherit the cascade direction.** Record the chosen side on `dataset.openLeft`; descendants read it so a chain that opened left stays left unless the left genuinely can't hold the next level — no zig-zag.

`clampSubmenu` now reads the inherited side, measures whether the submenu has nested children, calls `chooseSubmenuSide`, and records its own choice for its children. Vertical flip/pin logic is unchanged.

## Tests

- New `tests/renderer/utils/menuClamp.test.ts` covers the pure geometry: default-right, edge flip-left, the nested-reserve difference (leaf opens right / parent-of-submenu flips left at identical coords), inheritance staying left, and the inherited-left fallback to right.
- `pnpm lint` clean; full suite 3194 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)