### PR TITLE
feat: /compact conversation command (#824, re-land)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -793,4 +793,58 @@ export function registerConversation(): void {
       return conversation.setEffort(convId, effort);
     },
   );
+
+  ipcMain.handle(Channels.CONVERSATION_COMPACT, (_e, convId: string) => compactConversation(convId));
+}
+
+/**
+ * `/compact` (#824): client-side compaction. Summarizes the early history with
+ * a model call and seeds a fresh conversation with the summary + the retained
+ * recent turns. The pre-compaction original is archived (filed as a
+ * thought:Source, recoverable from the archived list), never silently
+ * destroyed. The summarization call's own token usage is recorded on the
+ * summary message (#820). Decision/assembly logic is in `llm/compact.ts`.
+ */
+async function compactConversation(
+  convId: string,
+): Promise<import('../../shared/types').CompactResult> {
+  const conv = await conversation.load(convId);
+  if (!conv) throw new Error(`Conversation not found: ${convId}`);
+  if (conv.status !== 'active') {
+    return { compacted: false, reason: 'This conversation is archived and can\'t be compacted.' };
+  }
+  const { planCompaction, buildSummaryPrompt, buildSummaryMessage, COMPACT_SYSTEM_PROMPT } =
+    await import('../llm/compact');
+  const plan = planCompaction(conv.messages);
+  if (!plan.ok) return { compacted: false, reason: plan.reason };
+
+  let usage: import('../../shared/types').TurnUsage | undefined;
+  let usageModel: string | undefined;
+  const { complete } = await import('../llm/index');
+  const summary = await complete(buildSummaryPrompt(plan.transcript), {
+    system: COMPACT_SYSTEM_PROMPT,
+    model: conv.model,
+    onUsage: (u, m) => { usage = u; usageModel = m; },
+  });
+  const summaryMsg = buildSummaryMessage(
+    plan.prefix.length,
+    summary,
+    usage,
+    usageModel,
+    new Date().toISOString(),
+  );
+
+  // Archive the original (files the full transcript as a thought:Source —
+  // recoverable) before opening the compacted continuation.
+  await conversation.archive(convId);
+  const createOpts: { systemPrompt?: string; model?: string } = {};
+  if (conv.systemPrompt) createOpts.systemPrompt = conv.systemPrompt;
+  if (conv.model) createOpts.model = conv.model;
+  const fresh = await conversation.create(
+    conv.contextBundle,
+    conv.triggerNodeUri,
+    Object.keys(createOpts).length > 0 ? createOpts : undefined,
+  );
+  const updated = await conversation.replaceMessages(fresh.id, [summaryMsg, ...plan.recent]);
+  return { compacted: true, conversation: updated };
 }

--- a/src/main/llm/compact.ts
+++ b/src/main/llm/compact.ts
@@ -1,0 +1,79 @@
+/**
+ * Client-side conversation compaction logic (#824).
+ *
+ * Server-side compaction (`compact-2026-01-12`) needs raw `compaction` content
+ * blocks preserved across turns, but Minerva stores messages as plain strings
+ * — so `/compact` summarizes the early history with a model call and seeds a
+ * fresh conversation with the summary + the retained recent turns. The pure
+ * decision/assembly bits live here so they're testable without IPC; the IPC
+ * handler does the model call + archive/create orchestration.
+ */
+
+import type { ConversationMessage, TurnUsage } from '../../shared/types';
+
+/** Earlier turns kept verbatim after a compaction, for continuity. Four
+ *  messages ≈ the last two exchanges. */
+export const COMPACT_KEEP_RECENT = 4;
+
+/** Below this many messages there's nothing worth summarizing. */
+export const COMPACT_MIN_MESSAGES = COMPACT_KEEP_RECENT + 4;
+
+export const COMPACT_SYSTEM_PROMPT = [
+  'You are compacting a long assistant conversation so it stays within a workable length.',
+  'Produce a faithful, information-dense summary of the conversation so far.',
+  "Preserve: the user's goals and constraints, key facts and decisions, open questions, and every",
+  'file path, note name, source, or identifier referenced — anything needed to continue the work.',
+  'Use concise bullet points or short paragraphs. Do NOT invent information or add commentary;',
+  'summarize only what is in the transcript.',
+].join('\n');
+
+export type CompactionPlan =
+  | { ok: false; reason: string }
+  | { ok: true; prefix: ConversationMessage[]; recent: ConversationMessage[]; transcript: string };
+
+/**
+ * Decide whether/how to compact. A short thread is left alone; otherwise the
+ * earliest `length - KEEP_RECENT` messages are summarized and the last
+ * KEEP_RECENT kept verbatim. `transcript` is the role-labeled text fed to the
+ * summarizer (internal `system` messages excluded).
+ */
+export function planCompaction(messages: ConversationMessage[]): CompactionPlan {
+  if (messages.length < COMPACT_MIN_MESSAGES) {
+    return { ok: false, reason: 'This conversation is too short to compact.' };
+  }
+  const cutoff = messages.length - COMPACT_KEEP_RECENT;
+  const prefix = messages.slice(0, cutoff);
+  const recent = messages.slice(cutoff);
+  const transcript = prefix
+    .filter((m) => m.role !== 'system')
+    .map((m) => `[${m.role}] ${m.content}`)
+    .join('\n\n');
+  return { ok: true, prefix, recent, transcript };
+}
+
+export function buildSummaryPrompt(transcript: string): string {
+  return `Summarize the following earlier portion of a conversation:\n\n${transcript}`;
+}
+
+/**
+ * The single condensed message that replaces the summarized prefix. Role is
+ * `user` (not `system`) deliberately: the conversation send path filters out
+ * `system` messages, and a `user`-role summary keeps the API's first-message-
+ * is-user invariant when the compacted history is sent on the next turn. Usage
+ * from the summarization call rides along so its cost is counted (#820/#821).
+ */
+export function buildSummaryMessage(
+  prefixCount: number,
+  summary: string,
+  usage: TurnUsage | undefined,
+  usageModel: string | undefined,
+  timestamp: string,
+): ConversationMessage {
+  return {
+    role: 'user',
+    content: `**Summary of earlier conversation** (${prefixCount} messages compacted):\n\n${summary.trim()}`,
+    timestamp,
+    ...(usage ? { usage } : {}),
+    ...(usageModel ? { usageModel } : {}),
+  };
+}

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -215,6 +215,23 @@ export async function setEffort(
   return conv;
 }
 
+/**
+ * Replace a conversation's entire message array (used by `/compact`, #824, to
+ * seed a fresh conversation with a summary + the retained recent turns).
+ * Re-persists the whole JSON like every other mutation; no graph re-projection
+ * since the conversation subject's triples don't depend on message content.
+ */
+export async function replaceMessages(
+  id: string,
+  messages: ConversationMessage[],
+): Promise<Conversation> {
+  const conv = await load(id);
+  if (!conv) throw new Error(`Conversation not found: ${id}`);
+  conv.messages = messages;
+  await persist(conv);
+  return conv;
+}
+
 export async function load(id: string): Promise<Conversation | null> {
   try {
     const data = await fs.readFile(convPath(id), 'utf-8');

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -237,6 +237,8 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke(Channels.CONVERSATION_SET_MODEL, conversationId, model),
     setEffort: (conversationId: string, effort: string | undefined) =>
       ipcRenderer.invoke(Channels.CONVERSATION_SET_EFFORT, conversationId, effort),
+    compact: (conversationId: string) =>
+      ipcRenderer.invoke(Channels.CONVERSATION_COMPACT, conversationId),
   },
   proposals: {
     list: (status?: string) => ipcRenderer.invoke(Channels.PROPOSAL_LIST, status),

--- a/src/renderer/lib/conversations/builtin-commands.ts
+++ b/src/renderer/lib/conversations/builtin-commands.ts
@@ -35,7 +35,7 @@ export const BUILTIN_COMMANDS: BuiltinCommand[] = [
     name: 'compact',
     slashCommand: '/compact',
     description: 'Summarize earlier turns to shorten a long thread',
-    available: false,
+    available: true,
   },
 ];
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -463,6 +463,9 @@ export interface ConversationsApi {
     conversationId: string,
     effort: import('../../../shared/tools/effort').Effort | undefined,
   ): Promise<Conversation>;
+  /** Client-side compaction (#824): summarize earlier turns into a fresh
+   *  conversation, archiving the original. */
+  compact(conversationId: string): Promise<import('../../../shared/types').CompactResult>;
   /** Subscribe to drafts produced by the propose_notes tool. Drafts are scoped per conversation. */
   onDraft(cb: (draft: import('../../../shared/conversation-drafts').ConversationDraft) => void): void;
   /** File a draft as a Proposal AND auto-approve it (the user already reviewed the inline card). */

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -564,6 +564,43 @@ async function send(content: string, currentNotePath?: string): Promise<void> {
   }
 }
 
+/**
+ * `/compact` (#824): summarize earlier turns into a fresh conversation, then
+ * swap it into the same tab slot. The original is archived main-side (filed as
+ * a thought:Source). Shows a brief busy state while the summarization call
+ * runs; a too-short conversation is left untouched.
+ */
+async function compactConversation(): Promise<void> {
+  const tab = activeTab();
+  if (!tab || tab.streaming) return;
+  tab.streaming = true;
+  tab.streamedChunks = 'Compacting earlier turns…';
+  try {
+    const result = await api.conversations.compact(tab.id);
+    if (!result.compacted || !result.conversation) {
+      // Nothing to compact (or skipped) — leave the conversation as-is.
+      if (result.reason) console.info(`[conv] /compact: ${result.reason}`);
+      return;
+    }
+    const newTab = blankTabRuntime(result.conversation, [...tab.extraTools]);
+    const idx = tabs.findIndex((t) => t.id === tab.id);
+    if (idx === -1) {
+      tabs = [...tabs, newTab];
+    } else {
+      tabs = [...tabs.slice(0, idx), newTab, ...tabs.slice(idx + 1)];
+    }
+    activeTabId = newTab.id;
+    scheduleSave();
+  } catch (e) {
+    console.error('[conv] /compact failed:', e);
+  } finally {
+    // If the tab was swapped out, this just touches the now-detached old tab
+    // object; the new tab starts with streaming=false.
+    tab.streaming = false;
+    tab.streamedChunks = '';
+  }
+}
+
 async function answerQuestion(tabId: string, answer: string): Promise<void> {
   const tab = findTab(tabId);
   if (!tab || !tab.pendingQuestion) return;
@@ -601,9 +638,12 @@ function runBuiltinCommand(name: string): void {
     case 'clear':
       void clearConversation();
       break;
+    case 'compact':
+      void compactConversation();
+      break;
     default:
-      // Reserved but not yet wired (handler lands in #824). No-op loudly
-      // rather than throwing into the composer's keydown path.
+      // Reserved but not yet wired. No-op loudly rather than throwing into
+      // the composer's keydown path.
       console.warn(`[conv] no handler for built-in command: /${name}`);
   }
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -439,6 +439,9 @@ export const Channels = {
   CONVERSATION_SET_MODEL: 'conversation:setModel',
   /** Per-conversation reasoning-effort override (#825). */
   CONVERSATION_SET_EFFORT: 'conversation:setEffort',
+  /** Client-side compaction (#824): summarize earlier turns into a fresh
+   *  conversation, archiving the original. */
+  CONVERSATION_COMPACT: 'conversation:compact',
   /** Load tool-window UI state (.minerva/conversations/_ui.json). */
   CONVERSATION_UI_STATE_LOAD: 'conversation:uiStateLoad',
   /** Persist tool-window UI state (visibility, height, last-active tab). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -379,6 +379,19 @@ export interface PrivilegedSite {
 export type ConversationStatus = 'active' | 'archived';
 
 /**
+ * Result of a `/compact` (#824). On success, `conversation` is the fresh
+ * conversation (earlier turns replaced by a summary, recent turns kept
+ * verbatim); the pre-compaction original is archived and recoverable. When the
+ * thread is too short to be worth compacting, `compacted` is false and `reason`
+ * explains why — nothing is changed.
+ */
+export interface CompactResult {
+  compacted: boolean;
+  conversation?: Conversation;
+  reason?: string;
+}
+
+/**
  * Tool-window UI state for the conversations panel. Persisted in
  * `.minerva/conversations/_ui.json` so it survives relaunch but stays
  * project-scoped (different projects can have different layouts).

--- a/tests/main/llm/compact.test.ts
+++ b/tests/main/llm/compact.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Client-side compaction decision/assembly (#824).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  planCompaction,
+  buildSummaryMessage,
+  buildSummaryPrompt,
+  COMPACT_KEEP_RECENT,
+  COMPACT_MIN_MESSAGES,
+} from '../../../src/main/llm/compact';
+import type { ConversationMessage, TurnUsage } from '../../../src/shared/types';
+
+function convo(n: number): ConversationMessage[] {
+  return Array.from({ length: n }, (_, i) => ({
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `m${i}`,
+    timestamp: 't',
+  }));
+}
+
+describe('planCompaction (#824)', () => {
+  it('leaves a short conversation alone', () => {
+    const plan = planCompaction(convo(COMPACT_MIN_MESSAGES - 1));
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) expect(plan.reason).toMatch(/too short/i);
+  });
+
+  it('summarizes the prefix and keeps the last KEEP_RECENT verbatim', () => {
+    const msgs = convo(10);
+    const plan = planCompaction(msgs);
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.recent).toHaveLength(COMPACT_KEEP_RECENT);
+    expect(plan.recent).toEqual(msgs.slice(-COMPACT_KEEP_RECENT));
+    expect(plan.prefix).toHaveLength(10 - COMPACT_KEEP_RECENT);
+    // Transcript is role-labeled and covers exactly the prefix.
+    expect(plan.transcript).toContain('[user] m0');
+    expect(plan.transcript).toContain(`[assistant] m${10 - COMPACT_KEEP_RECENT - 1}`);
+    expect(plan.transcript).not.toContain(`m${10 - COMPACT_KEEP_RECENT}`); // first recent
+  });
+
+  it('excludes internal system messages from the transcript', () => {
+    const msgs = convo(10);
+    msgs[0] = { role: 'system', content: 'internal', timestamp: 't' };
+    const plan = planCompaction(msgs);
+    if (!plan.ok) throw new Error('expected ok');
+    expect(plan.transcript).not.toContain('internal');
+  });
+});
+
+describe('buildSummaryMessage', () => {
+  const usage: TurnUsage = { inputTokens: 10, outputTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0 };
+
+  it('produces a user-role summary carrying the summarization usage', () => {
+    const m = buildSummaryMessage(6, '  the summary  ', usage, 'claude-sonnet-4-6', 'ts');
+    // user role keeps the API first-message-is-user invariant + survives the
+    // system-message filter on the send path.
+    expect(m.role).toBe('user');
+    expect(m.content).toContain('6 messages compacted');
+    expect(m.content).toContain('the summary');
+    expect(m.content).not.toMatch(/ {2}the summary {2}/); // trimmed
+    expect(m.usage).toEqual(usage);
+    expect(m.usageModel).toBe('claude-sonnet-4-6');
+  });
+
+  it('omits usage fields when the call reported none', () => {
+    const m = buildSummaryMessage(6, 's', undefined, undefined, 'ts');
+    expect(m.usage).toBeUndefined();
+    expect(m.usageModel).toBeUndefined();
+  });
+});
+
+describe('buildSummaryPrompt', () => {
+  it('embeds the transcript', () => {
+    expect(buildSummaryPrompt('[user] hi')).toContain('[user] hi');
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -56,6 +56,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "archive",
     "askUserReply",
     "cancel",
+    "compact",
     "create",
     "fileClaimsDraft",
     "fileDraft",

--- a/tests/renderer/stores/conversation-compact.test.ts
+++ b/tests/renderer/stores/conversation-compact.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `/compact` store wiring (#824): swap the active tab to the fresh,
+ * summarized conversation returned by the main process; leave it alone when
+ * there's nothing to compact.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Conversation, CompactResult } from '../../../src/shared/types';
+
+const h = vi.hoisted(() => {
+  const noop = vi.fn();
+  let nextId = 100;
+  const api = {
+    conversations: {
+      onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onAskUser: noop,
+      saveUIState: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (contextBundle: unknown) => ({
+        id: `conv-${nextId++}`,
+        contextBundle: contextBundle as Conversation['contextBundle'],
+        messages: [],
+        status: 'active' as const,
+        startedAt: 't',
+      })),
+      compact: vi.fn<(id: string) => Promise<CompactResult>>(),
+    },
+  };
+  return { api };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const store = getConversationsStore();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('/compact (#824)', () => {
+  it('swaps the active tab to the compacted conversation', async () => {
+    await store.openFreeform('notes/origin.md');
+    const originalId = store.activeTab!.id;
+
+    const compacted: Conversation = {
+      id: 'conv-compacted',
+      contextBundle: { notePath: 'notes/origin.md' },
+      messages: [
+        { role: 'user', content: '**Summary of earlier conversation** (6 messages compacted):\n\nfoo', timestamp: 't' },
+        { role: 'user', content: 'recent', timestamp: 't' },
+      ],
+      status: 'active',
+      startedAt: 't',
+    };
+    h.api.conversations.compact.mockResolvedValueOnce({ compacted: true, conversation: compacted });
+
+    store.runBuiltinCommand('compact');
+    await vi.waitFor(() => expect(store.activeTab!.id).toBe('conv-compacted'));
+
+    expect(h.api.conversations.compact).toHaveBeenCalledWith(originalId);
+    expect(store.activeTab!.conversation.messages[0].content).toContain('Summary of earlier conversation');
+    expect(store.tabs.filter((t) => t.id === originalId)).toHaveLength(0);
+    expect(store.activeTab!.streaming).toBe(false);
+  });
+
+  it('leaves the conversation untouched when there is nothing to compact', async () => {
+    await store.openFreeform('notes/origin.md');
+    const id = store.activeTab!.id;
+    h.api.conversations.compact.mockResolvedValueOnce({ compacted: false, reason: 'too short' });
+
+    store.runBuiltinCommand('compact');
+    await vi.waitFor(() => expect(store.activeTab!.streaming).toBe(false));
+
+    expect(store.activeTab!.id).toBe(id);
+  });
+});


### PR DESCRIPTION
Re-lands #824 directly onto `main`. The original #859 was merged into a stale stack branch and never reached `main`; the first re-land (#862) auto-closed when its base branch was deleted on #861's merge. This one targets `main`.

Part of #819. Depends on #822 + #823 (both merged).

## What
`/compact` summarizes early turns client-side via `complete()`, archives the original (filed as a `thought:Source`, recoverable), and seeds a fresh conversation with `[summary, ...recent]`. Summarization usage counted (#820). Pure decision/assembly in `llm/compact.ts`. Flips the `compact` built-in to `available`; adds `conversations.compact` to the preload snapshot.

## Tests
- `tests/main/llm/compact.test.ts` — planCompaction (short-skip, prefix/recent split, system exclusion), summary role/usage/trim.
- `tests/renderer/stores/conversation-compact.test.ts` — tab swap; no-op when nothing to compact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)