### PR TITLE
feat: bind charts to a compute cell's output via data.cell (#884)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -118,9 +118,29 @@ SQL / table (the project's CSV files are registered as DuckDB tables):
 - Table names come from the CSV path (`deriveTableName`) or a `table_name:` in
   the CSV's companion `.md`; the Tables view lists them.
 
-The remaining source — `data.cell` (a compute cell's output) — is planned
-(#884); until then it renders a short "not available yet" notice. Bound charts
-also don't yet render in **exports** (#885) — they degrade to the spec there.
+**Compute cell** — bind to the output of a runnable cell in the same note. Give
+the cell a stable id and reference it:
+
+````markdown
+```sql {id=sales}
+SELECT month, revenue FROM sales
+```
+
+```vega-lite
+{
+  "data": { "cell": "sales" },
+  "mark": "line",
+  "encoding": { "x": {"field":"month","type":"ordinal"}, "y": {"field":"revenue","type":"quantitative"} }
+}
+```
+````
+
+The chart reads the cell's stored `output` block, so **run the cell first**; its
+⟳ refresh button re-reads the latest output. A cell that hasn't run (or whose
+output isn't tabular) renders a clear notice.
+
+Bound charts don't yet render in **exports** (#885) — they degrade to the spec
+there.
 
 ## Export
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -657,7 +657,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // Vega-Lite / Vega chart hydration (#827) — same shape as mermaid:
       // lazy-loads vega-embed, replaces .vega-block placeholders with SVG
       // charts, surfaces parse / security errors inline.
-      if (previewEl) void hydrateVegaBlocks(previewEl);
+      if (previewEl) void hydrateVegaBlocks(previewEl, content);
     });
   });
 
@@ -672,7 +672,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     invalidateVegaTheme();
     if (previewEl) {
       void hydrateMermaidBlocks(previewEl);
-      void hydrateVegaBlocks(previewEl);
+      void hydrateVegaBlocks(previewEl, content);
     }
   }
 
@@ -1110,7 +1110,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         if (vegaBlock) {
           vegaBlock.removeAttribute('data-vega-rendered');
           vegaBlock.innerHTML = '';
-          if (previewEl) void hydrateVegaBlocks(previewEl);
+          if (previewEl) void hydrateVegaBlocks(previewEl, content);
         }
         return;
       }

--- a/src/renderer/lib/editor/output-block.ts
+++ b/src/renderer/lib/editor/output-block.ts
@@ -25,6 +25,11 @@
  */
 
 import type { FenceRange } from '../../../shared/compute/fences';
+// The pure adjacent-output scan now lives in shared so the chart cell-binding
+// finder (#884) and the export pipeline (#885) reuse it. Re-exported here so the
+// editing helpers below — and existing importers / tests — keep their entry point.
+import { findAdjacentOutputBlock } from '../../../shared/compute/cell-output';
+export { findAdjacentOutputBlock };
 
 export type CellResultLike =
   | { ok: true; output: unknown }
@@ -63,62 +68,6 @@ export function planOutputEdit(
     to: fence.endOffset,
     insert: `\n${body}`,
   };
-}
-
-/**
- * Scan forward from `after` for an `output` fence that belongs to the
- * previous executable fence. "Adjacent" means: only whitespace (including
- * at most one blank line) between the previous fence's close and this
- * one's opening backticks. Anything else means the user wrote prose
- * between the two — treat the output as new, don't blow away content.
- */
-export function findAdjacentOutputBlock(
-  doc: string,
-  after: number,
-): { from: number; to: number } | null {
-  let i = after;
-  // Skip a single trailing newline + an optional blank line.
-  let blankLines = 0;
-  while (i < doc.length && (doc[i] === ' ' || doc[i] === '\t' || doc[i] === '\n')) {
-    if (doc[i] === '\n') {
-      blankLines++;
-      if (blankLines > 2) return null; // more than one blank line → not adjacent
-    }
-    i++;
-  }
-  // Must find the opening ``` here.
-  if (!doc.startsWith('```output', i)) return null;
-  const from = i;
-  // Opening line must end with a newline (possibly after whitespace).
-  const openEnd = doc.indexOf('\n', i + '```output'.length);
-  if (openEnd < 0) return null;
-  // Find the closing ``` line.
-  const closeLine = findClosingFence(doc, openEnd + 1);
-  if (closeLine < 0) return null;
-  // Include the trailing newline in the range so the replacement lines
-  // up cleanly with the insert path.
-  const to = closeLine + 3 + (doc[closeLine + 3] === '\n' ? 1 : 0);
-  return { from, to };
-}
-
-function findClosingFence(doc: string, searchStart: number): number {
-  let i = searchStart;
-  while (i < doc.length) {
-    // Closing ``` must start at column 0 of its own line.
-    if (doc.startsWith('```', i)) {
-      // Fence closes only when the ``` is followed by newline or EOF
-      // (otherwise it's the opening of a nested fence, which doesn't
-      // happen inside `output` blocks we emit, but be tolerant).
-      const after = i + 3;
-      if (after >= doc.length || doc[after] === '\n' || doc[after] === '\r') {
-        return i;
-      }
-    }
-    const nl = doc.indexOf('\n', i);
-    if (nl < 0) return -1;
-    i = nl + 1;
-  }
-  return -1;
 }
 
 /**

--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -42,9 +42,11 @@ import {
   detectDataSource,
   resolveVegaData,
   tableQuerySql,
+  rowsFromTable,
   type DataSourceRef,
   type VegaRows,
 } from '../../../shared/vega/data-binding';
+import { findCellOutput } from '../../../shared/compute/cell-output';
 
 type VegaView = { finalize: () => void };
 type VegaEmbed = (
@@ -152,10 +154,11 @@ function findUrlRefs(node: unknown, acc: string[], depth = 0): void {
 
 /**
  * Resolve a Minerva data source to rows in the renderer (#832), running against
- * the open project via IPC. SPARQL (#882) hits the graph; SQL / table (#883) hit
- * DuckDB. `cell` (#884) lands in a later sub-issue and surfaces a clear notice.
+ * the open project. SPARQL (#882) hits the graph; SQL / table (#883) hit DuckDB;
+ * cell (#884) reads a compute cell's stored output block out of the note's
+ * source (`noteContent`).
  */
-async function rendererExecutor(ref: DataSourceRef): Promise<VegaRows> {
+async function rendererExecutor(ref: DataSourceRef, noteContent: string): Promise<VegaRows> {
   if (ref.kind === 'sparql') {
     const res = await api.graph.query(ref.query);
     if (res.error) throw new Error(res.error);
@@ -167,7 +170,12 @@ async function rendererExecutor(ref: DataSourceRef): Promise<VegaRows> {
     if (!res.ok) throw new Error(res.error);
     return res.rows;
   }
-  throw new Error(`Binding a chart to "${ref.kind}" data isn't available yet.`);
+  // ref.kind === 'cell'
+  const output = findCellOutput(noteContent, ref.id);
+  if (!output) throw new Error(`No output found for cell "${ref.id}" — run the cell first.`);
+  if (output.type === 'error') throw new Error(output.message);
+  if (output.type !== 'table') throw new Error(`Cell "${ref.id}" output isn't tabular.`);
+  return rowsFromTable(output.columns, output.rows);
 }
 
 /**
@@ -193,8 +201,11 @@ function makeBlockingLoader(): Record<string, unknown> {
  * Walk `root` for unrendered `.vega-block` placeholders and render each one.
  * Idempotent: blocks already marked `data-vega-rendered` are skipped, so the
  * post-render `$effect` firing repeatedly doesn't double-render.
+ *
+ * `noteContent` is the note's markdown source — needed to resolve `data.cell`
+ * bindings (#884), which read a compute cell's output block out of the source.
  */
-export async function hydrateVegaBlocks(root: HTMLElement): Promise<void> {
+export async function hydrateVegaBlocks(root: HTMLElement, noteContent = ''): Promise<void> {
   const blocks = Array.from(
     root.querySelectorAll<HTMLElement>('.vega-block:not([data-vega-rendered])'),
   );
@@ -248,7 +259,7 @@ export async function hydrateVegaBlocks(root: HTMLElement): Promise<void> {
     const ref = detectDataSource(spec);
     if (ref) {
       try {
-        spec = await resolveVegaData(spec as Record<string, unknown>, ref, rendererExecutor);
+        spec = await resolveVegaData(spec as Record<string, unknown>, ref, (r) => rendererExecutor(r, noteContent));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         el.innerHTML = renderNoticeHtml('Chart data unavailable', escapeHtml(msg));

--- a/src/shared/compute/cell-output.ts
+++ b/src/shared/compute/cell-output.ts
@@ -1,0 +1,108 @@
+/**
+ * Find a compute cell's stored output by id (#832 pt 5 / #884).
+ *
+ * A runnable cell carries a stable id in its fence info (`sparql {id=a1b2c3d4}`,
+ * `cell-id.ts`) and stores its result in a companion ```output block directly
+ * below it (`output-block.ts`). To bind a chart to a cell's output we locate the
+ * cell by id and read the adjacent block's JSON. Shared so both the renderer
+ * (#884) and the export pipeline (#885) resolve cells the same way.
+ *
+ * The pure adjacent-output scan (`findAdjacentOutputBlock`) lives here too — the
+ * renderer's `editor/output-block.ts` re-exports it so its editing helpers and
+ * this finder share one implementation.
+ */
+
+import { parseFenceInfo } from './cell-id';
+import type { CellOutput } from './types';
+
+/** What's stored in an ```output block: a CellOutput, or the `{type:'error'}`
+ *  shape a failed cell serializes (`resultToJson`). */
+export type StoredCellOutput = CellOutput | { type: 'error'; message: string };
+
+/** Languages whose fences can be compute cells (and thus carry an output). */
+const CELL_LANGS: ReadonlySet<string> = new Set(['python', 'py', 'python3', 'sparql', 'sql']);
+
+/**
+ * Scan forward from `after` for an `output` fence belonging to the cell that
+ * just closed. "Adjacent" = only whitespace (at most one blank line) between the
+ * cell's close and the opening backticks; anything else means the user wrote
+ * prose between them, so it isn't this cell's output. Returns the block's range.
+ */
+export function findAdjacentOutputBlock(
+  doc: string,
+  after: number,
+): { from: number; to: number } | null {
+  let i = after;
+  let blankLines = 0;
+  while (i < doc.length && (doc[i] === ' ' || doc[i] === '\t' || doc[i] === '\n')) {
+    if (doc[i] === '\n') {
+      blankLines++;
+      if (blankLines > 2) return null; // more than one blank line → not adjacent
+    }
+    i++;
+  }
+  if (!doc.startsWith('```output', i)) return null;
+  const from = i;
+  const openEnd = doc.indexOf('\n', i + '```output'.length);
+  if (openEnd < 0) return null;
+  const closeLine = findClosingFence(doc, openEnd + 1);
+  if (closeLine < 0) return null;
+  const to = closeLine + 3 + (doc[closeLine + 3] === '\n' ? 1 : 0);
+  return { from, to };
+}
+
+function findClosingFence(doc: string, searchStart: number): number {
+  let i = searchStart;
+  while (i < doc.length) {
+    if (doc.startsWith('```', i)) {
+      const after = i + 3;
+      if (after >= doc.length || doc[after] === '\n' || doc[after] === '\r') return i;
+    }
+    const nl = doc.indexOf('\n', i);
+    if (nl < 0) return -1;
+    i = nl + 1;
+  }
+  return -1;
+}
+
+/**
+ * Find the stored `CellOutput` for the cell whose fence info carries
+ * `{id=cellId}`. Returns null when no such cell exists or it has no adjacent
+ * output block (never run). A non-table / error output is returned as-is so the
+ * caller can surface a precise message.
+ */
+export function findCellOutput(content: string, cellId: string): StoredCellOutput | null {
+  const lines = content.split('\n');
+  let offset = 0;
+  for (const line of lines) {
+    const lineStart = offset;
+    offset += line.length + 1; // +1 for the '\n' split removed
+    const m = /^```(\S.*)$/.exec(line);
+    if (!m) continue;
+    const info = m[1];
+    const parsed = parseFenceInfo(info);
+    if (!CELL_LANGS.has(parsed.language) || parsed.attrs.id !== cellId) continue;
+
+    // Found the cell's opening fence. Find its closing ``` then the output block.
+    const closeLine = findClosingFence(content, lineStart + line.length + 1);
+    if (closeLine < 0) return null;
+    const cellEnd = closeLine + 3 + (content[closeLine + 3] === '\n' ? 1 : 0);
+    const block = findAdjacentOutputBlock(content, cellEnd);
+    if (!block) return null;
+    return parseOutputJson(content.slice(block.from, block.to));
+  }
+  return null;
+}
+
+/** Extract and parse the JSON payload from an ```output fenced block. */
+function parseOutputJson(block: string): StoredCellOutput | null {
+  const firstNl = block.indexOf('\n');
+  const lastFence = block.lastIndexOf('```');
+  if (firstNl < 0 || lastFence <= firstNl) return null;
+  const json = block.slice(firstNl + 1, lastFence).trim();
+  try {
+    return JSON.parse(json) as StoredCellOutput;
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/compute/fences.ts
+++ b/src/shared/compute/fences.ts
@@ -6,8 +6,10 @@
  * process needs `findRunnableFences` / `codeOf` / `FenceRange` to locate and
  * read executable fences when saving a cell's output as a note (#244). Main
  * must not import renderer code, so the language-agnostic fence scanning lives
- * here in `shared/` while the renderer-only output-block *editing* helpers
- * (`planOutputEdit`, `findAdjacentOutputBlock`, …) stay in the editor module.
+ * here in `shared/`. The pure output-block *reading* helpers
+ * (`findAdjacentOutputBlock`, `findCellOutput`) likewise live in shared
+ * (`cell-output.ts`); only the *editing* helpers (`planOutputEdit`) stay in the
+ * renderer's editor module.
  *
  * Operating on raw strings keeps them trivially unit-testable without a
  * CodeMirror view.

--- a/tests/shared/compute/cell-output.test.ts
+++ b/tests/shared/compute/cell-output.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Find a compute cell's stored output by id (#832 pt 5 / #884).
+ *
+ * Locates the runnable fence carrying `{id=…}` and reads its companion
+ * ```output block — the data a chart's `data.cell` form binds to.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findCellOutput, findAdjacentOutputBlock } from '../../../src/shared/compute/cell-output';
+
+const NOTE = `# Analysis
+
+Some prose.
+
+\`\`\`sql {id=a1b2c3d4}
+SELECT month, revenue FROM sales
+\`\`\`
+
+\`\`\`output
+{"type":"table","columns":["month","revenue"],"rows":[["Jan",100],["Feb",150]]}
+\`\`\`
+
+More prose.
+
+\`\`\`sparql {id=ffffffff}
+SELECT ?x WHERE { ?x a ?y }
+\`\`\`
+
+\`\`\`output
+{"type":"error","message":"Bad query"}
+\`\`\`
+`;
+
+describe('findCellOutput', () => {
+  it('finds a table output for the cell with a matching id', () => {
+    expect(findCellOutput(NOTE, 'a1b2c3d4')).toEqual({
+      type: 'table',
+      columns: ['month', 'revenue'],
+      rows: [['Jan', 100], ['Feb', 150]],
+    });
+  });
+
+  it('returns the error shape for a cell whose run failed', () => {
+    expect(findCellOutput(NOTE, 'ffffffff')).toEqual({ type: 'error', message: 'Bad query' });
+  });
+
+  it('returns null for an unknown cell id', () => {
+    expect(findCellOutput(NOTE, 'deadbeef')).toBeNull();
+  });
+
+  it('returns null when the cell exists but has no output block (never run)', () => {
+    const doc = '```python {id=aaaa1111}\nprint(1)\n```\n\nno output here\n';
+    expect(findCellOutput(doc, 'aaaa1111')).toBeNull();
+  });
+
+  it('does not match a fence in a non-cell language', () => {
+    const doc = '```text {id=aaaa1111}\nnot a cell\n```\n\n```output\n{"type":"text","value":"x"}\n```\n';
+    expect(findCellOutput(doc, 'aaaa1111')).toBeNull();
+  });
+
+  it('ignores an output block separated by prose (not adjacent)', () => {
+    const doc = '```sql {id=aaaa1111}\nSELECT 1\n```\n\nintervening prose\n\n```output\n{"type":"table","columns":["a"],"rows":[[1]]}\n```\n';
+    expect(findCellOutput(doc, 'aaaa1111')).toBeNull();
+  });
+});
+
+describe('findAdjacentOutputBlock', () => {
+  it('finds an output block immediately after a fence end', () => {
+    const doc = '```sql\nSELECT 1\n```\n```output\n{"type":"text","value":"x"}\n```\n';
+    const after = doc.indexOf('```output');
+    const block = findAdjacentOutputBlock(doc, doc.indexOf('```\n') + 4);
+    expect(block).not.toBeNull();
+    expect(doc.slice(block!.from, block!.to)).toContain('"type":"text"');
+    expect(block!.from).toBe(after);
+  });
+});


### PR DESCRIPTION
Final in-app data source for #832 (after SPARQL #887 and SQL/table #888). A chart can draw from a runnable cell's stored result in the same note.

## What it does

```markdown
```sql {id=sales}
SELECT month, revenue FROM sales
```

```vega-lite
{ "data": { "cell": "sales" }, "mark": "bar", "encoding": { … } }
```
```

The chart reads the cell's companion `output` block, so **run the cell first**; the ⟳ refresh button re-reads the latest output. A never-run cell, an error output, or a non-tabular output each render a precise notice.

## Implementation

- **Shared finder** `src/shared/compute/cell-output.ts` — `findCellOutput(content, id)` locates the cell whose fence info carries `{id=…}` and reads its adjacent `output` block. The pure adjacent-output scan (`findAdjacentOutputBlock`) **moved here** from the renderer's `editor/output-block.ts` (re-exported for back-compat) so the renderer (#884) and the export pipeline (#885) share one implementation.
- `rendererExecutor` resolves `data.cell` → `findCellOutput` → `rowsFromTable`. `hydrateVegaBlocks` now takes the note's markdown (threaded from Preview) since a cell's output lives in the source, not the DOM.
- `StoredCellOutput` covers the `{type:'error'}` shape a failed cell serializes (not part of `CellOutput`).

## Verification

- 52 vega/cell unit tests, incl. the finder (adjacency, error output, unknown id, never-run, non-cell language). Existing `output-block` tests stay green through the re-export. Lint clean.
- **Live, in the packaged app**: a `data.cell: "sales"` bar chart rendered bars matching the bound cell's output table exactly (30/75/45/90). Screenshot captured — cell output table and the chart below it, values aligned.

Part of #826 / #832. Closes #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)