### PR TITLE
feat: "Find Correlations" data-analysis skill

### DIFF
--- a/src/main/skills/stock/find-correlations.md
+++ b/src/main/skills/stock/find-correlations.md
@@ -1,0 +1,58 @@
+---
+id: analysis.find-correlations
+name: Find Correlations
+description: Surface the strongest correlations across the thoughtbase's tabular data, as a reviewable note
+menu: Analysis
+group: Data
+outputMode: openConversation
+model: claude-opus-4-8
+web: false
+slashCommand: /find-correlations
+firstMessage: "Find the strongest correlations in this thoughtbase's tabular data, and show me a note to review."
+longDescription: >-
+  Opens a conversation that surveys the thoughtbase's tabular data (CSV sources
+  and markdown tables, registered in DuckDB), computes correlations across the
+  numeric columns with read-only SQL, and proposes a note summarizing the
+  strongest relationships — with a reproducible SQL query and a scatter plot for
+  the top pairs. Nothing is written until you approve the note. It reports honest
+  statistics: correlation is not causation, and it flags small samples,
+  non-linear shapes, and outlier-driven results rather than dumping a matrix.
+---
+You are a careful data analyst. Your job is to find the **strongest, most trustworthy correlations** in the thoughtbase's tabular data and hand the user a concise note they can review. You **propose only** — you file the note through `propose_notes`; nothing is written until the user approves.
+
+Your data lives in **DuckDB**: CSV sources and markdown tables are registered as tables. You explore it with the read-only `query_sql` tool (autonomous — you run it and see the rows) and describe it with `describe_tables`. You cannot run Python here; everything below is expressible in SQL, and DuckDB has the statistics you need (`corr`, `regr_r2`, `stddev_samp`, `quantile_cont`, `SUMMARIZE`).
+
+## Procedure
+
+1. **Discover the tables.** Call `describe_tables` for the table names, row counts, and column names. If there are none, say so plainly and stop — there is nothing to correlate.
+2. **Profile the columns.** For each candidate table, run `SUMMARIZE "table_name"` via `query_sql`. This gives you each column's type, min/max, null count, and approximate distinct count. Pick the **numeric** columns with enough non-null rows to be worth correlating; ignore ids, keys, and near-constant columns.
+3. **Measure the correlations.** For the numeric pairs, compute Pearson's r and the sample size with `query_sql`, filtering nulls per pair:
+   ```
+   SELECT corr(revenue, ad_spend) AS r, count(*) AS n
+   FROM "sales" WHERE revenue IS NOT NULL AND ad_spend IS NOT NULL
+   ```
+   With many columns you can measure several pairs in one query (multiple `corr(...)` expressions). Rank by absolute r. Discard pairs with a trivially small sample or an r near zero — a strong-looking r on n=8 is noise.
+4. **Sanity-check before you report.** A high r can lie: it can be driven by a couple of outliers, hide a non-linear relationship (`corr` only sees linear), or reverse within subgroups (Simpson's paradox). Eyeball the top pairs — a quick scatter (`SELECT x, y … LIMIT`) or the min/max from step 2 — before you trust them.
+5. **Propose the note.** Call `propose_notes` ONCE with a single note that contains:
+   - A short prose summary of the strongest correlations — each with its r and sample size n, in plain language ("ad spend and revenue move together, r=0.82, n=240"). **Say "associated with", not "causes".** Note any caveats you found in step 4.
+   - A reproducible ` ```sql ` embed of the correlation query, so the user can re-run it.
+   - A ` ```vega-lite ` scatter for the top pair (or two), bound to the data with `data.sql` so the chart stays live and the user can see the shape:
+     ```
+     {
+       "mark": "point",
+       "data": { "sql": "SELECT ad_spend, revenue FROM \"sales\" WHERE ad_spend IS NOT NULL AND revenue IS NOT NULL" },
+       "encoding": {
+         "x": { "field": "ad_spend", "type": "quantitative" },
+         "y": { "field": "revenue", "type": "quantitative" }
+       }
+     }
+     ```
+     Use the real table and column names. For a large table, sample in the query (`USING SAMPLE 2000 ROWS`) so the scatter renders fast.
+6. **Explain briefly, then stop.** End the turn with a sentence or two naming what you found. Do NOT call the tools again this turn, and do NOT claim anything is filed — it isn't until the user approves the note.
+
+## Constraints
+
+- **Propose, never apply.** Your only write tool is `propose_notes`; measurement uses the read-only `query_sql`. You cannot and must not write files yourself.
+- **SQL only.** There is no Python tool in this skill — express the analysis in DuckDB SQL. (If a genuinely Python-only method is essential, say so in the note rather than pretending you ran it.)
+- **Honest statistics.** Report r WITH the sample size, prefer "associated with" over causal language, and flag outlier-driven or non-linear cases. A short, trustworthy note beats a wall of coefficients.
+- **Empty is a real answer.** If there are no tables, no numeric columns, or nothing meaningfully correlated, say so and propose little or nothing rather than inventing a finding.

--- a/tests/main/skills-find-correlations.test.ts
+++ b/tests/main/skills-find-correlations.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+describe('Find Correlations skill (data-analysis cluster)', () => {
+  it('ships in Analysis ▸ Data, SQL-first, propose-only, emitting sql + vega-lite embeds', async () => {
+    // Point at a non-existent user dir so only stock skills load.
+    const cat = await loadSkillCatalog(path.join(os.tmpdir(), 'minerva-no-user-skills-corr'));
+    expect(cat.errors).toEqual([]);
+
+    const s = cat.skills.find((sk) => sk.name === 'Find Correlations');
+    expect(s, 'Find Correlations should ship as a stock skill').toBeDefined();
+    expect(s!.source).toBe('stock');
+    expect(s!.menu).toBe('Analysis');
+    expect(s!.group).toBe('Data');
+    expect(s!.outputMode).toBe('openConversation');
+    // Whole-vault: no context requirement, so the item is always enabled and the
+    // agent discovers tables itself.
+    expect(s!.context ?? []).toEqual([]);
+
+    // Uses the autonomous tabular tools, and files results as a note.
+    expect(s!.body).toContain('describe_tables');
+    expect(s!.body).toContain('query_sql');
+    expect(s!.body).toContain('propose_notes');
+    // Correlation via DuckDB + a live-bound chart in the output note.
+    expect(s!.body).toContain('corr(');
+    expect(s!.body).toContain('vega-lite');
+    expect(s!.body).toContain('data');
+    // Trust principle: proposes a note, never writes directly.
+    expect(s!.body.toLowerCase()).toContain('propose, never apply');
+  });
+});


### PR DESCRIPTION
Drafts the first of the data-analysis cluster you're planning under **Analysis ▸ Data** — a concrete skill to pressure-test the pattern before "Find Outliers" and "Generate visualizations" follow.

## What it does

Surveys the thoughtbase's tabular data (CSV sources + markdown tables, registered in DuckDB), computes Pearson correlations across the numeric columns, and proposes a note summarizing the strongest relationships — with a reproducible ` ```sql ` query and a ` ```vega-lite ` scatter bound live via `data.sql`. Propose-only; nothing lands until the user approves the note.

## The design bet: SQL-first / autonomous

The thing that shaped this (and will shape the sibling skills): **there is no `run_python` tool.** Python is only `propose_compute` — a human-in-the-loop cell the user clicks Run on. But `query_sql` is autonomous (the agent runs it and sees rows), and DuckDB 1.5.3 has the stats natively (`corr`, `regr_r2`, `SUMMARIZE`, `quantile_cont`). So the skill reasons *and* measures in a single turn and files a **durable, reproducible note** instead of ephemeral cell output. Python stays out of scope here — the body says so explicitly rather than pretending it can run pandas.

Procedure the body drives: `describe_tables` (discover) → `SUMMARIZE "t"` (types + ranges + null counts → pick numeric columns) → `corr(y, x)` with sample size (rank by |r|) → sanity-check for outlier-driven / non-linear / Simpson's cases → `propose_notes` with prose + a reproducible SQL embed + a `data.sql`-bound scatter.

## Verified against the actual substrate

- vega fence is ` ```vega-lite `; `data.sql` binding is shipped (#832, `resolveVegaData`) and resolves to inline values with a live refresh button — so the embed shape in the body (`"data": { "sql": "…" }`) is the real one. (Avoided `data.cell`, which is #884-open.)
- `describe_tables` returns column *names*; types/ranges come from `SUMMARIZE` — the body routes through `SUMMARIZE`, not an assumption about `describe_tables` output.
- `query_sql` is read-only, single-statement, 200-row capped — fine for `corr()` (one row); the scatter binds through the renderer's executor, and the body tells the agent to `USING SAMPLE` for large tables.

## Honest-statistics framing

The prompt's load-bearing part: report r **with** sample size, say "associated with" not "causes", and flag outlier-driven / non-linear / small-n results rather than dumping a correlation matrix. That's where opus earns its slot. "Empty is a real answer" for thoughtbases with no tabular data.

## Tests

Loader test asserts menu/group/scope + the tool wiring (`describe_tables`/`query_sql`/`propose_notes`/`corr(`/`vega-lite`) + propose-only language. Stock loader validates the frontmatter + template (no stray `{{`}} from the JSON examples). Skills suite green; `pnpm lint` clean.

## For the sibling skills

If this shape feels right, **Find Outliers** is the same spine (`SUMMARIZE` + `quantile_cont`/`stddev` for IQR/z-score → note with the flagged rows + a highlighting chart), and **Generate Visualizations** is almost pure `data.sql`-bound vega-lite (pick chart types from column cardinality/types). Both stay autonomous. Happy to draft either next, or adjust this one's voice/output first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
