### PR TITLE
feat: forbid duplicate file open across panes (#815)

### DIFF
--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -136,6 +136,25 @@ export function getEditorStore() {
     return groups.flatMap((g) => g.tabs);
   }
 
+  /** First tab matching `match` across every group, with its group + index.
+   *  Backs the forbid-duplicate-open rule (#815): a file/source/pdf lives in
+   *  at most one pane, so opening one already open anywhere just refocuses it. */
+  function locateTab(match: (t: Tab) => boolean): { group: EditorGroup; index: number } | null {
+    for (const group of groups) {
+      const index = group.tabs.findIndex(match);
+      if (index !== -1) return { group, index };
+    }
+    return null;
+  }
+
+  /** Focus the pane + tab `found` points at, and persist the focus change.
+   *  The redirect target when a duplicate open is suppressed (#815). */
+  function focusExistingTab(found: { group: EditorGroup; index: number }): void {
+    activeGroupId = found.group.id;
+    found.group.activeIndex = found.index;
+    schedulePersistTabs();
+  }
+
   function activeTab(): Tab | null {
     const g = activeGroup();
     return g.activeIndex >= 0 && g.activeIndex < g.tabs.length ? g.tabs[g.activeIndex] : null;
@@ -239,16 +258,16 @@ export function getEditorStore() {
   // ── Source operations ───────────────────────────────────────────────────
 
   function openSource(sourceId: string, opts?: { highlightExcerptId?: string; groupId?: string }) {
-    const grp = resolveGroup(opts?.groupId);
-    activeGroupId = grp.id;
-    const existing = grp.tabs.findIndex((t) => isSource(t) && t.sourceId === sourceId);
-    if (existing !== -1) {
-      const existingTab = grp.tabs[existing] as SourceTab;
-      existingTab.highlightExcerptId = opts?.highlightExcerptId;
-      grp.activeIndex = existing;
-      schedulePersistTabs();
+    // Forbid duplicate open (#815): if this source is already open in any pane,
+    // refocus it (refreshing the excerpt highlight) instead of opening a copy.
+    const found = locateTab((t) => isSource(t) && t.sourceId === sourceId);
+    if (found) {
+      (found.group.tabs[found.index] as SourceTab).highlightExcerptId = opts?.highlightExcerptId;
+      focusExistingTab(found);
       return;
     }
+    const grp = resolveGroup(opts?.groupId);
+    activeGroupId = grp.id;
     const tab: SourceTab = {
       type: 'source',
       sourceId,
@@ -260,16 +279,16 @@ export function getEditorStore() {
   }
 
   function openPdf(sourceId: string, opts?: { page?: number; groupId?: string }) {
-    const grp = resolveGroup(opts?.groupId);
-    activeGroupId = grp.id;
-    const existing = grp.tabs.findIndex((t) => isPdf(t) && t.sourceId === sourceId);
-    if (existing !== -1) {
-      const existingTab = grp.tabs[existing] as PdfTab;
-      if (opts?.page) existingTab.page = opts.page;
-      grp.activeIndex = existing;
-      schedulePersistTabs();
+    // Forbid duplicate open (#815): if this PDF is already open in any pane,
+    // refocus it (jumping to the requested page) instead of opening a copy.
+    const found = locateTab((t) => isPdf(t) && t.sourceId === sourceId);
+    if (found) {
+      if (opts?.page) (found.group.tabs[found.index] as PdfTab).page = opts.page;
+      focusExistingTab(found);
       return;
     }
+    const grp = resolveGroup(opts?.groupId);
+    activeGroupId = grp.id;
     const tab: PdfTab = {
       type: 'pdf',
       sourceId,
@@ -297,14 +316,18 @@ export function getEditorStore() {
   // ── Note operations ─────────────────────────────────────────────────────
 
   async function openFile(relativePath: string, groupId?: string) {
-    const grp = resolveGroup(groupId);
-    activeGroupId = grp.id;
-    const existing = grp.tabs.findIndex((t) => isNote(t) && t.relativePath === relativePath);
-    if (existing !== -1) {
-      grp.activeIndex = existing;
+    // Forbid duplicate open (#815): a note lives in at most one pane. If it's
+    // already open anywhere, focus that pane + tab rather than spawning a second
+    // live buffer (which would race to last-write-wins on save). This holds for
+    // every caller — sidebar, wiki-link, search, split-open.
+    const found = locateTab((t) => isNote(t) && t.relativePath === relativePath);
+    if (found) {
+      focusExistingTab(found);
       return;
     }
 
+    const grp = resolveGroup(groupId);
+    activeGroupId = grp.id;
     const text = await api.notebase.readFile(relativePath);
     const fileName = relativePath.split('/').pop() ?? '';
     const tab: NoteTab = {
@@ -529,6 +552,16 @@ export function getEditorStore() {
     return v === 'preview' || v === 'editor-preview' || v === 'source' ? v : 'source';
   }
 
+  /** Cross-pane identity of a persisted tab, for the forbid-duplicate dedup on
+   *  restore (#815). Queries have no shared-buffer identity (each is its own
+   *  scratch buffer), so they return null and are never deduped. */
+  function savedTabIdentity(t: SavedTab): string | null {
+    if (t.type === 'note') return `note:${t.relativePath}`;
+    if (t.type === 'source') return `source:${t.sourceId}`;
+    if (t.type === 'pdf') return `pdf:${t.sourceId}`;
+    return null;
+  }
+
   /** Coerce whatever is on disk into the current multi-group shape. New
    *  sessions pass through; a legacy flat `TabSession` migrates to a single
    *  group (#816); anything else (null / empty / unrecognised) → null, so the
@@ -555,13 +588,22 @@ export function getEditorStore() {
     const session = normalizeSession(await api.tabs.load());
     if (!session) return; // nothing saved or corrupt → keep the default empty group
 
-    // Rebuild each group, dropping note tabs whose files have since vanished.
+    // Rebuild each group, dropping note tabs whose files have since vanished
+    // and any duplicate of a tab already restored in an earlier pane — the
+    // forbid-duplicate-open invariant (#815) must hold even if the on-disk
+    // session was hand-edited or written by an older build.
+    const seen = new Set<string>();
     const restored: EditorGroup[] = [];
     for (const sg of session.groups) {
       const tabs: Tab[] = [];
       for (const saved of sg.tabs) {
+        const identity = savedTabIdentity(saved);
+        if (identity && seen.has(identity)) continue;
         const tab = await reconstructTab(saved);
-        if (tab) tabs.push(tab);
+        if (tab) {
+          tabs.push(tab);
+          if (identity) seen.add(identity);
+        }
       }
       const activeIndex =
         sg.activeIndex >= 0 && sg.activeIndex < tabs.length

--- a/tests/renderer/editor-store.test.ts
+++ b/tests/renderer/editor-store.test.ts
@@ -485,3 +485,90 @@ describe('session persistence — multi-group layout (#816)', () => {
     expect(Number(newId.match(/\d+/)?.[0])).toBeGreaterThan(4);
   });
 });
+
+describe('forbid duplicate open (#815)', () => {
+  const countOpen = (pred: (t: { type: string }) => boolean) =>
+    editor.groups.flatMap((g) => g.tabs).filter(pred).length;
+
+  it('opening a note already open in another pane focuses that pane, no second buffer', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    await editor.openFile('b.md'); // into g2 (active)
+    expect(editor.activeGroupId).toBe(g2);
+
+    await editor.openFile('a.md'); // already open in g1 → refocus g1
+    expect(editor.activeGroupId).toBe(g1);
+    expect(editor.noteTabForGroup(g1)?.relativePath).toBe('a.md');
+    expect(editor.groups.find((g) => g.id === g2)?.tabs).toHaveLength(1); // g2 untouched
+    expect(countOpen((t) => t.type === 'note' && (t as { relativePath: string }).relativePath === 'a.md')).toBe(1);
+  });
+
+  it('an explicit target group is overridden when the note is already open elsewhere', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+
+    await editor.openFile('a.md', g2); // request g2, but a.md lives in g1
+    expect(editor.activeGroupId).toBe(g1);
+    expect(editor.groups.find((g) => g.id === g2)?.tabs).toHaveLength(0);
+  });
+
+  it('after the only copy is closed, the file can be opened again in any pane', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    editor.splitGroup(g1, 'horizontal'); // → g2 (active)
+    await editor.openFile('b.md'); // g2
+
+    editor.closeTab(0, g1); // closes a.md → g1 collapses, only g2 remains
+    expect(countOpen((t) => t.type === 'note' && (t as { relativePath: string }).relativePath === 'a.md')).toBe(0);
+
+    await editor.openFile('a.md'); // free to reopen now
+    expect(countOpen((t) => t.type === 'note' && (t as { relativePath: string }).relativePath === 'a.md')).toBe(1);
+    expect(editor.noteTabForGroup(editor.activeGroupId)?.relativePath).toBe('a.md');
+  });
+
+  it('sources and PDFs dedup across panes by id (and refresh highlight/page)', async () => {
+    editor.openSource('src-1'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    editor.openPdf('src-2'); // g2
+
+    editor.openSource('src-1', { highlightExcerptId: 'ex-9' }); // refocus g1
+    expect(editor.activeGroupId).toBe(g1);
+    expect(countOpen((t) => t.type === 'source' && (t as { sourceId: string }).sourceId === 'src-1')).toBe(1);
+    const srcTab = editor.groups.find((g) => g.id === g1)?.tabs[0];
+    expect(srcTab?.type === 'source' && srcTab.highlightExcerptId).toBe('ex-9');
+
+    editor.openPdf('src-2', { page: 7 }); // refocus g2
+    expect(editor.activeGroupId).toBe(g2);
+    expect(countOpen((t) => t.type === 'pdf' && (t as { sourceId: string }).sourceId === 'src-2')).toBe(1);
+    const pdfTab = editor.groups.find((g) => g.id === g2)?.tabs[0];
+    expect(pdfTab?.type === 'pdf' && pdfTab.page).toBe(7);
+  });
+
+  it('restore drops a duplicate that appears in two panes (keeps the first)', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [
+        { id: 'group-1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'dup.md' }] },
+        {
+          id: 'group-2', activeIndex: 0, viewMode: 'source',
+          tabs: [{ type: 'note', relativePath: 'dup.md' }, { type: 'note', relativePath: 'other.md' }],
+        },
+      ],
+      layout: {
+        kind: 'split', direction: 'horizontal', sizes: [0.5, 0.5],
+        children: [{ kind: 'leaf', groupId: 'group-1' }, { kind: 'leaf', groupId: 'group-2' }],
+      },
+    });
+    await editor.restoreTabs();
+
+    expect(countOpen((t) => t.type === 'note' && (t as { relativePath: string }).relativePath === 'dup.md')).toBe(1);
+    expect(editor.noteTabForGroup('group-1')?.relativePath).toBe('dup.md'); // kept in the first pane
+    const g2Paths = editor.groups.find((g) => g.id === 'group-2')?.tabs
+      .map((t) => (t.type === 'note' ? t.relativePath : t.type));
+    expect(g2Paths).toEqual(['other.md']);
+  });
+});


### PR DESCRIPTION
Part of #810 — **Phase 4** (#815). Builds on #813 (split layout), #814 (focus/commands), #816 (persist), all merged. **Locked decision: forbid duplicates.**

## Why
With multiple panes, opening the same file in two groups would create two independent live buffers of one file → last-write-wins on save → silent data loss. Real shared-document multi-view (one CodeMirror doc, per-view selection/scroll/undo) is the genuinely hard path; for v2.0 we forbid duplicate open instead — a file lives in at most one pane.

## What
- **Routing guard** (`editor.svelte.ts`): `openFile` / `openSource` / `openPdf` now check **every** group via a new `locateTab()` helper. If the file/source/pdf is already open anywhere, they focus that pane + tab (refreshing the source highlight / PDF page) instead of opening a copy. Because the policy lives in the store, it holds for **all** callers — sidebar, wiki-link, search-open, split-open. An explicit target `groupId` is overridden when the file is already open elsewhere.
- **Restore dedup**: `restoreTabs` drops cross-pane duplicates by identity (note path / source id / pdf id), so the invariant holds even for a hand-edited or older session — the first pane wins.
- **Queries**: each query is its own scratch buffer with no shared-file identity, so they're intentionally never deduped (no file → no data-loss path).
- Composes with #813 collapse + #814 focus: closing the only copy frees the file to open anywhere again.

## Out of scope
Shared-document multi-view sync — explicit v2.x fast-follow, noted in the epic, not built here.

## Tests
`tests/renderer/editor-store.test.ts` — cross-pane refocus (no second buffer), explicit-target override, reopen-after-close, source/pdf dedup with highlight/page refresh, restore duplicate-drop. Full `pnpm test` green (**3380**). Lint clean.

## ⚠️ Needs live verification
Mostly store-logic (unit-covered), but worth a quick GUI pass:
- [ ] Open a note, split, then open the same note from the sidebar/wiki-link in the other pane → it jumps to the original pane's tab; no duplicate.
- [ ] Same for a source detail tab and a PDF.
- [ ] Close the only copy, then reopen → opens normally in the focused pane.

## Acceptance (#815)
- [x] Opening a file already open in another pane focuses that pane + tab; no second buffer.
- [x] Works for notes, sources, and PDFs by identity (queries are scratch, N/A).
- [x] After closing a file, it can be opened freely in any pane again.
- [x] No last-write-wins data-loss path exists for a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)