### PR TITLE
feat: route Auto-Tag through approval, with review dialog (#940)

### DIFF
--- a/src/main/ipc/register-refactor.ts
+++ b/src/main/ipc/register-refactor.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import { writeAndReindex } from '../notebase/write-pipeline';
 import { markPathHandled } from '../window-manager';
-import { runAutoTag } from '../llm/auto-tag';
+import { runAutoTag, applyAutoTag } from '../llm/auto-tag';
 import {
   suggestLinksTo,
   applyAutoLinkToSuggestions,
@@ -24,19 +24,30 @@ import * as notebaseFs from '../notebase/fs';
 import { rootPathFromEvent, persistIndexes, broadcastRewritten, hooks } from './helpers';
 
 export function registerRefactor(): void {
-  ipcMain.handle(Channels.REFACTOR_AUTO_TAG, async (e, relativePath: string) => {
+  // Auto-tag is two-phase (#940): SUGGEST asks the LLM for tags and writes
+  // NOTHING; the renderer shows a review dialog; APPLY routes the accepted tags
+  // through the approval engine. This closes the historical bypass where the
+  // one-shot handler wrote directly with no proposal record.
+  ipcMain.handle(Channels.REFACTOR_AUTO_TAG_SUGGEST, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
-
     const plan = await runAutoTag(rootPath, relativePath);
-    if (!plan.content) return { added: [] };
-
-    // Route through the canonical 6-step write pipeline so heading-rename
-    // detection fires uniformly with direct edits (#341 — this site
-    // historically open-coded a 5-step variant that skipped step 6).
-    await writeAndReindex(rootPath, relativePath, plan.content, hooks);
     return { added: plan.added };
   });
+
+  ipcMain.handle(
+    Channels.REFACTOR_AUTO_TAG_APPLY,
+    async (e, relativePath: string, acceptedTags: string[]) => {
+      const rootPath = rootPathFromEvent(e);
+      if (!rootPath) throw new Error('No project open');
+      if (!Array.isArray(acceptedTags) || acceptedTags.length === 0) return { applied: [] };
+      const { applied, rewrittenPaths } = await applyAutoTag(rootPath, relativePath, acceptedTags);
+      // The approval engine wrote the note; broadcast so an open editor reloads
+      // the new frontmatter (approval.ts stays Electron-free and returns paths).
+      broadcastRewritten(rootPath, rewrittenPaths);
+      return { applied };
+    },
+  );
 
   ipcMain.handle(Channels.REFACTOR_AUTO_LINK_SUGGEST, async (e, activeRelPath: string) => {
     const rootPath = rootPathFromEvent(e);

--- a/src/main/llm/auto-tag.ts
+++ b/src/main/llm/auto-tag.ts
@@ -4,6 +4,7 @@ import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { complete } from './index';
 import { getSettings } from './settings';
+import { proposeWrite, approveProposal } from './approval';
 import {
   buildAutoTagPrompt,
   parseAutoTagResponse,
@@ -61,4 +62,51 @@ export async function runAutoTag(
   } finally {
     graph.exitLLMContext();
   }
+}
+
+export interface AutoTagApplyResult {
+  /** Tags actually merged into the note (may be a subset of what was accepted —
+   *  a tag the note already has is a no-op). Empty when nothing changed. */
+  applied: string[];
+  /** Path overwritten in place, for the caller's NOTEBASE_REWRITTEN broadcast.
+   *  Empty when nothing changed. */
+  rewrittenPaths: string[];
+}
+
+/**
+ * Apply the tags the user accepted from the Auto-tag review (#940). Unlike the
+ * old one-shot path, this routes the frontmatter change through the approval
+ * engine's `note-rewrite` payload (#936) rather than writing directly — so the
+ * Trust Principle holds (there's a `thought:Proposal` audit record) and the
+ * write is unified with every other LLM-originated note mutation.
+ *
+ * Recomputes the merge against the note's CURRENT on-disk content (not a
+ * snapshot from suggest time) so edits made between suggest and apply aren't
+ * clobbered. Electron-free: returns the rewritten path for the IPC layer to
+ * broadcast, mirroring the approval engine's own seam.
+ */
+export async function applyAutoTag(
+  rootPath: string,
+  relativePath: string,
+  acceptedTags: string[],
+): Promise<AutoTagApplyResult> {
+  const content = await notebaseFs.readFile(rootPath, relativePath);
+  const { content: next, addedTags } = mergeTagsIntoContent(content, acceptedTags);
+  if (addedTags.length === 0) return { applied: [], rewrittenPaths: [] };
+
+  const ctx = projectContext(rootPath);
+  const proposal = await proposeWrite(ctx, {
+    operationType: 'note_rewrite',
+    payloads: [{ kind: 'note-rewrite', path: relativePath, content: next }],
+    note: `Auto-tag: add ${addedTags.length} tag${addedTags.length === 1 ? '' : 's'} to ${relativePath}`,
+    proposedBy: 'llm:auto-tag',
+  });
+  // note_rewrite is requires_approval, so proposeWrite returns a pending
+  // proposal; the user already reviewed the tags on the card, so approve it now.
+  let rewrittenPaths: string[] = [];
+  if (proposal) {
+    const result = await approveProposal(ctx, proposal.uri);
+    rewrittenPaths = result.rewrittenPaths;
+  }
+  return { applied: addedTags, rewrittenPaths };
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -287,7 +287,9 @@ contextBridge.exposeInMainWorld('api', {
     load: () => ipcRenderer.invoke(Channels.TABS_LOAD),
   },
   refactor: {
-    autoTag: (relativePath: string) => ipcRenderer.invoke(Channels.REFACTOR_AUTO_TAG, relativePath),
+    autoTag: (relativePath: string) => ipcRenderer.invoke(Channels.REFACTOR_AUTO_TAG_SUGGEST, relativePath),
+    autoTagApply: (relativePath: string, acceptedTags: unknown) =>
+      ipcRenderer.invoke(Channels.REFACTOR_AUTO_TAG_APPLY, relativePath, acceptedTags),
     autoLinkSuggest: (relativePath: string) =>
       ipcRenderer.invoke(Channels.REFACTOR_AUTO_LINK_SUGGEST, relativePath),
     autoLinkApply: (relativePath: string, accepted: unknown) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -55,6 +55,7 @@
   import ToolPanel from './lib/components/ToolPanel.svelte';
   import ConversationsPanel from './lib/components/ConversationsPanel.svelte';
   import AutoLinkDialog from './lib/components/AutoLinkDialog.svelte';
+  import AutoTagDialog from './lib/components/AutoTagDialog.svelte';
   import AutoLinkInboundDialog from './lib/components/AutoLinkInboundDialog.svelte';
   import BusyOverlay from './lib/components/BusyOverlay.svelte';
   import CsvTable from './lib/components/CsvTable.svelte';
@@ -789,7 +790,7 @@
     handleExtractSelection, handleSplitByHeading, handleSplitHere,
     handleAutoLink, handleAutoLinkInbound, handleAutoLinkInboundApply, handleAutoLinkApply,
     handleAddTag, handleRemoveTag, handleToggleEntrypoint,
-    handleFormat, handleBibliography, handleAutoTag,
+    handleFormat, handleBibliography, handleAutoTag, handleAutoTagApply,
   } = createRefactorOps(refactorOpsCtx);
 
   // Template / note-creation handler cluster (#670): new-note-from-conversation
@@ -1717,6 +1718,14 @@
       activeStem={refactorFlow.autoLinkInboundReview.relativePath.replace(/\.md$/i, '')}
       onApply={handleAutoLinkInboundApply}
       onCancel={() => refactorFlow.setAutoLinkInboundReview(null)}
+    />
+  {/if}
+  {#if refactorFlow.autoTagReview}
+    <AutoTagDialog
+      tags={refactorFlow.autoTagReview.tags}
+      relativePath={refactorFlow.autoTagReview.relativePath}
+      onApply={handleAutoTagApply}
+      onCancel={() => refactorFlow.setAutoTagReview(null)}
     />
   {/if}
   {#if busy.label}

--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -582,8 +582,11 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
   }
 
   async function handleAutoTag(relativePath: string) {
-    if (!notebase.meta) return;
+    if (!notebase.meta || flow.autoTagBusy) return;
+    flow.setAutoTagBusy(true);
     try {
+      // SUGGEST phase (#940): the LLM proposes tags and writes NOTHING. The user
+      // reviews them in the dialog; Apply routes through the approval engine.
       const result = await busy.withBusy('Auto-tagging…', () =>
         api.refactor.autoTag(relativePath),
       );
@@ -593,11 +596,32 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
           CONFIRM_KEYS.autoTagNoSuggestions,
           'OK',
         );
+        return;
       }
-      // On success, the NOTEBASE_REWRITTEN listener reloads the note so the
-      // user sees the new frontmatter tags appear in the editor.
+      flow.setAutoTagReview({ relativePath, tags: result.added });
     } catch (err) {
       if (await ctx.maybeHandleMissingApiKey(err)) return;
+      const msg = err instanceof Error ? err.message : String(err);
+      await showConfirm(`Auto-tag failed: ${msg}`, CONFIRM_KEYS.autoTagFailed, 'OK');
+    } finally {
+      flow.setAutoTagBusy(false);
+    }
+  }
+
+  async function handleAutoTagApply(accepted: string[]) {
+    const review = flow.autoTagReview;
+    if (!review) return;
+    flow.setAutoTagReview(null);
+    try {
+      // Plain strings, but snapshot for symmetry with the auto-link apply path
+      // (the array came out of $state).
+      const plain = $state.snapshot(accepted);
+      await busy.withBusy('Applying tags…', () =>
+        api.refactor.autoTagApply(review.relativePath, plain),
+      );
+      // On success the note_rewrite approval broadcasts NOTEBASE_REWRITTEN, which
+      // reloads the note so the new frontmatter tags appear in the editor.
+    } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await showConfirm(`Auto-tag failed: ${msg}`, CONFIRM_KEYS.autoTagFailed, 'OK');
     }
@@ -607,6 +631,6 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     handleExtractSelection, handleSplitByHeading, handleSplitHere,
     handleAutoLink, handleAutoLinkInbound, handleAutoLinkInboundApply, handleAutoLinkApply,
     handleAddTag, handleRemoveTag, handleToggleEntrypoint,
-    handleFormat, handleBibliography, handleAutoTag,
+    handleFormat, handleBibliography, handleAutoTag, handleAutoTagApply,
   };
 }

--- a/src/renderer/lib/components/AutoTagDialog.svelte
+++ b/src/renderer/lib/components/AutoTagDialog.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  /**
+   * Review dialog for Auto-tag suggestions (#940). The LLM proposed these tags
+   * but wrote nothing; the user picks which to keep, and Apply files them through
+   * the note_rewrite approval payload. Mirrors AutoLinkDialog's chrome — no danger
+   * styling, per-item selection, esc to cancel.
+   */
+  interface Props {
+    tags: string[];
+    /** The note the tags will be added to (shown for context). */
+    relativePath: string;
+    onApply: (accepted: string[]) => void;
+    onCancel: () => void;
+  }
+
+  let { tags, relativePath, onApply, onCancel }: Props = $props();
+
+  // Each tag selected by default; the user opts tags out. One-time seed.
+  // svelte-ignore state_referenced_locally
+  let selected = $state<boolean[]>(tags.map(() => true));
+
+  const selectedCount = $derived(selected.filter(Boolean).length);
+
+  function toggleAll(value: boolean) {
+    selected = tags.map(() => value);
+  }
+  function apply() {
+    onApply(tags.filter((_, i) => selected[i]));
+  }
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="overlay"
+  onkeydown={handleKeydown}
+  onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+>
+  <div class="dialog" role="dialog" aria-modal="true">
+    <header class="card-header">
+      <div class="eyebrow">Auto-tag · {tags.length} {tags.length === 1 ? 'suggestion' : 'suggestions'}</div>
+      <h2 class="title">Review tags</h2>
+      <div class="subtitle">for <code>{relativePath}</code></div>
+    </header>
+
+    <div class="body">
+      <div class="bulk-row">
+        <span class="bulk-count">{selectedCount} of {tags.length} selected</span>
+        <span class="bulk-spacer"></span>
+        <button class="bulk-btn" onclick={() => toggleAll(true)}>Select all</button>
+        <button class="bulk-btn" onclick={() => toggleAll(false)}>Select none</button>
+      </div>
+      <div class="list">
+        {#each tags as tag, i (tag)}
+          <label class="row" class:selected={selected[i]}>
+            <input type="checkbox" bind:checked={selected[i]} />
+            <span class="tag">#{tag}</span>
+          </label>
+        {/each}
+      </div>
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel</span>
+      <span class="footer-actions">
+        <button class="btn ghost" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={selectedCount === 0} onclick={apply}>
+          Add {selectedCount} tag{selectedCount === 1 ? '' : 's'}
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 460px;
+    max-width: 100%;
+    max-height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-sans);
+    color: var(--text);
+  }
+  .card-header { padding: 20px 24px 0; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+  .subtitle { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
+  .subtitle code { font-family: var(--font-mono); font-size: 11px; }
+
+  .body {
+    padding: 14px 24px 18px;
+    overflow: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .bulk-row { display: flex; align-items: center; gap: 12px; }
+  .bulk-count { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
+  .bulk-spacer { flex: 1; }
+  .bulk-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 3px 9px;
+    border-radius: 5px;
+    font-family: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .bulk-btn:hover { color: var(--text); border-color: var(--border-strong); }
+
+  .list { display: flex; flex-wrap: wrap; gap: 8px; }
+  .row {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    cursor: pointer;
+  }
+  .row:hover { border-color: var(--border-strong); }
+  .row.selected {
+    border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+    background: color-mix(in oklch, var(--accent) 8%, var(--bg));
+  }
+  .row input[type='checkbox'] { flex-shrink: 0; accent-color: var(--accent); }
+  .tag { font-family: var(--font-mono); font-size: 12px; color: var(--text); }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint { margin-right: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); }
+  .footer-actions { display: inline-flex; gap: 8px; }
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .btn.ghost { background: transparent; color: var(--text-muted); }
+  .btn.ghost:hover { color: var(--text); border-color: var(--border-strong); }
+  .btn.primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .btn.primary:hover:not(:disabled) { opacity: 0.92; }
+  .btn:disabled { opacity: 0.4; cursor: default; }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -582,7 +582,10 @@ export interface TabsApi {
 }
 
 export interface RefactorApi {
+  /** SUGGEST phase (#940): ask the LLM for tags; writes nothing. */
   autoTag(relativePath: string): Promise<{ added: string[] }>;
+  /** APPLY phase (#940): file the accepted tags through the note_rewrite approval payload. */
+  autoTagApply(relativePath: string, acceptedTags: string[]): Promise<{ applied: string[] }>;
   autoLinkSuggest(relativePath: string): Promise<{
     suggestions: import('../../../shared/refactor/auto-link').AutoLinkSuggestion[];
     candidateCount: number;

--- a/src/renderer/lib/stores/refactor-flow.svelte.ts
+++ b/src/renderer/lib/stores/refactor-flow.svelte.ts
@@ -25,8 +25,15 @@ let autoLinkInboundReview = $state<{
   relativePath: string;
   suggestions: AutoLinkInboundSuggestion[];
 } | null>(null);
+/** Pending Auto-tag suggestions to review (#940). Non-null = the AutoTagDialog is shown. */
+let autoTagReview = $state<{
+  relativePath: string;
+  tags: string[];
+} | null>(null);
 /** Whether the Auto-link suggest request is currently in flight. Keeps the menu from re-triggering. */
 let autoLinkBusy = $state(false);
+/** Whether the Auto-tag suggest request is in flight — keeps the menu from re-triggering. */
+let autoTagBusy = $state(false);
 
 export function getRefactorFlowStore() {
   return {
@@ -36,5 +43,9 @@ export function getRefactorFlowStore() {
     setAutoLinkInboundReview(s: { relativePath: string; suggestions: AutoLinkInboundSuggestion[] } | null) { autoLinkInboundReview = s; },
     get autoLinkBusy() { return autoLinkBusy; },
     setAutoLinkBusy(b: boolean) { autoLinkBusy = b; },
+    get autoTagReview() { return autoTagReview; },
+    setAutoTagReview(s: { relativePath: string; tags: string[] } | null) { autoTagReview = s; },
+    get autoTagBusy() { return autoTagBusy; },
+    setAutoTagBusy(b: boolean) { autoTagBusy = b; },
   };
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -234,8 +234,10 @@ export const Channels = {
    */
   CITATION_RENDER_INLINE: 'citation:renderInline',
 
-  /** Renderer-initiated LLM Auto-tag of a note (#174). */
-  REFACTOR_AUTO_TAG: 'refactor:autoTag',
+  /** LLM-suggested tags for a note — review before applying (#174, #940). */
+  REFACTOR_AUTO_TAG_SUGGEST: 'refactor:autoTagSuggest',
+  /** Apply accepted Auto-tag tags — routes through the note_rewrite approval payload (#940). */
+  REFACTOR_AUTO_TAG_APPLY: 'refactor:autoTagApply',
   /** LLM-suggested outbound wiki-links for a note (#175). */
   REFACTOR_AUTO_LINK_SUGGEST: 'refactor:autoLinkSuggest',
   /** Apply accepted Auto-link suggestions to the active note. */

--- a/tests/main/llm/auto-tag-integration.test.ts
+++ b/tests/main/llm/auto-tag-integration.test.ts
@@ -21,9 +21,10 @@ const { completeMock, getSettingsMock } = vi.hoisted(() => ({
 vi.mock('../../../src/main/llm/index', () => ({ complete: completeMock }));
 vi.mock('../../../src/main/llm/settings', () => ({ getSettings: getSettingsMock }));
 
-import { runAutoTag } from '../../../src/main/llm/auto-tag';
-import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { runAutoTag, applyAutoTag } from '../../../src/main/llm/auto-tag';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { extractTagsFromContent } from '../../../src/shared/refactor/auto-tag';
 
 describe('runAutoTag() integration (#342)', () => {
   let root: string;
@@ -104,5 +105,61 @@ describe('runAutoTag() integration (#342)', () => {
     // doesn't dedupe across them, and that's fine for the prompt).
     expect(prompt).toContain('other-tag');
     expect(prompt).toContain('shared-tag');
+  });
+});
+
+describe('applyAutoTag() routes through the approval engine (#940)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-autotag-apply-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  async function plant(rel: string, content: string): Promise<void> {
+    const full = path.join(root, rel);
+    await fsp.mkdir(path.dirname(full), { recursive: true });
+    await fsp.writeFile(full, content, 'utf-8');
+    await indexNote(ctx, rel, content);
+  }
+
+  /** Count of approved note_rewrite proposals in the store — proof the write
+   *  went through the approval engine rather than bypassing it. */
+  async function approvedRewriteProposals(): Promise<number> {
+    const r = await queryGraph(ctx, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?p WHERE {
+        ?p a thought:Proposal ;
+           thought:operationType "note_rewrite" ;
+           thought:proposalStatus thought:approved .
+      }`);
+    return r.results.length;
+  }
+
+  it('merges accepted tags into the note AND files an approved note_rewrite proposal', async () => {
+    await plant('notes/x.md', '# X\n\nBody.\n');
+    const result = await applyAutoTag(root, 'notes/x.md', ['alpha', 'beta']);
+
+    expect(result.applied.sort()).toEqual(['alpha', 'beta']);
+    expect(result.rewrittenPaths).toEqual(['notes/x.md']);
+
+    // The file on disk actually carries the tags now.
+    const onDisk = await fsp.readFile(path.join(root, 'notes/x.md'), 'utf-8');
+    expect(extractTagsFromContent(onDisk).sort()).toEqual(['alpha', 'beta']);
+
+    // Trust principle: the write left an approved proposal behind (not a bypass).
+    expect(await approvedRewriteProposals()).toBe(1);
+  });
+
+  it('recomputes against current disk content and no-ops when tags already present', async () => {
+    await plant('notes/y.md', '---\ntags:\n  - kept\n---\n# Y\n');
+    const result = await applyAutoTag(root, 'notes/y.md', ['kept']);
+    expect(result.applied).toEqual([]);
+    expect(result.rewrittenPaths).toEqual([]);
+    // No pointless proposal filed for a no-op.
+    expect(await approvedRewriteProposals()).toBe(0);
   });
 });

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -269,6 +269,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "autoLinkInboundSuggest",
     "autoLinkSuggest",
     "autoTag",
+    "autoTagApply",
   ],
   "search": [
     "query",

--- a/tests/renderer/app/refactor-ops.test.ts
+++ b/tests/renderer/app/refactor-ops.test.ts
@@ -11,6 +11,7 @@ const h = vi.hoisted(() => {
   const api = {
     refactor: {
       autoTag: vi.fn(),
+      autoTagApply: vi.fn(),
       autoLinkSuggest: vi.fn(),
       autoLinkInboundSuggest: vi.fn(),
       autoLinkApply: vi.fn(),
@@ -59,6 +60,8 @@ function resetFlow() {
   flow.setAutoLinkReview(null);
   flow.setAutoLinkInboundReview(null);
   flow.setAutoLinkBusy(false);
+  flow.setAutoTagReview(null);
+  flow.setAutoTagBusy(false);
 }
 
 beforeEach(() => {
@@ -78,18 +81,24 @@ beforeEach(() => {
   ops = createRefactorOps(ctx);
 });
 
-describe('handleAutoTag', () => {
-  it('calls api.refactor.autoTag on the success path', async () => {
-    h.api.refactor.autoTag.mockResolvedValue({ added: ['x'] });
+describe('handleAutoTag (SUGGEST phase, #940)', () => {
+  it('opens the review dialog with the suggested tags and writes nothing', async () => {
+    h.api.refactor.autoTag.mockResolvedValue({ added: ['x', 'y'] });
     await ops.handleAutoTag('note.md');
     expect(h.api.refactor.autoTag).toHaveBeenCalledWith('note.md');
+    // Review state is set — apply hasn't run, so nothing was written.
+    expect(flow.autoTagReview?.relativePath).toBe('note.md');
+    expect(flow.autoTagReview?.tags).toEqual(['x', 'y']);
+    expect(h.api.refactor.autoTagApply).not.toHaveBeenCalled();
     expect(h.dialog.showConfirm).not.toHaveBeenCalled();
+    expect(flow.autoTagBusy).toBe(false);
   });
 
-  it('shows a notice when nothing was added', async () => {
+  it('shows a notice and leaves review null when nothing was suggested', async () => {
     h.api.refactor.autoTag.mockResolvedValue({ added: [] });
     await ops.handleAutoTag('note.md');
     expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(flow.autoTagReview).toBeNull();
   });
 
   it('skips the failure dialog when the error is a missing API key', async () => {
@@ -98,6 +107,21 @@ describe('handleAutoTag', () => {
     await ops.handleAutoTag('note.md');
     expect(maybeMissing).toHaveBeenCalled();
     expect(h.dialog.showConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAutoTagApply (APPLY phase, #940)', () => {
+  it('clears the review and files the accepted tags through approval', async () => {
+    flow.setAutoTagReview({ relativePath: 'note.md', tags: ['x', 'y'] });
+    h.api.refactor.autoTagApply.mockResolvedValue({ applied: ['x'] });
+    await ops.handleAutoTagApply(['x']);
+    expect(flow.autoTagReview).toBeNull();
+    expect(h.api.refactor.autoTagApply).toHaveBeenCalledWith('note.md', ['x']);
+  });
+
+  it('does nothing when there is no pending review', async () => {
+    await ops.handleAutoTagApply(['x']);
+    expect(h.api.refactor.autoTagApply).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #940. First of the **convergence** issues in epic #935 — routing an existing approval-bypass onto the `note-rewrite` payload the in-place-editing feature (#936–#939) established.

## The bypass being closed

Auto-Tag wrote frontmatter directly: `register-refactor.ts` → `writeAndReindex(...)` with **no `thought:Proposal` record**, so the CLAUDE.md trust-integrity query couldn't see it. (One of the five sites the audit surfaced.)

## Approach — make Auto-Tag two-phase, like Auto-Link

Auto-Link was already `suggest → review → apply`; Auto-Tag was one-shot (ran the LLM and wrote in a single call). I converted it to the same shape and pointed the apply at the approval engine, which also delivers the issue's "full review" requirement:

- **SUGGEST** (`REFACTOR_AUTO_TAG_SUGGEST`) — runs the LLM, **writes nothing**, returns the proposed tags.
- **Review** — new `AutoTagDialog` (mirrors `AutoLinkDialog` chrome): proposed tags as toggleable `#chips` with per-tag opt-out, Apply / Cancel, esc to dismiss. No danger styling.
- **APPLY** (`REFACTOR_AUTO_TAG_APPLY`) — new Electron-free `applyAutoTag()` reads the note's **current** content, merges the accepted tags, and files a `note_rewrite` proposal via `proposeWrite` + `approveProposal`; the handler broadcasts `NOTEBASE_REWRITTEN` from the returned `rewrittenPaths` so an open editor reloads.

Recomputing the merge **at apply time** (not a suggest-time snapshot) means edits made between suggest and apply aren't clobbered, and an accepted tag the note already has is a clean no-op (no pointless proposal). `applyAutoTag` returning `{applied, rewrittenPaths}` reuses the approval engine's own "return paths, handler broadcasts" seam — main stays Electron-free and unit-testable.

## Tests

- **`applyAutoTag` integration** — the load-bearing one: after apply, the tags are on disk **and an approved `note_rewrite` proposal exists** (proof the write went *through* approval, not around it). No-op case files nothing.
- **refactor-ops** — `handleAutoTag` now opens the review and writes nothing; `handleAutoTagApply` files through approval and clears the dialog.
- Preload bridge snapshot (`+autoTagApply`).

Full sweep: 1144 tests green across main llm/ipc + renderer + preload; `pnpm lint` clean.

## Verifying live

Same visual shape as before but now gated: open a note → **Auto-tag** → review the proposed tags → Apply → tags appear. Happy to `/verify` if you'd like a screenshot of the new dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
