### PR TITLE
feat: create-directory support + welcome New Thoughtbase button (#1036)

### DIFF
--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -9,7 +9,9 @@ const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
 
 export async function openNotebase(): Promise<NotebaseMeta | null> {
   const result = await dialog.showOpenDialog({
-    properties: ['openDirectory'],
+    // `createDirectory` (macOS) adds a New Folder button so the user can make a
+    // fresh directory to open as a thoughtbase without leaving the app (#1036).
+    properties: ['openDirectory', 'createDirectory'],
     title: 'Open Thoughtbase',
   });
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -675,15 +675,19 @@
   }
 
   async function handleNewThoughtbase(): Promise<void> {
-    const choice = await askOpenTarget('A thoughtbase is already open in this window. Create the new one in:');
-    if (choice === 'cancel') return;
-    if (choice === 'new') {
-      // New-window path emits `project:opened`, so the onProjectOpened
-      // handler in onMount fires maybeShowOnboarding there.
-      await api.notebase.newProjectInNewWindow();
-      return;
+    // Only ask "this window vs. new window" when a thoughtbase is already open —
+    // from the welcome screen (nothing open) go straight to the picker (#1036).
+    if (notebase.meta) {
+      const choice = await askOpenTarget('A thoughtbase is already open in this window. Create the new one in:');
+      if (choice === 'cancel') return;
+      if (choice === 'new') {
+        // New-window path emits `project:opened`, so the onProjectOpened
+        // handler in onMount fires maybeShowOnboarding there.
+        await api.notebase.newProjectInNewWindow();
+        return;
+      }
+      editor.clear();
     }
-    editor.clear();
     // Guard on the IPC result — a cancelled directory picker leaves
     // the previous project in place; we don't want to re-trigger the
     // onboarding modal on a thoughtbase the user already declined.
@@ -1562,7 +1566,10 @@
       <div class="welcome">
         <h1>Minerva</h1>
         <p>An integrated knowledge management environment</p>
-        <button onclick={notebase.open}>Open Thoughtbase</button>
+        <div class="welcome-actions">
+          <button onclick={handleNewThoughtbase}>New Thoughtbase</button>
+          <button onclick={notebase.open}>Open Thoughtbase</button>
+        </div>
       </div>
     {/if}
   </div>
@@ -1997,5 +2004,15 @@
 
   .welcome button:hover {
     background: var(--bg-button-hover);
+  }
+
+  .welcome-actions {
+    display: flex;
+    gap: 12px;
+  }
+
+  /* New Thoughtbase is the primary action for a first-time user. */
+  .welcome-actions button:first-child {
+    border-color: var(--accent);
   }
 </style>


### PR DESCRIPTION
## Problem
When setting up a thoughtbase there was no way to create a new folder inline. Root cause was two gaps working together:
- The **welcome screen had only "Open Thoughtbase"** — no New Thoughtbase button at all — so a first-time user's only entry point was Open.
- That Open picker (`openNotebase` in `fs.ts`) used `properties: ['openDirectory']` **without `createDirectory`**, so no "New Folder" button.

(The menu's *New Thoughtbase* handlers already had `createDirectory`, but they weren't discoverable from the welcome screen, and `handleNewThoughtbase` assumed a project was already open.)

## Fix
- **Welcome screen:** add a **"New Thoughtbase"** button (primary action) next to Open Thoughtbase.
- **`handleNewThoughtbase`:** skip the "this window vs. new window" prompt when nothing is open — from the welcome screen go straight to the create-directory-capable picker, then run onboarding. This also fixes a latent bug: the misleading *"A thoughtbase is already open in this window"* dialog that appeared even on the empty welcome screen.
- **`openNotebase`:** add `createDirectory` so the Open picker can also make a fresh folder inline (macOS New Folder button).

## Testing
- `pnpm lint` — 0 errors (svelte-check validates the template).
- `pnpm test tests/renderer/app tests/main/notebase` — 227 passed.
- UI/dialog change — best visually confirmed in-app (the folder picker's New Folder button is OS-native).

Closes #1036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)