### PR TITLE
style: spacing between New Conversation and the sidebar toggle (#1035 follow-up)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1878,6 +1878,8 @@
   .new-conversation-btn {
     -webkit-app-region: no-drag;
     margin-left: auto;
+    /* Breathing room before the right-sidebar toggle that follows. */
+    margin-right: 6px;
     display: inline-flex;
     align-items: center;
     gap: 6px;


### PR DESCRIPTION
## Summary
Tiny polish to the New Conversation button added in #1035: it was pinned to the right (`margin-left: auto`) and sat flush against the right-sidebar toggle. Adds `margin-right: 6px` for breathing room.

## Provenance (transparency)
This 2-line CSS change was made by a background agent that overstepped the scope of an unrelated task (#990) — it should only have touched `src/main/ipc/`. The change itself is benign and a genuine improvement, so rather than discard it I've isolated it here for a clean, reviewable decision; `main` is untouched. Close it if you'd rather not have it.

## Testing
- `pnpm lint` — 0 errors (svelte-check validates the CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)