### PR TITLE
feat: bind Vega-Lite charts to graph data via data.sparql (#880, #881, #882)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -66,9 +66,41 @@ Under the hood:
 - A spec's `usermeta.embedOptions` is stripped before rendering, so a spec can't
   re-enable codegen or swap the loader through that channel.
 
-Binding charts to Minerva's own data (compute-cell outputs, CSV/DuckDB tables,
-inline SPARQL/SQL) is planned (#832) and will resolve through the same safe-path
-layer — never a raw fetch.
+## Binding charts to Minerva data
+
+A chart can draw from the knowledge base's own live data instead of inlining
+values. Name a source in `data` and Minerva resolves it to rows before
+rendering — the chart still only ever sees inline values, so the security
+posture above is unchanged.
+
+**SPARQL** (against the knowledge graph) is supported today:
+
+````markdown
+```vega-lite
+{
+  "data": { "sparql": "SELECT ?tag (COUNT(?n) AS ?count) WHERE { ?n minerva:hasTag ?t . ?t minerva:tagName ?tag } GROUP BY ?tag" },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "tag", "type": "nominal" },
+    "y": { "field": "count", "type": "quantitative" }
+  }
+}
+```
+````
+
+- The standard prefixes (`minerva`, `thought`, `dc`, `rdf`, `rdfs`, `xsd`,
+  `csvw`, `owl`, `prov`, …) are auto-injected — no need to declare them.
+- SPARQL returns every value as a string; a column whose values are all numeric
+  is coerced to numbers so `quantitative` encodings work. Columns with dates or
+  labels stay strings (Vega infers `temporal` / `nominal`).
+- A data-bound chart shows a **⟳ refresh** button in its toolbar to re-run the
+  query after the graph changes; it also re-resolves whenever the note
+  re-renders.
+- A query error renders a clear inline notice, never a silent empty chart.
+
+Other sources — `data.sql` / `data.table` (DuckDB) and `data.cell` (a compute
+cell's output) — are planned (#832) and resolve through the same safe-path
+layer; until then they render a short "not available yet" notice.
 
 ## Export
 

--- a/src/main/publish/vega-render.ts
+++ b/src/main/publish/vega-render.ts
@@ -27,6 +27,8 @@
  * verbatim, which stays portable to other Vega-aware tools.
  */
 
+import { detectDataSource } from '../../shared/vega/data-binding';
+
 // Catppuccin-derived categorical palette, shared in spirit with the renderer
 // (#828) and the Chart.js adapter so all three charting paths feel consistent.
 const CATEGORY_PALETTE = [
@@ -140,6 +142,13 @@ async function renderOne(mode: 'vega' | 'vega-lite', specText: string): Promise<
   findUrlRefs(spec, urls);
   if (urls.length > 0) {
     return degrade(mode, specText, `remote data is disabled (${urls[0]})`);
+  }
+
+  // A chart bound to live Minerva data (#832 — data.sparql / sql / table / cell)
+  // isn't resolved at export time yet (#885 wires that). Degrade to the spec +
+  // a clear note rather than letting vega-lite render a silent empty chart.
+  if (detectDataSource(spec)) {
+    return degrade(mode, specText, 'data binding is not resolved in exports yet');
   }
 
   try {

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -21,6 +21,7 @@
   import { installWikiLinks, installNoteTags } from '../markdown/inline-tokens-plugin';
   import { hydrateMermaidBlocks, invalidateMermaidTheme } from '../markdown/mermaid-renderer';
   import { hydrateVegaBlocks, invalidateVegaTheme } from '../markdown/vega-renderer';
+  import { detectDataSource } from '../../../shared/vega/data-binding';
   import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
   import { normalizeSqlRows } from '../editor/sql-result';
@@ -363,10 +364,19 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // collapse toggle so a tall chart can be tucked away. The lazy hydrator
       // (vega-renderer.ts) swaps the placeholder for an embedded SVG chart.
       const block = `<div class="vega-block" data-vega-pending="1" data-vega-mode="${mode}">${escaped}</div>`;
+      // A data-bound chart (#832 — `data.sparql` etc.) gets a refresh button so
+      // the user can re-run the query after the graph changes without editing
+      // the note. Inline charts don't need it. Cheap parse — charts are few.
+      let isBound = false;
+      try { isBound = detectDataSource(JSON.parse(tok.content ?? '')) !== null; } catch { /* not bound */ }
       if (openingLine !== null) {
         const isCollapsed = collapsedFences.has(openingLine);
+        const refreshBtn = isBound
+          ? `<button class="fence-refresh-btn" data-fence-action="refresh-vega" type="button" title="Refresh chart data">⟳</button>`
+          : '';
         return `<div class="fence-block fence-vega${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}">`
           + `<div class="fence-toolbar"><span class="fence-lang">${info}</span>`
+          + refreshBtn
           + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
           + `</div>`
           + `<div class="fence-body">${block}</div>`
@@ -1091,6 +1101,17 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       }
       if (action === 'run') {
         void runFenceAt(openingLine);
+        return;
+      }
+      if (action === 'refresh-vega') {
+        // Re-resolve a data-bound chart (#832): drop its rendered state and
+        // re-hydrate, which re-runs the query against the current graph.
+        const vegaBlock = block.querySelector<HTMLElement>('.vega-block');
+        if (vegaBlock) {
+          vegaBlock.removeAttribute('data-vega-rendered');
+          vegaBlock.innerHTML = '';
+          if (previewEl) void hydrateVegaBlocks(previewEl);
+        }
         return;
       }
     }
@@ -2131,6 +2152,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     margin-right: auto;
   }
   .preview :global(.fence-run-btn),
+  .preview :global(.fence-refresh-btn),
   .preview :global(.fence-collapse-btn) {
     border: 1px solid transparent;
     background: transparent;
@@ -2143,6 +2165,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     font-family: var(--font-mono, monospace);
   }
   .preview :global(.fence-run-btn:hover:not([disabled])),
+  .preview :global(.fence-refresh-btn:hover),
   .preview :global(.fence-collapse-btn:hover) {
     background: var(--bg-button);
     color: var(--text);

--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -37,6 +37,13 @@
  */
 
 import { getEffectiveTheme, getThemeMode } from '../theme';
+import { api } from '../ipc/client';
+import {
+  detectDataSource,
+  resolveVegaData,
+  type DataSourceRef,
+  type VegaRows,
+} from '../../../shared/vega/data-binding';
 
 type VegaView = { finalize: () => void };
 type VegaEmbed = (
@@ -143,6 +150,20 @@ function findUrlRefs(node: unknown, acc: string[], depth = 0): void {
 }
 
 /**
+ * Resolve a Minerva data source to rows in the renderer (#832). SPARQL (#882)
+ * runs against the open project's graph via IPC; the other kinds land in later
+ * sub-issues (#883 sql/table, #884 cell) and surface a clear notice until then.
+ */
+async function rendererExecutor(ref: DataSourceRef): Promise<VegaRows> {
+  if (ref.kind === 'sparql') {
+    const res = await api.graph.query(ref.query);
+    if (res.error) throw new Error(res.error);
+    return (res.results as VegaRows) ?? [];
+  }
+  throw new Error(`Binding a chart to "${ref.kind}" data isn't available yet.`);
+}
+
+/**
  * A Vega `Loader` that refuses every fetch. Inline `data.values` never touch
  * the loader, so only remote / file references hit these rejections. Passes
  * vega-embed's `isLoader` check (it tests for a `load` method), so it's used
@@ -212,6 +233,21 @@ export async function hydrateVegaBlocks(root: HTMLElement): Promise<void> {
       el.innerHTML = renderErrorHtml(`Invalid JSON: ${msg}`);
       el.setAttribute('data-vega-rendered', 'error');
       return;
+    }
+
+    // #832 — a Minerva data form (`data.sparql` / `data.sql` / `data.table` /
+    // `data.cell`) is resolved to inline `data.values` before embedding, so the
+    // #829 guardrail below still only ever sees inline data.
+    const ref = detectDataSource(spec);
+    if (ref) {
+      try {
+        spec = await resolveVegaData(spec as Record<string, unknown>, ref, rendererExecutor);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        el.innerHTML = renderNoticeHtml('Chart data unavailable', escapeHtml(msg));
+        el.setAttribute('data-vega-rendered', 'error');
+        return;
+      }
     }
 
     // #829 — refuse specs that reach out to the network / filesystem, with a

--- a/src/shared/vega/data-binding.ts
+++ b/src/shared/vega/data-binding.ts
@@ -1,0 +1,116 @@
+/**
+ * Vega data binding — resolution layer (#832 pt 1, #880).
+ *
+ * A Vega-Lite chart can name a Minerva data source instead of inlining values:
+ *
+ *   "data": { "sparql": "SELECT …" }   // the knowledge graph
+ *   "data": { "sql":    "SELECT …" }   // a DuckDB query over registered tables
+ *   "data": { "table":  "sales_data" } // sugar for SELECT * FROM sales_data
+ *   "data": { "cell":   "a1b2c3d4" }   // a compute cell's output block
+ *
+ * This module is the process-agnostic core: it detects the form, and turns
+ * source rows into the inline `data.values` array Vega expects — coercing the
+ * stringly-typed rows SPARQL returns so quantitative/temporal encodings work.
+ * The actual query execution is injected by the caller (an `SourceExecutor`),
+ * so the renderer (`window.api.*`) and the export pipeline (main-process calls)
+ * reuse the same resolution without re-implementing execution.
+ *
+ * Resolving to inline values keeps the #829 security posture intact: vega-embed
+ * still only ever sees `data.values`, never a `url`.
+ */
+
+export type VegaRow = Record<string, unknown>;
+export type VegaRows = VegaRow[];
+
+export type DataSourceRef =
+  | { kind: 'sparql'; query: string }
+  | { kind: 'sql'; query: string }
+  | { kind: 'table'; name: string }
+  | { kind: 'cell'; id: string };
+
+/** An executor resolves one reference to rows. Callers provide the handlers
+ *  they support; an unhandled kind surfaces as a clear error (not a silent
+ *  empty chart). */
+export type SourceExecutor = (ref: DataSourceRef) => Promise<VegaRows>;
+
+/**
+ * Detect a Minerva data-binding form on a parsed spec. Returns null for plain
+ * inline `data.values`, a (blocked) `data.url`, or a full-Vega `data` array —
+ * all of which pass through untouched. Only the Vega-Lite object form binds.
+ */
+export function detectDataSource(spec: unknown): DataSourceRef | null {
+  if (!spec || typeof spec !== 'object') return null;
+  const data = (spec as { data?: unknown }).data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
+  const d = data as Record<string, unknown>;
+  if (typeof d.sparql === 'string') return { kind: 'sparql', query: d.sparql };
+  if (typeof d.sql === 'string') return { kind: 'sql', query: d.sql };
+  if (typeof d.table === 'string') return { kind: 'table', name: d.table };
+  if (typeof d.cell === 'string') return { kind: 'cell', id: d.cell };
+  return null;
+}
+
+/**
+ * Zip a column-ordered table (the compute-cell / SQL-executor output shape,
+ * `{ columns, rows: primitive[][] }`) into row objects keyed by column.
+ */
+export function rowsFromTable(columns: string[], rows: unknown[][]): VegaRows {
+  return rows.map((row) => {
+    const obj: VegaRow = {};
+    columns.forEach((col, i) => { obj[col] = row[i] ?? null; });
+    return obj;
+  });
+}
+
+/**
+ * Best-effort numeric coercion. SPARQL returns every value as a string, which
+ * breaks Vega's `quantitative` encodings ("10" sorts lexically, won't sum). For
+ * each column whose every non-empty value parses as a finite number, convert
+ * those values to numbers. Columns with any non-numeric value (dates, labels)
+ * are left as strings — Vega infers temporal/nominal from them fine.
+ */
+export function coerceRows(rows: VegaRows): VegaRows {
+  if (rows.length === 0) return rows;
+  const keys = new Set<string>();
+  for (const row of rows) for (const k of Object.keys(row)) keys.add(k);
+
+  const numericCols = new Set<string>();
+  for (const key of keys) {
+    let sawValue = false;
+    let allNumeric = true;
+    for (const row of rows) {
+      const v = row[key];
+      if (v === undefined || v === null || v === '') continue;
+      sawValue = true;
+      if (typeof v === 'number') continue;
+      if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) continue;
+      allNumeric = false;
+      break;
+    }
+    if (sawValue && allNumeric) numericCols.add(key);
+  }
+  if (numericCols.size === 0) return rows;
+
+  return rows.map((row) => {
+    const out: VegaRow = { ...row };
+    for (const key of numericCols) {
+      const v = out[key];
+      if (typeof v === 'string' && v.trim() !== '') out[key] = Number(v);
+    }
+    return out;
+  });
+}
+
+/**
+ * Resolve a detected source to inline values and return a NEW spec with
+ * `data: { values }`. Throws with a clear message when the executor can't
+ * handle the kind or the query fails — callers render that inline.
+ */
+export async function resolveVegaData(
+  spec: Record<string, unknown>,
+  ref: DataSourceRef,
+  exec: SourceExecutor,
+): Promise<Record<string, unknown>> {
+  const rows = await exec(ref);
+  return { ...spec, data: { values: coerceRows(rows) } };
+}

--- a/tests/main/publish/vega-render.test.ts
+++ b/tests/main/publish/vega-render.test.ts
@@ -75,6 +75,14 @@ describe('renderVegaBlocks', () => {
     expect(out).toContain('https://example.com/data.csv');
   });
 
+  it('degrades a data-bound chart (data.sparql) — not resolved in export yet (#885)', async () => {
+    const bound = '```vega-lite\n{ "data": { "sparql": "SELECT ?x WHERE { ?x a ?y }" }, "mark": "bar" }\n```';
+    const out = await renderVegaBlocks(bound);
+    expect(out).not.toContain('data:image'); // never rendered as an empty chart
+    expect(out.toLowerCase()).toContain('not resolved in exports yet');
+    expect(out).toContain('```vega-lite'); // spec preserved
+  });
+
   it('degrades invalid JSON to spec text + a note instead of throwing', async () => {
     const bad = '```vega-lite\n{ not valid json }\n```';
     const out = await renderVegaBlocks(bad);

--- a/tests/renderer/markdown/vega-renderer.test.ts
+++ b/tests/renderer/markdown/vega-renderer.test.ts
@@ -1,4 +1,6 @@
 /**
+ * @vitest-environment happy-dom
+ *
  * Vega security guardrail (#829) — the spec-scan that refuses charts which
  * reach out to the network / filesystem. Inline `data.values` are the only
  * supported data source until #832 adds safe-path local-vault resolution, so

--- a/tests/shared/vega/data-binding.test.ts
+++ b/tests/shared/vega/data-binding.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Vega data-binding resolution layer (#832 pt 1 / #880).
+ *
+ * The pure core: detect a Minerva data form, normalize/coerce rows, and resolve
+ * to inline `data.values` via an injected executor. Locks the contract the
+ * renderer (#882) and export (#885) paths both build on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectDataSource,
+  rowsFromTable,
+  coerceRows,
+  resolveVegaData,
+  type DataSourceRef,
+} from '../../../src/shared/vega/data-binding';
+
+describe('detectDataSource', () => {
+  it('detects each Minerva data form', () => {
+    expect(detectDataSource({ data: { sparql: 'SELECT 1' } })).toEqual({ kind: 'sparql', query: 'SELECT 1' });
+    expect(detectDataSource({ data: { sql: 'SELECT 1' } })).toEqual({ kind: 'sql', query: 'SELECT 1' });
+    expect(detectDataSource({ data: { table: 'sales' } })).toEqual({ kind: 'table', name: 'sales' });
+    expect(detectDataSource({ data: { cell: 'a1b2c3d4' } })).toEqual({ kind: 'cell', id: 'a1b2c3d4' });
+  });
+
+  it('returns null for plain inline values, a url, or a full-Vega data array', () => {
+    expect(detectDataSource({ data: { values: [{ a: 1 }] } })).toBeNull();
+    expect(detectDataSource({ data: { url: 'https://x/y.csv' } })).toBeNull();
+    expect(detectDataSource({ data: [{ name: 't', values: [] }] })).toBeNull(); // full vega
+    expect(detectDataSource({ mark: 'bar' })).toBeNull(); // no data
+    expect(detectDataSource(null)).toBeNull();
+    expect(detectDataSource('nope')).toBeNull();
+  });
+
+  it('ignores a non-string source value', () => {
+    expect(detectDataSource({ data: { sparql: 123 } })).toBeNull();
+  });
+});
+
+describe('rowsFromTable', () => {
+  it('zips column-ordered rows into objects', () => {
+    expect(rowsFromTable(['a', 'b'], [[1, 'x'], [2, 'y']])).toEqual([
+      { a: 1, b: 'x' },
+      { a: 2, b: 'y' },
+    ]);
+  });
+
+  it('fills missing cells with null', () => {
+    expect(rowsFromTable(['a', 'b'], [[1]])).toEqual([{ a: 1, b: null }]);
+  });
+});
+
+describe('coerceRows', () => {
+  it('converts an all-numeric-string column to numbers (the SPARQL case)', () => {
+    const rows = [{ x: 'A', y: '10' }, { x: 'B', y: '25' }];
+    expect(coerceRows(rows)).toEqual([{ x: 'A', y: 10 }, { x: 'B', y: 25 }]);
+  });
+
+  it('leaves a column with any non-numeric value as strings', () => {
+    const rows = [{ y: '10' }, { y: 'n/a' }];
+    expect(coerceRows(rows)).toEqual([{ y: '10' }, { y: 'n/a' }]);
+  });
+
+  it('does not turn dates into numbers', () => {
+    const rows = [{ d: '2024-01-01', v: '5' }, { d: '2024-02-01', v: '8' }];
+    expect(coerceRows(rows)).toEqual([{ d: '2024-01-01', v: 5 }, { d: '2024-02-01', v: 8 }]);
+  });
+
+  it('treats empty strings as absent, not as 0', () => {
+    const rows = [{ y: '10' }, { y: '' }, { y: '30' }];
+    // Column is "all numeric where present" → present values coerce, blanks stay.
+    expect(coerceRows(rows)).toEqual([{ y: 10 }, { y: '' }, { y: 30 }]);
+  });
+
+  it('handles empty input', () => {
+    expect(coerceRows([])).toEqual([]);
+  });
+});
+
+describe('resolveVegaData', () => {
+  it('replaces a bound data form with inline coerced values', async () => {
+    const spec = { mark: 'bar', data: { sparql: 'SELECT ?x ?y …' }, encoding: {} };
+    const ref: DataSourceRef = { kind: 'sparql', query: 'SELECT ?x ?y …' };
+    const exec = async () => [{ x: 'A', y: '10' }, { x: 'B', y: '20' }];
+    const out = await resolveVegaData(spec, ref, exec);
+    expect(out.data).toEqual({ values: [{ x: 'A', y: 10 }, { x: 'B', y: 20 }] });
+    expect(out.mark).toBe('bar'); // rest of the spec preserved
+  });
+
+  it('propagates an executor error (caller renders it inline)', async () => {
+    const exec = async () => { throw new Error('SPARQL parse error'); };
+    await expect(
+      resolveVegaData({ data: { sparql: 'BAD' } }, { kind: 'sparql', query: 'BAD' }, exec),
+    ).rejects.toThrow('SPARQL parse error');
+  });
+});


### PR DESCRIPTION
First data-binding slice of #832 (the epic's differentiator). A chart can now draw from the knowledge base's own **live graph data** instead of inlining values. SPARQL is the first source; this vertical slice delivers the shared resolution layer (#880) + renderer wiring (#881) + the SPARQL executor (#882).

## What it does

```vega-lite
{
  "data": { "sparql": "SELECT ?tag (COUNT(?n) AS ?count) WHERE { ?n minerva:hasTag ?t . ?t minerva:tagName ?tag } GROUP BY ?tag" },
  "mark": "bar",
  "encoding": { "x": {"field":"tag","type":"nominal"}, "y": {"field":"count","type":"quantitative"} }
}
```

The source is resolved to inline `data.values` **before** the spec reaches vega-embed, so the #829 guardrail still only ever sees inline data — no new network surface.

## Pieces

- **#880 resolution layer** (`src/shared/vega/data-binding.ts`, process-agnostic): detect a Minerva data form (`data.sparql`/`sql`/`table`/`cell`), normalize rows, **coerce all-numeric string columns to numbers** (SPARQL returns everything as strings, which would break `quantitative` encodings), resolve via an injected executor. Renderer and export reuse it.
- **#881 renderer wiring**: `hydrateVegaBlocks` resolves a bound spec before embed; a query error renders an inline notice (never a silent empty chart). A **⟳ refresh** button on the chart toolbar re-runs the query after the graph changes (shown for bound charts only).
- **#882 SPARQL source**: resolves via `api.graph.query` with the standard prefixes auto-injected. `data.sql`/`table`/`cell` surface a clear "not available yet" notice until #883/#884.
- **Export guard**: a bound chart hitting the export renderer (#831) degrades to spec text + a note rather than a silent empty chart, until #885 wires export-time resolution.

## Verification

- 67 unit tests; lint clean. New `data-binding` tests cover detection, row-zip, numeric coercion (incl. dates stay strings, blanks aren't zero), and resolve/error.
- **Live, in the packaged app**: a `data.sparql` bar chart rendered from real graph rows — note titles on the x-axis, bar heights matching `STRLEN(?title)` (10/4/5/14/19), proving the query ran, rows bound, and **coercion worked** (string `"10"` → numeric height). Themed, refresh button present, zero console errors. Screenshot captured.


Part of #826 / #832. Closes #880, closes #881, closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
