### PR TITLE
feat: recursive editor-layout tree model + split/collapse ops (#813, part 1)

### DIFF
--- a/src/renderer/lib/editor/layout-tree.ts
+++ b/src/renderer/lib/editor/layout-tree.ts
@@ -1,0 +1,112 @@
+/**
+ * Recursive editor-layout tree (#813).
+ *
+ * The editor area is a binary tree of split nodes (each `horizontal` or
+ * `vertical`) with editor-group leaves. A single open file is just a lone leaf,
+ * so the no-split case is the tree `{ kind: 'leaf', groupId }`. These are pure
+ * tree transforms — no Svelte, no store — so the split/collapse/rebalance logic
+ * is unit-testable in isolation; the store wires them to reactive state and the
+ * group lifecycle, and `SplitContainer.svelte` renders them.
+ */
+
+export type SplitDirection = 'horizontal' | 'vertical';
+
+export interface LeafNode {
+  kind: 'leaf';
+  groupId: string;
+}
+
+export interface SplitNode {
+  kind: 'split';
+  direction: SplitDirection;
+  children: LayoutNode[];
+  /** Fractional sizes (sum ≈ 1), one per child, in child order. */
+  sizes: number[];
+}
+
+export type LayoutNode = LeafNode | SplitNode;
+
+export function leaf(groupId: string): LeafNode {
+  return { kind: 'leaf', groupId };
+}
+
+/** Every group id referenced by the tree, in left-to-right (depth-first) order
+ *  — which is also the visual order of the panes. */
+export function collectGroupIds(node: LayoutNode): string[] {
+  if (node.kind === 'leaf') return [node.groupId];
+  return node.children.flatMap(collectGroupIds);
+}
+
+/** Normalize a sizes array to sum to 1 (guards against drift / bad input). */
+function normalizeSizes(sizes: number[]): number[] {
+  const total = sizes.reduce((a, b) => a + (b > 0 ? b : 0), 0);
+  if (total <= 0) return sizes.map(() => 1 / sizes.length);
+  return sizes.map((s) => (s > 0 ? s : 0) / total);
+}
+
+/**
+ * Split the leaf holding `groupId` into a two-child split that adds
+ * `newGroupId` alongside it.
+ *
+ * If the leaf's existing parent split runs in the *same* direction, the new
+ * leaf is inserted as a flat sibling (keeping the tree shallow and the existing
+ * panes' relative sizes intact). Otherwise the leaf is replaced by a fresh
+ * binary split of the requested direction, 50/50. Returns a new tree; the
+ * original is not mutated.
+ */
+export function splitLeaf(
+  root: LayoutNode,
+  groupId: string,
+  direction: SplitDirection,
+  newGroupId: string,
+): LayoutNode {
+  // Root is the target leaf → wrap it directly (no parent to flatten into).
+  if (root.kind === 'leaf') {
+    if (root.groupId !== groupId) return root;
+    return { kind: 'split', direction, children: [leaf(groupId), leaf(newGroupId)], sizes: [0.5, 0.5] };
+  }
+
+  // Same-direction parent that directly contains the target leaf → insert a
+  // flat sibling right after it, splitting the target's slice in two so the
+  // other panes keep their sizes.
+  if (root.direction === direction) {
+    const idx = root.children.findIndex((c) => c.kind === 'leaf' && c.groupId === groupId);
+    if (idx !== -1) {
+      const children = [...root.children];
+      const sizes = [...root.sizes];
+      children.splice(idx + 1, 0, leaf(newGroupId));
+      const half = sizes[idx] / 2;
+      sizes.splice(idx, 1, half, half);
+      return { ...root, children, sizes: normalizeSizes(sizes) };
+    }
+  }
+
+  // Otherwise recurse into children, rebuilding the path to the change.
+  return {
+    ...root,
+    children: root.children.map((c) => splitLeaf(c, groupId, direction, newGroupId)),
+  };
+}
+
+/**
+ * Remove the leaf holding `groupId` and rebalance: a split left with a single
+ * child collapses into that child. Returns the new tree, or `null` if the leaf
+ * was the entire tree (caller keeps the last pane — the window always has one).
+ */
+export function removeLeaf(root: LayoutNode, groupId: string): LayoutNode | null {
+  if (root.kind === 'leaf') {
+    return root.groupId === groupId ? null : root;
+  }
+  const kept: LayoutNode[] = [];
+  const keptSizes: number[] = [];
+  root.children.forEach((child, i) => {
+    const next = removeLeaf(child, groupId);
+    if (next !== null) {
+      kept.push(next);
+      keptSizes.push(root.sizes[i]);
+    }
+  });
+  if (kept.length === 0) return null;
+  if (kept.length === 1) return kept[0]; // collapse single-child split
+  return { ...root, children: kept, sizes: normalizeSizes(keptSizes) };
+}

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -1,6 +1,14 @@
 import { api } from '../ipc/client';
 import type { TabSession, SavedTab } from '../../../shared/types';
 import { normalizeSqlRows, unionColumns } from '../editor/sql-result';
+import {
+  type LayoutNode,
+  type SplitDirection,
+  leaf,
+  splitLeaf,
+  removeLeaf,
+  collectGroupIds,
+} from '../editor/layout-tree';
 
 // ── Tab types ───────────────────────────────────────────────────────────────
 
@@ -98,6 +106,9 @@ const groups = $state<EditorGroup[]>([
   { id: newGroupId(), tabs: [], activeIndex: -1, viewMode: 'source' },
 ]);
 let activeGroupId = $state(groups[0].id);
+// Recursive split layout (#813). A lone leaf = the single-pane case (today);
+// `splitGroup` grows it into a tree, `collapseGroup` rebalances it back.
+let layout = $state<LayoutNode>(leaf(groups[0].id));
 
 let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let tabPersistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -156,6 +167,41 @@ export function getEditorStore() {
 
   function setActiveGroup(id: string): void {
     if (groups.some((g) => g.id === id)) activeGroupId = id;
+  }
+
+  // ── Split layout (#813) ───────────────────────────────────────────────────
+
+  /**
+   * Split the pane holding `groupId` along `direction`, creating an empty new
+   * group beside it and focusing it. The new pane starts empty — opening a file
+   * (which targets the active group) populates it. Returns the new group id.
+   */
+  function splitGroup(groupId: string, direction: SplitDirection): string {
+    const source = groups.find((g) => g.id === groupId);
+    // New pane inherits the splitting pane's view mode so the split feels
+    // continuous; falls back to 'source'.
+    const newId = addGroup(source?.viewMode ?? 'source');
+    layout = splitLeaf(layout, groupId, direction, newId);
+    activeGroupId = newId;
+    return newId;
+  }
+
+  /**
+   * Remove a group's pane from the layout and rebalance the tree (a split left
+   * with one child collapses into it). No-op for the last remaining pane — the
+   * window always keeps one. Drops the group from `groups` and reassigns focus
+   * to the first surviving pane if the collapsed one was active.
+   */
+  function collapseGroup(groupId: string): void {
+    if (groups.length <= 1) return;
+    const next = removeLeaf(layout, groupId);
+    if (next === null) return; // was the whole tree — keep it
+    layout = next;
+    const idx = groups.findIndex((g) => g.id === groupId);
+    if (idx !== -1) groups.splice(idx, 1);
+    if (activeGroupId === groupId) {
+      activeGroupId = collectGroupIds(layout)[0] ?? groups[0]?.id;
+    }
   }
 
   // ── Source operations ───────────────────────────────────────────────────
@@ -558,6 +604,10 @@ export function getEditorStore() {
     grp.tabs.splice(index, 1);
     if (grp.tabs.length === 0) {
       grp.activeIndex = -1;
+      // Closing a split pane's last tab collapses the pane and rebalances the
+      // tree (#813). The final pane is kept (collapseGroup no-ops there) so a
+      // lone editor empties to its "no file" state exactly as today.
+      collapseGroup(grp.id);
     } else if (index <= grp.activeIndex) {
       grp.activeIndex = Math.max(0, grp.activeIndex - 1);
     }
@@ -653,10 +703,12 @@ export function getEditorStore() {
 
   function clear() {
     flushAutoSave();
-    // Collapse back to a single empty group — the start-of-session shape.
+    // Collapse back to a single empty group + single-leaf layout — the
+    // start-of-session shape.
     groups.length = 0;
     groups.push({ id: newGroupId(), tabs: [], activeIndex: -1, viewMode: 'source' });
     activeGroupId = groups[0].id;
+    layout = leaf(groups[0].id);
   }
 
   return {
@@ -680,9 +732,12 @@ export function getEditorStore() {
     get groups() { return groups; },
     get activeGroupId() { return activeGroupId; },
     get activeGroup() { return activeGroup(); },
+    get layout() { return layout; },
     noteTabForGroup,
     addGroup,
     setActiveGroup,
+    splitGroup,
+    collapseGroup,
     openFile,
     openSource,
     openPdf,

--- a/tests/renderer/editor-store.test.ts
+++ b/tests/renderer/editor-store.test.ts
@@ -180,3 +180,76 @@ describe('group-addressed editor sourcing (#812)', () => {
     expect([tb?.cursorOffset, tb?.scrollTop, tb?.historyJson]).toEqual([20, 200, { hist: 'B' }]);
   });
 });
+
+describe('split layout ops (#813)', () => {
+  it('starts as a single leaf for the lone group', () => {
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: editor.groups[0].id });
+  });
+
+  it('splitGroup grows the tree, creates a new empty group, and focuses it', async () => {
+    await editor.openFile('a.md');
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+
+    expect(editor.groups).toHaveLength(2);
+    expect(editor.activeGroupId).toBe(g2);
+    expect(editor.layout).toMatchObject({
+      kind: 'split',
+      direction: 'horizontal',
+      children: [{ kind: 'leaf', groupId: g1 }, { kind: 'leaf', groupId: g2 }],
+    });
+    // New pane is empty; opening a file lands in it (the active group).
+    expect(editor.noteTabForGroup(g2)).toBeNull();
+    await editor.openFile('b.md');
+    expect(editor.noteTabForGroup(g2)?.relativePath).toBe('b.md');
+    expect(editor.noteTabForGroup(g1)?.relativePath).toBe('a.md');
+  });
+
+  it('new pane inherits the splitting pane\'s view mode', async () => {
+    const g1 = editor.groups[0].id;
+    editor.setViewMode('preview', g1);
+    const g2 = editor.splitGroup(g1, 'vertical');
+    expect(editor.groups.find((g) => g.id === g2)?.viewMode).toBe('preview');
+  });
+
+  it('collapseGroup removes the pane, rebalances the tree, and reassigns focus', async () => {
+    await editor.openFile('a.md');
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    expect(editor.activeGroupId).toBe(g2);
+
+    editor.collapseGroup(g2);
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: g1 });
+    expect(editor.activeGroupId).toBe(g1); // focus fell back to the survivor
+  });
+
+  it('collapseGroup is a no-op for the last remaining pane', () => {
+    const only = editor.groups[0].id;
+    editor.collapseGroup(only);
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: only });
+  });
+
+  it('closing a split pane\'s last tab collapses it', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    await editor.openFile('b.md'); // into g2 (active)
+    expect(editor.groups).toHaveLength(2);
+
+    // Close g2's only tab → pane collapses, tree returns to the lone leaf.
+    editor.closeTab(0, g2);
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: g1 });
+  });
+
+  it('closing the last tab of the only pane empties it without collapsing', async () => {
+    await editor.openFile('a.md');
+    const only = editor.groups[0].id;
+    editor.closeTab(0);
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: only });
+    expect(editor.tabs).toHaveLength(0);
+  });
+});

--- a/tests/renderer/layout-tree.test.ts
+++ b/tests/renderer/layout-tree.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Recursive editor-layout tree transforms (#813).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  leaf,
+  splitLeaf,
+  removeLeaf,
+  collectGroupIds,
+  type LayoutNode,
+} from '../../src/renderer/lib/editor/layout-tree';
+
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0);
+
+describe('splitLeaf', () => {
+  it('wraps a lone leaf into a 50/50 binary split', () => {
+    const next = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
+    expect(next).toEqual({
+      kind: 'split',
+      direction: 'horizontal',
+      children: [leaf('a'), leaf('b')],
+      sizes: [0.5, 0.5],
+    });
+  });
+
+  it('inserts a flat sibling when the parent runs the same direction', () => {
+    const root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b'); // [a|b]
+    const next = splitLeaf(root, 'b', 'horizontal', 'c') as Extract<LayoutNode, { kind: 'split' }>;
+    // Stays one horizontal split of three, not a nested split.
+    expect(next.kind).toBe('split');
+    expect(collectGroupIds(next)).toEqual(['a', 'b', 'c']);
+    expect(next.children.every((c) => c.kind === 'leaf')).toBe(true);
+    expect(sum(next.sizes)).toBeCloseTo(1, 6);
+    // a kept its half; b's half was divided between b and c.
+    expect(next.sizes[0]).toBeCloseTo(0.5, 6);
+    expect(next.sizes[1]).toBeCloseTo(0.25, 6);
+    expect(next.sizes[2]).toBeCloseTo(0.25, 6);
+  });
+
+  it('nests a split of the opposite direction', () => {
+    const root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b'); // [a|b]
+    const next = splitLeaf(root, 'b', 'vertical', 'c') as Extract<LayoutNode, { kind: 'split' }>;
+    expect(next.direction).toBe('horizontal');
+    expect(next.children[0]).toEqual(leaf('a'));
+    const nested = next.children[1] as Extract<LayoutNode, { kind: 'split' }>;
+    expect(nested.kind).toBe('split');
+    expect(nested.direction).toBe('vertical');
+    expect(collectGroupIds(nested)).toEqual(['b', 'c']);
+  });
+
+  it('is a no-op for an unknown group id', () => {
+    const root = leaf('a');
+    expect(splitLeaf(root, 'zzz', 'horizontal', 'b')).toEqual(root);
+  });
+
+  it('does not mutate the original tree', () => {
+    const root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
+    const snapshot = JSON.parse(JSON.stringify(root));
+    splitLeaf(root, 'b', 'horizontal', 'c');
+    expect(root).toEqual(snapshot);
+  });
+});
+
+describe('removeLeaf', () => {
+  it('returns null when removing the only leaf', () => {
+    expect(removeLeaf(leaf('a'), 'a')).toBeNull();
+  });
+
+  it('collapses a two-child split into the surviving child', () => {
+    const root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b'); // [a|b]
+    expect(removeLeaf(root, 'b')).toEqual(leaf('a'));
+    expect(removeLeaf(root, 'a')).toEqual(leaf('b'));
+  });
+
+  it('keeps a three-way split as a split, renormalizing sizes', () => {
+    let root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
+    root = splitLeaf(root, 'b', 'horizontal', 'c'); // [a|b|c]
+    const next = removeLeaf(root, 'b') as Extract<LayoutNode, { kind: 'split' }>;
+    expect(collectGroupIds(next)).toEqual(['a', 'c']);
+    expect(sum(next.sizes)).toBeCloseTo(1, 6);
+  });
+
+  it('rebalances nested splits (collapse bubbles up)', () => {
+    let root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b'); // [a|b]
+    root = splitLeaf(root, 'b', 'vertical', 'c'); // a | (b/c)
+    // Removing c collapses the vertical split back to a leaf b, leaving [a|b].
+    const next = removeLeaf(root, 'c') as Extract<LayoutNode, { kind: 'split' }>;
+    expect(next.kind).toBe('split');
+    expect(next.children).toEqual([leaf('a'), leaf('b')]);
+  });
+
+  it('returns the tree unchanged when the leaf is absent', () => {
+    const root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
+    expect(removeLeaf(root, 'zzz')).toEqual(root);
+  });
+});
+
+describe('collectGroupIds', () => {
+  it('lists ids in left-to-right visual order', () => {
+    let root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
+    root = splitLeaf(root, 'b', 'vertical', 'c'); // a | (b/c)
+    expect(collectGroupIds(root)).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
Part of #810 — Phase 3, **part 1 of 2**. Depends on #811 + #812 (both merged). No new dependencies.

This lands the **layout model** that pane-splitting renders — the part that's fully unit-verifiable. The visible half (`SplitContainer` / `ResizeHandle` recursive render + drag-resize + App center-column rewrite + split triggers) follows in **part 2**, where the recursive render and drag math can be exercised in a running window.

## What
- **`lib/editor/layout-tree.ts`** — a binary `LayoutNode` tree (locked design: recursive, not capped 2-pane):
  ```ts
  type LayoutNode =
    | { kind: 'leaf'; groupId: string }
    | { kind: 'split'; direction: 'horizontal' | 'vertical'; children: LayoutNode[]; sizes: number[] };
  ```
  Pure transforms: `splitLeaf` (inserts a flat sibling into a same-direction parent to keep the tree shallow, else nests a new split), `removeLeaf` (collapses single-child splits and renormalizes sizes), `collectGroupIds` (left-to-right pane order). All immutable — no in-place mutation.
- **Store** — a `layout` `$state` (a lone leaf today = the current single-pane case), plus:
  - `splitGroup(groupId, direction)` — creates and focuses an empty new pane (view mode inherited from the splitting pane); opening a file then lands in it.
  - `collapseGroup(groupId)` — rebalances the tree, drops the group, reassigns focus; **no-ops on the last pane** (the window always keeps one).
  - `closeTab` now **auto-collapses** a split pane when its last tab closes; the lone pane just empties to its "no file" state, exactly as today.
  - `clear()` resets to the single-leaf shape.

## Tests
- `tests/renderer/layout-tree.test.ts` — split (wrap / flat-sibling / nest / no-op / immutability), remove (null-on-last / collapse / three-way renormalize / nested-rebalance / absent), `collectGroupIds` order.
- `tests/renderer/editor-store.test.ts` (new `#813` block) — grow + focus + inherit view mode, collapse + rebalance + refocus, last-pane no-op, close-last-tab auto-collapse, lone-pane empties without collapsing.

Full `pnpm test` green (3349); lint clean. **No behavior change yet** — nothing renders the tree until part 2.

## Acceptance (this PR covers the model; rendering acceptance lands in part 2)
- [x] Layout tree type + store ops (`split`, `collapseGroup`).
- [x] Closing a group's last tab collapses the pane and the tree rebalances.
- [x] Single-pane shape (one leaf) is the default and unchanged.
- [ ] `SplitContainer` recursive render + drag-resize + per-group TabBar/toolbar → **part 2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)