### PR TITLE
feat: confirm before closing a conversation (#1033)

### DIFF
--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -3,6 +3,8 @@
   import Icon from './Icon.svelte';
   import { getConversationsStore } from '../stores/conversations.svelte';
   import { getEditorStore } from '../stores/editor.svelte';
+  import { getDialogStore } from '../stores/dialogs.svelte';
+  import { CONFIRM_KEYS } from '../confirm-keys';
   import { getVoiceStore } from '../voice/voice.svelte';
   import { voiceSettings } from '../voice/voice-settings.svelte';
   import { api } from '../ipc/client';
@@ -98,6 +100,7 @@
 
   const store = getConversationsStore();
   const editor = getEditorStore();
+  const { showConfirm } = getDialogStore();
   const voice = getVoiceStore();
 
   let composerEl = $state<HTMLTextAreaElement>();
@@ -266,6 +269,14 @@
 
   async function handleCloseTab(id: string, e: Event) {
     e.stopPropagation();
+    // Closing archives the conversation and there's no reopen UI, so guard it
+    // with a dismissable confirm (#1033).
+    const ok = await showConfirm(
+      "Close this conversation? You won't be able to reopen it.",
+      CONFIRM_KEYS.closeConversation,
+      'Close',
+    );
+    if (!ok) return;
     await store.closeTab(id);
   }
 

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -12,6 +12,9 @@ export const CONFIRM_KEYS = {
   delete: 'confirm-delete',
   deletePartialFailure: 'delete-partial-failure',
   deleteSource: 'delete-source',
+  /** Closing a conversation archives it, and there's no reopen UI — so it's
+   *  effectively gone. Confirm before discarding the thread (#1033). */
+  closeConversation: 'close-conversation',
   rewriteConflict: 'confirm-rewrite-conflict',
   headingRenameSuggestion: 'heading-rename-suggestion',
   /** "Bookmark Section" invoked with the cursor above the first heading —
@@ -104,6 +107,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Delete: partial failure',
     description:
       'Shown after a multi-select Delete when some items could not be removed (e.g. permissions, file in use). Lists the failures so the user can investigate without re-issuing the whole delete.',
+  },
+  {
+    key: CONFIRM_KEYS.closeConversation,
+    title: 'Close conversation',
+    description:
+      'Prompt before closing a conversation. Closing archives the thread and there is no way to reopen it, so this guards against losing a conversation to a stray click.',
   },
   {
     key: CONFIRM_KEYS.deleteSource,


### PR DESCRIPTION
## Problem
Clicking the ✕ on a conversation archived it immediately (`closeTab → archive`), and there's **no UI to reopen an archived conversation** — so a stray click silently lost the whole thread with no undo.

## Fix
Guard `handleCloseTab` with the project's standard `showConfirm(message, key, label)`:
- Message: *"Close this conversation? You won't be able to reopen it."* — honest about the irreversibility (it archives, but there's no reopen).
- Carries the built-in **"Don't ask again"** checkbox; independently suppressible via `CONFIRM_KEYS.closeConversation` and listed in the Behaviors settings tab.
- No danger/red styling, per the project's UX conventions.
- Accessed via the global `getDialogStore()` (same pattern as `source-ops`), so no new prop.

Added the `closeConversation` key + its `CONFIRM_REGISTRY` entry (the drift guard test enforces the pairing).

## Testing
- `pnpm lint` — 0 errors.
- `pnpm test tests/renderer/confirm-keys.test.ts tests/renderer/stores tests/renderer/components` — 131 passed (incl. the confirm-keys drift guard).

Closes #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)