### PR TITLE
feat: resolve data-bound charts at export time (#885)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -139,9 +139,6 @@ The chart reads the cell's stored `output` block, so **run the cell first**; its
 ⟳ refresh button re-reads the latest output. A cell that hasn't run (or whose
 output isn't tabular) renders a clear notice.
 
-Bound charts don't yet render in **exports** (#885) — they degrade to the spec
-there.
-
 ## Export
 
 When you export a note, charts are rendered to **static SVG** so the published
@@ -154,6 +151,12 @@ artifact actually shows the visualization instead of a wall of JSON:
 - **Markdown export** keeps the spec fence **verbatim** — a Vega spec is
   portable to other Vega-aware tools, and a multi-kilobyte data URI would bloat
   the file. Re-render it wherever it's opened next.
+
+**Data-bound charts resolve at export too**: a `data.sparql` / `data.sql` /
+`data.table` / `data.cell` chart runs its query (or reads the cell output) in the
+main process and renders the result, so the exported artifact shows live data —
+not a binding stub. A binding that can't resolve (no project context, query
+error, a cell that never ran) degrades to the spec plus a note.
 
 The security policy holds at export too: a chart that references remote data is
 refused (no fetch from the export process), and any chart that can't render —

--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -36,7 +36,7 @@ export async function renderNoteBody(
   // #831 — pre-render ```vega-lite / ```vega fences to static SVG images
   // before markdown rendering (md.render is sync; vega's toSVG is async).
   // The result is `<img>` markdown, so it survives the `html: false` instance.
-  const bodyMarkdown = await renderVegaBlocks(stripFrontmatter(file.content));
+  const bodyMarkdown = await renderVegaBlocks(stripFrontmatter(file.content), { rootPath: plan.rootPath });
   return md.render(bodyMarkdown);
 }
 

--- a/src/main/publish/vega-render.ts
+++ b/src/main/publish/vega-render.ts
@@ -27,7 +27,18 @@
  * verbatim, which stays portable to other Vega-aware tools.
  */
 
-import { detectDataSource } from '../../shared/vega/data-binding';
+import {
+  detectDataSource,
+  resolveVegaData,
+  tableQuerySql,
+  rowsFromTable,
+  type DataSourceRef,
+  type VegaRows,
+} from '../../shared/vega/data-binding';
+import { findCellOutput } from '../../shared/compute/cell-output';
+import { queryGraph } from '../graph/queries';
+import { runQuery } from '../sources/tables';
+import { projectContext } from '../project-context-types';
 
 // Catppuccin-derived categorical palette, shared in spirit with the renderer
 // (#828) and the Chart.js adapter so all three charting paths feel consistent.
@@ -106,13 +117,21 @@ export function hasVegaBlocks(markdown: string): boolean {
   return VEGA_FENCE_RE.test(markdown);
 }
 
+/** Options carrying the project context export-time data binding needs (#885). */
+export interface RenderVegaOptions {
+  /** Project root, so `data.sparql` / `data.sql` / `data.table` can run against
+   *  the live graph / DuckDB. Absent (e.g. headless with no project) → bound
+   *  charts degrade gracefully. */
+  rootPath?: string;
+}
+
 /**
  * Replace every ```vega-lite / ```vega fence in `markdown` with a rendered SVG
  * image (`![chart](data:image/svg+xml;base64,…)`). A chart that can't render
  * degrades to its original spec fence plus an italic note. Returns the markdown
  * unchanged when it contains no charts (no library load).
  */
-export async function renderVegaBlocks(markdown: string): Promise<string> {
+export async function renderVegaBlocks(markdown: string, opts: RenderVegaOptions = {}): Promise<string> {
   if (!hasVegaBlocks(markdown)) return markdown;
 
   VEGA_FENCE_RE.lastIndex = 0;
@@ -123,14 +142,45 @@ export async function renderVegaBlocks(markdown: string): Promise<string> {
   let last = 0;
   for (const m of matches) {
     out += markdown.slice(last, m.index);
-    out += await renderOne(m[1] === 'vega' ? 'vega' : 'vega-lite', m[2]);
+    out += await renderOne(m[1] === 'vega' ? 'vega' : 'vega-lite', m[2], markdown, opts);
     last = m.index + m[0].length;
   }
   out += markdown.slice(last);
   return out;
 }
 
-async function renderOne(mode: 'vega' | 'vega-lite', specText: string): Promise<string> {
+/**
+ * Resolve a Minerva data source to rows in the export (main) process (#885) —
+ * the same sources the renderer binds (#882/#883/#884), run headlessly here.
+ * cell output is read from the note `markdown` being exported.
+ */
+async function exportExecutor(ref: DataSourceRef, markdown: string, rootPath?: string): Promise<VegaRows> {
+  if (ref.kind === 'cell') {
+    const output = findCellOutput(markdown, ref.id);
+    if (!output) throw new Error(`no output for cell "${ref.id}" — run it before exporting`);
+    if (output.type === 'error') throw new Error(output.message);
+    if (output.type !== 'table') throw new Error(`cell "${ref.id}" output isn't tabular`);
+    return rowsFromTable(output.columns, output.rows);
+  }
+  if (!rootPath) throw new Error('no project context to resolve the query against');
+  const ctx = projectContext(rootPath);
+  if (ref.kind === 'sparql') {
+    const res = await queryGraph(ctx, ref.query);
+    if (res.error) throw new Error(res.error);
+    return (res.results as VegaRows) ?? [];
+  }
+  const sql = ref.kind === 'table' ? tableQuerySql(ref.name) : ref.query;
+  const res = await runQuery(ctx, sql);
+  if (!res.ok) throw new Error(res.error);
+  return res.rows;
+}
+
+async function renderOne(
+  mode: 'vega' | 'vega-lite',
+  specText: string,
+  markdown: string,
+  opts: RenderVegaOptions,
+): Promise<string> {
   let spec: unknown;
   try {
     spec = JSON.parse(specText);
@@ -138,17 +188,22 @@ async function renderOne(mode: 'vega' | 'vega-lite', specText: string): Promise<
     return degrade(mode, specText, `invalid JSON: ${msgOf(err)}`);
   }
 
+  // #885 — resolve a Minerva data binding to inline values before anything else,
+  // so the url-scan below still only ever sees inline data. A resolution failure
+  // (no project, query error, empty cell) degrades to the spec + a note.
+  const ref = detectDataSource(spec);
+  if (ref) {
+    try {
+      spec = await resolveVegaData(spec as Record<string, unknown>, ref, (r) => exportExecutor(r, markdown, opts.rootPath));
+    } catch (err) {
+      return degrade(mode, specText, `data binding: ${msgOf(err)}`);
+    }
+  }
+
   const urls: string[] = [];
   findUrlRefs(spec, urls);
   if (urls.length > 0) {
     return degrade(mode, specText, `remote data is disabled (${urls[0]})`);
-  }
-
-  // A chart bound to live Minerva data (#832 — data.sparql / sql / table / cell)
-  // isn't resolved at export time yet (#885 wires that). Degrade to the spec +
-  // a clear note rather than letting vega-lite render a silent empty chart.
-  if (detectDataSource(spec)) {
-    return degrade(mode, specText, 'data binding is not resolved in exports yet');
   }
 
   try {

--- a/tests/main/publish/vega-render.test.ts
+++ b/tests/main/publish/vega-render.test.ts
@@ -75,12 +75,32 @@ describe('renderVegaBlocks', () => {
     expect(out).toContain('https://example.com/data.csv');
   });
 
-  it('degrades a data-bound chart (data.sparql) — not resolved in export yet (#885)', async () => {
+  it('degrades a query-bound chart with no project context, never a silent empty chart (#885)', async () => {
     const bound = '```vega-lite\n{ "data": { "sparql": "SELECT ?x WHERE { ?x a ?y }" }, "mark": "bar" }\n```';
-    const out = await renderVegaBlocks(bound);
-    expect(out).not.toContain('data:image'); // never rendered as an empty chart
-    expect(out.toLowerCase()).toContain('not resolved in exports yet');
+    const out = await renderVegaBlocks(bound); // no rootPath
+    expect(out).not.toContain('data:image');
+    expect(out.toLowerCase()).toContain('no project context');
     expect(out).toContain('```vega-lite'); // spec preserved
+  });
+
+  it('resolves a data.cell chart from the note output block and renders it (#885)', async () => {
+    // cell binding needs no project context — the output lives in the markdown.
+    const md = '```sql {id=sales}\nSELECT month, revenue FROM sales\n```\n\n'
+      + '```output\n{"type":"table","columns":["month","revenue"],"rows":[["Jan",30],["Feb",75]]}\n```\n\n'
+      + '```vega-lite\n{ "data": { "cell": "sales" }, "mark": "bar", '
+      + '"encoding": { "x": {"field":"month","type":"nominal"}, "y": {"field":"revenue","type":"quantitative"} } }\n```';
+    const out = await renderVegaBlocks(md);
+    expect(out).toContain('data:image/svg+xml;base64,'); // rendered from cell output
+    const m = out.match(/data:image\/svg\+xml;base64,([A-Za-z0-9+/=]+)/);
+    const svg = Buffer.from(m![1], 'base64').toString('utf8');
+    expect(svg).toContain('<svg');
+  });
+
+  it('degrades a data.cell chart whose cell never ran', async () => {
+    const md = '```sql {id=x}\nSELECT 1\n```\n\n```vega-lite\n{ "data": { "cell": "x" }, "mark": "bar" }\n```';
+    const out = await renderVegaBlocks(md);
+    expect(out).not.toContain('data:image');
+    expect(out.toLowerCase()).toContain('run it before exporting');
   });
 
   it('degrades invalid JSON to spec text + a note instead of throwing', async () => {


### PR DESCRIPTION
Bound charts (`data.sparql` / `data.sql` / `data.table` / `data.cell`) now render with **live data in HTML/PDF exports** instead of degrading to a spec stub. Builds on the resolution layer (#887) and the now-shared cell finder (#889).

## What it does

- `vega-render.ts` (the main-process export renderer from #831) gains `exportExecutor`: `sparql` → `queryGraph`, `sql`/`table` → `runQuery`, `cell` → `findCellOutput` on the note markdown. `renderOne` resolves a Minerva data form to inline values (via the shared `resolveVegaData` — same normalize + numeric coercion as the renderer) **before** the headless SVG render, so the url-scan still only ever sees inline data.
- `renderVegaBlocks` takes `{ rootPath }`, threaded from `renderNoteBody` via `plan.rootPath`, so graph / DuckDB queries run against the open project. Cell binding needs no project context — the output lives in the markdown being exported.
- **Graceful degrade unchanged**: no project context, a query error, or a cell that never ran falls back to the spec + a note; one chart never fails the whole export.

## Verification

- **Live, in the packaged app**: a `data.table: "sales"` chart exported to HTML resolved against DuckDB and embedded the rendered SVG — `htmlHasRenderedSvgImg: true`, no degrade note, the `"table"` binding replaced by real data, zero console errors.
- Unit: a `data.cell` chart renders to a real SVG in export from the note's `output` block (the cell path needs no project state, so it's fully unit-covered); query bindings with no project context degrade with a clear note.
- 292 publish tests; lint clean.

This completes the resolve-everywhere story: all four sources render both in the live preview (#887/#888/#889) and in exports.

Part of #826 / #832. Closes #885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)