### PR TITLE
feat: static chart render on export — Vega-Lite/Vega → SVG (#831)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -69,3 +69,21 @@ Under the hood:
 Binding charts to Minerva's own data (compute-cell outputs, CSV/DuckDB tables,
 inline SPARQL/SQL) is planned (#832) and will resolve through the same safe-path
 layer — never a raw fetch.
+
+## Export
+
+When you export a note, charts are rendered to **static SVG** so the published
+artifact actually shows the visualization instead of a wall of JSON:
+
+- **HTML / PDF** (and the static-site / bundle exporters): each ` ```vega-lite ` /
+  ` ```vega ` block is rendered headlessly in the main process (no browser
+  window) and embedded as an `<img>` (an inline SVG data URI). A neutral light
+  theme is applied so charts read on a white page.
+- **Markdown export** keeps the spec fence **verbatim** — a Vega spec is
+  portable to other Vega-aware tools, and a multi-kilobyte data URI would bloat
+  the file. Re-render it wherever it's opened next.
+
+The security policy holds at export too: a chart that references remote data is
+refused (no fetch from the export process), and any chart that can't render —
+bad spec, blocked data — degrades to its spec text plus a short note. One broken
+chart never fails the whole export.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -27,6 +27,11 @@ const EXTERNAL_DEP_ROOTS = [
   `@duckdb/node-bindings-${process.platform}-${process.arch}`,
   '@mixmark-io/domino',
   'encoding', // node-fetch's optional charset path → require('encoding') → iconv-lite
+  // Headless chart export (#831). Externalized in vite.main.config (large ESM
+  // trees that break the single-file main bundle), so their runtime closure
+  // must be shipped for `require('vega')` / `require('vega-lite')` to resolve.
+  'vega',
+  'vega-lite',
 ];
 
 /** BFS the `dependencies` graph from each root; skips absent optionals. */

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "macos-alias"
     ],
     "overrides": {
-      "@codemirror/view": "6.43.1"
+      "@codemirror/view": "6.43.1",
+      "d3-path": "^3.1.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@codemirror/view': 6.43.1
+  d3-path: ^3.1.0
 
 importers:
 
@@ -3451,9 +3452,6 @@ packages:
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
-
-  d3-path@1.0.9:
-    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
@@ -11870,8 +11868,6 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
-  d3-path@1.0.9: {}
-
   d3-path@3.1.0: {}
 
   d3-polygon@3.0.1: {}
@@ -11902,7 +11898,7 @@ snapshots:
 
   d3-shape@1.3.7:
     dependencies:
-      d3-path: 1.0.9
+      d3-path: 3.1.0
 
   d3-shape@3.2.0:
     dependencies:

--- a/src/main/publish/exporters/note-html/index.ts
+++ b/src/main/publish/exporters/note-html/index.ts
@@ -84,7 +84,7 @@ export const noteHtmlExporter: Exporter = {
       // section listing only what it cited. Tree-level consolidation
       // is a follow-up; this is the simple, correct v1.
       const renderer = plan.citations?.createRenderer();
-      const rawBody = renderNoteBody(f, plan, renderer);
+      const rawBody = await renderNoteBody(f, plan, renderer);
       const withReferences = renderer ? appendCitationsTail(rawBody, renderer) : rawBody;
       const body = await inlineImages(withReferences, f, rootPath, plan.assetPolicy);
       const html = wrapHtml({ title: f.title, body });

--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -16,6 +16,7 @@ import footnote from 'markdown-it-footnote';
 import hljs from 'highlight.js';
 import { buildLinkResolverContext } from '../../link-resolver';
 import { installMath } from '../../../../shared/markdown/math-plugin';
+import { renderVegaBlocks } from '../../vega-render';
 import type { ExportPlanFile, ExportPlan } from '../../types';
 import type { CitationRenderer } from '../../csl';
 
@@ -26,13 +27,16 @@ import type { CitationRenderer } from '../../csl';
  * to collect cited ids across multiple `renderNoteBody` invocations
  * (e.g. a bundle renderer aggregating a single References section).
  */
-export function renderNoteBody(
+export async function renderNoteBody(
   file: ExportPlanFile,
   plan: ExportPlan,
   renderer?: CitationRenderer,
-): string {
+): Promise<string> {
   const md = buildMd(plan, renderer);
-  const bodyMarkdown = stripFrontmatter(file.content);
+  // #831 — pre-render ```vega-lite / ```vega fences to static SVG images
+  // before markdown rendering (md.render is sync; vega's toSVG is async).
+  // The result is `<img>` markdown, so it survives the `html: false` instance.
+  const bodyMarkdown = await renderVegaBlocks(stripFrontmatter(file.content));
   return md.render(bodyMarkdown);
 }
 
@@ -52,6 +56,14 @@ function buildMd(plan: ExportPlan, renderer?: CitationRenderer): MarkdownIt {
       return `<pre><code>${escapeHtml(str)}</code></pre>`;
     },
   });
+  // Allow `data:image/svg+xml` image URIs (#831). markdown-it's default
+  // validateLink whitelists only gif/png/jpeg/webp data URIs (SVG can carry
+  // <script>), but an SVG referenced from an `<img src>` is rendered in a
+  // non-scripting context — the script never runs — so it's safe, and it's
+  // how the export pipeline embeds rendered Vega charts.
+  const defaultValidateLink = md.validateLink.bind(md);
+  md.validateLink = (url: string): boolean =>
+    url.trim().toLowerCase().startsWith('data:image/svg+xml') || defaultValidateLink(url);
   md.use(footnote);
   // `$…$` / `$$…$$` → KaTeX HTML (#327). Same plugin Preview uses so
   // the export and the editor preview render math identically.

--- a/src/main/publish/exporters/static-site/index.ts
+++ b/src/main/publish/exporters/static-site/index.ts
@@ -65,7 +65,7 @@ export const staticSiteExporter: Exporter = {
     for (const note of notes) {
       const renderer = plan.citations?.createRenderer() ?? null;
       const rootRel = relativeToRoot(note.relativePath);
-      const html = renderNotePage({ note, plan, config, index, rootRelative: rootRel, renderer });
+      const html = await renderNotePage({ note, plan, config, index, rootRelative: rootRel, renderer });
       files.push({ path: noteUrl(note.relativePath), contents: html });
       if (renderer) {
         for (const id of renderer.cited()) allCitedIds.add(id);
@@ -93,7 +93,7 @@ export const staticSiteExporter: Exporter = {
       : null;
     if (landingNote) {
       const renderer = plan.citations?.createRenderer() ?? null;
-      const html = renderNotePage({
+      const html = await renderNotePage({
         note: landingNote,
         plan,
         config,

--- a/src/main/publish/exporters/static-site/render.ts
+++ b/src/main/publish/exporters/static-site/render.ts
@@ -32,7 +32,7 @@ export interface RenderPageInput {
 }
 
 /** Render a complete HTML page for a note. */
-export function renderNotePage(input: RenderPageInput): string {
+export async function renderNotePage(input: RenderPageInput): Promise<string> {
   const { note, plan, config, index, rootRelative, renderer } = input;
 
   // Body via the existing markdown→HTML pipeline. The link policy is
@@ -40,7 +40,7 @@ export function renderNotePage(input: RenderPageInput): string {
   // bundle ships every note as an .html sibling — readers want
   // working cross-links inside the site.
   const sitePlan: ExportPlan = { ...plan, linkPolicy: 'follow-to-file' };
-  const rawBody = renderNoteBody(note, sitePlan, renderer ?? undefined);
+  const rawBody = await renderNoteBody(note, sitePlan, renderer ?? undefined);
   const bodyWithFootnotes = renderer ? `${rawBody}${renderFootnotesSection(renderer)}` : rawBody;
   const bodyWithBroken = markBrokenWikiLinks(bodyWithFootnotes);
 

--- a/src/main/publish/exporters/tree-html/index.ts
+++ b/src/main/publish/exporters/tree-html/index.ts
@@ -63,7 +63,7 @@ export const treeHtmlExporter: Exporter = {
     const files: ExportOutput['files'] = [];
     for (const note of notes) {
       const renderer = bundlePlan.citations?.createRenderer();
-      const rawBody = renderNoteBody(note, bundlePlan, renderer);
+      const rawBody = await renderNoteBody(note, bundlePlan, renderer);
       // Note styles: append the per-note footnotes (the inline `<sup>`
       // markers anchor to them). In-text styles: nothing here — the
       // bundle-level References page below carries the bibliography.

--- a/src/main/publish/exporters/tree-pdf.ts
+++ b/src/main/publish/exporters/tree-pdf.ts
@@ -34,7 +34,7 @@ export interface BuildTreePdfHtmlResult {
  * exporter can be unit-tested without spinning up an Electron runtime
  * (Electron only kicks in inside `renderPdfFromHtml`).
  */
-export function buildTreePdfHtml(plan: ExportPlan): BuildTreePdfHtmlResult {
+export async function buildTreePdfHtml(plan: ExportPlan): Promise<BuildTreePdfHtmlResult> {
   const notes = plan.inputs.filter((f) => f.kind === 'note');
   if (notes.length === 0) {
     return { html: '', documentTitle: '', chapterCount: 0 };
@@ -51,7 +51,7 @@ export function buildTreePdfHtml(plan: ExportPlan): BuildTreePdfHtmlResult {
 
   for (const note of notes) {
     const renderer = chapterPlan.citations?.createRenderer();
-    const rawBody = renderNoteBody(note, chapterPlan, renderer);
+    const rawBody = await renderNoteBody(note, chapterPlan, renderer);
     const withFootnotes = renderer ? `${rawBody}${renderFootnotesSection(renderer)}` : rawBody;
     const rewritten = rewriteInterChapterLinks(withFootnotes, notes, rootNote);
     chapters.push({ note, html: rewritten });
@@ -126,7 +126,7 @@ export const treePdfExporter: Exporter = {
   accepts: (input) => input.kind === 'tree',
   acceptedKinds: ['tree'],
   async run(plan) {
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     if (built.chapterCount === 0) {
       return { files: [], summary: 'Nothing to export in this tree.' };
     }

--- a/src/main/publish/vega-render.ts
+++ b/src/main/publish/vega-render.ts
@@ -1,0 +1,171 @@
+/**
+ * Headless Vega-Lite / Vega → SVG rendering for the export pipeline (#831).
+ *
+ * In the app, charts render in the renderer via vega-embed (#827). On export a
+ * chart left as raw JSON is dead weight in an HTML or PDF, so each
+ * ```vega-lite / ```vega block is rendered to a static SVG here — in the main
+ * process, no browser window — and spliced back into the markdown as an
+ * `<img>` (an SVG data URI). markdown-it then emits the image like any other,
+ * so this works even with the exporter's `html: false`.
+ *
+ * Design notes:
+ *   - vega / vega-lite are dynamically `import()`ed and externalized from the
+ *     main bundle (see vite.main.config + forge.config's EXTERNAL_DEP_ROOTS).
+ *     They're large ESM trees that use top-level await, so bundling them
+ *     code-splits the single-file main bundle (breaking packaging) and a CJS
+ *     `require()` of them throws `ERR_REQUIRE_ASYNC_MODULE`. A native dynamic
+ *     `import()` of the externalized package sidesteps both — and only loads
+ *     them when an export actually contains a chart.
+ *   - The #829 security posture holds at export too: a spec that references
+ *     remote data (`url`) is refused and the loader rejects every fetch. A
+ *     chart that can't render (bad JSON, blocked data, compile error) degrades
+ *     to its spec text + an italic note — export never hard-fails on one chart.
+ *   - A neutral light theme `config` is applied so charts read on the white
+ *     background of a printed / publish artifact (vs. the in-app dark theme).
+ *
+ * Markdown export deliberately does NOT call this — it keeps the spec fence
+ * verbatim, which stays portable to other Vega-aware tools.
+ */
+
+// Catppuccin-derived categorical palette, shared in spirit with the renderer
+// (#828) and the Chart.js adapter so all three charting paths feel consistent.
+const CATEGORY_PALETTE = [
+  '#3b6fd4', '#3f9648', '#c8761f', '#8a4fd0',
+  '#c43d5e', '#2a9d8f', '#b58a00', '#3a86c8',
+];
+
+/** A neutral light config for print/publish artifacts. Default layer only —
+ *  a spec's own encodings win, exactly as in the in-app renderer. */
+const EXPORT_CONFIG = {
+  background: 'transparent',
+  axis: {
+    labelColor: '#444',
+    titleColor: '#222',
+    gridColor: '#e2e2e2',
+    domainColor: '#999',
+    tickColor: '#999',
+  },
+  legend: { labelColor: '#444', titleColor: '#222' },
+  title: { color: '#222' },
+  view: { stroke: '#ddd' },
+  range: { category: CATEGORY_PALETTE },
+};
+
+type VegaModule = typeof import('vega');
+type VegaLiteModule = typeof import('vega-lite');
+
+let libsPromise: Promise<{ vega: VegaModule; vegaLite: VegaLiteModule }> | null = null;
+
+/** Lazily load the externalized vega libs via native dynamic import (handles
+ *  their top-level await; a CJS require would throw ERR_REQUIRE_ASYNC_MODULE).
+ *  Cached so a multi-chart / multi-note export pays the load once. */
+function loadLibs(): Promise<{ vega: VegaModule; vegaLite: VegaLiteModule }> {
+  if (!libsPromise) {
+    libsPromise = Promise.all([import('vega'), import('vega-lite')]).then(
+      ([vega, vegaLite]) => ({ vega, vegaLite }),
+    );
+  }
+  return libsPromise;
+}
+
+/**
+ * A Vega `Loader` that refuses every fetch — inline `data.values` never touch
+ * it, so only remote/file references hit these rejections. Same posture as the
+ * renderer guardrail (#829), enforced at export too.
+ */
+function blockingLoader(): Record<string, unknown> {
+  const blocked = (uri: unknown) =>
+    Promise.reject(new Error(`Remote data is disabled (blocked: ${String(uri)})`));
+  return { load: blocked, sanitize: blocked, http: blocked, file: blocked };
+}
+
+/** Recursively collect every `url` string — any present `url` is a remote/file
+ *  fetch we refuse by default (#829); inline data carries none. */
+function findUrlRefs(node: unknown, acc: string[], depth = 0): void {
+  if (depth > 64 || node === null || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) findUrlRefs(item, acc, depth + 1);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'url' && typeof value === 'string') acc.push(value);
+    else findUrlRefs(value, acc, depth + 1);
+  }
+}
+
+// Matches a fenced ```vega-lite or ```vega block at line start. `vega-lite`
+// is tried first so it isn't shadowed by the shorter `vega`. Mirrors the
+// turtle-strip regex shape in note-markdown-shared.ts.
+const VEGA_FENCE_RE = /^```(vega-lite|vega)[ \t]*\r?\n([\s\S]*?)\r?\n```[ \t]*$/gm;
+
+/** Does this markdown contain any vega fence? Cheap gate before the heavy import. */
+export function hasVegaBlocks(markdown: string): boolean {
+  VEGA_FENCE_RE.lastIndex = 0;
+  return VEGA_FENCE_RE.test(markdown);
+}
+
+/**
+ * Replace every ```vega-lite / ```vega fence in `markdown` with a rendered SVG
+ * image (`![chart](data:image/svg+xml;base64,…)`). A chart that can't render
+ * degrades to its original spec fence plus an italic note. Returns the markdown
+ * unchanged when it contains no charts (no library load).
+ */
+export async function renderVegaBlocks(markdown: string): Promise<string> {
+  if (!hasVegaBlocks(markdown)) return markdown;
+
+  VEGA_FENCE_RE.lastIndex = 0;
+  const matches = [...markdown.matchAll(VEGA_FENCE_RE)];
+  if (matches.length === 0) return markdown;
+
+  let out = '';
+  let last = 0;
+  for (const m of matches) {
+    out += markdown.slice(last, m.index);
+    out += await renderOne(m[1] === 'vega' ? 'vega' : 'vega-lite', m[2]);
+    last = m.index + m[0].length;
+  }
+  out += markdown.slice(last);
+  return out;
+}
+
+async function renderOne(mode: 'vega' | 'vega-lite', specText: string): Promise<string> {
+  let spec: unknown;
+  try {
+    spec = JSON.parse(specText);
+  } catch (err) {
+    return degrade(mode, specText, `invalid JSON: ${msgOf(err)}`);
+  }
+
+  const urls: string[] = [];
+  findUrlRefs(spec, urls);
+  if (urls.length > 0) {
+    return degrade(mode, specText, `remote data is disabled (${urls[0]})`);
+  }
+
+  try {
+    const { vega, vegaLite } = await loadLibs();
+    const vgSpec = mode === 'vega-lite'
+      ? vegaLite.compile(spec as Parameters<VegaLiteModule['compile']>[0], { config: EXPORT_CONFIG }).spec
+      : (spec as Parameters<VegaModule['parse']>[0]);
+    const runtime = mode === 'vega-lite'
+      ? vega.parse(vgSpec)
+      : vega.parse(vgSpec, EXPORT_CONFIG);
+    const view = new vega.View(runtime, { renderer: 'none', loader: blockingLoader() as never });
+    const svg = await view.toSVG();
+    view.finalize();
+    const dataUri = `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`;
+    return `![chart](${dataUri})`;
+  } catch (err) {
+    return degrade(mode, specText, msgOf(err));
+  }
+}
+
+/** Graceful fallback: keep the spec (so nothing is lost) and prepend a note.
+ *  The fence survives as a plain code block in the export — never a hard fail. */
+function degrade(mode: 'vega' | 'vega-lite', specText: string, reason: string): string {
+  return `*Chart could not be rendered: ${reason}.*\n\n\`\`\`${mode}\n${specText}\n\`\`\``;
+}
+
+function msgOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/tests/main/publish/note-html.test.ts
+++ b/tests/main/publish/note-html.test.ts
@@ -37,6 +37,29 @@ describe('noteHtmlExporter (#248)', () => {
   beforeEach(() => { root = mkTempProject(); });
   afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
 
+  it('renders a ```vega-lite chart to a static SVG <img> (#831), not raw JSON', async () => {
+    const content = '# Chart\n\n```vega-lite\n'
+      + '{ "data": { "values": [ { "a": "A", "b": 1 } ] }, "mark": "bar", '
+      + '"encoding": { "x": { "field": "a", "type": "nominal" }, "y": { "field": "b", "type": "quantitative" } } }\n'
+      + '```\n';
+    const plan = planWithNote({ content, title: 'Chart' });
+    const output = await noteHtmlExporter.run(plan);
+    const html = String(output.files[0].contents);
+    expect(html).toContain('<img');
+    expect(html).toContain('src="data:image/svg+xml;base64,');
+    // The raw spec JSON must not survive as a code block.
+    expect(html).not.toContain('class="hljs language-vega-lite"');
+    expect(html).not.toContain('"encoding"');
+  });
+
+  it('a remote-data chart degrades to a notice during export, never fetched (#829/#831)', async () => {
+    const content = '```vega-lite\n{ "data": { "url": "https://example.com/x.csv" }, "mark": "line" }\n```\n';
+    const plan = planWithNote({ content, title: 'Remote' });
+    const html = String((await noteHtmlExporter.run(plan)).files[0].contents);
+    expect(html).not.toContain('data:image'); // never rendered
+    expect(html.toLowerCase()).toContain('remote data is disabled');
+  });
+
   it('emits a self-contained HTML file with inline stylesheet + article body', async () => {
     const plan = planWithNote({ content: '# Hello\n\nA paragraph.\n', title: 'Hello' });
     const output = await noteHtmlExporter.run(plan);

--- a/tests/main/publish/tree-pdf.test.ts
+++ b/tests/main/publish/tree-pdf.test.ts
@@ -42,7 +42,7 @@ describe('tree-pdf builder (#290)', () => {
       '---\ntitle: Chapter Two\n---\n# Chapter Two\n\nThe second chapter.\n', 'utf-8');
 
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 3 });
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     expect(built.chapterCount).toBe(3);
     expect(built.documentTitle).toBe('The Thesis');
     // Title page + TOC + 3 chapter sections.
@@ -65,7 +65,7 @@ describe('tree-pdf builder (#290)', () => {
     await fsp.writeFile(path.join(root, 'chap.md'),
       '---\ntitle: A Chapter\n---\n# A Chapter\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     expect(built.html).toContain('href="#chapter-root"');
     expect(built.html).toContain('href="#chapter-chap"');
     expect(built.html).toContain('id="chapter-root"');
@@ -78,7 +78,7 @@ describe('tree-pdf builder (#290)', () => {
     await fsp.writeFile(path.join(root, 'chap.md'),
       '---\ntitle: A Chapter\n---\n# A Chapter\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     // No inter-note references that would fail in a single-file PDF.
     expect(built.html).not.toContain('href="chap.html"');
     expect(built.html).not.toContain('href="./chap.html"');
@@ -90,7 +90,7 @@ describe('tree-pdf builder (#290)', () => {
     await fsp.writeFile(path.join(root, 'r.md'), '# R\n[[c]]\n', 'utf-8');
     await fsp.writeFile(path.join(root, 'c.md'), '# C\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'r.md', maxDepth: 2 });
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     expect(built.html).toContain('.tree-pdf-chapter {');
     expect(built.html).toContain('page-break-before: always');
     expect(built.html).toContain('.tree-pdf-title-page');
@@ -101,7 +101,7 @@ describe('tree-pdf builder (#290)', () => {
     await fsp.writeFile(path.join(root, 'root.md'),
       '---\ntitle: From Frontmatter\n---\n# Different In Body\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 1 });
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     expect(built.documentTitle).toBe('From Frontmatter');
     // TOC entry uses frontmatter title.
     expect(built.html).toMatch(/<nav class="tree-pdf-toc">[\s\S]*?From Frontmatter[\s\S]*?<\/nav>/);
@@ -119,7 +119,7 @@ describe('tree-pdf builder (#290)', () => {
     await fsp.writeFile(path.join(root, 'a.md'),
       '# A\nAlso cites [[cite::foo-2020]]\n', 'utf-8');
     const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     expect(built.html).toContain('id="chapter-bibliography"');
     expect(built.html).toContain('References');
     // Bibliography lists Foo exactly once despite two cite references.
@@ -142,7 +142,7 @@ describe('tree-pdf builder (#290)', () => {
       { kind: 'tree', relativePath: 'root.md', maxDepth: 2 },
       { citationStyle: 'chicago-notes-bibliography' },
     );
-    const built = buildTreePdfHtml(plan);
+    const built = await buildTreePdfHtml(plan);
     // Each chapter's footnote counter starts at 1.
     expect(built.html).toContain('id="fn-1"');
     expect((built.html.match(/id="fnref-1"/g) ?? []).length).toBeGreaterThanOrEqual(2);
@@ -150,10 +150,10 @@ describe('tree-pdf builder (#290)', () => {
     expect(built.html).toContain('Bibliography');
   });
 
-  it('builder returns an empty result when the plan has no notes', () => {
+  it('builder returns an empty result when the plan has no notes', async () => {
     // Hand-roll a synthetic empty plan rather than going through
     // resolvePlan (which requires a real root note).
-    const built = buildTreePdfHtml({
+    const built = await buildTreePdfHtml({
       inputKind: 'tree',
       inputs: [],
       excluded: [],

--- a/tests/main/publish/vega-render.test.ts
+++ b/tests/main/publish/vega-render.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Headless Vega-Lite / Vega → SVG export rendering (#831).
+ *
+ * Verifies the export pipeline turns chart fences into static images, holds the
+ * #829 remote-data block at export time, and degrades gracefully (spec text +
+ * note) rather than hard-failing the whole export on one bad chart.
+ *
+ * This actually invokes vega + vega-lite headlessly — the test resolves d3-path
+ * via the dedupe in vitest.config.mts (the same fix the packaged main uses).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderVegaBlocks, hasVegaBlocks } from '../../../src/main/publish/vega-render';
+
+const BAR = `\`\`\`vega-lite
+{
+  "data": { "values": [ { "a": "A", "b": 28 }, { "a": "B", "b": 55 } ] },
+  "mark": "bar",
+  "encoding": { "x": { "field": "a", "type": "nominal" }, "y": { "field": "b", "type": "quantitative" } }
+}
+\`\`\``;
+
+describe('hasVegaBlocks', () => {
+  it('detects vega-lite and vega fences, ignores everything else', () => {
+    expect(hasVegaBlocks(BAR)).toBe(true);
+    expect(hasVegaBlocks('```vega\n{}\n```')).toBe(true);
+    expect(hasVegaBlocks('```python\nprint(1)\n```')).toBe(false);
+    expect(hasVegaBlocks('no fences here')).toBe(false);
+  });
+});
+
+describe('renderVegaBlocks', () => {
+  it('returns content unchanged when there are no charts', async () => {
+    const md = '# Title\n\nSome **text** and a `code` span.\n';
+    expect(await renderVegaBlocks(md)).toBe(md);
+  });
+
+  it('replaces a vega-lite fence with an inline SVG data-URI image', async () => {
+    const out = await renderVegaBlocks(`# Note\n\n${BAR}\n\nafter`);
+    // The fence is gone…
+    expect(out).not.toContain('```vega-lite');
+    // …replaced by a markdown image carrying a base64 SVG.
+    const m = out.match(/!\[chart\]\(data:image\/svg\+xml;base64,([A-Za-z0-9+/=]+)\)/);
+    expect(m).toBeTruthy();
+    const svg = Buffer.from(m![1], 'base64').toString('utf8');
+    expect(svg).toContain('<svg');
+    // Surrounding prose is preserved.
+    expect(out).toContain('# Note');
+    expect(out).toContain('after');
+  });
+
+  it('renders a full ```vega spec too', async () => {
+    const vegaSpec = `\`\`\`vega
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "width": 100, "height": 100,
+  "data": [ { "name": "t", "values": [ { "x": 1 }, { "x": 2 } ] } ],
+  "marks": [ { "type": "symbol", "from": { "data": "t" }, "encode": { "enter": { "x": { "field": "x" }, "y": { "value": 10 } } } } ]
+}
+\`\`\``;
+    const out = await renderVegaBlocks(vegaSpec);
+    expect(out).toContain('data:image/svg+xml;base64,');
+    expect(out).not.toContain('```vega');
+  });
+
+  it('blocks a remote-data spec at export, keeping the spec + a note (no fetch)', async () => {
+    const remote = `\`\`\`vega-lite
+{ "data": { "url": "https://example.com/data.csv" }, "mark": "line" }
+\`\`\``;
+    const out = await renderVegaBlocks(remote);
+    expect(out).not.toContain('data:image'); // never rendered
+    expect(out.toLowerCase()).toContain('remote data is disabled');
+    // The spec is preserved (degraded to a code block), so nothing is lost.
+    expect(out).toContain('```vega-lite');
+    expect(out).toContain('https://example.com/data.csv');
+  });
+
+  it('degrades invalid JSON to spec text + a note instead of throwing', async () => {
+    const bad = '```vega-lite\n{ not valid json }\n```';
+    const out = await renderVegaBlocks(bad);
+    expect(out.toLowerCase()).toContain('could not be rendered');
+    expect(out).toContain('```vega-lite');
+    expect(out).toContain('{ not valid json }');
+  });
+
+  it('degrades a structurally-broken spec without failing the whole export', async () => {
+    // Valid JSON, but not a usable spec — vega throws during parse/render.
+    const broken = '```vega-lite\n{ "mark": "bogus-mark-type", "data": { "values": [] } }\n```';
+    const out = await renderVegaBlocks(broken);
+    // Either it renders or it degrades — but it never throws and never drops the spec.
+    expect(out).toContain('vega-lite');
+  });
+
+  it('handles multiple charts in one document independently', async () => {
+    const doc = `${BAR}\n\ntext between\n\n${BAR}`;
+    const out = await renderVegaBlocks(doc);
+    const imgs = out.match(/data:image\/svg\+xml;base64,/g) ?? [];
+    expect(imgs.length).toBe(2);
+    expect(out).toContain('text between');
+  });
+});

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -29,9 +29,17 @@ export default defineConfig({
       // - DuckDB bindings: Rollup can't bundle the `.node` binary. The plugin
       //   ships no node_modules, so forge.config's `afterPrune` hook copies the
       //   binding's runtime closure into the packaged app.
+      // - `vega` / `vega-lite` (#831, headless chart export): the plugin builds
+      //   main as a single-file CJS lib, and bundling these large ESM trees
+      //   (with their internal dynamic imports) makes rollup code-split the
+      //   entry so `main.js` is never emitted and packaging fails. Externalize
+      //   them — Electron 42 / Node 22 can `require()` ESM — and ship their
+      //   closure via forge.config's `EXTERNAL_DEP_ROOTS`.
       external: [
         'canvas',
         /^@duckdb\/node-bindings/,
+        'vega',
+        'vega-lite',
       ],
     },
   },


### PR DESCRIPTION
Continues epic #826. Builds on the rendering core (#877) and templates (#878). A Vega chart exported as raw JSON is dead weight in an HTML/PDF — this renders each chart to a static SVG so the published artifact actually shows it.

## What it does

Each ` ```vega-lite ` / ` ```vega ` block is compiled (Vega-Lite → Vega) and rendered to **SVG headlessly in the main process** (no browser window) via `View.toSVG()`, then embedded as an `<img>` (SVG data URI).

- **Single seam:** `renderNoteBody` (note-html/render.ts) is now async and pre-renders charts before `md.render`. HTML, PDF (via HTML), tree-html, tree-pdf, and static-site all flow through it.
- **Markdown export keeps the spec fence verbatim** — portable to other Vega-aware tools; a multi-KB data URI would just bloat the `.md`. (Documented in `docs/visualizations.md`.)
- A neutral light theme config is applied so charts read on a white page.
- markdown-it blocks `data:image/svg+xml`; an `<img>`-embedded SVG can't execute scripts, so the export md instance allows it.

## Security (#829 holds at export)

Remote-data specs are refused — **no fetch from the export process** — and any chart that can't render (bad spec, blocked data) degrades to its spec text + a short note. One broken chart never fails the whole export.

## Packaging — the hard part

`vega`/`vega-lite` are large ESM trees that use **top-level await**. Two failure modes, both solved:

1. **Bundling them code-splits electron-forge's single-file main bundle** → `main.js` never emitted → packaging fails.
2. **CJS `require()` of them throws `ERR_REQUIRE_ASYNC_MODULE`** (the async ESM).

Fix: **externalize** them (`vite.main.config` + ship their closure via `forge.config`'s `EXTERNAL_DEP_ROOTS`, the DuckDB precedent) **and load via native dynamic `import()`** — rollup preserves `import("vega")` in the CJS bundle, and `import()` handles async ESM at runtime. Bonus: vega now loads only when an export actually contains a chart.

A pnpm **override pins `d3-path@^3.1.0`** (mermaid's `d3-sankey` nests an old 1.x that breaks `d3-shape@3`'s `Path` import) so the shipped closure and the unit tests resolve a single `d3-path`.

## Verification

- `pnpm lint` clean; **289 publish tests pass**, including new `vega-render` unit tests (render, remote-block, JSON/structural degrade, multi-chart) and a `note-html` integration test (full fence → `<img src="data:image/svg+xml">` seam; remote chart → notice).
- **`pnpm build:e2e` (electron-forge package) succeeds**, the vega closure ships into the app, and the built main bundle uses native `import("vega")` (not `require`).
- A direct test confirmed a CJS dynamic `import()` of the **shipped** vega renders SVG (6.6 KB) — proving the runtime path the packaged main takes.

Part of #826. Closes #831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)