### PR TITLE
feat: embed sources & excerpts — semantic search over the research library (#839)

### DIFF
--- a/src/main/embeddings/backfill.ts
+++ b/src/main/embeddings/backfill.ts
@@ -24,7 +24,9 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ProjectContext } from '../project-context-types';
 import { isIndexable } from '../notebase/indexable-files';
+import { citedTextFromTtl } from '../sources/create-excerpt';
 import * as store from './vector-store';
+import type { RefKind } from './vector-store';
 
 export interface BackfillProgress {
   done: number;
@@ -75,28 +77,26 @@ export async function runBackfill(ctx: ProjectContext, opts: BackfillOptions = {
   try {
     if (opts.force) await store.clear(ctx);
 
-    const notes = await (opts.listNotes ?? listMarkdownNotes)(ctx.rootPath);
-    const alreadyDone = opts.force ? new Set<string>() : await store.embeddedNotePaths(ctx);
-    const pending = notes.filter((p) => !alreadyDone.has(p));
-    const total = pending.length;
+    const { items, skipped } = await collectWork(ctx, opts);
+    const total = items.length;
 
     let done = 0;
     let embedded = 0;
     emit(opts, { done, total, running: true });
-    for (const rel of pending) {
-      if (signal.aborted) return { embedded, skipped: total - done, aborted: true };
+    for (const item of items) {
+      if (signal.aborted) return { embedded, skipped: skipped + (total - done), aborted: true };
       try {
-        const content = await fs.readFile(path.join(ctx.rootPath, rel), 'utf-8');
-        await store.indexNote(ctx, rel, content);
+        const content = await item.load();
+        await store.indexChunks(ctx, item.kind, item.ref, content);
         embedded++;
       } catch (err) {
-        // A single unreadable / oversized note must not abort the whole pass.
-        console.warn(`[backfill] skipped ${rel}:`, err);
+        // A single unreadable / oversized item must not abort the whole pass.
+        console.warn(`[backfill] skipped ${item.kind}:${item.ref}:`, err);
       }
       done++;
       emit(opts, { done, total, running: true });
     }
-    return { embedded, skipped: notes.length - total, aborted: false };
+    return { embedded, skipped, aborted: false };
   } finally {
     running.delete(ctx.rootPath);
     // Final tick so listeners can clear the indicator.
@@ -106,6 +106,79 @@ export async function runBackfill(ctx: ProjectContext, opts: BackfillOptions = {
 
 function emit(opts: BackfillOptions, p: BackfillProgress): void {
   try { opts.onProgress?.(p); } catch { /* a listener throwing must not derail the walk */ }
+}
+
+interface WorkItem {
+  kind: RefKind;
+  ref: string;
+  /** Lazily loads the text to embed (note body / source body / excerpt text). */
+  load: () => Promise<string>;
+}
+
+/** Assemble the not-yet-embedded work across all three corpora (#839): notes,
+ *  source bodies, and excerpts. The per-kind skip set makes this resumable +
+ *  cheap on re-run; `force` clears the skip sets so everything is reprocessed. */
+async function collectWork(ctx: ProjectContext, opts: BackfillOptions): Promise<{ items: WorkItem[]; skipped: number }> {
+  const rootPath = ctx.rootPath;
+  const notePaths = await (opts.listNotes ?? listMarkdownNotes)(rootPath);
+  const sourceIds = await listSourcesWithBody(rootPath);
+  const excerptIds = await listExcerptIds(rootPath);
+  const candidates = notePaths.length + sourceIds.length + excerptIds.length;
+
+  const [doneNotes, doneSources, doneExcerpts] = opts.force
+    ? [new Set<string>(), new Set<string>(), new Set<string>()]
+    : await Promise.all([
+        store.embeddedRefs(ctx, 'note'),
+        store.embeddedRefs(ctx, 'source'),
+        store.embeddedRefs(ctx, 'excerpt'),
+      ]);
+
+  const items: WorkItem[] = [];
+  for (const ref of notePaths) {
+    if (!doneNotes.has(ref)) items.push({ kind: 'note', ref, load: () => fs.readFile(path.join(rootPath, ref), 'utf-8') });
+  }
+  for (const ref of sourceIds) {
+    if (!doneSources.has(ref)) {
+      items.push({ kind: 'source', ref, load: () => fs.readFile(path.join(rootPath, '.minerva', 'sources', ref, 'body.md'), 'utf-8') });
+    }
+  }
+  for (const ref of excerptIds) {
+    if (!doneExcerpts.has(ref)) {
+      items.push({
+        kind: 'excerpt', ref,
+        load: async () => citedTextFromTtl(await fs.readFile(path.join(rootPath, '.minerva', 'excerpts', `${ref}.ttl`), 'utf-8')) ?? '',
+      });
+    }
+  }
+  return { items, skipped: candidates - items.length };
+}
+
+/** Source ids that have a `body.md` to embed (metadata-only sources are skipped —
+ *  their title/abstract still live in the graph for structural search). */
+async function listSourcesWithBody(rootPath: string): Promise<string[]> {
+  const dir = path.join(rootPath, '.minerva', 'sources');
+  const out: string[] = [];
+  let entries: import('node:fs').Dirent[];
+  try { entries = await fs.readdir(dir, { withFileTypes: true }); } catch { return out; }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      await fs.access(path.join(dir, entry.name, 'body.md'));
+      out.push(entry.name);
+    } catch { /* no body — skip */ }
+  }
+  return out;
+}
+
+/** Every excerpt id (`.minerva/excerpts/<id>.ttl`). */
+async function listExcerptIds(rootPath: string): Promise<string[]> {
+  const dir = path.join(rootPath, '.minerva', 'excerpts');
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    return entries.filter((e) => e.isFile() && e.name.endsWith('.ttl')).map((e) => e.name.slice(0, -'.ttl'.length));
+  } catch {
+    return [];
+  }
 }
 
 /** Default walker: every indexable markdown note under the root, skipping

--- a/src/main/embeddings/related.ts
+++ b/src/main/embeddings/related.ts
@@ -1,8 +1,8 @@
 /**
- * Pure transform from raw chunk hits to the Related panel's note list (#838).
+ * Pure transform from raw chunk hits to the Related panel's list (#838, #839).
  *
- * `relatedToNote` returns chunk-level hits that can repeat a note across its
- * sections; the panel wants one row per note (its best-matching section), ranked
+ * `relatedToRef` returns chunk-level hits that can repeat a ref across its
+ * sections; the panel wants one row per ref (its best-matching section), ranked
  * by score, capped, and enriched with a display title + snippet. Kept separate
  * from the electron-coupled IPC handler so it's unit-testable.
  */
@@ -12,19 +12,22 @@ import type { RelatedNote } from '../../shared/types';
 
 export function topRelatedNotes(
   hits: RelatedHit[],
-  opts: { limit: number; titleOf: (relativePath: string) => string },
+  opts: { limit: number; titleOf: (hit: RelatedHit) => string },
 ): RelatedNote[] {
+  // Best section per (kind, ref).
   const best = new Map<string, RelatedHit>();
   for (const h of hits) {
-    const prev = best.get(h.notePath);
-    if (!prev || h.score > prev.score) best.set(h.notePath, h);
+    const key = `${h.kind}:${h.ref}`;
+    const prev = best.get(key);
+    if (!prev || h.score > prev.score) best.set(key, h);
   }
   return [...best.values()]
     .sort((a, b) => b.score - a.score)
     .slice(0, opts.limit)
     .map((h) => ({
-      relativePath: h.notePath,
-      title: opts.titleOf(h.notePath),
+      kind: h.kind,
+      ref: h.ref,
+      title: opts.titleOf(h),
       sectionHeading: h.sectionHeading,
       snippet: h.chunkText.replace(/\s+/g, ' ').trim().slice(0, 160),
       score: h.score,

--- a/src/main/embeddings/vector-store.ts
+++ b/src/main/embeddings/vector-store.ts
@@ -1,22 +1,19 @@
 /**
- * Persisted DuckDB vector store + incremental indexer (#835).
+ * Persisted DuckDB vector store + incremental indexer (#835, generalized in #839).
  *
- * Per-section embeddings live in `.minerva/vectors.duckdb`, kept current on the
- * existing per-file write seam. Three properties matter:
+ * Embeds three corpora — notes, source bodies, and excerpts — into one table,
+ * each row tagged with its `kind` + owning `ref_id` (note relativePath, sourceId,
+ * or excerptId) so results route to the right place (open a note / the source
+ * viewer / a highlighted excerpt). Properties:
  *
- *  - **Persisted** — a file-backed DuckDB (not the in-memory CSV tables db), so
- *    embeddings survive a project reopen.
- *  - **Incremental + hashed** — `indexNote` re-embeds only chunks whose text
- *    changed; an unchanged chunk's vector is carried over verbatim, position-
- *    independent (keyed by content hash, not chunk index). Editing one section
- *    of a big note costs one embedding, not N.
- *  - **Offline brute-force KNN** — `array_cosine_distance` is a *core* DuckDB
- *    function (1.5), so exact nearest-neighbour needs no VSS extension and no
- *    network. At thoughtbase scale an exact scan is milliseconds; HNSW is
- *    deferred until a corpus actually grows (#833).
+ *  - **Persisted** — file-backed DuckDB at `.minerva/vectors.duckdb`.
+ *  - **Incremental + hashed** — re-embeds only chunks whose text changed; an
+ *    unchanged chunk's vector carries over, keyed by content hash (position-
+ *    independent).
+ *  - **Offline brute-force KNN** — `array_cosine_distance` is core DuckDB 1.5, so
+ *    exact nearest-neighbour needs no VSS extension and no network.
  *
- * Rows carry `embedding_model`, so a model swap leaves old rows detectably stale
- * (re-embedded lazily on next save; bulk backfill is #836).
+ * Rows carry `embedding_model`, so a model swap leaves old rows detectably stale.
  */
 
 import fs from 'node:fs/promises';
@@ -26,6 +23,9 @@ import type { ProjectContext } from '../project-context-types';
 import { MODEL } from './embedder';
 import { chunkMarkdown } from './chunk';
 
+export type RefKind = 'note' | 'source' | 'excerpt';
+export const ALL_KINDS: readonly RefKind[] = ['note', 'source', 'excerpt'];
+
 /** The embedding capability the store needs — satisfied by `EmbedderService`. */
 export interface ChunkEmbedder {
   readonly dim: number;
@@ -33,7 +33,9 @@ export interface ChunkEmbedder {
 }
 
 export interface RelatedHit {
-  notePath: string;
+  kind: RefKind;
+  /** Owning identity: note relativePath, sourceId, or excerptId. */
+  ref: string;
   sectionHeading: string;
   chunkText: string;
   /** Cosine similarity in [-1, 1]; higher is closer. */
@@ -41,10 +43,16 @@ export interface RelatedHit {
 }
 
 export interface VectorStoreInit {
-  /** Override the DB location (tests). Defaults to `<root>/.minerva/vectors.duckdb`. */
   dbPath?: string;
-  /** The embedder; production passes the shared worker-backed service. */
   embedder: ChunkEmbedder;
+}
+
+export interface SearchOptions {
+  limit?: number;
+  /** Exclude a specific row (kind + ref), e.g. the query note itself. */
+  exclude?: { kind: RefKind; ref: string };
+  /** Restrict results to these kinds; defaults to all. */
+  kinds?: readonly RefKind[];
 }
 
 interface StoreState {
@@ -52,8 +60,6 @@ interface StoreState {
   connection: DuckDBConnection;
   embedder: ChunkEmbedder;
   model: string;
-  /** Serializes DB mutations so concurrent saves can't interleave a note's
-   *  read-modify-write. */
   lock: Promise<unknown>;
 }
 
@@ -64,7 +70,6 @@ function defaultDbPath(rootPath: string): string {
   return path.join(rootPath, '.minerva', 'vectors.duckdb');
 }
 
-/** Open (or create) the per-project vector DB and ensure the schema. Idempotent. */
 export async function init(ctx: ProjectContext, opts: VectorStoreInit): Promise<void> {
   if (states.has(ctx.rootPath)) return;
   const dbPath = opts.dbPath ?? defaultDbPath(ctx.rootPath);
@@ -72,9 +77,23 @@ export async function init(ctx: ProjectContext, opts: VectorStoreInit): Promise<
 
   const instance = await DuckDBInstance.create(dbPath);
   const connection = await instance.connect();
+
+  // Migration (#839): the original schema keyed rows by `note_path`. A store
+  // predating the (kind, ref_id) generalization is dropped and rebuilt — the
+  // data is fully reconstructible by the backfill, so this is lossless in
+  // practice and avoids a fragile in-place column rename.
+  const cols = await connection.runAndReadAll(
+    `SELECT column_name FROM information_schema.columns WHERE table_name = '${TABLE}'`,
+  );
+  const colNames = new Set((cols.getRowObjectsJS() as Record<string, unknown>[]).map((r) => String(r.column_name)));
+  if (colNames.size > 0 && !colNames.has('kind')) {
+    await connection.run(`DROP TABLE IF EXISTS ${TABLE}`);
+  }
+
   await connection.run(
     `CREATE TABLE IF NOT EXISTS ${TABLE} (
-       note_path       VARCHAR NOT NULL,
+       kind            VARCHAR NOT NULL,
+       ref_id          VARCHAR NOT NULL,
        chunk_index     INTEGER NOT NULL,
        section_heading VARCHAR NOT NULL,
        chunk_text      VARCHAR NOT NULL,
@@ -85,11 +104,7 @@ export async function init(ctx: ProjectContext, opts: VectorStoreInit): Promise<
      )`,
   );
   states.set(ctx.rootPath, {
-    instance,
-    connection,
-    embedder: opts.embedder,
-    model: MODEL.name,
-    lock: Promise.resolve(),
+    instance, connection, embedder: opts.embedder, model: MODEL.name, lock: Promise.resolve(),
   });
 }
 
@@ -97,182 +112,174 @@ export function isEnabled(ctx: ProjectContext): boolean {
   return states.has(ctx.rootPath);
 }
 
-/** Flush + close the project's DB. Idempotent. */
 export async function dispose(ctx: ProjectContext): Promise<void> {
   const state = states.get(ctx.rootPath);
   if (!state) return;
   states.delete(ctx.rootPath);
-  // Drain any in-flight mutation before closing the connection.
   try { await state.lock; } catch { /* ignore */ }
   try { state.connection.closeSync(); } catch { /* already closed */ }
   try { state.instance.closeSync(); } catch { /* already closed */ }
 }
 
+// ── Indexing ────────────────────────────────────────────────────────────────
+
 /**
- * Re-index a note's chunks. Re-embeds only chunks whose hash isn't already
- * stored for this note under the current model; carries unchanged vectors over.
- * Replacing the note's rows is transactional. Resilient — a failure logs and
- * leaves the prior rows intact rather than throwing into the write pipeline.
+ * Re-index one ref's chunks. Re-embeds only chunks whose hash isn't already
+ * stored for this (kind, ref) under the current model; carries unchanged vectors
+ * over. Transactional. Resilient — failures log, leaving prior rows intact.
  */
-export async function indexNote(ctx: ProjectContext, relativePath: string, content: string): Promise<void> {
+export async function indexChunks(ctx: ProjectContext, kind: RefKind, ref: string, content: string): Promise<void> {
   const state = states.get(ctx.rootPath);
   if (!state) return;
   return runLocked(state, async () => {
     try {
       const chunks = chunkMarkdown(content);
       if (chunks.length === 0) {
-        await deleteNote(state, relativePath);
+        await deleteRef(state, kind, ref);
         return;
       }
-
-      // Reuse vectors for chunks whose text is unchanged (same hash, same model).
-      const existing = await readExisting(state, relativePath);
+      const existing = await readExisting(state, kind, ref);
       const toEmbed = chunks.filter((c) => !existing.has(c.hash));
-      const fresh = toEmbed.length > 0
-        ? await state.embedder.embed(toEmbed.map((c) => c.text))
-        : [];
+      const fresh = toEmbed.length > 0 ? await state.embedder.embed(toEmbed.map((c) => c.text)) : [];
       const freshByHash = new Map(toEmbed.map((c, i) => [c.hash, fresh[i]]));
-
-      const rows = chunks.map((c) => ({
-        chunk: c,
-        vec: existing.get(c.hash) ?? freshByHash.get(c.hash)!,
-      }));
+      const rows = chunks.map((c) => ({ chunk: c, vec: existing.get(c.hash) ?? freshByHash.get(c.hash)! }));
 
       await state.connection.run('BEGIN TRANSACTION');
       try {
-        await deleteNote(state, relativePath);
-        await insertRows(state, relativePath, rows);
+        await deleteRef(state, kind, ref);
+        await insertRows(state, kind, ref, rows);
         await state.connection.run('COMMIT');
       } catch (err) {
         await state.connection.run('ROLLBACK').catch(() => { /* ignore */ });
         throw err;
       }
     } catch (err) {
-      console.warn(`[vectors] indexNote failed for ${relativePath}:`, err);
+      console.warn(`[vectors] indexChunks failed for ${kind}:${ref}:`, err);
     }
   });
 }
 
-/** The set of note paths that already have chunks under the *current* model —
- *  the backfill's skip set (#836). A note absent here needs embedding (never
- *  indexed, or only has stale-model rows from a previous model). */
-export async function embeddedNotePaths(ctx: ProjectContext): Promise<Set<string>> {
+export const indexNote = (ctx: ProjectContext, relativePath: string, content: string) =>
+  indexChunks(ctx, 'note', relativePath, content);
+export const indexSource = (ctx: ProjectContext, sourceId: string, body: string) =>
+  indexChunks(ctx, 'source', sourceId, body);
+export const indexExcerpt = (ctx: ProjectContext, excerptId: string, text: string) =>
+  indexChunks(ctx, 'excerpt', excerptId, text);
+
+export async function removeRef(ctx: ProjectContext, kind: RefKind, ref: string): Promise<void> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return;
+  return runLocked(state, async () => {
+    try { await deleteRef(state, kind, ref); }
+    catch (err) { console.warn(`[vectors] removeRef failed for ${kind}:${ref}:`, err); }
+  });
+}
+
+export const removeNote = (ctx: ProjectContext, relativePath: string) => removeRef(ctx, 'note', relativePath);
+export const removeSource = (ctx: ProjectContext, sourceId: string) => removeRef(ctx, 'source', sourceId);
+export const removeExcerpt = (ctx: ProjectContext, excerptId: string) => removeRef(ctx, 'excerpt', excerptId);
+
+/** The refs of `kind` already embedded under the current model — the backfill's
+ *  per-kind skip set (#836/#839). */
+export async function embeddedRefs(ctx: ProjectContext, kind: RefKind): Promise<Set<string>> {
   const state = states.get(ctx.rootPath);
   if (!state) return new Set();
   const reader = await state.connection.runAndReadAll(
-    `SELECT DISTINCT note_path FROM ${TABLE} WHERE embedding_model = ${lit(state.model)}`,
+    `SELECT DISTINCT ref_id FROM ${TABLE} WHERE kind = ${lit(kind)} AND embedding_model = ${lit(state.model)}`,
   );
   const out = new Set<string>();
-  for (const r of reader.getRowObjectsJS() as Record<string, unknown>[]) {
-    out.add(String(r.note_path));
-  }
+  for (const r of reader.getRowObjectsJS() as Record<string, unknown>[]) out.add(String(r.ref_id));
   return out;
 }
 
-/** Wipe every chunk (manual "Rebuild Semantic Index" — force a full re-embed). */
+/** Back-compat alias (note-kind skip set). */
+export const embeddedNotePaths = (ctx: ProjectContext) => embeddedRefs(ctx, 'note');
+
 export async function clear(ctx: ProjectContext): Promise<void> {
   const state = states.get(ctx.rootPath);
   if (!state) return;
-  return runLocked(state, async () => {
-    await state.connection.run(`DELETE FROM ${TABLE}`);
-  });
+  return runLocked(state, async () => { await state.connection.run(`DELETE FROM ${TABLE}`); });
 }
 
-/** Drop a note's chunks (deletion / pre-rename). */
-export async function removeNote(ctx: ProjectContext, relativePath: string): Promise<void> {
-  const state = states.get(ctx.rootPath);
-  if (!state) return;
-  return runLocked(state, async () => {
-    try {
-      await deleteNote(state, relativePath);
-    } catch (err) {
-      console.warn(`[vectors] removeNote failed for ${relativePath}:`, err);
-    }
-  });
-}
+// ── Querying ──────────────────────────────────────────────────────────────────
 
-/**
- * Rank the chunks nearest to `query` (text → embedded first, or a vector) by
- * cosine similarity. Only rows under the active model are considered, so stale
- * rows never pollute results.
- */
 export async function searchRelated(
   ctx: ProjectContext,
   query: string | Float32Array,
-  opts: { limit?: number; excludePath?: string } = {},
+  opts: SearchOptions = {},
 ): Promise<RelatedHit[]> {
   const state = states.get(ctx.rootPath);
   if (!state) return [];
-  const limit = opts.limit ?? 10;
-  const vec = typeof query === 'string'
-    ? (await state.embedder.embed([query]))[0]
-    : query;
+  const vec = typeof query === 'string' ? (await state.embedder.embed([query]))[0] : query;
   if (!vec) return [];
 
-  const where = [`embedding_model = ${lit(state.model)}`];
-  if (opts.excludePath) where.push(`note_path <> ${lit(opts.excludePath)}`);
+  const where = [`embedding_model = ${lit(state.model)}`, kindClause(opts.kinds)];
+  if (opts.exclude) where.push(`NOT (kind = ${lit(opts.exclude.kind)} AND ref_id = ${lit(opts.exclude.ref)})`);
   const sql =
-    `SELECT note_path, section_heading, chunk_text, ` +
+    `SELECT kind, ref_id, section_heading, chunk_text, ` +
     `array_cosine_distance(embedding, ${arrayLit(vec)}) AS dist ` +
-    `FROM ${TABLE} WHERE ${where.join(' AND ')} ORDER BY dist ASC LIMIT ${Math.floor(limit)}`;
-
-  const reader = await state.connection.runAndReadAll(sql);
-  const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
-  return rows.map((r) => ({
-    notePath: String(r.note_path),
-    sectionHeading: String(r.section_heading),
-    chunkText: String(r.chunk_text),
-    score: 1 - Number(r.dist),
-  }));
+    `FROM ${TABLE} WHERE ${where.filter(Boolean).join(' AND ')} ORDER BY dist ASC LIMIT ${limitOf(opts)}`;
+  return mapHits(await runRows(state, sql));
 }
 
-/** Test-only: the live connection, for asserting on raw rows. */
+/**
+ * "Find chunks related to this ref" — rank every *other* ref's chunks by their
+ * nearest distance to any of this ref's stored chunks. Reuses stored vectors (no
+ * re-embedding). `kinds` restricts the result corpus.
+ */
+export async function relatedToRef(
+  ctx: ProjectContext,
+  kind: RefKind,
+  ref: string,
+  opts: SearchOptions = {},
+): Promise<RelatedHit[]> {
+  const state = states.get(ctx.rootPath);
+  if (!state) return [];
+  const model = lit(state.model);
+  const kc = kindClause(opts.kinds, 't.');
+  const sql =
+    `WITH q AS (SELECT embedding FROM ${TABLE} ` +
+    `WHERE kind = ${lit(kind)} AND ref_id = ${lit(ref)} AND embedding_model = ${model}) ` +
+    `SELECT t.kind, t.ref_id, t.section_heading, t.chunk_text, ` +
+    `MIN(array_cosine_distance(t.embedding, q.embedding)) AS dist ` +
+    `FROM ${TABLE} t, q ` +
+    `WHERE NOT (t.kind = ${lit(kind)} AND t.ref_id = ${lit(ref)}) ` +
+    `AND t.embedding_model = ${model}${kc ? ` AND ${kc}` : ''} ` +
+    `GROUP BY t.kind, t.ref_id, t.section_heading, t.chunk_text ORDER BY dist ASC LIMIT ${limitOf(opts)}`;
+  return mapHits(await runRows(state, sql));
+}
+
+/** Back-compat: relatives of a note (the active note in the Related panel). */
+export const relatedToNote = (ctx: ProjectContext, notePath: string, opts: SearchOptions = {}) =>
+  relatedToRef(ctx, 'note', notePath, opts);
+
+// ── internals ───────────────────────────────────────────────────────────────
+
 export function _connectionForTest(ctx: ProjectContext): DuckDBConnection {
   const state = states.get(ctx.rootPath);
   if (!state) throw new Error('vector store not initialized');
   return state.connection;
 }
 
-/**
- * "Find chunks related to this note" — rank every other note's chunks by their
- * nearest distance to *any* of `notePath`'s own stored chunks. Reuses the
- * already-stored vectors (no re-embedding). Returns chunk-level hits (the caller
- * de-dups to best-per-note); `[]` if the note has no embedded chunks yet.
- */
-export async function relatedToNote(
-  ctx: ProjectContext,
-  notePath: string,
-  opts: { limit?: number } = {},
-): Promise<RelatedHit[]> {
-  const state = states.get(ctx.rootPath);
-  if (!state) return [];
-  const limit = Math.floor(opts.limit ?? 10);
-  const model = lit(state.model);
-  const sql =
-    `WITH q AS (SELECT embedding FROM ${TABLE} ` +
-    `WHERE note_path = ${lit(notePath)} AND embedding_model = ${model}) ` +
-    `SELECT t.note_path, t.section_heading, t.chunk_text, ` +
-    `MIN(array_cosine_distance(t.embedding, q.embedding)) AS dist ` +
-    `FROM ${TABLE} t, q ` +
-    `WHERE t.note_path <> ${lit(notePath)} AND t.embedding_model = ${model} ` +
-    `GROUP BY t.note_path, t.section_heading, t.chunk_text ` +
-    `ORDER BY dist ASC LIMIT ${limit}`;
+async function runRows(state: StoreState, sql: string): Promise<Record<string, unknown>[]> {
   const reader = await state.connection.runAndReadAll(sql);
-  const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
+  return reader.getRowObjectsJS();
+}
+
+function mapHits(rows: Record<string, unknown>[]): RelatedHit[] {
   return rows.map((r) => ({
-    notePath: String(r.note_path),
+    kind: String(r.kind) as RefKind,
+    ref: String(r.ref_id),
     sectionHeading: String(r.section_heading),
     chunkText: String(r.chunk_text),
     score: 1 - Number(r.dist),
   }));
 }
 
-// ── internals ───────────────────────────────────────────────────────────────
-
-async function readExisting(state: StoreState, relativePath: string): Promise<Map<string, Float32Array>> {
+async function readExisting(state: StoreState, kind: RefKind, ref: string): Promise<Map<string, Float32Array>> {
   const reader = await state.connection.runAndReadAll(
     `SELECT content_hash, embedding FROM ${TABLE} ` +
-    `WHERE note_path = ${lit(relativePath)} AND embedding_model = ${lit(state.model)}`,
+    `WHERE kind = ${lit(kind)} AND ref_id = ${lit(ref)} AND embedding_model = ${lit(state.model)}`,
   );
   const out = new Map<string, Float32Array>();
   for (const r of reader.getRowObjectsJS() as Record<string, unknown>[]) {
@@ -281,18 +288,19 @@ async function readExisting(state: StoreState, relativePath: string): Promise<Ma
   return out;
 }
 
-async function deleteNote(state: StoreState, relativePath: string): Promise<void> {
-  await state.connection.run(`DELETE FROM ${TABLE} WHERE note_path = ${lit(relativePath)}`);
+async function deleteRef(state: StoreState, kind: RefKind, ref: string): Promise<void> {
+  await state.connection.run(`DELETE FROM ${TABLE} WHERE kind = ${lit(kind)} AND ref_id = ${lit(ref)}`);
 }
 
 async function insertRows(
   state: StoreState,
-  relativePath: string,
+  kind: RefKind,
+  ref: string,
   rows: { chunk: { index: number; heading: string; text: string; hash: string }; vec: Float32Array }[],
 ): Promise<void> {
   if (rows.length === 0) return;
   const values = rows.map(({ chunk, vec }) =>
-    `(${lit(relativePath)}, ${chunk.index}, ${lit(chunk.heading)}, ${lit(chunk.text)}, ` +
+    `(${lit(kind)}, ${lit(ref)}, ${chunk.index}, ${lit(chunk.heading)}, ${lit(chunk.text)}, ` +
     `${lit(chunk.hash)}, ${lit(state.model)}, ${arrayLit(vec)}, now())`,
   );
   await state.connection.run(`INSERT INTO ${TABLE} VALUES ${values.join(', ')}`);
@@ -304,13 +312,19 @@ function runLocked<T>(state: StoreState, fn: () => Promise<T>): Promise<T> {
   return run;
 }
 
-/** Single-quote-escaped SQL string literal. */
+function kindClause(kinds: readonly RefKind[] | undefined, prefix = ''): string {
+  if (!kinds || kinds.length === 0 || kinds.length === ALL_KINDS.length) return '';
+  return `${prefix}kind IN (${kinds.map(lit).join(', ')})`;
+}
+
+function limitOf(opts: SearchOptions): number {
+  return Math.floor(opts.limit ?? 10);
+}
+
 function lit(s: string): string {
   return `'${s.replace(/'/g, "''")}'`;
 }
 
-/** A `FLOAT[dim]` array literal from a vector. Values are finite normalized
- *  floats, so plain `toString` is exact enough for FLOAT. */
 function arrayLit(vec: Float32Array): string {
   return `[${Array.from(vec).join(',')}]::FLOAT[${MODEL.dim}]`;
 }

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -26,7 +26,7 @@ export {
   findNotesCitingSource, findNotesQuotingExcerpt, findNotesLinkingToAnchor, allNotePaths,
   injectSparqlPrefixes, schemaForCompletion, queryGraph,
   listTags, notesByTagPrefix, notesByTag, sourcesByTag, listAllSources, allTags,
-  outgoingLinks, findDerivedNoteForCell, findNotesLinkingTo, backlinks, findExternalInboundLinks, noteTitle,
+  outgoingLinks, findDerivedNoteForCell, findNotesLinkingTo, backlinks, findExternalInboundLinks, noteTitle, sourceTitle,
   getSourceDetail, getReadingQueueSourceIds, sourcesByReadStatus, citationsForNote, getExcerptSource,
 } from './queries';
 export type { AliasEntry, SchemaEntry, GraphSchema, ReadingQueueView } from './queries';

--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -491,6 +491,15 @@ export function noteTitle(ctx: ProjectContext, relativePath: string): string {
   return titleStmts[0]?.object.value ?? stem;
 }
 
+/** A source's display title from the graph (`dc:title`), falling back to its id.
+ *  Used by the semantic Related panel for source/excerpt hits (#839). */
+export function sourceTitle(ctx: ProjectContext, sourceId: string): string {
+  const state = getState(ctx);
+  if (!state) return sourceId;
+  const titleStmts = state.store.statementsMatching(sourceUri(state, sourceId), DC('title'), undefined);
+  return titleStmts[0]?.object.value ?? sourceId;
+}
+
 export function outgoingLinks(ctx: ProjectContext, relativePath: string): OutgoingLink[] {
   const state = getState(ctx);
   if (!state) return [];

--- a/src/main/ipc/register-links.ts
+++ b/src/main/ipc/register-links.ts
@@ -18,9 +18,17 @@ export function registerLinks(): void {
     const ctx = projectContext(rootPath);
     if (!vectors.isEnabled(ctx)) return { enabled: false, notes: [] };
     const n = Math.min(Math.max(Math.floor(limit ?? 8), 1), 25);
-    // Over-fetch chunk hits so best-per-note still yields ~n notes.
+    // Over-fetch chunk hits so best-per-ref de-dup still yields ~n results.
+    // Span all kinds — notes, source bodies, and excerpts (#839).
     const hits = await vectors.relatedToNote(ctx, relativePath, { limit: n * 5 });
-    const notes = topRelatedNotes(hits, { limit: n, titleOf: (p) => graph.noteTitle(ctx, p) });
+    const notes = topRelatedNotes(hits, {
+      limit: n,
+      titleOf: (h) => {
+        if (h.kind === 'source') return graph.sourceTitle(ctx, h.ref);
+        if (h.kind === 'excerpt') return 'Excerpt';
+        return graph.noteTitle(ctx, h.ref);
+      },
+    });
     return { enabled: true, notes };
   });
   // Links

--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -5,7 +5,7 @@ import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
 import * as vectors from '../embeddings/vector-store';
-import type { RelatedHit } from '../embeddings/vector-store';
+import type { RelatedHit, RefKind } from '../embeddings/vector-store';
 import * as tables from '../sources/tables';
 import ONTOLOGY_TTL from '../../shared/ontology.ttl?raw';
 import THOUGHT_ONTOLOGY_TTL from '../../shared/ontology-thought.ttl?raw';
@@ -140,12 +140,15 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
   {
     name: 'search_related',
     description:
-      'Semantic (meaning-based) search across the thoughtbase. Returns notes ' +
-      'whose content is conceptually similar to a query, even when they share ' +
-      'no keywords — embeddings, not text matching. Two modes: pass `query` ' +
-      'for free-text ("notes about how trust is established"), or `relative_path` ' +
-      'to find notes related to an existing note ("what else is like this one"). ' +
-      'Each result names the matched section and a similarity score (0–1).\n' +
+      'Semantic (meaning-based) search across the thoughtbase — notes, source ' +
+      'bodies, and excerpts. Returns items whose content is conceptually similar ' +
+      'to a query, even when they share no keywords — embeddings, not text ' +
+      'matching. Two modes: pass `query` for free-text ("how trust is ' +
+      'established"), or `relative_path` to find items related to an existing ' +
+      'note ("what else is like this one"). Optionally restrict with `kinds` ' +
+      '(e.g. ["excerpt"] to mine the research library). Each result names its ' +
+      'kind, the matched section, and a similarity score (0–1); a `[source]` / ' +
+      '`[excerpt]` tag marks library hits (use read_note only for plain notes).\n' +
       'Choosing among the search tools: use search_related for "find things ' +
       'like / about this" by meaning; use search_notes for exact keywords or ' +
       'phrases; use query_graph for structural questions (links, tags, types, ' +
@@ -165,9 +168,14 @@ export const NOTEBASE_TOOLS: Anthropic.Tool[] = [
         },
         limit: {
           type: 'integer',
-          description: 'Maximum number of notes to return. Defaults to 10.',
+          description: 'Maximum number of items to return. Defaults to 10.',
           minimum: 1,
           maximum: 50,
+        },
+        kinds: {
+          type: 'array',
+          description: 'Restrict to these corpora. Omit for all.',
+          items: { type: 'string', enum: ['note', 'source', 'excerpt'] },
         },
       },
     },
@@ -845,8 +853,8 @@ async function runSearchRelated(
   ctx: ToolContext,
   input: unknown,
 ): Promise<{ content: string; isError: boolean }> {
-  const { query, relative_path, limit } = input as {
-    query?: string; relative_path?: string; limit?: number;
+  const { query, relative_path, limit, kinds } = input as {
+    query?: string; relative_path?: string; limit?: number; kinds?: RefKind[];
   };
   const pctx = projectContext(ctx.rootPath);
 
@@ -858,50 +866,54 @@ async function runSearchRelated(
   }
 
   const n = Math.min(Math.max(Math.floor(limit ?? 10), 1), 50);
+  const kindFilter = Array.isArray(kinds) && kinds.length > 0 ? kinds : undefined;
   let hits: RelatedHit[];
   let descriptor: string;
 
   if (typeof relative_path === 'string' && relative_path.trim()) {
-    // Over-fetch chunk-level hits so best-per-note de-dup still yields ~n notes.
-    hits = await vectors.relatedToNote(pctx, relative_path.trim(), { limit: n * 5 });
+    // Over-fetch chunk-level hits so best-per-ref de-dup still yields ~n results.
+    hits = await vectors.relatedToNote(pctx, relative_path.trim(), { limit: n * 5, kinds: kindFilter });
     descriptor = `related to ${relative_path.trim()}`;
     if (hits.length === 0) {
       return {
         content:
-          `No related notes found for "${relative_path.trim()}". The note may not be ` +
+          `No related items found for "${relative_path.trim()}". The note may not be ` +
           `indexed yet — semantic indexing runs in the background, so results can be ` +
           `incomplete shortly after a note is created or the model changes.`,
         isError: false,
       };
     }
   } else if (typeof query === 'string' && query.trim()) {
-    hits = await vectors.searchRelated(pctx, query.trim(), { limit: n * 5 });
+    hits = await vectors.searchRelated(pctx, query.trim(), { limit: n * 5, kinds: kindFilter });
     descriptor = `for "${query.trim()}"`;
   } else {
     throw new Error('Provide either `query` (free text) or `relative_path` (a note to find relatives of).');
   }
 
-  const best = bestPerNote(hits).slice(0, n);
+  const best = bestPerRef(hits).slice(0, n);
   if (best.length === 0) {
-    return { content: `No semantically related notes found ${descriptor}.`, isError: false };
+    return { content: `No semantically related items found ${descriptor}.`, isError: false };
   }
   const body = best
     .map((h, i) => {
       const heading = h.sectionHeading || '(intro)';
       const snippet = h.chunkText.replace(/\s+/g, ' ').trim().slice(0, 240);
-      return `${i + 1}. ${h.notePath} — ${heading} (similarity ${h.score.toFixed(2)})\n   ${snippet}`;
+      // Label the corpus so the model can route (read_note vs. a source/excerpt).
+      const tag = h.kind === 'note' ? '' : `[${h.kind}] `;
+      return `${i + 1}. ${tag}${h.ref} — ${heading} (similarity ${h.score.toFixed(2)})\n   ${snippet}`;
     })
     .join('\n');
   return { content: body, isError: false };
 }
 
-/** Collapse chunk-level hits to one row per note, keeping each note's best
+/** Collapse chunk-level hits to one row per (kind, ref), keeping each ref's best
  *  (highest-scoring) chunk, ordered by score descending. */
-function bestPerNote(hits: RelatedHit[]): RelatedHit[] {
+function bestPerRef(hits: RelatedHit[]): RelatedHit[] {
   const best = new Map<string, RelatedHit>();
   for (const h of hits) {
-    const prev = best.get(h.notePath);
-    if (!prev || h.score > prev.score) best.set(h.notePath, h);
+    const key = `${h.kind}:${h.ref}`;
+    const prev = best.get(key);
+    if (!prev || h.score > prev.score) best.set(key, h);
   }
   return [...best.values()].sort((a, b) => b.score - a.score);
 }

--- a/src/main/sources/create-excerpt.ts
+++ b/src/main/sources/create-excerpt.ts
@@ -93,6 +93,21 @@ export function excerptIdFor(sourceId: string, citedText: string): string {
   return `${sourceId}-${shortHash(citedText.trim())}`;
 }
 
+/**
+ * Pull `thought:citedText` back out of an excerpt's TTL (the inverse of
+ * `ttlString`), for embedding the excerpt (#839). Returns null if absent.
+ */
+export function citedTextFromTtl(ttl: string): string | null {
+  const m = ttl.match(/thought:citedText\s+"((?:[^"\\]|\\.)*)"/);
+  if (!m) return null;
+  return m[1]
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}
+
 function ttlString(s: string): string {
   const escaped = s
     .replace(/\\/g, '\\\\')

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -15,6 +15,8 @@ import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
 import { acquireProject, releaseProject } from './project-context';
 import { runBackfill } from './embeddings/backfill';
+import * as vectors from './embeddings/vector-store';
+import { citedTextFromTtl } from './sources/create-excerpt';
 import { installNavigationGuards } from './security';
 import { ensureClipperRunning, stopClipperServer, isClipperEnabled } from './clipper/lifecycle';
 import type { ProjectContext } from './project-context-types';
@@ -429,12 +431,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
           bodyContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/body.md`);
         } catch { /* body optional */ }
         graph.indexSource(projectCtx, sourceId, metaContent, bodyContent);
+        void vectors.indexSource(projectCtx, sourceId, bodyContent ?? ''); // #839
         debouncedPersist();
         if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
       } catch { /* meta.ttl may have been deleted between events */ }
     },
     onSourceMetaDeleted: (sourceId) => {
       graph.removeSource(projectCtx, sourceId);
+      void vectors.removeSource(projectCtx, sourceId); // #839
       debouncedPersist();
       if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
     },
@@ -443,12 +447,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         const relPath = `.minerva/excerpts/${excerptId}.ttl`;
         const content = await notebaseFs.readFile(rootPath, relPath);
         graph.indexExcerpt(projectCtx, excerptId, content);
+        void vectors.indexExcerpt(projectCtx, excerptId, citedTextFromTtl(content) ?? ''); // #839
         debouncedPersist();
         if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
       } catch { /* file may have been deleted between events */ }
     },
     onExcerptDeleted: (excerptId) => {
       graph.removeExcerpt(projectCtx, excerptId);
+      void vectors.removeExcerpt(projectCtx, excerptId); // #839
       debouncedPersist();
       if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
     },

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -252,7 +252,7 @@
     {:else if activePanel === 'backlinks'}
       <BacklinksPanel {activeFilePath} {revision} {onFileSelect} {onOpenGraph} />
     {:else if activePanel === 'related'}
-      <RelatedPanel {activeFilePath} {revision} {indexing} {onFileSelect} {onNavigate} />
+      <RelatedPanel {activeFilePath} {revision} {indexing} {onFileSelect} {onNavigate} onOpenSource={onOpenSource} onOpenExcerpt={onOpenExcerpt} />
     {:else if activePanel === 'tags'}
       <TagsPanel {content} {onFileSelect} onSourceSelect={onOpenSource} />
     {:else if activePanel === 'tables'}

--- a/src/renderer/lib/components/right-sidebar/RelatedPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/RelatedPanel.svelte
@@ -13,9 +13,14 @@
     onFileSelect: (relativePath: string) => void;
     /** Opens a note and scrolls to a heading anchor (`path#slug`). */
     onNavigate?: (target: string) => void | Promise<void>;
+    /** Route source / excerpt hits to the source viewer (#839). */
+    onOpenSource?: (sourceId: string) => void;
+    onOpenExcerpt?: (excerptId: string) => void;
   }
 
-  let { activeFilePath, revision, indexing = false, onFileSelect, onNavigate }: Props = $props();
+  let { activeFilePath, revision, indexing = false, onFileSelect, onNavigate, onOpenSource, onOpenExcerpt }: Props = $props();
+
+  const KIND_ICON = { note: 'notes', source: 'source', excerpt: 'citations' } as const;
 
   let notes = $state<RelatedNote[]>([]);
   let enabled = $state(true);
@@ -35,13 +40,16 @@
     });
   });
 
-  /** Open the related note, scrolling to its matched section when there is one. */
+  /** Route a hit by kind: notes scroll to the matched section; sources/excerpts
+   *  open the source viewer (with the excerpt highlighted). */
   function open(note: RelatedNote) {
+    if (note.kind === 'source') { onOpenSource?.(note.ref); return; }
+    if (note.kind === 'excerpt') { onOpenExcerpt?.(note.ref); return; }
     const leaf = note.sectionHeading.split('>').pop()?.trim();
     if (leaf && onNavigate) {
-      void onNavigate(`${note.relativePath}#${slugify(leaf)}`);
+      void onNavigate(`${note.ref}#${slugify(leaf)}`);
     } else {
-      onFileSelect(note.relativePath);
+      onFileSelect(note.ref);
     }
   }
 
@@ -64,10 +72,10 @@
       {/if}
     {:else}
       <div class="related-count">{notes.length} related note{notes.length !== 1 ? 's' : ''}</div>
-      {#each notes as note (note.relativePath)}
-        <button class="related-item" onclick={() => open(note)} title={note.relativePath}>
+      {#each notes as note (note.kind + ':' + note.ref)}
+        <button class="related-item" onclick={() => open(note)} title={note.kind === 'note' ? note.ref : `${note.kind}: ${note.ref}`}>
           <div class="row-top">
-            <Icon name="sparkle" size={11} color="var(--text-faint)" />
+            <Icon name={KIND_ICON[note.kind]} size={11} color="var(--text-faint)" />
             <span class="related-title">{note.title}</span>
             <span class="score" title="{pct(note.score)}% similar">
               <span class="score-bar" style:width="{pct(note.score)}%"></span>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -67,8 +67,13 @@ export interface Backlink {
 
 // ── Semantic "Related" panel (#838) ─────────────────────────────────────────
 
+export type RelatedKind = 'note' | 'source' | 'excerpt';
+
 export interface RelatedNote {
-  relativePath: string;
+  /** Routes the click: open a note / the source viewer / a highlighted excerpt. */
+  kind: RelatedKind;
+  /** note relativePath, sourceId, or excerptId. */
+  ref: string;
   title: string;
   /** Heading breadcrumb of the best-matching section (`Parent > Child`). */
   sectionHeading: string;

--- a/tests/main/embeddings/backfill.test.ts
+++ b/tests/main/embeddings/backfill.test.ts
@@ -99,6 +99,27 @@ describe('runBackfill', () => {
     expect((await store.embeddedNotePaths(ctx())).has('good.md')).toBe(true);
   });
 
+  it('backfills sources and excerpts alongside notes (#839)', async () => {
+    await writeNote('note.md', '# Note\nphotosynthesis');
+    // A source with a body.md and a metadata-only source (no body → skipped).
+    await fsp.mkdir(path.join(root, '.minerva', 'sources', 'arxiv-1', ), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva', 'sources', 'arxiv-1', 'body.md'), '# Paper\nmarine biology');
+    await fsp.mkdir(path.join(root, '.minerva', 'sources', 'meta-only'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva', 'sources', 'meta-only', 'meta.ttl'), 'this: a thought:Source .');
+    // An excerpt.
+    await fsp.mkdir(path.join(root, '.minerva', 'excerpts'), { recursive: true });
+    await fsp.writeFile(
+      path.join(root, '.minerva', 'excerpts', 'arxiv-1-deadbeef.ttl'),
+      'this: a thought:Excerpt ;\n    thought:fromSource sources:arxiv-1 ;\n    thought:citedText "a quoted passage about reefs" .\n',
+    );
+
+    const res = await runBackfill(ctx());
+    expect(res.embedded).toBe(3); // note + source-with-body + excerpt (meta-only skipped)
+    expect((await store.embeddedRefs(ctx(), 'source')).has('arxiv-1')).toBe(true);
+    expect((await store.embeddedRefs(ctx(), 'source')).has('meta-only')).toBe(false);
+    expect((await store.embeddedRefs(ctx(), 'excerpt')).has('arxiv-1-deadbeef')).toBe(true);
+  });
+
   it('can be aborted mid-run and resumed', async () => {
     for (const n of ['a', 'b', 'c', 'd']) await writeNote(`${n}.md`, `# ${n}\nbody ${n}`);
     // Abort after the first note completes.

--- a/tests/main/embeddings/related.test.ts
+++ b/tests/main/embeddings/related.test.ts
@@ -1,22 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import { topRelatedNotes } from '../../../src/main/embeddings/related';
-import type { RelatedHit } from '../../../src/main/embeddings/vector-store';
+import type { RelatedHit, RefKind } from '../../../src/main/embeddings/vector-store';
 
-const hit = (notePath: string, sectionHeading: string, score: number, chunkText = 'body text'): RelatedHit =>
-  ({ notePath, sectionHeading, chunkText, score });
+const hit = (ref: string, sectionHeading: string, score: number, chunkText = 'body text', kind: RefKind = 'note'): RelatedHit =>
+  ({ kind, ref, sectionHeading, chunkText, score });
 
 describe('topRelatedNotes', () => {
-  const titleOf = (p: string) => p.replace(/\.md$/, '').toUpperCase();
+  const titleOf = (h: RelatedHit) => h.ref.replace(/\.md$/, '').toUpperCase();
 
-  it('keeps one row per note — the best-scoring section', () => {
+  it('keeps one row per ref — the best-scoring section', () => {
     const out = topRelatedNotes(
       [hit('a.md', 'Intro', 0.4), hit('a.md', 'Deep', 0.8), hit('b.md', 'X', 0.6)],
       { limit: 10, titleOf },
     );
     expect(out).toHaveLength(2);
-    const a = out.find((n) => n.relativePath === 'a.md')!;
+    const a = out.find((n) => n.ref === 'a.md')!;
     expect(a.score).toBe(0.8);
     expect(a.sectionHeading).toBe('Deep');
+  });
+
+  it('does not merge a note and a source that share an id string', () => {
+    const out = topRelatedNotes(
+      [hit('x', 'h', 0.5, 'note body', 'note'), hit('x', 'h', 0.9, 'source body', 'source')],
+      { limit: 10, titleOf },
+    );
+    expect(out).toHaveLength(2);
+    expect(out.map((n) => n.kind).sort()).toEqual(['note', 'source']);
   });
 
   it('ranks by score descending and caps at the limit', () => {
@@ -24,16 +33,15 @@ describe('topRelatedNotes', () => {
       [hit('a.md', 'h', 0.3), hit('b.md', 'h', 0.9), hit('c.md', 'h', 0.6)],
       { limit: 2, titleOf },
     );
-    expect(out.map((n) => n.relativePath)).toEqual(['b.md', 'c.md']);
+    expect(out.map((n) => n.ref)).toEqual(['b.md', 'c.md']);
   });
 
-  it('enriches with title and a collapsed snippet', () => {
+  it('carries kind through and enriches with title + collapsed snippet', () => {
     const out = topRelatedNotes(
-      [hit('notes/topic.md', 'Sec', 0.5, '  multi\n  line   text  ')],
-      { limit: 1, titleOf },
+      [hit('arxiv-1234', 'Sec', 0.5, '  multi\n  line   text  ', 'source')],
+      { limit: 1, titleOf: () => 'A Paper Title' },
     );
-    expect(out[0].title).toBe('NOTES/TOPIC');
-    expect(out[0].snippet).toBe('multi line text');
+    expect(out[0]).toMatchObject({ kind: 'source', ref: 'arxiv-1234', title: 'A Paper Title', snippet: 'multi line text' });
   });
 
   it('truncates a long snippet to 160 chars', () => {

--- a/tests/main/embeddings/vector-store.test.ts
+++ b/tests/main/embeddings/vector-store.test.ts
@@ -56,7 +56,7 @@ describe('vector-store', () => {
 
     const hits = await store.searchRelated(ctx(), 'feline predators purr', { limit: 1 });
     expect(hits).toHaveLength(1);
-    expect(hits[0].notePath).toBe('animals.md');
+    expect(hits[0].ref).toBe('animals.md');
     expect(hits[0].sectionHeading).toBe('Animals > Cats');
     expect(hits[0].score).toBeGreaterThan(0.3);
   });
@@ -89,7 +89,7 @@ describe('vector-store', () => {
     expect(embedder.calls.flat()).toHaveLength(0);
 
     const after = await store.searchRelated(ctx(), 'cats and dogs', { limit: 1 });
-    expect(after[0].notePath).toBe(before[0].notePath);
+    expect(after[0].ref).toBe(before[0].ref);
     expect(after[0].score).toBeCloseTo(before[0].score, 6); // reused vectors identical
   });
 
@@ -101,11 +101,11 @@ describe('vector-store', () => {
     // different embedding_model so it's detectably stale.
     const conn = store._connectionForTest(ctx());
     await conn.run(
-      `INSERT INTO note_chunks SELECT note_path || '-old', chunk_index, section_heading, ` +
+      `INSERT INTO note_chunks SELECT kind, ref_id || '-old', chunk_index, section_heading, ` +
       `chunk_text, content_hash, 'old-model-v0', embedding, updated_at FROM note_chunks`,
     );
     const hits = await store.searchRelated(ctx(), 'relevant words here', { limit: 10 });
-    expect(hits.every((h) => !h.notePath.endsWith('-old'))).toBe(true);
+    expect(hits.every((h) => !h.ref.endsWith('-old'))).toBe(true);
   });
 
   it('removes a note\'s chunks on removeNote', async () => {
@@ -125,14 +125,14 @@ describe('vector-store', () => {
     expect(await store.searchRelated(ctx(), 'content', { limit: 5 })).toHaveLength(0);
   });
 
-  it('honours excludePath', async () => {
+  it('honours the exclude option', async () => {
     const embedder = fakeEmbedder();
     await store.init(ctx(), { dbPath, embedder });
     await store.indexNote(ctx(), 'a.md', '# A\nshared topic words');
     await store.indexNote(ctx(), 'b.md', '# B\nshared topic words');
-    const hits = await store.searchRelated(ctx(), 'shared topic words', { limit: 5, excludePath: 'a.md' });
-    expect(hits.every((h) => h.notePath !== 'a.md')).toBe(true);
-    expect(hits.some((h) => h.notePath === 'b.md')).toBe(true);
+    const hits = await store.searchRelated(ctx(), 'shared topic words', { limit: 5, exclude: { kind: 'note', ref: 'a.md' } });
+    expect(hits.every((h) => h.ref !== 'a.md')).toBe(true);
+    expect(hits.some((h) => h.ref === 'b.md')).toBe(true);
   });
 
   it('relatedToNote ranks other notes by nearest chunk, excluding the source', async () => {
@@ -142,9 +142,42 @@ describe('vector-store', () => {
     await store.indexNote(ctx(), 'near.md', '# Near\nfeline animals that purr');
     await store.indexNote(ctx(), 'far.md', '# Far\nquarterly earnings and revenue');
     const hits = await store.relatedToNote(ctx(), 'src.md', { limit: 5 });
-    expect(hits.every((h) => h.notePath !== 'src.md')).toBe(true);
-    expect(hits[0].notePath).toBe('near.md');
+    expect(hits.every((h) => h.ref !== 'src.md')).toBe(true);
+    expect(hits[0].ref).toBe('near.md');
     expect(hits[0].score).toBeGreaterThan(hits[hits.length - 1].score);
+  });
+
+  it('embeds notes, sources, and excerpts together and can filter by kind (#839)', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'note.md', '# Note\nphotosynthesis converts sunlight to energy');
+    await store.indexSource(ctx(), 'arxiv-9999', '# Paper\nphotosynthesis in marine algae and sunlight');
+    await store.indexExcerpt(ctx(), 'arxiv-9999-abc', 'photosynthesis sunlight chlorophyll');
+
+    const all = await store.searchRelated(ctx(), 'photosynthesis sunlight', { limit: 10 });
+    expect(new Set(all.map((h) => h.kind))).toEqual(new Set(['note', 'source', 'excerpt']));
+
+    const onlyExcerpts = await store.searchRelated(ctx(), 'photosynthesis sunlight', { limit: 10, kinds: ['excerpt'] });
+    expect(onlyExcerpts.length).toBeGreaterThan(0);
+    expect(onlyExcerpts.every((h) => h.kind === 'excerpt')).toBe(true);
+
+    // embeddedRefs is per-kind.
+    expect((await store.embeddedRefs(ctx(), 'source')).has('arxiv-9999')).toBe(true);
+    expect((await store.embeddedRefs(ctx(), 'note')).has('arxiv-9999')).toBe(false);
+  });
+
+  it('relatedToNote spans kinds and can be scoped to one', async () => {
+    const embedder = fakeEmbedder();
+    await store.init(ctx(), { dbPath, embedder });
+    await store.indexNote(ctx(), 'q.md', '# Q\nquantum entanglement and superposition');
+    await store.indexSource(ctx(), 'src-q', '# Src\nquantum entanglement experiments');
+    await store.indexNote(ctx(), 'other.md', '# Other\nquantum superposition states');
+
+    const all = await store.relatedToNote(ctx(), 'q.md', { limit: 10 });
+    expect(all.some((h) => h.kind === 'source' && h.ref === 'src-q')).toBe(true);
+
+    const notesOnly = await store.relatedToNote(ctx(), 'q.md', { limit: 10, kinds: ['note'] });
+    expect(notesOnly.every((h) => h.kind === 'note')).toBe(true);
   });
 
   it('relatedToNote returns [] for a note with no embedded chunks', async () => {
@@ -152,6 +185,29 @@ describe('vector-store', () => {
     await store.init(ctx(), { dbPath, embedder });
     await store.indexNote(ctx(), 'other.md', '# Other\nsome content');
     expect(await store.relatedToNote(ctx(), 'missing.md', { limit: 5 })).toEqual([]);
+  });
+
+  it('migrates a pre-#839 (note_path) store by rebuilding it', async () => {
+    // Hand-create the original note-centric schema, as a store from before #839
+    // would have on disk.
+    const { DuckDBInstance } = await import('@duckdb/node-api');
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const inst = await DuckDBInstance.create(dbPath);
+    const conn = await inst.connect();
+    await conn.run(`CREATE TABLE note_chunks (note_path VARCHAR, chunk_index INTEGER, ` +
+      `section_heading VARCHAR, chunk_text VARCHAR, content_hash VARCHAR, embedding_model VARCHAR, ` +
+      `embedding FLOAT[${MODEL.dim}], updated_at TIMESTAMP)`);
+    await conn.run(`INSERT INTO note_chunks VALUES ('stale.md', 0, 'h', 't', 'hash', 'old', ` +
+      `[${new Array(MODEL.dim).fill(0).join(',')}]::FLOAT[${MODEL.dim}], now())`);
+    conn.closeSync(); inst.closeSync();
+
+    // Opening the store must not throw on the old shape; it rebuilds the table.
+    await store.init(ctx(), { dbPath, embedder: fakeEmbedder() });
+    // New-schema writes work, and the stale note_path row is gone.
+    await store.indexNote(ctx(), 'fresh.md', '# Fresh\nbrand new content');
+    const hits = await store.searchRelated(ctx(), 'brand new content', { limit: 5 });
+    expect(hits.some((h) => h.ref === 'fresh.md')).toBe(true);
+    expect(hits.some((h) => h.ref === 'stale.md')).toBe(false);
   });
 
   it('persists across reopen', async () => {
@@ -163,7 +219,7 @@ describe('vector-store', () => {
     // Reopen the same on-disk DB with a fresh embedder.
     await store.init(ctx(), { dbPath, embedder: fakeEmbedder() });
     const hits = await store.searchRelated(ctx(), 'durable turtles', { limit: 1 });
-    expect(hits[0]?.notePath).toBe('keep.md');
+    expect(hits[0]?.ref).toBe('keep.md');
   });
 });
 
@@ -181,7 +237,7 @@ realDescribe('vector-store with the real WASM embedder', () => {
       await store.indexNote(ctx(), 'fin.md', '# Markets\nQuarterly revenue exceeded analyst forecasts.');
 
       const hits = await store.searchRelated(ctx(), 'a kitten meowing', { limit: 2 });
-      expect(hits[0].notePath).toBe('cat.md');
+      expect(hits[0].ref).toBe('cat.md');
       expect(hits[0].score).toBeGreaterThan(hits[1].score);
     } finally {
       await embedder.dispose();

--- a/tests/main/sources/cited-text-from-ttl.test.ts
+++ b/tests/main/sources/cited-text-from-ttl.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { buildExcerptTtl, citedTextFromTtl } from '../../../src/main/sources/create-excerpt';
+
+describe('citedTextFromTtl', () => {
+  it('round-trips text through buildExcerptTtl, including escapes', () => {
+    for (const text of [
+      'a simple passage',
+      'quotes "inside" and a backslash \\ here',
+      'line one\nline two\ttabbed',
+      'unicode — em dash and café',
+    ]) {
+      const ttl = buildExcerptTtl({ sourceId: 'src-1', citedText: text });
+      expect(citedTextFromTtl(ttl)).toBe(text);
+    }
+  });
+
+  it('returns null when there is no citedText', () => {
+    expect(citedTextFromTtl('this: a thought:Excerpt .')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #839. Generalizes the note-centric vector store to **three corpora** — notes, source bodies, and excerpts — so semantic search and the Related panel span the research library, not just notes.

## Store: from `note_path` to `(kind, ref_id)`

- Rows carry a `kind` (`note` | `source` | `excerpt`) + owning `ref_id` (note relativePath / sourceId / excerptId). Generic `indexChunks` / `removeRef` with per-kind wrappers (`indexNote` / `indexSource` / `indexExcerpt`). `searchRelated` and `relatedToRef` gain a **`kinds` filter** and return `kind` + `ref` so hits route correctly. `embeddedRefs(kind)` is the per-kind backfill skip set.
- **Schema migration**: a pre-#839 store (the old `note_path` shape) is detected — no `kind` column — and **rebuilt**. Lossless in practice since the backfill repopulates. Unit-tested by hand-creating the old schema and re-opening.

## Wiring every corpus

- **Excerpt text**: `citedTextFromTtl` reverses the excerpt TTL's `thought:citedText` (round-trip tested, including escapes).
- **Incremental**: source-body changes (`onSourceMetaChanged`) and excerpt writes (`onExcerptChanged` — covers clipper / claim-mining / manual highlights) embed & remove on the same hooks that already update graph/search.
- **Backfill (#836)** now walks `.minerva/sources/<id>/body.md` (metadata-only sources skipped — their title/abstract stay in the graph for structural search) and `.minerva/excerpts/*.ttl` alongside notes, resumable per kind.

## Surfaces

- **`search_related` tool**: optional `kinds` param (e.g. `["excerpt"]` to mine the library); results tag `[source]` / `[excerpt]` so the model routes (uses `read_note` only for plain notes).
- **Related panel**: spans all kinds — a source/excerpt hit opens the **source viewer** (excerpt highlighted) instead of a note, with per-kind row icons.

## Tests

Store cross-kind search + kind filter + per-kind `embeddedRefs` + (note ≠ source same-id) + migration; backfill over sources/excerpts (meta-only skipped); `citedTextFromTtl` round-trip; the related transform keeps `kind`. Full suite green (**3628**), lint clean.

## Heads-up

On first open after this merges, an existing vault's embeddings **rebuild once** in the background (the schema migration drops the old note-only table; the backfill repopulates all three corpora). No user action needed — the status-bar indicator shows progress.

## Epic #833

#834 · #835 · #837 · #836 · #838 · **#839** ✅ — only **#840 (suggested links)** remains, the big finish that turns "here's what's related" into "want to link these?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)