### PR TITLE
fix: resolve the workspace a11y violations the axe net found (#1005 follow-up)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -446,6 +446,9 @@
 
   const extensions = [
     basicSetup,
+    // Give the `role="textbox"` content DOM an accessible name (#1005 a11y) —
+    // CodeMirror's editable div is otherwise unlabeled (axe aria-input-field-name).
+    EditorView.contentAttributes.of({ 'aria-label': 'Note editor' }),
     markdown({ codeLanguages: languages }),
     // Pin the frontmatter fold's gutter arrow to line 1 by claiming the
     // foldable range there ourselves. Without this, the markdown

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -84,51 +84,63 @@
 <div class="tab-bar">
   {#each tabs as tab, i}
     {@const dirty = tab.type === 'note' && tab.content !== tab.savedContent}
+    <!-- Presentational wrapper: carries the drag / middle-click / context-menu
+         gestures for the whole tab. The switch and close controls live inside
+         as siblings so no interactive element nests another (a11y #1005). The
+         wrapper's mouse gestures all have UI equivalents (context menu, close
+         button), so it needs no role of its own. -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="tab"
       class:active={i === activeIndex}
       class:dirty
       onpointerdown={(e) => { if (e.button === 0) onTabPointerDown?.(i, e); }}
-      onclick={() => onSwitch(i)}
-      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSwitch(i); } }}
       onauxclick={(e) => handleMiddleClick(e, i)}
       oncontextmenu={(e) => handleContextMenu(e, i)}
-      title={tab.type === 'note'
-        ? tab.relativePath
-        : tab.type === 'query'
-          ? tab.title
-          : tab.type === 'pdf'
-            ? `PDF: ${sourceTabLabel(tab.sourceId)}`
-            : tab.type === 'graph'
-              ? `Graph: ${tab.relativePath}`
-              : `Source: ${sourceTabLabel(tab.sourceId)}`}
-      role="tab"
-      tabindex="0"
     >
-      <!-- Leading slot: dirty pip OR type icon. The pip wins when the
-           note is dirty so the visual cue can't be missed (§7.2). -->
-      <span class="tab-lead">
-        {#if dirty}
-          <span class="dirty-dot" aria-label="Unsaved changes"></span>
-        {:else if tab.type === 'query'}
-          <Icon name="query" size={13} color="var(--text-faint)" />
-        {:else if tab.type === 'source'}
-          <Icon name="source" size={13} color="var(--text-faint)" />
-        {:else if tab.type === 'pdf'}
-          <Icon name="source" size={13} color="var(--text-faint)" />
-        {:else if tab.type === 'graph'}
-          <Icon name="graph" size={13} color="var(--text-faint)" />
-        {:else}
-          <Icon name="notes" size={13} color="var(--text-faint)" />
-        {/if}
-      </span>
-      <span class="tab-name">
-        {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
-        {:else if tab.type === 'query'}{tab.title}
-        {:else if tab.type === 'pdf'}{sourceTabLabel(tab.sourceId)} (PDF)
-        {:else if tab.type === 'graph'}{(tab.relativePath.split('/').pop() ?? tab.relativePath).replace(/\.md$/, '')} (Graph)
-        {:else}{sourceTabLabel(tab.sourceId)}{/if}
-      </span>
+      <!-- The tab proper: a plain button (Enter/Space switch natively). The
+           full ARIA tabs widget wants owned tabpanels the editor doesn't model,
+           so this is a button labelled by its text with aria-current marking the
+           open one — not a role="tab". -->
+      <button
+        class="tab-switch"
+        aria-current={i === activeIndex ? 'page' : undefined}
+        onclick={() => onSwitch(i)}
+        title={tab.type === 'note'
+          ? tab.relativePath
+          : tab.type === 'query'
+            ? tab.title
+            : tab.type === 'pdf'
+              ? `PDF: ${sourceTabLabel(tab.sourceId)}`
+              : tab.type === 'graph'
+                ? `Graph: ${tab.relativePath}`
+                : `Source: ${sourceTabLabel(tab.sourceId)}`}
+      >
+        <!-- Leading slot: dirty pip OR type icon. The pip wins when the
+             note is dirty so the visual cue can't be missed (§7.2). -->
+        <span class="tab-lead">
+          {#if dirty}
+            <span class="dirty-dot" aria-label="Unsaved changes"></span>
+          {:else if tab.type === 'query'}
+            <Icon name="query" size={13} color="var(--text-faint)" />
+          {:else if tab.type === 'source'}
+            <Icon name="source" size={13} color="var(--text-faint)" />
+          {:else if tab.type === 'pdf'}
+            <Icon name="source" size={13} color="var(--text-faint)" />
+          {:else if tab.type === 'graph'}
+            <Icon name="graph" size={13} color="var(--text-faint)" />
+          {:else}
+            <Icon name="notes" size={13} color="var(--text-faint)" />
+          {/if}
+        </span>
+        <span class="tab-name">
+          {#if tab.type === 'note'}{tab.fileName.replace(/\.md$/, '')}
+          {:else if tab.type === 'query'}{tab.title}
+          {:else if tab.type === 'pdf'}{sourceTabLabel(tab.sourceId)} (PDF)
+          {:else if tab.type === 'graph'}{(tab.relativePath.split('/').pop() ?? tab.relativePath).replace(/\.md$/, '')} (Graph)
+          {:else}{sourceTabLabel(tab.sourceId)}{/if}
+        </span>
+      </button>
       <button
         class="close-btn"
         onclick={(e) => { e.stopPropagation(); onClose(i); }}
@@ -205,17 +217,39 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 0 8px 0 14px;
-    border: none;
+    padding-right: 8px;
     border-right: 1px solid var(--border);
     background: transparent;
     color: var(--text-muted);
     font-family: var(--font-sans);
     font-size: 13px;
-    cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
     position: relative;
+  }
+
+  /* The switch control fills the tab's leading area; native button chrome is
+     reset so it reads as plain tab text. Sibling of .close-btn so no
+     interactive element nests another (a11y #1005). */
+  .tab-switch {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    align-self: stretch;
+    padding: 0 0 0 14px;
+    border: none;
+    background: none;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    white-space: nowrap;
+    appearance: none;
+  }
+
+  .tab-switch:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
   }
 
   .tab:hover {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -6,7 +6,9 @@
   --bg-inset:     oklch(0.175 0.010 70);
   --text:         oklch(0.925 0.018 85);
   --text-muted:   oklch(0.680 0.018 80);
-  --text-faint:   oklch(0.520 0.015 75);
+  /* Faint tier lifted to meet WCAG AA (4.5:1) on --bg / --bg-elev (#1005).
+     Was 0.520 (~2.6:1). Still clearly below muted so the 3-tier hierarchy reads. */
+  --text-faint:   oklch(0.630 0.015 75);
   --border:       oklch(0.330 0.012 70);
   --border-strong: oklch(0.420 0.014 70);
   --accent:       oklch(0.790 0.115 78);
@@ -53,7 +55,8 @@
   --bg-inset:     oklch(0.985 0.008 85);
   --text:         oklch(0.235 0.018 70);
   --text-muted:   oklch(0.460 0.018 75);
-  --text-faint:   oklch(0.620 0.015 75);
+  /* AA bump (#1005): was 0.620 (~2.7:1); 0.515 hits 4.5:1 on --bg / --bg-elev. */
+  --text-faint:   oklch(0.515 0.015 75);
   --border:       oklch(0.870 0.018 80);
   --border-strong: oklch(0.780 0.020 80);
   --accent:       oklch(0.560 0.115 65);
@@ -78,7 +81,7 @@
   --bg-inset:      #ffffff;
   --text:          #0a0a14;
   --text-muted:    #404050;
-  --text-faint:    #6a6a7a;
+  --text-faint:    #666677; /* AA bump (#1005): #6a6a7a was 4.47:1 on --bg-elev-2 */
   --border:        #c0c0cc;
   --border-strong: #9090a0;
   --accent:        oklch(0.500 0.150 65);

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -31,16 +31,23 @@ const projectRoot = path.resolve(__dirname, '..', '..');
 // without a product-a11y sweep. NEW rule ids fail the test. Tracked for a
 // follow-up fix — see #1005 / the PR.
 const KNOWN_WELCOME = new Set<string>([
-  'color-contrast', // faint Quick-Open placeholder (--text-faint) ~3.4:1 vs AA 4.5
+  // Clean: --text-faint was lifted to WCAG AA, so no tolerated violations here.
 ]);
 const KNOWN_WORKSPACE = new Set<string>([
-  'color-contrast',        // faint secondary text (status bar, link-type badges)
-  'nested-interactive',    // editor tab (role=tab) wraps a close <button>
-  'aria-required-parent',  // role=tab not contained by a role=tablist
-  'aria-input-field-name', // an unlabeled ARIA input in the workspace
+  // Remaining color-contrast is EDITOR-INTERNAL only: CodeMirror's oneDark
+  // theme syntax colors (e.g. its red #e06c75 at 4.38:1) + our link-type badge
+  // decorations (--text-faint) layered on oneDark's #282c34 background. The app
+  // chrome's faint text was lifted to AA (the welcome test enforces it, no
+  // allowlist there). Making the editor fully AA means retuning/replacing the
+  // oneDark theme — its own change; tracked as follow-up.
+  'color-contrast',
   // CodeMirror's `.cm-scroller` (tabindex=-1); its `.cm-content` editable IS
   // keyboard-focusable, so this axe finding is a known CM quirk, not a real trap.
   'scrollable-region-focusable',
+  // Fixed in this pass (kept out of the allowlist so a regression fails):
+  //   aria-input-field-name — CM content now has an aria-label
+  //   nested-interactive / aria-required-parent — editor tabs are plain
+  //     buttons (switch + sibling close), no half-applied role=tab widget.
 ]);
 
 /** Serious/critical violations whose rule id isn't in the tolerated set. */


### PR DESCRIPTION
Follow-up to #1005 — fixes the app-owned a11y violations that the new real-browser axe net surfaced, and tightens the allowlist so each stays fixed (a regression now fails CI).

## Fixes

| Rule | Impact | Fix |
|---|---|---|
| `aria-input-field-name` | serious | CodeMirror's `role="textbox"` content div was unlabeled → `EditorView.contentAttributes` gives it `aria-label="Note editor"` |
| `nested-interactive` | serious | editor tab was `<div role="tab" tabindex=0>` wrapping a close `<button>` (interactive-in-interactive) |
| `aria-required-parent` | **critical** | that `role="tab"` had no owning `role="tablist"` |
| `color-contrast` (app chrome) | serious | `--text-faint` was ~2.6–2.7:1, well below AA |

### Tabs → plain buttons

The tabs were a half-applied ARIA tabs widget. The full pattern wants owned `tabpanel`s the editor doesn't model, so I dropped the tab roles rather than fake them: each tab is now a **presentational wrapper** holding a plain **switch `<button>`** (Enter/Space switch natively; `aria-current="page"` marks the open one) and a **sibling close `<button>`** — no nesting, no orphaned role. Drag / middle-click / context-menu gestures stay on the wrapper (with the same `svelte-ignore a11y_no_static_element_interactions` the dialogs use for mouse-only handlers). CSS moved accordingly, plus a keyboard `:focus-visible` ring. The existing `TabBar.test.ts` stays green.

### `--text-faint` → WCAG AA

Lifted to 4.5:1 on `--bg` / `--bg-elev` (where faint text actually sits — status bar, sidebar timestamps, editor badges, Quick-Open placeholder) in all three themes:

| theme | before | after | min ratio |
|---|---|---|---|
| dark | `oklch(0.520 …)` | `oklch(0.630 …)` | 4.6:1 |
| light | `oklch(0.620 …)` | `oklch(0.515 …)` | 4.7:1 |
| contrast | `#6a6a7a` (4.47) | `#666677` | 4.7:1 |

Still clearly below `--text-muted`, so the 3-tier text hierarchy still reads. I targeted `--bg-elev` rather than the lightest `--bg-elev-2` on purpose: going all the way to elev2 would push faint almost into muted and flatten the hierarchy, and faint text doesn't render on elev2 surfaces. **The welcome test now enforces zero contrast violations** (no allowlist there).

## Remaining (documented, allowlisted — follow-up)

- **`color-contrast` inside the editor** — CodeMirror's `oneDark` theme colors (its own red `#e06c75` is 4.38:1) plus our link-badge decorations on oneDark's `#282c34` background. Making the editor fully AA means retuning or replacing the oneDark theme — its own change, worth doing deliberately (it shifts all syntax colors). Scoped precisely in the workspace allowlist.
- **`scrollable-region-focusable`** on CM's `.cm-scroller` — a known axe/CodeMirror quirk; the `.cm-content` editable inside is fully keyboard-accessible.

## Verification

- `pnpm lint` → 0/0/0
- full unit suite → **3924** green
- full e2e → **6/6**, incl. the a11y pass (welcome enforces contrast; workspace enforces the three ARIA/tab fixes)

> A visual pass on the tab bar + the faint-text change across dark/light/contrast is worth a look — the restructure and token bump are covered by tests for behaviour + axe for contrast, but the final look is a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
