### PR TITLE
refactor: naming & magic-number quick wins (#996)

### DIFF
--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -233,7 +233,6 @@ async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<
   if (uris.length === 0) return false;
   const values = uris.map((u) => `<${u}>`).join(' ');
   const r = await graph.queryGraph(ctx, `
-    PREFIX thought: <${THOUGHT}>
     SELECT ?n WHERE {
       VALUES ?n { ${values} }
       ?n thought:hasStatus thought:established .
@@ -382,7 +381,6 @@ export async function rejectProposal(ctx: ProjectContext, uri: string): Promise<
  */
 export async function expireProposals(ctx: ProjectContext): Promise<number> {
   const results = await graph.queryGraph(ctx, `
-    PREFIX thought: <${THOUGHT}>
     SELECT ?proposal ?expires WHERE {
       ?proposal a thought:Proposal .
       ?proposal thought:proposalStatus thought:pending .
@@ -411,7 +409,6 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
     : '';
 
   const results = await graph.queryGraph(ctx, `
-    PREFIX thought: <${THOUGHT}>
     SELECT ?proposal ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?payloadJson
            (GROUP_CONCAT(DISTINCT ?affectsNode; separator="\\u001f") AS ?affectsNodes)
            ?conversation WHERE {
@@ -432,7 +429,7 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
     ORDER BY DESC(?proposedAt)
   `);
 
-  return (results.results as Record<string, string>[]).map(r => proposalFromRow(r));
+  return (results.results as Record<string, string>[]).map(row => proposalFromRow(row));
 }
 
 /**
@@ -440,7 +437,6 @@ export async function listProposals(ctx: ProjectContext, status?: string): Promi
  */
 export async function getProposal(ctx: ProjectContext, uri: string): Promise<Proposal | null> {
   const results = await graph.queryGraph(ctx, `
-    PREFIX thought: <${THOUGHT}>
     SELECT ?status ?operationType ?note ?proposedBy ?proposedAt ?autoExpires ?payloadJson ?affectsNode ?conversation WHERE {
       <${uri}> a thought:Proposal .
       <${uri}> thought:proposalStatus ?statusNode .
@@ -458,36 +454,36 @@ export async function getProposal(ctx: ProjectContext, uri: string): Promise<Pro
 
   const rows = results.results as Record<string, string>[];
   if (rows.length === 0) return null;
-  const r = rows[0];
+  const firstRow = rows[0];
   const affectsNodeUris = Array.from(
     new Set(rows.map(row => row.affectsNode).filter((u): u is string => Boolean(u))),
   );
   return {
     uri,
-    status: r.status as Proposal['status'],
-    operationType: r.operationType,
-    payloads: parsePayloads(r.payloadJson),
-    note: r.note,
+    status: firstRow.status as Proposal['status'],
+    operationType: firstRow.operationType,
+    payloads: parsePayloads(firstRow.payloadJson),
+    note: firstRow.note,
     affectsNodeUris,
-    conversationUri: r.conversation,
-    proposedBy: r.proposedBy,
-    proposedAt: r.proposedAt,
-    autoExpires: r.autoExpires,
+    conversationUri: firstRow.conversation,
+    proposedBy: firstRow.proposedBy,
+    proposedAt: firstRow.proposedAt,
+    autoExpires: firstRow.autoExpires,
   };
 }
 
-function proposalFromRow(r: Record<string, string>): Proposal {
+function proposalFromRow(row: Record<string, string>): Proposal {
   return {
-    uri: r.proposal,
-    status: r.status as Proposal['status'],
-    operationType: r.operationType,
-    payloads: parsePayloads(r.payloadJson),
-    note: r.note,
-    affectsNodeUris: splitAffectsNodes(r.affectsNodes),
-    conversationUri: r.conversation,
-    proposedBy: r.proposedBy,
-    proposedAt: r.proposedAt,
-    autoExpires: r.autoExpires,
+    uri: row.proposal,
+    status: row.status as Proposal['status'],
+    operationType: row.operationType,
+    payloads: parsePayloads(row.payloadJson),
+    note: row.note,
+    affectsNodeUris: splitAffectsNodes(row.affectsNodes),
+    conversationUri: row.conversation,
+    proposedBy: row.proposedBy,
+    proposedAt: row.proposedAt,
+    autoExpires: row.autoExpires,
   };
 }
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -778,6 +778,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         return md.render(stripped, {lineOffset});
     }
 
+    // Turtle syntax-highlight patterns (applied in order — see renderTurtle).
+    const TTL_COMMENT_RE = /^([ \t]*#.*)$/gm;
+    const TTL_DIRECTIVE_RE = /(@(?:prefix|base|keywords)\b)/g;
+    const TTL_IRI_RE = /(&lt;[^&\s]*?&gt;)/g;
+
     function renderTurtle(c: string): string {
         // Escape HTML first so the IRI regex below can match the now-
         // safe `&lt; … &gt;` tokens without risking double-application.
@@ -790,9 +795,9 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         // because directives don't start with `#`); then IRIs (which
         // can appear inside non-comment lines).
         const highlighted = escaped
-            .replace(/^([ \t]*#.*)$/gm, '<span class="ttl-comment">$1</span>')
-            .replace(/(@(?:prefix|base|keywords)\b)/g, '<span class="ttl-directive">$1</span>')
-            .replace(/(&lt;[^&\s]*?&gt;)/g, '<span class="ttl-iri">$1</span>');
+            .replace(TTL_COMMENT_RE, '<span class="ttl-comment">$1</span>')
+            .replace(TTL_DIRECTIVE_RE, '<span class="ttl-directive">$1</span>')
+            .replace(TTL_IRI_RE, '<span class="ttl-iri">$1</span>');
         return `<pre class="ttl-source">${highlighted}</pre>`;
     }
 

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -172,6 +172,10 @@ interface TabRuntime {
 }
 
 const DEFAULT_HEIGHT = 320;
+/** Panel-height clamp bounds. MIN mirrors the hard min the renderer enforces
+ *  via CSS; MAX keeps the panel from growing past the editor area. */
+const MIN_PANEL_HEIGHT = 120;
+const MAX_PANEL_HEIGHT = 1200;
 const DEFAULT_UI: ConversationsUIState = {
   visible: false,
   height: DEFAULT_HEIGHT,
@@ -446,9 +450,8 @@ function toggle(): void {
 
 function setHeight(px: number): void {
   // Clamp to a sane range so the panel can't be dragged to invisibility
-  // or larger than the editor area. Renderer enforces a hard min via CSS,
-  // but we also belt-and-suspender it here.
-  const next = Math.max(120, Math.min(1200, Math.round(px)));
+  // or larger than the editor area (belt-and-suspenders alongside the CSS min).
+  const next = Math.max(MIN_PANEL_HEIGHT, Math.min(MAX_PANEL_HEIGHT, Math.round(px)));
   if (next !== height) {
     height = next;
     scheduleSave();


### PR DESCRIPTION
## Summary
Four low-risk readability cleanups from the refactoring review (L1–L4). Behavior-preserving.

### L1 — name the panel-height clamp bounds
`conversations.svelte.ts` used inline `Math.max(120, Math.min(1200, …))`. Extracted `MIN_PANEL_HEIGHT` / `MAX_PANEL_HEIGHT` next to `DEFAULT_HEIGHT`, with a note that MIN mirrors the CSS hard-min.

### L2 — drop redundant `PREFIX thought:` declarations (the report's caveat, resolved)
The review flagged four repeated `PREFIX thought: <…>` lines in `approval.ts` and suggested a `sparqlWithThoughtPrefix()` helper — **but told me to verify they weren't already covered first.** They are: `graph.queryGraph` calls `injectSparqlPrefixes`, `thought` is in `STANDARD_PREFIXES` (`state.ts:92`), and the injector skips already-declared prefixes. So the explicit lines were dead weight — **removed rather than wrapped in an unnecessary helper.**

Validated against the real graph: the approval/proposal integration tests (`approval.test.ts`, `proposal-bundle`, `proposal-large-bundle`, `conversation-drafts-flow`) exercise `getProposal` / `listProposals` / `expireProposals`, and the test suite itself already runs `queryGraph` with bare `thought:` and no PREFIX — direct proof injection supplies it.

### L3 — rename opaque single-letter row vars
`approval.ts`: `const r = rows[0]` → `firstRow`; `proposalFromRow(r)` → `proposalFromRow(row)` (+ its call site).

### L4 — name the Turtle-highlight regexes
`Preview.svelte`: hoisted the three inline `.replace()` patterns in `renderTurtle` to `TTL_COMMENT_RE` / `TTL_DIRECTIVE_RE` / `TTL_IRI_RE` (safe — global regexes reset `lastIndex` under `String.replace`).

## Testing
- `pnpm lint` — 0 errors.
- `pnpm test tests/main/llm/` — 202 passed (covers L2/L3 against a real graph).
- `pnpm test tests/renderer/stores/` — conversations store green (L1).

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)