### PR TITLE
feat: wire source-meta payload + route propose_source_properties through approval (#943)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -8,7 +8,8 @@ import { writeAndReindex } from '../notebase/write-pipeline';
 import { ingestUrl } from '../sources/ingest';
 import { ingestIdentifier } from '../sources/ingest-identifier';
 import { privilegedFetch } from '../privileged-sites';
-import { setSourceProperties, ttlString } from '../sources/source-meta-write';
+import { ttlString } from '../sources/source-meta-write';
+import { fileSourceProperties } from '../llm/source-properties';
 import { runCell as runComputeCell } from '../compute/registry';
 import { buildExcerptTtl } from '../sources/create-excerpt';
 import { slugify } from '../../shared/slug';
@@ -789,7 +790,10 @@ export function registerConversation(): void {
         const updates: { predicate: string; value: string }[] = [];
         if (draft.abstract) updates.push({ predicate: 'dc:abstract', value: ttlString(draft.abstract) });
         if (draft.tldr) updates.push({ predicate: 'thought:tldr', value: ttlString(draft.tldr) });
-        const changedPredicates = await setSourceProperties(rootPath, sourceId, updates);
+        // Route through the approval engine's source-meta payload (#943) rather
+        // than writing meta.ttl directly — leaves a thought:Proposal audit
+        // record. The user already reviewed the source-property card.
+        const { changedPredicates } = await fileSourceProperties(rootPath, sourceId, updates);
         return { outcome: { sourceId, changedPredicates } };
       } catch (err) {
         console.warn('[conv] FILE_SOURCE_PROPERTY_DRAFT failed for', sourceId, err);

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -5,6 +5,7 @@ import * as search from '../search/index';
 import * as vectors from '../embeddings/vector-store';
 import { markPathHandled } from '../notebase/path-dedup';
 import { planRename, renameWithLinkRewrites } from '../notebase/rename';
+import { setSourceProperties, readMeta, sourceMetaPath, restoreSourceMeta } from '../sources/source-meta-write';
 import type { ProjectContext } from '../project-context-types';
 import { escapeTurtleLiteral } from './turtle';
 
@@ -22,7 +23,8 @@ export type OperationType =
   | 'status_change'
   | 'note_refactor'
   | 'note_delete'
-  | 'note_rewrite';
+  | 'note_rewrite'
+  | 'source_properties';
 
 /**
  * One side-effect a proposal applies to the thoughtbase. The approval
@@ -68,6 +70,16 @@ export type ProposalPayload =
       metaTtl: string;
       bodyMd?: string;
       original?: { mimeType: string; bytes: Uint8Array };
+    }
+  | {
+      kind: 'source-meta';
+      /** Upsert single-valued predicates into an existing source's meta.ttl
+       *  (e.g. dc:abstract, thought:tldr — #103/#943). Distinct from the full
+       *  `source` ingest kind: this patches specific predicates in place, and
+       *  rollback restores the captured pre-image meta.ttl verbatim. `value` is
+       *  a ready Turtle term (literal/IRI); null deletes the predicate line. */
+      sourceId: string;
+      updates: { predicate: string; value: string | null }[];
     }
   | {
       kind: 'excerpt';
@@ -160,6 +172,9 @@ const DEFAULT_POLICY: Record<OperationType, ApprovalTier> = {
   // Rewriting a note's body in place replaces human-authored content — always
   // reviewed via the diff card (#936).
   note_rewrite: 'requires_approval',
+  // Upserting LLM-proposed source metadata (abstract / TL;DR) — reviewed via the
+  // source-property card (#943).
+  source_properties: 'requires_approval',
 };
 
 let policyOverrides: Partial<Record<OperationType, ApprovalTier>> = {};
@@ -230,7 +245,7 @@ async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<
 /** Payload kinds that `dispatchApply` actually knows how to apply. Keep in
  *  sync with the `switch` in dispatchApply — the `source` / `saved-query`
  *  kinds are defined on the type but not yet wired to a dispatcher. */
-const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt', 'note-refactor', 'note-delete', 'note-rewrite']);
+const WIRED_PAYLOAD_KINDS = new Set<ProposalPayload['kind']>(['graph-triples', 'note', 'excerpt', 'note-refactor', 'note-delete', 'note-rewrite', 'source-meta']);
 
 /**
  * Reject a bundle containing a payload kind that has no apply dispatcher (#665).
@@ -647,6 +662,15 @@ async function dispatchApply(ctx: ProjectContext, p: ProposalPayload): Promise<u
       void vectors.indexNote(ctx, p.path, p.content);
       return { path: p.path, before };
     }
+    case 'source-meta': {
+      // Upsert the proposed predicates into the source's meta.ttl (#943).
+      // Capture the whole meta.ttl as a pre-image so rollback restores it
+      // verbatim. setSourceProperties writes + reindexes; the .minerva/sources
+      // watcher notifies the renderer (same path the direct write used).
+      const before = await readMeta(sourceMetaPath(ctx.rootPath, p.sourceId));
+      await setSourceProperties(ctx.rootPath, p.sourceId, p.updates);
+      return { sourceId: p.sourceId, before };
+    }
     case 'source':
     case 'saved-query':
       throw new Error(
@@ -728,6 +752,16 @@ async function dispatchRollback(ctx: ProjectContext, a: AppliedRecord): Promise<
         void vectors.indexNote(ctx, data.path, data.before);
       } catch (err) {
         console.warn(`[approval] note-rewrite rollback restore failed for ${data.path}:`, err);
+      }
+      return;
+    }
+    case 'source-meta': {
+      // Restore the source's captured pre-image meta.ttl and reindex (#943).
+      const data = a.rollbackData as { sourceId: string; before: string };
+      try {
+        await restoreSourceMeta(ctx.rootPath, data.sourceId, data.before);
+      } catch (err) {
+        console.warn(`[approval] source-meta rollback restore failed for ${data.sourceId}:`, err);
       }
       return;
     }

--- a/src/main/llm/source-properties.ts
+++ b/src/main/llm/source-properties.ts
@@ -1,0 +1,60 @@
+/**
+ * Apply side of `propose_source_properties` (#943). The tool emits a
+ * ConversationSourcePropertyDraft (trust principle — it never writes); this runs
+ * when the user approves that draft, upserting the proposed dc:abstract /
+ * thought:tldr into the source's meta.ttl.
+ *
+ * The write routes through the approval engine's `source-meta` payload (#943)
+ * rather than a bare setSourceProperties, so the Trust Principle holds — every
+ * applied change leaves a `thought:Proposal` audit record. This closes the last
+ * of the approval-bypass sites the audit flagged.
+ *
+ * Lives in `llm/` (not `sources/`) to avoid a cycle: approval.ts imports the
+ * source-meta write primitives, and this imports approval.ts.
+ */
+import { projectContext } from '../project-context-types';
+import { proposeWrite, approveProposal } from './approval';
+import {
+  readMeta,
+  sourceMetaPath,
+  upsertSingleValuedPredicate,
+  type SourceMetaUpdate,
+} from '../sources/source-meta-write';
+
+export interface FileSourcePropertiesResult {
+  /** Predicates whose value actually changed — echoed to the outcome card. */
+  changedPredicates: string[];
+}
+
+/**
+ * Dry-run the upserts to learn which predicates actually change (so we neither
+ * file an empty proposal nor lose the changed-predicate report), then file +
+ * approve a single `source-meta` proposal. Recomputes against current meta.ttl.
+ */
+export async function fileSourceProperties(
+  rootPath: string,
+  sourceId: string,
+  updates: SourceMetaUpdate[],
+): Promise<FileSourcePropertiesResult> {
+  const before = await readMeta(sourceMetaPath(rootPath, sourceId));
+  let probe = before;
+  const changedPredicates: string[] = [];
+  for (const u of updates) {
+    const next = upsertSingleValuedPredicate(probe, u.predicate, u.value);
+    if (next !== probe) {
+      changedPredicates.push(u.predicate);
+      probe = next;
+    }
+  }
+  if (changedPredicates.length === 0) return { changedPredicates: [] };
+
+  const ctx = projectContext(rootPath);
+  const proposal = await proposeWrite(ctx, {
+    operationType: 'source_properties',
+    payloads: [{ kind: 'source-meta', sourceId, updates }],
+    note: `Set source properties on ${sourceId}: ${changedPredicates.join(', ')}`,
+    proposedBy: 'llm:source-properties',
+  });
+  if (proposal) await approveProposal(ctx, proposal.uri);
+  return { changedPredicates };
+}

--- a/src/main/sources/source-meta-write.ts
+++ b/src/main/sources/source-meta-write.ts
@@ -226,6 +226,17 @@ export async function setSourceProperties(
 }
 
 /**
+ * Overwrite a source's meta.ttl verbatim and reindex. Used to roll back an
+ * approved `source-meta` proposal to its captured pre-image (#943) — the apply
+ * path upserts predicates, so rollback needs a whole-file restore, not an
+ * inverse upsert.
+ */
+export async function restoreSourceMeta(rootPath: string, sourceId: string, ttl: string): Promise<void> {
+  await fs.writeFile(sourceMetaPath(rootPath, sourceId), ttl, 'utf-8');
+  await reindexSource(rootPath, sourceId);
+}
+
+/**
  * Rename a source by upserting its `dc:title` (#765). A source's display name
  * is its `dc:title`; `displaySourceTitle` falls back to URI/DOI/"Untitled" only
  * when it's absent, so renaming is just a single-predicate upsert + reindex —

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -392,6 +392,62 @@ describe('note-rewrite payload (#936)', () => {
   });
 });
 
+describe('source-meta payload (#943)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  const sourceId = 'smith-2023';
+  const META = `this: a thought:Article ;
+    dc:title "Test paper" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-sourcemeta-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    resetPolicy();
+    const dir = path.join(root, '.minerva', 'sources', sourceId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'meta.ttl'), META);
+  });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  function metaOnDisk(): string {
+    return fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+  }
+
+  it('source_properties defaults to requires_approval', () => {
+    expect(getApprovalTier('source_properties')).toBe('requires_approval');
+  });
+
+  it('applies the predicate upsert on approval', async () => {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'source_properties',
+      payloads: [{ kind: 'source-meta', sourceId, updates: [{ predicate: 'dc:abstract', value: '"An abstract."' }] }],
+      note: 'summary',
+      proposedBy: 'unit-test',
+    });
+    expect(metaOnDisk()).not.toContain('dc:abstract'); // gated
+    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect(metaOnDisk()).toContain('dc:abstract "An abstract." ;');
+  });
+
+  it('rolls back the meta.ttl to its pre-image when a later payload fails', async () => {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'source_properties',
+      payloads: [
+        { kind: 'source-meta', sourceId, updates: [{ predicate: 'dc:abstract', value: '"clobber"' }] },
+        { kind: 'graph-triples', turtle: 'not valid turtle @@@', affectsNodeUris: [] },
+      ],
+      note: 'source-meta + bad triples',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    // The upsert landed then rolled back — meta.ttl restored verbatim.
+    expect(metaOnDisk()).toBe(META);
+  });
+});
+
 describe('tier store effects (#666)', () => {
   let root: string;
   let ctx: ProjectContext;

--- a/tests/main/llm/source-properties.test.ts
+++ b/tests/main/llm/source-properties.test.ts
@@ -1,0 +1,77 @@
+/**
+ * fileSourceProperties (#943): the propose_source_properties apply path now
+ * routes the meta.ttl upsert through the approval engine's source-meta payload
+ * instead of writing directly. Verifies the predicates land in meta.ttl AND an
+ * approved thought:Proposal backs the write (the Trust Principle audit record) —
+ * the last of the approval-bypass sites the audit flagged.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileSourceProperties } from '../../../src/main/llm/source-properties';
+import { ttlString } from '../../../src/main/sources/source-meta-write';
+import { initGraph, indexSource, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const META = `this: a thought:Article ;
+    dc:title "Test paper" ;
+    dc:creator "Alice" ;
+    thought:accessedAt "2026-05-01T00:00:00Z"^^xsd:dateTime .
+`;
+
+let root: string;
+let ctx: ProjectContext;
+const sourceId = 'smith-2023';
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-source-props-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+  const dir = path.join(root, '.minerva', 'sources', sourceId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), META);
+  indexSource(ctx, sourceId, META);
+});
+afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+function metaOnDisk(): string {
+  return fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
+}
+
+async function approvedSourcePropsCount(): Promise<number> {
+  const r = await queryGraph(ctx, `
+    PREFIX thought: <https://minerva.dev/ontology/thought#>
+    SELECT ?p WHERE {
+      ?p a thought:Proposal ;
+         thought:operationType "source_properties" ;
+         thought:proposalStatus thought:approved .
+    }`);
+  return r.results.length;
+}
+
+describe('fileSourceProperties (#943)', () => {
+  it('upserts the predicates into meta.ttl AND files an approved proposal', async () => {
+    const { changedPredicates } = await fileSourceProperties(root, sourceId, [
+      { predicate: 'dc:abstract', value: ttlString('An abstract.') },
+      { predicate: 'thought:tldr', value: ttlString('The gist.') },
+    ]);
+
+    expect(changedPredicates.sort()).toEqual(['dc:abstract', 'thought:tldr']);
+    const meta = metaOnDisk();
+    expect(meta).toContain('dc:abstract "An abstract." ;');
+    expect(meta).toContain('thought:tldr "The gist." ;');
+    // Trust principle: an approved source_properties proposal backs the write.
+    expect(await approvedSourcePropsCount()).toBe(1);
+  });
+
+  it('files no proposal for a no-op (predicate already at that value)', async () => {
+    await fileSourceProperties(root, sourceId, [
+      { predicate: 'dc:title', value: ttlString('Test paper') }, // unchanged
+    ]);
+    expect(await approvedSourcePropsCount()).toBe(0);
+    // meta.ttl still has exactly one dc:title line.
+    expect((metaOnDisk().match(/dc:title/g) ?? []).length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #943. **The last of the five approval-bypass sites** (epic #935) — and the one with real new substrate.

## The bypass being closed

`propose_source_properties` wrote source `meta.ttl` directly via `setSourceProperties`, no `thought:Proposal` record. Unlike the note-body bypasses, this writes Turtle metadata, not a note — so `note_rewrite` doesn't fit and the approval engine needed a new payload kind.

## Why a new `source-meta` kind, not the existing `source`

The `source` payload kind was already *defined* (but unwired) — however it's shaped for **full ingestion**: `{ sourceId, metaTtl, bodyMd?, original: { bytes } }`. This operation is a **predicate upsert** (`dc:abstract`, `thought:tldr`) into an existing meta.ttl. Shoehorning it into `source` would mean computing a full-replacement metaTtl and carrying unused `body`/`bytes` fields. So I added a dedicated `source-meta` kind — `{ sourceId, updates }` — matching the operation, alongside a `source_properties` op type (`requires_approval`). The granular `source` ingest kind stays reserved for the future Research-tools ingestion work.

## How

- **`approval.ts`** — `source-meta` `dispatchApply` captures the whole meta.ttl as a pre-image, then `setSourceProperties` upserts + reindexes; `dispatchRollback` restores the pre-image **verbatim** (added `restoreSourceMeta` — the apply *upserts*, so rollback needs a whole-file restore, not an inverse-upsert).
- **`fileSourceProperties`** (new `llm/source-properties.ts`) — sited in `llm/` to avoid a cycle (approval imports the source-meta write primitives). Dry-runs the upserts to report `changedPredicates` and skip a no-op, then files + approves one `source-meta` proposal. The IPC handler calls it instead of writing directly.

The `.minerva/sources` watcher still notifies the renderer on the meta.ttl write — same path as the direct write, so no new broadcast.

## Tests

- `fileSourceProperties`: predicates land in meta.ttl **and** an approved `source_properties` proposal backs it; no-op files nothing.
- `approval.test.ts`: `source-meta` apply + **rollback** — a failing sibling payload restores meta.ttl verbatim (the rollback path the happy-path helper never exercises).

Full sweep: 957 tests green across llm/sources/ipc/graph; `pnpm lint` clean.

## Milestone

**With this merged, every LLM-originated note / graph / source write goes through the approval engine.** All five audit-found bypasses are closed. #944 is the capstone: turn that from "true by construction across five PRs" into an *enforced* invariant (write-guard + integrity test) so a sixth can't be added silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
