### PR TITLE
test: cover proposal expiry + malformed-bundle branches; raise llm branch floor to 45 (#1000)

### DIFF
--- a/tests/main/llm/malformed-payload.test.ts
+++ b/tests/main/llm/malformed-payload.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Malformed-bundle error branches on the trust path (#1000). A proposal whose
+ * stored payload JSON is corrupt / empty / not-an-array must NOT silently
+ * approve as a no-op — the user clicked Approve expecting something to land.
+ * These pin `parsePayloads`' guards (reached via getProposal / listProposals /
+ * approveProposal). Proposals are seeded directly into the store so we can
+ * inject payload JSON that proposeWrite would never produce.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  approveProposal,
+  listProposals,
+  getProposal,
+} from '../../../src/main/llm/approval';
+import { initGraph, parseIntoStore } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const THOUGHT = 'https://minerva.dev/ontology/thought#';
+
+describe('malformed-payload error branches (#1000)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-malformed-payload-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  /** Seed a pending proposal with an arbitrary raw payloadJson literal. */
+  function seedProposal(uri: string, payloadJson: string): void {
+    parseIntoStore(ctx, `
+      <${uri}> a <${THOUGHT}Proposal> ;
+        <${THOUGHT}proposalStatus> <${THOUGHT}pending> ;
+        <${THOUGHT}operationType> "new_claim" ;
+        <${THOUGHT}proposalNote> "seeded" ;
+        <${THOUGHT}proposedBy> "unit-test" ;
+        <${THOUGHT}proposedAt> "2026-01-01T00:00:00Z" ;
+        <${THOUGHT}autoExpires> "2030-01-01T00:00:00Z" ;
+        <${THOUGHT}payloadJson> ${JSON.stringify(payloadJson)} .
+    `);
+  }
+
+  it('getProposal throws on corrupt payload JSON (not a silent no-op)', async () => {
+    seedProposal('urn:test:bad-json', 'this is { not valid json');
+    await expect(getProposal(ctx, 'urn:test:bad-json')).rejects.toThrow(/failed to parse/i);
+  });
+
+  it('getProposal throws when the payload JSON parses but is not an array', async () => {
+    seedProposal('urn:test:not-array', '{"kind":"note"}');
+    await expect(getProposal(ctx, 'urn:test:not-array')).rejects.toThrow(/not an array/i);
+  });
+
+  it('approveProposal surfaces the parse error rather than approving a broken proposal', async () => {
+    seedProposal('urn:test:bad-approve', 'nope {');
+    await expect(approveProposal(ctx, 'urn:test:bad-approve')).rejects.toThrow(/failed to parse/i);
+    // Status must remain pending — a failed parse cannot advance it to approved.
+    // (getProposal itself throws, so re-read via a raw list-by-status.)
+    expect((await listProposals(ctx, 'approved')).length).toBe(0);
+  });
+
+  it('approveProposal refuses an empty-bundle proposal instead of a no-op approve', async () => {
+    // Empty payloadJson literal ⇒ parsePayloads returns [] ⇒ approve refuses.
+    seedProposal('urn:test:empty-bundle', '[]');
+    await expect(approveProposal(ctx, 'urn:test:empty-bundle')).rejects.toThrow(/no payloads to apply|no-op/i);
+    expect((await listProposals(ctx, 'approved')).length).toBe(0);
+  });
+
+  it('listProposals throws if any proposal in the set has corrupt payload JSON', async () => {
+    seedProposal('urn:test:bad-in-list', 'still } not json');
+    await expect(listProposals(ctx)).rejects.toThrow(/failed to parse/i);
+  });
+});

--- a/tests/main/llm/proposal-expiry.test.ts
+++ b/tests/main/llm/proposal-expiry.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Proposal lifecycle: expiry / auto-reject window, list/get, and the
+ * reject-non-pending guards (#1000). The trust path's happy path is well
+ * covered by approval.test.ts; this pins the time-based expiry sweep and the
+ * read/lifecycle branches that were previously untested.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  proposeWrite,
+  approveProposal,
+  rejectProposal,
+  expireProposals,
+  listProposals,
+  getProposal,
+} from '../../../src/main/llm/approval';
+import { initGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const THOUGHT = 'https://minerva.dev/ontology/thought#';
+
+describe('proposal expiry + lifecycle (#1000)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+  let seq = 0;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-proposal-expiry-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    seq = 0;
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  /** File a pending (requires_approval) proposal; `expiryDays` sets its
+   *  autoExpires relative to now (negative ⇒ already past). */
+  async function proposePending(expiryDays?: number) {
+    const subject = `urn:test:claim:${seq++}`;
+    const p = await proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{
+        kind: 'graph-triples' as const,
+        turtle: `<${subject}> a <${THOUGHT}Claim> .`,
+        affectsNodeUris: [subject],
+      }],
+      note: 'expiry test',
+      proposedBy: 'unit-test',
+      ...(expiryDays !== undefined ? { expiryDays } : {}),
+    });
+    expect(p).not.toBeNull();
+    return p!;
+  }
+
+  it('expires a pending proposal whose autoExpires is in the past', async () => {
+    const p = await proposePending(-1);
+    expect((await getProposal(ctx, p.uri))!.status).toBe('pending');
+
+    expect(await expireProposals(ctx)).toBe(1);
+    expect((await getProposal(ctx, p.uri))!.status).toBe('expired');
+  });
+
+  it('leaves a not-yet-expired proposal pending', async () => {
+    const p = await proposePending(7);
+    expect(await expireProposals(ctx)).toBe(0);
+    expect((await getProposal(ctx, p.uri))!.status).toBe('pending');
+  });
+
+  it('counts and expires only the past-due pending proposals', async () => {
+    await proposePending(-1);
+    await proposePending(-5);
+    await proposePending(30); // future — must survive
+    expect(await expireProposals(ctx)).toBe(2);
+    expect((await listProposals(ctx, 'expired')).length).toBe(2);
+    expect((await listProposals(ctx, 'pending')).length).toBe(1);
+  });
+
+  it('does not touch an already-approved proposal even if its window has passed', async () => {
+    const p = await proposePending(-1);
+    expect((await approveProposal(ctx, p.uri)).ok).toBe(true);
+    // The expiry sweep only looks at *pending* proposals.
+    expect(await expireProposals(ctx)).toBe(0);
+    expect((await getProposal(ctx, p.uri))!.status).toBe('approved');
+  });
+
+  it('is a no-op sweep when there are no proposals', async () => {
+    expect(await expireProposals(ctx)).toBe(0);
+  });
+
+  it('listProposals returns every proposal, and filters by status', async () => {
+    const a = await proposePending(7);
+    const b = await proposePending(7);
+    await rejectProposal(ctx, b.uri);
+
+    const all = await listProposals(ctx);
+    expect(all.map((p) => p.uri).sort()).toEqual([a.uri, b.uri].sort());
+
+    expect((await listProposals(ctx, 'pending')).map((p) => p.uri)).toEqual([a.uri]);
+    expect((await listProposals(ctx, 'rejected')).map((p) => p.uri)).toEqual([b.uri]);
+  });
+
+  it('getProposal returns null for a missing uri', async () => {
+    expect(await getProposal(ctx, 'urn:test:nonexistent')).toBeNull();
+  });
+
+  it('rejectProposal returns false for a missing uri', async () => {
+    expect(await rejectProposal(ctx, 'urn:test:nonexistent')).toBe(false);
+  });
+
+  it('rejectProposal returns false once a proposal is no longer pending', async () => {
+    const p = await proposePending(7);
+    expect((await approveProposal(ctx, p.uri)).ok).toBe(true);
+    // Already approved — a subsequent reject must not flip it.
+    expect(await rejectProposal(ctx, p.uri)).toBe(false);
+    expect((await getProposal(ctx, p.uri))!.status).toBe('approved');
+  });
+
+  it('approveProposal on a missing / non-pending proposal returns { ok: false } without applying', async () => {
+    expect((await approveProposal(ctx, 'urn:test:nonexistent')).ok).toBe(false);
+    const p = await proposePending(7);
+    await rejectProposal(ctx, p.uri);
+    expect((await approveProposal(ctx, p.uri)).ok).toBe(false);
+    expect((await getProposal(ctx, p.uri))!.status).toBe('rejected');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,7 +44,7 @@ export default defineConfig({
       // Floors per area (#679). Set below the current numbers with headroom
       // so a small refactor won't flap CI, but a real regression on the trust
       // (llm) and security (notebase) paths fails. Measured at floor-time:
-      // shared ~? , llm ~65% lines / 46% branch, notebase ~89% lines. CI runs
+      // shared ~? , llm ~74% lines / 51% branch, notebase ~89% lines. CI runs
       // `pnpm coverage`, so these gate on every PR.
       thresholds: {
         'src/shared/**': {
@@ -52,12 +52,14 @@ export default defineConfig({
           functions: 70,
           statements: 70,
         },
-        // Trust path — proposals, approval gate, tool dispatch, turtle.
+        // Trust path — proposals, approval gate, tool dispatch, turtle. Branch
+        // floor tightened 38 → 45 once the expiry/auto-reject + malformed-bundle
+        // branches got tests (#1000); measured ~51% branch now.
         'src/main/llm/**': {
           lines: 55,
           functions: 58,
           statements: 55,
-          branches: 38,
+          branches: 45,
         },
         // Security path — fs sandbox, write pipeline, rename/merge link rewrites.
         'src/main/notebase/**': {


### PR DESCRIPTION
Closes #1000.

The trust path's happy path + guard-bypass are well covered (`approval.test.ts`, `write-guard-wired.test.ts`), but two safety-critical areas were untested: the **time-based expiry sweep** and the **malformed-proposal error branches**. This adds 15 tests and tightens the `src/main/llm/**` **branch floor 38 → 45** (measured ~51% now; was ~46% at floor-time; `approval.ts` branch went 69% → 78%).

## `proposal-expiry.test.ts` (10)

- `expireProposals` marks past-due **pending** proposals `expired` and returns the count; not-yet-due ones survive; multiple past-due are all swept.
- An **already-approved** proposal is untouched even when its window has passed (the sweep only looks at pending).
- Empty-sweep no-op.
- Read/lifecycle branches: `listProposals` (all + status-filtered), `getProposal` null-for-missing, and the `rejectProposal` / `approveProposal` **non-pending / missing-uri guards** (return `false` / `{ ok: false }` without mutating status).

## `malformed-payload.test.ts` (5)

- Corrupt payload JSON → `getProposal` / `listProposals` / `approveProposal` **throw** (`parsePayloads` guard) rather than silently approving a no-op — the exact "approve succeeded but nothing landed" footgun the code comments call out.
- Valid-JSON-but-not-an-array → throws.
- Empty `[]` bundle → `approveProposal` refuses via its no-op guard.
- Proposals are seeded straight into the store so the payload JSON can take shapes `proposeWrite` would never emit.

## Verification

- `pnpm lint` → 0/0/0
- the two new files → **15 passed**
- `pnpm coverage` → green end-to-end with the raised floor (exit 0); `src/main/llm` branch **~51%** (floor now 45, ~6pts headroom so a small refactor won't flap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)