### PR TITLE
perf: memoize the skill-template AST (#984)

### DIFF
--- a/src/main/skills/template.ts
+++ b/src/main/skills/template.ts
@@ -252,6 +252,20 @@ export interface RenderResult {
   errors: string[];
 }
 
+// Parsing a template (tokenize → structural parse) depends only on its string,
+// and the resulting AST is walked read-only at render time — so memoize it.
+// Every skill invocation re-rendered the body from scratch before (#984); skill
+// bodies are a fixed, small set, so the cache is naturally bounded.
+const astCache = new Map<string, Node[]>();
+function parseTemplate(template: string): Node[] {
+  let nodes = astCache.get(template);
+  if (nodes === undefined) {
+    nodes = parse(trimStandalone(tokenize(template)));
+    astCache.set(template, nodes);
+  }
+  return nodes;
+}
+
 /** Render with diagnostics — never throws on unknown vars/filters; collects
  *  them in `errors`. Use for skill validation. */
 export function renderTemplateDiagnostic(
@@ -259,7 +273,7 @@ export function renderTemplateDiagnostic(
   ctx: SkillRenderContext,
 ): RenderResult {
   const errors: string[] = [];
-  const nodes = parse(trimStandalone(tokenize(template)));
+  const nodes = parseTemplate(template);
 
   function render(ns: Node[]): string {
     let out = '';

--- a/tests/main/skills-template.test.ts
+++ b/tests/main/skills-template.test.ts
@@ -23,6 +23,19 @@ describe('renderTemplate — interpolation', () => {
       .toBe('A sel B PX C');
   });
 
+  it('reuses the parsed AST across contexts without bleeding state (#984 cache)', () => {
+    // The template's tokenize→parse result is memoized by string; rendering the
+    // SAME template against different contexts must still yield each context's
+    // own result (the cached AST is walked read-only; vars/errors are per-call).
+    const tpl = 'X {{selection}} {{#if param.flag}}on{{else}}off{{/if}} Y';
+    expect(renderTemplate(tpl, ctx({ selection: 'first', param: { flag: 'y' } }))).toBe('X first on Y');
+    expect(renderTemplate(tpl, ctx({ selection: 'second', param: {} }))).toBe('X second off Y');
+    // Diagnostics stay per-call — the unknown var isn't accumulated across renders.
+    const t2 = '{{selection}} {{missing}}';
+    expect(renderTemplateDiagnostic(t2, ctx({ selection: 's' })).errors).toEqual(['unknown variable "missing"']);
+    expect(renderTemplateDiagnostic(t2, ctx({ selection: 's' })).errors).toEqual(['unknown variable "missing"']);
+  });
+
   it('renders unknown variables as empty (lenient)', () => {
     expect(renderTemplate('[{{nope}}]', ctx())).toBe('[]');
   });


### PR DESCRIPTION
## Summary
`renderTemplate` → `renderTemplateDiagnostic` re-ran `tokenize → parse` on the template string **every render** — i.e. on every skill invocation (`template.ts:262`). The parse depends only on the string, and the resulting AST is walked **read-only** at render time (`render()` never mutates nodes; `errors`/vars are per-call), so it's safe to memoize.

Adds a `Map<string, Node[]>` keyed by the template. Skill bodies are a fixed, small set, so the cache is naturally bounded.

## Honest scope
This is the modest item the architecture review flagged (Item 5) and explicitly gated on "if skill execution ever becomes hot." Skills run on user action, not in hot loops, so the runtime win is small — this is really redundant-work hygiene. Zero behavior change; low risk.

## Testing
- Transparent — output identical; existing `skills-template` + skills suites (129 tests) unchanged and green.
- New guard test: the **same** template rendered against **different** contexts still yields each context's own result, and diagnostics stay per-call — i.e. the cache holds only the read-only AST, never render state (the one real risk of caching here).
- `pnpm test tests/main/skills-template.test.ts` — 27 passed.
- `pnpm lint` — 0 errors.

Closes #984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)