### PR TITLE
test: assert the security.ts CSP / permissions / nav / webPreferences boundary (#1001)

### DIFF
--- a/src/main/security.ts
+++ b/src/main/security.ts
@@ -28,6 +28,20 @@ import { buildCsp, externalNavTarget, isOwnOrigin } from './security-helpers';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 
+/**
+ * Renderer hardening spread into every BrowserWindow's `webPreferences`. The
+ * renderer is treated as untrusted: `contextIsolation` + `sandbox` on,
+ * `nodeIntegration` off — all privileged work goes through the preload's
+ * contextBridge + IPC (#339, #684). Kept here (not inline at the window
+ * construction site) so the security boundary is asserted in one place and
+ * can't silently drift.
+ */
+export const HARDENED_WEB_PREFERENCES = {
+  contextIsolation: true,
+  nodeIntegration: false,
+  sandbox: true,
+} as const;
+
 /** Install the CSP for every response served to the default session. */
 export function installCsp(): void {
   const csp = buildCsp({ devServerOrigin: MAIN_WINDOW_VITE_DEV_SERVER_URL });

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -17,7 +17,7 @@ import { acquireProject, releaseProject } from './project-context';
 import { runBackfill } from './embeddings/backfill';
 import * as vectors from './embeddings/vector-store';
 import { citedTextFromTtl } from './sources/create-excerpt';
-import { installNavigationGuards } from './security';
+import { installNavigationGuards, HARDENED_WEB_PREFERENCES } from './security';
 import { ensureClipperRunning, stopClipperServer, isClipperEnabled } from './clipper/lifecycle';
 import type { ProjectContext } from './project-context-types';
 
@@ -75,12 +75,11 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
     trafficLightPosition: { x: 12, y: 12 },
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-      // The preload imports only `electron` + the pure `shared/channels`
-      // module (no Node builtins), so the renderer never needs Node — run it
-      // sandboxed, matching the privileged-site and PDF-render windows (#684).
-      sandbox: true,
+      // contextIsolation on / nodeIntegration off / sandbox on. The preload
+      // imports only `electron` + the pure `shared/channels` module (no Node
+      // builtins), so the renderer never needs Node — run it sandboxed,
+      // matching the privileged-site and PDF-render windows (#339, #684).
+      ...HARDENED_WEB_PREFERENCES,
     },
   });
 

--- a/tests/main/security.test.ts
+++ b/tests/main/security.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Security-boundary assertion tests (#1001).
+ *
+ * `security-helpers.ts` (the pure CSP string + routing decisions) is tested
+ * separately. This covers the *wiring* in `security.ts` — that the CSP header
+ * is actually installed, that the media-permission handlers grant only the
+ * app's own origin, and that the navigation guards deny window.open / divert
+ * foreign navigation — plus the renderer `webPreferences` hardening. Previously
+ * this real security boundary was only exercised indirectly by the e2e smoke's
+ * console-error check; here it fails a fast unit test if it regresses.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type HeadersCb = (r: { responseHeaders: Record<string, string[] | string> }) => void;
+const cap = vi.hoisted(() => ({
+  onHeaders: null as null | ((details: { responseHeaders: Record<string, string[]> }, cb: HeadersCb) => void),
+  permissionRequest: null as null | ((wc: { getURL(): string | undefined } | null, permission: string, cb: (granted: boolean) => void) => void),
+  permissionCheck: null as null | ((wc: unknown, permission: string, origin: string) => boolean),
+  openExternal: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  session: {
+    defaultSession: {
+      webRequest: {
+        onHeadersReceived: (fn: typeof cap.onHeaders) => { cap.onHeaders = fn; },
+      },
+      setPermissionRequestHandler: (fn: typeof cap.permissionRequest) => { cap.permissionRequest = fn; },
+      setPermissionCheckHandler: (fn: typeof cap.permissionCheck) => { cap.permissionCheck = fn; },
+    },
+  },
+  shell: { openExternal: (url: string) => { cap.openExternal.push(url); return Promise.resolve(); } },
+}));
+
+import { installCsp, installMediaPermissions, installNavigationGuards, HARDENED_WEB_PREFERENCES } from '../../src/main/security';
+
+// The vite `define` globals don't exist under vitest; undefined selects the
+// production (strict CSP, file:// own-origin) branch.
+vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined);
+
+beforeEach(() => {
+  cap.onHeaders = null;
+  cap.permissionRequest = null;
+  cap.permissionCheck = null;
+  cap.openExternal = [];
+});
+
+describe('installCsp (#1001)', () => {
+  it('adds a strict Content-Security-Policy header to every response', () => {
+    installCsp();
+    expect(cap.onHeaders).toBeTypeOf('function');
+
+    let out: { responseHeaders: Record<string, string[] | string> } | undefined;
+    cap.onHeaders!({ responseHeaders: { 'x-existing': ['1'] } }, (r) => { out = r; });
+
+    const csp = out?.responseHeaders['Content-Security-Policy'];
+    expect(Array.isArray(csp)).toBe(true);
+    const value = (csp as string[])[0];
+    expect(value).toContain("default-src 'self'");
+    expect(value).toContain("object-src 'none'");
+    // Existing headers are preserved, not clobbered.
+    expect(out?.responseHeaders['x-existing']).toEqual(['1']);
+  });
+});
+
+describe('installMediaPermissions (#1001)', () => {
+  it('grants media only to the app\'s own origin, denies everything else', () => {
+    installMediaPermissions();
+    const req = cap.permissionRequest!;
+
+    const grant = (url: string | undefined, permission: string) => {
+      let granted: boolean | undefined;
+      req({ getURL: () => url }, permission, (g) => { granted = g; });
+      return granted;
+    };
+
+    expect(grant('file:///Users/x/app/index.html', 'media')).toBe(true);
+    expect(grant('https://evil.example', 'media')).toBe(false);   // foreign origin
+    expect(grant('file:///Users/x/app/index.html', 'geolocation')).toBe(false); // non-media
+    expect(grant(undefined, 'media')).toBe(false);                // no URL
+  });
+
+  it('check handler mirrors the request handler', () => {
+    installMediaPermissions();
+    const check = cap.permissionCheck!;
+    expect(check(null, 'media', 'file:///Users/x/app/index.html')).toBe(true);
+    expect(check(null, 'media', 'https://evil.example')).toBe(false);
+    expect(check(null, 'notifications', 'file:///Users/x/app/index.html')).toBe(false);
+  });
+});
+
+describe('installNavigationGuards (#1001)', () => {
+  /** A minimal WebContents stub that records the handlers security.ts installs. */
+  function fakeWebContents() {
+    let openHandler: (d: { url: string }) => { action: string } = () => ({ action: '' });
+    const listeners = new Map<string, (...a: unknown[]) => void>();
+    const wc = {
+      setWindowOpenHandler: (fn: typeof openHandler) => { openHandler = fn; },
+      on: (event: string, fn: (...a: unknown[]) => void) => { listeners.set(event, fn); },
+    } as unknown as import('electron').WebContents;
+    return {
+      wc,
+      windowOpen: (url: string) => openHandler({ url }),
+      willNavigate: (event: { preventDefault(): void }, url: string) =>
+        listeners.get('will-navigate')?.(event, url),
+    };
+  }
+
+  it('denies every window.open and diverts http(s) targets to the OS browser', () => {
+    const h = fakeWebContents();
+    installNavigationGuards(h.wc);
+
+    expect(h.windowOpen('https://example.com/doc')).toEqual({ action: 'deny' });
+    expect(cap.openExternal).toEqual(['https://example.com/doc']);
+  });
+
+  it('blocks top-level navigation off the app origin and diverts it, allows own origin', () => {
+    const h = fakeWebContents();
+    installNavigationGuards(h.wc);
+
+    // Foreign navigation: prevented + diverted.
+    let prevented = false;
+    h.willNavigate({ preventDefault: () => { prevented = true; } }, 'https://example.com');
+    expect(prevented).toBe(true);
+    expect(cap.openExternal).toEqual(['https://example.com']);
+
+    // Own-origin navigation (file://): allowed, no divert.
+    cap.openExternal = [];
+    let preventedOwn = false;
+    h.willNavigate({ preventDefault: () => { preventedOwn = true; } }, 'file:///Users/x/app/index.html');
+    expect(preventedOwn).toBe(false);
+    expect(cap.openExternal).toEqual([]);
+  });
+});
+
+describe('HARDENED_WEB_PREFERENCES (#1001)', () => {
+  it('keeps the renderer sandboxed and isolated', () => {
+    expect(HARDENED_WEB_PREFERENCES).toMatchObject({
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes the QA review's M2 gap: `security.ts` is the app's real security boundary (CSP, media permissions, navigation guards, renderer sandboxing), but only `security-helpers.ts` (the pure CSP string + routing decisions) was tested. The *wiring* and the `webPreferences` hardening were exercised only indirectly by the e2e smoke's console-error check — a CSP or context-isolation regression would slip a fast unit run.

## What's added
`tests/main/security.test.ts` (mocks **only** `electron`):
- **`installCsp`** — installs a strict `Content-Security-Policy` header (`default-src 'self'`, `object-src 'none'`) on every response, preserving existing headers.
- **`installMediaPermissions`** — grants `media` only to the app's own origin (`file://` in prod); denies foreign origins, other permissions, and missing URLs. Covers both the request and check handlers.
- **`installNavigationGuards`** — denies every `window.open` and diverts `http(s)` targets to `shell.openExternal`; blocks top-level navigation off the app origin (divert) while allowing own-origin navigation.
- **`HARDENED_WEB_PREFERENCES`** — asserts `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`.

## Small production change
Lifted the three hardening flags out of the inline `createWindow` `webPreferences` into an exported `HARDENED_WEB_PREFERENCES` const in `security.ts`, spread back in. **Behavior identical** — it just puts the security-critical flags where the security module owns them and makes them directly assertable (matching this module's stated "pure logic lives in security-helpers.ts so tests can exercise it without electron" philosophy). Driving the real `createWindow` instead would have fought vite-injected globals (`__dirname`, `MAIN_WINDOW_VITE_NAME`, `loadFile`) for no added assurance.

## Testing
- `pnpm test tests/main/security.test.ts` — 6 passed.
- `pnpm test tests/main/security-helpers.test.ts` — still green (21 total across both).
- `pnpm lint` — 0 errors.

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)