### PR TITLE
chore: silence benign svelte boot warnings with svelte-ignore

### DIFF
--- a/src/renderer/lib/components/AutoLinkDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkDialog.svelte
@@ -12,6 +12,8 @@
   let { suggestions, activeNoteBody, onApply, onCancel }: Props = $props();
 
   // Each suggestion is selected by default. Track selection by index.
+  // Intentional one-time seed from `suggestions`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let selected = $state<boolean[]>(suggestions.map(() => true));
 
   const selectedCount = $derived(selected.filter(Boolean).length);

--- a/src/renderer/lib/components/AutoLinkInboundDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkInboundDialog.svelte
@@ -11,6 +11,8 @@
 
   let { suggestions, activeStem, onApply, onCancel }: Props = $props();
 
+  // Intentional one-time seed from `suggestions`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let selected = $state<boolean[]>(suggestions.map(() => true));
 
   const selectedCount = $derived(selected.filter(Boolean).length);

--- a/src/renderer/lib/components/FindInNotesDialog.svelte
+++ b/src/renderer/lib/components/FindInNotesDialog.svelte
@@ -29,6 +29,8 @@
 
   let { initialMode, onJumpTo, onClose }: Props = $props();
 
+  // Intentional one-time seed from `initialMode`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let mode = $state<Mode>(initialMode);
   let pattern = $state('');
   let replacement = $state('');

--- a/src/renderer/lib/components/GotoNoteDialog.svelte
+++ b/src/renderer/lib/components/GotoNoteDialog.svelte
@@ -66,6 +66,8 @@
     return acc;
   }
 
+  // Intentional one-time snapshot of `files`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   const allNotes = flattenNotes(files).filter((n) => n.relativePath !== excludePath);
   const allSources = $derived(sources ?? []);
   const allQueries = $derived(savedQueries ?? []);

--- a/src/renderer/lib/components/GraphCanvas.svelte
+++ b/src/renderer/lib/components/GraphCanvas.svelte
@@ -116,6 +116,10 @@
   }
 </script>
 
+<!-- Genuinely interactive: role="application" + aria-label, with keyboard
+     activation via onkeydown. The a11y heuristic doesn't credit the role. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
   class="graph-canvas"
   bind:this={container}

--- a/src/renderer/lib/components/MineReferencesDialog.svelte
+++ b/src/renderer/lib/components/MineReferencesDialog.svelte
@@ -22,6 +22,8 @@
 
   let { parentTitle, refs, onApply, onCancel }: Props = $props();
 
+  // Intentional one-time seed from `refs`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let selected = $state<boolean[]>(refs.map(() => true));
   let saving = $state(false);
 

--- a/src/renderer/lib/components/NewNoteDialog.svelte
+++ b/src/renderer/lib/components/NewNoteDialog.svelte
@@ -39,6 +39,8 @@
 
   let { onConfirm, onCancel, initialExt = '.md' }: Props = $props();
 
+  // Intentional one-time seed from `initialExt`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let ext = $state<NoteExt>(initialExt);
   let name = $state('');
   let inputEl = $state<HTMLInputElement>();

--- a/src/renderer/lib/components/OcrProgressDialog.svelte
+++ b/src/renderer/lib/components/OcrProgressDialog.svelte
@@ -23,6 +23,8 @@
   // Rough estimate — ~3s/page on a modern laptop at 2× scale. Users
   // with huge scans will see the real rate once it starts.
   const estSecondsPerPage = 3;
+  // Intentional one-time estimate from `pageCount`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   const totalEstSeconds = pageCount * estSecondsPerPage;
 
   type Stage = 'confirm' | 'running' | 'error';

--- a/src/renderer/lib/components/PdfViewer.svelte
+++ b/src/renderer/lib/components/PdfViewer.svelte
@@ -64,6 +64,8 @@
   let loadError = $state<string | null>(null);
   let loading = $state(true);
 
+  // Intentional one-time seed from `initialPage`; viewer is keyed per source.
+  // svelte-ignore state_referenced_locally
   let page = $state(initialPage);
   let numPages = $state(0);
   let scale = $state(DEFAULT_SCALE);

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -797,8 +797,13 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     }
 
     const RENDER_DEBOUNCE_MS = 120;
+    // Intentional initial seed; the $effect below tracks content/notePath
+    // reactively and reconciles on change (debounced).
+    // svelte-ignore state_referenced_locally
     let rendered = $state(renderContent(content));
+    // svelte-ignore state_referenced_locally
     let lastRendered = content;
+    // svelte-ignore state_referenced_locally
     let lastRenderedNotePath = notePath;
     let renderTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -17,6 +17,8 @@
   }
 
   let { message, onConfirm, onCancel, suggestions = [], initial = '' }: Props = $props();
+  // Intentional one-time seed from `initial`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let value = $state(initial);
   let inputEl = $state<HTMLInputElement>();
   // Stable id so multiple PromptDialogs (rare, but possible during

--- a/src/renderer/lib/components/ReorgDraftCard.svelte
+++ b/src/renderer/lib/components/ReorgDraftCard.svelte
@@ -18,6 +18,8 @@
   let { draft, onApprove, onDiscard }: Props = $props();
 
   // Everything selected by default; the user opts items out.
+  // Intentional one-time seed from `draft`; card is keyed to the draft.
+  // svelte-ignore state_referenced_locally
   let selected = $state<Set<string>>(new Set(draft.items.map((i) => i.fromPath)));
   let expanded = $state<Set<string>>(new Set());
 

--- a/src/renderer/lib/components/ResolveStubDialog.svelte
+++ b/src/renderer/lib/components/ResolveStubDialog.svelte
@@ -16,6 +16,8 @@
 
   let { stubTitle, candidates, onApply, onCancel }: Props = $props();
 
+  // Intentional one-time seed from `candidates`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let selectedDoi = $state<string | null>(candidates[0]?.doi ?? null);
   let applying = $state(false);
 

--- a/src/renderer/lib/components/SaveQueryDialog.svelte
+++ b/src/renderer/lib/components/SaveQueryDialog.svelte
@@ -20,7 +20,10 @@
 
   let { projectOpen, initialName = '', initialScope, onConfirm, onCancel }: Props = $props();
 
+  // Intentional one-time seed from props; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let name = $state(initialName);
+  // svelte-ignore state_referenced_locally
   let scope = $state<'project' | 'global'>(
     !projectOpen ? 'global' : (initialScope ?? 'project'),
   );

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -189,6 +189,8 @@
   let orphanSuppressedKeys = $derived(
     [...confirmSuppression.suppressed].filter((k) => !confirmRegistryEntry(k))
   );
+  // Intentional one-time seed from `initialTab`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let activeTab = $state<TabId>(initialTab ?? 'editor');
 
   // Editor settings

--- a/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
+++ b/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
@@ -34,13 +34,18 @@
   let { editing, onSave, onCancel }: Props = $props();
 
   const mode = $derived<'create' | 'edit'>(editing ? 'edit' : 'create');
+  // Intentional one-time seed from `editing`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let name = $state(editing?.name ?? '');
+  // svelte-ignore state_referenced_locally
   let kind = $state<PredicateKind>(editing?.predicate.kind ?? 'tags');
   /** Picked tags (allOf), preserved as a Set for O(1) lookup in the
    *  template. Initialised from the editing predicate when present. */
+  // svelte-ignore state_referenced_locally
   let selectedTags = $state<Set<string>>(new Set(
     editing && editing.predicate.kind === 'tags' ? editing.predicate.allOf : [],
   ));
+  // svelte-ignore state_referenced_locally
   let selectedStatuses = $state<Set<ReadStatus>>(new Set(
     editing && editing.predicate.kind === 'readStatus' ? editing.predicate.status : [],
   ));

--- a/src/renderer/lib/components/ToolParamsDialog.svelte
+++ b/src/renderer/lib/components/ToolParamsDialog.svelte
@@ -24,6 +24,8 @@
 
   const params = $derived(tool.parameters ?? []);
 
+  // Intentional one-time seed from `tool`; dialog is short-lived and keyed.
+  // svelte-ignore state_referenced_locally
   let paramValues = $state<Record<string, string>>(
     Object.fromEntries((tool.parameters ?? []).map((p) => [p.id, p.defaultValue ?? ''])),
   );


### PR DESCRIPTION
## What

The dev-boot console prints ~26 `vite-plugin-svelte` compiler warnings. All are **intentional-by-design**, not bugs. This adds documented `svelte-ignore` suppressions so the console is clean and the intent is recorded in-place. **Comments only — zero behavior change.**

## The two classes

**`state_referenced_locally` (24 sites, 16 files)** — short-lived, keyed dialogs/cards that deliberately seed editable local `$state` from a prop (`initial*` / `editing` / `refs` / `suggestions` / `candidates` / `files` / `draft` / `tool`) exactly once. Reacting to later prop changes would be *wrong* here — that's why a `$derived` is not the fix. The one scary-looking case (`Preview.svelte` seeding `content`/`notePath`) is explicitly reconciled by the debounced `$effect` directly below the seed lines.

**GraphCanvas a11y (2 warnings)** — the canvas `<div>` is genuinely interactive (`role="application"` + `aria-label` + keyboard activation via `onkeydown`); the a11y heuristic just doesn't credit the role.

Each suppression carries a one-line reason comment so future readers know the snapshot/interaction is deliberate.

## Notes

- Also folds in `PdfViewer` + `OcrProgressDialog`, which share the seed pattern but are lazy-loaded — they weren't in the initial boot snapshot but would warn on first use.
- Discovered along the way: `svelte-ignore` only honors the **first** code per comment line, so the GraphCanvas case uses two separate comment lines (a single line with both codes left the second warning live).

## Verification

- `npx svelte-check` — zero `state_referenced_locally` / `a11y_no_noninteractive_*` warnings remain.
- `pnpm lint` — passes clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)