### PR TITLE
feat: show "Recompute all" button in preview mode

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1312,10 +1312,17 @@
                 {@const hasRunnableFences =
                   findRunnableFences(note.content, RUNNABLE_LANGUAGE_SET).length > 0}
                 <div class="toolbar">
-                  {#if hasRunnableFences && group.viewMode !== 'preview'}
+                  {#if hasRunnableFences}
                     <button
                       class="nav-btn run-all-btn"
-                      onclick={() => void editorComponents[groupId]?.runAllCells()}
+                      onclick={() => {
+                        // Prefer the editor (writes through CodeMirror so the
+                        // edit lands in undo history / cursor state); fall back
+                        // to the preview when it's the only surface mounted
+                        // (preview-only view mode).
+                        const surface = editorComponents[groupId] ?? previewComponents[groupId];
+                        void surface?.runAllCells();
+                      }}
                       title="Recompute all cells (top to bottom, stops on error)"
                     ><Icon name="run-all" size={12} /></button>
                   {/if}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -36,6 +36,7 @@
     import mdFootnote from 'markdown-it-footnote';
     import {planOutputEdit} from '../editor/output-block';
     import {findRunnableFences, codeOf} from '../../../shared/compute/fences';
+    import {runAllCellsInContent} from '../compute/run-all-cells';
     import type {CellResult} from '../ipc/client';
     import {escapeHtml, escapeAttr, stripFrontmatter, countFrontmatterLines} from '../preview/text';
     import {resolveRelativeImagePath, mimeFromPath} from '../preview/image-paths';
@@ -1446,6 +1447,28 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         } finally {
             runningFences.delete(openingLine);
         }
+    }
+
+    /**
+     * Re-run every runnable fence in the note, top to bottom — the
+     * preview-mode counterpart to the editor's Run-all, so the toolbar
+     * button works when no editor is mounted. The sequential/stop-on-error
+     * loop lives in `runAllCellsInContent`; here we just wire it to the
+     * host's run + apply callbacks and the per-cell running indicator.
+     */
+    export async function runAllCells(): Promise<void> {
+        if (!onRunCell || !onApplyCellOutputEdit || !notePath) return;
+        const runCell = onRunCell;
+        const apply = onApplyCellOutputEdit;
+        const np = notePath;
+        await runAllCellsInContent(content, RUNNABLE_LANGS, {
+            runCell: (language, code) => runCell(language, code, np),
+            apply,
+            setRunning: (line, running) => {
+                if (running) runningFences.add(line);
+                else runningFences.delete(line);
+            },
+        });
     }
 
     // ── Note context menu (read-only mirror of Editor's right-click menu) ──────

--- a/src/renderer/lib/compute/run-all-cells.ts
+++ b/src/renderer/lib/compute/run-all-cells.ts
@@ -1,0 +1,62 @@
+/**
+ * Content-string batch runner for "Recompute all" from the preview
+ * (#238 follow-up). The editor's Run-all drives a live CodeMirror view
+ * (see `computeCellsExtension`), but the preview has no editor mounted in
+ * preview-only mode — it applies output edits by handing a new full
+ * content string back to the host. This helper is that string-threading
+ * loop, extracted so it's unit-testable without mounting the Preview
+ * component.
+ *
+ * Semantics match the editor side: fences run **strictly top-to-bottom**
+ * (a cell can depend on a prior cell's kernel state) and the batch
+ * **halts on the first error**.
+ */
+
+import { planOutputEdit } from '../editor/output-block';
+import { findRunnableFences, codeOf } from '../../../shared/compute/fences';
+import type { CellResult } from '../ipc/client';
+
+export interface RunAllCellsDeps {
+  /** Execute one cell. Rejections are caught and written as an error output. */
+  runCell: (language: string, code: string) => Promise<CellResult>;
+  /** Receive the full content after each cell's output block is spliced in. */
+  apply: (content: string) => void;
+  /** Toggle a per-cell running indicator, keyed by 1-based opening line. */
+  setRunning?: (openingLine: number, running: boolean) => void;
+}
+
+/**
+ * Re-run every runnable fence in `content`, returning the final content.
+ *
+ * We re-scan `content` (threaded forward as `working`) each iteration and
+ * take the i-th fence: writing an output block shifts every offset below
+ * it, but `output` fences aren't runnable, so the fence *count* is stable
+ * and index-based iteration is safe even when two fences share code.
+ */
+export async function runAllCellsInContent(
+  content: string,
+  langs: ReadonlySet<string>,
+  deps: RunAllCellsDeps,
+): Promise<string> {
+  let working = content;
+  const count = findRunnableFences(working, langs).length;
+  for (let i = 0; i < count; i++) {
+    const fence = findRunnableFences(working, langs)[i];
+    if (!fence) break; // content changed under us; stop cleanly
+    const code = codeOf(working, fence);
+    deps.setRunning?.(fence.openingLine, true);
+    let result: CellResult;
+    try {
+      result = await deps.runCell(fence.language, code);
+    } catch (e) {
+      result = { ok: false, error: e instanceof Error ? e.message : String(e) };
+    } finally {
+      deps.setRunning?.(fence.openingLine, false);
+    }
+    const edit = planOutputEdit(working, fence, result);
+    working = working.slice(0, edit.from) + edit.insert + working.slice(edit.to);
+    deps.apply(working); // apply per cell so output lands as it completes
+    if (!result.ok) break; // halt; the error output is already applied
+  }
+  return working;
+}

--- a/tests/renderer/compute/run-all-cells.test.ts
+++ b/tests/renderer/compute/run-all-cells.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Content-string batch runner behind the preview's "Recompute all"
+ * (#238 follow-up). Mirrors the editor-side test
+ * (`editor/compute-cells-run-all.test.ts`) but exercises the pure
+ * string-threading helper the Preview component wraps.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runAllCellsInContent } from '../../../src/renderer/lib/compute/run-all-cells';
+import type { CellResult } from '../../../src/renderer/lib/ipc/client';
+
+const LANGS = new Set(['sql', 'sparql', 'python']);
+const ok = (value: unknown): CellResult => ({ ok: true, value } as CellResult);
+
+describe('runAllCellsInContent (preview Recompute all)', () => {
+  it('runs every runnable fence top to bottom and returns the spliced content', async () => {
+    const content = '```sql\nSELECT 1\n```\n\ntext\n\n```python\nprint(2)\n```\n';
+    const calls: Array<{ language: string; code: string }> = [];
+    const applied: string[] = [];
+
+    const final = await runAllCellsInContent(content, LANGS, {
+      runCell: (language, code) => {
+        calls.push({ language, code });
+        return Promise.resolve(ok('r'));
+      },
+      apply: (c) => applied.push(c),
+    });
+
+    expect(calls).toEqual([
+      { language: 'sql', code: 'SELECT 1' },
+      { language: 'python', code: 'print(2)' },
+    ]);
+    // One apply per cell, and the final return equals the last applied content.
+    expect(applied).toHaveLength(2);
+    expect(final).toBe(applied[applied.length - 1]);
+    expect(final.match(/```output/g)?.length).toBe(2);
+  });
+
+  it('halts on the first error — later cells never run', async () => {
+    const content = '```sql\nA\n```\n\n```sql\nB\n```\n\n```sql\nC\n```\n';
+    const calls: string[] = [];
+
+    const final = await runAllCellsInContent(content, LANGS, {
+      runCell: (_language, code) => {
+        calls.push(code);
+        return Promise.resolve(code === 'B' ? { ok: false, error: 'boom' } : ok('r'));
+      },
+      apply: () => {},
+    });
+
+    expect(calls).toEqual(['A', 'B']); // C skipped
+    expect(final).toContain('boom'); // failing cell's error is written
+    expect(final.match(/```output/g)?.length).toBe(2); // A + B only
+  });
+
+  it('catches a runCell rejection and writes it as an error output, then halts', async () => {
+    const content = '```sql\nA\n```\n\n```sql\nB\n```\n';
+    const calls: string[] = [];
+
+    const final = await runAllCellsInContent(content, LANGS, {
+      runCell: (_language, code) => {
+        calls.push(code);
+        return code === 'A' ? Promise.reject(new Error('kaboom')) : Promise.resolve(ok('r'));
+      },
+      apply: () => {},
+    });
+
+    expect(calls).toEqual(['A']); // rejection halts before B
+    expect(final).toContain('kaboom');
+  });
+
+  it('toggles the running indicator on and off around each cell', async () => {
+    const content = '```sql\nA\n```\n';
+    const events: Array<[number, boolean]> = [];
+
+    await runAllCellsInContent(content, LANGS, {
+      runCell: () => Promise.resolve(ok('r')),
+      apply: () => {},
+      setRunning: (line, running) => events.push([line, running]),
+    });
+
+    expect(events).toEqual([
+      [1, true],
+      [1, false],
+    ]);
+  });
+
+  it('is a no-op on content with no runnable fences', async () => {
+    const content = '# prose\n\n```\nplain\n```\n';
+    const calls: string[] = [];
+    const final = await runAllCellsInContent(content, LANGS, {
+      runCell: (_l, code) => {
+        calls.push(code);
+        return Promise.resolve(ok('r'));
+      },
+      apply: () => {},
+    });
+    expect(calls).toEqual([]);
+    expect(final).toBe(content);
+  });
+});


### PR DESCRIPTION
## What

Makes the **Recompute all** button work (and appear) in preview-only mode, not just source / side-by-side.

Follow-up to #965, which hid the button in preview mode because it drove the editor's CodeMirror view — and no editor is mounted in preview-only mode.

## How

The preview already runs single cells through its own path (`findRunnableFences` + `planOutputEdit` + `onApplyCellOutputEdit` — the same one the inline ▶ buttons use, which works fine in preview mode). So it just needed a batch runner over that path.

- **`run-all-cells.ts`** — new `runAllCellsInContent()`, the content-string counterpart to the editor's `runAll`. It threads the content forward locally (each `onApplyCellOutputEdit` only reaches the preview as a new prop on the *next* reactive tick, so mid-loop the `content` prop is stale), re-scanning each iteration as output blocks splice in. Same semantics as the editor side: **sequential, halts on the first error**.
- **`Preview.svelte`** — exports `runAllCells()` as a thin wrapper that wires the host run/apply callbacks and the per-cell running indicator.
- **`App.svelte`** — drops the preview-mode gate on the button and routes the click to whichever surface is mounted: editor preferred (so the edit lands in CodeMirror undo/cursor history), preview as fallback.

## Tests

New `run-all-cells.test.ts` covers the extracted helper directly (Preview's own tests target extracted helpers rather than mounting the full markdown-it component):
- runs every fence top to bottom; final return equals the last applied content
- halts on the first error (failing cell's output written, downstream skipped)
- catches a `runCell` rejection, writes it as an error output, then halts
- toggles the running indicator on/off around each cell
- no-op on fence-less content

`pnpm lint` clean; full suite (3777) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)