### PR TITLE
test: guard TOOL_CALLBACK_KEYS completeness (#1003)

### DIFF
--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -95,10 +95,22 @@ export interface StreamCallbacks {
  *  (propose_*, ask_user) needs a renderer surface, its callback must be in this
  *  list or the tool reports "only available in conversation contexts." Add a new
  *  draft callback here when you add one to StreamCallbacks + ToolCallbacks. */
-const TOOL_CALLBACK_KEYS = [
+export const TOOL_CALLBACK_KEYS = [
   'onDraft', 'onSourceDraft', 'onPropertyDraft', 'onSourcePropertyDraft',
   'onClaimsDraft', 'onComputeDraft', 'onRefactorDraft', 'onReorgDraft', 'onDeleteDraft', 'onNoteBodyDraft', 'askUser',
-] as const;
+] as const satisfies readonly (keyof ToolCallbacks)[];
+
+// Completeness guard (#1003). `satisfies` above rejects a stale/typo'd key; this
+// catches the opposite, silent foot-gun: a callback added to `ToolCallbacks`
+// (and wired in the conversation IPC handler) but *not* listed here never
+// reaches the tool executor, so the tool reports "only available in conversation
+// contexts" at runtime with nothing failing at build. If any `ToolCallbacks` key
+// is missing from the list, `_UnlistedToolCallbacks` stops being `never` and
+// this assignment fails `tsc` (run by `pnpm lint`).
+type _UnlistedToolCallbacks = Exclude<keyof ToolCallbacks, (typeof TOOL_CALLBACK_KEYS)[number]>;
+const _allToolCallbacksListed: _UnlistedToolCallbacks extends never
+  ? true
+  : { readonly ERROR: 'key missing from TOOL_CALLBACK_KEYS'; readonly missing: _UnlistedToolCallbacks } = true;
 
 /** Project a conversation's `StreamCallbacks` down to the `ToolCallbacks` the
  *  tool executor expects, carrying every tool-facing callback that's set.

--- a/tests/main/llm/tool-callbacks-passthrough.test.ts
+++ b/tests/main/llm/tool-callbacks-passthrough.test.ts
@@ -1,16 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { toToolCallbacks } from '../../../src/main/llm/index';
+import { toToolCallbacks, TOOL_CALLBACK_KEYS } from '../../../src/main/llm/index';
 
 /**
- * Regression: the conversation runner projects its `StreamCallbacks` down to the
- * `ToolCallbacks` the tool executor receives. A callback missing from that
- * projection makes its tool report "only available in conversation contexts" —
- * which is exactly what happened to the note-refactor tools (#912/#914): their
- * callbacks were declared on the IPC side but dropped here, so propose_note_rename
- * / move / reorganization all failed inside a real conversation.
+ * Regression + completeness for the StreamCallbacks → ToolCallbacks projection.
+ *
+ * A callback missing from that projection makes its tool report "only available
+ * in conversation contexts" — exactly what happened to the note-refactor tools
+ * (#912/#914): their callbacks were declared on the IPC side but dropped here,
+ * so propose_note_rename / move / reorganization all failed inside a real
+ * conversation.
+ *
+ * These tests derive from the exported `TOOL_CALLBACK_KEYS` (no hardcoded copy)
+ * so they automatically cover any new key. The *completeness* invariant — that
+ * `TOOL_CALLBACK_KEYS` names every key of `ToolCallbacks` — is enforced at
+ * build time by the compile-time guard co-located with the constant in
+ * `src/main/llm/index.ts` (#1003); these runtime tests guard the projection
+ * behaviour and keep the constant honest.
  */
-describe('toToolCallbacks', () => {
+describe('toToolCallbacks (#912 / #914 / #1003)', () => {
   const noop = () => {};
+  // One stub per tool-facing callback, plus a stream-only callback (onChunk)
+  // that must NOT leak into the tool callbacks.
   const all = {
     onChunk: noop,
     onDraft: noop,
@@ -26,14 +36,24 @@ describe('toToolCallbacks', () => {
     askUser: async () => '',
   };
 
-  it('passes every tool-facing callback through to tool execution', () => {
+  it('passes every tool-facing callback (TOOL_CALLBACK_KEYS) through, and nothing else', () => {
     const out = toToolCallbacks(all) as Record<string, unknown>;
-    for (const key of [
-      'onDraft', 'onSourceDraft', 'onPropertyDraft', 'onSourcePropertyDraft',
-      'onClaimsDraft', 'onComputeDraft', 'onRefactorDraft', 'onReorgDraft', 'onDeleteDraft', 'onNoteBodyDraft', 'askUser',
-    ]) {
+    for (const key of TOOL_CALLBACK_KEYS) {
       expect(out[key], `${key} must reach the tool executor`).toBe((all as Record<string, unknown>)[key]);
     }
+    // Exactly the tool-facing keys — nothing less (dropped callback), nothing
+    // more (a stream-only callback like onChunk leaking through).
+    expect(Object.keys(out).sort()).toEqual([...TOOL_CALLBACK_KEYS].sort());
+  });
+
+  it('keeps the sample honest: a stub exists for every TOOL_CALLBACK_KEYS entry', () => {
+    for (const key of TOOL_CALLBACK_KEYS) {
+      expect(key in all, `add a stub for '${key}' to the test sample`).toBe(true);
+    }
+  });
+
+  it('lists each callback key exactly once', () => {
+    expect(new Set(TOOL_CALLBACK_KEYS).size).toBe(TOOL_CALLBACK_KEYS.length);
   });
 
   it('does not leak stream-only callbacks (onChunk) into tool callbacks', () => {


### PR DESCRIPTION
## Summary
Closes the documented `TOOL_CALLBACK_KEYS` foot-gun (team memory): a callback added to the `ToolCallbacks` interface and wired in the conversation IPC handler, but **not** listed in `TOOL_CALLBACK_KEYS`, never reaches the tool executor — the tool silently reports *"only available in conversation contexts"* at runtime, with nothing failing at build. This is exactly what bit the note-refactor tools (#912/#914).

## Approach — catch it at build time
Types are erased at runtime and test files aren't run through `tsc` (only `src/**` is), so the reliable catch is a **compile-time guard co-located with the constant** in `src/main/llm/index.ts`:

```ts
export const TOOL_CALLBACK_KEYS = [ ... ] as const satisfies readonly (keyof ToolCallbacks)[];

type _UnlistedToolCallbacks = Exclude<keyof ToolCallbacks, (typeof TOOL_CALLBACK_KEYS)[number]>;
const _allToolCallbacksListed: _UnlistedToolCallbacks extends never
  ? true
  : { readonly ERROR: 'key missing from TOOL_CALLBACK_KEYS'; readonly missing: _UnlistedToolCallbacks } = true;
```

- `satisfies` rejects a **stale/typo'd** key (in the list, not on the interface).
- The completeness guard rejects the **silent foot-gun** (on the interface, missing from the list) — the assignment stops typechecking, so `pnpm lint` fails.

**Verified it bites:** dropping `askUser` from the list produces `error TS2322 … missing: "askUser"`; restoring → clean.

## Runtime test
Reworked the existing `tool-callbacks-passthrough.test.ts` (which hardcoded a copy of the 11 keys — the very duplication that lets drift slip) to derive from the now-exported `TOOL_CALLBACK_KEYS`, so it auto-covers new keys. It asserts the projection carries **exactly** the tool-facing keys (nothing dropped, `onChunk` not leaked), keeps the test sample honest, and that each key is listed once.

## Testing
- `pnpm test tests/main/llm/` — 204 passed.
- `pnpm lint` — 0 errors; negative check confirmed the guard fails `tsc` on a missing key.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)