### PR TITLE
feat: enter tool arguments in a dismissable modal, not a bottom panel

### DIFF
--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -3,9 +3,10 @@
   import { handleToolOutput } from '../tools/output';
   import { api } from '../ipc/client';
   import Icon from './Icon.svelte';
+  import ToolParamsDialog from './ToolParamsDialog.svelte';
   import type { ToolContext } from '../../../shared/tools/types';
   import { isMissingApiKeyError } from '../../../shared/llm-errors';
-  import { resolveNoteParams, flattenNoteFiles } from '../tools/resolve-note-params';
+  import { resolveNoteParams } from '../tools/resolve-note-params';
 
   interface Props {
     onNoteCreated?: () => void;
@@ -22,26 +23,7 @@
   let { onNoteCreated, onOpenConversation, onMissingApiKey }: Props = $props();
 
   const panel = getToolPanelStore();
-  let paramValues = $state<Record<string, string>>({});
   let running = $state(false);
-  // Note-picker (#516) options — flat list of project .md files, loaded lazily
-  // the first time a tool with a `note` parameter is configured.
-  let noteOptions = $state<{ name: string; relativePath: string }[]>([]);
-
-  $effect(() => {
-    if (panel.panelState === 'configure') {
-      const params = panel.activeTool?.parameters;
-      if (!params) return;
-      const values: Record<string, string> = {};
-      for (const p of params) {
-        values[p.id] = p.defaultValue ?? '';
-      }
-      paramValues = values;
-      if (params.some((p) => p.type === 'note') && noteOptions.length === 0) {
-        void api.notebase.listFiles().then((tree) => { noteOptions = flattenNoteFiles(tree); });
-      }
-    }
-  });
 
   async function executeToolRun() {
     const tool = panel.activeTool;
@@ -72,14 +54,14 @@
     }
   }
 
-  async function handleRunWithParams() {
+  async function handleRunWithParams(rawValues: Record<string, string>) {
     const tool = panel.activeTool;
     if (!tool) return;
 
     // Resolve any note-picker params to the picked note's content/title before
     // folding them in (#516), so the prompt can reference {{param.x.content}}.
-    const snappedParams = Object.keys(paramValues).length > 0
-      ? await resolveNoteParams(tool.parameters, $state.snapshot(paramValues), (p) => api.notebase.readFile(p))
+    const snappedParams = Object.keys(rawValues).length > 0
+      ? await resolveNoteParams(tool.parameters, rawValues, (p) => api.notebase.readFile(p))
       : undefined;
 
     if (tool.outputMode === 'openConversation') {
@@ -151,7 +133,18 @@
   }
 </script>
 
-{#if panel.panelState !== 'hidden'}
+<!-- Argument entry is a dismissable modal (#: tool-args UX); streaming + review
+     stay in the bottom dock below, where output is read alongside the note. -->
+{#if panel.panelState === 'configure' && panel.activeTool}
+  <ToolParamsDialog
+    tool={panel.activeTool}
+    context={panel.context}
+    onRun={(values) => { void handleRunWithParams(values); }}
+    onCancel={() => panel.close()}
+  />
+{/if}
+
+{#if panel.panelState === 'running' || panel.panelState === 'review'}
   <div class="tool-panel">
     <div class="tool-header">
       <div class="tool-title">
@@ -161,64 +154,7 @@
       <button class="close-btn" onclick={() => { panel.close(); running = false; }}><Icon name="close" size={11} /></button>
     </div>
 
-    {#if panel.panelState === 'configure'}
-      <div class="tool-body">
-        <div class="tool-info">{panel.activeTool?.longDescription ?? ''}</div>
-        {#if panel.activeTool?.parameters}
-          <div class="params">
-            {#each panel.activeTool.parameters as param}
-              <label class="param-label">
-                <span>{param.label}{param.required ? ' *' : ''}</span>
-                {#if param.type === 'select' && param.options}
-                  <select bind:value={paramValues[param.id]}>
-                    {#each param.options as opt}
-                      <option value={opt.value}>{opt.label}</option>
-                    {/each}
-                  </select>
-                {:else if param.type === 'textarea'}
-                  <textarea
-                    bind:value={paramValues[param.id]}
-                    placeholder={param.placeholder ?? ''}
-                    rows="3"
-                  ></textarea>
-                {:else if param.type === 'note'}
-                  <input
-                    list={`notes-${param.id}`}
-                    bind:value={paramValues[param.id]}
-                    placeholder={param.placeholder ?? 'Type to find a note…'}
-                  />
-                  <datalist id={`notes-${param.id}`}>
-                    {#each noteOptions as n (n.relativePath)}
-                      <option value={n.relativePath}>{n.name}</option>
-                    {/each}
-                  </datalist>
-                {:else}
-                  <input
-                    type={param.type === 'number' ? 'number' : 'text'}
-                    bind:value={paramValues[param.id]}
-                    placeholder={param.placeholder ?? ''}
-                  />
-                {/if}
-              </label>
-            {/each}
-          </div>
-        {/if}
-        {#if panel.context.selectedText}
-          <div class="context-preview">
-            <span class="context-label">Selected text ({panel.context.selectedText.length} chars)</span>
-          </div>
-        {:else if panel.context.fullNoteContent}
-          <div class="context-preview">
-            <span class="context-label">Full note: {panel.context.fullNoteTitle ?? 'Untitled'}</span>
-          </div>
-        {/if}
-        <div class="actions">
-          <button class="btn primary" onclick={() => { void handleRunWithParams(); }}>Run</button>
-          <button class="btn" onclick={() => panel.close()}>Cancel</button>
-        </div>
-      </div>
-
-    {:else if panel.panelState === 'running'}
+    {#if panel.panelState === 'running'}
       <div class="tool-body output-body">
         <div class="output-scroll">
           <pre class="output">{panel.streamedOutput || 'Thinking...'}</pre>
@@ -314,56 +250,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-  }
-
-  .tool-info {
-    font-size: 12px;
-    color: var(--text-muted);
-    margin-bottom: 12px;
-    line-height: 1.5;
-  }
-
-  .params {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-bottom: 12px;
-  }
-
-  .param-label {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    font-size: 12px;
-    color: var(--text);
-  }
-
-  .param-label input,
-  .param-label textarea,
-  .param-label select {
-    padding: 6px 8px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--bg);
-    color: var(--text);
-    font-size: 12px;
-    font-family: inherit;
-  }
-
-  .param-label input:focus,
-  .param-label textarea:focus,
-  .param-label select:focus {
-    outline: none;
-    border-color: var(--accent);
-  }
-
-  .context-preview {
-    margin-bottom: 12px;
-  }
-
-  .context-label {
-    font-size: 11px;
-    color: var(--text-muted);
   }
 
   .output-scroll {

--- a/src/renderer/lib/components/ToolParamsDialog.svelte
+++ b/src/renderer/lib/components/ToolParamsDialog.svelte
@@ -1,0 +1,282 @@
+<script lang="ts">
+  /**
+   * Argument-entry modal for tools/skills that declare `parameters`. Replaces
+   * the old bottom-panel "configure" form with a dismissable modal (the standard
+   * dialog shell shared with PromptDialog). Streaming + review still live in the
+   * bottom ToolPanel — only arg entry moved here.
+   *
+   * Owns the local form state (param values + the lazily-loaded note-picker
+   * options); hands the raw values back via `onRun`. The caller resolves
+   * note-picker params and drives execution, so this stays a dumb form.
+   */
+  import { api } from '../ipc/client';
+  import { flattenNoteFiles } from '../tools/resolve-note-params';
+  import type { ThinkingToolInfo, ToolContext } from '../../../shared/tools/types';
+
+  interface Props {
+    tool: ThinkingToolInfo;
+    context: ToolContext;
+    onRun: (values: Record<string, string>) => void;
+    onCancel: () => void;
+  }
+
+  let { tool, context, onRun, onCancel }: Props = $props();
+
+  const params = $derived(tool.parameters ?? []);
+
+  let paramValues = $state<Record<string, string>>(
+    Object.fromEntries((tool.parameters ?? []).map((p) => [p.id, p.defaultValue ?? ''])),
+  );
+  // Note-picker (#516) options — flat list of project .md files, loaded lazily
+  // when a tool has a `note` parameter.
+  let noteOptions = $state<{ name: string; relativePath: string }[]>([]);
+  let dialogEl = $state<HTMLElement>();
+
+  $effect(() => {
+    if (params.some((p) => p.type === 'note') && noteOptions.length === 0) {
+      void api.notebase.listFiles().then((tree) => { noteOptions = flattenNoteFiles(tree); });
+    }
+  });
+
+  // Focus the first field so the user can start typing immediately.
+  $effect(() => { dialogEl?.querySelector<HTMLElement>('input, textarea, select')?.focus(); });
+
+  function run() {
+    onRun($state.snapshot(paramValues));
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      onCancel();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      run();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="tool-params-title" bind:this={dialogEl}>
+    <header class="card-header">
+      <div class="eyebrow">{tool.description || 'Tool'}</div>
+      <h2 class="title" id="tool-params-title">{tool.name}</h2>
+    </header>
+
+    <div class="body">
+      {#if tool.longDescription}
+        <p class="tool-info">{tool.longDescription}</p>
+      {/if}
+
+      {#if params.length > 0}
+        <div class="params">
+          {#each params as param (param.id)}
+            <label class="param-label">
+              <span>{param.label}{param.required ? ' *' : ''}</span>
+              {#if param.type === 'select' && param.options}
+                <select bind:value={paramValues[param.id]}>
+                  {#each param.options as opt}
+                    <option value={opt.value}>{opt.label}</option>
+                  {/each}
+                </select>
+              {:else if param.type === 'textarea'}
+                <textarea
+                  bind:value={paramValues[param.id]}
+                  placeholder={param.placeholder ?? ''}
+                  rows="3"
+                ></textarea>
+              {:else if param.type === 'note'}
+                <input
+                  list={`notes-${param.id}`}
+                  bind:value={paramValues[param.id]}
+                  placeholder={param.placeholder ?? 'Type to find a note…'}
+                />
+                <datalist id={`notes-${param.id}`}>
+                  {#each noteOptions as n (n.relativePath)}
+                    <option value={n.relativePath}>{n.name}</option>
+                  {/each}
+                </datalist>
+              {:else}
+                <input
+                  type={param.type === 'number' ? 'number' : 'text'}
+                  bind:value={paramValues[param.id]}
+                  placeholder={param.placeholder ?? ''}
+                />
+              {/if}
+            </label>
+          {/each}
+        </div>
+      {/if}
+
+      {#if context.selectedText}
+        <div class="context-preview">Selected text ({context.selectedText.length} chars)</div>
+      {:else if context.fullNoteContent}
+        <div class="context-preview">Full note: {context.fullNoteTitle ?? 'Untitled'}</div>
+      {/if}
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ⌘↵ run</span>
+      <span class="footer-actions">
+        <button class="btn secondary" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" onclick={run}>
+          Run
+          <span class="btn-kbd">⌘↵</span>
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 460px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+    color: var(--text);
+  }
+
+  .body {
+    padding: 14px 24px 18px;
+    overflow-y: auto;
+  }
+  .tool-info {
+    margin: 0 0 14px;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .params {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .param-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--text);
+  }
+  .param-label input,
+  .param-label textarea,
+  .param-label select {
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 14px;
+  }
+  .param-label input:focus,
+  .param-label textarea:focus,
+  .param-label select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+
+  .context-preview {
+    margin-top: 12px;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-actions {
+    display: inline-flex;
+    gap: 8px;
+  }
+
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .secondary {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .secondary:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover {
+    opacity: 0.92;
+  }
+  .btn-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    opacity: 0.7;
+  }
+</style>


### PR DESCRIPTION
Tools/skills that declare `parameters` used to collect them in the bottom `ToolPanel`'s **configure** state — a docked, half-height panel that pushed the editor up just to ask for a couple of inputs. Argument entry is a quick, transactional step; a centered, dismissable modal is the cleaner, more standard fit.

## Change
- **`ToolParamsDialog.svelte` (new)** — the parameter form (`select` / `textarea` / `note`-picker / `text`+`number`) rendered as a modal, reusing the shared dialog shell (overlay, card, footer kbd-hints) and theme tokens from `PromptDialog`. Esc or backdrop click dismisses, **⌘/Ctrl+↵** runs, the first field autofocuses. Owns its own form state and the lazily-loaded note-picker options.
- **`ToolPanel.svelte`** — renders the modal for the `configure` state and takes the raw values back via `onRun`. The bottom dock now only wraps **`running`** / **`review`**, where streaming output and the Save-as-Note / Append / Copy actions genuinely belong next to the note.

The store state machine and the `handleToolInvoke` trigger flow are unchanged — only the rendering of the `configure` state moved, so existing coverage (`conversation-ops.test.ts`) stays valid.

## Notes
- Running + review intentionally **stay** in the bottom panel — that's persistent output you read alongside your note, and review's actions write to the editor.
- No hard validation added on required fields (matches prior behavior + the "no hand-holding" guideline); `*` still marks them.

## Verification
- `pnpm lint` exit 0 (the one remaining `state_referenced_locally` warning is the standard one-time `$state(initial)` form-seed idiom, same as `PromptDialog`; non-fatal per CLAUDE.md).
- Full suite: **3259** tests pass.

Worth a quick visual check in-app on a skill with parameters (e.g. *Antithesize*, which has a `select`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)