### PR TITLE
feat: review card for Move/Rename proposals with blast-radius diff (#913)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -41,6 +41,8 @@
   import MessageCitations from './MessageCitations.svelte';
   import DraftCard from './DraftCard.svelte';
   import ComputeDraftCard from './ComputeDraftCard.svelte';
+  import RefactorDraftCard from './RefactorDraftCard.svelte';
+  import type { ConversationRefactorDraft } from '../../../shared/conversation-refactor-drafts';
   import { getSlashCommands } from '../tools/tool-registry';
   import { slashQueryFromComposer, buildSlashMenu, type SlashMenuItem } from '../conversations/slash-commands';
   import {
@@ -385,6 +387,20 @@
     store.discardDraft(tabId, draftId);
   }
 
+  async function handleApproveRefactor(tabId: string, draft: ConversationRefactorDraft) {
+    try {
+      await store.approveRefactorDraft(tabId, draft);
+      // Land the user on the note at its new path.
+      void editor.openFile(draft.toPath);
+    } catch (e) {
+      console.error('[conv-panel] approve refactor failed:', e);
+    }
+  }
+
+  function handleDiscardRefactor(tabId: string, draftId: string) {
+    store.discardRefactorDraft(tabId, draftId);
+  }
+
   async function handleApproveSource(tabId: string, draft: ConversationSourceDraft) {
     try {
       await store.approveSourceDraft(tabId, draft);
@@ -579,6 +595,13 @@
   function orphanComputeDrafts(tab: TabT) {
     const max = tab.conversation.messages.length;
     return tab.computeDrafts.filter((d) => d.afterMessageIndex >= max);
+  }
+  function refactorDraftsAt(tab: TabT, i: number) {
+    return tab.refactorDrafts.filter((d) => d.afterMessageIndex === i);
+  }
+  function orphanRefactorDrafts(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return tab.refactorDrafts.filter((d) => d.afterMessageIndex >= max);
   }
 </script>
 
@@ -1007,6 +1030,13 @@
                 onOpenInserted={openInsertedNote}
               />
             {/each}
+            {#each refactorDraftsAt(tab, i) as draft (draft.draftId)}
+              <RefactorDraftCard
+                {draft}
+                onApprove={() => handleApproveRefactor(tab.id, draft)}
+                onDiscard={() => handleDiscardRefactor(tab.id, draft.draftId)}
+              />
+            {/each}
           {/each}
 
           {#if tab.streaming}
@@ -1105,6 +1135,13 @@
               onInsert={onInsertCompute}
               onDiscard={onDiscardCompute}
               onOpenInserted={openInsertedNote}
+            />
+          {/each}
+          {#each orphanRefactorDrafts(tab) as draft (draft.draftId)}
+            <RefactorDraftCard
+              {draft}
+              onApprove={() => handleApproveRefactor(tab.id, draft)}
+              onDiscard={() => handleDiscardRefactor(tab.id, draft.draftId)}
             />
           {/each}
         </div>

--- a/src/renderer/lib/components/RefactorDraftCard.svelte
+++ b/src/renderer/lib/components/RefactorDraftCard.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  /**
+   * Review card for a note move/rename proposal (#913). A refactor is a
+   * structural change with a fan-out — one move plus link rewrites across N other
+   * notes — so the card leads with the destination and the blast radius, with an
+   * expandable per-file diff (rendered from the dry-run the tool already computed;
+   * nothing is recomputed on approve). No danger styling: a move is normal.
+   */
+  import type { ConversationRefactorDraft } from '../../../shared/conversation-refactor-drafts';
+  import DraftCard from './DraftCard.svelte';
+  import Icon from './Icon.svelte';
+  import { refactorVerb, changedLines } from './refactor-diff';
+
+  interface Props {
+    draft: ConversationRefactorDraft;
+    onApprove: () => void;
+    onDiscard: () => void;
+  }
+
+  let { draft, onApprove, onDiscard }: Props = $props();
+
+  let expanded = $state(false);
+
+  const verb = $derived(refactorVerb(draft.fromPath, draft.toPath));
+  const isRename = $derived(verb === 'Rename');
+  // Other notes whose inbound links get rewritten (excludes the moved note itself).
+  const otherNotes = $derived(draft.affectedNotes.filter((a) => !a.isMoved));
+</script>
+
+<DraftCard
+  headline={verb}
+  note="{draft.fromPath} → {draft.toPath}"
+  approveLabel={isRename ? 'Approve & rename' : 'Approve & move'}
+  {onApprove}
+  {onDiscard}
+>
+  <div class="refactor-body">
+    <div class="blast" class:none={otherNotes.length === 0}>
+      {#if otherNotes.length === 0}
+        No other notes link here — only the note moves.
+      {:else}
+        <strong>{otherNotes.length}</strong> note{otherNotes.length === 1 ? '' : 's'} will have links rewritten.
+      {/if}
+    </div>
+
+    {#if draft.affectedNotes.length > 0}
+      <button class="toggle" type="button" onclick={() => (expanded = !expanded)}>
+        <Icon name={expanded ? 'chevronDown' : 'chevronRight'} size={11} />
+        {expanded ? 'Hide changes' : 'Show changes'}
+      </button>
+      {#if expanded}
+        <div class="diffs">
+          {#each draft.affectedNotes as note (note.path)}
+            <div class="file-diff">
+              <div class="file-path">
+                {note.path}{#if note.isMoved}<span class="self"> · this note</span>{/if}
+              </div>
+              {#each changedLines(note.before, note.after) as line}
+                <div class="line removed">{line.before}</div>
+                <div class="line added">{line.after}</div>
+              {/each}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+  </div>
+</DraftCard>
+
+<style>
+  .refactor-body { display: flex; flex-direction: column; gap: 6px; }
+  .blast { font-size: 12.5px; color: var(--text); }
+  .blast.none { color: var(--text-muted); }
+  .toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    align-self: flex-start;
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 11.5px;
+  }
+  .toggle:hover { color: var(--text); }
+  .diffs { display: flex; flex-direction: column; gap: 8px; }
+  .file-diff {
+    border-left: 2px solid var(--border);
+    padding-left: 8px;
+  }
+  .file-path {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+    margin-bottom: 2px;
+  }
+  .self { color: var(--text-faint); }
+  .line {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    padding: 0 4px;
+    border-radius: 2px;
+  }
+  /* Quiet add/remove tints — no alarm red; removed leans muted, added leans sage. */
+  .line.removed { color: var(--text-muted); background: color-mix(in oklch, var(--text) 6%, transparent); }
+  .line.added { color: var(--text); background: color-mix(in oklch, var(--sage) 14%, transparent); }
+</style>

--- a/src/renderer/lib/components/refactor-diff.ts
+++ b/src/renderer/lib/components/refactor-diff.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure derivations for the refactor review card (#913), extracted so they're
+ * unit-testable without rendering Svelte.
+ */
+
+/** "Rename" when only the basename changes, "Move" when the folder changes. */
+export function refactorVerb(fromPath: string, toPath: string): 'Rename' | 'Move' {
+  const dir = (p: string) => (p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '');
+  return dir(fromPath) === dir(toPath) ? 'Rename' : 'Move';
+}
+
+export interface ChangedLine {
+  before: string;
+  after: string;
+}
+
+/**
+ * The lines that differ between `before` and `after`. Link rewrites are in-place
+ * text substitutions, so line structure is preserved — a simple index-wise
+ * comparison surfaces exactly the changed (link) lines for the card's diff.
+ */
+export function changedLines(before: string, after: string): ChangedLine[] {
+  const b = before.split('\n');
+  const a = after.split('\n');
+  const out: ChangedLine[] = [];
+  for (let i = 0; i < Math.max(b.length, a.length); i++) {
+    if (b[i] !== a[i]) out.push({ before: b[i] ?? '', after: a[i] ?? '' });
+  }
+  return out;
+}

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -5,6 +5,7 @@ import type {
   ConversationsUIState,
 } from '../../../shared/types';
 import type { ConversationDraft } from '../../../shared/conversation-drafts';
+import type { ConversationRefactorDraft } from '../../../shared/conversation-refactor-drafts';
 import type {
   ConversationSourceDraft,
   SourceIngestOutcome,
@@ -88,6 +89,7 @@ interface NoteDraftResultEntry {
   afterMessageIndex: number;
 }
 type AnchoredComputeDraft = ConversationComputeDraft & { afterMessageIndex: number };
+type AnchoredRefactorDraft = ConversationRefactorDraft & { afterMessageIndex: number };
 /** Per-draft state for compute proposals (#245). `result` holds the
  *  output of the most recent Run; `insertedAt` records the destination
  *  path when the user chose Insert into notebook. Both are optional —
@@ -140,6 +142,8 @@ interface TabRuntime {
   claimsDraftResults: Record<string, ClaimsDraftResultEntry>;
   /** propose_compute drafts awaiting Run / Insert / Discard. */
   computeDrafts: AnchoredComputeDraft[];
+  /** propose_note_rename/move drafts awaiting Approve/Discard (#913). */
+  refactorDrafts: AnchoredRefactorDraft[];
   /** Per-draft Run / Insert state. Stays alive after Run so the user
    *  can see the cell + output in the transcript; only Discard removes
    *  the draft entirely (which also drops the state entry). */
@@ -183,6 +187,7 @@ let propertyDraftSubscribed = false;
 let sourcePropertyDraftSubscribed = false;
 let claimsDraftSubscribed = false;
 let computeDraftSubscribed = false;
+let refactorDraftSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
 
@@ -285,6 +290,15 @@ function ensureSubscriptions(): void {
     });
     computeDraftSubscribed = true;
   }
+  if (!refactorDraftSubscribed) {
+    api.conversations.onRefactorDraft((draft) => {
+      const t = tabs.find((tab) => tab.id === draft.conversationId);
+      if (!t) return;
+      const afterMessageIndex = t.conversation.messages.length;
+      t.refactorDrafts = [...t.refactorDrafts, { ...draft, afterMessageIndex }];
+    });
+    refactorDraftSubscribed = true;
+  }
   if (!askUserSubscribed) {
     api.conversations.onAskUser((req) => {
       const t = tabs.find((tab) => tab.id === req.conversationId);
@@ -332,6 +346,7 @@ async function init(): Promise<void> {
       claimsDrafts: [],
       claimsDraftResults: {},
       computeDrafts: [],
+      refactorDrafts: [],
       computeDraftState: {},
       pendingQuestion: null,
       composer: '',
@@ -425,6 +440,7 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     claimsDrafts: [],
     claimsDraftResults: {},
     computeDrafts: [],
+    refactorDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
     composer: '',
@@ -485,6 +501,7 @@ async function openConversationTab(opts: {
     claimsDrafts: [],
     claimsDraftResults: {},
     computeDrafts: [],
+    refactorDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
     composer: '',
@@ -666,6 +683,7 @@ function blankTabRuntime(conv: Conversation, extraTools: ConversationToolKey[]):
     claimsDrafts: [],
     claimsDraftResults: {},
     computeDrafts: [],
+    refactorDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
     composer: '',
@@ -752,6 +770,23 @@ function discardDraft(tabId: string, draftId: string): void {
   const tab = findTab(tabId);
   if (!tab) return;
   tab.drafts = tab.drafts.filter((d) => d.draftId !== draftId);
+}
+
+async function approveRefactorDraft(tabId: string, draft: ConversationRefactorDraft): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  // Snapshot before crossing IPC ($state Proxies fail structured-clone).
+  const snapshot = $state.snapshot(draft);
+  await api.conversations.fileRefactorDraft(snapshot);
+  // Drop the card. The move + link rewrites land via the approval engine, and
+  // the NOTEBASE_RENAMED / NOTEBASE_REWRITTEN broadcasts update any open editors.
+  tab.refactorDrafts = tab.refactorDrafts.filter((d) => d.draftId !== draft.draftId);
+}
+
+function discardRefactorDraft(tabId: string, draftId: string): void {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  tab.refactorDrafts = tab.refactorDrafts.filter((d) => d.draftId !== draftId);
 }
 
 async function approveSourceDraft(
@@ -1014,6 +1049,8 @@ export function getConversationsStore() {
     runBuiltinCommand,
     approveDraft,
     discardDraft,
+    approveRefactorDraft,
+    discardRefactorDraft,
     approveSourceDraft,
     discardSourceDraft,
     dismissSourceDraftResult,

--- a/tests/renderer/refactor-diff.test.ts
+++ b/tests/renderer/refactor-diff.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { refactorVerb, changedLines } from '../../src/renderer/lib/components/refactor-diff';
+
+describe('refactorVerb', () => {
+  it('is Rename when only the basename changes', () => {
+    expect(refactorVerb('notes/raft.md', 'notes/raft-consensus.md')).toBe('Rename');
+    expect(refactorVerb('raft.md', 'paxos.md')).toBe('Rename');
+  });
+  it('is Move when the folder changes', () => {
+    expect(refactorVerb('raft.md', 'notes/algorithms/raft.md')).toBe('Move');
+    expect(refactorVerb('a/x.md', 'b/x.md')).toBe('Move');
+  });
+});
+
+describe('changedLines', () => {
+  it('surfaces only the lines that differ', () => {
+    const before = '# Note\n\nSee [[raft]] for details.\n\nUnrelated line.';
+    const after = '# Note\n\nSee [[raft-consensus]] for details.\n\nUnrelated line.';
+    const out = changedLines(before, after);
+    expect(out).toHaveLength(1);
+    expect(out[0].before).toContain('[[raft]]');
+    expect(out[0].after).toContain('[[raft-consensus]]');
+  });
+
+  it('is empty when nothing changed', () => {
+    expect(changedLines('same\ntext', 'same\ntext')).toEqual([]);
+  });
+
+  it('handles multiple changed lines', () => {
+    const out = changedLines('[[a]]\nx\n[[a]]', '[[b]]\nx\n[[b]]');
+    expect(out).toHaveLength(2);
+    expect(out.every((l) => l.after.includes('[[b]]'))).toBe(true);
+  });
+});

--- a/tests/renderer/stores/conversation-clear.test.ts
+++ b/tests/renderer/stores/conversation-clear.test.ts
@@ -14,7 +14,7 @@ const h = vi.hoisted(() => {
     conversations: {
       // subscriptions used by ensureSubscriptions()
       onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
-      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onAskUser: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onRefactorDraft: noop, onAskUser: noop,
       saveUIState: vi.fn().mockResolvedValue(undefined),
       archive: vi.fn().mockResolvedValue(undefined),
       create: vi.fn(async (contextBundle: unknown, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) => {

--- a/tests/renderer/stores/conversation-compact.test.ts
+++ b/tests/renderer/stores/conversation-compact.test.ts
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => {
   const api = {
     conversations: {
       onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
-      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onAskUser: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onRefactorDraft: noop, onAskUser: noop,
       saveUIState: vi.fn().mockResolvedValue(undefined),
       create: vi.fn(async (contextBundle: unknown) => ({
         id: `conv-${nextId++}`,


### PR DESCRIPTION
Closes #913. The **first visible surface of epic #910** — a distinct inline review card for a note move/rename draft (#912), making the structural fan-out legible before the user approves.

## The card

`RefactorDraftCard.svelte`, reusing the shared `DraftCard` shell:

- **Headline** — `Rename` / `Move`, with `from → to`.
- **Blast radius** — "**N notes** will have links rewritten" (or "only the note moves" when nothing links it), so the structural consequence is visible up front.
- **Expandable per-file diff** — click "Show changes" to see each affected note's changed link lines, **rendered from the dry-run the tool already computed** (`affectedNotes`) — not recomputed on approve.
- **Approve & move/rename · Discard.**

## Preview ≠ apply

Nothing is written until Approve, which routes through `CONVERSATION_FILE_REFACTOR_DRAFT` → `proposeWrite` / `approveProposal` → the engine's `renameWithLinkRewrites` (#911). On approve the panel opens the note at its new path; the apply's `NOTEBASE_RENAMED` / `NOTEBASE_REWRITTEN` broadcasts update any open editors. Per CLAUDE.md: no danger styling — quiet add/remove tints (muted / sage), no alarm red, fully dismissable.

The refactor draft is wired through the conversations store (subscribe + anchor + approve/discard) and the panel (inline + trailing render), mirroring the other specialized draft types.

## Tests

`refactorVerb` (rename vs move) and `changedLines` (the link-line diff) are extracted to a pure helper and unit-tested; the conversation store-test mocks gained the new `onRefactorDraft` subscription. Full suite green (**3661**), lint clean.

A live visual capture needs an LLM conversation to invoke `propose_note_rename` (non-deterministic), so it's not automated here — but the card composes the already-proven `DraftCard` shell, the apply path is tested in #911, and the draft emission in #912.

## Epic #910 — 3 of 5

#911 foundation ✅ · #912 tools ✅ · **#913 review card ✅** · #914 batch plans ⬜ · #915 reorg skills ⬜

🤖 Generated with [Claude Code](https://claude.com/claude-code)