### PR TITLE
release: v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minerva",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
Version bump `0.1.1` → `0.1.2`.

This is the **second published release** needed to prove the auto-update **download + install** path end to end (#961) — the check path is already verified (your installed 0.1.1 app gets a 204 "up to date" from the feed; an older 0.1.0 gets a 200 offer).

## After merging, to run the two-release test
1. `git checkout main && git pull`
2. `pnpm release:tag` → creates the `v0.1.2` tag (guards that it matches package.json)
3. `git push origin v0.1.2` → CI builds the signed DMG/ZIP + cuts a **draft** release
4. **Publish** the draft, then give `update.electronjs.org` ~10 min to re-index (it caches, as we saw)
5. Your running **0.1.1** app's next hourly/manual check should find 0.1.2, download it, and offer to restart-to-install

That last step closes out #961 and the packaging epic #958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)