### PR TITLE
feat: per-conversation reasoning-effort picker (#825)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -300,6 +300,7 @@ export function registerConversation(): void {
           messages,
           toolContext: { rootPath, conversationId: convId },
           model: conv.model,
+          effort: conv.effort,
           extraTools,
           // Re-echo any prior turn's code-execution sandbox id. Required
           // by the API whenever the persisted message history still
@@ -330,6 +331,7 @@ export function registerConversation(): void {
           messages: recoveredMessages,
           toolContext: { rootPath, conversationId: convId },
           model: conv.model,
+          effort: conv.effort,
           extraTools,
           callbacks: streamCallbacks,
         });
@@ -784,4 +786,11 @@ export function registerConversation(): void {
   ipcMain.handle(Channels.CONVERSATION_SET_MODEL, async (_e, convId: string, model: string | undefined) => {
     return conversation.setModel(convId, model);
   });
+
+  ipcMain.handle(
+    Channels.CONVERSATION_SET_EFFORT,
+    async (_e, convId: string, effort: import('../../shared/tools/effort').Effort | undefined) => {
+      return conversation.setEffort(convId, effort);
+    },
+  );
 }

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -198,6 +198,23 @@ export async function setModel(id: string, model: string | undefined): Promise<C
   return conv;
 }
 
+/**
+ * Pin a reasoning-effort override on this conversation (#825). Pass `undefined`
+ * to clear it so the conversation again inherits the global default. Mirrors
+ * `setModel`.
+ */
+export async function setEffort(
+  id: string,
+  effort: import('../../shared/tools/effort').Effort | undefined,
+): Promise<Conversation> {
+  const conv = await load(id);
+  if (!conv) throw new Error(`Conversation not found: ${id}`);
+  if (effort) conv.effort = effort;
+  else delete conv.effort;
+  await persist(conv);
+  return conv;
+}
+
 export async function load(id: string): Promise<Conversation | null> {
   try {
     const data = await fs.readFile(convPath(id), 'utf-8');

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -7,6 +7,7 @@ import {
   type ToolCallbacks,
 } from './tools';
 import type { Citation, TurnUsage } from '../../shared/types';
+import { resolveEffort, type Effort } from '../../shared/tools/effort';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { MISSING_API_KEY_MARKER } from '../../shared/llm-errors';
 import type { ConversationDraft } from '../../shared/conversation-drafts';
@@ -79,6 +80,12 @@ export interface CompleteOptions {
   /** Override the global default model for this call only. */
   model?: string;
   /**
+   * Per-call reasoning-effort override (#825). Resolved over the global default
+   * and clamped to the model; omitted entirely for models without effort
+   * support (Haiku). Sent as `output_config.effort`.
+   */
+  effort?: Effort;
+  /**
    * Fired once the single completion finishes, with this call's token usage
    * and the model that produced it (#820). `complete()` keeps returning a
    * plain string — five callers depend on that contract — so usage is
@@ -97,6 +104,9 @@ export interface CompleteWithToolsOptions {
   maxIterations?: number;
   /** Override the global default model for this call only. */
   model?: string;
+  /** Per-call reasoning-effort override (#825); resolved over the global
+   *  default and clamped to the model. Sent as `output_config.effort`. */
+  effort?: Effort;
   /** Template-scoped tools to enable in addition to the default toolset. */
   extraTools?: ConversationToolKey[];
   /**
@@ -133,6 +143,7 @@ async function getClient(): Promise<{
   client: Anthropic;
   model: string;
   web: NonNullable<Awaited<ReturnType<typeof getSettings>>['web']>;
+  effort: Effort | undefined;
 }> {
   const settings = await getSettings();
   if (!settings.apiKey) {
@@ -148,7 +159,24 @@ async function getClient(): Promise<{
     client: new Anthropic({ apiKey: settings.apiKey }),
     model: settings.model,
     web: settings.web ?? { ...DEFAULT_WEB_SETTINGS },
+    effort: settings.effort,
   };
+}
+
+/**
+ * Build the `output_config` to attach to a Messages call for a given
+ * (model, override) pair, or `undefined` to omit it. Effort is resolved from
+ * the per-call override over the global default, then clamped to what the model
+ * supports — Haiku gets nothing (sending effort 400s); `xhigh` only survives on
+ * Opus. Returned as a partial so callers can spread it onto the params.
+ */
+function outputConfigFor(
+  model: string,
+  override: Effort | undefined,
+  globalDefault: Effort | undefined,
+): { output_config: { effort: Effort } } | undefined {
+  const effort = resolveEffort(model, override, globalDefault);
+  return effort ? { output_config: { effort } } : undefined;
 }
 
 /**
@@ -164,6 +192,7 @@ export async function complete(
   let messages: Anthropic.MessageParam[];
   let callbacks: StreamCallbacks | undefined;
   let modelOverride: string | undefined;
+  let effortOverride: Effort | undefined;
   let onUsage: ((usage: TurnUsage, model: string) => void) | undefined;
 
   if (callbacksOrOptions && 'onChunk' in callbacksOrOptions) {
@@ -174,20 +203,23 @@ export async function complete(
     system = opts.system;
     callbacks = opts.callbacks;
     modelOverride = opts.model;
+    effortOverride = opts.effort;
     onUsage = opts.onUsage;
     messages = (opts.messages ?? [{ role: 'user', content: prompt }]);
   } else {
     messages = [{ role: 'user', content: prompt }];
   }
 
-  const { client, model: defaultModel } = await getClient();
+  const { client, model: defaultModel, effort: defaultEffort } = await getClient();
   const model = modelOverride ?? defaultModel;
+  const outputConfig = outputConfigFor(model, effortOverride, defaultEffort);
 
   if (!callbacks) {
     const response = await client.messages.create({
       model,
       max_tokens: 16000,
       ...(system ? { system } : {}),
+      ...outputConfig,
       messages,
     });
     if (onUsage) onUsage(addUsage(emptyUsage(), response.usage), model);
@@ -198,6 +230,7 @@ export async function complete(
     model,
     max_tokens: 64000,
     ...(system ? { system } : {}),
+    ...outputConfig,
     messages,
   }, { signal: callbacks.signal });
 
@@ -219,8 +252,9 @@ export async function complete(
 export async function completeWithTools(
   options: CompleteWithToolsOptions,
 ): Promise<CompleteWithToolsResult> {
-  const { client, model: defaultModel, web } = await getClient();
+  const { client, model: defaultModel, web, effort: defaultEffort } = await getClient();
   const model = options.model ?? defaultModel;
+  const outputConfig = outputConfigFor(model, options.effort, defaultEffort);
   const { toolContext, callbacks, maxIterations = 10 } = options;
   const messages: Anthropic.MessageParam[] = [...options.messages];
 
@@ -278,6 +312,7 @@ export async function completeWithTools(
       system,
       tools,
       messages,
+      ...outputConfig,
     };
     if (containerId) streamParams.container = containerId;
     // Per-iteration diagnostic so the "container_id is required" 400s

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import type { LLMSettings, WebSettings } from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
+import { isEffort, type Effort } from '../../shared/tools/effort';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-6';
 
@@ -26,6 +27,10 @@ function resolveWeb(stored: unknown): WebSettings {
   };
 }
 
+function resolveEffortSetting(stored: unknown): Effort | undefined {
+  return isEffort(stored) ? stored : undefined;
+}
+
 function settingsPath(): string {
   return path.join(app.getPath('userData'), 'llm-settings.json');
 }
@@ -38,6 +43,7 @@ export async function getSettings(): Promise<LLMSettings> {
       apiKey: parsed.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '',
       model: resolveModel(parsed.model),
       web: resolveWeb(parsed.web),
+      ...(resolveEffortSetting(parsed.effort) ? { effort: resolveEffortSetting(parsed.effort) } : {}),
     };
   } catch {
     return {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -235,6 +235,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.CONVERSATION_INSERT_COMPUTE_DRAFT, input),
     setModel: (conversationId: string, model: string | undefined) =>
       ipcRenderer.invoke(Channels.CONVERSATION_SET_MODEL, conversationId, model),
+    setEffort: (conversationId: string, effort: string | undefined) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_SET_EFFORT, conversationId, effort),
   },
   proposals: {
     list: (status?: string) => ipcRenderer.invoke(Channels.PROPOSAL_LIST, status),

--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -11,9 +11,11 @@
    * read-only (reflects what's already stored).
    */
   import { MODEL_OPTIONS } from '../../../shared/tools/models';
+  import { EFFORT_LEVELS, type Effort } from '../../../shared/tools/effort';
 
   interface Props {
     model: string;
+    effort: Effort | undefined;
     apiKeyInput: string;
     clearApiKey: boolean;
     apiKeyStatus: 'unknown' | 'set' | 'unset';
@@ -21,10 +23,18 @@
 
   let {
     model = $bindable(),
+    effort = $bindable(),
     apiKeyInput = $bindable(),
     clearApiKey = $bindable(),
     apiKeyStatus,
   }: Props = $props();
+
+  // '' in the <select> means "no override → built-in default"; map to/from
+  // the optional `effort` prop.
+  function onEffortChange(e: Event) {
+    const v = (e.currentTarget as HTMLSelectElement).value;
+    effort = v ? (v as Effort) : undefined;
+  }
 </script>
 
 <div class="field">
@@ -34,6 +44,21 @@
       <option value={m.value}>{m.label}</option>
     {/each}
   </select>
+</div>
+<div class="field">
+  <label for="effort">Default reasoning effort</label>
+  <select id="effort" value={effort ?? ''} onchange={onEffortChange}>
+    <option value="">Model default</option>
+    {#each EFFORT_LEVELS as lvl}
+      <option value={lvl.value}>{lvl.label}</option>
+    {/each}
+  </select>
+  <p class="hint">
+    Higher effort lets the model think longer. Leave on “Model default” to send
+    no preference. Per-conversation overrides take precedence. Not all models
+    support every level — the per-conversation picker only offers what the chosen
+    model accepts (Haiku has no effort control), and “Extra” is Opus-only.
+  </p>
 </div>
 <div class="field">
   <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -6,6 +6,15 @@
   import { api } from '../ipc/client';
   import MarkdownIt from 'markdown-it';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+  import {
+    EFFORT_LEVELS,
+    supportedEfforts,
+    modelSupportsEffort,
+    effortSupported,
+    clampEffort,
+    isEffort,
+    type Effort,
+  } from '../../../shared/tools/effort';
   import type { ConversationDraft } from '../../../shared/conversation-drafts';
   import type {
     ConversationSourceDraft,
@@ -89,6 +98,7 @@
   // Project-default model — used to label the "Default" option so the
   // user can see which concrete model "default" resolves to.
   let defaultModel = $state<string | null>(null);
+  let defaultEffort = $state<Effort | undefined>(undefined);
   // Width-of-tab-bar overflow handling deferred to polish (#505).
 
   onMount(async () => {
@@ -99,6 +109,7 @@
     try {
       const s = await api.tools.getSettings();
       defaultModel = s.model ?? null;
+      defaultEffort = s.effort;
     } catch { /* settings unavailable; picker still works without the label */ }
   });
 
@@ -192,9 +203,31 @@
     }
   }
 
+  /** Resolve the model a conversation actually runs on (override → global
+   *  default → built-in fallback), for gating the effort picker. */
+  function effectiveModel(model: string | undefined): string {
+    return model ?? defaultModel ?? 'claude-sonnet-4-6';
+  }
+
   async function handleModelChange(tabId: string, e: Event) {
     const value = (e.currentTarget as HTMLSelectElement).value;
     await store.setModel(tabId, value || undefined);
+    // Re-gate effort against the new model: if the conversation pinned an
+    // effort the new model can't honor (e.g. Extra → Sonnet, or any → Haiku),
+    // clamp it to the nearest supported level (or clear it for Haiku) so the
+    // next turn doesn't 400.
+    const tab = store.tabs.find((t) => t.id === tabId);
+    const current = tab?.conversation.effort;
+    if (current) {
+      const model = effectiveModel(value || undefined);
+      const clamped = clampEffort(model, current);
+      if (clamped !== current) await store.setEffort(tabId, clamped);
+    }
+  }
+
+  async function handleEffortChange(tabId: string, e: Event) {
+    const value = (e.currentTarget as HTMLSelectElement).value;
+    await store.setEffort(tabId, isEffort(value) ? value : undefined);
   }
 
   function scrollToBottom() {
@@ -623,6 +656,22 @@
               <option value={m.value}>{m.label}</option>
             {/each}
           </select>
+          {#if modelSupportsEffort(effectiveModel(tab.conversation.model))}
+            {@const convModel = effectiveModel(tab.conversation.model)}
+            {@const inherited = defaultEffort ? clampEffort(convModel, defaultEffort) : undefined}
+            {@const inheritedLabel = inherited ? EFFORT_LEVELS.find((l) => l.value === inherited)?.label : null}
+            <select
+              class="model-picker effort-picker"
+              value={tab.conversation.effort && effortSupported(convModel, tab.conversation.effort) ? tab.conversation.effort : ''}
+              onchange={(e) => handleEffortChange(tab.id, e)}
+              title="Reasoning effort for this conversation"
+            >
+              <option value="">Effort: default{inheritedLabel ? ` (${inheritedLabel})` : ''}</option>
+              {#each EFFORT_LEVELS.filter((l) => supportedEfforts(convModel).includes(l.value)) as lvl}
+                <option value={lvl.value}>Effort: {lvl.label}</option>
+              {/each}
+            </select>
+          {/if}
           {#if onCreateNoteFromConversation}
             <button
               type="button"

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -249,6 +249,7 @@
   let clipperRevealed = $state(false);
   let clipperCopied = $state(false);
   let model = $state('claude-sonnet-4-6');
+  let effort = $state<import('../../../shared/tools/effort').Effort | undefined>(undefined);
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');
   let clearApiKey = $state(false);
@@ -265,6 +266,7 @@
       const s = await api.tools.getSettings();
       loadedLlm = s;
       model = s.model;
+      effort = s.effort;
       apiKeyStatus = s.apiKey ? 'set' : 'unset';
       const web = s.web ?? { enabled: true, allowedDomains: [], blockedDomains: [] };
       webEnabled = web.enabled;
@@ -353,6 +355,7 @@
         allowedDomains: parseDomains(allowedDomainsText),
         blockedDomains: parseDomains(blockedDomainsText),
       },
+      ...(effort ? { effort } : {}),
       ...(Object.keys(toolModelOverrides).length > 0 ? { toolModelOverrides } : {}),
     };
     try {
@@ -852,6 +855,7 @@
         {:else if activeTab === 'ai'}
           <AiSettings
             bind:model
+            bind:effort
             bind:apiKeyInput
             bind:clearApiKey
             {apiKeyStatus}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -457,6 +457,12 @@ export interface ConversationsApi {
   onStream(cb: (chunk: string) => void): void;
   cancel(): Promise<void>;
   setModel(conversationId: string, model: string | undefined): Promise<Conversation>;
+  /** Per-conversation reasoning-effort override (#825). Pass undefined to
+   *  clear it and inherit the global default. */
+  setEffort(
+    conversationId: string,
+    effort: import('../../../shared/tools/effort').Effort | undefined,
+  ): Promise<Conversation>;
   /** Subscribe to drafts produced by the propose_notes tool. Drafts are scoped per conversation. */
   onDraft(cb: (draft: import('../../../shared/conversation-drafts').ConversationDraft) => void): void;
   /** File a draft as a Proposal AND auto-approve it (the user already reviewed the inline card). */

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -579,6 +579,16 @@ async function setModel(tabId: string, model: string | undefined): Promise<void>
   tab.conversation = updated;
 }
 
+async function setEffort(
+  tabId: string,
+  effort: import('../../../shared/tools/effort').Effort | undefined,
+): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  const updated = await api.conversations.setEffort(tabId, effort);
+  tab.conversation = updated;
+}
+
 /**
  * Dispatch a reserved built-in slash command (#822). Built-ins are app-level
  * conversation operations, not skills — the composer's slash menu routes them
@@ -888,6 +898,7 @@ export function getConversationsStore() {
     answerQuestion,
     cancel,
     setModel,
+    setEffort,
     runBuiltinCommand,
     approveDraft,
     discardDraft,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -437,6 +437,8 @@ export const Channels = {
   /** renderer → main: user clicked Insert into notebook on a compute draft. Appends the cell to a destination note with provenance frontmatter. */
   CONVERSATION_INSERT_COMPUTE_DRAFT: 'conversation:insertComputeDraft',
   CONVERSATION_SET_MODEL: 'conversation:setModel',
+  /** Per-conversation reasoning-effort override (#825). */
+  CONVERSATION_SET_EFFORT: 'conversation:setEffort',
   /** Load tool-window UI state (.minerva/conversations/_ui.json). */
   CONVERSATION_UI_STATE_LOAD: 'conversation:uiStateLoad',
   /** Persist tool-window UI state (visibility, height, last-active tab). */

--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -1,0 +1,101 @@
+/**
+ * Reasoning-effort levels and per-model gating (#825).
+ *
+ * Effort is sent as `output_config: { effort }` on the Messages call — NOT
+ * `budget_tokens` (deprecated on Sonnet 4.6, 400s on Opus 4.7/4.8). Support is
+ * model-gated, so the picker must only offer levels the selected model accepts,
+ * or the request 400s:
+ *
+ *   | Model       | Supported effort                    |
+ *   |-------------|-------------------------------------|
+ *   | Haiku 4.5   | none (sending effort 400s)          |
+ *   | Sonnet 4.6  | low / medium / high / max           |
+ *   | Opus 4.8    | low / medium / high / xhigh / max   |
+ *
+ * The UI label "Extra" maps to `xhigh`, which is Opus-only.
+ *
+ * Kept in `shared/` so the renderer picker, the Settings default, and the
+ * main-side guard all gate from one source of truth.
+ */
+
+export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+/** Canonical ordering low→max, used for the picker order and clamp distance. */
+export const EFFORT_LEVELS: { value: Effort; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra' },
+  { value: 'max', label: 'Max' },
+];
+
+const ORDER: Effort[] = EFFORT_LEVELS.map((l) => l.value);
+
+/** Sensible middle default when none is configured. */
+export const DEFAULT_EFFORT: Effort = 'medium';
+
+/**
+ * Supported effort levels per model. A model absent here (an unknown/future id)
+ * yields `[]` — we send no effort rather than risk a 400.
+ */
+const SUPPORT: Record<string, Effort[]> = {
+  'claude-opus-4-8': ['low', 'medium', 'high', 'xhigh', 'max'],
+  'claude-sonnet-4-6': ['low', 'medium', 'high', 'max'],
+  'claude-haiku-4-5': [],
+};
+
+export function supportedEfforts(model: string): Effort[] {
+  return SUPPORT[model] ?? [];
+}
+
+/** True when the model accepts any effort control at all (Haiku: false). */
+export function modelSupportsEffort(model: string): boolean {
+  return supportedEfforts(model).length > 0;
+}
+
+export function isEffort(v: unknown): v is Effort {
+  return typeof v === 'string' && (ORDER as string[]).includes(v);
+}
+
+export function effortSupported(model: string, effort: Effort): boolean {
+  return supportedEfforts(model).includes(effort);
+}
+
+/**
+ * Clamp an effort to what the model supports. Returns `undefined` when there's
+ * nothing to send — either the model has no effort support (Haiku) or no effort
+ * was requested (so the caller omits `output_config` and the API uses its own
+ * default; this preserves prior behavior for callers that never set effort).
+ * When the requested level is unsupported (e.g. `xhigh` on Sonnet), snaps to
+ * the nearest supported level by canonical distance, preferring the lower
+ * (cheaper) side on ties.
+ */
+export function clampEffort(model: string, effort: Effort | undefined): Effort | undefined {
+  const supported = supportedEfforts(model);
+  if (supported.length === 0) return undefined;
+  if (!effort) return undefined;
+  if (supported.includes(effort)) return effort;
+  const targetIdx = ORDER.indexOf(effort);
+  let best = supported[0];
+  let bestDist = Infinity;
+  for (const s of supported) {
+    const dist = Math.abs(ORDER.indexOf(s) - targetIdx);
+    // Strict `<` keeps the first (lower, since `supported` is in canonical
+    // order) on a tie — prefer stepping down over up.
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = s;
+    }
+  }
+  return best;
+}
+
+/** The effort actually sent for a turn: per-conversation override (if set) else
+ *  the global default, clamped to the model. `undefined` ⇒ omit output_config. */
+export function resolveEffort(
+  model: string,
+  override: Effort | undefined,
+  globalDefault: Effort | undefined,
+): Effort | undefined {
+  return clampEffort(model, override ?? globalDefault);
+}

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -226,6 +226,13 @@ export interface LLMSettings {
   model: string;
   web?: WebSettings;
   /**
+   * Global default reasoning effort (#825), sent as `output_config.effort`.
+   * A per-conversation `Conversation.effort` overrides this. Clamped to what
+   * the active model supports at call time; `undefined` ⇒ use the built-in
+   * default. See `shared/tools/effort.ts`.
+   */
+  effort?: import('./effort').Effort;
+  /**
    * User-level overrides of each tool's preferred model. Keyed by tool id.
    * Resolution order for a tool invocation:
    *   request.modelOverride ?? toolModelOverrides[id] ?? tool.preferredModel ?? model

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -407,6 +407,12 @@ export interface Conversation {
    */
   model?: string;
   /**
+   * Per-conversation reasoning-effort override (#825). `undefined` means inherit
+   * the global default (`LLMSettings.effort`). Clamped to the active model's
+   * supported levels at call time. Mirrors the `model` override pattern.
+   */
+  effort?: import('./tools/effort').Effort;
+  /**
    * Tool-specific system prompt pinned on the conversation. When set, every
    * `send` uses this as the tool/user-supplied system (on top of the
    * default tool-using system prompt built on the main side). Set when the

--- a/tests/main/llm/conversation-tool-dispatch.test.ts
+++ b/tests/main/llm/conversation-tool-dispatch.test.ts
@@ -238,6 +238,52 @@ describe('completeWithTools() dispatch loop (#342)', () => {
     expect(result.usageModel).toBe('claude-sonnet-4-6');
   });
 
+  it('sends output_config.effort, clamped to the model (#825)', async () => {
+    streamMock.mockReturnValue(streamReturning(textMessage('done')));
+
+    // Supported level passes through.
+    await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'go' }],
+      toolContext: { rootPath: root },
+      model: 'claude-opus-4-8',
+      effort: 'xhigh',
+    });
+    expect((streamMock.mock.calls[0][0] as { output_config?: { effort: string } }).output_config)
+      .toEqual({ effort: 'xhigh' });
+
+    // xhigh isn't valid on Sonnet → clamped to high.
+    await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'go' }],
+      toolContext: { rootPath: root },
+      model: 'claude-sonnet-4-6',
+      effort: 'xhigh',
+    });
+    expect((streamMock.mock.calls[1][0] as { output_config?: { effort: string } }).output_config)
+      .toEqual({ effort: 'high' });
+
+    // Haiku supports no effort → output_config omitted entirely.
+    await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'go' }],
+      toolContext: { rootPath: root },
+      model: 'claude-haiku-4-5',
+      effort: 'high',
+    });
+    expect((streamMock.mock.calls[2][0] as { output_config?: unknown }).output_config).toBeUndefined();
+  });
+
+  it('omits output_config when no effort is configured', async () => {
+    streamMock.mockReturnValueOnce(streamReturning(textMessage('done')));
+    await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'go' }],
+      toolContext: { rootPath: root },
+    });
+    expect((streamMock.mock.calls[0][0] as { output_config?: unknown }).output_config).toBeUndefined();
+  });
+
   it('honours maxIterations as a hard cap on tool-use cycles', async () => {
     // Always return tool_use — the loop should break at maxIterations
     // without ever emitting a final text response.

--- a/tests/shared/effort.test.ts
+++ b/tests/shared/effort.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Reasoning-effort gating + clamping (#825).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  supportedEfforts,
+  modelSupportsEffort,
+  effortSupported,
+  clampEffort,
+  resolveEffort,
+  isEffort,
+} from '../../src/shared/tools/effort';
+
+describe('model gating', () => {
+  it('Haiku supports no effort control', () => {
+    expect(supportedEfforts('claude-haiku-4-5')).toEqual([]);
+    expect(modelSupportsEffort('claude-haiku-4-5')).toBe(false);
+  });
+
+  it('Sonnet supports low/medium/high/max but not xhigh', () => {
+    expect(supportedEfforts('claude-sonnet-4-6')).toEqual(['low', 'medium', 'high', 'max']);
+    expect(effortSupported('claude-sonnet-4-6', 'xhigh')).toBe(false);
+    expect(effortSupported('claude-sonnet-4-6', 'high')).toBe(true);
+  });
+
+  it('Opus supports xhigh (the UI "Extra")', () => {
+    expect(supportedEfforts('claude-opus-4-8')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    expect(effortSupported('claude-opus-4-8', 'xhigh')).toBe(true);
+  });
+
+  it('an unknown model supports nothing (don\'t risk a 400)', () => {
+    expect(supportedEfforts('claude-future-9')).toEqual([]);
+    expect(modelSupportsEffort('claude-future-9')).toBe(false);
+  });
+});
+
+describe('clampEffort', () => {
+  it('returns undefined for a model with no effort support', () => {
+    expect(clampEffort('claude-haiku-4-5', 'high')).toBeUndefined();
+  });
+
+  it('passes a supported level through unchanged', () => {
+    expect(clampEffort('claude-opus-4-8', 'xhigh')).toBe('xhigh');
+    expect(clampEffort('claude-sonnet-4-6', 'high')).toBe('high');
+  });
+
+  it('snaps xhigh down to high on Sonnet (nearest, prefer lower on tie)', () => {
+    // xhigh (idx 3) is equidistant from high (2) and max (4); prefer lower.
+    expect(clampEffort('claude-sonnet-4-6', 'xhigh')).toBe('high');
+  });
+
+  it('returns undefined when no effort requested (omit output_config)', () => {
+    expect(clampEffort('claude-sonnet-4-6', undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveEffort', () => {
+  it('per-conversation override wins over the global default', () => {
+    expect(resolveEffort('claude-opus-4-8', 'max', 'low')).toBe('max');
+  });
+
+  it('inherits the global default when no override', () => {
+    expect(resolveEffort('claude-opus-4-8', undefined, 'high')).toBe('high');
+  });
+
+  it('clamps the resolved value to the model', () => {
+    // Override xhigh on Sonnet → clamped to high.
+    expect(resolveEffort('claude-sonnet-4-6', 'xhigh', undefined)).toBe('high');
+    // Anything on Haiku → undefined (omit output_config).
+    expect(resolveEffort('claude-haiku-4-5', 'max', 'high')).toBeUndefined();
+  });
+
+  it('omits effort entirely when neither override nor default is set', () => {
+    // Preserves prior behavior for callers that never configured effort.
+    expect(resolveEffort('claude-sonnet-4-6', undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('isEffort', () => {
+  it('accepts valid levels, rejects others', () => {
+    expect(isEffort('xhigh')).toBe(true);
+    expect(isEffort('medium')).toBe(true);
+    expect(isEffort('ludicrous')).toBe(false);
+    expect(isEffort(undefined)).toBe(false);
+    expect(isEffort(3)).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of #819. Independent of the other sub-issues.

## What

Pick reasoning **effort** per conversation, defaulting from a global setting. Sent as `output_config.effort` — **not** `budget_tokens` (deprecated on Sonnet 4.6, 400s on Opus 4.7/4.8).

- **`shared/tools/effort.ts`** — `Effort` type + per-model gating, one source of truth for the picker, the Settings default, and the main-side guard:
  | Model | Supported |
  |---|---|
  | Haiku 4.5 | none |
  | Sonnet 4.6 | low / medium / high / max |
  | Opus 4.8 | low / medium / high / xhigh / max |

  The UI label **"Extra" = `xhigh`, Opus-only.** `clampEffort` snaps an unsupported level to the nearest supported one (prefers the lower/cheaper side on ties) and **omits effort entirely when none is configured** — so callers that never set effort (auto-tag, auto-link, executor, …) keep their current behavior. `resolveEffort` = override → global default → clamp.
- **Settings** — `LLMSettings.effort` (global default) + `Conversation.effort` (per-conversation override), mirroring the existing `model` override pattern end to end (`setEffort` op → IPC → preload → client → store).
- **API** — `complete()` and `completeWithTools()` thread effort into `output_config`, only when the resolved model supports the resolved level. The SDK types `effort` as exactly `low|medium|high|xhigh|max`, matching `Effort`.
- **UI** — an effort `<select>` next to the model picker (gated by the active model; hidden for Haiku; **re-clamps a pinned effort when the model changes** so a now-invalid pairing can't 400) + a global default in AI settings.

## Deferred

`thinking: { type: "adaptive" }` is left as a follow-up — the issue flagged it as optional and it would touch the streaming path.

## Tests
- `tests/shared/effort.test.ts` — gating per model, clamp (xhigh→high on Sonnet, none on Haiku, omit when unset), resolve precedence.
- `tests/main/llm/conversation-tool-dispatch.test.ts` — `completeWithTools` emits `output_config` for a supported level, clamps xhigh→high on Sonnet, omits it for Haiku and when no effort is configured.

## Acceptance
- [x] Effort sent as `output_config.effort`, never `budget_tokens`.
- [x] Picker shows only model-valid levels; Haiku shows no control; "Extra"/`xhigh` only on Opus.
- [x] Switching model re-gates and clamps a now-invalid selection.
- [x] Per-conversation effort overrides the global default; unset inherits it.
- [x] No 400 from an unsupported effort/model pairing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)