### PR TITLE
docs: reframe README to match the features page emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,132 @@
 # Minerva
 
-An integrated knowledge management environment.
+**A desktop workspace for thinking and building with AI.**
 
-Minerva is a desktop application for managing markdown-based knowledge bases. It combines a markdown editor with semantic graph indexing, git integration, and tag-based navigation — designed to be a professional tool that stays out of your way.
+The best thinking you do with an AI vanishes into a scroll of throwaway
+conversations — unsourced, unstructured, impossible to build on. Minerva is
+where that work lands and stays: knowledge you can check, connect, and keep.
+You and the AI build it together — with you fully in control.
+
+Minerva is a local-first desktop app (Electron · Svelte 5 · TypeScript). Your
+notes are plain markdown files on your disk, backed by an automatically
+maintained knowledge graph.
+
+## Thoughtbases
+
+A **thoughtbase** is where your thinking on a subject lives and grows. Instead
+of scattered documents and lost chat threads, you collect what you're working
+through as **notes** — and notes link to each other, so ideas connect the way
+they do in your head. Some you write yourself; some you draft side by side with
+the AI. Over time it becomes a living map of what you know, not a folder of dead
+files.
+
+- **Notes of every kind** — a paragraph, an essay, a data table, a diagram, an
+  image, a math derivation, or a captured web page.
+- **Linked, not filed** — connect any note to any other: cite it, support it,
+  contradict it, build on it.
+- **Yours and the AI's, together** — write by hand, or let the AI draft,
+  summarize, and gather — with you approving what actually lands.
 
 ## Features
 
-- **Markdown editor** — CodeMirror 6 with syntax highlighting, tag autocomplete, and live preview (source, split, or preview modes)
-- **Knowledge graph** — RDF-based semantic graph that indexes notes, tags, wiki-links, and frontmatter metadata. Queryable via SPARQL, exportable as Turtle
-- **Wiki-links** — `[[note]]` and `[[note|display text]]` syntax for linking between notes
-- **Tags** — `#tag` syntax with a tag panel for browsing notes by tag
-- **Git integration** — Built-in version control via isomorphic-git (no system git required)
-- **Multi-window** — Each project opens in its own independent window
-- **File watching** — Automatic sync when files change on disk
+### The editor
+
+A fast CodeMirror 6 surface with live preview. Write plain markdown; get
+rendered blocks without leaving the keyboard.
+
+- **Three view modes** — source, preview, or split, toggled instantly.
+- **Wiki-links & typed links** — `[[note]]` plus 11 semantic link types
+  (supports, rebuts, depends-on, supersedes…), each color-coded.
+- **Rich blocks inline** — callouts, tables, footnotes, highlights, math
+  (KaTeX), and diagrams.
+- **Code sections that run** — Python, SQL, SPARQL, and Vega/Vega-Lite charts
+  render live against your data.
+- **Voice dictation** — on-device speech-to-text with AI-powered expansion.
+
+### The knowledge graph
+
+On every change, Minerva reads the structure out of your writing — titles,
+tags, links, metadata, even data tables — into an RDF **knowledge graph**: a
+precise map of everything you've written and how it connects. That's what lets
+the AI work from your real notes instead of guessing.
+
+- **Grounded, not guessed** — the AI queries your graph to answer from what you
+  actually wrote, and points back to the exact notes it drew on.
+- **Insights surfaced** — trace how a claim is supported, find where notes
+  contradict each other, or spot patterns across hundreds of them.
+- **Built automatically** — titles, `#tags`, wiki-links, metadata, and data
+  tables all fold in on save. No schema wrangling.
+- **Query it yourself** — a built-in panel for direct SQL and SPARQL.
+
+### Data & analysis
+
+- **Python cells** — a `python` code fence turns any note into a notebook, with
+  a `minerva.*` API (`notes()`, `sparql()`, `sql()`, `table()`) handing you your
+  own library as data; output renders inline.
+- **CSV → SQL tables** — any `.csv` becomes a typed DuckDB table you can query
+  and bind straight into charts.
+- **Analysis skills** — generate visualizations, find outliers, and find
+  correlations, each returned as a note you review.
+
+### Tools for Thought — skills
+
+Nearly 50 **skills**: structured thinking operations you invoke from the
+Learning, Research, and Analysis menus — *Explain Like I'm…*, *Check Facts*,
+*Extract Key Claims*, *Steelman*, *Double Crux*, *Murphyjitsu*, and many more.
+Each runs a careful prompt over your note and returns something you review.
+Author your own in a markdown file; it shows up in the menus alongside the
+built-ins.
+
+### The AI proposes. You confirm.
+
+Nothing an AI generates touches your thoughtbase directly. Every suggested
+claim, edit, tag, or source arrives as a **proposal** you review side by side
+and accept with a keystroke — or reject.
+
+- **Review before it counts** — see exactly what would change, before it does.
+- **You set the line** — new claims require your sign-off; trivial tags can
+  apply quietly. Tune what needs approval.
+- **Full provenance** — everything the AI touches records what proposed it, and
+  when.
+- **Guaranteed, not promised** — a built-in integrity check can prove nothing
+  the AI created ever skipped your approval.
+
+### Structured reasoning
+
+Under the hood, Minerva models the *shape* of an argument, not just its text.
+Its thought ontology captures claims, the grounds and warrants behind them,
+questions and hypotheses, and the ways reasoning goes wrong (fallacies, biases,
+rhetorical moves) — with anchored excerpts and W3C PROV-O provenance throughout,
+all queryable.
+
+### Sources & the web clipper
+
+- **Minerva Clipper** — one-click browser capture of the rendered page and a
+  canonical source ID, even behind a login.
+- **Import anything** — PDFs (with OCR), DOI / ISBN / arXiv IDs, BibTeX, and
+  Zotero RDF.
+- **Real metadata & a source viewer** — read a source inline, anchor excerpts,
+  and see every note that cites it.
+- **Citations** — CSL styles (APA, Chicago, MLA…) and BibTeX export.
+
+### Foundations
+
+- **Local & private** — plain files on your disk; voice, embeddings, and search
+  all run on-device.
+- **Semantic + full-text search** — on-device embeddings find notes by meaning,
+  not just keywords.
+- **Live file sync** — edit notes anywhere; Minerva re-indexes the moment
+  changes hit disk.
+- **Keyboard-first** — every major action has a shortcut. A professional tool
+  that stays out of your way.
+- **Themes & layout** — dark, light, and high-contrast themes; split panes and
+  multiple windows.
+
+### Export & publish
+
+No lock-in — export a single note or a whole folder tree to Markdown, HTML, PDF,
+a browsable static site, Anki decks (`.apkg`), BibTeX, Pandoc (DOCX / EPUB / …),
+or RDF/Turtle.
 
 ## Tech Stack
 
@@ -22,7 +136,9 @@ Minerva is a desktop application for managing markdown-based knowledge bases. It
 - **CodeMirror 6** — Editor
 - **markdown-it** — Rendering
 - **rdflib** — Knowledge graph
-- **isomorphic-git** — Version control
+- **DuckDB** — In-note SQL over CSV tables
+- **onnxruntime-web** — On-device embeddings for semantic search
+- **isomorphic-git** — Version control (no system git required)
 - **Vite + electron-forge** — Build tooling
 
 ## Development
@@ -40,12 +156,15 @@ pnpm lint
 # Run tests
 pnpm test
 
-# Package the appOn
+# Package the app
 pnpm package
 
 # Build distributable
 pnpm build
 ```
+
+Cutting a release (signing, tagging, publishing, auto-update) is documented in
+[`docs/releasing.md`](docs/releasing.md).
 
 ## Project Structure
 
@@ -54,7 +173,9 @@ src/
 ├── main/           # Electron main process
 │   ├── notebase/   # File system operations
 │   ├── graph/      # RDF knowledge graph
-│   └── git/        # Git operations
+│   ├── compute/    # Runnable code cells (Python / SQL / SPARQL)
+│   ├── skills/     # Tools-for-Thought skill files
+│   └── llm/        # Approval engine (the AI proposes, you confirm)
 ├── preload/        # Context-isolated IPC bridge
 ├── renderer/       # Svelte UI
 │   └── lib/


### PR DESCRIPTION
Brings `README.md` into line with the positioning we've built on the `docs/website/features.html` release page.

## Why

The README read like a dry "markdown knowledge management environment" with a flat bullet list — it omitted the entire thesis the features page leads with: a workspace for thinking **with** AI, where throwaway conversations become knowledge you own, and **the AI proposes while you confirm**. Whole pillars were missing: thoughtbases, skills, data analysis, sources/clipper, structured reasoning, export.

## What changed

- **Intro** now leads with the hero framing (thinking + building with AI; knowledge you can check, connect, keep; you're in control).
- **Features** reorganized to mirror the page's sections and emphasis: thoughtbases → editor → knowledge graph → data & analysis → Tools-for-Thought skills → propose-and-confirm trust model → structured reasoning → sources & clipper → foundations → export.
- **Git de-emphasized** to match the page (which omits it entirely while the version-control story is still settling). It stays in the tech stack and dev sections — just not featured.
- **Tech stack**: added DuckDB + onnxruntime-web (they back highlighted features); kept the rest.
- **Project structure**: added `compute/`, `skills/`, `llm/` so the tree reflects the featured capabilities.
- Linked `docs/releasing.md`; fixed the `# Package the appOn` typo.

Kept the developer-facing sections (Development, Project Structure, Keyboard Shortcuts, License) intact — this reframes emphasis without turning the README into a brochure.

## Not included

`docs/website/features.html` itself is left as-is (untracked, your in-progress draft copy) — this PR only touches the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)