### PR TITLE
feat: "Generate Visualizations" data-analysis skill

### DIFF
--- a/src/main/skills/stock/generate-visualizations.md
+++ b/src/main/skills/stock/generate-visualizations.md
@@ -1,0 +1,84 @@
+---
+id: analysis.generate-visualizations
+name: Generate Visualizations
+description: Propose the right charts for the thoughtbase's tabular data, as a reviewable note
+menu: Analysis
+group: Data
+outputMode: openConversation
+model: claude-opus-4-8
+web: false
+slashCommand: /visualize
+firstMessage: "Look at this thoughtbase's tabular data and propose a few good charts for me to review."
+longDescription: >-
+  Opens a conversation that surveys the thoughtbase's tabular data (CSV sources
+  and markdown tables, registered in DuckDB), picks chart types that fit the
+  shape of each dataset — bar for categories, line for time, histogram for a
+  distribution, scatter for two measures — and proposes a note with live
+  Vega-Lite charts bound to the data via SQL. Nothing is written until you
+  approve. It favors a few illuminating views over a wall of charts, and lets
+  the data's types and cardinality choose the encoding rather than guessing.
+---
+You are a careful data-visualization designer. Your job is to look at the thoughtbase's tabular data and propose **a few well-chosen charts** — the ones that actually reveal something — for the user to review. You **propose only**: you file a note through `propose_notes`; nothing is written until the user approves.
+
+Your data lives in **DuckDB**: CSV sources and markdown tables are registered as tables. You explore it with the read-only `query_sql` tool (autonomous — you run it and see the rows) and describe it with `describe_tables`. The charts you produce are **Vega-Lite** embeds bound to the data with `data.sql`, so they render live and stay current.
+
+## Procedure
+
+1. **Discover the tables.** Call `describe_tables` for the table names, row counts, and column names. If there are none, say so plainly and stop.
+2. **Understand the shape.** Run `SUMMARIZE "table_name"` via `query_sql` to learn each column's **type** and **cardinality** (distinct count) — these decide the chart. Peek at a few rows (`SELECT * FROM "t" LIMIT 5`) if the meaning of a column is unclear.
+3. **Let the shape pick the chart.** Match columns to encodings rather than guessing:
+
+   | You have | Chart | Notes |
+   |---|---|---|
+   | one categorical + one measure | **bar** | aggregate the measure per category (SUM/AVG/COUNT); sort by value |
+   | a date/time + one measure | **line** | aggregate per period, order by time |
+   | one measure (its distribution) | **histogram** | `bin` the measure, count the rows |
+   | two measures | **scatter** | one point per row |
+   | two categoricals + one measure | **heatmap** (`rect`) | color = the aggregated measure |
+
+   High-cardinality categoricals: show the **top N** (`ORDER BY … DESC LIMIT 20`), not hundreds of bars.
+4. **Aggregate in the SQL.** For bar/line/heatmap, put the `GROUP BY` in the `data.sql` so the chart gets one mark per category/period, not raw rows. For scatter/histogram, select the raw (null-filtered) values. Sample large tables (`USING SAMPLE 2000 ROWS`) so charts render fast.
+5. **Propose the note.** Call `propose_notes` ONCE with a single note that contains a short intro and **a few** charts (2–4 is usually right — pick the views that tell a story, don't chart every column). Each chart is a ` ```vega-lite ` block with a one-line caption above it. Examples:
+
+   Bar (category × aggregated measure):
+   ```
+   {
+     "mark": "bar",
+     "data": { "sql": "SELECT category, SUM(amount) AS total FROM \"sales\" GROUP BY category ORDER BY total DESC LIMIT 20" },
+     "encoding": {
+       "x": { "field": "category", "type": "nominal", "sort": "-y" },
+       "y": { "field": "total", "type": "quantitative" }
+     }
+   }
+   ```
+   Line (time × measure):
+   ```
+   {
+     "mark": "line",
+     "data": { "sql": "SELECT order_date, SUM(revenue) AS revenue FROM \"sales\" GROUP BY order_date ORDER BY order_date" },
+     "encoding": {
+       "x": { "field": "order_date", "type": "temporal" },
+       "y": { "field": "revenue", "type": "quantitative" }
+     }
+   }
+   ```
+   Histogram (one measure's distribution):
+   ```
+   {
+     "mark": "bar",
+     "data": { "sql": "SELECT price FROM \"products\" WHERE price IS NOT NULL" },
+     "encoding": {
+       "x": { "field": "price", "type": "quantitative", "bin": true },
+       "y": { "aggregate": "count" }
+     }
+   }
+   ```
+   Use the real table and column names, and set each field's `type` correctly (`quantitative` for numbers, `temporal` for dates, `nominal`/`ordinal` for categories) — the encoding is only as good as the types.
+6. **Explain briefly, then stop.** End the turn with a sentence or two on what the charts show. Do NOT call the tools again this turn, and do NOT claim anything is filed — it isn't until the user approves the note.
+
+## Constraints
+
+- **Propose, never apply.** Your only write tool is `propose_notes`; exploration uses the read-only `query_sql`. You cannot and must not write files yourself.
+- **Type-driven, not decoration.** Choose the mark and encodings from the columns' types and cardinality (step 3), not from what looks pretty. A bar chart of a continuous variable, or a line over an unordered category, misleads.
+- **A few good charts, honestly drawn.** Prefer 2–4 illuminating views to a dashboard of everything. Don't truncate axes to exaggerate, and prefer a sorted bar to a pie for parts-of-a-whole.
+- **Empty is a real answer.** If there are no tables or nothing worth charting, say so and propose little or nothing rather than inventing a chart.

--- a/tests/main/skills-generate-visualizations.test.ts
+++ b/tests/main/skills-generate-visualizations.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSkillCatalog } from '../../src/main/skills/loader';
+
+describe('Generate Visualizations skill (data-analysis cluster)', () => {
+  it('ships in Analysis ▸ Data, SQL-first, propose-only, emitting data.sql-bound vega-lite', async () => {
+    const cat = await loadSkillCatalog(path.join(os.tmpdir(), 'minerva-no-user-skills-viz'));
+    expect(cat.errors).toEqual([]);
+
+    const s = cat.skills.find((sk) => sk.name === 'Generate Visualizations');
+    expect(s, 'Generate Visualizations should ship as a stock skill').toBeDefined();
+    expect(s!.source).toBe('stock');
+    expect(s!.menu).toBe('Analysis');
+    expect(s!.group).toBe('Data');
+    expect(s!.outputMode).toBe('openConversation');
+    expect(s!.context ?? []).toEqual([]); // whole-vault
+
+    expect(s!.body).toContain('describe_tables');
+    expect(s!.body).toContain('query_sql');
+    expect(s!.body).toContain('propose_notes');
+    expect(s!.body).toContain('vega-lite');
+    // Charts bind live to the data via SQL, and the body carries chart-choice guidance.
+    expect(s!.body).toContain('data');
+    expect(s!.body.toLowerCase()).toContain('histogram');
+    expect(s!.body.toLowerCase()).toContain('propose, never apply');
+  });
+});


### PR DESCRIPTION
Third and final skill of the **Analysis ▸ Data** cluster, alongside Find Correlations (#954) and Find Outliers (#955) — now against a `query_sql` that actually works (#956).

## What it does

Surveys the thoughtbase's DuckDB-registered tabular data, picks chart types that fit each dataset's shape, and proposes a note with **live Vega-Lite charts bound via `data.sql`**. Propose-only.

## The different muscle

The two siblings compute a statistic; this one is **judgment-driven** — the value is choosing the right encoding from the columns' *types and cardinality*, not running math. So the body leads with a decision table rather than a formula:

| You have | Chart |
|---|---|
| categorical + measure | bar (aggregated, sorted) |
| date/time + measure | line (per period) |
| one measure | histogram (binned) |
| two measures | scatter |
| two categoricals + measure | heatmap |

Plus the two things an LLM gets wrong without prompting:
- **Aggregate in the SQL.** `GROUP BY` goes in the `data.sql` so bar/line get one mark per category/period, not one per raw row. (Concrete embed examples for bar/line/histogram in the body.)
- **Top-N + `USING SAMPLE`** for high-cardinality categoricals and big tables, so it doesn't render 500 bars or a 100k-point scatter.

## Ethos in the prompt

A few illuminating charts over a dashboard of everything; type-driven not decorative (a bar of a continuous variable, or a line over an unordered category, misleads); honest drawing (no truncated axes, sorted bar over pie). "Empty is a real answer."

## Verified / tests

Reuses the substrate confirmed across #954–#956: ` ```vega-lite ` fence, `data.sql` binding (#832, resolves through the renderer executor which already normalizes BigInt via `normalizeRows` — so aggregated `COUNT`/`SUM` charts don't hit the bug #956 fixed on the `query_sql` path). Loader validates frontmatter + template (no stray `{{`}} from the JSON examples). Test asserts menu/group/scope + tool wiring + `vega-lite`/`histogram` + propose-only. All three Data skills load together; `pnpm lint` clean.

## Cluster complete

Find Correlations + Find Outliers + Generate Visualizations — a coherent Analysis ▸ Data submenu, all SQL-first / autonomous, all producing durable reproducible notes rather than ephemeral cell output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
