### PR TITLE
feat: flag bookmarked lines in the editor gutter

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -65,7 +65,7 @@
   import { initAppearance } from './lib/appearance/settings';
   import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationsStore } from './lib/stores/conversations.svelte';
-  import { getBookmarksStore } from './lib/stores/bookmarks.svelte';
+  import { getBookmarksStore, collectBookmarksForPath } from './lib/stores/bookmarks.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
   import { sectionAnchorAt } from './lib/markdown/headings';
   import { isMissingApiKeyError } from '../shared/llm-errors';
@@ -98,6 +98,13 @@
   const toolPanel = getToolPanelStore();
   const conversationsStore = getConversationsStore();
   const bookmarkStore = getBookmarksStore();
+  // Position-bearing bookmarks for the active file, fed to the editor's
+  // gutter-flag extension (#756). Recomputes as bookmarks are added/removed.
+  const currentFileBookmarks = $derived(
+    editor.activeFilePath
+      ? collectBookmarksForPath(bookmarkStore.tree, editor.activeFilePath)
+      : [],
+  );
   let showSettings = $state(false);
   /** Tab the SettingsDialog should land on when next opened. Cleared
    *  on close so the next manual open returns to the default Editor
@@ -1202,6 +1209,7 @@
                     onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath); }}
                     onBookmarkSection={() => { void handleBookmarkSection(); }}
                     onBookmarkLine={handleBookmarkLine}
+                    bookmarks={currentFileBookmarks}
                     onExtractSelection={handleExtractSelection}
                     onSplitHere={handleSplitHere}
                     onSplitByHeading={handleSplitByHeading}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -33,6 +33,12 @@
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { highlightDecorations } from '../editor/highlight-decorations';
   import { computeCellsExtension } from '../editor/compute-cells';
+  import {
+    bookmarkGutterExtension,
+    applyBookmarkOffsets,
+    resolveBookmarkOffsets,
+    type BookmarkRef,
+  } from '../editor/bookmark-gutter';
   import { footnotePreview } from '../editor/footnote-preview';
   import { footnoteDecorations } from '../editor/footnote-decorations';
   import { linkCompletionSource } from '../editor/link-autocomplete';
@@ -88,6 +94,9 @@
     /** Bookmark the current line — stores the cursor offset so opening
      *  jumps back to it (#756). */
     onBookmarkLine?: () => void;
+    /** Position-bearing bookmarks for the current file. The editor renders
+     *  a filled-ribbon flag in the gutter on each resolved line (#756). */
+    bookmarks?: readonly BookmarkRef[];
     onInsertQueryList?: () => void;
     onNavigate?: (target: string) => void;
     /** Click on a `[[cite::source-id]]` in the editor → open the source tab. */
@@ -147,6 +156,7 @@
     onBookmark,
     onBookmarkSection,
     onBookmarkLine,
+    bookmarks,
     onInsertQueryList,
     onNavigate,
     onOpenSource,
@@ -473,6 +483,7 @@
         void api.shell.openExternal(url);
       },
     }),
+    bookmarkGutterExtension(),
     computeCellsExtension({
       runCell: (language, code) => (
         onRunCell
@@ -837,6 +848,10 @@
       : EditorState.create({ doc: content, extensions: allExtensions });
     view = new EditorView({ state, parent: editorContainer });
 
+    // Initial bookmark flags — the reactive $effect below only fires on
+    // subsequent changes (view isn't $state, so it can't re-run on mount).
+    applyBookmarkOffsets(view, resolveBookmarkOffsets(content, bookmarks ?? []));
+
     if (initSettings.alwaysCollapseFrontmatter) {
       // Defer so the folding extension is active before we dispatch
       requestAnimationFrame(() => foldFrontmatter());
@@ -859,6 +874,18 @@
       );
       view.destroy();
     };
+  });
+
+  // Push bookmark gutter flags whenever the file's bookmarks change. Keyed
+  // on `filePath` too so a tab-switch (same Editor instance isn't reused —
+  // the `{#key}` recreates it — but guard anyway) re-resolves cleanly.
+  // Resolved against the live doc; the field maps offsets forward on edits,
+  // so we deliberately don't depend on `content` (no per-keystroke churn).
+  $effect(() => {
+    const refs = bookmarks ?? [];
+    void filePath;
+    if (!view) return;
+    applyBookmarkOffsets(view, resolveBookmarkOffsets(view.state.doc.toString(), refs));
   });
 
   // Handle external content changes within the same tab (e.g. file reloaded from disk)
@@ -1192,6 +1219,20 @@
     animation: cm-compute-pulse 1s infinite;
   }
   @keyframes cm-compute-pulse { 50% { opacity: 0.4; } }
+
+  /* Bookmark-flag gutter (#756). Kept in sync with `bookmarkGutterStyles`
+     in src/renderer/lib/editor/bookmark-gutter.ts — inlined for the same
+     scoped-CSS :global() reason as the compute gutter above. min-width 0
+     lets the column collapse on notes with no bookmarks. */
+  .editor-wrapper :global(.cm-bookmark-gutter) { min-width: 0; }
+  .editor-wrapper :global(.cm-bookmark-flag) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    color: var(--accent);
+    line-height: 1;
+  }
 
   .context-menu {
     position: fixed;

--- a/src/renderer/lib/editor/bookmark-gutter.ts
+++ b/src/renderer/lib/editor/bookmark-gutter.ts
@@ -1,0 +1,173 @@
+/**
+ * CodeMirror extension: a gutter flag on every bookmarked line (#756).
+ *
+ * Bookmarks live in the side panel, but until now there was no in-editor
+ * sign that a given line/section/note was bookmarked. This renders the
+ * Minerva `bookmark` ribbon — filled — in its own narrow gutter column
+ * on each bookmarked line.
+ *
+ * Resolution (pure, in `resolveBookmarkOffsets`):
+ *   - **line** bookmark  → its stored `cursorOffset`
+ *   - **section** bookmark → the start of the heading whose slug matches
+ *     `anchor`
+ *   - **file** bookmark (no offset, no anchor) → offset 0 (line 1), so a
+ *     whole-note bookmark is still visible
+ *
+ * The host pushes the current file's bookmarks via `setBookmarkOffsets`;
+ * the field also maps offsets forward through edits so flags track the
+ * text as the user types within a session.
+ */
+
+import { EditorView, gutter, GutterMarker } from '@codemirror/view';
+import { StateEffect, StateField } from '@codemirror/state';
+import type { Extension } from '@codemirror/state';
+import { ICONS } from '../components/icons/registry';
+import { extractHeadings } from '../markdown/headings';
+import { slugify } from '../../../shared/slug';
+
+/** The position-bearing fields of a bookmark, as the editor needs them. */
+export interface BookmarkRef {
+  cursorOffset?: number;
+  anchor?: string;
+}
+
+/**
+ * Resolve a file's bookmarks to character offsets in `content`. Pure, so
+ * it's unit-testable without a DOM. Deduplicates — several bookmarks on
+ * one line yield a single flag.
+ */
+export function resolveBookmarkOffsets(
+  content: string,
+  bookmarks: readonly BookmarkRef[],
+): number[] {
+  if (bookmarks.length === 0) return [];
+  const out = new Set<number>();
+
+  // Built lazily — most notes have no section bookmarks, so we avoid
+  // scanning for headings / line starts unless an `anchor` needs it.
+  let headingLineBySlug: Map<string, number> | null = null;
+  let lineStarts: number[] | null = null;
+
+  const ensureHeadings = () => {
+    if (headingLineBySlug) return;
+    headingLineBySlug = new Map();
+    for (const h of extractHeadings(content)) {
+      const s = slugify(h.text);
+      // First heading wins — matches how anchor navigation resolves a
+      // duplicate slug to the earliest occurrence.
+      if (s && !headingLineBySlug.has(s)) headingLineBySlug.set(s, h.line);
+    }
+  };
+  const ensureLineStarts = () => {
+    if (lineStarts) return;
+    lineStarts = [0];
+    for (let i = 0; i < content.length; i++) {
+      if (content[i] === '\n') lineStarts.push(i + 1);
+    }
+  };
+
+  for (const bm of bookmarks) {
+    if (bm.cursorOffset != null) {
+      out.add(Math.max(0, Math.min(bm.cursorOffset, content.length)));
+    } else if (bm.anchor) {
+      ensureHeadings();
+      const line = headingLineBySlug!.get(bm.anchor);
+      if (line != null) {
+        ensureLineStarts();
+        out.add(lineStarts![line - 1] ?? 0);
+      }
+    } else {
+      // Whole-note bookmark — flag line 1 so it's still visible.
+      out.add(0);
+    }
+  }
+  return [...out];
+}
+
+/** Replace the set of bookmarked offsets for the current document. */
+export const setBookmarkOffsets = StateEffect.define<number[]>();
+
+const bookmarkField = StateField.define<Set<number>>({
+  create: () => new Set(),
+  update(set, tr) {
+    let next: Set<number> | null = null;
+    for (const e of tr.effects) {
+      if (e.is(setBookmarkOffsets)) next = new Set(e.value);
+    }
+    if (next) return next;
+    // Map offsets forward so a flag stays glued to its line as the user
+    // edits above it within the session.
+    if (tr.docChanged && set.size) {
+      const mapped = new Set<number>();
+      for (const pos of set) {
+        const m = tr.changes.mapPos(pos, -1);
+        if (m >= 0) mapped.add(m);
+      }
+      return mapped;
+    }
+    return set;
+  },
+});
+
+const FILLED_BOOKMARK =
+  `<svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" stroke="none" aria-hidden="true">${ICONS.bookmark}</svg>`;
+
+class BookmarkMarker extends GutterMarker {
+  override toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = 'cm-bookmark-flag';
+    el.innerHTML = FILLED_BOOKMARK;
+    el.title = 'Bookmarked';
+    return el;
+  }
+  override eq(other: GutterMarker): boolean {
+    return other instanceof BookmarkMarker;
+  }
+}
+const bookmarkMarker = new BookmarkMarker();
+
+const bookmarkGutter = gutter({
+  class: 'cm-bookmark-gutter',
+  lineMarker(view, line) {
+    const set = view.state.field(bookmarkField, false);
+    if (!set || set.size === 0) return null;
+    for (const pos of set) {
+      if (pos >= line.from && pos <= line.to) return bookmarkMarker;
+    }
+    return null;
+  },
+  // Re-evaluate markers when the offset set changes or the doc shifts.
+  // No initialSpacer — the column collapses to nothing on notes with no
+  // bookmarks rather than leaving a permanent dead strip.
+  lineMarkerChange(update) {
+    return (
+      update.docChanged ||
+      update.transactions.some((tr) =>
+        tr.effects.some((e) => e.is(setBookmarkOffsets)),
+      )
+    );
+  },
+});
+
+export function bookmarkGutterExtension(): Extension {
+  return [bookmarkField, bookmarkGutter];
+}
+
+/** Push the resolved offsets into a live view (no-op if unchanged is fine). */
+export function applyBookmarkOffsets(view: EditorView, offsets: number[]): void {
+  view.dispatch({ effects: setBookmarkOffsets.of(offsets) });
+}
+
+// Co-located styles, inlined into Editor.svelte's scoped block (Svelte's
+// scoped CSS needs :global wrappers at the component level).
+export const bookmarkGutterStyles = `
+  .cm-bookmark-gutter { min-width: 0; }
+  .cm-bookmark-flag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    color: var(--accent);
+    line-height: 1;
+  }
+`;

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -141,6 +141,29 @@ export function getBookmarksStore() {
   };
 }
 
+/**
+ * Flatten the bookmark tree to the position-bearing bookmarks targeting
+ * `relativePath` — what the editor's gutter-flag extension needs (#756).
+ * Pure (takes the tree explicitly) so callers in a `$derived` track it and
+ * it stays unit-testable.
+ */
+export function collectBookmarksForPath(
+  nodes: readonly BookmarkNode[],
+  relativePath: string,
+): Array<{ cursorOffset?: number; anchor?: string }> {
+  const out: Array<{ cursorOffset?: number; anchor?: string }> = [];
+  const walk = (ns: readonly BookmarkNode[]) => {
+    for (const n of ns) {
+      if (n.type === 'folder') walk(n.children);
+      else if (n.relativePath === relativePath) {
+        out.push({ cursorOffset: n.cursorOffset, anchor: n.anchor });
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
 // ── Tree helpers ─────────────────────────────────────────────────────────
 
 function findNode(nodes: BookmarkNode[], id: string): BookmarkNode | null {

--- a/tests/renderer/editor/bookmark-gutter.test.ts
+++ b/tests/renderer/editor/bookmark-gutter.test.ts
@@ -1,0 +1,77 @@
+/**
+ * resolveBookmarkOffsets — maps a file's bookmarks to gutter-flag offsets:
+ * line bookmarks by stored offset, section bookmarks by heading slug, and
+ * whole-note bookmarks to line 1.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// collectBookmarksForPath lives in the bookmarks store module, which pulls
+// in the IPC client (window.api) at load — mock it so this can run headless.
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { bookmarks: { save: vi.fn(), load: vi.fn() } },
+}));
+
+import { resolveBookmarkOffsets } from '../../../src/renderer/lib/editor/bookmark-gutter';
+import { collectBookmarksForPath } from '../../../src/renderer/lib/stores/bookmarks.svelte';
+import type { BookmarkNode } from '../../../src/shared/types';
+
+const DOC = '# Title\n\nsome\n## Section\nbody';
+//            0……7  8   9.. 13 14……….24 25
+
+describe('resolveBookmarkOffsets', () => {
+  it('returns [] for no bookmarks', () => {
+    expect(resolveBookmarkOffsets(DOC, [])).toEqual([]);
+  });
+
+  it('uses the stored cursorOffset for a line bookmark', () => {
+    expect(resolveBookmarkOffsets(DOC, [{ cursorOffset: 11 }])).toEqual([11]);
+  });
+
+  it('clamps an out-of-range cursorOffset into the document', () => {
+    expect(resolveBookmarkOffsets(DOC, [{ cursorOffset: 9999 }])).toEqual([DOC.length]);
+    expect(resolveBookmarkOffsets(DOC, [{ cursorOffset: -5 }])).toEqual([0]);
+  });
+
+  it('resolves a section anchor to its heading line start', () => {
+    expect(resolveBookmarkOffsets(DOC, [{ anchor: 'section' }])).toEqual([14]);
+    expect(resolveBookmarkOffsets(DOC, [{ anchor: 'title' }])).toEqual([0]);
+  });
+
+  it('drops a section anchor that matches no heading', () => {
+    expect(resolveBookmarkOffsets(DOC, [{ anchor: 'nope' }])).toEqual([]);
+  });
+
+  it('flags line 1 for a whole-note bookmark (no offset, no anchor)', () => {
+    expect(resolveBookmarkOffsets(DOC, [{}])).toEqual([0]);
+  });
+
+  it('deduplicates offsets that land on the same spot', () => {
+    expect(resolveBookmarkOffsets(DOC, [{ anchor: 'title' }, {}, { cursorOffset: 0 }])).toEqual([0]);
+  });
+});
+
+describe('collectBookmarksForPath', () => {
+  const tree: BookmarkNode[] = [
+    { type: 'bookmark', id: '1', name: 'A', relativePath: 'a.md', cursorOffset: 5 },
+    { type: 'bookmark', id: '2', name: 'B', relativePath: 'b.md', anchor: 'intro' },
+    {
+      type: 'folder', id: 'f', name: 'Folder', children: [
+        { type: 'bookmark', id: '3', name: 'C', relativePath: 'a.md', anchor: 'methods' },
+        { type: 'bookmark', id: '4', name: 'D', relativePath: 'a.md' },
+      ],
+    },
+  ];
+
+  it('flattens nested folders, keeping only the target path', () => {
+    expect(collectBookmarksForPath(tree, 'a.md')).toEqual([
+      { cursorOffset: 5, anchor: undefined },
+      { cursorOffset: undefined, anchor: 'methods' },
+      { cursorOffset: undefined, anchor: undefined },
+    ]);
+  });
+
+  it('returns [] when nothing targets the path', () => {
+    expect(collectBookmarksForPath(tree, 'zzz.md')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Bookmarks were only visible in the side panel — nothing in the editor itself showed that a line, section, or note was bookmarked. This renders the Minerva **bookmark ribbon, filled** (the concave-pentagon panel-header icon) in its own narrow gutter column on each bookmarked line.

## How

- **`src/renderer/lib/editor/bookmark-gutter.ts`** — a CodeMirror gutter extension (same shape as the compute-cells gutter):
  - Pure `resolveBookmarkOffsets(content, bookmarks)` maps the file's bookmarks to offsets — **line** bookmarks by stored `cursorOffset`, **section** bookmarks by the heading whose slug matches `anchor`, and **whole-note** bookmarks to line 1 so they're still visible. Deduped.
  - A `StateField` holds the offset set, pushed via the `setBookmarkOffsets` effect, and maps offsets forward through edits so a flag stays glued to its line as you type within a session.
  - The column collapses to zero width on notes with no bookmarks (`min-width: 0`, no `initialSpacer`).
- **`Editor.svelte`** — new `bookmarks` prop; applies flags on mount and reactively when the file's bookmarks change.
- **`bookmarks.svelte.ts`** — pure `collectBookmarksForPath(tree, path)` flattens the bookmark tree to the active file's position-bearing bookmarks.
- **`App.svelte`** — `$derived` feeds the active file's bookmarks to the editor; recomputes as bookmarks are added/removed.

## Note / judgment call

Whole-note (file) bookmarks have no position, so I flag **line 1** for them — otherwise the most common bookmark type would still be invisible in the gutter. Easy to drop if that reads as noise. Preview is untouched; this is editor-gutter only (matching the request).

## Tests

- `tests/renderer/editor/bookmark-gutter.test.ts` — 9 cases over `resolveBookmarkOffsets` (line / section / file / clamp / miss / dedup) and `collectBookmarksForPath` (nested folders, path filter).
- `pnpm lint` clean; full suite 3203 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)