### PR TITLE
feat: tab menu — split Close All, add Close All In Group + Move to group (#870)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -5,6 +5,7 @@
   import Editor from './lib/components/Editor.svelte';
   import SplitContainer from './lib/components/SplitContainer.svelte';
   import { dropZoneFromFraction, splitForZone, type DropZone } from './lib/editor/drop-zone';
+  import { collectGroupIds } from './lib/editor/layout-tree';
   import QueryPanel from './lib/components/QueryPanel.svelte';
   import RightSidebar from './lib/components/RightSidebar.svelte';
   import StatusBar from './lib/components/StatusBar.svelte';
@@ -223,6 +224,14 @@
   $effect(() => {
     document.body.classList.toggle('tab-dragging', draggingTab !== null);
   });
+
+  /** Other editor groups a tab in `groupId` can be moved to (#870), in visual
+   *  (left-to-right) order and labelled by position. Empty when single-pane. */
+  function otherGroupsFor(groupId: string): { id: string; label: string }[] {
+    return collectGroupIds(editor.layout)
+      .map((id, i) => ({ id, label: `Group ${i + 1}` }))
+      .filter((g) => g.id !== groupId);
+  }
 
   function onTabPointerDown(groupId: string, index: number, e: PointerEvent) {
     pendingDrag = { groupId, index, startX: e.clientX, startY: e.clientY };
@@ -1242,6 +1251,9 @@
                   onClose={(i) => editor.closeTab(i, groupId)}
                   onCloseOthers={(i) => editor.closeOthers(i, groupId)}
                   onCloseAll={() => editor.closeAll(groupId)}
+                  onCloseAllInGroup={() => editor.closeAllAndCollapse(groupId)}
+                  otherGroups={otherGroupsFor(groupId)}
+                  onMoveToGroup={(i, targetGroupId) => editor.moveTab(groupId, i, targetGroupId)}
                   onReveal={handleRevealInSidebar}
                   onOpenConversation={openConversation}
                   onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -20,6 +20,14 @@
     onReveal: (relativePath: string) => void;
     onOpenConversation?: () => void;
     onBookmark?: (relativePath: string) => void;
+    /** "Close All In Group" — empties + collapses this pane. Shown only when
+     *  there's more than one group (i.e. `otherGroups` is non-empty) (#870). */
+    onCloseAllInGroup?: () => void;
+    /** Other editor groups this tab can be moved to, in visual order (#870).
+     *  Empty when this is the only group. */
+    otherGroups?: { id: string; label: string }[];
+    /** Move the tab at `index` into the group `targetGroupId` (#870). */
+    onMoveToGroup?: (index: number, targetGroupId: string) => void;
     /** Trailing `+` button — opens a new note at the project root. */
     onNewTab?: () => void;
     /** Drag-tab-to-split (#817): pointer pressed on the tab at `index`. The
@@ -29,7 +37,7 @@
     onTabPointerDown?: (index: number, e: PointerEvent) => void;
   }
 
-  let { tabs, activeIndex, sources, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark, onNewTab, onTabPointerDown }: Props = $props();
+  let { tabs, activeIndex, sources, onSwitch, onClose, onCloseOthers, onCloseAll, onReveal, onOpenConversation, onBookmark, onNewTab, onTabPointerDown, onCloseAllInGroup, otherGroups, onMoveToGroup }: Props = $props();
 
   /** Map sourceId → metadata for label lookups. Rebuilds whenever the
    *  parent's `sources` array changes. */
@@ -143,6 +151,21 @@
     <button onclick={() => { onClose(contextMenu!.index); contextMenu = null; }}>Close</button>
     <button onclick={() => { onCloseOthers(contextMenu!.index); contextMenu = null; }}>Close Others</button>
     <button onclick={() => { onCloseAll(); contextMenu = null; }}>Close All</button>
+    {#if onCloseAllInGroup && (otherGroups?.length ?? 0) > 0}
+      <button onclick={() => { onCloseAllInGroup?.(); contextMenu = null; }}>Close All In Group</button>
+    {/if}
+    {#if otherGroups && otherGroups.length === 1}
+      <button onclick={() => { onMoveToGroup?.(contextMenu!.index, otherGroups[0].id); contextMenu = null; }}>Move to Other Group</button>
+    {:else if otherGroups && otherGroups.length > 1}
+      <div class="submenu-item">
+        <span class="submenu-trigger">Move to Group <Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          {#each otherGroups as g (g.id)}
+            <button onclick={() => { onMoveToGroup?.(contextMenu!.index, g.id); contextMenu = null; }}>{g.label}</button>
+          {/each}
+        </div>
+      </div>
+    {/if}
     {#if tabs[contextMenu.index]?.type === 'note'}
       <div class="separator"></div>
       <button onclick={() => { const t = tabs[contextMenu!.index]; if (t.type === 'note') onReveal(t.relativePath); contextMenu = null; }}>Reveal in Sidebar</button>

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -212,10 +212,10 @@ export function getEditorStore() {
   /**
    * Close the focused pane: drop all its tabs and collapse it, rebalancing the
    * tree (#814). On the lone pane this just empties it (collapse no-ops), so the
-   * window always keeps one group — same contract as {@link closeAll}.
+   * window always keeps one group.
    */
   function closeActiveGroup(): void {
-    closeAll(activeGroupId);
+    closeAllAndCollapse(activeGroupId);
   }
 
   // ── Split layout (#813) ───────────────────────────────────────────────────
@@ -834,15 +834,23 @@ export function getEditorStore() {
     schedulePersistTabs();
   }
 
+  /** "Close All" (#870): empty a pane's tabs but keep the pane — leaves an
+   *  empty/blank pane rather than collapsing the split. */
   function closeAll(groupId?: string) {
     const grp = resolveGroup(groupId);
     flushAutoSave();
     grp.tabs.length = 0;
     grp.activeIndex = -1;
-    // Emptying a split pane collapses it and rebalances the tree, same as
-    // closing its last tab one-by-one (#813). No-ops on the last pane.
-    collapseGroup(grp.id);
     schedulePersistTabs();
+  }
+
+  /** "Close All In Group" / Close Group (#870, #814): empty a pane AND collapse
+   *  it, rebalancing the tree. No-ops the collapse on the last remaining pane,
+   *  so the window always keeps one group. */
+  function closeAllAndCollapse(groupId?: string) {
+    const grp = resolveGroup(groupId);
+    closeAll(grp.id);
+    collapseGroup(grp.id);
   }
 
   /**
@@ -973,6 +981,7 @@ export function getEditorStore() {
     closeTab,
     closeOthers,
     closeAll,
+    closeAllAndCollapse,
     switchTab,
     clear,
     saveEditorState,

--- a/tests/renderer/components/TabBar.test.ts
+++ b/tests/renderer/components/TabBar.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Tab context-menu coverage for the close/move items (#870). Pins the
+ * group-aware conditionals: "Close All In Group" and the move targets only
+ * appear when there's more than one group, and the move surface is a single
+ * item for one other group vs a submenu for several.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import TabBar from '../../../src/renderer/lib/components/TabBar.svelte';
+
+afterEach(cleanup);
+
+const tabs = [
+  { type: 'note', relativePath: 'a.md', fileName: 'a.md', content: '', savedContent: '' },
+  { type: 'note', relativePath: 'b.md', fileName: 'b.md', content: '', savedContent: '' },
+];
+
+function renderBar(over: {
+  otherGroups?: { id: string; label: string }[];
+  onCloseAll?: () => void;
+  onCloseAllInGroup?: () => void;
+  onMoveToGroup?: (index: number, targetGroupId: string) => void;
+} = {}) {
+  const props = {
+    tabs,
+    activeIndex: 0,
+    onSwitch: vi.fn(),
+    onClose: vi.fn(),
+    onCloseOthers: vi.fn(),
+    onCloseAll: over.onCloseAll ?? vi.fn(),
+    onReveal: vi.fn(),
+    onCloseAllInGroup: over.onCloseAllInGroup,
+    otherGroups: over.otherGroups,
+    onMoveToGroup: over.onMoveToGroup,
+  };
+  const r = render(TabBar, props);
+  return r;
+}
+
+/** Right-click the first tab to open the context menu. */
+async function openMenu(container: HTMLElement) {
+  await fireEvent.contextMenu(container.querySelector('.tab') as HTMLElement);
+}
+
+describe('TabBar context menu — close/move (#870)', () => {
+  it('single group: no "Close All In Group" or move items', async () => {
+    const { container, queryByText } = renderBar({ otherGroups: [] });
+    await openMenu(container);
+    expect(queryByText('Close All')).toBeTruthy();
+    expect(queryByText('Close All In Group')).toBeNull();
+    expect(queryByText('Move to Other Group')).toBeNull();
+    expect(queryByText('Move to Group')).toBeNull();
+  });
+
+  it('two groups: "Close All In Group" + a single "Move to Other Group"', async () => {
+    const onCloseAllInGroup = vi.fn();
+    const onMoveToGroup = vi.fn();
+    const { container, getByText, queryByText } = renderBar({
+      otherGroups: [{ id: 'g2', label: 'Group 2' }],
+      onCloseAllInGroup,
+      onMoveToGroup,
+    });
+    await openMenu(container);
+    expect(queryByText('Close All In Group')).toBeTruthy();
+    expect(queryByText('Move to Group')).toBeNull(); // no submenu for one target
+
+    await fireEvent.click(getByText('Close All In Group'));
+    expect(onCloseAllInGroup).toHaveBeenCalledOnce();
+
+    await openMenu(container);
+    await fireEvent.click(getByText('Move to Other Group'));
+    expect(onMoveToGroup).toHaveBeenCalledWith(0, 'g2');
+  });
+
+  it('three+ groups: a "Move to Group" submenu listing each target', async () => {
+    const onMoveToGroup = vi.fn();
+    const { container, getByText, queryByText } = renderBar({
+      otherGroups: [{ id: 'g1', label: 'Group 1' }, { id: 'g3', label: 'Group 3' }],
+      onCloseAllInGroup: vi.fn(),
+      onMoveToGroup,
+    });
+    await openMenu(container);
+    expect(queryByText('Move to Group')).toBeTruthy();
+    expect(queryByText('Move to Other Group')).toBeNull();
+
+    await fireEvent.click(getByText('Group 3'));
+    expect(onMoveToGroup).toHaveBeenCalledWith(0, 'g3');
+  });
+});

--- a/tests/renderer/editor-store.test.ts
+++ b/tests/renderer/editor-store.test.ts
@@ -255,7 +255,7 @@ describe('split layout ops (#813)', () => {
     expect(editor.tabs).toHaveLength(0);
   });
 
-  it('closeAll on a split pane collapses it, same as closing each tab', async () => {
+  it('closeAll empties a split pane but keeps it (does NOT collapse) (#870)', async () => {
     await editor.openFile('a.md'); // g1
     const g1 = editor.groups[0].id;
     const g2 = editor.splitGroup(g1, 'horizontal');
@@ -263,19 +263,38 @@ describe('split layout ops (#813)', () => {
     await editor.openFile('c.md'); // g2 now has two tabs
     expect(editor.groups).toHaveLength(2);
 
-    // Close-all empties g2 → pane collapses, tree returns to the lone leaf.
     editor.closeAll(g2);
+    // "Close All" leaves the (now empty) pane in place, split intact.
+    expect(editor.groups).toHaveLength(2);
+    expect(editor.groups.find((g) => g.id === g2)?.tabs).toHaveLength(0);
+    expect(editor.layout).toMatchObject({ kind: 'split' });
+  });
+
+  it('closeAllAndCollapse empties a split pane and collapses it (#870)', async () => {
+    await editor.openFile('a.md'); // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.splitGroup(g1, 'horizontal');
+    await editor.openFile('b.md');
+    await editor.openFile('c.md'); // g2 has two tabs
+    expect(editor.groups).toHaveLength(2);
+
+    editor.closeAllAndCollapse(g2);
     expect(editor.groups).toHaveLength(1);
     expect(editor.layout).toEqual({ kind: 'leaf', groupId: g1 });
   });
 
-  it('closeAll on the only pane empties it without collapsing', async () => {
+  it('closeAll / closeAllAndCollapse on the only pane both just empty it', async () => {
     await editor.openFile('a.md');
     await editor.openFile('b.md');
     const only = editor.groups[0].id;
     editor.closeAll();
     expect(editor.groups).toHaveLength(1);
     expect(editor.layout).toEqual({ kind: 'leaf', groupId: only });
+    expect(editor.tabs).toHaveLength(0);
+
+    await editor.openFile('c.md');
+    editor.closeAllAndCollapse(); // collapse no-ops on the last pane
+    expect(editor.groups).toHaveLength(1);
     expect(editor.tabs).toHaveLength(0);
   });
 


### PR DESCRIPTION
Closes #870. Refines the tab context menu now that the editor splits into panes/groups (epic #810).

## Menu changes
| Item | Behavior | Shown when |
|---|---|---|
| **Close All** | Empties the pane's tabs, keeps the (now blank) pane — **no longer collapses** | Always |
| **Close All In Group** | Empties **and** collapses the pane, rebalancing the tree (the old `closeAll` behavior) | >1 group |
| **Move to Other Group** / **Move to Group ▸** | Moves the right-clicked tab to another group | >1 group |

"Move" is a single item when there's one other group, and a submenu (`Group N`, in visual order) when there are several.

## Implementation
- **Store** (`editor.svelte.ts`): `closeAll` no longer routes through `collapseGroup` (it just empties). New `closeAllAndCollapse` does empty-then-collapse; the ⌘⇧W **Close Group** command (`closeActiveGroup`) now uses it. **Move** reuses the existing `moveTab` op from the drag work (moves the tab, focuses the destination, collapses an emptied source).
- **`App.svelte`**: `otherGroupsFor(groupId)` builds the per-pane target list in visual order (`collectGroupIds`); wires `onCloseAllInGroup` / `otherGroups` / `onMoveToGroup` into the `TabBar`.
- **`TabBar.svelte`**: group-aware context-menu items.

## Tests
- `editor-store.test.ts`: `closeAll` keeps the split (no collapse) vs `closeAllAndCollapse` collapses; both no-op-collapse on the lone pane.
- `TabBar.test.ts` (new): menu hides the group items single-group; single "Move to Other Group" for 2 groups; "Move to Group" submenu for 3+; callbacks fire with the right args.
- Full `pnpm test` green (**3396** + 3 new); lint clean. No new `window.api` → preload snapshot unaffected.

## ⚠️ Live check
- [ ] One pane: menu shows only Close / Close Others / Close All.
- [ ] Split: "Close All In Group" collapses the pane; "Close All" leaves it blank without collapsing.
- [ ] 2 groups → "Move to Other Group" moves the tab; 3+ → submenu picks the destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)