### PR TITLE
test: two core happy-path e2e flows (#998)

### DIFF
--- a/src/main/e2e-hooks.ts
+++ b/src/main/e2e-hooks.ts
@@ -1,0 +1,54 @@
+/**
+ * End-to-end test seams (#998). Active ONLY when `MINERVA_E2E=1` — which the
+ * Playwright e2e job sets on launch; a no-op in every normal run.
+ *
+ * Why this exists: the "conversation → approve → graph mutation" happy path
+ * can't be driven end-to-end in CI — the conversation step needs a live LLM
+ * (non-deterministic, API-key-gated), and a pending proposal seeded into
+ * `graph.ttl` doesn't survive project open (acquireProject rebuilds the store
+ * from notes). So this hook files ONE fixed pending proposal through the real
+ * approval engine (`proposeWrite`); the e2e then approves it via the normal
+ * `api.proposals.approve` IPC and asserts the graph reflects the applied
+ * payload — exercising the deterministic approve→graph half of the flow.
+ *
+ * It lives on `globalThis`, not the preload bridge, so it adds nothing to the
+ * renderer API surface (no preload-snapshot change). The e2e reaches it through
+ * Playwright's `electronApp.evaluate()`, which runs in the main process.
+ */
+import { BrowserWindow } from 'electron';
+import { getRootPath } from './window-manager';
+import { projectContext } from './project-context-types';
+import { proposeWrite } from './llm/approval';
+
+export interface E2EHooks {
+  /** File a fixed pending proposal into the focused window's project.
+   *  Returns the proposal URI, or null if it applied autonomously (it won't —
+   *  new_claim is requires_approval). */
+  seedProposal(): Promise<string | null>;
+}
+
+/** The distinctive triple the seeded proposal adds on approval. */
+export const E2E_CLAIM_LABEL = 'E2E Approved Claim';
+
+export function installE2EHooks(): void {
+  if (process.env.MINERVA_E2E !== '1') return;
+  const hooks: E2EHooks = {
+    async seedProposal() {
+      const win = BrowserWindow.getFocusedWindow();
+      const rootPath = win ? getRootPath(win.id) : null;
+      if (!rootPath) throw new Error('[e2e] no open project to seed a proposal into');
+      const proposal = await proposeWrite(projectContext(rootPath), {
+        operationType: 'new_claim',
+        payloads: [{
+          kind: 'graph-triples',
+          turtle: `<urn:e2e:claim> <https://minerva.dev/ontology/thought#label> "${E2E_CLAIM_LABEL}" .`,
+          affectsNodeUris: ['urn:e2e:claim'],
+        }],
+        note: 'e2e seeded proposal',
+        proposedBy: 'e2e',
+      });
+      return proposal?.uri ?? null;
+    },
+  };
+  (globalThis as typeof globalThis & { __minervaE2E?: E2EHooks }).__minervaE2E = hooks;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,8 +15,12 @@ import { shutdownAllKernels } from './compute/python-kernel';
 import { stopClipperServer } from './clipper/lifecycle';
 import { registerSkillsAtStartup } from './skills/register';
 import { initAutoUpdate, setUpdateStateListener } from './auto-update';
+import { installE2EHooks } from './e2e-hooks';
 
 app.setName('Minerva');
+
+// e2e test seams (#998) — no-op unless MINERVA_E2E=1 (set by the Playwright job).
+installE2EHooks();
 
 // Boot-trace: stderr-tagged so the e2e smoke test (#394) can recover them
 // from the captured main-process stream when launch hangs on CI (#518).

--- a/tests/e2e/happy-paths.spec.ts
+++ b/tests/e2e/happy-paths.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Two core happy-path e2e flows (#998), each assembled end-to-end through the
+ * real Electron app + preload/IPC bridge + main-process pipeline:
+ *
+ *   1. write a note → it reindexes → a SPARQL query returns it.
+ *   2. a pending proposal → approve it → the graph reflects the applied mutation.
+ *
+ * Driven through `window.api` (the exact bridge the UI calls) rather than
+ * simulating CodeMirror keystrokes / panel clicks — those are brittle and just
+ * re-test what the component suite already covers, whereas these assert the full
+ * IPC → main → graph pipeline holds together. Flow 2's proposal is seeded via
+ * the `MINERVA_E2E` main-process hook (see `src/main/e2e-hooks.ts`) because a
+ * live LLM conversation isn't CI-deterministic; the approve→graph half — the
+ * safety-critical part — runs for real.
+ *
+ * Boots the in-tree `.vite/build` app (like smoke.spec.ts), so it needs
+ * `pnpm build:e2e` first (the `pnpm test:e2e` script does that).
+ */
+import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+// These flows call `window.api` (the preload bridge) inside `win.evaluate` —
+// the renderer's global typing isn't in this spec's scope, so `window` reads as
+// `any` here and the `.api.*` calls are validated at runtime, not by tsc.
+
+async function launchWithProject() {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-happy-userdata-'));
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-happy-project-'));
+  // Copy the fixture so the run can't dirty the tracked one.
+  fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataDir, 'session.json'),
+    JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: projectDir }]),
+  );
+  const app = await electron.launch({
+    args: [projectRoot, `--user-data-dir=${userDataDir}`],
+    cwd: projectRoot,
+    timeout: 60_000,
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1', MINERVA_E2E: '1' },
+  });
+  return { app, userDataDir, projectDir };
+}
+
+/** Wait until the workspace has replaced the welcome screen (project open). */
+async function waitForWorkspace(win: Page): Promise<void> {
+  await win.waitForLoadState('domcontentloaded');
+  await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toHaveCount(0, { timeout: 25_000 });
+}
+
+test('flow: write a note → reindex → SPARQL query returns it', async () => {
+  const { app, userDataDir, projectDir } = await launchWithProject();
+  try {
+    const win = await app.firstWindow({ timeout: 20_000 });
+    await waitForWorkspace(win);
+
+    const marker = 'E2E Flow Marker Note';
+    const rel = 'notes/e2e-flow.md';
+
+    // Save through the real notebase IPC. writeAndReindex indexes the note
+    // synchronously, so the graph reflects it the moment this resolves.
+    await win.evaluate(async ([relPath, title]) => {
+      await window.api.notebase.writeFile(relPath, `---\ntitle: ${title}\n---\n\nbody\n`);
+    }, [rel, marker] as const);
+
+    // The marquee assertion: a SPARQL query returns the freshly-saved note.
+    const res = await win.evaluate((title) =>
+      window.api.graph.query(
+        `SELECT ?title WHERE { ?note rdf:type minerva:Note ; dc:title ?title . FILTER(CONTAINS(STR(?title), "${title}")) }`,
+      ), marker);
+
+    expect(res.error, res.error).toBeFalsy();
+    const titles = (res.results as Array<{ title?: string }>).map((r) => r.title);
+    expect(titles).toContain(marker);
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('flow: pending proposal → approve → graph reflects the mutation', async () => {
+  const { app, userDataDir, projectDir } = await launchWithProject();
+  try {
+    const win = await app.firstWindow({ timeout: 20_000 });
+    await waitForWorkspace(win);
+
+    const claimQuery =
+      `SELECT ?c WHERE { ?c <https://minerva.dev/ontology/thought#label> "E2E Approved Claim" }`;
+
+    // Seed a pending proposal via the main-process e2e hook (stands in for the
+    // LLM conversation). requires_approval ⇒ its payload is NOT applied yet.
+    const uri = await app.evaluate(async () => {
+      const g = globalThis as typeof globalThis & { __minervaE2E?: { seedProposal(): Promise<string | null> } };
+      if (!g.__minervaE2E) throw new Error('e2e hook missing — MINERVA_E2E not set?');
+      return g.__minervaE2E.seedProposal();
+    });
+    expect(uri, 'seedProposal returned no uri').toBeTruthy();
+
+    // Before approval the claim triple must be absent (the gate holds).
+    const before = await win.evaluate((q) => window.api.graph.query(q), claimQuery);
+    expect(before.results.length, 'claim should be absent before approval').toBe(0);
+
+    // Approve through the normal proposals IPC — exactly what the Proposals
+    // panel's approve button calls.
+    const ok = await win.evaluate((u) => window.api.proposals.approve(u), uri as string);
+    expect(ok, 'approve returned false').toBe(true);
+
+    // After approval the applied mutation is reflected in the graph.
+    const after = await win.evaluate((q) => window.api.graph.query(q), claimQuery);
+    expect(after.results.length, 'claim should be present after approval').toBeGreaterThan(0);
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #998. Adds the two Playwright e2e cases that assemble the product's defining flows end-to-end — through the real Electron app + preload/IPC bridge + main-process pipeline. They were covered piecewise by unit/integration tests but never assembled.

## The two flows

1. **write a note → reindex → SPARQL query returns it** — `api.notebase.writeFile` (which reindexes synchronously) then `api.graph.query(SELECT … minerva:Note … dc:title …)` asserts the fresh note comes back.
2. **pending proposal → approve → graph reflects the mutation** — assert the payload triple is **absent**, `api.proposals.approve(uri)`, assert it's now **present**. That's the safety-critical approve→graph gate, running for real.

Both run in the existing CI `e2e` job (`pnpm test:e2e`).

## Design notes

- **Driven through `window.api`** (the exact bridge the UI calls), not by simulating CodeMirror keystrokes / panel clicks — those are brittle and re-test what the component suite already covers, whereas this asserts the IPC → main → graph pipeline holds together.
- **Why Flow 2 needs a seam:** a live conversation isn't CI-deterministic (LLM is non-deterministic + API-key-gated), and a proposal seeded into `graph.ttl` doesn't survive project open (`acquireProject` rebuilds the store from notes). So a **small env-gated main-process seam** (`src/main/e2e-hooks.ts`, active **only** under `MINERVA_E2E=1`) files one fixed pending proposal through the **real** approval engine (`proposeWrite`). The test then approves it via the normal IPC.
  - The seam lives on `globalThis` (reached via Playwright's `electronApp.evaluate()` in the main process), so it **adds nothing to the renderer API surface** — no preload-snapshot change — and is a **no-op in every normal launch**.

Keeps the "two flows, not a broad e2e suite" discipline the issue asks for (no pyramid inversion).

## Verification

- `pnpm lint` → 0/0/0
- full e2e → **8/8** (2 new + a11y + smoke + bundle-budget)
- unit suite → **3924** (the `main.ts` wiring change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)