### PR TITLE
feat: .apkg Anki deck exporter (sql.js, deck mapping, idempotent) (#853)

### DIFF
--- a/docs/flashcards.md
+++ b/docs/flashcards.md
@@ -61,6 +61,17 @@ Anki card (preserving its review history) instead of duplicating it.
 
 ## Exporting to Anki
 
-The Anki `.apkg` exporter (#853) is a follow-up; once it lands, **Export → Anki
-deck** will package the cards in the selected scope (note / folder / tree /
-whole base) into a file you import into Anki.
+**Export → Anki Deck** packages the `[!card]` callouts in the selected scope
+(note / folder / tree / whole base) into a `.apkg` file you import into Anki.
+
+- Cards become Basic (Front/Back) notes; the front/back markdown is rendered to
+  HTML so formatting survives.
+- Decks come from the deck precedence above; Anki rebuilds the `::` hierarchy on
+  import.
+- Each note carries its stable guid, so **re-importing after edits updates the
+  matching cards and preserves their scheduling** instead of duplicating them.
+- The summary reports the card count and per-deck breakdown; malformed cards and
+  duplicate ids are reported, never silently dropped. An empty scope says "no
+  flashcards found" rather than writing an empty file.
+
+Media (images) in cards is a planned follow-up — export is text-first today.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -32,6 +32,9 @@ const EXTERNAL_DEP_ROOTS = [
   // must be shipped for `require('vega')` / `require('vega-lite')` to resolve.
   'vega',
   'vega-lite',
+  // Anki .apkg writer (#853). sql.js reads its `sql-wasm.wasm` from disk, so
+  // the package (incl. the .wasm) must ship for `import('sql.js')` to resolve.
+  'sql.js',
 ];
 
 /** BFS the `dependencies` graph from each root; skips absent optionals. */

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "pdfjs-dist": "^6.0.227",
     "rdflib": "^2.3.9",
     "sql-formatter": "^15.8.1",
+    "sql.js": "^1.14.1",
     "tesseract.js": "^7.0.0",
     "tslib": "^2.8.1",
     "turndown": "^7.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       sql-formatter:
         specifier: ^15.8.1
         version: 15.8.1
+      sql.js:
+        specifier: ^1.14.1
+        version: 1.14.1
       tesseract.js:
         specifier: ^7.0.0
         version: 7.0.0(encoding@0.1.13)
@@ -5589,6 +5592,9 @@ packages:
   sql-formatter@15.8.1:
     resolution: {integrity: sha512-nT2r90kTEYBuse9fe4r1Rp78v1mOBD35KsGc07Vo9eQSVa1TcTSnCS0zouf6BCmdzvmqBsBW+cYuBoYkHO/OWg==}
     hasBin: true
+
+  sql.js@1.14.1:
+    resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
 
   ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
@@ -14316,6 +14322,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       nearley: 2.20.1
+
+  sql.js@1.14.1: {}
 
   ssri@9.0.1:
     dependencies:

--- a/src/main/publish/exporters/anki/anki-deck.ts
+++ b/src/main/publish/exporters/anki/anki-deck.ts
@@ -1,0 +1,94 @@
+/**
+ * Anki deck exporter (#850 / #853) — emits a `.apkg` from the `[!card]` callouts
+ * in the export scope. Registered as another format in the #802 pipeline.
+ *
+ * Per note: assign + persist card ids (#852 write-back, via the safe write path),
+ * extract cards (#851), derive each card's stable guid, map decks, and render the
+ * front/back markdown to HTML. Cards aggregate across the scope into one package
+ * keyed by guid, so re-importing after an edit updates cards instead of dupes.
+ *
+ * Text-first: media is a follow-up. Malformed cards and id collisions are
+ * reported in the summary, never silently dropped.
+ */
+
+import path from 'node:path';
+import MarkdownIt from 'markdown-it';
+import { writeFile } from '../../../notebase/fs';
+import { collectCards } from '../../../../shared/flashcards/cards';
+import { assignCardIds, cardGuid, findDuplicateCardIds } from '../../../../shared/flashcards/guid';
+import { buildApkg, type AnkiCard } from './apkg';
+import type { Exporter, ExportPlan } from '../../types';
+
+// Card fields are markdown; Anki renders HTML, so convert. `breaks: true` turns
+// a single newline into <br> (cards are short and line-oriented). Raw HTML is
+// dropped (html: false) — the field is the user's note text, not trusted markup.
+const cardMd = new MarkdownIt({ html: false, linkify: true, breaks: true });
+const renderField = (md: string): string => cardMd.render(md).trim();
+
+/** Filename for the package, derived from the scope. */
+function deckFileName(plan: ExportPlan): string {
+  if (plan.inputKind === 'single-note') {
+    const note = plan.inputs.find((f) => f.kind === 'note');
+    if (note) return `${path.basename(note.relativePath).replace(/\.md$/i, '')}.apkg`;
+  }
+  return 'flashcards.apkg';
+}
+
+export const ankiDeckExporter: Exporter = {
+  id: 'anki-deck',
+  label: 'Anki Deck (.apkg)',
+  group: 'anki',
+  // Note / folder / tree / project — anything but a source viewer.
+  accepts: (input) => input.kind !== 'source',
+  acceptedKinds: ['single-note', 'folder', 'tree', 'project'],
+
+  async run(plan): Promise<{ files: { path: string; contents: Uint8Array }[]; summary: string }> {
+    const cards: AnkiCard[] = [];
+    const warnings: string[] = [];
+    const deckCounts = new Map<string, number>();
+
+    for (const file of plan.inputs) {
+      if (file.kind !== 'note') continue;
+
+      // #852 — assign ids to id-less cards and persist them back to the note so
+      // the next export matches. Only rewrite notes that actually gained ids.
+      let content = file.content;
+      const assigned = assignCardIds(content);
+      if (assigned.assignedCount > 0 && plan.rootPath) {
+        await writeFile(plan.rootPath, file.relativePath, assigned.content);
+        content = assigned.content;
+      }
+
+      const noteDeck = typeof file.frontmatter.cardDeck === 'string' ? file.frontmatter.cardDeck : undefined;
+      const { cards: noteCards, warnings: noteWarnings } = collectCards(content, file.relativePath, noteDeck);
+      for (const w of noteWarnings) warnings.push(`${file.relativePath}:${w.line} — ${w.message}`);
+
+      const dupes = new Set(findDuplicateCardIds(noteCards));
+      for (const d of dupes) warnings.push(`${file.relativePath} — duplicate card id ^${d}; skipped`);
+
+      for (const c of noteCards) {
+        if (!c.id || dupes.has(c.id)) continue;
+        cards.push({
+          guid: cardGuid(file.relativePath, c.id),
+          deck: c.deck,
+          front: renderField(c.front),
+          back: renderField(c.back),
+        });
+        deckCounts.set(c.deck, (deckCounts.get(c.deck) ?? 0) + 1);
+      }
+    }
+
+    if (cards.length === 0) {
+      const tail = warnings.length ? ` (${warnings.length} skipped — see ${warnings[0]})` : '';
+      return { files: [], summary: `No flashcards found in this scope.${tail}` };
+    }
+
+    const apkg = await buildApkg(cards);
+    const breakdown = [...deckCounts.entries()].map(([d, n]) => `${d} (${n})`).join(', ');
+    const n = cards.length;
+    let summary = `${n} card${n === 1 ? '' : 's'} across ${deckCounts.size} deck${deckCounts.size === 1 ? '' : 's'}: ${breakdown}.`;
+    if (warnings.length) summary += ` ${warnings.length} skipped.`;
+
+    return { files: [{ path: deckFileName(plan), contents: apkg }], summary };
+  },
+};

--- a/src/main/publish/exporters/anki/apkg.ts
+++ b/src/main/publish/exporters/anki/apkg.ts
@@ -1,0 +1,193 @@
+/**
+ * `.apkg` (Anki package) writer (#850 / #853).
+ *
+ * An `.apkg` is a zip of a `collection.anki2` SQLite database (Anki schema
+ * version 11 — the legacy format every Anki version imports) plus a `media`
+ * manifest. We build the SQLite in-memory with `sql.js` (pure-WASM, no native
+ * dependency, lazy-loaded) and zip it with JSZip.
+ *
+ * The schema + default JSON blobs follow `genanki`'s reference layout. We emit a
+ * single Basic (Front/Back) note type; each note's **guid** is the caller's
+ * stable per-card guid (#852) so re-importing after an edit updates the card and
+ * preserves its scheduling history instead of duplicating it.
+ *
+ * Text-first: no media. The `media` manifest is empty (`{}`).
+ */
+
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import JSZip from 'jszip';
+import type { SqlJsStatic } from 'sql.js';
+
+export interface AnkiCard {
+  /** Stable Anki guid (#852). */
+  guid: string;
+  /** Full deck name; `::` denotes Anki's deck hierarchy. */
+  deck: string;
+  /** Front (prompt) — HTML. */
+  front: string;
+  /** Back (answer) — HTML. */
+  back: string;
+}
+
+// A fixed model id for the Minerva Basic note type. Stable across exports so
+// Anki matches the note type on re-import.
+const MODEL_ID = 1700000000001;
+const MODEL_NAME = 'Basic (Minerva)';
+
+let sqlPromise: Promise<SqlJsStatic> | null = null;
+
+/** Lazily init sql.js, loading the wasm from the (externalized, shipped) package. */
+function loadSql(): Promise<SqlJsStatic> {
+  if (!sqlPromise) {
+    sqlPromise = (async () => {
+      const initSqlJs = (await import('sql.js')).default;
+      const require = createRequire(import.meta.url);
+      const wasm = path.join(path.dirname(require.resolve('sql.js')), 'sql-wasm.wasm');
+      return initSqlJs({ wasmBinary: readFileSync(wasm) });
+    })();
+  }
+  return sqlPromise;
+}
+
+const SCHEMA = `
+CREATE TABLE col (id INTEGER PRIMARY KEY, crt INTEGER, mod INTEGER, scm INTEGER, ver INTEGER,
+  dty INTEGER, usn INTEGER, ls INTEGER, conf TEXT, models TEXT, decks TEXT, dconf TEXT, tags TEXT);
+CREATE TABLE notes (id INTEGER PRIMARY KEY, guid TEXT, mid INTEGER, mod INTEGER, usn INTEGER,
+  tags TEXT, flds TEXT, sfld TEXT, csum INTEGER, flags INTEGER, data TEXT);
+CREATE TABLE cards (id INTEGER PRIMARY KEY, nid INTEGER, did INTEGER, ord INTEGER, mod INTEGER,
+  usn INTEGER, type INTEGER, queue INTEGER, due INTEGER, ivl INTEGER, factor INTEGER, reps INTEGER,
+  lapses INTEGER, left INTEGER, odue INTEGER, odid INTEGER, flags INTEGER, data TEXT);
+CREATE TABLE revlog (id INTEGER PRIMARY KEY, cid INTEGER, usn INTEGER, ease INTEGER, ivl INTEGER,
+  lastIvl INTEGER, factor INTEGER, time INTEGER, type INTEGER);
+CREATE TABLE graves (usn INTEGER, oid INTEGER, type INTEGER);
+CREATE INDEX ix_notes_usn ON notes (usn);
+CREATE INDEX ix_cards_usn ON cards (usn);
+CREATE INDEX ix_cards_nid ON cards (nid);
+CREATE INDEX ix_cards_sched ON cards (did, queue, due);
+CREATE INDEX ix_revlog_cid ON revlog (cid);
+CREATE INDEX ix_revlog_usn ON revlog (usn);
+CREATE INDEX ix_notes_csum ON notes (csum);
+`;
+
+function basicModel(): unknown {
+  return {
+    [MODEL_ID]: {
+      id: MODEL_ID, name: MODEL_NAME, type: 0, mod: 0, usn: 0, sortf: 0, did: 1,
+      tmpls: [{
+        name: 'Card 1', ord: 0,
+        qfmt: '{{Front}}',
+        afmt: '{{FrontSide}}\n\n<hr id="answer">\n\n{{Back}}',
+        bqfmt: '', bafmt: '', did: null, bfont: '', bsize: 0,
+      }],
+      flds: [
+        { name: 'Front', ord: 0, sticky: false, rtl: false, font: 'Arial', size: 20, media: [] },
+        { name: 'Back', ord: 1, sticky: false, rtl: false, font: 'Arial', size: 20, media: [] },
+      ],
+      css: '.card { font-family: arial; font-size: 20px; text-align: center; color: black; background-color: white; }',
+      latexPre: '\\documentclass[12pt]{article}\n\\special{papersize=3in,5in}\n\\usepackage[utf8]{inputenc}\n\\usepackage{amssymb,amsmath}\n\\pagestyle{empty}\n\\setlength{\\parindent}{0in}\n\\begin{document}\n',
+      latexPost: '\\end{document}',
+      latexsvg: false,
+      req: [[0, 'any', [0]]],
+      tags: [], vers: [],
+    },
+  };
+}
+
+function defaultConf(): unknown {
+  return {
+    nextPos: 1, estTimes: true, activeDecks: [1], sortType: 'noteFld', timeLim: 0,
+    sortBackwards: false, addToCur: true, curDeck: 1, newSpread: 0, dueCounts: true,
+    curModel: String(MODEL_ID), collapseTime: 1200,
+  };
+}
+
+function deckEntry(id: number, name: string): unknown {
+  return {
+    id, name, mod: 0, usn: 0, lrnToday: [0, 0], revToday: [0, 0], newToday: [0, 0],
+    timeToday: [0, 0], collapsed: false, browserCollapsed: false, desc: '', dyn: 0,
+    conf: 1, extendNew: 0, extendRev: 0,
+  };
+}
+
+function defaultDconf(): unknown {
+  return {
+    1: {
+      id: 1, name: 'Default', mod: 0, usn: 0, maxTaken: 60, autoplay: true, timer: 0, replayq: true,
+      new: { bury: false, delays: [1, 10], initialFactor: 2500, ints: [1, 4, 0], order: 1, perDay: 20, separate: true },
+      rev: { bury: false, ease4: 1.3, fuzz: 0.05, ivlFct: 1, maxIvl: 36500, minSpace: 1, perDay: 200, hardFactor: 1.2 },
+      lapse: { delays: [10], leechAction: 0, leechFails: 8, minInt: 1, mult: 0 },
+      dyn: false,
+    },
+  };
+}
+
+/** Anki field checksum: first 8 hex of sha1 of the first field (HTML-stripped). */
+function fieldChecksum(text: string): number {
+  const stripped = text.replace(/<[^>]+>/g, '');
+  return parseInt(createHash('sha1').update(stripped).digest('hex').slice(0, 8), 16);
+}
+
+/**
+ * Build a `.apkg` byte array from cards. Decks are created from the distinct
+ * deck names (Anki rebuilds the `::` hierarchy on import). Throws only on a
+ * genuine sql.js / zip failure; an empty `cards` array still yields a valid
+ * (empty) package — callers decide whether that's worth writing.
+ */
+export async function buildApkg(cards: AnkiCard[], now = Date.now()): Promise<Uint8Array> {
+  const SQL = await loadSql();
+  const db = new SQL.Database();
+  db.run(SCHEMA);
+
+  // Distinct decks → stable-per-export ids (2, 3, …; 1 is Default). Anki matches
+  // decks by name on import, so the numeric ids only need to be internally consistent.
+  const deckIds = new Map<string, number>();
+  let nextDeckId = 2;
+  for (const c of cards) {
+    if (!deckIds.has(c.deck)) deckIds.set(c.deck, nextDeckId++);
+  }
+  const decks: Record<string, unknown> = { 1: deckEntry(1, 'Default') };
+  for (const [name, id] of deckIds) decks[id] = deckEntry(id, name);
+
+  const crtSec = Math.floor(now / 1000);
+  db.run(
+    `INSERT INTO col VALUES (1, ?, ?, ?, 11, 0, 0, 0, ?, ?, ?, ?, '{}')`,
+    [
+      crtSec, now, now,
+      JSON.stringify(defaultConf()),
+      JSON.stringify(basicModel()),
+      JSON.stringify(decks),
+      JSON.stringify(defaultDconf()),
+    ],
+  );
+
+  const insNote = db.prepare(
+    `INSERT INTO notes VALUES (?, ?, ?, ?, -1, '', ?, ?, ?, 0, '')`,
+  );
+  const insCard = db.prepare(
+    `INSERT INTO cards VALUES (?, ?, ?, 0, ?, -1, 0, 0, ?, 0, 0, 0, 0, 0, 0, 0, 0, '')`,
+  );
+
+  cards.forEach((c, i) => {
+    const noteId = now + i * 2;
+    const cardId = now + i * 2 + 1;
+    const flds = `${c.front}${c.back}`;
+    const modSec = Math.floor(now / 1000);
+    // notes: (id, guid, mid, mod, [usn=-1], [tags=''], flds, sfld, csum, [flags=0], [data=''])
+    insNote.run([noteId, c.guid, MODEL_ID, modSec, flds, c.front, fieldChecksum(c.front)]);
+    // cards: (id, nid, did, [ord=0], mod, [usn=-1], [type=0], [queue=0], due, …)
+    insCard.run([cardId, noteId, deckIds.get(c.deck) ?? 1, modSec, i + 1]);
+  });
+  insNote.free();
+  insCard.free();
+
+  const anki2 = db.export();
+  db.close();
+
+  const zip = new JSZip();
+  zip.file('collection.anki2', anki2);
+  zip.file('media', '{}');
+  return zip.generateAsync({ type: 'uint8array' });
+}

--- a/src/main/publish/exporters/anki/sql-js.d.ts
+++ b/src/main/publish/exporters/anki/sql-js.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Type shim for sql.js (#853 Anki .apkg writer).
+ *
+ * sql.js ships without @types; we touch only the slice the apkg builder needs —
+ * `initSqlJs({ wasmBinary })` → a `Database` we can `run` / `prepare` / `export`.
+ */
+declare module 'sql.js' {
+  export interface SqlJsStatement {
+    run(params?: unknown[]): void;
+    free(): void;
+  }
+  export interface SqlJsDatabase {
+    run(sql: string, params?: unknown[]): void;
+    prepare(sql: string): SqlJsStatement;
+    export(): Uint8Array;
+    close(): void;
+  }
+  export interface SqlJsStatic {
+    Database: new () => SqlJsDatabase;
+  }
+  const initSqlJs: (config: { wasmBinary: Uint8Array }) => Promise<SqlJsStatic>;
+  export default initSqlJs;
+}

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -18,6 +18,7 @@ import { staticSiteExporter } from './exporters/static-site';
 import { annotatedReadingExporter } from './exporters/annotated-reading';
 import { pandocExporter } from './exporters/pandoc';
 import { bibtexExporter } from './exporters/bibtex';
+import { ankiDeckExporter } from './exporters/anki/anki-deck';
 
 export function registerBuiltinExporters(): void {
   registerExporter(markdownExporter);
@@ -31,6 +32,7 @@ export function registerBuiltinExporters(): void {
   registerExporter(annotatedReadingExporter);
   registerExporter(pandocExporter);
   registerExporter(bibtexExporter);
+  registerExporter(ankiDeckExporter);
 }
 
 export * from './types';

--- a/src/main/publish/types.ts
+++ b/src/main/publish/types.ts
@@ -141,7 +141,7 @@ export interface ExportOutput {
  * `(group + scope [+ variant])` back to one concrete exporter.
  */
 export type ExportGroupId =
-  | 'markdown' | 'html' | 'pdf' | 'site' | 'annotated' | 'bibtex' | 'pandoc';
+  | 'markdown' | 'html' | 'pdf' | 'site' | 'annotated' | 'anki' | 'bibtex' | 'pandoc';
 
 /** Menu section a group sits in — drives the separators between families. */
 export type ExportGroupCategory = 'document' | 'publication' | 'citation';
@@ -161,8 +161,9 @@ export const EXPORT_GROUPS: Record<ExportGroupId, ExportGroupMeta> = {
   pdf:       { id: 'pdf',       label: 'PDF',              category: 'document',    order: 3 },
   site:      { id: 'site',      label: 'Static Site',      category: 'publication', order: 4 },
   annotated: { id: 'annotated', label: 'Annotated Source', category: 'publication', order: 5 },
-  bibtex:    { id: 'bibtex',    label: 'BibTeX',           category: 'citation',    order: 6 },
-  pandoc:    { id: 'pandoc',    label: 'Pandoc',           category: 'citation',    order: 7 },
+  anki:      { id: 'anki',      label: 'Anki Deck',        category: 'publication', order: 6 },
+  bibtex:    { id: 'bibtex',    label: 'BibTeX',           category: 'citation',    order: 7 },
+  pandoc:    { id: 'pandoc',    label: 'Pandoc',           category: 'citation',    order: 8 },
 };
 
 export interface Exporter {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -253,7 +253,7 @@ export type ExportInputKind = 'single-note' | 'folder' | 'project' | 'tree' | 's
 
 /** Format family metadata for the format-first export menu (#: export-menu-redesign). */
 export type ExportGroupId =
-  | 'markdown' | 'html' | 'pdf' | 'site' | 'annotated' | 'bibtex' | 'pandoc';
+  | 'markdown' | 'html' | 'pdf' | 'site' | 'annotated' | 'anki' | 'bibtex' | 'pandoc';
 export interface ExportGroupMeta {
   id: ExportGroupId;
   label: string;

--- a/tests/main/publish/anki-apkg.test.ts
+++ b/tests/main/publish/anki-apkg.test.ts
@@ -1,0 +1,88 @@
+/**
+ * `.apkg` Anki package writer (#853).
+ *
+ * Builds a package and reads it back: unzip → open the `collection.anki2`
+ * SQLite with sql.js → assert the notes carry the caller's guids, the fields
+ * split front/back, and the decks were created. This validates the package is
+ * well-formed without needing Anki itself.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import JSZip from 'jszip';
+import { buildApkg, type AnkiCard } from '../../../src/main/publish/exporters/anki/apkg';
+
+const CARDS: AnkiCard[] = [
+  { guid: 'g-one', deck: 'Spanish::Verbs', front: '<p>hola</p>', back: '<p>hello</p>' },
+  { guid: 'g-two', deck: 'Spanish::Verbs', front: '<p>adios</p>', back: '<p>goodbye</p>' },
+  { guid: 'g-three', deck: 'Geography', front: '<p>capital of France?</p>', back: '<p>Paris</p>' },
+];
+
+/** Open the collection.anki2 inside an .apkg and return a queryable handle. */
+async function openCollection(apkg: Uint8Array) {
+  const zip = await JSZip.loadAsync(apkg);
+  expect(zip.file('collection.anki2')).not.toBeNull();
+  expect(zip.file('media')).not.toBeNull();
+  const dbBytes = await zip.file('collection.anki2')!.async('uint8array');
+
+  const initSqlJs = (await import('sql.js')).default;
+  const require = createRequire(import.meta.url);
+  const wasm = path.join(path.dirname(require.resolve('sql.js')), 'sql-wasm.wasm');
+  const SQL = await initSqlJs({ wasmBinary: readFileSync(wasm) }) as unknown as {
+    Database: new (data: Uint8Array) => { exec(sql: string): { columns: string[]; values: unknown[][] }[]; close(): void };
+  };
+  return new SQL.Database(dbBytes);
+}
+
+describe('buildApkg', () => {
+  it('produces a zip with a SQLite collection.anki2 and a media manifest', async () => {
+    const apkg = await buildApkg(CARDS, 1_700_000_000_000);
+    expect(apkg.length).toBeGreaterThan(0);
+    const zip = await JSZip.loadAsync(apkg);
+    const db = await zip.file('collection.anki2')!.async('uint8array');
+    expect(Buffer.from(db.slice(0, 15)).toString()).toBe('SQLite format 3');
+    expect(await zip.file('media')!.async('string')).toBe('{}');
+  });
+
+  it('writes one note per card, each carrying the caller guid + split fields', async () => {
+    const db = await openCollection(await buildApkg(CARDS, 1_700_000_000_000));
+    const rows = db.exec('SELECT guid, flds FROM notes ORDER BY guid')[0];
+    const guids = rows.values.map((r) => r[0]);
+    expect(guids).toEqual(['g-one', 'g-three', 'g-two']);
+    // flds joins front + back with the 0x1f unit separator.
+    const oneFlds = rows.values.find((r) => r[0] === 'g-one')![1] as string;
+    expect(oneFlds).toBe('<p>hola</p>\x1f<p>hello</p>');
+    db.close();
+  });
+
+  it('creates a card per note and the decks from distinct deck names', async () => {
+    const db = await openCollection(await buildApkg(CARDS, 1_700_000_000_000));
+    const cardCount = db.exec('SELECT COUNT(*) FROM cards')[0].values[0][0];
+    expect(cardCount).toBe(3);
+    // The col.decks JSON carries Default + the two distinct decks.
+    const decksJson = db.exec('SELECT decks FROM col')[0].values[0][0] as string;
+    const decks = Object.values(JSON.parse(decksJson)).map((d) => (d as { name: string }).name);
+    expect(decks).toContain('Spanish::Verbs');
+    expect(decks).toContain('Geography');
+    expect(decks).toContain('Default');
+    db.close();
+  });
+
+  it('is deterministic for fixed cards + timestamp (stable re-export)', async () => {
+    const a = await buildApkg(CARDS, 1_700_000_000_000);
+    const b = await buildApkg(CARDS, 1_700_000_000_000);
+    // The SQLite bytes are identical → byte-identical decks for unchanged input.
+    const dbA = await (await JSZip.loadAsync(a)).file('collection.anki2')!.async('uint8array');
+    const dbB = await (await JSZip.loadAsync(b)).file('collection.anki2')!.async('uint8array');
+    expect(Buffer.from(dbA).equals(Buffer.from(dbB))).toBe(true);
+  });
+
+  it('yields a valid (empty) package for zero cards', async () => {
+    const apkg = await buildApkg([], 1_700_000_000_000);
+    const db = await openCollection(apkg);
+    expect(db.exec('SELECT COUNT(*) FROM notes')[0].values[0][0]).toBe(0);
+    db.close();
+  });
+});

--- a/tests/main/publish/anki-exporter.test.ts
+++ b/tests/main/publish/anki-exporter.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Anki deck exporter (#853) — end to end over a real plan: build cards across
+ * the scope, write missing ids back to the note, and emit a `.apkg`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import JSZip from 'jszip';
+import { createRequire } from 'node:module';
+import { ankiDeckExporter } from '../../../src/main/publish/exporters/anki/anki-deck';
+import { resolvePlan, runExporter } from '../../../src/main/publish/pipeline';
+
+let root: string;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'anki-test-')); });
+afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+async function noteCount(apkg: Uint8Array): Promise<number> {
+  const zip = await JSZip.loadAsync(apkg);
+  const db = await zip.file('collection.anki2')!.async('uint8array');
+  const initSqlJs = (await import('sql.js')).default;
+  const require = createRequire(import.meta.url);
+  const wasm = path.join(path.dirname(require.resolve('sql.js')), 'sql-wasm.wasm');
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(wasm) }) as unknown as {
+    Database: new (d: Uint8Array) => { exec(s: string): { values: unknown[][] }[]; close(): void };
+  };
+  const handle = new SQL.Database(db);
+  const n = handle.exec('SELECT COUNT(*) FROM notes')[0].values[0][0] as number;
+  handle.close();
+  return n;
+}
+
+describe('ankiDeckExporter', () => {
+  it('exports cards to a .apkg and writes missing ^ids back into the note', async () => {
+    await fsp.writeFile(path.join(root, 'es.md'),
+      '# Spanish\n\n> [!card] Verbs\n> hola\n> ---\n> hello\n\n> [!card] Verbs ^keep1\n> adios\n> ---\n> goodbye\n');
+    const plan = await resolvePlan(root, { kind: 'single-note', relativePath: 'es.md' });
+    const out = await runExporter(ankiDeckExporter, plan);
+
+    // One .apkg with two notes.
+    expect(out.files).toHaveLength(1);
+    expect(out.files[0].path).toBe('es.apkg');
+    expect(await noteCount(out.files[0].contents as Uint8Array)).toBe(2);
+    expect(out.summary).toContain('2 cards');
+    expect(out.summary).toContain('Verbs');
+
+    // The id-less card gained an ^id on disk; the existing one is untouched.
+    const after = await fsp.readFile(path.join(root, 'es.md'), 'utf8');
+    expect(after).toMatch(/> \[!card\] Verbs \^[\w-]+\n> hola/);
+    expect(after).toContain('> [!card] Verbs ^keep1\n> adios');
+  });
+
+  it('re-exporting after the write-back assigns no new ids (idempotent)', async () => {
+    await fsp.writeFile(path.join(root, 'n.md'), '> [!card]\n> Q\n> ---\n> A\n');
+    await runExporter(ankiDeckExporter, await resolvePlan(root, { kind: 'single-note', relativePath: 'n.md' }));
+    const afterFirst = await fsp.readFile(path.join(root, 'n.md'), 'utf8');
+    await runExporter(ankiDeckExporter, await resolvePlan(root, { kind: 'single-note', relativePath: 'n.md' }));
+    const afterSecond = await fsp.readFile(path.join(root, 'n.md'), 'utf8');
+    expect(afterSecond).toBe(afterFirst); // no new ids, byte-for-byte stable
+  });
+
+  it('reports a clean message and writes nothing when the scope has no cards', async () => {
+    await fsp.writeFile(path.join(root, 'plain.md'), '# Just a note\n\nNo cards here.\n');
+    const out = await runExporter(ankiDeckExporter, await resolvePlan(root, { kind: 'single-note', relativePath: 'plain.md' }));
+    expect(out.files).toHaveLength(0);
+    expect(out.summary.toLowerCase()).toContain('no flashcards');
+  });
+
+  it('accepts note/folder/tree/project scopes, not source', () => {
+    expect(ankiDeckExporter.accepts({ kind: 'single-note', relativePath: 'x.md' })).toBe(true);
+    expect(ankiDeckExporter.accepts({ kind: 'project' })).toBe(true);
+    expect(ankiDeckExporter.accepts({ kind: 'source', sourceId: 's' } as never)).toBe(false);
+  });
+});

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
         /^@duckdb\/node-bindings/,
         'vega',
         'vega-lite',
+        // sql.js (#853, Anki .apkg writer): loads its own `sql-wasm.wasm` from
+        // disk at runtime, so it must resolve from the shipped node_modules
+        // (forge `EXTERNAL_DEP_ROOTS`) rather than being bundled.
+        'sql.js',
       ],
     },
   },


### PR DESCRIPTION
The capstone of the flashcards epic (#850): export the `[!card]` callouts in a scope to an Anki `.apkg`, registered as another format in the #802 pipeline. Builds on the card model (#851) and the stable guids (#852).

## What it does

**Export → Anki Deck** packages the cards in the selected scope (note / folder / tree / whole base):

- `exporters/anki/apkg.ts` — builds a `collection.anki2` SQLite (Anki schema v11, the genanki reference layout) in-memory with **sql.js** (lazy-loaded pure-WASM, no native dep) and zips it with JSZip. One Basic (Front/Back) note type; each note's **guid is the caller's stable #852 guid** so re-import *updates* cards and keeps scheduling instead of duplicating. Decks built from distinct names (Anki rebuilds the `::` hierarchy).
- `exporters/anki/anki-deck.ts` — registers the `anki` group + `anki-deck` exporter (note/folder/tree/project). Per note: **assign + persist card ids** (#852 write-back via the safe write path), extract cards (#851), derive guids, map decks, render front/back markdown → HTML. Aggregates across the scope; reports counts + deck breakdown + skipped/duplicate cards; an empty scope says "no flashcards found" rather than writing a corrupt package.

## Packaging

`sql.js` is externalized (`vite.main.config`) and shipped via forge's `EXTERNAL_DEP_ROOTS` so its `sql-wasm.wasm` resolves at runtime — the DuckDB/vega pattern. `createRequire(import.meta.url)` locates the wasm next to the shipped package.

## Verification

- **9 unit/integration tests**: the apkg is validated by round-tripping it back through sql.js (SQLite header, notes carry the guids, `flds` split front/back via `\x1f`, decks created, byte-determinism for fixed input, empty package); the exporter's write-back to disk, re-export idempotency, empty-scope message, and `accepts()`.
- **Live, in the packaged app**: exporting a 2-card note produced a valid `.apkg` (`validApkgStructure: true`, the cards + `Verbs` deck present) — proving **sql.js loaded its wasm in the packaged runtime** — and wrote both `^ids` back to disk (`idsWrittenBack: 2`), with zero console errors. (Couldn't run Anki itself here; the SQLite schema follows genanki's, which Anki imports.)
- 332 publish tests; lint clean. `docs/flashcards.md` updated.

Part of #850. Closes #853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)