### PR TITLE
feat: local audio & video embeds — inline players for vault media (#908)

### DIFF
--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -18,6 +18,7 @@ import { buildLinkResolverContext } from '../../link-resolver';
 import { installMath } from '../../../../shared/markdown/math-plugin';
 import { renderVegaBlocks } from '../../vega-render';
 import { renderYouTubeBlocks } from '../../youtube-render';
+import { linkifyLocalMedia } from '../../media-export';
 import type { ExportPlanFile, ExportPlan } from '../../types';
 import type { CitationRenderer } from '../../csl';
 
@@ -41,7 +42,10 @@ export async function renderNoteBody(
   // #904 — degrade `youtube` fences to a linked thumbnail (an `<img>` in a
   // link, so it survives `html: false`). Sync; order vs. Vega is irrelevant —
   // the two operate on disjoint fence languages.
-  const bodyMarkdown = renderYouTubeBlocks(withCharts);
+  const withYouTube = renderYouTubeBlocks(withCharts);
+  // #908 — degrade local audio/video image-refs to links (inlining media into a
+  // single-file export isn't sensible; keep the reference).
+  const bodyMarkdown = linkifyLocalMedia(withYouTube);
   return md.render(bodyMarkdown);
 }
 

--- a/src/main/publish/media-export.ts
+++ b/src/main/publish/media-export.ts
@@ -1,0 +1,24 @@
+/**
+ * Export-time degrade for local audio/video embeds (#908).
+ *
+ * In the app a `![](clip.mp4)` renders an inline player. In an exported file
+ * that's meaningless (and base64-inlining a video is a non-starter), so each
+ * local-media image-ref degrades to a plain markdown **link** to the file — the
+ * artifact still references it, and it survives the exporter's `html: false`.
+ */
+
+import { mediaKind } from '../../shared/media';
+
+// `![alt](url)` or `![alt](url "title")` — same shape the image-inliner matches.
+const MD_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+/** Rewrite local-media image refs to links. Leaves real images, remote URLs, and
+ *  non-media refs untouched. */
+export function linkifyLocalMedia(markdown: string): string {
+  return markdown.replace(MD_IMAGE_RE, (full, alt: string, url: string) => {
+    if (/^(?:https?:|data:|blob:|file:|mailto:)/i.test(url) || url.startsWith('//')) return full;
+    if (!mediaKind(url)) return full;
+    const label = alt.trim() || url.split('/').pop() || url;
+    return `[${label}](${url})`;
+  });
+}

--- a/src/main/security-helpers.ts
+++ b/src/main/security-helpers.ts
@@ -45,6 +45,9 @@ export function buildCsp(opts: CspOptions = {}): string {
     ],
     // pdf.js + tesseract spawn workers from blob URLs.
     'worker-src': ["'self'", 'blob:'],
+    // Local audio/video (#908) is hydrated to `blob:` URLs from vault bytes —
+    // local-only; no external media origins (no phone-home).
+    'media-src': ["'self'", 'blob:'],
     // No <object>/<embed>; no <iframe> embed targets either.
     'object-src': ["'none'"],
     'frame-src': ["'none'"],

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import Icon from './Icon.svelte';
   import MarkdownIt from 'markdown-it';
   // The Token *value* (used below for `new Token(...)` to inject a
@@ -36,6 +37,7 @@
   import type { CellResult } from '../ipc/client';
   import { escapeHtml, escapeAttr, stripFrontmatter, countFrontmatterLines } from '../preview/text';
   import { resolveRelativeImagePath, mimeFromPath } from '../preview/image-paths';
+  import { mediaKind, mediaMime } from '../../../shared/media';
   import { type CiteMeta, type QuoteMeta, collapseCiteRows, buildCiteTooltip, buildQuoteTooltip, buildFootnoteTooltip } from '../preview/cite-meta';
   import { findSourceFenceBefore, renderComputeOutput, tableToCsv, outputToMarkdownClipboard } from '../preview/compute-output-render';
 
@@ -315,6 +317,15 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     const alt = altIdx >= 0 ? tok.attrs![altIdx][1] : (tok.content ?? '');
     const titleIdx = tok.attrIndex('title');
     const title = titleIdx >= 0 ? ` title="${escapeAttr(tok.attrs![titleIdx][1])}"` : '';
+    // Local audio/video (#908): emit a player placeholder hydrated to a blob URL
+    // by the post-render pass (videos are too large to base64-inline like images).
+    const kind = mediaKind(rel);
+    if (kind === 'video') {
+      return `<video class="local-media" data-rel="${escapeAttr(rel)}" controls preload="metadata"${title}></video>`;
+    }
+    if (kind === 'audio') {
+      return `<audio class="local-media" data-rel="${escapeAttr(rel)}" controls preload="metadata"${title}></audio>`;
+    }
     return `<img class="local-image" data-rel="${escapeAttr(rel)}" alt="${escapeAttr(alt)}"${title} />`;
   };
 
@@ -492,6 +503,43 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     }));
   }
 
+  /**
+   * Blob-URL cache for local audio/video (#908). Unlike images (base64 data
+   * URLs), media is held as `blob:` URLs — a 200 MB video can't be base64-inlined.
+   * Keyed by rel path so a re-render reuses the same blob; revoked on unmount.
+   * (Large-library seeking would want a streaming `app://` protocol — a follow-up.)
+   */
+  const mediaBlobCache = new Map<string, string>();
+
+  /** Post-render hydration for `.local-media[data-rel]` players — fetch the bytes
+   *  and point the element at a blob URL. Mirrors hydrateLocalImages. */
+  async function hydrateLocalMedia(): Promise<void> {
+    const root = previewEl;
+    if (!root) return;
+    const els = Array.from(root.querySelectorAll<HTMLMediaElement>('.local-media[data-rel]'));
+    await Promise.all(els.map(async (el) => {
+      const rel = el.dataset.rel;
+      if (!rel) return;
+      const cached = mediaBlobCache.get(rel);
+      if (cached) { if (el.src !== cached) el.src = cached; return; }
+      try {
+        const bytes = await api.notebase.readBinary(rel);
+        const view: Uint8Array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+        const url = URL.createObjectURL(new Blob([view as BlobPart], { type: mediaMime(rel) }));
+        mediaBlobCache.set(rel, url);
+        el.src = url;
+      } catch (err) {
+        console.warn('[preview] media hydration failed for', rel, err);
+        el.classList.add('local-media-broken');
+      }
+    }));
+  }
+
+  onDestroy(() => {
+    for (const url of mediaBlobCache.values()) URL.revokeObjectURL(url);
+    mediaBlobCache.clear();
+  });
+
   // Query directive plugin: :::query-list ... :::
   md.block.ruler.before('fence', 'query_directive', (state: StateBlock, startLine: number, endLine: number, silent: boolean) => {
     const startPos = state.bMarks[startLine] + state.tShift[startLine];
@@ -666,6 +714,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
       // binary IPC, swap in a data URL. Cached per-path so re-renders
       // skip the round-trip.
       void hydrateLocalImages();
+      void hydrateLocalMedia();
       // Mermaid hydration (#467) — lazy-loads the library on first use,
       // replaces .mermaid-block placeholders with rendered SVG, surfaces
       // parse errors inline.
@@ -2008,6 +2057,30 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     font-size: 11px;
     font-style: italic;
   }
+  /* Local audio/video players (#908). */
+  .preview :global(video.local-media) {
+    max-width: 100%;
+    max-height: 70vh;
+    border-radius: 6px;
+    display: block;
+    margin: 8px 0;
+    background: #000;
+  }
+  .preview :global(audio.local-media) {
+    width: 100%;
+    margin: 8px 0;
+  }
+  .preview :global(.local-media-broken) {
+    display: inline-block;
+    outline: 1px dashed var(--accent);
+    background: var(--bg-button);
+    padding: 8px 12px;
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-style: italic;
+  }
+  .preview :global(.local-media-broken)::after { content: 'media not found'; }
   .preview :global(.compute-output-image.zoomed) {
     cursor: zoom-out;
     max-width: none;

--- a/src/shared/media.ts
+++ b/src/shared/media.ts
@@ -1,0 +1,46 @@
+/**
+ * Local audio/video recognition for inline media embeds (#908).
+ *
+ * A relative `![](clip.mp4)` in a note renders as an inline `<video>` / `<audio>`
+ * player (renderer) and degrades to a link on export (main). Both sides classify
+ * the path by extension here so they agree on what counts as media.
+ */
+
+export type MediaKind = 'audio' | 'video';
+
+const VIDEO: Record<string, string> = {
+  mp4: 'video/mp4',
+  m4v: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  ogv: 'video/ogg',
+};
+
+const AUDIO: Record<string, string> = {
+  mp3: 'audio/mpeg',
+  m4a: 'audio/mp4',
+  wav: 'audio/wav',
+  oga: 'audio/ogg',
+  ogg: 'audio/ogg', // bare .ogg is overwhelmingly audio in practice
+  flac: 'audio/flac',
+  aac: 'audio/aac',
+  opus: 'audio/ogg',
+};
+
+function extOf(rel: string): string {
+  return rel.toLowerCase().match(/\.([^./\\]+)$/)?.[1] ?? '';
+}
+
+/** Which media element a path should render as, or null if it isn't audio/video. */
+export function mediaKind(rel: string): MediaKind | null {
+  const ext = extOf(rel);
+  if (ext in VIDEO) return 'video';
+  if (ext in AUDIO) return 'audio';
+  return null;
+}
+
+/** MIME type for a media path — used as the `Blob` type so the player can decode. */
+export function mediaMime(rel: string): string {
+  const ext = extOf(rel);
+  return VIDEO[ext] ?? AUDIO[ext] ?? 'application/octet-stream';
+}

--- a/tests/shared/media.test.ts
+++ b/tests/shared/media.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mediaKind, mediaMime } from '../../src/shared/media';
+import { linkifyLocalMedia } from '../../src/main/publish/media-export';
+
+describe('mediaKind', () => {
+  it('classifies video extensions', () => {
+    for (const f of ['clip.mp4', 'a/b/lecture.webm', 'rec.MOV', 'x.m4v', 'y.ogv']) {
+      expect(mediaKind(f)).toBe('video');
+    }
+  });
+  it('classifies audio extensions', () => {
+    for (const f of ['voice.mp3', 'note.m4a', 'r.WAV', 's.flac', 't.ogg', 'u.opus']) {
+      expect(mediaKind(f)).toBe('audio');
+    }
+  });
+  it('returns null for images and other files', () => {
+    for (const f of ['pic.png', 'doc.pdf', 'data.csv', 'note.md', 'noext']) {
+      expect(mediaKind(f)).toBeNull();
+    }
+  });
+});
+
+describe('mediaMime', () => {
+  it('maps known extensions', () => {
+    expect(mediaMime('a.mp4')).toBe('video/mp4');
+    expect(mediaMime('a.webm')).toBe('video/webm');
+    expect(mediaMime('a.mp3')).toBe('audio/mpeg');
+    expect(mediaMime('a.wav')).toBe('audio/wav');
+  });
+  it('falls back for unknown', () => {
+    expect(mediaMime('a.xyz')).toBe('application/octet-stream');
+  });
+});
+
+describe('linkifyLocalMedia (export degrade)', () => {
+  it('rewrites a local media image-ref to a link, keeping alt as the label', () => {
+    expect(linkifyLocalMedia('![My talk](media/talk.mp4)')).toBe('[My talk](media/talk.mp4)');
+  });
+  it('uses the filename when there is no alt', () => {
+    expect(linkifyLocalMedia('![](audio/voice.mp3)')).toBe('[voice.mp3](audio/voice.mp3)');
+  });
+  it('leaves real images, remote URLs, and non-media refs alone', () => {
+    expect(linkifyLocalMedia('![pic](photo.png)')).toBe('![pic](photo.png)');
+    expect(linkifyLocalMedia('![v](https://x.com/v.mp4)')).toBe('![v](https://x.com/v.mp4)');
+    expect(linkifyLocalMedia('![](doc.pdf)')).toBe('![](doc.pdf)');
+  });
+  it('handles multiple refs and leaves surrounding text intact', () => {
+    const out = linkifyLocalMedia('See ![](a.mp4) and ![pic](b.png) and ![](c.wav).');
+    expect(out).toBe('See [a.mp4](a.mp4) and ![pic](b.png) and [c.wav](c.wav).');
+  });
+});


### PR DESCRIPTION
Closes #908. A vault-local `![](clip.mp4)` / `![](voice.mp3)` now renders an inline `<video controls>` / `<audio controls>` player — the natural sibling of local images + the YouTube card, privacy-clean (files live in the vault, no phone-home).

## Pieces

- **`shared/media.ts`** — `mediaKind` (`audio | video | null`) + `mediaMime` by extension, shared so the renderer's render-rule and the export degrade agree on what counts as media.
- **Render rule** — a relative media `src` emits a `<video>` / `<audio>` placeholder (`class="local-media" data-rel`) instead of an `<img>`; images and unknown types are unchanged.
- **Hydration** — `hydrateLocalMedia` fetches the bytes via `readBinary` and points the player at a **`blob:` URL** — videos are far too large to base64-inline like images. Blobs are cached per rel and **revoked on unmount**. Missing/unreadable files get the same broken-placeholder treatment as images.
- **CSP** — add `media-src 'self' blob:` (local-only; no external media origins).
- **Export** — `linkifyLocalMedia` degrades a local-media image-ref to a markdown **link** (inlining video into a single-file export isn't sensible; keep the reference), wired into the note-html pre-pass chain beside the vega/youtube degrades.

## Verification

- Unit tests: `mediaKind`/`mediaMime` classification; `linkifyLocalMedia` (alt label, filename fallback, leaves images/remote/non-media alone, multiple refs). Full suite green (**3687**), lint clean.
- **Packaged-app check** ✅ — built the app, opened a note with `![](media/tone.wav)` (a generated tiny WAV) and a missing `.mp3`. The audio element loaded from a **`blob:` URL** and was **playable** (decoded, `duration > 0`), the missing file degraded to the broken placeholder, and there were **zero CSP violations** — confirming `media-src blob:` works end to end.

## Out of scope (noted)

A streaming `app://` protocol for huge files with seek support — a follow-up if large media libraries make the in-memory blob a pain point. The whole file is read into a blob today, which is fine for clips/voice memos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)