### PR TITLE
test: add coverage floors for publish/sources/graph/compute (#999)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -66,6 +66,37 @@ export default defineConfig({
           statements: 78,
           branches: 65,
         },
+        // Feature trees — well-tested today but previously unfenced (#999).
+        // Floors set ~10 points below the measured-at-floor-time numbers (in
+        // parens) so a small refactor won't flap, but new untested code fails.
+        // publish ~93% L / 92% F / 89% S / 75% B.
+        'src/main/publish/**': {
+          lines: 82,
+          functions: 82,
+          statements: 80,
+          branches: 65,
+        },
+        // sources ~89% L / 91% F / 87% S / 75% B.
+        'src/main/sources/**': {
+          lines: 80,
+          functions: 80,
+          statements: 78,
+          branches: 65,
+        },
+        // graph ~90% L / 90% F / 86% S / 73% B.
+        'src/main/graph/**': {
+          lines: 80,
+          functions: 80,
+          statements: 78,
+          branches: 62,
+        },
+        // compute ~86% L / 83% F / 83% S / 70% B.
+        'src/main/compute/**': {
+          lines: 75,
+          functions: 74,
+          statements: 74,
+          branches: 60,
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
Extends the CI coverage-floor regression fence (#679) from **3 trees to 7**. `src/main/publish`, `src/main/sources`, `src/main/graph`, and `src/main/compute` were well-tested but **unfenced** — nothing stopped a future PR from adding an untested exporter or ingest adapter and regressing silently.

## Floors (measured → floor, ~10pt headroom)
Set below the current numbers so a small refactor won't flap CI, matching the existing `llm`/`notebase`/`shared` convention.

| Tree | lines | funcs | stmts | branches | floor (L/F/S/B) |
|---|---|---|---|---|---|
| publish | 92.86 | 92.43 | 88.93 | 75.0 | 82 / 82 / 80 / 65 |
| sources | 89.37 | 91.28 | 86.72 | 75.12 | 80 / 80 / 78 / 65 |
| graph | 89.96 | 89.90 | 85.52 | 73.01 | 80 / 80 / 78 / 62 |
| compute | 85.82 | 82.79 | 83.21 | 70.0 | 75 / 74 / 74 / 60 |

Measured numbers are recorded in comments next to each floor (per the existing config style). The actuals were read by temporarily setting the globs to 99% and reading vitest's threshold-failure output.

## Still unfenced
The **renderer** remains without a floor (called out in the QA review as M3). That's a larger tree with partial render-test coverage; deferring it to its own pass rather than picking an arbitrary floor here.

## Testing
- `pnpm coverage` — exits 0; all floors (existing + 4 new) satisfied.
- `pnpm lint` — 0 errors.

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)