### PR TITLE
feat: note-body rewrite review card (#938)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -46,7 +46,9 @@
   import RefactorDraftCard from './RefactorDraftCard.svelte';
   import ReorgDraftCard from './ReorgDraftCard.svelte';
   import DeleteDraftCard from './DeleteDraftCard.svelte';
+  import NoteBodyDraftCard from './NoteBodyDraftCard.svelte';
   import type { ConversationRefactorDraft, ConversationReorgDraft, ConversationDeleteDraft } from '../../../shared/conversation-refactor-drafts';
+  import type { ConversationNoteBodyDraft } from '../../../shared/conversation-note-body-drafts';
   import { getSlashCommands } from '../tools/tool-registry';
   import { slashQueryFromComposer, buildSlashMenu, type SlashMenuItem } from '../conversations/slash-commands';
   import {
@@ -457,6 +459,18 @@
     store.discardDeleteDraft(tabId, draftId);
   }
 
+  async function handleApproveNoteBody(tabId: string, draft: ConversationNoteBodyDraft) {
+    try {
+      await store.approveNoteBodyDraft(tabId, draft);
+    } catch (e) {
+      console.error('[conv-panel] approve note-body rewrite failed:', e);
+    }
+  }
+
+  function handleDiscardNoteBody(tabId: string, draftId: string) {
+    store.discardNoteBodyDraft(tabId, draftId);
+  }
+
   async function handleApproveSource(tabId: string, draft: ConversationSourceDraft) {
     try {
       await store.approveSourceDraft(tabId, draft);
@@ -672,6 +686,13 @@
   function orphanDeleteDrafts(tab: TabT) {
     const max = tab.conversation.messages.length;
     return tab.deleteDrafts.filter((d) => d.afterMessageIndex >= max);
+  }
+  function noteBodyDraftsAt(tab: TabT, i: number) {
+    return tab.noteBodyDrafts.filter((d) => d.afterMessageIndex === i);
+  }
+  function orphanNoteBodyDrafts(tab: TabT) {
+    const max = tab.conversation.messages.length;
+    return tab.noteBodyDrafts.filter((d) => d.afterMessageIndex >= max);
   }
 </script>
 
@@ -1121,6 +1142,13 @@
                 onDiscard={() => handleDiscardDelete(tab.id, draft.draftId)}
               />
             {/each}
+            {#each noteBodyDraftsAt(tab, i) as draft (draft.draftId)}
+              <NoteBodyDraftCard
+                {draft}
+                onApprove={() => handleApproveNoteBody(tab.id, draft)}
+                onDiscard={() => handleDiscardNoteBody(tab.id, draft.draftId)}
+              />
+            {/each}
           {/each}
 
           {#if tab.streaming}
@@ -1240,6 +1268,13 @@
               {draft}
               onApprove={(selected) => handleApproveDelete(tab.id, draft, selected)}
               onDiscard={() => handleDiscardDelete(tab.id, draft.draftId)}
+            />
+          {/each}
+          {#each orphanNoteBodyDrafts(tab) as draft (draft.draftId)}
+            <NoteBodyDraftCard
+              {draft}
+              onApprove={() => handleApproveNoteBody(tab.id, draft)}
+              onDiscard={() => handleDiscardNoteBody(tab.id, draft.draftId)}
             />
           {/each}
         </div>

--- a/src/renderer/lib/components/NoteBodyDraftCard.svelte
+++ b/src/renderer/lib/components/NoteBodyDraftCard.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  /**
+   * Review card for an in-place note rewrite from `propose_note_body` (#938) —
+   * the first in-place-editing tool. Unlike the refactor card (where the move is
+   * the point and the diff is secondary), here the rewrite IS the point, so the
+   * before/after diff shows by default. Reuses `changedLines()` — the same
+   * positional line diff the refactor card renders. Approve routes through the
+   * `note_rewrite` approval payload (#936); nothing is written until then. No
+   * danger styling — rewriting a note is a normal edit, and it's git-backed.
+   */
+  import type { ConversationNoteBodyDraft } from '../../../shared/conversation-note-body-drafts';
+  import DraftCard from './DraftCard.svelte';
+  import Icon from './Icon.svelte';
+  import { changedLines } from './refactor-diff';
+
+  interface Props {
+    draft: ConversationNoteBodyDraft;
+    onApprove: () => void;
+    onDiscard: () => void;
+  }
+
+  let { draft, onApprove, onDiscard }: Props = $props();
+
+  let expanded = $state(true);
+
+  const lines = $derived(changedLines(draft.beforeContent, draft.afterContent));
+  // Count each side independently — an expansion is mostly additions, a trim
+  // mostly removals; showing both numbers tells the user which at a glance.
+  const removed = $derived(lines.filter((l) => l.before !== '').length);
+  const added = $derived(lines.filter((l) => l.after !== '').length);
+  // The rationale the tool passed, shown only when it adds something over the
+  // default "Rewrite <path>" (which the path slot already conveys).
+  const rationale = $derived(
+    draft.note && draft.note !== `Rewrite ${draft.relativePath}` ? draft.note : '',
+  );
+</script>
+
+<DraftCard
+  headline="Rewrite"
+  note={draft.relativePath}
+  approveLabel="Approve & rewrite"
+  {onApprove}
+  {onDiscard}
+>
+  <div class="body">
+    <div class="summary">
+      {#if rationale}<span class="rationale">{rationale}</span>{/if}
+      <span class="counts">
+        <span class="add">+{added}</span> <span class="rem">−{removed}</span>
+        line{added + removed === 1 ? '' : 's'} changed
+      </span>
+    </div>
+
+    <button class="toggle" type="button" onclick={() => (expanded = !expanded)}>
+      <Icon name={expanded ? 'chevronDown' : 'chevronRight'} size={11} />
+      {expanded ? 'Hide diff' : 'Show diff'}
+    </button>
+
+    {#if expanded}
+      {#if lines.length === 0}
+        <div class="empty">No line-level changes.</div>
+      {:else}
+        <div class="diff">
+          {#each lines as line}
+            {#if line.before !== ''}<div class="line removed">{line.before}</div>{/if}
+            {#if line.after !== ''}<div class="line added">{line.after}</div>{/if}
+          {/each}
+        </div>
+      {/if}
+    {/if}
+  </div>
+</DraftCard>
+
+<style>
+  .body { display: flex; flex-direction: column; gap: 6px; }
+  .summary { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; font-size: 12.5px; }
+  .rationale { color: var(--text); }
+  .counts { color: var(--text-muted); font-size: 11.5px; }
+  .counts .add { color: var(--sage); }
+  .counts .rem { color: var(--text-muted); }
+  .toggle {
+    display: inline-flex; align-items: center; gap: 4px; align-self: flex-start;
+    border: none; background: none; padding: 0; cursor: pointer;
+    color: var(--text-muted); font-size: 11.5px;
+  }
+  .toggle:hover { color: var(--text); }
+  .empty { font-size: 11.5px; color: var(--text-faint); }
+  /* Scroll-contain so a large rewrite doesn't blow out the transcript. */
+  .diff {
+    display: flex; flex-direction: column;
+    border-left: 2px solid var(--border); padding-left: 8px;
+    max-height: 340px; overflow-y: auto;
+  }
+  .line {
+    font-family: var(--font-mono); font-size: 11px;
+    white-space: pre-wrap; word-break: break-word;
+    padding: 0 4px; border-radius: 2px;
+  }
+  /* Quiet add/remove tints — no alarm red; removed leans muted, added leans sage. */
+  .line.removed { color: var(--text-muted); background: color-mix(in oklch, var(--text) 6%, transparent); }
+  .line.added { color: var(--text); background: color-mix(in oklch, var(--sage) 14%, transparent); }
+</style>

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../shared/types';
 import type { ConversationDraft } from '../../../shared/conversation-drafts';
 import type { ConversationRefactorDraft, ConversationReorgDraft, ConversationDeleteDraft } from '../../../shared/conversation-refactor-drafts';
+import type { ConversationNoteBodyDraft } from '../../../shared/conversation-note-body-drafts';
 import type {
   ConversationSourceDraft,
   SourceIngestOutcome,
@@ -92,6 +93,7 @@ type AnchoredComputeDraft = ConversationComputeDraft & { afterMessageIndex: numb
 type AnchoredRefactorDraft = ConversationRefactorDraft & { afterMessageIndex: number };
 type AnchoredReorgDraft = ConversationReorgDraft & { afterMessageIndex: number };
 type AnchoredDeleteDraft = ConversationDeleteDraft & { afterMessageIndex: number };
+type AnchoredNoteBodyDraft = ConversationNoteBodyDraft & { afterMessageIndex: number };
 /** Per-draft state for compute proposals (#245). `result` holds the
  *  output of the most recent Run; `insertedAt` records the destination
  *  path when the user chose Insert into notebook. Both are optional —
@@ -150,6 +152,8 @@ interface TabRuntime {
   reorgDrafts: AnchoredReorgDraft[];
   /** propose_note_delete batch deletions awaiting Approve/Discard. */
   deleteDrafts: AnchoredDeleteDraft[];
+  /** propose_note_body in-place rewrites awaiting Approve/Discard (#938). */
+  noteBodyDrafts: AnchoredNoteBodyDraft[];
   /** Per-draft Run / Insert state. Stays alive after Run so the user
    *  can see the cell + output in the transcript; only Discard removes
    *  the draft entirely (which also drops the state entry). */
@@ -196,6 +200,7 @@ let computeDraftSubscribed = false;
 let refactorDraftSubscribed = false;
 let reorgDraftSubscribed = false;
 let deleteDraftSubscribed = false;
+let noteBodyDraftSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
 
@@ -325,6 +330,15 @@ function ensureSubscriptions(): void {
     });
     deleteDraftSubscribed = true;
   }
+  if (!noteBodyDraftSubscribed) {
+    api.conversations.onNoteBodyDraft((draft) => {
+      const t = tabs.find((tab) => tab.id === draft.conversationId);
+      if (!t) return;
+      const afterMessageIndex = t.conversation.messages.length;
+      t.noteBodyDrafts = [...t.noteBodyDrafts, { ...draft, afterMessageIndex }];
+    });
+    noteBodyDraftSubscribed = true;
+  }
   if (!askUserSubscribed) {
     api.conversations.onAskUser((req) => {
       const t = tabs.find((tab) => tab.id === req.conversationId);
@@ -375,6 +389,7 @@ async function init(): Promise<void> {
       refactorDrafts: [],
       reorgDrafts: [],
       deleteDrafts: [],
+      noteBodyDrafts: [],
       computeDraftState: {},
       pendingQuestion: null,
       composer: '',
@@ -471,6 +486,7 @@ async function openFreeform(originNotePath?: string): Promise<TabRuntime> {
     refactorDrafts: [],
     reorgDrafts: [],
     deleteDrafts: [],
+    noteBodyDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
     composer: '',
@@ -534,6 +550,7 @@ async function openConversationTab(opts: {
     refactorDrafts: [],
     reorgDrafts: [],
     deleteDrafts: [],
+    noteBodyDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
     composer: '',
@@ -718,6 +735,7 @@ function blankTabRuntime(conv: Conversation, extraTools: ConversationToolKey[]):
     refactorDrafts: [],
     reorgDrafts: [],
     deleteDrafts: [],
+    noteBodyDrafts: [],
     computeDraftState: {},
     pendingQuestion: null,
     composer: '',
@@ -859,6 +877,22 @@ function discardDeleteDraft(tabId: string, draftId: string): void {
   const tab = findTab(tabId);
   if (!tab) return;
   tab.deleteDrafts = tab.deleteDrafts.filter((d) => d.draftId !== draftId);
+}
+
+async function approveNoteBodyDraft(tabId: string, draft: ConversationNoteBodyDraft): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  const snapshot = $state.snapshot(draft);
+  await api.conversations.fileNoteBodyDraft(snapshot);
+  // Drop the card. The rewrite lands via the approval engine, and the
+  // NOTEBASE_REWRITTEN broadcast reloads the note in any open editor.
+  tab.noteBodyDrafts = tab.noteBodyDrafts.filter((d) => d.draftId !== draft.draftId);
+}
+
+function discardNoteBodyDraft(tabId: string, draftId: string): void {
+  const tab = findTab(tabId);
+  if (!tab) return;
+  tab.noteBodyDrafts = tab.noteBodyDrafts.filter((d) => d.draftId !== draftId);
 }
 
 async function approveSourceDraft(
@@ -1127,6 +1161,8 @@ export function getConversationsStore() {
     discardReorgDraft,
     approveDeleteDraft,
     discardDeleteDraft,
+    approveNoteBodyDraft,
+    discardNoteBodyDraft,
     approveSourceDraft,
     discardSourceDraft,
     dismissSourceDraftResult,

--- a/tests/renderer/stores/conversation-clear.test.ts
+++ b/tests/renderer/stores/conversation-clear.test.ts
@@ -14,7 +14,7 @@ const h = vi.hoisted(() => {
     conversations: {
       // subscriptions used by ensureSubscriptions()
       onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
-      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onRefactorDraft: noop, onReorgDraft: noop, onDeleteDraft: noop, onAskUser: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onRefactorDraft: noop, onReorgDraft: noop, onDeleteDraft: noop, onNoteBodyDraft: noop, onAskUser: noop,
       saveUIState: vi.fn().mockResolvedValue(undefined),
       archive: vi.fn().mockResolvedValue(undefined),
       create: vi.fn(async (contextBundle: unknown, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) => {

--- a/tests/renderer/stores/conversation-compact.test.ts
+++ b/tests/renderer/stores/conversation-compact.test.ts
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => {
   const api = {
     conversations: {
       onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
-      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onRefactorDraft: noop, onReorgDraft: noop, onDeleteDraft: noop, onAskUser: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop, onRefactorDraft: noop, onReorgDraft: noop, onDeleteDraft: noop, onNoteBodyDraft: noop, onAskUser: noop,
       saveUIState: vi.fn().mockResolvedValue(undefined),
       create: vi.fn(async (contextBundle: unknown) => ({
         id: `conv-${nextId++}`,

--- a/tests/renderer/stores/conversation-note-body-draft.test.ts
+++ b/tests/renderer/stores/conversation-note-body-draft.test.ts
@@ -1,0 +1,98 @@
+/**
+ * propose_note_body review flow (#938): a note-body draft arrives over the
+ * subscription, renders as a pending card in the active tab, and Approve routes
+ * through `fileNoteBodyDraft` (the approval engine) while Discard writes nothing.
+ * Drives the conversations store with a mocked api client.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Conversation } from '../../../src/shared/types';
+import type { ConversationNoteBodyDraft } from '../../../src/shared/conversation-note-body-drafts';
+
+const h = vi.hoisted(() => {
+  const noop = vi.fn();
+  let nextId = 1;
+  // Capture the subscription callback the store registers so the test can
+  // simulate a draft arriving from main.
+  let noteBodyCb: ((draft: ConversationNoteBodyDraft) => void) | null = null;
+  const api = {
+    conversations: {
+      onStream: noop, onDraft: noop, onSourceDraft: noop, onPropertyDraft: noop,
+      onSourcePropertyDraft: noop, onClaimsDraft: noop, onComputeDraft: noop,
+      onRefactorDraft: noop, onReorgDraft: noop, onDeleteDraft: noop,
+      onNoteBodyDraft: (cb: (draft: ConversationNoteBodyDraft) => void) => { noteBodyCb = cb; },
+      onAskUser: noop,
+      saveUIState: vi.fn().mockResolvedValue(undefined),
+      archive: vi.fn().mockResolvedValue(undefined),
+      fileNoteBodyDraft: vi.fn().mockResolvedValue({ proposalUri: 'urn:p1', applied: true }),
+      create: vi.fn(async (contextBundle: unknown) => {
+        const conv: Conversation = {
+          id: `conv-${nextId++}`,
+          contextBundle: contextBundle as Conversation['contextBundle'],
+          messages: [],
+          status: 'active',
+          startedAt: 't',
+        };
+        return conv;
+      }),
+    },
+  };
+  return { api, getCb: () => noteBodyCb };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const store = getConversationsStore();
+
+function draftFor(conversationId: string): ConversationNoteBodyDraft {
+  return {
+    draftId: 'nb-1',
+    conversationId,
+    note: 'Flesh out the stub',
+    relativePath: 'notes/stub.md',
+    beforeContent: '# Stub\n\nrough.\n',
+    afterContent: '# Stub\n\nA fuller draft.\n',
+    createdAt: 't',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('propose_note_body review flow (#938)', () => {
+  it('surfaces an arriving draft as a pending card on the matching tab', async () => {
+    await store.openFreeform('notes/stub.md');
+    const tab = store.activeTab!;
+    h.getCb()!(draftFor(tab.id));
+    expect(tab.noteBodyDrafts.map((d) => d.draftId)).toEqual(['nb-1']);
+  });
+
+  it('Approve files the rewrite through the approval engine and drops the card', async () => {
+    await store.openFreeform('notes/stub.md');
+    const tab = store.activeTab!;
+    const draft = draftFor(tab.id);
+    h.getCb()!(draft);
+
+    await store.approveNoteBodyDraft(tab.id, tab.noteBodyDrafts[0]);
+
+    expect(h.api.conversations.fileNoteBodyDraft).toHaveBeenCalledTimes(1);
+    const [sent] = h.api.conversations.fileNoteBodyDraft.mock.calls[0];
+    expect(sent.relativePath).toBe('notes/stub.md');
+    expect(sent.afterContent).toBe(draft.afterContent);
+    // Card cleared after approval.
+    expect(tab.noteBodyDrafts).toHaveLength(0);
+  });
+
+  it('Discard removes the card without writing anything', async () => {
+    await store.openFreeform('notes/stub.md');
+    const tab = store.activeTab!;
+    h.getCb()!(draftFor(tab.id));
+
+    store.discardNoteBodyDraft(tab.id, 'nb-1');
+
+    expect(tab.noteBodyDrafts).toHaveLength(0);
+    expect(h.api.conversations.fileNoteBodyDraft).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #938. Third piece of epic #935 — the renderer counterpart to `propose_note_body` (#937, PR #946). This makes in-place editing visible end to end: tool → draft → **card** → approve → note rewritten + editor reloads.

## What

A review card that renders the before/after diff of an in-place note rewrite and wires Approve/Discard through the conversations store.

## How

- **`NoteBodyDraftCard.svelte`** — built on the shared `DraftCard` shell, reuses `changedLines()` (the same positional line diff the refactor card renders). Two deliberate departures from the refactor card:
  - the diff shows **by default** — a rewrite *is* the point, whereas a move's diff is secondary;
  - a `+added / −removed` summary line, and the diff is **scroll-contained** (`max-height`) so a big "fill out" rewrite can't blow out the transcript.
  No danger styling — rewriting a git-backed note is a normal edit.
- **conversations store** — `onNoteBodyDraft` subscription, anchored `noteBodyDrafts` per tab, `approveNoteBodyDraft` (snapshots `$state` before IPC — the documented Svelte-5 gotcha — files via `fileNoteBodyDraft`, drops the card; the `NOTEBASE_REWRITTEN` broadcast from #937's handler reloads the open editor) + `discardNoteBodyDraft`.
- **`ConversationsPanel`** — renders the card both inline (anchored to its turn) and as an orphan, mirroring the delete-draft wiring exactly.

## Tests

- New store-flow test: a draft arrives over the subscription → pending card on the matching tab; **Approve** files through the engine (`fileNoteBodyDraft` called with the snapshotted draft) and clears the card; **Discard** removes it and writes nothing.
- Added `onNoteBodyDraft` to the two existing store-test api mocks — the new subscription calls it during `ensureSubscriptions()`, so a missing mock method threw `TypeError`. (Caught locally, fixed here.)

Full sweep: 1140 tests across llm + preload + renderer; `pnpm lint` clean.

## Note on visual verification

The card is exercised at the store level, not pixel-tested (consistent with the other draft cards, which have no snapshot tests). It reuses the established `DraftCard` chrome + the refactor card's diff tints, so it inherits the theme. Easy to eyeball live once #939 (the "fill out this note" skill) lands and can trigger a real draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
