### PR TITLE
feat: route Auto-Link (outbound + inbound) through approval (#941)

### DIFF
--- a/src/main/ipc/register-refactor.ts
+++ b/src/main/ipc/register-refactor.ts
@@ -7,9 +7,9 @@ import { markPathHandled } from '../window-manager';
 import { runAutoTag, applyAutoTag } from '../llm/auto-tag';
 import {
   suggestLinksTo,
-  applyAutoLinkToSuggestions,
+  fileAutoLinkOutbound,
   suggestLinksInbound,
-  applyInboundSuggestions,
+  fileAutoLinkInbound,
 } from '../llm/auto-link';
 import {
   formatNoteContent,
@@ -73,15 +73,15 @@ export function registerRefactor(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
 
-      const { content, applied, skipped } = await applyAutoLinkToSuggestions(
+      // Route the rewrite through the approval engine (#941) rather than
+      // writing directly. broadcastRewritten reloads an open editor from the
+      // paths the approval apply returns.
+      const { applied, skipped, rewrittenPaths } = await fileAutoLinkOutbound(
         rootPath,
         activeRelPath,
         accepted,
       );
-      if (applied.length === 0) return { applied, skipped };
-
-      // 6-step pipeline (#341).
-      await writeAndReindex(rootPath, activeRelPath, content, hooks);
+      broadcastRewritten(rootPath, rewrittenPaths);
       return { applied, skipped };
     },
   );
@@ -163,28 +163,17 @@ export function registerRefactor(): void {
       const rootPath = rootPathFromEvent(e);
       if (!rootPath) throw new Error('No project open');
 
-      const { applied, skipped, touchedPaths, updatedContents } = await applyInboundSuggestions(
+      // Route through the approval engine (#941): all touched source notes are
+      // filed as ONE note_rewrite proposal (atomic — a partial failure rolls the
+      // whole batch back) and applied. broadcastRewritten emits a single
+      // NOTEBASE_REWRITTEN for every rewritten source so open editors reload.
+      const { applied, skipped, rewrittenPaths } = await fileAutoLinkInbound(
         rootPath,
         activeRelPath,
         accepted,
       );
-
-      // 6-step pipeline (#341), batched: each touched source goes through
-      // writeAndReindex with broadcast/persist suppressed so the loop emits
-      // a single NOTEBASE_REWRITTEN at the end. Heading-rename detection
-      // still fires per-file via the hooks.
-      for (const [source, content] of updatedContents) {
-        await writeAndReindex(rootPath, source, content, hooks, {
-          suppressRewrittenBroadcast: true,
-          skipPersist: true,
-        });
-      }
-      if (touchedPaths.length > 0) {
-        await persistIndexes(rootPath);
-        broadcastRewritten(rootPath, touchedPaths);
-      }
-
-      return { applied, skipped, touchedPaths };
+      broadcastRewritten(rootPath, rewrittenPaths);
+      return { applied, skipped, touchedPaths: rewrittenPaths };
     },
   );
 }

--- a/src/main/llm/auto-link.ts
+++ b/src/main/llm/auto-link.ts
@@ -6,6 +6,7 @@ import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { complete } from './index';
 import { getSettings } from './settings';
+import { proposeWrite, approveProposal } from './approval';
 import {
   buildAutoLinkToPrompt,
   parseAutoLinkResponse,
@@ -144,6 +145,43 @@ export async function applyAutoLinkToSuggestions(
   } finally {
     graph.exitLLMContext();
   }
+}
+
+export interface FileAutoLinkResult {
+  applied: AutoLinkSuggestion[];
+  skipped: AutoLinkSuggestion[];
+  /** Paths overwritten in place, for the caller's NOTEBASE_REWRITTEN broadcast. */
+  rewrittenPaths: string[];
+}
+
+/**
+ * File the accepted outbound links through the approval engine (#941). Inserts
+ * the `[[target]]` links into the active note, then routes the rewrite through
+ * the `note-rewrite` payload (#936) instead of writing directly — so the Trust
+ * Principle holds (there's a `thought:Proposal` audit record). Electron-free:
+ * returns the rewritten path for the IPC layer to broadcast.
+ */
+export async function fileAutoLinkOutbound(
+  rootPath: string,
+  activeRelPath: string,
+  accepted: AutoLinkSuggestion[],
+): Promise<FileAutoLinkResult> {
+  const { content, applied, skipped } = await applyAutoLinkToSuggestions(rootPath, activeRelPath, accepted);
+  if (applied.length === 0) return { applied, skipped, rewrittenPaths: [] };
+
+  const ctx = projectContext(rootPath);
+  const proposal = await proposeWrite(ctx, {
+    operationType: 'note_rewrite',
+    payloads: [{ kind: 'note-rewrite', path: activeRelPath, content }],
+    note: `Auto-link: add ${applied.length} link${applied.length === 1 ? '' : 's'} to ${activeRelPath}`,
+    proposedBy: 'llm:auto-link',
+  });
+  let rewrittenPaths: string[] = [];
+  if (proposal) {
+    const result = await approveProposal(ctx, proposal.uri);
+    rewrittenPaths = result.rewrittenPaths;
+  }
+  return { applied, skipped, rewrittenPaths };
 }
 
 // ── Inbound mode (#175 follow-up) ─────────────────────────────────────────
@@ -363,4 +401,45 @@ async function applyInboundSuggestionsInner(
   }
 
   return { applied, skipped, touchedPaths, updatedContents };
+}
+
+/**
+ * File the accepted inbound links through the approval engine (#941). Inbound
+ * touches MANY source notes, so it files them as ONE proposal carrying a
+ * `note-rewrite` payload per touched note — the engine applies the bundle
+ * atomically (a partial failure rolls the whole batch back), and one approval
+ * gates the lot. Electron-free: returns the rewritten paths to broadcast.
+ */
+export async function fileAutoLinkInbound(
+  rootPath: string,
+  activeRelPath: string,
+  accepted: AutoLinkInboundSuggestion[],
+): Promise<FileAutoLinkInboundResult> {
+  const { applied, skipped, updatedContents } = await applyInboundSuggestions(rootPath, activeRelPath, accepted);
+  if (updatedContents.size === 0) return { applied, skipped, rewrittenPaths: [] };
+
+  const ctx = projectContext(rootPath);
+  const payloads = [...updatedContents].map(([path, content]) => ({
+    kind: 'note-rewrite' as const,
+    path,
+    content,
+  }));
+  const proposal = await proposeWrite(ctx, {
+    operationType: 'note_rewrite',
+    payloads,
+    note: `Auto-link inbound: link ${payloads.length} note${payloads.length === 1 ? '' : 's'} to ${activeRelPath}`,
+    proposedBy: 'llm:auto-link-inbound',
+  });
+  let rewrittenPaths: string[] = [];
+  if (proposal) {
+    const result = await approveProposal(ctx, proposal.uri);
+    rewrittenPaths = result.rewrittenPaths;
+  }
+  return { applied, skipped, rewrittenPaths };
+}
+
+export interface FileAutoLinkInboundResult {
+  applied: AutoLinkInboundSuggestion[];
+  skipped: AutoLinkInboundSuggestion[];
+  rewrittenPaths: string[];
 }

--- a/tests/main/llm/auto-link-integration.test.ts
+++ b/tests/main/llm/auto-link-integration.test.ts
@@ -26,10 +26,12 @@ vi.mock('../../../src/main/llm/settings', () => ({ getSettings: getSettingsMock 
 import {
   suggestLinksTo,
   applyAutoLinkToSuggestions,
+  fileAutoLinkOutbound,
   suggestLinksInbound,
   applyInboundSuggestions,
+  fileAutoLinkInbound,
 } from '../../../src/main/llm/auto-link';
-import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 describe('Auto-link integration (#342)', () => {
@@ -176,6 +178,68 @@ describe('Auto-link integration (#342)', () => {
       expect(result.skipped).toHaveLength(1);
       expect(result.touchedPaths).toEqual([]);
       expect(result.updatedContents.size).toBe(0);
+    });
+  });
+
+  describe('approval routing (#941)', () => {
+    /** Approved note_rewrite proposals in the store — proof the write went
+     *  through the approval engine rather than bypassing it. */
+    async function approvedRewriteProposals(): Promise<Array<Record<string, string>>> {
+      const r = await queryGraph(ctx, `
+        PREFIX thought: <https://minerva.dev/ontology/thought#>
+        SELECT ?p ?payload WHERE {
+          ?p a thought:Proposal ;
+             thought:operationType "note_rewrite" ;
+             thought:proposalStatus thought:approved ;
+             thought:payloadJson ?payload .
+        }`);
+      return r.results as Array<Record<string, string>>;
+    }
+
+    it('outbound: files the link rewrite as an approved note_rewrite proposal', async () => {
+      await plant('notes/active.md', '# Active\n\nThis mentions cognitive bias here.\n');
+      await plant('notes/cognitive-bias.md', '# Cognitive Bias\n');
+      const accepted = [
+        { anchorText: 'cognitive bias', target: 'notes/cognitive-bias.md', rationale: 'r.' },
+      ];
+
+      const result = await fileAutoLinkOutbound(root, 'notes/active.md', accepted);
+      expect(result.applied).toHaveLength(1);
+      expect(result.rewrittenPaths).toEqual(['notes/active.md']);
+
+      // The link actually landed on disk.
+      const onDisk = await fsp.readFile(path.join(root, 'notes/active.md'), 'utf-8');
+      expect(onDisk).toContain('[[notes/cognitive-bias|cognitive bias]]');
+
+      // Trust principle: a single approved note_rewrite proposal backs the write.
+      const proposals = await approvedRewriteProposals();
+      expect(proposals).toHaveLength(1);
+    });
+
+    it('inbound: files ALL touched sources as ONE atomic note_rewrite proposal', async () => {
+      await plant('notes/active.md', '# Widgets\n');
+      await plant('notes/source-a.md', '# A\n\nWe use widgets daily.\n');
+      await plant('notes/source-b.md', '# B\n\nMore widgets discussion.\n');
+      const accepted = [
+        { source: 'notes/source-a.md', anchorText: 'widgets', rationale: 'r.', contextSnippet: '' },
+        { source: 'notes/source-b.md', anchorText: 'widgets', rationale: 'r.', contextSnippet: '' },
+      ];
+
+      const result = await fileAutoLinkInbound(root, 'notes/active.md', accepted);
+      expect(result.applied).toHaveLength(2);
+      expect(result.rewrittenPaths.sort()).toEqual(['notes/source-a.md', 'notes/source-b.md']);
+
+      // Both sources got the link on disk.
+      expect(await fsp.readFile(path.join(root, 'notes/source-a.md'), 'utf-8')).toContain('[[notes/active|widgets]]');
+      expect(await fsp.readFile(path.join(root, 'notes/source-b.md'), 'utf-8')).toContain('[[notes/active|widgets]]');
+
+      // ONE proposal (atomic batch), carrying a note-rewrite payload per source.
+      const proposals = await approvedRewriteProposals();
+      expect(proposals).toHaveLength(1);
+      const payloads = JSON.parse(proposals[0].payload) as Array<{ kind: string; path: string }>;
+      expect(payloads).toHaveLength(2);
+      expect(payloads.every((p) => p.kind === 'note-rewrite')).toBe(true);
+      expect(payloads.map((p) => p.path).sort()).toEqual(['notes/source-a.md', 'notes/source-b.md']);
     });
   });
 });


### PR DESCRIPTION
Closes #941. Second convergence issue in epic #935 — routing the last two `writeAndReindex` bypass sites (Auto-Link outbound + inbound) onto the `note-rewrite` approval payload.

## The bypasses being closed

`register-refactor.ts` wrote note bodies directly for both auto-link directions — no `thought:Proposal` record. These were sites #2 and #3 of the five the audit surfaced.

## Backend-only — as predicted

Auto-Link was **already** `suggest → review → apply` (unlike Auto-Tag, which I had to convert in #940). So the review dialogs (`AutoLinkDialog`, `AutoLinkInboundDialog`) and the renderer handlers are **untouched** — the change is purely swapping the write for an approval-routed one:

- **`fileAutoLinkOutbound`** — inserts the accepted links, files **one** `note_rewrite` proposal for the active note, approves it, returns `rewrittenPaths`.
- **`fileAutoLinkInbound`** — inbound rewrites **many** source notes, so it files them as **one proposal carrying a `note-rewrite` payload per source**. The approval engine applies the bundle **atomically** — a partial failure rolls the whole batch back — and one approval gates the lot. This is the nuance the issue called out, and it's exactly what the payload-bundle design from #936 was built for.

Both wrappers are Electron-free (return `rewrittenPaths`); the IPC handlers just `broadcastRewritten`. The pure compute functions (`applyAutoLinkToSuggestions` / `applyInboundSuggestions`) are unchanged — they still recompute against current disk content, so their existing tests hold untouched.

## Tests

- **outbound** — after apply, the link is on disk **and** an approved `note_rewrite` proposal backs it.
- **inbound** — files exactly **one** proposal whose payload array carries a `note-rewrite` per touched source (asserts `kind` + the two paths) — proving the atomic batch rather than N separate writes.

Both use the same "an approved proposal exists" assertion pattern from #940 that #944 will generalize into the write-guard integrity check.

Full sweep: 510 tests green across llm/ipc/renderer/refactor; `pnpm lint` clean. No renderer diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
