### PR TITLE
feat: 'Propose Flashcards' LLM skill (Learning menu, approval-gated) (#854)

### DIFF
--- a/docs/flashcards.md
+++ b/docs/flashcards.md
@@ -25,6 +25,13 @@ A card is a `[!card]` callout with a `---` divider separating the **front**
 
 **Insert → Flashcard** drops a scaffold with the front placeholder selected.
 
+Or let an LLM draft them: **Learning → Propose Flashcards** (`/cards`) reads the
+active note and proposes atomic Q/A pairs for your review. You refine them in the
+conversation; on approval they're filed — through the standard approval engine,
+so nothing is written until you confirm — as a sibling note of `[!card]`
+callouts the exporter then packages. Review happens in Anki; authoring is the
+Minerva-native half.
+
 In the preview the card renders as a themed callout with the front and back
 separated by a divider rule.
 

--- a/src/main/skills/stock/propose-flashcards.md
+++ b/src/main/skills/stock/propose-flashcards.md
@@ -1,0 +1,65 @@
+---
+id: learning.propose-flashcards
+name: Propose Flashcards
+description: Draft atomic spaced-repetition cards from the note for your review
+menu: Learning
+outputMode: openConversation
+context: [fullNote]
+slashCommand: /cards
+model: claude-opus-4-8
+firstMessage: "Propose flashcards from this note for my review."
+longDescription: >-
+  Reads the active note and drafts atomic, well-formed question/answer flashcards — one fact per card —
+  for spaced repetition. You review and refine them in the conversation; on approval they're filed as a
+  sibling note of `[!card]` callouts, which the Anki deck exporter then packages. Nothing is written until
+  you approve. The authoring half of the flashcards feature (#850); review happens in Anki.
+---
+You draft **spaced-repetition flashcards** from the active note. You propose Q/A pairs for review and only file them when the user approves — you never write directly.
+
+{{#if note.content}}
+## What makes a good card
+
+Spaced repetition rewards **atomic, well-formed** cards. For each card:
+
+- **One fact per card.** If a paragraph holds three ideas, make three cards, not one with a list answer.
+- **Avoid yes/no and trivially-cued questions** — they test recognition, not recall. Prefer "why", "how", "what distinguishes X from Y", "what happens when…".
+- **Self-contained.** The front must make sense without the note open ("In the Raft protocol, what triggers a leader election?", not "What triggers it?").
+- **Unambiguous answer.** The back should be the one thing the front asks for — short, precise, no hedging.
+- **Test understanding, not wording.** Don't quiz the note's exact phrasing; quiz the idea.
+
+Cover the note's load-bearing ideas — the facts, definitions, distinctions, and causal links worth remembering — not every incidental sentence.
+
+## Process
+
+1. Read the note below and identify what's worth committing to memory.
+2. Draft a set of atomic Q/A pairs. Markdown in the front/back is fine (emphasis, code, a short list).
+3. Show the user the drafts as a clean numbered list (front → back). Iterate with them — they may merge, split, drop, reword, or add cards. Aim for quality over quantity.
+
+## Filing the result
+
+When the user is satisfied, call `propose_notes` **exactly once** with a single note payload:
+
+- `relativePath`: a sibling of the source note named after it — e.g. if this note is `notes/raft.md`, propose `notes/Raft — Flashcards.md`. Keep the basename free of characters that are awkward to link to.
+- `content`: a level-1 heading (`# {{note.title}} — Flashcards`) followed by one `[!card]` callout per card, in this exact shape:
+
+  ```
+  > [!card]
+  > <front — the question>
+  > ---
+  > <back — the answer>
+  ```
+
+  The `---` divider is required; it separates front from back. Leave the deck (the text after `[!card]`) off unless the user asks for one — cards inherit a deck from their folder at export time. Do not add `^id` markers; those are assigned automatically on export.
+
+The user reviews the proposed note as an inline card; Approve files it through the standard approval engine, Reject discards. Don't paste the cards as prose instead of calling the tool — the tool is what makes them reviewable and filable.
+
+## Anti-flattery
+
+If the note has little worth memorizing — it's a stub, a pure index, or all prose with no retainable facts — say so and propose nothing. Don't manufacture cards to look thorough, and don't split one idea into padded near-duplicates.
+
+## Note{{#if note.title}} — {{note.title}}{{/if}}
+
+{{note.content}}
+{{else}}
+There's no active note to make flashcards from. Open a note and run Propose Flashcards from the Learning menu.
+{{/if}}

--- a/tests/main/skills-propose-flashcards.test.ts
+++ b/tests/main/skills-propose-flashcards.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Propose Flashcards (#854) — note-scoped Learning skill. Pins that it loads as
+ * a Learning conversation skill over the full note and instructs the model to
+ * file `[!card]` callouts via the existing `propose_notes` approval path.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+import { compileSkill } from '../../src/main/skills/compile';
+import type { ThinkingToolDef } from '../../src/shared/tools/types';
+
+let def: ThinkingToolDef;
+
+beforeAll(async () => {
+  const cat = await loadSkillCatalog(path.join(__dirname, '__no_user_skills__'));
+  expect(cat.errors).toEqual([]);
+  const skill = cat.skills.find((s) => s.id === 'learning.propose-flashcards');
+  expect(skill).toBeDefined();
+  def = compileSkill(skill!);
+});
+
+describe('propose-flashcards skill', () => {
+  it('is a note-scoped Learning conversation skill with a slash command', () => {
+    expect(def.category).toBe('learning');
+    expect(def.outputMode).toBe('openConversation');
+    expect(def.context).toContain('fullNote');
+    expect(def.slashCommand).toBe('/cards');
+  });
+
+  it('threads the note into the prompt and instructs propose_notes + the [!card] shape', () => {
+    const sys = def.buildSystemPrompt!({
+      fullNoteContent: 'the-note-body-zzz',
+      fullNoteTitle: 'Raft',
+    });
+    expect(sys).toContain('the-note-body-zzz');
+    expect(sys).toContain('Raft');
+    expect(sys).toContain('propose_notes'); // reuses the existing approval path
+    expect(sys).toContain('[!card]');       // the card callout shape (#851)
+    expect(sys).toContain('---');           // the front/back divider
+    expect(sys).toMatch(/atomic/i);         // card-writing guidance
+  });
+
+  it('degrades gracefully when there is no active note', () => {
+    const sys = def.buildSystemPrompt!({ fullNoteContent: '' });
+    expect(sys).toContain('no active note');
+  });
+});


### PR DESCRIPTION
Closes the flashcards epic (#850). The Minerva-native authoring win: an LLM reads a note and **drafts** atomic flashcards, which you review and approve before anything is written — straight down the Trust Principle. Depends only on the card model (#851).

## What it does

**Learning → Propose Flashcards** (`/cards`) opens a conversation that reads the active note and proposes atomic Q/A pairs. You refine them in the chat; on your go-ahead they're filed for review and, on approval, written as a sibling `<Note> — Flashcards` note of `[!card]` callouts (which #851 parses and #853 exports).

`src/main/skills/stock/propose-flashcards.md` — a note-scoped Learning conversation skill (opus, `context: [fullNote]`). The prompt teaches good card-writing (one fact per card, avoid yes/no, prefer why/how, self-contained, test understanding not wording) with an anti-flattery clause (propose nothing when there's little worth memorizing).

## Least new surface

It files via the **existing `propose_notes`** tool — the proven draft → inline review → approve → note-created path — so there's **no new tool or approval payload kind**. The skill is pure markdown; the whole approval flow is reused. Guids aren't assigned here (#852 handles that at export, keeping the skill's output clean markdown). Nothing lands without an approve step.

## Verification

- A focused test pins that the skill loads as a Learning conversation skill over the full note, threads the note into the prompt, and instructs `propose_notes` + the `[!card]` shape; degrades gracefully with no active note.
- All 131 skill tests stay green; lint clean. `docs/flashcards.md` updated.
- (The drafting quality is prompt-craft, not a deterministic test; the load + the `propose_notes` approval path it rides on are both covered.)

Part of #850. Closes #854 — and completes the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)