### PR TITLE
refactor: collapse conversation draft subscriptions via a factory (#980)

### DIFF
--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -195,16 +195,9 @@ let needsApiKey = $state(false);
 // resize, every visibility toggle) and we don't want to fan out a write
 // per change. Debounced via a single timeout that re-arms.
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
-let draftSubscribed = false;
-let sourceDraftSubscribed = false;
-let propertyDraftSubscribed = false;
-let sourcePropertyDraftSubscribed = false;
-let claimsDraftSubscribed = false;
-let computeDraftSubscribed = false;
-let refactorDraftSubscribed = false;
-let reorgDraftSubscribed = false;
-let deleteDraftSubscribed = false;
-let noteBodyDraftSubscribed = false;
+// One flag guards the whole uniform draft-subscription block below — the 10
+// per-kind subscriptions are all wired together in a single pass (#980).
+let draftsSubscribed = false;
 let streamSubscribed = false;
 let askUserSubscribed = false;
 
@@ -229,6 +222,25 @@ function scheduleSave(): void {
   }, 250);
 }
 
+/**
+ * Build a uniform draft handler (#980): find the tab by conversationId, anchor
+ * the draft at `afterMessageIndex` — the slot the streaming assistant message
+ * will land in post-reload (`messages.length` already counts the optimistic
+ * user turn `send()` pushed before awaiting the IPC) — and hand the anchored
+ * draft to `append`, which does the per-kind array push (and, for compute
+ * drafts, seeds the state entry).
+ */
+function draftHandler<T extends { conversationId: string; draftId: string }>(
+  append: (tab: TabRuntime, anchored: T & { afterMessageIndex: number }) => void,
+): (draft: T) => void {
+  return (draft) => {
+    const t = findTab(draft.conversationId);
+    if (!t) return;
+    const afterMessageIndex = t.conversation.messages.length;
+    append(t, { ...draft, afterMessageIndex });
+  };
+}
+
 function ensureSubscriptions(): void {
   if (!streamSubscribed) {
     api.conversations.onStream((chunk) => {
@@ -238,110 +250,31 @@ function ensureSubscriptions(): void {
     });
     streamSubscribed = true;
   }
-  if (!draftSubscribed) {
-    api.conversations.onDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      // Anchor to the slot the streaming assistant message will land in
-      // post-reload. `messages.length` already counts the optimistic
-      // user turn `send()` pushed before awaiting the IPC, so it points
-      // at where the assistant turn will be appended.
-      const afterMessageIndex = t.conversation.messages.length;
-      t.drafts = [...t.drafts, { ...draft, afterMessageIndex }];
-    });
-    draftSubscribed = true;
-  }
-  if (!sourceDraftSubscribed) {
-    api.conversations.onSourceDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.sourceDrafts = [...t.sourceDrafts, { ...draft, afterMessageIndex }];
-    });
-    sourceDraftSubscribed = true;
-  }
-  if (!propertyDraftSubscribed) {
-    api.conversations.onPropertyDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.propertyDrafts = [...t.propertyDrafts, { ...draft, afterMessageIndex }];
-    });
-    propertyDraftSubscribed = true;
-  }
-  if (!sourcePropertyDraftSubscribed) {
-    api.conversations.onSourcePropertyDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.sourcePropertyDrafts = [...t.sourcePropertyDrafts, { ...draft, afterMessageIndex }];
-    });
-    sourcePropertyDraftSubscribed = true;
-  }
-  if (!claimsDraftSubscribed) {
-    api.conversations.onClaimsDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.claimsDrafts = [...t.claimsDrafts, { ...draft, afterMessageIndex }];
-    });
-    claimsDraftSubscribed = true;
-  }
-  if (!computeDraftSubscribed) {
-    api.conversations.onComputeDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.computeDrafts = [...t.computeDrafts, { ...draft, afterMessageIndex }];
+  if (!draftsSubscribed) {
+    api.conversations.onDraft(draftHandler((t, d) => { t.drafts = [...t.drafts, d]; }));
+    api.conversations.onSourceDraft(draftHandler((t, d) => { t.sourceDrafts = [...t.sourceDrafts, d]; }));
+    api.conversations.onPropertyDraft(draftHandler((t, d) => { t.propertyDrafts = [...t.propertyDrafts, d]; }));
+    api.conversations.onSourcePropertyDraft(draftHandler((t, d) => { t.sourcePropertyDrafts = [...t.sourcePropertyDrafts, d]; }));
+    api.conversations.onClaimsDraft(draftHandler((t, d) => { t.claimsDrafts = [...t.claimsDrafts, d]; }));
+    api.conversations.onComputeDraft(draftHandler((t, d) => {
+      t.computeDrafts = [...t.computeDrafts, d];
       // Seed the state entry so the panel can render a pristine card
       // immediately (no Run yet, no Insert yet).
       t.computeDraftState = {
         ...t.computeDraftState,
-        [draft.draftId]: {
+        [d.draftId]: {
           result: null,
           running: false,
           insertedAt: null,
-          afterMessageIndex,
+          afterMessageIndex: d.afterMessageIndex,
         },
       };
-    });
-    computeDraftSubscribed = true;
-  }
-  if (!refactorDraftSubscribed) {
-    api.conversations.onRefactorDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.refactorDrafts = [...t.refactorDrafts, { ...draft, afterMessageIndex }];
-    });
-    refactorDraftSubscribed = true;
-  }
-  if (!reorgDraftSubscribed) {
-    api.conversations.onReorgDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.reorgDrafts = [...t.reorgDrafts, { ...draft, afterMessageIndex }];
-    });
-    reorgDraftSubscribed = true;
-  }
-  if (!deleteDraftSubscribed) {
-    api.conversations.onDeleteDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.deleteDrafts = [...t.deleteDrafts, { ...draft, afterMessageIndex }];
-    });
-    deleteDraftSubscribed = true;
-  }
-  if (!noteBodyDraftSubscribed) {
-    api.conversations.onNoteBodyDraft((draft) => {
-      const t = tabs.find((tab) => tab.id === draft.conversationId);
-      if (!t) return;
-      const afterMessageIndex = t.conversation.messages.length;
-      t.noteBodyDrafts = [...t.noteBodyDrafts, { ...draft, afterMessageIndex }];
-    });
-    noteBodyDraftSubscribed = true;
+    }));
+    api.conversations.onRefactorDraft(draftHandler((t, d) => { t.refactorDrafts = [...t.refactorDrafts, d]; }));
+    api.conversations.onReorgDraft(draftHandler((t, d) => { t.reorgDrafts = [...t.reorgDrafts, d]; }));
+    api.conversations.onDeleteDraft(draftHandler((t, d) => { t.deleteDrafts = [...t.deleteDrafts, d]; }));
+    api.conversations.onNoteBodyDraft(draftHandler((t, d) => { t.noteBodyDrafts = [...t.noteBodyDrafts, d]; }));
+    draftsSubscribed = true;
   }
   if (!askUserSubscribed) {
     api.conversations.onAskUser((req) => {

--- a/tests/renderer/stores/conversation-draft-subscriptions.test.ts
+++ b/tests/renderer/stores/conversation-draft-subscriptions.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Characterization tests for the conversations store's draft-subscription
+ * plumbing (#980). The store fans out ~10 near-identical `onXxxDraft`
+ * subscriptions, each of which: finds the tab by `conversationId`, anchors the
+ * draft at `afterMessageIndex = messages.length`, and appends it to that tab's
+ * `xxxDrafts` array. `computeDraft` additionally seeds `computeDraftState`.
+ *
+ * These lock the CURRENT behavior so the subscription-factory refactor (H4) is
+ * provably behavior-preserving. Drives the real store with a mocked api client
+ * that captures every subscription callback.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Conversation } from '../../../src/shared/types';
+
+type Cb = (draft: { draftId: string; conversationId: string }) => void;
+
+const h = vi.hoisted(() => {
+  const noop = vi.fn();
+  const cbs: Record<string, Cb> = {};
+  // Each subscribe fn is a vi.fn so we can both capture the callback and assert
+  // it was registered exactly once (the idempotency the per-kind flags enforce).
+  const cap = (name: string) => vi.fn((cb: Cb) => { cbs[name] = cb; });
+  let nextId = 1;
+  const api = {
+    conversations: {
+      onStream: noop,
+      onDraft: cap('onDraft'),
+      onSourceDraft: cap('onSourceDraft'),
+      onPropertyDraft: cap('onPropertyDraft'),
+      onSourcePropertyDraft: cap('onSourcePropertyDraft'),
+      onClaimsDraft: cap('onClaimsDraft'),
+      onComputeDraft: cap('onComputeDraft'),
+      onRefactorDraft: cap('onRefactorDraft'),
+      onReorgDraft: cap('onReorgDraft'),
+      onDeleteDraft: cap('onDeleteDraft'),
+      onNoteBodyDraft: cap('onNoteBodyDraft'),
+      onAskUser: noop,
+      saveUIState: vi.fn().mockResolvedValue(undefined),
+      archive: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (contextBundle: unknown) => {
+        const conv: Conversation = {
+          id: `conv-${nextId++}`,
+          contextBundle: contextBundle as Conversation['contextBundle'],
+          messages: [],
+          status: 'active',
+          startedAt: 't',
+        };
+        return conv;
+      }),
+    },
+  };
+  return { api, cbs };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const store = getConversationsStore();
+
+/** The uniform draft kinds: which subscription feeds which tab array. */
+const KINDS: Array<{ cb: string; array: string }> = [
+  { cb: 'onDraft', array: 'drafts' },
+  { cb: 'onSourceDraft', array: 'sourceDrafts' },
+  { cb: 'onPropertyDraft', array: 'propertyDrafts' },
+  { cb: 'onSourcePropertyDraft', array: 'sourcePropertyDrafts' },
+  { cb: 'onClaimsDraft', array: 'claimsDrafts' },
+  { cb: 'onComputeDraft', array: 'computeDrafts' },
+  { cb: 'onRefactorDraft', array: 'refactorDrafts' },
+  { cb: 'onReorgDraft', array: 'reorgDrafts' },
+  { cb: 'onDeleteDraft', array: 'deleteDrafts' },
+  { cb: 'onNoteBodyDraft', array: 'noteBodyDrafts' },
+];
+
+const arrayOf = (tab: unknown, key: string) =>
+  (tab as Record<string, Array<{ draftId: string; afterMessageIndex: number }>>)[key];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('conversation draft subscriptions (#980)', () => {
+  it('each draft kind lands in its tab array, anchored at messages.length', async () => {
+    for (const { cb, array } of KINDS) {
+      await store.openFreeform('notes/x.md');
+      const tab = store.activeTab!;
+      const at = tab.conversation.messages.length; // 0 for a fresh tab
+      h.cbs[cb]({ draftId: `${array}-1`, conversationId: tab.id });
+
+      const arr = arrayOf(tab, array);
+      expect(arr.map((d) => d.draftId), `${cb} → tab.${array}`).toEqual([`${array}-1`]);
+      expect(arr[0].afterMessageIndex, `${cb} anchor`).toBe(at);
+    }
+  });
+
+  it('ignores a draft whose conversationId matches no open tab', async () => {
+    await store.openFreeform('notes/y.md');
+    const tab = store.activeTab!;
+    const before = tab.drafts.length;
+    h.cbs.onDraft({ draftId: 'ghost', conversationId: 'no-such-tab' });
+    expect(tab.drafts.length).toBe(before);
+  });
+
+  it('compute drafts also seed a pristine computeDraftState entry', async () => {
+    await store.openFreeform('notes/z.md');
+    const tab = store.activeTab!;
+    h.cbs.onComputeDraft({ draftId: 'c-1', conversationId: tab.id });
+
+    expect(tab.computeDrafts.map((d) => d.draftId)).toEqual(['c-1']);
+    const state = (tab as unknown as {
+      computeDraftState: Record<string, { result: unknown; running: boolean; insertedAt: unknown; afterMessageIndex: number }>;
+    }).computeDraftState['c-1'];
+    expect(state).toBeDefined();
+    expect(state.result).toBeNull();
+    expect(state.running).toBe(false);
+    expect(state.insertedAt).toBeNull();
+    expect(state.afterMessageIndex).toBe(0);
+  });
+
+  it('subscribes to each draft channel exactly once across many opens', async () => {
+    // The store is a singleton; ensureSubscriptions runs on every open but the
+    // guard flags keep each channel subscribed once. clearAllMocks() has reset
+    // the counters, so no *new* registrations should occur on further opens.
+    await store.openFreeform('notes/a.md');
+    await store.openFreeform('notes/b.md');
+    for (const { cb } of KINDS) {
+      expect(h.api.conversations[cb as keyof typeof h.api.conversations], cb).not.toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
First, contained step of the draft-type abstraction (#980), following the refactoring review's explicit sequencing: **characterization tests + H4 (store subscription factory) now; H5 (panel filters) and the cross-file registry (M-STRUCT) as follow-ups** once the store has a test net.

The conversations store fanned out **10 near-identical `onXxxDraft` subscription blocks** — each *find tab by conversationId → anchor at `messages.length` → append to `tab.xxxDrafts`* — guarded by its own `*Subscribed` flag (12 flags total, ~105 lines, and the "forgot to set the flag" foot-gun the review called out).

## Change
- New `draftHandler(append)` factory owns the find/anchor logic; each kind becomes a one-liner doing only its per-kind array push. Compute keeps its extra `computeDraftState` seeding inline in its `append`.
- The 10 per-kind flags collapse into a single `draftsSubscribed` — they were always wired together in one `ensureSubscriptions` pass, so it's equivalent (the characterization test's "subscribed once" case confirms it).
- **Net −67 lines** (38 insertions / 105 deletions), store file only.

Explicit `t.<kind>Drafts = [...]` assignments are preserved (exact Svelte 5 reactivity semantics), so only the boilerplate is factored out.

## Characterization tests (the safety net, written FIRST)
`tests/renderer/stores/conversation-draft-subscriptions.test.ts` locks the current behavior — written and passing against the **old** code before refactoring, so the change is provably behavior-preserving:
- each of the 10 kinds lands in its tab array, anchored at `messages.length`;
- a draft for an unknown `conversationId` is ignored;
- compute drafts also seed a pristine `computeDraftState` entry;
- each draft channel is subscribed exactly once across many opens (the flag-guard invariant).

## Testing
- `pnpm lint` — 0 errors.
- `pnpm test tests/renderer` — **107 files / 965 tests pass** (incl. the new characterization suite, the existing note-body/clear/compact store tests, and the drafts-flow integration test).

## Follow-ups (tracked under #980)
- **H5** — collapse the ~30 `ConversationsPanel.svelte` filter helpers (`xxxDraftsAt` / `xxxResultsAt` / `orphan*`) into generics. Touches ~30 template call sites — higher-risk, done separately.
- **M-STRUCT** — the cross-file draft-type registry (channels/preload/client/register-conversation) that makes adding a draft kind a ≤2-file change. Now de-risked by this store test net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)