### PR TITLE
feat: Vega-Lite / Vega chart rendering core (#827, #828, #829)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -1,0 +1,66 @@
+# Charts — Vega-Lite & Vega
+
+Minerva renders [Vega-Lite](https://vega.github.io/vega-lite/) and full
+[Vega](https://vega.github.io/vega/) specs in the Markdown preview, the same way
+it renders Mermaid diagrams: write a fenced block whose body is the JSON spec and
+it renders to a chart.
+
+````markdown
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      { "category": "A", "value": 28 },
+      { "category": "B", "value": 55 },
+      { "category": "C", "value": 43 }
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}
+```
+````
+
+Use a ` ```vega ` fence for a full Vega spec. Both render through
+[`vega-embed`](https://github.com/vega/vega-embed), which is lazy-loaded on first
+use, so notes without charts pay nothing.
+
+Each chart gets the built-in **"⋯" actions menu** (export PNG/SVG, view
+source/compiled spec) and a **collapse toggle** in the fence toolbar. Charts are
+skinned to the active Catppuccin theme and re-skin automatically when you switch
+themes. A spec that sets its own colors keeps them — the theme is only the
+default layer.
+
+## Data: inline only (security)
+
+A chart spec can arrive from outside your control — via import, the web clipper,
+or a shared vault — so it is treated as partially-untrusted input, the same
+posture as file-path access elsewhere in Minerva.
+
+**Charts render from inline data only.** Any `url` reference in a spec — a
+`data.url` remote fetch, an image-mark `url`, a transform-lookup `url` — is
+**refused**, and the chart shows a clear "remote data disabled" notice instead of
+silently phoning home. Put your data in the spec:
+
+```json
+"data": { "values": [ { "x": 1, "y": 2 } ] }
+```
+
+Under the hood:
+
+- The Vega data **loader** is replaced with one that rejects every remote/file
+  fetch. Inline `data.values` never touch the loader.
+- Vega **expressions** run through the CSP-safe interpreter (the renderer's
+  Content-Security-Policy has no `unsafe-eval`). Pure data-transform expressions
+  — the point of Vega — keep working; nothing in the expression language can
+  reach the network or filesystem.
+- A spec's `usermeta.embedOptions` is stripped before rendering, so a spec can't
+  re-enable codegen or swap the loader through that channel.
+
+Binding charts to Minerva's own data (compute-cell outputs, CSV/DuckDB tables,
+inline SPARQL/SQL) is planned (#832) and will resolve through the same safe-path
+layer — never a raw fetch.

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -20,6 +20,7 @@
   import { installCallouts } from '../markdown/callout-plugin';
   import { installWikiLinks, installNoteTags } from '../markdown/inline-tokens-plugin';
   import { hydrateMermaidBlocks, invalidateMermaidTheme } from '../markdown/mermaid-renderer';
+  import { hydrateVegaBlocks, invalidateVegaTheme } from '../markdown/vega-renderer';
   import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
   import { normalizeSqlRows } from '../editor/sql-result';
@@ -352,6 +353,28 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       return `<div class="mermaid-block" data-mermaid-pending="1">${escaped}</div>\n`;
     }
 
+    if (info === 'vega-lite' || info === 'vega') {
+      const escaped = (tok.content ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      const mode = info === 'vega' ? 'full' : 'lite';
+      // Like mermaid, charts auto-render on view (no run button) but get a
+      // collapse toggle so a tall chart can be tucked away. The lazy hydrator
+      // (vega-renderer.ts) swaps the placeholder for an embedded SVG chart.
+      const block = `<div class="vega-block" data-vega-pending="1" data-vega-mode="${mode}">${escaped}</div>`;
+      if (openingLine !== null) {
+        const isCollapsed = collapsedFences.has(openingLine);
+        return `<div class="fence-block fence-vega${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}">`
+          + `<div class="fence-toolbar"><span class="fence-lang">${info}</span>`
+          + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
+          + `</div>`
+          + `<div class="fence-body">${block}</div>`
+          + `</div>\n`;
+      }
+      return `${block}\n`;
+    }
+
     // Runnable fences (python / sparql / sql) get a toolbar with a ▶
     // run button (when the host wired `onRunCell` + `onApplyCellOutputEdit`)
     // and a collapse toggle. The default highlighted-code body is
@@ -621,6 +644,10 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // replaces .mermaid-block placeholders with rendered SVG, surfaces
       // parse errors inline.
       if (previewEl) void hydrateMermaidBlocks(previewEl);
+      // Vega-Lite / Vega chart hydration (#827) — same shape as mermaid:
+      // lazy-loads vega-embed, replaces .vega-block placeholders with SVG
+      // charts, surfaces parse / security errors inline.
+      if (previewEl) void hydrateVegaBlocks(previewEl);
     });
   });
 
@@ -632,7 +659,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
    */
   export function updateTheme(): void {
     invalidateMermaidTheme();
-    if (previewEl) void hydrateMermaidBlocks(previewEl);
+    invalidateVegaTheme();
+    if (previewEl) {
+      void hydrateMermaidBlocks(previewEl);
+      void hydrateVegaBlocks(previewEl);
+    }
   }
 
   /**

--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -1,0 +1,302 @@
+/**
+ * Lazy-loaded Vega-Lite / Vega chart renderer (#827 / #828 / #829).
+ *
+ * Mirrors the Mermaid path (`mermaid-renderer.ts`): the fence rule emits a
+ * placeholder `<div class="vega-block">` carrying the raw JSON spec as text
+ * content. After preview HTML is injected, `hydrateVegaBlocks` walks the DOM,
+ * dynamic-imports `vega-embed` on first use (it's large — never bundle it into
+ * the main chunk), and renders each spec into its placeholder. Errors render
+ * inline so a single bad spec can't brick the page.
+ *
+ * Both ```vega-lite and ```vega fences route here; `vega-embed` compiles and
+ * renders either, so full Vega is nearly free. The fence's `data-vega-mode`
+ * (`lite` | `full`) selects the embed mode.
+ *
+ * Security (#829): a note can arrive via import, the clipper, or a shared
+ * vault, so a chart spec is partially-untrusted input. Two guardrails, both
+ * defense-in-depth:
+ *   1. The Vega data `loader` is replaced with one that rejects every remote
+ *      / file fetch — only inline `data.values` render. (#832 will add a
+ *      safe-path-resolved local-vault data form; until then any `url` is
+ *      refused.)
+ *   2. Before embedding we scan the spec for any `url` reference and, if one
+ *      is present, short-circuit to a clear "remote data disabled" notice
+ *      rather than a silent empty chart.
+ * Expressions run through Vega's CSP-safe interpreter: the renderer's CSP has
+ * no `unsafe-eval`, so Vega's default `new Function` codegen would throw.
+ * Passing `ast: true` makes vega-embed select the interpreter automatically.
+ * We also strip any `usermeta.embedOptions` from the spec — vega-embed merges
+ * those over our options, which would otherwise let a spec re-enable codegen
+ * or swap the loader.
+ *
+ * Theme (#828): a Vega `config` built from the live Catppuccin CSS tokens
+ * skins background / axes / legend / palette to match the surrounding note.
+ * The config is the default layer — a spec's own explicit encodings win.
+ * `invalidateVegaTheme` clears the cache and rendered state so a theme switch
+ * re-skins existing charts.
+ */
+
+import { getEffectiveTheme, getThemeMode } from '../theme';
+
+type VegaView = { finalize: () => void };
+type VegaEmbed = (
+  el: HTMLElement,
+  spec: unknown,
+  opts?: Record<string, unknown>,
+) => Promise<{ view: VegaView }>;
+
+let embedPromise: Promise<VegaEmbed> | null = null;
+
+/** Cached theme config, keyed by the mode it was built for (mirrors mermaid's
+ *  `initializedFor`) so steady-state re-renders don't recompute. */
+let configCache: { mode: 'dark' | 'light' | 'contrast'; config: Record<string, unknown> } | null = null;
+
+/** Live Vega views, so we can `finalize()` (free listeners / timers) before a
+ *  block is re-rendered on a theme switch. */
+const liveViews = new WeakMap<HTMLElement, VegaView>();
+
+async function loadEmbed(): Promise<VegaEmbed> {
+  if (embedPromise) return embedPromise;
+  embedPromise = import('vega-embed').then((m) => (m.default ?? m) as unknown as VegaEmbed);
+  return embedPromise;
+}
+
+// Catppuccin series palette, shared with the Chart.js query-block adapter so
+// the two charting paths look consistent. Reads well on dark / light / contrast.
+const CATEGORY_PALETTE = [
+  '#89b4fa', // blue (accent)
+  '#a6e3a1', // green
+  '#fab387', // peach
+  '#cba6f7', // mauve
+  '#f38ba8', // red
+  '#94e2d5', // teal
+  '#f9e2af', // yellow
+  '#74c7ec', // sapphire
+];
+
+function readThemeTokens(): {
+  bg: string; text: string; textMuted: string; border: string; accent: string;
+} {
+  const cs = getComputedStyle(document.documentElement);
+  const get = (name: string) => cs.getPropertyValue(name).trim() || '';
+  return {
+    bg: get('--bg'),
+    text: get('--text'),
+    textMuted: get('--text-muted'),
+    border: get('--border'),
+    accent: get('--accent'),
+  };
+}
+
+/**
+ * Build a Vega `config` from the active theme tokens (#828). This is the
+ * default layer: a spec that sets its own colors keeps them, because Vega
+ * merges per-spec encodings over `config`. Cached per theme mode.
+ */
+function buildThemeConfig(): Record<string, unknown> {
+  const mode = getEffectiveTheme(getThemeMode());
+  if (configCache && configCache.mode === mode) return configCache.config;
+  const t = readThemeTokens();
+  const config: Record<string, unknown> = {
+    background: t.bg || 'transparent',
+    title: { color: t.text, subtitleColor: t.textMuted },
+    arc: { fill: t.accent },
+    area: { fill: t.accent },
+    line: { stroke: t.accent },
+    path: { stroke: t.accent },
+    rect: { fill: t.accent },
+    shape: { stroke: t.accent },
+    symbol: { fill: t.accent },
+    bar: { fill: t.accent },
+    point: { fill: t.accent, filled: true },
+    axis: {
+      labelColor: t.textMuted,
+      titleColor: t.text,
+      gridColor: t.border,
+      domainColor: t.border,
+      tickColor: t.border,
+    },
+    legend: { labelColor: t.textMuted, titleColor: t.text },
+    view: { stroke: t.border },
+    range: { category: CATEGORY_PALETTE },
+  };
+  configCache = { mode, config };
+  return config;
+}
+
+/**
+ * Recursively collect every `url` string in the spec. Any present `url` is a
+ * remote/file fetch we refuse by default (#829) — inline `data.values` carry
+ * no `url`. (#832 will introduce a safe local-vault data form resolved before
+ * this layer; until then a `url` means "blocked".)
+ */
+function findUrlRefs(node: unknown, acc: string[], depth = 0): void {
+  if (depth > 64 || node === null || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) findUrlRefs(item, acc, depth + 1);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'url' && typeof value === 'string') acc.push(value);
+    else findUrlRefs(value, acc, depth + 1);
+  }
+}
+
+/**
+ * A Vega `Loader` that refuses every fetch. Inline `data.values` never touch
+ * the loader, so only remote / file references hit these rejections. Passes
+ * vega-embed's `isLoader` check (it tests for a `load` method), so it's used
+ * verbatim rather than wrapped around the default network loader.
+ */
+function makeBlockingLoader(): Record<string, unknown> {
+  const blocked = (uri: unknown) =>
+    Promise.reject(new Error(`Remote data is disabled (blocked: ${String(uri)})`));
+  return {
+    load: blocked,
+    sanitize: (uri: unknown) =>
+      Promise.reject(new Error(`Remote data is disabled (blocked: ${String(uri)})`)),
+    http: blocked,
+    file: (filename: unknown) =>
+      Promise.reject(new Error(`Local file data is disabled (blocked: ${String(filename)})`)),
+  };
+}
+
+/**
+ * Walk `root` for unrendered `.vega-block` placeholders and render each one.
+ * Idempotent: blocks already marked `data-vega-rendered` are skipped, so the
+ * post-render `$effect` firing repeatedly doesn't double-render.
+ */
+export async function hydrateVegaBlocks(root: HTMLElement): Promise<void> {
+  const blocks = Array.from(
+    root.querySelectorAll<HTMLElement>('.vega-block:not([data-vega-rendered])'),
+  );
+  if (blocks.length === 0) return;
+
+  let embed: VegaEmbed;
+  try {
+    embed = await loadEmbed();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    for (const el of blocks) {
+      el.setAttribute('data-vega-rendered', 'error');
+      el.innerHTML = renderErrorHtml(`Failed to load vega-embed: ${msg}`);
+    }
+    return;
+  }
+
+  const config = buildThemeConfig();
+
+  await Promise.all(blocks.map(async (el) => {
+    // Raw spec lives in textContent on first hydration, or stashed on
+    // dataset.vegaSpec on re-hydration after a theme change. Capture it before
+    // mutating innerHTML (pending / error rendering would wipe textContent).
+    const raw = (el.dataset.vegaSpec ?? el.textContent ?? '').trim();
+    el.dataset.vegaSpec = raw;
+    const mode = el.dataset.vegaMode === 'full' ? 'vega' : 'vega-lite';
+    el.removeAttribute('data-vega-pending');
+    el.setAttribute('data-vega-rendered', 'pending');
+
+    // Free a prior view (theme re-render) before discarding its DOM.
+    const prior = liveViews.get(el);
+    if (prior) {
+      try { prior.finalize(); } catch { /* ignore */ }
+      liveViews.delete(el);
+    }
+    el.innerHTML = '';
+
+    let spec: unknown;
+    try {
+      spec = JSON.parse(raw);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      el.innerHTML = renderErrorHtml(`Invalid JSON: ${msg}`);
+      el.setAttribute('data-vega-rendered', 'error');
+      return;
+    }
+
+    // #829 — refuse specs that reach out to the network / filesystem, with a
+    // clear notice rather than a silent empty chart.
+    const urls: string[] = [];
+    findUrlRefs(spec, urls);
+    if (urls.length > 0) {
+      el.innerHTML = renderNoticeHtml(
+        'Remote data disabled',
+        `This chart references external data (${escapeHtml(urls[0])}). For security, `
+          + 'Minerva renders charts from inline data only. Embed the data with '
+          + '`"data": { "values": [ … ] }`.',
+      );
+      el.setAttribute('data-vega-rendered', 'blocked');
+      return;
+    }
+
+    // Strip the usermeta.embedOptions injection vector — vega-embed merges it
+    // over our options, which could re-enable codegen or swap the loader.
+    if (spec && typeof spec === 'object' && 'usermeta' in spec) {
+      const usermeta = (spec as { usermeta?: unknown }).usermeta;
+      if (usermeta && typeof usermeta === 'object' && 'embedOptions' in usermeta) {
+        delete (usermeta as Record<string, unknown>).embedOptions;
+      }
+    }
+
+    try {
+      const { view } = await embed(el, spec, {
+        mode,
+        renderer: 'svg',
+        // `ast: true` makes vega-embed parse expressions to an AST and run them
+        // through the CSP-safe interpreter instead of `new Function` (#829).
+        ast: true,
+        config,
+        loader: makeBlockingLoader(),
+        // Built-in "⋯" menu: export PNG/SVG + view source/compiled. The Vega
+        // online editor action is disabled — it would POST the spec offsite.
+        actions: { export: true, source: true, compiled: true, editor: false },
+        tooltip: true,
+      });
+      liveViews.set(el, view);
+      el.setAttribute('data-vega-rendered', 'ok');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      el.innerHTML = renderErrorHtml(msg);
+      el.setAttribute('data-vega-rendered', 'error');
+    }
+  }));
+}
+
+/**
+ * Reset cached theme config and drop rendered state so the next hydration
+ * re-skins every chart with the current tokens. Called from the preview's
+ * `updateTheme` alongside `invalidateMermaidTheme`.
+ */
+export function invalidateVegaTheme(): void {
+  configCache = null;
+  document.querySelectorAll('.vega-block[data-vega-rendered]').forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    const view = liveViews.get(el);
+    if (view) {
+      try { view.finalize(); } catch { /* ignore */ }
+      liveViews.delete(el);
+    }
+    el.removeAttribute('data-vega-rendered');
+    el.innerHTML = '';
+  });
+}
+
+function renderErrorHtml(msg: string): string {
+  return `<div class="vega-error" role="alert"><strong>Vega error</strong><pre>${escapeHtml(msg)}</pre></div>`;
+}
+
+function renderNoticeHtml(title: string, body: string): string {
+  // `body` already contains escaped interpolations; the literal copy is safe.
+  return `<div class="vega-notice" role="note"><strong>${escapeHtml(title)}</strong><p>${body}</p></div>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Exported for unit tests — the spec-scan and JSON guardrail are the security
+// surface and deserve direct coverage without a DOM/vega-embed round-trip.
+export const __test = { findUrlRefs };

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -328,6 +328,66 @@ mark.hl-orange { background: color-mix(in oklch, var(--hl-orange) 30%, transpare
   color: var(--text-muted);
 }
 
+/* Vega-Lite / Vega chart blocks (#827). Bordered inset panel matching the
+   mermaid / code-block editorial look; the embedded SVG sizes to fit. Errors
+   and the security notice render inline so one bad spec can't brick the doc. */
+.vega-block {
+  margin: 0 0 12px;
+  padding: 16px 20px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-inset);
+  overflow-x: auto;
+  min-height: 40px;
+}
+.vega-block .vega-embed {
+  width: 100%;
+}
+.vega-block svg {
+  max-width: 100%;
+  height: auto;
+}
+.vega-block[data-vega-rendered="pending"]::before {
+  content: 'Rendering chart\2026';
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.vega-error {
+  width: 100%;
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-button);
+  color: var(--text);
+  font-size: 12px;
+  border-radius: 4px;
+  text-align: left;
+}
+.vega-error pre {
+  margin-top: 4px;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.vega-notice {
+  width: 100%;
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-button);
+  color: var(--text);
+  font-size: 12px;
+  border-radius: 4px;
+  text-align: left;
+}
+.vega-notice p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+}
+.vega-notice code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
 /* Footnote hover preview tooltip in the editor (#484). CodeMirror
    tooltips mount outside the editor's scoped CSS, so the styling
    lives here alongside the other shared markdown surfaces. */

--- a/tests/renderer/markdown/vega-renderer.test.ts
+++ b/tests/renderer/markdown/vega-renderer.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Vega security guardrail (#829) — the spec-scan that refuses charts which
+ * reach out to the network / filesystem. Inline `data.values` are the only
+ * supported data source until #832 adds safe-path local-vault resolution, so
+ * any `url` anywhere in the spec must be flagged. Tested at the pure-logic
+ * level — no DOM or vega-embed round-trip.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { __test } from '../../../src/renderer/lib/markdown/vega-renderer';
+
+const { findUrlRefs } = __test;
+
+function urls(spec: unknown): string[] {
+  const acc: string[] = [];
+  findUrlRefs(spec, acc);
+  return acc;
+}
+
+describe('findUrlRefs (vega remote-data guardrail)', () => {
+  it('finds nothing in an inline-data spec', () => {
+    const spec = {
+      $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+      data: { values: [{ a: 'A', b: 28 }, { a: 'B', b: 55 }] },
+      mark: 'bar',
+      encoding: { x: { field: 'a', type: 'nominal' }, y: { field: 'b', type: 'quantitative' } },
+    };
+    expect(urls(spec)).toEqual([]);
+  });
+
+  it('does NOT treat $schema or other non-url keys as a fetch', () => {
+    // $schema is a value, not a `url` key — must not trip the guardrail.
+    expect(urls({ $schema: 'https://vega.github.io/schema/vega-lite/v5.json' })).toEqual([]);
+  });
+
+  it('flags a top-level data.url remote fetch', () => {
+    const spec = { data: { url: 'https://example.com/data.csv' }, mark: 'line' };
+    expect(urls(spec)).toEqual(['https://example.com/data.csv']);
+  });
+
+  it('flags a url nested inside layers / concat', () => {
+    const spec = {
+      vconcat: [
+        { data: { values: [] }, mark: 'bar' },
+        { layer: [{ data: { url: 'http://evil.test/x.json' }, mark: 'point' }] },
+      ],
+    };
+    expect(urls(spec)).toEqual(['http://evil.test/x.json']);
+  });
+
+  it('flags a url inside a transform lookup', () => {
+    const spec = {
+      data: { values: [] },
+      transform: [{ lookup: 'id', from: { data: { url: 'https://cdn.test/lookup.json' }, key: 'id' } }],
+    };
+    expect(urls(spec)).toEqual(['https://cdn.test/lookup.json']);
+  });
+
+  it('flags relative and protocol-relative urls too (no url form supported yet)', () => {
+    expect(urls({ data: { url: '/vault/data.csv' } })).toEqual(['/vault/data.csv']);
+    expect(urls({ data: { url: '//cdn.test/x.json' } })).toEqual(['//cdn.test/x.json']);
+  });
+
+  it('flags an image mark url (also a remote fetch)', () => {
+    const spec = {
+      data: { values: [{ x: 1 }] },
+      mark: { type: 'image', url: 'https://example.com/logo.png' },
+    };
+    expect(urls(spec)).toEqual(['https://example.com/logo.png']);
+  });
+
+  it('collects multiple urls across the spec', () => {
+    const spec = {
+      layer: [
+        { data: { url: 'https://a.test/1.json' } },
+        { data: { url: 'https://b.test/2.json' } },
+      ],
+    };
+    expect(urls(spec).sort()).toEqual(['https://a.test/1.json', 'https://b.test/2.json']);
+  });
+
+  it('ignores a non-string url value', () => {
+    // A spec where `url` is, say, a field encoding object — not a fetch target.
+    expect(urls({ encoding: { url: { field: 'href', type: 'nominal' } } })).toEqual([]);
+  });
+
+  it('does not blow the stack / loop forever on deep nesting', () => {
+    let deep: Record<string, unknown> = { url: 'https://leaf.test/x.json' };
+    for (let i = 0; i < 200; i++) deep = { nested: deep };
+    // Depth guard caps recursion at 64; a url below that is simply not reached.
+    // The point is it returns without throwing.
+    expect(() => urls(deep)).not.toThrow();
+  });
+});

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -3,4 +3,15 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   plugins: [svelte()],
+  resolve: {
+    // vega-embed pulls in d3-shape@3, which imports the `Path` class from
+    // d3-path@3. mermaid (already a dep) drags in an old d3-path@1 via
+    // d3-sankey → d3-shape@1, and pnpm's hoisted linker nests that 1.x copy
+    // inside d3-shape@3's node_modules — so rollup resolves d3-shape@3's
+    // `import {Path} from 'd3-path'` to the 1.x copy, which has no `Path`
+    // export, and the production build fails. Deduping forces a single
+    // d3-path (the hoisted 3.1.0); 3.x is a superset of 1.x's API, so the
+    // mermaid path keeps working too.
+    dedupe: ['d3-path'],
+  },
 });


### PR DESCRIPTION
Takes a run at epic #826 — ships the **core trio** that the epic marks as "ships regardless": core rendering (#827), theme mapping (#828), and the security loader (#829). These three are interdependent (#828/#829 both extend the #827 hydrator, and #827 alone would render unthemed white boxes that can phone home), so they land together. Insert templates (#830), export (#831), and Minerva-data binding (#832) are follow-ups.

## What it does

A ` ```vega-lite ` or ` ```vega ` fence whose body is a JSON spec renders to a chart in the Markdown preview — the same four seams as Mermaid:

1. **Fence dispatch** (`Preview.svelte`) emits a `.vega-block` placeholder inside the existing collapse-toolbar wrapper.
2. **Lazy hydrator** (`vega-renderer.ts`) dynamic-imports `vega-embed` on first use (kept out of the entry chunk), parses the spec, embeds both `vega-lite` and full `vega`, and renders JSON/compile/security errors inline.
3. **Theme** — a Vega `config` built from live Catppuccin tokens skins background/axes/legend/palette; re-skins on theme switch via `invalidateVegaTheme()` wired into `Preview.updateTheme()`; cached per mode. A spec's own encodings win (config is the default layer).
4. Charts get the built-in "⋯" actions menu (export PNG/SVG, view source) and collapse for free.

## Security (#829 — core, not optional)

A note can arrive via import/clipper/shared vault, so a spec is partially-untrusted input. Three layers:
- The Vega data **loader** rejects every remote/file fetch — inline `data.values` only.
- A **pre-scan** flags any `url` and renders a clear "remote data disabled" notice instead of a silent empty chart.
- `usermeta.embedOptions` is **stripped** before embedding (vega-embed merges it over our options — an override vector for the loader / codegen).
- Expressions run through the **CSP-safe interpreter** (`ast: true`); the renderer CSP has no `unsafe-eval`.

## Bundling fix

`vega-embed` pulls in `d3-shape@3` (imports `Path` from `d3-path@3`), but mermaid's `d3-sankey` nests an old `d3-path@1` inside `d3-shape@3` under pnpm's hoisted linker — so the **production rollup build failed** resolving `Path` to the 1.x copy. Fixed by deduping `d3-path` in the renderer Vite config to a single 3.x copy (API-superset of 1.x, so the mermaid path keeps working). This only surfaced in the packaged build, not dev/vitest.

## Verification

- `pnpm lint` clean, unit tests for the #829 spec-scan pass (10/10).
- `pnpm build:e2e` (electron-forge package) succeeds — confirms the d3-path fix and that `vega-embed` bundles + code-splits.
- **Live run of the packaged app** under the real strict CSP, against a seeded note with one inline chart + one remote-`url` chart:
  ```json
  { "renderedSvg": true, "noticeCount": 1, "errCount": 0, "cspOrEvalErrors": [], "allConsoleErrors": [] }
  ```
  The inline chart renders to themed SVG; the remote chart shows the "remote data disabled" notice; no CSP/eval errors. (Screenshot captured locally.)

Part of #826. Closes #827, closes #828, closes #829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)