### PR TITLE
feat: bound-data chart scaffolds in Insert → Chart (#886)

### DIFF
--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -29,10 +29,16 @@ Use a ` ```vega ` fence for a full Vega spec. Both render through
 [`vega-embed`](https://github.com/vega/vega-embed), which is lazy-loaded on first
 use, so notes without charts pay nothing.
 
-**Insert → Chart…** offers starter scaffolds (Bar, Line, Area, Scatter, Time
-Series, Pie) that drop a complete, valid, inline-data spec and render
-immediately — the cursor lands in the data array so your first edit is "replace
-my data". An **Empty Block** option is there for starting from scratch.
+**Insert → Chart…** offers starter scaffolds that drop a complete, valid spec
+with the cursor positioned for the first edit:
+
+- inline-data charts (Bar, Line, Area, Scatter, Time Series, Pie) that render
+  immediately — the cursor lands in the data array so your first edit is
+  "replace my data";
+- live-data charts (From SPARQL, From Table, From Cell) wired to Minerva's own
+  data (see [Binding charts to Minerva data](#binding-charts-to-minerva-data)) —
+  the cursor lands in the query / table / cell reference;
+- an **Empty Block** for starting from scratch.
 
 Each chart gets the built-in **"⋯" actions menu** (export PNG/SVG, view
 source/compiled spec) and a **collapse toggle** in the fence toolbar. Charts are

--- a/src/renderer/lib/editor/formatting.ts
+++ b/src/renderer/lib/editor/formatting.ts
@@ -538,6 +538,44 @@ const PIE_TEMPLATE = `{
   }
 }`;
 
+// Bound-data scaffolds (#886) — charts that draw from Minerva's own live data
+// (#832) instead of inline values. Cursor lands in the query / table / cell ref
+// so the first edit points it at the user's data. The SPARQL one is runnable
+// as-is on a tagged project; the table / cell ones carry placeholder names.
+
+const SPARQL_BOUND_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Bar chart from a SPARQL query",
+  "data": { "sparql": "${CURSOR}SELECT ?tag (COUNT(?n) AS ?count) WHERE { ?n minerva:hasTag ?t . ?t minerva:tagName ?tag } GROUP BY ?tag" },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "tag", "type": "nominal" },
+    "y": { "field": "count", "type": "quantitative" }
+  }
+}`;
+
+const TABLE_BOUND_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Bar chart from a CSV / DuckDB table",
+  "data": { "table": "${CURSOR}my_table" },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}`;
+
+const CELL_BOUND_TEMPLATE = `{
+  "$schema": "${SCHEMA}",
+  "description": "Bar chart from a compute cell's output",
+  "data": { "cell": "${CURSOR}cell-id" },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}`;
+
 /** A bare ```vega-lite block — cursor on the empty body line (power users). */
 export const insertVegaLiteDiagram: Command = makeInsertFence('vega-lite');
 
@@ -548,8 +586,13 @@ export const insertVegaLiteScatter: Command = makeInsertTemplate('vega-lite', SC
 export const insertVegaLiteTimeSeries: Command = makeInsertTemplate('vega-lite', TIME_SERIES_TEMPLATE);
 export const insertVegaLitePie: Command = makeInsertTemplate('vega-lite', PIE_TEMPLATE);
 
-/** Chart-type chooser for the Insert menu, in a sensible order. The empty block
- *  trails the concrete scaffolds for users who'd rather start from scratch. */
+export const insertVegaLiteFromSparql: Command = makeInsertTemplate('vega-lite', SPARQL_BOUND_TEMPLATE);
+export const insertVegaLiteFromTable: Command = makeInsertTemplate('vega-lite', TABLE_BOUND_TEMPLATE);
+export const insertVegaLiteFromCell: Command = makeInsertTemplate('vega-lite', CELL_BOUND_TEMPLATE);
+
+/** Chart-type chooser for the Insert menu, in a sensible order: inline-data
+ *  scaffolds, then the live-data (#832) ones, then the empty block for users
+ *  who'd rather start from scratch. */
 export const vegaLiteInserts: { label: string; command: Command }[] = [
   { label: 'Bar', command: insertVegaLiteBar },
   { label: 'Line', command: insertVegaLiteLine },
@@ -557,6 +600,9 @@ export const vegaLiteInserts: { label: string; command: Command }[] = [
   { label: 'Scatter', command: insertVegaLiteScatter },
   { label: 'Time Series', command: insertVegaLiteTimeSeries },
   { label: 'Pie', command: insertVegaLitePie },
+  { label: 'From SPARQL', command: insertVegaLiteFromSparql },
+  { label: 'From Table', command: insertVegaLiteFromTable },
+  { label: 'From Cell', command: insertVegaLiteFromCell },
   { label: 'Empty Block', command: insertVegaLiteDiagram },
 ];
 

--- a/tests/renderer/editor/insert-commands.test.ts
+++ b/tests/renderer/editor/insert-commands.test.ts
@@ -56,10 +56,11 @@ describe('vega-lite chart scaffolds (#830)', () => {
     return m[1];
   }
 
-  it('offers a chart-type chooser ending in an empty-block option', () => {
-    expect(vegaLiteInserts.map((t) => t.label)).toEqual([
-      'Bar', 'Line', 'Area', 'Scatter', 'Time Series', 'Pie', 'Empty Block',
-    ]);
+  const INLINE = ['Bar', 'Line', 'Area', 'Scatter', 'Time Series', 'Pie'];
+  const BOUND = ['From SPARQL', 'From Table', 'From Cell'];
+
+  it('offers inline scaffolds, the live-data scaffolds, then the empty block', () => {
+    expect(vegaLiteInserts.map((t) => t.label)).toEqual([...INLINE, ...BOUND, 'Empty Block']);
   });
 
   it('the empty-block option inserts a bare fence with the cursor on the body line', () => {
@@ -69,25 +70,34 @@ describe('vega-lite chart scaffolds (#830)', () => {
     expect(v.state.selection.main.head).toBe('```vega-lite\n'.length);
   });
 
+  function cursorInBody(v: EditorView, doc: string) {
+    const head = v.state.selection.main.head;
+    expect(head).toBeGreaterThan('```vega-lite\n'.length);
+    expect(head).toBeLessThan(doc.length);
+  }
+
   for (const { label, command } of vegaLiteInserts) {
     if (label === 'Empty Block') continue;
-    it(`${label} scaffold inserts a valid inline-data spec, cursor inside the data`, () => {
+    const bound = BOUND.includes(label);
+    it(`${label} scaffold inserts a valid spec (${bound ? 'bound' : 'inline'}), cursor for the first edit`, () => {
       const v = mk('');
       command(v);
       const doc = v.state.doc.toString();
       const spec = JSON.parse(fenceBody(doc)) as Record<string, unknown>;
-      // Renders immediately → must be a complete spec with inline data and a mark.
       expect(spec.mark).toBeTruthy();
-      const data = spec.data as { values?: unknown[]; url?: string };
-      expect(Array.isArray(data.values)).toBe(true);
-      expect(data.values!.length).toBeGreaterThan(0);
-      // #829 posture: scaffolds never reference remote data.
+      const data = spec.data as { values?: unknown[]; sparql?: string; table?: string; cell?: string; url?: string };
+      if (bound) {
+        // A live-data form — exactly one of sparql / table / cell, no inline values.
+        expect([data.sparql, data.table, data.cell].filter(Boolean)).toHaveLength(1);
+        expect(data.values).toBeUndefined();
+      } else {
+        expect(Array.isArray(data.values)).toBe(true);
+        expect(data.values!.length).toBeGreaterThan(0);
+      }
+      // #829 posture: no scaffold references remote data.
       expect(data.url).toBeUndefined();
       expect(JSON.stringify(spec)).not.toContain('"url"');
-      // Cursor lands somewhere inside the body (the data array), not at column 0.
-      const head = v.state.selection.main.head;
-      expect(head).toBeGreaterThan('```vega-lite\n'.length);
-      expect(head).toBeLessThan(doc.length);
+      cursorInBody(v, doc);
     });
   }
 


### PR DESCRIPTION
Closes the in-app side of #832. The **Insert → Chart…** picker now offers live-data starter specs alongside the inline ones (#830).

## What it does

Three new scaffolds, each dropping a complete valid spec with the cursor in the query / table / cell reference:

- **From SPARQL** — a runnable `data.sparql` bar chart (counts notes by tag), works as-is on a tagged project.
- **From Table** — a `data.table` chart with a placeholder table name.
- **From Cell** — a `data.cell` chart with a placeholder cell id.

Ordered after the inline scaffolds (Bar/Line/…/Pie), before the Empty Block. `docs/visualizations.md` documents the picker layout and links the binding reference.

## Verification

- Tests assert each bound scaffold is valid JSON carrying exactly one live-data form (`sparql` | `table` | `cell`), no inline `values`, no remote `url`, cursor in the body. 18 insert-command tests; lint clean.
- The runtime paths are already live-verified: menu insertion (#878) and SPARQL→chart rendering (#887). These scaffolds just pre-fill specs of the same shape.

Part of #826 / #832. Closes #886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)