### PR TITLE
feat: persist & restore the full split-pane layout tree (#816)

### DIFF
--- a/src/main/ipc/register-bookmarks.ts
+++ b/src/main/ipc/register-bookmarks.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
-import type { TabSession } from '../../shared/types';
+import type { TabSession, LayoutSession } from '../../shared/types';
 import { rootPathFromEvent } from './helpers';
 
 export function registerBookmarks(): void {
@@ -25,8 +25,11 @@ export function registerBookmarks(): void {
     await fs.writeFile(bmPath, JSON.stringify(tree, null, 2), 'utf-8');
   });
 
-  // Tab session persistence
-  ipcMain.handle(Channels.TABS_SAVE, async (e, session: TabSession) => {
+  // Tab session persistence. The payload is opaque JSON to the main process —
+  // it round-trips the renderer's session shape (now the multi-group
+  // LayoutSession, #816) without inspecting it; the renderer validates and
+  // migrates legacy shapes on load.
+  ipcMain.handle(Channels.TABS_SAVE, async (e, session: LayoutSession | TabSession) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return;
     const tabsPath = path.join(rootPath, '.minerva', 'tabs.json');
@@ -34,7 +37,7 @@ export function registerBookmarks(): void {
     await fs.writeFile(tabsPath, JSON.stringify(session, null, 2), 'utf-8');
   });
 
-  ipcMain.handle(Channels.TABS_LOAD, async (e): Promise<TabSession | null> => {
+  ipcMain.handle(Channels.TABS_LOAD, async (e): Promise<LayoutSession | TabSession | null> => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return null;
     try {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1042,14 +1042,18 @@
       // Inspections hidden for v1.0: count polling disabled so the status-bar
       // badge stays hidden (inspectionCount stays 0). Restore the
       // setTimeout/setInterval(refreshInspectionCount) to re-enable.
-      // Restore position for the active tab after tabs are rendered
-      const activeTab = editor.activeNoteTab;
-      if (activeTab?.cursorOffset != null) {
-        await tick();
-        requestAnimationFrame(() => {
-          editorComponent?.restorePosition(activeTab.cursorOffset!, activeTab.scrollTop);
-        });
-      }
+      // Restore cursor/scroll for every pane's active note tab after the
+      // split layout has rendered and each pane's Editor has mounted (#816 —
+      // restore is now multi-group, not just the focused pane).
+      await tick();
+      requestAnimationFrame(() => {
+        for (const grp of editor.groups) {
+          const noteTab = editor.noteTabForGroup(grp.id);
+          if (noteTab?.cursorOffset != null) {
+            editorComponents[grp.id]?.restorePosition(noteTab.cursorOffset, noteTab.scrollTop);
+          }
+        }
+      });
 
       // Offer the onboarding journey on empty thoughtbases. Files have
       // already been loaded by `notebase.openPath` above, so the count
@@ -1353,7 +1357,7 @@
           {/if}
         {/snippet}
 
-        <SplitContainer node={editor.layout} leaf={groupPane} />
+        <SplitContainer node={editor.layout} leaf={groupPane} onLayoutChange={() => editor.schedulePersistTabs()} />
 
         <!-- Window-level status + tool surfaces, reflecting the active group's
              note. (Per-group status bars are #817 polish.) -->

--- a/src/renderer/lib/components/SplitContainer.svelte
+++ b/src/renderer/lib/components/SplitContainer.svelte
@@ -19,9 +19,12 @@
     node: LayoutNode;
     /** Renders one pane's content for a given groupId. */
     leaf: Snippet<[string]>;
+    /** Notified after a divider drag changes pane sizes, so the layout can be
+     *  persisted (#816). Threaded through the recursion unchanged. */
+    onLayoutChange?: () => void;
   }
 
-  let { node, leaf }: Props = $props();
+  let { node, leaf, onLayoutChange }: Props = $props();
 
   /** Minimum pane extent along the split axis, in px. */
   const MIN_PX = 140;
@@ -37,6 +40,7 @@
     const total = node.direction === 'horizontal' ? containerEl.clientWidth : containerEl.clientHeight;
     if (total <= 0) return;
     node.sizes = redistributeSizes(node.sizes, index, deltaPx / total, MIN_PX / total);
+    onLayoutChange?.();
   }
 </script>
 
@@ -51,7 +55,7 @@
         style:min-width={node.direction === 'horizontal' ? `${MIN_PX}px` : null}
         style:min-height={node.direction === 'vertical' ? `${MIN_PX}px` : null}
       >
-        <SplitContainer node={child} {leaf} />
+        <SplitContainer node={child} {leaf} {onLayoutChange} />
       </div>
       {#if i < node.children.length - 1}
         <ResizeHandle direction={node.direction} onResize={(d) => handleResize(i, d)} />

--- a/src/renderer/lib/editor/layout-tree.ts
+++ b/src/renderer/lib/editor/layout-tree.ts
@@ -37,6 +37,30 @@ export function collectGroupIds(node: LayoutNode): string[] {
   return node.children.flatMap(collectGroupIds);
 }
 
+/**
+ * Structural guard for an untrusted layout value (e.g. parsed from disk on
+ * session restore, #816). Verifies the recursive shape — leaf/split kinds,
+ * split direction, and one positive-length `sizes` entry per child — but not
+ * that the leaf group ids correspond to live groups (the caller checks that).
+ */
+export function isLayoutNode(value: unknown): value is LayoutNode {
+  if (!value || typeof value !== 'object') return false;
+  const n = value as Record<string, unknown>;
+  if (n.kind === 'leaf') return typeof n.groupId === 'string';
+  if (n.kind === 'split') {
+    return (
+      (n.direction === 'horizontal' || n.direction === 'vertical') &&
+      Array.isArray(n.children) &&
+      n.children.length > 0 &&
+      Array.isArray(n.sizes) &&
+      n.sizes.length === n.children.length &&
+      n.sizes.every((s) => typeof s === 'number') &&
+      n.children.every(isLayoutNode)
+    );
+  }
+  return false;
+}
+
 /** Normalize a sizes array to sum to 1 (guards against drift / bad input). */
 function normalizeSizes(sizes: number[]): number[] {
   const total = sizes.reduce((a, b) => a + (b > 0 ? b : 0), 0);

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
 
@@ -527,8 +527,10 @@ export interface ProposalsApi {
 }
 
 export interface TabsApi {
-  save(session: TabSession): Promise<void>;
-  load(): Promise<TabSession | null>;
+  save(session: LayoutSession): Promise<void>;
+  /** Returns the new multi-group format, or a legacy flat `TabSession` written
+   *  by an older build — the renderer migrates the latter on load (#816). */
+  load(): Promise<LayoutSession | TabSession | null>;
 }
 
 export interface RefactorApi {

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -1,5 +1,5 @@
 import { api } from '../ipc/client';
-import type { TabSession, SavedTab } from '../../../shared/types';
+import type { TabSession, SavedTab, SavedGroup, LayoutSession } from '../../../shared/types';
 import { normalizeSqlRows, unionColumns } from '../editor/sql-result';
 import {
   type LayoutNode,
@@ -8,6 +8,7 @@ import {
   splitLeaf,
   removeLeaf,
   collectGroupIds,
+  isLayoutNode,
 } from '../editor/layout-tree';
 
 // ── Tab types ───────────────────────────────────────────────────────────────
@@ -166,7 +167,10 @@ export function getEditorStore() {
   }
 
   function setActiveGroup(id: string): void {
-    if (groups.some((g) => g.id === id)) activeGroupId = id;
+    if (id !== activeGroupId && groups.some((g) => g.id === id)) {
+      activeGroupId = id;
+      schedulePersistTabs(); // focus is part of the persisted session (#816)
+    }
   }
 
   /**
@@ -181,6 +185,7 @@ export function getEditorStore() {
     const cur = ids.indexOf(activeGroupId);
     const start = cur === -1 ? 0 : cur;
     activeGroupId = ids[(start + delta + ids.length) % ids.length];
+    schedulePersistTabs();
   }
   const focusNextGroup = () => cycleFocus(1);
   const focusPreviousGroup = () => cycleFocus(-1);
@@ -208,6 +213,7 @@ export function getEditorStore() {
     const newId = addGroup(source?.viewMode ?? 'source');
     layout = splitLeaf(layout, groupId, direction, newId);
     activeGroupId = newId;
+    schedulePersistTabs();
     return newId;
   }
 
@@ -227,6 +233,7 @@ export function getEditorStore() {
     if (activeGroupId === groupId) {
       activeGroupId = collectGroupIds(layout)[0] ?? groups[0]?.id;
     }
+    schedulePersistTabs();
   }
 
   // ── Source operations ───────────────────────────────────────────────────
@@ -446,83 +453,163 @@ export function getEditorStore() {
     }, TAB_PERSIST_DELAY);
   }
 
+  function toSavedTab(t: Tab): SavedTab {
+    if (isNote(t)) {
+      return { type: 'note', relativePath: t.relativePath, cursorOffset: t.cursorOffset, scrollTop: t.scrollTop };
+    } else if (isQuery(t)) {
+      return { type: 'query', title: t.title, query: t.query, language: t.language };
+    } else if (isPdf(t)) {
+      return { type: 'pdf', sourceId: t.sourceId, page: t.page };
+    } else {
+      return { type: 'source', sourceId: t.sourceId, highlightExcerptId: t.highlightExcerptId };
+    }
+  }
+
   function persistTabs() {
-    // Persistence shape is unchanged (#816 owns the multi-group layout format):
-    // serialise the active group's tabs + active index, exactly as before.
-    const grp = activeGroup();
-    const savedTabs: SavedTab[] = grp.tabs.map((t): SavedTab => {
-      if (isNote(t)) {
-        return { type: 'note', relativePath: t.relativePath, cursorOffset: t.cursorOffset, scrollTop: t.scrollTop };
-      } else if (isQuery(t)) {
-        return { type: 'query', title: t.title, query: t.query, language: t.language };
-      } else if (isPdf(t)) {
-        return { type: 'pdf', sourceId: t.sourceId, page: t.page };
-      } else {
-        return { type: 'source', sourceId: t.sourceId, highlightExcerptId: t.highlightExcerptId };
-      }
-    });
-    const session: TabSession = { activeIndex: grp.activeIndex, tabs: savedTabs };
+    // Persist the whole split arrangement (#816): every group's tabs +
+    // active tab + view mode, the focused group, and the layout tree. The
+    // layout is reactive ($state) — snapshot it to a plain object so the
+    // structured-clone IPC boundary doesn't choke on the Svelte proxy.
+    const session: LayoutSession = {
+      version: 2,
+      activeGroupId,
+      groups: groups.map((g): SavedGroup => ({
+        id: g.id,
+        activeIndex: g.activeIndex,
+        viewMode: g.viewMode,
+        tabs: g.tabs.map(toSavedTab),
+      })),
+      layout: $state.snapshot(layout),
+    };
     void api.tabs.save(session);
   }
 
-  async function restoreTabs() {
-    const session = await api.tabs.load();
-    if (!session || session.tabs.length === 0) return;
-
-    const grp = activeGroup();
-    for (const saved of session.tabs) {
-      if (saved.type === 'note') {
-        try {
-          const text = await api.notebase.readFile(saved.relativePath);
-          const fileName = saved.relativePath.split('/').pop() ?? '';
-          const tab: NoteTab = {
-            type: 'note',
-            relativePath: saved.relativePath,
-            fileName,
-            content: text,
-            savedContent: text,
-            cursorOffset: saved.cursorOffset,
-            scrollTop: saved.scrollTop,
-          };
-          grp.tabs.push(tab);
-        } catch {
-          // File may have been deleted since last session
-        }
-      } else if (saved.type === 'query') {
-        queryCounter++;
-        const tab: QueryTab = {
-          type: 'query',
-          id: `query-${queryCounter}-${Date.now()}`,
-          title: saved.title,
-          query: saved.query,
-          language: saved.language ?? 'sparql',
-          results: null,
-          columns: [],
-          error: null,
-          executing: false,
-          executionTime: null,
+  /** Reconstruct a live tab from its persisted form. Notes read their file
+   *  back (returning null if it was deleted since last session, so the tab is
+   *  dropped); the other kinds rehydrate from saved fields. */
+  async function reconstructTab(saved: SavedTab): Promise<Tab | null> {
+    if (saved.type === 'note') {
+      try {
+        const text = await api.notebase.readFile(saved.relativePath);
+        const fileName = saved.relativePath.split('/').pop() ?? '';
+        return {
+          type: 'note',
+          relativePath: saved.relativePath,
+          fileName,
+          content: text,
+          savedContent: text,
+          cursorOffset: saved.cursorOffset,
+          scrollTop: saved.scrollTop,
         };
-        grp.tabs.push(tab);
-      } else if (saved.type === 'pdf') {
-        grp.tabs.push({
-          type: 'pdf',
-          sourceId: saved.sourceId,
-          page: saved.page ?? 1,
-        });
-      } else {
-        grp.tabs.push({
-          type: 'source',
-          sourceId: saved.sourceId,
-          highlightExcerptId: saved.highlightExcerptId,
-        });
+      } catch {
+        return null; // file deleted since last session
       }
+    } else if (saved.type === 'query') {
+      queryCounter++;
+      return {
+        type: 'query',
+        id: `query-${queryCounter}-${Date.now()}`,
+        title: saved.title,
+        query: saved.query,
+        language: saved.language ?? 'sparql',
+        results: null,
+        columns: [],
+        error: null,
+        executing: false,
+        executionTime: null,
+      };
+    } else if (saved.type === 'pdf') {
+      return { type: 'pdf', sourceId: saved.sourceId, page: saved.page ?? 1 };
+    } else {
+      return { type: 'source', sourceId: saved.sourceId, highlightExcerptId: saved.highlightExcerptId };
+    }
+  }
+
+  function asViewMode(v: unknown): ViewMode {
+    return v === 'preview' || v === 'editor-preview' || v === 'source' ? v : 'source';
+  }
+
+  /** Coerce whatever is on disk into the current multi-group shape. New
+   *  sessions pass through; a legacy flat `TabSession` migrates to a single
+   *  group (#816); anything else (null / empty / unrecognised) → null, so the
+   *  caller keeps the start-of-session empty group. */
+  function normalizeSession(raw: LayoutSession | TabSession | null): LayoutSession | null {
+    if (!raw || typeof raw !== 'object') return null;
+    if ('groups' in raw && Array.isArray(raw.groups)) {
+      return raw.groups.length > 0 ? raw : null;
+    }
+    if ('tabs' in raw && Array.isArray(raw.tabs)) {
+      if (raw.tabs.length === 0) return null;
+      const id = newGroupId();
+      return {
+        version: 2,
+        activeGroupId: id,
+        groups: [{ id, activeIndex: raw.activeIndex ?? 0, viewMode: 'source', tabs: raw.tabs }],
+        layout: { kind: 'leaf', groupId: id },
+      };
+    }
+    return null;
+  }
+
+  async function restoreTabs() {
+    const session = normalizeSession(await api.tabs.load());
+    if (!session) return; // nothing saved or corrupt → keep the default empty group
+
+    // Rebuild each group, dropping note tabs whose files have since vanished.
+    const restored: EditorGroup[] = [];
+    for (const sg of session.groups) {
+      const tabs: Tab[] = [];
+      for (const saved of sg.tabs) {
+        const tab = await reconstructTab(saved);
+        if (tab) tabs.push(tab);
+      }
+      const activeIndex =
+        sg.activeIndex >= 0 && sg.activeIndex < tabs.length
+          ? sg.activeIndex
+          : tabs.length > 0 ? 0 : -1;
+      restored.push({ id: sg.id, tabs, activeIndex, viewMode: asViewMode(sg.viewMode) });
+    }
+    if (restored.length === 0) return;
+
+    // The saved layout must structurally match the restored groups exactly
+    // (every leaf ↔ a live group, no orphans). If it doesn't, we can't trust
+    // the tree — recover by merging every restored tab into one pane rather
+    // than rendering a broken split or crashing.
+    const ids = new Set(restored.map((g) => g.id));
+    // SavedLayoutNode is structurally a LayoutNode; isLayoutNode still guards
+    // against a corrupt on-disk tree that doesn't match the declared shape.
+    const savedLayout = session.layout;
+    const layoutOk =
+      isLayoutNode(savedLayout) &&
+      (() => {
+        const leaves = collectGroupIds(savedLayout);
+        return leaves.length === ids.size && leaves.every((id) => ids.has(id));
+      })();
+
+    groups.length = 0;
+    if (layoutOk) {
+      groups.push(...restored);
+      layout = savedLayout;
+      activeGroupId = ids.has(session.activeGroupId) ? session.activeGroupId : restored[0].id;
+    } else {
+      const merged: EditorGroup = {
+        id: restored[0].id,
+        tabs: restored.flatMap((g) => g.tabs),
+        activeIndex: -1,
+        viewMode: restored[0].viewMode,
+      };
+      merged.activeIndex = merged.tabs.length > 0 ? 0 : -1;
+      groups.push(merged);
+      layout = leaf(merged.id);
+      activeGroupId = merged.id;
     }
 
-    // Clamp activeIndex to valid range
-    if (session.activeIndex >= 0 && session.activeIndex < grp.tabs.length) {
-      grp.activeIndex = session.activeIndex;
-    } else if (grp.tabs.length > 0) {
-      grp.activeIndex = 0;
+    // `groupCounter` reset to 0 at launch; restored ids came from disk. Advance
+    // it past the highest restored `group-N` so a later split can't re-mint an
+    // id that's already live.
+    for (const g of groups) {
+      const n = Number(g.id.match(/^group-(\d+)$/)?.[1]);
+      if (Number.isFinite(n) && n > groupCounter) groupCounter = n;
     }
   }
 
@@ -797,5 +884,6 @@ export function getEditorStore() {
     executeQuery,
     restoreTabs,
     persistTabs,
+    schedulePersistTabs,
   };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,9 +102,45 @@ export interface SavedPdfTab {
 
 export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab;
 
+/** Legacy flat session: one group's tabs + active index. Superseded by
+ *  {@link LayoutSession} (#816); still read on load and migrated to a single
+ *  group so no pre-split session is lost. */
 export interface TabSession {
   activeIndex: number;
   tabs: SavedTab[];
+}
+
+/** One persisted editor group (pane): its tabs, focused tab, and view mode. */
+export interface SavedGroup {
+  id: string;
+  activeIndex: number;
+  /** Persisted as a string; the renderer validates it against `ViewMode` on
+   *  load (unknown values fall back to 'source'). */
+  viewMode: string;
+  tabs: SavedTab[];
+}
+
+/** Structural mirror of the renderer's `LayoutNode` tree, for the persisted
+ *  split layout. Kept here (not imported from the renderer) so the shared/main
+ *  boundary stays free of renderer types; the renderer validates the shape on
+ *  load before casting back to `LayoutNode`. */
+export type SavedLayoutNode =
+  | { kind: 'leaf'; groupId: string }
+  | {
+      kind: 'split';
+      direction: 'horizontal' | 'vertical';
+      children: SavedLayoutNode[];
+      /** Fractional sizes (sum ≈ 1), one per child, in child order. */
+      sizes: number[];
+    };
+
+/** Full split-pane session (#816): every group, the focused group, and the
+ *  layout tree (directions + sizes). `version` gates future migrations. */
+export interface LayoutSession {
+  version: 2;
+  activeGroupId: string;
+  groups: SavedGroup[];
+  layout: SavedLayoutNode;
 }
 
 // ── Source detail ─────────────────────────────────────────────────────────

--- a/tests/renderer/editor-store.test.ts
+++ b/tests/renderer/editor-store.test.ts
@@ -7,12 +7,13 @@
  * new group-scoped mutation surface.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LayoutSession } from '../../src/shared/types';
 
 const h = vi.hoisted(() => ({
   readFile: vi.fn(async (p: string) => `# ${p}\nbody`),
   writeFile: vi.fn(async () => {}),
   tabsSave: vi.fn(async () => {}),
-  tabsLoad: vi.fn(async () => null),
+  tabsLoad: vi.fn(async (): Promise<unknown> => null),
 }));
 
 vi.mock('../../src/renderer/lib/ipc/client', () => ({
@@ -334,5 +335,153 @@ describe('split layout ops (#813)', () => {
     expect(editor.groups).toHaveLength(1);
     expect(editor.layout).toEqual({ kind: 'leaf', groupId: only });
     expect(editor.tabs).toHaveLength(0);
+  });
+});
+
+describe('session persistence — multi-group layout (#816)', () => {
+  it('persistTabs writes the versioned multi-group session', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    await editor.openFile('b.md'); // into g2 (active)
+
+    editor.persistTabs();
+    const saved = h.tabsSave.mock.calls.at(-1)?.[0] as LayoutSession;
+    expect(saved.version).toBe(2);
+    expect(saved.activeGroupId).toBe(g2);
+    expect(saved.groups).toHaveLength(2);
+    expect(saved.layout).toEqual({
+      kind: 'split',
+      direction: 'horizontal',
+      sizes: [0.5, 0.5],
+      children: [{ kind: 'leaf', groupId: g1 }, { kind: 'leaf', groupId: g2 }],
+    });
+    const sg2 = saved.groups.find((g) => g.id === g2);
+    expect(sg2?.tabs).toEqual([{ type: 'note', relativePath: 'b.md', cursorOffset: undefined, scrollTop: undefined }]);
+  });
+
+  it('persist → restore round-trips the split arrangement', async () => {
+    await editor.openFile('a.md');
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'vertical');
+    editor.setViewMode('preview', g2);
+    await editor.openFile('b.md');
+    editor.persistTabs();
+    const saved = h.tabsSave.mock.calls.at(-1)?.[0] as LayoutSession;
+
+    h.tabsLoad.mockResolvedValueOnce(saved);
+    await editor.restoreTabs();
+
+    expect(editor.groups).toHaveLength(2);
+    expect(editor.layout).toEqual(saved.layout);
+    expect(editor.activeGroupId).toBe(g2);
+    expect(editor.noteTabForGroup(g1)?.relativePath).toBe('a.md');
+    expect(editor.noteTabForGroup(g2)?.relativePath).toBe('b.md');
+    expect(editor.groups.find((g) => g.id === g2)?.viewMode).toBe('preview');
+  });
+
+  it('restores a saved multi-group session, focus, and view modes', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-2',
+      groups: [
+        { id: 'group-1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] },
+        { id: 'group-2', activeIndex: 0, viewMode: 'preview', tabs: [{ type: 'note', relativePath: 'b.md' }] },
+      ],
+      layout: {
+        kind: 'split', direction: 'horizontal', sizes: [0.4, 0.6],
+        children: [{ kind: 'leaf', groupId: 'group-1' }, { kind: 'leaf', groupId: 'group-2' }],
+      },
+    });
+    await editor.restoreTabs();
+
+    expect(editor.groups).toHaveLength(2);
+    expect(editor.activeGroupId).toBe('group-2');
+    expect((editor.layout as { sizes: number[] }).sizes).toEqual([0.4, 0.6]);
+    expect(editor.groups.find((g) => g.id === 'group-2')?.viewMode).toBe('preview');
+  });
+
+  it('migrates a legacy flat tabs.json into a single group', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      activeIndex: 1,
+      tabs: [
+        { type: 'note', relativePath: 'a.md' },
+        { type: 'note', relativePath: 'b.md' },
+      ],
+    });
+    await editor.restoreTabs();
+
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout.kind).toBe('leaf');
+    expect(editor.tabs).toHaveLength(2);
+    expect(editor.activeIndex).toBe(1);
+  });
+
+  it('falls back to one merged pane when the saved layout does not match the groups', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [
+        { id: 'group-1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] },
+        { id: 'group-2', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'b.md' }] },
+      ],
+      // Orphaned leaf id — references no restored group → untrusted tree.
+      layout: { kind: 'leaf', groupId: 'group-99' },
+    });
+    await editor.restoreTabs();
+
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.layout.kind).toBe('leaf');
+    expect(editor.tabs).toHaveLength(2); // both recovered, no data loss
+  });
+
+  it('drops a note tab whose file no longer exists on restore', async () => {
+    h.readFile.mockImplementationOnce(async () => { throw new Error('ENOENT'); });
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [{
+        id: 'group-1', activeIndex: 0, viewMode: 'source',
+        tabs: [{ type: 'note', relativePath: 'gone.md' }, { type: 'note', relativePath: 'keep.md' }],
+      }],
+      layout: { kind: 'leaf', groupId: 'group-1' },
+    });
+    await editor.restoreTabs();
+
+    expect(editor.tabs).toHaveLength(1);
+    expect(editor.noteTabForGroup('group-1')?.relativePath).toBe('keep.md');
+  });
+
+  it('corrupt / empty session keeps the start-of-session empty group', async () => {
+    h.tabsLoad.mockResolvedValueOnce(null);
+    await editor.restoreTabs();
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.tabs).toHaveLength(0);
+
+    h.tabsLoad.mockResolvedValueOnce({ nonsense: true });
+    await editor.restoreTabs();
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.tabs).toHaveLength(0);
+  });
+
+  it('advances the group-id counter past restored ids so later splits do not collide', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-3',
+      groups: [
+        { id: 'group-3', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] },
+        { id: 'group-4', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'b.md' }] },
+      ],
+      layout: {
+        kind: 'split', direction: 'horizontal', sizes: [0.5, 0.5],
+        children: [{ kind: 'leaf', groupId: 'group-3' }, { kind: 'leaf', groupId: 'group-4' }],
+      },
+    });
+    await editor.restoreTabs();
+
+    const newId = editor.splitGroup('group-3', 'horizontal');
+    expect(['group-3', 'group-4']).not.toContain(newId);
+    // The minted id is past the highest restored suffix, not a re-use of one.
+    expect(Number(newId.match(/\d+/)?.[0])).toBeGreaterThan(4);
   });
 });

--- a/tests/renderer/layout-tree.test.ts
+++ b/tests/renderer/layout-tree.test.ts
@@ -7,6 +7,7 @@ import {
   splitLeaf,
   removeLeaf,
   collectGroupIds,
+  isLayoutNode,
   type LayoutNode,
 } from '../../src/renderer/lib/editor/layout-tree';
 
@@ -100,5 +101,42 @@ describe('collectGroupIds', () => {
     let root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
     root = splitLeaf(root, 'b', 'vertical', 'c'); // a | (b/c)
     expect(collectGroupIds(root)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('isLayoutNode (restore validation, #816)', () => {
+  it('accepts a valid leaf and a valid nested split', () => {
+    expect(isLayoutNode(leaf('a'))).toBe(true);
+    let root = splitLeaf(leaf('a'), 'a', 'horizontal', 'b');
+    root = splitLeaf(root, 'b', 'vertical', 'c');
+    expect(isLayoutNode(root)).toBe(true);
+  });
+
+  it('rejects non-objects and unknown kinds', () => {
+    expect(isLayoutNode(null)).toBe(false);
+    expect(isLayoutNode('leaf')).toBe(false);
+    expect(isLayoutNode({})).toBe(false);
+    expect(isLayoutNode({ kind: 'frob' })).toBe(false);
+  });
+
+  it('rejects a leaf without a string groupId', () => {
+    expect(isLayoutNode({ kind: 'leaf' })).toBe(false);
+    expect(isLayoutNode({ kind: 'leaf', groupId: 7 })).toBe(false);
+  });
+
+  it('rejects a split with a bad direction, no children, or mismatched sizes', () => {
+    expect(isLayoutNode({ kind: 'split', direction: 'sideways', children: [leaf('a')], sizes: [1] })).toBe(false);
+    expect(isLayoutNode({ kind: 'split', direction: 'horizontal', children: [], sizes: [] })).toBe(false);
+    expect(isLayoutNode({
+      kind: 'split', direction: 'horizontal',
+      children: [leaf('a'), leaf('b')], sizes: [1], // sizes length ≠ children length
+    })).toBe(false);
+  });
+
+  it('rejects a split whose child is itself malformed', () => {
+    expect(isLayoutNode({
+      kind: 'split', direction: 'vertical',
+      children: [leaf('a'), { kind: 'leaf' }], sizes: [0.5, 0.5],
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
Part of #810 — **Phase 5** (#816). Builds on the split layout (#813) + focus/commands (#814), both merged.

## What
Session restore now rebuilds the **whole pane arrangement**, not just a flat tab list. `.minerva/tabs.json` becomes a versioned, multi-group `LayoutSession`.

**Persisted shape** (`src/shared/types.ts`)
- `LayoutSession { version: 2; activeGroupId; groups: SavedGroup[]; layout: SavedLayoutNode }`
- `SavedGroup { id; activeIndex; viewMode; tabs }`, `SavedLayoutNode` mirrors the renderer's `LayoutNode` (kept in shared so the main/shared boundary stays free of renderer types).
- `TabSession` (old flat shape) retained for migration.

**Serialization** (`editor.svelte.ts`)
- `persistTabs` writes the versioned session; the reactive `layout` is `$state.snapshot`'d to a plain object so structured-clone IPC doesn't choke on the Svelte proxy.
- `restoreTabs` rebuilds every group (dropping notes whose files vanished), then **validates** the saved layout structurally (`isLayoutNode`) *and* that its leaves map 1:1 to the restored groups; advances the group-id counter past restored ids so a later split can't re-mint a live id.

**Robustness**
- **Migration**: a legacy flat `{activeIndex, tabs}` loads as a single group.
- **Corruption / mismatch**: merges all recovered tabs into one pane (no data loss) rather than rendering a broken split or crashing.

**New persist triggers**: split / collapse / focus change (debounced), and divider **resize** (threaded via `SplitContainer`'s new `onLayoutChange`).

**Restore polish**: App restores cursor/scroll for *every* pane's active note tab, not just the focused one.

Main-process tabs handler treats the payload as opaque JSON — the renderer owns validation/migration.

## Tests
`tests/renderer/editor-store.test.ts` — persist shape, persist→restore round-trip, multi-group restore (focus + view modes + sizes), legacy migration, layout-mismatch merge fallback, deleted-file drop, corrupt/empty no-op, id-counter advance.
`tests/renderer/layout-tree.test.ts` — `isLayoutNode` guard coverage.
Full `pnpm test` green (**3375**). Lint clean. No new `window.api` methods → preload snapshot unchanged.

## ⚠️ Needs live verification
Restart restoring real CodeMirror panes can't be exercised headlessly:
- [ ] Split into a few panes (nest both ways), resize dividers, set different view modes per pane, focus one — quit and reopen: layout, sizes, per-group tabs, active tabs, view modes, and focus all return.
- [ ] Each pane's cursor/scroll is restored (not just the focused pane).
- [ ] An older single-pane `tabs.json` (pre-this-PR) still restores as one group.
- [ ] Delete a file that was open in a split, reopen: that tab drops; the rest survive.
- [ ] Hand-corrupt `.minerva/tabs.json` → app opens to a single pane, no crash.

## Acceptance (#816)
- [x] Splits, sizes, per-group tabs, active tabs, view modes, and focus survive restart.
- [x] A pre-existing flat `tabs.json` migrates cleanly to a single group.
- [x] Corrupt/partial layout falls back to a single (merged) group rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)