### PR TITLE
docs: release runbook + tag-safety helper (#960)

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -27,20 +27,20 @@ open out/Minerva-darwin-arm64/Minerva.app          # first launch
 
 ### 1. Gatekeeper (macOS)
 
-The build is **not code-signed or notarized** — there's no `osxSign` /
-`osxNotarize` block in `forge.config.ts`. First launch will throw:
+**Release builds from CI are signed + notarized** (`osxSign` / `osxNotarize`
+in `forge.config.ts`, wired into `release.yml` — #841/#959), so a DMG from a
+published Release opens without a Gatekeeper prompt.
+
+A **local** `pnpm build` is only signed if you have a Developer ID cert in your
+keychain and the notarization env vars set; otherwise it takes the unsigned
+path and first launch will throw:
 
 > "Minerva" cannot be opened because the developer cannot be verified.
 
-**Workaround:** right-click the `.app` → **Open** → confirm in the
-dialog. Subsequent launches don't prompt. If you'll be running on a
-borrowed or unfamiliar machine, do this once during setup, not in
-front of an audience.
+**Workaround for an unsigned local build:** right-click the `.app` → **Open** →
+confirm in the dialog. Subsequent launches don't prompt.
 
-**Fix (future):** add `osxSign` + `osxNotarize` to `packagerConfig` in
-`forge.config.ts`. Needs an Apple Developer ID certificate and
-notarytool credentials. See
-[electron-forge docs](https://www.electronforge.io/guides/code-signing/code-signing-macos).
+To cut a real signed release, follow [`releasing.md`](./releasing.md).
 
 ### 2. Python interpreter resolution
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,127 @@
+# Releasing Minerva
+
+The repeatable loop for cutting a signed, auto-updating macOS release. This
+ties together the two moving parts:
+
+- **Signed CI build** (`.github/workflows/release.yml`, #959) — a pushed
+  `vX.Y.Z` tag builds a signed + notarized + stapled DMG/ZIP and cuts a
+  **draft** GitHub Release.
+- **In-app auto-update** (`src/main/auto-update.ts`, #662) — a shipped app
+  polls `update.electronjs.org`, which serves **published** GitHub Releases
+  and offers the newer build to users.
+
+> **The load-bearing step is _Publish_.** `update.electronjs.org` ignores
+> draft releases, so nothing reaches users until you publish. Everything
+> before that is safe to redo.
+
+For what "signed" requires and the one-time secret setup, see
+[`packaging.md`](./packaging.md). This doc is the per-release checklist.
+
+---
+
+## Prerequisites (one-time)
+
+- The five Apple signing secrets are configured in the repo
+  (Settings → Secrets and variables → Actions) — listed in the header of
+  `release.yml`. Without them the CI build still succeeds but is **unsigned**,
+  and an unsigned build can't be auto-updated (Squirrel.Mac rejects it).
+- You're releasing **Apple Silicon (arm64)** only for now — the CI runner is
+  arm64 and the DuckDB native binding is per-arch. Intel/universal is deferred
+  (#962).
+
+---
+
+## The loop
+
+### 1. Bump the version
+
+`package.json` `version` is the single source of truth: it names the DMG and
+it's what the running app compares against the feed. Bump it with semver, one
+bump per release.
+
+This lands **via PR** like any other change (don't commit straight to `main`):
+
+```bash
+git checkout main && git pull
+git checkout -b release/vX.Y.Z
+# edit package.json "version" -> X.Y.Z
+git commit -am "release: vX.Y.Z"
+# open PR, get it merged
+```
+
+### 2. Tag the merged commit
+
+Once the bump is on `main`, create the matching tag. The helper enforces that
+the tag equals `package.json`'s version (a mismatch means the updater never
+offers the build), that you're on a clean `main`, and that the tag is new:
+
+```bash
+git checkout main && git pull
+pnpm release:tag        # creates the vX.Y.Z tag locally, prints the push cmd
+git push origin vX.Y.Z  # this is what triggers CI
+```
+
+### 3. CI builds the signed draft
+
+The tag push runs `release.yml`:
+
+- imports the Developer ID cert, builds signed + notarized + stapled artifacts,
+- uploads them, and
+- cuts a **draft** GitHub Release with auto-generated notes
+  (`generate_release_notes: true`).
+
+Watch it under **Actions**; a green run leaves a draft under **Releases**.
+
+### 4. Review the draft
+
+- Confirm the assets are attached: a `.dmg` and a `.zip`
+  (**the `.zip` is the one auto-update consumes** — don't remove it).
+- Sanity-check the signature on the DMG before shipping:
+
+  ```bash
+  spctl -a -t open --context context:primary-signature Minerva-*.dmg   # → accepted
+  codesign -dv --verbose=4 /Volumes/Minerva*/Minerva.app 2>&1 | grep Authority
+  ```
+
+- Edit the auto-generated notes if you want a curated summary at the top
+  (the generated commit list is fine as the tail).
+
+### 5. Publish
+
+Hit **Publish release**. This is the moment auto-update turns on for this
+version: within the next poll interval, already-installed apps see it and
+offer to update.
+
+---
+
+## Rollout timing & verification
+
+- Installed apps poll hourly (`updateInterval` in `auto-update.ts`) and on
+  launch. Expect update prompts to trickle out, not appear instantly.
+- The **first** published release has nothing to update *from* — auto-update is
+  only exercised once a **second** release is published and an older build
+  picks it up. That end-to-end apply is the acceptance check in #961.
+
+## Release notes
+
+`generate_release_notes: true` gives a PR/commit-derived changelog per release,
+which is enough for now — no separate hand-maintained `CHANGELOG.md`. Curate the
+draft's top section by hand when a release deserves a narrative.
+
+## If something's wrong
+
+- **Bad draft** — just delete the draft Release and (if needed) the tag
+  (`git push origin :vX.Y.Z`), fix, and re-tag. Nothing reached users.
+- **Published a bad build** — publish a follow-up patch release; auto-update
+  rolls users forward. There's no "unpublish that un-ships it" — forward is the
+  only direction, so the review in step 4 is where you catch problems.
+
+## Files involved
+
+| File | Role |
+|------|------|
+| `package.json` `version` | Source of truth for DMG name + update comparison |
+| `scripts/tag-release.mjs` (`pnpm release:tag`) | Guards version↔tag agreement |
+| `.github/workflows/release.yml` | Tag → signed build → draft Release |
+| `forge.config.ts` | Signing/notarization config (reads Apple env) |
+| `src/main/auto-update.ts` | In-app updater against update.electronjs.org |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "electron-forge start",
     "build": "electron-forge make",
     "package": "electron-forge package",
+    "release:tag": "node scripts/tag-release.mjs",
     "lint": "tsc --noEmit && svelte-check --threshold error && eslint .",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",

--- a/scripts/tag-release.mjs
+++ b/scripts/tag-release.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Create the git tag that matches package.json's `version` — the one manual
+ * release step that's easy to fat-finger. The tag (`vX.Y.Z`) must equal the
+ * packaged `version`, because release.yml keys the build off the tag while
+ * update.electronjs.org compares the running app's `version` to the release.
+ * A mismatch means the updater never offers the "new" build.
+ *
+ * This only creates the tag locally and prints the push command — pushing is
+ * the outward-facing step, left to a human. See docs/releasing.md.
+ *
+ *   node scripts/tag-release.mjs        # tag the current package.json version
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const git = (args) => execSync(`git ${args}`, { cwd: root }).toString().trim();
+
+const { version } = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+const tag = `v${version}`;
+
+function fail(msg) {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
+  fail(`package.json version "${version}" isn't semver — bump it first.`);
+}
+
+const branch = git('rev-parse --abbrev-ref HEAD');
+if (branch !== 'main') {
+  fail(`on branch "${branch}", not main. Release tags come off merged main.`);
+}
+
+if (git('status --porcelain')) {
+  fail('working tree is dirty. Commit or stash before tagging a release.');
+}
+
+const existing = git('tag --list').split('\n');
+if (existing.includes(tag)) {
+  fail(`tag ${tag} already exists. Bump the version in package.json first.`);
+}
+
+git(`tag -a ${tag} -m "Release ${tag}"`);
+console.log(`✓ Created tag ${tag} at ${git('rev-parse --short HEAD')}`);
+console.log(`\nNext: push it to trigger the signed build + draft release:\n`);
+console.log(`  git push origin ${tag}\n`);


### PR DESCRIPTION
Closes #960. The third piece of the packaging epic #958 — documents the "cut a release" loop that ties #959 (signed build) and #662 (auto-update) together.

## What's here

- **`docs/releasing.md`** — the per-release checklist: version bump (via PR, per our workflow), tag, CI signed draft, review, **publish**. Calls out the two things that bite people:
  - **Publish is load-bearing** — `update.electronjs.org` ignores draft releases, so nothing reaches users until you publish.
  - The **first** release has nothing to update *from*; end-to-end auto-update is only exercised once a second release ships (#961).
- **`scripts/tag-release.mjs`** (`pnpm release:tag`) — creates the `vX.Y.Z` tag matching `package.json`'s version. The version↔tag agreement is the easy-to-fat-finger step (a mismatch means the updater never offers the build), so the helper guards it: refuses off-`main`, dirty tree, or an existing tag, and **prints the push command rather than pushing** (the outward step stays human-driven).
- **`docs/packaging.md`** — corrected the stale "not code-signed or notarized" Gatekeeper note (release builds are signed now) and cross-linked the runbook.

## Verification

- `pnpm release:tag` runs and its guards fire (refuses on a non-`main` branch).
- `pnpm lint` clean.

Docs + a guarded local helper only — no app-code or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)