### PR TITLE
feat: voice dictation into the note editor (#voice Phase 2)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -41,6 +41,8 @@
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
+  import DictationIndicator from './lib/components/DictationIndicator.svelte';
+  import { toggleEditorDictation } from './lib/editor/dictation';
   import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import AboutDialog from './lib/components/AboutDialog.svelte';
@@ -540,6 +542,7 @@
     print: () => window.print(),
     saveAsTemplate: () => { void handleSaveAsTemplate(); },
     insertTemplate: () => { void handleInsertTemplate(); },
+    dictate: () => { void toggleEditorDictation(editorComponent?.getView() ?? null); },
     find: () => editorComponent?.openFind(),
     findReplace: () => editorComponent?.openFindReplace(),
     findInNotes: () => { findInNotesMode = 'find'; },
@@ -1673,6 +1676,7 @@
       onClose={() => { showCommandPalette = false; }}
     />
   {/if}
+  <DictationIndicator />
   {#if showAbout}
     <AboutDialog onClose={() => { showAbout = false; }} />
   {/if}

--- a/src/renderer/lib/command-palette/registry.ts
+++ b/src/renderer/lib/command-palette/registry.ts
@@ -37,6 +37,7 @@ export interface CommandDeps {
   saveAsTemplate(): void;
   // ── Edit ──
   insertTemplate(): void;
+  dictate(): void;
   find(): void;
   findReplace(): void;
   findInNotes(): void;
@@ -111,6 +112,9 @@ export function buildCommandRegistry(deps: CommandDeps): Command[] {
     { id: 'edit.insertTemplate', title: 'Insert Template…', category: 'Edit',
       keybinding: null, enabled: hasActiveNoteTab,
       run: () => deps.insertTemplate() },
+    { id: 'edit.dictate', title: 'Dictate (Voice to Text)', category: 'Edit',
+      keybinding: formatAccelerator('CmdOrCtrl+Shift+V'),
+      enabled: hasActiveNoteTab, run: () => deps.dictate() },
     // ── Edit / search ──
     { id: 'edit.find', title: 'Find', category: 'Edit',
       keybinding: formatAccelerator('CmdOrCtrl+F'),

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -1251,21 +1251,23 @@
               {/if}
               <span class="composer-spacer"></span>
               {#if voiceSettings.enabled}
-                {#if voice.status === 'transcribing'}
-                  <span class="composer-voice">Transcribing…</span>
-                {:else if voice.modelProgress}
-                  <span class="composer-voice">{voice.modelProgress}</span>
-                {:else if voice.error}
-                  <span class="composer-voice" title={voice.error}>Mic unavailable</span>
-                {:else if voice.recording}
-                  <span class="composer-voice">Listening…</span>
+                {#if voice.surface === 'composer'}
+                  {#if voice.status === 'transcribing'}
+                    <span class="composer-voice">Transcribing…</span>
+                  {:else if voice.modelProgress}
+                    <span class="composer-voice">{voice.modelProgress}</span>
+                  {:else if voice.error}
+                    <span class="composer-voice" title={voice.error}>Mic unavailable</span>
+                  {:else if voice.recording}
+                    <span class="composer-voice">Listening…</span>
+                  {/if}
                 {/if}
                 <button
                   type="button"
                   class="mic-btn"
-                  class:recording={voice.recording}
+                  class:recording={voice.recording && voice.surface === 'composer'}
                   onclick={toggleDictation}
-                  disabled={tab.streaming || voice.status === 'transcribing'}
+                  disabled={tab.streaming || voice.status === 'transcribing' || (voice.busy && voice.surface !== 'composer')}
                   title={voice.recording ? 'Stop & transcribe' : 'Dictate'}
                   aria-label={voice.recording ? 'Stop dictation and transcribe' : 'Start dictation'}
                 >

--- a/src/renderer/lib/components/DictationIndicator.svelte
+++ b/src/renderer/lib/components/DictationIndicator.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  /**
+   * Floating dictation indicator (#voice, Phase 2).
+   *
+   * The composer mic has its own inline affordance; dictation into the editor
+   * has no anchored button, so this global pill gives the recording/transcribe
+   * feedback and the stop/cancel controls. It only appears for the `editor`
+   * surface — composer dictation is shown in the composer footer.
+   */
+  import Icon from './Icon.svelte';
+  import { getVoiceStore } from '../voice/voice.svelte';
+  import { toggleEditorDictation, cancelEditorDictation } from '../editor/dictation';
+
+  const voice = getVoiceStore();
+
+  const mine = $derived(voice.surface === 'editor');
+  const visible = $derived(
+    mine && (voice.recording || voice.status === 'transcribing' || !!voice.modelProgress || !!voice.error),
+  );
+
+  function onKeydown(e: KeyboardEvent) {
+    if (!visible) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      if (voice.error) voice.clearError();
+      else cancelEditorDictation();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if visible}
+  <div class="dictation-pill" role="status" aria-live="polite">
+    {#if voice.error}
+      <Icon name="warn" size={13} />
+      <span class="label">{voice.error}</span>
+      <button class="pill-btn" onclick={() => voice.clearError()}>Dismiss</button>
+    {:else if voice.modelProgress}
+      <span class="dot pulse"></span>
+      <span class="label">{voice.modelProgress}</span>
+    {:else if voice.status === 'transcribing'}
+      <span class="dot pulse"></span>
+      <span class="label">Transcribing…</span>
+    {:else}
+      <span class="dot pulse"></span>
+      <span class="label">Listening<span class="ell">…</span></span>
+      <span class="hint">⌘⇧V insert · esc cancel</span>
+      <button class="pill-btn primary" onclick={() => void toggleEditorDictation(null)}>Insert</button>
+      <button class="pill-btn" onclick={() => cancelEditorDictation()}>Cancel</button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .dictation-pill {
+    position: fixed;
+    left: 50%;
+    bottom: 44px;
+    transform: translateX(-50%);
+    z-index: 60;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-elevated, var(--bg-button));
+    color: var(--text);
+    font-size: 12px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  }
+  .label { font-weight: 500; }
+  .hint {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+  }
+  /* Recording marker — accent, not red, per the house rules. */
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+    flex-shrink: 0;
+  }
+  .dot.pulse { animation: pill-pulse 1.4s ease-in-out infinite; }
+  @keyframes pill-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+  .pill-btn {
+    padding: 3px 9px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .pill-btn:hover { color: var(--text); border-color: var(--text-muted); }
+  .pill-btn.primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: transparent;
+    font-weight: 600;
+  }
+  .pill-btn.primary:hover { opacity: 0.9; color: var(--accent-ink); }
+</style>

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -31,6 +31,8 @@
     insertYouTubeEmbed, vegaLiteInserts,
   } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
+  import { toggleEditorDictation } from '../editor/dictation';
+  import { voiceSettings } from '../voice/voice-settings.svelte';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { highlightDecorations } from '../editor/highlight-decorations';
   import { computeCellsExtension } from '../editor/compute-cells';
@@ -1162,6 +1164,9 @@
       <div class="separator"></div>
     {/if}
     <button onclick={() => handleMenuAction(() => onOpenConversation?.())}>Ask About This...</button>
+    {#if voiceSettings.enabled}
+      <button onclick={() => handleMenuAction(() => void toggleEditorDictation(view))}>Dictate…</button>
+    {/if}
     <button onclick={() => handleMenuAction(() => onBookmark?.())}>Bookmark This Note</button>
     {#if onBookmarkSection}
       <button onclick={() => handleMenuAction(() => onBookmarkSection?.())}>Bookmark Section</button>

--- a/src/renderer/lib/editor/command-registry.ts
+++ b/src/renderer/lib/editor/command-registry.ts
@@ -5,6 +5,14 @@ import {
   toggleH1, toggleH2, toggleH3, toggleQuote, toggleBulletList, toggleNumberedList, toggleTaskList,
   insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage, insertWikiLink,
 } from './formatting';
+import { toggleEditorDictation } from './dictation';
+
+/** Voice dictation toggle (#voice). Fires the async start/stop+insert against
+ *  the focused view; returns true so the key isn't typed into the doc. */
+const dictate: Command = (view) => {
+  void toggleEditorDictation(view);
+  return true;
+};
 
 export interface CommandEntry {
   id: string;
@@ -43,6 +51,9 @@ export const COMMAND_REGISTRY: CommandEntry[] = [
   { id: 'editor.toggleBulletList', label: 'Bulleted List', defaultKey: '', command: toggleBulletList },
   { id: 'editor.toggleNumberedList', label: 'Numbered List', defaultKey: '', command: toggleNumberedList },
   { id: 'editor.toggleTaskList', label: 'Task List', defaultKey: '', command: toggleTaskList },
+
+  // Voice
+  { id: 'editor.dictate', label: 'Dictate (Voice to Text)', defaultKey: 'Mod-Shift-v', command: dictate },
 
   // Insert
   { id: 'editor.insertLink', label: 'Insert Link', defaultKey: 'Mod-k', command: insertLink },

--- a/src/renderer/lib/editor/dictation.ts
+++ b/src/renderer/lib/editor/dictation.ts
@@ -1,0 +1,82 @@
+/**
+ * Editor-side dictation coordination (#voice, Phase 2).
+ *
+ * Bridges the shared voice engine (`getVoiceStore`) to the CodeMirror editor:
+ * the first trigger starts recording, the second stops it and drops the
+ * transcript in at the cursor. All three entry points — the `Mod-Shift-v`
+ * keymap, the command palette, and the right-click menu — funnel through
+ * `toggleEditorDictation`.
+ *
+ * The insertion target (the `EditorView`) is captured when recording starts
+ * and reused on stop, so a transcript can't land in the wrong pane if focus
+ * shifts to the floating indicator while you speak.
+ */
+
+import type { EditorView } from '@codemirror/view';
+import { getVoiceStore } from '../voice/voice.svelte';
+import { voiceSettings } from '../voice/voice-settings.svelte';
+
+let pendingView: EditorView | null = null;
+
+/**
+ * Prepend a space when joining transcribed text onto a preceding word, so
+ * "the cat" + "sat" reads "the cat sat" rather than "the catsat". No space
+ * after whitespace, an opening bracket, or at the very start of the doc.
+ * Pure so it can be unit-tested without an editor.
+ */
+export function withLeadingSpace(prevChar: string, text: string): string {
+  if (!text) return text;
+  if (!prevChar) return text; // start of document
+  if (/[\s([{“"']$/.test(prevChar)) return text;
+  return ` ${text}`;
+}
+
+function insertAtCursor(view: EditorView, text: string): void {
+  const sel = view.state.selection.main;
+  const prevChar = sel.from > 0 ? view.state.sliceDoc(sel.from - 1, sel.from) : '';
+  const insert = withLeadingSpace(prevChar, text);
+  view.dispatch({
+    changes: { from: sel.from, to: sel.to, insert },
+    selection: { anchor: sel.from + insert.length },
+    scrollIntoView: true,
+  });
+}
+
+/**
+ * Toggle dictation for the editor. With `view` null (e.g. invoked from the
+ * floating indicator after focus moved), a stop still resolves against the
+ * view captured at start.
+ */
+export async function toggleEditorDictation(view: EditorView | null): Promise<void> {
+  if (!voiceSettings.enabled) return;
+  const voice = getVoiceStore();
+
+  if (voice.recording && voice.surface === 'editor') {
+    const target = pendingView ?? view;
+    pendingView = null;
+    const text = await voice.stopAndTranscribe();
+    if (text && target) {
+      insertAtCursor(target, text);
+      target.focus();
+    }
+    return;
+  }
+
+  if (voice.status === 'idle') {
+    pendingView = view;
+    await voice.start('editor');
+    view?.focus();
+  }
+}
+
+/** Abandon an in-flight editor dictation without inserting anything. */
+export function cancelEditorDictation(): void {
+  pendingView = null;
+  getVoiceStore().cancel();
+}
+
+/** True while a recording owned by the editor surface is live. */
+export function isEditorDictating(): boolean {
+  const voice = getVoiceStore();
+  return voice.surface === 'editor' && voice.recording;
+}

--- a/src/renderer/lib/voice/voice.svelte.ts
+++ b/src/renderer/lib/voice/voice.svelte.ts
@@ -12,8 +12,13 @@ import { createTranscriber, type Transcriber } from './transcriber';
 import { voiceSettings } from './voice-settings.svelte';
 
 export type VoiceStatus = 'idle' | 'recording' | 'transcribing';
+/** Which UI initiated the current capture. The engine is a singleton (one
+ *  mic), so this lets the composer and the editor each show only their own
+ *  state instead of both lighting up. */
+export type VoiceSurface = 'composer' | 'editor';
 
 let status = $state<VoiceStatus>('idle');
+let surface = $state<VoiceSurface>('composer');
 let error = $state<string | null>(null);
 /** Human-readable model-download progress, or null when not downloading. */
 let modelProgress = $state<string | null>(null);
@@ -42,8 +47,9 @@ function ensureTranscriber(): Transcriber {
   return transcriber;
 }
 
-async function start(): Promise<void> {
+async function start(initiator: VoiceSurface = 'composer'): Promise<void> {
   if (status !== 'idle') return;
+  surface = initiator;
   error = null;
   try {
     session = await startRecording();
@@ -103,6 +109,9 @@ export function getVoiceStore() {
   return {
     get status() {
       return status;
+    },
+    get surface() {
+      return surface;
     },
     get error() {
       return error;

--- a/tests/renderer/command-palette/registry.test.ts
+++ b/tests/renderer/command-palette/registry.test.ts
@@ -15,7 +15,7 @@ import { buildCommandRegistry, type CommandDeps } from '../../../src/renderer/li
 function makeDeps(overrides: Partial<CommandDeps> = {}): CommandDeps {
   const actionNames = [
     'newNote', 'save', 'openProject', 'newProject', 'closeProject', 'print',
-    'saveAsTemplate', 'insertTemplate', 'find', 'findReplace', 'findInNotes',
+    'saveAsTemplate', 'insertTemplate', 'dictate', 'find', 'findReplace', 'findInNotes',
     'replaceInNotes', 'gotoLine', 'sortLines', 'toggleSidebar', 'toggleRightSidebar',
     'togglePreview', 'toggleConversations', 'newConversation', 'cycleTheme', 'fontIncrease', 'fontDecrease',
     'fontReset', 'quickOpen', 'navBack', 'navForward', 'renameActive', 'moveActive',
@@ -41,6 +41,7 @@ describe('buildCommandRegistry', () => {
     expect(ids).toEqual([
       'file.newNote', 'file.save', 'file.openProject', 'file.newProject',
       'file.closeProject', 'file.print', 'file.saveAsTemplate', 'edit.insertTemplate',
+      'edit.dictate',
       'edit.find', 'edit.findReplace', 'edit.findInNotes', 'edit.replaceInNotes',
       'edit.gotoLine', 'edit.sortLines', 'view.toggleSidebar', 'view.toggleRightSidebar',
       'view.togglePreview', 'view.toggleConversations', 'view.newConversation', 'view.cycleTheme',
@@ -108,7 +109,7 @@ describe('buildCommandRegistry', () => {
       'file.newNote': 'newNote', 'file.save': 'save', 'file.openProject': 'openProject',
       'file.newProject': 'newProject', 'file.closeProject': 'closeProject',
       'file.print': 'print', 'file.saveAsTemplate': 'saveAsTemplate',
-      'edit.insertTemplate': 'insertTemplate', 'edit.find': 'find',
+      'edit.insertTemplate': 'insertTemplate', 'edit.dictate': 'dictate', 'edit.find': 'find',
       'edit.findReplace': 'findReplace', 'edit.findInNotes': 'findInNotes',
       'edit.replaceInNotes': 'replaceInNotes', 'edit.gotoLine': 'gotoLine',
       'edit.sortLines': 'sortLines', 'view.toggleSidebar': 'toggleSidebar',

--- a/tests/renderer/voice/dictation-spacing.test.ts
+++ b/tests/renderer/voice/dictation-spacing.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Spacing logic for inserting transcribed text into the editor (#voice P2).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { withLeadingSpace } from '../../../src/renderer/lib/editor/dictation';
+
+describe('withLeadingSpace', () => {
+  it('adds a space when joining onto a word character', () => {
+    expect(withLeadingSpace('t', 'sat')).toBe(' sat');
+  });
+
+  it('does not add a space at the start of the document', () => {
+    expect(withLeadingSpace('', 'Hello')).toBe('Hello');
+  });
+
+  it('does not double up after existing whitespace', () => {
+    expect(withLeadingSpace(' ', 'world')).toBe('world');
+    expect(withLeadingSpace('\n', 'world')).toBe('world');
+  });
+
+  it('does not add a space after an opening bracket or quote', () => {
+    expect(withLeadingSpace('(', 'aside')).toBe('aside');
+    expect(withLeadingSpace('"', 'quote')).toBe('quote');
+    expect(withLeadingSpace('“', 'quote')).toBe('quote');
+  });
+
+  it('adds a space after sentence punctuation', () => {
+    expect(withLeadingSpace('.', 'Next')).toBe(' Next');
+    expect(withLeadingSpace(',', 'then')).toBe(' then');
+  });
+
+  it('returns empty text unchanged', () => {
+    expect(withLeadingSpace('a', '')).toBe('');
+  });
+});


### PR DESCRIPTION
## What

Phase 2 of the voice story: dictation into the **markdown editor**. Phase 1 (#931) put a mic in the conversation composer; this extends the same on-device Whisper engine to insert transcribed text **at the cursor in a note**.

Three triggers, one shared engine, one floating indicator:
- **`⌘⇧V`** while editing (CodeMirror keymap)
- **Command palette** → "Dictate (Voice to Text)"
- **Right-click** in the editor → "Dictate…"

Trigger once to start, speak, trigger again to stop — the transcript drops in at the cursor with smart spacing (no glued-together words).

## How

- **`lib/editor/dictation.ts`** — `toggleEditorDictation(view)` captures the insertion `EditorView` at record-start and reuses it on stop, so a transcript can't land in the wrong pane if focus shifts to the indicator. Pure `withLeadingSpace()` helper (unit-tested) handles spacing.
- **`DictationIndicator.svelte`** — global floating pill shown only for the `editor` surface: Listening / Transcribing / model-download states, `Esc` to cancel, and Insert/Cancel buttons as a fallback when focus has left the editor. Accent pulse, no danger styling (house rules).
- **`voice.svelte.ts`** — adds a `surface: 'composer' | 'editor'` tag to the shared singleton engine (set in `start(surface)`), so the composer mic and the editor indicator each reflect only their own activity instead of both lighting up. The composer footer is gated on the composer surface.
- **Wiring** — CodeMirror command (`command-registry.ts`, `Mod-Shift-v`), palette command + dep (`command-palette/registry.ts`, `App.svelte`), right-click item (`Editor.svelte`).

## Reuse

No new dependencies and no new engine — this rides entirely on Phase 1's transcriber/worker/model. All the hard CSP/runtime work shipped in #931.

## Verification

- `pnpm lint` clean, **3723 tests pass** (added a unit test for the spacing helper; updated the command-registry contract test for the new command)
- Renderer builds clean
- **Verified live** in `pnpm dev`: all three triggers insert at the cursor; Esc/Insert/Cancel work; composer and editor surfaces don't cross-light

## Privacy

Unchanged from Phase 1: audio is captured, transcribed, and discarded entirely in-renderer; only the (already-cached) model weights ever touch the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)