### PR TITLE
feat: "Fill Out Note" stock skill (#939)

### DIFF
--- a/src/main/skills/stock/fill-out-note.md
+++ b/src/main/skills/stock/fill-out-note.md
@@ -1,0 +1,48 @@
+---
+id: analysis.fill-out-note
+name: Fill Out Note
+description: Expand a sparse or dictated note into a fuller draft, reviewed as a diff
+menu: Analysis
+group: Generation
+outputMode: openConversation
+context: [fullNote]
+model: claude-opus-4-8
+web: false
+slashCommand: /flesh-out
+firstMessage: "{{#if note}}Flesh out this note.{{/if}}"
+longDescription: >-
+  Opens a conversation that expands the active note — a rough stub, an outline, or
+  a dictated brain-dump — into a fuller, better-organized draft, building on what
+  you already wrote rather than replacing it. The rewrite is proposed as a
+  before/after diff you review and approve; nothing changes until you do. Great
+  right after dictating a note.
+---
+You are a careful writing collaborator. Your job is to **flesh out** the user's note below — take what they've drafted (a rough stub, a bare outline, or a dictated brain-dump) and develop it into a fuller, clearer, better-organized version, **building on their thinking rather than replacing it**.
+
+You **propose only**: you rewrite the note by calling the `propose_note_body` tool, which shows the user a before/after diff. Nothing is written until they approve. You never edit the file yourself.
+
+## Procedure
+
+1. **Read what's there.** The note's full current content is below. Understand the author's intent, voice, and structure before changing anything. If it helps, use `read_note` / `search_notes` to check notes it links to — but the rewrite is about *this* note.
+2. **Develop, don't replace.** Keep the author's own points, phrasing, and ordering where they work. Expand terse bullets into clear prose (or keep them as bullets if that's the note's style), add the connective tissue between ideas, surface the structure with headings where it earns them, and finish half-written thoughts in the direction the author was clearly heading.
+3. **Stay faithful — don't fabricate.** Do not invent facts, figures, citations, or claims the author didn't make or clearly imply. If a point needs a source or a decision the author hasn't made, leave a brief `<!-- TODO: … -->` marker rather than making something up. Filling a note with confident invented detail is worse than leaving a gap.
+4. **Preserve the note's machinery.** Keep any YAML frontmatter, existing `[[wiki-links]]`, and `#tags` intact unless the user asked to change them. `propose_note_body` REPLACES the whole file, so the `content` you pass must include the frontmatter and links, not just the prose.
+5. **Propose the rewrite.** Call `propose_note_body` ONCE with `relative_path` set to the note's path and `content` set to the complete new markdown. Optionally pass a one-line `note` describing what you did (e.g. "Expanded the dictated outline into sections").
+6. **Explain briefly, then stop.** End the turn with one or two sentences on what you developed. Do NOT call the tool again this turn, and do NOT claim the note has changed — it hasn't until the user approves the diff.
+
+## Constraints
+
+- **Propose, never apply.** Your one mutation tool is `propose_note_body`; it queues a diff for review. You cannot and must not write the note yourself.
+- **Faithful expansion, not a new note.** The result should read as *the author's note, more fully realized* — not as your essay on their topic.
+- **Empty is a real answer.** If the note is already well-developed and you'd only be padding it, say so and propose little or nothing rather than inventing filler.
+- If no note is open, don't guess — ask the user which note they'd like to flesh out.
+
+{{#if note}}
+## Note to flesh out — {{note.title}}
+
+Path: `{{note.path}}`
+
+{{note.content | trim}}
+{{else}}
+No note is open. Ask the user which note they'd like to flesh out.
+{{/if}}

--- a/tests/main/skills-fill-out-note.test.ts
+++ b/tests/main/skills-fill-out-note.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+describe('Fill Out Note skill (#939)', () => {
+  it('ships in the Analysis menu, note-scoped, driving propose_note_body — propose-only', async () => {
+    // Point at a non-existent user dir so only stock skills load.
+    const cat = await loadSkillCatalog(path.join(os.tmpdir(), 'minerva-no-user-skills-939'));
+    expect(cat.errors).toEqual([]);
+
+    const s = cat.skills.find((sk) => sk.name === 'Fill Out Note');
+    expect(s, 'Fill Out Note should ship as a stock skill').toBeDefined();
+    expect(s!.source).toBe('stock');
+    expect(s!.menu).toBe('Analysis');
+    expect(s!.group).toBe('Generation');
+    expect(s!.outputMode).toBe('openConversation');
+    // Acts on the active note, so it surfaces in the editor right-click.
+    expect(s!.context).toContain('fullNote');
+    // Drives the in-place rewrite tool (#937) — and the body carries the note.
+    expect(s!.body).toContain('propose_note_body');
+    expect(s!.body).toContain('{{note.content');
+    // Trust principle: proposes a diff, never writes the note itself.
+    expect(s!.body.toLowerCase()).toContain('propose, never apply');
+    // Auto-fires only when a note is open (guarded firstMessage).
+    expect(s!.firstMessage).toContain('{{#if note}}');
+  });
+});


### PR DESCRIPTION
Closes #939. The first **user-facing** piece of epic #935 — and the moment the whole chain pays off. This is the skill that motivated the epic: take a human-written or dictated stub and have the LLM fill it out, in place, gated by review.

## What

**Fill Out Note** — a stock skill that expands the active note (a rough stub, a bare outline, or a dictated brain-dump) into a fuller, better-organized draft, building on the author's thinking rather than replacing it. The rewrite is proposed as a before/after diff the user reviews and approves.

It drives the full stack built in this epic:
`propose_note_body` (#937) → `note-rewrite` approval payload (#936) → diff review card (#938) → editor reloads via `NOTEBASE_REWRITTEN`.

## Frontmatter

- **Analysis** menu, **Generation** group; `openConversation`; `model: claude-opus-4-8`; `/flesh-out` alias.
- `context: [fullNote]` — so it surfaces in the **editor right-click**, which is exactly where you want it right after dictating a note (Voice Phase 2).
- `firstMessage` guarded on `{{#if note}}` — auto-fires "Flesh out this note." when a note is open, stays quiet otherwise.

## The prompt (the part that matters)

Modeled on `organize-by-topic.md`'s propose-only pattern, tuned for faithful expansion:
- **Develop, don't replace** — keep the author's points/voice/ordering; expand terse bullets, add connective tissue, finish half-written thoughts in their direction.
- **Don't fabricate** — no invented facts/citations; leave `<!-- TODO -->` markers for gaps instead. ("Filling a note with confident invented detail is worse than leaving a gap.")
- **Preserve the machinery** — frontmatter, `[[wiki-links]]`, `#tags` must survive, since `propose_note_body` replaces the whole file.
- **Propose once, then stop**; **"Empty is a real answer"** so a well-developed note isn't padded.

## Tests

Per-skill test asserting the compiled skill's menu/group/scope + that the body drives `propose_note_body` and carries the propose-only trust language. The stock loader test validates the frontmatter + template vars (a load error would fail `cat.errors` empty). Full skills suite green; `pnpm lint` clean.

## Verifying live

The wiring is unit-tested, but the payoff is visual and LLM-driven, so it's best eyeballed in the running app: open a sparse note → right-click → **Fill Out Note** (or `/flesh-out`) → review the diff card → Approve → watch the editor reload. Happy to drive that in a `/verify` pass if you want a screenshot — it needs a real model turn, so I left it for a deliberate check rather than doing it headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
