### PR TITLE
chore: enable noFallthroughCasesInSwitch (#1007)

### DIFF
--- a/clipper/tsconfig.json
+++ b/clipper/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    // Beyond `strict`: flag switch cases that fall through without an explicit
+    // break/return/throw (#1007). Zero fallout at adoption time.
+    "noFallthroughCasesInSwitch": true,
     // Incremental typecheck: cache results so a repeat `pnpm lint` only
     // re-checks what changed (#664). DX-only — CI always starts cold. The
     // buildinfo lives under node_modules/.cache (gitignored); tsconfig.eslint


### PR DESCRIPTION
## Summary
Enables `noFallthroughCasesInSwitch` — the first of the two strictness flags in #1007. **Zero fallout**: `tsc --noEmit --noFallthroughCasesInSwitch` reports 0 errors against the current tree.

Added to `tsconfig.json` (inherited by `tsconfig.eslint.json` via `extends`) and `clipper/tsconfig.json`.

## Scope note
This PR is **partial** for #1007 — it does not close the issue. The companion flag `noUncheckedIndexedAccess` surfaces **~652 errors** across a long tail of files (including trust-critical `approval.ts`, `graph/indexers.ts`), which is the "1–2 day, incremental, one-flag-per-PR" job the modernization review anticipated. It's being handled separately so this safe flag can land immediately.

## Testing
- `pnpm lint` (tsc + svelte-check + eslint) — 0 errors.
- `pnpm exec tsc --noEmit -p clipper/tsconfig.json` — exit 0.

Part of #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)