### PR TITLE
feat: filter neighborhood graph by link type (#848)

### DIFF
--- a/src/renderer/lib/components/NeighborhoodGraph.svelte
+++ b/src/renderer/lib/components/NeighborhoodGraph.svelte
@@ -13,8 +13,9 @@
   import GraphCanvas from './GraphCanvas.svelte';
   import { api } from '../ipc/client';
   import { getEditorStore } from '../stores/editor.svelte';
+  import { filterNeighborhood } from '../graph/filter-neighborhood';
   import type { LayoutOptions, ElementDefinition } from 'cytoscape';
-  import type { NeighborhoodResult, NeighborhoodNode } from '../../../shared/types';
+  import type { NeighborhoodResult, NeighborhoodNode, NeighborhoodEdge } from '../../../shared/types';
 
   interface Props {
     relativePath: string;
@@ -34,6 +35,8 @@
   let selected = $state<NeighborhoodNode | null>(null);
   let loading = $state(false);
   let graph = $state<GraphCanvas>();
+  // #848 — link types the user has hidden (display filter, not a re-traversal).
+  let hiddenTypes = $state<Set<string>>(new Set());
 
   const layout: LayoutOptions = {
     name: 'cose',
@@ -57,21 +60,20 @@
     });
   });
 
-  // Merge base + expanded, deduped by id/edge-key, into Cytoscape elements.
+  // Merge base + expanded (deduped), then apply the link-type filter (#848) —
+  // hidden-type edges drop out and orphaned nodes drop with them — and map the
+  // survivors to Cytoscape elements.
   const elements = $derived.by(() => {
     const nodeById = new Map<string, NeighborhoodNode>();
     for (const n of [...result.nodes, ...extra.nodes]) nodeById.set(n.id, n);
-    const edgeKeys = new Set<string>();
-    const edges: ElementDefinition[] = [];
+    const edgeByKey = new Map<string, NeighborhoodEdge>();
     for (const e of [...result.edges, ...extra.edges]) {
-      const key = `${e.source} ${e.target} ${e.linkType}`;
-      if (edgeKeys.has(key)) continue;
-      // Drop an edge whose endpoints aren't both present.
-      if (!nodeById.has(e.source) || !nodeById.has(e.target)) continue;
-      edgeKeys.add(key);
-      edges.push({ data: { id: `edge:${key}`, source: e.source, target: e.target, linkType: e.linkType, linkColor: e.linkColor } });
+      edgeByKey.set(`${e.source} ${e.target} ${e.linkType}`, e);
     }
-    const nodes: ElementDefinition[] = [...nodeById.values()].map((n) => ({
+
+    const filtered = filterNeighborhood([...nodeById.values()], [...edgeByKey.values()], relativePath, hiddenTypes);
+
+    const nodes: ElementDefinition[] = filtered.nodes.map((n) => ({
       data: {
         id: n.id,
         label: n.label,
@@ -80,8 +82,17 @@
         missing: n.exists ? undefined : true,
       },
     }));
+    const edges: ElementDefinition[] = filtered.edges.map((e) => ({
+      data: { id: `edge:${e.source} ${e.target} ${e.linkType}`, source: e.source, target: e.target, linkType: e.linkType, linkColor: e.linkColor },
+    }));
     return { nodes, edges };
   });
+
+  function toggleType(type: string): void {
+    const next = new Set(hiddenTypes);
+    if (next.has(type)) next.delete(type); else next.add(type);
+    hiddenTypes = next;
+  }
 
   // Legend: the distinct link types present, with their colors.
   const legend = $derived.by(() => {
@@ -140,9 +151,15 @@
     {#if legend.length > 0}
       <span class="legend">
         {#each legend as item (item.type)}
-          <span class="legend-item" title={item.label}>
+          <button
+            type="button"
+            class="legend-item"
+            class:off={hiddenTypes.has(item.type)}
+            onclick={() => toggleType(item.type)}
+            title={hiddenTypes.has(item.type) ? `Show ${item.label}` : `Hide ${item.label}`}
+          >
             <span class="swatch" style:background={item.color}></span>{item.label}
-          </span>
+          </button>
         {/each}
       </span>
     {/if}
@@ -192,9 +209,23 @@
   .step:disabled { opacity: 0.4; cursor: default; }
   .step:hover:not(:disabled), .expand-btn:hover { border-color: var(--accent); }
   .truncation { color: var(--rust, var(--accent)); }
-  .legend { display: inline-flex; gap: 10px; flex-wrap: wrap; }
-  .legend-item { display: inline-flex; align-items: center; gap: 4px; }
-  .swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+  .legend { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: 1px solid transparent;
+    background: none;
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+  .legend-item:hover { border-color: var(--border); }
+  /* A hidden type reads as struck-through + dimmed. */
+  .legend-item.off { opacity: 0.45; text-decoration: line-through; }
+  .swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; flex-shrink: 0; }
   .canvas-wrap { position: relative; flex: 1; min-height: 0; }
   .status {
     position: absolute;

--- a/src/renderer/lib/graph/filter-neighborhood.ts
+++ b/src/renderer/lib/graph/filter-neighborhood.ts
@@ -1,0 +1,50 @@
+/**
+ * Link-type display filter for View B (#848).
+ *
+ * Purely a display pass over the already-fetched neighborhood (#846) — no
+ * re-traversal. Drops edges whose link type the user hid, then drops any node
+ * left unreachable from the root by the surviving (undirected) edges, so hiding
+ * a type never leaves orphan nodes floating. The root is always kept.
+ */
+
+import type { NeighborhoodNode, NeighborhoodEdge } from '../../../shared/types';
+
+export interface FilteredGraph {
+  nodes: NeighborhoodNode[];
+  edges: NeighborhoodEdge[];
+}
+
+export function filterNeighborhood(
+  nodes: NeighborhoodNode[],
+  edges: NeighborhoodEdge[],
+  rootId: string,
+  hiddenTypes: ReadonlySet<string>,
+): FilteredGraph {
+  const present = new Set(nodes.map((n) => n.id));
+  // Edges that survive: both endpoints present, type not hidden.
+  const visible = edges.filter(
+    (e) => present.has(e.source) && present.has(e.target) && !hiddenTypes.has(e.linkType),
+  );
+
+  // Undirected reachability from the root over the surviving edges.
+  const adj = new Map<string, string[]>();
+  const link = (a: string, b: string) => {
+    const list = adj.get(a);
+    if (list) list.push(b); else adj.set(a, [b]);
+  };
+  for (const e of visible) { link(e.source, e.target); link(e.target, e.source); }
+
+  const reachable = new Set<string>([rootId]);
+  const queue: string[] = [rootId];
+  while (queue.length > 0) {
+    const id = queue.shift() as string;
+    for (const n of adj.get(id) ?? []) {
+      if (!reachable.has(n)) { reachable.add(n); queue.push(n); }
+    }
+  }
+
+  return {
+    nodes: nodes.filter((n) => reachable.has(n.id)),
+    edges: visible.filter((e) => reachable.has(e.source) && reachable.has(e.target)),
+  };
+}

--- a/tests/renderer/graph/filter-neighborhood.test.ts
+++ b/tests/renderer/graph/filter-neighborhood.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Link-type display filter (#848) — hide edges by type and drop nodes the hide
+ * orphans from the root.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { filterNeighborhood } from '../../../src/renderer/lib/graph/filter-neighborhood';
+import type { NeighborhoodNode, NeighborhoodEdge } from '../../../src/shared/types';
+
+const n = (id: string): NeighborhoodNode => ({ id, kind: 'note', label: id, exists: true });
+const e = (source: string, target: string, linkType: string): NeighborhoodEdge => ({
+  source, target, linkType, linkLabel: linkType, linkColor: '#fff', direction: 'out',
+});
+
+describe('filterNeighborhood', () => {
+  const nodes = [n('root'), n('a'), n('b'), n('c')];
+  // root —references→ a, root —rebuts→ b, b —references→ c
+  const edges = [e('root', 'a', 'references'), e('root', 'b', 'rebuts'), e('b', 'c', 'references')];
+
+  it('returns the whole graph when nothing is hidden', () => {
+    const f = filterNeighborhood(nodes, edges, 'root', new Set());
+    expect(f.nodes.map((x) => x.id).sort()).toEqual(['a', 'b', 'c', 'root']);
+    expect(f.edges).toHaveLength(3);
+  });
+
+  it('hides edges of a hidden type', () => {
+    const f = filterNeighborhood(nodes, edges, 'root', new Set(['references']));
+    expect(f.edges.every((x) => x.linkType !== 'references')).toBe(true);
+  });
+
+  it('drops nodes orphaned from the root by a hidden type', () => {
+    // Hiding "rebuts" cuts root→b; b and (its child) c both fall away.
+    const f = filterNeighborhood(nodes, edges, 'root', new Set(['rebuts']));
+    expect(f.nodes.map((x) => x.id).sort()).toEqual(['a', 'root']);
+    expect(f.edges).toHaveLength(1);
+  });
+
+  it('keeps a node still reachable via another edge type', () => {
+    // a is reachable from root via references AND (add) via depends-on; hiding one keeps it.
+    const ns = [n('root'), n('a')];
+    const es = [e('root', 'a', 'references'), e('root', 'a', 'depends-on')];
+    const f = filterNeighborhood(ns, es, 'root', new Set(['references']));
+    expect(f.nodes.map((x) => x.id).sort()).toEqual(['a', 'root']);
+    expect(f.edges).toHaveLength(1);
+  });
+
+  it('always keeps the root, even when fully isolated', () => {
+    const f = filterNeighborhood(nodes, edges, 'root', new Set(['references', 'rebuts']));
+    expect(f.nodes.map((x) => x.id)).toEqual(['root']);
+    expect(f.edges).toEqual([]);
+  });
+
+  it('treats edges as undirected for reachability (backlink in)', () => {
+    // inbound —references→ root ; root still reaches inbound.
+    const ns = [n('root'), n('inbound')];
+    const es = [e('inbound', 'root', 'references')];
+    const f = filterNeighborhood(ns, es, 'root', new Set());
+    expect(f.nodes.map((x) => x.id).sort()).toEqual(['inbound', 'root']);
+  });
+});


### PR DESCRIPTION
The View B legend (#847) becomes an interactive filter. A neighborhood at depth ≥ 2 mixes many link types; toggling which ones show cuts clutter and answers focused questions ("show me only what *rebuts* this").

## What it does

Each link type **present in the current graph** is a toggle in the toolbar (color swatch + label, all on by default). Clicking one **hides its edges live** and **drops any node thereby orphaned** from the root — no floating nodes. It's purely a display pass over the already-fetched neighborhood (#846); it never re-runs traversal. The hidden set persists while you adjust depth / expand on the same note's graph.

## Implementation

- **`src/renderer/lib/graph/filter-neighborhood.ts`** — pure `filterNeighborhood(nodes, edges, rootId, hiddenTypes)`: drops hidden-type edges, then keeps only nodes reachable from the root over the survivors (treated as **undirected**, so a backlink keeps its node). The root is always kept.
- `NeighborhoodGraph` wires it into the elements derivation and turns the legend items into toggle buttons (struck-through + dimmed when off).

## Verification

6 unit tests cover the filter matrix — nothing hidden, hide a type, **orphan removal** (hiding `rebuts` cuts `root→b` so `b` and its child `c` both fall away), a node kept via an alternative edge type, root-always-kept, undirected reachability. 17 graph tests pass; lint clean.

(The legend render + the graph itself are already live-verified in #847; this PR makes those legend chips clickable filters over the same proven render.)

Part of #843. Closes #848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)