### PR TITLE
feat: "Recompute all" toolbar button for code fences

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -80,10 +80,18 @@
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
+  import { findRunnableFences } from '../shared/compute/fences';
+  import { DEFAULT_RUNNABLE_LANGUAGES } from './lib/editor/compute-cells';
   import { loadFormatSettings } from './lib/formatter/settings';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
   import { registerSkillInfos } from './lib/tools/tool-registry';
   import { applyMenuConfig } from '../shared/skills/menu-config';
+
+  // Lower-cased once so the "Recompute all" button's reactive
+  // has-runnable-fences check matches the editor extension's allow-list.
+  const RUNNABLE_LANGUAGE_SET = new Set(
+    DEFAULT_RUNNABLE_LANGUAGES.map((s) => s.toLowerCase()),
+  );
 
 
   const notebase = getNotebaseStore();
@@ -1301,7 +1309,16 @@
                 <CsvTable relativePath={active.relativePath} content={active.content} />
               {:else if active?.type === 'note'}
                 {@const note = active}
+                {@const hasRunnableFences =
+                  findRunnableFences(note.content, RUNNABLE_LANGUAGE_SET).length > 0}
                 <div class="toolbar">
+                  {#if hasRunnableFences && group.viewMode !== 'preview'}
+                    <button
+                      class="nav-btn run-all-btn"
+                      onclick={() => void editorComponents[groupId]?.runAllCells()}
+                      title="Recompute all cells (top to bottom, stops on error)"
+                    ><Icon name="run-all" size={12} /></button>
+                  {/if}
                   <div class="view-toggle">
                     <button
                       class:active={group.viewMode === 'source'}
@@ -1847,6 +1864,16 @@
     border: 1px solid var(--border);
     border-radius: 4px;
     overflow: hidden;
+    /* Breathing room before the split buttons that follow. */
+    margin-right: 8px;
+  }
+
+  /* Separate the Recompute-all button from the view toggle to its right.
+     The margin lives on the button (not the toggle) so a note without
+     runnable fences — where the button is absent — keeps the toggle flush
+     against the toolbar's left padding. */
+  .run-all-btn {
+    margin-right: 8px;
   }
 
   .view-toggle button {

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -35,7 +35,7 @@
   import { voiceSettings } from '../voice/voice-settings.svelte';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { highlightDecorations } from '../editor/highlight-decorations';
-  import { computeCellsExtension } from '../editor/compute-cells';
+  import { computeCellsExtension, type RunAllRef } from '../editor/compute-cells';
   import {
     bookmarkGutterExtension,
     applyBookmarkOffsets,
@@ -209,6 +209,8 @@
 
   let editorContainer: HTMLDivElement;
   let view: EditorView;
+  // Populated by computeCellsExtension; lets the host trigger Run-all.
+  const runAllRef: RunAllRef = { run: null };
   let ignoreNextUpdate = false;
   let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean; docPos: number | null; claimUri: string | null } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
@@ -502,6 +504,7 @@
           ? onRunCell(language, code, filePath)
           : api.compute.runCell(language, code, filePath)
       ),
+      runAllRef,
     }),
     footnotePreview(),
     footnoteDecorations(),
@@ -699,6 +702,16 @@
 
   export function getView(): EditorView | undefined {
     return view;
+  }
+
+  /**
+   * Re-run every runnable code fence in the note, top to bottom
+   * (the "Recompute all" toolbar action). Sequential, halts on the
+   * first error — see `runAll` in compute-cells.ts.
+   */
+  export async function runAllCells(): Promise<void> {
+    if (!view || !runAllRef.run) return;
+    await runAllRef.run(view);
   }
 
   export function getSelectionRange(): { from: number; to: number } | null {

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -142,6 +142,13 @@ export const ICONS = {
     '<rect x="2.5" y="3" width="11" height="10" rx="1"/>' +
     '<path d="M2.5 8h11"/>',
 
+  // ── Compute (#238) ────────────────────────────────────────────────
+  // "Recompute all": a fast-forward double-triangle — run every runnable
+  // fence top to bottom. Echoes the gutter's ▶ single-cell run marker.
+  'run-all':
+    '<path d="M3 4 7.5 8 3 12z" fill="currentColor" stroke="none"/>' +
+    '<path d="M8.5 4 13 8 8.5 12z" fill="currentColor" stroke="none"/>',
+
   // ── Brand ─────────────────────────────────────────────────────────
   minervaMark:
     '<circle cx="8" cy="8" r="6"/>' +

--- a/src/renderer/lib/editor/compute-cells.ts
+++ b/src/renderer/lib/editor/compute-cells.ts
@@ -25,6 +25,9 @@ import {
 } from '../../../shared/compute/fences';
 import type { CellResult } from '../ipc/client';
 
+/** Fence languages that show the run affordance unless the host overrides. */
+export const DEFAULT_RUNNABLE_LANGUAGES = ['sparql', 'sql', 'python'] as const;
+
 // ── Running state ──────────────────────────────────────────────────────────
 
 /** Effect marking a fence at `fenceStart` as running (`true`) or idle (`false`). */
@@ -74,6 +77,16 @@ class RunMarker extends GutterMarker {
 
 // ── Extension factory ──────────────────────────────────────────────────────
 
+/**
+ * Handle the host holds to trigger a Run-all from outside the editor
+ * (e.g. a toolbar button). The extension populates `.run` once built; the
+ * host calls it with the live `EditorView`. Null until wired / after the
+ * view is torn down.
+ */
+export interface RunAllRef {
+  run: ((view: EditorView) => Promise<void>) | null;
+}
+
 export interface ComputeCellsOptions {
   /**
    * Dispatch a cell to the backend and return the result. The extension
@@ -83,14 +96,24 @@ export interface ComputeCellsOptions {
   runCell: (language: string, code: string) => Promise<CellResult>;
   /** Allow-list of fence languages that show the run affordance. */
   runnableLanguages?: Iterable<string>;
+  /**
+   * Optional handle populated with the batch runner so the host can
+   * trigger "Recompute all" from a toolbar/menu.
+   */
+  runAllRef?: RunAllRef;
 }
 
 export function computeCellsExtension(opts: ComputeCellsOptions): Extension {
   const allowed = new Set<string>(
-    [...(opts.runnableLanguages ?? ['sparql', 'sql', 'python'])].map((s) => s.toLowerCase()),
+    [...(opts.runnableLanguages ?? DEFAULT_RUNNABLE_LANGUAGES)].map((s) => s.toLowerCase()),
   );
 
-  async function runFence(view: EditorView, fence: FenceRange): Promise<void> {
+  /**
+   * Run a single fence and write its output block. Returns the result so
+   * callers (e.g. Run-all) can decide whether to continue. The doc may
+   * shift while we await, so we re-find the fence before writing.
+   */
+  async function runFence(view: EditorView, fence: FenceRange): Promise<CellResult> {
     const doc = view.state.doc.toString();
     const code = codeOf(doc, fence);
     view.dispatch({ effects: setRunning.of({ fenceStart: fence.startOffset, running: true }) });
@@ -113,7 +136,33 @@ export function computeCellsExtension(opts: ComputeCellsOptions): Extension {
       changes: { from: edit.from, to: edit.to, insert: edit.insert },
       effects: setRunning.of({ fenceStart: target.startOffset, running: false }),
     });
+    return result;
   }
+
+  /**
+   * Re-run every runnable fence in the note, top to bottom. Cells can
+   * depend on prior cells' state (a Python fence building on an earlier
+   * one's namespace), so runs are strictly sequential and the batch
+   * **halts on the first error** — a failed cell invalidates anything
+   * downstream that leaned on it.
+   *
+   * We re-scan the doc each iteration and take the i-th fence rather than
+   * caching ranges: writing an output block shifts every offset below it.
+   * Output blocks use the `output` language, which isn't runnable, so the
+   * fence *count* stays stable and index-based iteration is safe even when
+   * two fences share identical code.
+   */
+  async function runAll(view: EditorView): Promise<void> {
+    const count = findRunnableFences(view.state.doc.toString(), allowed).length;
+    for (let i = 0; i < count; i++) {
+      const fence = findRunnableFences(view.state.doc.toString(), allowed)[i];
+      if (!fence) break; // doc was edited out from under us; stop cleanly
+      const result = await runFence(view, fence);
+      if (!result.ok) break; // halt the batch; the error is already written
+    }
+  }
+
+  if (opts.runAllRef) opts.runAllRef.run = runAll;
 
   function fenceAtCursor(view: EditorView): FenceRange | null {
     const doc = view.state.doc.toString();

--- a/tests/renderer/editor/compute-cells-run-all.test.ts
+++ b/tests/renderer/editor/compute-cells-run-all.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * "Recompute all" batch runner (compute-cells.ts). Cells can depend on
+ * prior cells' state, so the batch runs strictly top-to-bottom and halts
+ * on the first error. We stand up a detached EditorView wired with the
+ * extension, capture the `runAllRef` handle it populates, and drive it
+ * against a fake executor.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import {
+  computeCellsExtension,
+  type RunAllRef,
+} from '../../../src/renderer/lib/editor/compute-cells';
+import type { CellResult } from '../../../src/renderer/lib/ipc/client';
+
+let view: EditorView;
+afterEach(() => view?.destroy());
+
+/**
+ * Build an editor over `doc` with the compute extension. `runCell`
+ * records each (language, code) call and returns whatever the map/fn
+ * dictates (defaulting to a trivial ok result).
+ */
+function mk(
+  doc: string,
+  runCell: (language: string, code: string) => CellResult,
+): { view: EditorView; runAll: RunAllRef; calls: Array<{ language: string; code: string }> } {
+  const calls: Array<{ language: string; code: string }> = [];
+  const runAll: RunAllRef = { run: null };
+  view = new EditorView({
+    state: EditorState.create({
+      doc,
+      extensions: [
+        computeCellsExtension({
+          runCell: (language, code) => {
+            calls.push({ language, code });
+            return Promise.resolve(runCell(language, code));
+          },
+          runAllRef: runAll,
+        }),
+      ],
+    }),
+  });
+  return { view, runAll, calls };
+}
+
+const ok = (value: unknown): CellResult => ({ ok: true, value } as CellResult);
+
+describe('runAll (Recompute all, #238)', () => {
+  it('runs every runnable fence top to bottom', async () => {
+    const doc = '```sql\nSELECT 1\n```\n\ntext\n\n```python\nprint(2)\n```\n';
+    const { runAll, view: v, calls } = mk(doc, () => ok('r'));
+
+    await runAll.run!(v);
+
+    expect(calls).toEqual([
+      { language: 'sql', code: 'SELECT 1' },
+      { language: 'python', code: 'print(2)' },
+    ]);
+    // Both fences got an output block written beneath them.
+    expect(v.state.doc.toString().match(/```output/g)?.length).toBe(2);
+  });
+
+  it('halts on the first error — later cells never run', async () => {
+    const doc = '```sql\nA\n```\n\n```sql\nB\n```\n\n```sql\nC\n```\n';
+    const { runAll, view: v, calls } = mk(doc, (_lang, code) =>
+      code === 'B' ? { ok: false, error: 'boom' } : ok('r'),
+    );
+
+    await runAll.run!(v);
+
+    // A ran, B ran and failed, C was skipped.
+    expect(calls.map((c) => c.code)).toEqual(['A', 'B']);
+    const out = v.state.doc.toString();
+    // The failing cell's error output is still written…
+    expect(out).toContain('boom');
+    // …but the third cell has no output block.
+    expect(out.match(/```output/g)?.length).toBe(2);
+  });
+
+  it('is a no-op on a note with no runnable fences', async () => {
+    const { runAll, view: v, calls } = mk('# just prose\n\n```\nplain\n```\n', () => ok('r'));
+    await runAll.run!(v);
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds a **Recompute all** toolbar button (▶▶) that re-runs every runnable code fence in the current note, **top to bottom**.

Runs are **strictly sequential** — cells can depend on a prior cell's state (a Python fence building on an earlier one's namespace), so parallel execution would be wrong — and the batch **halts on the first error**, since a failed cell invalidates anything downstream that leaned on it.

## How

- **`compute-cells.ts`** — `runFence` now returns its `CellResult`; a new `runAll()` batch runner iterates fences top-to-bottom, re-scanning the doc each iteration (writing an output block shifts offsets below it, but `output` fences aren't runnable, so the fence *count* stays stable → index-based iteration is safe even with duplicate code) and stops on the first non-`ok` result. Surfaced to the host via a `RunAllRef` handle the extension populates. Extracted `DEFAULT_RUNNABLE_LANGUAGES` so the button's visibility check can't drift from the extension's allow-list.
- **`Editor.svelte`** — holds the ref, exports `runAllCells()`.
- **`App.svelte`** — toolbar button, shown only when the note has runnable fences **and** an editor is mounted (hidden in preview-only mode, where there's no editor `view` to write through). Added spacing around the view toggle so the button and split buttons aren't flush against it.
- **`icons/registry.ts`** — new `run-all` double-triangle icon.

Each cell reuses the exact same `runFence` path as a manual gutter-click, so the per-cell gutter "…" indicator gives free progress feedback and the Python trust prompt still gates correctly (prompts once per thoughtbase, caches consent).

## Tests

New `compute-cells-run-all.test.ts` drives `runAll` through a real detached `EditorView`:
- runs every fence top to bottom, writing an output block under each
- halts on the first error — failing cell's error output is written, downstream cells skipped
- no-op on a note with no runnable fences

`pnpm lint` clean; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)