### PR TITLE
docs: point IPC-registration step at register-*.ts modules (#985)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ This is a **professional tool**. Design accordingly:
 To add a new main-process operation:
 1. Add channel constant to `src/shared/channels.ts`
 2. Implement the operation in `src/main/notebase/fs.ts` (or appropriate module)
-3. Register the handler in `src/main/ipc.ts`
+3. Register the handler in the appropriate `src/main/ipc/register-*.ts` module (`src/main/ipc.ts` is just the orchestrator that calls each `register*()`)
 4. Expose it in `src/preload/preload.ts`
 5. Add the type to the API interface in `src/renderer/lib/ipc/client.ts`
 


### PR DESCRIPTION
## Summary
Fixes the stale IPC-registration instruction in `CLAUDE.md`. The "IPC Pattern" step 3 told contributors to *"Register the handler in `src/main/ipc.ts`"*, but `ipc.ts` is only a 41-line orchestrator — it imports and calls the 19 `src/main/ipc/register-*.ts` modules, which is where the actual `ipcMain.handle` registrations live.

Step 3 now points at the correct site.

## Change
```diff
-3. Register the handler in `src/main/ipc.ts`
+3. Register the handler in the appropriate `src/main/ipc/register-*.ts` module (`src/main/ipc.ts` is just the orchestrator that calls each `register*()`)
```

Docs-only change; no code touched.

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)