### PR TITLE
fix: normalize oklch theme tokens before handing them to mermaid

### DIFF
--- a/src/renderer/lib/markdown/mermaid-renderer.ts
+++ b/src/renderer/lib/markdown/mermaid-renderer.ts
@@ -15,6 +15,7 @@
  */
 
 import { getEffectiveTheme, getThemeMode } from '../theme';
+import { normalizeColor } from '../utils/oklch';
 
 type MermaidApi = {
   initialize: (config: Record<string, unknown>) => void;
@@ -70,7 +71,12 @@ function readThemeTokens(): {
   text: string; textMuted: string; border: string; accent: string;
 } {
   const cs = getComputedStyle(document.documentElement);
-  const get = (name: string) => cs.getPropertyValue(name).trim() || '';
+  // Our theme tokens are authored in `oklch()` (CSS Color 4). The browser
+  // renders them fine, but mermaid's color lib (khroma) can't parse `oklch()`
+  // and throws "Unsupported color format", bricking every diagram. Convert
+  // each oklch token to an sRGB hex string khroma accepts (non-oklch tokens,
+  // e.g. the contrast theme's hex values, pass through untouched).
+  const get = (name: string) => normalizeColor(cs.getPropertyValue(name).trim());
   return {
     bg: get('--bg'),
     bgTitlebar: get('--bg-titlebar'),

--- a/src/renderer/lib/utils/oklch.ts
+++ b/src/renderer/lib/utils/oklch.ts
@@ -1,0 +1,63 @@
+/**
+ * oklch() → sRGB hex conversion.
+ *
+ * The app's theme tokens (`global.css`) are authored in `oklch()` (CSS Color 4)
+ * for a wide-gamut, perceptually-uniform palette. Chromium renders them fine,
+ * but some downstream color libraries we hand computed token values to — notably
+ * mermaid's `khroma` — can't parse `oklch()` and throw "Unsupported color
+ * format". Converting a token to a plain sRGB hex string keeps those libraries
+ * working while the CSS keeps its oklch authoring.
+ *
+ * Done with explicit math (Björn Ottosson's OKLab conversion) rather than a
+ * canvas / getComputedStyle round-trip: Electron's canvas color parser doesn't
+ * reliably normalize `oklch()`, which left an earlier canvas-based attempt at
+ * this fix still broken.
+ */
+
+const OKLCH_RE = /^oklch\(\s*([\d.]+)(%?)\s+([\d.]+)\s+([\d.]+)(?:deg)?\s*(?:\/\s*[\d.]+%?\s*)?\)$/i;
+
+/**
+ * Convert an `oklch(...)` color string to an sRGB `#rrggbb`. Any other color
+ * format (hex, `rgb()`, named, …) is returned unchanged — the consumer's own
+ * parser is assumed to handle those.
+ */
+export function normalizeColor(input: string): string {
+  const m = OKLCH_RE.exec(input.trim());
+  if (!m) return input;
+  const L = m[2] ? parseFloat(m[1]) / 100 : parseFloat(m[1]);
+  const C = parseFloat(m[3]);
+  const H = parseFloat(m[4]);
+  return oklchToHex(L, C, H);
+}
+
+/**
+ * oklch(L C H) → sRGB `#rrggbb`. L in [0,1] (lightness), C ≥ 0 (chroma), H in
+ * degrees (hue). Out-of-sRGB-gamut results are clamped per channel.
+ */
+export function oklchToHex(L: number, C: number, H: number): string {
+  const hr = (H * Math.PI) / 180;
+  const a = C * Math.cos(hr);
+  const b = C * Math.sin(hr);
+
+  // OKLab → non-linear LMS → LMS.
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+
+  // LMS → linear-light sRGB.
+  const r = +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const bl = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+  return '#' + [r, g, bl].map(channelToHex).join('');
+}
+
+/** Linear-light sRGB channel → gamma-encoded 2-digit hex byte (clamped 0–255). */
+function channelToHex(c: number): string {
+  const enc = c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  const byte = Math.max(0, Math.min(255, Math.round(enc * 255)));
+  return byte.toString(16).padStart(2, '0');
+}

--- a/tests/renderer/utils/oklch.test.ts
+++ b/tests/renderer/utils/oklch.test.ts
@@ -1,0 +1,45 @@
+/**
+ * oklch() → sRGB hex conversion (theme tokens fed to mermaid's khroma, which
+ * can't parse oklch()). Reference values computed from Björn Ottosson's OKLab
+ * math; the achromatic anchors (#000000 / #ffffff) are exact by construction.
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeColor, oklchToHex } from '../../../src/renderer/lib/utils/oklch';
+
+describe('oklchToHex', () => {
+  it('maps achromatic lightness endpoints to black and white', () => {
+    expect(oklchToHex(0, 0, 0)).toBe('#000000');
+    expect(oklchToHex(1, 0, 0)).toBe('#ffffff');
+  });
+
+  it('converts real theme tokens to their sRGB hex', () => {
+    expect(oklchToHex(0.285, 0.014, 70)).toBe('#2f2923'); // --bg-elev-2 (the reported error value)
+    expect(oklchToHex(0.205, 0.012, 70)).toBe('#1b1611'); // --bg
+    expect(oklchToHex(0.925, 0.018, 85)).toBe('#ece6d9'); // --text
+    expect(oklchToHex(0.79, 0.115, 78)).toBe('#e3b160'); // --accent
+  });
+
+  it('clamps out-of-sRGB-gamut results into range', () => {
+    expect(oklchToHex(0.7, 0.4, 30)).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});
+
+describe('normalizeColor', () => {
+  it('converts the exact oklch string that broke mermaid', () => {
+    expect(normalizeColor('oklch(0.285 0.014 70)')).toBe('#2f2923');
+  });
+
+  it('accepts percentage lightness and an optional deg hue / alpha', () => {
+    expect(normalizeColor('oklch(100% 0 0)')).toBe('#ffffff');
+    expect(normalizeColor('oklch(0% 0 0)')).toBe('#000000');
+    expect(normalizeColor('oklch(0.285 0.014 70deg)')).toBe('#2f2923');
+    expect(normalizeColor('oklch(0.285 0.014 70 / 0.5)')).toBe('#2f2923');
+  });
+
+  it('passes non-oklch colors through untouched', () => {
+    expect(normalizeColor('#3a3a4a')).toBe('#3a3a4a');
+    expect(normalizeColor('rgb(10, 20, 30)')).toBe('rgb(10, 20, 30)');
+    expect(normalizeColor('rebeccapurple')).toBe('rebeccapurple');
+    expect(normalizeColor('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Symptom

Mermaid blocks that used to render error with:

> Failed to load mermaid: Unsupported color format: "oklch(0.285 0.014 70)"

## Root cause

`mermaid-renderer.ts`'s `readThemeTokens()` reads the app's theme tokens straight out of CSS with `getComputedStyle().getPropertyValue()` and feeds them to mermaid's `themeVariables`. The tokens in `global.css` are authored in **`oklch()`** (CSS Color 4), so `getPropertyValue` returns the literal string `oklch(0.285 0.014 70)`. Mermaid's color library (**khroma**) only understands hex / rgb / hsl / named colors and throws on `oklch()` — and a single unparseable `themeVariable` brings down every diagram on the page.

The exact value in the error is `--bg-button` → `var(--bg-elev-2)` → `oklch(0.285 0.014 70)`, which mermaid receives as `primaryColor` / `secondaryColor` / `mainBkg`.

## Fix

Convert each `oklch()` token to a plain sRGB `#rrggbb` before passing it to mermaid, using explicit OKLab math in a new `src/renderer/lib/utils/oklch.ts`. Non-oklch tokens (e.g. the contrast theme's hex values) pass through untouched.

```ts
const get = (name: string) => normalizeColor(cs.getPropertyValue(name).trim());
```

### Why not a canvas round-trip

The first cut of this fix round-tripped the value through a canvas 2d `fillStyle` (letting the browser's color parser normalize it). That **did not work** — Electron's canvas color parser doesn't reliably normalize `oklch()`, so it left the raw string in place and the diagrams still errored on a fresh `pnpm dev`. The explicit conversion has no browser-parser dependency and is deterministic.

## Verification

- New unit test `tests/renderer/utils/oklch.test.ts` — 6 cases, including the **exact** value from the error (`oklch(0.285 0.014 70)` → `#2f2923`), achromatic anchors (`#000000`/`#ffffff`), percentage/deg/alpha syntax, and non-oklch passthrough.
- `pnpm lint` — 0 errors; `pnpm test tests/renderer` — 971 green.
- Please re-check a note with a mermaid block in dark/light/contrast after pulling — the raw-oklch path is gone, so khroma now receives hex.

## Note

`cytoscape-theme.ts` and `vega-renderer.ts` read the same oklch tokens the same raw way but weren't reported broken (their renderers parse `oklch` natively). The new `normalizeColor` helper is reusable if either surfaces the same error later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)