### PR TITLE
feat: add Claude Sonnet 5 + Fable 5, modernize model defaults

### DIFF
--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -5,11 +5,14 @@ import type { LLMSettings, WebSettings } from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_MODEL = 'claude-sonnet-5';
 
 const DEPRECATED_MODELS = new Set<string>([
   'claude-sonnet-4-20250514',
 ]);
+// Note: claude-sonnet-4-6 is intentionally NOT deprecated — it's still active
+// and remains in the picker, so a user who explicitly selected it keeps it. Only
+// the default for fresh installs / unset configs moves to Sonnet 5.
 
 function resolveModel(stored: unknown): string {
   if (typeof stored !== 'string' || !stored) return DEFAULT_MODEL;

--- a/src/main/skills/stock/aversionfactor.md
+++ b/src/main/skills/stock/aversionfactor.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Motivation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, aversion-factor the underlying objection."
 longDescription: >-

--- a/src/main/skills/stock/check-facts.md
+++ b/src/main/skills/stock/check-facts.md
@@ -7,7 +7,7 @@ group: Verification
 outputMode: openConversation
 context: [claimUnderCursor, selectedText, fullNote]
 slashCommand: /check-facts
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if claim.label}}Fact-check this claim against the web:

--- a/src/main/skills/stock/crystallize.md
+++ b/src/main/skills/stock/crystallize.md
@@ -6,7 +6,7 @@ menu: Research
 group: Decomposition
 outputMode: openConversation
 context: [fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "{{#if note.path}}Crystallize `{{note.path}}` as components.{{else}}Crystallize this note as components.{{/if}}"
 longDescription: >-

--- a/src/main/skills/stock/date-scope-check.md
+++ b/src/main/skills/stock/date-scope-check.md
@@ -7,7 +7,7 @@ group: Verification
 outputMode: openConversation
 context: [claimUnderCursor, selectedText, fullNote]
 slashCommand: /currency
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if claim.label}}Check whether this claim is still current and whether it ever held in the form stated:

--- a/src/main/skills/stock/decompose-into-claims.md
+++ b/src/main/skills/stock/decompose-into-claims.md
@@ -6,7 +6,7 @@ menu: Research
 group: Decomposition
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: |-
   {{#if selection}}Decompose this passage into individual claims. List each one with its kind so I can confirm or adjust before you file.

--- a/src/main/skills/stock/deep-dive.md
+++ b/src/main/skills/stock/deep-dive.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [selectedText, fullNote]
 slashCommand: /deep-dive
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 requiresSelection: true
 firstMessage: "Explain \"{{selection | trim}}\" in depth."

--- a/src/main/skills/stock/define-terms.md
+++ b/src/main/skills/stock/define-terms.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /define-terms
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "{{#if note}}Define the terms in this note.{{/if}}"
 longDescription: >-

--- a/src/main/skills/stock/dimensionalize.md
+++ b/src/main/skills/stock/dimensionalize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Semantic
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, extract the dimensions."
 longDescription: >-

--- a/src/main/skills/stock/explain-like-im.md
+++ b/src/main/skills/stock/explain-like-im.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /eli
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "{{#if note}}Explain this like I’m {{param.audience}}.{{/if}}"
 longDescription: >-

--- a/src/main/skills/stock/fill-out-note.md
+++ b/src/main/skills/stock/fill-out-note.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Generation
 outputMode: openConversation
 context: [fullNote]
-model: claude-opus-4-8
+model: claude-sonnet-5
 web: false
 slashCommand: /flesh-out
 firstMessage: "{{#if note}}Flesh out this note.{{/if}}"

--- a/src/main/skills/stock/find-counterexamples.md
+++ b/src/main/skills/stock/find-counterexamples.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /counterexamples
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "Where does this break down?"
 longDescription: >-

--- a/src/main/skills/stock/find-opposing-arguments.md
+++ b/src/main/skills/stock/find-opposing-arguments.md
@@ -6,7 +6,7 @@ menu: Research
 group: Argumentation
 outputMode: openConversation
 context: [claimUnderCursor]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if claim.label}}Find the strongest arguments that rebut this claim:

--- a/src/main/skills/stock/find-prerequisites.md
+++ b/src/main/skills/stock/find-prerequisites.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /prerequisites
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "What should I know before reading this?"
 longDescription: >-

--- a/src/main/skills/stock/find-primary-sources.md
+++ b/src/main/skills/stock/find-primary-sources.md
@@ -7,7 +7,7 @@ group: Verification
 outputMode: openConversation
 context: [claimUnderCursor, selectedText, fullNote]
 slashCommand: /primary-sources
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if claim.label}}Find the primary source behind this claim — not the citation chain, the original:

--- a/src/main/skills/stock/find-sources.md
+++ b/src/main/skills/stock/find-sources.md
@@ -7,7 +7,7 @@ group: Discovery
 outputMode: openConversation
 context: [selectedText, fullNote]
 slashCommand: /find-sources
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if selection}}Build me a reading list on this:

--- a/src/main/skills/stock/find-supporting-arguments.md
+++ b/src/main/skills/stock/find-supporting-arguments.md
@@ -6,7 +6,7 @@ menu: Research
 group: Argumentation
 outputMode: openConversation
 context: [claimUnderCursor]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if claim.label}}Find the strongest arguments that support this claim:

--- a/src/main/skills/stock/give-examples.md
+++ b/src/main/skills/stock/give-examples.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /examples
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "Give me examples."
 longDescription: >-

--- a/src/main/skills/stock/goalfactor.md
+++ b/src/main/skills/stock/goalfactor.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Motivation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, goal-factor the underlying needs."
 longDescription: >-

--- a/src/main/skills/stock/handlize.md
+++ b/src/main/skills/stock/handlize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Semantic
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, extract the handles."
 longDescription: >-

--- a/src/main/skills/stock/inductify.md
+++ b/src/main/skills/stock/inductify.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, extract the inductive pattern."
 longDescription: >-

--- a/src/main/skills/stock/innerloop.md
+++ b/src/main/skills/stock/innerloop.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Motivation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, sim the inner loop."
 longDescription: >-

--- a/src/main/skills/stock/load-bearing-claim.md
+++ b/src/main/skills/stock/load-bearing-claim.md
@@ -6,7 +6,7 @@ menu: Research
 group: Argumentation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if selection}}Find the load-bearing claim in this passage.

--- a/src/main/skills/stock/metaphorize.md
+++ b/src/main/skills/stock/metaphorize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, build the metaphor."
 longDescription: >-

--- a/src/main/skills/stock/negspace.md
+++ b/src/main/skills/stock/negspace.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, find the negative space."
 longDescription: >-

--- a/src/main/skills/stock/noticing.md
+++ b/src/main/skills/stock/noticing.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, name what is being noticed."
 longDescription: >-

--- a/src/main/skills/stock/propose-flashcards.md
+++ b/src/main/skills/stock/propose-flashcards.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /cards
-model: claude-opus-4-8
+model: claude-sonnet-5
 firstMessage: "Propose flashcards from this note for my review."
 longDescription: >-
   Reads the active note and drafts atomic, well-formed question/answer flashcards — one fact per card —

--- a/src/main/skills/stock/propose-source-summary.md
+++ b/src/main/skills/stock/propose-source-summary.md
@@ -7,7 +7,7 @@ group: Summarize
 scope: source
 outputMode: openConversation
 context: [sourceMetadata, sourceBody]
-model: claude-opus-4-8
+model: claude-sonnet-5
 firstMessage: |-
   {{#if source}}{{#if source.body}}Summarize "{{source.title}}" — propose an abstract and a one-paragraph TL;DR for my review.{{else}}This source has no extracted body text to summarize yet — ingest or add its body.md first.{{/if}}{{else}}Open a source first, then run Propose Summary from its Tools menu.{{/if}}
 longDescription: >-

--- a/src/main/skills/stock/quiz-me.md
+++ b/src/main/skills/stock/quiz-me.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /quiz
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "Quiz me."
 longDescription: >-

--- a/src/main/skills/stock/referenceclass.md
+++ b/src/main/skills/stock/referenceclass.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Planning
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, find the reference class."
 longDescription: >-

--- a/src/main/skills/stock/rhetoricize.md
+++ b/src/main/skills/stock/rhetoricize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Diagnostic
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, map the rhetorical spin-space."
 longDescription: >-

--- a/src/main/skills/stock/rhyme.md
+++ b/src/main/skills/stock/rhyme.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Pattern
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, find the rhymes."
 longDescription: >-

--- a/src/main/skills/stock/summarize.md
+++ b/src/main/skills/stock/summarize.md
@@ -6,7 +6,7 @@ menu: Learning
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /summarize
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: "Summarize."
 longDescription: >-

--- a/src/main/skills/stock/tidy-filenames.md
+++ b/src/main/skills/stock/tidy-filenames.md
@@ -5,7 +5,7 @@ description: Propose renaming notes toward a consistent filename convention
 menu: Analysis
 group: Organization
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-sonnet-5
 web: false
 firstMessage: "Look over this thoughtbase's filenames and propose renames toward a consistent, tidy convention. Show me the plan to review."
 longDescription: >-

--- a/src/main/skills/stock/translate-magnitude.md
+++ b/src/main/skills/stock/translate-magnitude.md
@@ -7,7 +7,7 @@ group: Verification
 outputMode: openConversation
 context: [claimUnderCursor, selectedText, fullNote]
 slashCommand: /magnitude
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 web: true
 firstMessage: |-
   {{#if claim.label}}Re-ground the magnitude in this claim — base rate, normalisation, baseline:

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -215,7 +215,7 @@
   /** Resolve the model a conversation actually runs on (override → global
    *  default → built-in fallback), for gating the effort picker. */
   function effectiveModel(model: string | undefined): string {
-    return model ?? defaultModel ?? 'claude-sonnet-4-6';
+    return model ?? defaultModel ?? 'claude-sonnet-5';
   }
 
   async function handleModelChange(tabId: string, e: Event) {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -250,7 +250,7 @@
   let clipper = $state<import('../../../shared/clipper-pairing').ClipperState | null>(null);
   let clipperRevealed = $state(false);
   let clipperCopied = $state(false);
-  let model = $state('claude-sonnet-4-6');
+  let model = $state('claude-sonnet-5');
   let effort = $state<import('../../../shared/tools/effort').Effort | undefined>(undefined);
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');

--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -6,13 +6,15 @@
  * model-gated, so the picker must only offer levels the selected model accepts,
  * or the request 400s:
  *
- *   | Model       | Supported effort                    |
- *   |-------------|-------------------------------------|
- *   | Haiku 4.5   | none (sending effort 400s)          |
- *   | Sonnet 4.6  | low / medium / high / max           |
- *   | Opus 4.8    | low / medium / high / xhigh / max   |
+ *   | Model            | Supported effort                    |
+ *   |------------------|-------------------------------------|
+ *   | Haiku 4.5        | none (sending effort 400s)          |
+ *   | Sonnet 4.6 / 5   | low / medium / high / max           |
+ *   | Opus 4.8         | low / medium / high / xhigh / max   |
+ *   | Fable 5          | low / medium / high / xhigh / max   |
  *
- * The UI label "Extra" maps to `xhigh`, which is Opus-only.
+ * The UI label "Extra" maps to `xhigh`, which is Opus/Fable-tier only (Sonnet
+ * tops out at `max`). Sonnet 5 mirrors Sonnet 4.6's set; both default to `high`.
  *
  * Kept in `shared/` so the renderer picker, the Settings default, and the
  * main-side guard all gate from one source of truth.
@@ -39,7 +41,9 @@ export const DEFAULT_EFFORT: Effort = 'medium';
  * yields `[]` — we send no effort rather than risk a 400.
  */
 const SUPPORT: Record<string, Effort[]> = {
+  'claude-fable-5': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-opus-4-8': ['low', 'medium', 'high', 'xhigh', 'max'],
+  'claude-sonnet-5': ['low', 'medium', 'high', 'max'],
   'claude-sonnet-4-6': ['low', 'medium', 'high', 'max'],
   'claude-haiku-4-5': [],
 };

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -13,10 +13,14 @@ export interface ModelOption {
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
-  // Opus 4.8 and Sonnet 4.6 ship with a 1M-token context window by default —
-  // there is no separate "1M context" model ID at the Anthropic API, so we
-  // don't list duplicate entries for it.
+  // Fable 5, Opus 4.8, and Sonnet 5 all ship with a 1M-token context window by
+  // default — there is no separate "1M context" model ID at the Anthropic API,
+  // so we don't list duplicate entries for it. Ordered most→least capable.
+  // Sonnet 4.6 is kept (still active) so users who selected it aren't reset to
+  // the default; Sonnet 5 is its successor tier.
+  { value: 'claude-fable-5', label: 'Claude Fable 5' },
   { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
 ];
@@ -41,7 +45,13 @@ export interface ModelPrice {
  * cost degrades to a token count with no dollar figure rather than a guess.
  */
 export const MODEL_PRICING: Record<string, ModelPrice> = {
+  'claude-fable-5': { input: 10, output: 50 },
   'claude-opus-4-8': { input: 5, output: 25 },
+  // Sonnet 5 standard rate. It has introductory pricing of $2/$10 through
+  // 2026-08-31, but this map has no expiry mechanism — using the standard rate
+  // slightly over-estimates cost during the intro window rather than silently
+  // under-reporting after it ends. Revisit if we add time-aware pricing.
+  'claude-sonnet-5': { input: 3, output: 15 },
   'claude-sonnet-4-6': { input: 3, output: 15 },
   'claude-haiku-4-5': { input: 1, output: 5 },
 };


### PR DESCRIPTION
Surfaces the two new models and modernizes the tool defaults onto Sonnet 5.

## Model IDs — verified, not guessed

I pinned the exact strings against the platform model docs before writing anything (a wrong ID 404s at runtime):
- **`claude-sonnet-5`** — the successor to Sonnet 4.6, "best speed + intelligence" tier. 1M ctx / 128K out, adaptive thinking, `effort` defaults to `high`, and `xhigh` remains Opus/Fable-tier only (so it mirrors 4.6's `low/medium/high/max`). Intro pricing $2/$10 through 2026-08-31.
- **`claude-fable-5`** — most capable widely released model. "Fable 5.0" is just Fable 5 — same ID, already GA. $10/$50, full effort set incl. `xhigh`.

## Selection lists

Both pickers (Settings default + per-conversation override) render from `MODEL_OPTIONS`, so one edit covers both:
- Added Fable 5 + Sonnet 5 (ordered most→least capable). Kept Sonnet 4.6 in the list — it's still active, and dropping it would reset any user who'd selected it.
- `MODEL_PRICING`: Fable 5 `$10/$50`; Sonnet 5 at the **standard** `$3/$15` — the intro rate has no expiry mechanism in a static map, and over-estimating slightly now beats silently under-reporting after Aug 31. Flagged in a comment.
- **`effort.ts` `SUPPORT` map** — the load-bearing one: a model absent here sends *no* effort at all, so Sonnet 5 / Fable 5 would silently lose effort control. Added both.

## Default changes (full modernization, per decision)

- Global `DEFAULT_MODEL` `claude-sonnet-4-6` → `claude-sonnet-5`. Deliberately **not** added to `DEPRECATED_MODELS` — 4.6 is still active, so only fresh/unset configs move; a user who explicitly chose 4.6 keeps it.
- **30 skills** on Sonnet 4.6 → Sonnet 5 (pure upgrade — same tier, newer, cheaper intro).
- **4 simpler Opus skills** → Sonnet 5: `tidy-filenames`, `propose-flashcards`, `propose-source-summary`, `fill-out-note`. The reasoning/accuracy-heavy Opus skills (synthesize, doublecrux, decompose, extract-key-claims, organize-by-topic, the data-analysis trio, …) **stay on Opus 4.8**.
- Two hardcoded fallback strings (conversation effective-model resolver, Settings initial `$state`) → `claude-sonnet-5` to match the new default.

**Net:** 34 skills on Sonnet 5, 12 on Opus 4.8.

## Tests

59 green across effort / tool-model resolution / conversation-cost / AiSettings / skills compile+parse+loader + the four data/fill-out skill tests; `pnpm lint` clean. No test pinned the old model list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
