### PR TITLE
fix: silence url.parse DEP0169 warning on publish

### DIFF
--- a/src/main/git/publish-git.ts
+++ b/src/main/git/publish-git.ts
@@ -13,7 +13,12 @@
  */
 
 import git from 'isomorphic-git';
-import http from 'isomorphic-git/http/node';
+// The `http/web` transport uses the standard WHATWG `fetch` (built into
+// Electron's Node). We use it instead of `http/node` because the latter pulls
+// in `simple-get`, which calls the deprecated `url.parse()` and prints a
+// DEP0169 warning on every publish. `fetch` handles our auth headers + body
+// the same way (bodies are buffered, so no `duplex` needed).
+import http from 'isomorphic-git/http/web';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';


### PR DESCRIPTION
Publishing printed:

> (node) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead.

## Cause
The `url.parse()` call comes from **`simple-get`** (`index.js:19,55`), which isomorphic-git's **`http/node`** transport depends on. `simple-get@4.0.1` is the latest release and unmaintained — no upstream fix.

## Fix
Switch our publish path (`git/publish-git.ts`) from `isomorphic-git/http/node` to **`isomorphic-git/http/web`**, which uses the standard WHATWG **`fetch`** — built into Electron's Node — so `simple-get` is never loaded and the deprecated call never fires.

Verified `http/web` is compatible for our use:
- Auth (`onAuth` → Basic auth headers) is transport-agnostic.
- It buffers the request body (`collect(body)`), so there's no `duplex: 'half'` requirement that would otherwise break streaming uploads in Node.

## Testing
No behaviour change to the push flow. The clone/push transport can't be `file://`-unit-tested with isomorphic-git (documented in #973), so it's validated against a real remote — the warning should be gone on your next publish. `pnpm lint` clean; publish tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)