### PR TITLE
fix: relative cross-links in markdown-tree exports

### DIFF
--- a/src/main/publish/exporters/markdown.ts
+++ b/src/main/publish/exporters/markdown.ts
@@ -37,7 +37,10 @@ export const markdownExporter: Exporter = {
       .filter((f) => f.kind === 'note')
       .map((f) => ({
         path: f.relativePath,
-        contents: rewriteWikiLinksInContent(f.content, ctx),
+        // fromPath makes cross-links relative to this note's folder: a tree
+        // export mirrors the note folders, so a root-relative href would
+        // double the directory from a nested note.
+        contents: rewriteWikiLinksInContent(f.content, ctx, f.relativePath),
       }));
     const dropped = plan.excluded.length;
     const summary = dropped > 0

--- a/src/main/publish/exporters/tree-markdown.ts
+++ b/src/main/publish/exporters/tree-markdown.ts
@@ -52,8 +52,9 @@ export const treeMarkdownExporter: Exporter = {
       //    or References. The same single-note `note-markdown`
       //    pipeline does this; we share that helper.
       const cleaned = rewriteCitationsAndCleanup(content, renderer, bundlePlan.citations);
-      // 2. Wiki-link rewrite — `[[other]]` → `[Title](other.md)`.
-      content = rewriteWikiLinksInContent(cleaned, ctx);
+      // 2. Wiki-link rewrite — `[[other]]` → `[Title](other.md)`, relative to
+      //    this note's folder so nested-note cross-links don't double the dir.
+      content = rewriteWikiLinksInContent(cleaned, ctx, note.relativePath);
       zip.file(note.relativePath, content);
       if (renderer) {
         for (const id of renderer.cited()) allCitedIds.add(id);

--- a/src/main/publish/link-resolver.ts
+++ b/src/main/publish/link-resolver.ts
@@ -12,6 +12,7 @@
  * decide.
  */
 
+import path from 'node:path';
 import type { ExportPlan, LinkPolicy } from './types';
 
 export interface LinkResolverContext {
@@ -53,6 +54,7 @@ export function resolveWikiLink(
   anchor: string | null,
   display: string | null,
   ctx: LinkResolverContext,
+  fromPath?: string,
 ): string {
   const title = titleFor(target, ctx);
   switch (ctx.linkPolicy) {
@@ -64,7 +66,8 @@ export function resolveWikiLink(
       const asMd = target.endsWith('.md') ? target : `${target}.md`;
       if (ctx.includedPaths.has(asMd)) {
         const label = display ?? title ?? target;
-        const href = anchor ? `${asMd}#${anchor}` : asMd;
+        const rel = relativeTarget(fromPath, asMd);
+        const href = anchor ? `${rel}#${anchor}` : rel;
         return `[${label}](${href})`;
       }
       return title ?? display ?? target;
@@ -73,11 +76,28 @@ export function resolveWikiLink(
 }
 
 /**
+ * A link href relative to the linking note's folder. `fromPath` is the note
+ * being rendered; without it (single-file exports) the target's project-root-
+ * relative path is kept. For directory-tree exports that mirror the note
+ * folders (markdown / tree-markdown), a root-relative href would double the
+ * folder when the linking note itself sits in a subfolder — so relativize.
+ */
+function relativeTarget(fromPath: string | undefined, asMd: string): string {
+  if (!fromPath) return asMd;
+  const rel = path.posix.relative(path.posix.dirname(fromPath), asMd);
+  return rel === '' ? path.posix.basename(asMd) : rel;
+}
+
+/**
  * Rewrite every wiki-link in `content` using the given resolver context.
  * `[[cite::…]]` and `[[quote::…]]` pass through verbatim — those are
  * source references, resolved by a separate mechanism.
  */
-export function rewriteWikiLinksInContent(content: string, ctx: LinkResolverContext): string {
+export function rewriteWikiLinksInContent(
+  content: string,
+  ctx: LinkResolverContext,
+  fromPath?: string,
+): string {
   // [[target]], [[target|display]], [[type::target]], [[type::target|display]]
   // with optional #anchor inside the target. Lazy target/display captures
   // to keep away from nested brackets in link text.
@@ -93,7 +113,7 @@ export function rewriteWikiLinksInContent(content: string, ctx: LinkResolverCont
     const target = hashIdx >= 0 ? untyped.slice(0, hashIdx).trim() : untyped.trim();
     const anchor = hashIdx >= 0 ? untyped.slice(hashIdx + 1).trim() : null;
     if (!target) return full;
-    return resolveWikiLink(target, anchor, display ? display.trim() : null, ctx);
+    return resolveWikiLink(target, anchor, display ? display.trim() : null, ctx, fromPath);
   });
 }
 

--- a/tests/main/publish/link-resolver.test.ts
+++ b/tests/main/publish/link-resolver.test.ts
@@ -84,3 +84,32 @@ describe('rewriteWikiLinksInContent', () => {
     expect(out).toBe('See the old one.');
   });
 });
+
+describe('resolveWikiLink — fromPath relativization (tree exports)', () => {
+  const ctx = buildLinkResolverContext(mkPlan('follow-to-file'));
+
+  it('same-folder link → bare filename (no doubled directory)', () => {
+    expect(resolveWikiLink('notes/foo', null, null, ctx, 'notes/other.md'))
+      .toBe('[Foo Title](foo.md)');
+  });
+
+  it('keeps the anchor when relativizing', () => {
+    expect(resolveWikiLink('notes/foo', 'sec', 'display', ctx, 'notes/other.md'))
+      .toBe('[display](foo.md#sec)');
+  });
+
+  it('climbs with ../ from a deeper folder', () => {
+    expect(resolveWikiLink('notes/foo', null, null, ctx, 'a/b/c.md'))
+      .toBe('[Foo Title](../../notes/foo.md)');
+  });
+
+  it('from a root note the target path is unchanged', () => {
+    expect(resolveWikiLink('notes/foo', null, null, ctx, 'top.md'))
+      .toBe('[Foo Title](notes/foo.md)');
+  });
+
+  it('rewriteWikiLinksInContent threads fromPath to every link', () => {
+    const out = rewriteWikiLinksInContent('See [[notes/foo]] and [[notes/bar]].', ctx, 'notes/here.md');
+    expect(out).toBe('See [Foo Title](foo.md) and [Bar Title](bar.md).');
+  });
+});

--- a/tests/main/publish/pipeline.test.ts
+++ b/tests/main/publish/pipeline.test.ts
@@ -120,7 +120,10 @@ describe('markdownExporter end-to-end (#246)', () => {
     expect(plan.excluded.map((e) => e.relativePath)).toEqual(['private/secret.md']);
 
     const publicOut = output.files.find((f) => f.path === 'notes/public.md')!;
-    expect(publicOut.contents).toContain('See [Other](notes/other.md) for details.');
+    // Link is relative to the linking note's folder: both are in notes/, so
+    // the href is the bare filename (a root-relative `notes/other.md` would
+    // resolve to `notes/notes/other.md` from this page — the doubling bug).
+    expect(publicOut.contents).toContain('See [Other](other.md) for details.');
     expect(publicOut.contents).toContain('---');
     expect(publicOut.contents).toContain('title: Public');
   });

--- a/tests/main/publish/tree-markdown.test.ts
+++ b/tests/main/publish/tree-markdown.test.ts
@@ -78,6 +78,25 @@ describe('tree-markdown zip exporter (#291)', () => {
     expect(rootContent).not.toContain('[[ch1]]');
   });
 
+  it('cross-links from a nested note climb with ../ (no doubled directory)', async () => {
+    await fsp.mkdir(path.join(root, 'sub'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'root.md'),
+      '---\ntitle: Root\n---\n# Root\n\nSee [[sub/deep]].\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'sub/deep.md'),
+      '---\ntitle: Deep\n---\n# Deep\n\nBack to [[root]].\n', 'utf-8');
+
+    const plan = await resolvePlan(root, { kind: 'tree', relativePath: 'root.md', maxDepth: 2 });
+    const output = await runExporter(treeMarkdownExporter, plan);
+    const unzipped = await loadZip(output.files[0].contents as Uint8Array);
+
+    // root (dir '.') → nested: path unchanged.
+    expect(unzipped.get('root.md')).toContain('[Deep](sub/deep.md)');
+    // nested (dir 'sub') → root: climbs, does NOT stay root-relative (which
+    // would resolve to sub/root.md from the deep page).
+    expect(unzipped.get('sub/deep.md')).toContain('[Root](../root.md)');
+    expect(unzipped.get('sub/deep.md')).not.toContain('[Root](root.md)');
+  });
+
   it('drops embedded turtle blocks but preserves other fenced blocks', async () => {
     await fsp.writeFile(path.join(root, 'root.md'),
       '# Root\n\n```turtle\n@prefix ex: <http://x.com/> .\n```\n\n```python\nprint("hi")\n```\n', 'utf-8');


### PR DESCRIPTION
The follow-up flagged in #975: the same doubled-directory link bug, in the **markdown** export path.

## Bug
The `markdown` and `tree-markdown` exporters mirror the note folder tree but emitted **project-root-relative** `.md` cross-links (`[X](notes/x.md)`). From a note that itself lives under `notes/`, that resolves to `notes/notes/x.md` — same class as the HTML-site bug, different resolver (`link-resolver.ts`, which the HTML path doesn't use).

## Fix
`resolveWikiLink` / `rewriteWikiLinksInContent` take an optional **`fromPath`** and relativize `follow-to-file` hrefs to the linking note's folder (`path.posix.relative`):
- same-folder → bare filename,
- cross-folder → correct `../` climb.

The two directory-tree exporters pass each note's path; the single-file exporters (`note-markdown`, `pandoc`) omit it and keep the old root-relative shape (backward compatible — their existing tests are untouched).

## Note
A `pipeline.test.ts` integration test had **baked in the buggy** `notes/other.md` form — corrected to the relative `other.md` (with a comment explaining why the bare filename is right).

## Tests
- Resolver: same-folder, anchor preserved, `../` climb from a deeper folder, unchanged-from-root, and `fromPath` threaded through `rewriteWikiLinksInContent`.
- Integration: a `tree-markdown` nested note asserts `[Root](../root.md)` (climbs) and *not* `[Root](root.md)`.

`pnpm lint` clean; full suite (3813) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)