### PR TITLE
feat: loopback ingest endpoint for the browser clipper (#790)

### DIFF
--- a/src/main/clipper/clipper-ingest.ts
+++ b/src/main/clipper/clipper-ingest.ts
@@ -1,0 +1,52 @@
+/**
+ * The clipper's extraction wiring (#222 → #790).
+ *
+ * Maps a clipper payload onto the existing Source pipeline:
+ *   - `ingestHtmlString` runs Readability + site-handlers + Turndown over the
+ *     browser-supplied HTML (no refetch — that's the whole point), writing the
+ *     Source the same way "Ingest URL…" does;
+ *   - a non-empty `selection` is filed as a `thought:Excerpt` linked to the
+ *     new source, via `createExcerpt` (idempotent on the source + quote text).
+ *
+ * Offset-accurate excerpt anchoring (mapping the selection into body.md) is a
+ * separate concern — see #794. v1 stores the quote text only.
+ */
+
+import { ingestHtmlString } from '../sources/ingest';
+import { createExcerpt } from '../sources/create-excerpt';
+import { getIngestSettings } from '../sources/ingest-settings';
+import type { ClipperPayload, ClipperIngestOutcome } from './clipper-server';
+
+export async function clipperIngest(
+  payload: ClipperPayload,
+  rootPath: string,
+): Promise<ClipperIngestOutcome> {
+  // Honour the same upstream-tags preference as the menu-driven ingest (#473).
+  const settings = await getIngestSettings();
+
+  const result = await ingestHtmlString(rootPath, payload.html, {
+    url: payload.url,
+    titleFallback: payload.pageTitle,
+    importUpstreamTags: settings.importUpstreamTags,
+  });
+
+  const outcome: ClipperIngestOutcome = {
+    sourceId: result.sourceId,
+    relativePath: result.relativePath,
+    duplicate: result.duplicate,
+    title: result.title,
+    kind: result.kind,
+  };
+
+  const selection = payload.selection?.trim();
+  if (selection) {
+    const excerpt = await createExcerpt(rootPath, {
+      sourceId: result.sourceId,
+      citedText: selection,
+    });
+    outcome.excerptId = excerpt.excerptId;
+    outcome.excerptDuplicate = excerpt.duplicate;
+  }
+
+  return outcome;
+}

--- a/src/main/clipper/clipper-server.ts
+++ b/src/main/clipper/clipper-server.ts
@@ -1,0 +1,238 @@
+/**
+ * Loopback HTTP ingest endpoint for the browser clipper (#222 → #790).
+ *
+ * The clipper extension can't reach the renderer's IPC bridge, so the main
+ * process exposes a tiny HTTP server bound to `127.0.0.1`. The browser POSTs
+ * the page it's looking at — `{ url, html, selection?, pageTitle }` — and we
+ * run it through the *same* extraction the in-app "Ingest URL…" uses, minus
+ * the fetch (the browser already has the authenticated HTML, so paywalled
+ * pages work).
+ *
+ * This module is the transport only — generic and dependency-injected so it's
+ * unit-testable without touching the filesystem or Electron. The real
+ * extraction wiring lives in `clipper-ingest.ts`; lifecycle + secret issuance
+ * in `lifecycle.ts`.
+ *
+ * Security posture for this slice (#790):
+ *   - bound to loopback only;
+ *   - every request gated on a shared-secret header (constant-time compare);
+ *   - a permissive CORS reflection so the extension's cross-origin fetch
+ *     works. Tightening to a per-extension origin allowlist + the pairing
+ *     UX that distributes the secret is #791.
+ */
+
+import http from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+
+export interface ClipperPayload {
+  /** The page URL — enables site-handler metadata + a bibo:uri on the source. */
+  url?: string;
+  /** Rendered HTML as the browser sees it. Required. */
+  html: string;
+  /** Page title, used as a fallback when extraction can't find one. */
+  pageTitle?: string;
+  /** Selected text → filed as a linked thought:Excerpt when present. */
+  selection?: string;
+}
+
+export interface ClipperIngestOutcome {
+  sourceId: string;
+  relativePath: string;
+  duplicate: boolean;
+  title?: string;
+  kind?: string;
+  /** Set when a selection was supplied and an excerpt was filed. */
+  excerptId?: string;
+  excerptDuplicate?: boolean;
+}
+
+export type ClipperIngestFn = (
+  payload: ClipperPayload,
+  rootPath: string,
+) => Promise<ClipperIngestOutcome>;
+
+export interface ClipperListenerOptions {
+  /** Shared secret required in the `x-minerva-clipper-secret` header. */
+  secret: string;
+  /** Which open thoughtbase a clip lands in — null when none is open. */
+  resolveRootPath: () => string | null;
+  /** Does the extraction + write. Injected so the transport stays pure. */
+  ingest: ClipperIngestFn;
+  /** Reject bodies larger than this (default 32 MB). */
+  maxBodyBytes?: number;
+}
+
+export interface ClipperServerHandle {
+  port: number;
+  secret: string;
+  close: () => Promise<void>;
+}
+
+export const SECRET_HEADER = 'x-minerva-clipper-secret';
+const DEFAULT_MAX_BODY = 32 * 1024 * 1024;
+
+/** Length-safe, constant-time secret comparison. */
+function secretsMatch(provided: string | undefined, expected: string): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const text = JSON.stringify(body);
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(text);
+}
+
+function applyCors(req: http.IncomingMessage, res: http.ServerResponse): void {
+  // Reflect the requesting origin (a chrome-extension:// URL). The secret
+  // header is the real gate; #791 narrows this to a paired-extension allowlist.
+  res.setHeader('Access-Control-Allow-Origin', req.headers.origin ?? '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', `Content-Type, ${SECRET_HEADER}`);
+  res.setHeader('Access-Control-Max-Age', '600');
+}
+
+function tooLarge(): Error & { statusCode: number } {
+  return Object.assign(new Error('Payload too large'), { statusCode: 413 });
+}
+
+function readBody(req: http.IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let overflowed = false;
+    req.on('data', (chunk: Buffer) => {
+      if (overflowed) return;
+      size += chunk.length;
+      if (size > maxBytes) {
+        // Reject but don't destroy the socket — we still want to flush a clean
+        // 413 response, which an abrupt socket teardown would race away.
+        overflowed = true;
+        reject(tooLarge());
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => { if (!overflowed) resolve(Buffer.concat(chunks).toString('utf-8')); });
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Build the `(req, res)` listener. Exposed separately from the server so tests
+ * can drive it directly or over an ephemeral port.
+ */
+export function createClipperRequestListener(
+  opts: ClipperListenerOptions,
+): (req: http.IncomingMessage, res: http.ServerResponse) => void {
+  const maxBytes = opts.maxBodyBytes ?? DEFAULT_MAX_BODY;
+
+  return (req, res) => {
+    void (async () => {
+      applyCors(req, res);
+
+      // Preflight — answered before the secret check so the browser can send
+      // the real, secret-bearing request.
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      if (!secretsMatch(req.headers[SECRET_HEADER] as string | undefined, opts.secret)) {
+        sendJson(res, 401, { error: 'Unauthorized' });
+        return;
+      }
+
+      const url = req.url ?? '/';
+
+      // Health/pairing probe — lets the extension verify the secret + see
+      // whether a thoughtbase is currently open.
+      if (req.method === 'GET' && url === '/ping') {
+        sendJson(res, 200, { ok: true, projectOpen: opts.resolveRootPath() != null });
+        return;
+      }
+
+      if (req.method === 'POST' && url === '/ingest') {
+        // Fast-path rejection on a declared oversized body — avoids reading it.
+        const declared = Number(req.headers['content-length'] ?? '0');
+        if (Number.isFinite(declared) && declared > maxBytes) {
+          sendJson(res, 413, { error: 'Payload too large' });
+          return;
+        }
+
+        let payload: ClipperPayload;
+        try {
+          const raw = await readBody(req, maxBytes);
+          payload = JSON.parse(raw) as ClipperPayload;
+        } catch (err) {
+          const status = (err as { statusCode?: number }).statusCode ?? 400;
+          sendJson(res, status, { error: status === 413 ? 'Payload too large' : 'Invalid JSON body' });
+          return;
+        }
+
+        if (typeof payload?.html !== 'string' || payload.html.trim() === '') {
+          sendJson(res, 400, { error: 'Missing `html` in payload' });
+          return;
+        }
+
+        const rootPath = opts.resolveRootPath();
+        if (!rootPath) {
+          sendJson(res, 503, { error: 'No thoughtbase open' });
+          return;
+        }
+
+        try {
+          const outcome = await opts.ingest(payload, rootPath);
+          sendJson(res, 200, outcome);
+        } catch (err) {
+          sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
+        return;
+      }
+
+      sendJson(res, 404, { error: 'Not found' });
+    })();
+  };
+}
+
+/**
+ * Start the loopback server. Prefers `port`; on `EADDRINUSE` falls back to an
+ * OS-assigned ephemeral port so a stale instance / port clash can't wedge the
+ * feature (the actual port is reported back for pairing).
+ */
+export function startClipperServer(
+  opts: ClipperListenerOptions & { port?: number },
+): Promise<ClipperServerHandle> {
+  const listener = createClipperRequestListener(opts);
+
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(listener);
+    let triedFallback = false;
+
+    const onError = (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE' && !triedFallback) {
+        triedFallback = true;
+        server.listen(0, '127.0.0.1');
+        return;
+      }
+      server.removeListener('error', onError);
+      reject(err);
+    };
+    server.on('error', onError);
+
+    server.listen(opts.port ?? 0, '127.0.0.1', () => {
+      server.removeListener('error', onError);
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        port,
+        secret: opts.secret,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}

--- a/src/main/clipper/lifecycle.ts
+++ b/src/main/clipper/lifecycle.ts
@@ -1,0 +1,81 @@
+/**
+ * Clipper server lifecycle (#222 → #790).
+ *
+ * One loopback server per app run, started when a thoughtbase opens and torn
+ * down when the last one closes. Idempotent start (concurrent project opens
+ * race harmlessly); the shared secret is generated once and held for the run,
+ * so a stop/start keeps pairing stable.
+ *
+ * Enable gate: `isClipperEnabled()` currently reads an env flag and defaults
+ * OFF, so a normal run opens no port. #791 replaces this with the persisted
+ * "enable browser clipper" setting + the Settings/pairing UI that surfaces the
+ * port + secret this module already exposes via `getClipperInfo()`.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { startClipperServer, type ClipperServerHandle } from './clipper-server';
+import { clipperIngest } from './clipper-ingest';
+
+/** Preferred loopback port; falls back to an ephemeral one if taken. */
+const PREFERRED_PORT = 41599;
+
+let handle: ClipperServerHandle | null = null;
+let starting: Promise<ClipperServerHandle> | null = null;
+let secret: string | null = null;
+
+export interface ClipperInfo {
+  port: number;
+  secret: string;
+}
+
+/**
+ * Whether the clipper should auto-start on project open. Off by default;
+ * opt in for now with `MINERVA_CLIPPER=1`. Replaced by the persisted setting
+ * in #791.
+ */
+export function isClipperEnabled(): boolean {
+  return process.env.MINERVA_CLIPPER === '1';
+}
+
+/**
+ * Ensure the loopback server is running, returning its port + secret.
+ * Idempotent and concurrency-safe.
+ */
+export async function ensureClipperRunning(
+  resolveRootPath: () => string | null,
+): Promise<ClipperInfo> {
+  if (handle) return { port: handle.port, secret: handle.secret };
+  if (!starting) {
+    secret ??= randomBytes(32).toString('hex');
+    const issued = secret;
+    starting = startClipperServer({
+      secret: issued,
+      resolveRootPath,
+      ingest: clipperIngest,
+      port: PREFERRED_PORT,
+    })
+      .then((h) => {
+        handle = h;
+        starting = null;
+        return h;
+      })
+      .catch((err) => {
+        starting = null;
+        throw err;
+      });
+  }
+  const h = await starting;
+  return { port: h.port, secret: h.secret };
+}
+
+/** Stop the server if running. Safe to call when it isn't. */
+export async function stopClipperServer(): Promise<void> {
+  const h = handle;
+  handle = null;
+  if (h) await h.close();
+}
+
+/** Current port + secret, or null when not running. Surfaced by #791's UI. */
+export function getClipperInfo(): ClipperInfo | null {
+  return handle ? { port: handle.port, secret: handle.secret } : null;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,7 @@ import { registerBuiltinExporters } from './publish';
 import { installCsp } from './security';
 import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
+import { stopClipperServer } from './clipper/lifecycle';
 import { registerSkillsAtStartup } from './skills/register';
 
 app.setName('Minerva');
@@ -96,6 +97,7 @@ app.on('before-quit', (event) => {
   Promise.allSettled([
     flushAllProjects(),
     shutdownAllKernels(),
+    stopClipperServer(),
   ])
     .catch((err) => console.warn('[quit] shutdown failed:', err))
     .finally(() => app.quit());

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -14,6 +14,7 @@ import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
 import { acquireProject, releaseProject } from './project-context';
 import { installNavigationGuards } from './security';
+import { ensureClipperRunning, stopClipperServer, isClipperEnabled } from './clipper/lifecycle';
 import type { ProjectContext } from './project-context-types';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -122,6 +123,7 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
       void releaseProject(heldRoot, win.id);
     }
     persistSession();
+    syncClipperLifecycle();
   });
 
   win.on('move', persistSession);
@@ -155,6 +157,35 @@ export function windowsForProject(rootPath: string): BrowserWindow[] {
     if (contexts.get(win.id)?.rootPath === rootPath) hits.push(win);
   }
   return hits;
+}
+
+/**
+ * Which thoughtbase a clipped page lands in: the focused window's project if
+ * it has one, else the first open project. When the clip arrives Minerva isn't
+ * focused (the browser is), so the fallback is the common path — fine for the
+ * single-project norm; a multi-project picker is a later refinement.
+ */
+function resolveActiveRootPath(): string | null {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (focused && !focused.isDestroyed()) {
+    const r = contexts.get(focused.id)?.rootPath;
+    if (r) return r;
+  }
+  for (const ctx of contexts.values()) {
+    if (ctx.rootPath) return ctx.rootPath;
+  }
+  return null;
+}
+
+/**
+ * Start the clipper server when a project is open (and the feature is
+ * enabled), stop it when none are. Called after any project open/close.
+ */
+function syncClipperLifecycle(): void {
+  if (!isClipperEnabled()) return;
+  const anyOpen = [...contexts.values()].some((c) => c.rootPath);
+  if (anyOpen) void ensureClipperRunning(resolveActiveRootPath);
+  else void stopClipperServer();
 }
 
 export async function openProjectInWindow(win: BrowserWindow, rootPath: string): Promise<void> {
@@ -397,6 +428,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   // registered, but the renderer still needs a kick to load it.)
   if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
   persistSession();
+  syncClipperLifecycle();
 }
 
 export function closeProjectInWindow(winId: number): void {
@@ -414,6 +446,7 @@ export function closeProjectInWindow(winId: number): void {
   }
   rebuildMenu();
   persistSession();
+  syncClipperLifecycle();
 }
 
 export function getWindowById(id: number): BrowserWindow | null {

--- a/tests/main/clipper/clipper-ingest.test.ts
+++ b/tests/main/clipper/clipper-ingest.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Clipper extraction wiring (#790). Mocks the underlying Source pipeline so the
+ * test isolates the mapping logic: HTML → ingestHtmlString, selection →
+ * createExcerpt, and the upstream-tags setting passed through.
+ */
+
+import { it, expect, beforeEach, vi } from 'vitest';
+
+const { ingestHtmlString, createExcerpt, getIngestSettings } = vi.hoisted(() => ({
+  ingestHtmlString: vi.fn(),
+  createExcerpt: vi.fn(),
+  getIngestSettings: vi.fn(),
+}));
+
+vi.mock('../../../src/main/sources/ingest', () => ({ ingestHtmlString }));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ createExcerpt }));
+vi.mock('../../../src/main/sources/ingest-settings', () => ({ getIngestSettings }));
+
+import { clipperIngest } from '../../../src/main/clipper/clipper-ingest';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getIngestSettings.mockResolvedValue({ importUpstreamTags: true });
+  ingestHtmlString.mockResolvedValue({
+    sourceId: 'url-abc123',
+    relativePath: '.minerva/sources/url-abc123/meta.ttl',
+    duplicate: false,
+    title: 'A Page',
+    kind: 'web',
+  });
+  createExcerpt.mockResolvedValue({ excerptId: 'url-abc123-deadbeef0000', relativePath: '...', duplicate: false });
+});
+
+it('runs HTML through ingestHtmlString with url + title fallback + the tags setting', async () => {
+  getIngestSettings.mockResolvedValue({ importUpstreamTags: false });
+  const out = await clipperIngest(
+    { url: 'https://example.com/a', html: '<h1>Hi</h1>', pageTitle: 'A' },
+    '/tmp/project',
+  );
+  expect(ingestHtmlString).toHaveBeenCalledWith('/tmp/project', '<h1>Hi</h1>', {
+    url: 'https://example.com/a',
+    titleFallback: 'A',
+    importUpstreamTags: false,
+  });
+  expect(out).toMatchObject({ sourceId: 'url-abc123', duplicate: false, title: 'A Page' });
+});
+
+it('files a thought:Excerpt when a selection is present', async () => {
+  const out = await clipperIngest(
+    { url: 'https://example.com/a', html: '<h1>Hi</h1>', selection: '  a quoted passage  ' },
+    '/tmp/project',
+  );
+  expect(createExcerpt).toHaveBeenCalledWith('/tmp/project', {
+    sourceId: 'url-abc123',
+    citedText: 'a quoted passage', // trimmed
+  });
+  expect(out.excerptId).toBe('url-abc123-deadbeef0000');
+  expect(out.excerptDuplicate).toBe(false);
+});
+
+it('skips the excerpt when the selection is absent or whitespace', async () => {
+  await clipperIngest({ html: '<h1>Hi</h1>' }, '/tmp/project');
+  await clipperIngest({ html: '<h1>Hi</h1>', selection: '   ' }, '/tmp/project');
+  expect(createExcerpt).not.toHaveBeenCalled();
+});

--- a/tests/main/clipper/clipper-server.test.ts
+++ b/tests/main/clipper/clipper-server.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Clipper loopback ingest server (#790) — the transport. Driven over a real
+ * ephemeral port with an injected fake `ingest`, so every branch (secret gate,
+ * preflight, routing, validation, no-project, error) is exercised end to end.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  startClipperServer,
+  SECRET_HEADER,
+  type ClipperServerHandle,
+  type ClipperIngestFn,
+} from '../../../src/main/clipper/clipper-server';
+
+const SECRET = 'test-secret-abc';
+
+let server: ClipperServerHandle;
+let rootPath: string | null;
+let ingest: ReturnType<typeof vi.fn> & ClipperIngestFn;
+
+async function start(opts: { maxBodyBytes?: number } = {}) {
+  server = await startClipperServer({
+    secret: SECRET,
+    resolveRootPath: () => rootPath,
+    ingest,
+    port: 0,
+    maxBodyBytes: opts.maxBodyBytes,
+  });
+}
+
+function url(path: string): string {
+  return `http://127.0.0.1:${server.port}${path}`;
+}
+
+beforeEach(() => {
+  rootPath = '/tmp/project';
+  ingest = vi.fn(async () => ({
+    sourceId: 'url-abc123',
+    relativePath: '.minerva/sources/url-abc123/meta.ttl',
+    duplicate: false,
+    title: 'Clipped Page',
+    kind: 'web',
+  })) as ReturnType<typeof vi.fn> & ClipperIngestFn;
+});
+
+afterEach(async () => {
+  await server?.close();
+});
+
+describe('auth', () => {
+  it('rejects a request with no secret header (401)', async () => {
+    await start();
+    const res = await fetch(url('/ingest'), { method: 'POST', body: '{}' });
+    expect(res.status).toBe(401);
+    expect(ingest).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong secret (401)', async () => {
+    await start();
+    const res = await fetch(url('/ingest'), {
+      method: 'POST',
+      headers: { [SECRET_HEADER]: 'nope' },
+      body: '{}',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('answers an OPTIONS preflight without a secret (204 + CORS)', async () => {
+    await start();
+    const res = await fetch(url('/ingest'), { method: 'OPTIONS' });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-headers')?.toLowerCase()).toContain(SECRET_HEADER);
+  });
+});
+
+describe('routing', () => {
+  it('GET /ping reports project-open status', async () => {
+    await start();
+    const res = await fetch(url('/ping'), { headers: { [SECRET_HEADER]: SECRET } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, projectOpen: true });
+
+    rootPath = null;
+    const res2 = await fetch(url('/ping'), { headers: { [SECRET_HEADER]: SECRET } });
+    expect((await res2.json()).projectOpen).toBe(false);
+  });
+
+  it('returns 404 for an unknown route', async () => {
+    await start();
+    const res = await fetch(url('/nope'), { headers: { [SECRET_HEADER]: SECRET } });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /ingest', () => {
+  function post(body: unknown) {
+    return fetch(url('/ingest'), {
+      method: 'POST',
+      headers: { [SECRET_HEADER]: SECRET, 'Content-Type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    });
+  }
+
+  it('ingests a payload and returns the outcome', async () => {
+    await start();
+    const res = await post({ url: 'https://example.com/a', html: '<h1>Hi</h1>', pageTitle: 'A' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ sourceId: 'url-abc123', duplicate: false });
+    expect(ingest).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://example.com/a', html: '<h1>Hi</h1>', pageTitle: 'A' }),
+      '/tmp/project',
+    );
+  });
+
+  it('rejects a payload with no html (400)', async () => {
+    await start();
+    const res = await post({ url: 'https://example.com/a' });
+    expect(res.status).toBe(400);
+    expect(ingest).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid JSON (400)', async () => {
+    await start();
+    const res = await post('{not json');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when no thoughtbase is open', async () => {
+    await start();
+    rootPath = null;
+    const res = await post({ html: '<h1>Hi</h1>' });
+    expect(res.status).toBe(503);
+    expect(ingest).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an ingest failure as 500', async () => {
+    await start();
+    ingest.mockRejectedValueOnce(new Error('disk full'));
+    const res = await post({ html: '<h1>Hi</h1>' });
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('disk full');
+  });
+
+  it('rejects an over-sized body (413)', async () => {
+    await start({ maxBodyBytes: 100 });
+    const res = await post({ html: 'x'.repeat(500) });
+    expect(res.status).toBe(413);
+    expect(ingest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implements #790 — the app-side seam the browser clipper (#222) POSTs to. First slice of the clipper epic.

## What

A tiny HTTP server bound to `127.0.0.1` that accepts `{ url, html, selection?, pageTitle }` and runs it through the **existing** Source pipeline with **no server-side refetch** — so the browser's authenticated/paywalled HTML is exactly what gets extracted. This is the finding that kept #222 out of "Large": `ingestHtmlString` and `createExcerpt` already do the work; this PR is the transport + wiring over them.

## Modules (`src/main/clipper/`)

- **`clipper-server.ts`** — generic, dependency-injected transport (no Electron/fs deps, fully unit-testable):
  - secret-gated via `x-minerva-clipper-secret` (constant-time compare), loopback-only bind;
  - CORS preflight handling; `POST /ingest` + `GET /ping` (health/pairing probe);
  - body-size cap (Content-Length fast-path + streaming backstop);
  - preferred fixed port `41599` with ephemeral fallback on `EADDRINUSE`; reports the actual port.
- **`clipper-ingest.ts`** — wiring: `ingestHtmlString(rootPath, html, { url, titleFallback, importUpstreamTags })`, plus a `thought:Excerpt` via `createExcerpt` when a selection is present (text-only; honours the same upstream-tags setting as menu ingest).
- **`lifecycle.ts`** — one server per app run; stable per-run secret; `getClipperInfo()` exposes `{ port, secret }` for the pairing UI.

## Lifecycle

Started when a thoughtbase opens, stopped when the last one closes (wired into `window-manager` open/close + `main.ts` before-quit). A clip resolves to the focused window's project, else the first open one.

## Scope boundary with #791

Auto-start is gated by `isClipperEnabled()` — currently an env flag (`MINERVA_CLIPPER=1`), **OFF by default**, so a normal run opens **no port**. #791 replaces that gate with the persisted "enable clipper" setting and the Settings/pairing UX that surfaces the port + secret this PR already exposes. The CORS reflection here is permissive (secret is the real gate); #791 narrows it to a paired-extension allowlist.

Out of scope (own issues): offset-accurate excerpt anchoring → #794; extension itself → #792.

## Tests

- `clipper-server.test.ts` (11) — drives a real ephemeral-port server with an injected fake ingest: 401 no/wrong secret, OPTIONS preflight, `/ping` project-open status, 404, success outcome, 400 missing-html / invalid-JSON, 503 no-project, 500 ingest-failure, 413 oversized.
- `clipper-ingest.test.ts` (3) — mapping logic with the pipeline mocked: url+title+tags pass-through, selection→excerpt (trimmed), excerpt skipped when blank.
- `pnpm lint` clean; full suite **3217** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)