### PR TITLE
build(clipper): zip packaging target + sideload docs (#795)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 out/
+clipper/*.zip
 test-results/
 playwright-report/
 .vite/

--- a/clipper/README.md
+++ b/clipper/README.md
@@ -7,22 +7,27 @@ app does the Readability extraction, not the extension).
 
 Chrome only for now (#792). The toolbar button opens a popup to curate before
 saving — add tags / a note and confirm the canonical source id (#793) — while
-the keyboard shortcut stays a no-UI instant save. Packaging/signing is #795.
+the keyboard shortcut stays a no-UI instant save. Installs unpacked today;
+Chrome Web Store listing + signing is the remaining part of #795.
 
 ## Build
 
 ```sh
-pnpm build:clipper      # → clipper/dist/
+pnpm build:clipper      # → clipper/dist/ (load this unpacked during dev)
+pnpm package:clipper    # → clipper/minerva-clipper-<version>.zip (shareable / Web Store upload)
 pnpm typecheck:clipper  # tsc over the extension sources
 ```
+
+`package:clipper` rebuilds `dist/` and zips its contents (manifest at the archive
+root). You don't need the zip for local install — "Load unpacked" points straight
+at `dist/`.
 
 ## Install (unpacked)
 
 1. `pnpm build:clipper`
 2. Chrome → `chrome://extensions` → enable **Developer mode** → **Load unpacked** → pick `clipper/dist`.
 3. Click the puzzle-piece (Extensions) icon → **Pin** *Minerva Clipper* so its
-   button stays on the toolbar. (Until packaging adds an icon, it shows a
-   default placeholder.)
+   button stays on the toolbar.
 
 ## Pair
 
@@ -56,4 +61,5 @@ service worker), whose `chrome-extension://` origin the endpoint accepts — it
 rejects content-script / web-page origins, so capture and send are split.
 
 Branded toolbar + extension icons live in `clipper/icons/` (16/32/48/128) and
-are copied into `dist/` by the build. Store packaging/signing is still #795.
+are copied into `dist/` by the build. `pnpm package:clipper` zips a release
+artifact; the Chrome Web Store listing + review is the open part of #795.

--- a/clipper/package.mjs
+++ b/clipper/package.mjs
@@ -1,0 +1,38 @@
+/**
+ * Package the built clipper into a single distributable zip (#795).
+ * `pnpm package:clipper` rebuilds `dist/` then zips its CONTENTS into
+ * `clipper/minerva-clipper-<version>.zip` (version read from the built
+ * manifest, so it can't drift from the source).
+ *
+ * The manifest must sit at the ARCHIVE ROOT — the Chrome Web Store rejects a zip
+ * with a wrapping top-level folder — so we zip from inside `dist/` with relative
+ * paths. The zip is for handing someone a file / a future Web Store upload;
+ * day-to-day "Load unpacked" uses `dist/` directly and doesn't need it.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const dist = path.join(root, 'dist');
+
+// Always rebuild so the zip reflects current sources.
+execFileSync('node', [path.join(root, 'build.mjs')], { stdio: 'inherit' });
+
+const { version } = JSON.parse(await readFile(path.join(dist, 'manifest.json'), 'utf-8'));
+const zipPath = path.join(root, `minerva-clipper-${version}.zip`);
+await rm(zipPath, { force: true });
+
+try {
+  // cwd=dist + '.' → manifest.json lands at the zip root. -X drops extra
+  // filesystem attributes for a clean, reproducible archive.
+  execFileSync('zip', ['-r', '-X', zipPath, '.'], { cwd: dist, stdio: 'inherit' });
+} catch (err) {
+  throw new Error(
+    `[clipper] zip failed — is the \`zip\` CLI available on PATH? (${err instanceof Error ? err.message : String(err)})`,
+  );
+}
+
+console.log('Minerva Clipper packaged →', path.relative(process.cwd(), zipPath));

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:e2e": "NODE_OPTIONS=--max-old-space-size=4096 electron-forge package",
     "test:e2e": "pnpm build:e2e && playwright test",
     "build:clipper": "node clipper/build.mjs",
+    "package:clipper": "node clipper/package.mjs",
     "typecheck:clipper": "tsc -p clipper/tsconfig.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## What

Packages the (already feature-complete) browser clipper for distribution. The extension itself — skeleton #792, pairing #791, popup #793, anchoring #794, ingest endpoint #790 — is all merged; this is the "ship it" layer.

### Changes
- **`clipper/package.mjs` + `pnpm package:clipper`** — rebuilds `dist/` then zips its **contents** into `clipper/minerva-clipper-<version>.zip`. Manifest sits at the archive root (no wrapping folder, as the Chrome Web Store requires), and the version is read from the built manifest so it can't drift from source.
- **`clipper/README.md`** — documents the new zip step, drops the stale "until packaging adds an icon" note (branded icons ship now), and re-scopes the remaining #795 work to the Chrome Web Store listing.
- **`.gitignore`** — ignore `clipper/*.zip`.

### Verified
`pnpm package:clipper` → 31 KB zip with `manifest.json` at the root and all entry points/icons present. `pnpm lint` clean.

## Distribution status
- **Sideload (now):** build → `chrome://extensions` → Developer mode → Load unpacked `clipper/dist`, then pair via Settings → Browser Clipper. Fully documented in the README — **shippable to early users today.**
- **Chrome Web Store (later, the open part of #795):** needs a $5 developer account, a screenshot, a per-permission/privacy justification (reviewers will ask about the `127.0.0.1` host permission), and submission for review. The `package:clipper` zip is the upload artifact.

Refs #795 #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)