### PR TITLE
test: render tests for top interactive components, rune-reactivity focus (#1002)

### DIFF
--- a/tests/renderer/components/BreadcrumbsBar.test.ts
+++ b/tests/renderer/components/BreadcrumbsBar.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render + rune-reactivity coverage for BreadcrumbsBar (#476, #1002). The
+ * folder crumbs + leaf name are a `$derived.by` off the `filePath` prop, so
+ * the headline risk is a stale derivation: the bar keeps showing the old
+ * path's segments after the active file changes. These tests re-render with a
+ * new `filePath` and assert the crumbs track it, plus pin the click-to-reveal
+ * callback contract and the null/root/deep edge cases.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import BreadcrumbsBar from '../../../src/renderer/lib/components/BreadcrumbsBar.svelte';
+
+afterEach(cleanup);
+
+function baseProps(over: Record<string, unknown> = {}) {
+  return {
+    filePath: 'notes/sub/deep.md',
+    content: '',
+    cursorLine: 1,
+    showHeadings: false,
+    onRevealFolder: vi.fn(),
+    onScrollToLine: vi.fn(),
+    ...over,
+  };
+}
+
+/** Folder crumbs are the only <button>s on the bar (the leaf is a span). */
+function folderLabels(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('button.crumb.folder')).map(
+    (b) => b.textContent?.trim() ?? '',
+  );
+}
+
+describe('BreadcrumbsBar (#1002)', () => {
+  it('renders each folder as a clickable crumb and the note leaf (extension stripped)', () => {
+    const { container, getByText } = render(BreadcrumbsBar, baseProps());
+    expect(folderLabels(container)).toEqual(['notes', 'sub']);
+    // Leaf drops the `.md` and is the current-page marker, not a button.
+    const leaf = getByText('deep');
+    expect(leaf.tagName).toBe('SPAN');
+    expect(leaf.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('re-derives the crumbs when filePath changes (stale $derived guard)', async () => {
+    const { container, rerender, getByText, queryByText } = render(
+      BreadcrumbsBar,
+      baseProps({ filePath: 'notes/sub/deep.md' }),
+    );
+    expect(folderLabels(container)).toEqual(['notes', 'sub']);
+    expect(getByText('deep')).toBeTruthy();
+
+    await rerender(baseProps({ filePath: 'research/paper.md' }));
+
+    // Old segments are gone, new ones are present — no stale derivation.
+    expect(folderLabels(container)).toEqual(['research']);
+    expect(getByText('paper')).toBeTruthy();
+    expect(queryByText('deep')).toBeNull();
+    expect(queryByText('sub')).toBeNull();
+  });
+
+  it('clicking a folder crumb reveals its accumulated path from root', async () => {
+    const onRevealFolder = vi.fn();
+    const { getByText } = render(
+      BreadcrumbsBar,
+      baseProps({ filePath: 'notes/sub/deep.md', onRevealFolder }),
+    );
+    await fireEvent.click(getByText('sub'));
+    // `sub` sits under `notes`, so the reveal target is the full path.
+    expect(onRevealFolder).toHaveBeenCalledWith('notes/sub');
+
+    await fireEvent.click(getByText('notes'));
+    expect(onRevealFolder).toHaveBeenCalledWith('notes');
+  });
+
+  it('root-level file renders just the leaf with no folder crumbs', () => {
+    const { container, getByText } = render(
+      BreadcrumbsBar,
+      baseProps({ filePath: 'readme.md' }),
+    );
+    expect(folderLabels(container)).toEqual([]);
+    expect(getByText('readme')).toBeTruthy();
+  });
+
+  it('renders nothing when there is no active file', () => {
+    const { container } = render(BreadcrumbsBar, baseProps({ filePath: null }));
+    expect(container.querySelector('nav.breadcrumbs')).toBeNull();
+  });
+
+  it('reactively appears when a file opens and disappears when it closes', async () => {
+    const { container, rerender } = render(
+      BreadcrumbsBar,
+      baseProps({ filePath: null }),
+    );
+    expect(container.querySelector('nav.breadcrumbs')).toBeNull();
+
+    await rerender(baseProps({ filePath: 'a/b.md' }));
+    expect(container.querySelector('nav.breadcrumbs')).not.toBeNull();
+    expect(folderLabels(container)).toEqual(['a']);
+
+    await rerender(baseProps({ filePath: null }));
+    expect(container.querySelector('nav.breadcrumbs')).toBeNull();
+  });
+
+  it('renders every ancestor of a deeply nested path as its own crumb', () => {
+    const { container, getByText } = render(
+      BreadcrumbsBar,
+      baseProps({ filePath: 'a/b/c/d/e/leaf.md' }),
+    );
+    expect(folderLabels(container)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(getByText('leaf')).toBeTruthy();
+  });
+});

--- a/tests/renderer/components/FileTree.test.ts
+++ b/tests/renderer/components/FileTree.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render + rune-reactivity coverage for FileTree (#1002) — the recursive
+ * left-sidebar file/folder tree. Focus is on the reactive surfaces:
+ *   - the `active` class tracks the `activeFilePath` prop (a `$derived`-ish
+ *     class binding) and moves when the prop changes,
+ *   - folder children mount/unmount off the `expanded` map,
+ *   - the `contextMenu` `$state` re-targets between opens so an action
+ *     always reads the *currently* right-clicked node's path (guards the
+ *     known Svelte 5 stale-`{@const}`/stale-state-on-click gotcha).
+ *
+ * The component pulls `api` from ../ipc/client for the context-menu
+ * entrypoint probe + shell actions; we mock it so no real IPC fires.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { NoteFile } from '../../../src/shared/types';
+
+// Hoisted api mock — FileTree reads api.notebase.readFile (entrypoint probe)
+// and api.shell.* (Open In submenu). readFile resolves to empty content so the
+// async entrypoint block after a right-click never rejects.
+const h = vi.hoisted(() => ({
+  api: {
+    notebase: { readFile: vi.fn().mockResolvedValue('') },
+    shell: {
+      revealFile: vi.fn(),
+      openInDefault: vi.fn(),
+      openInTerminal: vi.fn(),
+    },
+  },
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import FileTree from '../../../src/renderer/lib/components/FileTree.svelte';
+
+afterEach(cleanup);
+
+/** notes/ (dir) → alpha.md, beta.md ; plus a root-level readme.md. */
+function tree(): NoteFile[] {
+  return [
+    {
+      name: 'notes',
+      relativePath: 'notes',
+      isDirectory: true,
+      children: [
+        { name: 'alpha.md', relativePath: 'notes/alpha.md', isDirectory: false },
+        { name: 'beta.md', relativePath: 'notes/beta.md', isDirectory: false },
+      ],
+    },
+    { name: 'readme.md', relativePath: 'readme.md', isDirectory: false },
+  ];
+}
+
+type Props = Record<string, unknown>;
+
+/** Full prop set with every callback stubbed; overridable per test. */
+function props(over: Props = {}): Props {
+  return {
+    files: tree(),
+    activeFilePath: null,
+    expanded: {},
+    selection: new Set<string>(),
+    focusedPath: null,
+    canPaste: false,
+    onToggleDir: vi.fn(),
+    onItemClick: vi.fn(),
+    onNewNote: vi.fn(),
+    onNewFolder: vi.fn(),
+    onDelete: vi.fn(),
+    onContextMenuTarget: vi.fn(),
+    onRename: vi.fn(),
+    onCut: vi.fn(),
+    onCopy: vi.fn(),
+    onPaste: vi.fn(),
+    onMove: vi.fn(),
+    ...over,
+  };
+}
+
+const row = (c: HTMLElement, path: string) =>
+  c.querySelector<HTMLElement>(`[data-relative-path="${path}"]`);
+
+describe('FileTree (#1002)', () => {
+  it('renders a nested tree — folder + expanded children + root file', () => {
+    const { container, getByText } = render(
+      FileTree,
+      props({ expanded: { notes: true } }),
+    );
+    // Folder label is raw; file labels strip the .md extension.
+    expect(getByText('notes')).toBeTruthy();
+    expect(getByText('alpha')).toBeTruthy();
+    expect(getByText('beta')).toBeTruthy();
+    expect(getByText('readme')).toBeTruthy();
+
+    // Children live one depth deeper than the folder row.
+    expect(row(container, 'notes')).toBeTruthy();
+    expect(row(container, 'notes/alpha.md')).toBeTruthy();
+    expect(row(container, 'readme.md')).toBeTruthy();
+  });
+
+  it('marks the active file and moves the highlight when activeFilePath changes', async () => {
+    const { container, rerender } = render(
+      FileTree,
+      props({ expanded: { notes: true }, activeFilePath: 'notes/alpha.md' }),
+    );
+    expect(row(container, 'notes/alpha.md')!.classList.contains('active')).toBe(true);
+    expect(row(container, 'notes/beta.md')!.classList.contains('active')).toBe(false);
+
+    // Rerender with a new active file: the old row must lose `active`, the
+    // new one gain it — a stale class binding would keep alpha lit.
+    await rerender(props({ expanded: { notes: true }, activeFilePath: 'notes/beta.md' }));
+    expect(row(container, 'notes/alpha.md')!.classList.contains('active')).toBe(false);
+    expect(row(container, 'notes/beta.md')!.classList.contains('active')).toBe(true);
+  });
+
+  it('reflects the selection set on the matching rows and updates on rerender', async () => {
+    const { container, rerender } = render(
+      FileTree,
+      props({ expanded: { notes: true }, selection: new Set(['notes/alpha.md']) }),
+    );
+    expect(row(container, 'notes/alpha.md')!.classList.contains('selected')).toBe(true);
+    expect(row(container, 'readme.md')!.classList.contains('selected')).toBe(false);
+
+    await rerender(props({ expanded: { notes: true }, selection: new Set(['readme.md']) }));
+    expect(row(container, 'notes/alpha.md')!.classList.contains('selected')).toBe(false);
+    expect(row(container, 'readme.md')!.classList.contains('selected')).toBe(true);
+  });
+
+  it('mounts/unmounts folder children off the expanded map', async () => {
+    const { container, rerender } = render(FileTree, props({ expanded: {} }));
+    // Collapsed: the folder row exists but its children are not rendered.
+    expect(row(container, 'notes')).toBeTruthy();
+    expect(row(container, 'notes/alpha.md')).toBeNull();
+
+    await rerender(props({ expanded: { notes: true } }));
+    expect(row(container, 'notes/alpha.md')).toBeTruthy();
+    expect(row(container, 'notes/beta.md')).toBeTruthy();
+  });
+
+  it('clicking the disclosure chevron fires onToggleDir with the folder path', async () => {
+    const onToggleDir = vi.fn();
+    const { getByLabelText } = render(FileTree, props({ onToggleDir }));
+    // Collapsed folder → chevron carries the "Expand folder" label.
+    await fireEvent.click(getByLabelText('Expand folder'));
+    expect(onToggleDir).toHaveBeenCalledWith('notes');
+  });
+
+  it('clicking a file row fires onItemClick with its path and modifier flags', async () => {
+    const onItemClick = vi.fn();
+    const { container } = render(
+      FileTree,
+      props({ expanded: { notes: true }, onItemClick }),
+    );
+    await fireEvent.click(row(container, 'notes/alpha.md')!);
+    expect(onItemClick).toHaveBeenCalledWith(
+      'notes/alpha.md',
+      false,
+      { shift: false, meta: false },
+    );
+  });
+
+  it('right-clicking a file opens the context menu with item actions', async () => {
+    const onContextMenuTarget = vi.fn();
+    const { container, getByText } = render(
+      FileTree,
+      props({ expanded: { notes: true }, onContextMenuTarget }),
+    );
+    await fireEvent.contextMenu(row(container, 'notes/alpha.md')!);
+    // The right-clicked item is promoted into the selection first…
+    expect(onContextMenuTarget).toHaveBeenCalledWith('notes/alpha.md');
+    // …then the menu renders its target-scoped actions.
+    expect(getByText('Rename')).toBeTruthy();
+    expect(getByText('Delete')).toBeTruthy();
+    expect(getByText('Copy Path')).toBeTruthy();
+  });
+
+  it('context-menu actions read the currently right-clicked node across reopens', async () => {
+    const onRename = vi.fn();
+    const onDelete = vi.fn();
+    const { container, getByText } = render(
+      FileTree,
+      props({ expanded: { notes: true }, onRename, onDelete }),
+    );
+
+    // Open on alpha, invoke Rename → must carry alpha's path.
+    await fireEvent.contextMenu(row(container, 'notes/alpha.md')!);
+    await fireEvent.click(getByText('Rename'));
+    expect(onRename).toHaveBeenCalledWith('notes/alpha.md');
+
+    // Reopen on beta, invoke Delete → must carry beta's path, not alpha's.
+    // A stale `contextMenu` target (the known Svelte 5 gotcha) would fire
+    // with 'notes/alpha.md' here.
+    await fireEvent.contextMenu(row(container, 'notes/beta.md')!);
+    await fireEvent.click(getByText('Delete'));
+    expect(onDelete).toHaveBeenCalledWith('notes/beta.md', false);
+  });
+});

--- a/tests/renderer/components/GotoLineDialog.test.ts
+++ b/tests/renderer/components/GotoLineDialog.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render + rune-reactivity coverage for GotoLineDialog (#1002).
+ *
+ * Drives the real dialog the way a user does: type a target into the bound
+ * input, then press Enter (or Escape / click the backdrop). The `value` rune is
+ * two-way bound to the input; the parse ("line" or "line:col") runs in the
+ * keydown handler, so these tests assert the reactively-bound value is parsed
+ * and dispatched through onGoto with the correct line/column, and that the
+ * empty / non-numeric guards suppress the callback.
+ *
+ * NOTE: there is no submit button and no clamping to a max line — the handler
+ * trusts whatever integer the user typed. Tests pin that actual behavior.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import GotoLineDialog from '../../../src/renderer/lib/components/GotoLineDialog.svelte';
+
+afterEach(cleanup);
+
+function renderDialog(over: {
+  currentLine?: number;
+  currentColumn?: number;
+  onGoto?: (line: number, column: number) => void;
+  onCancel?: () => void;
+} = {}) {
+  const onGoto = over.onGoto ?? vi.fn();
+  const onCancel = over.onCancel ?? vi.fn();
+  const r = render(GotoLineDialog, {
+    currentLine: over.currentLine ?? 12,
+    currentColumn: over.currentColumn ?? 3,
+    onGoto,
+    onCancel,
+  });
+  const input = r.container.querySelector('input.input') as HTMLInputElement;
+  return { ...r, input, onGoto, onCancel };
+}
+
+/** Type into the bound input, then press Enter — mirrors a real "go to line". */
+async function typeAndEnter(input: HTMLInputElement, text: string) {
+  await fireEvent.input(input, { target: { value: text } });
+  await fireEvent.keyDown(input, { key: 'Enter' });
+}
+
+describe('GotoLineDialog (#1002)', () => {
+  it('seeds the placeholder from the current line:column props', () => {
+    const { input } = renderDialog({ currentLine: 12, currentColumn: 3 });
+    expect(input.placeholder).toBe('12:3');
+  });
+
+  it('Enter parses a bare line number and fires onGoto with column 1', async () => {
+    const { input, onGoto } = renderDialog();
+    await typeAndEnter(input, '42');
+    expect(onGoto).toHaveBeenCalledTimes(1);
+    expect(onGoto).toHaveBeenCalledWith(42, 1);
+  });
+
+  it('Enter splits "line:col" and fires onGoto with both parsed values', async () => {
+    const { input, onGoto } = renderDialog();
+    await typeAndEnter(input, '42:7');
+    expect(onGoto).toHaveBeenCalledWith(42, 7);
+  });
+
+  it('a non-numeric column falls back to column 1 while keeping the line', async () => {
+    const { input, onGoto } = renderDialog();
+    await typeAndEnter(input, '42:abc');
+    expect(onGoto).toHaveBeenCalledWith(42, 1);
+  });
+
+  it('empty / non-numeric input does not fire onGoto', async () => {
+    const { input, onGoto } = renderDialog();
+
+    await fireEvent.keyDown(input, { key: 'Enter' }); // empty value → guarded out
+    await typeAndEnter(input, '   ');                 // whitespace → trim() falsy
+    await typeAndEnter(input, 'abc');                 // NaN line → rejected
+
+    expect(onGoto).not.toHaveBeenCalled();
+  });
+
+  it('Escape fires onCancel without dispatching a goto', async () => {
+    const { input, onGoto, onCancel } = renderDialog();
+    await fireEvent.input(input, { target: { value: '42' } });
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onGoto).not.toHaveBeenCalled();
+  });
+
+  it('clicking the backdrop (not the dialog) cancels', async () => {
+    const { container, onCancel } = renderDialog();
+    const overlay = container.querySelector('.overlay') as HTMLElement;
+    await fireEvent.mouseDown(overlay);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/renderer/components/GotoNoteDialog.test.ts
+++ b/tests/renderer/components/GotoNoteDialog.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Rune-reactivity coverage for the quick-open fuzzy finder (GotoNoteDialog,
+ * #1002). The dialog is a nest of runes: a `$derived.by` scored/filtered
+ * result list, a `$state` selectedIndex that a `.selected` class reacts to,
+ * and an `$effect` that resets the selection whenever the results change.
+ *
+ * These tests drive the real component the way a user does — type to filter,
+ * arrow to move, Enter/click to pick — and assert the visible DOM and the
+ * onSelect callback, so a stale `$derived`/`$effect` (results not narrowing,
+ * a click firing with a stale row) fails the suite. The fuzzy scoring
+ * (scoreMatch) runs for real; nothing is stubbed.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, within } from '@testing-library/svelte';
+import type { NoteFile } from '../../../src/shared/types';
+import GotoNoteDialog from '../../../src/renderer/lib/components/GotoNoteDialog.svelte';
+
+afterEach(cleanup);
+
+// Flatten order (depth-first): Readme, Recipes, Project Plan, Ideas.
+function makeFiles(): NoteFile[] {
+  return [
+    { name: 'Readme.md', relativePath: 'Readme.md', isDirectory: false, mtimeMs: Date.now() },
+    { name: 'Recipes.md', relativePath: 'Recipes.md', isDirectory: false },
+    { name: 'Project Plan.md', relativePath: 'Project Plan.md', isDirectory: false },
+    {
+      name: 'notes',
+      relativePath: 'notes',
+      isDirectory: true,
+      children: [
+        { name: 'Ideas.md', relativePath: 'notes/Ideas.md', isDirectory: false },
+      ],
+    },
+  ];
+}
+
+function renderDialog(over: {
+  onSelect?: (p: string) => void;
+  onCancel?: () => void;
+  files?: NoteFile[];
+} = {}) {
+  const onSelect = over.onSelect ?? vi.fn();
+  const onCancel = over.onCancel ?? vi.fn();
+  const r = render(GotoNoteDialog, {
+    files: over.files ?? makeFiles(),
+    onSelect,
+    onCancel,
+  });
+  return { ...r, onSelect, onCancel };
+}
+
+/** Visible result rows, in DOM (score) order, by their display name. */
+function resultNames(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('.goto-results .result-name')].map(
+    (el) => el.textContent ?? '',
+  );
+}
+
+/** The single currently-highlighted row's name, or null. */
+function selectedName(container: HTMLElement): string | null {
+  const el = container.querySelector('.result-item.selected .result-name');
+  return el ? el.textContent : null;
+}
+
+async function type(input: Element, value: string) {
+  await fireEvent.input(input, { target: { value } });
+}
+
+describe('GotoNoteDialog — rune reactivity (#1002)', () => {
+  it('lists every note when the query is empty (flatten order preserved)', () => {
+    const { container } = renderDialog();
+    expect(resultNames(container)).toEqual(['Readme', 'Recipes', 'Project Plan', 'Ideas']);
+  });
+
+  it('typing reactively narrows the $derived result list', async () => {
+    const { container, getByPlaceholderText } = renderDialog();
+    const input = getByPlaceholderText('Go to...');
+
+    // "readme" is a substring of Readme only; no other note (or its path)
+    // fuzzy-matches it, so the rest drop out.
+    await type(input, 'readme');
+    expect(resultNames(container)).toEqual(['Readme']);
+
+    // Broaden back out: "re" matches Readme/Recipes (substring) + Project
+    // Plan (fuzzy r..e). Ideas has no 'r' before an 'e', so it stays gone.
+    await type(input, 're');
+    const names = resultNames(container);
+    expect(names).toContain('Readme');
+    expect(names).toContain('Recipes');
+    expect(names).toContain('Project Plan');
+    expect(names).not.toContain('Ideas');
+  });
+
+  it('orders results by descending score (substring above fuzzy)', async () => {
+    const { container, getByPlaceholderText } = renderDialog();
+    await type(getByPlaceholderText('Go to...'), 're');
+
+    const names = resultNames(container);
+    // Readme/Recipes score 100 (substring); Project Plan scores 50 (fuzzy)
+    // and must sort last.
+    expect(names.indexOf('Readme')).toBeLessThan(names.indexOf('Project Plan'));
+    expect(names.indexOf('Recipes')).toBeLessThan(names.indexOf('Project Plan'));
+    expect(names[names.length - 1]).toBe('Project Plan');
+  });
+
+  it('ArrowDown/ArrowUp move the highlighted row; Enter selects it', async () => {
+    const onSelect = vi.fn();
+    const { container } = renderDialog({ onSelect });
+    const overlay = container.querySelector('.overlay')!;
+
+    // Row 0 (Readme) is highlighted initially.
+    expect(selectedName(container)).toBe('Readme');
+
+    await fireEvent.keyDown(overlay, { key: 'ArrowDown' }); // → Recipes
+    await fireEvent.keyDown(overlay, { key: 'ArrowDown' }); // → Project Plan
+    expect(selectedName(container)).toBe('Project Plan');
+
+    await fireEvent.keyDown(overlay, { key: 'ArrowUp' }); // → Recipes
+    expect(selectedName(container)).toBe('Recipes');
+
+    await fireEvent.keyDown(overlay, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('Recipes.md');
+  });
+
+  it('resets the highlight to the top row after the results change ($effect)', async () => {
+    const { container, getByPlaceholderText } = renderDialog();
+    const overlay = container.querySelector('.overlay')!;
+
+    await fireEvent.keyDown(overlay, { key: 'ArrowDown' });
+    await fireEvent.keyDown(overlay, { key: 'ArrowDown' });
+    expect(selectedName(container)).toBe('Project Plan');
+
+    // A new query rebuilds `results`; the $effect must snap the selection
+    // back to row 0 rather than leaving a stale out-of-range index.
+    await type(getByPlaceholderText('Go to...'), 're');
+    expect(selectedName(container)).toBe('Readme');
+  });
+
+  it('clicking a filtered row selects the CURRENT row, not a stale one', async () => {
+    const onSelect = vi.fn();
+    const { container, getByPlaceholderText } = renderDialog({ onSelect });
+    const input = getByPlaceholderText('Go to...');
+
+    // Filter down, then re-filter to a different single row before clicking —
+    // exercises the onclick closure over the reactive `result` in the {#each}.
+    await type(input, 'read');
+    await type(input, 'recipes');
+
+    const list = container.querySelector('.goto-results') as HTMLElement;
+    expect(resultNames(list)).toEqual(['Recipes']);
+    await fireEvent.click(within(list).getByText('Recipes'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('Recipes.md');
+  });
+
+  it('shows the "No matches" empty state when nothing scores', async () => {
+    const { container, getByPlaceholderText, getByText } = renderDialog();
+    await type(getByPlaceholderText('Go to...'), 'zzzqqq');
+
+    expect(resultNames(container)).toEqual([]);
+    expect(getByText('No matches')).toBeTruthy();
+  });
+
+  it('Escape cancels without selecting anything', async () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const { container } = renderDialog({ onSelect, onCancel });
+
+    await fireEvent.keyDown(container.querySelector('.overlay')!, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/renderer/components/right-sidebar/RelatedPanel.test.ts
+++ b/tests/renderer/components/right-sidebar/RelatedPanel.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Right-sidebar RelatedPanel rune reactivity (#1002). The panel's `$effect`
+ * fetches related notes whenever the active file path / revision changes and
+ * drives loading → results / indexing / empty / disabled branches. We mock the
+ * coalesced fetch (`getRelatedNotes`) and the IPC client so we control the async
+ * result and can pin the promise open to exercise the loading + stale-guard
+ * paths. Nothing here touches real IPC.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import type { RelatedNote, RelatedNotesResult } from '../../../../src/shared/types';
+
+const h = vi.hoisted(() => ({
+  getRelatedNotes: vi.fn(),
+  api: { refactor: { applySuggestedLink: vi.fn() } },
+}));
+
+vi.mock('../../../../src/renderer/lib/sidebar-related', () => ({
+  getRelatedNotes: h.getRelatedNotes,
+  invalidateRelatedNotes: vi.fn(),
+}));
+vi.mock('../../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import RelatedPanel from '../../../../src/renderer/lib/components/right-sidebar/RelatedPanel.svelte';
+
+// Node's experimental Web Storage global shadows happy-dom's localStorage but is
+// non-functional here (no backing file), so `localStorage.getItem`/`setItem`
+// throw and the panel's dismiss-persistence path silently no-ops. Swap in a
+// simple in-memory Storage so the persistence branch is actually exercised.
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string): string | null { return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string): void { this.m.set(k, String(v)); }
+  removeItem(k: string): void { this.m.delete(k); }
+  clear(): void { this.m.clear(); }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', new MemStorage());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+function note(over: Partial<RelatedNote> = {}): RelatedNote {
+  return {
+    kind: 'note',
+    ref: 'topics/raft.md',
+    title: 'Raft consensus',
+    sectionHeading: '',
+    snippet: 'A consensus algorithm.',
+    score: 0.9,
+    alreadyLinked: true,
+    ...over,
+  };
+}
+
+function result(notes: RelatedNote[], enabled = true): RelatedNotesResult {
+  return { enabled, notes };
+}
+
+/** A promise we resolve by hand, to hold the panel in its loading state. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+const baseProps = () => ({ activeFilePath: 'topics/consensus.md', revision: 1, onFileSelect: vi.fn() });
+
+describe('right-sidebar RelatedPanel — $effect reactivity (#1002)', () => {
+  it('runs the effect on mount: shows loading, then the resolved results', async () => {
+    const d = deferred<RelatedNotesResult>();
+    h.getRelatedNotes.mockReturnValueOnce(d.promise);
+
+    const { findByText, queryByText } = render(RelatedPanel, baseProps());
+
+    // The effect fired with the mounted path and the panel is loading.
+    expect(h.getRelatedNotes).toHaveBeenCalledWith('topics/consensus.md', 1);
+    expect(await findByText('Finding related notes…')).toBeTruthy();
+    expect(queryByText('Raft consensus')).toBeNull();
+
+    d.resolve(result([note()]));
+
+    expect(await findByText('Raft consensus')).toBeTruthy();
+    expect(await findByText('1 related')).toBeTruthy();
+    expect(queryByText('Finding related notes…')).toBeNull();
+  });
+
+  it('re-runs the effect and refetches when activeFilePath changes', async () => {
+    h.getRelatedNotes
+      .mockResolvedValueOnce(result([note({ ref: 'a.md', title: 'First note' })]))
+      .mockResolvedValueOnce(result([note({ ref: 'b.md', title: 'Second note' })]));
+
+    const { rerender, findByText, queryByText } = render(RelatedPanel, baseProps());
+    expect(await findByText('First note')).toBeTruthy();
+
+    await rerender({ activeFilePath: 'other/topic.md', revision: 1, onFileSelect: vi.fn() });
+
+    expect(await findByText('Second note')).toBeTruthy();
+    await waitFor(() => expect(queryByText('First note')).toBeNull());
+    expect(h.getRelatedNotes).toHaveBeenNthCalledWith(2, 'other/topic.md', 1);
+  });
+
+  it('re-runs the effect when the revision prop is bumped', async () => {
+    h.getRelatedNotes
+      .mockResolvedValueOnce(result([note({ title: 'Rev one' })]))
+      .mockResolvedValueOnce(result([note({ title: 'Rev two' })]));
+
+    const { rerender, findByText } = render(RelatedPanel, baseProps());
+    expect(await findByText('Rev one')).toBeTruthy();
+
+    await rerender({ activeFilePath: 'topics/consensus.md', revision: 2, onFileSelect: vi.fn() });
+
+    expect(await findByText('Rev two')).toBeTruthy();
+    expect(h.getRelatedNotes).toHaveBeenNthCalledWith(2, 'topics/consensus.md', 2);
+  });
+
+  it('drops a stale resolution when the path changed before the fetch resolved', async () => {
+    const first = deferred<RelatedNotesResult>();
+    const second = deferred<RelatedNotesResult>();
+    h.getRelatedNotes
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const { rerender, findByText, queryByText } = render(RelatedPanel, baseProps());
+
+    // Switch tabs while the first fetch is still in flight.
+    await rerender({ activeFilePath: 'other/topic.md', revision: 1, onFileSelect: vi.fn() });
+
+    // The (now stale) first fetch resolves — its result must be ignored.
+    first.resolve(result([note({ ref: 'stale.md', title: 'Stale result' })]));
+    await Promise.resolve();
+
+    // The current fetch resolves and wins.
+    second.resolve(result([note({ ref: 'fresh.md', title: 'Fresh result' })]));
+    expect(await findByText('Fresh result')).toBeTruthy();
+    expect(queryByText('Stale result')).toBeNull();
+  });
+
+  it('shows the disabled message when the vector store is not enabled', async () => {
+    h.getRelatedNotes.mockResolvedValueOnce(result([], false));
+    const { findByText } = render(RelatedPanel, baseProps());
+    expect(await findByText('Semantic search is not available for this thoughtbase.')).toBeTruthy();
+  });
+
+  it('reads an empty result as "indexing" while the backfill is running', async () => {
+    h.getRelatedNotes.mockResolvedValueOnce(result([]));
+    const { findByText } = render(RelatedPanel, { ...baseProps(), indexing: true });
+    expect(await findByText(/Indexing…/)).toBeTruthy();
+  });
+
+  it('shows "no related notes" for an empty result when not indexing', async () => {
+    h.getRelatedNotes.mockResolvedValueOnce(result([]));
+    const { findByText } = render(RelatedPanel, { ...baseProps(), indexing: false });
+    expect(await findByText('No related notes found.')).toBeTruthy();
+  });
+
+  it('offers a link affordance for a high-score unlinked note and hides it optimistically on link', async () => {
+    h.getRelatedNotes.mockResolvedValueOnce(
+      result([note({ ref: 'topics/paxos.md', title: 'Paxos', alreadyLinked: false, score: 0.7 })]),
+    );
+    h.api.refactor.applySuggestedLink.mockResolvedValueOnce(undefined);
+
+    const { findByText, container } = render(RelatedPanel, baseProps());
+    expect(await findByText('Paxos')).toBeTruthy();
+
+    const linkBtn = container.querySelector('.suggest-btn.link') as HTMLButtonElement;
+    expect(linkBtn).toBeTruthy();
+
+    await fireEvent.click(linkBtn);
+
+    expect(h.api.refactor.applySuggestedLink).toHaveBeenCalledWith('topics/consensus.md', 'topics/paxos.md');
+    // Optimistic justLinked hides the affordance immediately.
+    await waitFor(() => expect(container.querySelector('.suggest-btn.link')).toBeNull());
+  });
+
+  it('hides the affordance and persists the pair when a suggestion is dismissed', async () => {
+    h.getRelatedNotes.mockResolvedValueOnce(
+      result([note({ ref: 'topics/paxos.md', title: 'Paxos', alreadyLinked: false, score: 0.7 })]),
+    );
+
+    const { findByText, container, getByLabelText } = render(RelatedPanel, baseProps());
+    expect(await findByText('Paxos')).toBeTruthy();
+
+    await fireEvent.click(getByLabelText('Dismiss'));
+
+    await waitFor(() => expect(container.querySelector('.suggest-btn.dismiss')).toBeNull());
+    const persisted = JSON.parse(localStorage.getItem('minerva.related.dismissed') ?? '[]') as string[];
+    // The dismissed pair key joins active + ref with a NUL separator (not a
+    // space) — see `pairKey` in the component.
+    expect(persisted).toContain('topics/consensus.md\u0000topics/paxos.md');
+  });
+
+  it('does not offer an affordance for a low-score or already-linked note', async () => {
+    h.getRelatedNotes.mockResolvedValueOnce(
+      result([
+        note({ ref: 'low.md', title: 'Low score', alreadyLinked: false, score: 0.2 }),
+        note({ ref: 'linked.md', title: 'Already linked', alreadyLinked: true, score: 0.9 }),
+      ]),
+    );
+    const { findByText, container } = render(RelatedPanel, baseProps());
+    expect(await findByText('Low score')).toBeTruthy();
+    expect(container.querySelector('.suggest-btn')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1002.

Adds render tests for **5 high-traffic interactive Svelte components**, deliberately targeting the Svelte 5 `$derived`/`$effect` gotchas this codebase has hit before (stale derivations on prop change, `$effect`-ordering, `{@const}`/closure staleness) — the class of bug that otherwise only shows up at runtime. **40 tests**, harness identical to the existing `tests/renderer/components/*` (`@vitest-environment happy-dom` + `@testing-library/svelte`).

| Component | Tests | Reactivity focus |
|---|---|---|
| **BreadcrumbsBar** | 7 | crumbs are `$derived.by` off `filePath`; rerender → old segments drop, new render (stale-derivation guard); null↔path appear/disappear |
| **GotoNoteDialog** | 8 | `$derived.by` fuzzy filter narrows on input; score ordering; keyboard-nav `$state` + `.selected` class; `$effect` selection-reset on query change; each-closure click resolves to current row |
| **GotoLineDialog** | 7 | input parse (`N`, `N:C`, column fallback); invalid-input guards; Enter/Escape/backdrop |
| **FileTree** | 8 | `active`/`selected` classes track props across rerender (old loses / new gains); folder children mount/unmount off `expanded`; **context-menu re-target guard** (open on one node, act on another → current target, not stale) |
| **RelatedPanel** | 10 | the `$effect` fetch on `activeFilePath`/`revision` change — mount→loading→results, refetch on both, the **in-flight stale-guard** (`if (activeFilePath !== path) return`), enabled/indexing/empty branches, suggest link/dismiss affordances |

Mocking is minimal: BreadcrumbsBar / GotoNoteDialog / GotoLineDialog are pure-props (no mocks); FileTree mocks `api`; RelatedPanel mocks `getRelatedNotes` + `api.refactor` and stubs `localStorage`.

## Things the tests surfaced (no component changes — flagging for you)

- **`localStorage` under vitest**: Node's experimental Web Storage shadows happy-dom's `localStorage` (the `--localstorage-file` warning), so bare `localStorage` calls throw and RelatedPanel's dismiss-persistence silently no-ops (swallowed by its `try/catch`). Real renderer is fine; the test injects a working in-memory stub to actually exercise the persistence branch. Worth knowing for future component tests that touch storage.
- **`RelatedPanel.pairKey` uses a NUL (`\0`) separator, not a space** — reads as a space in most editors but is a literal NUL byte. Not a bug (avoids collision with paths containing spaces), but a latent footgun for anyone hand-building those keys.
- **`GotoNoteDialog` fuzzy-matches the path *including* the `.md` extension**, so e.g. `read` keeps `Project Plan.md` (trailing `.md` supplies the `d`). Mild surprise if reasoning by display name.
- **`GotoLineDialog` doesn't clamp** the target line to the file length — tested as-built; confirm the goto consumer clamps.

## Verification

- `pnpm lint` → 0/0/0
- full suite → **3909 passed** (+40); the 5 files also pass run-together (no global-stub leakage)

Scoped to render-testable, reactivity-rich components — deliberately left the CodeMirror-heavy editor host and the markdown-it Preview out (their logic already lives in tested `.ts` modules, and a render test there would be mostly harness, not reactivity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
