### PR TITLE
design: round-2 consistency & drift fixes (#1118–#1122)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,6 +12,12 @@ if [ "$SKIP_HOOKS" = "1" ]; then
   exit 0
 fi
 
+echo "→ pre-push: pnpm lint:fonts (skip with --no-verify)…"
+if ! pnpm lint:fonts; then
+  echo "✗ pre-push: hardcoded mono font literal found — use var(--font-mono). See reports/design-review-2.md §2." >&2
+  exit 1
+fi
+
 echo "→ pre-push: pnpm lint (skip with --no-verify)…"
 if ! pnpm lint; then
   echo "✗ pre-push: lint failed — push aborted. Fix it, or bypass with: git push --no-verify" >&2

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "tsc --noEmit && svelte-check --threshold error && eslint .",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
+    "lint:fonts": "! grep -rnE \"SF Mono|Fira Code|SFMono-Regular|'Cascadia\" src/renderer --include=*.svelte --include=*.ts | grep -v 'appearance/settings.ts'",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage --test-timeout=30000",

--- a/src/renderer/lib/components/AboutDialog.svelte
+++ b/src/renderer/lib/components/AboutDialog.svelte
@@ -40,7 +40,7 @@
       <div class="brand">
         <div class="eyebrow">About</div>
         <h2 class="title" id="about-title">Minerva</h2>
-        <p class="tagline">Thoughts Worth Keeping</p>
+        <p class="tagline">Thoughts worth keeping.</p>
       </div>
     </header>
 
@@ -137,6 +137,7 @@
   }
   .tagline {
     margin: 6px 0 0;
+    font-family: var(--font-display);
     font-size: 13.5px;
     font-style: italic;
     color: var(--text-muted);

--- a/src/renderer/lib/components/ComputeDraftCard.svelte
+++ b/src/renderer/lib/components/ComputeDraftCard.svelte
@@ -259,7 +259,7 @@
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: 4px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
     font-size: 12px;
     color: var(--text);
     white-space: pre;
@@ -278,7 +278,7 @@
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: 4px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
     font-size: 12px;
     color: var(--text);
     resize: vertical;
@@ -320,11 +320,11 @@
   .compute-output-error {
     color: var(--text);
     font-size: 12px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
   }
   .compute-output-text {
     margin: 0;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
     font-size: 11px;
     color: var(--text);
     white-space: pre-wrap;

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -144,6 +144,16 @@
         onDoiClick,
     }: Props = $props();
 
+    // §-numeral opt-in (#1120). The decimal-leading-zero "§ 01" H2 counter
+    // only makes sense for long-form/essay notes, so it's gated on a
+    // `numbered: true` frontmatter flag rather than firing on every note
+    // (a journal or grocery list shouldn't grow section numerals). A
+    // targeted regex over the frontmatter block is enough for one boolean.
+    const numbered = $derived.by(() => {
+        const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
+        return fm ? /^\s*numbered:\s*true\s*$/m.test(fm) : false;
+    });
+
     // Per-fence collapse state, keyed by the fence's opening line in the
     // source markdown. Survives doc-edit re-renders (line numbers may
     // shift, but the user toggling collapse means "I'm done with this
@@ -1727,6 +1737,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 <!-- svelte-ignore a11y_mouse_events_have_key_events -->
 <div
         class="preview"
+        class:numbered
         bind:this={previewEl}
         onclick={handleClick}
         oncontextmenu={handlePreviewContextMenu}
@@ -1884,7 +1895,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     .cite-tooltip :global(.tt-meta) {
         font-size: 12px;
         color: var(--text-muted);
-        font-family: 'SF Mono', 'Fira Code', monospace;
+        font-family: var(--font-mono);
     }
 
     .cite-tooltip :global(.tt-quote) {
@@ -1925,9 +1936,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     }
 
     /* Heading scale per IMPLEMENTATION.md §8.1. H1/H2/H3 in the display
-       serif; H2 carries a § numeral eyebrow rendered via a CSS counter,
-       so any section markdown source (## …) shows up as "§ 01 Heading". */
-    .preview {
+       serif. The § numeral eyebrow (rendered via a CSS counter) is opt-in
+       per note (#1120): only `.preview.numbered` — set from a
+       `numbered: true` frontmatter flag — resets/increments the counter and
+       shows the "§ 01" prefix. The serif H2 itself stays unconditional. */
+    .preview.numbered {
         counter-reset: h2;
     }
 
@@ -1949,10 +1962,13 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         font-weight: 500;
         letter-spacing: -0.01em;
         margin: 24px 0 12px;
+    }
+
+    .preview.numbered :global(h2) {
         counter-increment: h2;
     }
 
-    .preview :global(h2)::before {
+    .preview.numbered :global(h2)::before {
         content: '§ ' counter(h2, decimal-leading-zero);
         font-family: var(--font-mono);
         font-size: 11px;

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -234,7 +234,7 @@
         EditorView.theme({
           '&': { height: '100%' },
           '.cm-content': {
-            fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
+            fontFamily: 'var(--font-mono)',
             fontSize: '13px',
             lineHeight: '1.5',
           },

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -3,6 +3,9 @@
   import { api } from '../ipc/client';
   import Preview from './Preview.svelte';
   import ExcerptDensityGutter from './ExcerptDensityGutter.svelte';
+  import Icon from './Icon.svelte';
+  import Eyebrow from './ui/Eyebrow.svelte';
+  import Chip from './ui/Chip.svelte';
   import { renderInlineWithMath } from '../markdown/inline-math';
   import type { SourceDetail, SourceExcerpt, SourceBacklink, ReadStatus } from '../../../shared/types';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
@@ -403,7 +406,7 @@
       {#if onInvokeTool && hasSourceTools}
         <div class="tools-menu">
           <button class="tools-btn" onclick={() => (toolMenuOpen = !toolMenuOpen)} aria-haspopup="menu" aria-expanded={toolMenuOpen}>
-            Tools <span class="caret">▾</span>
+            Tools <span class="caret"><Icon name="chevronDown" size={11} /></span>
           </button>
           {#if toolMenuOpen}
             <button type="button" class="tools-backdrop" aria-label="Close menu" onclick={() => (toolMenuOpen = false)}></button>
@@ -429,10 +432,12 @@
       {/if}
       <div class="source-tags">
         {#each detail.metadata.tags as tag (tag)}
-          <span class="tag-chip">
+          <Chip>
             #{tag}
-            <button class="tag-remove" title="Remove tag" onclick={() => handleRemoveTag(tag)}>×</button>
-          </span>
+            <button class="tag-remove" title="Remove tag" onclick={() => handleRemoveTag(tag)}>
+              <Icon name="close" size={11} />
+            </button>
+          </Chip>
         {/each}
         {#if addingTag}
           <input
@@ -450,7 +455,7 @@
             {/each}
           </datalist>
         {:else}
-          <button class="add-tag-btn" onclick={startAddTag}>+ tag</button>
+          <button class="add-tag-btn" onclick={startAddTag}><Icon name="plus" size={11} /> tag</button>
         {/if}
       </div>
       {#if detail.metadata.stubStatus === 'unresolved' && onResolveStub}
@@ -531,7 +536,7 @@
 
     {#if detail.metadata.abstract}
       <section class="abstract">
-        <h2>Abstract</h2>
+        <div class="sect-head"><Eyebrow>Abstract</Eyebrow></div>
         <p>{@html renderInlineWithMath(detail.metadata.abstract)}</p>
       </section>
     {/if}
@@ -539,7 +544,7 @@
     {#if bodyLoaded && (bodyContent !== null || editMode)}
       <section class="body">
         <div class="body-header">
-          <h2>Content</h2>
+          <Eyebrow>Content</Eyebrow>
           {#if !editMode}
             <button class="body-edit" onclick={enterEditMode}>Edit body</button>
           {/if}
@@ -607,7 +612,7 @@
     {/if}
 
     <section>
-      <h2>Excerpts ({detail.excerpts.length})</h2>
+      <div class="sect-head"><Eyebrow>Excerpts <span class="ct">{detail.excerpts.length}</span></Eyebrow></div>
       {#if detail.excerpts.length === 0}
         <p class="muted">No excerpts linked to this source yet.</p>
       {:else}
@@ -656,7 +661,7 @@
 
     <section>
       <div class="section-header">
-        <h2>Notes ({detail.aboutNotes.length})</h2>
+        <Eyebrow>Notes <span class="ct">{detail.aboutNotes.length}</span></Eyebrow>
         {#if onCreateAboutNote}
           <button class="section-action" disabled={creatingAbout} onclick={handleNewAboutNote}>
             {creatingAbout ? 'Creating…' : 'New note about this source'}
@@ -681,7 +686,7 @@
 
     {#if detail.references.length > 0}
       <section>
-        <h2>References ({detail.references.length})</h2>
+        <div class="sect-head"><Eyebrow>References <span class="ct">{detail.references.length}</span></Eyebrow></div>
         <ul class="about-list">
           {#each detail.references as ref (ref.sourceId)}
             <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -698,7 +703,7 @@
     {/if}
 
     <section>
-      <h2>Referenced from ({detail.backlinks.length})</h2>
+      <div class="sect-head"><Eyebrow>Referenced from <span class="ct">{detail.backlinks.length}</span></Eyebrow></div>
       {#if detail.backlinks.length === 0}
         <p class="muted">No notes reference this source.</p>
       {:else}
@@ -746,6 +751,9 @@
     right: 0;
   }
   .tools-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     padding: 4px 10px;
     border: 1px solid var(--border);
     border-radius: 4px;
@@ -755,7 +763,7 @@
     cursor: pointer;
   }
   .tools-btn:hover { background: var(--bg-button-hover); }
-  .tools-btn .caret { color: var(--text-muted); margin-left: 2px; }
+  .tools-btn .caret { display: inline-flex; align-items: center; color: var(--text-muted); }
   .tools-backdrop {
     position: fixed;
     inset: 0;
@@ -812,23 +820,28 @@
   }
 
   h1 {
-    font-size: 26px;
-    font-weight: 600;
+    font-family: var(--font-display);
+    font-size: 30px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
     margin: 0 0 6px;
   }
 
-  h2 {
-    font-size: 15px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-muted);
+  /* Section headings use the shared Eyebrow primitive (#1119). The wrapper
+     just restores the vertical rhythm the old <h2> margin provided; the
+     count renders in accent. */
+  .sect-head {
     margin: 24px 0 12px;
+  }
+  .ct {
+    color: var(--accent);
   }
 
   .byline {
+    font-family: var(--font-display);
+    font-style: italic;
     color: var(--text-muted);
-    font-size: 14px;
+    font-size: 15px;
   }
 
   /* Tag editor (#766) */
@@ -839,33 +852,30 @@
     gap: 6px;
     margin-top: 8px;
   }
-  .tag-chip {
+  /* Remove-tag glyph inside the shared Chip (#1119) — an <Icon name="close">
+     rather than a bare ×. */
+  .tag-remove {
     display: inline-flex;
     align-items: center;
-    gap: 3px;
-    padding: 1px 4px 1px 7px;
-    border-radius: 10px;
-    background: var(--bg-button);
-    color: var(--text);
-    font-size: 12px;
-  }
-  .tag-remove {
     border: none;
     background: none;
     color: var(--text-muted);
     cursor: pointer;
-    font-size: 13px;
     line-height: 1;
-    padding: 0 2px;
+    padding: 0;
+    margin: 0 -2px 0 1px;
   }
   .tag-remove:hover { color: var(--text); }
   .add-tag-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
     border: 1px dashed var(--border);
     background: none;
     color: var(--text-muted);
-    border-radius: 10px;
+    border-radius: 999px;
     font-size: 12px;
-    padding: 1px 8px;
+    padding: 2px 9px;
     cursor: pointer;
   }
   .add-tag-btn:hover { color: var(--text); border-color: var(--text-muted); }
@@ -873,7 +883,7 @@
     border: 1px solid var(--accent);
     background: var(--bg);
     color: var(--text);
-    border-radius: 10px;
+    border-radius: 999px;
     font-size: 12px;
     padding: 1px 8px;
     width: 100px;
@@ -981,7 +991,7 @@
     word-break: break-word;
   }
   .mono {
-    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
   }
 
@@ -992,7 +1002,9 @@
   .external:hover { text-decoration: underline; }
 
   .abstract p {
-    font-size: 14px;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 15px;
     color: var(--text-muted);
     margin: 0;
   }
@@ -1242,7 +1254,6 @@
     gap: 12px;
     margin: 0 0 8px;
   }
-  .section-header h2 { margin: 0; }
   .section-action {
     font-family: var(--font-sans);
     font-size: 12px;
@@ -1324,7 +1335,7 @@
     background: var(--bg-button);
     padding: 1px 5px;
     border-radius: 3px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-family: var(--font-mono);
     font-size: 13px;
   }
 

--- a/src/renderer/lib/components/TablesPanel.svelte
+++ b/src/renderer/lib/components/TablesPanel.svelte
@@ -162,7 +162,7 @@
   }
 
   .table-name {
-    font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+    font-family: var(--font-mono);
     font-weight: 500;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -150,10 +150,14 @@ export const ICONS = {
     '<path d="M8.5 4 13 8 8.5 12z" fill="currentColor" stroke="none"/>',
 
   // ── Brand ─────────────────────────────────────────────────────────
+  // A crop of the app owl's eye looking back (#1121): outer socket ring,
+  // honey (accent) iris fill, dark pupil, catchlight. Inherits currentColor so
+  // it takes the accent in the title bar and the muted tone elsewhere.
   minervaMark:
-    '<circle cx="8" cy="8" r="6"/>' +
-    '<circle cx="8" cy="8" r="2.5"/>' +
-    '<circle cx="8" cy="8" r=".8" fill="currentColor" stroke="none"/>',
+    '<circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.4"/>' +
+    '<circle cx="8" cy="8" r="4.2" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.2"/>' +
+    '<circle cx="8" cy="8" r="1.7" fill="currentColor" stroke="none"/>' +
+    '<circle cx="7.2" cy="7.2" r="0.6" fill="#fff" fill-opacity="0.7" stroke="none"/>',
 } as const;
 
 export type IconName = keyof typeof ICONS;

--- a/src/renderer/lib/components/right-sidebar/AutocompleteDropdown.svelte
+++ b/src/renderer/lib/components/right-sidebar/AutocompleteDropdown.svelte
@@ -220,7 +220,7 @@
     font-size: 12px;
     color: var(--text);
     cursor: pointer;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -881,7 +881,7 @@
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: 3px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
     font-size: 11px;
     color: var(--text-muted);
     white-space: pre-wrap;
@@ -1001,7 +1001,7 @@
   }
   .error .message {
     color: var(--text-muted);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
     font-size: 11px;
     white-space: pre-wrap;
     margin-bottom: 4px;

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -472,7 +472,7 @@
     min-width: 90px;
   }
   .payload-summary {
-    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-family: var(--font-mono);
     font-size: 11px;
     flex: 1;
     overflow: hidden;
@@ -489,7 +489,7 @@
     border: 1px solid var(--border);
     border-radius: 3px;
     font-size: 11px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-family: var(--font-mono);
     color: var(--text);
     white-space: pre-wrap;
     word-wrap: break-word;


### PR DESCRIPTION
Design-review round 2 (consistency & drift) — the five smaller fixes from `reports/design-review-2.md` §2–§6. `#1117` (the oneDark → token-driven HighlightStyle rewrite) follows in a separate PR.

## What's here

**#1118 — Font consistency (§2).** Seven surfaces hardcoded an `SF Mono` / `Menlo` stack; each now uses `var(--font-mono)`: Preview cite-tooltip, SourceDetail, ProposalsPanel, QueryPanel (results grid + CodeMirror config), PropertiesPanel, ComputeDraftCard, AutocompleteDropdown. Also cleaned a redundant `SFMono-Regular` fallback in TablesPanel. Added a `lint:fonts` grep guard and wired it into `.githooks/pre-push` **before** `pnpm lint`.
- The guard excludes `appearance/settings.ts`, whose font-picker presets legitimately name concrete fonts (`SF Mono`, `Fira Code`, …) as user-selectable options — that's a feature, not a token violation. Implemented via a `| grep -v 'appearance/settings.ts'` on the pipeline so `.ts` coverage is retained everywhere else.

**#1119 — SourceDetail typography (§3).** Brought the source reading surface in line with the note surface: title → `var(--font-display)` 30/500/`-0.01em`; byline → italic display serif in `--text-muted`; section headings → shared **Eyebrow** primitive with accent counts; tags → shared **Chip** primitive with `<Icon name="close">` / `<Icon name="plus">` (no `×` / `+` glyphs); Tools caret → `<Icon name="chevronDown" size={11}>`; abstract body → italic display serif.

**#1120 — § numeral opt-in (§4).** The `§ 01` H2 counter fired on every note. Now gated behind a `numbered: true` frontmatter flag (`.preview.numbered`); the serif H2 itself stays unconditional. No source-mode decoration exists, so nothing to gate there.

**#1121 — minervaMark (§5).** Redrawn as a crop of the app owl's eye (socket ring, honey iris, pupil, catchlight). Still resolves to `currentColor`; `minerva-icon.svg` untouched.

**#1122 — Tagline casing (§6).** `AboutDialog` → "Thoughts worth keeping." (sentence case, trailing full stop, italic display serif). It was the only occurrence in the repo.

## Verification
- `pnpm lint` clean (tsc + svelte-check + eslint).
- `pnpm lint:fonts` passes; confirmed it fails on a reintroduced `Fira Code` literal and passes again once removed.
- Source-detail + source-actions tests pass.

Closes #1118, #1119, #1120, #1121, #1122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)