### PR TITLE
fix: query_sql crashed serializing DuckDB integer columns (BigInt)

### DIFF
--- a/src/main/llm/tools.ts
+++ b/src/main/llm/tools.ts
@@ -1683,6 +1683,24 @@ const SQL_READONLY_FIRST_WORDS = new Set([
 ]);
 const QUERY_SQL_ROW_CAP = 200;
 
+/**
+ * JSON.stringify replacer that survives DuckDB's integer columns. The node-api
+ * returns BIGINT/HUGEINT (and COUNT(*), which SUMMARIZE is full of) as JS
+ * `bigint`, which plain JSON.stringify refuses to serialize ("Do not know how to
+ * serialize a BigInt"). Render a bigint as a real number when it fits in a
+ * double without precision loss, else as a string so a 19-digit id isn't
+ * silently rounded. (Date columns are already handled — Date.toJSON emits ISO
+ * before the replacer sees them.)
+ */
+function bigintSafeReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    return value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(value)
+      : value.toString();
+  }
+  return value;
+}
+
 /** query_sql (#781): immediate read-only SQL over the project's DuckDB. */
 async function runQuerySql(ctx: ToolContext, input: unknown): Promise<{ content: string; isError: boolean }> {
   const { sql } = input as { sql: string };
@@ -1718,7 +1736,7 @@ async function runQuerySql(ctx: ToolContext, input: unknown): Promise<{ content:
     return { content: 'No rows.', isError: false };
   }
   const shown = response.rows.slice(0, QUERY_SQL_ROW_CAP);
-  const body = JSON.stringify(shown, null, 2);
+  const body = JSON.stringify(shown, bigintSafeReplacer, 2);
   const note =
     response.rows.length > QUERY_SQL_ROW_CAP
       ? `\n\n(${response.rows.length} rows total; showing the first ${QUERY_SQL_ROW_CAP}. Add LIMIT or aggregate to narrow.)`

--- a/tests/main/llm/sql-tools.test.ts
+++ b/tests/main/llm/sql-tools.test.ts
@@ -56,6 +56,31 @@ describe('LLM SQL tools — describe_tables (#780) + query_sql (#781)', () => {
     expect(rows.map((r) => r.name)).toEqual(['Alpha', 'Beta']);
   });
 
+  it('query_sql serializes integer columns without a BigInt crash (regression)', async () => {
+    // DuckDB returns BIGINT columns as JS bigint; plain JSON.stringify throws
+    // "Do not know how to serialize a BigInt". The Find Correlations / Find
+    // Outliers skills hit this on their first real query.
+    await writeCsv('stations.csv', 'id,name\n1,Alpha\n2,Beta\n');
+    const res = await executeNotebaseTool({ rootPath: root }, 'query_sql', {
+      sql: 'SELECT id, name FROM stations ORDER BY id',
+    });
+    expect(res.isError).toBe(false);
+    const rows = JSON.parse(res.content) as Array<{ id: number; name: string }>;
+    expect(rows).toEqual([{ id: 1, name: 'Alpha' }, { id: 2, name: 'Beta' }]);
+  });
+
+  it('query_sql handles SUMMARIZE (all-BigInt count columns) — the reported failure', async () => {
+    await writeCsv('mandolin_models.csv', 'id,price\n1,1200\n2,3400\n3,900\n');
+    const res = await executeNotebaseTool({ rootPath: root }, 'query_sql', {
+      sql: 'SUMMARIZE "mandolin_models"',
+    });
+    expect(res.isError).toBe(false);
+    // Parses (no BigInt throw) and carries the profiling columns SUMMARIZE emits.
+    const rows = JSON.parse(res.content) as Array<Record<string, unknown>>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((r) => r.column_name === 'price')).toBe(true);
+  });
+
   it('query_sql rejects non-read-only statements', async () => {
     await writeCsv('stations.csv', 'id,name\n1,Alpha\n');
     for (const sql of ['DELETE FROM stations', 'CREATE TABLE x (a int)', 'DROP TABLE stations']) {


### PR DESCRIPTION
## The bug

`query_sql` aborted the entire conversation turn with:

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify
    at runQuerySql
```

The `@duckdb/node-api` driver returns `BIGINT`/`HUGEINT` columns — and **every count column `SUMMARIZE` emits** — as JS `bigint`, which plain `JSON.stringify` refuses to serialize. `runQuerySql` (tools.ts) was the one DuckDB-row path still using a bare `JSON.stringify`, so any `SELECT <int-col>` or `SUMMARIZE` from the LLM's `query_sql` tool threw.

Surfaced by live-testing the new Find Correlations / Find Outliers skills — their first move is `SUMMARIZE "table"`, which is all-BigInt, so they face-planted immediately.

## Why it slipped through

The existing `query_sql` test only selected a *string* column (`name`), which never produces a BigInt. Any integer column would have caught it.

## The fix

A bigint-safe JSON replacer: render a `bigint` as a real number when it fits a double exactly, else as a string so a 19-digit id isn't silently rounded to a float. (Date columns were already fine — `Date.toJSON` emits ISO before the replacer runs.)

Every other DuckDB-row path already handled this — `executors/sql.ts` (`normalizeCell`), `rpc-server.ts`, and the vega `normalizeRows`. `query_sql` was the lone gap. (Those three use three slightly different strategies — Number vs String; not unifying them here, but worth a future tidy.)

## Tests

Two regressions in `sql-tools.test.ts`, both against real DuckDB: `SELECT id, name …` round-trips the integer, and `SUMMARIZE "table"` (the reported failure) parses without throwing and carries its profiling columns.

Independent of the two skill PRs (#954 merged, #955 open) — it's a general `query_sql` bug that predates them; they just exposed it. Worth landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
