### PR TITLE
build(macOS): code-sign + notarize for a distributable DMG

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- V8 / Electron need executable JIT memory under the hardened runtime. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- We ship third-party prebuilt native binaries (DuckDB's @duckdb/node-bindings,
+       copied in via forge's afterPrune) that are NOT signed by our team. Hardened
+       runtime's library validation would refuse to load them without this. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -4,6 +4,7 @@ import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDMG } from '@electron-forge/maker-dmg';
 import path from 'node:path';
 import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
 // @electron-forge/plugin-vite bundles the main process and ships NO node_modules
 // in the package. That's fine for everything Rollup can bundle — but a few deps
@@ -65,9 +66,47 @@ function copyExternalDeps(buildPath: string): void {
   }
 }
 
+// macOS code signing + notarization (#661/#662). Signing runs only on macOS;
+// notarization additionally requires the App Store Connect API-key env vars, so a
+// plain local `pnpm build` (no creds) still signs but skips notarization instead
+// of erroring. Credentials are read from the environment and never committed:
+//   APPLE_API_KEY     — path to the AuthKey_XXXX.p8 file
+//   APPLE_API_KEY_ID  — the key's Key ID (10 chars)
+//   APPLE_API_ISSUER  — the App Store Connect Issuer ID (UUID)
+// The Developer ID Application identity is auto-detected from the login keychain;
+// set OSX_SIGN_IDENTITY to disambiguate if more than one is installed.
+const isDarwin = process.platform === 'darwin';
+const hasNotarizeCreds = Boolean(
+  process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER,
+);
+// Only sign for real release builds. Otherwise `electron-forge package` (used by
+// `pnpm build:e2e`) would try to sign on every dev/CI run and fail wherever no
+// Developer ID cert is installed. Signing turns on when notarize creds are present
+// (the release path), or when OSX_SIGN_IDENTITY is set to force sign-without-notarize.
+const wantSign = isDarwin && (hasNotarizeCreds || Boolean(process.env.OSX_SIGN_IDENTITY));
+
 const config: ForgeConfig = {
   packagerConfig: {
     name: 'Minerva',
+    // Hardened runtime + entitlements (auto-detected Developer ID Application cert).
+    // @electron/osx-sign applies the hardened runtime and signs nested binaries
+    // (the DuckDB .node, dylibs) automatically; entitlements come from the plist.
+    osxSign: wantSign
+      ? {
+          optionsForFile: () => ({
+            entitlements: path.resolve(process.cwd(), 'build', 'entitlements.mac.plist'),
+          }),
+          ...(process.env.OSX_SIGN_IDENTITY ? { identity: process.env.OSX_SIGN_IDENTITY } : {}),
+        }
+      : undefined,
+    osxNotarize:
+      isDarwin && hasNotarizeCreds
+        ? {
+            appleApiKey: process.env.APPLE_API_KEY as string,
+            appleApiKeyId: process.env.APPLE_API_KEY_ID as string,
+            appleApiIssuer: process.env.APPLE_API_ISSUER as string,
+          }
+        : undefined,
     // App icon (#805). Base path without extension — electron-packager picks
     // `.icns` on macOS and `.ico` on Windows. Linux has no embedded app icon,
     // so the window/taskbar icon is set at runtime from resources/icons.
@@ -113,6 +152,33 @@ const config: ForgeConfig = {
       ],
     }),
   ],
+  hooks: {
+    // Forge signs + notarizes + staples the .app during the package step, but the
+    // DMG maker wraps that app WITHOUT stapling the .dmg itself. An un-stapled DMG
+    // still works online (Gatekeeper checks notarization on mount) but fails to
+    // open offline. Notarize + staple each produced DMG here so the wrapper is
+    // self-contained. Runs only for release builds (notarize creds present); a
+    // plain dev `pnpm build` with no creds produces an unsigned DMG and skips this.
+    postMake: (_forgeConfig, makeResults) => {
+      if (!(isDarwin && hasNotarizeCreds)) return makeResults;
+      const dmgs = makeResults.flatMap((r) => r.artifacts).filter((a) => a.endsWith('.dmg'));
+      for (const dmg of dmgs) {
+        execFileSync(
+          'xcrun',
+          [
+            'notarytool', 'submit', dmg,
+            '--key', process.env.APPLE_API_KEY as string,
+            '--key-id', process.env.APPLE_API_KEY_ID as string,
+            '--issuer', process.env.APPLE_API_ISSUER as string,
+            '--wait',
+          ],
+          { stdio: 'inherit' },
+        );
+        execFileSync('xcrun', ['stapler', 'staple', dmg], { stdio: 'inherit' });
+      }
+      return makeResults;
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
## What

Wires up macOS **Developer ID signing + notarization** so the DMG opens on other Macs instead of being blocked by Gatekeeper. This is the last item before a shippable 1.0 build.

### Changes
- **`build/entitlements.mac.plist`** — hardened-runtime entitlements: `allow-jit`, `allow-unsigned-executable-memory` (V8), and `disable-library-validation` (required because we ship DuckDB's prebuilt `@duckdb/node-bindings` native binary, which isn't signed by our team).
- **`forge.config.ts` → `osxSign` + `osxNotarize`** — hardened-runtime signing with the entitlements, App Store Connect **API-key** notarization. Credentials come from env (`APPLE_API_KEY` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER`); the Developer ID Application identity is auto-detected from the keychain.
- **Gating** — signing only runs for release builds (notarize creds present, or `OSX_SIGN_IDENTITY` set). A plain dev/CI `pnpm build` / `pnpm build:e2e` with no creds produces an unsigned DMG and skips signing, so CI isn't broken.
- **`postMake` hook** — forge signs/notarizes/staples the `.app` but leaves the `.dmg` wrapper un-stapled (which fails to open *offline*). The hook notarizes + staples each produced DMG so the wrapper is self-contained.

## Verification (this build, Apple Silicon)
- `codesign --verify --deep --strict` → valid · satisfies Designated Requirement
- `spctl -a -vvv` on the app (incl. mounted from the DMG) → **accepted · source=Notarized Developer ID · Developer ID Application: Dave Griffith (ZC2MK8M828)**
- `xcrun stapler validate` → passes on both the `.app` and the `.dmg`

## Notes
- Builds for the host arch only (arm64). A universal Intel+Apple-Silicon DMG is a possible follow-up.
- Notary round-trips can be slow during Apple backlogs (this build waited ~3h once); not a config issue.

Refs #661 #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)