### PR TITLE
feat: clipper popup — tags, note & source-id preview (#793)

### DIFF
--- a/clipper/README.md
+++ b/clipper/README.md
@@ -5,8 +5,9 @@ selection rides along as a linked excerpt. The browser sends the **rendered
 HTML it can see**, so authenticated / paywalled pages extract correctly (the
 app does the Readability extraction, not the extension).
 
-This is the first cut (#792): Chrome only, save-with-defaults, no popup UI.
-Richer popup (tags / note / id preview) is #793; packaging/signing is #795.
+Chrome only for now (#792). The toolbar button opens a popup to curate before
+saving — add tags / a note and confirm the canonical source id (#793) — while
+the keyboard shortcut stays a no-UI instant save. Packaging/signing is #795.
 
 ## Build
 
@@ -33,17 +34,26 @@ pnpm typecheck:clipper  # tsc over the extension sources
 
 ## Use
 
-- Click the toolbar button (pin it first — see Install), or press
-  **⌘⇧S / Ctrl+Shift+S**, on any page.
-- A badge flashes **✓** on success, **!** on failure, **?** if not yet paired.
+- **Curate, then save:** click the toolbar button (pin it first — see Install)
+  to open the popup. It shows the page title + the canonical source **id** the
+  save will produce (e.g. `arxiv-2604.18561`), and lets you add **tags** and a
+  **note** before hitting **Save**. A current text selection is saved as a
+  linked excerpt.
+- **Instant save:** press **⌘⇧S / Ctrl+Shift+S** on any page — no popup,
+  defaults only. A badge flashes **✓** on success, **!** on failure, **?** if
+  not yet paired.
 
 ## How it talks to Minerva
 
-POSTs `{ url, html, selection?, pageTitle }` to the app's loopback endpoint
-(`http://127.0.0.1:<port>/ingest`) with the shared secret in the
-`x-minerva-clipper-secret` header. The request goes out from the **service
-worker** (extension origin) — the endpoint rejects content-script / web-page
-origins, so capture and send are deliberately split.
+- `POST /ingest` — `{ url, html, pageTitle, selection?, tags?, note? }` saves the
+  Source (and an excerpt / tags / about-note as supplied).
+- `POST /preview` — `{ url, html }` → `{ sourceId, method, title }`: the id the
+  save *would* produce, with no write. Powers the popup's live id preview.
+
+Both carry the shared secret in the `x-minerva-clipper-secret` header and go to
+`http://127.0.0.1:<port>`. Requests originate from the extension (popup /
+service worker), whose `chrome-extension://` origin the endpoint accepts — it
+rejects content-script / web-page origins, so capture and send are split.
 
 > Icons are intentionally omitted for the unpacked dev build; Chrome shows a
 > default. A branded icon set lands with packaging (#795).

--- a/clipper/build.mjs
+++ b/clipper/build.mjs
@@ -20,6 +20,7 @@ await build({
   entryPoints: {
     background: path.join(root, 'src/background.ts'),
     options: path.join(root, 'src/options.ts'),
+    popup: path.join(root, 'src/popup.ts'),
   },
   bundle: true,
   format: 'esm',
@@ -30,5 +31,6 @@ await build({
 
 await cp(path.join(root, 'manifest.json'), path.join(out, 'manifest.json'));
 await cp(path.join(root, 'options.html'), path.join(out, 'options.html'));
+await cp(path.join(root, 'popup.html'), path.join(out, 'popup.html'));
 
 console.log('Minerva Clipper built →', path.relative(process.cwd(), out));

--- a/clipper/manifest.json
+++ b/clipper/manifest.json
@@ -10,7 +10,8 @@
     "type": "module"
   },
   "action": {
-    "default_title": "Save to Minerva"
+    "default_title": "Save to Minerva",
+    "default_popup": "popup.html"
   },
   "options_ui": {
     "page": "options.html",

--- a/clipper/popup.html
+++ b/clipper/popup.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Save to Minerva</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        font: 13px/1.45 system-ui, sans-serif;
+        width: 20rem;
+        margin: 0;
+        padding: 0.85rem;
+      }
+      h1 { font-size: 0.95rem; margin: 0 0 0.5rem; }
+      label { display: block; font-weight: 600; margin: 0.6rem 0 0.2rem; }
+      input, textarea {
+        width: 100%;
+        box-sizing: border-box;
+        font: inherit;
+        padding: 0.35rem 0.4rem;
+      }
+      textarea { min-height: 3.2rem; resize: vertical; }
+      .preview {
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        opacity: 0.85;
+        word-break: break-all;
+        min-height: 1.2em;
+        margin: 0.1rem 0 0.2rem;
+      }
+      .title { opacity: 0.7; font-size: 12px; min-height: 1.2em; }
+      .sel { opacity: 0.7; font-size: 12px; font-style: italic; }
+      .row { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.75rem; }
+      button { padding: 0.4rem 0.9rem; font: inherit; cursor: pointer; }
+      button[disabled] { opacity: 0.5; cursor: default; }
+      #status { min-height: 1.2em; font-size: 12px; margin-left: auto; text-align: right; }
+    </style>
+  </head>
+  <body>
+    <h1>Save to Minerva</h1>
+
+    <div class="title" id="title">Reading the page…</div>
+    <div class="preview" id="preview"></div>
+    <div class="sel" id="selection"></div>
+
+    <label for="tags">Tags <span style="font-weight: 400; opacity: 0.6;">(optional)</span></label>
+    <input id="tags" type="text" placeholder="comma or space separated" />
+
+    <label for="note">Note <span style="font-weight: 400; opacity: 0.6;">(optional)</span></label>
+    <textarea id="note" placeholder="A note filed alongside the source"></textarea>
+
+    <div class="row">
+      <button id="save" disabled>Save</button>
+      <span id="status"></span>
+    </div>
+
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/clipper/src/background.ts
+++ b/clipper/src/background.ts
@@ -1,48 +1,16 @@
 /**
- * Service worker — the one-click capture-and-save path (#792).
+ * Service worker — the instant capture-and-save path (#792).
  *
- * Triggered by the toolbar action click or the keyboard command. Captures the
- * active tab's rendered HTML + selection (via `scripting.executeScript`, gated
- * by `activeTab` so no broad host access is needed to read pages), then POSTs
- * from here — the service worker, whose `chrome-extension://` Origin the app
- * endpoint accepts. A badge flashes the outcome.
+ * The toolbar button now opens the popup (curate-before-save, #793), so the
+ * one-click path here is driven by the keyboard command: capture the active
+ * tab and POST from the service worker (whose `chrome-extension://` Origin the
+ * app endpoint accepts), flashing a badge with the outcome. The popup handles
+ * the click; this keeps the no-UI shortcut.
  */
 
 import { loadPairing } from './pairing-store';
 import { sendClip } from './ingest';
-import { normalizeSelection, type ClipPayload } from './payload';
-
-/**
- * Runs in the page context (serialized by executeScript) — must be
- * self-contained, referencing only page globals.
- */
-function capturePage() {
-  return {
-    url: location.href,
-    html: document.documentElement.outerHTML,
-    pageTitle: document.title,
-    selection: window.getSelection()?.toString() ?? '',
-  };
-}
-
-async function captureActiveTab(): Promise<ClipPayload | null> {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!tab?.id) return null;
-  const [injected] = await chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: capturePage,
-  });
-  const r = injected?.result as
-    | { url: string; html: string; pageTitle: string; selection: string }
-    | undefined;
-  if (!r?.html) return null;
-  return {
-    url: r.url,
-    html: r.html,
-    pageTitle: r.pageTitle,
-    selection: normalizeSelection(r.selection),
-  };
-}
+import { captureActiveTab } from './capture';
 
 async function flashBadge(text: string, color: string): Promise<void> {
   await chrome.action.setBadgeBackgroundColor({ color });
@@ -71,7 +39,6 @@ async function saveCurrentPage(): Promise<void> {
   }
 }
 
-chrome.action.onClicked.addListener(() => { void saveCurrentPage(); });
 chrome.commands.onCommand.addListener((command) => {
   if (command === 'save-to-minerva') void saveCurrentPage();
 });

--- a/clipper/src/capture.ts
+++ b/clipper/src/capture.ts
@@ -1,0 +1,41 @@
+/**
+ * Capture the active tab's rendered HTML + selection (#792/#793). Shared by the
+ * service worker (instant save via the keyboard command) and the popup
+ * (curate-before-save). Uses `scripting.executeScript` gated by `activeTab`, so
+ * no broad host permission is needed to read the page.
+ */
+
+import { normalizeSelection, type ClipPayload } from './payload';
+
+/**
+ * Runs in the page context (serialized by executeScript) — must be
+ * self-contained, referencing only page globals.
+ */
+function capturePage() {
+  return {
+    url: location.href,
+    html: document.documentElement.outerHTML,
+    pageTitle: document.title,
+    selection: window.getSelection()?.toString() ?? '',
+  };
+}
+
+/** Capture the active tab, or null when there's no scriptable tab. */
+export async function captureActiveTab(): Promise<ClipPayload | null> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) return null;
+  const [injected] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: capturePage,
+  });
+  const r = injected?.result as
+    | { url: string; html: string; pageTitle: string; selection: string }
+    | undefined;
+  if (!r?.html) return null;
+  return {
+    url: r.url,
+    html: r.html,
+    pageTitle: r.pageTitle,
+    selection: normalizeSelection(r.selection),
+  };
+}

--- a/clipper/src/ingest.ts
+++ b/clipper/src/ingest.ts
@@ -62,6 +62,43 @@ export async function sendClip(
   };
 }
 
+export interface PreviewResult {
+  ok: boolean;
+  /** Canonical source id the save would produce (e.g. `arxiv-2604.18561`). */
+  sourceId?: string;
+  method?: string;
+  title?: string;
+  error?: string;
+}
+
+/** Ask the app for the canonical source id a clip would produce (no write). */
+export async function preview(
+  pairing: PairingPayload,
+  payload: { url: string; html: string },
+  fetchImpl: typeof fetch = fetch,
+): Promise<PreviewResult> {
+  let res: Response;
+  try {
+    res = await fetchImpl(endpoint(pairing, '/preview'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [SECRET_HEADER]: pairing.secret },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    return { ok: false, error: 'Minerva isn’t reachable.' };
+  }
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    return { ok: false, error: typeof body.error === 'string' ? body.error : `HTTP ${res.status}` };
+  }
+  return {
+    ok: true,
+    sourceId: typeof body.sourceId === 'string' ? body.sourceId : undefined,
+    method: typeof body.method === 'string' ? body.method : undefined,
+    title: typeof body.title === 'string' ? body.title : undefined,
+  };
+}
+
 export interface PingResult {
   ok: boolean;
   projectOpen?: boolean;

--- a/clipper/src/payload.ts
+++ b/clipper/src/payload.ts
@@ -9,10 +9,27 @@ export interface ClipPayload {
   html: string;
   pageTitle: string;
   selection?: string;
+  /** User tags from the popup (#793). */
+  tags?: string[];
+  /** Free-text note from the popup (#793). */
+  note?: string;
 }
 
 /** Normalise a raw selection: trimmed, or `undefined` when empty. */
 export function normalizeSelection(raw: string | null | undefined): string | undefined {
   const trimmed = raw?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Parse the popup's free-text tag field into a clean, de-duplicated list.
+ * Tags are separated by commas or whitespace; a leading `#` is tolerated.
+ */
+export function parseTags(raw: string | null | undefined): string[] {
+  const seen = new Set<string>();
+  for (const part of (raw ?? '').split(/[,\s]+/)) {
+    const tag = part.replace(/^#+/, '').trim();
+    if (tag) seen.add(tag);
+  }
+  return [...seen];
 }

--- a/clipper/src/popup.ts
+++ b/clipper/src/popup.ts
@@ -1,0 +1,86 @@
+/**
+ * Toolbar popup — the curate-before-save path (#793). On open it captures the
+ * active tab and asks the app for a source-id preview, then lets the user add
+ * tags / a note before saving. The keyboard shortcut (handled in the service
+ * worker) remains the no-UI instant-save path.
+ */
+
+import { loadPairing } from './pairing-store';
+import { sendClip, preview } from './ingest';
+import { captureActiveTab } from './capture';
+import { parseTags, type ClipPayload } from './payload';
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) throw new Error(`missing #${id}`);
+  return node as T;
+}
+
+const titleEl = el<HTMLDivElement>('title');
+const previewEl = el<HTMLDivElement>('preview');
+const selectionEl = el<HTMLDivElement>('selection');
+const tagsInput = el<HTMLInputElement>('tags');
+const noteInput = el<HTMLTextAreaElement>('note');
+const saveBtn = el<HTMLButtonElement>('save');
+const statusEl = el<HTMLSpanElement>('status');
+
+function setStatus(msg: string): void { statusEl.textContent = msg; }
+
+/** The captured page, held so Save reuses exactly what was previewed. */
+let captured: ClipPayload | null = null;
+
+async function init(): Promise<void> {
+  const pairing = await loadPairing();
+  if (!pairing) {
+    titleEl.textContent = 'Not paired yet.';
+    setStatus('');
+    saveBtn.textContent = 'Pair…';
+    saveBtn.disabled = false;
+    saveBtn.addEventListener('click', () => { void chrome.runtime.openOptionsPage(); });
+    return;
+  }
+
+  captured = await captureActiveTab();
+  if (!captured) {
+    titleEl.textContent = 'Can’t read this page.';
+    return;
+  }
+
+  titleEl.textContent = captured.pageTitle || captured.url;
+  selectionEl.textContent = captured.selection
+    ? `Selection will be saved as an excerpt (${captured.selection.length} chars).`
+    : '';
+  saveBtn.disabled = false;
+  saveBtn.addEventListener('click', () => { void save(pairing); });
+
+  // Preview the canonical id in the background — non-blocking, best-effort.
+  const p = await preview(pairing, { url: captured.url, html: captured.html });
+  if (p.ok) {
+    if (p.title) titleEl.textContent = p.title;
+    previewEl.textContent = p.sourceId ? `id: ${p.sourceId}` : '';
+  } else {
+    previewEl.textContent = p.error ?? '';
+  }
+}
+
+async function save(pairing: NonNullable<Awaited<ReturnType<typeof loadPairing>>>): Promise<void> {
+  if (!captured) return;
+  saveBtn.disabled = true;
+  setStatus('Saving…');
+  const tags = parseTags(tagsInput.value);
+  const note = noteInput.value.trim();
+  const result = await sendClip(pairing, {
+    ...captured,
+    tags: tags.length ? tags : undefined,
+    note: note || undefined,
+  });
+  if (result.ok) {
+    setStatus(result.duplicate ? 'Updated ✓' : 'Saved ✓');
+    setTimeout(() => window.close(), 700);
+  } else {
+    setStatus(result.error ?? 'Failed');
+    saveBtn.disabled = false;
+  }
+}
+
+void init();

--- a/src/main/clipper/clipper-ingest.ts
+++ b/src/main/clipper/clipper-ingest.ts
@@ -6,7 +6,9 @@
  *     browser-supplied HTML (no refetch — that's the whole point), writing the
  *     Source the same way "Ingest URL…" does;
  *   - a non-empty `selection` is filed as a `thought:Excerpt` linked to the
- *     new source, via `createExcerpt` (idempotent on the source + quote text).
+ *     new source, via `createExcerpt` (idempotent on the source + quote text);
+ *   - popup `tags` are applied as user `minerva:tag`s, and a popup `note` is
+ *     filed as a Zotero-style about-note (#793).
  *
  * Offset-accurate excerpt anchoring (mapping the selection into body.md) is a
  * separate concern — see #794. v1 stores the quote text only.
@@ -14,6 +16,8 @@
 
 import { ingestHtmlString } from '../sources/ingest';
 import { createExcerpt } from '../sources/create-excerpt';
+import { createAboutNote } from '../sources/about-note';
+import { addSourceTag } from '../sources/source-meta-write';
 import { getIngestSettings } from '../sources/ingest-settings';
 import type { ClipperPayload, ClipperIngestOutcome } from './clipper-server';
 
@@ -46,6 +50,27 @@ export async function clipperIngest(
     });
     outcome.excerptId = excerpt.excerptId;
     outcome.excerptDuplicate = excerpt.duplicate;
+  }
+
+  // Popup tags (#793): apply each as a user tag. addSourceTag is idempotent and
+  // reindexes; collect the ones that were newly added for the response.
+  const applied: string[] = [];
+  for (const raw of payload.tags ?? []) {
+    const tag = raw.trim();
+    if (!tag) continue;
+    if (await addSourceTag(rootPath, result.sourceId, tag)) applied.push(tag);
+  }
+  if (applied.length) outcome.tags = applied;
+
+  // Popup note (#793): file a Zotero-style about-note linked to the source.
+  const note = payload.note?.trim();
+  if (note) {
+    const { relativePath } = await createAboutNote(rootPath, {
+      sourceId: result.sourceId,
+      title: `Note on ${result.title || result.sourceId}`,
+      body: note,
+    });
+    outcome.notePath = relativePath;
   }
 
   return outcome;

--- a/src/main/clipper/clipper-server.ts
+++ b/src/main/clipper/clipper-server.ts
@@ -33,7 +33,25 @@ export interface ClipperPayload {
   pageTitle?: string;
   /** Selected text → filed as a linked thought:Excerpt when present. */
   selection?: string;
+  /** Optional user tags from the popup → applied as `minerva:tag` (#793). */
+  tags?: string[];
+  /** Optional free-text note → filed as a Zotero-style about-note (#793). */
+  note?: string;
 }
+
+/** Body of a `POST /preview` — enough to derive the canonical id (#793). */
+export interface ClipperPreviewPayload {
+  url?: string;
+  html: string;
+}
+
+export interface ClipperPreviewResult {
+  sourceId: string;
+  method: string;
+  title: string;
+}
+
+export type ClipperPreviewFn = (payload: ClipperPreviewPayload) => ClipperPreviewResult;
 
 export interface ClipperIngestOutcome {
   sourceId: string;
@@ -44,6 +62,10 @@ export interface ClipperIngestOutcome {
   /** Set when a selection was supplied and an excerpt was filed. */
   excerptId?: string;
   excerptDuplicate?: boolean;
+  /** Tags that were newly applied to the source (#793). */
+  tags?: string[];
+  /** Project-relative path of the about-note filed from `note`, if any (#793). */
+  notePath?: string;
 }
 
 export type ClipperIngestFn = (
@@ -58,6 +80,8 @@ export interface ClipperListenerOptions {
   resolveRootPath: () => string | null;
   /** Does the extraction + write. Injected so the transport stays pure. */
   ingest: ClipperIngestFn;
+  /** Derives the canonical id for `/preview` (no write). Injected (#793). */
+  preview: ClipperPreviewFn;
   /** Reject bodies larger than this (default 32 MB). */
   maxBodyBytes?: number;
 }
@@ -194,6 +218,29 @@ export function createClipperRequestListener(
       // whether a thoughtbase is currently open.
       if (req.method === 'GET' && url === '/ping') {
         sendJson(res, 200, { ok: true, projectOpen: opts.resolveRootPath() != null });
+        return;
+      }
+
+      // Source-id preview (#793). Pure id derivation from the captured HTML —
+      // no write, so it works even before a thoughtbase is open.
+      if (req.method === 'POST' && url === '/preview') {
+        let payload: ClipperPreviewPayload;
+        try {
+          payload = JSON.parse(await readBody(req, maxBytes)) as ClipperPreviewPayload;
+        } catch (err) {
+          const status = (err as { statusCode?: number }).statusCode ?? 400;
+          sendJson(res, status, { error: status === 413 ? 'Payload too large' : 'Invalid JSON body' });
+          return;
+        }
+        if (typeof payload?.html !== 'string' || payload.html.trim() === '') {
+          sendJson(res, 400, { error: 'Missing `html` in payload' });
+          return;
+        }
+        try {
+          sendJson(res, 200, opts.preview(payload));
+        } catch (err) {
+          sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
         return;
       }
 

--- a/src/main/clipper/lifecycle.ts
+++ b/src/main/clipper/lifecycle.ts
@@ -14,6 +14,7 @@
 
 import { startClipperServer, type ClipperServerHandle } from './clipper-server';
 import { clipperIngest } from './clipper-ingest';
+import { previewSourceFromHtml } from '../sources/ingest';
 import { getClipperConfig, ensureClipperSecret } from './clipper-config';
 
 /** Preferred loopback port; falls back to an ephemeral one if taken. */
@@ -47,6 +48,7 @@ export async function ensureClipperRunning(
         secret,
         resolveRootPath,
         ingest: clipperIngest,
+        preview: ({ html, url }) => previewSourceFromHtml(html, url),
         port: PREFERRED_PORT,
       }))
       .then((h) => {

--- a/src/main/sources/about-note.ts
+++ b/src/main/sources/about-note.ts
@@ -1,0 +1,66 @@
+/**
+ * Create a Zotero-style "about" note for a source (#474, used by the clipper
+ * #793). A note is a plain markdown file with `about: [[sources/<id>]]`
+ * frontmatter — the indexer materialises that into a `dc:subject` edge so the
+ * note surfaces under the source's Notes section. This is the same shape the
+ * renderer's "New note about this source" produces; factored into main so the
+ * clipper's loopback ingest can file one without the renderer.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface AboutNoteParams {
+  sourceId: string;
+  /** Note title → the `# heading` and the basis for the filename. */
+  title: string;
+  /** Markdown body beneath the heading. */
+  body: string;
+}
+
+export interface AboutNoteResult {
+  /** Project-relative path of the note that was written. */
+  relativePath: string;
+}
+
+/**
+ * Write a new about-note at the project root, picking a filename from the title
+ * and disambiguating with a numeric suffix so an existing note is never
+ * overwritten. The chokidar watcher reindexes it; no manual index call needed
+ * (same contract as `createExcerpt`).
+ */
+export async function createAboutNote(
+  rootPath: string,
+  params: AboutNoteParams,
+): Promise<AboutNoteResult> {
+  const stem = slugifyTitle(params.title) || 'clipped-note';
+  const relativePath = await uniqueNotePath(rootPath, stem);
+  const content =
+    `---\nabout: [[sources/${params.sourceId}]]\n---\n\n` +
+    `# ${params.title.trim() || 'Note'}\n\n` +
+    `${params.body.trim()}\n`;
+  await fs.writeFile(path.join(rootPath, relativePath), content, 'utf-8');
+  return { relativePath };
+}
+
+/** Filename-safe, lowercase, hyphenated stem from a free-text title. */
+export function slugifyTitle(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+/** `<stem>.md`, or `<stem>-2.md`, `<stem>-3.md`, … if earlier ones exist. */
+async function uniqueNotePath(rootPath: string, stem: string): Promise<string> {
+  for (let n = 1; ; n++) {
+    const rel = n === 1 ? `${stem}.md` : `${stem}-${n}.md`;
+    try {
+      await fs.access(path.join(rootPath, rel));
+    } catch {
+      return rel; // doesn't exist → free to use
+    }
+  }
+}

--- a/src/main/sources/ingest.ts
+++ b/src/main/sources/ingest.ts
@@ -21,7 +21,7 @@ import { Buffer } from 'node:buffer';
 import { parseHTML } from 'linkedom';
 import { Readability } from '@mozilla/readability';
 import TurndownService from 'turndown';
-import { canonicalSourceId, normalizeUrl } from './source-id';
+import { canonicalSourceId, normalizeUrl, type CanonicalIdMethod } from './source-id';
 import { mergeMetaTtl } from './source-merge';
 import { extractStructured, structuredToArticleMetadata } from './site-handlers';
 import { buildMetaTtl as buildArticleMetaTtl } from './ingest-identifier';
@@ -203,6 +203,48 @@ export async function ingestHtmlString(
   }
 
   return { sourceId, relativePath, duplicate: false, title, kind: 'web' };
+}
+
+export interface SourceIdPreview {
+  sourceId: string;
+  method: CanonicalIdMethod;
+  /** Best-effort extracted title, for the clipper popup to confirm what it'll save. */
+  title: string;
+}
+
+/**
+ * Derive the canonical source id (and a title) a clip *would* produce, without
+ * writing anything (#793). Mirrors `ingestHtmlString`'s id derivation exactly —
+ * site-handler structured ids over the HTML, then `canonicalSourceId` — so the
+ * clipper popup can show `arxiv-2604.18561` before the user commits. Title
+ * extraction is best-effort: Readability failures fall back to the `<title>`.
+ */
+export function previewSourceFromHtml(html: string, url?: string): SourceIdPreview {
+  const { document } = parseHTML(html);
+  if (url) {
+    Object.defineProperty(document, 'documentURI', { value: url, configurable: true });
+    Object.defineProperty(document, 'baseURI', { value: url, configurable: true });
+  }
+
+  const structured = url ? extractStructured(document, new URL(url)) : null;
+  const { id: sourceId, method } = canonicalSourceId(
+    {
+      doi: structured?.doi ?? undefined,
+      arxiv: structured?.arxiv ?? undefined,
+      pubmed: structured?.pubmed ?? undefined,
+      isbn: structured?.isbn ?? undefined,
+      url: url ?? undefined,
+    },
+    url ? undefined : html,
+  );
+
+  let title: string;
+  try {
+    title = extractReadableFromDoc(document, url ?? '').title;
+  } catch {
+    title = document.title || '';
+  }
+  return { sourceId, method, title };
 }
 
 // ── Fetch + content-type routing ─────────────────────────────────────────

--- a/tests/clipper/ingest.test.ts
+++ b/tests/clipper/ingest.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { sendClip, ping } from '../../clipper/src/ingest';
+import { sendClip, ping, preview } from '../../clipper/src/ingest';
 import type { ClipPayload } from '../../clipper/src/payload';
 
 const PAIRING = { v: 1 as const, port: 41599, secret: 'sekret' };
@@ -41,6 +41,34 @@ describe('sendClip', () => {
     const result = await sendClip(PAIRING, PAYLOAD, fetchImpl);
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/reachable/i);
+  });
+});
+
+describe('preview', () => {
+  it('POSTs to /preview and maps the source-id result', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, {
+      sourceId: 'arxiv-2604.18561', method: 'arxiv', title: 'Some Paper',
+    }));
+    const result = await preview(PAIRING, { url: 'https://arxiv.org/abs/2604.18561', html: '<h1>x</h1>' }, fetchImpl);
+    expect(result).toEqual({ ok: true, sourceId: 'arxiv-2604.18561', method: 'arxiv', title: 'Some Paper' });
+    const [calledUrl] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe('http://127.0.0.1:41599/preview');
+  });
+
+  it('maps an error response to ok:false', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(400, { error: 'Missing `html` in payload' }));
+    const result = await preview(PAIRING, { url: 'x', html: '' }, fetchImpl);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/html/i);
+  });
+});
+
+describe('sendClip — tags + note (#793)', () => {
+  it('includes tags and note in the POST body when present', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { sourceId: 'url-abc', duplicate: false }));
+    await sendClip(PAIRING, { ...PAYLOAD, tags: ['ai', 'ml'], note: 'read later' }, fetchImpl);
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toMatchObject({ tags: ['ai', 'ml'], note: 'read later' });
   });
 });
 

--- a/tests/clipper/payload.test.ts
+++ b/tests/clipper/payload.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { normalizeSelection } from '../../clipper/src/payload';
+import { normalizeSelection, parseTags } from '../../clipper/src/payload';
 
 describe('normalizeSelection', () => {
   it('trims a real selection', () => {
@@ -15,5 +15,18 @@ describe('normalizeSelection', () => {
     expect(normalizeSelection('   \n ')).toBeUndefined();
     expect(normalizeSelection(null)).toBeUndefined();
     expect(normalizeSelection(undefined)).toBeUndefined();
+  });
+});
+
+describe('parseTags', () => {
+  it('splits on commas and whitespace, strips #, de-dupes', () => {
+    expect(parseTags('ai, #papers  ml,ai')).toEqual(['ai', 'papers', 'ml']);
+  });
+
+  it('returns an empty list for blank / nullish input', () => {
+    expect(parseTags('')).toEqual([]);
+    expect(parseTags('  ,  ')).toEqual([]);
+    expect(parseTags(null)).toEqual([]);
+    expect(parseTags(undefined)).toEqual([]);
   });
 });

--- a/tests/main/clipper/clipper-ingest.test.ts
+++ b/tests/main/clipper/clipper-ingest.test.ts
@@ -6,14 +6,18 @@
 
 import { it, expect, beforeEach, vi } from 'vitest';
 
-const { ingestHtmlString, createExcerpt, getIngestSettings } = vi.hoisted(() => ({
+const { ingestHtmlString, createExcerpt, getIngestSettings, addSourceTag, createAboutNote } = vi.hoisted(() => ({
   ingestHtmlString: vi.fn(),
   createExcerpt: vi.fn(),
   getIngestSettings: vi.fn(),
+  addSourceTag: vi.fn(),
+  createAboutNote: vi.fn(),
 }));
 
 vi.mock('../../../src/main/sources/ingest', () => ({ ingestHtmlString }));
 vi.mock('../../../src/main/sources/create-excerpt', () => ({ createExcerpt }));
+vi.mock('../../../src/main/sources/about-note', () => ({ createAboutNote }));
+vi.mock('../../../src/main/sources/source-meta-write', () => ({ addSourceTag }));
 vi.mock('../../../src/main/sources/ingest-settings', () => ({ getIngestSettings }));
 
 import { clipperIngest } from '../../../src/main/clipper/clipper-ingest';
@@ -29,6 +33,8 @@ beforeEach(() => {
     kind: 'web',
   });
   createExcerpt.mockResolvedValue({ excerptId: 'url-abc123-deadbeef0000', relativePath: '...', duplicate: false });
+  addSourceTag.mockResolvedValue(true);
+  createAboutNote.mockResolvedValue({ relativePath: 'note-on-a-page.md' });
 });
 
 it('runs HTML through ingestHtmlString with url + title fallback + the tags setting', async () => {
@@ -62,4 +68,36 @@ it('skips the excerpt when the selection is absent or whitespace', async () => {
   await clipperIngest({ html: '<h1>Hi</h1>' }, '/tmp/project');
   await clipperIngest({ html: '<h1>Hi</h1>', selection: '   ' }, '/tmp/project');
   expect(createExcerpt).not.toHaveBeenCalled();
+});
+
+it('applies popup tags and reports the ones newly added (#793)', async () => {
+  addSourceTag.mockResolvedValueOnce(true).mockResolvedValueOnce(false); // 2nd already present
+  const out = await clipperIngest(
+    { html: '<h1>Hi</h1>', tags: ['ai', 'dup', '  ', ''] },
+    '/tmp/project',
+  );
+  expect(addSourceTag).toHaveBeenCalledTimes(2); // blank tags skipped
+  expect(addSourceTag).toHaveBeenNthCalledWith(1, '/tmp/project', 'url-abc123', 'ai');
+  expect(out.tags).toEqual(['ai']); // only the newly-added one
+});
+
+it('files an about-note from the popup note (#793)', async () => {
+  const out = await clipperIngest(
+    { html: '<h1>Hi</h1>', note: '  worth revisiting  ' },
+    '/tmp/project',
+  );
+  expect(createAboutNote).toHaveBeenCalledWith('/tmp/project', {
+    sourceId: 'url-abc123',
+    title: 'Note on A Page',
+    body: 'worth revisiting', // trimmed
+  });
+  expect(out.notePath).toBe('note-on-a-page.md');
+});
+
+it('skips tags/note application when none are supplied', async () => {
+  const out = await clipperIngest({ html: '<h1>Hi</h1>' }, '/tmp/project');
+  expect(addSourceTag).not.toHaveBeenCalled();
+  expect(createAboutNote).not.toHaveBeenCalled();
+  expect(out.tags).toBeUndefined();
+  expect(out.notePath).toBeUndefined();
 });

--- a/tests/main/clipper/clipper-server.test.ts
+++ b/tests/main/clipper/clipper-server.test.ts
@@ -13,6 +13,7 @@ import {
   isAllowedOrigin,
   type ClipperServerHandle,
   type ClipperIngestFn,
+  type ClipperPreviewFn,
 } from '../../../src/main/clipper/clipper-server';
 
 const SECRET = 'test-secret-abc';
@@ -20,12 +21,14 @@ const SECRET = 'test-secret-abc';
 let server: ClipperServerHandle;
 let rootPath: string | null;
 let ingest: ReturnType<typeof vi.fn> & ClipperIngestFn;
+let preview: ReturnType<typeof vi.fn> & ClipperPreviewFn;
 
 async function start(opts: { maxBodyBytes?: number } = {}) {
   server = await startClipperServer({
     secret: SECRET,
     resolveRootPath: () => rootPath,
     ingest,
+    preview,
     port: 0,
     maxBodyBytes: opts.maxBodyBytes,
   });
@@ -44,6 +47,11 @@ beforeEach(() => {
     title: 'Clipped Page',
     kind: 'web',
   })) as ReturnType<typeof vi.fn> & ClipperIngestFn;
+  preview = vi.fn(() => ({
+    sourceId: 'url-abc123',
+    method: 'url',
+    title: 'Clipped Page',
+  })) as ReturnType<typeof vi.fn> & ClipperPreviewFn;
 });
 
 afterEach(async () => {
@@ -193,5 +201,55 @@ describe('POST /ingest', () => {
     const res = await post({ html: 'x'.repeat(500) });
     expect(res.status).toBe(413);
     expect(ingest).not.toHaveBeenCalled();
+  });
+
+  it('passes popup tags + note through to ingest (#793)', async () => {
+    await start();
+    await post({ html: '<h1>Hi</h1>', tags: ['ai', 'paper'], note: 'read later' });
+    expect(ingest).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ['ai', 'paper'], note: 'read later' }),
+      '/tmp/project',
+    );
+  });
+});
+
+describe('POST /preview (#793)', () => {
+  function post(body: unknown) {
+    return fetch(url('/preview'), {
+      method: 'POST',
+      headers: { [SECRET_HEADER]: SECRET, 'Content-Type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    });
+  }
+
+  it('returns the previewed source id + title without a write', async () => {
+    await start();
+    const res = await post({ url: 'https://example.com/a', html: '<h1>Hi</h1>' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sourceId: 'url-abc123', method: 'url', title: 'Clipped Page' });
+    expect(preview).toHaveBeenCalledWith({ url: 'https://example.com/a', html: '<h1>Hi</h1>' });
+    expect(ingest).not.toHaveBeenCalled();
+  });
+
+  it('works even with no thoughtbase open (id derivation is project-independent)', async () => {
+    await start();
+    rootPath = null;
+    const res = await post({ url: 'https://example.com/a', html: '<h1>Hi</h1>' });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a payload with no html (400)', async () => {
+    await start();
+    const res = await post({ url: 'https://example.com/a' });
+    expect(res.status).toBe(400);
+    expect(preview).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a preview failure as 500', async () => {
+    await start();
+    preview.mockImplementationOnce(() => { throw new Error('bad html'); });
+    const res = await post({ html: '<h1>Hi</h1>' });
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('bad html');
   });
 });

--- a/tests/main/sources/about-note.test.ts
+++ b/tests/main/sources/about-note.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Zotero-style about-note creation for the clipper (#793/#474).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createAboutNote, slugifyTitle } from '../../../src/main/sources/about-note';
+
+const roots: string[] = [];
+function mkRoot(): string {
+  const r = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-about-note-'));
+  roots.push(r);
+  return r;
+}
+afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+describe('slugifyTitle', () => {
+  it('lowercases, hyphenates, and trims', () => {
+    expect(slugifyTitle('  Note on A Great Page!  ')).toBe('note-on-a-great-page');
+  });
+  it('caps length and strips edge hyphens', () => {
+    expect(slugifyTitle('--- @@@ ---')).toBe('');
+    expect(slugifyTitle('x'.repeat(100)).length).toBe(60);
+  });
+});
+
+describe('createAboutNote', () => {
+  it('writes about frontmatter, heading, and body', async () => {
+    const root = mkRoot();
+    const { relativePath } = await createAboutNote(root, {
+      sourceId: 'arxiv-2604.18561',
+      title: 'Note on Attention Is All You Need',
+      body: 'Key result: transformers.',
+    });
+    expect(relativePath).toBe('note-on-attention-is-all-you-need.md');
+    const content = await fsp.readFile(path.join(root, relativePath), 'utf-8');
+    expect(content).toBe(
+      '---\nabout: [[sources/arxiv-2604.18561]]\n---\n\n' +
+      '# Note on Attention Is All You Need\n\nKey result: transformers.\n',
+    );
+  });
+
+  it('disambiguates the filename instead of overwriting', async () => {
+    const root = mkRoot();
+    const a = await createAboutNote(root, { sourceId: 's', title: 'Same Title', body: 'one' });
+    const b = await createAboutNote(root, { sourceId: 's', title: 'Same Title', body: 'two' });
+    expect(a.relativePath).toBe('same-title.md');
+    expect(b.relativePath).toBe('same-title-2.md');
+    expect(await fsp.readFile(path.join(root, a.relativePath), 'utf-8')).toContain('one');
+    expect(await fsp.readFile(path.join(root, b.relativePath), 'utf-8')).toContain('two');
+  });
+
+  it('falls back to a default stem when the title has no usable chars', async () => {
+    const root = mkRoot();
+    const { relativePath } = await createAboutNote(root, { sourceId: 's', title: '!!!', body: 'x' });
+    expect(relativePath).toBe('clipped-note.md');
+  });
+});

--- a/tests/main/sources/ingest.test.ts
+++ b/tests/main/sources/ingest.test.ts
@@ -8,6 +8,7 @@ import {
   extractReadable,
   buildBodyMarkdown,
   buildMetaTtl,
+  previewSourceFromHtml,
 } from '../../../src/main/sources/ingest';
 
 function mkTempProject(): string {
@@ -42,6 +43,31 @@ function samplePageHtml(overrides: Partial<{
   </body>
 </html>`;
 }
+
+describe('previewSourceFromHtml (#793)', () => {
+  it('derives a url-method id + title from a web page without writing', () => {
+    const p = previewSourceFromHtml(samplePageHtml(), 'https://example.com/foo');
+    expect(p.method).toBe('url');
+    expect(p.sourceId).toMatch(/^url-[0-9a-f]{12}$/);
+    expect(p.title).toBe('A Reasonable Headline');
+  });
+
+  it('matches the id ingestUrl would produce for the same URL', async () => {
+    const root = mkTempProject();
+    const fetchImpl = (async () => new Response(samplePageHtml(), {
+      status: 200, headers: { 'Content-Type': 'text/html' },
+    })) as unknown as typeof fetch;
+    const ingested = await ingestUrl(root, 'https://example.com/foo', { fetchImpl });
+    const preview = previewSourceFromHtml(samplePageHtml(), 'https://example.com/foo');
+    expect(preview.sourceId).toBe(ingested.sourceId);
+  });
+
+  it('falls back to a content-hash id when no URL is supplied', () => {
+    const p = previewSourceFromHtml(samplePageHtml());
+    expect(p.method).toBe('hash');
+    expect(p.sourceId).toMatch(/^sha-[0-9a-f]{12}$/);
+  });
+});
 
 describe('extractReadable (#93)', () => {
   it('extracts title, byline, siteName, and content', () => {


### PR DESCRIPTION
Closes #793. Part of the ingestion epic (#222), on top of the extension skeleton (#792).

The optional **curate-before-save** popup. One-click-with-defaults stays the primary path — the keyboard shortcut (**⌘⇧S**) still saves instantly with no UI; the toolbar button now opens the popup.

## Extension (`clipper/`)
- **`popup.html` + `popup.ts`** — on open, captures the active tab and `POST /preview`s for a live **source-id preview** (e.g. `arxiv-2604.18561`) + title, before any write. Optional **tags** + **note**; **Save** posts `/ingest` and closes on success (shows "Saved ✓" / "Updated ✓"). A current text selection still rides along as a linked excerpt.
- **`capture.ts`** — capture logic extracted from `background.ts`, shared by popup + service worker. `background.ts` drops the now-inert `action.onClicked` (a `default_popup` supersedes it) and keeps the `commands` shortcut for instant save.
- **`payload.ts`** — `tags`/`note` fields + `parseTags` (comma/space split, strips `#`, de-dupes). **`ingest.ts`** — `preview()` transport. Manifest `default_popup`; build bundles `popup` + copies `popup.html`.

## App (main)
- **`previewSourceFromHtml`** (`sources/ingest.ts`) — derives `{sourceId, method, title}` reusing the real site-handler + `canonicalSourceId` path, **no write**. This is the "via the pure source-id.ts normalisation" the issue asks for, server-side so it stays accurate (the id needs HTML, not just the URL — arxiv/doi come from site-handlers). Wired as the server's injected `preview` fn; `/preview` works even with no thoughtbase open since id derivation is project-independent.
- **`clipper-server.ts`** — `ClipperPayload` gains `tags`/`note`; new `POST /preview` route + `ClipperPreviewFn`; outcome gains `tags`/`notePath`.
- **`clipper-ingest.ts`** — applies tags via `addSourceTag` and files the note as a Zotero-style about-note.
- **`about-note.ts`** — `createAboutNote` writes `about: [[sources/<id>]]` frontmatter with a unique, slugified filename (the #474 note shape, factored into main).

## Decisions
- **Tags → `minerva:tag`** (the user-tag path from #766), not the `upstreamTag` the issue mentions. These are user-chosen tags; `upstreamTag` is the strippable API-derived path. `minerva:tag` indexes to `minerva:hasTag` and shows in the source's tag tree.
- **Note → Zotero-style child note** (per your call) rather than a `dc:description` literal, so it's a real, editable, linked note under the source's Notes.
- **Preview → `/preview` endpoint** (per your call) over a client-side reimplementation.

## Tests
- clipper: `preview` transport + tags/note in the POST body; `parseTags`.
- server: `/preview` route (success, no-project, missing-html, 500) + tags/note passthrough.
- ingest wiring: tag application (newly-added vs already-present, blanks skipped) + about-note filing.
- `about-note`: frontmatter/heading/body, filename disambiguation, slug fallback.
- `previewSourceFromHtml`: url/hash methods + id matches what `ingestUrl` produces.
- Full `pnpm lint` exit 0; **3259** tests pass; `typecheck:clipper` + `build:clipper` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)