### PR TITLE
feat: Vega-Lite insert command + chart-type scaffolds (#830)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -29,6 +29,11 @@ Use a ` ```vega ` fence for a full Vega spec. Both render through
 [`vega-embed`](https://github.com/vega/vega-embed), which is lazy-loaded on first
 use, so notes without charts pay nothing.
 
+**Insert → Chart…** offers starter scaffolds (Bar, Line, Area, Scatter, Time
+Series, Pie) that drop a complete, valid, inline-data spec and render
+immediately — the cursor lands in the data array so your first edit is "replace
+my data". An **Empty Block** option is there for starting from scratch.
+
 Each chart gets the built-in **"⋯" actions menu** (export PNG/SVG, view
 source/compiled spec) and a **collapse toggle** in the fence toolbar. Charts are
 skinned to the active Catppuccin theme and re-skin automatically when you switch
@@ -47,7 +52,7 @@ posture as file-path access elsewhere in Minerva.
 silently phoning home. Put your data in the spec:
 
 ```json
-"data": { "values": [ { "x": 1, "y": 2 } ] }
+{ "data": { "values": [ { "x": 1, "y": 2 } ] }, "mark": "point" }
 ```
 
 Under the hood:

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -28,6 +28,7 @@
     insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage,
     insertWikiLink, insertTypedLinks, insertCallouts,
     insertSparqlQuery, insertSqlQuery, insertPythonScript, insertMermaidDiagram,
+    vegaLiteInserts,
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
@@ -1070,6 +1071,14 @@
         </div>
         <button onclick={() => runCmd(insertPythonScript)}>Python Script</button>
         <button onclick={() => runCmd(insertMermaidDiagram)}>Mermaid Diagram</button>
+        <div class="submenu-item" onmouseenter={adjustSubmenu}>
+          <span class="submenu-trigger">Chart...<Icon name="chevronRight" size={10} /></span>
+          <div class="submenu">
+            {#each vegaLiteInserts as t (t.label)}
+              <button onclick={() => runCmd(t.command)}>{t.label}</button>
+            {/each}
+          </div>
+        </div>
         <div class="submenu-separator"></div>
         <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
       </div>

--- a/src/renderer/lib/editor/formatting.ts
+++ b/src/renderer/lib/editor/formatting.ts
@@ -397,6 +397,169 @@ export const insertSqlQuery: Command = makeInsertFence('sql');
 export const insertPythonScript: Command = makeInsertFence('python');
 export const insertMermaidDiagram: Command = makeInsertFence('mermaid');
 
+// ── Vega-Lite chart scaffolds (#830) ───────────────────────────────────────
+//
+// Vega-Lite is intimidating JSON, so a bare empty fence is a poor starting
+// point. Each scaffold is a complete, valid, inline-data spec that renders
+// immediately; the cursor lands in the data array (marked by CURSOR) so the
+// first edit is "replace my data". A bare empty-block option remains for power
+// users (`insertVegaLiteDiagram`).
+
+/** Private-use sentinel marking where the cursor should land inside a template
+ *  body. Stripped before insertion; can't collide with real spec text. */
+const CURSOR = '';
+
+/** Insert a ```lang fenced block wrapping a complete `body`, placing the cursor
+ *  at the `CURSOR` sentinel (or the body start if absent). */
+function makeInsertTemplate(lang: string, bodyWithCursor: string): Command {
+  return (view: EditorView) => {
+    const pos = view.state.selection.main.head;
+    const line = view.state.doc.lineAt(pos);
+    const prefix = pos === line.from ? '' : '\n';
+    const cursorInBody = bodyWithCursor.indexOf(CURSOR);
+    const body = bodyWithCursor.replace(CURSOR, '');
+    const open = `${prefix}\`\`\`${lang}\n`;
+    const anchor = pos + open.length + (cursorInBody >= 0 ? cursorInBody : 0);
+    view.dispatch({
+      changes: { from: pos, insert: `${open}${body}\n\`\`\`\n` },
+      selection: { anchor },
+    });
+    return true;
+  };
+}
+
+const SCHEMA = 'https://vega.github.io/schema/vega-lite/v5.json';
+
+const BAR_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Bar chart",
+  "data": {
+    "values": [
+      { "category": "${CURSOR}A", "value": 28 },
+      { "category": "B", "value": 55 },
+      { "category": "C", "value": 43 },
+      { "category": "D", "value": 91 }
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}`;
+
+const LINE_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Line chart",
+  "data": {
+    "values": [
+      { "x": ${CURSOR}1, "y": 4 },
+      { "x": 2, "y": 7 },
+      { "x": 3, "y": 5 },
+      { "x": 4, "y": 9 }
+    ]
+  },
+  "mark": { "type": "line", "point": true },
+  "encoding": {
+    "x": { "field": "x", "type": "quantitative" },
+    "y": { "field": "y", "type": "quantitative" }
+  }
+}`;
+
+const AREA_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Area chart",
+  "data": {
+    "values": [
+      { "x": ${CURSOR}1, "y": 4 },
+      { "x": 2, "y": 7 },
+      { "x": 3, "y": 5 },
+      { "x": 4, "y": 9 }
+    ]
+  },
+  "mark": "area",
+  "encoding": {
+    "x": { "field": "x", "type": "quantitative" },
+    "y": { "field": "y", "type": "quantitative" }
+  }
+}`;
+
+const SCATTER_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Scatter plot",
+  "data": {
+    "values": [
+      { "x": ${CURSOR}1.2, "y": 3.4 },
+      { "x": 2.5, "y": 1.8 },
+      { "x": 3.1, "y": 4.6 },
+      { "x": 4.7, "y": 2.9 }
+    ]
+  },
+  "mark": "point",
+  "encoding": {
+    "x": { "field": "x", "type": "quantitative" },
+    "y": { "field": "y", "type": "quantitative" }
+  }
+}`;
+
+const TIME_SERIES_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Time series",
+  "data": {
+    "values": [
+      { "date": "${CURSOR}2024-01-01", "value": 120 },
+      { "date": "2024-02-01", "value": 145 },
+      { "date": "2024-03-01", "value": 138 },
+      { "date": "2024-04-01", "value": 172 }
+    ]
+  },
+  "mark": { "type": "line", "point": true },
+  "encoding": {
+    "x": { "field": "date", "type": "temporal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}`;
+
+const PIE_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Pie chart",
+  "data": {
+    "values": [
+      { "category": "${CURSOR}A", "value": 30 },
+      { "category": "B", "value": 25 },
+      { "category": "C", "value": 20 },
+      { "category": "D", "value": 25 }
+    ]
+  },
+  "mark": "arc",
+  "encoding": {
+    "theta": { "field": "value", "type": "quantitative" },
+    "color": { "field": "category", "type": "nominal" }
+  }
+}`;
+
+/** A bare ```vega-lite block — cursor on the empty body line (power users). */
+export const insertVegaLiteDiagram: Command = makeInsertFence('vega-lite');
+
+export const insertVegaLiteBar: Command = makeInsertTemplate('vega-lite', BAR_TEMPLATE);
+export const insertVegaLiteLine: Command = makeInsertTemplate('vega-lite', LINE_TEMPLATE);
+export const insertVegaLiteArea: Command = makeInsertTemplate('vega-lite', AREA_TEMPLATE);
+export const insertVegaLiteScatter: Command = makeInsertTemplate('vega-lite', SCATTER_TEMPLATE);
+export const insertVegaLiteTimeSeries: Command = makeInsertTemplate('vega-lite', TIME_SERIES_TEMPLATE);
+export const insertVegaLitePie: Command = makeInsertTemplate('vega-lite', PIE_TEMPLATE);
+
+/** Chart-type chooser for the Insert menu, in a sensible order. The empty block
+ *  trails the concrete scaffolds for users who'd rather start from scratch. */
+export const vegaLiteInserts: { label: string; command: Command }[] = [
+  { label: 'Bar', command: insertVegaLiteBar },
+  { label: 'Line', command: insertVegaLiteLine },
+  { label: 'Area', command: insertVegaLiteArea },
+  { label: 'Scatter', command: insertVegaLiteScatter },
+  { label: 'Time Series', command: insertVegaLiteTimeSeries },
+  { label: 'Pie', command: insertVegaLitePie },
+  { label: 'Empty Block', command: insertVegaLiteDiagram },
+];
+
 // ── Callout inserts ────────────────────────────────────────────────────────
 
 /** Callout types supported by the preview's callout plugin, in a sensible

--- a/tests/renderer/editor/insert-commands.test.ts
+++ b/tests/renderer/editor/insert-commands.test.ts
@@ -14,6 +14,8 @@ import {
   insertSparqlQuery,
   insertPythonScript,
   insertMermaidDiagram,
+  insertVegaLiteDiagram,
+  vegaLiteInserts,
   insertCallouts,
 } from '../../../src/renderer/lib/editor/formatting';
 
@@ -43,6 +45,56 @@ describe('fenced-block inserts', () => {
     const v = mk('text', 4);
     insertSqlQuery(v);
     expect(v.state.doc.toString()).toBe('text\n```sql\n\n```\n');
+  });
+});
+
+describe('vega-lite chart scaffolds (#830)', () => {
+  /** Pull the JSON body out of an inserted ```vega-lite … ``` block. */
+  function fenceBody(doc: string): string {
+    const m = doc.match(/^```vega-lite\n([\s\S]*?)\n```\n$/);
+    if (!m) throw new Error(`not a vega-lite fence:\n${doc}`);
+    return m[1];
+  }
+
+  it('offers a chart-type chooser ending in an empty-block option', () => {
+    expect(vegaLiteInserts.map((t) => t.label)).toEqual([
+      'Bar', 'Line', 'Area', 'Scatter', 'Time Series', 'Pie', 'Empty Block',
+    ]);
+  });
+
+  it('the empty-block option inserts a bare fence with the cursor on the body line', () => {
+    const v = mk('');
+    insertVegaLiteDiagram(v);
+    expect(v.state.doc.toString()).toBe('```vega-lite\n\n```\n');
+    expect(v.state.selection.main.head).toBe('```vega-lite\n'.length);
+  });
+
+  for (const { label, command } of vegaLiteInserts) {
+    if (label === 'Empty Block') continue;
+    it(`${label} scaffold inserts a valid inline-data spec, cursor inside the data`, () => {
+      const v = mk('');
+      command(v);
+      const doc = v.state.doc.toString();
+      const spec = JSON.parse(fenceBody(doc)) as Record<string, unknown>;
+      // Renders immediately → must be a complete spec with inline data and a mark.
+      expect(spec.mark).toBeTruthy();
+      const data = spec.data as { values?: unknown[]; url?: string };
+      expect(Array.isArray(data.values)).toBe(true);
+      expect(data.values!.length).toBeGreaterThan(0);
+      // #829 posture: scaffolds never reference remote data.
+      expect(data.url).toBeUndefined();
+      expect(JSON.stringify(spec)).not.toContain('"url"');
+      // Cursor lands somewhere inside the body (the data array), not at column 0.
+      const head = v.state.selection.main.head;
+      expect(head).toBeGreaterThan('```vega-lite\n'.length);
+      expect(head).toBeLessThan(doc.length);
+    });
+  }
+
+  it('adds a leading newline when not at the start of a line', () => {
+    const v = mk('text', 4);
+    vegaLiteInserts[0].command(v); // Bar
+    expect(v.state.doc.toString().startsWith('text\n```vega-lite\n')).toBe(true);
   });
 });
 


### PR DESCRIPTION
Continues epic #826. Builds on the rendering core (#877). Gives users runnable starter specs instead of a bare, intimidating empty fence.

## What it does

**Insert → Chart…** opens a chart-type chooser. Each option drops a complete, valid, **inline-data** Vega-Lite spec that renders immediately, with the cursor placed in the data array so the first edit is "replace my data":

- Bar · Line · Area · Scatter · Time Series · Pie
- **Empty Block** trails the list for power users who'd rather start from scratch.

## Implementation

- `formatting.ts`: `makeInsertTemplate()` inserts a full spec and positions the cursor at a private-use sentinel char (stripped before insertion). Six scaffolds + the bare `insertVegaLiteDiagram`, exported together as `vegaLiteInserts` so the menu just maps over them.
- `Editor.svelte`: a `Chart…` submenu beside Mermaid, modeled on the existing Query submenu — the established insert pattern. Like the other inserts, it's menu-only (no command-palette entry), consistent with how Mermaid is offered.
- Scaffolds are minimal and idiomatic (small `data.values`, clear encodings) so they teach the spec shape rather than overwhelm.

## Tests

Extends `insert-commands.test.ts`: every scaffold parses as valid JSON, carries inline `data.values` with **no `url`** (the #829 inline-only posture), declares a `mark`, and leaves the cursor inside the body. The chooser order and the empty-block fallback are locked in. `pnpm lint` clean; 25 tests pass.

(Rendering of these specs is already proven by #877's live verification — the bar scaffold is the same spec shape that rendered there under the real CSP.)

Part of #826. Closes #830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)