### PR TITLE
feat: Help menu — keyboard shortcuts reference, docs, issues, About (#804)

### DIFF
--- a/src/main/ipc/register-app.ts
+++ b/src/main/ipc/register-app.ts
@@ -1,5 +1,6 @@
 import { ipcMain, app } from 'electron';
 import { Channels } from '../../shared/channels';
+import { getMenuShortcuts } from '../menu';
 
 // Injected by vite.main.config.ts `define` at build time — a packaged app has
 // no git to query at runtime, so the commit + date are baked in.
@@ -27,4 +28,7 @@ export function registerApp(): void {
     chrome: process.versions.chrome,
     node: process.versions.node,
   }));
+
+  // Keyboard-shortcut reference for the Help menu (#804).
+  ipcMain.handle(Channels.APP_GET_SHORTCUTS, () => getMenuShortcuts());
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -668,28 +668,85 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
 
     // Help
     {
+      role: 'help',
       label: 'Help',
       submenu: [
         {
-          label: 'Keyboard Shortcuts',
+          label: 'Keyboard Shortcuts…',
           accelerator: 'CmdOrCtrl+/',
-          enabled: false,
-          click: () => {},
+          click: () => send(Channels.MENU_SHORTCUTS),
         },
         { type: 'separator' },
         {
-          label: 'Report Issue',
-          click: () => {
-            void shell.openExternal('https://github.com/dgriffith/minerva/issues');
-          },
+          label: 'Documentation',
+          click: () => { void shell.openExternal(DOCS_URL); },
         },
+        {
+          label: 'Report an Issue…',
+          click: () => { void shell.openExternal(ISSUES_URL); },
+        },
+        // macOS keeps About in the app menu; Windows/Linux have no app menu,
+        // so About lives at the foot of Help (the platform convention).
+        ...(isMac
+          ? []
+          : [
+              { type: 'separator' as const },
+              { label: 'About Minerva', click: () => send(Channels.MENU_ABOUT) },
+            ]),
       ],
     },
   ];
 
+  lastTemplate = template;
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
   return template;
+}
+
+const DOCS_URL = 'https://github.com/dgriffith/ide-for-thought/tree/main/docs';
+const ISSUES_URL = 'https://github.com/dgriffith/ide-for-thought/issues';
+
+/** The most recently built menu template — the source for the shortcuts
+ *  reference, so it reflects whatever menu state the user is actually in. */
+let lastTemplate: Electron.MenuItemConstructorOptions[] | null = null;
+
+export interface ShortcutItem { label: string; keys: string }
+export interface ShortcutGroup { menu: string; items: ShortcutItem[] }
+
+/**
+ * The keyboard-shortcut reference for the Help menu (#804) — every accelerator
+ * in the live menu, grouped by top-level menu, with keys formatted for the
+ * current platform. Built from the last menu template so it tracks real state.
+ */
+export function getMenuShortcuts(): ShortcutGroup[] {
+  const template = lastTemplate ?? rebuildMenu();
+  const groups: ShortcutGroup[] = [];
+  for (const [menu, entries] of collectAcceleratorsByMenu(template)) {
+    const items = entries.map((e) => ({
+      // Drop the top-level menu label; keep any submenu nesting.
+      label: e.path.slice(1).join(' › ') || menu,
+      keys: formatAccelerator(e.accelerator),
+    }));
+    groups.push({ menu, items });
+  }
+  return groups;
+}
+
+/** Render an Electron accelerator string for display on the current platform
+ *  (⌘⇧S on macOS, Ctrl+Shift+S elsewhere). */
+export function formatAccelerator(accelerator: string, platform: NodeJS.Platform = process.platform): string {
+  const isMac = platform === 'darwin';
+  const mac: Record<string, string> = {
+    CmdOrCtrl: '⌘', Cmd: '⌘', Command: '⌘', Ctrl: '⌃', Control: '⌃',
+    Alt: '⌥', Option: '⌥', Shift: '⇧', Super: '⌘', Plus: '+', Minus: '−',
+  };
+  const other: Record<string, string> = {
+    CmdOrCtrl: 'Ctrl', Cmd: 'Ctrl', Command: 'Ctrl', Ctrl: 'Ctrl', Control: 'Ctrl',
+    Alt: 'Alt', Option: 'Alt', Shift: 'Shift', Super: 'Win', Plus: '+', Minus: '−',
+  };
+  const map = isMac ? mac : other;
+  const tokens = accelerator.split('+').map((t) => map[t] ?? t);
+  return isMac ? tokens.join('') : tokens.join('+');
 }
 
 /**

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -179,6 +179,7 @@ contextBridge.exposeInMainWorld('api', {
   },
   app: {
     getInfo: () => ipcRenderer.invoke(Channels.APP_GET_INFO),
+    getShortcuts: () => ipcRenderer.invoke(Channels.APP_GET_SHORTCUTS),
   },
   shell: {
     revealFile: (relativePath?: string) =>
@@ -505,6 +506,9 @@ contextBridge.exposeInMainWorld('api', {
     },
     onAbout: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_ABOUT, () => cb());
+    },
+    onShortcuts: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_SHORTCUTS, () => cb());
     },
     onOpenInDefault: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_OPEN_IN_DEFAULT, () => cb());

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -40,6 +40,7 @@
   import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import AboutDialog from './lib/components/AboutDialog.svelte';
+  import ShortcutsDialog from './lib/components/ShortcutsDialog.svelte';
   import GotoLineDialog from './lib/components/GotoLineDialog.svelte';
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
   import SaveQueryDialog from './lib/components/SaveQueryDialog.svelte';
@@ -227,6 +228,7 @@
   // The format-family group id the Export menu launched with (#: export-menu-redesign).
   let exportDialogGroup = $state<string | null>(null);
   let showAbout = $state(false);
+  let showShortcuts = $state(false);
 
   /**
    * Bookmark the section the cursor sits in — the nearest heading at/above
@@ -908,6 +910,7 @@
     api.menu.onReplaceInNotes(() => { findInNotesMode = 'replace'; });
     api.menu.onPrint(() => window.print());
     api.menu.onAbout(() => { showAbout = true; });
+    api.menu.onShortcuts(() => { showShortcuts = true; });
     api.menu.onOpenInDefault(() => { if (editor.activeFilePath) void api.shell.openInDefault(editor.activeFilePath); });
     api.menu.onOpenInTerminal(() => { void api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
     api.menu.onOpenSettings(() => { showSettings = true; });
@@ -1495,6 +1498,9 @@
   {/if}
   {#if showAbout}
     <AboutDialog onClose={() => { showAbout = false; }} />
+  {/if}
+  {#if showShortcuts}
+    <ShortcutsDialog onClose={() => { showShortcuts = false; }} />
   {/if}
   {#if exportDialogGroup}
     <ExportDialog

--- a/src/renderer/lib/components/ShortcutsDialog.svelte
+++ b/src/renderer/lib/components/ShortcutsDialog.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  /**
+   * Keyboard Shortcuts reference (#804). Launched from Help ▸ Keyboard Shortcuts
+   * (App wires `api.menu.onShortcuts`). Pulls the live accelerators from main —
+   * generated from the real menu, so it never drifts from what the menu binds.
+   */
+  import { api } from '../ipc/client';
+  import type { ShortcutGroup } from '../ipc/client';
+
+  interface Props {
+    onClose: () => void;
+  }
+  let { onClose }: Props = $props();
+
+  let groups = $state<ShortcutGroup[]>([]);
+  $effect(() => { void api.app.getShortcuts().then((g) => { groups = g; }); });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onClose();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">
+    <header class="card-header">
+      <div class="eyebrow">Help</div>
+      <h2 class="title" id="shortcuts-title">Keyboard Shortcuts</h2>
+    </header>
+
+    <div class="body">
+      {#if groups.length === 0}
+        <p class="empty">No shortcuts to show.</p>
+      {:else}
+        <div class="cols">
+          {#each groups as group (group.menu)}
+            <section class="group">
+              <h3>{group.menu}</h3>
+              <ul>
+                {#each group.items as item (item.label + item.keys)}
+                  <li>
+                    <span class="label">{item.label}</span>
+                    <kbd>{item.keys}</kbd>
+                  </li>
+                {/each}
+              </ul>
+            </section>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · close</span>
+      <button class="btn primary" onclick={onClose}>Done</button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 640px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    color: var(--text);
+  }
+  .body {
+    padding: 16px 24px;
+    overflow-y: auto;
+  }
+  .cols {
+    columns: 2;
+    column-gap: 28px;
+  }
+  .group {
+    break-inside: avoid;
+    margin-bottom: 16px;
+  }
+  .group h3 {
+    margin: 0 0 6px;
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  li {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 2px 0;
+    font-size: 12.5px;
+  }
+  .label {
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  kbd {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-muted);
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1px 6px;
+  }
+  .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .btn {
+    padding: 7px 16px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover { opacity: 0.92; }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -408,8 +408,19 @@ export interface AppInfo {
   node: string;
 }
 
+/** One keyboard shortcut for the Help ▸ Keyboard Shortcuts reference (#804). */
+export interface ShortcutItem {
+  label: string;
+  keys: string;
+}
+export interface ShortcutGroup {
+  menu: string;
+  items: ShortcutItem[];
+}
+
 export interface AppApi {
   getInfo(): Promise<AppInfo>;
+  getShortcuts(): Promise<ShortcutGroup[]>;
 }
 
 export interface BookmarksApi {
@@ -608,6 +619,7 @@ export interface MenuApi {
   onOpenSettings(cb: () => void): void;
   onPrint(cb: () => void): void;
   onAbout(cb: () => void): void;
+  onShortcuts(cb: () => void): void;
   onOpenInDefault(cb: () => void): void;
   onOpenInTerminal(cb: () => void): void;
   onOpenProject(cb: () => void): void;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -136,6 +136,7 @@ export const Channels = {
   MENU_CLEAR_RECENT: 'menu:clearRecent',
   MENU_PRINT: 'menu:print',
   MENU_ABOUT: 'menu:about',
+  MENU_SHORTCUTS: 'menu:shortcuts',
   MENU_OPEN_IN_DEFAULT: 'menu:openInDefault',
   MENU_OPEN_IN_TERMINAL: 'menu:openInTerminal',
   MENU_NEW_NOTE: 'menu:newNote',
@@ -500,6 +501,7 @@ export const Channels = {
 
   // Renderer → main (for menu-triggered main-process actions)
   APP_GET_INFO: 'app:getInfo',
+  APP_GET_SHORTCUTS: 'app:getShortcuts',
   EXPORT_CSV: 'export:csv',
   SHELL_REVEAL_FILE: 'shell:revealFile',
   SHELL_OPEN_IN_DEFAULT: 'shell:openInDefault',

--- a/tests/main/menu-accelerators.test.ts
+++ b/tests/main/menu-accelerators.test.ts
@@ -63,7 +63,7 @@ vi.mock('../../src/main/publish', () => ({
 
 // ── The actual test ──────────────────────────────────────────────────────
 
-import { rebuildMenu, collectAcceleratorsByMenu } from '../../src/main/menu';
+import { rebuildMenu, collectAcceleratorsByMenu, formatAccelerator, getMenuShortcuts } from '../../src/main/menu';
 
 describe('collectAcceleratorsByMenu (#398)', () => {
   it('returns empty for an empty template', () => {
@@ -140,5 +140,36 @@ describe('production menu has no within-menu accelerator collisions (#398)', () 
       }
     }
     expect(collisions, collisions.join('\n')).toEqual([]);
+  });
+});
+
+describe('formatAccelerator (#804)', () => {
+  it('renders macOS symbol form, joined without separators', () => {
+    expect(formatAccelerator('CmdOrCtrl+Shift+S', 'darwin')).toBe('⌘⇧S');
+    expect(formatAccelerator('Cmd+,', 'darwin')).toBe('⌘,');
+    expect(formatAccelerator('Alt+Ctrl+P', 'darwin')).toBe('⌥⌃P');
+  });
+
+  it('renders Ctrl-word form on other platforms, plus-joined', () => {
+    expect(formatAccelerator('CmdOrCtrl+Shift+S', 'win32')).toBe('Ctrl+Shift+S');
+    expect(formatAccelerator('CmdOrCtrl+/', 'linux')).toBe('Ctrl+/');
+  });
+});
+
+describe('getMenuShortcuts (#804)', () => {
+  it('groups the live accelerators by top-level menu, top label dropped', () => {
+    rebuildMenu(); // populate the cached template
+    const groups = getMenuShortcuts();
+    expect(groups.length).toBeGreaterThan(0);
+    for (const g of groups) {
+      expect(typeof g.menu).toBe('string');
+      expect(g.items.length).toBeGreaterThan(0);
+      for (const item of g.items) {
+        expect(item.label).not.toBe('');
+        expect(item.keys).not.toBe('');
+        // The top-level menu label is dropped from the item label.
+        expect(item.label.startsWith(`${g.menu} › `)).toBe(false);
+      }
+    }
   });
 });

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -4,6 +4,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
 {
   "app": [
     "getInfo",
+    "getShortcuts",
   ],
   "bibliography": [
     "generate",
@@ -175,6 +176,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onReplaceInNotes",
     "onSave",
     "onSaveAsTemplate",
+    "onShortcuts",
     "onSortLines",
     "onToggleConversations",
     "onTogglePreview",


### PR DESCRIPTION
Closes #804.

The Help menu was a stub — a **disabled** "Keyboard Shortcuts" item, no docs link, and a "Report Issue" pointing at the **wrong repo** (`dgriffith/minerva`). This fills it in.

## What's in it
- **Keyboard Shortcuts…** — opens a themed modal (`ShortcutsDialog`) listing the live accelerators grouped by top-level menu. It's **generated from the real menu template** (the existing `collectAcceleratorsByMenu()` + new `getMenuShortcuts()` / `formatAccelerator()`), surfaced over a new `app:getShortcuts` IPC — so it can never drift from what the menu actually binds. Keys render per-platform: `⌘⇧S` on macOS, `Ctrl+Shift+S` elsewhere. Bound to `⌘/` / `Ctrl+/`.
- **Documentation** → repo docs; **Report an Issue…** → `dgriffith/ide-for-thought/issues` (fixes the stale link).
- **About Minerva** added to the foot of Help on **Windows/Linux** (macOS keeps it in the app menu) — completes the cross-platform reach #803 deferred here.
- Help marked `role: 'help'` so macOS gives it the native Help search box.

## Wiring
channels (`MENU_SHORTCUTS`, `APP_GET_SHORTCUTS`) + preload (`app.getShortcuts`, `menu.onShortcuts`) + client types + an App handler/render. Preload-bridge snapshot updated (diff is exactly the two new methods); added a `formatAccelerator` (mac + non-mac) and `getMenuShortcuts` test.

## Notes
- The shortcuts list shows **explicit accelerators** from the menu; role-default OS shortcuts (Cmd+C/V…) aren't enumerated — those are standard and platform-owned.
- Docs/issues URLs point at the `ide-for-thought` repo (matching the About dialog); easy to retarget to a public docs site later.

## Verification
- `pnpm lint` exit 0; **3273** tests pass.
- Visual pass worth doing: **Help ▸ Keyboard Shortcuts** (grid of real bindings, two columns, Esc closes), **Documentation** / **Report an Issue** open in the browser, and on Win/Linux **Help ▸ About Minerva**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)