### PR TITLE
test: graph + embedding benchmarks in a non-gating job (#1004)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,39 @@
+# Non-gating performance benchmarks (#1004).
+#
+# Runs the `*.bench.ts` suite — graph index/query latency and embedding
+# throughput — to make scale regressions visible as a knowledge base grows.
+#
+# Deliberately NOT on `pull_request` / `push`: micro-benchmarks are noisy on
+# shared CI runners, so gating a PR on them would flap. Trigger it by hand
+# (workflow_dispatch) or let the weekly schedule run it, and read the numbers in
+# the job log. macos-latest matches ci.yml and the dev machine.
+name: Bench
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+
+jobs:
+  bench:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run benchmarks
+        run: pnpm bench

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:eslint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench": "vitest bench --run --config vitest.bench.config.ts",
     "coverage": "vitest run --coverage --test-timeout=30000",
     "build:e2e": "NODE_OPTIONS=--max-old-space-size=4096 electron-forge package",
     "test:e2e": "pnpm build:e2e && playwright test",

--- a/tests/main/embeddings/pooling.bench.ts
+++ b/tests/main/embeddings/pooling.bench.ts
@@ -1,0 +1,56 @@
+/**
+ * Embedding hot-path throughput benchmark (#1004). Not run by `pnpm test` —
+ * invoke with `pnpm bench`.
+ *
+ * Guards the two numeric loops that back local semantic search:
+ *   - `meanPoolNormalize` — reduce a model's `[seq × dim]` token output to one
+ *     sentence vector (runs once per embedded chunk);
+ *   - `cosineSimilarity` — score a query vector against the corpus (runs once
+ *     per candidate on every search).
+ * A regression here scales with corpus size, so it's exactly the kind of thing
+ * that silently degrades search as a vault grows.
+ */
+import { describe, bench, beforeAll } from 'vitest';
+import { meanPoolNormalize, cosineSimilarity } from '../../../src/main/embeddings/pooling';
+
+const DIM = 384;   // all-MiniLM-L6-v2 embedding width
+const SEQ = 512;   // the model's max sequence length — the worst-case pool
+
+/** Deterministic filler so runs are comparable (no Math.random). */
+function fill(v: Float32Array, phase: number): Float32Array {
+  for (let i = 0; i < v.length; i++) v[i] = Math.sin(i + phase) * 0.1;
+  return v;
+}
+
+describe('embedding pooling', () => {
+  let tokens: Float32Array;
+  let mask: Float32Array;
+
+  beforeAll(() => {
+    tokens = fill(new Float32Array(SEQ * DIM), 0);
+    mask = new Float32Array(SEQ).fill(1);
+  });
+
+  bench(`meanPoolNormalize: seq=${SEQ} dim=${DIM}`, () => {
+    meanPoolNormalize(tokens, mask, SEQ, DIM);
+  });
+});
+
+describe('embedding similarity', () => {
+  const CORPUS = 10_000;
+  let query: Float32Array;
+  let corpus: Float32Array[];
+
+  beforeAll(() => {
+    query = fill(new Float32Array(DIM), 1);
+    corpus = Array.from({ length: CORPUS }, (_, i) => fill(new Float32Array(DIM), i));
+  });
+
+  bench(`cosineSimilarity: query vs ${CORPUS.toLocaleString()} corpus vectors (dim=${DIM})`, () => {
+    let best = -Infinity;
+    for (let i = 0; i < corpus.length; i++) {
+      const s = cosineSimilarity(query, corpus[i]!);
+      if (s > best) best = s;
+    }
+  });
+});

--- a/tests/main/graph/graph-index.bench.ts
+++ b/tests/main/graph/graph-index.bench.ts
@@ -1,0 +1,47 @@
+/**
+ * Graph indexing-latency benchmark (#1004). Not run by `pnpm test` — invoke
+ * with `pnpm bench`.
+ *
+ * Measures the per-note cost of `indexNote` against a store that already holds
+ * a realistic number of notes, so a regression in the indexer's cost-at-scale
+ * (extract title/tags/wiki-links, mutate the rdflib store, invalidate the N3
+ * mirror) becomes visible as vaults grow.
+ */
+import { describe, bench, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const SEED_NOTES = 500;
+
+describe('graph indexing', () => {
+  let ctx: ProjectContext;
+
+  beforeAll(async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-idxbench-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    // Populate the store so indexNote runs against a non-trivial graph, not an
+    // empty one — that's where the cost that matters lives.
+    for (let i = 0; i < SEED_NOTES; i++) {
+      await indexNote(
+        ctx,
+        `seed-${i}.md`,
+        `# Seed ${i}\n\n${'lorem ipsum '.repeat(40)}\n\n#tag-${i % 10}\n\n[[seed-${(i + 1) % SEED_NOTES}]]\n`,
+      );
+    }
+  });
+
+  // Re-index the same path in place (indexNote strips the note's prior triples
+  // then re-adds), so each iteration is a stable steady-state cost rather than
+  // a monotonically growing store.
+  bench(`indexNote: a note (title + tag + wiki-link) into a ${SEED_NOTES}-note store`, async () => {
+    await indexNote(
+      ctx,
+      'bench-note.md',
+      `# Bench Note\n\nBody with a #tag-3 and a [[seed-1]] link and ${'more words '.repeat(30)}.\n`,
+    );
+  });
+});

--- a/tests/main/graph/n3-cache.bench.ts
+++ b/tests/main/graph/n3-cache.bench.ts
@@ -1,11 +1,10 @@
 /**
- * Manual benchmark for the N3 store cache (#334). Not run by `pnpm test` —
- * invoke with:
+ * Graph query-latency benchmark for the N3 store cache (#334, #1004). Not run
+ * by `pnpm test` (that includes only `*.test.ts`) — invoke with `pnpm bench`.
  *
- *     pnpm vitest run --config vitest.bench.config.ts tests/main/graph/n3-cache.bench.ts
- *
- * (or just port the script body to a one-shot tsx call). Kept here as
- * documentation of the relative cost we paid before vs. after.
+ * Measures SPARQL query cost once the N3 mirror is warm (cache hit) — the
+ * common case behind panel refreshes — documenting the cost the cache buys and
+ * guarding a regression in it.
  */
 
 import { describe, bench, beforeAll } from 'vitest';
@@ -15,7 +14,7 @@ import os from 'node:os';
 import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
-describe.skip('N3 cache benchmark', () => {
+describe('N3 cache query benchmark', () => {
   let root: string;
   let ctx: ProjectContext;
 

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Standalone config for `pnpm bench` (vitest benchmark mode, #1004).
+ *
+ * Kept apart from vitest.config.mts so the `*.bench.ts` files never run in the
+ * gating `pnpm test` / coverage passes (those include only `*.test.ts`), and so
+ * a bench run skips the svelte plugin the main config loads for component tests.
+ *
+ * Non-gating: run manually (`pnpm bench`) or from the scheduled `Bench` workflow
+ * — never on PR CI (benchmarks are noisy on shared runners). The point is to
+ * make scale regressions visible — graph index/query latency and embedding
+ * throughput, the costs that grow with the knowledge base.
+ */
+export default defineConfig({
+  test: {
+    benchmark: {
+      include: ['tests/**/*.bench.ts'],
+    },
+  },
+});


### PR DESCRIPTION
Closes #1004.

Bundle-budget guards startup size, but nothing guarded **graph/query/embedding latency** — the costs that degrade a knowledge-base IDE as vaults grow, and exactly the kind of regression that slips through unit tests. Adds a small `*.bench.ts` set, a `pnpm bench` runner, and a non-gating scheduled job.

## What's added

| | |
|---|---|
| **runner** | `vitest.bench.config.ts` + `pnpm bench` (`vitest bench --run`). Benches match `tests/**/*.bench.ts`, which the gating `pnpm test` / coverage globs (`*.test.ts`) never pick up — so benchmarks stay out of PR CI. |
| **graph query** | un-skipped the existing `n3-cache.bench.ts` (warm-mirror SPARQL cost). It referenced a `vitest.bench.config.ts` that never existed; now actually runnable. |
| **graph index** | new `graph-index.bench.ts` — per-note `indexNote` cost, re-indexed **in place** against a 500-note store (steady-state, not a monotonically growing store). |
| **embedding throughput** | new `pooling.bench.ts` — `meanPoolNormalize` (seq=512, dim=384) and `cosineSimilarity` scoring a query against a **10k-vector corpus**, the two loops behind local semantic search. |
| **job** | `.github/workflows/bench.yml` — `workflow_dispatch` + a **weekly cron**, **not** `pull_request`/`push`. Micro-benchmarks are noisy on shared runners, so this never gates a PR; read the numbers in the job log. |

## Verification

- `pnpm bench` → runs all four benchmarks (embedding pooling + similarity, graph index, graph query).
- `pnpm test tests/main/graph` → 36 files / 341 tests, **benches excluded** (the `*.test.ts` glob doesn't match `*.bench.ts`).
- `pnpm lint` → 0/0/0.

Keeps the "make regressions visible, don't gate on them" intent — the job reports, it doesn't block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)