### PR TITLE
refactor: extract context-menu dismissal idiom into a shared util (#989)

### DIFF
--- a/src/renderer/lib/components/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/BookmarksPanel.svelte
@@ -4,6 +4,7 @@
   import Ribbon from './right-sidebar/Ribbon.svelte';
   import Icon from './Icon.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
@@ -87,8 +88,7 @@
   function showContextMenu(e: MouseEvent, node: BookmarkNode) {
     e.preventDefault();
     contextMenu = { x: e.clientX, y: e.clientY, nodeId: node.id, nodeType: node.type };
-    const close = () => { contextMenu = null; window.removeEventListener('click', close); };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { contextMenu = null; });
   }
 
   async function handleRename(id: string) {

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import Icon from './Icon.svelte';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import { EditorView, keymap } from '@codemirror/view';
   import { basicSetup } from 'codemirror';
   import { markdown } from '@codemirror/lang-markdown';
@@ -335,11 +336,7 @@
       }
     }
     contextMenu = { x: e.clientX, y: e.clientY, link, hasSelection, docPos, claimUri };
-    const close = () => {
-      closeMenu();
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(closeMenu);
   }
 
   function closeMenu() {
@@ -356,11 +353,7 @@
     e.stopPropagation();
     const current = getEditorSettings();
     gutterMenu = { x: e.clientX, y: e.clientY, lineNumbers: current.lineNumbers };
-    const close = () => {
-      gutterMenu = null;
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { gutterMenu = null; });
   }
 
   function toggleLineNumbers() {

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -5,6 +5,7 @@
   import { formatRelativeTime } from '../utils/format-relative-time';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import { extractTagsFromContent } from '../../../shared/refactor/auto-tag';
   import { ENTRYPOINT_TAG } from '../../../shared/entrypoint';
   import type { IconName } from './icons/registry';
@@ -169,12 +170,8 @@
         }
       })();
     }
-    const close = () => {
-      contextMenu = null;
-      window.removeEventListener('click', close);
-    };
-    // Close on next click anywhere
-    setTimeout(() => window.addEventListener('click', close), 0);
+    // Close on next click anywhere.
+    installDismissOnClickOutside(() => { contextMenu = null; });
   }
 </script>
 

--- a/src/renderer/lib/components/PdfViewer.svelte
+++ b/src/renderer/lib/components/PdfViewer.svelte
@@ -18,6 +18,7 @@
   import type { SourceExcerpt } from '../../../shared/types';
   import { getEditorStore } from '../stores/editor.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import {
     MIN_SCALE, MAX_SCALE, DEFAULT_SCALE,
     zoomInScale, zoomOutScale,
@@ -250,11 +251,7 @@
     e.preventDefault();
     excerptMenu = { x: e.clientX, y: e.clientY, text };
     saveError = null;
-    const close = () => {
-      excerptMenu = null;
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { excerptMenu = null; });
   }
 
   async function saveExcerpt(): Promise<void> {

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import {onDestroy} from 'svelte';
     import Icon from './Icon.svelte';
+    import {installDismissOnClickOutside} from '../dismiss-menu';
     import MarkdownIt from 'markdown-it';
     // The Token *value* (used below for `new Token(...)` to inject a
     // task-list checkbox) is now recovered from `inlineTok.constructor`
@@ -1496,13 +1497,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         if (!onToolInvoke && !onOpenConversation && !onBookmark && !notePath) return;
         e.preventDefault();
         noteMenu = {x: e.clientX, y: e.clientY};
-        const close = (ev: MouseEvent) => {
-            const t = ev.target as HTMLElement | null;
-            if (t?.closest('.note-context-menu')) return;
-            noteMenu = null;
-            window.removeEventListener('click', close);
-        };
-        setTimeout(() => window.addEventListener('click', close), 0);
+        installDismissOnClickOutside(() => { noteMenu = null; }, '.note-context-menu');
     }
 
     function runMenuAction(fn: (() => void) | undefined): void {
@@ -1538,13 +1533,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
                 source: {language, code},
                 output,
             };
-            const close = (ev: MouseEvent) => {
-                const target = ev.target as HTMLElement | null;
-                if (target?.closest('.compute-output-menu')) return;
-                outputMenu = null;
-                window.removeEventListener('click', close);
-            };
-            setTimeout(() => window.addEventListener('click', close), 0);
+            installDismissOnClickOutside(() => { outputMenu = null; }, '.compute-output-menu');
         } catch {
             outputMenu = null;
         }

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -15,6 +15,7 @@
   import { sql, PostgreSQL } from '@codemirror/lang-sql';
   import { oneDark } from '@codemirror/theme-one-dark';
   import { getEffectiveTheme, getThemeMode } from '../theme';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import type { QueryTab, QueryLanguage } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
   import { formatSparql } from '../../../shared/sparql-format';
@@ -90,16 +91,8 @@
   function toggleCopyMenu(): void {
     copyMenuOpen = !copyMenuOpen;
     if (copyMenuOpen) {
-      // Close on the next outside click. setTimeout so the current click
-      // that opened the menu doesn't immediately re-close it.
-      const close = (e: MouseEvent) => {
-        const target = e.target as HTMLElement | null;
-        if (!target?.closest('.copy-as-wrap')) {
-          copyMenuOpen = false;
-          window.removeEventListener('click', close);
-        }
-      };
-      setTimeout(() => window.addEventListener('click', close), 0);
+      // Close on the next outside click, ignoring clicks inside the picker.
+      installDismissOnClickOutside(() => { copyMenuOpen = false; }, '.copy-as-wrap');
     }
   }
 

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -7,6 +7,7 @@
   import BookmarksPanel from './BookmarksPanel.svelte';
   import Icon from './Icon.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import { getSidebarSelectionStore } from '../stores/sidebar-selection.svelte';
   import { flattenVisible } from '../sidebar-tree-utils';
   import { getSidebarSettings, setSidebarSettings } from '../sidebar/settings';
@@ -435,11 +436,7 @@
 
   function openRootContextMenu(x: number, y: number) {
     contextMenu = { x, y };
-    const close = () => {
-      contextMenu = null;
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { contextMenu = null; });
   }
 
   function handleContextMenu(e: MouseEvent) {

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -10,6 +10,7 @@
   import { groupToolsByGroup } from '../../../shared/tools/grouping';
   import { getAllToolInfos } from '../tools/tool-registry';
   import { displaySourceTitle } from '../../../shared/source-display';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
 
   const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
     { value: 'unread', label: 'Unread' },
@@ -290,11 +291,7 @@
     e.preventDefault();
     excerptMenu = { x: e.clientX, y: e.clientY, text };
     excerptError = null;
-    const close = () => {
-      excerptMenu = null;
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { excerptMenu = null; });
   }
 
   async function saveExcerpt(): Promise<void> {

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -3,6 +3,7 @@
   import type { SourceMetadata, Collection, SmartCollection, SmartCollectionPredicate, ReadStatus } from '../../../shared/types';
   import { displaySourceTitle } from '../../../shared/source-display';
   import { clampMenuToViewport, clampSubmenu } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import SourcePickerDialog from './SourcePickerDialog.svelte';
   import CollectionPickerDialog from './CollectionPickerDialog.svelte';
   import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
@@ -193,8 +194,7 @@
     e.preventDefault();
     e.stopPropagation();
     contextMenu = { x: e.clientX, y: e.clientY, source };
-    const close = () => { contextMenu = null; window.removeEventListener('click', close); };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { contextMenu = null; });
   }
 
   async function handleDelete(source: SourceMetadata) {
@@ -449,8 +449,7 @@
     e.preventDefault();
     e.stopPropagation();
     collectionMenu = { x: e.clientX, y: e.clientY, collection };
-    const close = () => { collectionMenu = null; window.removeEventListener('click', close); };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { collectionMenu = null; });
   }
 
   let smartMenu = $state<{ x: number; y: number; smart: SmartCollection } | null>(null);
@@ -467,8 +466,7 @@
     e.preventDefault();
     e.stopPropagation();
     smartMenu = { x: e.clientX, y: e.clientY, smart };
-    const close = () => { smartMenu = null; window.removeEventListener('click', close); };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { smartMenu = null; });
   }
 
   function openNewCollectionMenu(e: MouseEvent) {
@@ -476,8 +474,7 @@
     e.stopPropagation();
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     newCollectionMenu = { x: rect.right, y: rect.bottom + 2 };
-    const close = () => { newCollectionMenu = null; window.removeEventListener('click', close); };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { newCollectionMenu = null; });
   }
 
   function smartHoverHint(s: SmartCollection): string {

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -4,6 +4,7 @@
   import { displaySourceTitle } from '../../../shared/source-display';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
   import Icon from './Icon.svelte';
 
   interface Props {
@@ -69,11 +70,7 @@
   function handleContextMenu(e: MouseEvent, index: number) {
     e.preventDefault();
     contextMenu = { x: e.clientX, y: e.clientY, index };
-    const close = () => {
-      contextMenu = null;
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { contextMenu = null; });
   }
 
   function handleMiddleClick(e: MouseEvent, index: number) {

--- a/src/renderer/lib/components/TablesPanel.svelte
+++ b/src/renderer/lib/components/TablesPanel.svelte
@@ -2,6 +2,7 @@
   import { api } from '../ipc/client';
   import type { TableInfo } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
 
   interface Props {
     onTableClick: (tableName: string) => void;
@@ -45,11 +46,7 @@
     e.preventDefault();
     e.stopPropagation();
     contextMenu = { x: e.clientX, y: e.clientY, table };
-    const close = () => {
-      contextMenu = null;
-      window.removeEventListener('click', close);
-    };
-    setTimeout(() => window.addEventListener('click', close), 0);
+    installDismissOnClickOutside(() => { contextMenu = null; });
   }
 </script>
 

--- a/src/renderer/lib/dismiss-menu.ts
+++ b/src/renderer/lib/dismiss-menu.ts
@@ -1,0 +1,29 @@
+/**
+ * Install a one-shot "dismiss this menu on the next outside click" listener —
+ * the idiom every context / overflow menu in the app shares (#989).
+ *
+ * Registration is deferred to the next tick (`setTimeout(…, 0)`) so the very
+ * click that opened the menu doesn't immediately dismiss it. The listener
+ * removes itself once it fires.
+ *
+ * @param onDismiss       Runs when an outside click lands — set the menu state
+ *                        to `null`/`false` here.
+ * @param ignoreSelector  When provided, a click whose target is inside a
+ *                        matching element is ignored: the menu stays open and
+ *                        the listener stays armed. Used for menus with
+ *                        interactive contents (e.g. submenus, copy-as pickers).
+ */
+export function installDismissOnClickOutside(
+  onDismiss: () => void,
+  ignoreSelector?: string,
+): void {
+  const close = (ev: MouseEvent) => {
+    if (ignoreSelector) {
+      const target = ev.target as HTMLElement | null;
+      if (target?.closest(ignoreSelector)) return;
+    }
+    onDismiss();
+    window.removeEventListener('click', close);
+  };
+  setTimeout(() => window.addEventListener('click', close), 0);
+}

--- a/tests/renderer/dismiss-menu.test.ts
+++ b/tests/renderer/dismiss-menu.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { installDismissOnClickOutside } from '../../src/renderer/lib/dismiss-menu';
+
+describe('installDismissOnClickOutside (#989)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('does not dismiss on the click that opened the menu (deferred registration)', () => {
+    const onDismiss = vi.fn();
+    installDismissOnClickOutside(onDismiss);
+    // Same tick: listener isn't armed yet.
+    window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('dismisses on the next outside click and removes its listener', () => {
+    const onDismiss = vi.fn();
+    installDismissOnClickOutside(onDismiss);
+    vi.advanceTimersByTime(0);
+
+    window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    // Listener removed itself — a second click does nothing.
+    window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores clicks inside ignoreSelector and stays armed', () => {
+    const inner = document.createElement('button');
+    inner.className = 'inside';
+    const menu = document.createElement('div');
+    menu.className = 'menu';
+    menu.appendChild(inner);
+    document.body.appendChild(menu);
+
+    const onDismiss = vi.fn();
+    installDismissOnClickOutside(onDismiss, '.menu');
+    vi.advanceTimersByTime(0);
+
+    // Click inside the menu: ignored, listener still armed.
+    inner.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // Click outside (on a real element, as a real bubbled click would be): dismisses.
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
The "dismiss this menu on the next outside click" idiom was copy-pasted across **11 components (16 call sites)** — a self-removing `close` listener registered a tick late via `setTimeout(…, 0)` so the opening click doesn't immediately dismiss the menu. This extracts it into one utility.

```ts
installDismissOnClickOutside(onDismiss: () => void, ignoreSelector?: string): void
```

- **Family A (always-close)** — TabBar, TablesPanel, PdfViewer, SourceDetail, Sidebar, FileTree, Editor (×2), BookmarksPanel, SourcesPanel (×4): `installDismissOnClickOutside(() => { menu = null; })`.
- **Family B (guarded)** — Preview's note menu (`.note-context-menu`) and compute-output menu (`.compute-output-menu`), QueryPanel's copy-as picker (`.copy-as-wrap`): the optional `ignoreSelector` reproduces the original behavior where a click *inside* the menu is ignored and the listener stays armed.

Net: removes ~60 lines of duplicated listener plumbing; one place to change timing/cleanup.

## Behavior
Preserved at every site. The deferred registration and self-removal are identical; the guarded variant keeps the same "ignore inside-clicks, stay armed" semantics.

## Testing
- New `tests/renderer/dismiss-menu.test.ts` (3 cases): deferred registration, dismiss-and-self-remove, and `ignoreSelector` (ignore inside / dismiss outside).
- `pnpm test tests/renderer/` — **961 passed**.
- `pnpm lint` — 0 errors.

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)