### PR TITLE
feat: conversation cost calculation & display (#821)

### DIFF
--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import * as graph from '../graph/index';
 import { projectContext, type ProjectContext } from '../project-context-types';
 import { escapeTurtleLiteral } from './turtle';
+import { costForUsage } from '../../shared/tools/models';
 import type {
   Conversation,
   ConversationMessage,
@@ -123,11 +124,16 @@ export async function appendMessage(
     message.citations = extra.citations;
   }
   // Persist per-turn token usage + producing model on the assistant message
-  // so the conversation's running cost survives reload (#820). Cost math
-  // keyed off this lands in #821.
+  // so the conversation's running cost survives reload (#820), and derive the
+  // dollar cost once at append time (#821). An unpriced model leaves costUSD
+  // absent — the UI shows tokens only rather than a guessed figure.
   if (extra?.usage) {
     message.usage = extra.usage;
-    if (extra.usageModel) message.usageModel = extra.usageModel;
+    if (extra.usageModel) {
+      message.usageModel = extra.usageModel;
+      const cost = costForUsage(extra.usage, extra.usageModel);
+      if (cost !== null) message.costUSD = cost;
+    }
   }
   conv.messages.push(message);
   await persist(conv);

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -42,6 +42,10 @@
     basename,
     sourceKindLabel,
   } from '../conversations/conversation-display';
+  import {
+    costBadgeFor,
+    formatTurnCost,
+  } from '../conversations/conversation-cost';
 
   // Lightweight markdown-it for assistant message rendering. Mirrors the
   // configuration in the legacy ConversationDialog so prose renders the
@@ -592,6 +596,7 @@
 
     {#if store.activeTab}
       {@const tab = store.activeTab}
+      {@const costBadge = costBadgeFor(tab.conversation.messages)}
       <div class="content">
         <div class="context-rail">
           {#if tab.conversation.contextBundle.notePath}
@@ -629,7 +634,15 @@
         {#snippet messageBlock(msg: ConversationMessage, tab: TabT, msgIndex: number)}
           {#if msg.role !== 'system'}
             <div class="msg {msg.role}">
-              <div class="msg-role">{msg.role}</div>
+              <div class="msg-role">
+                <span>{msg.role}</span>
+                {#if msg.role === 'assistant'}
+                  {@const turnCost = formatTurnCost(msg)}
+                  {#if turnCost}
+                    <span class="msg-cost" title="Token usage / cost for this turn">{turnCost}</span>
+                  {/if}
+                {/if}
+              </div>
               {#if msg.role === 'assistant'}
                 <div class="msg-content">{@html md.render(msg.content)}</div>
                 {#if msg.citations && msg.citations.length > 0}
@@ -1078,6 +1091,12 @@
                 <span class="composer-context">{tab.conversation.contextBundle.notePath}</span>
               {/if}
               <span class="composer-spacer"></span>
+              {#if costBadge}
+                <span
+                  class="composer-cost"
+                  title={costBadge.title}
+                >{costBadge.text}</span>
+              {/if}
               <span class="composer-hint">⏎ send · ⇧⏎ newline</span>
               {#if tab.streaming}
                 <button type="button" class="send-btn" onclick={() => store.cancel()}>Cancel</button>
@@ -1312,8 +1331,17 @@
     font-weight: 600;
     text-transform: uppercase;
     color: var(--text-muted);
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
   }
   .msg.user .msg-role { color: var(--accent); }
+  .msg-cost {
+    font-weight: 400;
+    text-transform: none;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
   .msg-content {
     font-size: 13px;
     line-height: 1.5;
@@ -1745,6 +1773,14 @@
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--text-faint);
+  }
+  .composer-cost {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    margin-right: 10px;
+    cursor: default;
   }
 
   .send-btn {

--- a/src/renderer/lib/conversations/conversation-cost.ts
+++ b/src/renderer/lib/conversations/conversation-cost.ts
@@ -1,0 +1,100 @@
+/**
+ * Conversation cost/token aggregation + formatting (#821).
+ *
+ * Per-turn usage and a derived `costUSD` are persisted on each assistant
+ * message (#820/#821). These pure helpers roll those per-turn records up into a
+ * conversation running total and format it for the quiet badge near the
+ * composer. Kept out of the component so the summation + formatting are
+ * testable without a DOM.
+ */
+
+import type { ConversationMessage } from '../../../shared/types';
+import { costForUsage } from '../../../shared/tools/models';
+
+export interface ConversationCost {
+  /** Summed input + output tokens across every turn that reported usage. */
+  totalTokens: number;
+  /** Summed USD cost across priced turns, or null if no turn was priced. */
+  totalUSD: number | null;
+  /** True if at least one turn reported usage from an unpriced model — the
+   *  dollar figure then covers only the priced turns and shouldn't read as the
+   *  whole story. */
+  hasUnpriced: boolean;
+}
+
+/**
+ * Roll up per-turn usage into a conversation total. `costUSD` is read from the
+ * persisted record when present; for a message that has `usage` but no stored
+ * cost (e.g. a turn persisted before cost derivation, or recomputed live) we
+ * fall back to the pricing table so the total still reflects it.
+ */
+export function conversationCost(messages: ConversationMessage[]): ConversationCost {
+  let totalTokens = 0;
+  let totalUSD = 0;
+  let anyPriced = false;
+  let hasUnpriced = false;
+  for (const m of messages) {
+    if (!m.usage) continue;
+    totalTokens += m.usage.inputTokens + m.usage.outputTokens;
+    const cost = m.costUSD ?? (m.usageModel ? costForUsage(m.usage, m.usageModel) : null);
+    if (cost !== null && cost !== undefined) {
+      totalUSD += cost;
+      anyPriced = true;
+    } else {
+      hasUnpriced = true;
+    }
+  }
+  return { totalTokens, totalUSD: anyPriced ? totalUSD : null, hasUnpriced };
+}
+
+/** Compact token count: `812` / `12.3k` / `1.4M`. */
+export function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+/**
+ * Dollar figure for the badge. Small costs get four decimals ($0.0142) so a
+ * cheap turn isn't rounded down to near-nothing; at a dime or more, two
+ * decimals read fine.
+ */
+export function formatUSD(usd: number): string {
+  if (usd > 0 && usd < 0.1) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+/** One-line badge text, e.g. `$0.0142 · 12.3k tok`, or just tokens when no turn
+ *  was priced. Returns null when there's nothing to show yet (no usage). */
+export function formatCostBadge(cost: ConversationCost): string | null {
+  if (cost.totalTokens === 0 && cost.totalUSD === null) return null;
+  const tokens = `${formatTokens(cost.totalTokens)} tok`;
+  if (cost.totalUSD === null) return tokens;
+  return `${formatUSD(cost.totalUSD)} · ${tokens}`;
+}
+
+/**
+ * Badge text + hover title for a conversation, or null when there's nothing to
+ * show. The title carries the precise token breakdown and an unpriced-turn
+ * caveat so the badge itself can stay terse.
+ */
+export function costBadgeFor(
+  messages: ConversationMessage[],
+): { text: string; title: string } | null {
+  const cost = conversationCost(messages);
+  const text = formatCostBadge(cost);
+  if (!text) return null;
+  const parts = [`${cost.totalTokens.toLocaleString()} tokens this conversation`];
+  if (cost.totalUSD !== null) parts.push(`≈ ${formatUSD(cost.totalUSD)}`);
+  if (cost.hasUnpriced) parts.push('(excludes turns from unpriced models)');
+  return { text, title: parts.join(' · ') };
+}
+
+/** Per-turn cost label for the hover/expand detail on an assistant message. */
+export function formatTurnCost(m: ConversationMessage): string | null {
+  if (!m.usage) return null;
+  const tokens = `${formatTokens(m.usage.inputTokens + m.usage.outputTokens)} tok`;
+  const cost = m.costUSD ?? (m.usageModel ? costForUsage(m.usage, m.usageModel) : null);
+  if (cost === null || cost === undefined) return tokens;
+  return `${formatUSD(cost)} · ${tokens}`;
+}

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -24,3 +24,59 @@ export const MODEL_OPTIONS: ModelOption[] = [
 export function modelLabel(value: string): string {
   return MODEL_OPTIONS.find((m) => m.value === value)?.label ?? value;
 }
+
+// ── Pricing (#821) ───────────────────────────────────────────────────────────
+
+/** Per-model token price in US dollars per million tokens (`$/MTok`). */
+export interface ModelPrice {
+  /** Input (and the base for cache multipliers). */
+  input: number;
+  /** Output. */
+  output: number;
+}
+
+/**
+ * Pricing keyed by model id, co-located with `MODEL_OPTIONS` so adding a model
+ * means adding its price in one place. A model absent here is "unpriced" —
+ * cost degrades to a token count with no dollar figure rather than a guess.
+ */
+export const MODEL_PRICING: Record<string, ModelPrice> = {
+  'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 1, output: 5 },
+};
+
+/**
+ * Cache-token price multipliers relative to the model's input rate. A cache
+ * read is far cheaper than fresh input; writing the cache carries a premium.
+ * Anthropic prices these uniformly as multiples of the input rate, so one pair
+ * covers every model.
+ */
+const CACHE_READ_MULTIPLIER = 0.1;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+
+/** Minimal usage shape the cost function needs — matches `TurnUsage`. */
+interface UsageLike {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+}
+
+/**
+ * Cost in USD for one turn's usage under a given model, or `null` if the model
+ * isn't priced (caller should show tokens only — don't invent a price).
+ *
+ *   input·in + output·out + cacheRead·in·0.1 + cacheWrite·in·1.25   (per MTok)
+ */
+export function costForUsage(usage: UsageLike, model: string): number | null {
+  const price = MODEL_PRICING[model];
+  if (!price) return null;
+  const perToken = (rate: number) => rate / 1_000_000;
+  return (
+    usage.inputTokens * perToken(price.input) +
+    usage.outputTokens * perToken(price.output) +
+    usage.cacheReadTokens * perToken(price.input * CACHE_READ_MULTIPLIER) +
+    usage.cacheCreationTokens * perToken(price.input * CACHE_WRITE_MULTIPLIER)
+  );
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -351,6 +351,13 @@ export interface ConversationMessage {
    * keyed off this lands in #821.
    */
   usageModel?: string;
+  /**
+   * Derived turn cost in USD, computed from `usage` under `usageModel`'s
+   * pricing at append time and persisted so a conversation's running total
+   * survives reload (#821). Absent when the producing model is unpriced — the
+   * UI then shows tokens only, never a guessed dollar figure.
+   */
+  costUSD?: number;
 }
 
 /**

--- a/tests/renderer/conversation-cost.test.ts
+++ b/tests/renderer/conversation-cost.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Cost calculation + aggregation/formatting (#821).
+ *
+ * Covers the pricing math (cache multipliers, unpriced → null) in
+ * `shared/tools/models.ts` and the conversation roll-up/formatting in
+ * `conversation-cost.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { costForUsage } from '../../src/shared/tools/models';
+import {
+  conversationCost,
+  costBadgeFor,
+  formatTokens,
+  formatUSD,
+  formatCostBadge,
+  formatTurnCost,
+} from '../../src/renderer/lib/conversations/conversation-cost';
+import type { ConversationMessage, TurnUsage } from '../../src/shared/types';
+
+const usage = (u: Partial<TurnUsage>): TurnUsage => ({
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  ...u,
+});
+
+function asstMsg(u: Partial<TurnUsage>, model: string | undefined): ConversationMessage {
+  const m: ConversationMessage = { role: 'assistant', content: 'x', timestamp: '2026-01-01T00:00:00Z', usage: usage(u) };
+  if (model) {
+    m.usageModel = model;
+    const c = costForUsage(usage(u), model);
+    if (c !== null) m.costUSD = c;
+  }
+  return m;
+}
+
+describe('costForUsage (#821)', () => {
+  it('prices plain input + output at the model rate', () => {
+    // 1M input @ $3, 1M output @ $15 → $18 for Sonnet.
+    const c = costForUsage(usage({ inputTokens: 1_000_000, outputTokens: 1_000_000 }), 'claude-sonnet-4-6');
+    expect(c).toBeCloseTo(18, 6);
+  });
+
+  it('prices cache reads at 0.1x and cache writes at 1.25x input', () => {
+    // Opus input $5. 1M cache read → $0.5; 1M cache write → $6.25.
+    const c = costForUsage(
+      usage({ cacheReadTokens: 1_000_000, cacheCreationTokens: 1_000_000 }),
+      'claude-opus-4-8',
+    );
+    expect(c).toBeCloseTo(0.5 + 6.25, 6);
+  });
+
+  it('returns null for an unpriced model (no guessing)', () => {
+    expect(costForUsage(usage({ inputTokens: 1000 }), 'some-future-model')).toBeNull();
+  });
+});
+
+describe('conversationCost roll-up', () => {
+  it('sums tokens and dollars across priced turns', () => {
+    const msgs: ConversationMessage[] = [
+      { role: 'user', content: 'hi', timestamp: 't' },
+      asstMsg({ inputTokens: 1_000_000, outputTokens: 0 }, 'claude-sonnet-4-6'), // $3
+      asstMsg({ inputTokens: 0, outputTokens: 1_000_000 }, 'claude-sonnet-4-6'), // $15
+    ];
+    const c = conversationCost(msgs);
+    expect(c.totalTokens).toBe(2_000_000);
+    expect(c.totalUSD).toBeCloseTo(18, 6);
+    expect(c.hasUnpriced).toBe(false);
+  });
+
+  it('flags unpriced turns and still counts their tokens', () => {
+    const msgs: ConversationMessage[] = [
+      asstMsg({ inputTokens: 1000, outputTokens: 500 }, 'claude-sonnet-4-6'),
+      asstMsg({ inputTokens: 200, outputTokens: 100 }, 'mystery-model'),
+    ];
+    const c = conversationCost(msgs);
+    expect(c.totalTokens).toBe(1800);
+    expect(c.totalUSD).not.toBeNull();
+    expect(c.hasUnpriced).toBe(true);
+  });
+
+  it('returns a null total when no turn is priced', () => {
+    const c = conversationCost([asstMsg({ inputTokens: 100 }, 'mystery-model')]);
+    expect(c.totalUSD).toBeNull();
+    expect(c.hasUnpriced).toBe(true);
+  });
+
+  it('falls back to live pricing when costUSD is absent but usage+model present', () => {
+    const msg: ConversationMessage = {
+      role: 'assistant', content: 'x', timestamp: 't',
+      usage: usage({ inputTokens: 1_000_000 }), usageModel: 'claude-sonnet-4-6',
+      // no costUSD persisted
+    };
+    expect(conversationCost([msg]).totalUSD).toBeCloseTo(3, 6);
+  });
+});
+
+describe('formatting', () => {
+  it('formats token counts compactly', () => {
+    expect(formatTokens(812)).toBe('812');
+    expect(formatTokens(12_300)).toBe('12.3k');
+    expect(formatTokens(1_400_000)).toBe('1.40M');
+  });
+
+  it('uses 4 decimals for sub-cent, 2 otherwise', () => {
+    expect(formatUSD(0.0142)).toBe('$0.0142');
+    expect(formatUSD(1.5)).toBe('$1.50');
+  });
+
+  it('badge shows dollars + tokens, or tokens only when unpriced', () => {
+    expect(formatCostBadge({ totalTokens: 12_300, totalUSD: 0.0142, hasUnpriced: false }))
+      .toBe('$0.0142 · 12.3k tok');
+    expect(formatCostBadge({ totalTokens: 500, totalUSD: null, hasUnpriced: true }))
+      .toBe('500 tok');
+    expect(formatCostBadge({ totalTokens: 0, totalUSD: null, hasUnpriced: false })).toBeNull();
+  });
+
+  it('costBadgeFor returns null when no usage recorded', () => {
+    expect(costBadgeFor([{ role: 'user', content: 'hi', timestamp: 't' }])).toBeNull();
+  });
+
+  it('formatTurnCost returns null without usage', () => {
+    expect(formatTurnCost({ role: 'assistant', content: 'x', timestamp: 't' })).toBeNull();
+  });
+});


### PR DESCRIPTION
Part of #819. Builds on #820 (merged).

## What

Computes and surfaces per-turn and running-total cost from the usage captured in #820.

- **Pricing table** — `MODEL_PRICING` + `costForUsage()` co-located with `MODEL_OPTIONS` in `shared/tools/models.ts`, so adding a model means adding its price in one place. Opus 4.8 `$5`/`$25`, Sonnet 4.6 `$3`/`$15`, Haiku 4.5 `$1`/`$5` (input/output per MTok). Cache reads priced at 0.1× input, cache writes at 1.25×.
- **Persist** — `costUSD` is derived once at append time and stored on the assistant `ConversationMessage`, so the running total survives reload. An unpriced model leaves it absent — never a guessed figure.
- **Display** — a quiet `$0.0142 · 12.3k tok` badge in the composer footer (running total; token breakdown + unpriced caveat on hover), plus a muted per-turn cost on each assistant message. Matches the dark-theme tokens, no red/alarm styling.
- **Degradation** — unpriced/unknown model → token count only.

## Roll-up helper

`conversation-cost.ts` does the summation + formatting as pure functions (testable without a DOM). It reads persisted `costUSD` but falls back to live pricing when a message has `usage` but no stored cost.

## Tests
`tests/renderer/conversation-cost.test.ts` — pricing math + cache multipliers + unpriced→null; roll-up summation, unpriced flagging, live-pricing fallback; token/USD/badge formatting.

## Acceptance
- [x] Per-turn cost computed from that turn's model and persisted on the message.
- [x] Conversation running total survives reload.
- [x] Cache reads/writes priced at their multipliers.
- [x] Unpriced model degrades to a token count, no dollar figure.
- [x] Cost display is unobtrusive and matches the dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)