### PR TITLE
feat: embed YouTube videos as click-to-open poster cards (#904)

### DIFF
--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -17,6 +17,7 @@ import hljs from 'highlight.js';
 import { buildLinkResolverContext } from '../../link-resolver';
 import { installMath } from '../../../../shared/markdown/math-plugin';
 import { renderVegaBlocks } from '../../vega-render';
+import { renderYouTubeBlocks } from '../../youtube-render';
 import type { ExportPlanFile, ExportPlan } from '../../types';
 import type { CitationRenderer } from '../../csl';
 
@@ -36,7 +37,11 @@ export async function renderNoteBody(
   // #831 — pre-render ```vega-lite / ```vega fences to static SVG images
   // before markdown rendering (md.render is sync; vega's toSVG is async).
   // The result is `<img>` markdown, so it survives the `html: false` instance.
-  const bodyMarkdown = await renderVegaBlocks(stripFrontmatter(file.content), { rootPath: plan.rootPath });
+  const withCharts = await renderVegaBlocks(stripFrontmatter(file.content), { rootPath: plan.rootPath });
+  // #904 — degrade `youtube` fences to a linked thumbnail (an `<img>` in a
+  // link, so it survives `html: false`). Sync; order vs. Vega is irrelevant —
+  // the two operate on disjoint fence languages.
+  const bodyMarkdown = renderYouTubeBlocks(withCharts);
   return md.render(bodyMarkdown);
 }
 

--- a/src/main/publish/youtube-render.ts
+++ b/src/main/publish/youtube-render.ts
@@ -1,0 +1,56 @@
+/**
+ * Export-time degrade for `youtube` fences (#904).
+ *
+ * In the app a `youtube` fence renders an interactive poster card whose click
+ * opens the browser (youtube-embed.ts). That DOM is meaningless in an exported
+ * file, so on export each fence becomes a plain linked thumbnail —
+ * `[![caption](thumb.jpg)](watch-url)` — which survives the exporter's
+ * `html: false` markdown-it (it's an image wrapped in a link, no raw HTML) and
+ * stays click-to-open for a reader viewing the artifact online.
+ *
+ * Synchronous, unlike the Vega pre-pass: there's no library to load and no
+ * rendering to do, just URL parsing. A fence whose URL doesn't parse degrades
+ * to an italic note rather than a broken image.
+ */
+
+import { parseYouTubeUrl, thumbnailUrl } from '../../shared/youtube/youtube';
+
+// A fenced ```youtube block at line start. Mirrors VEGA_FENCE_RE in
+// vega-render.ts so the two pre-passes recognize fences identically.
+const YOUTUBE_FENCE_RE = /^```youtube[ \t]*\r?\n([\s\S]*?)\r?\n```[ \t]*$/gm;
+
+/** Cheap gate: does this markdown contain any `youtube` fence? */
+export function hasYouTubeBlocks(markdown: string): boolean {
+  YOUTUBE_FENCE_RE.lastIndex = 0;
+  return YOUTUBE_FENCE_RE.test(markdown);
+}
+
+/**
+ * Replace every `youtube` fence with a linked-thumbnail markdown image. Returns
+ * the input unchanged when there are no such fences.
+ */
+export function renderYouTubeBlocks(markdown: string): string {
+  if (!hasYouTubeBlocks(markdown)) return markdown;
+
+  YOUTUBE_FENCE_RE.lastIndex = 0;
+  return markdown.replace(YOUTUBE_FENCE_RE, (_full, body: string) => renderOne(body));
+}
+
+function renderOne(body: string): string {
+  const lines = body.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+  const urlLine = lines[0] ?? '';
+  const caption = lines.slice(1).join(' ').trim();
+
+  const ref = parseYouTubeUrl(urlLine);
+  if (!ref) {
+    return `*Video could not be embedded: unrecognized YouTube URL (${escapeMd(urlLine || body.trim())}).*`;
+  }
+
+  const alt = caption || 'Watch on YouTube';
+  return `[![${escapeMd(alt)}](${thumbnailUrl(ref.id)})](${ref.url})`;
+}
+
+/** Escape the characters that would break out of the `![alt](url)` syntax. */
+function escapeMd(s: string): string {
+  return s.replace(/([[\]()\\])/g, '\\$1');
+}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -28,7 +28,7 @@
     insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage,
     insertWikiLink, insertTypedLinks, insertCallouts, insertCardCallout,
     insertSparqlQuery, insertSqlQuery, insertPythonScript, insertMermaidDiagram,
-    vegaLiteInserts,
+    insertYouTubeEmbed, vegaLiteInserts,
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
@@ -1071,6 +1071,7 @@
         </div>
         <button onclick={() => runCmd(insertPythonScript)}>Python Script</button>
         <button onclick={() => runCmd(insertMermaidDiagram)}>Mermaid Diagram</button>
+        <button onclick={() => runCmd(insertYouTubeEmbed)}>YouTube Video</button>
         <button onclick={() => runCmd(insertCardCallout)}>Flashcard</button>
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
           <span class="submenu-trigger">Chart...<Icon name="chevronRight" size={10} /></span>

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -21,6 +21,7 @@
   import { installWikiLinks, installNoteTags } from '../markdown/inline-tokens-plugin';
   import { hydrateMermaidBlocks, invalidateMermaidTheme } from '../markdown/mermaid-renderer';
   import { hydrateVegaBlocks, invalidateVegaTheme } from '../markdown/vega-renderer';
+  import { renderYouTubeFence } from '../markdown/youtube-embed';
   import { detectDataSource } from '../../../shared/vega/data-binding';
   import { slugify } from '../../../shared/slug';
   import { api } from '../ipc/client';
@@ -383,6 +384,13 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
           + `</div>\n`;
       }
       return `${block}\n`;
+    }
+
+    // A `youtube` fence renders a click-to-open poster card (#904) — thumbnail
+    // + ▶, opens in the browser on click. No live iframe, so no CSP change; the
+    // card is self-explanatory, so it skips the code-fence toolbar wrapper.
+    if (info === 'youtube') {
+      return `${renderYouTubeFence(tok.content ?? '')}\n`;
     }
 
     // Runnable fences (python / sparql / sql) get a toolbar with a ▶
@@ -1114,6 +1122,18 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         }
         return;
       }
+    }
+
+    // YouTube poster card (#904) — open the video in the real browser rather
+    // than navigating the renderer. `data-youtube-url` is a normalized
+    // youtube.com watch URL; openExternal's main-process handler re-validates
+    // it's http(s) before handing off to the OS.
+    const ytEmbed = el.closest<HTMLElement>('.youtube-embed');
+    if (ytEmbed) {
+      e.preventDefault();
+      const url = ytEmbed.getAttribute('data-youtube-url');
+      if (url) void api.shell.openExternal(url);
+      return;
     }
 
     // DOI link click — the doi-plugin auto-linker rendered this. The

--- a/src/renderer/lib/editor/formatting.ts
+++ b/src/renderer/lib/editor/formatting.ts
@@ -396,6 +396,7 @@ export const insertSparqlQuery: Command = makeInsertFence('sparql');
 export const insertSqlQuery: Command = makeInsertFence('sql');
 export const insertPythonScript: Command = makeInsertFence('python');
 export const insertMermaidDiagram: Command = makeInsertFence('mermaid');
+export const insertYouTubeEmbed: Command = makeInsertFence('youtube');
 
 // ── Vega-Lite chart scaffolds (#830) ───────────────────────────────────────
 //

--- a/src/renderer/lib/markdown/youtube-embed.ts
+++ b/src/renderer/lib/markdown/youtube-embed.ts
@@ -1,0 +1,61 @@
+/**
+ * Renderer-side poster card for a `youtube` fence (#904, Tier 1).
+ *
+ * The fence rule in `Preview.svelte` calls `renderYouTubeFence` with the fence
+ * body and splices the returned HTML straight into the preview. The card is an
+ * `<a href>` so it's keyboard-focusable and Enter-activates for free; the
+ * preview's delegated click handler intercepts `.youtube-embed`,
+ * `preventDefault`s, and routes to `api.shell.openExternal` — nothing
+ * third-party loads inside the renderer, so the CSP's `frame-src 'none'` stays
+ * intact. (`will-navigate` in the main process would open the href externally
+ * too, but handling it explicitly keeps the behavior testable and obvious.)
+ *
+ * The fence body is `<url>` on the first non-empty line, with any remaining
+ * lines used as an optional caption — we can't fetch the real title without a
+ * network round-trip, which this tier deliberately avoids.
+ */
+
+import { parseYouTubeUrl, thumbnailUrl } from '../../../shared/youtube/youtube';
+
+/** Build the poster-card HTML for a `youtube` fence body, or an inline error
+ *  if the URL doesn't parse as a YouTube video. */
+export function renderYouTubeFence(body: string): string {
+  const lines = body.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+  const urlLine = lines[0] ?? '';
+  const caption = lines.slice(1).join(' ').trim();
+
+  const ref = parseYouTubeUrl(urlLine);
+  if (!ref) {
+    return `<div class="youtube-embed-error" role="alert">`
+      + `<strong>Unrecognized YouTube URL</strong>`
+      + `<pre>${escapeHtml(urlLine || body.trim())}</pre>`
+      + `</div>`;
+  }
+
+  const thumb = thumbnailUrl(ref.id);
+  const label = caption || 'Watch on YouTube';
+  // `ref.url` and `thumb` are built from a validated 11-char id, so they carry
+  // no user-controlled characters; `label` is user text and must be escaped.
+  return `<a class="youtube-embed" href="${escapeAttr(ref.url)}" data-youtube-url="${escapeAttr(ref.url)}"`
+    + ` target="_blank" rel="noopener noreferrer" title="${escapeAttr(label)} — opens in your browser">`
+    + `<span class="youtube-embed-thumb">`
+    + `<img src="${escapeAttr(thumb)}" alt="${escapeAttr(label)}" loading="lazy" />`
+    + `<span class="youtube-embed-play" aria-hidden="true"></span>`
+    + `</span>`
+    + `<span class="youtube-embed-caption">`
+    + `<span class="youtube-embed-label">${escapeHtml(label)}</span>`
+    + `<span class="youtube-embed-host">youtube.com</span>`
+    + `</span>`
+    + `</a>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s).replace(/"/g, '&quot;');
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -400,6 +400,108 @@ mark.hl-orange { background: color-mix(in oklch, var(--hl-orange) 30%, transpare
   font-size: 11px;
 }
 
+/* YouTube click-to-open poster card (#904). A thumbnail with a ▶ badge that
+   opens the video in the real browser on click — no live iframe, no CSP
+   change. Sized like a media block, not a code fence. */
+.youtube-embed {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 560px;
+  margin: 12px 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  background: var(--bg-button);
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.youtube-embed:hover,
+.youtube-embed:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+  outline: none;
+}
+.youtube-embed-thumb {
+  position: relative;
+  display: block;
+  aspect-ratio: 16 / 9;
+  background: #000;
+}
+.youtube-embed-thumb img {
+  width: 100%;
+  height: 100%;
+  /* hqdefault is 4:3 with letterbox bars; cover crops to the 16:9 frame. */
+  object-fit: cover;
+  display: block;
+}
+/* ▶ play badge: a rounded red lozenge with a white triangle, centered. */
+.youtube-embed-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 54px;
+  height: 38px;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 10px;
+  transition: background 0.12s ease;
+}
+.youtube-embed:hover .youtube-embed-play,
+.youtube-embed:focus-visible .youtube-embed-play {
+  background: #f00;
+}
+.youtube-embed-play::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-40%, -50%);
+  border-style: solid;
+  border-width: 9px 0 9px 15px;
+  border-color: transparent transparent transparent #fff;
+}
+.youtube-embed-caption {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+}
+.youtube-embed-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.youtube-embed-host {
+  flex: none;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.youtube-embed-error {
+  width: 100%;
+  padding: 8px 12px;
+  margin: 12px 0;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-button);
+  color: var(--text);
+  font-size: 12px;
+  border-radius: 4px;
+  text-align: left;
+}
+.youtube-embed-error pre {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 /* Footnote hover preview tooltip in the editor (#484). CodeMirror
    tooltips mount outside the editor's scoped CSS, so the styling
    lives here alongside the other shared markdown surfaces. */

--- a/src/shared/youtube/youtube.ts
+++ b/src/shared/youtube/youtube.ts
@@ -1,0 +1,103 @@
+/**
+ * YouTube URL parsing + thumbnail helpers (#904).
+ *
+ * Tier 1 "click-to-open" embeds: a `youtube` fence's URL is parsed to a video
+ * id here, the renderer draws a poster card (thumbnail + ▶) that opens the
+ * video in the real browser on click, and the exporter degrades the same fence
+ * to a linked thumbnail. Pure + shared so the renderer card, the export
+ * pre-pass, and their tests all agree on what counts as a YouTube URL.
+ *
+ * Deliberately no network: the title/duration would need a YouTube API call,
+ * which is exactly the phone-home this tier avoids. The thumbnail is a static
+ * `img.youtube.com` URL the page loads only when the note is viewed.
+ */
+
+export interface YouTubeRef {
+  /** The 11-character video id. */
+  id: string;
+  /**
+   * Canonical watch URL — tracking params stripped, timestamp preserved. This
+   * is what we hand to `shell.openExternal`, so it's normalized to a plain
+   * `youtube.com/watch?v=…` form rather than echoing arbitrary query junk.
+   */
+  url: string;
+  /** Start offset in seconds, when the source URL carried a `t=` / `start=`. */
+  start?: number;
+}
+
+// A YouTube video id is exactly 11 chars of the URL-safe base64 alphabet.
+const ID_RE = /^[A-Za-z0-9_-]{11}$/;
+
+// Hosts we accept. `youtube-nocookie.com` is included so a privacy-embed URL a
+// user pasted still resolves; `m.` / `www.` are normalized off before this set.
+const WATCH_HOSTS = new Set(['youtube.com', 'youtube-nocookie.com']);
+
+/**
+ * Parse a YouTube URL into a `{ id, url, start? }`, or `null` if it isn't one
+ * we recognize. Accepts the common shapes:
+ *   - `youtube.com/watch?v=ID`
+ *   - `youtu.be/ID`
+ *   - `youtube.com/embed/ID`, `/shorts/ID`, `/live/ID`
+ * and tolerates extra query params (`&t=`, `&list=`, …). A `t=` / `start=`
+ * offset is preserved on the canonical URL so "start at 1:30" survives.
+ */
+export function parseYouTubeUrl(input: string): YouTubeRef | null {
+  const raw = input.trim();
+  if (!raw) return null;
+
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+
+  const host = u.hostname.replace(/^(www\.|m\.)/, '').toLowerCase();
+  let id: string | null = null;
+  if (host === 'youtu.be') {
+    id = u.pathname.slice(1).split('/')[0];
+  } else if (WATCH_HOSTS.has(host)) {
+    if (u.pathname === '/watch') {
+      id = u.searchParams.get('v');
+    } else {
+      const m = u.pathname.match(/^\/(embed|shorts|live|v)\/([^/]+)/);
+      if (m) id = m[2];
+    }
+  }
+  if (!id || !ID_RE.test(id)) return null;
+
+  const start = parseStart(u.searchParams.get('t') ?? u.searchParams.get('start'));
+  const url = start != null
+    ? `https://www.youtube.com/watch?v=${id}&t=${start}s`
+    : `https://www.youtube.com/watch?v=${id}`;
+  return start != null ? { id, url, start } : { id, url };
+}
+
+/**
+ * Parse a YouTube timestamp into seconds. Accepts bare seconds (`90`, `90s`)
+ * and the colloquial `1h2m3s` / `2m30s` / `45s` forms. Returns undefined for
+ * anything unrecognized or zero-length.
+ */
+function parseStart(t: string | null): number | undefined {
+  if (!t) return undefined;
+  if (/^\d+$/.test(t)) {
+    const n = parseInt(t, 10);
+    return n > 0 ? n : undefined;
+  }
+  const m = t.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!m || (!m[1] && !m[2] && !m[3])) return undefined;
+  const secs = (parseInt(m[1] ?? '0', 10) * 3600)
+    + (parseInt(m[2] ?? '0', 10) * 60)
+    + parseInt(m[3] ?? '0', 10);
+  return secs > 0 ? secs : undefined;
+}
+
+/**
+ * The poster thumbnail for a video id. `hqdefault.jpg` exists for every public
+ * video (480×360), served over https so it loads under the renderer's
+ * `img-src https:` without any CSP change.
+ */
+export function thumbnailUrl(id: string): string {
+  return `https://img.youtube.com/vi/${id}/hqdefault.jpg`;
+}

--- a/tests/main/publish/youtube-render.test.ts
+++ b/tests/main/publish/youtube-render.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { renderYouTubeBlocks, hasYouTubeBlocks } from '../../../src/main/publish/youtube-render';
+
+const ID = 'dQw4w9WgXcQ';
+
+describe('renderYouTubeBlocks (export degrade)', () => {
+  it('replaces a youtube fence with a linked-thumbnail markdown image', () => {
+    const md = '# Note\n\n```youtube\nhttps://youtu.be/' + ID + '\n```\n\nAfter.';
+    const out = renderYouTubeBlocks(md);
+    expect(out).toContain(
+      `[![Watch on YouTube](https://img.youtube.com/vi/${ID}/hqdefault.jpg)](https://www.youtube.com/watch?v=${ID})`,
+    );
+    // Surrounding prose is preserved; the fence is gone.
+    expect(out).toContain('# Note');
+    expect(out).toContain('After.');
+    expect(out).not.toContain('```youtube');
+  });
+
+  it('uses the fence caption as the image alt text', () => {
+    const md = '```youtube\nhttps://www.youtube.com/watch?v=' + ID + '\nMy Talk\n```';
+    expect(renderYouTubeBlocks(md)).toContain(`[![My Talk](https://img.youtube.com/vi/${ID}/hqdefault.jpg)]`);
+  });
+
+  it('degrades a bad URL to an italic note rather than a broken image', () => {
+    const md = '```youtube\nhttps://vimeo.com/12345\n```';
+    const out = renderYouTubeBlocks(md);
+    expect(out).toContain('Video could not be embedded');
+    expect(out).not.toContain('img.youtube.com');
+  });
+
+  it('leaves markdown without youtube fences untouched', () => {
+    const md = '# Just text\n\n```python\nprint(1)\n```\n';
+    expect(renderYouTubeBlocks(md)).toBe(md);
+    expect(hasYouTubeBlocks(md)).toBe(false);
+  });
+
+  it('handles multiple fences in one document', () => {
+    const md = '```youtube\nhttps://youtu.be/' + ID + '\n```\n\n```youtube\nhttps://youtu.be/' + ID + '\n```';
+    const matches = renderYouTubeBlocks(md).match(/img\.youtube\.com/g);
+    expect(matches).toHaveLength(2);
+  });
+});

--- a/tests/renderer/markdown/youtube-embed.test.ts
+++ b/tests/renderer/markdown/youtube-embed.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { renderYouTubeFence } from '../../../src/renderer/lib/markdown/youtube-embed';
+
+const ID = 'dQw4w9WgXcQ';
+
+describe('renderYouTubeFence', () => {
+  it('renders a poster card anchor with the canonical URL and thumbnail', () => {
+    const html = renderYouTubeFence(`https://youtu.be/${ID}`);
+    expect(html).toContain('class="youtube-embed"');
+    expect(html).toContain(`href="https://www.youtube.com/watch?v=${ID}"`);
+    expect(html).toContain(`data-youtube-url="https://www.youtube.com/watch?v=${ID}"`);
+    expect(html).toContain(`src="https://img.youtube.com/vi/${ID}/hqdefault.jpg"`);
+    expect(html).toContain('youtube-embed-play');
+    // Opens externally, never frames in-app.
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it('uses a caption from the fence body, defaulting to "Watch on YouTube"', () => {
+    expect(renderYouTubeFence(`https://youtu.be/${ID}`)).toContain('>Watch on YouTube<');
+    const captioned = renderYouTubeFence(`https://youtu.be/${ID}\nRick Astley — Never Gonna Give You Up`);
+    expect(captioned).toContain('>Rick Astley — Never Gonna Give You Up<');
+  });
+
+  it('escapes a caption so it cannot inject markup', () => {
+    const html = renderYouTubeFence(`https://youtu.be/${ID}\n<img src=x onerror=alert(1)>`);
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img src=x');
+  });
+
+  it('renders an inline error for a non-YouTube URL (escaped)', () => {
+    const html = renderYouTubeFence('https://example.com/<script>');
+    expect(html).toContain('youtube-embed-error');
+    expect(html).toContain('Unrecognized YouTube URL');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/tests/shared/youtube/youtube.test.ts
+++ b/tests/shared/youtube/youtube.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseYouTubeUrl, thumbnailUrl } from '../../../src/shared/youtube/youtube';
+
+describe('parseYouTubeUrl', () => {
+  const ID = 'dQw4w9WgXcQ';
+
+  it('parses the canonical watch URL', () => {
+    expect(parseYouTubeUrl(`https://www.youtube.com/watch?v=${ID}`)).toEqual({
+      id: ID,
+      url: `https://www.youtube.com/watch?v=${ID}`,
+    });
+  });
+
+  it('parses the short youtu.be form', () => {
+    expect(parseYouTubeUrl(`https://youtu.be/${ID}`)?.id).toBe(ID);
+  });
+
+  it('parses /embed/, /shorts/, /live/, /v/ paths', () => {
+    for (const path of ['embed', 'shorts', 'live', 'v']) {
+      expect(parseYouTubeUrl(`https://www.youtube.com/${path}/${ID}`)?.id).toBe(ID);
+    }
+  });
+
+  it('accepts youtube-nocookie and m. / bare hosts', () => {
+    expect(parseYouTubeUrl(`https://www.youtube-nocookie.com/embed/${ID}`)?.id).toBe(ID);
+    expect(parseYouTubeUrl(`https://m.youtube.com/watch?v=${ID}`)?.id).toBe(ID);
+    expect(parseYouTubeUrl(`https://youtube.com/watch?v=${ID}`)?.id).toBe(ID);
+  });
+
+  it('tolerates extra query params and normalizes away tracking junk', () => {
+    const ref = parseYouTubeUrl(`https://www.youtube.com/watch?v=${ID}&list=PLxyz&feature=share`);
+    // Only the canonical watch URL survives — list / feature are dropped.
+    expect(ref?.url).toBe(`https://www.youtube.com/watch?v=${ID}`);
+  });
+
+  it('preserves a timestamp from t= (seconds, 90s, and 1m30s forms)', () => {
+    expect(parseYouTubeUrl(`https://youtu.be/${ID}?t=90`)).toMatchObject({ start: 90, url: `https://www.youtube.com/watch?v=${ID}&t=90s` });
+    expect(parseYouTubeUrl(`https://youtu.be/${ID}?t=90s`)?.start).toBe(90);
+    expect(parseYouTubeUrl(`https://www.youtube.com/watch?v=${ID}&t=1m30s`)?.start).toBe(90);
+    expect(parseYouTubeUrl(`https://www.youtube.com/watch?v=${ID}&t=1h2m3s`)?.start).toBe(3723);
+    expect(parseYouTubeUrl(`https://www.youtube.com/watch?v=${ID}&start=45`)?.start).toBe(45);
+  });
+
+  it('rejects non-YouTube and malformed URLs', () => {
+    expect(parseYouTubeUrl('https://vimeo.com/12345')).toBeNull();
+    expect(parseYouTubeUrl('https://example.com/watch?v=dQw4w9WgXcQ')).toBeNull();
+    expect(parseYouTubeUrl('not a url')).toBeNull();
+    expect(parseYouTubeUrl('')).toBeNull();
+    expect(parseYouTubeUrl('   ')).toBeNull();
+  });
+
+  it('rejects non-http(s) schemes (no javascript:/file: smuggling)', () => {
+    expect(parseYouTubeUrl(`javascript:alert(1)//youtube.com/watch?v=${ID}`)).toBeNull();
+    expect(parseYouTubeUrl(`file:///watch?v=${ID}`)).toBeNull();
+  });
+
+  it('rejects a watch URL with a wrong-length / missing id', () => {
+    expect(parseYouTubeUrl('https://www.youtube.com/watch?v=short')).toBeNull();
+    expect(parseYouTubeUrl('https://www.youtube.com/watch')).toBeNull();
+    expect(parseYouTubeUrl('https://youtu.be/')).toBeNull();
+  });
+});
+
+describe('thumbnailUrl', () => {
+  it('builds the https hqdefault thumbnail URL', () => {
+    expect(thumbnailUrl('dQw4w9WgXcQ')).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg');
+  });
+});


### PR DESCRIPTION
Closes #904.

## What

Tier 1 ("click-to-open") of the embedding-construct idea. A `youtube` fenced block renders a **poster card** — thumbnail + ▶ + caption — that opens the video in the user's real browser on click. **No live iframe, so the CSP's `frame-src 'none'` / `object-src 'none'` stay exactly as they are.** Nothing third-party loads when a note is viewed — this fits the existing privacy posture rather than relaxing it.

````
```youtube
https://www.youtube.com/watch?v=dQw4w9WgXcQ
Optional caption line
```
````

## How it fits the codebase

- **Shared parser** (`src/shared/youtube/youtube.ts`) — `parseYouTubeUrl` accepts `watch?v=`, `youtu.be/`, `/embed/`, `/shorts/`, `/live/`, and `nocookie` shapes; tolerates extra params; preserves a `t=`/`start=` timestamp on a normalized canonical URL (tracking junk dropped). `thumbnailUrl` builds the https `img.youtube.com/.../hqdefault.jpg` poster — loads under the existing `img-src https:`, **zero CSP change**.
- **Renderer card** (`youtube-embed.ts` + a `youtube` branch in Preview's fence dispatch) — an `<a href>` poster card (focusable, Enter-activates). Preview's delegated click handler intercepts `.youtube-embed` and routes to `api.shell.openExternal` (the main-process handler re-validates http(s)). Caption comes from the fence body's 2nd+ lines — deliberately no title fetch, since that's the phone-home this tier avoids — defaulting to "Watch on YouTube". A non-YouTube URL degrades to an inline error.
- **Export degrade** (`youtube-render.ts`, wired into the note-html exporter) — each fence becomes a linked-thumbnail markdown image `[![caption](thumb)](watch-url)` that survives the exporter's `html: false` and stays click-to-open. Mirrors the Vega export pre-pass.
- **Insert menu** — a "YouTube Video" entry alongside Mermaid / Flashcard.

## Out of scope (deliberately, per #904)

Tier 2 facade-embed / Tier 3 live iframe and the `frame-src` relaxation they'd need. Non-YouTube providers — the parser is structured so adding them later is mechanical.

## Verification

- New tests: parser (shapes, timestamps, scheme/host/id rejection), card render (canonical href, thumbnail, caption default + escaping, error case), export degrade (linked thumbnail, alt text, bad-URL note, multi-fence, passthrough).
- Full suite green (**3552**), lint clean.
- **Live-verified in the packaged app**: 2 cards render, the thumbnail loads under the live CSP, the malformed URL degrades inline, and **zero CSP violations** fire.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
