### PR TITLE
feat: bind charts to SQL / DuckDB tables via data.sql and data.table (#883)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -73,7 +73,10 @@ values. Name a source in `data` and Minerva resolves it to rows before
 rendering — the chart still only ever sees inline values, so the security
 posture above is unchanged.
 
-**SPARQL** (against the knowledge graph) is supported today:
+**SPARQL** (against the knowledge graph) and **SQL** (against the project's
+CSV/DuckDB tables) are supported today.
+
+SPARQL:
 
 ````markdown
 ```vega-lite
@@ -98,9 +101,26 @@ posture above is unchanged.
   re-renders.
 - A query error renders a clear inline notice, never a silent empty chart.
 
-Other sources — `data.sql` / `data.table` (DuckDB) and `data.cell` (a compute
-cell's output) — are planned (#832) and resolve through the same safe-path
-layer; until then they render a short "not available yet" notice.
+SQL / table (the project's CSV files are registered as DuckDB tables):
+
+````markdown
+```vega-lite
+{
+  "data": { "sql": "SELECT month, revenue FROM sales ORDER BY month" },
+  "mark": "line",
+  "encoding": { "x": {"field":"month","type":"ordinal"}, "y": {"field":"revenue","type":"quantitative"} }
+}
+```
+````
+
+- `"data": { "table": "sales" }` is sugar for `SELECT * FROM "sales"` (the name
+  is quoted as a DuckDB identifier).
+- Table names come from the CSV path (`deriveTableName`) or a `table_name:` in
+  the CSV's companion `.md`; the Tables view lists them.
+
+The remaining source — `data.cell` (a compute cell's output) — is planned
+(#884); until then it renders a short "not available yet" notice. Bound charts
+also don't yet render in **exports** (#885) — they degrade to the spec there.
 
 ## Export
 

--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -41,6 +41,7 @@ import { api } from '../ipc/client';
 import {
   detectDataSource,
   resolveVegaData,
+  tableQuerySql,
   type DataSourceRef,
   type VegaRows,
 } from '../../../shared/vega/data-binding';
@@ -150,15 +151,21 @@ function findUrlRefs(node: unknown, acc: string[], depth = 0): void {
 }
 
 /**
- * Resolve a Minerva data source to rows in the renderer (#832). SPARQL (#882)
- * runs against the open project's graph via IPC; the other kinds land in later
- * sub-issues (#883 sql/table, #884 cell) and surface a clear notice until then.
+ * Resolve a Minerva data source to rows in the renderer (#832), running against
+ * the open project via IPC. SPARQL (#882) hits the graph; SQL / table (#883) hit
+ * DuckDB. `cell` (#884) lands in a later sub-issue and surfaces a clear notice.
  */
 async function rendererExecutor(ref: DataSourceRef): Promise<VegaRows> {
   if (ref.kind === 'sparql') {
     const res = await api.graph.query(ref.query);
     if (res.error) throw new Error(res.error);
     return (res.results as VegaRows) ?? [];
+  }
+  if (ref.kind === 'sql' || ref.kind === 'table') {
+    const sql = ref.kind === 'table' ? tableQuerySql(ref.name) : ref.query;
+    const res = await api.tables.query(sql);
+    if (!res.ok) throw new Error(res.error);
+    return res.rows;
   }
   throw new Error(`Binding a chart to "${ref.kind}" data isn't available yet.`);
 }

--- a/src/shared/vega/data-binding.ts
+++ b/src/shared/vega/data-binding.ts
@@ -63,6 +63,26 @@ export function rowsFromTable(columns: string[], rows: unknown[][]): VegaRows {
 }
 
 /**
+ * Normalize cell values that Vega/JSON can't handle. DuckDB returns BigInt for
+ * integer columns and Date objects for date/timestamp columns; vega-embed
+ * throws trying to serialize a BigInt and mishandles Dates. Convert BigInt →
+ * number (fine for chart ranges) and Date → ISO string (Vega parses `temporal`
+ * from it). Everything else passes through untouched.
+ */
+export function normalizeRows(rows: VegaRows): VegaRows {
+  return rows.map((row) => {
+    let changed = false;
+    const out: VegaRow = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (typeof v === 'bigint') { out[k] = Number(v); changed = true; }
+      else if (v instanceof Date) { out[k] = v.toISOString(); changed = true; }
+      else out[k] = v;
+    }
+    return changed ? out : row;
+  });
+}
+
+/**
  * Best-effort numeric coercion. SPARQL returns every value as a string, which
  * breaks Vega's `quantitative` encodings ("10" sorts lexically, won't sum). For
  * each column whose every non-empty value parses as a finite number, convert
@@ -102,6 +122,15 @@ export function coerceRows(rows: VegaRows): VegaRows {
 }
 
 /**
+ * Build the SQL for a `data.table` reference. The table name is a DuckDB
+ * identifier, double-quoted with embedded quotes escaped so a crafted name
+ * can't break out of the identifier (`evil"; DROP …`).
+ */
+export function tableQuerySql(name: string): string {
+  return `SELECT * FROM "${name.replace(/"/g, '""')}"`;
+}
+
+/**
  * Resolve a detected source to inline values and return a NEW spec with
  * `data: { values }`. Throws with a clear message when the executor can't
  * handle the kind or the query fails — callers render that inline.
@@ -112,5 +141,5 @@ export async function resolveVegaData(
   exec: SourceExecutor,
 ): Promise<Record<string, unknown>> {
   const rows = await exec(ref);
-  return { ...spec, data: { values: coerceRows(rows) } };
+  return { ...spec, data: { values: coerceRows(normalizeRows(rows)) } };
 }

--- a/tests/shared/vega/data-binding.test.ts
+++ b/tests/shared/vega/data-binding.test.ts
@@ -12,6 +12,8 @@ import {
   rowsFromTable,
   coerceRows,
   resolveVegaData,
+  normalizeRows,
+  tableQuerySql,
   type DataSourceRef,
 } from '../../../src/shared/vega/data-binding';
 
@@ -74,6 +76,37 @@ describe('coerceRows', () => {
 
   it('handles empty input', () => {
     expect(coerceRows([])).toEqual([]);
+  });
+});
+
+describe('normalizeRows', () => {
+  it('converts DuckDB BigInt to number and Date to ISO string', () => {
+    const rows = [{ n: 100n, d: new Date('2024-01-02T03:04:05.000Z'), s: 'x' }];
+    expect(normalizeRows(rows)).toEqual([{ n: 100, d: '2024-01-02T03:04:05.000Z', s: 'x' }]);
+  });
+
+  it('leaves plain rows untouched (same reference when nothing changes)', () => {
+    const rows = [{ a: 1, b: 'x' }];
+    expect(normalizeRows(rows)[0]).toBe(rows[0]);
+  });
+
+  it('feeds coercion — resolveVegaData turns a BigInt column into chart numbers', async () => {
+    const out = await resolveVegaData(
+      { data: { sql: 'SELECT …' } },
+      { kind: 'sql', query: 'SELECT …' },
+      async () => [{ k: 'A', v: 10n }, { k: 'B', v: 25n }],
+    );
+    expect(out.data).toEqual({ values: [{ k: 'A', v: 10 }, { k: 'B', v: 25 }] });
+  });
+});
+
+describe('tableQuerySql', () => {
+  it('builds a SELECT over the double-quoted table identifier', () => {
+    expect(tableQuerySql('sales_data')).toBe('SELECT * FROM "sales_data"');
+  });
+
+  it('escapes embedded quotes so a crafted name can\'t break out', () => {
+    expect(tableQuerySql('evil" ; DROP TABLE x --')).toBe('SELECT * FROM "evil"" ; DROP TABLE x --"');
   });
 });
 


### PR DESCRIPTION
Second data source for #832, built on the resolution layer from #887.

## What it does

```vega-lite
{ "data": { "sql": "SELECT month, revenue FROM sales ORDER BY month" }, "mark": "line", "encoding": { … } }
{ "data": { "table": "sales" } }   // sugar for SELECT * FROM "sales"
```

A chart can now draw from the project's CSV files (registered as DuckDB tables) — via an arbitrary `data.sql` query or a `data.table` name. Resolves through `api.tables.query`, same pipeline as SPARQL (#882): resolve to inline `data.values` before embed, so the #829 guardrail is unchanged.

## Notable bits

- **Identifier safety** — `tableQuerySql()` double-quotes the table name and escapes embedded quotes, so a crafted name (`evil"; DROP …`) can't break out of the SQL. Unit-tested.
- **BigInt / Date normalization** — DuckDB returns `BigInt` for integer columns and `Date` objects for date/timestamp columns; **vega-embed throws serializing a BigInt** and mishandles Dates. `normalizeRows()` converts them to `number` / ISO string before coercion, so it benefits every source (not just SQL).
- `data.cell` still shows a clear "not available yet" notice until #884.

## Verification

- 36 vega unit tests (incl. identifier-escaping and BigInt→number); lint clean.
- **Live, in the packaged app**: a `data.table: "sales"` bar chart rendered from a seeded CSV registered as a DuckDB table — months on the x-axis, bars at the exact revenue values (100/150/120/180). Since DuckDB returns those integers as BigInt, this confirms the normalization end-to-end. Screenshot captured.

Part of #826 / #832. Closes #883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)