### PR TITLE
feat: auto-navigate-on-click toggle for the graph views (#849)

### DIFF
--- a/src/renderer/lib/components/NeighborhoodGraph.svelte
+++ b/src/renderer/lib/components/NeighborhoodGraph.svelte
@@ -14,6 +14,7 @@
   import { api } from '../ipc/client';
   import { getEditorStore } from '../stores/editor.svelte';
   import { filterNeighborhood } from '../graph/filter-neighborhood';
+  import { getGraphSettings } from '../stores/graph-settings.svelte';
   import type { LayoutOptions, ElementDefinition } from 'cytoscape';
   import type { NeighborhoodResult, NeighborhoodNode, NeighborhoodEdge } from '../../../shared/types';
 
@@ -28,6 +29,7 @@
   let { relativePath, depth, revision = 0, onOpenNote }: Props = $props();
 
   const editor = getEditorStore();
+  const settings = getGraphSettings();
 
   let result = $state<NeighborhoodResult>({ nodes: [], edges: [], truncated: false });
   // Nodes pulled in via expand-on-demand, merged over the base fetch.
@@ -136,6 +138,17 @@
       <button class="step" disabled={depth >= 5} onclick={() => changeDepth(depth + 1)} title="Deeper">+</button>
     </span>
 
+    <button
+      class="toggle"
+      class:on={settings.autoNavigate}
+      onclick={() => settings.toggleAutoNavigate()}
+      title={settings.autoNavigate
+        ? 'Click opens the node. Switch to: click selects'
+        : 'Click selects (double-click opens). Switch to: click opens'}
+    >
+      {settings.autoNavigate ? 'Click: open' : 'Click: select'}
+    </button>
+
     {#if selected && selected.kind === 'note'}
       <button class="expand-btn" onclick={expandSelected} title="Pull in this node's links">
         Expand “{selected.label}”
@@ -171,7 +184,7 @@
     {:else if result.nodes.length <= 1 && extra.nodes.length === 0}
       <div class="status">No links to or from this note yet.</div>
     {/if}
-    <GraphCanvas bind:this={graph} {elements} {layout} {navigate} {onSelect} />
+    <GraphCanvas bind:this={graph} {elements} {layout} {navigate} {onSelect} autoNavigate={settings.autoNavigate} />
   </div>
 </div>
 
@@ -207,7 +220,18 @@
     line-height: 1.4;
   }
   .step:disabled { opacity: 0.4; cursor: default; }
-  .step:hover:not(:disabled), .expand-btn:hover { border-color: var(--accent); }
+  .step:hover:not(:disabled), .expand-btn:hover, .toggle:hover { border-color: var(--accent); }
+  .toggle {
+    border: 1px solid var(--border);
+    background: var(--bg-button);
+    color: var(--text-muted);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 1px 8px;
+  }
+  /* "Click opens" mode is the live-navigator state — accented so it's obvious. */
+  .toggle.on { color: var(--bg); background: var(--accent); border-color: var(--accent); }
   .truncation { color: var(--rust, var(--accent)); }
   .legend { display: inline-flex; gap: 6px; flex-wrap: wrap; }
   .legend-item {

--- a/src/renderer/lib/components/right-sidebar/HeadingGraphPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/HeadingGraphPanel.svelte
@@ -10,6 +10,7 @@
   import GraphCanvas from '../GraphCanvas.svelte';
   import { extractHeadings } from '../../markdown/headings';
   import { buildHeadingElements } from '../../graph/heading-graph';
+  import { getGraphSettings } from '../../stores/graph-settings.svelte';
   import type { LayoutOptions } from 'cytoscape';
 
   interface Props {
@@ -20,6 +21,8 @@
   }
 
   let { content, title = 'Note', onScrollToLine }: Props = $props();
+
+  const settings = getGraphSettings();
 
   const headings = $derived(extractHeadings(content));
   const elements = $derived(buildHeadingElements(headings, title));
@@ -48,7 +51,19 @@
   {#if headings.length === 0}
     <div class="empty">No headings to map</div>
   {:else}
-    <GraphCanvas bind:this={graph} {elements} {layout} {navigate} />
+    <div class="hg-toolbar">
+      <button
+        class="hg-toggle"
+        class:on={settings.autoNavigate}
+        onclick={() => settings.toggleAutoNavigate()}
+        title={settings.autoNavigate
+          ? 'Click scrolls to the heading. Switch to: click selects'
+          : 'Click selects (double-click scrolls). Switch to: click scrolls'}
+      >
+        {settings.autoNavigate ? 'Click: open' : 'Click: select'}
+      </button>
+    </div>
+    <GraphCanvas bind:this={graph} {elements} {layout} {navigate} autoNavigate={settings.autoNavigate} />
   {/if}
 </div>
 
@@ -66,4 +81,22 @@
     color: var(--text-muted);
     text-align: center;
   }
+  .hg-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .hg-toggle {
+    border: 1px solid var(--border);
+    background: var(--bg-button);
+    color: var(--text-muted);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 11px;
+    padding: 1px 6px;
+  }
+  .hg-toggle:hover { border-color: var(--accent); }
+  .hg-toggle.on { color: var(--bg); background: var(--accent); border-color: var(--accent); }
 </style>

--- a/src/renderer/lib/stores/graph-settings.svelte.ts
+++ b/src/renderer/lib/stores/graph-settings.svelte.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared graph-view settings (#849).
+ *
+ * The "auto-navigate on click" toggle — off by default. Off, a single click on a
+ * graph node *selects* it and navigation needs an explicit gesture (double-click
+ * / Enter); on, a single click *navigates* (View A scrolls to the heading, View
+ * B opens the note / source). One persisted global setting both views obey, so
+ * the click model is consistent — defined in the shared GraphCanvas interaction
+ * layer (#844) and fed this flag.
+ */
+
+const STORAGE_KEY = 'minerva.graph.autoNavigate';
+
+function readFromStorage(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+let autoNavigate = $state<boolean>(readFromStorage());
+
+export function getGraphSettings() {
+  function setAutoNavigate(value: boolean): void {
+    autoNavigate = value;
+    try { localStorage.setItem(STORAGE_KEY, String(value)); } catch { /* ignore */ }
+  }
+  return {
+    /** When true, a single click navigates instead of selecting. */
+    get autoNavigate() { return autoNavigate; },
+    setAutoNavigate,
+    toggleAutoNavigate() { setAutoNavigate(!autoNavigate); },
+  };
+}
+
+/** Test-only: re-read from localStorage. */
+export function __resetGraphSettingsForTests(): void {
+  autoNavigate = readFromStorage();
+}

--- a/tests/renderer/graph/graph-settings.test.ts
+++ b/tests/renderer/graph/graph-settings.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Auto-navigate setting (#849) — persisted, off by default, toggleable.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getGraphSettings, __resetGraphSettingsForTests } from '../../../src/renderer/lib/stores/graph-settings.svelte';
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => store.clear(),
+    },
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+beforeEach(() => {
+  localStorage.clear();
+  __resetGraphSettingsForTests();
+});
+
+describe('graph auto-navigate setting', () => {
+  it('defaults to off', () => {
+    expect(getGraphSettings().autoNavigate).toBe(false);
+  });
+
+  it('persists when set, and surfaces the new value', () => {
+    getGraphSettings().setAutoNavigate(true);
+    expect(getGraphSettings().autoNavigate).toBe(true);
+    expect(localStorage.getItem('minerva.graph.autoNavigate')).toBe('true');
+  });
+
+  it('toggles', () => {
+    const s = getGraphSettings();
+    s.toggleAutoNavigate();
+    expect(s.autoNavigate).toBe(true);
+    s.toggleAutoNavigate();
+    expect(s.autoNavigate).toBe(false);
+  });
+
+  it('reads a persisted value on (re)load', () => {
+    localStorage.setItem('minerva.graph.autoNavigate', 'true');
+    __resetGraphSettingsForTests();
+    expect(getGraphSettings().autoNavigate).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the graph-visualization epic (#843). The IDE-centric ideal that "everything is a link" — but **opt-in**. A persisted global toggle, **off by default**, that promotes single-click from *select* to *navigate*; both graph views obey it.

## What it does

- **`graph-settings.svelte.ts`** — a reactive, localStorage-persisted `autoNavigate` setting (off by default) with set/toggle.
- The **shared click model already lives in `GraphCanvas`** (#844): off → single-click selects, double-click / Enter navigates; on → single-click navigates. Both views now feed it `settings.autoNavigate` and surface a **"Click: select / Click: open"** toggle (accented when on, so the active mode is obvious): View B in its toolbar, View A's heading map in a compact header.
- View B's node **expansion was already an explicit affordance** (the Expand button, #847), so it never collides with select/navigate under either mode.

## Behavior (the shared model)

| | single-click | double-click / Enter |
|---|---|---|
| **off (default)** | selects | navigates |
| **on** | navigates | navigates |

View A navigate = scroll to the heading; View B navigate = open the note / source viewer.

## Verification

4 unit tests cover the setting (default off, persist, toggle, reload-from-storage). The navigate **mechanism** itself was live-verified in #847 (double-click opened a note); auto-navigate just flips that same `activate()` path onto single-click (the node-click path is canvas-drawn, so not Playwright-automatable — hence the unit-tested setting + proven mechanism). Lint clean.

Part of #843. **Closes #849 — and completes the epic.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)