### PR TITLE
feat: format-first export menu — format in the menu, scope in the dialog

### DIFF
--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -17,6 +17,12 @@ export function registerPublish(): void {
       // tree is opt-in (only exporters that know how to walk wiki-link
       // closures should expose it as a scope in the dialog).
       acceptedKinds: e.acceptedKinds ?? ['single-note', 'folder', 'project'],
+      // Format-first menu metadata (#: export-menu-redesign): the group the
+      // dialog buckets this exporter under, plus its variant label/order for
+      // groups where >1 exporter is valid at the same scope (Markdown).
+      group: publish.EXPORT_GROUPS[e.group],
+      variantLabel: e.variantLabel,
+      variantOrder: e.variantOrder ?? 0,
     })),
   );
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -168,14 +168,15 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
         },
         { type: 'separator' },
 
-        // Print / export single-note PDF (the Export menu is the canonical
-        // path; these remain for "just print what's on screen" flows).
+        // Print / quick-PDF of the current view. Distinct from Export ▸ PDF,
+        // which runs the note through the real publish pipeline; these two are
+        // the "just capture what's on screen" escape hatches (named to say so).
         gate({
           label: 'Print…',
           click: () => send(Channels.MENU_PRINT),
         }),
         gate({
-          label: 'Export as PDF…',
+          label: 'Print to PDF…',
           click: async () => {
             const win = BrowserWindow.getFocusedWindow();
             if (!win) return;
@@ -583,22 +584,34 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
       ],
     },
 
-    // Export (#282) — dynamically populated from the publish registry.
-    // Empty submenu is a placeholder that surfaces a disabled item when
-    // no exporter is registered; in practice #246's markdown passthrough
-    // always registers at app-ready. The knowledge-graph dump is a
-    // separate hard-coded entry — the note-export pipeline's ExportPlan
-    // shape doesn't fit an RDF dump, so it stays outside the registry.
+    // Export (#282, format-first redesign) — one item per *format family*
+    // (Markdown / HTML / PDF / Static Site / …), grouped into sections by
+    // category. The dialog picks scope (note/folder/tree/project/source) and,
+    // where a family has more than one exporter at a scope, the variant. The
+    // knowledge-graph dump is a separate hard-coded entry — the note-export
+    // pipeline's ExportPlan shape doesn't fit an RDF dump.
     {
       label: 'Export',
       submenu: (() => {
-        const exporters = publish.listExporters();
-        const items: Electron.MenuItemConstructorOptions[] = exporters.length === 0
-          ? [{ label: 'No exporters registered', enabled: false }]
-          : exporters.map((e) => gate({
-              label: `Export as ${e.label}…`,
-              click: () => send(Channels.MENU_EXPORT, e.id),
+        const groups = publish.listExportGroups();
+        const items: Electron.MenuItemConstructorOptions[] = [];
+        if (groups.length === 0) {
+          items.push({ label: 'No exporters registered', enabled: false });
+        } else {
+          let prevCategory: string | null = null;
+          for (const { group } of groups) {
+            // Separator between format categories (document / publication /
+            // citation) so the families read as comprehensible chunks.
+            if (prevCategory !== null && group.category !== prevCategory) {
+              items.push({ type: 'separator' });
+            }
+            prevCategory = group.category;
+            items.push(gate({
+              label: `${group.label}…`,
+              click: () => send(Channels.MENU_EXPORT, group.id),
             }));
+          }
+        }
         items.push({ type: 'separator' });
         items.push(gate({
           label: 'Export Knowledge Graph…',

--- a/src/main/publish/exporters/annotated-reading/index.ts
+++ b/src/main/publish/exporters/annotated-reading/index.ts
@@ -20,6 +20,7 @@ import type { Exporter, ExportPlanFile } from '../../types';
 export const annotatedReadingExporter: Exporter = {
   id: 'annotated-reading-html',
   label: 'Annotated Source as HTML',
+  group: 'annotated',
   // Source-only — needs a single source's body + its excerpts.
   accepts: (input) => input.kind === 'source',
   acceptedKinds: ['source'],

--- a/src/main/publish/exporters/bibtex.ts
+++ b/src/main/publish/exporters/bibtex.ts
@@ -26,6 +26,7 @@ import { scanCitations } from '../../bibliography/scan-citations';
 export const bibtexExporter: Exporter = {
   id: 'bibtex',
   label: 'BibTeX (.bib)',
+  group: 'bibtex',
   acceptedKinds: ['project', 'folder', 'single-note'],
   accepts: (input) => input.kind !== 'tree',
 

--- a/src/main/publish/exporters/markdown.ts
+++ b/src/main/publish/exporters/markdown.ts
@@ -21,6 +21,9 @@ import type { Exporter } from '../types';
 export const markdownExporter: Exporter = {
   id: 'markdown',
   label: 'Markdown (passthrough)',
+  group: 'markdown',
+  variantLabel: 'Verbatim — files as written',
+  variantOrder: 1,
   accepts: (input) => input.kind !== 'tree',
   acceptedKinds: ['single-note', 'folder', 'project'],
   // Exporter contract requires Promise<ExportOutput>; this trivial

--- a/src/main/publish/exporters/note-html/index.ts
+++ b/src/main/publish/exporters/note-html/index.ts
@@ -63,6 +63,7 @@ function appendCitationsTail(body: string, renderer: CitationRenderer): string {
 export const noteHtmlExporter: Exporter = {
   id: 'note-html',
   label: 'Note as HTML',
+  group: 'html',
   // Single-note HTML is the canonical use; folder / project scopes also
   // work (emits one file per note) but the tree scope belongs to the
   // dedicated tree-html exporter which handles the bundle shape.

--- a/src/main/publish/exporters/note-markdown.ts
+++ b/src/main/publish/exporters/note-markdown.ts
@@ -38,6 +38,9 @@ import type { CitationRenderer } from '../csl';
 export const noteMarkdownExporter: Exporter = {
   id: 'note-markdown',
   label: 'Note as Clean Markdown',
+  group: 'markdown',
+  variantLabel: 'Cleaned — normalized markdown',
+  variantOrder: 0,
   // Single-note + folder + project; tree mode belongs to a future
   // bundle-shaped markdown exporter (`#291`).
   accepts: (input) => input.kind !== 'tree' && input.kind !== 'source',

--- a/src/main/publish/exporters/note-pdf/index.ts
+++ b/src/main/publish/exporters/note-pdf/index.ts
@@ -19,6 +19,7 @@ import { renderPdfFromHtml } from './electron-render';
 export const notePdfExporter: Exporter = {
   id: 'note-pdf',
   label: 'Note as PDF',
+  group: 'pdf',
   accepts: (input) => input.kind === 'single-note',
   acceptedKinds: ['single-note'],
   async run(plan) {

--- a/src/main/publish/exporters/pandoc.ts
+++ b/src/main/publish/exporters/pandoc.ts
@@ -29,6 +29,7 @@ import { buildLinkResolverContext, rewriteWikiLinksInContent } from '../link-res
 export const pandocExporter: Exporter = {
   id: 'pandoc',
   label: 'Pandoc (Markdown + CSL JSON)',
+  group: 'pandoc',
   // Pandoc is fundamentally per-document; folder/project would just
   // concatenate naively without the chapter structure most users
   // actually want. Keep the surface honest.

--- a/src/main/publish/exporters/static-site/index.ts
+++ b/src/main/publish/exporters/static-site/index.ts
@@ -38,6 +38,7 @@ import { SITE_SEARCH_SCRIPT } from './search-script';
 export const staticSiteExporter: Exporter = {
   id: 'static-site',
   label: 'Project as Static Site',
+  group: 'site',
   // Project-only — the whole point is "publish this thoughtbase".
   // Single-note / folder static sites would be a separate, weirder
   // product (a one-page site? a folder-of-notes site?).

--- a/src/main/publish/exporters/tree-html/index.ts
+++ b/src/main/publish/exporters/tree-html/index.ts
@@ -30,6 +30,7 @@ import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../../t
 export const treeHtmlExporter: Exporter = {
   id: 'tree-html',
   label: 'Note Tree as HTML Bundle',
+  group: 'html',
   // Only the tree scope — walking wiki-link closures is the whole point.
   accepts: (input) => input.kind === 'tree',
   acceptedKinds: ['tree'],

--- a/src/main/publish/exporters/tree-markdown.ts
+++ b/src/main/publish/exporters/tree-markdown.ts
@@ -24,6 +24,9 @@ import type { Exporter, ExportPlan, ExportPlanFile } from '../types';
 export const treeMarkdownExporter: Exporter = {
   id: 'tree-markdown',
   label: 'Note Tree as Markdown Zip',
+  group: 'markdown',
+  variantLabel: 'Bundle (zip)',
+  variantOrder: 2,
   // Tree-only — same input shape as tree-html and tree-pdf.
   accepts: (input) => input.kind === 'tree',
   acceptedKinds: ['tree'],

--- a/src/main/publish/exporters/tree-pdf.ts
+++ b/src/main/publish/exporters/tree-pdf.ts
@@ -120,6 +120,7 @@ ${bibSection}
 export const treePdfExporter: Exporter = {
   id: 'tree-pdf',
   label: 'Note Tree as Single PDF',
+  group: 'pdf',
   // Same input shape as tree-html — walking the wiki-link closure is
   // the whole point.
   accepts: (input) => input.kind === 'tree',

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -35,5 +35,5 @@ export function registerBuiltinExporters(): void {
 
 export * from './types';
 export { resolvePlan, runExporter } from './pipeline';
-export { listExporters, exportersFor, getExporter } from './registry';
+export { listExporters, exportersFor, getExporter, listExportGroups, type ExportGroupListing } from './registry';
 export { runExport, type RunExportInput, type RunExportResult } from './run-export';

--- a/src/main/publish/registry.ts
+++ b/src/main/publish/registry.ts
@@ -8,7 +8,8 @@
  * shape don't appear.
  */
 
-import type { Exporter, ExportInput } from './types';
+import type { Exporter, ExportInput, ExportGroupMeta } from './types';
+import { EXPORT_GROUPS } from './types';
 
 const exporters = new Map<string, Exporter>();
 
@@ -28,6 +29,29 @@ export function listExporters(): Exporter[] {
 /** Only the exporters that can handle this input — drives the menu's dynamic contents. */
 export function exportersFor(input: ExportInput): Exporter[] {
   return listExporters().filter((e) => e.accepts(input));
+}
+
+export interface ExportGroupListing {
+  group: ExportGroupMeta;
+  exporterIds: string[];
+}
+
+/**
+ * Registered exporters collapsed into format families, ordered for the
+ * format-first Export menu (#: export-menu-redesign). One listing per group
+ * that has at least one registered exporter.
+ */
+export function listExportGroups(): ExportGroupListing[] {
+  const byGroup = new Map<string, string[]>();
+  for (const e of listExporters()) {
+    const ids = byGroup.get(e.group) ?? [];
+    ids.push(e.id);
+    byGroup.set(e.group, ids);
+  }
+  return [...byGroup.entries()]
+    .map(([id, exporterIds]) => ({ group: EXPORT_GROUPS[id as ExportGroupMeta['id']], exporterIds }))
+    .filter((entry) => entry.group != null)
+    .sort((a, b) => a.group.order - b.group.order);
 }
 
 /** Exposed for tests to reset state between cases. */

--- a/src/main/publish/types.ts
+++ b/src/main/publish/types.ts
@@ -132,11 +132,54 @@ export interface ExportOutput {
   summary: string;
 }
 
+/**
+ * Format-first export menu (#: export-menu-redesign). Scope (note/folder/tree/
+ * project/source) and format (markdown/html/pdf/…) are orthogonal, so the menu
+ * organizes by *format family* — one item per group — and the export dialog
+ * picks scope. Several exporters can share a group (e.g. note-html + tree-html
+ * are both `html`, differing only in scope); the dialog resolves
+ * `(group + scope [+ variant])` back to one concrete exporter.
+ */
+export type ExportGroupId =
+  | 'markdown' | 'html' | 'pdf' | 'site' | 'annotated' | 'bibtex' | 'pandoc';
+
+/** Menu section a group sits in — drives the separators between families. */
+export type ExportGroupCategory = 'document' | 'publication' | 'citation';
+
+export interface ExportGroupMeta {
+  id: ExportGroupId;
+  /** Menu item + dialog title ("Export as <label>"). */
+  label: string;
+  category: ExportGroupCategory;
+  /** Sort order within the Export menu. */
+  order: number;
+}
+
+export const EXPORT_GROUPS: Record<ExportGroupId, ExportGroupMeta> = {
+  markdown:  { id: 'markdown',  label: 'Markdown',         category: 'document',    order: 1 },
+  html:      { id: 'html',      label: 'HTML',             category: 'document',    order: 2 },
+  pdf:       { id: 'pdf',       label: 'PDF',              category: 'document',    order: 3 },
+  site:      { id: 'site',      label: 'Static Site',      category: 'publication', order: 4 },
+  annotated: { id: 'annotated', label: 'Annotated Source', category: 'publication', order: 5 },
+  bibtex:    { id: 'bibtex',    label: 'BibTeX',           category: 'citation',    order: 6 },
+  pandoc:    { id: 'pandoc',    label: 'Pandoc',           category: 'citation',    order: 7 },
+};
+
 export interface Exporter {
   /** Stable id — used by the menu registry and IPC. */
   id: string;
   /** Human-readable label for the menu / palette. */
   label: string;
+  /** Format family this exporter belongs to (#: export-menu-redesign). */
+  group: ExportGroupId;
+  /**
+   * Distinguishes exporters that share a group AND a scope — e.g. Markdown's
+   * verbatim (`markdown`) vs cleaned (`note-markdown`), both valid at
+   * note/folder/project. Shown in the dialog's variant picker; omit when the
+   * exporter is the only candidate at its scopes. Lower `variantOrder` first.
+   */
+  variantLabel?: string;
+  variantOrder?: number;
   /** Whether the exporter can handle this input kind. Falsy = hidden in the menu. */
   accepts(input: ExportInput): boolean;
   /**

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -223,7 +223,8 @@
   // so the many call sites read unchanged. <DialogHost> renders the state.
   const dialogs = getDialogStore();
   const { showPrompt, showConfirm } = dialogs;
-  let exportDialogFor = $state<string | null>(null);
+  // The format-family group id the Export menu launched with (#: export-menu-redesign).
+  let exportDialogGroup = $state<string | null>(null);
 
   /**
    * Bookmark the section the cursor sits in — the nearest heading at/above
@@ -932,7 +933,7 @@
     api.menu.onIngestFile(() => handleIngestFileAsSource());
     api.menu.onImportBibtex(() => handleImportBibtex());
     api.menu.onImportZoteroRdf(() => handleImportZoteroRdf());
-    api.menu.onExport((id) => { exportDialogFor = id; });
+    api.menu.onExport((groupId) => { exportDialogGroup = groupId; });
 
     // Progress updates during a bulk import — rewrites the busy-overlay
     // label in place so the user sees running counts on large imports.
@@ -1489,13 +1490,14 @@
       onClose={() => { showCommandPalette = false; }}
     />
   {/if}
-  {#if exportDialogFor}
+  {#if exportDialogGroup}
     <ExportDialog
-      exporterId={exportDialogFor}
+      group={exportDialogGroup}
       activeFilePath={editor.activeFilePath}
-      onCancel={() => { exportDialogFor = null; }}
+      activeSourceId={editor.activeSourceTab?.sourceId ?? null}
+      onCancel={() => { exportDialogGroup = null; }}
       onExported={async (result) => {
-        exportDialogFor = null;
+        exportDialogGroup = null;
         const pathPreview = result.writtenPaths.slice(0, 5).map((p) => `  • ${p}`).join('\n');
         const more = result.writtenPaths.length > 5
           ? `\n  …and ${result.writtenPaths.length - 5} more`

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -28,6 +28,9 @@
   // Index into scopeCandidates — the variant within a family at the chosen
   // scope (e.g. Markdown Cleaned vs Verbatim). Usually there's only one.
   let variantIndex = $state(0);
+  // How many wiki-link hops out from the current note the 'tree' scope walks
+  // (#: export-menu-redesign). 1 = this note + what it directly links to.
+  let treeDepth = $state(3);
   let linkPolicy = $state<LinkPolicy>('inline-title');
   let citationStyle = $state<string>('apa');
   let citationLocale = $state<string>('en-US');
@@ -95,7 +98,7 @@
   function scopeInput(): { kind: Scope; relativePath?: string; maxDepth?: number } {
     if (scope === 'single-note') return { kind: 'single-note', relativePath: activeFilePath ?? '' };
     if (scope === 'folder') return { kind: 'folder', relativePath: activeFolder };
-    if (scope === 'tree') return { kind: 'tree', relativePath: activeFilePath ?? '', maxDepth: 3 };
+    if (scope === 'tree') return { kind: 'tree', relativePath: activeFilePath ?? '', maxDepth: treeDepth };
     if (scope === 'source') return { kind: 'source', relativePath: activeSourceId ?? '' };
     return { kind: 'project' };
   }
@@ -148,6 +151,7 @@
   $effect(() => {
     void scope;
     void variantIndex;
+    void treeDepth;
     void linkPolicy;
     void citationStyle;
     void citationLocale;
@@ -223,7 +227,7 @@
           {#if availableScopes.includes('tree')}
             <label>
               <input type="radio" name="scope" value="tree" bind:group={scope} />
-              Note tree from current note (depth 3)
+              Linked notes <span class="scope-hint">— this note and the notes it links to</span>
             </label>
           {/if}
           {#if availableScopes.includes('project')}
@@ -238,6 +242,22 @@
               This source{activeSourceId ? ` (${activeSourceId})` : ''}
             </label>
           {/if}
+        </div>
+      </div>
+    {/if}
+
+    {#if scope === 'tree'}
+      <div class="option-row">
+        <span class="field-label">Depth</span>
+        <div class="depth-control">
+          <select bind:value={treeDepth}>
+            {#each [1, 2, 3, 4, 5] as d (d)}
+              <option value={d}>{d} hop{d === 1 ? '' : 's'}</option>
+            {/each}
+          </select>
+          <span class="scope-hint">
+            how far to follow links out from this note{plan ? ` — ${plan.inputs.length} note${plan.inputs.length === 1 ? '' : 's'}` : ''}
+          </span>
         </div>
       </div>
     {/if}
@@ -479,6 +499,20 @@
     border-radius: 4px;
     padding: 10px 12px;
     margin-bottom: 12px;
+  }
+
+  .scope-hint {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+
+  .depth-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .depth-control select {
+    flex: 0 0 auto;
   }
   .radio-group {
     display: flex;

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { api } from '../ipc/client';
-  import type { ExportPreviewPlan } from '../ipc/client';
+  import type { ExportPreviewPlan, ExporterInfo } from '../ipc/client';
 
   interface Props {
-    /** Registered exporter id the menu launched with. */
-    exporterId: string;
-    /** The note the user currently has open — used for 'single-note' scope and the folder default. */
+    /** Format-family group id the menu launched with (#: export-menu-redesign). */
+    group: string;
+    /** The note the user currently has open — used for note/folder/tree scope. */
     activeFilePath: string | null;
+    /** The source whose tab is active, if any — enables the `source` scope. */
+    activeSourceId: string | null;
     /** Close the dialog without exporting. */
     onCancel: () => void;
     /**
@@ -17,16 +19,15 @@
     onExported: (result: { filesWritten: number; summary: string; outputDir: string; writtenPaths: string[] }) => void;
   }
 
-  let { exporterId, activeFilePath, onCancel, onExported }: Props = $props();
+  let { group, activeFilePath, activeSourceId, onCancel, onExported }: Props = $props();
 
-  // The dialog only renders the four user-facing scopes; `source`
-  // (#253) is invoked from the Sources sidebar context menu, not
-  // through this dialog's radio group, so the dialog filters it out
-  // when populating from the registry.
-  type Scope = 'project' | 'folder' | 'single-note' | 'tree';
+  type Scope = 'project' | 'folder' | 'single-note' | 'tree' | 'source';
   type LinkPolicy = 'drop' | 'inline-title' | 'follow-to-file';
 
   let scope = $state<Scope>('project');
+  // Index into scopeCandidates — the variant within a family at the chosen
+  // scope (e.g. Markdown Cleaned vs Verbatim). Usually there's only one.
+  let variantIndex = $state(0);
   let linkPolicy = $state<LinkPolicy>('inline-title');
   let citationStyle = $state<string>('apa');
   let citationLocale = $state<string>('en-US');
@@ -34,8 +35,10 @@
   let loading = $state(false);
   let exporting = $state(false);
   let error = $state<string | null>(null);
-  let acceptedKinds = $state<readonly Scope[]>(['single-note', 'folder', 'project']);
-  let acceptedLoaded = $state(false);
+  // Every exporter in the launched family. The dialog resolves which concrete
+  // one runs from (group + scope + variant).
+  let groupExporters = $state<ExporterInfo[]>([]);
+  let loaded = $state(false);
   // Per-export exclusion overrides (#283). Set of relative paths the
   // user has explicitly re-included; the pipeline force-includes them
   // even when the private-by-default rules would otherwise exclude.
@@ -65,28 +68,45 @@
     return slash >= 0 ? activeFilePath.slice(0, slash) : '';
   });
 
-  // Scopes that don't apply to the current context (e.g. 'single-note'
-  // when no file is open) get disabled rather than hidden — keeps the
-  // radio layout stable.
-  const canScopeNote = $derived(activeFilePath != null);
-  const canScopeTree = $derived(activeFilePath != null && acceptedKinds.includes('tree'));
-  const canScopeProject = $derived(acceptedKinds.includes('project'));
-  const canScopeFolder = $derived(acceptedKinds.includes('folder'));
-  const canScopeSingleNote = $derived(acceptedKinds.includes('single-note'));
+  const groupLabel = $derived(groupExporters[0]?.group.label ?? 'Export');
+
+  // A scope is offered only when the family supports it AND the current
+  // context can satisfy it (a note open for note/folder/tree; a source tab
+  // for source). Unavailable scopes are hidden, not disabled — the menu is
+  // format-first, so the live scopes follow from what you're looking at.
+  function scopeAvailable(s: Scope): boolean {
+    if (!groupExporters.some((e) => e.acceptedKinds.includes(s))) return false;
+    if (s === 'project') return true;
+    if (s === 'source') return activeSourceId != null;
+    return activeFilePath != null; // single-note / folder / tree
+  }
+  const SCOPE_ORDER: Scope[] = ['single-note', 'folder', 'tree', 'project', 'source'];
+  const availableScopes = $derived(SCOPE_ORDER.filter(scopeAvailable));
+
+  // Exporters in this family valid at the chosen scope, sorted for the variant
+  // picker (Markdown → Cleaned / Verbatim / Bundle). Usually exactly one.
+  const scopeCandidates = $derived(
+    groupExporters
+      .filter((e) => e.acceptedKinds.includes(scope))
+      .sort((a, b) => a.variantOrder - b.variantOrder || a.label.localeCompare(b.label)),
+  );
+  const selectedExporterId = $derived((scopeCandidates[variantIndex] ?? scopeCandidates[0])?.id ?? '');
 
   function scopeInput(): { kind: Scope; relativePath?: string; maxDepth?: number } {
     if (scope === 'single-note') return { kind: 'single-note', relativePath: activeFilePath ?? '' };
     if (scope === 'folder') return { kind: 'folder', relativePath: activeFolder };
     if (scope === 'tree') return { kind: 'tree', relativePath: activeFilePath ?? '', maxDepth: 3 };
+    if (scope === 'source') return { kind: 'source', relativePath: activeSourceId ?? '' };
     return { kind: 'project' };
   }
 
   async function refreshPlan(): Promise<void> {
+    if (!selectedExporterId) { plan = null; return; }
     loading = true;
     error = null;
     try {
       plan = await api.publish.resolvePlan(scopeInput(), {
-        exporterId,
+        exporterId: selectedExporterId,
         linkPolicy,
         citationStyle,
         citationLocale,
@@ -101,52 +121,50 @@
     }
   }
 
-  // On mount, fetch acceptedKinds so the scope radios can disable
-  // kinds the exporter doesn't support, and pick a sensible initial
-  // scope (tree when only tree is accepted; else project).
+  // On mount, load the family's exporters and pick a sensible default scope:
+  // the current note if the family handles it, else the current source, else
+  // the whole project, else whatever's available.
   $effect(() => {
+    void group; // re-load if the launched family changes
     void (async () => {
-      const list = await api.publish.listExporters();
-      const entry = list.find((e) => e.id === exporterId);
-      if (entry) {
-        // Filter out `source` — that scope is reachable only from the
-        // Sources sidebar context menu (#253), not this dialog.
-        acceptedKinds = entry.acceptedKinds.filter((k): k is Scope => k !== 'source');
-        // Pick the best default scope given what the exporter accepts
-        // AND what the context supports.
-        if (!acceptedKinds.includes(scope)) {
-          if (acceptedKinds.includes('tree') && activeFilePath) scope = 'tree';
-          else if (acceptedKinds.includes('project')) scope = 'project';
-          else if (acceptedKinds.includes('single-note') && activeFilePath) scope = 'single-note';
-          else scope = acceptedKinds[0] ?? 'project';
-        }
+      const all = await api.publish.listExporters();
+      groupExporters = all.filter((e) => e.group.id === group);
+      const avail = SCOPE_ORDER.filter(scopeAvailable);
+      if (!avail.includes(scope)) {
+        scope = avail.includes('single-note') ? 'single-note'
+          : avail.includes('source') ? 'source'
+          : avail.includes('project') ? 'project'
+          : avail[0] ?? 'project';
       }
-      acceptedLoaded = true;
+      loaded = true;
     })();
   });
 
-  // Re-resolve whenever an input affecting the plan changes. `$effect`
-  // re-runs on any tracked read, so wrapping refreshPlan() in here
-  // subscribes to scope, linkPolicy, citationStyle/locale, activeFilePath.
+  // Reset the variant when scope changes so the index can't dangle onto a
+  // candidate that doesn't exist at the new scope.
+  $effect(() => { void scope; variantIndex = 0; });
+
+  // Re-resolve whenever an input affecting the plan changes.
   $effect(() => {
     void scope;
+    void variantIndex;
     void linkPolicy;
     void citationStyle;
     void citationLocale;
     void activeFilePath;
     void overrides;
     void deselections;
-    if (!acceptedLoaded) return;
+    if (!loaded) return;
     void refreshPlan();
   });
 
   async function handleExport(): Promise<void> {
-    if (!plan) return;
+    if (!plan || !selectedExporterId) return;
     exporting = true;
     error = null;
     try {
       const result = await api.publish.runExport({
-        exporterId,
+        exporterId: selectedExporterId,
         input: scopeInput(),
         linkPolicy,
         citationStyle,
@@ -174,39 +192,69 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="export-dialog-backdrop" onclick={handleBackdropClick}>
   <div class="export-dialog" role="dialog" aria-labelledby="export-dialog-title">
-    <h2 id="export-dialog-title">
-      {plan ? `Export as ${plan.exporterLabel}` : 'Export'}
-    </h2>
+    <h2 id="export-dialog-title">Export as {groupLabel}</h2>
 
-    <div class="option-row">
-      <span class="field-label">Scope</span>
-      <div class="radio-group">
-        {#if canScopeProject}
-          <label>
-            <input type="radio" name="scope" value="project" bind:group={scope} />
-            Entire project
-          </label>
-        {/if}
-        {#if canScopeFolder}
-          <label>
-            <input type="radio" name="scope" value="folder" bind:group={scope} disabled={!activeFilePath} />
-            Current folder{activeFolder ? ` (${activeFolder || 'root'})` : ''}
-          </label>
-        {/if}
-        {#if canScopeSingleNote}
-          <label>
-            <input type="radio" name="scope" value="single-note" bind:group={scope} disabled={!canScopeNote} />
-            Current note{activeFilePath ? ` (${activeFilePath})` : ''}
-          </label>
-        {/if}
-        {#if acceptedKinds.includes('tree')}
-          <label>
-            <input type="radio" name="scope" value="tree" bind:group={scope} disabled={!canScopeTree} />
-            Note tree from current note (depth 3)
-          </label>
+    {#if loaded && availableScopes.length === 0}
+      <div class="empty-scope">
+        {#if groupExporters.some((e) => e.acceptedKinds.includes('source'))}
+          Open a source to export it as {groupLabel}.
+        {:else}
+          Open a note to export it as {groupLabel}.
         {/if}
       </div>
-    </div>
+    {/if}
+
+    {#if availableScopes.length > 0}
+      <div class="option-row">
+        <span class="field-label">Scope</span>
+        <div class="radio-group">
+          {#if availableScopes.includes('single-note')}
+            <label>
+              <input type="radio" name="scope" value="single-note" bind:group={scope} />
+              Current note{activeFilePath ? ` (${activeFilePath})` : ''}
+            </label>
+          {/if}
+          {#if availableScopes.includes('folder')}
+            <label>
+              <input type="radio" name="scope" value="folder" bind:group={scope} />
+              Current folder ({activeFolder || 'root'})
+            </label>
+          {/if}
+          {#if availableScopes.includes('tree')}
+            <label>
+              <input type="radio" name="scope" value="tree" bind:group={scope} />
+              Note tree from current note (depth 3)
+            </label>
+          {/if}
+          {#if availableScopes.includes('project')}
+            <label>
+              <input type="radio" name="scope" value="project" bind:group={scope} />
+              Entire project
+            </label>
+          {/if}
+          {#if availableScopes.includes('source')}
+            <label>
+              <input type="radio" name="scope" value="source" bind:group={scope} />
+              This source{activeSourceId ? ` (${activeSourceId})` : ''}
+            </label>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    {#if scopeCandidates.length > 1}
+      <div class="option-row">
+        <span class="field-label">Variant</span>
+        <div class="radio-group">
+          {#each scopeCandidates as cand, i (cand.id)}
+            <label>
+              <input type="radio" name="variant" checked={variantIndex === i} onchange={() => (variantIndex = i)} />
+              {cand.variantLabel ?? cand.label}
+            </label>
+          {/each}
+        </div>
+      </div>
+    {/if}
 
     <div class="option-row">
       <label for="link-policy">Link handling</label>
@@ -364,7 +412,7 @@
       <button
         class="primary"
         onclick={handleExport}
-        disabled={exporting || loading || !plan || plan.inputs.length === 0}
+        disabled={exporting || loading || !plan || !selectedExporterId || plan.inputs.length === 0}
       >
         {exporting ? 'Exporting…' : 'Export…'}
       </button>
@@ -417,10 +465,20 @@
     margin-bottom: 12px;
     font-size: 12px;
   }
-  .option-row > label:first-child {
+  .option-row > label:first-child,
+  .field-label {
     min-width: 90px;
     color: var(--text-muted);
     padding-top: 3px;
+  }
+
+  .empty-scope {
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--bg-button);
+    border-radius: 4px;
+    padding: 10px 12px;
+    margin-bottom: 12px;
   }
   .radio-group {
     display: flex;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -251,6 +251,27 @@ export interface ExportPreviewPlan {
 
 export type ExportInputKind = 'single-note' | 'folder' | 'project' | 'tree' | 'source';
 
+/** Format family metadata for the format-first export menu (#: export-menu-redesign). */
+export type ExportGroupId =
+  | 'markdown' | 'html' | 'pdf' | 'site' | 'annotated' | 'bibtex' | 'pandoc';
+export interface ExportGroupMeta {
+  id: ExportGroupId;
+  label: string;
+  category: 'document' | 'publication' | 'citation';
+  order: number;
+}
+
+/** One registered exporter, as surfaced to the menu + export dialog. */
+export interface ExporterInfo {
+  id: string;
+  label: string;
+  acceptedKinds: ExportInputKind[];
+  group: ExportGroupMeta;
+  /** Set when the exporter shares a group + scope with another (Markdown). */
+  variantLabel?: string;
+  variantOrder: number;
+}
+
 export interface RunExportInput {
   exporterId: string;
   input: {
@@ -277,7 +298,7 @@ export interface RunExportResult {
 
 export interface PublishApi {
   /** Every registered exporter, for menu + dialog population. */
-  listExporters(): Promise<Array<{ id: string; label: string; acceptedKinds: ExportInputKind[] }>>;
+  listExporters(): Promise<ExporterInfo[]>;
   /** Resolve an ExportPlan without running it — for the preview dialog. */
   resolvePlan(
     input: RunExportInput['input'],

--- a/tests/main/menu-accelerators.test.ts
+++ b/tests/main/menu-accelerators.test.ts
@@ -58,6 +58,7 @@ vi.mock('../../src/main/saved-queries', () => ({ listSavedQueries: () => [] }));
 vi.mock('../../src/main/compute/python-kernel', () => ({ restartKernel: () => undefined }));
 vi.mock('../../src/main/publish', () => ({
   listExporters: () => [],
+  listExportGroups: () => [],
 }));
 
 // ── The actual test ──────────────────────────────────────────────────────

--- a/tests/main/publish/registry.test.ts
+++ b/tests/main/publish/registry.test.ts
@@ -2,17 +2,19 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   registerExporter,
   listExporters,
+  listExportGroups,
   exportersFor,
   getExporter,
   _clearRegistry,
 } from '../../../src/main/publish/registry';
-import type { Exporter } from '../../../src/main/publish/types';
+import type { Exporter, ExportGroupId } from '../../../src/main/publish/types';
 
-function mkExporter(id: string, accepts = true): Exporter {
+function mkExporter(id: string, opts: { accepts?: boolean; group?: ExportGroupId } = {}): Exporter {
   return {
     id,
     label: id,
-    accepts: () => accepts,
+    group: opts.group ?? 'markdown',
+    accepts: () => opts.accepts ?? true,
     async run() { return { files: [], summary: '' }; },
   };
 }
@@ -35,9 +37,30 @@ describe('publish registry (#246)', () => {
   });
 
   it('exportersFor filters out exporters whose accepts() returns false', () => {
-    registerExporter(mkExporter('yes', true));
-    registerExporter(mkExporter('no', false));
+    registerExporter(mkExporter('yes', { accepts: true }));
+    registerExporter(mkExporter('no', { accepts: false }));
     const list = exportersFor({ kind: 'project' });
     expect(list.map((x) => x.id)).toEqual(['yes']);
+  });
+
+  describe('listExportGroups (format-first menu)', () => {
+    it('collapses exporters into ordered format families', () => {
+      // Register out of menu order to prove the result is sorted by group order.
+      registerExporter(mkExporter('bibtex', { group: 'bibtex' }));
+      registerExporter(mkExporter('note-html', { group: 'html' }));
+      registerExporter(mkExporter('note-md', { group: 'markdown' }));
+      registerExporter(mkExporter('note-md-clean', { group: 'markdown' }));
+
+      const groups = listExportGroups();
+      // markdown (1) before html (2) before bibtex (6).
+      expect(groups.map((g) => g.group.id)).toEqual(['markdown', 'html', 'bibtex']);
+      // Both markdown exporters collapse under one family entry.
+      expect(groups[0].exporterIds).toEqual(['note-md', 'note-md-clean']);
+      expect(groups[0].group.label).toBe('Markdown');
+    });
+
+    it('returns nothing when no exporters are registered', () => {
+      expect(listExportGroups()).toEqual([]);
+    });
   });
 });

--- a/tests/main/publish/run-export.test.ts
+++ b/tests/main/publish/run-export.test.ts
@@ -54,6 +54,7 @@ describe('runExport (#282)', () => {
     const attackerExporter = {
       id: 'attacker',
       label: 'Bad',
+      group: 'markdown' as const,
       accepts: () => true,
       async run() {
         return {


### PR DESCRIPTION
## The problem (from the QA readout)
The Export menu listed **all 11 exporters flat** as "Export as <X>…" regardless of context, while `ExportDialog` *also* had scope radios — so scope was expressed in two places and the menu conflated two orthogonal axes (**format × scope**). Symptoms: three Markdown items, three "Note Tree as…" items, three differently-named PDF paths, and an "Annotated Source as HTML" item that **couldn't run from anywhere** (it only accepts `source` scope, which the dialog explicitly filtered out, and nothing else invoked it).

## The redesign: organize the menu by format family, pick scope in the dialog
Scope and format are orthogonal, so each gets exactly one home.

- **Data model:** each exporter now declares a `group` (Markdown / HTML / PDF / Static Site / Annotated Source / BibTeX / Pandoc) + an optional `variantLabel`/`variantOrder`. New `EXPORT_GROUPS` metadata and `listExportGroups()` collapse the 11 exporters into **7 ordered families**, sectioned by category.
- **Menu:** one item per family, grouped by separators (document / publication / citation), plus Knowledge Graph. ~6–7 items instead of 11.
- **Dialog:** resolves `(group + scope + variant)` → a concrete exporter. Scope radios are derived from the family's accepted kinds **intersected with the current context** (only show what's exportable right now — no more disabled radios), default to the current note / source / project, and a **Variant** picker appears only when a family has more than one exporter at a scope (Markdown → Cleaned / Verbatim / Bundle).

```
Export ▸
  Markdown…        ┐
  HTML…            │ document
  PDF…             ┘
  ───────────
  Static Site…     ┐ publication
  Annotated Source…┘ (works only when a source tab is active)
  ───────────
  BibTeX…          ┐ citation
  Pandoc…          ┘
  ───────────
  Knowledge Graph…
```

## Fixes folded in
- **Annotated Source export is now reachable.** The dialog gains a real `source` scope wired to the active source tab; previously the feature had no working entry point.
- **File ▸ "Export as PDF…" → "Print to PDF…"** (next to Print…), so it stops reading as a third competing PDF export against Export ▸ PDF's real pipeline.

## Notes / deliberate calls
- **Running/streaming exports unchanged** — only the menu + dialog scope/format wiring changed; every exporter's `run()` is untouched.
- **Markdown variant default = Cleaned** (`variantOrder` 0), with Verbatim and Bundle (tree zip) as the other variants.
- Annotated Source stays visible in the menu but the dialog shows "Open a source to export it as Annotated Source" when no source tab is active (rather than silently producing an empty export, as today).

## Verification
- `pnpm lint` exit 0 (no new warnings).
- **3261** tests pass (added `listExportGroups` ordering/collapse coverage; updated registry + menu mocks for the new metadata).
- Worth a visual pass in-app: open the Export menu (note the short grouped list), try Markdown (variant picker), PDF (note vs tree scope), and Annotated Source with/without a source tab open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)