### PR TITLE
feat: recursive split layout — SplitContainer + dividers + per-group panes (#813, part 2)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -3,6 +3,7 @@
   import TabBar from './lib/components/TabBar.svelte';
   import Sidebar from './lib/components/Sidebar.svelte';
   import Editor from './lib/components/Editor.svelte';
+  import SplitContainer from './lib/components/SplitContainer.svelte';
   import QueryPanel from './lib/components/QueryPanel.svelte';
   import RightSidebar from './lib/components/RightSidebar.svelte';
   import StatusBar from './lib/components/StatusBar.svelte';
@@ -99,13 +100,9 @@
   const toolPanel = getToolPanelStore();
   const conversationsStore = getConversationsStore();
   const bookmarkStore = getBookmarksStore();
-  // Position-bearing bookmarks for the active file, fed to the editor's
-  // gutter-flag extension (#756). Recomputes as bookmarks are added/removed.
-  const currentFileBookmarks = $derived(
-    editor.activeFilePath
-      ? collectBookmarksForPath(bookmarkStore.tree, editor.activeFilePath)
-      : [],
-  );
+  // Position-bearing bookmarks are resolved per pane at the Editor mount via
+  // `collectBookmarksForPath(bookmarkStore.tree, <that pane's file>)` (#813),
+  // so each split pane shows its own file's gutter flags (#756).
   let showSettings = $state(false);
   /** Tab the SettingsDialog should land on when next opened. Cleared
    *  on close so the next manual open returns to the default Editor
@@ -193,9 +190,17 @@
   let sidebar = $state<Sidebar>();
   let rightSidebar = $state<RightSidebar>();
   let rightSidebarVisible = $state(false);
-  let editorComponent = $state<Editor>();
-  let queryPanelComponent = $state<QueryPanel>();
-  let previewComponent = $state<Preview>();
+  // Per-group component instances, keyed by group id (#813). Each split pane
+  // binds its own Editor / Preview / QueryPanel into these maps; the bare
+  // `editorComponent` / `previewComponent` / `queryPanelComponent` accessors
+  // resolve to the *active* group's instance so all the imperative command
+  // sites (nav, goto-line, insert, theme re-skin) target the focused pane.
+  let editorComponents = $state<Record<string, Editor | undefined>>({});
+  let queryPanelComponents = $state<Record<string, QueryPanel | undefined>>({});
+  let previewComponents = $state<Record<string, Preview | undefined>>({});
+  const editorComponent = $derived(editorComponents[editor.activeGroupId]);
+  const queryPanelComponent = $derived(queryPanelComponents[editor.activeGroupId]);
+  const previewComponent = $derived(previewComponents[editor.activeGroupId]);
   let toolPanelComponent = $state<ToolPanel>();
   let cursorInfo = $state<CursorInfo>({ line: 1, column: 1, selectionLength: 0, wordCount: 0 });
 
@@ -735,7 +740,10 @@
     previewComponent?.updateTheme();
   }
 
-  async function handleSwitchTab(index: number) {
+  async function handleSwitchTab(index: number, groupId?: string) {
+    // Focus the target pane first so the active-group delegates (editor.tabs,
+    // editor.openFile, the editorComponent accessor) all operate on it (#813).
+    if (groupId) editor.setActiveGroup(groupId);
     recordCurrentPosition();
 
     const targetTab = editor.tabs[index];
@@ -1132,156 +1140,218 @@
           void handleExternalDrop(destDir, files);
         }}
       >
-        {#if editor.tabs.length > 0}
-          <TabBar
-            tabs={editor.tabs}
-            activeIndex={editor.activeIndex}
-            sources={sourcesCache}
-            onSwitch={handleSwitchTab}
-            onClose={editor.closeTab}
-            onCloseOthers={editor.closeOthers}
-            onCloseAll={editor.closeAll}
-            onReveal={handleRevealInSidebar}
-            onOpenConversation={openConversation}
-            onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
-            onNewTab={() => handleNewNote()}
-          />
-        {/if}
-        {#if editor.activeTab?.type === 'note'}
-          <BreadcrumbsBar
-            filePath={editor.activeFilePath}
-            content={editor.activeTab.content}
-            cursorLine={cursorInfo.line}
-            showHeadings={breadcrumbsSettings.showHeadingChain}
-            onRevealFolder={(folder) => { void sidebar?.revealFolder(folder); }}
-            onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
-          />
-        {/if}
-        {#if editor.activeTab?.type === 'note' && editor.activeTab.relativePath.endsWith('.csv')}
-          <CsvTable
-            relativePath={editor.activeTab.relativePath}
-            content={editor.activeTab.content}
-          />
-        {:else if editor.activeTab?.type === 'note'}
-          <div class="toolbar">
-            <div class="view-toggle">
-              <button
-                class:active={editor.viewMode === 'source'}
-                onclick={() => editor.setViewMode('source')}
-                title="Source (Cmd+Shift+P to cycle)"
-              >Source</button>
-              <button
-                class:active={editor.viewMode === 'editor-preview'}
-                onclick={() => editor.setViewMode('editor-preview')}
-                title="Source + preview side by side"
-              >Side by side</button>
-              <button
-                class:active={editor.viewMode === 'preview'}
-                onclick={() => editor.setViewMode('preview')}
-                title="Preview"
-              >Preview</button>
+        <!-- Per-group pane (#813): one editor group's tab bar + active-tab
+             content, rendered at each leaf of the recursive split layout.
+             Clicking anywhere in a pane focuses its group so the active-group
+             delegates (commands, status bar, right sidebar) follow it. -->
+        {#snippet groupPane(groupId: string)}
+          {@const group = editor.groups.find((g) => g.id === groupId)}
+          {#if group}
+            {@const active = group.tabs[group.activeIndex] ?? null}
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="group-pane"
+              class:focused={groupId === editor.activeGroupId && editor.groups.length > 1}
+              onpointerdowncapture={() => editor.setActiveGroup(groupId)}
+            >
+              {#if group.tabs.length > 0}
+                <TabBar
+                  tabs={group.tabs}
+                  activeIndex={group.activeIndex}
+                  sources={sourcesCache}
+                  onSwitch={(i) => handleSwitchTab(i, groupId)}
+                  onClose={(i) => editor.closeTab(i, groupId)}
+                  onCloseOthers={(i) => editor.closeOthers(i, groupId)}
+                  onCloseAll={() => editor.closeAll(groupId)}
+                  onReveal={handleRevealInSidebar}
+                  onOpenConversation={openConversation}
+                  onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
+                  onNewTab={() => { editor.setActiveGroup(groupId); void handleNewNote(); }}
+                />
+              {/if}
+              {#if active?.type === 'note'}
+                <BreadcrumbsBar
+                  filePath={active.relativePath}
+                  content={active.content}
+                  cursorLine={cursorInfo.line}
+                  showHeadings={breadcrumbsSettings.showHeadingChain}
+                  onRevealFolder={(folder) => { void sidebar?.revealFolder(folder); }}
+                  onScrollToLine={(line) => editorComponents[groupId]?.gotoLineColumn(line, 1)}
+                />
+              {/if}
+              {#if active?.type === 'note' && active.relativePath.endsWith('.csv')}
+                <CsvTable relativePath={active.relativePath} content={active.content} />
+              {:else if active?.type === 'note'}
+                {@const note = active}
+                <div class="toolbar">
+                  <div class="view-toggle">
+                    <button
+                      class:active={group.viewMode === 'source'}
+                      onclick={() => editor.setViewMode('source', groupId)}
+                      title="Source (Cmd+Shift+P to cycle)"
+                    >Source</button>
+                    <button
+                      class:active={group.viewMode === 'editor-preview'}
+                      onclick={() => editor.setViewMode('editor-preview', groupId)}
+                      title="Source + preview side by side"
+                    >Side by side</button>
+                    <button
+                      class:active={group.viewMode === 'preview'}
+                      onclick={() => editor.setViewMode('preview', groupId)}
+                      title="Preview"
+                    >Preview</button>
+                  </div>
+                  <button
+                    class="nav-btn"
+                    onclick={() => editor.splitGroup(groupId, 'horizontal')}
+                    title="Split right"
+                  ><Icon name="split-h" size={12} /></button>
+                  <button
+                    class="nav-btn"
+                    onclick={() => editor.splitGroup(groupId, 'vertical')}
+                    title="Split down"
+                  ><Icon name="split-v" size={12} /></button>
+                  <button
+                    class="nav-btn sidebar-toggle"
+                    class:active={rightSidebarVisible}
+                    onclick={() => { rightSidebarVisible = !rightSidebarVisible; }}
+                    title="Toggle Right Sidebar (Cmd+Shift+B)"
+                  ><Icon name="outline" size={12} /></button>
+                </div>
+                <div class="editor-content" class:editor-preview={group.viewMode === 'editor-preview'}>
+                  {#if group.viewMode === 'source' || group.viewMode === 'editor-preview'}
+                    <div class="editor-panel">
+                      {#key groupId + ':' + note.relativePath}
+                        <Editor
+                          bind:this={editorComponents[groupId]}
+                          groupId={groupId}
+                          filePath={note.relativePath}
+                          content={note.content}
+                          initialHistory={note.historyJson}
+                          searchQuery={pendingSearchQuery}
+                          onContentChange={(text) => editor.setContent(text, groupId)}
+                          onSave={handleSave}
+                          onSearchQueryConsumed={() => { pendingSearchQuery = null; }}
+                          onEditorStateSave={editor.saveEditorState}
+                          onCursorChange={(info) => { cursorInfo = info; }}
+                          onToolInvoke={handleToolInvoke}
+                          onOpenConversation={openConversation}
+                          onNavigate={handleNavigate}
+                          onOpenSource={handleOpenSource}
+                          onOpenExcerpt={handleOpenExcerpt}
+                          getNotePaths={() => flattenNotePaths(notebase.files)}
+                          getSources={() => sourcesCache}
+                          getAliases={() => aliasEntries}
+                          onBookmark={() => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath)}
+                          onBookmarkSection={() => { void handleBookmarkSection(); }}
+                          onBookmarkLine={handleBookmarkLine}
+                          bookmarks={collectBookmarksForPath(bookmarkStore.tree, note.relativePath)}
+                          onExtractSelection={handleExtractSelection}
+                          onSplitHere={handleSplitHere}
+                          onSplitByHeading={handleSplitByHeading}
+                          onRename={() => void handleRename(note.relativePath)}
+                          onMove={() => void handleMoveWithPrompt(note.relativePath)}
+                          onCopyFile={() => void handleCopyWithPrompt(note.relativePath)}
+                          onMerge={() => handleMerge(note.relativePath)}
+                          onAutoTag={() => void handleAutoTag(note.relativePath)}
+                          onAutoLink={() => void handleAutoLink(note.relativePath)}
+                          onAutoLinkInbound={() => void handleAutoLinkInbound(note.relativePath)}
+                          onFormatCurrentNote={() => handleFormat()}
+                          onUploadError={(message) => {
+                            void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
+                          }}
+                          onRunCell={(language, code, notePath) =>
+                            runCellWithTrust(language, code, notePath, { showConfirm })
+                          }
+                          onInsertQueryList={async () => {
+                            const tag = await showPrompt('Tag name:');
+                            if (!tag) return;
+                            const block = `\n:::query-list\nSELECT ?title ?path WHERE {\n  ?note minerva:hasTag ?t .\n  ?t minerva:tagName "${tag}" .\n  ?note dc:title ?title .\n  ?note minerva:relativePath ?path .\n} ORDER BY ?title\n:::\n`;
+                            editorComponents[groupId]?.insertText(block);
+                          }}
+                        />
+                      {/key}
+                    </div>
+                  {/if}
+                  {#if group.viewMode === 'preview' || group.viewMode === 'editor-preview'}
+                    <div class="preview-panel">
+                      <Preview
+                        bind:this={previewComponents[groupId]}
+                        content={note.content}
+                        notePath={note.relativePath}
+                        onNavigate={handleNavigate}
+                        onTagSelect={handleTagSelect}
+                        onOpenSource={handleOpenSource}
+                        onOpenExcerpt={handleOpenExcerpt}
+                        pendingAnchor={pendingPreviewAnchor}
+                        onAnchorResolved={() => { pendingPreviewAnchor = null; }}
+                        onTaskToggle={handleTaskToggle}
+                        onDoiClick={handleDoiClick}
+                        onSaveCellOutput={handleSaveCellOutput}
+                        onToolInvoke={handleToolInvoke}
+                        onOpenConversation={openConversation}
+                        onBookmark={() => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath)}
+                        onRunCell={(language, code, notePath) =>
+                          runCellWithTrust(language, code, notePath, { showConfirm })
+                        }
+                        onApplyCellOutputEdit={(newContent) => { editor.setContent(newContent, groupId); }}
+                      />
+                    </div>
+                  {/if}
+                </div>
+              {:else if active?.type === 'query'}
+                <QueryPanel
+                  bind:this={queryPanelComponents[groupId]}
+                  tab={active}
+                  onQueryChange={editor.setQueryText}
+                  onLanguageChange={editor.setQueryLanguage}
+                  onExecute={editor.executeQuery}
+                  onSave={handleSaveQuery}
+                />
+              {:else if active?.type === 'source'}
+                {#key active.sourceId}
+                  <SourceDetail
+                    sourceId={active.sourceId}
+                    highlightExcerptId={active.highlightExcerptId}
+                    onNavigate={handleNavigate}
+                    onShowConfirm={showConfirm}
+                    onShowPrompt={showPrompt}
+                    onDeleted={handleSourceDeleted}
+                    onCreateAboutNote={handleNewAboutSourceNote}
+                    onOpenReference={handleOpenSource}
+                    onResolveStub={handleResolveStub}
+                    onOpenPdf={handleOpenPdf}
+                    onCreateNoteFromExcerpt={handleCreateNoteFromExcerpt}
+                    onAppendExcerptToCurrent={handleAppendExcerptToCurrent}
+                    canAppendToCurrent={lastNotePath !== null}
+                    onInvokeTool={handleToolInvoke}
+                  />
+                {/key}
+              {:else if active?.type === 'pdf'}
+                {#key active.sourceId}
+                  <!-- Lazy: pdfjs-dist only loads when a PDF tab is opened (#691). -->
+                  {#await import('./lib/components/PdfViewer.svelte') then { default: PdfViewer }}
+                    <PdfViewer
+                      sourceId={active.sourceId}
+                      initialPage={active.page}
+                      onShowMarkdown={handleShowMarkdownFromPdf}
+                    />
+                  {/await}
+                {/key}
+              {:else}
+                <div class="no-file">
+                  <p>Select a note from the sidebar</p>
+                </div>
+              {/if}
             </div>
-            <button
-              class="nav-btn sidebar-toggle"
-              class:active={rightSidebarVisible}
-              onclick={() => { rightSidebarVisible = !rightSidebarVisible; }}
-              title="Toggle Right Sidebar (Cmd+Shift+B)"
-            ><Icon name="outline" size={12} /></button>
-          </div>
-          <!-- Editor instance bound to a specific group (#812). Sources
-               filePath / content / history from that group's active note tab
-               and routes content changes back to it, so each split pane (#813)
-               stays independent. Rendered once today (the active group). -->
-          {#snippet editorPane(group: import('./lib/stores/editor.svelte').EditorGroup)}
-            {@const note = editor.noteTabForGroup(group.id)}
-            {#if note}
-              {#key group.id + ':' + note.relativePath}
-                <Editor
-                  bind:this={editorComponent}
-                  groupId={group.id}
-                  filePath={note.relativePath}
-                  content={note.content}
-                  initialHistory={note.historyJson}
-                  searchQuery={pendingSearchQuery}
-                  onContentChange={(text) => editor.setContent(text, group.id)}
-                  onSave={handleSave}
-                  onSearchQueryConsumed={() => { pendingSearchQuery = null; }}
-                  onEditorStateSave={editor.saveEditorState}
-                  onCursorChange={(info) => { cursorInfo = info; }}
-                  onToolInvoke={handleToolInvoke}
-                  onOpenConversation={openConversation}
-                  onNavigate={handleNavigate}
-                  onOpenSource={handleOpenSource}
-                  onOpenExcerpt={handleOpenExcerpt}
-                  getNotePaths={() => flattenNotePaths(notebase.files)}
-                  getSources={() => sourcesCache}
-                  getAliases={() => aliasEntries}
-                  onBookmark={() => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath)}
-                  onBookmarkSection={() => { void handleBookmarkSection(); }}
-                  onBookmarkLine={handleBookmarkLine}
-                  bookmarks={currentFileBookmarks}
-                  onExtractSelection={handleExtractSelection}
-                  onSplitHere={handleSplitHere}
-                  onSplitByHeading={handleSplitByHeading}
-                  onRename={() => void handleRename(note.relativePath)}
-                  onMove={() => void handleMoveWithPrompt(note.relativePath)}
-                  onCopyFile={() => void handleCopyWithPrompt(note.relativePath)}
-                  onMerge={() => handleMerge(note.relativePath)}
-                  onAutoTag={() => void handleAutoTag(note.relativePath)}
-                  onAutoLink={() => void handleAutoLink(note.relativePath)}
-                  onAutoLinkInbound={() => void handleAutoLinkInbound(note.relativePath)}
-                  onFormatCurrentNote={() => handleFormat()}
-                  onUploadError={(message) => {
-                    // Image-upload rejection (#455). Surface via the
-                    // existing confirm dialog with a dismissable key —
-                    // user-facing but not blocking.
-                    void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
-                  }}
-                  onRunCell={(language, code, notePath) =>
-                    runCellWithTrust(language, code, notePath, { showConfirm })
-                  }
-                  onInsertQueryList={async () => {
-                    const tag = await showPrompt('Tag name:');
-                    if (!tag) return;
-                    const block = `\n:::query-list\nSELECT ?title ?path WHERE {\n  ?note minerva:hasTag ?t .\n  ?t minerva:tagName "${tag}" .\n  ?note dc:title ?title .\n  ?note minerva:relativePath ?path .\n} ORDER BY ?title\n:::\n`;
-                    editorComponent?.insertText(block);
-                  }}
-                />
-              {/key}
-            {/if}
-          {/snippet}
-          <div class="editor-content" class:editor-preview={editor.viewMode === 'editor-preview'}>
-            {#if editor.viewMode === 'source' || editor.viewMode === 'editor-preview'}
-              <div class="editor-panel">
-                {@render editorPane(editor.activeGroup)}
-              </div>
-            {/if}
-            {#if editor.viewMode === 'preview' || editor.viewMode === 'editor-preview'}
-              <div class="preview-panel">
-                <Preview
-                  bind:this={previewComponent}
-                  content={editor.content}
-                  notePath={editor.activeFilePath}
-                  onNavigate={handleNavigate}
-                  onTagSelect={handleTagSelect}
-                  onOpenSource={handleOpenSource}
-                  onOpenExcerpt={handleOpenExcerpt}
-                  pendingAnchor={pendingPreviewAnchor}
-                  onAnchorResolved={() => { pendingPreviewAnchor = null; }}
-                  onTaskToggle={handleTaskToggle}
-                  onDoiClick={handleDoiClick}
-                  onSaveCellOutput={handleSaveCellOutput}
-                  onToolInvoke={handleToolInvoke}
-                  onOpenConversation={openConversation}
-                  onBookmark={() => { if (editor.activeFilePath) bookmarkStore.add(editor.activeFileName.replace(/\.(md|ttl|csv)$/, ''), editor.activeFilePath); }}
-                  onRunCell={(language, code, notePath) =>
-                    runCellWithTrust(language, code, notePath, { showConfirm })
-                  }
-                  onApplyCellOutputEdit={(newContent) => { editor.setContent(newContent); }}
-                />
-              </div>
-            {/if}
-          </div>
+          {/if}
+        {/snippet}
+
+        <SplitContainer node={editor.layout} leaf={groupPane} />
+
+        <!-- Window-level status + tool surfaces, reflecting the active group's
+             note. (Per-group status bars are #817 polish.) -->
+        {#if editor.activeTab?.type === 'note'}
           <StatusBar
             cursor={cursorInfo}
             fontSize={editorFontSize}
@@ -1304,50 +1374,6 @@
             onOpenConversation={handleOpenConversationFromTool}
             onMissingApiKey={() => { void handleMissingApiKey(); }}
           />
-        {:else if editor.activeTab?.type === 'query'}
-          <QueryPanel
-            bind:this={queryPanelComponent}
-            tab={editor.activeQueryTab!}
-            onQueryChange={editor.setQueryText}
-            onLanguageChange={editor.setQueryLanguage}
-            onExecute={editor.executeQuery}
-            onSave={handleSaveQuery}
-          />
-        {:else if editor.activeTab?.type === 'source'}
-          {#key editor.activeTab.sourceId}
-            <SourceDetail
-              sourceId={editor.activeTab.sourceId}
-              highlightExcerptId={editor.activeTab.highlightExcerptId}
-              onNavigate={handleNavigate}
-              onShowConfirm={showConfirm}
-              onShowPrompt={showPrompt}
-              onDeleted={handleSourceDeleted}
-              onCreateAboutNote={handleNewAboutSourceNote}
-              onOpenReference={handleOpenSource}
-              onResolveStub={handleResolveStub}
-              onOpenPdf={handleOpenPdf}
-              onCreateNoteFromExcerpt={handleCreateNoteFromExcerpt}
-              onAppendExcerptToCurrent={handleAppendExcerptToCurrent}
-              canAppendToCurrent={lastNotePath !== null}
-              onInvokeTool={handleToolInvoke}
-            />
-          {/key}
-        {:else if editor.activeTab?.type === 'pdf'}
-          {#key editor.activeTab.sourceId}
-            <!-- Lazy: pdfjs-dist only loads when a PDF tab is opened, keeping it
-                 out of the eager startup graph (#691). -->
-            {#await import('./lib/components/PdfViewer.svelte') then { default: PdfViewer }}
-              <PdfViewer
-                sourceId={editor.activeTab.sourceId}
-                initialPage={editor.activeTab.page}
-                onShowMarkdown={handleShowMarkdownFromPdf}
-              />
-            {/await}
-          {/key}
-        {:else}
-          <div class="no-file">
-            <p>Select a note from the sidebar</p>
-          </div>
         {/if}
       </div>
       {#if rightSidebarVisible && editor.activeTab?.type === 'note'}
@@ -1596,6 +1622,21 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+  }
+
+  /* One editor group's pane within the split layout (#813). Fills its leaf
+     cell; stacks tab bar → breadcrumbs → content. */
+  .group-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+  /* Subtle focus ring on the active pane — only meaningful once split. */
+  .group-pane.focused {
+    box-shadow: inset 0 2px 0 0 var(--accent);
   }
 
   .toolbar {

--- a/src/renderer/lib/components/ResizeHandle.svelte
+++ b/src/renderer/lib/components/ResizeHandle.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  /**
+   * Draggable divider between two split siblings (#813). Reports incremental
+   * pixel deltas along its axis; the parent `SplitContainer` converts them to
+   * fractional size changes against the measured container. Built standalone so
+   * it can later retrofit the fixed-width sidebars.
+   *
+   * `direction` is the parent split's layout direction: `horizontal` lays panes
+   * left↔right, so this is a vertical bar dragged on the x-axis (col-resize);
+   * `vertical` lays panes top↕bottom, a horizontal bar on the y-axis.
+   */
+  import type { SplitDirection } from '../editor/layout-tree';
+
+  interface Props {
+    direction: SplitDirection;
+    /** Incremental drag distance in px since the last move, along the axis. */
+    onResize: (deltaPx: number) => void;
+    onResizeEnd?: () => void;
+  }
+
+  let { direction, onResize, onResizeEnd }: Props = $props();
+
+  let dragging = $state(false);
+  let last = 0;
+
+  function coord(e: PointerEvent): number {
+    return direction === 'horizontal' ? e.clientX : e.clientY;
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    e.preventDefault();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragging = true;
+    last = coord(e);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging) return;
+    const cur = coord(e);
+    const delta = cur - last;
+    if (delta !== 0) {
+      last = cur;
+      onResize(delta);
+    }
+  }
+
+  function endDrag(e: PointerEvent) {
+    if (!dragging) return;
+    dragging = false;
+    (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+    onResizeEnd?.();
+  }
+</script>
+
+<div
+  class="resize-handle {direction}"
+  class:dragging
+  role="separator"
+  aria-orientation={direction === 'horizontal' ? 'vertical' : 'horizontal'}
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={endDrag}
+  onpointercancel={endDrag}
+></div>
+
+<style>
+  .resize-handle {
+    flex: 0 0 auto;
+    background: var(--border);
+    z-index: 2;
+  }
+  .resize-handle.horizontal {
+    width: 1px;
+    cursor: col-resize;
+    /* Widen the hit target without taking layout width. */
+    margin: 0 -2px;
+    padding: 0 2px;
+    background-clip: content-box;
+  }
+  .resize-handle.vertical {
+    height: 1px;
+    cursor: row-resize;
+    margin: -2px 0;
+    padding: 2px 0;
+    background-clip: content-box;
+  }
+  .resize-handle:hover,
+  .resize-handle.dragging {
+    background-color: var(--accent);
+  }
+</style>

--- a/src/renderer/lib/components/SplitContainer.svelte
+++ b/src/renderer/lib/components/SplitContainer.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  /**
+   * Recursively renders the editor split layout (#813). A leaf delegates to the
+   * `leaf` snippet (which mounts a group's pane); a split lays its children out
+   * as a flex row (`horizontal`) or column (`vertical`) with draggable dividers
+   * between them. Sizes are fractional; dragging a divider redistributes the
+   * two adjacent panes only, clamped to a per-pane minimum.
+   */
+  import type { Snippet } from 'svelte';
+  import {
+    type LayoutNode,
+    collectGroupIds,
+  } from '../editor/layout-tree';
+  import { redistributeSizes } from '../editor/split-resize';
+  import ResizeHandle from './ResizeHandle.svelte';
+  import SplitContainer from './SplitContainer.svelte';
+
+  interface Props {
+    node: LayoutNode;
+    /** Renders one pane's content for a given groupId. */
+    leaf: Snippet<[string]>;
+  }
+
+  let { node, leaf }: Props = $props();
+
+  /** Minimum pane extent along the split axis, in px. */
+  const MIN_PX = 140;
+
+  let containerEl = $state<HTMLDivElement>();
+
+  function keyOf(child: LayoutNode): string {
+    return child.kind === 'leaf' ? `leaf:${child.groupId}` : `split:${collectGroupIds(child).join(',')}`;
+  }
+
+  function handleResize(index: number, deltaPx: number) {
+    if (node.kind !== 'split' || !containerEl) return;
+    const total = node.direction === 'horizontal' ? containerEl.clientWidth : containerEl.clientHeight;
+    if (total <= 0) return;
+    node.sizes = redistributeSizes(node.sizes, index, deltaPx / total, MIN_PX / total);
+  }
+</script>
+
+{#if node.kind === 'leaf'}
+  {@render leaf(node.groupId)}
+{:else}
+  <div class="split-container {node.direction}" bind:this={containerEl}>
+    {#each node.children as child, i (keyOf(child))}
+      <div
+        class="split-child"
+        style:flex="{node.sizes[i] ?? 1 / node.children.length} 1 0"
+        style:min-width={node.direction === 'horizontal' ? `${MIN_PX}px` : null}
+        style:min-height={node.direction === 'vertical' ? `${MIN_PX}px` : null}
+      >
+        <SplitContainer node={child} {leaf} />
+      </div>
+      {#if i < node.children.length - 1}
+        <ResizeHandle direction={node.direction} onResize={(d) => handleResize(i, d)} />
+      {/if}
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .split-container {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .split-container.horizontal { flex-direction: row; }
+  .split-container.vertical { flex-direction: column; }
+  .split-child {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+</style>

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -126,6 +126,17 @@ export const ICONS = {
     '<path d="M10.5 5.5 13 8l-2.5 2.5"/>' +
     '<path d="M9.5 4.5 6.5 11.5"/>',
 
+  // ── Editor split (#813) ───────────────────────────────────────────
+  // A framed pane divided by the axis the split adds along: split-h adds a
+  // pane to the right (vertical divider); split-v adds one below (horizontal
+  // divider).
+  'split-h':
+    '<rect x="2.5" y="3" width="11" height="10" rx="1"/>' +
+    '<path d="M8 3v10"/>',
+  'split-v':
+    '<rect x="2.5" y="3" width="11" height="10" rx="1"/>' +
+    '<path d="M2.5 8h11"/>',
+
   // ── Brand ─────────────────────────────────────────────────────────
   minervaMark:
     '<circle cx="8" cy="8" r="6"/>' +

--- a/src/renderer/lib/editor/split-resize.ts
+++ b/src/renderer/lib/editor/split-resize.ts
@@ -1,0 +1,28 @@
+/**
+ * Divider-drag math for `SplitContainer` (#813).
+ *
+ * A split node holds fractional `sizes` (summing to ~1), one per child. Dragging
+ * the divider between child `index` and `index+1` moves their shared boundary:
+ * one grows by the same amount the other shrinks, so every *other* pane keeps
+ * its size. Each of the pair is clamped to a minimum fraction so a pane can't be
+ * dragged to nothing. Pure so the clamping is unit-testable without a DOM.
+ */
+
+export function redistributeSizes(
+  sizes: number[],
+  index: number,
+  deltaFraction: number,
+  minFraction: number,
+): number[] {
+  if (index < 0 || index + 1 >= sizes.length) return sizes;
+  const next = [...sizes];
+  const pair = next[index] + next[index + 1];
+  // The growing side can range over [min, pair - min] so neither falls below
+  // the minimum. If the pair is too small to honor both minimums, the upper
+  // bound wins (Math.min first), keeping behavior deterministic.
+  const upper = Math.max(minFraction, pair - minFraction);
+  const a = Math.min(upper, Math.max(minFraction, next[index] + deltaFraction));
+  next[index] = a;
+  next[index + 1] = pair - a;
+  return next;
+}

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -617,6 +617,7 @@ export function getEditorStore() {
   function closeOthers(index: number, groupId?: string) {
     const grp = resolveGroup(groupId);
     const kept = grp.tabs[index];
+    if (!kept) return; // out-of-range — nothing to keep, leave the pane as-is
     grp.tabs.length = 0;
     grp.tabs.push(kept);
     grp.activeIndex = 0;
@@ -628,6 +629,9 @@ export function getEditorStore() {
     flushAutoSave();
     grp.tabs.length = 0;
     grp.activeIndex = -1;
+    // Emptying a split pane collapses it and rebalances the tree, same as
+    // closing its last tab one-by-one (#813). No-ops on the last pane.
+    collapseGroup(grp.id);
     schedulePersistTabs();
   }
 

--- a/tests/renderer/editor-store.test.ts
+++ b/tests/renderer/editor-store.test.ts
@@ -252,4 +252,40 @@ describe('split layout ops (#813)', () => {
     expect(editor.layout).toEqual({ kind: 'leaf', groupId: only });
     expect(editor.tabs).toHaveLength(0);
   });
+
+  it('closeAll on a split pane collapses it, same as closing each tab', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    await editor.openFile('b.md'); // into g2 (active)
+    await editor.openFile('c.md'); // g2 now has two tabs
+    expect(editor.groups).toHaveLength(2);
+
+    // Close-all empties g2 → pane collapses, tree returns to the lone leaf.
+    editor.closeAll(g2);
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: g1 });
+  });
+
+  it('closeAll on the only pane empties it without collapsing', async () => {
+    await editor.openFile('a.md');
+    await editor.openFile('b.md');
+    const only = editor.groups[0].id;
+    editor.closeAll();
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout).toEqual({ kind: 'leaf', groupId: only });
+    expect(editor.tabs).toHaveLength(0);
+  });
+
+  it('closeOthers keeps the named tab and leaves the pane intact', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    await editor.openFile('b.md'); // into g2
+    await editor.openFile('c.md'); // g2: [b, c]
+
+    editor.closeOthers(0, g2); // keep b.md
+    expect(editor.groups).toHaveLength(2);
+    expect(editor.noteTabForGroup(g2)?.relativePath).toBe('b.md');
+  });
 });

--- a/tests/renderer/split-resize.test.ts
+++ b/tests/renderer/split-resize.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Divider-drag size redistribution for SplitContainer (#813).
+ */
+import { describe, it, expect } from 'vitest';
+import { redistributeSizes } from '../../src/renderer/lib/editor/split-resize';
+
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0);
+
+describe('redistributeSizes', () => {
+  it('moves the boundary between the two adjacent panes only', () => {
+    const next = redistributeSizes([0.5, 0.5], 0, 0.1, 0.05);
+    expect(next).toEqual([0.6, 0.4]);
+  });
+
+  it('leaves non-adjacent panes untouched and conserves the pair total', () => {
+    const next = redistributeSizes([0.25, 0.25, 0.5], 0, 0.1, 0.05);
+    expect(next[2]).toBe(0.5); // third pane unchanged
+    expect(next[0] + next[1]).toBeCloseTo(0.5, 6); // pair total conserved
+    expect(sum(next)).toBeCloseTo(1, 6);
+  });
+
+  it('clamps the shrinking pane to the minimum', () => {
+    // Dragging far left would drive pane 0 below min; it stops at min.
+    const next = redistributeSizes([0.5, 0.5], 0, -0.9, 0.1);
+    expect(next[0]).toBeCloseTo(0.1, 6);
+    expect(next[1]).toBeCloseTo(0.9, 6);
+  });
+
+  it('clamps the growing pane so its sibling keeps the minimum', () => {
+    const next = redistributeSizes([0.5, 0.5], 0, 0.9, 0.1);
+    expect(next[0]).toBeCloseTo(0.9, 6);
+    expect(next[1]).toBeCloseTo(0.1, 6);
+  });
+
+  it('is a no-op for an out-of-range boundary index', () => {
+    expect(redistributeSizes([0.5, 0.5], 1, 0.1, 0.05)).toEqual([0.5, 0.5]);
+    expect(redistributeSizes([1], 0, 0.1, 0.05)).toEqual([1]);
+  });
+
+  it('handles a zero delta as identity', () => {
+    expect(redistributeSizes([0.3, 0.7], 0, 0, 0.05)).toEqual([0.3, 0.7]);
+  });
+});


### PR DESCRIPTION
Part of #810 — Phase 3, **part 2 of 2** (the visible feature). Builds on the layout model in #868. Depends on #811 / #812 / #813-pt1 (all merged). No new dependencies.

## What
- **`SplitContainer.svelte`** — recursively renders `editor.layout`: a leaf delegates to a `leaf` snippet (one group's pane); a split lays its children out as a flex row (`horizontal`) / column (`vertical`) with dividers between them. Self-imports for recursion.
- **`ResizeHandle.svelte`** — reusable draggable divider (pointer-captured, reports px deltas along its axis). **`lib/editor/split-resize.ts`** converts deltas to fractional size changes, redistributing only the two adjacent panes and clamping each to a 140px minimum (pure + unit-tested).
- **`App.svelte`** — the editor center column is now a `groupPane(groupId)` snippet rendered at every leaf. Each pane gets its **own** TabBar, breadcrumbs, view-mode toolbar, and editor/preview/query/source/pdf bound to *its* group. **Split-right / split-down** buttons in the note toolbar call `editor.splitGroup`; **clicking a pane focuses its group**. `StatusBar` / `ToolPanel` / `RightSidebar` stay window-level on the active group.
- Per-pane component instances live in `editorComponents` / `previewComponents` / `queryPanelComponents` maps keyed by group id; the bare `editorComponent` etc. accessors are `$derived` to the active group's instance, so every imperative command site (nav, goto-line, insert, theme re-skin) targets the focused pane.
- Per-pane **bookmarks/breadcrumbs** resolve from each pane's own file. **Cursor/search remain active-global** (per-group is #817 polish).
- New `split-h` / `split-v` icons.

## ⚠️ Needs live verification
The recursive render + drag-resize + focus are GUI behaviors I can't exercise headlessly. Please sanity-check in the running app:
- [ ] Split right / split down from the toolbar; nest splits both ways.
- [ ] Each pane shows its own tabs/toolbar/editor; editing one doesn't disturb the other.
- [ ] Dragging a divider resizes the two adjacent panes; panes respect the min size.
- [ ] Closing a pane's last tab collapses it and the tree rebalances; single-pane looks identical to before.
- [ ] Clicking a pane focuses it (status bar / right sidebar / commands follow).

## Tests
`tests/renderer/split-resize.test.ts` — boundary move, pair conservation, both-sides min-clamp, out-of-range no-op. Layout-tree + store ops already covered in part 1. Full `pnpm test` green (3355); lint clean.

## Acceptance (#813)
- [x] Split horizontally and vertically; splits nest recursively.
- [x] Each pane renders its own tab bar, toolbar, and editor bound to its group.
- [x] Dividers drag to resize; panes respect a minimum size.
- [x] Closing a group's last tab collapses the pane and the tree rebalances.
- [x] Single-pane layout looks identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)