### PR TITLE
feat: /clear conversation command (#823)

### DIFF
--- a/src/renderer/lib/conversations/builtin-commands.ts
+++ b/src/renderer/lib/conversations/builtin-commands.ts
@@ -29,7 +29,7 @@ export const BUILTIN_COMMANDS: BuiltinCommand[] = [
     name: 'clear',
     slashCommand: '/clear',
     description: 'Archive this conversation and start a fresh one',
-    available: false,
+    available: true,
   },
   {
     name: 'compact',

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -588,11 +588,83 @@ async function setModel(tabId: string, model: string | undefined): Promise<void>
  */
 function runBuiltinCommand(name: string): void {
   switch (name) {
+    case 'clear':
+      void clearConversation();
+      break;
     default:
-      // Reserved but not yet wired (handlers land in #823/#824). No-op
-      // loudly rather than throwing into the composer's keydown path.
+      // Reserved but not yet wired (handler lands in #824). No-op loudly
+      // rather than throwing into the composer's keydown path.
       console.warn(`[conv] no handler for built-in command: /${name}`);
   }
+}
+
+/** Empty per-turn state for a freshly-created conversation tab. Keeps the
+ *  three tab-construction sites from drifting as draft kinds are added. */
+function blankTabRuntime(conv: Conversation, extraTools: ConversationToolKey[]): TabRuntime {
+  return {
+    id: conv.id,
+    title: null,
+    conversation: conv,
+    drafts: [],
+    sourceDrafts: [],
+    sourceDraftResults: {},
+    noteDraftResults: {},
+    propertyDrafts: [],
+    propertyDraftResults: {},
+    sourcePropertyDrafts: [],
+    sourcePropertyDraftResults: {},
+    claimsDrafts: [],
+    claimsDraftResults: {},
+    computeDrafts: [],
+    computeDraftState: {},
+    pendingQuestion: null,
+    composer: '',
+    streaming: false,
+    streamedChunks: '',
+    extraTools,
+  };
+}
+
+/**
+ * `/clear` (#823): archive the active conversation and open a fresh one in its
+ * place, carrying the same context (origin note, trigger node, system prompt,
+ * model, template tools). Archive is non-destructive — it files the transcript
+ * as a `thought:Source` and leaves any pending approval proposals (which are
+ * graph-global, not conversation-scoped) untouched. Truncating in place would
+ * orphan those proposals, hence archive-and-new.
+ */
+async function clearConversation(): Promise<void> {
+  const tab = activeTab();
+  if (!tab) return;
+  const prev = tab.conversation;
+  // A brand-new, never-used conversation has nothing to archive — just no-op
+  // so spamming /clear doesn't litter the archived list with empties.
+  if (prev.messages.length === 0) return;
+  try {
+    await api.conversations.archive(prev.id);
+  } catch (e) {
+    // Already-archived or transient failure — proceed to open a fresh tab
+    // regardless so the user still gets their clean slate.
+    console.warn('[conv] /clear: archive failed', e);
+  }
+  const createOpts: { systemPrompt?: string; model?: string } = {};
+  if (prev.systemPrompt) createOpts.systemPrompt = prev.systemPrompt;
+  if (prev.model) createOpts.model = prev.model;
+  const fresh = await api.conversations.create(
+    prev.contextBundle,
+    prev.triggerNodeUri,
+    Object.keys(createOpts).length > 0 ? createOpts : undefined,
+  );
+  const newTab = blankTabRuntime(fresh, [...tab.extraTools]);
+  // Replace in place so the fresh conversation keeps the same tab slot.
+  const idx = tabs.findIndex((t) => t.id === tab.id);
+  if (idx === -1) {
+    tabs = [...tabs, newTab];
+  } else {
+    tabs = [...tabs.slice(0, idx), newTab, ...tabs.slice(idx + 1)];
+  }
+  activeTabId = newTab.id;
+  scheduleSave();
 }
 
 async function cancel(): Promise<void> {

--- a/tests/renderer/stores/conversation-clear.test.ts
+++ b/tests/renderer/stores/conversation-clear.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `/clear` built-in command (#823): archive the active conversation and open a
+ * fresh one in its place, carrying the same context. Drives the conversations
+ * store with a mocked api client.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Conversation } from '../../../src/shared/types';
+
+const h = vi.hoisted(() => {
+  const noop = vi.fn();
+  let nextId = 1;
+  const created: Conversation[] = [];
+  const api = {
+    conversations: {
+      // subscriptions used by ensureSubscriptions()
+      onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onAskUser: noop,
+      saveUIState: vi.fn().mockResolvedValue(undefined),
+      archive: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (contextBundle: unknown, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) => {
+        const conv: Conversation = {
+          id: `conv-${nextId++}`,
+          contextBundle: contextBundle as Conversation['contextBundle'],
+          triggerNodeUri,
+          messages: [],
+          status: 'active',
+          startedAt: 't',
+          ...(options?.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
+          ...(options?.model ? { model: options.model } : {}),
+        };
+        created.push(conv);
+        return conv;
+      }),
+    },
+  };
+  return { api, created };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const store = getConversationsStore();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('/clear (#823)', () => {
+  it('archives the current conversation and opens a fresh one with the same context', async () => {
+    await store.openFreeform('notes/origin.md');
+    const original = store.activeTab!;
+    original.conversation.model = 'claude-opus-4-8';
+    // Make the conversation non-empty so /clear has something to archive.
+    original.conversation.messages.push({ role: 'user', content: 'hi', timestamp: 't' });
+    const originalId = original.id;
+
+    store.runBuiltinCommand('clear');
+    await vi.waitFor(() => expect(store.activeTab!.id).not.toBe(originalId));
+
+    expect(h.api.conversations.archive).toHaveBeenCalledWith(originalId);
+    // Fresh conversation carries the same origin note + the model override.
+    const last = h.created[h.created.length - 1];
+    expect(last.contextBundle.notePath).toBe('notes/origin.md');
+    expect(last.model).toBe('claude-opus-4-8');
+    // The fresh conversation is active, empty, and occupies the same single tab.
+    expect(store.activeTab!.conversation.messages).toHaveLength(0);
+    expect(store.tabs.filter((t) => t.id === originalId)).toHaveLength(0);
+  });
+
+  it('no-ops on an empty, never-used conversation (no archive churn)', async () => {
+    await store.openFreeform('notes/origin.md');
+    const id = store.activeTab!.id;
+    store.runBuiltinCommand('clear');
+    await Promise.resolve();
+    expect(h.api.conversations.archive).not.toHaveBeenCalled();
+    expect(store.activeTab!.id).toBe(id);
+  });
+});


### PR DESCRIPTION
Part of #819. Depends on #822 (built-in router). **Base is the #822 branch** — review/merge after #857.

## What

`/clear` archives the active conversation and opens a fresh one in its place, carrying the same context (origin note, trigger node, system prompt, model override, template tools).

- Flips `clear` to `available` in the registry; `runBuiltinCommand` routes it to the new `clearConversation()` store handler.
- **Archive, not truncate** — archiving files the transcript as a `thought:Source` and is reversible-by-history. Truncating the live `messages` in place would orphan pending approval proposals (graph-global, referenced by conversation URI, not owned by it). Archive-and-new is the locked decision.
- **Pending proposals untouched** — they have their own lifecycle/expiry.
- **No confirmation dialog** — archive is non-destructive; per project UX rules, any future dialog would need a `showConfirm` "don't ask again" key.
- No-ops on an empty, never-used conversation so repeated `/clear` doesn't litter the archived list.
- Extracted `blankTabRuntime()` so the (now third) tab-construction site can't drift as draft kinds are added.

## Test
`tests/renderer/stores/conversation-clear.test.ts` — archives the current conversation, creates a fresh one with the same context + model, swaps it into the same tab slot; empty-conversation no-op.

## Acceptance
- [x] `/clear` archives the current conversation and opens a fresh, empty one with the same context.
- [x] The archived conversation is still readable from the archived list (existing list behavior).
- [x] Pending proposals are unaffected.
- [x] No new always-on confirmation dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)