### PR TITLE
refactor: collapse the IPC rootPath guard into withRootPath wrappers (#990)

### DIFF
--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -20,6 +20,38 @@ export function rootPathFromEvent(e: Electron.IpcMainInvokeEvent): string | null
   return getRootPath(win.id);
 }
 
+/**
+ * Wrap an invoke handler so it runs only with an open project, receiving the
+ * resolved `rootPath` as its first argument. Throws "No project open"
+ * otherwise — collapsing the guard the throw-style handlers hand-rolled 86×
+ * (#990). Use for handlers whose contract is "there must be a project".
+ */
+export function withRootPath<A extends unknown[], R>(
+  fn: (rootPath: string, ...args: A) => R,
+): (e: Electron.IpcMainInvokeEvent, ...args: A) => R {
+  return (e, ...args) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return fn(rootPath, ...args);
+  };
+}
+
+/**
+ * Like {@link withRootPath}, but returns `fallback` — each handler's own
+ * project-less empty value (`[]`, `null`, `false`, `{ ok: false }`, …) —
+ * instead of throwing when no project is open (#990).
+ */
+export function withRootPathOr<A extends unknown[], R>(
+  fallback: R,
+  fn: (rootPath: string, ...args: A) => R,
+): (e: Electron.IpcMainInvokeEvent, ...args: A) => R {
+  return (e, ...args) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) return fallback;
+    return fn(rootPath, ...args);
+  };
+}
+
 export async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
   if (!isIndexable(relativePath)) return;
   const content = await notebaseFs.readFile(rootPath, relativePath);

--- a/src/main/ipc/register-bibliography.ts
+++ b/src/main/ipc/register-bibliography.ts
@@ -22,8 +22,8 @@ import {
   USER_STYLES_DIR,
   USER_LOCALES_DIR,
 } from '../publish/csl/user-assets';
-import { renderInlineCitations, type InlineCiteRequest } from '../citations/render-inline';
-import { rootPathFromEvent, winFromEvent, hooks } from './helpers';
+import { renderInlineCitations, type InlineCiteRequest, type InlineCiteResponse } from '../citations/render-inline';
+import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr, hooks } from './helpers';
 
 export function registerBibliography(): void {
   // Bibliography (#113)
@@ -40,39 +40,33 @@ export function registerBibliography(): void {
       isUser: merged.userIds.has(id),
     }));
   });
-  ipcMain.handle(Channels.BIBLIOGRAPHY_GET_STYLE, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return DEFAULT_STYLE;
+  ipcMain.handle(Channels.BIBLIOGRAPHY_GET_STYLE, withRootPathOr(DEFAULT_STYLE, (rootPath) => {
     return getBibliographyStyleId(rootPath) ?? DEFAULT_STYLE;
-  });
-  ipcMain.handle(Channels.BIBLIOGRAPHY_SET_STYLE, async (e, styleId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  }));
+  ipcMain.handle(Channels.BIBLIOGRAPHY_SET_STYLE, withRootPath(async (rootPath, styleId: string) => {
     const merged = await getMergedStyles(rootPath);
     if (!Object.prototype.hasOwnProperty.call(merged.styles, styleId)) {
       throw new Error(`Unknown CSL style: ${styleId}`);
     }
     setBibliographyStyleId(rootPath, styleId);
-  });
+  }));
 
   // User-imported CSL styles + locales (#302)
-  ipcMain.handle(Channels.CSL_LIST_USER_STYLES, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  type UserStyleInfo = { id: string; label: string; filePath: string };
+  ipcMain.handle(Channels.CSL_LIST_USER_STYLES, withRootPathOr<[], UserStyleInfo[] | Promise<UserStyleInfo[]>>([], async (rootPath) => {
     return (await loadUserStyles(rootPath)).map((s) => ({
       id: s.id,
       label: s.label,
       filePath: s.filePath,
     }));
-  });
-  ipcMain.handle(Channels.CSL_LIST_USER_LOCALES, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  }));
+  type UserLocaleInfo = { id: string; filePath: string };
+  ipcMain.handle(Channels.CSL_LIST_USER_LOCALES, withRootPathOr<[], UserLocaleInfo[] | Promise<UserLocaleInfo[]>>([], async (rootPath) => {
     return (await loadUserLocales(rootPath)).map((l) => ({
       id: l.id,
       filePath: l.filePath,
     }));
-  });
+  }));
   ipcMain.handle(Channels.CSL_IMPORT_STYLE, async (e) => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) throw new Error('No project open');
@@ -121,31 +115,21 @@ export function registerBibliography(): void {
     await fs.writeFile(destPath, xml, 'utf-8');
     return { id, filePath: destPath };
   });
-  ipcMain.handle(Channels.CSL_REMOVE_STYLE, async (e, id: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.CSL_REMOVE_STYLE, withRootPath(async (rootPath, id: string) => {
     if (!/^[a-z0-9_-]+$/i.test(id)) throw new Error('Invalid style id.');
     const target = path.join(rootPath, USER_STYLES_DIR, `${id}.csl`);
     await fs.unlink(target).catch(() => undefined);
-  });
-  ipcMain.handle(Channels.CSL_REMOVE_LOCALE, async (e, id: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  }));
+  ipcMain.handle(Channels.CSL_REMOVE_LOCALE, withRootPath(async (rootPath, id: string) => {
     if (!/^[A-Za-z0-9_-]+$/.test(id)) throw new Error('Invalid locale id.');
     const target = path.join(rootPath, USER_LOCALES_DIR, `${id}.xml`);
     await fs.unlink(target).catch(() => undefined);
-  });
-  ipcMain.handle(Channels.CITATION_RENDER_INLINE, async (e, refs: InlineCiteRequest[]) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) {
-      return { markers: [], bibliography: null, missing: [], styleId: DEFAULT_STYLE };
-    }
+  }));
+  ipcMain.handle(Channels.CITATION_RENDER_INLINE, withRootPathOr<[InlineCiteRequest[]], InlineCiteResponse | Promise<InlineCiteResponse>>({ markers: [], bibliography: null, missing: [], styleId: DEFAULT_STYLE }, async (rootPath, refs: InlineCiteRequest[]) => {
     return await renderInlineCitations(rootPath, refs ?? []);
-  });
+  }));
 
-  ipcMain.handle(Channels.BIBLIOGRAPHY_GENERATE, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.BIBLIOGRAPHY_GENERATE, withRootPath(async (rootPath, relativePath: string) => {
     const original = await notebaseFs.readFile(rootPath, relativePath);
     const result = await generateBibliography(rootPath, original);
     if (result.changed) {
@@ -159,5 +143,5 @@ export function registerBibliography(): void {
       changed: result.changed,
       styleId: result.styleId,
     };
-  });
+  }));
 }

--- a/src/main/ipc/register-bookmarks.ts
+++ b/src/main/ipc/register-bookmarks.ts
@@ -3,39 +3,33 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import type { TabSession, LayoutSession } from '../../shared/types';
-import { rootPathFromEvent } from './helpers';
+import { rootPathFromEvent, withRootPathOr } from './helpers';
 
 export function registerBookmarks(): void {
   // Bookmarks
-  ipcMain.handle(Channels.BOOKMARKS_LOAD, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  ipcMain.handle(Channels.BOOKMARKS_LOAD, withRootPathOr<[], unknown[] | Promise<unknown[]>>([], async (rootPath) => {
     try {
       const bmPath = path.join(rootPath, '.minerva', 'bookmarks.json');
       const data = await fs.readFile(bmPath, 'utf-8');
       return JSON.parse(data) as unknown[];
     } catch { return []; }
-  });
+  }));
 
-  ipcMain.handle(Channels.BOOKMARKS_SAVE, async (e, tree: unknown) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.BOOKMARKS_SAVE, withRootPathOr(undefined, async (rootPath, tree: unknown) => {
     const bmPath = path.join(rootPath, '.minerva', 'bookmarks.json');
     await fs.mkdir(path.dirname(bmPath), { recursive: true });
     await fs.writeFile(bmPath, JSON.stringify(tree, null, 2), 'utf-8');
-  });
+  }));
 
   // Tab session persistence. The payload is opaque JSON to the main process —
   // it round-trips the renderer's session shape (now the multi-group
   // LayoutSession, #816) without inspecting it; the renderer validates and
   // migrates legacy shapes on load.
-  ipcMain.handle(Channels.TABS_SAVE, async (e, session: LayoutSession | TabSession) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.TABS_SAVE, withRootPathOr(undefined, async (rootPath, session: LayoutSession | TabSession) => {
     const tabsPath = path.join(rootPath, '.minerva', 'tabs.json');
     await fs.mkdir(path.dirname(tabsPath), { recursive: true });
     await fs.writeFile(tabsPath, JSON.stringify(session, null, 2), 'utf-8');
-  });
+  }));
 
   ipcMain.handle(Channels.TABS_LOAD, async (e): Promise<LayoutSession | TabSession | null> => {
     const rootPath = rootPathFromEvent(e);

--- a/src/main/ipc/register-compute.ts
+++ b/src/main/ipc/register-compute.ts
@@ -11,7 +11,7 @@ import {
   type PythonSettings,
 } from '../compute/python-settings';
 import { saveCellOutput, type SaveCellOutputInput } from '../compute/save-cell-output';
-import { rootPathFromEvent, winFromEvent } from './helpers';
+import { winFromEvent, withRootPath, withRootPathOr } from './helpers';
 
 // propose_compute helpers (#245) now live in ../compute/proposal-helpers (#676,
 // extracted so they're unit-testable without electron). Re-exported here for
@@ -23,25 +23,18 @@ export {
 } from '../compute/proposal-helpers';
 
 export function registerCompute(): void {
-  ipcMain.handle(Channels.COMPUTE_RUN_CELL, async (e, language: string, code: string, notePath?: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COMPUTE_RUN_CELL, withRootPath(async (rootPath, language: string, code: string, notePath?: string) => {
     return await runComputeCell(language, code, { rootPath, notePath });
-  });
+  }));
 
   ipcMain.handle(Channels.COMPUTE_LANGUAGES, () => computeLanguages());
 
-  ipcMain.handle(Channels.COMPUTE_RESTART_PYTHON_KERNEL, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.COMPUTE_RESTART_PYTHON_KERNEL, withRootPathOr(undefined, async (rootPath) => {
     await restartPythonKernel(rootPath);
-  });
+  }));
 
-  ipcMain.handle(Channels.COMPUTE_INTERRUPT_PYTHON, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { ok: false, reason: 'no-kernel' };
-    return interruptPythonKernel(rootPath);
-  });
+  ipcMain.handle(Channels.COMPUTE_INTERRUPT_PYTHON, withRootPathOr({ ok: false, reason: 'no-kernel' }, (rootPath) =>
+    interruptPythonKernel(rootPath)));
 
   ipcMain.handle(Channels.COMPUTE_GET_PYTHON_SETTINGS, async () => {
     return await getPythonSettings();
@@ -61,17 +54,12 @@ export function registerCompute(): void {
     return await probePythonInterpreter(target);
   });
 
-  ipcMain.handle(Channels.COMPUTE_GET_PYTHON_TRUST, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return false;
-    return getPythonTrust(rootPath);
-  });
+  ipcMain.handle(Channels.COMPUTE_GET_PYTHON_TRUST, withRootPathOr(false, (rootPath) =>
+    getPythonTrust(rootPath)));
 
-  ipcMain.handle(Channels.COMPUTE_SET_PYTHON_TRUST, (e, trusted: boolean) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COMPUTE_SET_PYTHON_TRUST, withRootPath((rootPath, trusted: boolean) => {
     setPythonTrust(rootPath, trusted === true);
-  });
+  }));
 
   ipcMain.handle(Channels.COMPUTE_BROWSE_PYTHON, async (e) => {
     const win = winFromEvent(e);
@@ -88,9 +76,7 @@ export function registerCompute(): void {
     return result.filePaths[0];
   });
 
-  ipcMain.handle(Channels.COMPUTE_SAVE_CELL_OUTPUT, async (e, input: SaveCellOutputInput) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COMPUTE_SAVE_CELL_OUTPUT, withRootPath(async (rootPath, input: SaveCellOutputInput) => {
     return await saveCellOutput(rootPath, input);
-  });
+  }));
 }

--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -15,6 +15,7 @@ import { buildExcerptTtl } from '../sources/create-excerpt';
 import { slugify } from '../../shared/slug';
 import { applyPropertyUpdates } from '../llm/set-properties';
 import * as approval from '../llm/approval';
+import type { Proposal } from '../llm/approval';
 import { orderRefactors } from '../notebase/reorg';
 import * as conversation from '../llm/conversation';
 import type { ContextBundle, ConversationMessage } from '../../shared/types';
@@ -23,7 +24,7 @@ import {
   recordComputeProposalRun,
   buildComputeProposalNoteBlock,
 } from './register-compute';
-import { rootPathFromEvent, winFromEvent, reindexFile, persistIndexes, hooks } from './helpers';
+import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr, reindexFile, persistIndexes, hooks } from './helpers';
 
 const DEFAULT_CONVERSATION_SYSTEM_PROMPT = [
   'You are an assistant embedded in Minerva, a markdown-based thinking tool.',
@@ -125,32 +126,18 @@ function buildClaimNoteContent(
 
 export function registerConversation(): void {
   // Proposals
-  ipcMain.handle(Channels.PROPOSAL_LIST, (e, status?: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return approval.listProposals(projectContext(rootPath), status);
-  });
-  ipcMain.handle(Channels.PROPOSAL_DETAIL, (e, uri: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return null;
-    return approval.getProposal(projectContext(rootPath), uri);
-  });
-  ipcMain.handle(Channels.PROPOSAL_APPROVE, async (e, uri: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return false;
+  ipcMain.handle(Channels.PROPOSAL_LIST, withRootPathOr<[string?], Proposal[] | Promise<Proposal[]>>([], (rootPath, status?: string) =>
+    approval.listProposals(projectContext(rootPath), status)));
+  ipcMain.handle(Channels.PROPOSAL_DETAIL, withRootPathOr(null, (rootPath, uri: string) =>
+    approval.getProposal(projectContext(rootPath), uri)));
+  ipcMain.handle(Channels.PROPOSAL_APPROVE, withRootPathOr<[string], boolean | Promise<boolean>>(false, async (rootPath, uri: string) => {
     const result = await approval.approveProposal(projectContext(rootPath), uri);
     return result.ok;
-  });
-  ipcMain.handle(Channels.PROPOSAL_REJECT, (e, uri: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return false;
-    return approval.rejectProposal(projectContext(rootPath), uri);
-  });
-  ipcMain.handle(Channels.PROPOSAL_EXPIRE, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return 0;
-    return approval.expireProposals(projectContext(rootPath));
-  });
+  }));
+  ipcMain.handle(Channels.PROPOSAL_REJECT, withRootPathOr<[string], boolean | Promise<boolean>>(false, (rootPath, uri: string) =>
+    approval.rejectProposal(projectContext(rootPath), uri)));
+  ipcMain.handle(Channels.PROPOSAL_EXPIRE, withRootPathOr<[], number | Promise<number>>(0, (rootPath) =>
+    approval.expireProposals(projectContext(rootPath))));
 
   // Conversations
   ipcMain.handle(Channels.CONVERSATION_CREATE, (_e, contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) =>
@@ -409,9 +396,7 @@ export function registerConversation(): void {
   // time by planRename, so only fromPath/toPath go onto the payload.
   ipcMain.handle(
     Channels.CONVERSATION_FILE_REFACTOR_DRAFT,
-    async (e, draft: import('../../shared/conversation-refactor-drafts').ConversationRefactorDraft) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
+    withRootPath(async (rootPath, draft: import('../../shared/conversation-refactor-drafts').ConversationRefactorDraft) => {
       if (!draft?.fromPath || !draft?.toPath) throw new Error('FILE_REFACTOR_DRAFT: draft is missing fromPath/toPath');
       const ctx = projectContext(rootPath);
       const proposal = await approval.proposeWrite(ctx, {
@@ -423,7 +408,7 @@ export function registerConversation(): void {
       });
       if (proposal) await approval.approveProposal(ctx, proposal.uri);
       return { proposalUri: proposal?.uri ?? null, applied: true };
-    },
+    }),
   );
 
   // Approve a reorganization plan (#914): file + apply the SELECTED items as one
@@ -432,13 +417,11 @@ export function registerConversation(): void {
   // item re-plans at apply time (picking up earlier moves in the same bundle).
   ipcMain.handle(
     Channels.CONVERSATION_FILE_REORG_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       draft: import('../../shared/conversation-refactor-drafts').ConversationReorgDraft,
       selected: Array<{ fromPath: string; toPath: string }>,
     ) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       if (!Array.isArray(selected) || selected.length === 0) {
         return { proposalUri: null, applied: false };
       }
@@ -453,7 +436,7 @@ export function registerConversation(): void {
       });
       if (proposal) await approval.approveProposal(ctx, proposal.uri);
       return { proposalUri: proposal?.uri ?? null, applied: true };
-    },
+    }),
   );
 
   // Approve a deletion: file + apply the SELECTED notes as one note-delete bundle.
@@ -462,13 +445,11 @@ export function registerConversation(): void {
   // blast radius), so this auto-approves once the selection comes back.
   ipcMain.handle(
     Channels.CONVERSATION_FILE_DELETE_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       draft: import('../../shared/conversation-refactor-drafts').ConversationDeleteDraft,
       selected: string[],
     ) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       if (!Array.isArray(selected) || selected.length === 0) {
         return { proposalUri: null, applied: false };
       }
@@ -482,7 +463,7 @@ export function registerConversation(): void {
       });
       if (proposal) await approval.approveProposal(ctx, proposal.uri);
       return { proposalUri: proposal?.uri ?? null, applied: true };
-    },
+    }),
   );
 
   // Counterpart to CONVERSATION_FILE_DELETE_DRAFT for propose_note_body (#937).
@@ -492,12 +473,10 @@ export function registerConversation(): void {
   // new content — approval.ts stays Electron-free and just returns the paths.
   ipcMain.handle(
     Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       draft: import('../../shared/conversation-note-body-drafts').ConversationNoteBodyDraft,
     ): Promise<import('../../shared/conversation-note-body-drafts').FileNoteBodyDraftResult> => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       if (!draft?.relativePath || typeof draft.afterContent !== 'string') {
         throw new Error(
           `FILE_NOTE_BODY_DRAFT: draft missing relativePath/afterContent (received ${JSON.stringify(draft).slice(0, 200)}). ` +
@@ -523,7 +502,7 @@ export function registerConversation(): void {
         }
         return { proposalUri: proposal?.uri ?? null, applied };
       });
-    },
+    }),
   );
 
   // Counterpart to CONVERSATION_FILE_DRAFT for the propose_claims tool (#104).
@@ -533,12 +512,10 @@ export function registerConversation(): void {
   // payloads go first so the node exists before the note's quotes edge resolves.
   ipcMain.handle(
     Channels.CONVERSATION_FILE_CLAIMS_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       draft: import('../../shared/conversation-claims-drafts').ConversationClaimsDraft,
     ): Promise<import('../../shared/conversation-claims-drafts').FileClaimsDraftResult> => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       const sourceId = draft?.sourceId;
       if (!sourceId || !Array.isArray(draft.claims) || draft.claims.length === 0) {
         throw new Error(
@@ -601,7 +578,7 @@ export function registerConversation(): void {
           },
         };
       }
-    },
+    }),
   );
 
   // Counterpart to CONVERSATION_FILE_DRAFT for source-ingest drafts. The
@@ -735,12 +712,10 @@ export function registerConversation(): void {
   // LLM-originated source-metadata write.
   ipcMain.handle(
     Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       draft: import('../../shared/conversation-source-property-drafts').ConversationSourcePropertyDraft,
     ): Promise<import('../../shared/conversation-source-property-drafts').FileSourcePropertyDraftResult> => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       const sourceId = draft?.sourceId;
       if (!sourceId) {
         throw new Error(
@@ -779,7 +754,7 @@ export function registerConversation(): void {
           },
         };
       }
-    },
+    }),
   );
 
   // Counterpart for propose_compute draft cells (#245). The user
@@ -789,12 +764,10 @@ export function registerConversation(): void {
   // turn sees it as user-role context.
   ipcMain.handle(
     Channels.CONVERSATION_RUN_COMPUTE_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       input: import('../../shared/conversation-compute-drafts').RunComputeDraftInput,
     ): Promise<import('../../shared/conversation-compute-drafts').RunComputeDraftResult> => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       const { draft, editedCode } = input;
       if (!draft || !draft.language || !draft.code) {
         throw new Error('RUN_COMPUTE_DRAFT: draft is missing language or code.');
@@ -821,7 +794,7 @@ export function registerConversation(): void {
         console.warn('[conv] failed to record ComputeProposal in graph:', err);
       }
       return { result };
-    },
+    }),
   );
 
   // Insert a compute-draft cell into a notebook with provenance
@@ -830,12 +803,10 @@ export function registerConversation(): void {
   // override via the destinationPath argument.
   ipcMain.handle(
     Channels.CONVERSATION_INSERT_COMPUTE_DRAFT,
-    async (
-      e,
+    withRootPath(async (
+      rootPath,
       input: import('../../shared/conversation-compute-drafts').InsertComputeDraftInput,
     ): Promise<import('../../shared/conversation-compute-drafts').InsertComputeDraftResult> => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
       const { draft, editedCode, destinationPath } = input;
       if (!draft || !draft.language || !draft.code) {
         throw new Error('INSERT_COMPUTE_DRAFT: draft is missing language or code.');
@@ -857,7 +828,7 @@ export function registerConversation(): void {
         : `# Conversation: ${draft.conversationId}\n\n${block}\n`;
       await writeAndReindex(rootPath, dest, next, hooks);
       return { destinationPath: dest };
-    },
+    }),
   );
 
   ipcMain.handle(Channels.CONVERSATION_SET_MODEL, async (_e, convId: string, model: string | undefined) => {

--- a/src/main/ipc/register-git.ts
+++ b/src/main/ipc/register-git.ts
@@ -1,20 +1,17 @@
 import { ipcMain } from 'electron';
 import { Channels } from '../../shared/channels';
 import * as gitOps from '../git/index';
-import { rootPathFromEvent } from './helpers';
+import type { GitStatus } from '../git/index';
+import { withRootPath, withRootPathOr } from './helpers';
 
 export function registerGit(): void {
   // Git
-  ipcMain.handle(Channels.GIT_STATUS, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { isRepo: false, branch: null, files: [] };
+  ipcMain.handle(Channels.GIT_STATUS, withRootPathOr<[], GitStatus | Promise<GitStatus>>({ isRepo: false, branch: null, files: [] }, async (rootPath) => {
     return gitOps.getStatus(rootPath);
-  });
+  }));
 
-  ipcMain.handle(Channels.GIT_COMMIT, async (e, message: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.GIT_COMMIT, withRootPath(async (rootPath, message: string) => {
     const sha = await gitOps.commitAll(rootPath, message);
     return { success: true, sha };
-  });
+  }));
 }

--- a/src/main/ipc/register-graph.ts
+++ b/src/main/ipc/register-graph.ts
@@ -4,82 +4,49 @@ import { Channels } from '../../shared/channels';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import * as tables from '../sources/tables';
+import type { QueryResult, TableInfo } from '../sources/tables';
 import * as healthChecks from '../graph/health-checks';
-import { rootPathFromEvent } from './helpers';
+import type { Inspection } from '../graph/health-checks';
+import { withRootPath, withRootPathOr } from './helpers';
 
 export function registerGraph(): void {
   // Graph
-  ipcMain.handle(Channels.GRAPH_QUERY, async (e, sparql: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-    return graph.queryGraph(projectContext(rootPath), sparql);
-  });
+  ipcMain.handle(Channels.GRAPH_QUERY, withRootPath((rootPath, sparql: string) =>
+    graph.queryGraph(projectContext(rootPath), sparql)));
 
   // Tables (DuckDB)
-  ipcMain.handle(Channels.TABLES_QUERY, async (e, sql: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { ok: false, error: 'No project open' };
-    return tables.runQuery(projectContext(rootPath), sql);
-  });
+  ipcMain.handle(Channels.TABLES_QUERY, withRootPathOr<[string], QueryResult | Promise<QueryResult>>({ ok: false, error: 'No project open' }, (rootPath, sql: string) =>
+    tables.runQuery(projectContext(rootPath), sql)));
 
-  ipcMain.handle(Channels.TABLES_LIST, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return tables.listTables(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.TABLES_LIST, withRootPathOr<[], TableInfo[] | Promise<TableInfo[]>>([], (rootPath) =>
+    tables.listTables(projectContext(rootPath))));
 
-  ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return null;
-    return graph.schemaForCompletion(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, withRootPathOr(null, (rootPath) =>
+    graph.schemaForCompletion(projectContext(rootPath))));
 
-  ipcMain.handle(Channels.GRAPH_SOURCE_DETAIL, (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return null;
-    return graph.getSourceDetail(projectContext(rootPath), sourceId);
-  });
+  ipcMain.handle(Channels.GRAPH_SOURCE_DETAIL, withRootPathOr(null, (rootPath, sourceId: string) =>
+    graph.getSourceDetail(projectContext(rootPath), sourceId)));
 
-  ipcMain.handle(Channels.GRAPH_EXCERPT_SOURCE, (e, excerptId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return null;
-    return graph.getExcerptSource(projectContext(rootPath), excerptId);
-  });
+  ipcMain.handle(Channels.GRAPH_EXCERPT_SOURCE, withRootPathOr(null, (rootPath, excerptId: string) =>
+    graph.getExcerptSource(projectContext(rootPath), excerptId)));
 
-  ipcMain.handle(Channels.GRAPH_ALIAS_MAP, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return {};
-    return graph.getAliasMap(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.GRAPH_ALIAS_MAP, withRootPathOr({}, (rootPath) =>
+    graph.getAliasMap(projectContext(rootPath))));
 
-  ipcMain.handle(Channels.GRAPH_ALIAS_ENTRIES, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.getAliasEntries(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.GRAPH_ALIAS_ENTRIES, withRootPathOr([], (rootPath) =>
+    graph.getAliasEntries(projectContext(rootPath))));
 
-  ipcMain.handle(Channels.GRAPH_FRONTMATTER_KEYS, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.getAllFrontmatterKeys(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.GRAPH_FRONTMATTER_KEYS, withRootPathOr([], (rootPath) =>
+    graph.getAllFrontmatterKeys(projectContext(rootPath))));
 
   // Inspections
-  ipcMain.handle(Channels.INSPECTIONS_LIST, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return healthChecks.getInspections(projectContext(rootPath));
-  });
-  ipcMain.handle(Channels.INSPECTIONS_RUN, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return healthChecks.runAllChecks(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.INSPECTIONS_LIST, withRootPathOr([], (rootPath) =>
+    healthChecks.getInspections(projectContext(rootPath))));
+  ipcMain.handle(Channels.INSPECTIONS_RUN, withRootPathOr<[], Inspection[] | Promise<Inspection[]>>([], (rootPath) =>
+    healthChecks.runAllChecks(projectContext(rootPath))));
 
   // Grounding check — fuzzy match a claim against graph labels
-  ipcMain.handle(Channels.GRAPH_GROUND_CHECK, async (e, claimText: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  ipcMain.handle(Channels.GRAPH_GROUND_CHECK, withRootPathOr<[string], unknown[] | Promise<unknown[]>>([], async (rootPath, claimText: string) => {
     const escaped = claimText.replace(/"/g, '\\"').replace(/\n/g, ' ');
     const results = await graph.queryGraph(projectContext(rootPath), `
       PREFIX dc: <http://purl.org/dc/terms/>
@@ -93,12 +60,10 @@ export function registerGraph(): void {
       } LIMIT 5
     `);
     return results.results;
-  });
+  }));
 
   // Graph management
-  ipcMain.handle(Channels.GRAPH_EXPORT, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.GRAPH_EXPORT, withRootPathOr(undefined, async (rootPath) => {
     const result = await dialog.showSaveDialog({
       title: 'Export Graph',
       defaultPath: 'graph.ttl',
@@ -110,5 +75,5 @@ export function registerGraph(): void {
       const srcPath = path.join(rootPath, '.minerva', 'graph.ttl');
       await fs.copyFile(srcPath, result.filePath);
     }
-  });
+  }));
 }

--- a/src/main/ipc/register-links.ts
+++ b/src/main/ipc/register-links.ts
@@ -5,16 +5,14 @@ import * as graph from '../graph/index';
 import * as vectors from '../embeddings/vector-store';
 import { topRelatedNotes, markAlreadyLinked } from '../embeddings/related';
 import { projectContext } from '../project-context-types';
-import { rootPathFromEvent } from './helpers';
-import type { RelatedNotesResult } from '../../shared/types';
+import { withRootPathOr } from './helpers';
+import type { RelatedNotesResult, CitationGroup } from '../../shared/types';
 
 export function registerLinks(): void {
   // Semantically-related notes for the Related sidebar panel (#838). Uses the
   // active note's stored chunk vectors (no embedding at query time), de-duped to
   // the single best section per note and enriched with display titles.
-  ipcMain.handle(Channels.EMBEDDINGS_RELATED, async (e, relativePath: string, limit?: number): Promise<RelatedNotesResult> => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { enabled: false, notes: [] };
+  ipcMain.handle(Channels.EMBEDDINGS_RELATED, withRootPathOr<[string, number?], RelatedNotesResult | Promise<RelatedNotesResult>>({ enabled: false, notes: [] }, async (rootPath, relativePath: string, limit?: number): Promise<RelatedNotesResult> => {
     const ctx = projectContext(rootPath);
     if (!vectors.isEnabled(ctx)) return { enabled: false, notes: [] };
     const n = Math.min(Math.max(Math.floor(limit ?? 8), 1), 25);
@@ -36,64 +34,45 @@ export function registerLinks(): void {
       ...graph.backlinks(ctx, relativePath).map((l) => l.source),
     ]);
     return { enabled: true, notes: markAlreadyLinked(ranked, linked) };
-  });
+  }));
   // Links
-  ipcMain.handle(Channels.LINKS_OUTGOING, (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.outgoingLinks(projectContext(rootPath), relativePath);
-  });
+  ipcMain.handle(Channels.LINKS_OUTGOING, withRootPathOr([], (rootPath, relativePath: string) =>
+    graph.outgoingLinks(projectContext(rootPath), relativePath)));
 
-  ipcMain.handle(Channels.LINKS_BACKLINKS, (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.backlinks(projectContext(rootPath), relativePath);
-  });
+  ipcMain.handle(Channels.LINKS_BACKLINKS, withRootPathOr([], (rootPath, relativePath: string) =>
+    graph.backlinks(projectContext(rootPath), relativePath)));
 
   // Coalesced bundle for the right-sidebar link panels (#351). Replaces
   // the parallel LINKS_OUTGOING + LINKS_BACKLINKS round-trips on every
   // tab switch — one IPC, one graph-state pass, both directions together.
-  ipcMain.handle(Channels.LINKS_BUNDLE, (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { outgoing: [], backlinks: [] };
+  ipcMain.handle(Channels.LINKS_BUNDLE, withRootPathOr({ outgoing: [], backlinks: [] }, (rootPath, relativePath: string) => {
     const ctx = projectContext(rootPath);
     return {
       outgoing: graph.outgoingLinks(ctx, relativePath),
       backlinks: graph.backlinks(ctx, relativePath),
     };
-  });
+  }));
 
   ipcMain.handle(
     Channels.LINKS_CITATIONS_FOR_NOTE,
-    async (e, relativePath: string, content?: string) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) return [];
+    withRootPathOr<[string, string?], CitationGroup[] | Promise<CitationGroup[]>>([], async (rootPath, relativePath: string, content?: string) => {
       // Renderer can pass live content (current editor buffer) so the
       // count reflects what the user is typing right now. Falling back
       // to disk preserves correctness when the panel refreshes from a
       // graph event without an open editor buffer.
       const text = content ?? await notebaseFs.readFile(rootPath, relativePath).catch(() => '');
       return graph.citationsForNote(projectContext(rootPath), relativePath, text);
-    },
+    }),
   );
 
-  ipcMain.handle(Channels.LINKS_EXTERNAL_INBOUND, (e, paths: string[]) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.findExternalInboundLinks(projectContext(rootPath), paths);
-  });
+  ipcMain.handle(Channels.LINKS_EXTERNAL_INBOUND, withRootPathOr([], (rootPath, paths: string[]) =>
+    graph.findExternalInboundLinks(projectContext(rootPath), paths)));
 
   // Depth-N link neighborhood for the graph view (#846).
-  ipcMain.handle(Channels.LINKS_NEIGHBORHOOD, (e, relativePath: string, opts?: graph.NeighborhoodOptions) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { nodes: [], edges: [], truncated: false };
-    return graph.neighborhood(projectContext(rootPath), relativePath, opts ?? {});
-  });
+  ipcMain.handle(Channels.LINKS_NEIGHBORHOOD, withRootPathOr({ nodes: [], edges: [], truncated: false }, (rootPath, relativePath: string, opts?: graph.NeighborhoodOptions) =>
+    graph.neighborhood(projectContext(rootPath), relativePath, opts ?? {})));
 
   // Single hop out of a node — expand-on-demand (#846).
-  ipcMain.handle(Channels.LINKS_EXPAND_NODE, (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { nodes: [], edges: [], expandTo: [] };
-    return graph.expandNode(projectContext(rootPath), relativePath);
-  });
+  ipcMain.handle(Channels.LINKS_EXPAND_NODE, withRootPathOr({ nodes: [], edges: [], expandTo: [] }, (rootPath, relativePath: string) =>
+    graph.expandNode(projectContext(rootPath), relativePath)));
 }

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -22,6 +22,8 @@ import { handle } from './typed-ipc';
 import {
   winFromEvent,
   rootPathFromEvent,
+  withRootPath,
+  withRootPathOr,
   reindexFile,
   removeFromIndexes,
   listIndexableFiles,
@@ -125,29 +127,23 @@ export function registerNotebase(): void {
     return notebaseFs.listFiles(rootPath);
   });
 
-  handle(Channels.NOTEBASE_READ_FILE, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_READ_FILE, withRootPath(async (rootPath, relativePath: string) => {
     return notebaseFs.readFile(rootPath, relativePath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_READ_BINARY, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_READ_BINARY, withRootPath(async (rootPath, relativePath: string) => {
     // Pass the bytes back as a Buffer; Electron's structured-clone
     // bridge wraps it in a Uint8Array on the renderer side.
     return notebaseFs.readBinaryFile(rootPath, relativePath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_WRITE_BINARY, async (e, relativePath: string, bytes: Uint8Array) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_WRITE_BINARY, withRootPath(async (rootPath, relativePath: string, bytes: Uint8Array) => {
     // The renderer wraps payload as a Uint8Array; structured-clone
     // hands us a Buffer at this end. Either way `writeBinaryFile`
     // re-wraps as a strict Uint8Array view.
     const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
     await notebaseFs.writeBinaryFile(rootPath, relativePath, view);
-  });
+  }));
 
   handle(Channels.NOTEBASE_FILE_EXISTS, async (e, relativePath: string) => {
     const rootPath = rootPathFromEvent(e);
@@ -155,54 +151,41 @@ export function registerNotebase(): void {
     return notebaseFs.fileExists(rootPath, relativePath);
   });
 
-  handle(Channels.NOTEBASE_WRITE_FILE, async (e, relativePath: string, content: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_WRITE_FILE, withRootPath(async (rootPath, relativePath: string, content: string) => {
     // Renderer-initiated save — it already has the content, so suppress
     // the rewritten broadcast (no need to tell the renderer it just wrote).
     await writeAndReindex(rootPath, relativePath, content, hooks, {
       suppressRewrittenBroadcast: true,
     });
-  });
+  }));
 
-  handle(Channels.NOTEBASE_CREATE_FILE, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_CREATE_FILE, withRootPath(async (rootPath, relativePath: string) => {
     markPathHandled(relativePath);
     await notebaseFs.createFile(rootPath, relativePath);
     const ctx = projectContext(rootPath);
     await graph.indexNote(ctx, relativePath, '');
     search.indexNote(ctx, relativePath, '');
-  });
+  }));
 
-  handle(Channels.NOTEBASE_DELETE_FILE, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_DELETE_FILE, withRootPath(async (rootPath, relativePath: string) => {
     markPathHandled(relativePath);
     await notebaseFs.deleteFile(rootPath, relativePath);
     removeFromIndexes(rootPath, relativePath);
     await persistIndexes(rootPath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_CREATE_FOLDER, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_CREATE_FOLDER, withRootPath(async (rootPath, relativePath: string) => {
     await notebaseFs.createFolder(rootPath, relativePath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_DELETE_FOLDER, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_DELETE_FOLDER, withRootPath(async (rootPath, relativePath: string) => {
     const files = await listIndexableFiles(rootPath, relativePath);
     await notebaseFs.deleteFolder(rootPath, relativePath);
     for (const f of files) removeFromIndexes(rootPath, f);
     await persistIndexes(rootPath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_RENAME, async (e, oldRelPath: string, newRelPath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-
+  handle(Channels.NOTEBASE_RENAME, withRootPath(async (rootPath, oldRelPath: string, newRelPath: string) => {
     const ctx = projectContext(rootPath);
     const { transitions, rewrittenPaths } = await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
       markPathHandled,
@@ -230,17 +213,13 @@ export function registerNotebase(): void {
     }
 
     await persistIndexes(rootPath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_MERGE_PREVIEW, async (e, sourceRelPath: string, targetRelPath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_MERGE_PREVIEW, withRootPath(async (rootPath, sourceRelPath: string, targetRelPath: string) => {
     return previewMergeNotes(rootPath, sourceRelPath, targetRelPath);
-  });
+  }));
 
-  handle(Channels.NOTEBASE_MERGE, async (e, sourceRelPath: string, targetRelPath: string, separator?: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_MERGE, withRootPath(async (rootPath, sourceRelPath: string, targetRelPath: string, separator?: string) => {
     const ctx = projectContext(rootPath);
     const result = await mergeNotes(rootPath, sourceRelPath, targetRelPath, {
       separator,
@@ -274,11 +253,9 @@ export function registerNotebase(): void {
     }
     await persistIndexes(rootPath);
     return result;
-  });
+  }));
 
-  handle(Channels.NOTEBASE_RENAME_SOURCE, async (e, oldId: string, newId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_RENAME_SOURCE, withRootPath(async (rootPath, oldId: string, newId: string) => {
     const ctx = projectContext(rootPath);
     const { rewrittenPaths } = await renameSource(rootPath, oldId, newId, {
       markPathHandled,
@@ -289,11 +266,9 @@ export function registerNotebase(): void {
     broadcastRewritten(rootPath, rewrittenPaths);
     await persistIndexes(rootPath);
     return { rewrittenPaths };
-  });
+  }));
 
-  handle(Channels.NOTEBASE_RENAME_EXCERPT, async (e, oldId: string, newId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_RENAME_EXCERPT, withRootPath(async (rootPath, oldId: string, newId: string) => {
     const ctx = projectContext(rootPath);
     const { rewrittenPaths } = await renameExcerpt(rootPath, oldId, newId, {
       markPathHandled,
@@ -304,14 +279,11 @@ export function registerNotebase(): void {
     broadcastRewritten(rootPath, rewrittenPaths);
     await persistIndexes(rootPath);
     return { rewrittenPaths };
-  });
+  }));
 
   ipcMain.handle(
     Channels.NOTEBASE_RENAME_ANCHOR,
-    async (e, targetRelativePath: string, oldSlug: string, newSlug: string) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
-
+    withRootPath(async (rootPath, targetRelativePath: string, oldSlug: string, newSlug: string) => {
       const ctx = projectContext(rootPath);
       const { rewrittenPaths } = await renameAnchor(rootPath, targetRelativePath, oldSlug, newSlug, {
         markPathHandled,
@@ -330,12 +302,10 @@ export function registerNotebase(): void {
 
       await persistIndexes(rootPath);
       return { rewrittenPaths };
-    },
+    }),
   );
 
-  handle(Channels.NOTEBASE_COPY, async (e, srcRelPath: string, destRelPath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_COPY, withRootPath(async (rootPath, srcRelPath: string, destRelPath: string) => {
     await notebaseFs.copyItem(rootPath, srcRelPath, destRelPath);
     const stat = await fs.stat(path.join(rootPath, destRelPath));
     if (stat.isDirectory()) {
@@ -345,7 +315,7 @@ export function registerNotebase(): void {
       await reindexFile(rootPath, destRelPath);
     }
     await persistIndexes(rootPath);
-  });
+  }));
 
   handle(Channels.NOTEBASE_SEARCH_IN_NOTES, async (e, opts: SearchOptions) => {
     const rootPath = rootPathFromEvent(e);
@@ -367,21 +337,14 @@ export function registerNotebase(): void {
     return result;
   });
 
-  handle(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return false;
-    return getOnboardingDismissed(rootPath);
-  });
+  handle(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED, withRootPathOr(false, (rootPath) =>
+    getOnboardingDismissed(rootPath)));
 
-  handle(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, (e, dismissed: boolean) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  handle(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, withRootPath((rootPath, dismissed: boolean) => {
     setOnboardingDismissed(rootPath, dismissed === true);
-  });
+  }));
 
-  ipcMain.handle(Channels.FILES_DROP_IMPORT, async (e, targetFolder: string, localPaths: string[]) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.FILES_DROP_IMPORT, withRootPath(async (rootPath, targetFolder: string, localPaths: string[]) => {
     return await dropImport(rootPath, targetFolder ?? '', localPaths ?? []);
-  });
+  }));
 }

--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -10,7 +10,7 @@ import {
   removePublishTarget,
   type PublishTarget,
 } from '../project-config';
-import { rootPathFromEvent, winFromEvent } from './helpers';
+import { rootPathFromEvent, winFromEvent, withRootPath } from './helpers';
 
 export function registerPublish(): void {
   // ── Publication (#282) ─────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ export function registerPublish(): void {
     })),
   );
 
-  ipcMain.handle(Channels.PUBLISH_RESOLVE_PLAN, async (e, input: publish.ExportInput, opts?: {
+  ipcMain.handle(Channels.PUBLISH_RESOLVE_PLAN, withRootPath(async (rootPath, input: publish.ExportInput, opts?: {
     exporterId?: string;
     linkPolicy?: publish.LinkPolicy;
     citationStyle?: string;
@@ -40,8 +40,6 @@ export function registerPublish(): void {
     forceInclude?: string[];
     forceExclude?: string[];
   }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
     const plan = await publish.resolvePlan(rootPath, input, {
       linkPolicy: opts?.linkPolicy,
       citationStyle: opts?.citationStyle,
@@ -83,7 +81,7 @@ export function registerPublish(): void {
         missing: audit.missing,
       },
     };
-  });
+  }));
 
   ipcMain.handle(Channels.PUBLISH_RUN_EXPORT, async (e, args: Omit<publish.RunExportInput, 'outputDir'> & { outputDir?: string }) => {
     const rootPath = rootPathFromEvent(e);
@@ -107,25 +105,19 @@ export function registerPublish(): void {
 
   // ── Publish → git remote (#254) ────────────────────────────────────────────
 
-  ipcMain.handle(Channels.PUBLISH_LIST_TARGETS, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.PUBLISH_LIST_TARGETS, withRootPath((rootPath) => {
     return getPublishTargets(rootPath);
-  });
+  }));
 
-  ipcMain.handle(Channels.PUBLISH_UPSERT_TARGET, (e, target: PublishTarget) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.PUBLISH_UPSERT_TARGET, withRootPath((rootPath, target: PublishTarget) => {
     upsertPublishTarget(rootPath, target);
     return getPublishTargets(rootPath);
-  });
+  }));
 
-  ipcMain.handle(Channels.PUBLISH_REMOVE_TARGET, (e, id: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.PUBLISH_REMOVE_TARGET, withRootPath((rootPath, id: string) => {
     removePublishTarget(rootPath, id);
     return getPublishTargets(rootPath);
-  });
+  }));
 
   // Export + commit + push (or dry-run preview). Errors — auth, network,
   // non-fast-forward — come back as `{ ok: false, error }` carrying the raw
@@ -133,9 +125,7 @@ export function registerPublish(): void {
   // rejection (#254 acceptance).
   ipcMain.handle(
     Channels.PUBLISH_TO_GIT,
-    async (e, targetId: string, opts?: { dryRun?: boolean }) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
+    withRootPath(async (rootPath, targetId: string, opts?: { dryRun?: boolean }) => {
       try {
         const result = await publish.publishToGit(rootPath, targetId, {
           dryRun: opts?.dryRun ?? false,
@@ -145,6 +135,6 @@ export function registerPublish(): void {
       } catch (err) {
         return { ok: false as const, error: err instanceof Error ? err.message : String(err) };
       }
-    },
+    }),
   );
 }

--- a/src/main/ipc/register-queries.ts
+++ b/src/main/ipc/register-queries.ts
@@ -4,7 +4,7 @@ import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
 import * as savedQueries from '../saved-queries';
 import { rebuildMenu } from '../menu';
-import { rootPathFromEvent } from './helpers';
+import { rootPathFromEvent, withRootPathOr } from './helpers';
 
 export function registerQueries(): void {
   // Saved queries
@@ -57,9 +57,6 @@ export function registerQueries(): void {
   });
 
   // Search
-  ipcMain.handle(Channels.SEARCH_QUERY, (e, query: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return search.search(projectContext(rootPath), query);
-  });
+  ipcMain.handle(Channels.SEARCH_QUERY, withRootPathOr([], (rootPath, query: string) =>
+    search.search(projectContext(rootPath), query)));
 }

--- a/src/main/ipc/register-refactor.ts
+++ b/src/main/ipc/register-refactor.ts
@@ -21,58 +21,47 @@ import type { AutoLinkSuggestion } from '../../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../../shared/refactor/auto-link-inbound';
 import { appendSeeAlsoLink } from '../../shared/refactor/see-also';
 import * as notebaseFs from '../notebase/fs';
-import { rootPathFromEvent, persistIndexes, broadcastRewritten, hooks } from './helpers';
+import { rootPathFromEvent, withRootPath, withRootPathOr, persistIndexes, broadcastRewritten, hooks } from './helpers';
 
 export function registerRefactor(): void {
   // Auto-tag is two-phase (#940): SUGGEST asks the LLM for tags and writes
   // NOTHING; the renderer shows a review dialog; APPLY routes the accepted tags
   // through the approval engine. This closes the historical bypass where the
   // one-shot handler wrote directly with no proposal record.
-  ipcMain.handle(Channels.REFACTOR_AUTO_TAG_SUGGEST, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.REFACTOR_AUTO_TAG_SUGGEST, withRootPath(async (rootPath, relativePath: string) => {
     const plan = await runAutoTag(rootPath, relativePath);
     return { added: plan.added };
-  });
+  }));
 
   ipcMain.handle(
     Channels.REFACTOR_AUTO_TAG_APPLY,
-    async (e, relativePath: string, acceptedTags: string[]) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
+    withRootPath(async (rootPath, relativePath: string, acceptedTags: string[]) => {
       if (!Array.isArray(acceptedTags) || acceptedTags.length === 0) return { applied: [] };
       const { applied, rewrittenPaths } = await applyAutoTag(rootPath, relativePath, acceptedTags);
       // The approval engine wrote the note; broadcast so an open editor reloads
       // the new frontmatter (approval.ts stays Electron-free and returns paths).
       broadcastRewritten(rootPath, rewrittenPaths);
       return { applied };
-    },
+    }),
   );
 
-  ipcMain.handle(Channels.REFACTOR_AUTO_LINK_SUGGEST, async (e, activeRelPath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.REFACTOR_AUTO_LINK_SUGGEST, withRootPath(async (rootPath, activeRelPath: string) => {
     return suggestLinksTo(rootPath, activeRelPath);
-  });
+  }));
 
   // Accept a semantic "suggested link" (#840): file `[[target]]` under the
   // active note's "See also" section. Unlike AutoLink, semantic neighbors share
   // no anchor word, so it appends rather than inlining. Idempotent.
-  ipcMain.handle(Channels.REFACTOR_APPLY_SUGGESTED_LINK, async (e, activeRelPath: string, targetRelPath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.REFACTOR_APPLY_SUGGESTED_LINK, withRootPath(async (rootPath, activeRelPath: string, targetRelPath: string) => {
     const content = await notebaseFs.readFile(rootPath, activeRelPath);
     const { content: next, changed } = appendSeeAlsoLink(content, targetRelPath);
     if (changed) await writeAndReindex(rootPath, activeRelPath, next, hooks);
     return { changed };
-  });
+  }));
 
   ipcMain.handle(
     Channels.REFACTOR_AUTO_LINK_APPLY,
-    async (e, activeRelPath: string, accepted: AutoLinkSuggestion[]) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
-
+    withRootPath(async (rootPath, activeRelPath: string, accepted: AutoLinkSuggestion[]) => {
       // Route the rewrite through the approval engine (#941) rather than
       // writing directly. broadcastRewritten reloads an open editor from the
       // paths the approval apply returns.
@@ -83,14 +72,12 @@ export function registerRefactor(): void {
       );
       broadcastRewritten(rootPath, rewrittenPaths);
       return { applied, skipped };
-    },
+    }),
   );
 
-  ipcMain.handle(Channels.REFACTOR_AUTO_LINK_INBOUND_SUGGEST, async (e, activeRelPath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.REFACTOR_AUTO_LINK_INBOUND_SUGGEST, withRootPath(async (rootPath, activeRelPath: string) => {
     return suggestLinksInbound(rootPath, activeRelPath);
-  });
+  }));
 
   // Formatter (issue #153)
   ipcMain.handle(
@@ -101,9 +88,8 @@ export function registerRefactor(): void {
 
   // Project-scoped formatter settings (#154). Stored in .minerva/formatter.json
   // so rule choices travel with the thoughtbase in git.
-  ipcMain.handle(Channels.FORMATTER_LOAD_SETTINGS, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { enabled: {}, configs: {} };
+  type FormatterSettings = { enabled: Record<string, boolean>; configs: Record<string, unknown> };
+  ipcMain.handle(Channels.FORMATTER_LOAD_SETTINGS, withRootPathOr<[], FormatterSettings | Promise<FormatterSettings>>({ enabled: {}, configs: {} }, async (rootPath) => {
     try {
       const p = path.join(rootPath, '.minerva', 'formatter.json');
       const data = await fs.readFile(p, 'utf-8');
@@ -113,21 +99,17 @@ export function registerRefactor(): void {
         configs: (parsed?.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
       };
     } catch { return { enabled: {}, configs: {} }; }
-  });
+  }));
 
-  ipcMain.handle(Channels.FORMATTER_SAVE_SETTINGS, async (e, settings: FormatSettings) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.FORMATTER_SAVE_SETTINGS, withRootPathOr(undefined, async (rootPath, settings: FormatSettings) => {
     const p = path.join(rootPath, '.minerva', 'formatter.json');
     await fs.mkdir(path.dirname(p), { recursive: true });
     await fs.writeFile(p, JSON.stringify(settings, null, 2), 'utf-8');
-  });
+  }));
 
   ipcMain.handle(
     Channels.FORMATTER_FORMAT_FILE,
-    async (e, relativePath: string, settings: FormatSettings) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
+    withRootPath(async (rootPath, relativePath: string, settings: FormatSettings) => {
       const result = await formatFileOnDisk(rootPath, relativePath, settings);
       const touched = result.changed
         ? [relativePath, ...result.cascadedPaths]
@@ -138,14 +120,12 @@ export function registerRefactor(): void {
         broadcastRewritten(rootPath, touched);
       }
       return result;
-    },
+    }),
   );
 
   ipcMain.handle(
     Channels.FORMATTER_FORMAT_FOLDER,
-    async (e, relDir: string, settings: FormatSettings) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
+    withRootPath(async (rootPath, relDir: string, settings: FormatSettings) => {
       const summary = await formatFolderOnDisk(rootPath, relDir ?? '', settings);
       const touched = [...summary.changedPaths, ...summary.cascadedPaths];
       if (touched.length > 0) {
@@ -154,15 +134,12 @@ export function registerRefactor(): void {
         broadcastRewritten(rootPath, touched);
       }
       return summary;
-    },
+    }),
   );
 
   ipcMain.handle(
     Channels.REFACTOR_AUTO_LINK_INBOUND_APPLY,
-    async (e, activeRelPath: string, accepted: AutoLinkInboundSuggestion[]) => {
-      const rootPath = rootPathFromEvent(e);
-      if (!rootPath) throw new Error('No project open');
-
+    withRootPath(async (rootPath, activeRelPath: string, accepted: AutoLinkInboundSuggestion[]) => {
       // Route through the approval engine (#941): all touched source notes are
       // filed as ONE note_rewrite proposal (atomic — a partial failure rolls the
       // whole batch back) and applied. broadcastRewritten emits a single
@@ -174,6 +151,6 @@ export function registerRefactor(): void {
       );
       broadcastRewritten(rootPath, rewrittenPaths);
       return { applied, skipped, touchedPaths: rewrittenPaths };
-    },
+    }),
   );
 }

--- a/src/main/ipc/register-shell.ts
+++ b/src/main/ipc/register-shell.ts
@@ -2,7 +2,7 @@ import { ipcMain, shell, dialog } from 'electron';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { Channels } from '../../shared/channels';
-import { rootPathFromEvent, winFromEvent } from './helpers';
+import { winFromEvent, withRootPathOr } from './helpers';
 
 export function registerShell(): void {
   // Export
@@ -20,24 +20,18 @@ export function registerShell(): void {
   });
 
   // Shell
-  ipcMain.handle(Channels.SHELL_REVEAL_FILE, (e, relativePath?: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.SHELL_REVEAL_FILE, withRootPathOr(undefined, (rootPath, relativePath?: string) => {
     const fullPath = relativePath
       ? path.join(rootPath, relativePath)
       : rootPath;
     shell.showItemInFolder(fullPath);
-  });
+  }));
 
-  ipcMain.handle(Channels.SHELL_OPEN_IN_DEFAULT, (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.SHELL_OPEN_IN_DEFAULT, withRootPathOr(undefined, (rootPath, relativePath: string) => {
     void shell.openPath(path.join(rootPath, relativePath));
-  });
+  }));
 
-  ipcMain.handle(Channels.SHELL_OPEN_IN_TERMINAL, (e, relativePath?: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return;
+  ipcMain.handle(Channels.SHELL_OPEN_IN_TERMINAL, withRootPathOr(undefined, (rootPath, relativePath?: string) => {
     const dir = relativePath
       ? path.join(rootPath, path.dirname(relativePath))
       : rootPath;
@@ -63,7 +57,7 @@ export function registerShell(): void {
       });
       child.unref();
     }
-  });
+  }));
 
   ipcMain.handle(Channels.SHELL_OPEN_EXTERNAL, async (_e, url: string) => {
     // Only http(s) — don't let anyone (or the LLM) coerce us into opening

--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -19,7 +19,7 @@ import { ingestSmart } from '../sources/ingest-smart';
 import { mineSourceReferences, type ParsedReference } from '../sources/mine-references';
 import { createReferenceStubs } from '../sources/create-reference-stubs';
 import { resolveStub, applyStubResolution } from '../sources/resolve-stub';
-import type { ReadStatus } from '../../shared/types';
+import type { ReadStatus, SourceMetadata, CollectionsFile } from '../../shared/types';
 import type { ReadingQueueView } from '../graph/index';
 import {
   loadCollections,
@@ -39,44 +39,36 @@ import { importBibtex } from '../sources/import-bibtex';
 import { importZoteroRdf } from '../sources/import-zotero-rdf';
 import { getExcerptNoteFolder, setExcerptNoteFolder } from '../project-config';
 import { createExcerpt } from '../sources/create-excerpt';
-import { rootPathFromEvent, winFromEvent, reindexFile, persistIndexes } from './helpers';
+import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr, reindexFile, persistIndexes } from './helpers';
 
 export function registerSources(): void {
-  ipcMain.handle(Channels.SOURCES_INGEST_URL, async (e, url: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_INGEST_URL, withRootPath(async (rootPath, url: string) => {
     const ingestSettings = await getIngestSettings();
     return await ingestUrl(rootPath, url, {
       fetchImpl: privilegedFetch,
       importUpstreamTags: ingestSettings.importUpstreamTags,
     });
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_INGEST_IDENTIFIER, async (e, identifier: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_INGEST_IDENTIFIER, withRootPath(async (rootPath, identifier: string) => {
     const ingestSettings = await getIngestSettings();
     return await ingestIdentifier(rootPath, identifier, {
       fetchImpl: privilegedFetch,
       importUpstreamTags: ingestSettings.importUpstreamTags,
     });
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_INGEST_SMART, async (e, rawInput: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_INGEST_SMART, withRootPath(async (rootPath, rawInput: string) => {
     const ingestSettings = await getIngestSettings();
     return await ingestSmart(rootPath, rawInput, {
       fetchImpl: privilegedFetch,
       importUpstreamTags: ingestSettings.importUpstreamTags,
     });
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_MINE_REFERENCES, async (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_MINE_REFERENCES, withRootPath(async (rootPath, sourceId: string) => {
     return await mineSourceReferences(rootPath, sourceId);
-  });
+  }));
 
   ipcMain.handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, async (e, params: { sourceId: string; refs: ParsedReference[] }) => {
     const rootPath = rootPathFromEvent(e);
@@ -88,11 +80,9 @@ export function registerSources(): void {
     return result;
   });
 
-  ipcMain.handle(Channels.SOURCES_RESOLVE_STUB, async (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_RESOLVE_STUB, withRootPath(async (rootPath, sourceId: string) => {
     return await resolveStub(rootPath, sourceId, { fetchImpl: privilegedFetch });
-  });
+  }));
 
   ipcMain.handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, async (e, params: { sourceId: string; doi: string }) => {
     const rootPath = rootPathFromEvent(e);
@@ -172,34 +162,25 @@ export function registerSources(): void {
 
   // Read the raw PDF bytes of a previously-persisted source, for the
   // renderer-side OCR worker (#95).
-  ipcMain.handle(Channels.SOURCES_READ_PDF, async (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_READ_PDF, withRootPath(async (rootPath, sourceId: string) => {
     return await readOriginalPdf(rootPath, sourceId);
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_HAS_PDF, async (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return false;
+  ipcMain.handle(Channels.SOURCES_HAS_PDF, withRootPathOr<[string], boolean | Promise<boolean>>(false, async (rootPath, sourceId: string) => {
     try {
       await fs.stat(path.join(rootPath, '.minerva', 'sources', sourceId, 'original.pdf'));
       return true;
     } catch {
       return false;
     }
-  });
+  }));
 
   // Excerpt → Note flow defaults (#101).
-  ipcMain.handle(Channels.EXCERPT_GET_NOTE_FOLDER, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return '';
-    return getExcerptNoteFolder(rootPath);
-  });
-  ipcMain.handle(Channels.EXCERPT_SET_NOTE_FOLDER, (e, folder: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.EXCERPT_GET_NOTE_FOLDER, withRootPathOr('', (rootPath) =>
+    getExcerptNoteFolder(rootPath)));
+  ipcMain.handle(Channels.EXCERPT_SET_NOTE_FOLDER, withRootPath((rootPath, folder: string) => {
     setExcerptNoteFolder(rootPath, folder);
-  });
+  }));
 
   // Finalise a scanned-PDF ingest: the renderer has run OCR and hands
   // back the per-page text. We rewrite body.md + stamp meta.ttl with
@@ -214,11 +195,8 @@ export function registerSources(): void {
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
   });
 
-  ipcMain.handle(Channels.SOURCES_LIST_ALL, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.listAllSources(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.SOURCES_LIST_ALL, withRootPathOr([], (rootPath) =>
+    graph.listAllSources(projectContext(rootPath))));
 
   ipcMain.handle(Channels.SOURCES_DELETE, async (e, sourceId: string) => {
     const rootPath = rootPathFromEvent(e);
@@ -313,14 +291,12 @@ export function registerSources(): void {
     return result;
   });
 
-  ipcMain.handle(Channels.SOURCES_QUEUE_MEMBERS, (e, view: ReadingQueueView) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  ipcMain.handle(Channels.SOURCES_QUEUE_MEMBERS, withRootPathOr([], (rootPath, view: ReadingQueueView) => {
     const ctx = projectContext(rootPath);
     const ids = new Set(graph.getReadingQueueSourceIds(ctx, view));
     if (ids.size === 0) return [];
     return graph.listAllSources(ctx).filter((s) => ids.has(s.sourceId));
-  });
+  }));
 
   // ── Collections (#470) ────────────────────────────────────────────────────
   const broadcastCollectionsChanged = (e: Electron.IpcMainInvokeEvent) => {
@@ -328,11 +304,9 @@ export function registerSources(): void {
     if (!win.isDestroyed()) win.webContents.send(Channels.COLLECTIONS_CHANGED);
   };
 
-  ipcMain.handle(Channels.COLLECTIONS_LIST, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { collections: [] };
+  ipcMain.handle(Channels.COLLECTIONS_LIST, withRootPathOr<[], { collections: never[] } | Promise<CollectionsFile>>({ collections: [] }, async (rootPath) => {
     return await loadCollections(rootPath);
-  });
+  }));
 
   ipcMain.handle(Channels.COLLECTIONS_CREATE, async (e, args: { name: string; parent?: string | null }) => {
     const rootPath = rootPathFromEvent(e);
@@ -399,9 +373,7 @@ export function registerSources(): void {
     broadcastCollectionsChanged(e);
   });
 
-  ipcMain.handle(Channels.COLLECTIONS_SMART_MEMBERS, async (e, id: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  ipcMain.handle(Channels.COLLECTIONS_SMART_MEMBERS, withRootPathOr<[string], SourceMetadata[] | Promise<SourceMetadata[]>>([], async (rootPath, id: string) => {
     const data = await loadCollections(rootPath);
     const smart = data.smartCollections.find((s) => s.id === id);
     if (!smart) return [];
@@ -416,17 +388,15 @@ export function registerSources(): void {
     if (matchingIds.size === 0) return [];
     const all = graph.listAllSources(ctx);
     return all.filter((s) => matchingIds.has(s.sourceId));
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, async (e, params: {
+  ipcMain.handle(Channels.SOURCES_CREATE_EXCERPT, withRootPath(async (rootPath, params: {
     sourceId: string;
     citedText: string;
     page?: number | null;
     pageRange?: string | null;
     locationText?: string | null;
   }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
     return await createExcerpt(rootPath, params);
-  });
+  }));
 }

--- a/src/main/ipc/register-tags.ts
+++ b/src/main/ipc/register-tags.ts
@@ -2,37 +2,22 @@ import { ipcMain } from 'electron';
 import { Channels } from '../../shared/channels';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
-import { rootPathFromEvent } from './helpers';
+import { withRootPathOr } from './helpers';
 
 export function registerTags(): void {
   // Tags
-  ipcMain.handle(Channels.TAGS_LIST, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.listTags(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.TAGS_LIST, withRootPathOr([], (rootPath) =>
+    graph.listTags(projectContext(rootPath))));
 
-  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG, (e, tag: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.notesByTag(projectContext(rootPath), tag);
-  });
+  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG, withRootPathOr([], (rootPath, tag: string) =>
+    graph.notesByTag(projectContext(rootPath), tag)));
 
-  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG_PREFIX, (e, prefix: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.notesByTagPrefix(projectContext(rootPath), prefix);
-  });
+  ipcMain.handle(Channels.TAGS_NOTES_BY_TAG_PREFIX, withRootPathOr([], (rootPath, prefix: string) =>
+    graph.notesByTagPrefix(projectContext(rootPath), prefix)));
 
-  ipcMain.handle(Channels.TAGS_SOURCES_BY_TAG, (e, tag: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.sourcesByTag(projectContext(rootPath), tag);
-  });
+  ipcMain.handle(Channels.TAGS_SOURCES_BY_TAG, withRootPathOr([], (rootPath, tag: string) =>
+    graph.sourcesByTag(projectContext(rootPath), tag)));
 
-  ipcMain.handle(Channels.TAGS_ALL_NAMES, (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return graph.allTags(projectContext(rootPath));
-  });
+  ipcMain.handle(Channels.TAGS_ALL_NAMES, withRootPathOr([], (rootPath) =>
+    graph.allTags(projectContext(rootPath))));
 }

--- a/src/main/ipc/register-templates.ts
+++ b/src/main/ipc/register-templates.ts
@@ -1,29 +1,24 @@
 import { ipcMain } from 'electron';
 import { Channels } from '../../shared/channels';
 import * as templates from '../notebase/templates';
-import { rootPathFromEvent } from './helpers';
+import type { TemplateInfo } from '../notebase/templates';
+import { withRootPath, withRootPathOr } from './helpers';
 
 export function registerTemplates(): void {
   // Templates (#475)
-  ipcMain.handle(Channels.TEMPLATES_LIST, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
+  ipcMain.handle(Channels.TEMPLATES_LIST, withRootPathOr<[], TemplateInfo[] | Promise<TemplateInfo[]>>([], async (rootPath) => {
     return templates.listTemplates(rootPath);
-  });
+  }));
 
-  ipcMain.handle(Channels.TEMPLATES_GET, async (e, filename: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return null;
+  ipcMain.handle(Channels.TEMPLATES_GET, withRootPathOr(null, async (rootPath, filename: string) => {
     try {
       return await templates.readTemplate(rootPath, filename);
     } catch {
       return null;
     }
-  });
+  }));
 
-  ipcMain.handle(Channels.TEMPLATES_SAVE_AS, async (e, name: string, content: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.TEMPLATES_SAVE_AS, withRootPath(async (rootPath, name: string, content: string) => {
     return await templates.saveTemplate(rootPath, name, content);
-  });
+  }));
 }


### PR DESCRIPTION
## Summary
`const rootPath = rootPathFromEvent(e); if (!rootPath) …` was hand-rolled **~169×** across the `register-*.ts` handlers — 86 throwing `"No project open"`, the rest returning heterogeneous empties (`[]`, `null`, `false`, `{ ok: false }`, various object shapes). This collapses that guard into two wrappers.

```ts
// helpers.ts
withRootPath(fn)              // throws "No project open"; passes rootPath as the 1st arg
withRootPathOr(fallback, fn)  // returns the handler's OWN empty value when no project
```

A handler goes from:
```ts
ipcMain.handle(Channels.TAGS_LIST, (e) => {
  const rootPath = rootPathFromEvent(e);
  if (!rootPath) return [];
  return graph.listTags(projectContext(rootPath));
});
```
to:
```ts
ipcMain.handle(Channels.TAGS_LIST, withRootPathOr([], (rootPath) =>
  graph.listTags(projectContext(rootPath))));
```

## Scope
- **14 register files migrated** (+ `register-tags` as the template). `rootPathFromEvent` drops **169 → 51**. **Net −221 lines.**
- Handler **bodies moved verbatim**; every fallback value preserved **exactly** (spot-checked in the diff: `GitStatus`, `{ ok:false, error }`, `[]`, `null`, `{ nodes:[] }`, …).

## Deliberately left unmigrated
Per the review's incremental / leave-what-doesn't-fit guidance:
- Handlers that still need the event `e` after the guard (`winFromEvent` / `e.sender`) — the wrappers drop `e`.
- Handlers with **no early-return guard** (they pass a possibly-`null` rootPath onward for global/no-project queries — e.g. `QUERIES_LIST/SAVE/MOVE`).
- A couple where a debug log runs before the guard (migrating would reorder it).

## Type note
Async result-style handlers pin an explicit `T | Promise<T>` union (TS otherwise locks `R = Promise<T>` and rejects a plain `[]`/object fallback), using **real named return types** — the same shape the typed `handle` wrapper from #981 already expects, so `register-notebase` composed cleanly. **No types weakened.**

## Testing
- `pnpm lint` — 0 errors.
- `pnpm test tests/main` — **195 files / 1962 tests pass** (incl. the #997 IPC-registration/channel-completeness test).

Closes #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)