### PR TITLE
feat: instance-bind Editor.svelte to an editor group (#812)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1188,61 +1188,72 @@
               title="Toggle Right Sidebar (Cmd+Shift+B)"
             ><Icon name="outline" size={12} /></button>
           </div>
+          <!-- Editor instance bound to a specific group (#812). Sources
+               filePath / content / history from that group's active note tab
+               and routes content changes back to it, so each split pane (#813)
+               stays independent. Rendered once today (the active group). -->
+          {#snippet editorPane(group: import('./lib/stores/editor.svelte').EditorGroup)}
+            {@const note = editor.noteTabForGroup(group.id)}
+            {#if note}
+              {#key group.id + ':' + note.relativePath}
+                <Editor
+                  bind:this={editorComponent}
+                  groupId={group.id}
+                  filePath={note.relativePath}
+                  content={note.content}
+                  initialHistory={note.historyJson}
+                  searchQuery={pendingSearchQuery}
+                  onContentChange={(text) => editor.setContent(text, group.id)}
+                  onSave={handleSave}
+                  onSearchQueryConsumed={() => { pendingSearchQuery = null; }}
+                  onEditorStateSave={editor.saveEditorState}
+                  onCursorChange={(info) => { cursorInfo = info; }}
+                  onToolInvoke={handleToolInvoke}
+                  onOpenConversation={openConversation}
+                  onNavigate={handleNavigate}
+                  onOpenSource={handleOpenSource}
+                  onOpenExcerpt={handleOpenExcerpt}
+                  getNotePaths={() => flattenNotePaths(notebase.files)}
+                  getSources={() => sourcesCache}
+                  getAliases={() => aliasEntries}
+                  onBookmark={() => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath)}
+                  onBookmarkSection={() => { void handleBookmarkSection(); }}
+                  onBookmarkLine={handleBookmarkLine}
+                  bookmarks={currentFileBookmarks}
+                  onExtractSelection={handleExtractSelection}
+                  onSplitHere={handleSplitHere}
+                  onSplitByHeading={handleSplitByHeading}
+                  onRename={() => void handleRename(note.relativePath)}
+                  onMove={() => void handleMoveWithPrompt(note.relativePath)}
+                  onCopyFile={() => void handleCopyWithPrompt(note.relativePath)}
+                  onMerge={() => handleMerge(note.relativePath)}
+                  onAutoTag={() => void handleAutoTag(note.relativePath)}
+                  onAutoLink={() => void handleAutoLink(note.relativePath)}
+                  onAutoLinkInbound={() => void handleAutoLinkInbound(note.relativePath)}
+                  onFormatCurrentNote={() => handleFormat()}
+                  onUploadError={(message) => {
+                    // Image-upload rejection (#455). Surface via the
+                    // existing confirm dialog with a dismissable key —
+                    // user-facing but not blocking.
+                    void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
+                  }}
+                  onRunCell={(language, code, notePath) =>
+                    runCellWithTrust(language, code, notePath, { showConfirm })
+                  }
+                  onInsertQueryList={async () => {
+                    const tag = await showPrompt('Tag name:');
+                    if (!tag) return;
+                    const block = `\n:::query-list\nSELECT ?title ?path WHERE {\n  ?note minerva:hasTag ?t .\n  ?t minerva:tagName "${tag}" .\n  ?note dc:title ?title .\n  ?note minerva:relativePath ?path .\n} ORDER BY ?title\n:::\n`;
+                    editorComponent?.insertText(block);
+                  }}
+                />
+              {/key}
+            {/if}
+          {/snippet}
           <div class="editor-content" class:editor-preview={editor.viewMode === 'editor-preview'}>
             {#if editor.viewMode === 'source' || editor.viewMode === 'editor-preview'}
               <div class="editor-panel">
-                {#key editor.activeFilePath}
-                  <Editor
-                    bind:this={editorComponent}
-                    filePath={editor.activeFilePath!}
-                    content={editor.content}
-                    initialHistory={editor.activeNoteTab?.historyJson}
-                    searchQuery={pendingSearchQuery}
-                    onContentChange={editor.setContent}
-                    onSave={handleSave}
-                    onSearchQueryConsumed={() => { pendingSearchQuery = null; }}
-                    onEditorStateSave={editor.saveEditorState}
-                    onCursorChange={(info) => { cursorInfo = info; }}
-                    onToolInvoke={handleToolInvoke}
-                    onOpenConversation={openConversation}
-                    onNavigate={handleNavigate}
-                    onOpenSource={handleOpenSource}
-                    onOpenExcerpt={handleOpenExcerpt}
-                    getNotePaths={() => flattenNotePaths(notebase.files)}
-                    getSources={() => sourcesCache}
-                    getAliases={() => aliasEntries}
-                    onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath); }}
-                    onBookmarkSection={() => { void handleBookmarkSection(); }}
-                    onBookmarkLine={handleBookmarkLine}
-                    bookmarks={currentFileBookmarks}
-                    onExtractSelection={handleExtractSelection}
-                    onSplitHere={handleSplitHere}
-                    onSplitByHeading={handleSplitByHeading}
-                    onRename={() => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); }}
-                    onMove={() => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); }}
-                    onCopyFile={() => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); }}
-                    onMerge={() => { if (editor.activeFilePath) handleMerge(editor.activeFilePath); }}
-                    onAutoTag={() => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); }}
-                    onAutoLink={() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); }}
-                    onAutoLinkInbound={() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); }}
-                    onFormatCurrentNote={() => handleFormat()}
-                    onUploadError={(message) => {
-                      // Image-upload rejection (#455). Surface via the
-                      // existing confirm dialog with a dismissable key —
-                      // user-facing but not blocking.
-                      void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
-                    }}
-                    onRunCell={(language, code, notePath) =>
-                      runCellWithTrust(language, code, notePath, { showConfirm })
-                    }
-                    onInsertQueryList={async () => {
-                      const tag = await showPrompt('Tag name:');
-                      if (!tag) return;
-                      const block = `\n:::query-list\nSELECT ?title ?path WHERE {\n  ?note minerva:hasTag ?t .\n  ?t minerva:tagName "${tag}" .\n  ?note dc:title ?title .\n  ?note minerva:relativePath ?path .\n} ORDER BY ?title\n:::\n`;
-                      editorComponent?.insertText(block);
-                    }}
-                  />
-                {/key}
+                {@render editorPane(editor.activeGroup)}
               </div>
             {/if}
             {#if editor.viewMode === 'preview' || editor.viewMode === 'editor-preview'}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -65,6 +65,14 @@
   import { groupToolsByGroup, hasNamedGroups } from '../../../shared/tools/grouping';
 
   interface Props {
+    /**
+     * The editor group this instance belongs to (#812). The parent sources
+     * `filePath` / `content` / `initialHistory` from this group's active tab
+     * and routes state-changing callbacks back to it, so multiple instances
+     * (one per split pane, #813) stay independent. Surfaced as `data-group-id`
+     * for identification.
+     */
+    groupId: string;
     filePath: string;
     content: string;
     searchQuery?: string | null;
@@ -143,6 +151,7 @@
   }
 
   let {
+    groupId,
     filePath,
     content,
     searchQuery = null,
@@ -942,7 +951,7 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="editor-wrapper" bind:this={editorContainer} oncontextmenu={handleWrapperContextMenu}></div>
+<div class="editor-wrapper" data-group-id={groupId} bind:this={editorContainer} oncontextmenu={handleWrapperContextMenu}></div>
 
 {#if gutterMenu}
   <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -310,6 +310,14 @@ export function getEditorStore() {
     return tab && isNote(tab) ? tab : null;
   }
 
+  /** Active note tab of a specific group — what an `Editor` bound to that group
+   *  renders from (#812). Returns null if the group's active tab isn't a note
+   *  (or the group doesn't exist). */
+  function noteTabForGroup(groupId: string): NoteTab | null {
+    const grp = groups.find((g) => g.id === groupId);
+    return grp ? noteTabOf(grp) : null;
+  }
+
   function scheduleAutoSave() {
     if (autoSaveTimer) clearTimeout(autoSaveTimer);
     autoSaveTimer = setTimeout(async () => {
@@ -671,6 +679,8 @@ export function getEditorStore() {
     // arrives in #813/#814.
     get groups() { return groups; },
     get activeGroupId() { return activeGroupId; },
+    get activeGroup() { return activeGroup(); },
+    noteTabForGroup,
     addGroup,
     setActiveGroup,
     openFile,

--- a/tests/renderer/editor-store.test.ts
+++ b/tests/renderer/editor-store.test.ts
@@ -137,3 +137,46 @@ describe('group-scoped mutations (#811)', () => {
     expect(editor.groups[1].tabs[0].type === 'note' && editor.groups[1].tabs[0].relativePath).toBe('other.md');
   });
 });
+
+describe('group-addressed editor sourcing (#812)', () => {
+  it('noteTabForGroup sources each group independently', async () => {
+    await editor.openFile('one.md'); // group 1
+    const g2 = editor.addGroup();
+    await editor.openFile('two.md', g2);
+
+    const t1 = editor.noteTabForGroup(editor.groups[0].id);
+    const t2 = editor.noteTabForGroup(g2);
+    expect(t1?.relativePath).toBe('one.md');
+    expect(t2?.relativePath).toBe('two.md');
+    expect(t1).not.toBe(t2);
+  });
+
+  it('returns null for an unknown group or a non-note active tab', () => {
+    expect(editor.noteTabForGroup('nope')).toBeNull();
+    const g = editor.addGroup();
+    editor.openQuery('SELECT 1', 'sparql', g);
+    expect(editor.noteTabForGroup(g)).toBeNull();
+  });
+
+  it('content / cursor / scroll / history stay independent per group', async () => {
+    await editor.openFile('a.md'); // group 1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.addGroup();
+    await editor.openFile('b.md', g2);
+
+    // Edit each group's buffer through the group-targeted setter — what the
+    // Editor's onContentChange routes to.
+    editor.setContent('edited-A', g1);
+    editor.setContent('edited-B', g2);
+    expect(editor.noteTabForGroup(g1)?.content).toBe('edited-A');
+    expect(editor.noteTabForGroup(g2)?.content).toBe('edited-B');
+
+    // Per-file cursor/scroll/history capture lands on the right group's tab.
+    editor.saveEditorState('a.md', 10, 100, { hist: 'A' });
+    editor.saveEditorState('b.md', 20, 200, { hist: 'B' });
+    const ta = editor.noteTabForGroup(g1);
+    const tb = editor.noteTabForGroup(g2);
+    expect([ta?.cursorOffset, ta?.scrollTop, ta?.historyJson]).toEqual([10, 100, { hist: 'A' }]);
+    expect([tb?.cursorOffset, tb?.scrollTop, tb?.historyJson]).toEqual([20, 200, { hist: 'B' }]);
+  });
+});


### PR DESCRIPTION
Part of #810 — Phase 2. Depends on #811 (merged). No new dependencies. No behavior change with a single group.

## What
With editor groups (#811), `Editor.svelte` must bind to a *specific* group's active tab so multiple instances can coexist (the layout that renders them is #813).

- **`Editor.svelte`** gains a required `groupId` prop, surfaced as `data-group-id` on the wrapper. The component was already **fully prop-driven** (it reads nothing from the editor store), so "no global `activeNoteTab()` / `activeFilePath` reads inside the component" was already true — the binding is established at the mount.
- **`App.svelte`**: the Editor mount is extracted into a `editorPane(group)` snippet that:
  - sources `filePath` / `content` / `initialHistory` from that group's active note tab (via the new `editor.noteTabForGroup(group.id)`),
  - routes content changes back with `editor.setContent(text, group.id)`,
  - scopes the file-action callbacks (rename / move / copy / merge / auto-tag / auto-link / bookmark) to the **group's** file rather than the global active file,
  - keys remount on `group.id + ':' + path` (so file-switch remounts as before, and a second group would mount its own `EditorView`).
  - Rendered once today — `{@render editorPane(editor.activeGroup)}` — so behavior is identical; #813 renders it per split leaf.
- **Store**: added `activeGroup` getter + `noteTabForGroup(groupId)` — the group-addressed sourcing primitive the snippet uses.

## Why verify at the data layer
`Editor.svelte` is a pure view of its props (heavy CodeMirror; not mounted in the unit suite). Two instances staying independent is therefore a property of the **store** (each group owns its active tab's content/cursor/scroll/history) plus App feeding each its own group's props. The tests pin exactly that.

## Tests (`tests/renderer/editor-store.test.ts`)
- `noteTabForGroup` sources each group independently; returns null for an unknown group or a non-note active tab.
- Per-group **content / cursor / scroll / history** independence — `setContent(text, groupId)` (what `onContentChange` routes to) and `saveEditorState(path, …)` land on the right group's tab.

Full `pnpm test` green (3331).

## Acceptance
- [x] `Editor.svelte` takes a `groupId`; its state derives from that group (via props sourced from `noteTabForGroup`).
- [x] No global `activeNoteTab()` / `activeFilePath` reads inside the editor component (there were none; mount now sources per-group).
- [x] Single-group behavior unchanged (remount on file switch, cursor/scroll/history restore, save).
- [x] Two groups maintain independent cursor/scroll/history (verified at the data layer the editors render from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)