### PR TITLE
fix: wire note-refactor draft callbacks through the conversation runner (#910)

### DIFF
--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -14,6 +14,7 @@ import type { ConversationDraft } from '../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../shared/conversation-source-drafts';
 import type { ConversationPropertyDraft } from '../../shared/conversation-property-drafts';
 import type { ConversationComputeDraft } from '../../shared/conversation-compute-drafts';
+import type { ConversationRefactorDraft, ConversationReorgDraft } from '../../shared/conversation-refactor-drafts';
 import type { ConversationSourcePropertyDraft } from '../../shared/conversation-source-property-drafts';
 import type { ConversationClaimsDraft } from '../../shared/conversation-claims-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
@@ -60,12 +61,43 @@ export interface StreamCallbacks {
    */
   onComputeDraft?: (draft: ConversationComputeDraft) => void;
   /**
+   * Counterparts to `onDraft` for the note-refactor tools (#912/#914):
+   * propose_note_rename / propose_note_move produce a refactor draft, and
+   * propose_reorganization a batch reorg plan. Forwarded to the renderer via
+   * CONVERSATION_REFACTOR_DRAFT / CONVERSATION_REORG_DRAFT. Without these the
+   * tools report "only available in conversation contexts."
+   */
+  onRefactorDraft?: (draft: ConversationRefactorDraft) => void;
+  onReorgDraft?: (draft: ConversationReorgDraft) => void;
+  /**
    * Wired by the conversation IPC handler when a template declares the
    * `ask_user` tool. The agent's call to `ask_user` resolves with the
    * user's reply. Without this callback the tool reports an error and
    * the agent must continue without the answer.
    */
   askUser?: (input: { question: string; choices?: string[] }) => Promise<string>;
+}
+
+/** The conversation callbacks that pass through to tool execution. When a tool
+ *  (propose_*, ask_user) needs a renderer surface, its callback must be in this
+ *  list or the tool reports "only available in conversation contexts." Add a new
+ *  draft callback here when you add one to StreamCallbacks + ToolCallbacks. */
+const TOOL_CALLBACK_KEYS = [
+  'onDraft', 'onSourceDraft', 'onPropertyDraft', 'onSourcePropertyDraft',
+  'onClaimsDraft', 'onComputeDraft', 'onRefactorDraft', 'onReorgDraft', 'askUser',
+] as const;
+
+/** Project a conversation's `StreamCallbacks` down to the `ToolCallbacks` the
+ *  tool executor expects, carrying every tool-facing callback that's set.
+ *  Exported for the regression test that guards against a dropped callback. */
+export function toToolCallbacks(callbacks?: StreamCallbacks): ToolCallbacks {
+  const out: ToolCallbacks = {};
+  if (!callbacks) return out;
+  for (const key of TOOL_CALLBACK_KEYS) {
+    const fn = callbacks[key];
+    if (fn) (out as Record<string, unknown>)[key] = fn;
+  }
+  return out;
 }
 
 export interface ChatMessage {
@@ -418,33 +450,11 @@ export async function completeWithTools(
         textPieces.push(indicator);
         if (callbacks) callbacks.onChunk(indicator);
       }
-      const toolCallbacks: ToolCallbacks = {};
-      if (callbacks?.onDraft) {
-        toolCallbacks.onDraft = callbacks.onDraft;
-      }
-      if (callbacks?.onSourceDraft) {
-        toolCallbacks.onSourceDraft = callbacks.onSourceDraft;
-      }
-      if (callbacks?.onPropertyDraft) {
-        toolCallbacks.onPropertyDraft = callbacks.onPropertyDraft;
-      }
-      if (callbacks?.onSourcePropertyDraft) {
-        toolCallbacks.onSourcePropertyDraft = callbacks.onSourcePropertyDraft;
-      }
-      if (callbacks?.onClaimsDraft) {
-        toolCallbacks.onClaimsDraft = callbacks.onClaimsDraft;
-      }
-      if (callbacks?.onComputeDraft) {
-        toolCallbacks.onComputeDraft = callbacks.onComputeDraft;
-      }
-      if (callbacks?.askUser) {
-        toolCallbacks.askUser = callbacks.askUser;
-      }
       const { content, isError } = await executeNotebaseTool(
         toolContext,
         use.name,
         use.input,
-        toolCallbacks,
+        toToolCallbacks(callbacks),
       );
       if (isError) {
         console.warn(`[conv] tool ${use.name} returned error:`, content.slice(0, 300));

--- a/tests/main/llm/tool-callbacks-passthrough.test.ts
+++ b/tests/main/llm/tool-callbacks-passthrough.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { toToolCallbacks } from '../../../src/main/llm/index';
+
+/**
+ * Regression: the conversation runner projects its `StreamCallbacks` down to the
+ * `ToolCallbacks` the tool executor receives. A callback missing from that
+ * projection makes its tool report "only available in conversation contexts" —
+ * which is exactly what happened to the note-refactor tools (#912/#914): their
+ * callbacks were declared on the IPC side but dropped here, so propose_note_rename
+ * / move / reorganization all failed inside a real conversation.
+ */
+describe('toToolCallbacks', () => {
+  const noop = () => {};
+  const all = {
+    onChunk: noop,
+    onDraft: noop,
+    onSourceDraft: noop,
+    onPropertyDraft: noop,
+    onSourcePropertyDraft: noop,
+    onClaimsDraft: noop,
+    onComputeDraft: noop,
+    onRefactorDraft: noop,
+    onReorgDraft: noop,
+    askUser: async () => '',
+  };
+
+  it('passes every tool-facing callback through to tool execution', () => {
+    const out = toToolCallbacks(all) as Record<string, unknown>;
+    for (const key of [
+      'onDraft', 'onSourceDraft', 'onPropertyDraft', 'onSourcePropertyDraft',
+      'onClaimsDraft', 'onComputeDraft', 'onRefactorDraft', 'onReorgDraft', 'askUser',
+    ]) {
+      expect(out[key], `${key} must reach the tool executor`).toBe((all as Record<string, unknown>)[key]);
+    }
+  });
+
+  it('does not leak stream-only callbacks (onChunk) into tool callbacks', () => {
+    expect('onChunk' in toToolCallbacks(all)).toBe(false);
+  });
+
+  it('omits callbacks that are not set, and handles undefined', () => {
+    expect(toToolCallbacks(undefined)).toEqual({});
+    const partial = toToolCallbacks({ onChunk: noop, onRefactorDraft: noop });
+    expect(partial.onRefactorDraft).toBe(noop);
+    expect('onReorgDraft' in partial).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the *"propose_reorganization is only available in conversation contexts"* error when running the reorg skills (Reorganize by Topic / Tidy Filenames).

## Root cause

The conversation runner (`llm/index.ts`) has its **own** `StreamCallbacks` type and projects it down to the `ToolCallbacks` the executor receives via a hand-maintained field-by-field copy:

```ts
if (callbacks?.onClaimsDraft) toolCallbacks.onClaimsDraft = callbacks.onClaimsDraft;
if (callbacks?.onComputeDraft) toolCallbacks.onComputeDraft = callbacks.onComputeDraft;
if (callbacks?.askUser)        toolCallbacks.askUser = callbacks.askUser;
// ← no onRefactorDraft, no onReorgDraft
```

`onRefactorDraft` (#912) and `onReorgDraft` (#914) were wired on the IPC side (register-conversation forwards them) but **never added here**, so they were silently dropped before reaching `executeNotebaseTool`. Every refactor tool then hit its "no UI surface" guard inside a real conversation — **`propose_note_rename`, `propose_note_move`, and `propose_reorganization` all affected**, not just the batch one.

It slipped through because the #912/#914 tests call `executeNotebaseTool` **directly** with a fake callback, bypassing this projection layer entirely.

## Fix

- Declare `onRefactorDraft` / `onReorgDraft` on `StreamCallbacks`.
- Replace the inline copy with a pure **`toToolCallbacks(callbacks)`** mapper driven by a single `TOOL_CALLBACK_KEYS` list — so adding a draft callback is a one-line change and a future one can't be silently dropped.

## Regression test

`tool-callbacks-passthrough.test.ts` asserts `toToolCallbacks` carries **every** tool-facing callback (including the two that were missing), doesn't leak the stream-only `onChunk`, and handles `undefined`/partial input. This is the exact layer the bug lived in.

Full suite green (**3676**), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)