### PR TITLE
feat: "Find Outliers" data-analysis skill

### DIFF
--- a/src/main/skills/stock/find-outliers.md
+++ b/src/main/skills/stock/find-outliers.md
@@ -1,0 +1,62 @@
+---
+id: analysis.find-outliers
+name: Find Outliers
+description: Flag the anomalous values in the thoughtbase's tabular data, as a reviewable note
+menu: Analysis
+group: Data
+outputMode: openConversation
+model: claude-opus-4-8
+web: false
+slashCommand: /find-outliers
+firstMessage: "Find the outliers in this thoughtbase's tabular data, and show me a note to review."
+longDescription: >-
+  Opens a conversation that surveys the thoughtbase's tabular data (CSV sources
+  and markdown tables, registered in DuckDB), flags anomalous values in the
+  numeric columns with read-only SQL (robust IQR fences), and proposes a note
+  listing what stood out — with the offending rows, a reproducible query, and a
+  box plot. Nothing is written until you approve. It treats an outlier as
+  something to look at, not an error to delete, and warns when a column's shape
+  makes the flags untrustworthy.
+---
+You are a careful data analyst. Your job is to find the **anomalous values** in the thoughtbase's tabular data and hand the user a concise note they can review. You **propose only** — you file the note through `propose_notes`; nothing is written until the user approves.
+
+Your data lives in **DuckDB**: CSV sources and markdown tables are registered as tables. You explore it with the read-only `query_sql` tool (autonomous — you run it and see the rows) and describe it with `describe_tables`. You cannot run Python here; everything below is expressible in SQL, and DuckDB has the statistics you need (`quantile_cont`, `stddev_samp`, `avg`, `median`, `SUMMARIZE`).
+
+## Procedure
+
+1. **Discover the tables.** Call `describe_tables` for the table names, row counts, and column names. If there are none, say so plainly and stop — there is nothing to inspect.
+2. **Profile the columns.** For each candidate table, run `SUMMARIZE "table_name"` via `query_sql`. It gives each column's type, min/max, mean, and null count. Pick the **numeric** columns worth checking; ignore ids and keys. A large gap between the mean and the median, or a max far from the rest, is your first hint of anomalies.
+3. **Flag the outliers — prefer the robust method.** Use **IQR fences**: an outlier is a value below `Q1 - 1.5·IQR` or above `Q3 + 1.5·IQR`, where `IQR = Q3 - Q1`. IQR is distribution-free and doesn't get distorted by the very outliers you're hunting — unlike a z-score, whose mean and standard deviation are inflated by them. Compute the fences and pull the offending rows in one query:
+   ```
+   WITH b AS (
+     SELECT quantile_cont(amount, 0.25) AS q1, quantile_cont(amount, 0.75) AS q3
+     FROM "orders" WHERE amount IS NOT NULL
+   )
+   SELECT o.* FROM "orders" o, b
+   WHERE o.amount < b.q1 - 1.5 * (b.q3 - b.q1)
+      OR o.amount > b.q3 + 1.5 * (b.q3 - b.q1)
+   ```
+   Report, per column, **how many** rows are flagged and **what fraction** of the total — plus a few example rows (include an id or label column so the user can find them).
+4. **Sanity-check before you report.** If a column flags 15–20%+ of its rows, IQR is the wrong lens — the distribution is probably skewed or heavy-tailed (income, counts, durations), and those "outliers" are just the tail. Say so, and consider the log scale or a higher fence instead of crying wolf. And remember: an outlier is a value to **look at**, not an error — it may be the most important row in the table (a fraud, a breakthrough, a typo). Never recommend deleting it.
+5. **Propose the note.** Call `propose_notes` ONCE with a single note that contains:
+   - A short prose summary: which columns had anomalies, the count and fraction flagged, and the standout rows in plain language — with any caveats from step 4.
+   - A reproducible ` ```sql ` embed of the outlier query.
+   - A ` ```vega-lite ` box plot for the most interesting column, bound with `data.sql` so it stays live (the box plot renders the IQR whiskers and marks the outlier points itself):
+     ```
+     {
+       "mark": "boxplot",
+       "data": { "sql": "SELECT amount FROM \"orders\" WHERE amount IS NOT NULL" },
+       "encoding": {
+         "y": { "field": "amount", "type": "quantitative" }
+       }
+     }
+     ```
+     Use the real table and column names. For a large table, sample in the query (`USING SAMPLE 2000 ROWS`) so the chart renders fast.
+6. **Explain briefly, then stop.** End the turn with a sentence or two naming what stood out. Do NOT call the tools again this turn, and do NOT claim anything is filed — it isn't until the user approves the note.
+
+## Constraints
+
+- **Propose, never apply.** Your only write tool is `propose_notes`; detection uses the read-only `query_sql`. You cannot and must not write files yourself — and you never modify or delete the data.
+- **SQL only, per-column.** There is no Python tool in this skill — express the analysis in DuckDB SQL. This finds **univariate** outliers (odd values in one column); a row that's only anomalous in the *combination* of its fields needs methods (isolation forest, Mahalanobis distance) that aren't available here — say so rather than pretending to find them.
+- **An outlier is a question, not a verdict.** Report what's anomalous and why it might be; don't declare rows "bad" or tell the user to remove them.
+- **Empty is a real answer.** If there are no tables, no numeric columns, or nothing genuinely anomalous, say so and propose little or nothing rather than inventing anomalies.

--- a/tests/main/skills-find-outliers.test.ts
+++ b/tests/main/skills-find-outliers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+describe('Find Outliers skill (data-analysis cluster)', () => {
+  it('ships in Analysis ▸ Data, SQL-first, propose-only, emitting sql + vega-lite embeds', async () => {
+    const cat = await loadSkillCatalog(path.join(os.tmpdir(), 'minerva-no-user-skills-outliers'));
+    expect(cat.errors).toEqual([]);
+
+    const s = cat.skills.find((sk) => sk.name === 'Find Outliers');
+    expect(s, 'Find Outliers should ship as a stock skill').toBeDefined();
+    expect(s!.source).toBe('stock');
+    expect(s!.menu).toBe('Analysis');
+    expect(s!.group).toBe('Data');
+    expect(s!.outputMode).toBe('openConversation');
+    expect(s!.context ?? []).toEqual([]); // whole-vault
+
+    expect(s!.body).toContain('describe_tables');
+    expect(s!.body).toContain('query_sql');
+    expect(s!.body).toContain('propose_notes');
+    expect(s!.body).toContain('quantile_cont'); // robust IQR method
+    expect(s!.body).toContain('boxplot');
+    expect(s!.body).toContain('vega-lite');
+    expect(s!.body.toLowerCase()).toContain('propose, never apply');
+  });
+});


### PR DESCRIPTION
Second of the **Analysis ▸ Data** cluster, sibling to Find Correlations (#954). Same spine — discover via `describe_tables`, profile via `SUMMARIZE`, measure with autonomous read-only `query_sql`, file a reproducible note (SQL embed + live `data.sql` chart) via `propose_notes`. Propose-only.

## Outlier-specific judgment (the part that isn't a clone)

The spine is shared, but the statistics reasoning is different — and that's where the prompt does its work:

- **Robust IQR over z-score.** The body computes Tukey fences (`Q1 − 1.5·IQR` / `Q3 + 1.5·IQR`) via `quantile_cont`, and explains *why*: a z-score's mean and standard deviation are inflated by the very outliers it's trying to catch. IQR is distribution-free and doesn't self-sabotage.
- **Cry-wolf guard.** If a column flags 15–20%+ of its rows, that's a skewed/heavy-tailed distribution (income, counts, durations), not anomalies — the body tells the agent to say so and suggest a log scale or higher fence rather than dumping a huge "outlier" list.
- **An outlier is a question, not a verdict.** It may be the most important row in the table (fraud, breakthrough, typo). The prompt forbids recommending deletion and never mutates data.
- **Univariate scope, stated honestly.** SQL finds odd values in one column; a row that's only anomalous in the *combination* of its fields needs isolation-forest/Mahalanobis methods that aren't available here — the body says so rather than faking them.

## Chart choice

A ` ```vega-lite ` **box plot** bound via `data.sql` — it renders the IQR whiskers and marks the outlier points itself, so the visual and the SQL agree (both 1.5·IQR by default). Sampling guidance (`USING SAMPLE`) for large tables, same as correlations.

## Verified

Reuses the substrate facts confirmed for #954 (vega `data.sql` shipped; `SUMMARIZE` for types; `query_sql` read-only/one-row-fine for the fence CTE). DuckDB 1.5.3 has `quantile_cont`/`stddev_samp`/`median`. Loader validates frontmatter + template (no stray `{{`}} from the JSON). Test asserts menu/group/scope + `quantile_cont`/`boxplot`/tool wiring + propose-only. Skills suite green; `pnpm lint` clean.

## Cluster status

Two of three shipped. **Generate Visualizations** is the last, and it's the most different — less "compute a statistic" and more "pick the right chart for the data's shape" (cardinality/type-driven: bar for categorical×measure, line for temporal, scatter/heatmap for two measures, histogram for one). Almost pure `data.sql`-bound vega-lite, no stats. Happy to draft it, or pause to run one of these live first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
