### PR TITLE
feat: About Minerva dialog (version/build + Future Tokens attribution) — #803

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,6 +16,7 @@ import { registerPublish } from './ipc/register-publish';
 import { registerConversation } from './ipc/register-conversation';
 import { registerBookmarks } from './ipc/register-bookmarks';
 import { registerClipper } from './ipc/register-clipper';
+import { registerApp } from './ipc/register-app';
 
 export function registerIpcHandlers(): void {
   registerNotebase();
@@ -36,4 +37,5 @@ export function registerIpcHandlers(): void {
   registerConversation();
   registerBookmarks();
   registerClipper();
+  registerApp();
 }

--- a/src/main/ipc/register-app.ts
+++ b/src/main/ipc/register-app.ts
@@ -1,0 +1,30 @@
+import { ipcMain, app } from 'electron';
+import { Channels } from '../../shared/channels';
+
+// Injected by vite.main.config.ts `define` at build time — a packaged app has
+// no git to query at runtime, so the commit + date are baked in.
+declare const __APP_COMMIT__: string;
+declare const __BUILD_DATE__: string;
+
+export interface AppInfo {
+  name: string;
+  version: string;
+  commit: string;
+  buildDate: string;
+  electron: string;
+  chrome: string;
+  node: string;
+}
+
+/** App/build metadata for the About dialog (#803). */
+export function registerApp(): void {
+  ipcMain.handle(Channels.APP_GET_INFO, (): AppInfo => ({
+    name: app.getName(),
+    version: app.getVersion(),
+    commit: typeof __APP_COMMIT__ === 'string' ? __APP_COMMIT__ : 'unknown',
+    buildDate: typeof __BUILD_DATE__ === 'string' ? __BUILD_DATE__ : 'unknown',
+    electron: process.versions.electron,
+    chrome: process.versions.chrome,
+    node: process.versions.node,
+  }));
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -72,7 +72,7 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           {
             label: 'Minerva',
             submenu: [
-              { role: 'about' as const },
+              { label: 'About Minerva', click: () => send(Channels.MENU_ABOUT) },
               { type: 'separator' as const },
               {
                 label: 'Preferences\u2026',

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -177,6 +177,9 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.PUBLISH_RESOLVE_PLAN, input, opts),
     runExport: (args: unknown) => ipcRenderer.invoke(Channels.PUBLISH_RUN_EXPORT, args),
   },
+  app: {
+    getInfo: () => ipcRenderer.invoke(Channels.APP_GET_INFO),
+  },
   shell: {
     revealFile: (relativePath?: string) =>
       ipcRenderer.invoke(Channels.SHELL_REVEAL_FILE, relativePath),
@@ -499,6 +502,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onPrint: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_PRINT, () => cb());
+    },
+    onAbout: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_ABOUT, () => cb());
     },
     onOpenInDefault: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_OPEN_IN_DEFAULT, () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -39,6 +39,7 @@
   import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
   import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
   import ExportDialog from './lib/components/ExportDialog.svelte';
+  import AboutDialog from './lib/components/AboutDialog.svelte';
   import GotoLineDialog from './lib/components/GotoLineDialog.svelte';
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
   import SaveQueryDialog from './lib/components/SaveQueryDialog.svelte';
@@ -225,6 +226,7 @@
   const { showPrompt, showConfirm } = dialogs;
   // The format-family group id the Export menu launched with (#: export-menu-redesign).
   let exportDialogGroup = $state<string | null>(null);
+  let showAbout = $state(false);
 
   /**
    * Bookmark the section the cursor sits in — the nearest heading at/above
@@ -905,6 +907,7 @@
     api.menu.onFindInNotes(() => { findInNotesMode = 'find'; });
     api.menu.onReplaceInNotes(() => { findInNotesMode = 'replace'; });
     api.menu.onPrint(() => window.print());
+    api.menu.onAbout(() => { showAbout = true; });
     api.menu.onOpenInDefault(() => { if (editor.activeFilePath) void api.shell.openInDefault(editor.activeFilePath); });
     api.menu.onOpenInTerminal(() => { void api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
     api.menu.onOpenSettings(() => { showSettings = true; });
@@ -1489,6 +1492,9 @@
       {commands}
       onClose={() => { showCommandPalette = false; }}
     />
+  {/if}
+  {#if showAbout}
+    <AboutDialog onClose={() => { showAbout = false; }} />
   {/if}
   {#if exportDialogGroup}
     <ExportDialog

--- a/src/renderer/lib/components/AboutDialog.svelte
+++ b/src/renderer/lib/components/AboutDialog.svelte
@@ -55,7 +55,7 @@
       <section class="ack">
         <h3>Acknowledgments</h3>
         <p>
-          Several thinking skills — Rhyme, Metaphorize, and Dimensionalize — are adapted from
+          Many of Minerva's thinking skills are adapted from
           <button class="link" onclick={() => open(FUTURE_TOKENS_URL)}>Future Tokens</button>
           by Jordan Rubin, used with thanks under its Creative Commons license.
         </p>

--- a/src/renderer/lib/components/AboutDialog.svelte
+++ b/src/renderer/lib/components/AboutDialog.svelte
@@ -35,7 +35,7 @@
     <header class="card-header">
       <div class="eyebrow">About</div>
       <h2 class="title" id="about-title">Minerva</h2>
-      <p class="tagline">A desktop IDE for thought — markdown notes backed by a knowledge graph and git.</p>
+      <p class="tagline">Thoughts Worth Keeping</p>
     </header>
 
     <div class="body">
@@ -119,7 +119,8 @@
   }
   .tagline {
     margin: 6px 0 0;
-    font-size: 12.5px;
+    font-size: 13.5px;
+    font-style: italic;
     color: var(--text-muted);
     line-height: 1.5;
   }

--- a/src/renderer/lib/components/AboutDialog.svelte
+++ b/src/renderer/lib/components/AboutDialog.svelte
@@ -1,0 +1,221 @@
+<script lang="ts">
+  /**
+   * About Minerva (#803). Themed modal launched from the app menu's About item
+   * (App.svelte wires `api.menu.onAbout`). Shows version + build provenance,
+   * runtime versions, and acknowledgments — including the required attribution
+   * for the Future Tokens thinking skills (Creative Commons).
+   */
+  import { api } from '../ipc/client';
+  import type { AppInfo } from '../ipc/client';
+
+  interface Props {
+    onClose: () => void;
+  }
+  let { onClose }: Props = $props();
+
+  const REPO_URL = 'https://github.com/dgriffith/ide-for-thought';
+  const ISSUES_URL = 'https://github.com/dgriffith/ide-for-thought/issues';
+  const FUTURE_TOKENS_URL = 'https://github.com/jordanrubin/FUTURE_TOKENS';
+
+  let info = $state<AppInfo | null>(null);
+  $effect(() => { void api.app.getInfo().then((i) => { info = i; }); });
+
+  function open(url: string) {
+    void api.shell.openExternal(url);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onClose();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="about-title">
+    <header class="card-header">
+      <div class="eyebrow">About</div>
+      <h2 class="title" id="about-title">Minerva</h2>
+      <p class="tagline">A desktop IDE for thought — markdown notes backed by a knowledge graph and git.</p>
+    </header>
+
+    <div class="body">
+      <dl class="facts">
+        <dt>Version</dt>
+        <dd>{info ? `${info.version} · ${info.commit} · ${info.buildDate}` : '…'}</dd>
+        <dt>Runtime</dt>
+        <dd>{info ? `Electron ${info.electron} · Chromium ${info.chrome} · Node ${info.node}` : '…'}</dd>
+      </dl>
+
+      <div class="links">
+        <button class="link" onclick={() => open(REPO_URL)}>Source on GitHub</button>
+        <span class="dot">·</span>
+        <button class="link" onclick={() => open(ISSUES_URL)}>Report an issue</button>
+      </div>
+
+      <section class="ack">
+        <h3>Acknowledgments</h3>
+        <p>
+          Several thinking skills — Rhyme, Metaphorize, and Dimensionalize — are adapted from
+          <button class="link" onclick={() => open(FUTURE_TOKENS_URL)}>Future Tokens</button>
+          by Jordan Rubin, used with thanks under its Creative Commons license.
+        </p>
+      </section>
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · close</span>
+      <button class="btn primary" onclick={onClose}>OK</button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 440px;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--text);
+  }
+  .tagline {
+    margin: 6px 0 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .body {
+    padding: 16px 24px 4px;
+  }
+
+  .facts {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 14px;
+    margin: 0 0 14px;
+    font-size: 12px;
+  }
+  .facts dt {
+    color: var(--text-muted);
+  }
+  .facts dd {
+    margin: 0;
+    font-family: var(--font-mono);
+    color: var(--text);
+  }
+
+  .links {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    margin-bottom: 14px;
+  }
+  .dot { color: var(--text-faint); }
+
+  .ack {
+    border-top: 1px solid var(--border);
+    padding-top: 12px;
+  }
+  .ack h3 {
+    margin: 0 0 6px;
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .ack p {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--text-muted);
+  }
+
+  /* Inline link-styled buttons (no native anchors — navigation goes through
+     the sandboxed shell.openExternal IPC, never the renderer). */
+  .link {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: var(--accent);
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .link:hover { opacity: 0.85; }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+    margin-top: 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .btn {
+    padding: 7px 16px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover { opacity: 0.92; }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -397,6 +397,21 @@ export interface ShellApi {
   openExternal(url: string): Promise<void>;
 }
 
+/** App + build metadata for the About dialog (#803). */
+export interface AppInfo {
+  name: string;
+  version: string;
+  commit: string;
+  buildDate: string;
+  electron: string;
+  chrome: string;
+  node: string;
+}
+
+export interface AppApi {
+  getInfo(): Promise<AppInfo>;
+}
+
 export interface BookmarksApi {
   load(): Promise<BookmarkNode[]>;
   save(tree: BookmarkNode[]): Promise<void>;
@@ -592,6 +607,7 @@ export interface MenuApi {
   onSortLines(cb: () => void): void;
   onOpenSettings(cb: () => void): void;
   onPrint(cb: () => void): void;
+  onAbout(cb: () => void): void;
   onOpenInDefault(cb: () => void): void;
   onOpenInTerminal(cb: () => void): void;
   onOpenProject(cb: () => void): void;
@@ -635,6 +651,7 @@ export interface IdeApi {
   compute: ComputeApi;
   publish: PublishApi;
   shell: ShellApi;
+  app: AppApi;
   bookmarks: BookmarksApi;
   clipper: ClipperApi;
   conversations: ConversationsApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -135,6 +135,7 @@ export const Channels = {
   MENU_CLOSE_PROJECT: 'menu:closeProject',
   MENU_CLEAR_RECENT: 'menu:clearRecent',
   MENU_PRINT: 'menu:print',
+  MENU_ABOUT: 'menu:about',
   MENU_OPEN_IN_DEFAULT: 'menu:openInDefault',
   MENU_OPEN_IN_TERMINAL: 'menu:openInTerminal',
   MENU_NEW_NOTE: 'menu:newNote',
@@ -498,6 +499,7 @@ export const Channels = {
   MENU_EXPORT: 'menu:export',
 
   // Renderer → main (for menu-triggered main-process actions)
+  APP_GET_INFO: 'app:getInfo',
   EXPORT_CSV: 'export:csv',
   SHELL_REVEAL_FILE: 'shell:revealFile',
   SHELL_OPEN_IN_DEFAULT: 'shell:openInDefault',

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`preload contextBridge contract (#676) > matches the full method surface (snapshot — drift must be reviewed) 1`] = `
 {
+  "app": [
+    "getInfo",
+  ],
   "bibliography": [
     "generate",
     "getStyle",
@@ -123,6 +126,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "outgoing",
   ],
   "menu": [
+    "onAbout",
     "onBibliography",
     "onClearRecent",
     "onCloseProject",

--- a/tests/preload/preload-bridge.test.ts
+++ b/tests/preload/preload-bridge.test.ts
@@ -54,7 +54,7 @@ describe('preload contextBridge contract (#676)', () => {
 
   it('exposes exactly the expected namespace set', () => {
     expect(Object.keys(api()).sort()).toEqual([
-      'bibliography', 'bookmarks', 'citations', 'clipper', 'collections', 'compute',
+      'app', 'bibliography', 'bookmarks', 'citations', 'clipper', 'collections', 'compute',
       'conversations', 'csl', 'export', 'files', 'formatter', 'git', 'graph',
       'links', 'menu', 'notebase', 'proposals', 'publish', 'queries',
       'refactor', 'search', 'shell', 'sites', 'skills', 'sources', 'tables',

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,6 +1,24 @@
 import { defineConfig } from 'vite';
+import { execSync } from 'node:child_process';
+
+// Stamp the build with the current commit + date so the About dialog (#803)
+// can show what's running. Resolved at config-eval time (Node); a packaged
+// build has no git, so these are baked in here. Falls back gracefully in a
+// checkout without git / a shallow clone.
+function gitCommit(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
 
 export default defineConfig({
+  define: {
+    __APP_COMMIT__: JSON.stringify(gitCommit()),
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString().slice(0, 10)),
+  },
   build: {
     rollupOptions: {
       // Kept as runtime `require`s rather than bundled:


### PR DESCRIPTION
Closes #803.

Replaces the macOS app menu's native **About** with a themed dialog (the shared PromptDialog modal shell) that shows what's running and credits the borrowed skill content.

## What's in it
- **Build provenance.** `vite.main.config.ts` stamps the commit (`git rev-parse --short HEAD`) + build date into the main bundle via `define`; a new **`app:getInfo`** IPC returns `{ version, commit, buildDate, electron, chrome, node }` (version from `app.getVersion()`, runtime from `process.versions`). A packaged build has no git, so these are baked in at build time — fallback `"unknown"`.
- **`AboutDialog.svelte`** — name + tagline, version/commit/date, runtime versions, Source / Report-an-issue links, and an Acknowledgments section. All links route through the sandboxed `shell.openExternal` IPC (no raw `<a>` navigation out of the renderer).
- **Attribution (the ask).** The **Rhyme / Metaphorize / Dimensionalize** stock skills are adapted from **Jordan Rubin's Future Tokens** under a Creative Commons license. The dialog thanks him and links `https://github.com/jordanrubin/FUTURE_TOKENS` — satisfying the CC attribution requirement. (That repo is the exact "canonical definition" URL those three skill files already cite.)
- **Menu.** App-menu "About Minerva" now sends `MENU_ABOUT` → App opens the dialog. Wiring: channels + preload (`app.getInfo`, `menu.onAbout`) + client types. Preload-bridge **snapshot** + the explicit namespace-set assertion updated for the new `app` surface (diff is exactly those two additions).

## Scope notes
- **Win/Linux reachability** lands with the Help menu (**#804**) — this PR does the macOS app-menu entry + the whole dialog/IPC. (Per #803's own acceptance criteria.)
- **No license line for the app itself** — `package.json` declares none, so I didn't invent one. Easy to add once you pick one.
- Repo/issues links point at `dgriffith/ide-for-thought` (the current git remote) — trivial to retarget if the public home differs.

## Verification
- `pnpm lint` exit 0 (AboutDialog warning-free).
- **3270** tests pass; preload snapshot regenerated + reviewed.
- Worth a quick visual pass: **Minerva ▸ About Minerva** → version/commit/build show, links open in the browser, the Future Tokens link is correct, Esc/backdrop/OK all close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)