### PR TITLE
feat: View B — interactive neighborhood graph in a full-pane tab (#847)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -7,6 +7,7 @@
   import { dropZoneFromFraction, splitForZone, type DropZone } from './lib/editor/drop-zone';
   import { collectGroupIds } from './lib/editor/layout-tree';
   import QueryPanel from './lib/components/QueryPanel.svelte';
+  import NeighborhoodGraph from './lib/components/NeighborhoodGraph.svelte';
   import RightSidebar from './lib/components/RightSidebar.svelte';
   import StatusBar from './lib/components/StatusBar.svelte';
   import BreadcrumbsBar from './lib/components/BreadcrumbsBar.svelte';
@@ -199,9 +200,14 @@
   // sites (nav, goto-line, insert, theme re-skin) target the focused pane.
   let editorComponents = $state<Record<string, Editor | undefined>>({});
   let queryPanelComponents = $state<Record<string, QueryPanel | undefined>>({});
+  let neighborhoodGraphComponents = $state<Record<string, NeighborhoodGraph | undefined>>({});
   let previewComponents = $state<Record<string, Preview | undefined>>({});
+  // Bumped on save / auto-save so an open neighborhood graph re-fetches when
+  // links change (#847 live-update).
+  let graphRevision = $state(0);
   const editorComponent = $derived(editorComponents[editor.activeGroupId]);
   const queryPanelComponent = $derived(queryPanelComponents[editor.activeGroupId]);
+  const neighborhoodGraphComponent = $derived(neighborhoodGraphComponents[editor.activeGroupId]);
   const previewComponent = $derived(previewComponents[editor.activeGroupId]);
   let toolPanelComponent = $state<ToolPanel>();
   let cursorInfo = $state<CursorInfo>({ line: 1, column: 1, selectionLength: 0, wordCount: 0 });
@@ -607,6 +613,7 @@
     editor.flushAutoSave(); // cancel pending auto-save, save immediately
     sidebar?.refreshTags();
     rightSidebar?.refresh();
+    graphRevision++;
     void refreshBacklinkCount();
     void refreshAliasMap();
   }
@@ -815,6 +822,7 @@
     editorComponent?.updateTheme();
     queryPanelComponent?.updateTheme();
     previewComponent?.updateTheme();
+    neighborhoodGraphComponent?.updateTheme();
     rightSidebar?.updateTheme();
   }
 
@@ -935,6 +943,7 @@
     editor.onAutoSaved = () => {
       sidebar?.refreshTags();
       rightSidebar?.refresh();
+      graphRevision++;
       void refreshBacklinkCount();
       void refreshAliasMap();
     };
@@ -1431,6 +1440,16 @@
                     />
                   {/await}
                 {/key}
+              {:else if active?.type === 'graph'}
+                {#key active.relativePath}
+                  <NeighborhoodGraph
+                    bind:this={neighborhoodGraphComponents[groupId]}
+                    relativePath={active.relativePath}
+                    depth={active.depth}
+                    revision={graphRevision}
+                    onOpenNote={(p) => handleFileSelect(p)}
+                  />
+                {/key}
               {:else if editor.groups.length > 1}
                 <!-- A freshly split pane is empty until a note lands in it.
                      It has no tab bar, so offer a way back out (#817). -->
@@ -1498,6 +1517,7 @@
           onOpenSource={handleOpenSource}
           onOpenExcerpt={handleOpenExcerpt}
           onContentChange={editor.setContent}
+          onOpenGraph={(p) => editor.openNeighborhood(p)}
         />
       {/if}
     {:else}
@@ -1692,6 +1712,7 @@
         editorComponent?.updateTheme();
         queryPanelComponent?.updateTheme();
         previewComponent?.updateTheme();
+        neighborhoodGraphComponent?.updateTheme();
         rightSidebar?.updateTheme();
       }}
       onClose={() => {

--- a/src/renderer/lib/components/GraphCanvas.svelte
+++ b/src/renderer/lib/components/GraphCanvas.svelte
@@ -23,6 +23,9 @@
     autoNavigate?: boolean;
     /** The view's navigate action, given the clicked node's data. */
     navigate?: (data: Record<string, unknown>) => void;
+    /** Fired on select (node data) / deselect (null) — drives per-view actions
+     *  like View B's expand affordance. */
+    onSelect?: (data: Record<string, unknown> | null) => void;
   }
 
   let {
@@ -30,6 +33,7 @@
     layout = { name: 'breadthfirst' },
     autoNavigate = false,
     navigate,
+    onSelect,
   }: Props = $props();
 
   let container = $state<HTMLDivElement>();
@@ -62,11 +66,14 @@
       cy.on('tap', 'node', (evt) => {
         const node = evt.target as NodeSingular;
         if (autoNavigate) { activate(node); return; }
+        onSelect?.(node.data() as Record<string, unknown>);
         const now = Date.now();
         if (lastTapId === node.id() && now - lastTapTime < 300) activate(node);
         lastTapId = node.id();
         lastTapTime = now;
       });
+      // A tap on empty canvas deselects.
+      cy.on('tap', (evt) => { if (evt.target === cy) onSelect?.(null); });
 
       // Re-fit when the container resizes (sidebar width / pane resize).
       ro = new ResizeObserver(() => { cy?.resize(); cy?.fit(undefined, 24); });

--- a/src/renderer/lib/components/NeighborhoodGraph.svelte
+++ b/src/renderer/lib/components/NeighborhoodGraph.svelte
@@ -1,0 +1,210 @@
+<!--
+  View B (#847) — a note's link neighborhood as an interactive force graph.
+
+  Fetches the depth-N neighborhood (#846) for `relativePath`, renders it through
+  the shared GraphCanvas (#844) with a cose force layout, and wires the shared
+  click model: activating a note opens it, a source opens the source viewer.
+  Notes/sources are styled distinctly (GraphCanvas stylesheet), the root is
+  highlighted, missing targets muted, and edges are colored by link type with a
+  legend. A depth control reshapes the walk; a selected node can be expanded one
+  hop on demand (explicit, never plain single-click). Truncation shows "+N more".
+-->
+<script lang="ts">
+  import GraphCanvas from './GraphCanvas.svelte';
+  import { api } from '../ipc/client';
+  import { getEditorStore } from '../stores/editor.svelte';
+  import type { LayoutOptions, ElementDefinition } from 'cytoscape';
+  import type { NeighborhoodResult, NeighborhoodNode } from '../../../shared/types';
+
+  interface Props {
+    relativePath: string;
+    depth: number;
+    /** Active note's revision — re-fetch when its links change. */
+    revision?: number;
+    onOpenNote: (relativePath: string) => void;
+  }
+
+  let { relativePath, depth, revision = 0, onOpenNote }: Props = $props();
+
+  const editor = getEditorStore();
+
+  let result = $state<NeighborhoodResult>({ nodes: [], edges: [], truncated: false });
+  // Nodes pulled in via expand-on-demand, merged over the base fetch.
+  let extra = $state<{ nodes: NeighborhoodResult['nodes']; edges: NeighborhoodResult['edges'] }>({ nodes: [], edges: [] });
+  let selected = $state<NeighborhoodNode | null>(null);
+  let loading = $state(false);
+  let graph = $state<GraphCanvas>();
+
+  const layout: LayoutOptions = {
+    name: 'cose',
+    animate: false,
+    padding: 24,
+    nodeRepulsion: () => 8000,
+    idealEdgeLength: () => 90,
+  };
+
+  // Re-fetch when the note, depth, or its revision changes; expansions reset.
+  $effect(() => {
+    const path = relativePath;
+    const d = depth;
+    void revision;
+    loading = true;
+    extra = { nodes: [], edges: [] };
+    selected = null;
+    void api.links.neighborhood(path, { depth: d }).then((r) => {
+      // Ignore a stale response if the inputs changed mid-flight.
+      if (path === relativePath && d === depth) { result = r; loading = false; }
+    });
+  });
+
+  // Merge base + expanded, deduped by id/edge-key, into Cytoscape elements.
+  const elements = $derived.by(() => {
+    const nodeById = new Map<string, NeighborhoodNode>();
+    for (const n of [...result.nodes, ...extra.nodes]) nodeById.set(n.id, n);
+    const edgeKeys = new Set<string>();
+    const edges: ElementDefinition[] = [];
+    for (const e of [...result.edges, ...extra.edges]) {
+      const key = `${e.source} ${e.target} ${e.linkType}`;
+      if (edgeKeys.has(key)) continue;
+      // Drop an edge whose endpoints aren't both present.
+      if (!nodeById.has(e.source) || !nodeById.has(e.target)) continue;
+      edgeKeys.add(key);
+      edges.push({ data: { id: `edge:${key}`, source: e.source, target: e.target, linkType: e.linkType, linkColor: e.linkColor } });
+    }
+    const nodes: ElementDefinition[] = [...nodeById.values()].map((n) => ({
+      data: {
+        id: n.id,
+        label: n.label,
+        kind: n.kind,
+        root: n.id === relativePath ? true : undefined,
+        missing: n.exists ? undefined : true,
+      },
+    }));
+    return { nodes, edges };
+  });
+
+  // Legend: the distinct link types present, with their colors.
+  const legend = $derived.by(() => {
+    const seen = new Map<string, { label: string; color: string }>();
+    for (const e of [...result.edges, ...extra.edges]) {
+      if (!seen.has(e.linkType)) seen.set(e.linkType, { label: e.linkLabel, color: e.linkColor });
+    }
+    return [...seen.entries()].map(([type, v]) => ({ type, ...v }));
+  });
+
+  function navigate(data: Record<string, unknown>): void {
+    const id = String(data.id);
+    if (data.kind === 'source') editor.openSource(id.replace(/^source:/, ''));
+    else onOpenNote(id);
+  }
+
+  function onSelect(data: Record<string, unknown> | null): void {
+    if (!data) { selected = null; return; }
+    selected = { id: String(data.id), kind: data.kind === 'source' ? 'source' : 'note', label: String(data.label ?? data.id), exists: !data.missing };
+  }
+
+  async function expandSelected(): Promise<void> {
+    if (!selected || selected.kind !== 'note') return;
+    const hop = await api.links.expandNode(selected.id);
+    extra = { nodes: [...extra.nodes, ...hop.nodes], edges: [...extra.edges, ...hop.edges] };
+  }
+
+  function changeDepth(next: number): void {
+    editor.setGraphDepth(relativePath, next);
+  }
+
+  export function updateTheme(): void { graph?.updateTheme(); }
+</script>
+
+<div class="neighborhood-graph">
+  <div class="toolbar">
+    <span class="depth-control">
+      Depth
+      <button class="step" disabled={depth <= 1} onclick={() => changeDepth(depth - 1)} title="Shallower">−</button>
+      <span class="depth-val">{depth}</span>
+      <button class="step" disabled={depth >= 5} onclick={() => changeDepth(depth + 1)} title="Deeper">+</button>
+    </span>
+
+    {#if selected && selected.kind === 'note'}
+      <button class="expand-btn" onclick={expandSelected} title="Pull in this node's links">
+        Expand “{selected.label}”
+      </button>
+    {/if}
+
+    {#if result.truncated}
+      <span class="truncation" title="The neighborhood was capped">+ more (capped)</span>
+    {/if}
+
+    <span class="spacer"></span>
+
+    {#if legend.length > 0}
+      <span class="legend">
+        {#each legend as item (item.type)}
+          <span class="legend-item" title={item.label}>
+            <span class="swatch" style:background={item.color}></span>{item.label}
+          </span>
+        {/each}
+      </span>
+    {/if}
+  </div>
+
+  <div class="canvas-wrap">
+    {#if loading && result.nodes.length === 0}
+      <div class="status">Loading neighborhood…</div>
+    {:else if result.nodes.length <= 1 && extra.nodes.length === 0}
+      <div class="status">No links to or from this note yet.</div>
+    {/if}
+    <GraphCanvas bind:this={graph} {elements} {layout} {navigate} {onSelect} />
+  </div>
+</div>
+
+<style>
+  .neighborhood-graph {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    background: var(--bg-inset);
+  }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-muted);
+    flex-wrap: wrap;
+  }
+  .spacer { flex: 1; }
+  .depth-control { display: inline-flex; align-items: center; gap: 4px; }
+  .depth-val { min-width: 12px; text-align: center; color: var(--text); }
+  .step, .expand-btn {
+    border: 1px solid var(--border);
+    background: var(--bg-button);
+    color: var(--text);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 1px 8px;
+    line-height: 1.4;
+  }
+  .step:disabled { opacity: 0.4; cursor: default; }
+  .step:hover:not(:disabled), .expand-btn:hover { border-color: var(--accent); }
+  .truncation { color: var(--rust, var(--accent)); }
+  .legend { display: inline-flex; gap: 10px; flex-wrap: wrap; }
+  .legend-item { display: inline-flex; align-items: center; gap: 4px; }
+  .swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+  .canvas-wrap { position: relative; flex: 1; min-height: 0; }
+  .status {
+    position: absolute;
+    top: 12px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-muted);
+    pointer-events: none;
+    z-index: 1;
+  }
+</style>

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -102,12 +102,14 @@
     onOpenSource: (sourceId: string) => void;
     onOpenExcerpt: (excerptId: string) => void;
     onContentChange?: (next: string) => void;
+    /** Open a note's link neighborhood as a graph (#847). */
+    onOpenGraph?: (relativePath: string) => void;
   }
 
   let {
     activeFilePath, content, onFileSelect, onNavigate, onOpenAtOffset, onScrollToLine,
     onOpenConversation, onOpenQuery, onOpenSource, onOpenExcerpt,
-    onContentChange,
+    onContentChange, onOpenGraph,
   }: Props = $props();
 
   let activePanel = $state<PanelType>('outline');
@@ -242,9 +244,9 @@
         <div class="panel-disabled">No active note.</div>
       {/if}
     {:else if activePanel === 'outgoing'}
-      <OutgoingLinksPanel {activeFilePath} {revision} {onFileSelect} />
+      <OutgoingLinksPanel {activeFilePath} {revision} {onFileSelect} {onOpenGraph} />
     {:else if activePanel === 'backlinks'}
-      <BacklinksPanel {activeFilePath} {revision} {onFileSelect} />
+      <BacklinksPanel {activeFilePath} {revision} {onFileSelect} {onOpenGraph} />
     {:else if activePanel === 'tags'}
       <TagsPanel {content} {onFileSelect} onSourceSelect={onOpenSource} />
     {:else if activePanel === 'tables'}

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -102,7 +102,9 @@
           ? tab.title
           : tab.type === 'pdf'
             ? `PDF: ${sourceTabLabel(tab.sourceId)}`
-            : `Source: ${sourceTabLabel(tab.sourceId)}`}
+            : tab.type === 'graph'
+              ? `Graph: ${tab.relativePath}`
+              : `Source: ${sourceTabLabel(tab.sourceId)}`}
       role="tab"
       tabindex="0"
     >
@@ -117,6 +119,8 @@
           <Icon name="source" size={13} color="var(--text-faint)" />
         {:else if tab.type === 'pdf'}
           <Icon name="source" size={13} color="var(--text-faint)" />
+        {:else if tab.type === 'graph'}
+          <Icon name="graph" size={13} color="var(--text-faint)" />
         {:else}
           <Icon name="notes" size={13} color="var(--text-faint)" />
         {/if}
@@ -125,6 +129,7 @@
         {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
         {:else if tab.type === 'query'}{tab.title}
         {:else if tab.type === 'pdf'}{sourceTabLabel(tab.sourceId)} (PDF)
+        {:else if tab.type === 'graph'}{(tab.relativePath.split('/').pop() ?? tab.relativePath).replace(/\.md$/, '')} (Graph)
         {:else}{sourceTabLabel(tab.sourceId)}{/if}
       </span>
       <button

--- a/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
@@ -9,9 +9,11 @@
     activeFilePath: string | null;
     revision: number;
     onFileSelect: (relativePath: string) => void;
+    /** Open this note's neighborhood as a graph (#847). */
+    onOpenGraph?: (relativePath: string) => void;
   }
 
-  let { activeFilePath, revision, onFileSelect }: Props = $props();
+  let { activeFilePath, revision, onFileSelect, onOpenGraph }: Props = $props();
   let links = $state<Backlink[]>([]);
   let search = $state('');
   let sortId = $state<'type' | 'title'>('type');
@@ -64,6 +66,7 @@
 
 <div class="links-panel">
   <Ribbon
+    onOpenGraph={activeFilePath ? () => onOpenGraph?.(activeFilePath) : undefined}
     {search}
     onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find mention…"

--- a/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
@@ -9,9 +9,11 @@
     activeFilePath: string | null;
     revision: number;
     onFileSelect: (relativePath: string) => void;
+    /** Open this note's neighborhood as a graph (#847). */
+    onOpenGraph?: (relativePath: string) => void;
   }
 
-  let { activeFilePath, revision, onFileSelect }: Props = $props();
+  let { activeFilePath, revision, onFileSelect, onOpenGraph }: Props = $props();
   let links = $state<OutgoingLink[]>([]);
   let search = $state('');
   let sortId = $state<'type' | 'title'>('type');
@@ -67,6 +69,7 @@
 
 <div class="links-panel">
   <Ribbon
+    onOpenGraph={activeFilePath ? () => onOpenGraph?.(activeFilePath) : undefined}
     {search}
     onSearch={(q: string) => { search = q; }}
     searchPlaceholder="Find link…"

--- a/src/renderer/lib/components/right-sidebar/Ribbon.svelte
+++ b/src/renderer/lib/components/right-sidebar/Ribbon.svelte
@@ -24,6 +24,8 @@
     onSort?: (id: string) => void;
     onExpandAll?: () => void;
     onCollapseAll?: () => void;
+    /** Open this note's link neighborhood as a graph (#847). */
+    onOpenGraph?: () => void;
   }
 
   let {
@@ -35,6 +37,7 @@
     onSort,
     onExpandAll,
     onCollapseAll,
+    onOpenGraph,
   }: Props = $props();
 </script>
 
@@ -65,6 +68,9 @@
   {/if}
   {#if onExpandAll}
     <button class="icon-btn" onclick={onExpandAll} title="Expand all"><Icon name="expandAll" size={12} /></button>
+  {/if}
+  {#if onOpenGraph}
+    <button class="icon-btn" onclick={onOpenGraph} title="Open as graph"><Icon name="graph" size={12} /></button>
   {/if}
 </div>
 

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -61,7 +61,15 @@ export interface PdfTab {
   page: number;
 }
 
-export type Tab = NoteTab | QueryTab | SourceTab | PdfTab;
+export interface GraphTab {
+  type: 'graph';
+  /** The note whose link neighborhood is shown (#847). */
+  relativePath: string;
+  /** Traversal depth (1–N). */
+  depth: number;
+}
+
+export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab;
 
 /**
  * Source / preview view mode. `'editor-preview'` = source editor + rendered
@@ -89,6 +97,7 @@ function isNote(tab: Tab): tab is NoteTab { return tab.type === 'note'; }
 function isQuery(tab: Tab): tab is QueryTab { return tab.type === 'query'; }
 function isSource(tab: Tab): tab is SourceTab { return tab.type === 'source'; }
 function isPdf(tab: Tab): tab is PdfTab { return tab.type === 'pdf'; }
+function isGraph(tab: Tab): tab is GraphTab { return tab.type === 'graph'; }
 
 let queryCounter = 0;
 let groupCounter = 0;
@@ -334,6 +343,28 @@ export function getEditorStore() {
     schedulePersistTabs();
   }
 
+  /** Open (or refocus) the link-neighborhood graph for a note (#847). One graph
+   *  tab per note; reopening refocuses rather than duplicating. */
+  function openNeighborhood(relativePath: string, opts?: { depth?: number; groupId?: string }) {
+    const found = locateTab((t) => isGraph(t) && t.relativePath === relativePath);
+    if (found) { focusExistingTab(found); return; }
+    const grp = resolveGroup(opts?.groupId);
+    activeGroupId = grp.id;
+    const tab: GraphTab = { type: 'graph', relativePath, depth: opts?.depth ?? 1 };
+    grp.tabs.push(tab);
+    grp.activeIndex = grp.tabs.length - 1;
+    schedulePersistTabs();
+  }
+
+  /** Update a graph tab's traversal depth (the depth control). */
+  function setGraphDepth(relativePath: string, depth: number) {
+    const found = locateTab((t) => isGraph(t) && t.relativePath === relativePath);
+    if (found) {
+      (found.group.tabs[found.index] as GraphTab).depth = Math.max(1, depth);
+      schedulePersistTabs();
+    }
+  }
+
   function openPdf(sourceId: string, opts?: { page?: number; groupId?: string }) {
     // Forbid duplicate open (#815): if this PDF is already open in any pane,
     // refocus it (jumping to the requested page) instead of opening a copy.
@@ -539,6 +570,8 @@ export function getEditorStore() {
       return { type: 'query', title: t.title, query: t.query, language: t.language };
     } else if (isPdf(t)) {
       return { type: 'pdf', sourceId: t.sourceId, page: t.page };
+    } else if (isGraph(t)) {
+      return { type: 'graph', relativePath: t.relativePath, depth: t.depth };
     } else {
       return { type: 'source', sourceId: t.sourceId, highlightExcerptId: t.highlightExcerptId };
     }
@@ -599,6 +632,8 @@ export function getEditorStore() {
       };
     } else if (saved.type === 'pdf') {
       return { type: 'pdf', sourceId: saved.sourceId, page: saved.page ?? 1 };
+    } else if (saved.type === 'graph') {
+      return { type: 'graph', relativePath: saved.relativePath, depth: saved.depth ?? 1 };
     } else {
       return { type: 'source', sourceId: saved.sourceId, highlightExcerptId: saved.highlightExcerptId };
     }
@@ -968,6 +1003,8 @@ export function getEditorStore() {
     openFile,
     openSource,
     openPdf,
+    openNeighborhood,
+    setGraphDepth,
     setPdfPage,
     save,
     isPathDirty,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -141,7 +141,15 @@ export interface SavedPdfTab {
   page?: number;
 }
 
-export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab;
+export interface SavedGraphTab {
+  type: 'graph';
+  /** The note whose link neighborhood the graph shows (#847). */
+  relativePath: string;
+  /** Traversal depth; restored on reload. */
+  depth?: number;
+}
+
+export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab | SavedGraphTab;
 
 /** Legacy flat session: one group's tabs + active index. Superseded by
  *  {@link LayoutSession} (#816); still read on load and migrated to a single


### PR DESCRIPTION
The headline of the graph epic: a note's link neighborhood (#846) rendered through the shared `GraphCanvas` (#844) as an interactive force graph in its own full-pane tab.

## What it does

- **New `graph` tab type** (`editor.svelte.ts`) + `openNeighborhood(path)` / `setGraphDepth` store methods (mirroring `openSource`), **persisted across sessions** (`SavedGraphTab`). App render branch + TabBar title/icon/name; theme switches forward to the graph.
- **`NeighborhoodGraph.svelte`** — fetches `api.links.neighborhood`, builds cytoscape elements (kind/root/missing node data + per-edge `linkColor`), **cose force layout**. Notes vs sources styled distinctly, root highlighted, **missing targets muted** — all from the #844 stylesheet. **Edge color by link type** with a **legend** of the types present + direction arrows.
- **Shared click model (#849 mechanism)**: double-click / Enter navigates — a note node opens the note, a source node opens the source viewer; single-click selects. **Expand is an explicit affordance**: selecting a node reveals an "Expand" button that pulls its next hop (`api.links.expandNode`) — never plain single-click, so it never collides with select/navigate. **Depth control (1–5)** re-runs the walk; truncation shows a notice.
- **Live-update**: a `graphRevision` bumped on save/auto-save re-fetches when links change.
- **Entry point**: an "Open as graph" button on the Outgoing/Backlinks panels (threaded App → RightSidebar → panels → Ribbon).
- `GraphCanvas` gains an `onSelect` callback driving the expand affordance.

## Verification

**Live in the packaged app** (screenshot): opening `hub`'s neighborhood via the panel button renders the force graph — `Spoke A` (bidirectional), `Inbound` (backlink), `Spoke B`, and `ghost` around the root. Edges are colored per the legend: **References** (blue), **Supports** (green), **Rebuts** (pink), with direction arrows. The non-existent `[[ghost]]` target is **muted with a dashed border**. Depth control present; zero errors.

73 editor/layout/graph tests pass; lint clean.

Part of #843. Closes #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)