### PR TITLE
feat: surface New Conversation in the editor toolbar (#1035)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1350,6 +1350,11 @@
                     title="Split down"
                   ><Icon name="split-v" size={12} /></button>
                   <button
+                    class="nav-btn new-conversation-btn"
+                    onclick={() => { void newConversation(); }}
+                    title="New Conversation"
+                  ><Icon name="conversation" size={12} /><span>New Conversation</span></button>
+                  <button
                     class="nav-btn sidebar-toggle"
                     class:active={rightSidebarVisible}
                     onclick={() => { rightSidebarVisible = !rightSidebarVisible; }}
@@ -1856,12 +1861,33 @@
     flex-shrink: 0;
   }
 
-  .sidebar-toggle {
-    margin-left: auto;
-  }
-
   .sidebar-toggle.active {
     color: var(--accent);
+  }
+
+  /* New Conversation is a primary action — a labeled, accent-tinted button
+     pinned to the right of the toolbar (always visible while editing) rather
+     than a bare "+" buried in the conversations panel header (#1035). */
+  .new-conversation-btn {
+    -webkit-app-region: no-drag;
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    width: auto;
+    height: auto;
+    padding: 3px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--accent);
+    font-size: 11px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .new-conversation-btn:hover {
+    background: color-mix(in oklch, var(--accent) 12%, transparent);
   }
 
   .view-toggle {


### PR DESCRIPTION
## Problem
The only "New Conversation" affordance was a bare **"+" icon in the conversations-panel list header**. Since that's a *bottom* panel, the icon sat halfway down the window and read as cryptic — easy to miss for a primary action.

## Fix
Add a **labeled, accent-tinted "New Conversation" button** to the editor toolbar (right side, next to the right-sidebar toggle), always visible while editing. It reuses the existing `newConversation()` handler — the same one the View menu drives — which opens a fresh conversation and reveals the panel.

Placement rationale: the editor toolbar is the top-of-window strip users are already looking at, and it's where the comparable "open a panel" action (right-sidebar toggle) lives. The in-panel "+" stays as-is.

## Testing
- `pnpm lint` — 0 errors (svelte-check validates the `conversation` icon + CSS).
- `pnpm test tests/renderer/app` — 83 passed.
- UI change — best visually confirmed in-app.

Closes #1035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)