### PR TITLE
fix: scope vite dev dependency-scan to the renderer entry

### DIFF
--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -3,6 +3,15 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   plugins: [svelte()],
+  optimizeDeps: {
+    // Scope the dev dependency-scan to the renderer entry. Vite otherwise
+    // auto-discovers every `*.html` in the project root — including the browser
+    // extension's `clipper/popup.html` / `clipper/options.html`, whose relative
+    // `popup.js` / `options.js` scripts (built separately by clipper/build.mjs)
+    // it can't resolve, producing a noisy "Failed to run dependency scan" on any
+    // re-optimize (e.g. after a lockfile change).
+    entries: ['index.html'],
+  },
   resolve: {
     // vega-embed pulls in d3-shape@3, which imports the `Path` class from
     // d3-path@3. mermaid (already a dep) drags in an old d3-path@1 via


### PR DESCRIPTION
## Symptom

`pnpm dev` printed:

```
(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error: The following dependencies are imported but could not be resolved:
  popup.js (imported by clipper/popup.html)
  options.js (imported by clipper/options.html)
```

Harmless — the app still boots — but noisy, and it fires on every dependency re-optimize (e.g. after the `sql.js` lockfile change from #853).

## Cause

Vite's dev dependency-scan auto-discovers **every `*.html` in the project root** to find entry points. That includes the browser extension's `clipper/popup.html` and `clipper/options.html`, whose relative `popup.js` / `options.js` scripts are built separately by `clipper/build.mjs` and aren't resolvable by the renderer's vite.

## Fix

Set `optimizeDeps.entries: ['index.html']` in `vite.renderer.config.mts` so the scan only follows the actual renderer entry, ignoring the clipper HTML.

## Verification

Forced a fresh re-optimization (`rm -rf node_modules/.vite` then `pnpm dev`): the scan now runs clean — `Forced re-optimization of dependencies` with **no scan failure and no clipper resolution errors**, app boots normally. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)