### PR TITLE
feat: /clear conversation command (#823, re-land)

### DIFF
--- a/src/renderer/lib/conversations/builtin-commands.ts
+++ b/src/renderer/lib/conversations/builtin-commands.ts
@@ -29,7 +29,7 @@ export const BUILTIN_COMMANDS: BuiltinCommand[] = [
     name: 'clear',
     slashCommand: '/clear',
     description: 'Archive this conversation and start a fresh one',
-    available: false,
+    available: true,
   },
   {
     name: 'compact',

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -598,11 +598,83 @@ async function setEffort(
  */
 function runBuiltinCommand(name: string): void {
   switch (name) {
+    case 'clear':
+      void clearConversation();
+      break;
     default:
-      // Reserved but not yet wired (handlers land in #823/#824). No-op
-      // loudly rather than throwing into the composer's keydown path.
+      // Reserved but not yet wired (handler lands in #824). No-op loudly
+      // rather than throwing into the composer's keydown path.
       console.warn(`[conv] no handler for built-in command: /${name}`);
   }
+}
+
+/** Empty per-turn state for a freshly-created conversation tab. Keeps the
+ *  three tab-construction sites from drifting as draft kinds are added. */
+function blankTabRuntime(conv: Conversation, extraTools: ConversationToolKey[]): TabRuntime {
+  return {
+    id: conv.id,
+    title: null,
+    conversation: conv,
+    drafts: [],
+    sourceDrafts: [],
+    sourceDraftResults: {},
+    noteDraftResults: {},
+    propertyDrafts: [],
+    propertyDraftResults: {},
+    sourcePropertyDrafts: [],
+    sourcePropertyDraftResults: {},
+    claimsDrafts: [],
+    claimsDraftResults: {},
+    computeDrafts: [],
+    computeDraftState: {},
+    pendingQuestion: null,
+    composer: '',
+    streaming: false,
+    streamedChunks: '',
+    extraTools,
+  };
+}
+
+/**
+ * `/clear` (#823): archive the active conversation and open a fresh one in its
+ * place, carrying the same context (origin note, trigger node, system prompt,
+ * model, template tools). Archive is non-destructive — it files the transcript
+ * as a `thought:Source` and leaves any pending approval proposals (which are
+ * graph-global, not conversation-scoped) untouched. Truncating in place would
+ * orphan those proposals, hence archive-and-new.
+ */
+async function clearConversation(): Promise<void> {
+  const tab = activeTab();
+  if (!tab) return;
+  const prev = tab.conversation;
+  // A brand-new, never-used conversation has nothing to archive — just no-op
+  // so spamming /clear doesn't litter the archived list with empties.
+  if (prev.messages.length === 0) return;
+  try {
+    await api.conversations.archive(prev.id);
+  } catch (e) {
+    // Already-archived or transient failure — proceed to open a fresh tab
+    // regardless so the user still gets their clean slate.
+    console.warn('[conv] /clear: archive failed', e);
+  }
+  const createOpts: { systemPrompt?: string; model?: string } = {};
+  if (prev.systemPrompt) createOpts.systemPrompt = prev.systemPrompt;
+  if (prev.model) createOpts.model = prev.model;
+  const fresh = await api.conversations.create(
+    prev.contextBundle,
+    prev.triggerNodeUri,
+    Object.keys(createOpts).length > 0 ? createOpts : undefined,
+  );
+  const newTab = blankTabRuntime(fresh, [...tab.extraTools]);
+  // Replace in place so the fresh conversation keeps the same tab slot.
+  const idx = tabs.findIndex((t) => t.id === tab.id);
+  if (idx === -1) {
+    tabs = [...tabs, newTab];
+  } else {
+    tabs = [...tabs.slice(0, idx), newTab, ...tabs.slice(idx + 1)];
+  }
+  activeTabId = newTab.id;
+  scheduleSave();
 }
 
 async function cancel(): Promise<void> {

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -78,6 +78,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "runComputeDraft",
     "saveUIState",
     "send",
+    "setEffort",
     "setModel",
   ],
   "csl": [

--- a/tests/renderer/stores/conversation-clear.test.ts
+++ b/tests/renderer/stores/conversation-clear.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `/clear` built-in command (#823): archive the active conversation and open a
+ * fresh one in its place, carrying the same context. Drives the conversations
+ * store with a mocked api client.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Conversation } from '../../../src/shared/types';
+
+const h = vi.hoisted(() => {
+  const noop = vi.fn();
+  let nextId = 1;
+  const created: Conversation[] = [];
+  const api = {
+    conversations: {
+      // subscriptions used by ensureSubscriptions()
+      onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onAskUser: noop,
+      saveUIState: vi.fn().mockResolvedValue(undefined),
+      archive: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (contextBundle: unknown, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) => {
+        const conv: Conversation = {
+          id: `conv-${nextId++}`,
+          contextBundle: contextBundle as Conversation['contextBundle'],
+          triggerNodeUri,
+          messages: [],
+          status: 'active',
+          startedAt: 't',
+          ...(options?.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
+          ...(options?.model ? { model: options.model } : {}),
+        };
+        created.push(conv);
+        return conv;
+      }),
+    },
+  };
+  return { api, created };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const store = getConversationsStore();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('/clear (#823)', () => {
+  it('archives the current conversation and opens a fresh one with the same context', async () => {
+    await store.openFreeform('notes/origin.md');
+    const original = store.activeTab!;
+    original.conversation.model = 'claude-opus-4-8';
+    // Make the conversation non-empty so /clear has something to archive.
+    original.conversation.messages.push({ role: 'user', content: 'hi', timestamp: 't' });
+    const originalId = original.id;
+
+    store.runBuiltinCommand('clear');
+    await vi.waitFor(() => expect(store.activeTab!.id).not.toBe(originalId));
+
+    expect(h.api.conversations.archive).toHaveBeenCalledWith(originalId);
+    // Fresh conversation carries the same origin note + the model override.
+    const last = h.created[h.created.length - 1];
+    expect(last.contextBundle.notePath).toBe('notes/origin.md');
+    expect(last.model).toBe('claude-opus-4-8');
+    // The fresh conversation is active, empty, and occupies the same single tab.
+    expect(store.activeTab!.conversation.messages).toHaveLength(0);
+    expect(store.tabs.filter((t) => t.id === originalId)).toHaveLength(0);
+  });
+
+  it('no-ops on an empty, never-used conversation (no archive churn)', async () => {
+    await store.openFreeform('notes/origin.md');
+    const id = store.activeTab!.id;
+    store.runBuiltinCommand('clear');
+    await Promise.resolve();
+    expect(h.api.conversations.archive).not.toHaveBeenCalled();
+    expect(store.activeTab!.id).toBe(id);
+  });
+});


### PR DESCRIPTION
Re-lands #823 directly onto `main`. The original PR #858 was merged into the **stale `feat/822` stack branch** after #822 had already squash-merged to main, so `/clear`'s content never reached `main` (the `available` flag was still `false` there). This PR targets `main` directly.

Part of #819. Builds on #822 (merged).

## What
`/clear` archives the active conversation (transcript filed as a `thought:Source`; pending proposals untouched) and opens a fresh tab carrying the same context. Flips the `clear` built-in to `available` and wires `clearConversation()` into the router. Extracts `blankTabRuntime()`. No always-on confirmation dialog.

## Test
`tests/renderer/stores/conversation-clear.test.ts` — archive + same-context create + in-place tab swap; empty-conversation no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)