### PR TITLE
feat: keyboard-operable split dividers + empty-pane affordance (#817 pt 1)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1348,6 +1348,16 @@
                     />
                   {/await}
                 {/key}
+              {:else if editor.groups.length > 1}
+                <!-- A freshly split pane is empty until a note lands in it.
+                     It has no tab bar, so offer a way back out (#817). -->
+                <div class="no-file empty-pane">
+                  <p>Empty pane</p>
+                  <p class="empty-pane-hint">Open a note from the sidebar to fill it.</p>
+                  <button class="empty-pane-close" onclick={() => editor.collapseGroup(groupId)}>
+                    Close this pane
+                  </button>
+                </div>
               {:else}
                 <div class="no-file">
                   <p>Select a note from the sidebar</p>
@@ -1359,8 +1369,10 @@
 
         <SplitContainer node={editor.layout} leaf={groupPane} onLayoutChange={() => editor.schedulePersistTabs()} />
 
-        <!-- Window-level status + tool surfaces, reflecting the active group's
-             note. (Per-group status bars are #817 polish.) -->
+        <!-- One window-level status bar that reflects the focused group's note
+             (word count, cursor, dirty state) — the deliberate #817 choice over
+             a bar per pane: it tracks `editor.activeTab`, which follows the
+             active group. -->
         {#if editor.activeTab?.type === 'note'}
           <StatusBar
             cursor={cursorInfo}
@@ -1732,6 +1744,28 @@
   .no-file p {
     color: var(--text-muted);
     font-size: 14px;
+  }
+
+  .empty-pane {
+    flex-direction: column;
+    gap: 6px;
+  }
+  .empty-pane-hint {
+    font-size: 12px !important;
+    opacity: 0.8;
+  }
+  .empty-pane-close {
+    margin-top: 8px;
+    padding: 4px 12px;
+    font-size: 12px;
+    color: var(--text);
+    background: var(--bg-button);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .empty-pane-close:hover {
+    border-color: var(--accent);
   }
 
   .welcome {

--- a/src/renderer/lib/components/ResizeHandle.svelte
+++ b/src/renderer/lib/components/ResizeHandle.svelte
@@ -23,6 +23,9 @@
   let dragging = $state(false);
   let last = 0;
 
+  /** Pixels nudged per arrow-key press (keyboard divider operation, #817). */
+  const KEY_STEP = 24;
+
   function coord(e: PointerEvent): number {
     return direction === 'horizontal' ? e.clientX : e.clientY;
   }
@@ -50,17 +53,44 @@
     (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
     onResizeEnd?.();
   }
+
+  /**
+   * Keyboard operation (#817 a11y): the focused divider nudges the boundary by
+   * a fixed step. Arrow keys map to the split axis — Left/Right for a vertical
+   * bar (horizontal split), Up/Down for a horizontal bar (vertical split) —
+   * with "forward" growing the leading pane, matching a rightward/downward drag.
+   */
+  function onKeydown(e: KeyboardEvent) {
+    const forward = direction === 'horizontal' ? 'ArrowRight' : 'ArrowDown';
+    const backward = direction === 'horizontal' ? 'ArrowLeft' : 'ArrowUp';
+    let delta: number;
+    if (e.key === forward) delta = KEY_STEP;
+    else if (e.key === backward) delta = -KEY_STEP;
+    else return;
+    e.preventDefault();
+    onResize(delta);
+    onResizeEnd?.();
+  }
 </script>
 
+<!-- A focusable separator is the ARIA "window splitter" pattern: it carries
+     role="separator" + tabindex and is operated with the arrow keys (#817).
+     Svelte's a11y lint treats a separator as non-interactive, so the
+     tabindex + keyboard/pointer listeners are intentional here. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
   class="resize-handle {direction}"
   class:dragging
   role="separator"
+  tabindex="0"
   aria-orientation={direction === 'horizontal' ? 'vertical' : 'horizontal'}
+  aria-label="Resize split panes (use arrow keys)"
   onpointerdown={onPointerDown}
   onpointermove={onPointerMove}
   onpointerup={endDrag}
   onpointercancel={endDrag}
+  onkeydown={onKeydown}
 ></div>
 
 <style>
@@ -87,5 +117,11 @@
   .resize-handle:hover,
   .resize-handle.dragging {
     background-color: var(--accent);
+  }
+  /* Keyboard focus: the 1px bar is easy to miss, so widen the accent hit. */
+  .resize-handle:focus-visible {
+    background-color: var(--accent);
+    outline: 1px solid var(--accent);
+    outline-offset: 1px;
   }
 </style>

--- a/tests/renderer/components/ResizeHandle.test.ts
+++ b/tests/renderer/components/ResizeHandle.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Keyboard + ARIA coverage for the split divider (#817 a11y). The pointer-drag
+ * path is exercised by `split-resize.test.ts` (the pure math); here we pin that
+ * a focused divider is operable from the keyboard and exposes the right roles —
+ * arrow keys nudge the boundary by a fixed step, mapped to the split axis.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import ResizeHandle from '../../../src/renderer/lib/components/ResizeHandle.svelte';
+
+afterEach(cleanup);
+
+const STEP = 24;
+
+function renderHandle(direction: 'horizontal' | 'vertical') {
+  const onResize = vi.fn();
+  const onResizeEnd = vi.fn();
+  const { getByRole } = render(ResizeHandle, { direction, onResize, onResizeEnd });
+  return { handle: getByRole('separator'), onResize, onResizeEnd };
+}
+
+describe('ResizeHandle a11y (#817)', () => {
+  it('exposes a focusable separator with orientation and a label', () => {
+    const { handle } = renderHandle('horizontal');
+    expect(handle.getAttribute('role')).toBe('separator');
+    expect(handle.getAttribute('tabindex')).toBe('0');
+    // A horizontal split (panes left↔right) is a vertically-oriented divider.
+    expect(handle.getAttribute('aria-orientation')).toBe('vertical');
+    expect(handle.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  it('horizontal divider: Right grows the leading pane, Left shrinks it', async () => {
+    const { handle, onResize, onResizeEnd } = renderHandle('horizontal');
+    await fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(onResize).toHaveBeenLastCalledWith(STEP);
+    await fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(onResize).toHaveBeenLastCalledWith(-STEP);
+    expect(onResizeEnd).toHaveBeenCalledTimes(2); // persists after each nudge
+  });
+
+  it('vertical divider: Down grows the leading pane, Up shrinks it', async () => {
+    const { handle, onResize } = renderHandle('vertical');
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    expect(onResize).toHaveBeenLastCalledWith(STEP);
+    await fireEvent.keyDown(handle, { key: 'ArrowUp' });
+    expect(onResize).toHaveBeenLastCalledWith(-STEP);
+  });
+
+  it('ignores the cross-axis arrows and other keys', async () => {
+    const { handle, onResize } = renderHandle('horizontal');
+    await fireEvent.keyDown(handle, { key: 'ArrowUp' });
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    await fireEvent.keyDown(handle, { key: 'Enter' });
+    expect(onResize).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Part of #810 — **Phase 6 polish** (#817), **part 1 of 2**. The contained a11y + empty-state fixes; **drag-tab-to-split is the follow-up PR**.

Several #817 items were already satisfied by earlier phases (status bar follows the focused group; source/PDF/query render per-pane). This PR closes the genuinely-remaining contained items.

## What
- **Keyboard-operable dividers** (`ResizeHandle.svelte`): the divider becomes a focusable ARIA *window splitter* — `tabindex` + `aria-label` on top of the existing `role="separator"`/`aria-orientation`. Arrow keys nudge the boundary by a fixed **24px** step (Left/Right for a vertical bar, Up/Down for a horizontal one), reusing the same `onResize` path as pointer drag (so it persists via the layout-change hook). A `focus-visible` ring makes the 1px bar discoverable.
- **Empty-pane affordance** (`App.svelte`): a freshly split pane has no tab bar, so it was a visual dead-end. It now shows an "Empty pane" placeholder with a **"Close this pane"** button (only when split) that collapses it. The lone-pane "Select a note from the sidebar" message is unchanged.
- **Status bar**: documented the deliberate #817 decision — one window-level bar reflecting the focused group (it tracks `editor.activeTab`, which follows the active group) rather than a bar per pane. No behavior change.
- **Non-note tabs**: verified Source / PDF / Query already render per-pane inside `groupPane` — no change needed.

## Tests
`tests/renderer/components/ResizeHandle.test.ts` — separator roles/label, per-axis arrow nudging (Right/Down = +step, Left/Up = −step), cross-axis + other-key no-op. Full `pnpm test` green (**3384**). Lint clean.

## ⚠️ Needs live verification
- [ ] Tab to a divider (it shows a focus ring); arrow keys resize the two adjacent panes, respecting the min size.
- [ ] Split a pane → the new empty pane shows the placeholder; "Close this pane" collapses it and rebalances.
- [ ] Status bar reflects whichever pane is focused (cursor / word count / dirty).

## Acceptance (#817 — this PR)
- [x] Empty panes show a sensible state (placeholder + close affordance) consistently.
- [x] Status bar reflects the focused group.
- [x] Source / PDF / query tabs render correctly inside split panes (verified).
- [x] Dividers are keyboard-operable.
- [ ] Dragging a tab to a pane edge splits and moves it → **part 2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)