### PR TITLE
feat: browser clipper MV3 extension — one-click capture & save (#792)

### DIFF
--- a/clipper/README.md
+++ b/clipper/README.md
@@ -1,0 +1,49 @@
+# Minerva Clipper (Chrome, MV3)
+
+One-click capture of the page you're reading into Minerva as a Source — your
+selection rides along as a linked excerpt. The browser sends the **rendered
+HTML it can see**, so authenticated / paywalled pages extract correctly (the
+app does the Readability extraction, not the extension).
+
+This is the first cut (#792): Chrome only, save-with-defaults, no popup UI.
+Richer popup (tags / note / id preview) is #793; packaging/signing is #795.
+
+## Build
+
+```sh
+pnpm build:clipper      # → clipper/dist/
+pnpm typecheck:clipper  # tsc over the extension sources
+```
+
+## Install (unpacked)
+
+1. `pnpm build:clipper`
+2. Chrome → `chrome://extensions` → enable **Developer mode** → **Load unpacked** → pick `clipper/dist`.
+3. Click the puzzle-piece (Extensions) icon → **Pin** *Minerva Clipper* so its
+   button stays on the toolbar. (Until packaging adds an icon, it shows a
+   default placeholder.)
+
+## Pair
+
+1. In Minerva: **Settings → Browser Clipper** → enable it, open a thoughtbase,
+   and copy the **pairing code**.
+2. Click the extension's **Details → Extension options** (or the `?` badge the
+   first time you use it) and paste the code → **Pair**. **Test connection**
+   confirms the secret + whether a thoughtbase is open.
+
+## Use
+
+- Click the toolbar button (pin it first — see Install), or press
+  **⌘⇧S / Ctrl+Shift+S**, on any page.
+- A badge flashes **✓** on success, **!** on failure, **?** if not yet paired.
+
+## How it talks to Minerva
+
+POSTs `{ url, html, selection?, pageTitle }` to the app's loopback endpoint
+(`http://127.0.0.1:<port>/ingest`) with the shared secret in the
+`x-minerva-clipper-secret` header. The request goes out from the **service
+worker** (extension origin) — the endpoint rejects content-script / web-page
+origins, so capture and send are deliberately split.
+
+> Icons are intentionally omitted for the unpacked dev build; Chrome shows a
+> default. A branded icon set lands with packaging (#795).

--- a/clipper/build.mjs
+++ b/clipper/build.mjs
@@ -1,0 +1,34 @@
+/**
+ * Build the Minerva Clipper extension into `clipper/dist/` — a separate target
+ * from the Electron app (`pnpm build:clipper`). esbuild bundles the TS entry
+ * points; the manifest + options page are copied alongside. Load `dist/` as an
+ * unpacked extension (chrome://extensions → Load unpacked).
+ */
+
+import { build } from 'esbuild';
+import { cp, mkdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(root, 'dist');
+
+await rm(out, { recursive: true, force: true });
+await mkdir(out, { recursive: true });
+
+await build({
+  entryPoints: {
+    background: path.join(root, 'src/background.ts'),
+    options: path.join(root, 'src/options.ts'),
+  },
+  bundle: true,
+  format: 'esm',
+  target: 'chrome114',
+  outdir: out,
+  logLevel: 'info',
+});
+
+await cp(path.join(root, 'manifest.json'), path.join(out, 'manifest.json'));
+await cp(path.join(root, 'options.html'), path.join(out, 'options.html'));
+
+console.log('Minerva Clipper built →', path.relative(process.cwd(), out));

--- a/clipper/manifest.json
+++ b/clipper/manifest.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 3,
+  "name": "Minerva Clipper",
+  "version": "0.1.0",
+  "description": "Send the page you're reading to Minerva as a Source — with your selection as a linked excerpt.",
+  "permissions": ["activeTab", "scripting", "storage"],
+  "host_permissions": ["http://127.0.0.1/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Save to Minerva"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+  "commands": {
+    "save-to-minerva": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
+      },
+      "description": "Save the current page to Minerva"
+    }
+  }
+}

--- a/clipper/options.html
+++ b/clipper/options.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Minerva Clipper</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        font: 14px/1.5 system-ui, sans-serif;
+        max-width: 32rem;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      h1 { font-size: 1.2rem; }
+      ol { padding-left: 1.2rem; }
+      textarea {
+        width: 100%;
+        min-height: 4rem;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        box-sizing: border-box;
+      }
+      .row { display: flex; gap: 0.5rem; margin: 0.75rem 0; }
+      button { padding: 0.4rem 0.8rem; cursor: pointer; }
+      #status { min-height: 1.4em; font-size: 13px; opacity: 0.85; }
+    </style>
+  </head>
+  <body>
+    <h1>Minerva Clipper</h1>
+    <ol>
+      <li>In Minerva, open <strong>Settings → Browser Clipper</strong> and turn it on.</li>
+      <li>Open a thoughtbase, then copy the <strong>pairing code</strong>.</li>
+      <li>Paste it below and click <strong>Pair</strong>.</li>
+    </ol>
+    <textarea id="code" placeholder="Paste pairing code here"></textarea>
+    <div class="row">
+      <button id="pair">Pair</button>
+      <button id="test">Test connection</button>
+      <button id="unpair">Unpair</button>
+    </div>
+    <p id="status"></p>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/clipper/src/background.ts
+++ b/clipper/src/background.ts
@@ -1,0 +1,77 @@
+/**
+ * Service worker — the one-click capture-and-save path (#792).
+ *
+ * Triggered by the toolbar action click or the keyboard command. Captures the
+ * active tab's rendered HTML + selection (via `scripting.executeScript`, gated
+ * by `activeTab` so no broad host access is needed to read pages), then POSTs
+ * from here — the service worker, whose `chrome-extension://` Origin the app
+ * endpoint accepts. A badge flashes the outcome.
+ */
+
+import { loadPairing } from './pairing-store';
+import { sendClip } from './ingest';
+import { normalizeSelection, type ClipPayload } from './payload';
+
+/**
+ * Runs in the page context (serialized by executeScript) — must be
+ * self-contained, referencing only page globals.
+ */
+function capturePage() {
+  return {
+    url: location.href,
+    html: document.documentElement.outerHTML,
+    pageTitle: document.title,
+    selection: window.getSelection()?.toString() ?? '',
+  };
+}
+
+async function captureActiveTab(): Promise<ClipPayload | null> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) return null;
+  const [injected] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: capturePage,
+  });
+  const r = injected?.result as
+    | { url: string; html: string; pageTitle: string; selection: string }
+    | undefined;
+  if (!r?.html) return null;
+  return {
+    url: r.url,
+    html: r.html,
+    pageTitle: r.pageTitle,
+    selection: normalizeSelection(r.selection),
+  };
+}
+
+async function flashBadge(text: string, color: string): Promise<void> {
+  await chrome.action.setBadgeBackgroundColor({ color });
+  await chrome.action.setBadgeText({ text });
+  setTimeout(() => { void chrome.action.setBadgeText({ text: '' }); }, 3000);
+}
+
+async function saveCurrentPage(): Promise<void> {
+  const pairing = await loadPairing();
+  if (!pairing) {
+    await flashBadge('?', '#888888');
+    await chrome.runtime.openOptionsPage();
+    return;
+  }
+  const payload = await captureActiveTab();
+  if (!payload) {
+    await flashBadge('!', '#cc3333');
+    return;
+  }
+  const result = await sendClip(pairing, payload);
+  if (result.ok) {
+    await flashBadge('✓', '#22aa22');
+  } else {
+    await flashBadge('!', '#cc3333');
+    console.error('[minerva-clipper]', result.error);
+  }
+}
+
+chrome.action.onClicked.addListener(() => { void saveCurrentPage(); });
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'save-to-minerva') void saveCurrentPage();
+});

--- a/clipper/src/ingest.ts
+++ b/clipper/src/ingest.ts
@@ -1,0 +1,88 @@
+/**
+ * Talk to Minerva's loopback clipper endpoint (#790/#791). Pure transport —
+ * `fetch` is injectable so it's unit-testable without a browser or a server.
+ *
+ * The POST goes out from the extension service worker (not a content script),
+ * so its Origin is `chrome-extension://…` — which the app's endpoint allows;
+ * a content-script Origin (the page's `http(s)://`) is rejected with 403.
+ */
+
+import type { PairingPayload } from '../../src/shared/clipper-pairing';
+import type { ClipPayload } from './payload';
+
+const SECRET_HEADER = 'x-minerva-clipper-secret';
+
+export interface ClipResult {
+  ok: boolean;
+  /** Set on success. */
+  sourceId?: string;
+  duplicate?: boolean;
+  title?: string;
+  excerptId?: string;
+  /** Human-readable failure reason. */
+  error?: string;
+}
+
+function endpoint(pairing: PairingPayload, path: string): string {
+  return `http://127.0.0.1:${pairing.port}${path}`;
+}
+
+/** POST a clip; resolves to a `ClipResult` (never throws — errors are mapped). */
+export async function sendClip(
+  pairing: PairingPayload,
+  payload: ClipPayload,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ClipResult> {
+  let res: Response;
+  try {
+    res = await fetchImpl(endpoint(pairing, '/ingest'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [SECRET_HEADER]: pairing.secret },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    return { ok: false, error: 'Minerva isn’t reachable — is it running with a thoughtbase open?' };
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await res.json()) as Record<string, unknown>;
+  } catch { /* non-JSON / empty body */ }
+
+  if (!res.ok) {
+    const reason = typeof body.error === 'string' ? body.error : `HTTP ${res.status}`;
+    return { ok: false, error: reason };
+  }
+  return {
+    ok: true,
+    sourceId: typeof body.sourceId === 'string' ? body.sourceId : undefined,
+    duplicate: typeof body.duplicate === 'boolean' ? body.duplicate : undefined,
+    title: typeof body.title === 'string' ? body.title : undefined,
+    excerptId: typeof body.excerptId === 'string' ? body.excerptId : undefined,
+  };
+}
+
+export interface PingResult {
+  ok: boolean;
+  projectOpen?: boolean;
+  error?: string;
+}
+
+/** Verify a pairing: secret accepted + whether a thoughtbase is open. */
+export async function ping(
+  pairing: PairingPayload,
+  fetchImpl: typeof fetch = fetch,
+): Promise<PingResult> {
+  let res: Response;
+  try {
+    res = await fetchImpl(endpoint(pairing, '/ping'), {
+      headers: { [SECRET_HEADER]: pairing.secret },
+    });
+  } catch {
+    return { ok: false, error: 'Not reachable' };
+  }
+  if (res.status === 401) return { ok: false, error: 'Secret rejected — re-pair the extension.' };
+  if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  return { ok: true, projectOpen: body.projectOpen === true };
+}

--- a/clipper/src/options.ts
+++ b/clipper/src/options.ts
@@ -1,0 +1,59 @@
+/**
+ * Options page — pair the extension with a running Minerva (#791/#792):
+ * paste the pairing code, test the connection, unpair.
+ */
+
+import { savePairingCode, loadPairing, clearPairing } from './pairing-store';
+import { ping } from './ingest';
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) throw new Error(`missing #${id}`);
+  return node as T;
+}
+
+const codeInput = el<HTMLTextAreaElement>('code');
+const statusEl = el<HTMLParagraphElement>('status');
+
+function setStatus(msg: string): void {
+  statusEl.textContent = msg;
+}
+
+async function refresh(): Promise<void> {
+  const pairing = await loadPairing();
+  setStatus(pairing ? `Paired — port ${pairing.port}.` : 'Not paired.');
+}
+
+el<HTMLButtonElement>('pair').addEventListener('click', () => {
+  void (async () => {
+    const pairing = await savePairingCode(codeInput.value);
+    if (!pairing) {
+      setStatus('That doesn’t look like a valid pairing code.');
+      return;
+    }
+    codeInput.value = '';
+    setStatus(`Paired — port ${pairing.port}.`);
+  })();
+});
+
+el<HTMLButtonElement>('test').addEventListener('click', () => {
+  void (async () => {
+    const pairing = await loadPairing();
+    if (!pairing) {
+      setStatus('Pair first.');
+      return;
+    }
+    const result = await ping(pairing);
+    if (!result.ok) setStatus(`Connection failed: ${result.error}`);
+    else setStatus(result.projectOpen ? 'Connected — a thoughtbase is open.' : 'Connected, but no thoughtbase is open.');
+  })();
+});
+
+el<HTMLButtonElement>('unpair').addEventListener('click', () => {
+  void (async () => {
+    await clearPairing();
+    setStatus('Unpaired.');
+  })();
+});
+
+void refresh();

--- a/clipper/src/pairing-store.ts
+++ b/clipper/src/pairing-store.ts
@@ -1,0 +1,29 @@
+/**
+ * Persist the decoded pairing (port + secret) in `chrome.storage.local`.
+ * Thin chrome glue around the shared `decodePairingCode` codec.
+ */
+
+import { decodePairingCode, type PairingPayload } from '../../src/shared/clipper-pairing';
+
+const KEY = 'pairing';
+
+export async function loadPairing(): Promise<PairingPayload | null> {
+  const got = await chrome.storage.local.get(KEY);
+  const p = got[KEY] as Partial<PairingPayload> | undefined;
+  if (p && typeof p.port === 'number' && typeof p.secret === 'string') {
+    return { v: 1, port: p.port, secret: p.secret };
+  }
+  return null;
+}
+
+/** Decode + store a pairing code. Returns the pairing, or null if malformed. */
+export async function savePairingCode(code: string): Promise<PairingPayload | null> {
+  const decoded = decodePairingCode(code);
+  if (!decoded) return null;
+  await chrome.storage.local.set({ [KEY]: decoded });
+  return decoded;
+}
+
+export async function clearPairing(): Promise<void> {
+  await chrome.storage.local.remove(KEY);
+}

--- a/clipper/src/payload.ts
+++ b/clipper/src/payload.ts
@@ -1,0 +1,18 @@
+/**
+ * The clip payload the extension sends to Minerva's loopback endpoint — the
+ * shape `POST /ingest` expects (mirrors `ClipperPayload` in the app's
+ * `clipper-server.ts`). Pure + framework-free so it's unit-testable.
+ */
+
+export interface ClipPayload {
+  url: string;
+  html: string;
+  pageTitle: string;
+  selection?: string;
+}
+
+/** Normalise a raw selection: trimmed, or `undefined` when empty. */
+export function normalizeSelection(raw: string | null | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/clipper/tsconfig.json
+++ b/clipper/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["chrome"]
+  },
+  "include": ["src/**/*", "../src/shared/clipper-pairing.ts"]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,11 @@ export default tseslint.config(
       // CLI scripts run by `pnpm new-tool` (#511). Plain Node ESM, not
       // part of the TS project; lint via `node --check` if needed.
       'scripts/**',
+      // The browser-clipper extension (#792) is a separate build target with
+      // its own tsconfig (DOM + chrome globals) and esbuild bundle — not part
+      // of the app's Node/Electron TS project. Type-check via
+      // `pnpm typecheck:clipper`; its pure logic is covered by tests/clipper.
+      'clipper/**',
     ],
   },
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage --test-timeout=30000",
     "build:e2e": "NODE_OPTIONS=--max-old-space-size=4096 electron-forge package",
-    "test:e2e": "pnpm build:e2e && playwright test"
+    "test:e2e": "pnpm build:e2e && playwright test",
+    "build:clipper": "node clipper/build.mjs",
+    "typecheck:clipper": "tsc -p clipper/tsconfig.json --noEmit"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
@@ -69,7 +71,6 @@
     }
   },
   "devDependencies": {
-    "axe-core": "^4.10.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.3",
@@ -81,12 +82,15 @@
     "@playwright/test": "^1.60.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@testing-library/svelte": "^5.3.1",
+    "@types/chrome": "^0.2.0",
     "@types/markdown-it": "^14.1.2",
     "@types/n3": "^1.26.1",
     "@types/turndown": "^5.0.6",
     "@vitest/coverage-v8": "^4.1.8",
+    "axe-core": "^4.10.3",
     "codemirror": "^6.0.2",
     "electron": "^42.4.0",
+    "esbuild": "^0.28.1",
     "eslint": "^10.4.1",
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^17.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
         version: 6.1.3
       '@electron-forge/cli':
         specifier: ^7.11.2
-        version: 7.11.2(encoding@0.1.13)
+        version: 7.11.2(encoding@0.1.13)(esbuild@0.28.1)
       '@electron-forge/maker-dmg':
         specifier: ^7.11.2
         version: 7.11.2
@@ -147,6 +147,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.3.1
         version: 5.3.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@7.3.5(@types/node@25.9.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vitest@4.1.8)
+      '@types/chrome':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
@@ -168,6 +171,9 @@ importers:
       electron:
         specifier: ^42.4.0
         version: 42.4.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^10.4.1
         version: 10.4.1(jiti@2.6.1)
@@ -1447,8 +1453,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1459,8 +1477,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1471,8 +1501,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1483,8 +1525,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1495,8 +1549,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1507,8 +1573,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1519,8 +1597,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1531,8 +1621,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1543,8 +1645,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1555,8 +1669,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1567,8 +1693,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1579,8 +1717,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1591,8 +1741,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2303,6 +2465,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/chrome@0.2.0':
+    resolution: {integrity: sha512-K/i7EKEVSpmyXXjE0ev5oASWBYMY6yM8LFSutG2PkM1DmxJUggZsoaTc0W1RsVwDDKrsZEjpHFAbqqxlRxGsSg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -2414,8 +2579,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -3544,6 +3718,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9211,9 +9390,9 @@ snapshots:
       '@duckdb/node-bindings-win32-arm64': 1.5.3-r.3
       '@duckdb/node-bindings-win32-x64': 1.5.3-r.3
 
-  '@electron-forge/cli@7.11.2(encoding@0.1.13)':
+  '@electron-forge/cli@7.11.2(encoding@0.1.13)(esbuild@0.28.1)':
     dependencies:
-      '@electron-forge/core': 7.11.2(encoding@0.1.13)
+      '@electron-forge/core': 7.11.2(encoding@0.1.13)(esbuild@0.28.1)
       '@electron-forge/core-utils': 7.11.2
       '@electron-forge/shared-types': 7.11.2
       '@electron/get': 3.1.0
@@ -9251,7 +9430,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron-forge/core@7.11.2(encoding@0.1.13)':
+  '@electron-forge/core@7.11.2(encoding@0.1.13)(esbuild@0.28.1)':
     dependencies:
       '@electron-forge/core-utils': 7.11.2
       '@electron-forge/maker-base': 7.11.2
@@ -9262,7 +9441,7 @@ snapshots:
       '@electron-forge/template-vite': 7.11.2
       '@electron-forge/template-vite-typescript': 7.11.2
       '@electron-forge/template-webpack': 7.11.2
-      '@electron-forge/template-webpack-typescript': 7.11.2
+      '@electron-forge/template-webpack-typescript': 7.11.2(esbuild@0.28.1)
       '@electron-forge/tracer': 7.11.2
       '@electron/get': 3.1.0
       '@electron/packager': 18.4.4
@@ -9394,13 +9573,13 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron-forge/template-webpack-typescript@7.11.2':
+  '@electron-forge/template-webpack-typescript@7.11.2(esbuild@0.28.1)':
     dependencies:
       '@electron-forge/shared-types': 7.11.2
       '@electron-forge/template-base': 7.11.2
       fs-extra: 10.1.0
       typescript: 5.4.5
-      webpack: 5.105.4
+      webpack: 5.105.4(esbuild@0.28.1)
     transitivePeerDependencies:
       - '@swc/core'
       - bluebird
@@ -9563,79 +9742,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.6.1))':
@@ -10335,6 +10592,11 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/chrome@0.2.0':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -10470,7 +10732,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
   '@types/geojson@7946.0.16': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -11754,6 +12024,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -13980,13 +14279,15 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.4.0(webpack@5.105.4):
+  terser-webpack-plugin@5.4.0(esbuild@0.28.1)(webpack@5.105.4(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.105.4
+      webpack: 5.105.4(esbuild@0.28.1)
+    optionalDependencies:
+      esbuild: 0.28.1
 
   terser@5.46.1:
     dependencies:
@@ -14310,7 +14611,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.105.4:
+  webpack@5.105.4(esbuild@0.28.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -14334,7 +14635,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(esbuild@0.28.1)(webpack@5.105.4(esbuild@0.28.1))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/src/shared/clipper-pairing.ts
+++ b/src/shared/clipper-pairing.ts
@@ -25,14 +25,17 @@ export interface ClipperState {
   pairingCode: string | null;
 }
 
+// `btoa`/`atob` (global in Node 16+ and every browser) keep this importable
+// from the browser extension (#792), where `Buffer` doesn't exist. The payload
+// is ASCII (digits, hex secret, JSON punctuation), so the Latin1 round-trip
+// btoa requires is safe; forgiving-base64 in both runtimes tolerates the
+// stripped `=` padding on decode.
 function toBase64Url(s: string): string {
-  return Buffer.from(s, 'utf-8').toString('base64')
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 function fromBase64Url(s: string): string {
-  const padded = s.replace(/-/g, '+').replace(/_/g, '/');
-  return Buffer.from(padded, 'base64').toString('utf-8');
+  return atob(s.replace(/-/g, '+').replace(/_/g, '/'));
 }
 
 export function encodePairingCode(port: number, secret: string): string {

--- a/tests/clipper/ingest.test.ts
+++ b/tests/clipper/ingest.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Extension → app transport (#792). `fetch` is injected, so the request shape
+ * (URL, secret header, body) and the response → ClipResult mapping are tested
+ * without a browser or a live server.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { sendClip, ping } from '../../clipper/src/ingest';
+import type { ClipPayload } from '../../clipper/src/payload';
+
+const PAIRING = { v: 1 as const, port: 41599, secret: 'sekret' };
+const PAYLOAD: ClipPayload = { url: 'https://example.com/a', html: '<h1>Hi</h1>', pageTitle: 'A' };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('sendClip', () => {
+  it('POSTs to the loopback /ingest with the secret header and maps the result', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, {
+      sourceId: 'url-abc', duplicate: false, title: 'A Page', excerptId: 'url-abc-deadbeef',
+    }));
+    const result = await sendClip(PAIRING, { ...PAYLOAD, selection: 'quote' }, fetchImpl);
+
+    expect(result).toEqual({ ok: true, sourceId: 'url-abc', duplicate: false, title: 'A Page', excerptId: 'url-abc-deadbeef' });
+    const [calledUrl, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe('http://127.0.0.1:41599/ingest');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['x-minerva-clipper-secret']).toBe('sekret');
+    expect(JSON.parse(init.body as string)).toMatchObject({ url: 'https://example.com/a', selection: 'quote' });
+  });
+
+  it('maps a server error response to ok:false with the reason', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(503, { error: 'No thoughtbase open' }));
+    const result = await sendClip(PAIRING, PAYLOAD, fetchImpl);
+    expect(result).toEqual({ ok: false, error: 'No thoughtbase open' });
+  });
+
+  it('maps a network failure to a friendly error', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    const result = await sendClip(PAIRING, PAYLOAD, fetchImpl);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/reachable/i);
+  });
+});
+
+describe('ping', () => {
+  it('reports projectOpen on success', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { ok: true, projectOpen: true }));
+    expect(await ping(PAIRING, fetchImpl)).toEqual({ ok: true, projectOpen: true });
+  });
+
+  it('flags a rejected secret distinctly', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(401, { error: 'Unauthorized' }));
+    const result = await ping(PAIRING, fetchImpl);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/re-pair/i);
+  });
+});

--- a/tests/clipper/payload.test.ts
+++ b/tests/clipper/payload.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Selection normalisation for the clip payload (#792).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeSelection } from '../../clipper/src/payload';
+
+describe('normalizeSelection', () => {
+  it('trims a real selection', () => {
+    expect(normalizeSelection('  a quote  ')).toBe('a quote');
+  });
+
+  it('returns undefined for empty / whitespace / nullish', () => {
+    expect(normalizeSelection('')).toBeUndefined();
+    expect(normalizeSelection('   \n ')).toBeUndefined();
+    expect(normalizeSelection(null)).toBeUndefined();
+    expect(normalizeSelection(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #792. Part of the ingestion epic (#222), building on the loopback ingest endpoint (#790) and pairing (#791).

A greenfield `clipper/` package: a Chrome MV3 extension that sends the page you're reading to Minerva as a Source, with your selection riding along as a linked excerpt. Separate build target (esbuild → `clipper/dist/`), **not** part of the Electron bundle.

## What it does
- **Manifest V3**: service worker (module) + toolbar `action` + `commands` shortcut (`⌘⇧S` / `Ctrl+Shift+S`) + options page. Permissions `activeTab`/`scripting`/`storage`; `host_permissions: http://127.0.0.1/*`.
- **One click, no UI** (`background.ts`): capture the active tab's rendered HTML + selection via `scripting.executeScript` (gated by `activeTab` — no broad host access), then POST `{ url, html, pageTitle, selection? }` from the **service worker** so the endpoint sees a `chrome-extension://` origin (the app rejects page origins). Badge flashes ✓ / ! / ? (`?` opens options when unpaired).
- **Transport** (`ingest.ts`) and **selection normalization** (`payload.ts`) are pure and `fetch`-injectable. Pairing persisted in `chrome.storage.local` via the shared decode codec; options page pairs / tests / unpairs.
- Shared `clipper-pairing.ts` now uses `btoa`/`atob` instead of `Buffer` so the codec imports in the browser (no Node `Buffer`).
- Build/typecheck scripts (`build:clipper`, `typecheck:clipper`); `@types/chrome` + `esbuild` devDeps; ESLint ignores `clipper/` (own tsconfig: DOM + chrome globals).

Payload/response shapes match `clipper-server.ts` exactly (`{url, html, pageTitle, selection}` → `{sourceId, duplicate, title, excerptId}`; `/ping` → `projectOpen`).

## Out of scope (separate issues)
- Richer popup w/ tags / note / **id preview** → #793. (Deferred deliberately: "no UI" leaves nowhere to surface a preview, and the server returns the real `sourceId` anyway.)
- Offset-accurate excerpt anchoring → #794.
- Store packaging + branded icons → #795. (Dev build shows Chrome's default placeholder; pin the extension to see the toolbar button — noted in the README.)

## Implementation note
The issue says "content script"; I used MV3's `scripting.executeScript` injection from the service worker (gated by `activeTab`) instead of a declared content script — same capture, no persistent page-side script, no broad host grant.

## Verification
- `pnpm typecheck:clipper` clean · `pnpm build:clipper` clean · `tests/clipper` 7/7 · full `pnpm lint` exit 0.
- Confirmed working end-to-end on local Chrome (load unpacked → pair → ⌘⇧S / toolbar click → ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)