### PR TITLE
feat: route set_properties through approval (#942)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -12,7 +12,7 @@ import { setSourceProperties, ttlString } from '../sources/source-meta-write';
 import { runCell as runComputeCell } from '../compute/registry';
 import { buildExcerptTtl } from '../sources/create-excerpt';
 import { slugify } from '../../shared/slug';
-import { patchFrontmatterProperties } from '../../shared/refactor/frontmatter-patch';
+import { applyPropertyUpdates } from '../llm/set-properties';
 import * as approval from '../llm/approval';
 import { orderRefactors } from '../notebase/reorg';
 import * as conversation from '../llm/conversation';
@@ -741,55 +741,15 @@ export function registerConversation(): void {
           `If this came from a Svelte 5 $state value, snapshot it before sending across IPC.`,
         );
       }
-      const outcomes: import('../../shared/conversation-property-drafts').PropertyUpdateOutcome[] = [];
-      for (const u of draft.updates) {
-        try {
-          if (!u.properties || typeof u.properties !== 'object' || Object.keys(u.properties).length === 0) {
-            // Don't silently produce a no-op outcome — that's what hid
-            // the original cross-IPC serialization bug. Surface it as
-            // an explicit error so the user sees something on the
-            // Filed line and the log captures the bad payload.
-            outcomes.push({
-              relativePath: u.relativePath,
-              changedKeys: [],
-              deletedKeys: [],
-              error: 'properties payload arrived empty across IPC — frontmatter not written.',
-            });
-            continue;
-          }
-          const before = await notebaseFs.readFile(rootPath, u.relativePath);
-          const result = patchFrontmatterProperties(before, u.properties);
-          if (result.changedKeys.length > 0) {
-            // Route through the standard write pipeline rather than
-            // bare `notebaseFs.writeFile`. Without this the file lands
-            // on disk but the renderer's open editor + right-sidebar
-            // Properties panel don't refresh until the note is closed
-            // and reopened — the pipeline marks the watcher dedup,
-            // reindexes the graph + search, AND emits the
-            // NOTEBASE_REWRITTEN broadcast that triggers the in-place
-            // reload. Same flow auto-tag/auto-link use after their
-            // frontmatter mutations.
-            await writeAndReindex(rootPath, u.relativePath, result.content, hooks);
-          }
-          outcomes.push({
-            relativePath: u.relativePath,
-            changedKeys: result.changedKeys,
-            deletedKeys: result.deletedKeys,
-          });
-        } catch (err) {
-          console.warn(`[conv] FILE_PROPERTY_DRAFT patch failed for`, u.relativePath, err);
-          outcomes.push({
-            relativePath: u.relativePath,
-            changedKeys: [],
-            deletedKeys: [],
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-      // The graph indexer watches for file changes, so reindexing
-      // happens automatically. We don't broadcast a separate event
-      // here — the file watcher's NOTEBASE_FILE_CHANGED event is
-      // what the renderer already listens for to refresh views.
+      // Apply each per-note frontmatter patch through the approval engine's
+      // note_rewrite payload (#942) — see applyPropertyUpdates. broadcastRewritten
+      // reloads open editors + the Properties panel from the rewritten paths.
+      const { outcomes, rewrittenPaths } = await applyPropertyUpdates(
+        rootPath,
+        draft.updates,
+        draft.conversationId,
+      );
+      hooks.broadcastRewritten(rootPath, rewrittenPaths);
       return { outcomes };
     },
   );

--- a/src/main/llm/set-properties.ts
+++ b/src/main/llm/set-properties.ts
@@ -1,0 +1,89 @@
+/**
+ * Apply side of the `set_properties` tool (#942). The tool itself only emits a
+ * ConversationPropertyDraft (trust principle — it never writes); this runs when
+ * the user approves that draft, applying each per-note frontmatter patch.
+ *
+ * The write routes through the approval engine's `note-rewrite` payload (#936)
+ * rather than a bare writeAndReindex, so the Trust Principle holds — every
+ * applied change leaves a `thought:Proposal` audit record. Per-note proposals
+ * (not one atomic bundle) preserve the handler's long-standing non-fatal-per-note
+ * behavior: one note failing doesn't roll back the rest of the bundle.
+ *
+ * Electron-free: returns the rewritten paths for the IPC layer to broadcast
+ * (NOTEBASE_REWRITTEN), mirroring the approval engine's own seam.
+ */
+import * as notebaseFs from '../notebase/fs';
+import { projectContext } from '../project-context-types';
+import { proposeWrite, approveProposal } from './approval';
+import { patchFrontmatterProperties } from '../../shared/refactor/frontmatter-patch';
+import type {
+  PropertyUpdate,
+  PropertyUpdateOutcome,
+} from '../../shared/conversation-property-drafts';
+
+export interface ApplyPropertyUpdatesResult {
+  outcomes: PropertyUpdateOutcome[];
+  /** Paths overwritten by an approved note_rewrite — the caller broadcasts
+   *  NOTEBASE_REWRITTEN so open editors + the Properties panel reload. */
+  rewrittenPaths: string[];
+}
+
+export async function applyPropertyUpdates(
+  rootPath: string,
+  updates: PropertyUpdate[],
+  conversationId: string,
+): Promise<ApplyPropertyUpdatesResult> {
+  const ctx = projectContext(rootPath);
+  const outcomes: PropertyUpdateOutcome[] = [];
+  const rewrittenPaths: string[] = [];
+
+  for (const u of updates) {
+    try {
+      if (!u.properties || typeof u.properties !== 'object' || Object.keys(u.properties).length === 0) {
+        // Don't silently produce a no-op outcome — that's what hid the original
+        // cross-IPC serialization bug. Surface it as an explicit error so the
+        // user sees something on the Filed line and the log captures the payload.
+        outcomes.push({
+          relativePath: u.relativePath,
+          changedKeys: [],
+          deletedKeys: [],
+          error: 'properties payload arrived empty across IPC — frontmatter not written.',
+        });
+        continue;
+      }
+      const before = await notebaseFs.readFile(rootPath, u.relativePath);
+      const result = patchFrontmatterProperties(before, u.properties);
+      if (result.changedKeys.length > 0) {
+        // Route through the approval engine. The user already reviewed the
+        // property draft card, so approve immediately; a thought:Proposal is
+        // still filed as the audit record.
+        const proposal = await proposeWrite(ctx, {
+          operationType: 'note_rewrite',
+          payloads: [{ kind: 'note-rewrite', path: u.relativePath, content: result.content }],
+          note: `Set properties on ${u.relativePath}: ${result.changedKeys.join(', ')}`,
+          conversationUri: `https://minerva.dev/ontology/thought#conversation/${conversationId}`,
+          proposedBy: `llm:conversation:${conversationId}`,
+        });
+        if (proposal) {
+          const applied = await approveProposal(ctx, proposal.uri);
+          rewrittenPaths.push(...applied.rewrittenPaths);
+        }
+      }
+      outcomes.push({
+        relativePath: u.relativePath,
+        changedKeys: result.changedKeys,
+        deletedKeys: result.deletedKeys,
+      });
+    } catch (err) {
+      console.warn(`[set_properties] patch failed for`, u.relativePath, err);
+      outcomes.push({
+        relativePath: u.relativePath,
+        changedKeys: [],
+        deletedKeys: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { outcomes, rewrittenPaths };
+}

--- a/tests/main/llm/set-properties-apply.test.ts
+++ b/tests/main/llm/set-properties-apply.test.ts
@@ -1,0 +1,106 @@
+/**
+ * applyPropertyUpdates (#942): the set_properties apply path now routes each
+ * per-note frontmatter patch through the approval engine's note_rewrite payload
+ * instead of writing directly. Verifies the patch lands on disk AND leaves an
+ * approved thought:Proposal (the Trust Principle audit record), while preserving
+ * the handler's non-fatal-per-note behavior.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { applyPropertyUpdates } from '../../../src/main/llm/set-properties';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-setprops-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+async function plant(rel: string, content: string): Promise<void> {
+  const full = path.join(root, rel);
+  await fsp.mkdir(path.dirname(full), { recursive: true });
+  await fsp.writeFile(full, content, 'utf-8');
+  await indexNote(ctx, rel, content);
+}
+
+async function approvedRewriteCount(): Promise<number> {
+  const r = await queryGraph(ctx, `
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    SELECT ?p WHERE {
+      ?p a thought:Proposal ;
+         thought:operationType "note_rewrite" ;
+         thought:proposalStatus thought:approved .
+    }`);
+  return r.results.length;
+}
+
+describe('applyPropertyUpdates (#942)', () => {
+  it('applies the patch on disk AND files an approved note_rewrite proposal', async () => {
+    await plant('notes/a.md', '# A\n\nBody.\n');
+    const { outcomes, rewrittenPaths } = await applyPropertyUpdates(
+      root,
+      [{ relativePath: 'notes/a.md', properties: { status: 'done' } }],
+      'conv-1',
+    );
+
+    expect(outcomes[0].changedKeys).toEqual(['status']);
+    expect(outcomes[0].error).toBeUndefined();
+    expect(rewrittenPaths).toEqual(['notes/a.md']);
+
+    const onDisk = await fsp.readFile(path.join(root, 'notes/a.md'), 'utf-8');
+    expect(onDisk).toContain('status: done');
+    // Trust principle: an approved proposal backs the write.
+    expect(await approvedRewriteCount()).toBe(1);
+  });
+
+  it('is non-fatal per note: a failing entry does not block the others', async () => {
+    await plant('notes/ok.md', '# OK\n');
+    const { outcomes, rewrittenPaths } = await applyPropertyUpdates(
+      root,
+      [
+        { relativePath: 'notes/missing.md', properties: { x: 1 } }, // read throws
+        { relativePath: 'notes/ok.md', properties: { x: 1 } },
+      ],
+      'conv-1',
+    );
+
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes[0].error).toBeTruthy();      // missing file surfaced, not thrown
+    expect(outcomes[1].changedKeys).toEqual(['x']);
+    expect(rewrittenPaths).toEqual(['notes/ok.md']);
+    // Only the successful note filed a proposal.
+    expect(await approvedRewriteCount()).toBe(1);
+  });
+
+  it('surfaces an empty-properties payload as an error and writes nothing', async () => {
+    await plant('notes/a.md', '# A\n');
+    const { outcomes, rewrittenPaths } = await applyPropertyUpdates(
+      root,
+      [{ relativePath: 'notes/a.md', properties: {} }],
+      'conv-1',
+    );
+    expect(outcomes[0].error).toMatch(/empty/i);
+    expect(rewrittenPaths).toEqual([]);
+    expect(await approvedRewriteCount()).toBe(0);
+  });
+
+  it('files no proposal for a no-op patch (key already at that value)', async () => {
+    await plant('notes/a.md', '---\nstatus: done\n---\n# A\n');
+    const { outcomes, rewrittenPaths } = await applyPropertyUpdates(
+      root,
+      [{ relativePath: 'notes/a.md', properties: { status: 'done' } }],
+      'conv-1',
+    );
+    expect(outcomes[0].changedKeys).toEqual([]);
+    expect(rewrittenPaths).toEqual([]);
+    expect(await approvedRewriteCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #942. Fourth convergence issue in epic #935 — the first of the two **audit-found** bypasses (the ones with a review card but a direct write and no proposal record).

## The bypass being closed

`set_properties` already surfaces a review card (it's a conversation draft), but its apply handler (`CONVERSATION_FILE_PROPERTY_DRAFT`) patched frontmatter and wrote directly via `writeAndReindex` — no `thought:Proposal`, invisible to the trust-integrity query. So this is a pure backend swap: no new UI, no two-phase conversion.

## Approach

Extracted the per-note apply loop out of the IPC handler into an Electron-free, testable helper `applyPropertyUpdates` — same shape as `applyAutoTag` (#940) and `fileAutoLink*` (#941). It reads each note, patches frontmatter, and routes the rewrite through the `note_rewrite` approval payload (#936) + `approveProposal`, returning `{ outcomes, rewrittenPaths }`. The handler collapses to: validate → call helper → `broadcastRewritten`.

**Per-note proposals, not one atomic bundle** — this is the deliberate choice here (opposite of inbound auto-link in #941). `set_properties` has always been non-fatal-per-note: one note failing doesn't block the rest. An atomic multi-payload proposal would roll the whole bundle back on a single failure, changing that behavior. Per-note proposals preserve it.

Behavior otherwise unchanged: recomputes the patch against current disk content, a no-op patch files no proposal, and the outcome reporting (`changedKeys` / `deletedKeys` / `error`) is identical. The handler shrank ~50 lines.

## Tests

`applyPropertyUpdates` unit test:
- patch lands on disk **and** an approved `note_rewrite` proposal backs it;
- **non-fatal-per-note** — a missing-file entry surfaces as an error outcome while its sibling still applies (and only the sibling files a proposal);
- empty-payload → error, no write, no proposal;
- no-op patch (key already at that value) → no proposal.

Full sweep: 212 tests green across llm/ipc/stores; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
