### PR TITLE
feat: local voice dictation — talk into the conversation composer

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -12,5 +12,9 @@
        runtime's library validation would refuse to load them without this. -->
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <!-- Microphone access for local dictation (#voice). Required under the
+       hardened runtime for getUserMedia({audio}) to reach the input device. -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
 </dict>
 </plist>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -123,6 +123,13 @@ const config: ForgeConfig = {
     // `.icns` on macOS and `.ico` on Windows. Linux has no embedded app icon,
     // so the window/taskbar icon is set at runtime from resources/icons.
     icon: path.resolve(process.cwd(), 'assets', 'Minerva'),
+    // macOS shows this string in the system microphone-permission prompt the
+    // first time dictation (#voice) calls getUserMedia. Without it, the
+    // hardened-runtime app is denied the mic outright.
+    extendInfo: {
+      NSMicrophoneUsageDescription:
+        'Minerva uses the microphone for on-device voice dictation. Audio is transcribed locally and never leaves your computer.',
+    },
     // Stage `resources/python/minerva_kernel.py` (and anything else
     // we drop under `resources/`) next to the main bundle in the
     // packaged app, so process.resourcesPath finds it (#241).

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/ibm-plex-serif": "^5.2.7",
+    "@huggingface/transformers": "^4.2.0",
     "@mozilla/readability": "^0.6.0",
     "@retorquere/bibtex-parser": "^9.0.29",
     "@types/markdown-it-footnote": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@fontsource/ibm-plex-serif':
         specifier: ^5.2.7
         version: 5.2.7
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1460,6 +1463,9 @@ packages:
     engines: {node: '>=14.14'}
     hasBin: true
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -1836,6 +1842,16 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1861,6 +1877,159 @@ packages:
 
   '@iconify/utils@3.1.3':
     resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/checkbox@3.0.1':
     resolution: {integrity: sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==}
@@ -2942,6 +3111,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -4963,8 +5136,21 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
   onnxruntime-common@1.27.0:
     resolution: {integrity: sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   onnxruntime-web@1.27.0:
     resolution: {integrity: sha512-ogDLsqIozHZwifPuN37OproAo0byX6t43/bP8GzeZWBWD6MOGExswFAx3up4NS/vvWBOg2u2PXomDt3rMmdQSg==}
@@ -5537,6 +5723,10 @@ packages:
 
   shaclc-write@1.6.3:
     resolution: {integrity: sha512-R6rHiDov9kppjXTTaSwuaOUC3JXhJWvlrxR++Eng1jNdtD3oywkAagRu6mS5rzTcMA4WBxLUXdJxu4CbPOG04A==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -9961,6 +10151,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -10163,6 +10358,18 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -10186,6 +10393,102 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/checkbox@3.0.1':
     dependencies:
@@ -11387,6 +11690,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.17: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -11538,8 +11843,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  boolean@3.2.0:
-    optional: true
+  boolean@3.2.0: {}
 
   bplist-creator@0.0.8:
     dependencies:
@@ -12102,7 +12406,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   delaunator@5.1.0:
     dependencies:
@@ -12112,8 +12415,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0:
-    optional: true
+  detect-node@2.1.0: {}
 
   devalue@5.8.1: {}
 
@@ -12247,8 +12549,7 @@ snapshots:
 
   es-toolkit@1.47.0: {}
 
-  es6-error@4.1.1:
-    optional: true
+  es6-error@4.1.1: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -12746,7 +13047,6 @@ snapshots:
       roarr: 2.15.4
       semver: 7.8.4
       serialize-error: 7.0.1
-    optional: true
 
   global-dirs@3.0.1:
     dependencies:
@@ -12760,7 +13060,6 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -13129,8 +13428,7 @@ snapshots:
 
   json-stringify-pretty-compact@4.0.0: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -13388,7 +13686,6 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
-    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -13621,8 +13918,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   obug@2.1.2: {}
 
@@ -13643,7 +13939,26 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
   onnxruntime-common@1.27.0: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.4
 
   onnxruntime-web@1.27.0:
     dependencies:
@@ -14189,7 +14504,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
-    optional: true
 
   robust-predicates@3.0.3: {}
 
@@ -14260,8 +14574,7 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
 
-  semver-compare@1.0.0:
-    optional: true
+  semver-compare@1.0.0: {}
 
   semver@5.7.2: {}
 
@@ -14272,7 +14585,6 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
-    optional: true
 
   set-function-length@1.2.2:
     dependencies:
@@ -14303,6 +14615,37 @@ snapshots:
       rdf-string-ttl: 2.0.1
     transitivePeerDependencies:
       - encoding
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@1.2.0:
     dependencies:
@@ -14423,8 +14766,7 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  sprintf-js@1.1.3:
-    optional: true
+  sprintf-js@1.1.3: {}
 
   sql-formatter@15.8.1:
     dependencies:
@@ -14704,8 +15046,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@0.13.1:
-    optional: true
+  type-fest@0.13.1: {}
 
   type-fest@0.21.3: {}
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,7 +9,7 @@ import { appIconPath } from './app-icon';
 import { loadSession } from './session';
 import { registerBuiltinExecutors } from './compute/executors';
 import { registerBuiltinExporters } from './publish';
-import { installCsp } from './security';
+import { installCsp, installMediaPermissions } from './security';
 import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
 import { stopClipperServer } from './clipper/lifecycle';
@@ -38,6 +38,7 @@ void app.whenReady().then(async () => {
     app.dock?.setIcon(appIconPath());
   }
   installCsp();
+  installMediaPermissions();
   boot('csp installed');
   registerIpcHandlers();
   boot('ipc handlers registered');

--- a/src/main/security-helpers.ts
+++ b/src/main/security-helpers.ts
@@ -12,10 +12,22 @@ export interface CspOptions {
  *  adapters (Crossref, arXiv, PubMed, Anthropic) talk to their endpoints
  *  in main, so renderer connect-src stays narrow. */
 export const RENDERER_FETCH_HOSTS = [
-  // tesseract.js core/wasm + worker glue. Keep both so a tesseract
-  // upgrade that switches CDN doesn't break OCR silently.
+  // tesseract.js core/wasm + worker glue, and transformers.js's
+  // onnxruntime-web WASM. Keep both so a CDN switch in either doesn't
+  // break OCR / voice silently.
   'https://cdn.jsdelivr.net',
   'https://unpkg.com',
+  // Local Whisper model weights for dictation (#voice) are fetched once
+  // from the HF hub and then cached by the browser. The hub redirects the
+  // actual file bytes to its LFS / Xet CDN, whose hostnames are regional and
+  // drift (cdn-lfs.huggingface.co, us.aws.cdn.hf.co, cas-bridge.xethub.hf.co,
+  // …) — so we allow the hub plus wildcard subdomains of its two CDN apexes
+  // rather than chase individual hosts. CSP `*.hf.co` matches multi-level
+  // subdomains like `us.aws.cdn.hf.co`. Only model weights traverse the
+  // network — captured audio never leaves the renderer.
+  'https://huggingface.co',
+  'https://*.huggingface.co',
+  'https://*.hf.co',
 ];
 
 export function buildCsp(opts: CspOptions = {}): string {
@@ -27,7 +39,9 @@ export function buildCsp(opts: CspOptions = {}): string {
     'default-src': ["'self'"],
     // 'wasm-unsafe-eval' for tesseract.js's bundled wasm. In dev,
     // allow the Vite origin so the bootstrap script + HMR client load.
-    'script-src': ["'self'", "'wasm-unsafe-eval'", ...(dev ? [devServerOrigin!] : [])],
+    // 'blob:' so onnxruntime-web (the Whisper voice backend, #voice) can
+    // load its WASM proxy glue, which it dynamically imports from a blob URL.
+    'script-src': ["'self'", "'wasm-unsafe-eval'", 'blob:', ...(dev ? [devServerOrigin!] : [])],
     // Svelte component styles compile to inline-style attributes; KaTeX
     // also writes inline styles. 'unsafe-inline' for style-src is the
     // accepted compromise — it doesn't apply to script-src.

--- a/src/main/security.ts
+++ b/src/main/security.ts
@@ -42,6 +42,32 @@ export function installCsp(): void {
 }
 
 /**
+ * Grant microphone access to the app's own renderer for dictation (#voice),
+ * and deny everything else. Chromium gates `getUserMedia` behind both an async
+ * request handler and a sync check handler; we approve `media` only when the
+ * request originates from our own origin (file:// in prod, the Vite dev server
+ * in dev). The OS-level mic prompt still applies on macOS — this only governs
+ * the in-app Chromium permission layer. No other permission (geolocation,
+ * notifications, …) is ever auto-granted.
+ */
+export function installMediaPermissions(): void {
+  const ownOrigin = (url: string | undefined): boolean =>
+    !!url && isOwnOrigin(url, MAIN_WINDOW_VITE_DEV_SERVER_URL);
+
+  session.defaultSession.setPermissionRequestHandler((wc, permission, callback) => {
+    if (permission === 'media' && ownOrigin(wc?.getURL())) {
+      callback(true);
+      return;
+    }
+    callback(false);
+  });
+
+  session.defaultSession.setPermissionCheckHandler((_wc, permission, requestingOrigin) => {
+    return permission === 'media' && ownOrigin(requestingOrigin);
+  });
+}
+
+/**
  * Install the per-WebContents navigation guards. Called once per window
  * from window-manager.createWindow, after the BrowserWindow is built.
  */

--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -12,6 +12,7 @@
    */
   import { MODEL_OPTIONS } from '../../../shared/tools/models';
   import { EFFORT_LEVELS, type Effort } from '../../../shared/tools/effort';
+  import { voiceSettings, VOICE_MODEL_OPTIONS } from '../voice/voice-settings.svelte';
 
   interface Props {
     model: string;
@@ -103,6 +104,30 @@
   {/if}
 </div>
 
+<!-- Voice/dictation (#voice). Unlike the model/key above (saved by the dialog
+     on Done), these are renderer-local prefs persisted immediately to
+     localStorage by the voiceSettings store — the transcriber runs entirely in
+     the renderer, so main never needs them. -->
+<div class="field">
+  <label class="checkbox-row">
+    <input type="checkbox" bind:checked={voiceSettings.enabled} />
+    Enable voice dictation
+  </label>
+  <p class="hint">
+    Shows a microphone in the conversation composer. Speech is transcribed
+    on-device with Whisper — your audio never leaves your computer. The model
+    (tens of MB) downloads once on first use.
+  </p>
+</div>
+<div class="field" class:disabled={!voiceSettings.enabled}>
+  <label for="voice-model">Voice model</label>
+  <select id="voice-model" bind:value={voiceSettings.model} disabled={!voiceSettings.enabled}>
+    {#each VOICE_MODEL_OPTIONS as m}
+      <option value={m.value}>{m.label} — {m.note}</option>
+    {/each}
+  </select>
+</div>
+
 <style>
   /* Shared form vocabulary, scoped to this panel (app's per-dialog convention). */
   .field {
@@ -113,6 +138,14 @@
     font-size: 12px;
   }
   .field label { color: var(--text); }
+  .field.disabled { opacity: 0.5; }
+  .checkbox-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .checkbox-row input { cursor: pointer; }
   .field input[type="password"],
   .field select {
     padding: 5px 8px;

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -3,6 +3,8 @@
   import Icon from './Icon.svelte';
   import { getConversationsStore } from '../stores/conversations.svelte';
   import { getEditorStore } from '../stores/editor.svelte';
+  import { getVoiceStore } from '../voice/voice.svelte';
+  import { voiceSettings } from '../voice/voice-settings.svelte';
   import { api } from '../ipc/client';
   import MarkdownIt from 'markdown-it';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
@@ -93,6 +95,7 @@
 
   const store = getConversationsStore();
   const editor = getEditorStore();
+  const voice = getVoiceStore();
 
   let composerEl = $state<HTMLTextAreaElement>();
   let scrollEl = $state<HTMLDivElement>();
@@ -268,6 +271,27 @@
     if (!tab) return;
     const text = tab.composer;
     await store.send(text, currentNotePath ?? undefined);
+  }
+
+  // ── Dictation (#voice) ──────────────────────────────────────────────────
+  // The mic toggles recording; stopping transcribes the clip locally (Whisper
+  // in a renderer worker) and appends the text to the composer. Audio never
+  // leaves the process — only the model weights are fetched, once.
+  async function toggleDictation() {
+    if (voice.recording) {
+      const text = await voice.stopAndTranscribe();
+      if (text) {
+        const tab = store.activeTab;
+        if (tab) {
+          const sep = tab.composer && !/\s$/.test(tab.composer) ? ' ' : '';
+          store.setComposer(tab.composer + sep + text);
+          await tick();
+          composerEl?.focus();
+        }
+      }
+    } else {
+      await voice.start();
+    }
   }
 
   // ── Slash-command launcher (#648, #822) ─────────────────────────────────
@@ -1226,6 +1250,28 @@
                 <span class="composer-context">{tab.conversation.contextBundle.notePath}</span>
               {/if}
               <span class="composer-spacer"></span>
+              {#if voiceSettings.enabled}
+                {#if voice.status === 'transcribing'}
+                  <span class="composer-voice">Transcribing…</span>
+                {:else if voice.modelProgress}
+                  <span class="composer-voice">{voice.modelProgress}</span>
+                {:else if voice.error}
+                  <span class="composer-voice" title={voice.error}>Mic unavailable</span>
+                {:else if voice.recording}
+                  <span class="composer-voice">Listening…</span>
+                {/if}
+                <button
+                  type="button"
+                  class="mic-btn"
+                  class:recording={voice.recording}
+                  onclick={toggleDictation}
+                  disabled={tab.streaming || voice.status === 'transcribing'}
+                  title={voice.recording ? 'Stop & transcribe' : 'Dictate'}
+                  aria-label={voice.recording ? 'Stop dictation and transcribe' : 'Start dictation'}
+                >
+                  <Icon name="mic" size={13} />
+                </button>
+              {/if}
               {#if costBadge}
                 <span
                   class="composer-cost"
@@ -1916,6 +1962,37 @@
     font-variant-numeric: tabular-nums;
     margin-right: 10px;
     cursor: default;
+  }
+
+  .composer-voice {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+    margin-right: 8px;
+  }
+  .mic-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    margin-right: 8px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .mic-btn:hover:not(:disabled) { color: var(--text); background: var(--bg-button); }
+  .mic-btn:disabled { opacity: 0.4; cursor: default; }
+  /* Recording: tint with the accent and breathe so it's clearly live —
+     no red/danger styling, per the house rules. */
+  .mic-btn.recording {
+    color: var(--accent);
+    animation: mic-pulse 1.4s ease-in-out infinite;
+  }
+  @keyframes mic-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.45; }
   }
 
   .send-btn {

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -111,6 +111,11 @@ export const ICONS = {
     '<path d="M8 2.5v3M8 10.5v3M2.5 8h3M10.5 8h3"/>' +
     '<path d="m4.5 4.5 1.5 1.5M10 10l1.5 1.5M11.5 4.5 10 6M6 10l-1.5 1.5"/>',
   send: '<path d="M2.5 8 13.5 3 11 13.5 7.5 9.5z"/>',
+  // Dictation (#voice): a capsule mic over a curved stand.
+  mic:
+    '<rect x="6" y="2.5" width="4" height="7" rx="2"/>' +
+    '<path d="M4 7.5a4 4 0 0 0 8 0"/>' +
+    '<path d="M8 11.5V13.5M6 13.5h4"/>',
 
   // ── Note types (sidebar + New Note picker) ───────────────────────
   // `notes` (page-with-fold) is the markdown default; `tables` (grid)

--- a/src/renderer/lib/voice/messages.ts
+++ b/src/renderer/lib/voice/messages.ts
@@ -1,0 +1,17 @@
+/**
+ * Wire types shared between the voice UI thread and the Whisper Web Worker
+ * (#voice). Kept dependency-free so both the worker bundle and the main
+ * renderer bundle can import them without dragging in transformers.js.
+ */
+
+/** UI → worker. */
+export type WhisperRequest =
+  | { type: 'load'; model: string }
+  | { type: 'transcribe'; id: number; pcm: Float32Array };
+
+/** worker → UI. */
+export type WhisperResponse =
+  | { type: 'ready' }
+  | { type: 'progress'; status: string; loaded?: number; total?: number }
+  | { type: 'result'; id: number; text: string }
+  | { type: 'error'; id?: number; message: string };

--- a/src/renderer/lib/voice/pcm.ts
+++ b/src/renderer/lib/voice/pcm.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure PCM helpers for the voice pipeline (#voice).
+ *
+ * Whisper wants mono 16 kHz float samples. The browser hands us decoded
+ * audio at the device's capture rate (typically 44.1/48 kHz) across one or
+ * more channels, so we downmix and resample here. Keeping this logic pure
+ * (no `AudioContext`) lets it be unit-tested without a DOM — the recorder
+ * only contributes the `decodeAudioData` call that produces the channel
+ * arrays we operate on.
+ */
+
+/** Whisper's expected input sample rate. */
+export const TARGET_SAMPLE_RATE = 16_000;
+
+/**
+ * Average N channel buffers into a single mono track. All channels are
+ * assumed equal length (true for `AudioBuffer.getChannelData`). A single
+ * channel is returned as-is.
+ */
+export function mixToMono(channels: Float32Array[]): Float32Array {
+  if (channels.length === 0) return new Float32Array(0);
+  if (channels.length === 1) return channels[0];
+  const len = channels[0].length;
+  const out = new Float32Array(len);
+  for (const ch of channels) {
+    for (let i = 0; i < len; i++) out[i] += ch[i];
+  }
+  const n = channels.length;
+  for (let i = 0; i < len; i++) out[i] /= n;
+  return out;
+}
+
+/**
+ * Resample a mono signal with linear interpolation. Good enough for speech
+ * recognition — Whisper's mel frontend is forgiving, and a polyphase filter
+ * would be overkill for a dictation feature. Returns the input untouched
+ * when the rates already match.
+ */
+export function resampleLinear(
+  input: Float32Array,
+  inputRate: number,
+  outputRate: number,
+): Float32Array {
+  if (inputRate === outputRate) return input;
+  if (input.length === 0) return input;
+  const ratio = inputRate / outputRate;
+  const outLength = Math.max(1, Math.round(input.length / ratio));
+  const out = new Float32Array(outLength);
+  for (let i = 0; i < outLength; i++) {
+    const srcPos = i * ratio;
+    const i0 = Math.floor(srcPos);
+    const i1 = Math.min(i0 + 1, input.length - 1);
+    const frac = srcPos - i0;
+    out[i] = input[i0] * (1 - frac) + input[i1] * frac;
+  }
+  return out;
+}
+
+/**
+ * Full path from decoded channel data to Whisper-ready samples: downmix to
+ * mono, then resample to 16 kHz.
+ */
+export function toMono16k(channels: Float32Array[], inputRate: number): Float32Array {
+  return resampleLinear(mixToMono(channels), inputRate, TARGET_SAMPLE_RATE);
+}

--- a/src/renderer/lib/voice/recorder.ts
+++ b/src/renderer/lib/voice/recorder.ts
@@ -1,0 +1,110 @@
+/**
+ * Microphone capture for dictation (#voice).
+ *
+ * `getUserMedia` → `MediaRecorder` collects compressed audio while the user
+ * speaks; on stop we decode the blob with an `AudioContext` and hand the raw
+ * channel data to the pure helpers in `pcm.ts` for downmix + resample to the
+ * 16 kHz mono float track Whisper expects.
+ *
+ * We don't stream to the recogniser mid-utterance — dictation is push-to-talk
+ * (or click-to-toggle): the user finishes, then we transcribe the whole clip.
+ * That keeps the model invocation to a single pass and avoids partial-decode
+ * bookkeeping.
+ */
+
+import { TARGET_SAMPLE_RATE, toMono16k } from './pcm';
+
+/** A live capture session. `stop()` resolves with Whisper-ready samples. */
+export interface RecordingSession {
+  /** Stop capture, release the mic, and resolve with 16 kHz mono samples. */
+  stop(): Promise<Float32Array>;
+  /** Abandon capture without producing samples (release the mic). */
+  cancel(): void;
+}
+
+/** Pick a container/codec the platform's MediaRecorder actually supports. */
+function preferredMimeType(): string | undefined {
+  // Electron/Chromium reliably encodes Opus in WebM; some builds also offer
+  // ogg. Fall back to the UA default (undefined) if neither is advertised.
+  if (typeof MediaRecorder === 'undefined') return undefined;
+  for (const t of ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus']) {
+    if (MediaRecorder.isTypeSupported(t)) return t;
+  }
+  return undefined;
+}
+
+async function decodeToSamples(blob: Blob): Promise<Float32Array> {
+  const bytes = await blob.arrayBuffer();
+  // A fresh context per clip; closed in `finally` so we don't leak the (small,
+  // but capped) pool of hardware audio contexts across many dictations.
+  const ctx = new AudioContext();
+  try {
+    const audio = await ctx.decodeAudioData(bytes);
+    const channels: Float32Array[] = [];
+    for (let c = 0; c < audio.numberOfChannels; c++) channels.push(audio.getChannelData(c));
+    return toMono16k(channels, audio.sampleRate);
+  } finally {
+    void ctx.close();
+  }
+}
+
+/**
+ * Begin capturing from the default microphone. Rejects if permission is
+ * denied or no input device is available — callers surface that to the user.
+ */
+export async function startRecording(): Promise<RecordingSession> {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new Error('navigator.mediaDevices.getUserMedia is unavailable in this renderer');
+  }
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+  });
+
+  const mimeType = preferredMimeType();
+  const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+  const chunks: BlobPart[] = [];
+  recorder.ondataavailable = (e) => {
+    if (e.data.size > 0) chunks.push(e.data);
+  };
+  recorder.start();
+
+  const releaseMic = () => {
+    for (const track of stream.getTracks()) track.stop();
+  };
+
+  return {
+    stop() {
+      return new Promise<Float32Array>((resolve, reject) => {
+        recorder.onstop = () => {
+          releaseMic();
+          const blob = new Blob(chunks, { type: mimeType ?? recorder.mimeType });
+          if (blob.size === 0) {
+            resolve(new Float32Array(0));
+            return;
+          }
+          decodeToSamples(blob).then(resolve, reject);
+        };
+        try {
+          recorder.stop();
+        } catch (err) {
+          releaseMic();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    },
+    cancel() {
+      try {
+        recorder.onstop = null;
+        if (recorder.state !== 'inactive') recorder.stop();
+      } catch {
+        // already stopped
+      }
+      releaseMic();
+    },
+  };
+}
+
+/** Seconds of audio a sample buffer represents, for UI/empty-clip checks. */
+export function durationSeconds(samples: Float32Array): number {
+  return samples.length / TARGET_SAMPLE_RATE;
+}

--- a/src/renderer/lib/voice/transcriber.ts
+++ b/src/renderer/lib/voice/transcriber.ts
@@ -1,0 +1,135 @@
+/**
+ * Front for the Whisper Web Worker (#voice).
+ *
+ * Owns the worker's lifecycle and multiplexes transcription requests by id,
+ * mirroring the main-process `embedder-service` pattern. The worker (and the
+ * ~50MB model download it triggers) is created lazily on first `preload`/
+ * `transcribe`, so the cost is only paid once the user actually reaches for
+ * voice — the renderer's initial load stays lean.
+ */
+
+import type { WhisperRequest, WhisperResponse } from './messages';
+
+export interface LoadProgress {
+  status: string;
+  loaded?: number;
+  total?: number;
+}
+
+export interface Transcriber {
+  /** Spin up the worker and download/warm the model. Idempotent. */
+  preload(): Promise<void>;
+  /** Transcribe 16 kHz mono samples to text. */
+  transcribe(pcm: Float32Array): Promise<string>;
+  /** Subscribe to model-download/warm progress. Returns an unsubscribe fn. */
+  onProgress(cb: (p: LoadProgress) => void): () => void;
+  /** Tear down the worker (releases the model from memory). */
+  dispose(): void;
+}
+
+export function createTranscriber(model: string): Transcriber {
+  let worker: Worker | null = null;
+  let readyPromise: Promise<void> | null = null;
+  let nextId = 1;
+  const pending = new Map<number, { resolve: (t: string) => void; reject: (e: Error) => void }>();
+  const progressCbs = new Set<(p: LoadProgress) => void>();
+
+  function ensureWorker(): Worker {
+    if (worker) return worker;
+    const w = new Worker(new URL('./whisper.worker.ts', import.meta.url), {
+      type: 'module',
+      name: 'whisper',
+    });
+    w.onmessage = (e: MessageEvent<WhisperResponse>) => {
+      const msg = e.data;
+      switch (msg.type) {
+        case 'progress':
+          for (const cb of progressCbs) cb({ status: msg.status, loaded: msg.loaded, total: msg.total });
+          break;
+        case 'ready':
+          resolveReady?.();
+          break;
+        case 'result': {
+          const p = pending.get(msg.id);
+          if (p) {
+            pending.delete(msg.id);
+            p.resolve(msg.text);
+          }
+          break;
+        }
+        case 'error': {
+          if (msg.id !== undefined) {
+            const p = pending.get(msg.id);
+            if (p) {
+              pending.delete(msg.id);
+              p.reject(new Error(msg.message));
+            }
+          } else {
+            rejectReady?.(new Error(msg.message));
+          }
+          break;
+        }
+      }
+    };
+    w.onerror = (e) => {
+      console.error('[voice] worker error:', e.message, e);
+      const err = new Error(e.message || 'voice worker crashed');
+      rejectReady?.(err);
+      for (const p of pending.values()) p.reject(err);
+      pending.clear();
+    };
+    worker = w;
+    return w;
+  }
+
+  let resolveReady: (() => void) | null = null;
+  let rejectReady: ((e: Error) => void) | null = null;
+
+  function preload(): Promise<void> {
+    if (!readyPromise) {
+      const w = ensureWorker();
+      readyPromise = new Promise<void>((resolve, reject) => {
+        resolveReady = resolve;
+        rejectReady = (e) => {
+          // Let a later preload retry after a failed download.
+          readyPromise = null;
+          reject(e);
+        };
+      });
+      post(w, { type: 'load', model });
+    }
+    return readyPromise;
+  }
+
+  function post(w: Worker, msg: WhisperRequest): void {
+    w.postMessage(msg);
+  }
+
+  async function transcribe(pcm: Float32Array): Promise<string> {
+    await preload();
+    const w = ensureWorker();
+    const id = nextId++;
+    return new Promise<string>((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      // Transfer the sample buffer rather than copying it across the boundary.
+      w.postMessage({ type: 'transcribe', id, pcm } satisfies WhisperRequest, [pcm.buffer]);
+    });
+  }
+
+  function onProgress(cb: (p: LoadProgress) => void): () => void {
+    progressCbs.add(cb);
+    return () => progressCbs.delete(cb);
+  }
+
+  function dispose(): void {
+    worker?.terminate();
+    worker = null;
+    readyPromise = null;
+    resolveReady = null;
+    rejectReady = null;
+    for (const p of pending.values()) p.reject(new Error('transcriber disposed'));
+    pending.clear();
+  }
+
+  return { preload, transcribe, onProgress, dispose };
+}

--- a/src/renderer/lib/voice/voice-settings.svelte.ts
+++ b/src/renderer/lib/voice/voice-settings.svelte.ts
@@ -1,0 +1,79 @@
+/**
+ * Voice/dictation preferences (#voice).
+ *
+ * These are renderer-local UI prefs — which Whisper model to run and whether
+ * the mic affordance is shown — so they live in `localStorage` rather than the
+ * main-process `llm-settings.json` (which holds the Anthropic key/model the
+ * conversation runner needs). The transcriber runs entirely in the renderer,
+ * so there's nothing for main to know about.
+ */
+
+export interface VoiceModelOption {
+  value: string;
+  label: string;
+  note: string;
+}
+
+/** English-only Whisper variants, smallest→largest. base.en is the default
+ *  knee between footprint and accuracy for dictation. We use the `Xenova`
+ *  repos (not `onnx-community`): they ship plain int8 quantization the WASM
+ *  runtime can construct, whereas onnx-community's q8 build uses 4-bit
+ *  MatMulNBits weights that only load under WebGPU. */
+export const VOICE_MODEL_OPTIONS: VoiceModelOption[] = [
+  { value: 'Xenova/whisper-tiny.en', label: 'Tiny (fastest)', note: '~25MB · quickest, least accurate' },
+  { value: 'Xenova/whisper-base.en', label: 'Base (recommended)', note: '~50MB · good balance' },
+  { value: 'Xenova/whisper-small.en', label: 'Small (most accurate)', note: '~180MB · slower, best quality' },
+];
+
+const ENABLED_KEY = 'minerva.voice.enabled';
+const MODEL_KEY = 'minerva.voice.model';
+const DEFAULT_MODEL = 'Xenova/whisper-base.en';
+
+// localStorage may be absent or a stub under tests / non-browser contexts;
+// fall back to defaults rather than throwing at module-eval time.
+function lsGet(key: string): string | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+  } catch {
+    return null;
+  }
+}
+
+function lsSet(key: string, value: string): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(key, value);
+  } catch {
+    // best-effort persistence; ignore quota/availability errors
+  }
+}
+
+function readEnabled(): boolean {
+  // Default on: the affordance is unobtrusive and only downloads a model when
+  // first used. Users who never click it pay nothing.
+  return lsGet(ENABLED_KEY) !== 'false';
+}
+
+function readModel(): string {
+  const stored = lsGet(MODEL_KEY);
+  return VOICE_MODEL_OPTIONS.some((o) => o.value === stored) ? (stored as string) : DEFAULT_MODEL;
+}
+
+let enabled = $state(readEnabled());
+let model = $state(readModel());
+
+export const voiceSettings = {
+  get enabled() {
+    return enabled;
+  },
+  set enabled(v: boolean) {
+    enabled = v;
+    lsSet(ENABLED_KEY, String(v));
+  },
+  get model() {
+    return model;
+  },
+  set model(v: string) {
+    model = v;
+    lsSet(MODEL_KEY, v);
+  },
+};

--- a/src/renderer/lib/voice/voice.svelte.ts
+++ b/src/renderer/lib/voice/voice.svelte.ts
@@ -1,0 +1,126 @@
+/**
+ * Dictation state machine (#voice).
+ *
+ * Coordinates the microphone recorder and the Whisper transcriber behind a
+ * tiny status surface the UI can bind to. One recording is in flight at a
+ * time; the transcriber (and its model) is created lazily and rebuilt only
+ * when the user picks a different model in settings.
+ */
+
+import { startRecording, durationSeconds, type RecordingSession } from './recorder';
+import { createTranscriber, type Transcriber } from './transcriber';
+import { voiceSettings } from './voice-settings.svelte';
+
+export type VoiceStatus = 'idle' | 'recording' | 'transcribing';
+
+let status = $state<VoiceStatus>('idle');
+let error = $state<string | null>(null);
+/** Human-readable model-download progress, or null when not downloading. */
+let modelProgress = $state<string | null>(null);
+
+let session: RecordingSession | null = null;
+let transcriber: Transcriber | null = null;
+let transcriberModel = '';
+let unsubProgress: (() => void) | null = null;
+
+function ensureTranscriber(): Transcriber {
+  if (transcriber && transcriberModel === voiceSettings.model) return transcriber;
+  // Model changed (or first use): drop the old worker so we don't hold two
+  // models in memory.
+  transcriber?.dispose();
+  unsubProgress?.();
+  transcriber = createTranscriber(voiceSettings.model);
+  transcriberModel = voiceSettings.model;
+  unsubProgress = transcriber.onProgress((p) => {
+    if (p.total && p.loaded !== undefined && p.status !== 'done' && p.status !== 'ready') {
+      const pct = Math.min(100, Math.round((p.loaded / p.total) * 100));
+      modelProgress = `Downloading voice model… ${pct}%`;
+    } else if (p.status === 'ready' || p.status === 'done') {
+      modelProgress = null;
+    }
+  });
+  return transcriber;
+}
+
+async function start(): Promise<void> {
+  if (status !== 'idle') return;
+  error = null;
+  try {
+    session = await startRecording();
+    status = 'recording';
+  } catch (e) {
+    console.error('[voice] start failed:', e);
+    error = micErrorMessage(e);
+    status = 'idle';
+  }
+}
+
+/**
+ * Stop recording and transcribe. Resolves with the recognised text (empty
+ * string if nothing usable was captured). On failure, sets `error` and
+ * resolves with ''.
+ */
+async function stopAndTranscribe(): Promise<string> {
+  if (status !== 'recording' || !session) return '';
+  const s = session;
+  session = null;
+  status = 'transcribing';
+  error = null;
+  try {
+    const pcm = await s.stop();
+    if (durationSeconds(pcm) < 0.2) {
+      // Too short to be speech — treat as a no-op rather than an error.
+      status = 'idle';
+      return '';
+    }
+    const text = await ensureTranscriber().transcribe(pcm);
+    status = 'idle';
+    modelProgress = null;
+    return text;
+  } catch (e) {
+    console.error('[voice] transcribe failed:', e);
+    error = e instanceof Error ? e.message : String(e);
+    status = 'idle';
+    modelProgress = null;
+    return '';
+  }
+}
+
+function cancel(): void {
+  session?.cancel();
+  session = null;
+  if (status !== 'transcribing') status = 'idle';
+}
+
+function micErrorMessage(e: unknown): string {
+  const name = e instanceof DOMException ? e.name : '';
+  if (name === 'NotAllowedError') return 'Microphone access was denied.';
+  if (name === 'NotFoundError') return 'No microphone was found.';
+  return e instanceof Error ? e.message : 'Could not start recording.';
+}
+
+export function getVoiceStore() {
+  return {
+    get status() {
+      return status;
+    },
+    get error() {
+      return error;
+    },
+    get modelProgress() {
+      return modelProgress;
+    },
+    get recording() {
+      return status === 'recording';
+    },
+    get busy() {
+      return status !== 'idle';
+    },
+    start,
+    stopAndTranscribe,
+    cancel,
+    clearError() {
+      error = null;
+    },
+  };
+}

--- a/src/renderer/lib/voice/whisper.worker.ts
+++ b/src/renderer/lib/voice/whisper.worker.ts
@@ -1,0 +1,88 @@
+/// <reference lib="webworker" />
+/**
+ * Whisper speech-to-text Web Worker (#voice).
+ *
+ * Runs `@huggingface/transformers` off the UI thread so a multi-second
+ * transcription never janks the editor. In a worker (browser context)
+ * transformers.js selects the `onnxruntime-web` (WASM) backend — the native
+ * `onnxruntime-node` binary is never loaded, which is the whole reason the
+ * voice engine lives in the renderer rather than the main process (matching
+ * the embeddings/tesseract precedent of WASM-in-renderer ML).
+ *
+ * Model weights are fetched from the HF hub on first use and cached by the
+ * browser Cache API thereafter — the same shape as tesseract.js pulling its
+ * trained data from a CDN. Only weights are fetched; captured audio never
+ * leaves the process.
+ */
+
+import {
+  pipeline,
+  env,
+  type AutomaticSpeechRecognitionPipeline,
+} from '@huggingface/transformers';
+import type { WhisperRequest, WhisperResponse } from './messages';
+
+declare const self: DedicatedWorkerGlobalScope;
+
+// Fetch from the hub (no bundled local copy); cache downloads so the
+// first-run cost is paid once.
+env.allowLocalModels = false;
+env.useBrowserCache = true;
+
+function reply(msg: WhisperResponse, transfer: Transferable[] = []): void {
+  self.postMessage(msg, transfer);
+}
+
+const DEFAULT_MODEL = 'Xenova/whisper-base.en';
+let pipePromise: Promise<AutomaticSpeechRecognitionPipeline> | null = null;
+let loadedModel = DEFAULT_MODEL;
+
+function load(model: string): Promise<AutomaticSpeechRecognitionPipeline> {
+  if (!pipePromise) {
+    loadedModel = model;
+    pipePromise = pipeline('automatic-speech-recognition', model, {
+      // q8 keeps base.en near ~50MB and runs comfortably on CPU/WASM.
+      dtype: 'q8',
+      device: 'wasm',
+      // onnxruntime-web's default ('all') graph optimization runs a
+      // TransposeDQWeightsForMatMulNBits pass that fails on Whisper's merged
+      // decoder embed-token weights ("Missing required scale"). Dropping to
+      // 'basic' skips that pass; the model still runs, just without that
+      // (CPU-irrelevant) rewrite.
+      session_options: { graphOptimizationLevel: 'basic' },
+      progress_callback: (p: { status?: string; loaded?: number; total?: number }) => {
+        reply({ type: 'progress', status: p.status ?? 'loading', loaded: p.loaded, total: p.total });
+      },
+    });
+  }
+  return pipePromise;
+}
+
+self.onmessage = (e: MessageEvent<WhisperRequest>) => {
+  const msg = e.data;
+  void (async () => {
+    try {
+      if (msg.type === 'load') {
+        await load(msg.model);
+        reply({ type: 'ready' });
+        return;
+      }
+      // transcribe — `load` is idempotent, so this just awaits the pipeline
+      // the preceding `load` message already kicked off.
+      const transcriber = await load(loadedModel);
+      const out = (await transcriber(msg.pcm, {
+        // Dictation clips are usually short, but chunking lets a long
+        // ramble transcribe correctly instead of truncating at 30s.
+        chunk_length_s: 30,
+        stride_length_s: 5,
+      })) as { text?: string } | { text?: string }[];
+      const text = Array.isArray(out)
+        ? out.map((o) => o.text ?? '').join(' ')
+        : (out.text ?? '');
+      reply({ type: 'result', id: msg.id, text: text.trim() });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      reply({ type: 'error', id: msg.type === 'transcribe' ? msg.id : undefined, message });
+    }
+  })();
+};

--- a/tests/main/security-helpers.test.ts
+++ b/tests/main/security-helpers.test.ts
@@ -11,18 +11,25 @@ describe('buildCsp (#339)', () => {
   it('production CSP: strict default-src self, no external script-src, no inline script', () => {
     const csp = buildCsp();
     expect(csp).toMatch(/default-src 'self'/);
-    // 'self' + 'wasm-unsafe-eval' for tesseract; nothing else for scripts.
-    expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval'/);
+    // 'self' + 'wasm-unsafe-eval' for tesseract; 'blob:' for onnxruntime-web's
+    // WASM proxy glue (#voice); nothing else for scripts.
+    expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval' blob:/);
     // Crucially, no 'unsafe-inline' for script-src.
     const scriptSrc = csp.match(/script-src ([^;]+)/)![1];
     expect(scriptSrc).not.toContain("'unsafe-inline'");
-    // No external host in script-src in prod.
+    // No external host in script-src in prod (blob: is a local scheme, not a host).
     expect(scriptSrc).not.toMatch(/https?:/);
   });
 
   it('connect-src allows the renderer-direct hosts but is otherwise tight', () => {
     const csp = buildCsp();
     expect(csp).toMatch(/connect-src 'self' https:\/\/cdn\.jsdelivr\.net https:\/\/unpkg\.com/);
+    // Whisper model weights for voice dictation (#voice) come from the HF hub,
+    // whose file bytes redirect to regional LFS/Xet CDN subdomains.
+    const connectSrc = csp.match(/connect-src ([^;]+)/)![1];
+    expect(connectSrc).toContain('https://huggingface.co');
+    expect(connectSrc).toContain('https://*.huggingface.co');
+    expect(connectSrc).toContain('https://*.hf.co');
     // No leakage to the main-process API hosts (those are server-side calls).
     expect(csp).not.toContain('api.crossref.org');
     expect(csp).not.toContain('api.anthropic.com');
@@ -56,7 +63,7 @@ describe('buildCsp (#339)', () => {
 
   it('dev mode adds the Vite origin to script-src and connect-src + ws to connect-src', () => {
     const csp = buildCsp({ devServerOrigin: 'http://localhost:5173' });
-    expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval' http:\/\/localhost:5173/);
+    expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval' blob: http:\/\/localhost:5173/);
     const connectSrc = csp.match(/connect-src ([^;]+)/)![1];
     expect(connectSrc).toContain('http://localhost:5173');
     expect(connectSrc).toContain('ws://localhost:5173');

--- a/tests/renderer/voice/pcm.test.ts
+++ b/tests/renderer/voice/pcm.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure PCM helper tests (#voice). These cover the audio math that turns
+ * browser-decoded channel data into Whisper-ready 16 kHz mono samples,
+ * without needing a real AudioContext.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mixToMono, resampleLinear, toMono16k, TARGET_SAMPLE_RATE } from '../../../src/renderer/lib/voice/pcm';
+
+describe('mixToMono', () => {
+  it('returns the single channel unchanged', () => {
+    const ch = new Float32Array([0.1, -0.2, 0.3]);
+    expect(mixToMono([ch])).toBe(ch);
+  });
+
+  it('averages stereo channels sample-wise', () => {
+    const l = new Float32Array([1, 0, -1]);
+    const r = new Float32Array([0, 0, 1]);
+    expect(Array.from(mixToMono([l, r]))).toEqual([0.5, 0, 0]);
+  });
+
+  it('handles the empty case', () => {
+    expect(mixToMono([]).length).toBe(0);
+  });
+});
+
+describe('resampleLinear', () => {
+  it('returns the input untouched when rates match', () => {
+    const x = new Float32Array([1, 2, 3]);
+    expect(resampleLinear(x, 16_000, 16_000)).toBe(x);
+  });
+
+  it('downsamples by the rate ratio (length)', () => {
+    const x = new Float32Array(48_000); // 1s @ 48k
+    const out = resampleLinear(x, 48_000, 16_000);
+    expect(out.length).toBe(16_000);
+  });
+
+  it('upsamples by the rate ratio (length)', () => {
+    const x = new Float32Array(8_000); // 1s @ 8k
+    const out = resampleLinear(x, 8_000, 16_000);
+    expect(out.length).toBe(16_000);
+  });
+
+  it('linearly interpolates between samples', () => {
+    // 0,1,2,3 at 4Hz -> 8Hz should put interpolated midpoints between.
+    const x = new Float32Array([0, 1, 2, 3]);
+    const out = resampleLinear(x, 4, 8);
+    expect(out.length).toBe(8);
+    // First sample is exact; an interior one lands on a half-step.
+    expect(out[0]).toBeCloseTo(0, 5);
+    expect(out[1]).toBeCloseTo(0.5, 5);
+    expect(out[2]).toBeCloseTo(1, 5);
+  });
+
+  it('preserves a constant signal', () => {
+    const x = new Float32Array(1000).fill(0.42);
+    const out = resampleLinear(x, 44_100, 16_000);
+    for (const v of out) expect(v).toBeCloseTo(0.42, 5);
+  });
+});
+
+describe('toMono16k', () => {
+  it('downmixes and resamples in one pass', () => {
+    const l = new Float32Array(44_100).fill(1);
+    const r = new Float32Array(44_100).fill(0);
+    const out = toMono16k([l, r], 44_100);
+    expect(out.length).toBe(TARGET_SAMPLE_RATE);
+    // averaged 1 and 0 -> 0.5 everywhere
+    expect(out[0]).toBeCloseTo(0.5, 5);
+    expect(out[out.length - 1]).toBeCloseTo(0.5, 5);
+  });
+});


### PR DESCRIPTION
## What

The first surface of a **voice story** for Minerva: on-device speech-to-text. Click the mic in the conversation composer, speak, and your words are transcribed locally and appended to the message. No cloud, no API key — **captured audio never leaves the process**; only the Whisper model weights are fetched once from the HF hub and browser-cached (exactly how `tesseract.js` already pulls its trained data).

This is Phase 1 (engine + composer mic). **Phase 2 — dictation into the note editor** — is the planned follow-up.

## How

One local Whisper engine, fronted cleanly so a second surface can reuse it:

- **`src/renderer/lib/voice/`**
  - `pcm.ts` — pure mixdown + linear resample to 16 kHz mono (unit-tested, no DOM)
  - `recorder.ts` — `getUserMedia` → `MediaRecorder` → decode → PCM
  - `whisper.worker.ts` — `@huggingface/transformers` ASR in a Web Worker. In a renderer worker this uses the **`onnxruntime-web` (WASM) backend — no native binary**, matching the embeddings/tesseract precedent of WASM-in-renderer ML.
  - `transcriber.ts` / `voice.svelte.ts` / `voice-settings.svelte.ts` — id-multiplexed worker front, recording state machine, localStorage-backed prefs
- **`ConversationsPanel.svelte`** — mic toggle in the composer footer (accent pulse while recording — no danger styling, per house rules); appends the transcript to the composer
- **`AiSettings.svelte`** — a Voice section to enable dictation and pick the model (tiny / base / small)
- **Main process** — own-origin-only microphone permission handler; macOS `audio-input` entitlement + `NSMicrophoneUsageDescription`; CSP allows the HF model CDNs (`connect-src`) and ort-web's `blob:` WASM glue (`script-src`)

## Engine notes (learned debugging live)

Four non-obvious blockers, all fixed with explanatory comments in-code:
1. HF model bytes redirect to regional Xet/LFS CDNs → wildcard `connect-src` (`*.hf.co`, `*.huggingface.co`)
2. ort-web loads WASM proxy glue from a `blob:` script → added `blob:` to `script-src`
3. `onnx-community` q8 ships WebGPU-only 4-bit MatMulNBits weights → use `Xenova/whisper-*` (plain int8)
4. ort-web's default graph optimization crashes on Whisper's merged decoder embed weights → `session_options: { graphOptimizationLevel: 'basic' }`

## Verification

- `pnpm lint` clean, **3717 tests pass** (added unit tests for the PCM math + CSP allowlist)
- **Verified live** in `pnpm dev`: mic → record → transcript appended to the composer, end-to-end
- Build confirms transformers.js bundles into a **lazy ~525 KB worker chunk**, not the main bundle — initial load stays lean; the engine only loads on first dictation

## Privacy

Audio is captured, transcribed, and discarded entirely in-renderer. The only network traffic is the one-time model-weights download (then cached). The mic permission is granted only to the app's own origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)