### PR TITLE
refactor: break the menu.ts <-> window-manager.ts import cycle (#986)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { registerIpcHandlers } from './ipc';
 import { buildMenu, rebuildMenu } from './menu';
-import { createWindow, openProjectInWindow } from './window-manager';
+import { createWindow, openProjectInWindow, setMenuRebuilder } from './window-manager';
 import { appIconPath } from './app-icon';
 import { loadSession } from './session';
 import { registerBuiltinExecutors } from './compute/executors';
@@ -32,6 +32,11 @@ boot('main module loaded');
 
 void app.whenReady().then(async () => {
   boot('app ready');
+  // Break the menu.ts <-> window-manager.ts import cycle (#986): window-manager
+  // triggers menu rebuilds through this injected callback rather than importing
+  // `rebuildMenu` directly. Registered before any window is created so the
+  // focus/project-change rebuild triggers are wired from the first window.
+  setMenuRebuilder(rebuildMenu);
   // macOS dev dock icon (#805). A packaged .app gets its icon from the bundle
   // (packagerConfig.icon); an unpackaged `electron-forge start` shows the stock
   // Electron icon unless we set the dock icon here.

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -11,7 +11,6 @@ import * as templates from './notebase/templates';
 import * as tables from './sources/tables';
 import { invalidate as invalidatePythonModules } from './compute/python-kernel';
 import { addRecentProject } from './recent-projects';
-import { rebuildMenu } from './menu';
 import { saveSession, type WindowState } from './session';
 import { acquireProject, releaseProject } from './project-context';
 import { runBackfill } from './embeddings/backfill';
@@ -23,6 +22,17 @@ import type { ProjectContext } from './project-context-types';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
+
+// Menu-rebuild trigger, injected rather than imported (#986). window-manager
+// needs to rebuild the native menu when window/project state changes (focus,
+// project open/close), but importing `rebuildMenu` from `./menu` created a
+// runtime import cycle — `menu.ts` already imports window helpers from here.
+// main.ts (the composition root) registers `rebuildMenu` via
+// `setMenuRebuilder` at startup, so the edge points one way now: menu → window.
+let menuRebuilder: (() => void) | null = null;
+export function setMenuRebuilder(fn: () => void): void {
+  menuRebuilder = fn;
+}
 
 interface WindowContext {
   rootPath: string | null;
@@ -136,7 +146,7 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
   win.on('resize', persistSession);
 
   win.on('focus', () => {
-    rebuildMenu();
+    menuRebuilder?.();
   });
 
   return win;
@@ -251,7 +261,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     console.warn('[window-manager] template seed failed', err);
   }
   addRecentProject(rootPath);
-  rebuildMenu();
+  menuRebuilder?.();
 
   // Background embedding backfill (#836): embed any not-yet-embedded notes so
   // semantic search works on an existing thoughtbase, not just on edited notes.
@@ -482,7 +492,7 @@ export function closeProjectInWindow(winId: number): void {
       void releaseProject(previousRoot, winId);
     }
   }
-  rebuildMenu();
+  menuRebuilder?.();
   persistSession();
   void syncClipperLifecycle();
 }


### PR DESCRIPTION
Closes #986.

## The cycle

`madge` flagged a real runtime import cycle:
- `menu.ts` imports window helpers (`createWindow`, `getRootPath`, `openProjectInWindow`, `broadcastBackfillProgress`) from `window-manager.ts`
- `window-manager.ts` imported `rebuildMenu` back from `menu.ts` (called on window **focus** and **project open/close** — 3 sites)

## The fix

Invert the `window-manager → menu` edge into an injected callback:

```ts
// window-manager.ts
let menuRebuilder: (() => void) | null = null;
export function setMenuRebuilder(fn: () => void): void { menuRebuilder = fn; }
// ...the 3 sites now call menuRebuilder?.() instead of rebuildMenu()
```

`main.ts` — the composition root, which already imports both modules — registers it at the top of `app.whenReady`, before any window is created, so the focus/project-change triggers are wired from the first window:

```ts
setMenuRebuilder(rebuildMenu);
```

The dependency graph now points **one way** (`menu → window-manager`). Behavior is unchanged — the same `rebuildMenu` runs at the same moments.

## Verification

- `madge --circular` on `menu.ts` + `window-manager.ts` (136 files traversed) → **"No circular dependency found!"** (was a reported cycle)
- `pnpm lint` → 0/0/0
- full suite → **3869/3869**

> The other cycle the review mentioned (`shared/skills/types.ts <-> menu-config.ts`) is type-only `import type` and erases at compile — not actionable, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)