### PR TITLE
refactor: type-link the notebase IPC boundary via a ChannelMap (#981)

### DIFF
--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -18,6 +18,7 @@ import { createWindow, openProjectInWindow, closeProjectInWindow, markPathHandle
 import { getOnboardingDismissed, setOnboardingDismissed } from '../project-config';
 import { dropImport } from '../notebase/drop-import';
 import { searchInNotes, replaceInNotes, type SearchOptions, type ReplaceSelection } from '../notebase/search-in-notes';
+import { handle } from './typed-ipc';
 import {
   winFromEvent,
   rootPathFromEvent,
@@ -30,7 +31,7 @@ import {
 } from './helpers';
 
 export function registerNotebase(): void {
-  ipcMain.handle(Channels.NOTEBASE_OPEN, async (e) => {
+  handle(Channels.NOTEBASE_OPEN, async (e) => {
     const meta = await notebaseFs.openNotebase();
     if (meta) {
       const win = winFromEvent(e);
@@ -39,13 +40,13 @@ export function registerNotebase(): void {
     return meta;
   });
 
-  ipcMain.handle(Channels.NOTEBASE_OPEN_PATH, async (e, rootPath: string) => {
+  handle(Channels.NOTEBASE_OPEN_PATH, async (e, rootPath: string) => {
     const win = winFromEvent(e);
     await openProjectInWindow(win, rootPath);
     return { rootPath, name: path.basename(rootPath) };
   });
 
-  ipcMain.handle(Channels.NOTEBASE_NEW_PROJECT, async (e) => {
+  handle(Channels.NOTEBASE_NEW_PROJECT, async (e) => {
     const result = await dialog.showOpenDialog({
       properties: ['openDirectory', 'createDirectory'],
       title: 'Choose location for new thoughtbase',
@@ -59,7 +60,7 @@ export function registerNotebase(): void {
     return { rootPath, name: path.basename(rootPath) };
   });
 
-  ipcMain.handle(Channels.NOTEBASE_CLOSE, (e) => {
+  handle(Channels.NOTEBASE_CLOSE, (e) => {
     const win = winFromEvent(e);
     closeProjectInWindow(win.id);
     return null;
@@ -71,7 +72,7 @@ export function registerNotebase(): void {
   // invoking window for focus; the fresh window is created once the user
   // commits to a path.
 
-  ipcMain.handle(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW, async (e) => {
+  handle(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW, async (e) => {
     const parentWin = winFromEvent(e);
     const result = await dialog.showOpenDialog(parentWin, {
       properties: ['openDirectory'],
@@ -87,7 +88,7 @@ export function registerNotebase(): void {
     return { rootPath, name: path.basename(rootPath) };
   });
 
-  ipcMain.handle(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW, async (e) => {
+  handle(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW, async (e) => {
     const parentWin = winFromEvent(e);
     const result = await dialog.showOpenDialog(parentWin, {
       properties: ['openDirectory', 'createDirectory'],
@@ -104,7 +105,7 @@ export function registerNotebase(): void {
     return { rootPath, name: path.basename(rootPath) };
   });
 
-  ipcMain.handle(Channels.NOTEBASE_OPEN_PATH_IN_NEW_WINDOW, (_e, rootPath: string) => {
+  handle(Channels.NOTEBASE_OPEN_PATH_IN_NEW_WINDOW, (_e, rootPath: string) => {
     const freshWin = createWindow();
     freshWin.webContents.once('did-finish-load', async () => {
       await openProjectInWindow(freshWin, rootPath);
@@ -113,24 +114,24 @@ export function registerNotebase(): void {
     return { rootPath, name: path.basename(rootPath) };
   });
 
-  ipcMain.handle(Channels.RECENT_CLEAR, () => {
+  handle(Channels.RECENT_CLEAR, () => {
     clearRecentProjects();
     rebuildMenu();
   });
 
-  ipcMain.handle(Channels.NOTEBASE_LIST_FILES, async (e) => {
+  handle(Channels.NOTEBASE_LIST_FILES, async (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return [];
     return notebaseFs.listFiles(rootPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_READ_FILE, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_READ_FILE, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     return notebaseFs.readFile(rootPath, relativePath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_READ_BINARY, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_READ_BINARY, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     // Pass the bytes back as a Buffer; Electron's structured-clone
@@ -138,7 +139,7 @@ export function registerNotebase(): void {
     return notebaseFs.readBinaryFile(rootPath, relativePath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_WRITE_BINARY, async (e, relativePath: string, bytes: Uint8Array) => {
+  handle(Channels.NOTEBASE_WRITE_BINARY, async (e, relativePath: string, bytes: Uint8Array) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     // The renderer wraps payload as a Uint8Array; structured-clone
@@ -148,13 +149,13 @@ export function registerNotebase(): void {
     await notebaseFs.writeBinaryFile(rootPath, relativePath, view);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_FILE_EXISTS, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_FILE_EXISTS, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return false;
     return notebaseFs.fileExists(rootPath, relativePath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_WRITE_FILE, async (e, relativePath: string, content: string) => {
+  handle(Channels.NOTEBASE_WRITE_FILE, async (e, relativePath: string, content: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     // Renderer-initiated save — it already has the content, so suppress
@@ -164,7 +165,7 @@ export function registerNotebase(): void {
     });
   });
 
-  ipcMain.handle(Channels.NOTEBASE_CREATE_FILE, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_CREATE_FILE, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
@@ -174,7 +175,7 @@ export function registerNotebase(): void {
     search.indexNote(ctx, relativePath, '');
   });
 
-  ipcMain.handle(Channels.NOTEBASE_DELETE_FILE, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_DELETE_FILE, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     markPathHandled(relativePath);
@@ -183,13 +184,13 @@ export function registerNotebase(): void {
     await persistIndexes(rootPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_CREATE_FOLDER, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_CREATE_FOLDER, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     await notebaseFs.createFolder(rootPath, relativePath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_DELETE_FOLDER, async (e, relativePath: string) => {
+  handle(Channels.NOTEBASE_DELETE_FOLDER, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     const files = await listIndexableFiles(rootPath, relativePath);
@@ -198,7 +199,7 @@ export function registerNotebase(): void {
     await persistIndexes(rootPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_RENAME, async (e, oldRelPath: string, newRelPath: string) => {
+  handle(Channels.NOTEBASE_RENAME, async (e, oldRelPath: string, newRelPath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
 
@@ -231,13 +232,13 @@ export function registerNotebase(): void {
     await persistIndexes(rootPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_MERGE_PREVIEW, async (e, sourceRelPath: string, targetRelPath: string) => {
+  handle(Channels.NOTEBASE_MERGE_PREVIEW, async (e, sourceRelPath: string, targetRelPath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     return previewMergeNotes(rootPath, sourceRelPath, targetRelPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_MERGE, async (e, sourceRelPath: string, targetRelPath: string, separator?: string) => {
+  handle(Channels.NOTEBASE_MERGE, async (e, sourceRelPath: string, targetRelPath: string, separator?: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     const ctx = projectContext(rootPath);
@@ -275,7 +276,7 @@ export function registerNotebase(): void {
     return result;
   });
 
-  ipcMain.handle(Channels.NOTEBASE_RENAME_SOURCE, async (e, oldId: string, newId: string) => {
+  handle(Channels.NOTEBASE_RENAME_SOURCE, async (e, oldId: string, newId: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     const ctx = projectContext(rootPath);
@@ -290,7 +291,7 @@ export function registerNotebase(): void {
     return { rewrittenPaths };
   });
 
-  ipcMain.handle(Channels.NOTEBASE_RENAME_EXCERPT, async (e, oldId: string, newId: string) => {
+  handle(Channels.NOTEBASE_RENAME_EXCERPT, async (e, oldId: string, newId: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     const ctx = projectContext(rootPath);
@@ -332,7 +333,7 @@ export function registerNotebase(): void {
     },
   );
 
-  ipcMain.handle(Channels.NOTEBASE_COPY, async (e, srcRelPath: string, destRelPath: string) => {
+  handle(Channels.NOTEBASE_COPY, async (e, srcRelPath: string, destRelPath: string) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     await notebaseFs.copyItem(rootPath, srcRelPath, destRelPath);
@@ -346,13 +347,13 @@ export function registerNotebase(): void {
     await persistIndexes(rootPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_SEARCH_IN_NOTES, async (e, opts: SearchOptions) => {
+  handle(Channels.NOTEBASE_SEARCH_IN_NOTES, async (e, opts: SearchOptions) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return [];
     return searchInNotes(rootPath, opts);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_REPLACE_IN_NOTES, async (e, opts: SearchOptions & { replacement: string; selections: ReplaceSelection[] }) => {
+  handle(Channels.NOTEBASE_REPLACE_IN_NOTES, async (e, opts: SearchOptions & { replacement: string; selections: ReplaceSelection[] }) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return { changedPaths: [], replacedCount: 0 };
     const result = await replaceInNotes(rootPath, opts);
@@ -366,13 +367,13 @@ export function registerNotebase(): void {
     return result;
   });
 
-  ipcMain.handle(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED, (e) => {
+  handle(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED, (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return false;
     return getOnboardingDismissed(rootPath);
   });
 
-  ipcMain.handle(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, (e, dismissed: boolean) => {
+  handle(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, (e, dismissed: boolean) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
     setOnboardingDismissed(rootPath, dismissed === true);

--- a/src/main/ipc/typed-ipc.ts
+++ b/src/main/ipc/typed-ipc.ts
@@ -1,0 +1,11 @@
+import { ipcMain, type IpcMainInvokeEvent } from 'electron';
+import type { ChannelMap } from '../../shared/ipc-contract';
+
+/** Typed `ipcMain.handle`: the handler's args + return are checked against the ChannelMap. */
+export function handle<K extends keyof ChannelMap>(
+  channel: K,
+  handler: (event: IpcMainInvokeEvent, ...args: Parameters<ChannelMap[K]>) =>
+    Awaited<ReturnType<ChannelMap[K]>> | Promise<Awaited<ReturnType<ChannelMap[K]>>>,
+): void {
+  ipcMain.handle(channel, handler as (e: IpcMainInvokeEvent, ...a: unknown[]) => unknown);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,5 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { Channels } from '../shared/channels';
+import { invoke } from './typed-invoke';
+import type { SearchInNotesOptions, ReplaceInNotesOptions } from '../shared/types';
 
 /**
  * Subscribe to an IPC channel and forward the typed payload to `cb`.
@@ -15,43 +17,43 @@ function subscribeIpc<T>(channel: string, cb: (payload: T) => void): () => void 
 
 contextBridge.exposeInMainWorld('api', {
   notebase: {
-    open: () => ipcRenderer.invoke(Channels.NOTEBASE_OPEN),
-    openPath: (rootPath: string) => ipcRenderer.invoke(Channels.NOTEBASE_OPEN_PATH, rootPath),
-    newProject: () => ipcRenderer.invoke(Channels.NOTEBASE_NEW_PROJECT),
-    openInNewWindow: () => ipcRenderer.invoke(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW),
-    newProjectInNewWindow: () => ipcRenderer.invoke(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW),
-    openPathInNewWindow: (rootPath: string) => ipcRenderer.invoke(Channels.NOTEBASE_OPEN_PATH_IN_NEW_WINDOW, rootPath),
-    close: () => ipcRenderer.invoke(Channels.NOTEBASE_CLOSE),
-    clearRecent: () => ipcRenderer.invoke(Channels.RECENT_CLEAR),
-    listFiles: () => ipcRenderer.invoke(Channels.NOTEBASE_LIST_FILES),
+    open: () => invoke(Channels.NOTEBASE_OPEN),
+    openPath: (rootPath: string) => invoke(Channels.NOTEBASE_OPEN_PATH, rootPath),
+    newProject: () => invoke(Channels.NOTEBASE_NEW_PROJECT),
+    openInNewWindow: () => invoke(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW),
+    newProjectInNewWindow: () => invoke(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW),
+    openPathInNewWindow: (rootPath: string) => invoke(Channels.NOTEBASE_OPEN_PATH_IN_NEW_WINDOW, rootPath),
+    close: () => invoke(Channels.NOTEBASE_CLOSE),
+    clearRecent: () => invoke(Channels.RECENT_CLEAR),
+    listFiles: () => invoke(Channels.NOTEBASE_LIST_FILES),
     readFile: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_READ_FILE, relativePath),
+      invoke(Channels.NOTEBASE_READ_FILE, relativePath),
     readBinary: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_READ_BINARY, relativePath),
+      invoke(Channels.NOTEBASE_READ_BINARY, relativePath),
     writeBinary: (relativePath: string, bytes: Uint8Array) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_WRITE_BINARY, relativePath, bytes),
+      invoke(Channels.NOTEBASE_WRITE_BINARY, relativePath, bytes),
     fileExists: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_FILE_EXISTS, relativePath),
+      invoke(Channels.NOTEBASE_FILE_EXISTS, relativePath),
     writeFile: (relativePath: string, content: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_WRITE_FILE, relativePath, content),
+      invoke(Channels.NOTEBASE_WRITE_FILE, relativePath, content),
     createFile: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_CREATE_FILE, relativePath),
+      invoke(Channels.NOTEBASE_CREATE_FILE, relativePath),
     deleteFile: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_DELETE_FILE, relativePath),
+      invoke(Channels.NOTEBASE_DELETE_FILE, relativePath),
     createFolder: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_CREATE_FOLDER, relativePath),
+      invoke(Channels.NOTEBASE_CREATE_FOLDER, relativePath),
     deleteFolder: (relativePath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_DELETE_FOLDER, relativePath),
+      invoke(Channels.NOTEBASE_DELETE_FOLDER, relativePath),
     rename: (oldRelPath: string, newRelPath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_RENAME, oldRelPath, newRelPath),
+      invoke(Channels.NOTEBASE_RENAME, oldRelPath, newRelPath),
     mergePreview: (sourceRelPath: string, targetRelPath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_MERGE_PREVIEW, sourceRelPath, targetRelPath),
+      invoke(Channels.NOTEBASE_MERGE_PREVIEW, sourceRelPath, targetRelPath),
     merge: (sourceRelPath: string, targetRelPath: string, separator?: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_MERGE, sourceRelPath, targetRelPath, separator),
+      invoke(Channels.NOTEBASE_MERGE, sourceRelPath, targetRelPath, separator),
     copy: (srcRelPath: string, destRelPath: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_COPY, srcRelPath, destRelPath),
-    searchInNotes: (opts: unknown) => ipcRenderer.invoke(Channels.NOTEBASE_SEARCH_IN_NOTES, opts),
-    replaceInNotes: (opts: unknown) => ipcRenderer.invoke(Channels.NOTEBASE_REPLACE_IN_NOTES, opts),
+      invoke(Channels.NOTEBASE_COPY, srcRelPath, destRelPath),
+    searchInNotes: (opts: SearchInNotesOptions) => invoke(Channels.NOTEBASE_SEARCH_IN_NOTES, opts),
+    replaceInNotes: (opts: ReplaceInNotesOptions) => invoke(Channels.NOTEBASE_REPLACE_IN_NOTES, opts),
     onFileChanged: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_CHANGED, cb),
     onFileCreated: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_CREATED, cb),
     onFileDeleted: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_DELETED, cb),
@@ -67,15 +69,15 @@ contextBridge.exposeInMainWorld('api', {
       incomingLinkCount: number;
     }) => void) => subscribeIpc(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, cb),
     renameAnchor: (targetRelativePath: string, oldSlug: string, newSlug: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_RENAME_ANCHOR, targetRelativePath, oldSlug, newSlug),
+      invoke(Channels.NOTEBASE_RENAME_ANCHOR, targetRelativePath, oldSlug, newSlug),
     renameSource: (oldId: string, newId: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_RENAME_SOURCE, oldId, newId),
+      invoke(Channels.NOTEBASE_RENAME_SOURCE, oldId, newId),
     renameExcerpt: (oldId: string, newId: string) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_RENAME_EXCERPT, oldId, newId),
+      invoke(Channels.NOTEBASE_RENAME_EXCERPT, oldId, newId),
     getOnboardingDismissed: () =>
-      ipcRenderer.invoke(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED),
+      invoke(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED),
     setOnboardingDismissed: (dismissed: boolean) =>
-      ipcRenderer.invoke(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, dismissed),
+      invoke(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, dismissed),
   },
   links: {
     outgoing: (relativePath: string) => ipcRenderer.invoke(Channels.LINKS_OUTGOING, relativePath),

--- a/src/preload/typed-invoke.ts
+++ b/src/preload/typed-invoke.ts
@@ -1,0 +1,9 @@
+import { ipcRenderer } from 'electron';
+import type { ChannelMap } from '../shared/ipc-contract';
+
+/** Typed `ipcRenderer.invoke`: args checked, return typed, against the ChannelMap. */
+export function invoke<K extends keyof ChannelMap>(
+  channel: K, ...args: Parameters<ChannelMap[K]>
+): Promise<Awaited<ReturnType<ChannelMap[K]>>> {
+  return ipcRenderer.invoke(channel, ...args) as Promise<Awaited<ReturnType<ChannelMap[K]>>>;
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
 
@@ -58,49 +58,15 @@ export interface NotebaseApi {
   setOnboardingDismissed(dismissed: boolean): Promise<void>;
 }
 
-export interface SearchInNotesOptions {
-  pattern: string;
-  caseSensitive: boolean;
-  regex: boolean;
-}
-
-export interface SearchInNotesMatch {
-  line: number;
-  startCol: number;
-  endCol: number;
-  lineText: string;
-}
-
-export interface SearchInNotesFileResult {
-  relativePath: string;
-  matches: SearchInNotesMatch[];
-}
-
-export interface ReplaceInNotesSelection {
-  relativePath: string;
-  line: number;
-  startCol: number;
-  endCol: number;
-}
-
-export interface ReplaceInNotesOptions extends SearchInNotesOptions {
-  replacement: string;
-  selections: ReplaceInNotesSelection[];
-}
-
-export interface ReplaceInNotesResult {
-  changedPaths: string[];
-  replacedCount: number;
-}
-
-export interface HeadingRenameCandidate {
-  relativePath: string;
-  oldSlug: string;
-  oldText: string;
-  newSlug: string;
-  newText: string;
-  incomingLinkCount: number;
-}
+export type {
+  SearchInNotesOptions,
+  SearchInNotesMatch,
+  SearchInNotesFileResult,
+  ReplaceInNotesSelection,
+  ReplaceInNotesOptions,
+  ReplaceInNotesResult,
+  HeadingRenameCandidate,
+} from '../../../shared/types';
 
 export interface LinksApi {
   outgoing(relativePath: string): Promise<OutgoingLink[]>;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,0 +1,61 @@
+/**
+ * Typed IPC contract for the notebase domain (#981).
+ *
+ * ONE source of truth linking channel ↔ handler ↔ preload ↔ client
+ * signatures. Keys are the channel string literals (matching the
+ * `Channels.*` values in `./channels`); values are the renderer-facing
+ * signature `(...args) => ReturnValue`, where `ReturnValue` is the
+ * RESOLVED value (Promises are unwrapped — the wrappers re-wrap).
+ *
+ * Pure type module: no runtime, no electron import. The typed
+ * `handle`/`invoke` wrappers derive their arg + return types from here,
+ * so a wrong param/return type fails `tsc` instead of silently
+ * corrupting renderer state.
+ */
+import type {
+  NotebaseMeta,
+  NoteFile,
+  SearchInNotesOptions,
+  SearchInNotesFileResult,
+  ReplaceInNotesOptions,
+  ReplaceInNotesResult,
+  HeadingRenameCandidate,
+} from './types';
+
+// `HeadingRenameCandidate` is part of the notebase wire contract (the
+// NOTEBASE_HEADING_RENAME_SUGGESTED event payload) but isn't an
+// invoke channel, so it isn't a ChannelMap key — reference it here to
+// keep the import meaningful for the domain's type surface.
+export type { HeadingRenameCandidate };
+
+export interface ChannelMap {
+  'notebase:open': () => NotebaseMeta | null;
+  'notebase:openPath': (rootPath: string) => NotebaseMeta;
+  'notebase:newProject': () => NotebaseMeta | null;
+  'notebase:openInNewWindow': () => NotebaseMeta | null;
+  'notebase:newProjectInNewWindow': () => NotebaseMeta | null;
+  'notebase:openPathInNewWindow': (rootPath: string) => NotebaseMeta;
+  'notebase:close': () => null;
+  'recent:clear': () => void;
+  'notebase:listFiles': () => NoteFile[];
+  'notebase:readFile': (relativePath: string) => string;
+  'notebase:readBinary': (relativePath: string) => Uint8Array;
+  'notebase:writeBinary': (relativePath: string, bytes: Uint8Array) => void;
+  'notebase:fileExists': (relativePath: string) => boolean;
+  'notebase:writeFile': (relativePath: string, content: string) => void;
+  'notebase:createFile': (relativePath: string) => void;
+  'notebase:deleteFile': (relativePath: string) => void;
+  'notebase:createFolder': (relativePath: string) => void;
+  'notebase:deleteFolder': (relativePath: string) => void;
+  'notebase:rename': (oldRelPath: string, newRelPath: string) => void;
+  'notebase:mergePreview': (sourceRelPath: string, targetRelPath: string) => { linkOccurrences: number; affectedFiles: number };
+  'notebase:merge': (sourceRelPath: string, targetRelPath: string, separator?: string) => { targetPath: string; mergeOffset: number; mergeLine: number; rewrittenLinks: number; rewrittenPaths: string[]; deletedSource: string };
+  'notebase:copy': (srcRelPath: string, destRelPath: string) => void;
+  'notebase:searchInNotes': (opts: SearchInNotesOptions) => SearchInNotesFileResult[];
+  'notebase:replaceInNotes': (opts: ReplaceInNotesOptions) => ReplaceInNotesResult;
+  'notebase:renameAnchor': (targetRelativePath: string, oldSlug: string, newSlug: string) => { rewrittenPaths: string[] };
+  'notebase:renameSource': (oldId: string, newId: string) => { rewrittenPaths: string[] };
+  'notebase:renameExcerpt': (oldId: string, newId: string) => { rewrittenPaths: string[] };
+  'notebase:getOnboardingDismissed': () => boolean;
+  'notebase:setOnboardingDismissed': (dismissed: boolean) => void;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,6 +15,50 @@ export interface NotebaseMeta {
   name: string;
 }
 
+export interface SearchInNotesOptions {
+  pattern: string;
+  caseSensitive: boolean;
+  regex: boolean;
+}
+
+export interface SearchInNotesMatch {
+  line: number;
+  startCol: number;
+  endCol: number;
+  lineText: string;
+}
+
+export interface SearchInNotesFileResult {
+  relativePath: string;
+  matches: SearchInNotesMatch[];
+}
+
+export interface ReplaceInNotesSelection {
+  relativePath: string;
+  line: number;
+  startCol: number;
+  endCol: number;
+}
+
+export interface ReplaceInNotesOptions extends SearchInNotesOptions {
+  replacement: string;
+  selections: ReplaceInNotesSelection[];
+}
+
+export interface ReplaceInNotesResult {
+  changedPaths: string[];
+  replacedCount: number;
+}
+
+export interface HeadingRenameCandidate {
+  relativePath: string;
+  oldSlug: string;
+  oldText: string;
+  newSlug: string;
+  newText: string;
+  incomingLinkCount: number;
+}
+
 export interface TagInfo {
   tag: string;
   /** Notes carrying this tag (deduped by note). */


### PR DESCRIPTION
## Summary
The 302 IPC channels were stringly-typed with **no compile-time link** between a handler's signature, its preload exposure, and its `client.ts` type — three hand-maintained truths. A wrong param or return type surfaced only at runtime, silently corrupting renderer state (architecture review C1).

This lands the **`ChannelMap` mechanism** and migrates the **notebase domain end-to-end as the template**. Other domains keep raw `ipcMain.handle` and compile unchanged; they adopt the wrappers incrementally later.

## Design
- **`src/shared/ipc-contract.ts`** (new) — a pure-type `ChannelMap`: one source of truth mapping each of the 29 notebase invoke channels to its renderer-facing `(...args) => ReturnValue` signature. No electron import (layer-clean).
- **`src/main/ipc/typed-ipc.ts`** (new) — `handle<K extends keyof ChannelMap>(channel, handler)`: the handler's args + return are checked against the contract.
- **`src/preload/typed-invoke.ts`** (new) — `invoke<K>(channel, ...args)`: args checked, return typed.
- **`register-notebase.ts` / `preload.ts`** — the 29 notebase channels now flow through the typed wrappers. Handler bodies verbatim; event `send`/`on` channels and non-notebase handlers untouched.
- **`shared/types.ts`** — the 7 notebase wire interfaces (`SearchInNotes*`, `ReplaceInNotes*`, `HeadingRenameCandidate`) moved here so main and renderer share **one** definition; `client.ts` re-exports them so existing importers are unaffected.

## Proof the linkage bites (verified independently)
Temporarily changing a `ChannelMap` **arg** type (`notebase:readFile` `string → number`) errors in **both** layers:
```
register-notebase.ts(128,39): error TS2345 … relativePath: number
preload.ts(30,43):            error TS2345 … 'string' not assignable to 'number'
```
A **return-type** break errors at the handler (`register-notebase.ts`). Return values flow through the untyped `contextBridge`, so the return type is pinned at the main/handler end — which is where a wrong-return bug originates. Reverted; tsc clean.

## Scope
7 files (3 new + 4 modified). Notebase invoke channels only — the request/response ones with the correctness gap. Event subscriptions (`onFileChanged`, etc.) are a separate `on`-based concern, left as-is.

## Testing
- `pnpm lint` — 0 errors.
- `pnpm test tests/main tests/preload` — **196 files / 1966 tests pass**.
- Preload contextBridge snapshot **unchanged** (no `-u`) — public API shape identical, confirming behavior preservation.

Closes #981 (the 5 orphaned menu channels were removed in #1026). Remaining domains can adopt `handle`/`invoke` incrementally against a growing `ChannelMap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)