### PR TITLE
refactor: extract a shared source-actions module (#995)

### DIFF
--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -10,6 +10,7 @@
   import { groupToolsByGroup } from '../../../shared/tools/grouping';
   import { getAllToolInfos } from '../tools/tool-registry';
   import { displaySourceTitle } from '../../../shared/source-display';
+  import { renameSource, deleteSource, addSourceTag, sourceTagSuggestions } from '../sources/source-actions';
   import { installDismissOnClickOutside } from '../dismiss-menu';
 
   const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
@@ -116,28 +117,12 @@
 
   async function handleRename() {
     if (!detail) return;
-    const current = displaySourceTitle(detail.metadata);
-    const name = await onShowPrompt('Rename source:', current);
-    if (!name || name.trim() === current) return;
-    try {
-      await api.sources.setTitle(sourceId, name.trim());
-      await load(sourceId);
-    } catch (err) {
-      console.error('[minerva] Rename source failed:', err);
-    }
+    await renameSource(detail.metadata, onShowPrompt, () => load(sourceId));
   }
 
   async function handleDelete() {
     if (!detail) return;
-    const label = displaySourceTitle(detail.metadata);
-    const confirmed = await onShowConfirm(
-      `Delete source "${label}"? Any excerpts from this source will also be removed.`,
-      'delete-source',
-      'Delete',
-    );
-    if (!confirmed) return;
-    await api.sources.delete(sourceId);
-    onDeleted?.(sourceId);
+    await deleteSource(detail.metadata, onShowConfirm, () => onDeleted?.(sourceId));
   }
 
   // ── Tags (#766) ──────────────────────────────────────────────────────────
@@ -159,25 +144,14 @@
   }
 
   async function loadTagVocab() {
-    try {
-      const have = new Set(detail?.metadata.tags ?? []);
-      tagVocab = (await api.tags.list()).map((t) => t.tag).filter((t) => !have.has(t));
-    } catch {
-      tagVocab = [];
-    }
+    tagVocab = await sourceTagSuggestions(detail?.metadata);
   }
 
   async function commitAddTag() {
     const t = newTagText.trim();
     addingTag = false;
     newTagText = '';
-    if (!t) return;
-    try {
-      await api.sources.addTag(sourceId, t);
-      await load(sourceId);
-    } catch (err) {
-      console.error('[minerva] add source tag failed:', err);
-    }
+    await addSourceTag(sourceId, t, () => load(sourceId));
   }
 
   function tagInputKeydown(e: KeyboardEvent) {

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -9,6 +9,7 @@
   import SmartCollectionEditorDialog from './SmartCollectionEditorDialog.svelte';
   import SourceListItem from './SourceListItem.svelte';
   import { formatDueStamp } from '../sources/source-display';
+  import { renameSource, deleteSource, addSourceTag, sourceTagSuggestions } from '../sources/source-actions';
   import {
     collectionSubtree,
     membersInSubtree,
@@ -199,48 +200,27 @@
 
   async function handleDelete(source: SourceMetadata) {
     contextMenu = null;
-    const label = displaySourceTitle(source);
-    const confirmed = await onShowConfirm(
-      `Delete source "${label}"? Any excerpts from this source will also be removed.`,
-      'delete-source',
-      'Delete',
-    );
-    if (!confirmed) return;
-    await api.sources.delete(source.sourceId);
-    onSourceDeleted?.(source.sourceId);
-    await refresh();
+    await deleteSource(source, onShowConfirm, () => {
+      onSourceDeleted?.(source.sourceId);
+      return refresh();
+    });
   }
 
   async function handleRenameSource(source: SourceMetadata): Promise<void> {
     contextMenu = null;
-    const current = displaySourceTitle(source);
-    const name = await onShowPrompt('Rename source:', current);
-    if (!name || name.trim() === current) return;
-    try {
-      await api.sources.setTitle(source.sourceId, name.trim());
-      // setTitle broadcasts SOURCES_CHANGED → host refreshes the sidebar.
-    } catch (err) {
-      console.error('[minerva] Rename source failed:', err);
-    }
+    // No onDone: setTitle broadcasts SOURCES_CHANGED → host refreshes the sidebar.
+    await renameSource(source, onShowPrompt);
   }
 
   async function handleAddTag(source: SourceMetadata): Promise<void> {
     contextMenu = null;
     // Offer the project tag vocabulary (minus what this source already has) as
     // autocomplete, so tags get reused rather than re-spelled.
-    let suggestions: string[] = [];
-    try {
-      const have = new Set(source.tags);
-      suggestions = (await api.tags.list()).map((t) => t.tag).filter((t) => !have.has(t));
-    } catch { /* fall back to a plain prompt */ }
+    const suggestions = await sourceTagSuggestions(source);
     const tag = await onShowPrompt('Add tag to source:', { suggestions });
     if (!tag || !tag.trim()) return;
-    try {
-      await api.sources.addTag(source.sourceId, tag.trim());
-      // addTag broadcasts SOURCES_CHANGED → host refreshes the sidebar.
-    } catch (err) {
-      console.error('[minerva] Add source tag failed:', err);
-    }
+    // No onDone: addTag broadcasts SOURCES_CHANGED → host refreshes the sidebar.
+    await addSourceTag(source.sourceId, tag);
   }
 
   function handleMergeStart(source: SourceMetadata) {

--- a/src/renderer/lib/sources/source-actions.ts
+++ b/src/renderer/lib/sources/source-actions.ts
@@ -1,0 +1,99 @@
+// Shared source mutations (#995). SourceDetail and SourcesPanel both rename,
+// delete, and tag sources with byte-identical confirm/prompt copy and API
+// calls — only their post-mutation refresh differs (SourceDetail reloads the
+// open detail; SourcesPanel leans on the SOURCES_CHANGED broadcast, and for
+// delete also refreshes its list). These helpers own the copy + API calls and
+// take an `onDone` callback for that refresh seam, so each surface keeps its
+// own refresh strategy while the duplicated logic lives in one place.
+
+import { api } from '../ipc/client';
+import { displaySourceTitle } from '../../../shared/source-display';
+import type { SourceMetadata } from '../../../shared/types';
+
+/** Dialog seams, matching the components' `onShowPrompt` / `onShowConfirm`
+ *  props. Typed to exactly what these helpers invoke (a string initial value),
+ *  so both the string-only and string-or-options prompt props are assignable. */
+type ShowPrompt = (message: string, initial?: string) => Promise<string | null>;
+type ShowConfirm = (message: string, key: string, label?: string) => Promise<boolean>;
+
+/** Runs after a successful mutation to refresh the surface. */
+type OnDone = () => void | Promise<void>;
+
+/**
+ * Rename a source. Prompts with the current title pre-filled; a blank or
+ * unchanged name is a no-op. Swallows + logs API errors (matching both call
+ * sites' prior behavior).
+ */
+export async function renameSource(
+  source: SourceMetadata,
+  showPrompt: ShowPrompt,
+  onDone?: OnDone,
+): Promise<void> {
+  const current = displaySourceTitle(source);
+  const name = await showPrompt('Rename source:', current);
+  if (!name || name.trim() === current) return;
+  try {
+    await api.sources.setTitle(source.sourceId, name.trim());
+    await onDone?.();
+  } catch (err) {
+    console.error('[minerva] Rename source failed:', err);
+  }
+}
+
+/**
+ * Delete a source after confirming. The confirm copy is defined here once
+ * (both surfaces used a byte-identical string). Returns true if the delete
+ * ran. Errors from the delete propagate (neither call site caught them).
+ */
+export async function deleteSource(
+  source: SourceMetadata,
+  showConfirm: ShowConfirm,
+  onDone?: OnDone,
+): Promise<boolean> {
+  const label = displaySourceTitle(source);
+  const confirmed = await showConfirm(
+    `Delete source "${label}"? Any excerpts from this source will also be removed.`,
+    'delete-source',
+    'Delete',
+  );
+  if (!confirmed) return false;
+  await api.sources.delete(source.sourceId);
+  await onDone?.();
+  return true;
+}
+
+/**
+ * The project tag vocabulary minus tags the source already carries — the
+ * autocomplete pool for the add-tag input/prompt. Returns [] on any error (so
+ * the caller falls back to a plain input).
+ */
+export async function sourceTagSuggestions(
+  source: SourceMetadata | null | undefined,
+): Promise<string[]> {
+  try {
+    const have = new Set(source?.tags ?? []);
+    return (await api.tags.list()).map((t) => t.tag).filter((t) => !have.has(t));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Add a tag to a source. Trims + ignores a blank tag. Swallows + logs API
+ * errors. The differing add-tag UX (SourceDetail's inline datalist input vs
+ * SourcesPanel's prompt) stays in each component; this owns only the commit.
+ */
+export async function addSourceTag(
+  sourceId: string,
+  tag: string,
+  onDone?: OnDone,
+): Promise<void> {
+  const t = tag.trim();
+  if (!t) return;
+  try {
+    await api.sources.addTag(sourceId, t);
+    await onDone?.();
+  } catch (err) {
+    console.error('[minerva] add source tag failed:', err);
+  }
+}

--- a/tests/renderer/sources/source-actions.test.ts
+++ b/tests/renderer/sources/source-actions.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit coverage for the shared source-actions module (#995) — the
+ * rename/delete/tag helpers SourceDetail and SourcesPanel both route through.
+ * Mocks the api client; uses the real displaySourceTitle. Verifies the confirm
+ * copy, the no-op guards, the onDone refresh seam, and error swallowing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  api: {
+    sources: { setTitle: vi.fn(), delete: vi.fn(), addTag: vi.fn() },
+    tags: { list: vi.fn() },
+  },
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import {
+  renameSource,
+  deleteSource,
+  addSourceTag,
+  sourceTagSuggestions,
+} from '../../../src/renderer/lib/sources/source-actions';
+import type { SourceMetadata } from '../../../src/shared/types';
+
+const source = { sourceId: 's1', title: 'My Source', uri: null, doi: null, tags: ['keep'] } as unknown as SourceMetadata;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('renameSource', () => {
+  it('sets the trimmed title and runs onDone when the name changes', async () => {
+    const showPrompt = vi.fn().mockResolvedValue('  New Title  ');
+    const onDone = vi.fn();
+    await renameSource(source, showPrompt, onDone);
+    expect(showPrompt).toHaveBeenCalledWith('Rename source:', 'My Source');
+    expect(h.api.sources.setTitle).toHaveBeenCalledWith('s1', 'New Title');
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('is a no-op on a blank or unchanged name', async () => {
+    const onDone = vi.fn();
+    await renameSource(source, vi.fn().mockResolvedValue(null), onDone);
+    await renameSource(source, vi.fn().mockResolvedValue('My Source'), onDone);
+    expect(h.api.sources.setTitle).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('swallows + does not run onDone on API error', async () => {
+    h.api.sources.setTitle.mockRejectedValueOnce(new Error('boom'));
+    const onDone = vi.fn();
+    await expect(renameSource(source, vi.fn().mockResolvedValue('X'), onDone)).resolves.toBeUndefined();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteSource', () => {
+  it('confirms with the canonical copy, deletes, then runs onDone', async () => {
+    const showConfirm = vi.fn().mockResolvedValue(true);
+    const onDone = vi.fn();
+    const result = await deleteSource(source, showConfirm, onDone);
+    expect(showConfirm).toHaveBeenCalledWith(
+      'Delete source "My Source"? Any excerpts from this source will also be removed.',
+      'delete-source',
+      'Delete',
+    );
+    expect(h.api.sources.delete).toHaveBeenCalledWith('s1');
+    expect(onDone).toHaveBeenCalledOnce();
+    expect(result).toBe(true);
+  });
+
+  it('does nothing when the user cancels', async () => {
+    const onDone = vi.fn();
+    const result = await deleteSource(source, vi.fn().mockResolvedValue(false), onDone);
+    expect(h.api.sources.delete).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+});
+
+describe('addSourceTag', () => {
+  it('adds a trimmed tag and runs onDone', async () => {
+    const onDone = vi.fn();
+    await addSourceTag('s1', '  topic  ', onDone);
+    expect(h.api.sources.addTag).toHaveBeenCalledWith('s1', 'topic');
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a blank tag', async () => {
+    const onDone = vi.fn();
+    await addSourceTag('s1', '   ', onDone);
+    expect(h.api.sources.addTag).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('swallows API errors', async () => {
+    h.api.sources.addTag.mockRejectedValueOnce(new Error('boom'));
+    await expect(addSourceTag('s1', 'topic')).resolves.toBeUndefined();
+  });
+});
+
+describe('sourceTagSuggestions', () => {
+  it('returns the vocabulary minus tags the source already carries', async () => {
+    h.api.tags.list.mockResolvedValue([{ tag: 'keep' }, { tag: 'fresh' }, { tag: 'other' }]);
+    expect(await sourceTagSuggestions(source)).toEqual(['fresh', 'other']);
+  });
+
+  it('tolerates a null source (offers the whole vocabulary)', async () => {
+    h.api.tags.list.mockResolvedValue([{ tag: 'a' }, { tag: 'b' }]);
+    expect(await sourceTagSuggestions(null)).toEqual(['a', 'b']);
+  });
+
+  it('returns [] on error', async () => {
+    h.api.tags.list.mockRejectedValueOnce(new Error('boom'));
+    expect(await sourceTagSuggestions(source)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #995.

## What

`SourceDetail` and `SourcesPanel` both rename, delete, and tag sources with byte-identical confirm/prompt copy and API calls — they diverged only in the post-mutation refresh. This extracts the shared logic into `src/renderer/lib/sources/source-actions.ts`:

- `renameSource(source, showPrompt, onDone?)` — owns the `'Rename source:'` prompt + the blank/unchanged no-op guard.
- `deleteSource(source, showConfirm, onDone?)` — owns the (once-defined) delete-confirm copy; returns whether it ran.
- `addSourceTag(sourceId, tag, onDone?)` — owns the trimmed-tag commit.
- `sourceTagSuggestions(source)` — the project-vocab-minus-existing-tags autocomplete pool.

Each takes an optional `onDone` callback — the seam for the refresh difference.

## The callback seam

| | SourceDetail | SourcesPanel |
|---|---|---|
| rename | `onDone = () => load(sourceId)` | omitted (SOURCES_CHANGED broadcast) |
| delete | `onDone = () => onDeleted?.(id)` | `onDone = () => { onSourceDeleted?.(id); return refresh(); }` |
| add tag | `onDone = () => load(sourceId)` | omitted (broadcast) |

Each component keeps its distinctive UX — SourceDetail's inline datalist tag input vs SourcesPanel's prompt-with-suggestions — and its own refresh strategy; only the duplicated copy + API calls moved.

## Behavior preservation

Faithful move. One intentional consolidation: the add-tag error log was cased differently between the two files (`'add source tag failed'` vs `'Add source tag failed'`) — both now use the single lowercase string from the module.

## Verification

- New unit test `tests/renderer/sources/source-actions.test.ts` — 11 cases covering confirm copy, no-op guards, the `onDone` seam, error swallowing, and suggestion filtering.
- `pnpm lint` — 0 errors
- `pnpm test tests/renderer` — 108 files / 976 tests green (+11)

The panels remain lightly covered at the component level, so a live check of rename/delete/add-tag in **both** the source detail view and the sources sidebar is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)