### PR TITLE
feat: anchor clipper selections into body.md with char offsets (#794)

### DIFF
--- a/src/main/clipper/clipper-ingest.ts
+++ b/src/main/clipper/clipper-ingest.ts
@@ -8,12 +8,16 @@
  *   - a non-empty `selection` is filed as a `thought:Excerpt` linked to the
  *     new source, via `createExcerpt` (idempotent on the source + quote text).
  *
- * Offset-accurate excerpt anchoring (mapping the selection into body.md) is a
- * separate concern — see #794. v1 stores the quote text only.
+ * A non-empty selection is anchored into body.md best-effort (#794): we re-find
+ * the selection in the extracted markdown and store `charStart`/`charEnd` when
+ * the match is unambiguous, falling back to text-only when it isn't.
  */
 
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { ingestHtmlString } from '../sources/ingest';
 import { createExcerpt } from '../sources/create-excerpt';
+import { locateExcerptOffsets } from '../sources/excerpt-anchor';
 import { getIngestSettings } from '../sources/ingest-settings';
 import type { ClipperPayload, ClipperIngestOutcome } from './clipper-server';
 
@@ -40,13 +44,37 @@ export async function clipperIngest(
 
   const selection = payload.selection?.trim();
   if (selection) {
+    const offsets = await anchorSelection(rootPath, result.sourceId, selection);
     const excerpt = await createExcerpt(rootPath, {
       sourceId: result.sourceId,
       citedText: selection,
+      charStart: offsets?.charStart ?? null,
+      charEnd: offsets?.charEnd ?? null,
     });
     outcome.excerptId = excerpt.excerptId;
     outcome.excerptDuplicate = excerpt.duplicate;
   }
 
   return outcome;
+}
+
+/**
+ * Read the source's extracted body.md and try to anchor the selection into it.
+ * Returns null (text-only excerpt) when body.md is unreadable or the selection
+ * can't be located unambiguously — never throws, anchoring is best-effort.
+ */
+async function anchorSelection(
+  rootPath: string,
+  sourceId: string,
+  selection: string,
+): Promise<{ charStart: number; charEnd: number } | null> {
+  try {
+    const body = await fs.readFile(
+      path.join(rootPath, '.minerva', 'sources', sourceId, 'body.md'),
+      'utf-8',
+    );
+    return locateExcerptOffsets(body, selection);
+  } catch {
+    return null;
+  }
 }

--- a/src/main/sources/excerpt-anchor.ts
+++ b/src/main/sources/excerpt-anchor.ts
@@ -1,0 +1,76 @@
+/**
+ * Best-effort anchoring of a clipped selection into the extracted body.md (#794).
+ *
+ * The selection text comes from the raw page DOM, but `body.md` is the
+ * Readability + Turndown extraction — Readability strips page chrome and
+ * Turndown reshapes the rest into markdown, so raw DOM offsets don't map. We
+ * re-find the selection in `body.md` whitespace-tolerantly and return character
+ * offsets ONLY when the match is unambiguous.
+ *
+ * Deliberately conservative (per #794): if the selection isn't found, or it
+ * occurs more than once, we return null and let the excerpt stay text-anchored
+ * rather than guess a wrong location. Inline markdown markers around the
+ * selection (`**bold**`, `[link](url)`) don't break the match — they're not
+ * whitespace and the selection text remains a substring — but markup *inside*
+ * the selection (a word bolded mid-phrase) legitimately yields no clean match,
+ * which we treat as "leave it null".
+ */
+
+export interface ExcerptOffsets {
+  /** 0-based, inclusive start offset into body.md. */
+  charStart: number;
+  /** 0-based, exclusive end offset into body.md. */
+  charEnd: number;
+}
+
+/** Collapse all whitespace runs to a single space and trim the ends. */
+function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Whitespace-normalized view of `body` plus a `map` from each normalized-string
+ * index back to its originating offset in `body`. A collapsed space maps to the
+ * first character of the whitespace run it replaced; leading/trailing whitespace
+ * is dropped, so the normalized string mirrors `collapseWhitespace`'s output.
+ */
+function normalizeWithMap(body: string): { normalized: string; map: number[] } {
+  const chars: string[] = [];
+  const map: number[] = [];
+  let inWs = false;
+  let wsRunStart = -1;
+  for (let i = 0; i < body.length; i++) {
+    if (/\s/.test(body[i])) {
+      if (!inWs) { inWs = true; wsRunStart = i; }
+      continue;
+    }
+    if (inWs) {
+      // Emit one collapsed space — but skip leading whitespace so the
+      // normalized view is trimmed at the front.
+      if (chars.length > 0) { chars.push(' '); map.push(wsRunStart); }
+      inWs = false;
+    }
+    chars.push(body[i]);
+    map.push(i);
+  }
+  return { normalized: chars.join(''), map };
+}
+
+/**
+ * Locate `selection` within `body` and return its body.md character offsets, or
+ * null when there's no unambiguous single match.
+ */
+export function locateExcerptOffsets(body: string, selection: string): ExcerptOffsets | null {
+  const needle = collapseWhitespace(selection);
+  if (!needle) return null;
+
+  const { normalized, map } = normalizeWithMap(body);
+  const first = normalized.indexOf(needle);
+  if (first === -1) return null;
+  // More than one occurrence — anchoring to either would be a guess.
+  if (normalized.indexOf(needle, first + 1) !== -1) return null;
+
+  const charStart = map[first];
+  const charEnd = map[first + needle.length - 1] + 1;
+  return { charStart, charEnd };
+}

--- a/tests/main/clipper/clipper-ingest.test.ts
+++ b/tests/main/clipper/clipper-ingest.test.ts
@@ -4,7 +4,11 @@
  * createExcerpt, and the upstream-tags setting passed through.
  */
 
-import { it, expect, beforeEach, vi } from 'vitest';
+import { it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 
 const { ingestHtmlString, createExcerpt, getIngestSettings } = vi.hoisted(() => ({
   ingestHtmlString: vi.fn(),
@@ -17,6 +21,12 @@ vi.mock('../../../src/main/sources/create-excerpt', () => ({ createExcerpt }));
 vi.mock('../../../src/main/sources/ingest-settings', () => ({ getIngestSettings }));
 
 import { clipperIngest } from '../../../src/main/clipper/clipper-ingest';
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) fs.rmSync(tempRoots.pop()!, { recursive: true, force: true });
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -45,17 +55,36 @@ it('runs HTML through ingestHtmlString with url + title fallback + the tags sett
   expect(out).toMatchObject({ sourceId: 'url-abc123', duplicate: false, title: 'A Page' });
 });
 
-it('files a thought:Excerpt when a selection is present', async () => {
+it('files a thought:Excerpt when a selection is present (text-only when body.md is unavailable)', async () => {
   const out = await clipperIngest(
     { url: 'https://example.com/a', html: '<h1>Hi</h1>', selection: '  a quoted passage  ' },
-    '/tmp/project',
+    '/tmp/project-does-not-exist',
   );
-  expect(createExcerpt).toHaveBeenCalledWith('/tmp/project', {
+  // body.md can't be read → anchoring is best-effort, so offsets fall back to null.
+  expect(createExcerpt).toHaveBeenCalledWith('/tmp/project-does-not-exist', {
     sourceId: 'url-abc123',
     citedText: 'a quoted passage', // trimmed
+    charStart: null,
+    charEnd: null,
   });
   expect(out.excerptId).toBe('url-abc123-deadbeef0000');
   expect(out.excerptDuplicate).toBe(false);
+});
+
+it('anchors the excerpt with body.md offsets when the selection is found (#794)', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-clip-anchor-'));
+  tempRoots.push(root);
+  const dir = path.join(root, '.minerva', 'sources', 'url-abc123');
+  await fsp.mkdir(dir, { recursive: true });
+  await fsp.writeFile(path.join(dir, 'body.md'), 'Intro.\n\nThe quick brown fox jumps.\n', 'utf-8');
+
+  await clipperIngest(
+    { url: 'https://example.com/a', html: '<h1>Hi</h1>', selection: 'quick brown fox' },
+    root,
+  );
+  const [, params] = createExcerpt.mock.calls[0] as [string, { charStart: number; charEnd: number }];
+  expect(params.charStart).toBeGreaterThanOrEqual(0);
+  expect(params).toMatchObject({ sourceId: 'url-abc123', citedText: 'quick brown fox' });
 });
 
 it('skips the excerpt when the selection is absent or whitespace', async () => {

--- a/tests/main/sources/excerpt-anchor.test.ts
+++ b/tests/main/sources/excerpt-anchor.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Best-effort selection → body.md anchoring for the clipper (#794).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { locateExcerptOffsets } from '../../../src/main/sources/excerpt-anchor';
+
+describe('locateExcerptOffsets', () => {
+  const body = 'The quick brown fox\njumps over the lazy dog.\n';
+
+  it('anchors an exact selection to its body.md offsets', () => {
+    const off = locateExcerptOffsets(body, 'quick brown fox');
+    expect(off).toEqual({ charStart: 4, charEnd: 19 });
+    expect(body.slice(off!.charStart, off!.charEnd)).toBe('quick brown fox');
+  });
+
+  it('matches whitespace-tolerantly across newlines and runs', () => {
+    // Selection as the browser hands it over: collapsed spaces, no newline.
+    const off = locateExcerptOffsets(body, 'brown fox jumps over');
+    expect(off).not.toBeNull();
+    // The matched span in body.md spans the newline that the selection flattened.
+    expect(body.slice(off!.charStart, off!.charEnd)).toBe('brown fox\njumps over');
+  });
+
+  it('ignores leading/trailing whitespace on the selection', () => {
+    const off = locateExcerptOffsets(body, '   quick brown   ');
+    expect(off).not.toBeNull();
+    expect(body.slice(off!.charStart, off!.charEnd)).toBe('quick brown');
+  });
+
+  it('sees through markdown markers wrapping the selection', () => {
+    const md = 'A paragraph with **emphasised text** in the middle.';
+    const off = locateExcerptOffsets(md, 'emphasised text');
+    expect(off).not.toBeNull();
+    expect(md.slice(off!.charStart, off!.charEnd)).toBe('emphasised text');
+  });
+
+  it('returns null when the selection is absent', () => {
+    expect(locateExcerptOffsets(body, 'not present here')).toBeNull();
+  });
+
+  it('returns null when the selection is ambiguous (multiple matches)', () => {
+    expect(locateExcerptOffsets('cat dog cat', 'cat')).toBeNull();
+  });
+
+  it('returns null for an empty / whitespace-only selection', () => {
+    expect(locateExcerptOffsets(body, '   ')).toBeNull();
+    expect(locateExcerptOffsets(body, '')).toBeNull();
+  });
+
+  it('returns null when markup interrupts the selection mid-phrase', () => {
+    // "the big dog" is not a clean substring of "the **big** dog".
+    const md = 'the **big** dog';
+    expect(locateExcerptOffsets(md, 'the big dog')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #794. Part of the ingestion epic (#222).

#794's v1 (persist a selection as a text-only `thought:Excerpt`) already shipped with #790 — `clipper-ingest.ts` files an excerpt for any selection. This PR adds the **stretch goal**: best-effort offset anchoring into `body.md`.

## Problem
The clipped selection comes from the *raw page DOM*, but `createExcerpt()` anchors into the *extracted* `body.md` (Readability strips chrome, Turndown reshapes to markdown). Raw DOM offsets don't map.

## Approach
- New pure `locateExcerptOffsets(body, selection)` (`src/main/sources/excerpt-anchor.ts`): whitespace-tolerant search that returns `charStart`/`charEnd` **only on an unambiguous single match**. Returns `null` (→ text-only excerpt, the prior behaviour) when the selection is absent or occurs more than once — per the issue's "leave offsets null rather than guess wrong".
  - Sees through markdown markers *wrapping* the selection (`**bold**`, `[link](url)`) since the selection text stays a substring.
  - Markup *interrupting* the selection mid-phrase (a word bolded inside it) legitimately yields no clean match → null.
- `clipper-ingest.ts` reads the freshly-written `body.md` and passes offsets to `createExcerpt` (which already emits `thought:charStart`/`thought:charEnd`, from #104). Anchoring is best-effort and never throws — an unreadable `body.md` falls back to text-only.

## Tests
- `excerpt-anchor.test.ts` — exact match, whitespace/newline tolerance, leading/trailing trim, markdown-wrapped, absent, ambiguous, empty, mid-phrase-markup (8 cases).
- `clipper-ingest.test.ts` — added an end-to-end case writing a real `body.md` and asserting offsets pass through; updated the text-only case to assert the `null` fallback.
- Full `pnpm lint` exit 0; `tests/main/clipper` + `tests/main/sources` 431 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)