### PR TITLE
build: upgrade Electron 42 -> 43 (#1006)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "axe-core": "^4.10.3",
     "codemirror": "^6.0.2",
-    "electron": "^42.4.0",
+    "electron": "^43.0.0",
     "esbuild": "^0.28.1",
     "eslint": "^10.6.0",
     "eslint-plugin-svelte": "^3.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       electron:
-        specifier: ^42.4.0
-        version: 42.4.0
+        specifier: ^43.0.0
+        version: 43.0.0
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -3861,8 +3861,8 @@ packages:
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
-  electron@42.4.0:
-    resolution: {integrity: sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==}
+  electron@43.0.0:
+    resolution: {integrity: sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -12493,7 +12493,7 @@ snapshots:
 
   electron-to-chromium@1.5.328: {}
 
-  electron@42.4.0:
+  electron@43.0.0:
     dependencies:
       '@electron-internal/extract-zip': 1.0.2
       '@electron/get': 5.0.0


### PR DESCRIPTION
Closes #1006.

Scheduled support-window maintenance — bump `electron` `^42.4.0 → ^43.0.0` before the gap reaches two majors (which would exit Electron's supported 3-major window). Electron 43 = **Chromium 150 / V8 15 / Node 24.17** (Node API baseline unchanged).

## Change

The whole diff is `package.json` (`electron` → `^43.0.0`) + `pnpm-lock.yaml`. No app-code changes were needed:
- Main-process APIs in use (`BrowserWindow`, `session`, `webContents`) rely on nothing removed in 43.
- No `protocol` / `registerSchemesAsPrivileged` / `desktopCapturer` / `systemPreferences` call sites sensitive to the major.

Kept as its own PR (never batch majors — bisectability), per the issue.

## Verification

Focused on the fragile surface the modernization plan flagged (native bindings + hardened-runtime signing):

| Check | Result |
|---|---|
| `pnpm install` (native rebuild) | electron **43.0.0** installed |
| `pnpm lint` | 0 errors |
| `pnpm test` | **3869/3869** green |
| `pnpm test:e2e` (real `electron-forge package` + Playwright) | **4/4** green |
| DuckDB native binding shipped/loads | ✅ e2e "packaged app opens a DuckDB-backed project (native binding shipped)" boots the packaged E43 app and opens a DuckDB project |
| Signing (hardened runtime) | ✅ see below |

### Signing re-validation

Ran a hardened-runtime `package` with `OSX_SIGN_IDENTITY` (signs locally, no notarize upload):

- `codesign --verify --deep --strict` → **valid on disk** + **satisfies its Designated Requirement**
- `.app` CodeDirectory `flags=0x10000(runtime)` (hardened runtime on), `Authority=Developer ID Application`, `TeamIdentifier=ZC2MK8M828`
- **Nested `@duckdb/node-bindings-darwin-arm64/duckdb.node`** signed with the same Developer ID **and** hardened runtime — the specific fragile case the issue called out

**Notarization** (the network upload to Apple) needs `APPLE_API_KEY` creds and runs in the release pipeline — not exercised here, but the `forge.config.ts` signing/notarize path is unchanged and the produced bundle is notarization-ready.

> Signed/packaged + tested on macOS **arm64**. A real signed `make` on CI (with Apple creds) will exercise notarization + stapling + the DMG maker end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)