### PR TITLE
test: real-browser (Playwright) axe pass over welcome + workspace surfaces (#1005)

### DIFF
--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Real-browser accessibility pass (#1005).
+ *
+ * The unit suite runs axe against modal dialogs in jsdom with `color-contrast`
+ * disabled (jsdom computes no layout/colour). This spec extends the net to the
+ * main workspace surfaces — welcome screen, sidebar/file-tree, editor tabs +
+ * status bar — in the actual Electron renderer, where Chromium computes layout
+ * and colour, so the `color-contrast` check runs for real.
+ *
+ * Baseline, not zero. The app has some pre-existing violations (faint
+ * secondary text below AA contrast; a couple of structural ARIA-role issues on
+ * the editor tabs). Rather than block this net on a full product-a11y sweep
+ * (its own reviewed change), each surface carries an allowlist of the
+ * currently-known violation *rule ids*; the test fails only on a NEW rule —
+ * a real regression guard — and logs the tolerated ones so they stay visible.
+ * The known set is tracked for a follow-up fix (see the PR).
+ *
+ * Launches the in-tree `.vite/build` app (like smoke.spec.ts), so it needs
+ * `pnpm build:e2e` first (the `pnpm test:e2e` script does that). Gates on
+ * serious + critical impact; minor/moderate are reported, non-fatal.
+ */
+import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { runAxe, formatViolations, seriousOrWorse, type AxeViolation } from '../helpers/axe-playwright';
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+// Pre-existing serious/critical violations tolerated so the net can land
+// without a product-a11y sweep. NEW rule ids fail the test. Tracked for a
+// follow-up fix — see #1005 / the PR.
+const KNOWN_WELCOME = new Set<string>([
+  'color-contrast', // faint Quick-Open placeholder (--text-faint) ~3.4:1 vs AA 4.5
+]);
+const KNOWN_WORKSPACE = new Set<string>([
+  'color-contrast',        // faint secondary text (status bar, link-type badges)
+  'nested-interactive',    // editor tab (role=tab) wraps a close <button>
+  'aria-required-parent',  // role=tab not contained by a role=tablist
+  'aria-input-field-name', // an unlabeled ARIA input in the workspace
+  // CodeMirror's `.cm-scroller` (tabindex=-1); its `.cm-content` editable IS
+  // keyboard-focusable, so this axe finding is a known CM quirk, not a real trap.
+  'scrollable-region-focusable',
+]);
+
+/** Serious/critical violations whose rule id isn't in the tolerated set. */
+function unexpected(violations: AxeViolation[], allow: Set<string>): AxeViolation[] {
+  return seriousOrWorse(violations).filter((v) => !allow.has(v.id));
+}
+
+/** Log the tolerated pre-existing violations so they stay visible in CI. */
+function reportKnown(surface: string, violations: AxeViolation[], allow: Set<string>): void {
+  const known = seriousOrWorse(violations).filter((v) => allow.has(v.id));
+  if (known.length > 0) {
+    console.log(`[a11y] ${surface}: ${known.length} known/tolerated violation(s):\n${formatViolations(known)}`);
+  }
+}
+
+/** Launch the dev build with an isolated userData dir (optionally seeded to
+ *  auto-open the sample project on boot via session restore). */
+async function launchApp(seedProjectDir?: string) {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-a11y-userdata-'));
+  if (seedProjectDir) {
+    fs.writeFileSync(
+      path.join(userDataDir, 'session.json'),
+      JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: seedProjectDir }]),
+    );
+  }
+  const app = await electron.launch({
+    args: [projectRoot, `--user-data-dir=${userDataDir}`],
+    cwd: projectRoot,
+    timeout: 60_000,
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
+  });
+  return { app, userDataDir };
+}
+
+test('welcome screen: no NEW serious a11y violations (real-browser, incl. color-contrast)', async () => {
+  const { app, userDataDir } = await launchApp();
+  try {
+    const win: Page = await app.firstWindow({ timeout: 20_000 });
+    await win.waitForLoadState('domcontentloaded');
+    await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toBeVisible({ timeout: 15_000 });
+
+    const violations = await runAxe(win);
+    reportKnown('welcome', violations, KNOWN_WELCOME);
+    const regressions = unexpected(violations, KNOWN_WELCOME);
+    expect(regressions, `NEW welcome-screen a11y violations:\n${formatViolations(regressions)}`).toHaveLength(0);
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test('workspace (sidebar + editor): no NEW serious a11y violations (real-browser, incl. color-contrast)', async () => {
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-a11y-project-'));
+  fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
+  const { app, userDataDir } = await launchApp(projectDir);
+  try {
+    const win: Page = await app.firstWindow({ timeout: 20_000 });
+    await win.waitForLoadState('domcontentloaded');
+    // Session restore replaces the welcome screen with the workspace.
+    await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toHaveCount(0, { timeout: 25_000 });
+    await win.waitForTimeout(500); // let the sidebar tree + panels settle
+
+    // Sidebar + shell.
+    const shell = await runAxe(win);
+    reportKnown('workspace shell', shell, KNOWN_WORKSPACE);
+    const shellRegressions = unexpected(shell, KNOWN_WORKSPACE);
+    expect(shellRegressions, `NEW workspace-shell a11y violations:\n${formatViolations(shellRegressions)}`).toHaveLength(0);
+
+    // Open a note so the editor surface is populated, then re-check.
+    const firstFile = win.locator('[data-relative-path$=".md"]').first();
+    if (await firstFile.count()) {
+      await firstFile.click();
+      await win.waitForTimeout(500);
+      const withEditor = await runAxe(win);
+      reportKnown('workspace+editor', withEditor, KNOWN_WORKSPACE);
+      const editorRegressions = unexpected(withEditor, KNOWN_WORKSPACE);
+      expect(editorRegressions, `NEW workspace+editor a11y violations:\n${formatViolations(editorRegressions)}`).toHaveLength(0);
+    }
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/tests/helpers/axe-playwright.ts
+++ b/tests/helpers/axe-playwright.ts
@@ -1,0 +1,81 @@
+/**
+ * Real-browser axe-core pass for the Playwright/Electron e2e suite (#1005).
+ *
+ * The jsdom component net (`tests/helpers/axe.ts`) disables `color-contrast`
+ * because jsdom computes no layout or colours. Here we run against the actual
+ * Electron renderer, so Chromium DOES compute layout and colour — enabling the
+ * `color-contrast` check the unit pass can't do. Injects axe-core from
+ * node_modules into the page and runs it there.
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import type { Page } from '@playwright/test';
+
+const require = createRequire(__filename);
+// axe-core's main entry is a UMD bundle; running it defines `window.axe`.
+const AXE_SOURCE = fs.readFileSync(require.resolve('axe-core'), 'utf8');
+
+export interface AxeViolationNode {
+  html: string;
+  target: string[];
+  failureSummary?: string;
+}
+export interface AxeViolation {
+  id: string;
+  impact: 'minor' | 'moderate' | 'serious' | 'critical' | null;
+  help: string;
+  helpUrl: string;
+  nodes: AxeViolationNode[];
+}
+
+/**
+ * Inject axe-core and run it against `context` (a CSS selector, or the whole
+ * document by default). `color-contrast` is ON — that's the point of the
+ * real-browser pass. Returns the raw violations.
+ */
+export async function runAxe(page: Page, context?: string): Promise<AxeViolation[]> {
+  // The app ships a hardened CSP (`script-src 'self' 'wasm-unsafe-eval' blob:`)
+  // that blocks Playwright's `addScriptTag` inline injection. blob: URLs ARE
+  // allowed, so load axe from an object URL — which also proves the pass runs
+  // under the real production CSP, not a relaxed test one.
+  await page.evaluate(async (src) => {
+    if ((globalThis as unknown as { axe?: unknown }).axe) return;
+    const url = URL.createObjectURL(new Blob([src], { type: 'text/javascript' }));
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = url;
+        s.onload = () => resolve();
+        s.onerror = () => reject(new Error('axe-core failed to load'));
+        document.head.appendChild(s);
+      });
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }, AXE_SOURCE);
+  return page.evaluate(async (ctx) => {
+    // `axe` is defined on window by the injected UMD bundle.
+    const axe = (globalThis as unknown as { axe: { run: (c: unknown, o: unknown) => Promise<{ violations: AxeViolation[] }> } }).axe;
+    const results = await axe.run(ctx ?? document, {
+      // WCAG 2.0/2.1 A + AA — the level a professional tool should meet.
+      runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] },
+    });
+    return results.violations;
+  }, context);
+}
+
+/** Human-readable violation dump for a failing assertion. */
+export function formatViolations(violations: AxeViolation[]): string {
+  if (violations.length === 0) return 'no violations';
+  return violations
+    .map((v) =>
+      `  • [${v.impact ?? 'n/a'}] ${v.id} — ${v.help} (${v.helpUrl})\n` +
+      v.nodes.map((n) => `      ${n.target.join(' ')} :: ${n.html}`).join('\n'),
+    )
+    .join('\n');
+}
+
+/** Filter to the impacts that should gate CI (serious + critical). */
+export function seriousOrWorse(violations: AxeViolation[]): AxeViolation[] {
+  return violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+}


### PR DESCRIPTION
Closes #1005.

Extends the axe a11y net beyond jsdom dialogs to the **real Electron renderer** via Playwright — where Chromium computes layout + colour, so the **`color-contrast` check runs for real** (jsdom can't). Covers the **welcome screen** and the **workspace** (sidebar / file tree, editor tabs, status bar, and the editor with a note open).

## How

- **`tests/helpers/axe-playwright.ts`** — injects axe-core into the page and runs it (WCAG 2.0/2.1 A+AA tags). The app's hardened CSP (`script-src 'self' 'wasm-unsafe-eval' blob:`) blocks Playwright's inline `addScriptTag`, so axe loads from a **`blob:` URL** (which the CSP allows) — a nice side effect: the pass runs under the **real production CSP**, not a relaxed test one.
- **`tests/e2e/a11y.spec.ts`** — welcome + workspace(+editor) axe passes, gating on **serious/critical** impact. Runs in the existing e2e job (`pnpm test:e2e`).

## Baseline, not zero

The app has some pre-existing violations. Rather than block this net on a full product-a11y sweep (which deserves its own reviewed change — restructuring tab roles, retuning theme contrast), each surface carries an allowlist of the currently-known violation **rule ids**. The test fails only on a **new** rule — a real regression guard — and logs the tolerated ones so they stay visible in CI.

### Tolerated today (tracked for a follow-up fix)

| Rule | Impact | Where |
|---|---|---|
| `color-contrast` | serious | faint `--text-faint` secondary text — Quick-Open placeholder (~3.4:1), status-bar items, link-type badges |
| `nested-interactive` | serious | editor tab (`role="tab"`) wraps a close `<button>` |
| `aria-required-parent` | critical | `role="tab"` not contained by a `role="tablist"` |
| `aria-input-field-name` | serious | an unlabeled ARIA input in the workspace |
| `scrollable-region-focusable` | serious | CodeMirror `.cm-scroller` (`tabindex=-1`); its `.cm-content` editable IS keyboard-focusable, so this is a known CM quirk rather than a real trap |

The `aria-required-parent` (critical) + `aria-input-field-name` are likely the quickest real wins (a `role="tablist"` wrapper / an `aria-label`); `nested-interactive` is a small TabBar restructure; `color-contrast` is a theme-token decision. Happy to take those in a follow-up **fix** PR — kept separate here so this stays a clean testing change.

## Scope

Lands the two highest-traffic surfaces (welcome, sidebar+editor) with real color-contrast. The helper makes adding the **graph view** and **PDF viewer** passes a few lines each once there's a reliable way to open them in the fixture — noted as the obvious next extension rather than claiming full coverage.

## Verification

- full e2e suite → **6/6** (2 new a11y + smoke + bundle-budget)
- `pnpm lint` → 0/0/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
