### PR TITLE
fix: Reveal in Sidebar reveals in the tree; drop duplicate Full Screen menu item

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -427,8 +427,12 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
           click: () => send(Channels.MENU_FONT_RESET),
         }),
         { type: 'separator' },
-        { role: 'togglefullscreen' },
-        { type: 'separator' },
+        // macOS auto-injects its own "Enter/Exit Full Screen" item into the
+        // View menu, so adding `togglefullscreen` here produced a duplicate.
+        // Keep the explicit item only where the OS doesn't provide one.
+        ...(isMac
+          ? []
+          : [{ role: 'togglefullscreen' as const }, { type: 'separator' as const }]),
         { role: 'toggleDevTools', label: 'Developer Tools' },
       ],
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -852,7 +852,11 @@
   }
 
   function handleRevealInSidebar(relativePath: string) {
-    void api.shell.revealFile(relativePath);
+    // Reveal in the in-app file tree — switch to Notes, expand the note's
+    // ancestor folders, select + scroll it into view. (The separate "Reveal
+    // in Finder" menu item opens the OS file manager; this handler used to
+    // call that by mistake, duplicating it.)
+    void sidebar?.revealFile(relativePath);
   }
 
   // Refresh tags when notebase opens

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -204,6 +204,33 @@
   }
 
   /**
+   * Imperative reveal for a file (note) — switches to the Notes panel,
+   * expands the note's ancestor folders, selects it, and scrolls it into
+   * view. Used by the tab context menu's "Reveal in Sidebar" (the in-app
+   * counterpart to "Reveal in Finder"). Doesn't open the note — it's
+   * already open if you're revealing its tab.
+   */
+  export async function revealFile(relativePath: string): Promise<void> {
+    if (!relativePath) return;
+    activePanel = 'notes';
+    if (rootName && !rootExpanded) rootExpanded = true;
+    // Expand every ANCESTOR folder — drop the filename itself (not a folder).
+    const parts = relativePath.split('/').filter(Boolean);
+    parts.pop();
+    const patch: Record<string, boolean> = {};
+    let acc = '';
+    for (const part of parts) {
+      acc = acc ? `${acc}/${part}` : part;
+      if (!expanded[acc]) patch[acc] = true;
+    }
+    if (Object.keys(patch).length > 0) {
+      expanded = { ...expanded, ...patch };
+    }
+    selectionStore.setSingle(relativePath);
+    await scrollPathIntoView(relativePath);
+  }
+
+  /**
    * Look up a node by its relative path. Linear walk; the tree is
    * small enough (typical thoughtbase < 5k notes) that the `Map`
    * variant in `sidebar-tree-utils` would be over-engineering for


### PR DESCRIPTION
Two small menu bugs, both reported from use.

## 1. "Reveal in Sidebar" opened Finder

The tab right-click menu's **Reveal in Sidebar** called `api.shell.revealFile`, which opens the OS file manager — so it (a) did nothing in-app and (b) duplicated the adjacent **Reveal in Finder** item, which runs the identical call. The handler is even named `handleRevealInSidebar`; the in-app file tree was always the intent.

- **`Sidebar.revealFile(relativePath)`** (new) — switches to the Notes panel, expands the note's **ancestor folders**, **selects** it (`setSingle`), and scrolls it into view. It's the file-level sibling of the existing `revealFolder`.
- `handleRevealInSidebar` now calls `sidebar?.revealFile(...)`.

**Verified live** (screenshot): revealing a note buried two folders deep expands `research/deep` and highlights `buried` in the tree — `rowVisibleAfterReveal: true, rowSelected: true`, no errors. The two menu items now do distinct, sensible things (in-app tree vs. OS file manager).

## 2. Two "Toggle Full Screen" items in the View menu

macOS auto-injects its own Enter/Exit Full Screen item into the View menu, so the explicit `{ role: 'togglefullscreen' }` was a duplicate. It's the **only** one in code — the other comes from the OS — so removing the explicit one on macOS leaves exactly the native item. Kept off macOS (Windows/Linux get no native one):

```ts
...(isMac ? [] : [{ role: 'togglefullscreen' }, { type: 'separator' }]),
```

(The native menu bar isn't automatable, but the reasoning is airtight from the symptom: two visible, one in code.)

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)