### PR TITLE
feat: note-refactor proposals — approval-engine Move/Rename foundation (#911)

### DIFF
--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -1,6 +1,10 @@
 import * as $rdf from 'rdflib';
 import * as graph from '../graph/index';
 import * as notebaseFs from '../notebase/fs';
+import * as search from '../search/index';
+import * as vectors from '../embeddings/vector-store';
+import { markPathHandled } from '../notebase/path-dedup';
+import { planRename, renameWithLinkRewrites } from '../notebase/rename';
 import type { ProjectContext } from '../project-context-types';
 import { escapeTurtleLiteral } from './turtle';
 
@@ -15,7 +19,8 @@ export type OperationType =
   | 'tag_addition'
   | 'staleness_flag'
   | 'component_creation'
-  | 'status_change';
+  | 'status_change'
+  | 'note_refactor';
 
 /**
  * One side-effect a proposal applies to the thoughtbase. The approval
@@ -74,6 +79,13 @@ export type ProposalPayload =
       query: string;
       language: 'sparql' | 'sql';
       group?: string | null;
+    }
+  | {
+      kind: 'note-refactor';
+      /** Move/rename a single note. Inbound links are rewritten by
+       *  `renameWithLinkRewrites`; rollback restores captured pre-images (#911). */
+      fromPath: string;
+      toPath: string;
     };
 
 export interface ProposedWrite {
@@ -118,6 +130,9 @@ const DEFAULT_POLICY: Record<OperationType, ApprovalTier> = {
   status_change: 'notify_only',
   tag_addition: 'autonomous',
   staleness_flag: 'autonomous',
+  // A move/rename restructures the vault + rewrites links across notes — always
+  // reviewed (#911).
+  note_refactor: 'requires_approval',
 };
 
 let policyOverrides: Partial<Record<OperationType, ApprovalTier>> = {};
@@ -181,7 +196,7 @@ async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<
 /** Payload kinds that `dispatchApply` actually knows how to apply. Keep in
  *  sync with the `switch` in dispatchApply — the `source` / `saved-query`
  *  kinds are defined on the type but not yet wired to a dispatcher. */
-const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt']);
+const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt', 'note-refactor']);
 
 /**
  * Reject a bundle containing a payload kind that has no apply dispatcher (#665).
@@ -527,6 +542,34 @@ async function dispatchApply(ctx: ProjectContext, p: ProposalPayload): Promise<u
       graph.indexExcerpt(ctx, p.excerptId, p.excerptTtl);
       return { excerptPath: relativePath };
     }
+    case 'note-refactor': {
+      // Capture pre-images of every file the refactor will touch BEFORE applying,
+      // so rollback can restore them verbatim (a reverse rename can mis-rewrite a
+      // note that already linked to the destination). planRename also runs the
+      // guardrails (collision / no-op / unsafe / folder) — it throws on violation.
+      const plan = await planRename(ctx.rootPath, p.fromPath, p.toPath);
+      const preImages: Record<string, string> = {
+        [p.fromPath]: await notebaseFs.readFile(ctx.rootPath, p.fromPath),
+      };
+      for (const a of plan.affectedNotes) {
+        if (!(a.path in preImages)) preImages[a.path] = a.before;
+      }
+
+      const { transitions, rewrittenPaths } = await renameWithLinkRewrites(ctx.rootPath, p.fromPath, p.toPath, {
+        markPathHandled,
+        reindexHook: (relPath, content) => {
+          if (relPath.endsWith('.md')) {
+            search.indexNote(ctx, relPath, content);
+            void vectors.indexNote(ctx, relPath, content);
+          }
+        },
+        removeHook: (relPath) => {
+          search.removeNote(ctx, relPath);
+          void vectors.removeNote(ctx, relPath);
+        },
+      });
+      return { fromPath: p.fromPath, toPath: p.toPath, preImages, transitions, rewrittenPaths };
+    }
     case 'source':
     case 'saved-query':
       throw new Error(
@@ -555,6 +598,29 @@ async function dispatchRollback(ctx: ProjectContext, a: AppliedRecord): Promise<
       catch { /* file may already be gone */ }
       // No graph.removeExcerpt today; rollback is best-effort and a reindex
       // reconciles any drift (same posture as the triples-last convention).
+      return;
+    }
+    case 'note-refactor': {
+      const data = a.rollbackData as { fromPath: string; toPath: string; preImages: Record<string, string> };
+      // Move the note back: drop the destination, then restore every captured
+      // pre-image (the moved file at its original path + each rewritten note's
+      // verbatim original content). Reindex each across graph/search/vectors.
+      markPathHandled(data.toPath);
+      try { await notebaseFs.deleteFile(ctx.rootPath, data.toPath); } catch { /* already gone */ }
+      graph.removeNote(ctx, data.toPath);
+      search.removeNote(ctx, data.toPath);
+      void vectors.removeNote(ctx, data.toPath);
+      for (const [relPath, content] of Object.entries(data.preImages)) {
+        try {
+          markPathHandled(relPath);
+          await notebaseFs.writeFile(ctx.rootPath, relPath, content);
+          await graph.indexNote(ctx, relPath, content);
+          search.indexNote(ctx, relPath, content);
+          void vectors.indexNote(ctx, relPath, content);
+        } catch (err) {
+          console.warn(`[approval] note-refactor rollback restore failed for ${relPath}:`, err);
+        }
+      }
       return;
     }
     case 'source':

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -53,6 +53,90 @@ async function listAllFiles(rootPath: string, relDir: string): Promise<string[]>
   return results;
 }
 
+/** A note refactor (move/rename) that can't proceed — collision, no-op, an
+ *  unsupported folder move, etc. Carries a user-facing reason (#911). */
+export class RefactorError extends Error {
+  constructor(message: string) { super(message); this.name = 'RefactorError'; }
+}
+
+export interface AffectedNote {
+  /** Pre-apply path of the note whose content changes. */
+  path: string;
+  before: string;
+  after: string;
+  /** True for the note being moved itself (relative links re-relativized). */
+  isMoved: boolean;
+}
+
+export interface RenamePlan {
+  fromPath: string;
+  toPath: string;
+  /** Every note whose content changes if this refactor is applied — the moved
+   *  note (re-relativized links) plus other notes (inbound link rewrites). */
+  affectedNotes: AffectedNote[];
+  warnings: string[];
+}
+
+/**
+ * Compute what a note move/rename would do — the destination, and every note
+ * whose links would be rewritten, with before/after — **without writing
+ * anything** (#911). Drives the proposal preview's blast radius, and is the
+ * pre-flight guardrail check. Uses the same rewriter helpers as
+ * `renameWithLinkRewrites`, so the preview matches the commit.
+ *
+ * Notes only (folder moves are out of scope for the proposal path).
+ */
+export async function planRename(rootPath: string, fromPath: string, toPath: string): Promise<RenamePlan> {
+  if (fromPath === toPath) throw new RefactorError('The source and destination are the same.');
+  if (!isIndexable(fromPath) || !fromPath.endsWith('.md')) {
+    throw new RefactorError('Only note (.md) files can be moved or renamed this way.');
+  }
+  if (!toPath.endsWith('.md')) throw new RefactorError('The destination must be a .md note path.');
+
+  // Safe-path (throws on traversal / hidden / ignored dirs). Same check the
+  // commit performs via notebaseFs.rename.
+  notebaseFs.assertSafePath(rootPath, fromPath);
+  notebaseFs.assertSafePath(rootPath, toPath);
+
+  let stat: import('node:fs').Stats;
+  try {
+    stat = await fs.stat(path.join(rootPath, fromPath));
+  } catch {
+    throw new RefactorError(`The note to move no longer exists: ${fromPath}`);
+  }
+  if (stat.isDirectory()) throw new RefactorError('Folder moves are not supported here — move a single note.');
+  if (await notebaseFs.fileExists(rootPath, toPath)) {
+    throw new RefactorError(`A file already exists at the destination: ${toPath}`);
+  }
+
+  const ctx = projectContext(rootPath);
+  const rewrites = new Map([[normalizeLinkPath(fromPath), normalizeLinkPath(toPath)]]);
+  const mdRewrites = new Map([[fromPath, toPath]]);
+  const referringNotes = new Set(graph.findNotesLinkingTo(ctx, `${normalizeLinkPath(fromPath)}.md`));
+
+  const affectedNotes: AffectedNote[] = [];
+  for (const currentPath of await listIndexableFiles(rootPath, '')) {
+    const isMoved = currentPath === fromPath;
+    let content: string;
+    try { content = await notebaseFs.readFile(rootPath, currentPath); } catch { continue; }
+
+    let rewritten = content;
+    if (!isMoved && referringNotes.has(currentPath)) {
+      rewritten = rewriteWikiLinks(rewritten, rewrites);
+    }
+    rewritten = rewriteRelativeMarkdownLinks(
+      rewritten,
+      isMoved ? fromPath : currentPath,
+      isMoved ? toPath : currentPath,
+      mdRewrites,
+    );
+    if (rewritten !== content) {
+      affectedNotes.push({ path: currentPath, before: content, after: rewritten, isMoved });
+    }
+  }
+  return { fromPath, toPath, affectedNotes, warnings: [] };
+}
+
 export interface RenameWithLinksOptions {
   /** Called for every relative path we're about to touch so the watcher can dedupe. Optional. */
   markPathHandled?: (relativePath: string) => void;

--- a/tests/main/llm/note-refactor-proposal.test.ts
+++ b/tests/main/llm/note-refactor-proposal.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { proposeWrite, approveProposal, getApprovalTier } from '../../../src/main/llm/approval';
+import { initGraph, indexNote, disposeProject as disposeGraph } from '../../../src/main/graph/index';
+import { initSearch, indexNote as searchIndex, disposeProject as disposeSearch } from '../../../src/main/search/index';
+import { projectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+const ctx = () => projectContext(root);
+const read = (rel: string) => fsp.readFile(path.join(root, rel), 'utf-8');
+const exists = (rel: string) => fs.existsSync(path.join(root, rel));
+
+async function seed(rel: string, body: string): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, body, 'utf-8');
+  await indexNote(ctx(), rel, body);
+  searchIndex(ctx(), rel, body);
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-note-refactor-'));
+  await initGraph(ctx());
+  await initSearch(ctx());
+  await seed('raft.md', '# Raft\n\nThe Raft consensus algorithm.');
+  await seed('consensus.md', '# Consensus\n\nSee [[raft]] for the protocol.');
+});
+afterEach(async () => {
+  disposeGraph(ctx());
+  disposeSearch(ctx());
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+function refactor(fromPath: string, toPath: string) {
+  return proposeWrite(ctx(), {
+    operationType: 'note_refactor',
+    payloads: [{ kind: 'note-refactor', fromPath, toPath }],
+    note: `Move ${fromPath} → ${toPath}`,
+    proposedBy: 'unit-test',
+  });
+}
+
+describe('note-refactor proposal (#911)', () => {
+  it('is requires_approval — files as pending, not auto-applied', async () => {
+    expect(getApprovalTier('note_refactor')).toBe('requires_approval');
+    const proposal = await refactor('raft.md', 'algorithms/raft.md');
+    expect(proposal).not.toBeNull();
+    // Nothing moved yet — it's pending review.
+    expect(exists('raft.md')).toBe(true);
+    expect(exists('algorithms/raft.md')).toBe(false);
+  });
+
+  it('on approval moves the note and rewrites inbound links', async () => {
+    const proposal = await refactor('raft.md', 'algorithms/raft.md');
+    expect((await approveProposal(ctx(), proposal!.uri)).ok).toBe(true);
+
+    expect(exists('raft.md')).toBe(false);
+    expect(exists('algorithms/raft.md')).toBe(true);
+    expect(await read('consensus.md')).toContain('[[algorithms/raft]]');
+    expect(await read('consensus.md')).not.toContain('[[raft]]');
+  });
+
+  it('rolls back exactly when a later payload fails', async () => {
+    const before = await read('consensus.md');
+    // Bundle the refactor with a malformed-turtle payload that throws at apply,
+    // forcing reverse-order rollback of the already-applied refactor.
+    const proposal = await proposeWrite(ctx(), {
+      operationType: 'note_refactor',
+      payloads: [
+        { kind: 'note-refactor', fromPath: 'raft.md', toPath: 'algorithms/raft.md' },
+        { kind: 'graph-triples', turtle: 'this is not valid turtle @@@', affectsNodeUris: [] },
+      ],
+      note: 'refactor + bad triples',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx(), proposal!.uri)).rejects.toThrow();
+
+    // The vault is exactly as it was: note back, destination gone, links verbatim.
+    expect(exists('raft.md')).toBe(true);
+    expect(exists('algorithms/raft.md')).toBe(false);
+    expect(await read('consensus.md')).toBe(before);
+    expect(await read('consensus.md')).toContain('[[raft]]');
+  });
+
+  it('rejects a colliding destination at approval time', async () => {
+    await seed('archive.md', '# Archive\n\nexisting');
+    const proposal = await refactor('raft.md', 'archive.md');
+    await expect(approveProposal(ctx(), proposal!.uri)).rejects.toThrow(/already exists/);
+    // Both notes untouched.
+    expect(await read('archive.md')).toContain('existing');
+    expect(exists('raft.md')).toBe(true);
+  });
+});

--- a/tests/main/notebase/plan-rename.test.ts
+++ b/tests/main/notebase/plan-rename.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { planRename, renameWithLinkRewrites, RefactorError } from '../../../src/main/notebase/rename';
+import { initGraph, indexNote, disposeProject } from '../../../src/main/graph/index';
+import { projectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+const ctx = () => projectContext(root);
+
+async function write(rel: string, body: string): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, body, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-plan-rename-'));
+  await initGraph(ctx());
+});
+afterEach(async () => {
+  disposeProject(ctx());
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('planRename', () => {
+  it('reports the inbound wiki-link rewrite without writing anything', async () => {
+    await write('raft.md', '# Raft\n\nbody');
+    await write('consensus.md', '# Consensus\n\nSee [[raft]] for details.');
+    await indexNote(ctx(), 'raft.md', await fsp.readFile(path.join(root, 'raft.md'), 'utf-8'));
+    await indexNote(ctx(), 'consensus.md', await fsp.readFile(path.join(root, 'consensus.md'), 'utf-8'));
+
+    const plan = await planRename(root, 'raft.md', 'algorithms/raft.md');
+    const consensus = plan.affectedNotes.find((a) => a.path === 'consensus.md')!;
+    expect(consensus).toBeDefined();
+    expect(consensus.before).toContain('[[raft]]');
+    expect(consensus.after).toContain('[[algorithms/raft]]');
+
+    // Nothing on disk changed.
+    expect(await fsp.readFile(path.join(root, 'consensus.md'), 'utf-8')).toContain('[[raft]]');
+    expect(fs.existsSync(path.join(root, 'algorithms/raft.md'))).toBe(false);
+    expect(fs.existsSync(path.join(root, 'raft.md'))).toBe(true);
+  });
+
+  it("the plan's affected set matches what the commit actually rewrites", async () => {
+    await write('a.md', '# A\n\nlinks to [[target]] here');
+    await write('b.md', '# B\n\nalso [[target]]');
+    await write('target.md', '# Target');
+    for (const f of ['a.md', 'b.md', 'target.md']) {
+      await indexNote(ctx(), f, await fsp.readFile(path.join(root, f), 'utf-8'));
+    }
+    const plan = await planRename(root, 'target.md', 'moved/target.md');
+    const planned = new Set(plan.affectedNotes.filter((a) => !a.isMoved).map((a) => a.path));
+
+    const { rewrittenPaths } = await renameWithLinkRewrites(root, 'target.md', 'moved/target.md');
+    expect(planned).toEqual(new Set(rewrittenPaths));
+  });
+
+  describe('guardrails', () => {
+    beforeEach(async () => { await write('note.md', '# Note'); await write('exists.md', '# Exists'); });
+
+    it('rejects a no-op (same path)', async () => {
+      await expect(planRename(root, 'note.md', 'note.md')).rejects.toBeInstanceOf(RefactorError);
+    });
+    it('rejects a collision with an existing file', async () => {
+      await expect(planRename(root, 'note.md', 'exists.md')).rejects.toThrow(/already exists/);
+    });
+    it('rejects a missing source', async () => {
+      await expect(planRename(root, 'ghost.md', 'x.md')).rejects.toThrow(/no longer exists/);
+    });
+    it('rejects a non-note source', async () => {
+      await write('data.csv', 'a,b\n1,2');
+      await expect(planRename(root, 'data.csv', 'data2.csv')).rejects.toBeInstanceOf(RefactorError);
+    });
+    it('rejects an unsafe destination (path traversal)', async () => {
+      await expect(planRename(root, 'note.md', '../escape.md')).rejects.toThrow();
+    });
+    it('rejects a folder source', async () => {
+      await write('folder/inner.md', '# Inner');
+      await expect(planRename(root, 'folder', 'folder2')).rejects.toBeInstanceOf(RefactorError);
+    });
+  });
+});


### PR DESCRIPTION
Closes #911. **Foundation for epic #910** (LLM-proposed note refactors → reorganization skills). Teaches the approval engine to carry a note move/rename as a proposal, applied by the existing `renameWithLinkRewrites` — no new link-integrity code, just wiring + safety + preview.

## Payload + tier

- New `ProposalPayload` kind `{ kind: 'note-refactor'; fromPath; toPath }` + `OperationType` `note_refactor` at **`requires_approval`** (a structural vault change is always reviewed). Registered in `WIRED_PAYLOAD_KINDS`.

## Apply + exact rollback

- **Apply** captures **pre-images** of every file the refactor will touch, then calls `renameWithLinkRewrites` with hooks that also reindex search + embeddings.
- **Rollback** is the careful part: a naïve reverse rename isn't a faithful undo (it can mis-rewrite a note that *already* linked to the destination). So rollback restores the captured bytes **verbatim**, moves the note back, and reindexes across graph/search/vectors. Proven by a test that bundles the refactor with a failing payload and asserts the vault returns to its exact prior state.

## Dry-run preview (`planRename`)

- A **read-only** computation of the blast radius — the destination + every note whose links would change, with before/after — **writing nothing**. It drives the future review preview (#913) and runs the guardrails up front.
- It shares the same rewriter helpers as the commit path, so the preview can't drift from what apply does — asserted by a test: `plan.affectedNotes == commit.rewrittenPaths`.

## Guardrails

No-op (same path), collision (destination exists), missing source, non-note / folder source, and unsafe path (`assertSafePath`) all rejected with a `RefactorError`. Missing destination folders are created (`notebaseFs.rename` already does `mkdir -p` + safe-path).

## Scope note

Notes only — folder moves stay out of the proposal path (the existing IPC rename handler still does both files and folders; `renameWithLinkRewrites` is untouched, so that path is unaffected).

## Tests

`planRename` (inbound-link rewrite reported with nothing written; each guardrail; plan==commit drift-guard) and the approval path (files pending not applied; approve → move + link rewrite; **exact rollback** on a failing bundle; collision rejected at approval). Full suite green (**3648**), lint clean.

## Epic #910 next

#912 (LLM tools `propose_note_rename` / `propose_note_move` + `planRename`-backed drafts) and #913 (review card with the blast-radius diff) build directly on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)