### PR TITLE
feat: note-rewrite approval payload kind (#936)

### DIFF
--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -21,7 +21,8 @@ export type OperationType =
   | 'component_creation'
   | 'status_change'
   | 'note_refactor'
-  | 'note_delete';
+  | 'note_delete'
+  | 'note_rewrite';
 
 /**
  * One side-effect a proposal applies to the thoughtbase. The approval
@@ -29,13 +30,14 @@ export type OperationType =
  * bundle as one proposal in the diff view and approves / rejects
  * atomically (#418).
  *
- * Five kinds defined; only `graph-triples` and `note` are wired to a
- * dispatcher today. The other three are reserved for the Research
- * tools that will need them (#415 wants `source`, #414 wants
- * `excerpt` for cited passages, the metacognitive cluster wants
- * `saved-query` for "watch this" queries). Apply attempts on an
- * un-wired kind throw `NotImplementedError` so the type stays
- * accurate without forcing the runtime cost up front.
+ * Most kinds are wired to a dispatcher (`graph-triples`, `note`,
+ * `excerpt`, `note-refactor`, `note-delete`, `note-rewrite`). `source`
+ * and `saved-query` are defined but not yet wired — reserved for the
+ * Research tools that will need them (#415 wants `source`, the
+ * metacognitive cluster wants `saved-query` for "watch this" queries).
+ * Apply attempts on an un-wired kind throw `NotImplementedError` so the
+ * type stays accurate without forcing the runtime cost up front; see
+ * `WIRED_PAYLOAD_KINDS` for the authoritative set.
  */
 export type ProposalPayload =
   | {
@@ -95,6 +97,17 @@ export type ProposalPayload =
        *  are intentionally left dangling (matching the manual-delete path),
        *  with the blast radius shown on the review card. */
       path: string;
+    }
+  | {
+      kind: 'note-rewrite';
+      /** Overwrite an existing note's full content in place (#936). Apply
+       *  captures the prior content as a pre-image so rollback can restore it
+       *  verbatim. The note must already exist — this rewrites, it does not
+       *  create (that's the `note` kind). The resolved path is surfaced on
+       *  ApproveResult.rewrittenPaths so the IPC layer can fire a
+       *  NOTEBASE_REWRITTEN broadcast that reloads an open editor. */
+      path: string;
+      content: string;
     };
 
 export interface ProposedWrite {
@@ -144,6 +157,9 @@ const DEFAULT_POLICY: Record<OperationType, ApprovalTier> = {
   note_refactor: 'requires_approval',
   // Deleting a note is destructive — always reviewed, never autonomous.
   note_delete: 'requires_approval',
+  // Rewriting a note's body in place replaces human-authored content — always
+  // reviewed via the diff card (#936).
+  note_rewrite: 'requires_approval',
 };
 
 let policyOverrides: Partial<Record<OperationType, ApprovalTier>> = {};
@@ -178,6 +194,13 @@ function collectAffectsNodes(ctx: ProjectContext, payloads: ProposalPayload[]): 
     } else if (p.kind === 'note') {
       const uri = graph.noteUriFor(ctx, p.relativePath);
       if (uri) out.add(uri);
+    } else if (p.kind === 'note-rewrite') {
+      // The rewritten note already exists, so it has a stable IRI. Tie it to
+      // the proposal so the trust-integrity query can join an LLM-attributed
+      // rewrite back to its approval, and so an established-note rewrite is
+      // covered by the escalation check (#936).
+      const uri = graph.noteUriFor(ctx, p.path);
+      if (uri) out.add(uri);
     }
   }
   return [...out];
@@ -207,7 +230,7 @@ async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<
 /** Payload kinds that `dispatchApply` actually knows how to apply. Keep in
  *  sync with the `switch` in dispatchApply — the `source` / `saved-query`
  *  kinds are defined on the type but not yet wired to a dispatcher. */
-const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt', 'note-refactor', 'note-delete']);
+const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt', 'note-refactor', 'note-delete', 'note-rewrite']);
 
 /**
  * Reject a bundle containing a payload kind that has no apply dispatcher (#665).
@@ -292,11 +315,16 @@ export interface ApproveResult {
    *  — collisions are dedup'd at apply time so the resolved path can
    *  differ from `p.relativePath`. */
   filedPaths: string[];
+  /** Project-relative paths of existing notes overwritten in place by
+   *  `note-rewrite` payloads in this bundle (#936). The IPC caller broadcasts
+   *  NOTEBASE_REWRITTEN for these so an open editor reloads the new content —
+   *  the approval engine stays Electron-free and only returns the paths. */
+  rewrittenPaths: string[];
 }
 
 export async function approveProposal(ctx: ProjectContext, uri: string): Promise<ApproveResult> {
   const proposal = await getProposal(ctx, uri);
-  if (!proposal || proposal.status !== 'pending') return { ok: false, filedPaths: [] };
+  if (!proposal || proposal.status !== 'pending') return { ok: false, filedPaths: [], rewrittenPaths: [] };
 
   if (proposal.payloads.length === 0) {
     // Don't quietly flip status to approved on an empty bundle — that's
@@ -317,7 +345,10 @@ export async function approveProposal(ctx: ProjectContext, uri: string): Promise
   const filedPaths = applied
     .filter((a): a is AppliedRecord & { kind: 'note' } => a.kind === 'note')
     .map((a) => (a.rollbackData as { resolvedPath: string }).resolvedPath);
-  return { ok: true, filedPaths };
+  const rewrittenPaths = applied
+    .filter((a): a is AppliedRecord & { kind: 'note-rewrite' } => a.kind === 'note-rewrite')
+    .map((a) => (a.rollbackData as { path: string }).path);
+  return { ok: true, filedPaths, rewrittenPaths };
 }
 
 /**
@@ -595,6 +626,27 @@ async function dispatchApply(ctx: ProjectContext, p: ProposalPayload): Promise<u
       void vectors.removeNote(ctx, p.path);
       return { path: p.path, content };
     }
+    case 'note-rewrite': {
+      // Overwrite an existing note in place (#936). Guardrails: must be a .md
+      // note that already exists — readFile throws ENOENT for a missing file,
+      // which propagates and rolls the bundle back (a rewrite of a nonexistent
+      // note is a bug in the caller, not a note to create). Capture the prior
+      // content as a pre-image for rollback, then write + reindex inline.
+      // markPathHandled dedups the watcher's re-index of our own write; the
+      // renderer refresh is driven by the IPC layer via NOTEBASE_REWRITTEN
+      // (which consumes ApproveResult.rewrittenPaths), mirroring how the
+      // bypassing auto-tag/set_properties paths broadcast today.
+      if (!p.path.endsWith('.md')) {
+        throw new Error(`note-rewrite: refusing to rewrite non-markdown path "${p.path}".`);
+      }
+      const before = await notebaseFs.readFile(ctx.rootPath, p.path);
+      markPathHandled(p.path);
+      await notebaseFs.writeFile(ctx.rootPath, p.path, p.content);
+      await graph.indexNote(ctx, p.path, p.content);
+      search.indexNote(ctx, p.path, p.content);
+      void vectors.indexNote(ctx, p.path, p.content);
+      return { path: p.path, before };
+    }
     case 'source':
     case 'saved-query':
       throw new Error(
@@ -660,6 +712,22 @@ async function dispatchRollback(ctx: ProjectContext, a: AppliedRecord): Promise<
         void vectors.indexNote(ctx, data.path, data.content);
       } catch (err) {
         console.warn(`[approval] note-delete rollback restore failed for ${data.path}:`, err);
+      }
+      return;
+    }
+    case 'note-rewrite': {
+      // Restore the note's captured pre-image and reindex (#936). Same posture
+      // as note-delete rollback: best-effort, markPathHandled dedups the
+      // watcher, reindex across graph/search/vectors.
+      const data = a.rollbackData as { path: string; before: string };
+      try {
+        markPathHandled(data.path);
+        await notebaseFs.writeFile(ctx.rootPath, data.path, data.before);
+        await graph.indexNote(ctx, data.path, data.before);
+        search.indexNote(ctx, data.path, data.before);
+        void vectors.indexNote(ctx, data.path, data.before);
+      } catch (err) {
+        console.warn(`[approval] note-rewrite rollback restore failed for ${data.path}:`, err);
       }
       return;
     }

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -307,6 +307,91 @@ describe('payload-kind validation at proposeWrite time (#665)', () => {
   });
 });
 
+describe('note-rewrite payload (#936)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-rewrite-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+  });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  const REL = 'notes/stub.md';
+
+  async function seedNote(content: string): Promise<void> {
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, REL), content, 'utf-8');
+  }
+
+  function rewriteWrite(pathRel: string, content: string) {
+    return {
+      operationType: 'note_rewrite' as OperationType,
+      payloads: [{ kind: 'note-rewrite' as const, path: pathRel, content }],
+      note: 'fill out the note',
+      proposedBy: 'unit-test',
+    };
+  }
+
+  it('note_rewrite defaults to requires_approval', () => {
+    expect(getApprovalTier('note_rewrite')).toBe('requires_approval');
+  });
+
+  it('is gated: the file is unchanged until approved, then holds the new content', async () => {
+    await seedNote('# Stub\n\nrough idea.\n');
+    const proposal = await proposeWrite(ctx, rewriteWrite(REL, '# Stub\n\nA fully fleshed-out idea.\n'));
+    expect(proposal).not.toBeNull();
+    // Not applied yet.
+    expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('# Stub\n\nrough idea.\n');
+
+    const result = await approveProposal(ctx, proposal!.uri);
+    expect(result.ok).toBe(true);
+    expect(result.rewrittenPaths).toEqual([REL]);
+    expect(result.filedPaths).toEqual([]);
+    expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('# Stub\n\nA fully fleshed-out idea.\n');
+  });
+
+  it('rejecting a rewrite leaves the original content untouched', async () => {
+    await seedNote('original\n');
+    const proposal = await proposeWrite(ctx, rewriteWrite(REL, 'replaced\n'));
+    expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);
+    expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('original\n');
+  });
+
+  it('rolls back to the pre-image when a later payload in the bundle fails', async () => {
+    await seedNote('keep me\n');
+    // A rewrite followed by a deliberately-malformed graph-triples payload:
+    // the triples parse blows up at apply time, and the reverse-order rollback
+    // must restore the note's original bytes.
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'note_rewrite',
+      payloads: [
+        { kind: 'note-rewrite', path: REL, content: 'clobbered\n' },
+        { kind: 'graph-triples', turtle: 'this is not valid turtle @@@', affectsNodeUris: [] },
+      ],
+      note: 'rewrite + bad triples',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    // The rewrite landed then rolled back — original content restored.
+    expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('keep me\n');
+  });
+
+  it('rejects a rewrite of a non-markdown path', async () => {
+    // Guardrail check runs at apply time; the proposal files fine, approval fails.
+    await fsp.writeFile(path.join(root, 'data.txt'), 'x', 'utf-8');
+    const proposal = await proposeWrite(ctx, rewriteWrite('data.txt', 'y'));
+    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow(/non-markdown/);
+  });
+
+  it('fails (and rolls back) when the target note does not exist', async () => {
+    const proposal = await proposeWrite(ctx, rewriteWrite('notes/ghost.md', 'content'));
+    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+  });
+});
+
 describe('tier store effects (#666)', () => {
   let root: string;
   let ctx: ProjectContext;


### PR DESCRIPTION
Closes #936. First foundation piece of epic #935 (in-place note editing + closing the LLM approval-bypass gaps).

## What

Adds a `note-rewrite` payload kind to the approval engine — the missing primitive for overwriting an **existing** note's body in place, gated by the diff-review approval flow. (`note` today only *creates*; nothing rewrote in place.)

Everything downstream in the epic builds on this: the `propose_note_body` tool (#937) + review card (#938) + "fill out this note" skill (#939), and the five current bypass sites (Auto-Tag, Auto-Link out/in, `set_properties`, `propose_source_properties`) all converge onto this kind.

## How

Mirrors the existing `note-delete` kind precisely:

- **apply** — guard `.md` + existence, capture the prior content as a pre-image, `markPathHandled` (dedup the watcher's re-index of our own write), write, reindex graph/search/vectors.
- **rollback** — restore the captured pre-image + reindex (reverse-order rollback already fires when a later payload in the bundle throws).
- `note_rewrite` `OperationType` → `requires_approval` tier.
- `collectAffectsNodes` ties the rewritten note's IRI to the proposal, so the trust-integrity query joins it back to its approval and established-note escalation covers it.

The engine stays Electron-free by design: `ApproveResult.rewrittenPaths` surfaces the overwritten paths so the IPC layer (#937) fires `NOTEBASE_REWRITTEN` to reload an open editor — the same seam `filedPaths` already uses. (Confirmed during scoping that `NOTEBASE_FILE_CHANGED` from the watcher has no renderer subscriber; in-place editor reload runs exclusively through `NOTEBASE_REWRITTEN`.)

## Tests

New `note-rewrite` block in `approval.test.ts`: gated apply (unchanged until approved), reject-leaves-original, **bundle rollback** to the pre-image when a later payload fails, and the non-markdown + missing-file guardrails. Full suite green; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
