### PR TITLE
feat: DuckDB vector store + section chunking + incremental reindex (#835)

### DIFF
--- a/src/main/embeddings/chunk.ts
+++ b/src/main/embeddings/chunk.ts
@@ -1,0 +1,118 @@
+/**
+ * Section chunking for embeddings (#835).
+ *
+ * A note is split into section chunks — one per ATX heading, plus any preamble
+ * before the first heading — so semantic search can point at the *part* of a
+ * note that's relevant, not just the note. Each chunk carries a heading
+ * breadcrumb (`Parent > Child`) for display. Code fences are respected so a `#`
+ * inside ```…``` never starts a section (matches the graph heading extractor).
+ *
+ * A section longer than `maxChars` is sub-split on paragraph boundaries so its
+ * tail isn't lost to the model's token cap — each sub-chunk keeps the same
+ * breadcrumb and gets its own index. Pure + dependency-light (just a hash) so
+ * it's fast to test.
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface Chunk {
+  /** 0-based position of this chunk within the note (stable ordering). */
+  index: number;
+  /** Heading breadcrumb for display, e.g. `Background > Prior work`. Empty for
+   *  the pre-heading preamble. */
+  heading: string;
+  /** The chunk's markdown (heading line + body, or a paragraph group). */
+  text: string;
+  /** sha256 of the text — the incremental-reindex key (#835). */
+  hash: string;
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+const DEFAULT_MAX_CHARS = 1000;
+
+interface RawSection {
+  /** Heading stack at this section (ancestors + self), texts only. Empty for preamble. */
+  breadcrumb: string[];
+  lines: string[];
+}
+
+/**
+ * Split note `content` into section chunks. Frontmatter is stripped first.
+ * Returns `[]` for empty/whitespace-only notes.
+ */
+export function chunkMarkdown(content: string, opts: { maxChars?: number } = {}): Chunk[] {
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  const sections = splitIntoSections(stripFrontmatter(content));
+
+  const chunks: Chunk[] = [];
+  for (const section of sections) {
+    const heading = section.breadcrumb.join(' > ');
+    const text = section.lines.join('\n').trim();
+    if (text.length === 0) continue;
+
+    for (const piece of text.length > maxChars ? splitLong(text, maxChars) : [text]) {
+      const body = piece.trim();
+      if (body.length === 0) continue;
+      chunks.push({ index: chunks.length, heading, text: body, hash: sha256(body) });
+    }
+  }
+  return chunks;
+}
+
+/** Walk lines, tracking the heading stack + fenced-code state, emitting one
+ *  section per heading (and a leading preamble section). */
+function splitIntoSections(content: string): RawSection[] {
+  const sections: RawSection[] = [];
+  const stack: { level: number; text: string }[] = [];
+  let current: RawSection = { breadcrumb: [], lines: [] };
+  let inFence = false;
+
+  for (const line of content.split('\n')) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      current.lines.push(line);
+      continue;
+    }
+    const m = inFence ? null : line.match(HEADING_RE);
+    if (m) {
+      // Close the running section, open a new one under the updated stack.
+      sections.push(current);
+      const level = m[1].length;
+      const text = m[2].trim();
+      while (stack.length > 0 && stack[stack.length - 1].level >= level) stack.pop();
+      stack.push({ level, text });
+      current = { breadcrumb: stack.map((s) => s.text), lines: [line] };
+    } else {
+      current.lines.push(line);
+    }
+  }
+  sections.push(current);
+  return sections;
+}
+
+/** Sub-split an over-long section on blank-line (paragraph) boundaries, packing
+ *  paragraphs up to `maxChars`. A single huge paragraph is hard-sliced. */
+function splitLong(text: string, maxChars: number): string[] {
+  const paras = text.split(/\n\s*\n/);
+  const out: string[] = [];
+  let buf = '';
+  for (const para of paras) {
+    if (para.length > maxChars) {
+      if (buf) { out.push(buf); buf = ''; }
+      for (let i = 0; i < para.length; i += maxChars) out.push(para.slice(i, i + maxChars));
+      continue;
+    }
+    if (buf.length + para.length + 2 > maxChars) { out.push(buf); buf = ''; }
+    buf = buf ? `${buf}\n\n${para}` : para;
+  }
+  if (buf) out.push(buf);
+  return out;
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s, 'utf8').digest('hex');
+}

--- a/src/main/embeddings/shared-embedder.ts
+++ b/src/main/embeddings/shared-embedder.ts
@@ -1,0 +1,31 @@
+/**
+ * Process-wide embedder singleton (#835).
+ *
+ * The model is project-independent, so one worker serves every open project.
+ * Resolves the bundled-model location from electron (`process.resourcesPath`
+ * packaged, repo `resources/` in dev) and hands it to the off-thread service.
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import { createEmbedderService, type EmbedderService } from './embedder-service';
+
+let shared: EmbedderService | null = null;
+
+export function getSharedEmbedder(): EmbedderService {
+  if (!shared) {
+    // `app` is absent outside electron (unit tests) — fall back to the repo's
+    // resources dir so the dev/test path resolves the bundled model.
+    const resourcesBase = app?.isPackaged
+      ? path.join(process.resourcesPath, 'resources')
+      : path.join(process.cwd(), 'resources');
+    shared = createEmbedderService({ resourcesBase });
+  }
+  return shared;
+}
+
+export async function disposeSharedEmbedder(): Promise<void> {
+  const s = shared;
+  shared = null;
+  if (s) await s.dispose();
+}

--- a/src/main/embeddings/vector-store.ts
+++ b/src/main/embeddings/vector-store.ts
@@ -1,0 +1,257 @@
+/**
+ * Persisted DuckDB vector store + incremental indexer (#835).
+ *
+ * Per-section embeddings live in `.minerva/vectors.duckdb`, kept current on the
+ * existing per-file write seam. Three properties matter:
+ *
+ *  - **Persisted** — a file-backed DuckDB (not the in-memory CSV tables db), so
+ *    embeddings survive a project reopen.
+ *  - **Incremental + hashed** — `indexNote` re-embeds only chunks whose text
+ *    changed; an unchanged chunk's vector is carried over verbatim, position-
+ *    independent (keyed by content hash, not chunk index). Editing one section
+ *    of a big note costs one embedding, not N.
+ *  - **Offline brute-force KNN** — `array_cosine_distance` is a *core* DuckDB
+ *    function (1.5), so exact nearest-neighbour needs no VSS extension and no
+ *    network. At thoughtbase scale an exact scan is milliseconds; HNSW is
+ *    deferred until a corpus actually grows (#833).
+ *
+ * Rows carry `embedding_model`, so a model swap leaves old rows detectably stale
+ * (re-embedded lazily on next save; bulk backfill is #836).
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
+import type { ProjectContext } from '../project-context-types';
+import { MODEL } from './embedder';
+import { chunkMarkdown } from './chunk';
+
+/** The embedding capability the store needs — satisfied by `EmbedderService`. */
+export interface ChunkEmbedder {
+  readonly dim: number;
+  embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+export interface RelatedHit {
+  notePath: string;
+  sectionHeading: string;
+  chunkText: string;
+  /** Cosine similarity in [-1, 1]; higher is closer. */
+  score: number;
+}
+
+export interface VectorStoreInit {
+  /** Override the DB location (tests). Defaults to `<root>/.minerva/vectors.duckdb`. */
+  dbPath?: string;
+  /** The embedder; production passes the shared worker-backed service. */
+  embedder: ChunkEmbedder;
+}
+
+interface StoreState {
+  instance: DuckDBInstance;
+  connection: DuckDBConnection;
+  embedder: ChunkEmbedder;
+  model: string;
+  /** Serializes DB mutations so concurrent saves can't interleave a note's
+   *  read-modify-write. */
+  lock: Promise<unknown>;
+}
+
+const states = new Map<string, StoreState>();
+const TABLE = 'note_chunks';
+
+function defaultDbPath(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'vectors.duckdb');
+}
+
+/** Open (or create) the per-project vector DB and ensure the schema. Idempotent. */
+export async function init(ctx: ProjectContext, opts: VectorStoreInit): Promise<void> {
+  if (states.has(ctx.rootPath)) return;
+  const dbPath = opts.dbPath ?? defaultDbPath(ctx.rootPath);
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+
+  const instance = await DuckDBInstance.create(dbPath);
+  const connection = await instance.connect();
+  await connection.run(
+    `CREATE TABLE IF NOT EXISTS ${TABLE} (
+       note_path       VARCHAR NOT NULL,
+       chunk_index     INTEGER NOT NULL,
+       section_heading VARCHAR NOT NULL,
+       chunk_text      VARCHAR NOT NULL,
+       content_hash    VARCHAR NOT NULL,
+       embedding_model VARCHAR NOT NULL,
+       embedding       FLOAT[${MODEL.dim}] NOT NULL,
+       updated_at      TIMESTAMP NOT NULL
+     )`,
+  );
+  states.set(ctx.rootPath, {
+    instance,
+    connection,
+    embedder: opts.embedder,
+    model: MODEL.name,
+    lock: Promise.resolve(),
+  });
+}
+
+export function isEnabled(ctx: ProjectContext): boolean {
+  return states.has(ctx.rootPath);
+}
+
+/** Flush + close the project's DB. Idempotent. */
+export async function dispose(ctx: ProjectContext): Promise<void> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return;
+  states.delete(ctx.rootPath);
+  // Drain any in-flight mutation before closing the connection.
+  try { await state.lock; } catch { /* ignore */ }
+  try { state.connection.closeSync(); } catch { /* already closed */ }
+  try { state.instance.closeSync(); } catch { /* already closed */ }
+}
+
+/**
+ * Re-index a note's chunks. Re-embeds only chunks whose hash isn't already
+ * stored for this note under the current model; carries unchanged vectors over.
+ * Replacing the note's rows is transactional. Resilient — a failure logs and
+ * leaves the prior rows intact rather than throwing into the write pipeline.
+ */
+export async function indexNote(ctx: ProjectContext, relativePath: string, content: string): Promise<void> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return;
+  return runLocked(state, async () => {
+    try {
+      const chunks = chunkMarkdown(content);
+      if (chunks.length === 0) {
+        await deleteNote(state, relativePath);
+        return;
+      }
+
+      // Reuse vectors for chunks whose text is unchanged (same hash, same model).
+      const existing = await readExisting(state, relativePath);
+      const toEmbed = chunks.filter((c) => !existing.has(c.hash));
+      const fresh = toEmbed.length > 0
+        ? await state.embedder.embed(toEmbed.map((c) => c.text))
+        : [];
+      const freshByHash = new Map(toEmbed.map((c, i) => [c.hash, fresh[i]]));
+
+      const rows = chunks.map((c) => ({
+        chunk: c,
+        vec: existing.get(c.hash) ?? freshByHash.get(c.hash)!,
+      }));
+
+      await state.connection.run('BEGIN TRANSACTION');
+      try {
+        await deleteNote(state, relativePath);
+        await insertRows(state, relativePath, rows);
+        await state.connection.run('COMMIT');
+      } catch (err) {
+        await state.connection.run('ROLLBACK').catch(() => { /* ignore */ });
+        throw err;
+      }
+    } catch (err) {
+      console.warn(`[vectors] indexNote failed for ${relativePath}:`, err);
+    }
+  });
+}
+
+/** Drop a note's chunks (deletion / pre-rename). */
+export async function removeNote(ctx: ProjectContext, relativePath: string): Promise<void> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return;
+  return runLocked(state, async () => {
+    try {
+      await deleteNote(state, relativePath);
+    } catch (err) {
+      console.warn(`[vectors] removeNote failed for ${relativePath}:`, err);
+    }
+  });
+}
+
+/**
+ * Rank the chunks nearest to `query` (text → embedded first, or a vector) by
+ * cosine similarity. Only rows under the active model are considered, so stale
+ * rows never pollute results.
+ */
+export async function searchRelated(
+  ctx: ProjectContext,
+  query: string | Float32Array,
+  opts: { limit?: number; excludePath?: string } = {},
+): Promise<RelatedHit[]> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return [];
+  const limit = opts.limit ?? 10;
+  const vec = typeof query === 'string'
+    ? (await state.embedder.embed([query]))[0]
+    : query;
+  if (!vec) return [];
+
+  const where = [`embedding_model = ${lit(state.model)}`];
+  if (opts.excludePath) where.push(`note_path <> ${lit(opts.excludePath)}`);
+  const sql =
+    `SELECT note_path, section_heading, chunk_text, ` +
+    `array_cosine_distance(embedding, ${arrayLit(vec)}) AS dist ` +
+    `FROM ${TABLE} WHERE ${where.join(' AND ')} ORDER BY dist ASC LIMIT ${Math.floor(limit)}`;
+
+  const reader = await state.connection.runAndReadAll(sql);
+  const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
+  return rows.map((r) => ({
+    notePath: String(r.note_path),
+    sectionHeading: String(r.section_heading),
+    chunkText: String(r.chunk_text),
+    score: 1 - Number(r.dist),
+  }));
+}
+
+/** Test-only: the live connection, for asserting on raw rows. */
+export function _connectionForTest(ctx: ProjectContext): DuckDBConnection {
+  const state = states.get(ctx.rootPath);
+  if (!state) throw new Error('vector store not initialized');
+  return state.connection;
+}
+
+// ── internals ───────────────────────────────────────────────────────────────
+
+async function readExisting(state: StoreState, relativePath: string): Promise<Map<string, Float32Array>> {
+  const reader = await state.connection.runAndReadAll(
+    `SELECT content_hash, embedding FROM ${TABLE} ` +
+    `WHERE note_path = ${lit(relativePath)} AND embedding_model = ${lit(state.model)}`,
+  );
+  const out = new Map<string, Float32Array>();
+  for (const r of reader.getRowObjectsJS() as Record<string, unknown>[]) {
+    out.set(String(r.content_hash), Float32Array.from(r.embedding as number[]));
+  }
+  return out;
+}
+
+async function deleteNote(state: StoreState, relativePath: string): Promise<void> {
+  await state.connection.run(`DELETE FROM ${TABLE} WHERE note_path = ${lit(relativePath)}`);
+}
+
+async function insertRows(
+  state: StoreState,
+  relativePath: string,
+  rows: { chunk: { index: number; heading: string; text: string; hash: string }; vec: Float32Array }[],
+): Promise<void> {
+  if (rows.length === 0) return;
+  const values = rows.map(({ chunk, vec }) =>
+    `(${lit(relativePath)}, ${chunk.index}, ${lit(chunk.heading)}, ${lit(chunk.text)}, ` +
+    `${lit(chunk.hash)}, ${lit(state.model)}, ${arrayLit(vec)}, now())`,
+  );
+  await state.connection.run(`INSERT INTO ${TABLE} VALUES ${values.join(', ')}`);
+}
+
+function runLocked<T>(state: StoreState, fn: () => Promise<T>): Promise<T> {
+  const run = state.lock.then(fn, fn);
+  state.lock = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+/** Single-quote-escaped SQL string literal. */
+function lit(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+/** A `FLOAT[dim]` array literal from a vector. Values are finite normalized
+ *  floats, so plain `toString` is exact enough for FLOAT. */
+function arrayLit(vec: Float32Array): string {
+  return `[${Array.from(vec).join(',')}]::FLOAT[${MODEL.dim}]`;
+}

--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -6,6 +6,7 @@ import * as notebaseFs from '../notebase/fs';
 import { isIndexable } from '../notebase/indexable-files';
 import * as graph from '../graph/index';
 import * as search from '../search/index';
+import * as vectors from '../embeddings/vector-store';
 import { projectContext } from '../project-context-types';
 import { getRootPath, markPathHandled, windowsForProject } from '../window-manager';
 import type { WritePipelineHooks } from '../notebase/write-pipeline';
@@ -26,6 +27,7 @@ export async function reindexFile(rootPath: string, relativePath: string): Promi
   await graph.indexNote(ctx, relativePath, content);
   if (relativePath.endsWith('.md')) {
     search.indexNote(ctx, relativePath, content);
+    void vectors.indexNote(ctx, relativePath, content); // #835; no-op when disabled
   }
 }
 
@@ -34,6 +36,7 @@ export function removeFromIndexes(rootPath: string, relativePath: string): void 
   const ctx = projectContext(rootPath);
   search.removeNote(ctx, relativePath);
   graph.removeNote(ctx, relativePath);
+  void vectors.removeNote(ctx, relativePath); // #835; no-op when disabled
 }
 
 export async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -11,6 +11,7 @@ import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { writeAndReindex } from '../notebase/write-pipeline';
 import * as search from '../search/index';
+import * as vectors from '../embeddings/vector-store';
 import { clearRecentProjects } from '../recent-projects';
 import { rebuildMenu } from '../menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, markPathHandled, windowsForProject } from '../window-manager';
@@ -205,9 +206,15 @@ export function registerNotebase(): void {
     const { transitions, rewrittenPaths } = await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
       markPathHandled,
       reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
+        if (relPath.endsWith(".md")) {
+          search.indexNote(ctx, relPath, content);
+          void vectors.indexNote(ctx, relPath, content); // #835
+        }
       },
-      removeHook: (relPath) => search.removeNote(ctx, relPath),
+      removeHook: (relPath) => {
+        search.removeNote(ctx, relPath);
+        void vectors.removeNote(ctx, relPath); // #835
+      },
     });
 
     // Broadcast to every window showing this project so their editor tabs
@@ -238,9 +245,15 @@ export function registerNotebase(): void {
       separator,
       markPathHandled,
       reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
+        if (relPath.endsWith(".md")) {
+          search.indexNote(ctx, relPath, content);
+          void vectors.indexNote(ctx, relPath, content); // #835
+        }
       },
-      removeHook: (relPath) => search.removeNote(ctx, relPath),
+      removeHook: (relPath) => {
+        search.removeNote(ctx, relPath);
+        void vectors.removeNote(ctx, relPath); // #835
+      },
     });
     // Broadcast: source disappeared (RENAMED with one transition signals
     // editor tabs to drop / reroute) plus the rewritten set so other

--- a/src/main/notebase/write-pipeline.ts
+++ b/src/main/notebase/write-pipeline.ts
@@ -24,6 +24,7 @@
 import * as notebaseFs from './fs';
 import * as graph from '../graph/index';
 import * as search from '../search/index';
+import * as vectors from '../embeddings/vector-store';
 import { projectContext } from '../project-context-types';
 import type { HeadingRenameCandidate } from '../graph/index';
 
@@ -68,6 +69,9 @@ export async function writeAndReindex(
   await notebaseFs.writeFile(rootPath, relativePath, content);
   const { headingRenameCandidate } = await graph.indexNote(ctx, relativePath, content);
   search.indexNote(ctx, relativePath, content);
+  // Embeddings reindex (#835) — fire-and-forget so a save never blocks on the
+  // model. No-op when the vector store isn't initialized; resilient internally.
+  if (relativePath.endsWith('.md')) void vectors.indexNote(ctx, relativePath, content);
   if (!opts.skipPersist) {
     await search.persist(ctx);
   }

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -13,6 +13,8 @@
 import * as graph from './graph/index';
 import * as search from './search/index';
 import * as tables from './sources/tables';
+import * as vectors from './embeddings/vector-store';
+import { getSharedEmbedder } from './embeddings/shared-embedder';
 import * as healthChecks from './graph/health-checks';
 import * as conversation from './llm/conversation';
 import { projectContext, type ProjectContext } from './project-context-types';
@@ -52,6 +54,16 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
     const initPromise = (async () => {
       await graph.initGraph(ctx);
       await tables.initTablesDb(ctx);
+      // Vector store (#835): open the persisted embeddings DB + schema. Cheap —
+      // no model load (the embedder is lazy). Existing notes are embedded
+      // incrementally on save, or in bulk by the backfill (#836); opening a
+      // project doesn't eagerly embed the corpus. Non-fatal: semantic search is
+      // an enhancement, so a store-open failure must never block project open.
+      try {
+        await vectors.init(ctx, { embedder: getSharedEmbedder() });
+      } catch (err) {
+        console.warn(`[project-context] vector store init failed for ${rootPath}:`, err);
+      }
       conversation.initConversations(rootPath);
       // graph.indexAllNotes resets the rdflib store (`state.store = $rdf.graph()`)
       // then rebuilds it; registerAllCsvs writes the CSV table-schema overlay to
@@ -109,6 +121,7 @@ export async function releaseProject(rootPath: string, winId: number): Promise<v
   tables.disposeProject(rec.ctx);
   search.disposeProject(rec.ctx);
   graph.disposeProject(rec.ctx);
+  await vectors.dispose(rec.ctx); // flush + close the embeddings DB (#835)
   projects.delete(rootPath);
 }
 

--- a/tests/main/embeddings/chunk.test.ts
+++ b/tests/main/embeddings/chunk.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { chunkMarkdown } from '../../../src/main/embeddings/chunk';
+
+describe('chunkMarkdown', () => {
+  it('splits a note into one chunk per heading with breadcrumbs', () => {
+    const md = [
+      '# Title', 'Intro line.', '',
+      '## Background', 'Some background.', '',
+      '### Prior work', 'Details here.', '',
+      '## Method', 'How it works.',
+    ].join('\n');
+    const chunks = chunkMarkdown(md);
+    expect(chunks.map((c) => c.heading)).toEqual([
+      'Title',
+      'Title > Background',
+      'Title > Background > Prior work',
+      'Title > Method',
+    ]);
+    // The heading line is part of the embedded text.
+    expect(chunks[1].text).toContain('## Background');
+    expect(chunks[1].text).toContain('Some background.');
+    // Indices are sequential.
+    expect(chunks.map((c) => c.index)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('captures preamble before the first heading as its own chunk', () => {
+    const chunks = chunkMarkdown('Loose intro paragraph.\n\n# First\nBody.');
+    expect(chunks[0].heading).toBe('');
+    expect(chunks[0].text).toBe('Loose intro paragraph.');
+  });
+
+  it('strips frontmatter', () => {
+    const chunks = chunkMarkdown('---\ntitle: X\ntags: [a]\n---\n# Head\nBody.');
+    expect(chunks.every((c) => !c.text.includes('tags:'))).toBe(true);
+    expect(chunks[0].heading).toBe('Head');
+  });
+
+  it('does not treat # inside a code fence as a heading', () => {
+    const md = '# Real\ntext\n\n```python\n# this is a comment\nx = 1\n```\nmore';
+    const chunks = chunkMarkdown(md);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].heading).toBe('Real');
+    expect(chunks[0].text).toContain('# this is a comment');
+  });
+
+  it('pops the heading stack correctly when levels decrease', () => {
+    const md = '# A\n\n## B\n\n### C\n\n## D';
+    const headings = chunkMarkdown(md).map((c) => c.heading);
+    expect(headings).toEqual(['A', 'A > B', 'A > B > C', 'A > D']);
+  });
+
+  it('sub-splits an over-long section, preserving the breadcrumb', () => {
+    const para = (n: number) => `Paragraph ${n} ` + 'word '.repeat(40);
+    const md = '# Big\n\n' + [1, 2, 3, 4].map(para).join('\n\n');
+    const chunks = chunkMarkdown(md, { maxChars: 200 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.heading === 'Big')).toBe(true);
+    expect(chunks.every((c) => c.text.length <= 200 + 50)).toBe(true);
+    expect(chunks.map((c) => c.index)).toEqual(chunks.map((_, i) => i));
+  });
+
+  it('gives identical text the same hash and different text different hashes', () => {
+    const a = chunkMarkdown('# H\nsame body');
+    const b = chunkMarkdown('# H\nsame body');
+    const c = chunkMarkdown('# H\ndifferent body');
+    expect(a[0].hash).toBe(b[0].hash);
+    expect(a[0].hash).not.toBe(c[0].hash);
+  });
+
+  it('returns [] for empty or whitespace-only content', () => {
+    expect(chunkMarkdown('')).toEqual([]);
+    expect(chunkMarkdown('   \n\n  ')).toEqual([]);
+    expect(chunkMarkdown('---\ntitle: x\n---\n')).toEqual([]);
+  });
+});

--- a/tests/main/embeddings/vector-store.test.ts
+++ b/tests/main/embeddings/vector-store.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as store from '../../../src/main/embeddings/vector-store';
+import type { ChunkEmbedder } from '../../../src/main/embeddings/vector-store';
+import { MODEL, modelDir } from '../../../src/main/embeddings/embedder';
+import { projectContext } from '../../../src/main/project-context-types';
+
+/** Deterministic bag-of-words hashing embedder: shared words → higher cosine,
+ *  so ranking is meaningful, and it records what it was asked to embed. */
+function fakeEmbedder(): ChunkEmbedder & { calls: string[][] } {
+  const calls: string[][] = [];
+  return {
+    dim: MODEL.dim,
+    calls,
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      calls.push(texts);
+      return texts.map((t) => {
+        const v = new Float32Array(MODEL.dim);
+        for (const w of t.toLowerCase().split(/\W+/).filter(Boolean)) {
+          let h = 0;
+          for (const ch of w) h = (h * 31 + ch.charCodeAt(0)) >>> 0;
+          v[h % MODEL.dim] += 1;
+        }
+        const n = Math.hypot(...v);
+        if (n > 0) for (let i = 0; i < MODEL.dim; i++) v[i] /= n;
+        return v;
+      });
+    },
+  };
+}
+
+let dir: string;
+let dbPath: string;
+const ctx = () => projectContext(dir);
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-vec-'));
+  dbPath = path.join(dir, '.minerva', 'vectors.duckdb');
+});
+afterEach(async () => {
+  await store.dispose(ctx());
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('vector-store', () => {
+  it('embeds a note\'s sections and finds them by similarity', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'animals.md', [
+      '# Animals', '',
+      '## Cats', 'Cats are feline predators that purr.', '',
+      '## Finance', 'Quarterly revenue and earnings reports.',
+    ].join('\n'));
+
+    const hits = await store.searchRelated(ctx(), 'feline predators purr', { limit: 1 });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].notePath).toBe('animals.md');
+    expect(hits[0].sectionHeading).toBe('Animals > Cats');
+    expect(hits[0].score).toBeGreaterThan(0.3);
+  });
+
+  it('re-embeds ONLY the changed section on re-index (hash skip)', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    const v1 = '# Doc\n\n## A\nalpha text\n\n## B\nbeta text';
+    await store.indexNote(ctx(), 'doc.md', v1);
+    const callsAfterFirst = embedder.calls.flat().length;
+    expect(callsAfterFirst).toBe(3); // preamble-less: A, B headings → 2 sections + the "# Doc" title section = 3
+
+    // Edit only section B.
+    embedder.calls.length = 0;
+    await store.indexNote(ctx(), 'doc.md', '# Doc\n\n## A\nalpha text\n\n## B\nbeta text CHANGED');
+    const reEmbedded = embedder.calls.flat();
+    expect(reEmbedded).toHaveLength(1);
+    expect(reEmbedded[0]).toContain('CHANGED');
+  });
+
+  it('reuses stored vectors verbatim when content is unchanged', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    const md = '# Topic\n\n## One\ncats and dogs\n\n## Two\nstocks and bonds';
+    await store.indexNote(ctx(), 'n.md', md);
+    const before = await store.searchRelated(ctx(), 'cats and dogs', { limit: 1 });
+
+    embedder.calls.length = 0;
+    await store.indexNote(ctx(), 'n.md', md); // identical → nothing re-embedded
+    expect(embedder.calls.flat()).toHaveLength(0);
+
+    const after = await store.searchRelated(ctx(), 'cats and dogs', { limit: 1 });
+    expect(after[0].notePath).toBe(before[0].notePath);
+    expect(after[0].score).toBeCloseTo(before[0].score, 6); // reused vectors identical
+  });
+
+  it('does not return rows stored under a different (stale) model', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'cur.md', '# Cur\nrelevant words here');
+    // Simulate a row left by a previous model: clone the current row with a
+    // different embedding_model so it's detectably stale.
+    const conn = store._connectionForTest(ctx());
+    await conn.run(
+      `INSERT INTO note_chunks SELECT note_path || '-old', chunk_index, section_heading, ` +
+      `chunk_text, content_hash, 'old-model-v0', embedding, updated_at FROM note_chunks`,
+    );
+    const hits = await store.searchRelated(ctx(), 'relevant words here', { limit: 10 });
+    expect(hits.every((h) => !h.notePath.endsWith('-old'))).toBe(true);
+  });
+
+  it('removes a note\'s chunks on removeNote', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'gone.md', '# Gone\nbody about cats');
+    expect(await store.searchRelated(ctx(), 'cats', { limit: 5 })).not.toHaveLength(0);
+    await store.removeNote(ctx(), 'gone.md');
+    expect(await store.searchRelated(ctx(), 'cats', { limit: 5 })).toHaveLength(0);
+  });
+
+  it('drops all chunks when a note becomes empty', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'n.md', '# H\nsome content');
+    await store.indexNote(ctx(), 'n.md', '   ');
+    expect(await store.searchRelated(ctx(), 'content', { limit: 5 })).toHaveLength(0);
+  });
+
+  it('honours excludePath', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'a.md', '# A\nshared topic words');
+    await store.indexNote(ctx(), 'b.md', '# B\nshared topic words');
+    const hits = await store.searchRelated(ctx(), 'shared topic words', { limit: 5, excludePath: 'a.md' });
+    expect(hits.every((h) => h.notePath !== 'a.md')).toBe(true);
+    expect(hits.some((h) => h.notePath === 'b.md')).toBe(true);
+  });
+
+  it('persists across reopen', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'keep.md', '# Keep\ndurable content about turtles');
+    await store.dispose(ctx());
+
+    // Reopen the same on-disk DB with a fresh embedder.
+    await store.init(ctx(), { dbPath, embedder: fakeEmbedder() });
+    const hits = await store.searchRelated(ctx(), 'durable turtles', { limit: 1 });
+    expect(hits[0]?.notePath).toBe('keep.md');
+  });
+});
+
+// Real-model end-to-end — needs the bundled weights (skipped without them).
+const haveModel = fs.existsSync(path.join(modelDir(), 'onnx', 'model_quantized.onnx'));
+const realDescribe = haveModel ? describe : describe.skip;
+
+realDescribe('vector-store with the real WASM embedder', () => {
+  it('ranks semantically related notes first', async () => {
+    const { createWasmEmbedder } = await import('../../../src/main/embeddings/wasm-embedder');
+    const embedder = await createWasmEmbedder();
+    try {
+      await store.init(ctx(), { dbPath, embedder });
+      await store.indexNote(ctx(), 'cat.md', '# Pets\nThe cat is a small domesticated feline that purrs.');
+      await store.indexNote(ctx(), 'fin.md', '# Markets\nQuarterly revenue exceeded analyst forecasts.');
+
+      const hits = await store.searchRelated(ctx(), 'a kitten meowing', { limit: 2 });
+      expect(hits[0].notePath).toBe('cat.md');
+      expect(hits[0].score).toBeGreaterThan(hits[1].score);
+    } finally {
+      await embedder.dispose();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #835. Foundation B of the semantic-search epic (#833) — stores per-section embeddings, keeps them current on every save, and exposes the cosine query API that #837 (`search_related`) and #838 (Related panel) will call.

## Pieces

- **Chunking** (`chunk.ts`) — split a note into section chunks by ATX heading with a `Parent > Child` breadcrumb. Code-fence aware (a `#` inside a ``` block never starts a section, matching the graph heading extractor); over-long sections sub-split on paragraph boundaries so their tail isn't lost to the model's 256-token cap. Each chunk carries a sha256 of its text — the incremental key.
- **Store** (`vector-store.ts`) — a **persisted** file-backed DuckDB at `.minerva/vectors.duckdb` (the CSV tables db is in-memory, so vectors need their own durable file). `indexNote` re-embeds **only chunks whose hash isn't already stored** under the current model, carrying unchanged vectors over verbatim and position-independently — so editing one section of a big note costs **one** embedding, not N. `searchRelated(text | vector, { limit, excludePath })` ranks by `array_cosine_distance`.
- **Query is offline + extension-free** — `array_cosine_distance` is a **core** DuckDB 1.5 function, so exact brute-force KNN needs no VSS extension and no network. (The issue mentioned `INSTALL vss` — skipped deliberately: `INSTALL` requires egress, and VSS only adds the HNSW index, which #833 defers. Exact scan is milliseconds at thoughtbase scale.) Rows carry `embedding_model` so a model swap leaves old rows **detectably stale**.

## Wiring (every path that mutates notes)

Fire-and-forget `vectors.indexNote` beside `search.indexNote` in the write pipeline + watcher reindex; `removeNote` on delete; both in the rename/merge hooks. All **no-op when the store isn't initialized**, so nothing else has to know about embeddings. The store opens on project acquire (**non-fatal** — a store-open failure never blocks project open) and closes on release. One shared worker-backed embedder serves all projects.

Saves embed incrementally; **opening a project does NOT eagerly embed the corpus** — that bulk backfill is #836.

## Tests

18 new: chunker (headings / breadcrumbs / fence-safety / long-section split / hashing), store (similarity ranking, hash-skip, **verbatim vector reuse**, delete, empty-note, excludePath, **persistence across reopen**, **stale-model filtering**) including a **real-embedder end-to-end** ranking check. Full suite green (**3602**), lint clean.

## Scope / next

- The `search_related` LLM tool (#837) and Related panel (#838) consume `searchRelated` — not in this PR.
- The end-to-end *packaged* save→embed→search flow (worker spawned from the bundled main) gets its real exercise once #837/#838 add a way to drive it from the UI; the worker itself was packaged-verified offline in #834, and the store rides the already-shipped `@duckdb/node-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)