### PR TITLE
refactor: single source of truth for runnable fence languages

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -80,18 +80,11 @@
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
-  import { findRunnableFences } from '../shared/compute/fences';
-  import { DEFAULT_RUNNABLE_LANGUAGES } from './lib/editor/compute-cells';
+  import { findRunnableFences, RUNNABLE_LANGUAGE_SET } from '../shared/compute/fences';
   import { loadFormatSettings } from './lib/formatter/settings';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
   import { registerSkillInfos } from './lib/tools/tool-registry';
   import { applyMenuConfig } from '../shared/skills/menu-config';
-
-  // Lower-cased once so the "Recompute all" button's reactive
-  // has-runnable-fences check matches the editor extension's allow-list.
-  const RUNNABLE_LANGUAGE_SET = new Set(
-    DEFAULT_RUNNABLE_LANGUAGES.map((s) => s.toLowerCase()),
-  );
 
 
   const notebase = getNotebaseStore();

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -35,7 +35,7 @@
     import {getToolInfosByCategory} from '../tools/tool-registry';
     import mdFootnote from 'markdown-it-footnote';
     import {planOutputEdit} from '../editor/output-block';
-    import {findRunnableFences, codeOf} from '../../../shared/compute/fences';
+    import {findRunnableFences, codeOf, RUNNABLE_LANGUAGE_SET} from '../../../shared/compute/fences';
     import {runAllCellsInContent} from '../compute/run-all-cells';
     import type {CellResult} from '../ipc/client';
     import {escapeHtml, escapeAttr, stripFrontmatter, countFrontmatterLines} from '../preview/text';
@@ -153,8 +153,6 @@
     // a cell is in flight so a double-click can't fire two parallel
     // executions.
     const runningFences = $state<Set<number>>(new Set());
-
-    const RUNNABLE_LANGS = new Set(['python', 'py', 'python3', 'sparql', 'sql']);
 
     // Tool lists for the right-click menu's Learning / Analysis submenus.
     // Loaded once at mount — the registry is project-stable.
@@ -445,7 +443,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         // run button (when the host wired `onRunCell` + `onApplyCellOutputEdit`)
         // and a collapse toggle. The default highlighted-code body is
         // wrapped inside `.fence-body` so the toggle can hide it.
-        const isRunnable = RUNNABLE_LANGS.has(info);
+        const isRunnable = RUNNABLE_LANGUAGE_SET.has(info);
         if (isRunnable && openingLine !== null) {
             const isCollapsed = collapsedFences.has(openingLine);
             const isRunning = runningFences.has(openingLine);
@@ -1429,7 +1427,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         // number from markdown-it, but the doc may have been edited since
         // last render — re-scanning is cheap and rules out stale-token
         // bugs.
-        const fences = findRunnableFences(content, RUNNABLE_LANGS);
+        const fences = findRunnableFences(content, RUNNABLE_LANGUAGE_SET);
         const fence = fences.find((f) => f.openingLine === openingLine);
         if (!fence) {
             console.warn(`[preview] runFenceAt: no fence at line ${openingLine}`);
@@ -1461,7 +1459,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         const runCell = onRunCell;
         const apply = onApplyCellOutputEdit;
         const np = notePath;
-        await runAllCellsInContent(content, RUNNABLE_LANGS, {
+        await runAllCellsInContent(content, RUNNABLE_LANGUAGE_SET, {
             runCell: (language, code) => runCell(language, code, np),
             apply,
             setRunning: (line, running) => {

--- a/src/renderer/lib/editor/compute-cells.ts
+++ b/src/renderer/lib/editor/compute-cells.ts
@@ -21,12 +21,10 @@ import { planOutputEdit } from './output-block';
 import {
   findRunnableFences,
   codeOf,
+  RUNNABLE_LANGUAGES,
   type FenceRange,
 } from '../../../shared/compute/fences';
 import type { CellResult } from '../ipc/client';
-
-/** Fence languages that show the run affordance unless the host overrides. */
-export const DEFAULT_RUNNABLE_LANGUAGES = ['sparql', 'sql', 'python'] as const;
 
 // ── Running state ──────────────────────────────────────────────────────────
 
@@ -105,7 +103,7 @@ export interface ComputeCellsOptions {
 
 export function computeCellsExtension(opts: ComputeCellsOptions): Extension {
   const allowed = new Set<string>(
-    [...(opts.runnableLanguages ?? DEFAULT_RUNNABLE_LANGUAGES)].map((s) => s.toLowerCase()),
+    [...(opts.runnableLanguages ?? RUNNABLE_LANGUAGES)].map((s) => s.toLowerCase()),
   );
 
   /**

--- a/src/renderer/lib/preview/compute-output-render.ts
+++ b/src/renderer/lib/preview/compute-output-render.ts
@@ -11,6 +11,7 @@ import type Token from 'markdown-it/lib/token.mjs';
 import { escapeHtml, escapeAttr } from './text';
 import { sanitizeComputeOutputHtml } from '../compute-output-sanitize';
 import type { CellOutput } from '../../../shared/compute/types';
+import { RUNNABLE_LANGUAGE_SET } from '../../../shared/compute/fences';
 
 /**
  * Walk backwards from the output fence token to find the executable
@@ -20,12 +21,11 @@ import type { CellOutput } from '../../../shared/compute/types';
  * paste an isolated output block.
  */
 export function findSourceFenceBefore(tokens: Token[], idx: number): { language: string; code: string } | null {
-  const RUNNABLE = new Set(['sparql', 'sql', 'python']);
   for (let i = idx - 1; i >= 0; i--) {
     const t = tokens[i];
     if (t.type === 'fence') {
       const lang = (t.info ?? '').trim().split(/\s+/)[0]?.toLowerCase() ?? '';
-      if (RUNNABLE.has(lang)) {
+      if (RUNNABLE_LANGUAGE_SET.has(lang)) {
         return { language: lang, code: (t.content ?? '').replace(/\n$/, '') };
       }
       return null;

--- a/src/shared/compute/cell-output.ts
+++ b/src/shared/compute/cell-output.ts
@@ -13,14 +13,12 @@
  */
 
 import { parseFenceInfo } from './cell-id';
+import { RUNNABLE_LANGUAGE_SET } from './fences';
 import type { CellOutput } from './types';
 
 /** What's stored in an ```output block: a CellOutput, or the `{type:'error'}`
  *  shape a failed cell serializes (`resultToJson`). */
 export type StoredCellOutput = CellOutput | { type: 'error'; message: string };
-
-/** Languages whose fences can be compute cells (and thus carry an output). */
-const CELL_LANGS: ReadonlySet<string> = new Set(['python', 'py', 'python3', 'sparql', 'sql']);
 
 /**
  * Scan forward from `after` for an `output` fence belonging to the cell that
@@ -81,7 +79,7 @@ export function findCellOutput(content: string, cellId: string): StoredCellOutpu
     if (!m) continue;
     const info = m[1];
     const parsed = parseFenceInfo(info);
-    if (!CELL_LANGS.has(parsed.language) || parsed.attrs.id !== cellId) continue;
+    if (!RUNNABLE_LANGUAGE_SET.has(parsed.language) || parsed.attrs.id !== cellId) continue;
 
     // Found the cell's opening fence. Find its closing ``` then the output block.
     const closeLine = findClosingFence(content, lineStart + line.length + 1);

--- a/src/shared/compute/fences.ts
+++ b/src/shared/compute/fences.ts
@@ -15,6 +15,23 @@
  * CodeMirror view.
  */
 
+/**
+ * Fence languages the compute shell can execute — the single source of truth
+ * for "which fences get a run affordance", shared by the editor gutter, the
+ * preview run buttons, the Recompute-all button's visibility check, and the
+ * cell-output scanners. `py` / `python3` are aliases the backend maps to the
+ * Python executor.
+ *
+ * Must stay in sync with the executors registered in
+ * `main/compute/executors/index.ts`; `tests/main/compute/registry.test.ts`
+ * asserts the two match so this list can't silently drift from what the
+ * backend can actually run.
+ */
+export const RUNNABLE_LANGUAGES = ['sparql', 'sql', 'python', 'py', 'python3'] as const;
+
+/** Lower-cased set form for `findRunnableFences` and membership checks. */
+export const RUNNABLE_LANGUAGE_SET: ReadonlySet<string> = new Set(RUNNABLE_LANGUAGES);
+
 export interface FenceRange {
   /** Byte offset where the opening triple-backtick line begins. */
   startOffset: number;

--- a/tests/main/compute/registry.test.ts
+++ b/tests/main/compute/registry.test.ts
@@ -6,6 +6,8 @@ import {
   runCell,
   _clearRegistry,
 } from '../../../src/main/compute/registry';
+import { registerBuiltinExecutors } from '../../../src/main/compute/executors';
+import { RUNNABLE_LANGUAGES } from '../../../src/shared/compute/fences';
 
 describe('compute registry (#238)', () => {
   beforeEach(() => {
@@ -57,6 +59,15 @@ describe('compute registry (#238)', () => {
     registerExecutor('sql', async () => ({ ok: true, output: { type: 'text', value: 'v2' } }));
     const result = await runCell('sql', 'x', { rootPath: '/tmp' });
     expect(result.ok && result.output.type === 'text' && result.output.value).toBe('v2');
+  });
+
+  it('builtin registrations match the shared RUNNABLE_LANGUAGES list', () => {
+    // Drift guard: the renderer decides which fences show a run affordance
+    // from RUNNABLE_LANGUAGES (shared/compute/fences.ts). If it and the
+    // backend's registered executors disagree, a fence can show a ▶ the
+    // backend can't run (or vice versa). Keep the two in lockstep.
+    registerBuiltinExecutors();
+    expect(registeredLanguages()).toEqual([...RUNNABLE_LANGUAGES].sort());
   });
 
   it('passes the ExecutorContext through to the executor', async () => {


### PR DESCRIPTION
## What

Unifies the "which fence languages are runnable" definition, which had drifted across **five** places. Fixes the rough edge noted in #966: a note whose only runnable fence is ```` ```py ```` showed no run affordance / Recompute-all button in the editor, even though the backend happily runs it.

## The drift

| Location | Set | Correct? |
|---|---|---|
| `main/compute/executors/index.ts` (backend registration) | sparql, sql, python, **py, python3** | source of truth |
| `Preview.svelte` | sparql, sql, python, py, python3 | ✅ |
| `cell-output.ts` | sparql, sql, python, py, python3 | ✅ |
| `compute-cells.ts` (editor) | sparql, sql, python | ❌ too narrow |
| `App.svelte` (button visibility) | sparql, sql, python | ❌ too narrow |
| `compute-output-render.ts` (Save-as-note) | sparql, sql, python | ❌ too narrow |

The backend registers `py`/`python3` as aliases of the Python executor, so the **full set is correct** — the editor and the button check were the bugs.

## How

- New exported `RUNNABLE_LANGUAGES` / `RUNNABLE_LANGUAGE_SET` in `shared/compute/fences.ts` (the fence-detection module already shared by main + renderer).
- All five consumers now import it — no more local copies.
- **Drift guard:** a new `registry.test.ts` case registers the real builtin executors and asserts `registeredLanguages()` equals the shared list, so the renderer's affordances can't diverge from what the backend can actually run.

Net effect: `py` / `python3` fences now get the editor gutter ▶, the keyboard shortcut, the Recompute-all button, and Save-as-note source detection — matching the preview, which already handled them.

## Tests

`pnpm lint` clean; full suite (3778, +1 drift guard) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)