### PR TITLE
feat: search_related LLM tool — semantic retrieval (#837)

### DIFF
--- a/src/main/embeddings/vector-store.ts
+++ b/src/main/embeddings/vector-store.ts
@@ -208,6 +208,40 @@ export function _connectionForTest(ctx: ProjectContext): DuckDBConnection {
   return state.connection;
 }
 
+/**
+ * "Find chunks related to this note" — rank every other note's chunks by their
+ * nearest distance to *any* of `notePath`'s own stored chunks. Reuses the
+ * already-stored vectors (no re-embedding). Returns chunk-level hits (the caller
+ * de-dups to best-per-note); `[]` if the note has no embedded chunks yet.
+ */
+export async function relatedToNote(
+  ctx: ProjectContext,
+  notePath: string,
+  opts: { limit?: number } = {},
+): Promise<RelatedHit[]> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return [];
+  const limit = Math.floor(opts.limit ?? 10);
+  const model = lit(state.model);
+  const sql =
+    `WITH q AS (SELECT embedding FROM ${TABLE} ` +
+    `WHERE note_path = ${lit(notePath)} AND embedding_model = ${model}) ` +
+    `SELECT t.note_path, t.section_heading, t.chunk_text, ` +
+    `MIN(array_cosine_distance(t.embedding, q.embedding)) AS dist ` +
+    `FROM ${TABLE} t, q ` +
+    `WHERE t.note_path <> ${lit(notePath)} AND t.embedding_model = ${model} ` +
+    `GROUP BY t.note_path, t.section_heading, t.chunk_text ` +
+    `ORDER BY dist ASC LIMIT ${limit}`;
+  const reader = await state.connection.runAndReadAll(sql);
+  const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
+  return rows.map((r) => ({
+    notePath: String(r.note_path),
+    sectionHeading: String(r.section_heading),
+    chunkText: String(r.chunk_text),
+    score: 1 - Number(r.dist),
+  }));
+}
+
 // ── internals ───────────────────────────────────────────────────────────────
 
 async function readExisting(state: StoreState, relativePath: string): Promise<Map<string, Float32Array>> {

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -4,6 +4,8 @@ import * as fs from '../notebase/fs';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
+import * as vectors from '../embeddings/vector-store';
+import type { RelatedHit } from '../embeddings/vector-store';
 import * as tables from '../sources/tables';
 import ONTOLOGY_TTL from '../../shared/ontology.ttl?raw';
 import THOUGHT_ONTOLOGY_TTL from '../../shared/ontology-thought.ttl?raw';
@@ -133,6 +135,41 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
         },
       },
       required: ['relative_path'],
+    },
+  },
+  {
+    name: 'search_related',
+    description:
+      'Semantic (meaning-based) search across the thoughtbase. Returns notes ' +
+      'whose content is conceptually similar to a query, even when they share ' +
+      'no keywords — embeddings, not text matching. Two modes: pass `query` ' +
+      'for free-text ("notes about how trust is established"), or `relative_path` ' +
+      'to find notes related to an existing note ("what else is like this one"). ' +
+      'Each result names the matched section and a similarity score (0–1).\n' +
+      'Choosing among the search tools: use search_related for "find things ' +
+      'like / about this" by meaning; use search_notes for exact keywords or ' +
+      'phrases; use query_graph for structural questions (links, tags, types, ' +
+      'claims). They complement each other — combine when unsure.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Free-text description of what to find, matched by meaning.',
+        },
+        relative_path: {
+          type: 'string',
+          description:
+            'Instead of `query`, find notes related to this note (uses the ' +
+            'note\'s own content as the query). The note itself is excluded.',
+        },
+        limit: {
+          type: 'integer',
+          description: 'Maximum number of notes to return. Defaults to 10.',
+          minimum: 1,
+          maximum: 50,
+        },
+      },
     },
   },
   {
@@ -754,6 +791,8 @@ export async function executeNotebaseTool(
         return { content: await runRead(ctx, input), isError: false };
       case 'query_graph':
         return runQuery(ctx, input);
+      case 'search_related':
+        return await runSearchRelated(ctx, input);
       case 'describe_graph_schema':
         return { content: runDescribeSchema(), isError: false };
       case 'describe_tables':
@@ -800,6 +839,71 @@ function runSearch(ctx: ToolContext, input: unknown): string {
       return `${i + 1}. ${r.title} (${r.relativePath})\n   ${snippet}`;
     })
     .join('\n');
+}
+
+async function runSearchRelated(
+  ctx: ToolContext,
+  input: unknown,
+): Promise<{ content: string; isError: boolean }> {
+  const { query, relative_path, limit } = input as {
+    query?: string; relative_path?: string; limit?: number;
+  };
+  const pctx = projectContext(ctx.rootPath);
+
+  if (!vectors.isEnabled(pctx)) {
+    return {
+      content: 'Semantic search is not available for this thoughtbase (embeddings are not initialized).',
+      isError: false,
+    };
+  }
+
+  const n = Math.min(Math.max(Math.floor(limit ?? 10), 1), 50);
+  let hits: RelatedHit[];
+  let descriptor: string;
+
+  if (typeof relative_path === 'string' && relative_path.trim()) {
+    // Over-fetch chunk-level hits so best-per-note de-dup still yields ~n notes.
+    hits = await vectors.relatedToNote(pctx, relative_path.trim(), { limit: n * 5 });
+    descriptor = `related to ${relative_path.trim()}`;
+    if (hits.length === 0) {
+      return {
+        content:
+          `No related notes found for "${relative_path.trim()}". The note may not be ` +
+          `indexed yet — semantic indexing runs in the background, so results can be ` +
+          `incomplete shortly after a note is created or the model changes.`,
+        isError: false,
+      };
+    }
+  } else if (typeof query === 'string' && query.trim()) {
+    hits = await vectors.searchRelated(pctx, query.trim(), { limit: n * 5 });
+    descriptor = `for "${query.trim()}"`;
+  } else {
+    throw new Error('Provide either `query` (free text) or `relative_path` (a note to find relatives of).');
+  }
+
+  const best = bestPerNote(hits).slice(0, n);
+  if (best.length === 0) {
+    return { content: `No semantically related notes found ${descriptor}.`, isError: false };
+  }
+  const body = best
+    .map((h, i) => {
+      const heading = h.sectionHeading || '(intro)';
+      const snippet = h.chunkText.replace(/\s+/g, ' ').trim().slice(0, 240);
+      return `${i + 1}. ${h.notePath} — ${heading} (similarity ${h.score.toFixed(2)})\n   ${snippet}`;
+    })
+    .join('\n');
+  return { content: body, isError: false };
+}
+
+/** Collapse chunk-level hits to one row per note, keeping each note's best
+ *  (highest-scoring) chunk, ordered by score descending. */
+function bestPerNote(hits: RelatedHit[]): RelatedHit[] {
+  const best = new Map<string, RelatedHit>();
+  for (const h of hits) {
+    const prev = best.get(h.notePath);
+    if (!prev || h.score > prev.score) best.set(h.notePath, h);
+  }
+  return [...best.values()].sort((a, b) => b.score - a.score);
 }
 
 async function runRead(ctx: ToolContext, input: unknown): Promise<string> {

--- a/tests/main/embeddings/vector-store.test.ts
+++ b/tests/main/embeddings/vector-store.test.ts
@@ -135,6 +135,25 @@ describe('vector-store', () => {
     expect(hits.some((h) => h.notePath === 'b.md')).toBe(true);
   });
 
+  it('relatedToNote ranks other notes by nearest chunk, excluding the source', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'src.md', '# Source\nfeline animals purr and hunt');
+    await store.indexNote(ctx(), 'near.md', '# Near\nfeline animals that purr');
+    await store.indexNote(ctx(), 'far.md', '# Far\nquarterly earnings and revenue');
+    const hits = await store.relatedToNote(ctx(), 'src.md', { limit: 5 });
+    expect(hits.every((h) => h.notePath !== 'src.md')).toBe(true);
+    expect(hits[0].notePath).toBe('near.md');
+    expect(hits[0].score).toBeGreaterThan(hits[hits.length - 1].score);
+  });
+
+  it('relatedToNote returns [] for a note with no embedded chunks', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'other.md', '# Other\nsome content');
+    expect(await store.relatedToNote(ctx(), 'missing.md', { limit: 5 })).toEqual([]);
+  });
+
   it('persists across reopen', async () => {
     const embedder = fakeEmbedder();
     await store.init(ctx(), { dbPath, embedder });

--- a/tests/main/llm/search-related-tool.test.ts
+++ b/tests/main/llm/search-related-tool.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool } from '../../../src/main/llm/tools';
+import * as store from '../../../src/main/embeddings/vector-store';
+import type { ChunkEmbedder } from '../../../src/main/embeddings/vector-store';
+import { MODEL } from '../../../src/main/embeddings/embedder';
+import { projectContext } from '../../../src/main/project-context-types';
+
+/** Deterministic bag-of-words hashing embedder — shared words → higher cosine. */
+function fakeEmbedder(): ChunkEmbedder {
+  return {
+    dim: MODEL.dim,
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      return texts.map((t) => {
+        const v = new Float32Array(MODEL.dim);
+        for (const w of t.toLowerCase().split(/\W+/).filter(Boolean)) {
+          let h = 0;
+          for (const ch of w) h = (h * 31 + ch.charCodeAt(0)) >>> 0;
+          v[h % MODEL.dim] += 1;
+        }
+        const n = Math.hypot(...v);
+        if (n > 0) for (let i = 0; i < MODEL.dim; i++) v[i] /= n;
+        return v;
+      });
+    },
+  };
+}
+
+describe('search_related tool (#837)', () => {
+  let root: string;
+  const ctx = () => projectContext(root);
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-search-related-'));
+  });
+  afterEach(async () => {
+    await store.dispose(ctx());
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function seed(): Promise<void> {
+    await store.init(ctx(), { dbPath: path.join(root, '.minerva', 'vectors.duckdb'), embedder: fakeEmbedder() });
+    await store.indexNote(ctx(), 'cats.md', '# Cats\nCats are feline animals that purr and hunt mice.');
+    await store.indexNote(ctx(), 'dogs.md', '# Dogs\nDogs are canine animals that bark and fetch.');
+    await store.indexNote(ctx(), 'finance.md', '# Finance\nQuarterly revenue and earnings reports for shareholders.');
+  }
+
+  it('returns a clear message when embeddings are not initialized', async () => {
+    const out = await executeNotebaseTool({ rootPath: root }, 'search_related', { query: 'anything' });
+    expect(out.isError).toBe(false);
+    expect(out.content).toMatch(/not available|not initialized/i);
+  });
+
+  it('ranks semantically related notes for a free-text query', async () => {
+    await seed();
+    const out = await executeNotebaseTool({ rootPath: root }, 'search_related', {
+      query: 'feline animals that purr',
+      limit: 3,
+    });
+    expect(out.isError).toBe(false);
+    expect(out.content).toContain('cats.md');
+    // The cat note ranks first; a similarity score is shown.
+    expect(out.content).toMatch(/cats\.md.*similarity \d/s);
+    expect(out.content.indexOf('cats.md')).toBeLessThan(
+      out.content.indexOf('finance.md') === -1 ? Infinity : out.content.indexOf('finance.md'),
+    );
+  });
+
+  it('finds notes related to a given note, excluding the note itself', async () => {
+    await seed();
+    const out = await executeNotebaseTool({ rootPath: root }, 'search_related', {
+      relative_path: 'cats.md',
+    });
+    expect(out.isError).toBe(false);
+    // Its own path must not appear; the other animal note should rank above finance.
+    expect(out.content).not.toContain('cats.md');
+    expect(out.content).toContain('dogs.md');
+  });
+
+  it('de-dups multiple chunk hits from one note to a single best row', async () => {
+    await store.init(ctx(), { dbPath: path.join(root, '.minerva', 'vectors.duckdb'), embedder: fakeEmbedder() });
+    // A note with several sections all about the same topic.
+    await store.indexNote(ctx(), 'multi.md', '# T\n\n## A\ngardening soil plants\n\n## B\ngardening soil plants\n\n## C\ngardening soil plants');
+    const out = await executeNotebaseTool({ rootPath: root }, 'search_related', { query: 'gardening soil plants' });
+    const occurrences = out.content.split('multi.md').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('errors when neither query nor relative_path is provided', async () => {
+    await seed();
+    const out = await executeNotebaseTool({ rootPath: root }, 'search_related', {});
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/query|relative_path/);
+  });
+});


### PR DESCRIPTION
Closes #837. The **headline** of the semantic-search epic (#833): the LLM can now retrieve by *meaning*, alongside lexical (`search_notes`) and structural (`query_graph`). Small, as planned — #835 already exposed `searchRelated`.

## The tool

`search_related`, registered in `NOTEBASE_TOOLS` so every conversation gets it. Two modes:

- **`query`** — free text, embedded then matched by cosine similarity ("notes about how trust is established").
- **`relative_path`** — "find notes like this one." Uses the note's *own stored chunk vectors* as the query via a new `relatedToNote` store method (a self-join — **no re-embedding**), excluding the note itself.

Results are **de-duped best-per-note** (one row per note, its closest section), each carrying the matched section heading + a 0–1 similarity score.

## Picks the right tool

The description steers the model: `search_related` for "find things like / about this" by meaning, `search_notes` for exact keywords, `query_graph` for structural questions (links, tags, types, claims) — and combine when unsure.

## Graceful states

- Embeddings not initialized → a clear "semantic search is not available" message (not an error).
- Note not indexed yet → explains background indexing can leave results incomplete (real progress reporting lands with the backfill, #836).
- Neither `query` nor `relative_path` → tool error guiding the model.

## Tests

- Store `relatedToNote`: ranking, self-exclusion, empty-when-unindexed.
- Tool executor: disabled message, free-text ranking (`cats.md` first), related-to-note (excludes self, ranks the sibling animal note above finance), best-per-note de-dup, missing-args error.

Full suite green (**3609**), lint clean.

## Scope / next

Out of scope: the human-facing **Related panel UI (#838)**, which (with this tool) gives the epic its first end-to-end packaged exercise of the save→embed→search flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)