### PR TITLE
fix: remove 5 dead Edit-menu items shadowing the editor keymap (#981)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -334,36 +334,10 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
         }),
         { type: 'separator' },
         gate({
-          label: 'Toggle Case',
-          accelerator: 'CmdOrCtrl+Shift+U',
-          click: () => send(Channels.MENU_TOGGLE_CASE),
-        }),
-        gate({
           label: 'Insert Template…',
           click: () => send(Channels.MENU_INSERT_TEMPLATE),
         }),
         { type: 'separator' },
-        gate({
-          label: 'Extend Selection',
-          accelerator: 'Alt+Up',
-          click: () => send(Channels.MENU_EXTEND_SELECTION),
-        }),
-        gate({
-          label: 'Shrink Selection',
-          accelerator: 'Alt+Down',
-          click: () => send(Channels.MENU_SHRINK_SELECTION),
-        }),
-        { type: 'separator' },
-        gate({
-          label: 'Join Lines',
-          accelerator: 'Ctrl+Shift+J',
-          click: () => send(Channels.MENU_JOIN_LINES),
-        }),
-        gate({
-          label: 'Duplicate Line',
-          accelerator: 'CmdOrCtrl+D',
-          click: () => send(Channels.MENU_DUPLICATE_LINE),
-        }),
         gate({
           label: 'Sort Lines',
           click: () => send(Channels.MENU_SORT_LINES),

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -175,11 +175,6 @@ export const Channels = {
   MENU_FIND_REPLACE: 'menu:findReplace',
   MENU_FIND_IN_NOTES: 'menu:findInNotes',
   MENU_REPLACE_IN_NOTES: 'menu:replaceInNotes',
-  MENU_TOGGLE_CASE: 'menu:toggleCase',
-  MENU_EXTEND_SELECTION: 'menu:extendSelection',
-  MENU_SHRINK_SELECTION: 'menu:shrinkSelection',
-  MENU_JOIN_LINES: 'menu:joinLines',
-  MENU_DUPLICATE_LINE: 'menu:duplicateLine',
   MENU_SORT_LINES: 'menu:sortLines',
   MENU_OPEN_SETTINGS: 'menu:openSettings',
 


### PR DESCRIPTION
## Summary
Removes the 5 orphaned menu channels the architecture review flagged (C1 — evidence of IPC boundary drift): **Toggle Case, Extend Selection, Shrink Selection, Join Lines, Duplicate Line**. These Edit-menu items `send()` a `menu:*` IPC event that **no renderer handler ever listens for** — they were never bridged in `preload.ts`, so clicking them did nothing.

## Why they were worse than merely dead
Each carried an accelerator identical to the real CodeMirror binding for the same command in `src/renderer/lib/editor/command-registry.ts`:

| Menu item | Menu accelerator | CM command (`command-registry.ts`) |
|---|---|---|
| Toggle Case | `CmdOrCtrl+Shift+U` | `toggleCase` — `Mod-Shift-u` |
| Extend Selection | `Alt+Up` | `extendSelection` — `Alt-ArrowUp` |
| Shrink Selection | `Alt+Down` | `shrinkSelection` — `Alt-ArrowDown` |
| Join Lines | `Ctrl+Shift+J` | `joinLines` — `Ctrl-Shift-j` |
| Duplicate Line | `CmdOrCtrl+D` | `duplicateLine` — `Mod-d` |

Electron menu accelerators are global and take precedence over web content, so the dead menu accelerator **shadowed the live CodeMirror keymap**. Removing the items lets CodeMirror handle the keys, and the commands stay discoverable via the command palette + keymap. (The codebase already navigates this exact collision class — see the `Mod-Shift-y` highlight comment in `command-registry.ts`.)

## Changes
- `src/main/menu.ts` — remove the 5 `gate({…})` items + their now-redundant separators. **Sort Lines** (renderer-wired via `api.menu.onSortLines`) and **Insert Template** stay.
- `src/shared/channels.ts` — remove the 5 orphaned `MENU_*` constants.

## Testing
- `grep` confirms zero remaining references to the 5 channels anywhere.
- `pnpm lint` — 0 errors.
- `tests/main/menu-accelerators.test.ts` — 8 passed; preload-bridge snapshot + IPC-registration tests unaffected (these channels were never bridged/handled).

Part of #981 (the ChannelMap type-linkage lands separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)