### PR TITLE
feat: Check for Updates menu item + quiet update UX (#963)

### DIFF
--- a/src/main/auto-update.ts
+++ b/src/main/auto-update.ts
@@ -1,12 +1,18 @@
 /**
- * In-app auto-update (#662).
+ * In-app auto-update (#662) + update UX (#963).
  *
  * The repo is public and the app is signed (#959), so we use the hosted
  * Squirrel.Mac feed at update.electronjs.org via `update-electron-app`
  * rather than a self-hosted server or electron-updater (which would mismatch
  * a forge project). It reads the target repo from package.json's `repository`
- * field, polls the feed, downloads a newer *published* release's `.zip` via
- * Squirrel.Mac, and prompts the user to restart.
+ * field, polls the feed, and downloads a newer *published* release's `.zip`.
+ *
+ * We pass `notifyUser: false` and own the UX ourselves (#963): rather than the
+ * library's modal "restart now?" the moment a download finishes — which would
+ * hijack the user mid-task — a background-downloaded update surfaces quietly (a
+ * native notification + a "Restart to Install Update" menu item). A user-
+ * initiated **Check for Updates…** is allowed to be chatty (dialogs), since the
+ * user asked and is waiting on the answer.
  *
  * `update.electronjs.org` only serves **published** (non-draft) releases, so
  * auto-update begins the moment a drafted release is published (see the
@@ -14,8 +20,43 @@
  * releases in #961.
  */
 
-import { app } from 'electron';
+import { app, autoUpdater, dialog, Notification } from 'electron';
 import { updateElectronApp } from 'update-electron-app';
+
+export type UpdateState =
+  | 'idle'
+  | 'checking'
+  | 'downloading' // update-available → Squirrel.Mac downloads automatically
+  | 'downloaded'
+  | 'up-to-date'
+  | 'error';
+
+let state: UpdateState = 'idle';
+let downloadedVersion: string | null = null;
+// True while a check was kicked off by the user (menu item), so the terminal
+// event reports back with a dialog instead of surfacing quietly.
+let manualCheck = false;
+let wired = false;
+let onStateChange: (() => void) | null = null;
+
+/** Register a callback fired whenever the update state changes (e.g. to
+ *  rebuild the menu so the "Restart to Install Update" item appears). */
+export function setUpdateStateListener(fn: () => void): void {
+  onStateChange = fn;
+}
+
+export function getUpdateState(): UpdateState {
+  return state;
+}
+
+export function isUpdateDownloaded(): boolean {
+  return state === 'downloaded';
+}
+
+function setState(next: UpdateState): void {
+  state = next;
+  onStateChange?.();
+}
 
 /**
  * Wire up the hosted updater. Inert unless the app is packaged: an
@@ -27,13 +68,141 @@ import { updateElectronApp } from 'update-electron-app';
 export function initAutoUpdate(): void {
   if (!app.isPackaged) return;
   try {
+    wireEvents();
     updateElectronApp({
       // Default updateSource is update.electronjs.org; the repo is inferred
       // from package.json `repository`. Hourly is gentle but still same-day.
       updateInterval: '1 hour',
+      notifyUser: false, // we own the update UX (#963)
       logger: console,
     });
   } catch (err) {
     console.warn('[auto-update] setup failed; continuing without updates:', err);
   }
+}
+
+/** Attach our listeners to the shared Electron autoUpdater. `update-electron-app`
+ *  drives the same singleton, so these coexist with its polling. */
+function wireEvents(): void {
+  if (wired) return;
+  wired = true;
+
+  autoUpdater.on('checking-for-update', () => setState('checking'));
+
+  autoUpdater.on('update-available', () => {
+    setState('downloading');
+    if (manualCheck) {
+      manualCheck = false;
+      void infoDialog(
+        'Update available',
+        'A new version is downloading in the background. You’ll be notified when it’s ready to install.',
+      );
+    }
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    setState('up-to-date');
+    if (manualCheck) {
+      manualCheck = false;
+      void infoDialog('You’re up to date', `Minerva ${app.getVersion()} is the latest version.`);
+    }
+  });
+
+  autoUpdater.on('update-downloaded', (_event, _notes, releaseName?: string) => {
+    downloadedVersion = releaseName ?? null;
+    const wasManual = manualCheck;
+    manualCheck = false;
+    setState('downloaded');
+    // User is waiting on a manual check → offer the restart now. Otherwise stay
+    // out of the way: a native notification + the menu item carry it.
+    if (wasManual) promptRestart();
+    else notifyReady();
+  });
+
+  autoUpdater.on('error', (err) => {
+    console.warn('[auto-update] error:', err);
+    setState('error');
+    if (manualCheck) {
+      manualCheck = false;
+      void infoDialog(
+        'Update check failed',
+        'Could not check for updates right now. Please try again later.',
+      );
+    }
+  });
+}
+
+/**
+ * On-demand check from the "Check for Updates…" menu item. Reports the result
+ * to the user (up-to-date / downloading / ready), since they explicitly asked.
+ */
+export function checkForUpdatesNow(): void {
+  if (!app.isPackaged) {
+    void infoDialog(
+      'Updates unavailable',
+      'Automatic updates are only available in packaged, signed builds — not in development.',
+    );
+    return;
+  }
+  // Already have a build staged — just offer to install it rather than re-check.
+  if (state === 'downloaded') {
+    promptRestart();
+    return;
+  }
+  try {
+    manualCheck = true;
+    setState('checking');
+    autoUpdater.checkForUpdates();
+  } catch (err) {
+    manualCheck = false;
+    console.warn('[auto-update] manual check failed:', err);
+    void infoDialog('Update check failed', 'Could not check for updates right now.');
+  }
+}
+
+/** Confirm, then quit + install the downloaded update. Invoked by the menu
+ *  item, the notification click, or a manual check that found a staged build. */
+export function quitAndInstallUpdate(): void {
+  promptRestart();
+}
+
+function promptRestart(): void {
+  const label = downloadedVersion ? `Minerva ${downloadedVersion}` : 'A new version of Minerva';
+  const choice = dialog.showMessageBoxSync({
+    type: 'info',
+    buttons: ['Restart Now', 'Later'],
+    defaultId: 0,
+    cancelId: 1,
+    title: 'Install update',
+    message: `${label} is ready to install.`,
+    detail: 'Minerva will restart to finish updating. Your work is saved when the window closes.',
+  });
+  if (choice === 0) {
+    // Triggers app quit → our before-quit flush (main.ts) → Squirrel swaps the
+    // bundle and relaunches.
+    autoUpdater.quitAndInstall();
+  }
+}
+
+/** Unobtrusive, dismissable "update ready" surface for a background download. */
+function notifyReady(): void {
+  if (!Notification.isSupported()) return;
+  const body = downloadedVersion
+    ? `Minerva ${downloadedVersion} has been downloaded. Restart to install.`
+    : 'A new version has been downloaded. Restart to install.';
+  const notice = new Notification({ title: 'Update ready', body });
+  notice.on('click', () => promptRestart());
+  notice.show();
+}
+
+function infoDialog(message: string, detail: string): Promise<unknown> {
+  return dialog.showMessageBox({ type: 'info', message, detail, buttons: ['OK'] });
+}
+
+/** Reset transient state between tests. Leaves the (idempotent) autoUpdater
+ *  listeners in place so re-init doesn't double-wire them. */
+export function _resetUpdateStateForTest(): void {
+  state = 'idle';
+  downloadedVersion = null;
+  manualCheck = false;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { registerIpcHandlers } from './ipc';
-import { buildMenu } from './menu';
+import { buildMenu, rebuildMenu } from './menu';
 import { createWindow, openProjectInWindow } from './window-manager';
 import { appIconPath } from './app-icon';
 import { loadSession } from './session';
@@ -14,7 +14,7 @@ import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
 import { stopClipperServer } from './clipper/lifecycle';
 import { registerSkillsAtStartup } from './skills/register';
-import { initAutoUpdate } from './auto-update';
+import { initAutoUpdate, setUpdateStateListener } from './auto-update';
 
 app.setName('Minerva');
 
@@ -50,6 +50,9 @@ void app.whenReady().then(async () => {
 
   // In-app auto-update via the hosted update.electronjs.org feed (#662).
   // No-ops in dev (unpackaged); only a signed packaged build polls + applies.
+  // Rebuild the menu on state changes so the "Restart to Install Update" item
+  // appears once a build is staged (#963).
+  setUpdateStateListener(() => rebuildMenu());
   initAutoUpdate();
   boot('auto-update initialized');
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -15,6 +15,12 @@ import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
 import { groupToolsByGroup, hasNamedGroups } from '../shared/tools/grouping';
 import { isSourceScoped } from '../shared/tools/types';
+import {
+  checkForUpdatesNow,
+  isUpdateDownloaded,
+  quitAndInstallUpdate,
+  getUpdateState,
+} from './auto-update';
 
 function send(channel: string, ...args: unknown[]) {
   const win = BrowserWindow.getFocusedWindow();
@@ -74,6 +80,17 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
             label: 'Minerva',
             submenu: [
               { label: 'About Minerva', click: () => send(Channels.MENU_ABOUT) },
+              { type: 'separator' as const },
+              {
+                // "Checking\u2026" (disabled) while a check is in flight (#963).
+                label: getUpdateState() === 'checking' ? 'Checking for Updates\u2026' : 'Check for Updates\u2026',
+                enabled: getUpdateState() !== 'checking',
+                click: () => checkForUpdatesNow(),
+              },
+              // Only present once a build is staged; installs on confirm+restart.
+              ...(isUpdateDownloaded()
+                ? [{ label: 'Restart to Install Update', click: () => quitAndInstallUpdate() }]
+                : []),
               { type: 'separator' as const },
               {
                 label: 'Preferences\u2026',

--- a/tests/main/auto-update.test.ts
+++ b/tests/main/auto-update.test.ts
@@ -1,34 +1,82 @@
 /**
- * Auto-update wiring (#662).
+ * Auto-update wiring (#662) + update UX (#963).
  *
- * The one invariant worth pinning without two real releases: the updater is
- * inert in dev (`!app.isPackaged`) — no polling, no dialogs — and it never
- * crashes launch, even if `update-electron-app` throws during setup. We mock
- * both `electron` and `update-electron-app` and assert the gating.
+ * We can't exercise a real Squirrel.Mac apply without two published releases
+ * (#961), but we can pin the behaviour that matters: inert in dev, wired when
+ * packaged, a manual check that reports its result, and a background download
+ * that surfaces quietly (notification) rather than hijacking with a modal.
+ * `electron` and `update-electron-app` are mocked; the fake `autoUpdater` is a
+ * tiny emitter we drive to simulate feed events.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const h = vi.hoisted(() => ({
-  isPackaged: false,
-  updateElectronApp: vi.fn(),
-}));
+const h = vi.hoisted(() => {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const autoUpdater = {
+    on: (evt: string, cb: (...args: unknown[]) => void) => {
+      (listeners[evt] ??= []).push(cb);
+    },
+    emit: (evt: string, ...args: unknown[]) => {
+      (listeners[evt] ?? []).forEach((cb) => cb(...args));
+    },
+    checkForUpdates: vi.fn(),
+    quitAndInstall: vi.fn(),
+  };
+  return {
+    isPackaged: false,
+    updateElectronApp: vi.fn(),
+    autoUpdater,
+    showMessageBox: vi.fn(() => Promise.resolve({ response: 0 })),
+    showMessageBoxSync: vi.fn(() => 1), // default: 'Later'
+    notificationShow: vi.fn(),
+    notificationSupported: true,
+  };
+});
 
-vi.mock('electron', () => ({
-  app: {
-    get isPackaged() { return h.isPackaged; },
-  },
-}));
+vi.mock('electron', () => {
+  class Notification {
+    static isSupported() { return h.notificationSupported; }
+    on() { return this; }
+    show() { h.notificationShow(); }
+  }
+  return {
+    app: {
+      get isPackaged() { return h.isPackaged; },
+      getVersion: () => '1.2.3',
+    },
+    autoUpdater: h.autoUpdater,
+    dialog: {
+      showMessageBox: h.showMessageBox,
+      showMessageBoxSync: h.showMessageBoxSync,
+    },
+    Notification,
+  };
+});
 
-vi.mock('update-electron-app', () => ({
-  updateElectronApp: h.updateElectronApp,
-}));
+vi.mock('update-electron-app', () => ({ updateElectronApp: h.updateElectronApp }));
 
-import { initAutoUpdate } from '../../src/main/auto-update';
+import {
+  initAutoUpdate,
+  checkForUpdatesNow,
+  getUpdateState,
+  isUpdateDownloaded,
+  quitAndInstallUpdate,
+  setUpdateStateListener,
+  _resetUpdateStateForTest,
+} from '../../src/main/auto-update';
 
 beforeEach(() => {
   h.isPackaged = false;
   h.updateElectronApp.mockReset();
+  h.autoUpdater.checkForUpdates.mockReset();
+  h.autoUpdater.quitAndInstall.mockReset();
+  h.showMessageBox.mockClear();
+  h.showMessageBoxSync.mockReset().mockReturnValue(1);
+  h.notificationShow.mockReset();
+  h.notificationSupported = true;
+  setUpdateStateListener(() => {});
+  _resetUpdateStateForTest();
 });
 
 describe('initAutoUpdate', () => {
@@ -38,20 +86,99 @@ describe('initAutoUpdate', () => {
     expect(h.updateElectronApp).not.toHaveBeenCalled();
   });
 
-  it('wires the hosted updater when the app is packaged', () => {
+  it('wires the hosted updater with notifyUser:false when packaged', () => {
     h.isPackaged = true;
     initAutoUpdate();
     expect(h.updateElectronApp).toHaveBeenCalledTimes(1);
-    // Default source (update.electronjs.org) + an update interval configured.
-    const opts = h.updateElectronApp.mock.calls[0][0];
-    expect(opts).toMatchObject({ updateInterval: expect.any(String) });
+    expect(h.updateElectronApp.mock.calls[0][0]).toMatchObject({
+      updateInterval: expect.any(String),
+      notifyUser: false,
+    });
   });
 
   it('swallows a setup failure so a broken updater cannot crash launch', () => {
     h.isPackaged = true;
-    h.updateElectronApp.mockImplementation(() => {
-      throw new Error('bad repository field');
-    });
+    h.updateElectronApp.mockImplementation(() => { throw new Error('bad repository'); });
     expect(() => initAutoUpdate()).not.toThrow();
+  });
+});
+
+describe('feed events', () => {
+  beforeEach(() => {
+    h.isPackaged = true;
+    initAutoUpdate(); // attach listeners (idempotent)
+    _resetUpdateStateForTest();
+  });
+
+  it('tracks state and notifies the listener on each transition', () => {
+    const seen: string[] = [];
+    setUpdateStateListener(() => seen.push(getUpdateState()));
+
+    h.autoUpdater.emit('checking-for-update');
+    expect(getUpdateState()).toBe('checking');
+
+    h.autoUpdater.emit('update-available');
+    expect(getUpdateState()).toBe('downloading');
+
+    expect(seen).toEqual(['checking', 'downloading']);
+  });
+
+  it('a background download surfaces via notification, not a modal', () => {
+    h.autoUpdater.emit('update-downloaded', {}, 'notes', 'v1.3.0');
+    expect(getUpdateState()).toBe('downloaded');
+    expect(isUpdateDownloaded()).toBe(true);
+    expect(h.notificationShow).toHaveBeenCalledTimes(1);
+    expect(h.showMessageBoxSync).not.toHaveBeenCalled(); // no hijacking modal
+  });
+});
+
+describe('checkForUpdatesNow', () => {
+  it('in dev, reports unavailable and never touches the updater', () => {
+    h.isPackaged = false;
+    checkForUpdatesNow();
+    expect(h.showMessageBox).toHaveBeenCalledTimes(1);
+    expect(h.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('packaged, triggers a check and reports "up to date" when none is found', () => {
+    h.isPackaged = true;
+    initAutoUpdate();
+    _resetUpdateStateForTest();
+
+    checkForUpdatesNow();
+    expect(getUpdateState()).toBe('checking');
+    expect(h.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    // A user-initiated check DOES report its result (dialog), unlike background.
+    h.autoUpdater.emit('update-not-available');
+    expect(getUpdateState()).toBe('up-to-date');
+    expect(h.showMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers restart immediately when a build is already staged', () => {
+    h.isPackaged = true;
+    initAutoUpdate();
+    _resetUpdateStateForTest();
+    h.autoUpdater.emit('update-downloaded', {}, 'notes', 'v1.3.0'); // now 'downloaded'
+    h.showMessageBoxSync.mockReset().mockReturnValue(0); // user clicks 'Restart Now'
+
+    checkForUpdatesNow();
+    expect(h.autoUpdater.checkForUpdates).not.toHaveBeenCalled(); // no re-check
+    expect(h.showMessageBoxSync).toHaveBeenCalledTimes(1);
+    expect(h.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('quitAndInstallUpdate', () => {
+  it('installs when the user confirms the restart', () => {
+    h.showMessageBoxSync.mockReturnValue(0); // 'Restart Now'
+    quitAndInstallUpdate();
+    expect(h.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the user picks Later', () => {
+    h.showMessageBoxSync.mockReturnValue(1); // 'Later'
+    quitAndInstallUpdate();
+    expect(h.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #963. Optional-polish tail of the packaging epic #958, on top of the background updater (#662).

## What & why

`update-electron-app` shows a default "update ready — restart now?" **modal** the instant a background download finishes, which hijacks the user mid-task. This passes `notifyUser: false` and owns the UX:

- **`auto-update.ts`** becomes a small state machine over Electron's `autoUpdater` events (`checking` / `downloading` / `downloaded` / `up-to-date` / `error`), exposing `checkForUpdatesNow()`, `isUpdateDownloaded()`, `quitAndInstallUpdate()`, `getUpdateState()`, and a state-change listener.
- **Background download → quiet surface:** an unobtrusive, dismissable native **Notification** plus a **"Restart to Install Update"** menu item. No modal. (This also makes the issue's optional "suppress while mid-task" moot — nothing interrupts in the first place.)
- **User-initiated "Check for Updates…"** (new item in the Minerva menu) **does** report its result — up-to-date / downloading / ready — because the user asked and is waiting. Shows "Checking…" (disabled) while in flight; in dev it explains updates need a packaged, signed build.
- **`main.ts`** rebuilds the menu on state change so the restart item appears the moment a build is staged.

## Acceptance

- [x] Manual "Check for Updates…" works and reports up-to-date vs downloading.
- [x] Update readiness is surfaced without hijacking the user mid-task (notification + menu item, not a modal).

## Tests

`tests/main/auto-update.test.ts` (mocking `electron` + `update-electron-app`, driving a fake `autoUpdater`): gating (inert in dev), `notifyUser:false`, state transitions + listener firing, **background download surfaces via notification not modal**, manual check reports its result, staged-build offers restart, and restart-only-on-confirm.

`pnpm lint` clean; full suite (3788, +7) passes.

## Scope note

The **arm64 app menu** carries these items (mac-only release for now). Real end-to-end apply still requires two published releases (#961). x64/universal remains deferred (#962).

🤖 Generated with [Claude Code](https://claude.com/claude-code)