### PR TITLE
feat: harden the write-guard — fatal under test + arm the LLM apply paths (#944)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,25 @@ When reviewing PRs that touch LLM integration or graph write paths:
 
 ### Write Guard
 
-The graph module exposes `enterLLMContext()` / `exitLLMContext()` to mark call paths originating from LLM operations. Any direct `store.add()` call while in LLM context that doesn't go through the approval engine will log a warning. This is a development-time guardrail, not a runtime security boundary — the goal is to catch accidental bypasses during development.
+The graph module exposes `enterLLMContext()` / `exitLLMContext()` (and the
+`withLLMContext(fn)` wrapper) to mark call paths originating from LLM operations.
+Any graph write while in LLM context that doesn't go through the approval engine
+(which marks its own writes with `enterTrustedContext()`, applied across the
+whole `applyBundle`) trips `checkLLMWriteGuard`.
+
+**The guard is fatal under test and non-fatal in dev/prod (#944):** under the
+test runner it **throws**, so an accidental approval-engine bypass fails CI —
+the invariant "every LLM-originated write goes through
+`proposeWrite()`/`approveProposal()`" is *enforced*, not merely observed. In dev
+and production it stays a `console.warn` (a development guardrail must never
+crash the user's app; it's not a runtime security boundary).
+
+For the guard to catch a bypass, the offending write must run in LLM context.
+The converged LLM apply paths — auto-tag, auto-link (out/inbound),
+`set_properties`, `propose_source_properties`, and the note-body rewrite — wrap
+themselves in `withLLMContext` (or `enterLLMContext`) so a regression that writes
+directly instead of via the approval engine is caught. **Wrap any new
+LLM-originated apply path the same way.**
 
 ### Integrity Query
 

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -63,6 +63,7 @@ export {
   enterLLMContext,
   exitLLMContext,
   isInLLMContext,
+  withLLMContext,
   enterTrustedContext,
   exitTrustedContext,
 } from './write-guard';

--- a/src/main/graph/write-guard.ts
+++ b/src/main/graph/write-guard.ts
@@ -34,6 +34,23 @@ export function isInLLMContext(): boolean {
 }
 
 /**
+ * Run an LLM-originated operation with the guard armed (#944). Exception-safe:
+ * the context is always exited. Any graph write inside `fn` that doesn't route
+ * through the approval engine (trusted context) trips checkLLMWriteGuard — so
+ * the converged apply helpers (auto-tag/-link, set/source properties, note-body)
+ * are wrapped in this, and a regression that writes directly instead of via
+ * proposeWrite() fails CI.
+ */
+export async function withLLMContext<T>(fn: () => Promise<T>): Promise<T> {
+  enterLLMContext();
+  try {
+    return await fn();
+  } finally {
+    exitLLMContext();
+  }
+}
+
+/**
  * Mark the start of a trusted graph mutation — i.e. one going through the
  * approval engine. Used by approval.ts to wrap its own parseIntoStore /
  * removeMatchingTriples calls so the write guard doesn't flag them.
@@ -51,17 +68,31 @@ export function isInTrustedContext(): boolean {
   return trustedContextDepth > 0;
 }
 
-/** Dev-time guard. Logs once per offending call when an LLM-originated
- *  call path mutates the graph without going through the approval engine.
- *  No-op in trusted context (proposeWrite / approveProposal / approval-only
- *  mutators) and outside LLM context. */
+/** True when running under the test runner, where the guard is FATAL (throws)
+ *  so an accidental approval-engine bypass fails CI instead of scrolling past in
+ *  a warning. In dev + production it stays a non-fatal warning — a development
+ *  guardrail must never crash the user's app (per CLAUDE.md). */
+function guardIsFatal(): boolean {
+  return process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
+}
+
+/**
+ * Trust guard. Fires when an LLM-originated call path mutates the graph without
+ * going through the approval engine. No-op in trusted context (proposeWrite /
+ * approveProposal / approval-only mutators) and outside LLM context.
+ *
+ * Under test it THROWS — the invariant "every LLM-originated write goes through
+ * proposeWrite()/approveProposal()" (#935) is enforced, not merely observed, so
+ * a sixth bypass can't be added silently. In dev/prod it warns (#671).
+ */
 export function checkLLMWriteGuard(operation: string): void {
   if (!isInLLMContext()) return;
   if (trustedContextDepth > 0) return;
-  console.warn(
+  const message =
     `[trust-guard] ${operation} called from LLM context outside the approval engine. ` +
-    `LLM-originated writes must go through proposeWrite()/approveProposal().`,
-  );
+    `LLM-originated writes must go through proposeWrite()/approveProposal().`;
+  if (guardIsFatal()) throw new Error(message);
+  console.warn(message);
 }
 
 /** Test-only: reset both counters between cases. */

--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -535,20 +535,24 @@ export function registerConversation(): void {
         );
       }
       const ctx = projectContext(rootPath);
-      const proposal = await approval.proposeWrite(ctx, {
-        operationType: 'note_rewrite',
-        payloads: [{ kind: 'note-rewrite', path: draft.relativePath, content: draft.afterContent }],
-        note: draft.note,
-        conversationUri: `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`,
-        proposedBy: `llm:conversation:${draft.conversationId}`,
+      // Arm the trust guard (#944): LLM-originated, so a direct write here that
+      // skips the approval engine trips checkLLMWriteGuard.
+      return graph.withLLMContext(async () => {
+        const proposal = await approval.proposeWrite(ctx, {
+          operationType: 'note_rewrite',
+          payloads: [{ kind: 'note-rewrite', path: draft.relativePath, content: draft.afterContent }],
+          note: draft.note,
+          conversationUri: `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`,
+          proposedBy: `llm:conversation:${draft.conversationId}`,
+        });
+        let applied = false;
+        if (proposal) {
+          const result = await approval.approveProposal(ctx, proposal.uri);
+          applied = result.ok;
+          hooks.broadcastRewritten(rootPath, result.rewrittenPaths);
+        }
+        return { proposalUri: proposal?.uri ?? null, applied };
       });
-      let applied = false;
-      if (proposal) {
-        const result = await approval.approveProposal(ctx, proposal.uri);
-        applied = result.ok;
-        hooks.broadcastRewritten(rootPath, result.rewrittenPaths);
-      }
-      return { proposalUri: proposal?.uri ?? null, applied };
     },
   );
 

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -548,6 +548,12 @@ async function applyBundle(ctx: ProjectContext, payloads: ProposalPayload[]): Pr
     ...payloads.filter((p) => p.kind === 'graph-triples'),
   ];
 
+  // Everything a bundle applies is a *trusted* mutation. Wrapping the whole
+  // apply (not just applyTurtle) means the graph writes inside dispatchApply —
+  // indexNote / indexSource / indexExcerpt — are exempt from the trust guard
+  // even when the caller is in LLM context (e.g. an approve-handler wrapped in
+  // enterLLMContext so the guard is armed on its non-approval writes, #944).
+  graph.enterTrustedContext();
   const applied: AppliedRecord[] = [];
   try {
     for (const p of ordered) {
@@ -563,6 +569,8 @@ async function applyBundle(ctx: ProjectContext, payloads: ProposalPayload[]): Pr
       catch (rollbackErr) { console.warn(`[approval] rollback of ${a.kind} failed:`, rollbackErr); }
     }
     throw err;
+  } finally {
+    graph.exitTrustedContext();
   }
 }
 

--- a/src/main/llm/auto-link.ts
+++ b/src/main/llm/auto-link.ts
@@ -166,22 +166,26 @@ export async function fileAutoLinkOutbound(
   activeRelPath: string,
   accepted: AutoLinkSuggestion[],
 ): Promise<FileAutoLinkResult> {
-  const { content, applied, skipped } = await applyAutoLinkToSuggestions(rootPath, activeRelPath, accepted);
-  if (applied.length === 0) return { applied, skipped, rewrittenPaths: [] };
+  // Armed with the trust guard (#944) — a direct graph write here (not via the
+  // approval engine) trips checkLLMWriteGuard.
+  return graph.withLLMContext(async () => {
+    const { content, applied, skipped } = await applyAutoLinkToSuggestions(rootPath, activeRelPath, accepted);
+    if (applied.length === 0) return { applied, skipped, rewrittenPaths: [] };
 
-  const ctx = projectContext(rootPath);
-  const proposal = await proposeWrite(ctx, {
-    operationType: 'note_rewrite',
-    payloads: [{ kind: 'note-rewrite', path: activeRelPath, content }],
-    note: `Auto-link: add ${applied.length} link${applied.length === 1 ? '' : 's'} to ${activeRelPath}`,
-    proposedBy: 'llm:auto-link',
+    const ctx = projectContext(rootPath);
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'note_rewrite',
+      payloads: [{ kind: 'note-rewrite', path: activeRelPath, content }],
+      note: `Auto-link: add ${applied.length} link${applied.length === 1 ? '' : 's'} to ${activeRelPath}`,
+      proposedBy: 'llm:auto-link',
+    });
+    let rewrittenPaths: string[] = [];
+    if (proposal) {
+      const result = await approveProposal(ctx, proposal.uri);
+      rewrittenPaths = result.rewrittenPaths;
+    }
+    return { applied, skipped, rewrittenPaths };
   });
-  let rewrittenPaths: string[] = [];
-  if (proposal) {
-    const result = await approveProposal(ctx, proposal.uri);
-    rewrittenPaths = result.rewrittenPaths;
-  }
-  return { applied, skipped, rewrittenPaths };
 }
 
 // ── Inbound mode (#175 follow-up) ─────────────────────────────────────────
@@ -415,27 +419,30 @@ export async function fileAutoLinkInbound(
   activeRelPath: string,
   accepted: AutoLinkInboundSuggestion[],
 ): Promise<FileAutoLinkInboundResult> {
-  const { applied, skipped, updatedContents } = await applyInboundSuggestions(rootPath, activeRelPath, accepted);
-  if (updatedContents.size === 0) return { applied, skipped, rewrittenPaths: [] };
+  // Armed with the trust guard (#944).
+  return graph.withLLMContext(async () => {
+    const { applied, skipped, updatedContents } = await applyInboundSuggestions(rootPath, activeRelPath, accepted);
+    if (updatedContents.size === 0) return { applied, skipped, rewrittenPaths: [] };
 
-  const ctx = projectContext(rootPath);
-  const payloads = [...updatedContents].map(([path, content]) => ({
-    kind: 'note-rewrite' as const,
-    path,
-    content,
-  }));
-  const proposal = await proposeWrite(ctx, {
-    operationType: 'note_rewrite',
-    payloads,
-    note: `Auto-link inbound: link ${payloads.length} note${payloads.length === 1 ? '' : 's'} to ${activeRelPath}`,
-    proposedBy: 'llm:auto-link-inbound',
+    const ctx = projectContext(rootPath);
+    const payloads = [...updatedContents].map(([path, content]) => ({
+      kind: 'note-rewrite' as const,
+      path,
+      content,
+    }));
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'note_rewrite',
+      payloads,
+      note: `Auto-link inbound: link ${payloads.length} note${payloads.length === 1 ? '' : 's'} to ${activeRelPath}`,
+      proposedBy: 'llm:auto-link-inbound',
+    });
+    let rewrittenPaths: string[] = [];
+    if (proposal) {
+      const result = await approveProposal(ctx, proposal.uri);
+      rewrittenPaths = result.rewrittenPaths;
+    }
+    return { applied, skipped, rewrittenPaths };
   });
-  let rewrittenPaths: string[] = [];
-  if (proposal) {
-    const result = await approveProposal(ctx, proposal.uri);
-    rewrittenPaths = result.rewrittenPaths;
-  }
-  return { applied, skipped, rewrittenPaths };
 }
 
 export interface FileAutoLinkInboundResult {

--- a/src/main/llm/auto-tag.ts
+++ b/src/main/llm/auto-tag.ts
@@ -90,23 +90,27 @@ export async function applyAutoTag(
   relativePath: string,
   acceptedTags: string[],
 ): Promise<AutoTagApplyResult> {
-  const content = await notebaseFs.readFile(rootPath, relativePath);
-  const { content: next, addedTags } = mergeTagsIntoContent(content, acceptedTags);
-  if (addedTags.length === 0) return { applied: [], rewrittenPaths: [] };
+  // Armed with the trust guard (#944): this is LLM-originated, so any graph
+  // write here that doesn't go through the approval engine trips the guard.
+  return graph.withLLMContext(async () => {
+    const content = await notebaseFs.readFile(rootPath, relativePath);
+    const { content: next, addedTags } = mergeTagsIntoContent(content, acceptedTags);
+    if (addedTags.length === 0) return { applied: [], rewrittenPaths: [] };
 
-  const ctx = projectContext(rootPath);
-  const proposal = await proposeWrite(ctx, {
-    operationType: 'note_rewrite',
-    payloads: [{ kind: 'note-rewrite', path: relativePath, content: next }],
-    note: `Auto-tag: add ${addedTags.length} tag${addedTags.length === 1 ? '' : 's'} to ${relativePath}`,
-    proposedBy: 'llm:auto-tag',
+    const ctx = projectContext(rootPath);
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'note_rewrite',
+      payloads: [{ kind: 'note-rewrite', path: relativePath, content: next }],
+      note: `Auto-tag: add ${addedTags.length} tag${addedTags.length === 1 ? '' : 's'} to ${relativePath}`,
+      proposedBy: 'llm:auto-tag',
+    });
+    // note_rewrite is requires_approval, so proposeWrite returns a pending
+    // proposal; the user already reviewed the tags on the card, so approve now.
+    let rewrittenPaths: string[] = [];
+    if (proposal) {
+      const result = await approveProposal(ctx, proposal.uri);
+      rewrittenPaths = result.rewrittenPaths;
+    }
+    return { applied: addedTags, rewrittenPaths };
   });
-  // note_rewrite is requires_approval, so proposeWrite returns a pending
-  // proposal; the user already reviewed the tags on the card, so approve it now.
-  let rewrittenPaths: string[] = [];
-  if (proposal) {
-    const result = await approveProposal(ctx, proposal.uri);
-    rewrittenPaths = result.rewrittenPaths;
-  }
-  return { applied: addedTags, rewrittenPaths };
 }

--- a/src/main/llm/set-properties.ts
+++ b/src/main/llm/set-properties.ts
@@ -13,6 +13,7 @@
  * (NOTEBASE_REWRITTEN), mirroring the approval engine's own seam.
  */
 import * as notebaseFs from '../notebase/fs';
+import { enterLLMContext, exitLLMContext } from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { proposeWrite, approveProposal } from './approval';
 import { patchFrontmatterProperties } from '../../shared/refactor/frontmatter-patch';
@@ -37,6 +38,11 @@ export async function applyPropertyUpdates(
   const outcomes: PropertyUpdateOutcome[] = [];
   const rewrittenPaths: string[] = [];
 
+  // Arm the trust guard (#944): a direct graph write below that skips the
+  // approval engine trips checkLLMWriteGuard (surfaced per-note as an error
+  // outcome via the existing try/catch, which the tests assert against).
+  enterLLMContext();
+  try {
   for (const u of updates) {
     try {
       if (!u.properties || typeof u.properties !== 'object' || Object.keys(u.properties).length === 0) {
@@ -83,6 +89,9 @@ export async function applyPropertyUpdates(
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+  } finally {
+    exitLLMContext();
   }
 
   return { outcomes, rewrittenPaths };

--- a/src/main/llm/source-properties.ts
+++ b/src/main/llm/source-properties.ts
@@ -12,6 +12,7 @@
  * Lives in `llm/` (not `sources/`) to avoid a cycle: approval.ts imports the
  * source-meta write primitives, and this imports approval.ts.
  */
+import { withLLMContext } from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { proposeWrite, approveProposal } from './approval';
 import {
@@ -36,25 +37,28 @@ export async function fileSourceProperties(
   sourceId: string,
   updates: SourceMetaUpdate[],
 ): Promise<FileSourcePropertiesResult> {
-  const before = await readMeta(sourceMetaPath(rootPath, sourceId));
-  let probe = before;
-  const changedPredicates: string[] = [];
-  for (const u of updates) {
-    const next = upsertSingleValuedPredicate(probe, u.predicate, u.value);
-    if (next !== probe) {
-      changedPredicates.push(u.predicate);
-      probe = next;
+  // Armed with the trust guard (#944).
+  return withLLMContext(async () => {
+    const before = await readMeta(sourceMetaPath(rootPath, sourceId));
+    let probe = before;
+    const changedPredicates: string[] = [];
+    for (const u of updates) {
+      const next = upsertSingleValuedPredicate(probe, u.predicate, u.value);
+      if (next !== probe) {
+        changedPredicates.push(u.predicate);
+        probe = next;
+      }
     }
-  }
-  if (changedPredicates.length === 0) return { changedPredicates: [] };
+    if (changedPredicates.length === 0) return { changedPredicates: [] };
 
-  const ctx = projectContext(rootPath);
-  const proposal = await proposeWrite(ctx, {
-    operationType: 'source_properties',
-    payloads: [{ kind: 'source-meta', sourceId, updates }],
-    note: `Set source properties on ${sourceId}: ${changedPredicates.join(', ')}`,
-    proposedBy: 'llm:source-properties',
+    const ctx = projectContext(rootPath);
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'source_properties',
+      payloads: [{ kind: 'source-meta', sourceId, updates }],
+      note: `Set source properties on ${sourceId}: ${changedPredicates.join(', ')}`,
+      proposedBy: 'llm:source-properties',
+    });
+    if (proposal) await approveProposal(ctx, proposal.uri);
+    return { changedPredicates };
   });
-  if (proposal) await approveProposal(ctx, proposal.uri);
-  return { changedPredicates };
 }

--- a/tests/main/graph/write-guard-wired.test.ts
+++ b/tests/main/graph/write-guard-wired.test.ts
@@ -1,25 +1,30 @@
 /**
- * Integration coverage for the LLM write guard (#657 / QA Q-C1).
+ * Integration coverage for the LLM write guard (#657, hardened in #944).
  *
  * write-guard.test.ts unit-tests the guard primitive (checkLLMWriteGuard). This
  * file proves the guard is actually WIRED INTO the real graph write path: it
  * drives the genuine `parseIntoStore` / `removeMatchingTriples` and asserts that
  *   - a direct write in LLM context (i.e. bypassing the approval engine) is
- *     caught (warned), and
+ *     caught, and
  *   - the same write inside the approval engine's *trusted* context is exempt.
  *
  * That's the "verify the approval gate cannot be skipped" check CLAUDE.md's
- * LLM/Graph checklist asks for — the previous test only exercised the counter
- * and never touched a real write.
+ * LLM/Graph checklist asks for.
+ *
+ * #944 made the guard FATAL under test (it throws), so the invariant "every
+ * LLM-originated write goes through proposeWrite()/approveProposal()" is
+ * enforced in CI, not merely observed in a warning. In dev/prod it stays a
+ * non-fatal warning (a dev guardrail must never crash the user's app).
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { parseIntoStore, removeMatchingTriples, queryGraph } from '../../../src/main/graph/index';
 import {
   enterLLMContext,
   exitLLMContext,
   enterTrustedContext,
   exitTrustedContext,
+  withLLMContext,
   __resetWriteGuardForTests,
 } from '../../../src/main/graph/write-guard';
 import { type ProjectContext } from '../../../src/main/project-context-types';
@@ -34,32 +39,33 @@ async function objectsOf(ctx: ProjectContext): Promise<string[]> {
   return (r.results as Array<{ o: string }>).map((x) => x.o);
 }
 
-describe('LLM write guard wired into the graph write path (#657)', () => {
+describe('LLM write guard wired into the graph write path (#657, fatal #944)', () => {
   const project = useGraphProject('minerva-guard-wired-');
   let ctx: ProjectContext;
-  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     ctx = project.ctx; // fresh per test (useGraphProject's beforeEach ran first)
     __resetWriteGuardForTests();
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    // A thrown guard skips the paired exitLLMContext(); reset so the counter
+    // doesn't leak into the next test.
     __resetWriteGuardForTests();
   });
 
-  it('a direct parseIntoStore in LLM context (bypassing approval) trips the guard', () => {
+  it('a direct parseIntoStore in LLM context (bypassing approval) throws — and the write is rejected', async () => {
     enterLLMContext();
-    parseIntoStore(ctx, TRIPLE);
+    expect(() => parseIntoStore(ctx, TRIPLE)).toThrow(/\[trust-guard\].*parseIntoStore/);
     exitLLMContext();
+    // Fatal means blocked: the triple never landed.
+    expect(await objectsOf(ctx)).not.toContain('guarded');
+  });
 
-    expect(warnSpy).toHaveBeenCalled();
-    const msg = String(warnSpy.mock.calls[0][0]);
-    expect(msg).toContain('[trust-guard]');
-    expect(msg).toContain('parseIntoStore');
-    expect(msg).toContain('proposeWrite'); // the message tells you the right path
+  it('the trust-guard message names the right path (proposeWrite/approveProposal)', () => {
+    enterLLMContext();
+    expect(() => parseIntoStore(ctx, TRIPLE)).toThrow(/proposeWrite\(\)\/approveProposal\(\)/);
+    exitLLMContext();
   });
 
   it('the SAME write inside the approval engine\'s trusted context is exempt', async () => {
@@ -68,41 +74,33 @@ describe('LLM write guard wired into the graph write path (#657)', () => {
     // legitimate.
     enterLLMContext();
     enterTrustedContext();
-    parseIntoStore(ctx, TRIPLE);
+    expect(() => parseIntoStore(ctx, TRIPLE)).not.toThrow();
     exitTrustedContext();
     exitLLMContext();
-
-    expect(warnSpy).not.toHaveBeenCalled();
     expect(await objectsOf(ctx)).toContain('guarded'); // and it actually landed
   });
 
   it('a normal write outside any LLM context is silent', async () => {
-    parseIntoStore(ctx, TRIPLE);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(() => parseIntoStore(ctx, TRIPLE)).not.toThrow();
     expect(await objectsOf(ctx)).toContain('guarded');
   });
 
   it('removeMatchingTriples is guarded on the same path', () => {
     parseIntoStore(ctx, TRIPLE); // seed outside LLM context
-    warnSpy.mockClear();
-
     enterLLMContext();
-    removeMatchingTriples(ctx, S, P);
+    expect(() => removeMatchingTriples(ctx, S, P)).toThrow(/\[trust-guard\].*removeMatchingTriples/);
     exitLLMContext();
-
-    expect(warnSpy).toHaveBeenCalled();
-    expect(String(warnSpy.mock.calls[0][0])).toContain('removeMatchingTriples');
   });
 
-  it('warns but does NOT block — a dev guardrail, not a hard gate (per CLAUDE.md)', async () => {
-    // The guard's documented contract: it surfaces a bypass, it doesn't reject
-    // the write. Pinning that so a future "make it throw" is a conscious change,
-    // not an accidental one.
-    enterLLMContext();
-    parseIntoStore(ctx, TRIPLE);
-    exitLLMContext();
-
-    expect(warnSpy).toHaveBeenCalled();
-    expect(await objectsOf(ctx)).toContain('guarded');
+  it('withLLMContext arms the guard — a bypass write inside it is rejected (#944)', async () => {
+    // This is exactly what the converged apply helpers (auto-tag/-link, set/
+    // source properties, note-body) wrap themselves in. A regression that writes
+    // to the graph directly instead of via proposeWrite() fails here.
+    await expect(
+      withLLMContext(async () => parseIntoStore(ctx, TRIPLE)),
+    ).rejects.toThrow(/\[trust-guard\]/);
+    expect(await objectsOf(ctx)).not.toContain('guarded'); // rejected, never landed
+    // The wrapper still exited LLM context despite the throw.
+    expect(() => parseIntoStore(ctx, TRIPLE)).not.toThrow();
   });
 });

--- a/tests/main/graph/write-guard.test.ts
+++ b/tests/main/graph/write-guard.test.ts
@@ -3,7 +3,7 @@
  * write-guard module, including the actual guard *behaviour* (does it warn?),
  * which the previous version only gestured at (QA #657 / Q-C1).
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   enterLLMContext,
   exitLLMContext,
@@ -61,40 +61,31 @@ describe('trusted context counter', () => {
   });
 });
 
-describe('checkLLMWriteGuard behaviour', () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
-  beforeEach(() => { warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
-  afterEach(() => warnSpy.mockRestore());
+describe('checkLLMWriteGuard behaviour (fatal under test, #944)', () => {
+  // These run under vitest, where the guard is FATAL — it throws rather than
+  // warns, so an accidental approval-engine bypass fails CI. (In dev/prod it
+  // stays a non-fatal console.warn; that branch isn't exercised here.)
 
   it('stays silent outside LLM context', () => {
-    checkLLMWriteGuard('indexNote');
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(() => checkLLMWriteGuard('indexNote')).not.toThrow();
   });
 
-  it('WARNS when a graph write happens in LLM context outside the approval engine', () => {
+  it('THROWS when a graph write happens in LLM context outside the approval engine', () => {
     enterLLMContext();
-    checkLLMWriteGuard('indexNote');
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    const msg = String(warnSpy.mock.calls[0][0]);
-    expect(msg).toContain('[trust-guard]');
-    expect(msg).toContain('indexNote');
-    expect(msg).toContain('proposeWrite');
+    expect(() => checkLLMWriteGuard('indexNote')).toThrow(/\[trust-guard\].*indexNote.*proposeWrite/s);
   });
 
   it('stays silent in LLM context when the write is inside a trusted (approval-engine) context', () => {
     enterLLMContext();
     enterTrustedContext();
-    checkLLMWriteGuard('indexSource');
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(() => checkLLMWriteGuard('indexSource')).not.toThrow();
   });
 
-  it('re-warns once the trusted context is exited but LLM context remains', () => {
+  it('re-arms once the trusted context is exited but LLM context remains', () => {
     enterLLMContext();
     enterTrustedContext();
-    checkLLMWriteGuard('indexSource');
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(() => checkLLMWriteGuard('indexSource')).not.toThrow();
     exitTrustedContext();
-    checkLLMWriteGuard('indexSource');
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(() => checkLLMWriteGuard('indexSource')).toThrow(/\[trust-guard\]/);
   });
 });


### PR DESCRIPTION
Closes #944. **The capstone of epic #935.** All five approval-bypass sites are closed (#940–#943); this turns "every LLM-originated write goes through the approval engine" from *true-by-construction* into an *enforced* invariant — so a sixth bypass can't be added silently.

## The problem it solves

The write-guard existed but was toothless for the paths we just fixed: it only fires on graph writes *while in LLM context*, and the approve-handlers ran **outside** LLM context. So "make it throw" alone would catch nothing real. Three coordinated changes fix that.

## Three parts

1. **Fatal under test, non-fatal in dev/prod.** `checkLLMWriteGuard` now **throws** under the test runner (`VITEST`/`NODE_ENV=test`) — an accidental bypass fails CI instead of scrolling past in a warning. In dev/prod it stays a `console.warn`; a dev guardrail must never crash the user's app (per CLAUDE.md).

2. **`applyBundle` wrapped in trusted context.** Previously only `applyTurtle` was trusted, so the graph writes inside `dispatchApply` (`indexNote`/`indexSource`/`indexExcerpt`) relied on the caller *not* being in LLM context. Now the whole bundle apply is trusted — a latent correctness fix, and the prerequisite for (3).

3. **Arm the converged apply paths.** The five helpers the last four PRs fixed — `applyAutoTag`, `fileAutoLink{Outbound,Inbound}`, `applyPropertyUpdates`, `fileSourceProperties`, and the note-body approve handler — now wrap themselves in a new `graph.withLLMContext`. A regression that writes directly instead of via `proposeWrite()` trips the guard *there*, at the exact sites we care about.

Because those helpers route through approval (trusted), arming them causes **no false trips**.

## The proof

**The full suite — 3763 tests — passes under the now-fatal guard with zero trust-guard throws.** That's suite-wide evidence that no legitimate path writes to the graph in LLM context outside the approval engine. (One unrelated static-site test timed out under full-parallel load and passes 18/18 in isolation — a load flake, not a guard trip, which would throw a `[trust-guard]` error rather than time out.)

## Tests

- `write-guard` + `write-guard-wired` rewritten for the fatal contract — the old *"warns but does NOT block"* pin (which explicitly said "so a future 'make it throw' is a conscious change") is now *"throws + the write is rejected."*
- New test proves `withLLMContext` arms the guard: a bypass write inside it is rejected and never lands, and the wrapper still exits context on throw.
- CLAUDE.md Write Guard section updated to document the fatal-under-test contract and the "wrap any new LLM apply path in `withLLMContext`" rule.

## Epic complete

With this, epic #935 is done end to end: in-place LLM note editing shipped (#936–#939), all five write-path bypasses converged onto the approval engine (#940–#943), and the invariant is now enforced (#944).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
