### PR TITLE
feat: runtime-validate IPC payloads at the invoke() boundary (#983)

### DIFF
--- a/src/preload/typed-invoke.ts
+++ b/src/preload/typed-invoke.ts
@@ -1,9 +1,31 @@
 import { ipcRenderer } from 'electron';
 import type { ChannelMap } from '../shared/ipc-contract';
+import { CHANNEL_VALIDATORS } from '../shared/ipc-validators';
 
-/** Typed `ipcRenderer.invoke`: args checked, return typed, against the ChannelMap. */
+// A main-process response that fails its ChannelMap shape (#983) is a bug. Like
+// the graph write guard (#944), it is FATAL under the test runner — so a shape
+// regression fails CI — but only a `console.error` in dev/prod: a boundary
+// guardrail must never crash the user's app over a validator that might itself
+// be too strict. The malformed value is still returned in prod so behavior is
+// unchanged there; the point is to make the corruption loud, not silent.
+const VALIDATION_FATAL =
+  typeof process !== 'undefined' &&
+  (process.env?.VITEST === 'true' || process.env?.NODE_ENV === 'test');
+
+/** Typed `ipcRenderer.invoke`: args checked, return typed, and the resolved
+ *  payload runtime-validated against the ChannelMap (#981 / #983). */
 export function invoke<K extends keyof ChannelMap>(
-  channel: K, ...args: Parameters<ChannelMap[K]>
+  channel: K,
+  ...args: Parameters<ChannelMap[K]>
 ): Promise<Awaited<ReturnType<ChannelMap[K]>>> {
-  return ipcRenderer.invoke(channel, ...args) as Promise<Awaited<ReturnType<ChannelMap[K]>>>;
+  const result = ipcRenderer.invoke(channel, ...args) as Promise<Awaited<ReturnType<ChannelMap[K]>>>;
+  return result.then((value) => {
+    const validate = CHANNEL_VALIDATORS[channel] as ((v: unknown) => boolean) | undefined;
+    if (validate && !validate(value)) {
+      const message = `IPC channel "${channel}" returned a payload that failed runtime validation`;
+      if (VALIDATION_FATAL) throw new Error(message);
+      console.error(message, value);
+    }
+    return value;
+  });
 }

--- a/src/shared/ipc-validators.ts
+++ b/src/shared/ipc-validators.ts
@@ -1,0 +1,89 @@
+/**
+ * Runtime payload validators for the typed IPC boundary (#983).
+ *
+ * The `ChannelMap` (`./ipc-contract`) pins channel signatures at *compile* time,
+ * but `ipcRenderer.invoke` returns `unknown` — a main-process shape bug (or a
+ * handler returning the wrong thing) would flow into the renderer untyped and
+ * silently corrupt state. These guards re-check each channel's return shape at
+ * *runtime* in the `invoke()` wrapper.
+ *
+ * The map is compile-time-linked to the ChannelMap: each guard's `v is …` must
+ * match that channel's return type, so a contract change forces the guard to
+ * follow. Channels returning `void` have no guard (nothing to check). Array
+ * checks are intentionally SHALLOW — a main-side shape bug is uniform across
+ * elements, so checking the first catches it without an O(n) walk on every call.
+ */
+import type { ChannelMap } from './ipc-contract';
+import type {
+  NotebaseMeta,
+  NoteFile,
+  SearchInNotesFileResult,
+  ReplaceInNotesResult,
+} from './types';
+
+type ResultOf<K extends keyof ChannelMap> = Awaited<ReturnType<ChannelMap[K]>>;
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+const isString = (v: unknown): v is string => typeof v === 'string';
+const isNumber = (v: unknown): v is number => typeof v === 'number';
+const isBool = (v: unknown): v is boolean => typeof v === 'boolean';
+const isStringArray = (v: unknown): v is string[] => Array.isArray(v) && v.every(isString);
+
+/** Shallow array guard: empty, or the first element matches `guard`. */
+function shallowArrayOf<T>(guard: (x: unknown) => x is T): (v: unknown) => v is T[] {
+  return (v): v is T[] => Array.isArray(v) && (v.length === 0 || guard(v[0]));
+}
+
+function isNotebaseMeta(v: unknown): v is NotebaseMeta {
+  return isObj(v) && isString(v.rootPath) && isString(v.name);
+}
+const isMetaOrNull = (v: unknown): v is NotebaseMeta | null => v === null || isNotebaseMeta(v);
+
+function isNoteFile(v: unknown): v is NoteFile {
+  return isObj(v) && isString(v.name) && isString(v.relativePath) && isBool(v.isDirectory);
+}
+function isRewrittenPaths(v: unknown): v is { rewrittenPaths: string[] } {
+  return isObj(v) && isStringArray(v.rewrittenPaths);
+}
+function isSearchFileResult(v: unknown): v is SearchInNotesFileResult {
+  return isObj(v) && isString(v.relativePath) && Array.isArray(v.matches);
+}
+function isReplaceResult(v: unknown): v is ReplaceInNotesResult {
+  return isObj(v) && isStringArray(v.changedPaths) && isNumber(v.replacedCount);
+}
+
+export const CHANNEL_VALIDATORS: {
+  [K in keyof ChannelMap]?: (v: unknown) => v is ResultOf<K>;
+} = {
+  'notebase:open': isMetaOrNull,
+  'notebase:openPath': isNotebaseMeta,
+  'notebase:newProject': isMetaOrNull,
+  'notebase:openInNewWindow': isMetaOrNull,
+  'notebase:newProjectInNewWindow': isMetaOrNull,
+  'notebase:openPathInNewWindow': isNotebaseMeta,
+  'notebase:close': (v): v is null => v === null,
+  'notebase:listFiles': shallowArrayOf(isNoteFile),
+  'notebase:readFile': isString,
+  'notebase:readBinary': (v): v is Uint8Array => v instanceof Uint8Array,
+  'notebase:fileExists': isBool,
+  'notebase:mergePreview': (v): v is ResultOf<'notebase:mergePreview'> =>
+    isObj(v) && isNumber(v.linkOccurrences) && isNumber(v.affectedFiles),
+  'notebase:merge': (v): v is ResultOf<'notebase:merge'> =>
+    isObj(v) &&
+    isString(v.targetPath) &&
+    isNumber(v.mergeOffset) &&
+    isNumber(v.mergeLine) &&
+    isNumber(v.rewrittenLinks) &&
+    isStringArray(v.rewrittenPaths) &&
+    isString(v.deletedSource),
+  'notebase:searchInNotes': shallowArrayOf(isSearchFileResult),
+  'notebase:replaceInNotes': isReplaceResult,
+  'notebase:renameAnchor': isRewrittenPaths,
+  'notebase:renameSource': isRewrittenPaths,
+  'notebase:renameExcerpt': isRewrittenPaths,
+  'notebase:getOnboardingDismissed': isBool,
+  // Channels returning `void` (recent:clear, write*, create*, delete*, rename,
+  // copy, setOnboardingDismissed) have nothing to validate.
+};

--- a/tests/preload/typed-invoke-validation.test.ts
+++ b/tests/preload/typed-invoke-validation.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The typed `invoke()` wrapper runtime-validates the resolved payload against
+ * the ChannelMap (#983). Under the test runner validation is FATAL (mirrors the
+ * write guard), so a shape regression rejects the invoke promise here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted((): { result: unknown } => ({ result: undefined }));
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: vi.fn(() => Promise.resolve(h.result)),
+  },
+}));
+
+import { invoke } from '../../src/preload/typed-invoke';
+import { Channels } from '../../src/shared/channels';
+
+beforeEach(() => {
+  h.result = undefined;
+});
+
+describe('invoke() payload validation (#983)', () => {
+  it('passes a well-shaped payload straight through', async () => {
+    h.result = [{ name: 'a.md', relativePath: 'a.md', isDirectory: false }];
+    await expect(invoke(Channels.NOTEBASE_LIST_FILES)).resolves.toEqual(h.result);
+  });
+
+  it('rejects (fatal under test) when main returns the wrong shape', async () => {
+    h.result = { not: 'an array' };
+    await expect(invoke(Channels.NOTEBASE_LIST_FILES)).rejects.toThrow(/failed runtime validation/);
+  });
+
+  it('rejects a primitive-typed channel returning the wrong primitive', async () => {
+    h.result = 123; // readFile must be a string
+    await expect(invoke(Channels.NOTEBASE_READ_FILE, 'a.md')).rejects.toThrow(/failed runtime validation/);
+  });
+
+  it('does not validate void channels (no guard, passes through)', async () => {
+    h.result = undefined;
+    await expect(invoke(Channels.NOTEBASE_WRITE_FILE, 'a.md', 'x')).resolves.toBeUndefined();
+  });
+});

--- a/tests/shared/ipc-validators.test.ts
+++ b/tests/shared/ipc-validators.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { CHANNEL_VALIDATORS } from '../../src/shared/ipc-validators';
+import { Channels } from '../../src/shared/channels';
+
+/**
+ * Runtime IPC payload validators (#983). Each guard must accept the real return
+ * shape for its channel and reject a plausible wrong-shaped payload (the
+ * main-side-bug case). Array guards are shallow by design.
+ */
+describe('CHANNEL_VALIDATORS (#983)', () => {
+  const meta = { rootPath: '/x', name: 'X' };
+  const noteFile = { name: 'a.md', relativePath: 'a.md', isDirectory: false };
+
+  it('open-family accepts NotebaseMeta or null, rejects junk', () => {
+    const v = CHANNEL_VALIDATORS[Channels.NOTEBASE_OPEN]!;
+    expect(v(meta)).toBe(true);
+    expect(v(null)).toBe(true);
+    expect(v({ rootPath: 1 })).toBe(false);
+    expect(v('nope')).toBe(false);
+  });
+
+  it('openPath requires a real meta (null is NOT allowed)', () => {
+    const v = CHANNEL_VALIDATORS[Channels.NOTEBASE_OPEN_PATH]!;
+    expect(v(meta)).toBe(true);
+    expect(v(null)).toBe(false);
+  });
+
+  it('listFiles shallow-checks NoteFile[]', () => {
+    const v = CHANNEL_VALIDATORS[Channels.NOTEBASE_LIST_FILES]!;
+    expect(v([])).toBe(true);
+    expect(v([noteFile])).toBe(true);
+    expect(v([{ name: 'a' }])).toBe(false); // missing relativePath/isDirectory
+    expect(v('notarray')).toBe(false);
+  });
+
+  it('readFile/fileExists check primitives', () => {
+    expect(CHANNEL_VALIDATORS[Channels.NOTEBASE_READ_FILE]!('hi')).toBe(true);
+    expect(CHANNEL_VALIDATORS[Channels.NOTEBASE_READ_FILE]!(42)).toBe(false);
+    expect(CHANNEL_VALIDATORS[Channels.NOTEBASE_FILE_EXISTS]!(true)).toBe(true);
+    expect(CHANNEL_VALIDATORS[Channels.NOTEBASE_FILE_EXISTS]!('true')).toBe(false);
+  });
+
+  it('readBinary requires a Uint8Array', () => {
+    const v = CHANNEL_VALIDATORS[Channels.NOTEBASE_READ_BINARY]!;
+    expect(v(new Uint8Array([1, 2, 3]))).toBe(true);
+    expect(v([1, 2, 3])).toBe(false);
+  });
+
+  it('merge validates the full result shape', () => {
+    const v = CHANNEL_VALIDATORS[Channels.NOTEBASE_MERGE]!;
+    expect(v({ targetPath: 't', mergeOffset: 0, mergeLine: 1, rewrittenLinks: 2, rewrittenPaths: ['a'], deletedSource: 's' })).toBe(true);
+    expect(v({ targetPath: 't', mergeOffset: 0 })).toBe(false); // missing fields
+  });
+
+  it('rename-family checks { rewrittenPaths }', () => {
+    const v = CHANNEL_VALIDATORS[Channels.NOTEBASE_RENAME_SOURCE]!;
+    expect(v({ rewrittenPaths: ['a', 'b'] })).toBe(true);
+    expect(v({ rewrittenPaths: [1] })).toBe(false);
+    expect(v({})).toBe(false);
+  });
+
+  it('void channels have no validator', () => {
+    expect(CHANNEL_VALIDATORS[Channels.NOTEBASE_WRITE_FILE]).toBeUndefined();
+    expect(CHANNEL_VALIDATORS[Channels.RECENT_CLEAR]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
The `ChannelMap` (#981) pins channel signatures at **compile** time, but `ipcRenderer.invoke` returns `unknown` — a main-process shape bug (or a handler returning the wrong thing) flows into the renderer untyped and silently corrupts state. This adds the **runtime complement**: a shape guard per ChannelMap channel, run on the resolved payload inside the typed `invoke()` wrapper.

Scope (per the chosen option): **all 29 notebase ChannelMap channels**, so the runtime layer tracks the compile-time one.

## Design
- **`src/shared/ipc-validators.ts`** — `CHANNEL_VALIDATORS`, one guard per channel (void channels have none). The map is **compile-time-linked to the ChannelMap**: each guard is typed `(v) => v is Awaited<ReturnType<ChannelMap[K]>>`, so a contract change forces the guard to follow (tsc enforces it). Array checks are **shallow** — a main-side shape bug is uniform across elements, so checking the first catches it without an O(n) walk on every call.
- **`src/preload/typed-invoke.ts`** — validate on resolve. A failure is **fatal under the test runner** (mirrors the graph write guard #944 — a shape regression fails CI) but only a `console.error` in dev/prod, where the value is still returned. Rationale (the codebase's own guardrail philosophy): *a boundary guardrail must never crash the user's app over a validator that might itself be too strict.* The win is making corruption **loud, not silent**.

## Why fatal-under-test is safe here
No existing test flows through the real `invoke()` wrapper (verified), so making validation fatal under vitest breaks nothing — and my own wrapper test exercises exactly that path.

## Testing
- `tests/shared/ipc-validators.test.ts` — each guard accepts the real shape and rejects a plausible wrong one (open-family null handling, shallow `NoteFile[]`, primitives, `Uint8Array`, full merge shape, `{rewrittenPaths}`, void→no guard).
- `tests/preload/typed-invoke-validation.test.ts` — the wrapper passes well-shaped payloads and **rejects** mis-shaped ones under test; void channels pass through.
- `pnpm lint` — 0 errors.
- Full suite — **401 files / 3840 tests pass**.

Closes #983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)