### PR TITLE
feat: in-app auto-update via update.electronjs.org (#662)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "node": ">=24"
   },
   "description": "Minerva — an integrated knowledge management environment",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dgriffith/ide-for-thought.git"
+  },
   "main": ".vite/build/main.js",
   "scripts": {
     "prepare": "git config core.hooksPath .githooks || true",
@@ -66,6 +70,7 @@
     "tslib": "^2.8.1",
     "turndown": "^7.2.4",
     "unpdf": "^1.6.2",
+    "update-electron-app": "^3.3.0",
     "vega-embed": "^7.1.0",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       unpdf:
         specifier: ^1.6.2
         version: 1.6.2(@napi-rs/canvas@0.1.99)
+      update-electron-app:
+        specifier: ^3.3.0
+        version: 3.3.0
       vega-embed:
         specifier: ^7.1.0
         version: 7.1.0(vega-lite@6.4.3(vega@6.2.0))(vega@6.2.0)
@@ -4279,6 +4282,9 @@ packages:
   git-url-parse@5.0.1:
     resolution: {integrity: sha512-4uSiOgrryNEMBX+gTWogenYRUh2j1D+95STTSEF2RCTgLkfJikl8c7BGr0Bn274hwuxTsbS2/FQ5pVS9FoXegQ==}
 
+  github-url-to-object@4.0.6:
+    resolution: {integrity: sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -6210,6 +6216,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  update-electron-app@3.3.0:
+    resolution: {integrity: sha512-5s73OcyNhAvogjxzAy8pbephY+bP6aXpXFv68OT1dNiEbcUpIUCv/ZZPalqGclnXUgx3oyn+yVdAIIVUpn/C1g==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -13012,6 +13021,10 @@ snapshots:
     dependencies:
       git-up: 1.2.1
 
+  github-url-to-object@4.0.6:
+    dependencies:
+      is-url: 1.2.4
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -15144,6 +15157,11 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  update-electron-app@3.3.0:
+    dependencies:
+      github-url-to-object: 4.0.6
+      ms: 2.1.3
 
   uri-js@4.4.1:
     dependencies:

--- a/src/main/auto-update.ts
+++ b/src/main/auto-update.ts
@@ -1,0 +1,39 @@
+/**
+ * In-app auto-update (#662).
+ *
+ * The repo is public and the app is signed (#959), so we use the hosted
+ * Squirrel.Mac feed at update.electronjs.org via `update-electron-app`
+ * rather than a self-hosted server or electron-updater (which would mismatch
+ * a forge project). It reads the target repo from package.json's `repository`
+ * field, polls the feed, downloads a newer *published* release's `.zip` via
+ * Squirrel.Mac, and prompts the user to restart.
+ *
+ * `update.electronjs.org` only serves **published** (non-draft) releases, so
+ * auto-update begins the moment a drafted release is published (see the
+ * release runbook, #960). End-to-end apply is verified across two real
+ * releases in #961.
+ */
+
+import { app } from 'electron';
+import { updateElectronApp } from 'update-electron-app';
+
+/**
+ * Wire up the hosted updater. Inert unless the app is packaged: an
+ * `electron-forge start` dev run has no code signature and nothing to update
+ * to, so we skip setup entirely — no polling, no dialogs, no errors. Any
+ * config/runtime error (e.g. a missing `repository` field) is swallowed with
+ * a warning: a broken updater must never crash the user's app on launch.
+ */
+export function initAutoUpdate(): void {
+  if (!app.isPackaged) return;
+  try {
+    updateElectronApp({
+      // Default updateSource is update.electronjs.org; the repo is inferred
+      // from package.json `repository`. Hourly is gentle but still same-day.
+      updateInterval: '1 hour',
+      logger: console,
+    });
+  } catch (err) {
+    console.warn('[auto-update] setup failed; continuing without updates:', err);
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
 import { stopClipperServer } from './clipper/lifecycle';
 import { registerSkillsAtStartup } from './skills/register';
+import { initAutoUpdate } from './auto-update';
 
 app.setName('Minerva');
 
@@ -46,6 +47,11 @@ void app.whenReady().then(async () => {
   boot('executors registered');
   registerBuiltinExporters();
   boot('exporters registered');
+
+  // In-app auto-update via the hosted update.electronjs.org feed (#662).
+  // No-ops in dev (unpackaged); only a signed packaged build polls + applies.
+  initAutoUpdate();
+  boot('auto-update initialized');
 
   // Load + register skill files (#625) before any menu is built, so the
   // dynamic Learning/Analysis menus include them on first paint. Failure to

--- a/tests/main/auto-update.test.ts
+++ b/tests/main/auto-update.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Auto-update wiring (#662).
+ *
+ * The one invariant worth pinning without two real releases: the updater is
+ * inert in dev (`!app.isPackaged`) — no polling, no dialogs — and it never
+ * crashes launch, even if `update-electron-app` throws during setup. We mock
+ * both `electron` and `update-electron-app` and assert the gating.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  isPackaged: false,
+  updateElectronApp: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() { return h.isPackaged; },
+  },
+}));
+
+vi.mock('update-electron-app', () => ({
+  updateElectronApp: h.updateElectronApp,
+}));
+
+import { initAutoUpdate } from '../../src/main/auto-update';
+
+beforeEach(() => {
+  h.isPackaged = false;
+  h.updateElectronApp.mockReset();
+});
+
+describe('initAutoUpdate', () => {
+  it('does nothing when the app is not packaged (dev)', () => {
+    h.isPackaged = false;
+    initAutoUpdate();
+    expect(h.updateElectronApp).not.toHaveBeenCalled();
+  });
+
+  it('wires the hosted updater when the app is packaged', () => {
+    h.isPackaged = true;
+    initAutoUpdate();
+    expect(h.updateElectronApp).toHaveBeenCalledTimes(1);
+    // Default source (update.electronjs.org) + an update interval configured.
+    const opts = h.updateElectronApp.mock.calls[0][0];
+    expect(opts).toMatchObject({ updateInterval: expect.any(String) });
+  });
+
+  it('swallows a setup failure so a broken updater cannot crash launch', () => {
+    h.isPackaged = true;
+    h.updateElectronApp.mockImplementation(() => {
+      throw new Error('bad repository field');
+    });
+    expect(() => initAutoUpdate()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #662. Part of the packaging epic #958.

## Approach

The repo is public and — with #959 — the CI build is signed, so this uses the **hosted Squirrel.Mac feed** at `update.electronjs.org` through [`update-electron-app`](https://github.com/electron/update-electron-app), the low-effort idiomatic path for a forge project. No self-hosted feed, no `latest-mac.yml`, no electron-updater.

## What changed

- Add the `update-electron-app` dependency.
- **`src/main/auto-update.ts`** — `initAutoUpdate()` wires the hosted updater, **gated to `app.isPackaged`** so dev runs (`electron-forge start`) stay completely inert: no polling, no dialogs, no errors. Setup errors are caught and logged — a broken updater must never crash the user's app on launch.
- Call it from `main.ts` startup (with a boot trace).
- Add the **`repository`** field to `package.json` so `update-electron-app` can infer the GitHub repo for the feed.

## How it behaves

A packaged, signed build polls the feed hourly; when a newer **published** release exists, Squirrel.Mac downloads its `.zip` and the app offers to restart. `update.electronjs.org` ignores drafts, so auto-update activates the moment the first release is published (see the runbook, #960).

## Tests

`tests/main/auto-update.test.ts` pins the gating (mocking `electron` + `update-electron-app`):
- inert when unpackaged (updater never called)
- wired when packaged
- a setup throw doesn't propagate (launch survives a misconfig)

`pnpm lint` clean; full suite (3781, +3) passes.

## Not covered here

End-to-end apply needs two real published releases — that's #961, inherently a post-merge verification. This PR is the app-side wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)