### PR TITLE
feat: graph viz foundation + View A heading-map panel (#844, #845)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "chokidar": "^5.0.0",
     "citeproc": "^2.4.63",
+    "cytoscape": "^3.34.0",
     "date-fns": "^4.4.0",
     "dompurify": "^3.4.9",
     "isomorphic-git": "^1.38.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       citeproc:
         specifier: ^2.4.63
         version: 2.4.63
+      cytoscape:
+        specifier: ^3.34.0
+        version: 3.34.0
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -815,6 +815,7 @@
     editorComponent?.updateTheme();
     queryPanelComponent?.updateTheme();
     previewComponent?.updateTheme();
+    rightSidebar?.updateTheme();
   }
 
   async function handleSwitchTab(index: number, groupId?: string) {
@@ -1691,6 +1692,7 @@
         editorComponent?.updateTheme();
         queryPanelComponent?.updateTheme();
         previewComponent?.updateTheme();
+        rightSidebar?.updateTheme();
       }}
       onClose={() => {
         showSettings = false;

--- a/src/renderer/lib/components/GraphCanvas.svelte
+++ b/src/renderer/lib/components/GraphCanvas.svelte
@@ -1,0 +1,132 @@
+<!--
+  GraphCanvas — the reusable Cytoscape host both graph views mount (#843 / #844).
+
+  Owns the cytoscape instance lifecycle (lazy-load → create → destroy), themes it
+  from the Catppuccin tokens, re-fits on resize, and implements the shared click
+  model (#849): single-click selects, double-click (or Enter) navigates; with
+  `autoNavigate` on, single-click navigates immediately. Each view supplies its
+  own `navigate(data)` action (View A scrolls to a heading, View B opens a note /
+  source), so both inherit identical behavior.
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { Core, ElementDefinition, LayoutOptions, NodeSingular } from 'cytoscape';
+  import { loadCytoscape } from '../graph/load-cytoscape';
+  import { readGraphTokens, buildGraphStyle } from '../graph/cytoscape-theme';
+
+  interface Props {
+    /** Cytoscape elements, split into nodes + edges. */
+    elements: { nodes: ElementDefinition[]; edges: ElementDefinition[] };
+    /** Cytoscape layout options (e.g. breadthfirst for View A, cose for View B). */
+    layout?: LayoutOptions;
+    /** #849 — when on, a single click navigates instead of selecting. */
+    autoNavigate?: boolean;
+    /** The view's navigate action, given the clicked node's data. */
+    navigate?: (data: Record<string, unknown>) => void;
+  }
+
+  let {
+    elements,
+    layout = { name: 'breadthfirst' },
+    autoNavigate = false,
+    navigate,
+  }: Props = $props();
+
+  let container = $state<HTMLDivElement>();
+  let cy: Core | null = null;
+  let ready = $state(false);
+
+  // Double-tap detection (cytoscape has no native double-click event).
+  let lastTapId = '';
+  let lastTapTime = 0;
+
+  function activate(node: NodeSingular): void {
+    navigate?.(node.data() as Record<string, unknown>);
+  }
+
+  onMount(() => {
+    let disposed = false;
+    let ro: ResizeObserver | null = null;
+
+    void (async () => {
+      const cytoscape = await loadCytoscape();
+      if (disposed || !container) return;
+      cy = cytoscape({
+        container,
+        style: buildGraphStyle(readGraphTokens()),
+        minZoom: 0.2,
+        maxZoom: 3,
+        wheelSensitivity: 0.2,
+      });
+
+      cy.on('tap', 'node', (evt) => {
+        const node = evt.target as NodeSingular;
+        if (autoNavigate) { activate(node); return; }
+        const now = Date.now();
+        if (lastTapId === node.id() && now - lastTapTime < 300) activate(node);
+        lastTapId = node.id();
+        lastTapTime = now;
+      });
+
+      // Re-fit when the container resizes (sidebar width / pane resize).
+      ro = new ResizeObserver(() => { cy?.resize(); cy?.fit(undefined, 24); });
+      ro.observe(container);
+
+      ready = true;
+    })();
+
+    return () => {
+      disposed = true;
+      ro?.disconnect();
+      cy?.destroy();
+      cy = null;
+    };
+  });
+
+  // Populate + live-update: (re)load elements and re-run layout whenever they
+  // change (or once the instance becomes ready).
+  $effect(() => {
+    const els = elements;
+    if (!ready || !cy) return;
+    cy.batch(() => {
+      cy!.elements().remove();
+      cy!.add([...els.nodes, ...els.edges]);
+    });
+    cy.layout(layout).run();
+    cy.fit(undefined, 24);
+  });
+
+  /** Re-skin the live graph from the current palette — wired to the theme switch. */
+  export function updateTheme(): void {
+    cy?.style(buildGraphStyle(readGraphTokens()));
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && cy) {
+      const sel = cy.$('node:selected');
+      if (sel.length > 0) { e.preventDefault(); activate(sel[0]); }
+    }
+  }
+</script>
+
+<div
+  class="graph-canvas"
+  bind:this={container}
+  tabindex="0"
+  role="application"
+  aria-label="Graph"
+  onkeydown={onKeydown}
+></div>
+
+<style>
+  .graph-canvas {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    background: var(--bg-inset);
+    outline: none;
+  }
+  .graph-canvas:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--accent);
+  }
+</style>

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import OutlinePanel from './right-sidebar/OutlinePanel.svelte';
+  import HeadingGraphPanel from './right-sidebar/HeadingGraphPanel.svelte';
   import FootnotesPanel from './right-sidebar/FootnotesPanel.svelte';
   import PropertiesPanel from './right-sidebar/PropertiesPanel.svelte';
   import OutgoingLinksPanel from './right-sidebar/OutgoingLinksPanel.svelte';
@@ -14,7 +15,7 @@
   import type { IconName } from './icons/registry';
 
   type PanelType =
-    | 'outline' | 'footnotes' | 'properties' | 'outgoing' | 'backlinks' | 'tags' | 'tables' | 'citations'
+    | 'outline' | 'headingGraph' | 'footnotes' | 'properties' | 'outgoing' | 'backlinks' | 'tags' | 'tables' | 'citations'
     | 'bookmarks' | 'inspections' | 'proposals';
 
   type PanelGroupId = 'note' | 'links' | 'activity';
@@ -42,6 +43,7 @@
       label: 'Note',
       items: [
         { id: 'outline',    label: 'Outline',    icon: 'outline' },
+        { id: 'headingGraph', label: 'Heading Map', icon: 'graph' },
         { id: 'properties', label: 'Properties', icon: 'properties' },
         { id: 'footnotes',  label: 'Footnotes',  icon: 'footnotes' },
         // Tags and Tables describe what's *inside* the active note's
@@ -110,6 +112,18 @@
 
   let activePanel = $state<PanelType>('outline');
   let revision = $state(0);
+
+  // View A (#845) root label — the note's filename stem.
+  const noteTitle = $derived(
+    activeFilePath ? (activeFilePath.split('/').pop() ?? activeFilePath).replace(/\.md$/i, '') : 'Note',
+  );
+  let headingGraphPanel = $state<HeadingGraphPanel>();
+
+  /** Re-skin the graph panel on theme switch (called from App.svelte). The
+   *  cytoscape graph re-styles live; other panels are plain DOM. */
+  export function updateTheme(): void {
+    headingGraphPanel?.updateTheme();
+  }
 
   /** Group is derived from the active panel — keeps `showPanel(p)` as
    *  the single way to switch the right sidebar's state. Clicking a
@@ -217,6 +231,8 @@
   <div class="panel-content">
     {#if activePanel === 'outline'}
       <OutlinePanel {content} {onScrollToLine} />
+    {:else if activePanel === 'headingGraph'}
+      <HeadingGraphPanel bind:this={headingGraphPanel} {content} title={noteTitle} {onScrollToLine} />
     {:else if activePanel === 'footnotes'}
       <FootnotesPanel {content} {onScrollToLine} />
     {:else if activePanel === 'properties'}

--- a/src/renderer/lib/components/right-sidebar/HeadingGraphPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/HeadingGraphPanel.svelte
@@ -1,0 +1,69 @@
+<!--
+  View A (#845) — the active note's heading tree as an interactive graph.
+
+  Same data as the Outline panel (`extractHeadings`), laid out spatially via the
+  shared GraphCanvas (#844) and clickable: activating a node scrolls the editor
+  to that heading (`onScrollToLine`). Re-derives live as the buffer changes,
+  since `content` is reactive.
+-->
+<script lang="ts">
+  import GraphCanvas from '../GraphCanvas.svelte';
+  import { extractHeadings } from '../../markdown/headings';
+  import { buildHeadingElements } from '../../graph/heading-graph';
+  import type { LayoutOptions } from 'cytoscape';
+
+  interface Props {
+    content: string;
+    /** Note display name → the synthetic root label. */
+    title?: string;
+    onScrollToLine: (line: number) => void;
+  }
+
+  let { content, title = 'Note', onScrollToLine }: Props = $props();
+
+  const headings = $derived(extractHeadings(content));
+  const elements = $derived(buildHeadingElements(headings, title));
+
+  let graph = $state<GraphCanvas>();
+
+  // Tidy top-down tree; the root sits above its headings.
+  const layout: LayoutOptions = {
+    name: 'breadthfirst',
+    directed: true,
+    padding: 16,
+    spacingFactor: 1.15,
+  };
+
+  function navigate(data: Record<string, unknown>): void {
+    if (typeof data.line === 'number') onScrollToLine(data.line);
+  }
+
+  /** Forwarded from RightSidebar on theme switch. */
+  export function updateTheme(): void {
+    graph?.updateTheme();
+  }
+</script>
+
+<div class="heading-graph-panel">
+  {#if headings.length === 0}
+    <div class="empty">No headings to map</div>
+  {:else}
+    <GraphCanvas bind:this={graph} {elements} {layout} {navigate} />
+  {/if}
+</div>
+
+<style>
+  .heading-graph-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .empty {
+    padding: 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+</style>

--- a/src/renderer/lib/graph/cytoscape-theme.ts
+++ b/src/renderer/lib/graph/cytoscape-theme.ts
@@ -1,0 +1,102 @@
+/**
+ * Catppuccin theming for the graph views (#843 / #844).
+ *
+ * Reads the app's CSS custom properties (the same tokens mermaid / vega skin
+ * from) into a Cytoscape stylesheet, so graphs blend with the surrounding UI and
+ * re-skin on theme switch. `readGraphTokens` touches the DOM; `buildGraphStyle`
+ * is pure (takes resolved tokens) so the style rules are unit-testable.
+ */
+
+export interface GraphTokens {
+  bg: string;
+  bgInset: string;
+  bgButton: string;
+  text: string;
+  textMuted: string;
+  border: string;
+  accent: string;
+}
+
+/** Read the live Catppuccin tokens off the document root. */
+export function readGraphTokens(): GraphTokens {
+  const cs = getComputedStyle(document.documentElement);
+  const get = (name: string, fallback: string) => cs.getPropertyValue(name).trim() || fallback;
+  return {
+    bg: get('--bg', '#1e1e2e'),
+    bgInset: get('--bg-inset', '#181825'),
+    bgButton: get('--bg-button', '#313244'),
+    text: get('--text', '#cdd6f4'),
+    textMuted: get('--text-muted', '#6c7086'),
+    border: get('--border', '#313244'),
+    accent: get('--accent', '#89b4fa'),
+  };
+}
+
+/** Minimal shape we use from Cytoscape's stylesheet — avoids importing types. */
+export type GraphStylesheet = Array<{ selector: string; style: Record<string, unknown> }>;
+
+/**
+ * Build the Cytoscape stylesheet from resolved tokens. Notes are rounded chips;
+ * the synthetic root (View A) and graph root (View B) get the accent; source
+ * nodes (View B) are a distinct diamond; non-existent targets render muted.
+ * Edges use their own `linkColor` when present, falling back to the border.
+ */
+export function buildGraphStyle(tokens: GraphTokens): GraphStylesheet {
+  return [
+    {
+      selector: 'node',
+      style: {
+        'background-color': tokens.bgButton,
+        'border-width': 1,
+        'border-color': tokens.border,
+        shape: 'round-rectangle',
+        label: 'data(label)',
+        color: tokens.text,
+        'font-size': 11,
+        'font-family': 'inherit',
+        'text-valign': 'center',
+        'text-halign': 'center',
+        'text-wrap': 'ellipsis',
+        'text-max-width': 140,
+        width: 'label',
+        height: 'label',
+        padding: 8,
+      },
+    },
+    {
+      // The note-title root (View A) / focused root (View B).
+      selector: 'node[?root]',
+      style: { 'background-color': tokens.accent, color: tokens.bg, 'border-color': tokens.accent, 'font-weight': 'bold' },
+    },
+    {
+      // Source nodes (View B) — leaves, visually distinct.
+      selector: 'node[kind = "source"]',
+      style: { shape: 'diamond', 'background-color': tokens.bgInset, 'border-color': tokens.accent },
+    },
+    {
+      // Link targets that don't exist on disk yet (View B).
+      selector: 'node[?missing]',
+      style: { 'background-color': tokens.bgInset, color: tokens.textMuted, 'border-style': 'dashed' },
+    },
+    {
+      selector: 'node:selected',
+      style: { 'border-width': 2, 'border-color': tokens.accent },
+    },
+    {
+      selector: 'edge',
+      style: {
+        width: 1.5,
+        'line-color': tokens.textMuted,
+        'target-arrow-color': tokens.textMuted,
+        'target-arrow-shape': 'triangle',
+        'arrow-scale': 0.8,
+        'curve-style': 'bezier',
+      },
+    },
+    {
+      // View B carries a per-edge color by link type (#844 sets it from linkColor).
+      selector: 'edge[linkColor]',
+      style: { 'line-color': 'data(linkColor)', 'target-arrow-color': 'data(linkColor)' },
+    },
+  ];
+}

--- a/src/renderer/lib/graph/heading-graph.ts
+++ b/src/renderer/lib/graph/heading-graph.ts
@@ -1,0 +1,59 @@
+/**
+ * Build Cytoscape elements for View A — a note's heading tree (#843 / #845).
+ *
+ * `extractHeadings` yields a flat list of headings with ATX `level` + `line`.
+ * The tree nesting is reconstructed the same way `activeHeadingChain` does it:
+ * a heading's parent is the nearest preceding heading of a *lower* level; with
+ * none, it hangs off a synthetic root (the note title). Pure so the nesting
+ * logic is unit-tested without a DOM / cytoscape.
+ */
+
+import type { Heading } from '../markdown/headings';
+
+export interface GraphNode {
+  data: {
+    id: string;
+    label: string;
+    /** 1-based editor line the node navigates to (root → 1). */
+    line: number;
+    /** ATX level; 0 for the synthetic root. Drives depth styling. */
+    level: number;
+    /** Marks the synthetic note-title root for distinct styling. */
+    root?: boolean;
+  };
+}
+export interface GraphEdge {
+  data: { id: string; source: string; target: string };
+}
+export interface HeadingElements {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+const ROOT_ID = 'root';
+const headingId = (i: number): string => `h${i}`;
+
+/**
+ * Reconstruct the heading tree as Cytoscape nodes + edges. The root is always
+ * present (so a heading-less note still renders one tidy node); every heading
+ * links to its nearest lower-level ancestor, or the root.
+ */
+export function buildHeadingElements(headings: Heading[], rootLabel: string): HeadingElements {
+  const nodes: GraphNode[] = [
+    { data: { id: ROOT_ID, label: rootLabel.trim() || 'Note', line: 1, level: 0, root: true } },
+  ];
+  const edges: GraphEdge[] = [];
+
+  for (let i = 0; i < headings.length; i++) {
+    const h = headings[i];
+    nodes.push({ data: { id: headingId(i), label: h.text, line: h.line, level: h.level } });
+
+    let parent = ROOT_ID;
+    for (let j = i - 1; j >= 0; j--) {
+      if (headings[j].level < h.level) { parent = headingId(j); break; }
+    }
+    edges.push({ data: { id: `e${i}`, source: parent, target: headingId(i) } });
+  }
+
+  return { nodes, edges };
+}

--- a/src/renderer/lib/graph/load-cytoscape.ts
+++ b/src/renderer/lib/graph/load-cytoscape.ts
@@ -1,0 +1,19 @@
+/**
+ * Lazy-load Cytoscape (#844). It's a heavy dep, so it's dynamic-`import()`ed and
+ * cached in a module-level promise — kept out of the initial renderer bundle,
+ * the same posture as mermaid / vega-embed. First graph view to mount pays the
+ * load once; everyone after reuses it.
+ */
+
+import type cytoscape from 'cytoscape';
+
+type CytoscapeFactory = typeof cytoscape;
+
+let promise: Promise<CytoscapeFactory> | null = null;
+
+export function loadCytoscape(): Promise<CytoscapeFactory> {
+  if (!promise) {
+    promise = import('cytoscape').then((m) => m.default ?? m);
+  }
+  return promise;
+}

--- a/tests/renderer/graph/cytoscape-theme.test.ts
+++ b/tests/renderer/graph/cytoscape-theme.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Graph stylesheet building (#844) — pure mapping of Catppuccin tokens to a
+ * Cytoscape stylesheet. (DOM token reading is exercised in the live verify.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildGraphStyle, type GraphTokens } from '../../../src/renderer/lib/graph/cytoscape-theme';
+
+const TOKENS: GraphTokens = {
+  bg: '#1e1e2e', bgInset: '#181825', bgButton: '#313244',
+  text: '#cdd6f4', textMuted: '#6c7086', border: '#45475a', accent: '#89b4fa',
+};
+
+function rule(style: ReturnType<typeof buildGraphStyle>, selector: string) {
+  return style.find((s) => s.selector === selector)?.style;
+}
+
+describe('buildGraphStyle', () => {
+  it('colors nodes + labels from the tokens', () => {
+    const node = rule(buildGraphStyle(TOKENS), 'node')!;
+    expect(node['background-color']).toBe('#313244');
+    expect(node.color).toBe('#cdd6f4');
+    expect(node.label).toBe('data(label)');
+  });
+
+  it('accents the root node', () => {
+    expect(rule(buildGraphStyle(TOKENS), 'node[?root]')!['background-color']).toBe('#89b4fa');
+  });
+
+  it('styles source nodes distinctly (diamond) and missing targets muted', () => {
+    expect(rule(buildGraphStyle(TOKENS), 'node[kind = "source"]')!.shape).toBe('diamond');
+    expect(rule(buildGraphStyle(TOKENS), 'node[?missing]')!.color).toBe('#6c7086');
+  });
+
+  it('defaults edges to the muted color but lets per-edge linkColor win (View B)', () => {
+    const style = buildGraphStyle(TOKENS);
+    expect(rule(style, 'edge')!['line-color']).toBe('#6c7086');
+    expect(rule(style, 'edge[linkColor]')!['line-color']).toBe('data(linkColor)');
+  });
+
+  it('re-skins: different tokens produce different colors', () => {
+    const light = buildGraphStyle({ ...TOKENS, text: '#11111b', bgButton: '#e6e9ef' });
+    expect(rule(light, 'node')!.color).toBe('#11111b');
+    expect(rule(light, 'node')!['background-color']).toBe('#e6e9ef');
+  });
+});

--- a/tests/renderer/graph/heading-graph.test.ts
+++ b/tests/renderer/graph/heading-graph.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Heading-tree element building (#845) — nesting reconstruction from the flat
+ * `extractHeadings` level list, the substrate of View A.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildHeadingElements } from '../../../src/renderer/lib/graph/heading-graph';
+import type { Heading } from '../../../src/renderer/lib/markdown/headings';
+
+const h = (level: number, text: string, line: number): Heading => ({ level, text, line });
+
+describe('buildHeadingElements', () => {
+  it('renders just the root for a note with no headings', () => {
+    const { nodes, edges } = buildHeadingElements([], 'My Note');
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].data).toMatchObject({ id: 'root', label: 'My Note', root: true, line: 1 });
+    expect(edges).toEqual([]);
+  });
+
+  it('falls back to a default root label when blank', () => {
+    expect(buildHeadingElements([], '   ').nodes[0].data.label).toBe('Note');
+  });
+
+  it('nests headings under their nearest lower-level ancestor', () => {
+    const headings = [
+      h(1, 'A', 1),   // h0 → root
+      h(2, 'A.1', 2), // h1 → h0
+      h(3, 'A.1.a', 3), // h2 → h1
+      h(2, 'A.2', 4), // h3 → h0
+      h(1, 'B', 5),   // h4 → root
+    ];
+    const { nodes, edges } = buildHeadingElements(headings, 'Doc');
+    expect(nodes).toHaveLength(6); // root + 5
+    const parentOf = (target: string) => edges.find((e) => e.data.target === target)!.data.source;
+    expect(parentOf('h0')).toBe('root');
+    expect(parentOf('h1')).toBe('h0');
+    expect(parentOf('h2')).toBe('h1');
+    expect(parentOf('h3')).toBe('h0'); // back up to A, not A.1.a
+    expect(parentOf('h4')).toBe('root');
+  });
+
+  it('handles a level jump (h1 → h3) by attaching to the nearest lower level', () => {
+    const { edges } = buildHeadingElements([h(1, 'A', 1), h(3, 'deep', 2)], 'Doc');
+    expect(edges.find((e) => e.data.target === 'h1')!.data.source).toBe('h0');
+  });
+
+  it('attaches a leading high-level heading directly to the root', () => {
+    const { edges } = buildHeadingElements([h(3, 'orphan', 1)], 'Doc');
+    expect(edges[0].data.source).toBe('root');
+  });
+
+  it('carries each heading\'s line for navigation', () => {
+    const { nodes } = buildHeadingElements([h(2, 'Intro', 7)], 'Doc');
+    expect(nodes.find((n) => n.data.id === 'h0')!.data.line).toBe(7);
+  });
+});


### PR DESCRIPTION
Starts the local graph-visualization epic (#843). The foundation (#844) has no UI surface of its own, so it ships with its first consumer (#845) — a coherent, live-verifiable feature.

## #844 — rendering foundation

- **`load-cytoscape.ts`** — dynamic `import()` cached in a module promise, so cytoscape ships as a **separate lazy chunk** (`cytoscape.esm-*.js`, confirmed in the build), not the entry bundle.
- **`GraphCanvas.svelte`** — owns the cytoscape lifecycle (create on mount, `destroy()` on unmount), themes from the Catppuccin tokens with a live `updateTheme()` re-skin, re-fits on container resize (ResizeObserver), and implements the **shared click model (#849)**: single-click selects, double-click / Enter navigates, and an `autoNavigate` prop promotes single-click to navigate. Each view supplies its own `navigate(data)` action.
- **`cytoscape-theme.ts`** — pure `buildGraphStyle(tokens)` → stylesheet (note chips, accent root, distinct source/missing-target nodes, per-edge `linkColor` ready for View B).

## #845 — View A: heading map

- **`heading-graph.ts`** — pure `buildHeadingElements()` reconstructs the tree from the flat `extractHeadings()` level list (nearest-lower-level parent, synthetic filename root).
- **`HeadingGraphPanel.svelte`** — `extractHeadings → elements → GraphCanvas`, breadthfirst layout, `navigate = onScrollToLine(heading.line)`; empty-state for heading-less notes; live-updates as the buffer changes (reactive `content`).
- Registered as a **"Heading Map"** panel in the right sidebar's Note group; `RightSidebar.updateTheme()` forwards theme switches to the graph (wired from App.svelte alongside the editor/preview re-skins).

## Verification

- **Live in the packaged app** (screenshot): the heading tree renders with **correct nesting** — root `doc` → `Distributed Systems` (H1) → `Consensus`/`Replication`/`Conclusion` (H2) → `Raft`/`Paxos`/`Primary-Backup` (H3) → `Leader Election` (H4) — themed, lazy-loaded, zero errors, and re-skins cleanly on a theme cycle.
- Build confirms cytoscape is a separate chunk (acceptance: not in the initial bundle).
- 11 unit tests on the pure nesting + stylesheet logic; lint clean.

Part of #843. Closes #844, closes #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)