### PR TITLE
feat: notebase-reorganization skills — the epic payoff (#915)

### DIFF
--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -296,6 +296,42 @@ before referencing thought-ontology types), the read-only `search_notes` /
 `read_note` / `query_graph`, and `web_search` / `web_fetch` (set `web: true` to
 default them on).
 
+## Whole-vault skills (reorganization)
+
+Most skills operate on the active note (`context: [fullNote]`). A skill can also
+operate on the **whole thoughtbase** — set no `context` at all (it defaults to
+empty) so the menu item is always enabled, and have the agent discover what it
+needs with read-only tools:
+
+- **`list_notes`** — every note's path + title (the structure, compactly). The
+  starting point for any reorg.
+- **`search_related`** — semantically-near notes/sources/excerpts.
+- `search_notes` / `read_note` / `query_graph` for content, tags, and links.
+
+To restructure the vault, the agent proposes file refactors — and, per the trust
+principle, **only proposes**. The mutation tools:
+
+- **`propose_note_rename`** `{ path, newName }` and **`propose_note_move`**
+  `{ path, destFolder }` — a single move/rename, reviewed as a card showing every
+  note whose links would be rewritten.
+- **`propose_reorganization`** `{ operations: [{ path, newPath }] }` — a **batch**
+  plan: many moves/renames reviewed as one card with per-item checkboxes (the user
+  approves a subset). Inbound wiki-links are rewritten automatically on approval;
+  nothing moves until then.
+
+Stock examples: **Reorganize by Topic** (`organize-by-topic.md`) clusters loose
+notes into topic folders; **Tidy Filenames** (`tidy-filenames.md`) renames toward
+a consistent convention. Both are propose-only — the agent's body must never claim
+to move files itself.
+
+**Worked example.** A flat vault with `raft.md` ↔ `paxos.md` (linking each other)
+and `risotto.md` → `stock.md`, all at the root. "Reorganize by Topic" calls
+`list_notes`, clusters by title, and proposes
+`propose_reorganization([{raft.md → distributed-systems/raft.md}, … ])`. The user
+reviews the plan, ticks the moves they like, and approves — the notes land in
+their folders and every `[[…]]` is rewritten (`[[paxos]]` → `[[distributed-systems/paxos]]`),
+all through the approval engine.
+
 <a name="grouping"></a>
 ## Grouping (thematic sub-menus)
 

--- a/src/main/skills/stock/organize-by-topic.md
+++ b/src/main/skills/stock/organize-by-topic.md
@@ -1,0 +1,35 @@
+---
+id: analysis.organize-by-topic
+name: Reorganize by Topic
+description: Propose moving loose notes into topic folders, reviewed as one plan
+menu: Analysis
+group: Organization
+outputMode: openConversation
+model: claude-opus-4-8
+web: false
+firstMessage: "Survey this thoughtbase and propose a tidier organization — group related notes into topic folders. Show me the plan to review."
+longDescription: >-
+  Opens a conversation that surveys the whole thoughtbase and proposes a tidier
+  folder structure — clustering related notes into topic folders — as a single
+  reviewable reorganization plan. Nothing moves until you approve; you can approve
+  the whole plan or just the moves you like. Inbound wiki-links are rewritten
+  automatically on approval. The agent proposes only — it never touches the vault
+  itself.
+---
+You are proposing a tidier **folder organization** for a thoughtbase: cluster related notes into topic folders and file the moves as ONE reviewable reorganization plan. You **propose only** — the human reviews and approves; nothing moves until then.
+
+## Procedure
+
+1. **Survey the structure.** Call `list_notes` to get every note's path and title. This is your map: which notes sit loose at the root, which folders already exist, and what the titles suggest about topics.
+2. **Find the clusters.** Group notes by what they're *about*, reading from titles first. When a title is ambiguous and would change which cluster a note belongs to, use `read_note` on that one note — don't read the whole vault (it's slow and rarely needed). `query_graph` can surface tags / link structure if titles aren't enough.
+3. **Design a conservative structure.** Propose topic folders only for clusters that are genuinely cohesive (≈3+ related notes). Prefer a shallow tree — one level of topic folders is usually right; don't over-nest. **Leave a note where it is** when it's already well-placed or doesn't clearly belong to a cluster — a half-organized vault the user trusts beats an over-organized one they don't.
+4. **Propose the plan.** Call `propose_reorganization` ONCE. Each operation is `{ path: <current path>, newPath: <topic-folder>/<same filename> }`. **Move only — keep each note's filename unchanged** (renaming for consistency is a separate skill). Use clear, lowercase folder names (e.g. `notes/distributed-systems/`).
+5. **Explain briefly, then stop.** After `propose_reorganization` returns, end the turn with one or two sentences naming the topic folders you proposed and how many notes each gathers. Do NOT call the tool again this turn, and do NOT claim anything has moved — it hasn't until the user approves.
+
+## Constraints
+
+- **Propose, never apply.** Your only mutation tool is `propose_reorganization`, which queues a plan for review. You cannot and must not move files yourself.
+- Keep filenames identical — only the folder changes.
+- Don't propose moving a note that's already in a sensible folder.
+- If the vault is already well-organized, say so and propose little or nothing rather than inventing churn.
+- One `propose_reorganization` call. The user can approve a subset, so put every reasonable move in the single plan rather than holding some back.

--- a/src/main/skills/stock/tidy-filenames.md
+++ b/src/main/skills/stock/tidy-filenames.md
@@ -1,0 +1,34 @@
+---
+id: analysis.tidy-filenames
+name: Tidy Filenames
+description: Propose renaming notes toward a consistent filename convention
+menu: Analysis
+group: Organization
+outputMode: openConversation
+model: claude-opus-4-8
+web: false
+firstMessage: "Look over this thoughtbase's filenames and propose renames toward a consistent, tidy convention. Show me the plan to review."
+longDescription: >-
+  Opens a conversation that scans the thoughtbase's filenames and proposes renames
+  toward one consistent convention (kebab-case by default) — without moving notes
+  between folders. Filed as a single reviewable plan; nothing is renamed until you
+  approve, and you can approve just the renames you like. Inbound wiki-links are
+  rewritten automatically. The agent proposes only.
+---
+You are proposing **filename tidying** for a thoughtbase: rename notes toward one consistent convention, in place (same folder), filed as ONE reviewable plan. You **propose only** — the human reviews and approves.
+
+## Procedure
+
+1. **Survey.** Call `list_notes` to get every note's path. You're looking at the *filenames*, not the content.
+2. **Pick the target convention.** Default to **kebab-case** (lowercase words joined by hyphens, `.md` extension): `My Note (draft).md` → `my-note-draft.md`. If the vault already follows a clear different convention (e.g. `Title Case.md`, or `YYYY-MM-DD-` date prefixes), match the existing majority instead of imposing kebab-case — consistency with what's there matters more than any one style.
+3. **Find the offenders.** Flag filenames that break the convention: stray capitals, spaces, punctuation (`()[]&,`), redundant words, inconsistent separators. **Skip files already conforming** — don't propose a rename that changes nothing meaningful.
+4. **Propose the plan.** Call `propose_reorganization` ONCE. Each operation is `{ path: <current path>, newPath: <same folder>/<tidied-filename>.md }`. **Keep each note in its folder — change only the filename.** Preserve the meaning of the name; tidy the form, don't reword the title.
+5. **Explain, then stop.** End the turn with one sentence naming the convention you applied and how many files it touches. Do NOT call the tool again, and do NOT claim anything was renamed — it isn't until the user approves.
+
+## Constraints
+
+- **Propose, never apply.** `propose_reorganization` only queues a plan; you cannot rename files yourself.
+- Same folder — only the filename changes. (Moving notes between folders is a separate skill.)
+- Don't rename a file that already fits the convention.
+- Don't change a name's meaning — `Raft Consensus.md` → `raft-consensus.md`, never `raft.md`.
+- One `propose_reorganization` call; the user can deselect any rename they want to keep.

--- a/tests/main/notebase/reorg-worked-example.test.ts
+++ b/tests/main/notebase/reorg-worked-example.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { planReorg } from '../../../src/main/notebase/reorg';
+import { proposeWrite, approveProposal, type ProposalPayload } from '../../../src/main/llm/approval';
+import { initGraph, indexNote, disposeProject as disposeGraph } from '../../../src/main/graph/index';
+import { initSearch, indexNote as searchIndex, disposeProject as disposeSearch } from '../../../src/main/search/index';
+import { projectContext } from '../../../src/main/project-context-types';
+
+/**
+ * The #915 worked example, end to end at the substrate level: a messy flat vault
+ * → a reorganization plan → approve → tidy folders with every wiki-link intact.
+ * (The skill's LLM clustering is what produces these moves; here we supply a
+ * plausible plan and prove the propose → apply machinery delivers the result.)
+ */
+let root: string;
+const ctx = () => projectContext(root);
+const read = (rel: string) => fsp.readFile(path.join(root, rel), 'utf-8');
+const exists = (rel: string) => fs.existsSync(path.join(root, rel));
+
+async function seed(rel: string, body: string): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, body, 'utf-8');
+  await indexNote(ctx(), rel, body);
+  searchIndex(ctx(), rel, body);
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-reorg-example-'));
+  await initGraph(ctx());
+  await initSearch(ctx());
+  // A messy, flat thoughtbase: two distributed-systems notes that link each
+  // other, two cooking notes, all loose at the root.
+  await seed('raft.md', '# Raft\n\nA consensus algorithm. Compare with [[paxos]].');
+  await seed('paxos.md', '# Paxos\n\nThe classic consensus protocol. See [[raft]].');
+  await seed('risotto.md', '# Risotto\n\nStir constantly. Pairs with [[stock]].');
+  await seed('stock.md', '# Stock\n\nSimmer bones for hours.');
+});
+afterEach(async () => {
+  disposeGraph(ctx());
+  disposeSearch(ctx());
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('reorg worked example (#915)', () => {
+  it('moves loose notes into topic folders with links intact', async () => {
+    // The plan a "Reorganize by Topic" run would produce.
+    const plan = await planReorg(root, [
+      { path: 'raft.md', newPath: 'distributed-systems/raft.md' },
+      { path: 'paxos.md', newPath: 'distributed-systems/paxos.md' },
+      { path: 'risotto.md', newPath: 'cooking/risotto.md' },
+      { path: 'stock.md', newPath: 'cooking/stock.md' },
+    ]);
+    expect(plan.warnings).toEqual([]);
+    expect(plan.items).toHaveLength(4);
+
+    // Approve the whole plan (one atomic bundle).
+    const payloads: ProposalPayload[] = plan.items.map((i) => ({
+      kind: 'note-refactor', fromPath: i.fromPath, toPath: i.toPath,
+    }));
+    const proposal = await proposeWrite(ctx(), { operationType: 'note_refactor', payloads, note: 'reorg', proposedBy: 'unit-test' });
+    expect((await approveProposal(ctx(), proposal!.uri)).ok).toBe(true);
+
+    // Tidy: every note now lives under its topic folder.
+    for (const p of ['distributed-systems/raft.md', 'distributed-systems/paxos.md', 'cooking/risotto.md', 'cooking/stock.md']) {
+      expect(exists(p)).toBe(true);
+    }
+    expect(exists('raft.md')).toBe(false);
+
+    // Links intact: the cross-references were rewritten to the new paths.
+    expect(await read('distributed-systems/raft.md')).toContain('[[distributed-systems/paxos]]');
+    expect(await read('distributed-systems/paxos.md')).toContain('[[distributed-systems/raft]]');
+    expect(await read('cooking/risotto.md')).toContain('[[cooking/stock]]');
+  });
+});

--- a/tests/main/skills-reorg.test.ts
+++ b/tests/main/skills-reorg.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+describe('reorganization skills (#915)', () => {
+  it('ships the reorg skills in the Analysis menu, grouped + propose-only', async () => {
+    // Point at a non-existent user dir so only stock skills load.
+    const cat = await loadSkillCatalog(path.join(os.tmpdir(), 'minerva-no-user-skills-915'));
+    expect(cat.errors).toEqual([]);
+    const byName = new Map(cat.skills.map((s) => [s.name, s]));
+
+    for (const name of ['Reorganize by Topic', 'Tidy Filenames']) {
+      const s = byName.get(name);
+      expect(s, `${name} should ship as a stock skill`).toBeDefined();
+      expect(s!.source).toBe('stock');
+      expect(s!.menu).toBe('Analysis');
+      expect(s!.group).toBe('Organization');
+      expect(s!.outputMode).toBe('openConversation');
+      // Drives the batch review substrate (#914) — and only that.
+      expect(s!.body).toContain('propose_reorganization');
+      // Trust principle: the skill proposes, never applies. It must not claim a
+      // capability to move files directly.
+      expect(s!.body.toLowerCase()).toContain('propose, never apply');
+    }
+  });
+});


### PR DESCRIPTION
Closes #915 — and **completes epic #910.** Stock skills that survey a thoughtbase and propose a tidier structure as a reviewable reorganization plan. *Skills can now re-organize notebases.*

## The skills

- **Reorganize by Topic** (`organize-by-topic.md`, flagship) — surveys structure via `list_notes`, clusters loose notes by topic, proposes moving them into topic folders.
- **Tidy Filenames** (`tidy-filenames.md`) — proposes renames toward a consistent filename convention (kebab-case by default), in place.

Both are **whole-vault skills** — no `context` field, so the menu item is always enabled and the agent discovers structure with `list_notes` rather than receiving an active note. They sit in the **Analysis** menu under an **"Organization"** group. They drive **`propose_reorganization`** (#914) and are strictly **propose-only**: the bodies instruct *"propose, never apply,"* and the agent has no tool to move files itself (Trust Principle). The refactor tools are already in `NOTEBASE_TOOLS`, so no per-skill tool opt-in is needed.

## Docs

A new **"Whole-vault skills (reorganization)"** section in `docs/authoring-skills.md` — the no-`context` pattern, the `propose_*` refactor tools, and a worked example — so users can write their own reorg skills.

## Tests

- Skills load with no errors, ship in the Analysis/Organization menu, are `openConversation`, and are **propose-only** (body drives `propose_reorganization` + asserts "propose, never apply").
- **Worked example** (substrate, end to end): a messy flat vault (`raft.md` ↔ `paxos.md`, `risotto.md` → `stock.md`, all at root) → a reorg plan → approve → notes land in `distributed-systems/` and `cooking/` folders with **every wiki-link rewritten** (`[[paxos]]` → `[[distributed-systems/paxos]]`).

Full suite green (**3675**), lint clean. (The agent's LLM clustering is non-deterministic, so the live skill→plan run isn't automated — but the skills are validated and the propose→apply→tidy substrate they drive is proven end to end.)

## Epic #910 — COMPLETE 🎉

| # | | |
|---|---|---|
| #911 foundation | ✅ | note-refactor proposal: apply, exact rollback, dry-run, guardrails |
| #912 tools | ✅ | propose_note_rename / move + list_notes |
| #913 review card | ✅ | single move/rename with blast-radius diff |
| #914 batch plans | ✅ | review many refactors as one atomic set |
| **#915 reorg skills** | ✅ | survey + propose a tidier structure |

From "the approval engine should handle small note refactors" to skills that reorganize a whole vault — every move reviewed, every link rewritten, nothing applied without approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)