### PR TITLE
design: single token-driven CodeMirror highlight, drop oneDark (#1117)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
   "devDependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
-    "@codemirror/theme-one-dark": "^6.1.3",
     "@electron-forge/cli": "^7.11.2",
     "@electron-forge/maker-dmg": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,9 +139,6 @@ importers:
       '@codemirror/language-data':
         specifier: ^6.5.2
         version: 6.5.2
-      '@codemirror/theme-one-dark':
-        specifier: ^6.1.3
-        version: 6.1.3
       '@electron-forge/cli':
         specifier: ^7.11.2
         version: 7.11.2(encoding@0.1.13)(esbuild@0.28.1)
@@ -394,9 +391,6 @@ packages:
 
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
-
-  '@codemirror/theme-one-dark@6.1.3':
-    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
   '@codemirror/view@6.43.1':
     resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
@@ -6850,13 +6844,6 @@ snapshots:
   '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
-
-  '@codemirror/theme-one-dark@6.1.3':
-    dependencies:
-      '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
-      '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.43.1':
     dependencies:

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -14,7 +14,7 @@
     import type Token from 'markdown-it/lib/token.mjs';
     import type StateBlock from 'markdown-it/lib/rules_block/state_block.mjs';
     import hljs from 'highlight.js';
-    import 'highlight.js/styles/github-dark.min.css';
+    import '../../styles/hljs-minerva.css';
     import 'katex/dist/katex.min.css';
     import {installMath} from '../../../shared/markdown/math-plugin';
     import {installDoiAutolink} from '../../../shared/markdown/doi-plugin';

--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -7,14 +7,10 @@
     bracketMatching,
     indentUnit,
     StreamLanguage,
-    syntaxHighlighting,
-    HighlightStyle,
   } from '@codemirror/language';
-  import { tags as t } from '@lezer/highlight';
   import { sparql } from '@codemirror/legacy-modes/mode/sparql';
   import { sql, PostgreSQL } from '@codemirror/lang-sql';
-  import { oneDark } from '@codemirror/theme-one-dark';
-  import { getEffectiveTheme, getThemeMode } from '../theme';
+  import { minervaSurfaceTheme, minervaSyntaxHighlighting } from '../editor/minerva-highlight';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import type { QueryTab, QueryLanguage } from '../stores/editor.svelte';
   import { api } from '../ipc/client';
@@ -160,50 +156,17 @@
     return autocompletion({ defaultKeymap: false, override: [createSparqlCompletionSource(() => schema)] });
   }
 
-  function isDark(): boolean {
-    return getEffectiveTheme(getThemeMode()) === 'dark';
-  }
-
+  // The query editor shares the note editor's single token-driven surface +
+  // highlight (#1117), so SPARQL / SQL land on the same warm palette (iris
+  // keywords, honey functions, sage strings, rust numbers, muted punctuation)
+  // as code fences and the note editor — no more cold oneDark box. The colors
+  // are `var()` tokens, so all three themes re-skin live.
   function cmTheme(): Extension {
-    return isDark() ? oneDark : [];
+    return minervaSurfaceTheme();
   }
-
-  // Custom SPARQL palette — Catppuccin-inspired, with deliberately wide hue
-  // distance so the four things you scan for in a query (keywords, variables,
-  // IRIs/prefixed names, string literals) land on four different points of
-  // the color wheel. Two variants so contrast holds on both backgrounds.
-
-  // Mocha (dark): saturated pastels that read on a dark editor.
-  const sparqlHighlightDark = HighlightStyle.define([
-    { tag: t.keyword, color: '#cba6f7', fontWeight: '600' },                                  // purple
-    { tag: [t.variableName, t.labelName], color: '#f9e2af' },                                 // yellow
-    { tag: t.atom, color: '#89dceb' },                                                        // sky
-    { tag: [t.standard(t.variableName), t.function(t.variableName)], color: '#89b4fa' },     // blue
-    { tag: t.string, color: '#a6e3a1' },                                                      // green
-    { tag: t.number, color: '#fab387' },                                                      // peach
-    { tag: t.meta, color: '#94e2d5' },                                                        // teal
-    { tag: t.operator, color: 'inherit' },
-    { tag: [t.bracket, t.punctuation], color: '#9399b2' },
-    { tag: t.comment, color: '#6c7086', fontStyle: 'italic' },
-  ]);
-
-  // Latte (light): darker, more saturated hues so they read on white. Yellow
-  // is replaced with maroon/red for variables — yellow-on-white is unreadable.
-  const sparqlHighlightLight = HighlightStyle.define([
-    { tag: t.keyword, color: '#8839ef', fontWeight: '600' },                                  // mauve
-    { tag: [t.variableName, t.labelName], color: '#c92f5a' },                                 // deep rose
-    { tag: t.atom, color: '#0370a1' },                                                        // deep sky
-    { tag: [t.standard(t.variableName), t.function(t.variableName)], color: '#1e66f5' },     // blue
-    { tag: t.string, color: '#2d7d1f' },                                                      // deep green
-    { tag: t.number, color: '#d13f00' },                                                      // burnt orange
-    { tag: t.meta, color: '#117276' },                                                        // deep teal
-    { tag: t.operator, color: 'inherit' },
-    { tag: [t.bracket, t.punctuation], color: '#7a7f91' },
-    { tag: t.comment, color: '#6c6f85', fontStyle: 'italic' },
-  ]);
 
   function cmHighlight(): Extension {
-    return syntaxHighlighting(isDark() ? sparqlHighlightDark : sparqlHighlightLight);
+    return minervaSyntaxHighlighting();
   }
 
   /** Replace the editor contents with `text` without triggering the onQueryChange callback. */
@@ -224,9 +187,8 @@
         bracketMatching(),
         indentUnit.of('  '),
         languageCompartment.of(languageExt(tab.language)),
-        // Custom highlighter \u2014 dark vs light palette swapped via compartment
-        // whenever the theme changes. Non-fallback so it overrides oneDark's
-        // own mappings in dark mode.
+        // Shared token-driven highlighter, in a compartment so the theme-change
+        // hook can reconfigure it. Non-fallback, so it wins over any base style.
         highlightCompartment.of(cmHighlight()),
         placeholderCompartment.of(placeholder(placeholderFor(tab.language))),
         completionCompartment.of(completionFor(tab.language)),

--- a/src/renderer/lib/editor/editor-theme.ts
+++ b/src/renderer/lib/editor/editor-theme.ts
@@ -8,18 +8,19 @@
 
 import { EditorView } from '@codemirror/view';
 import type { Extension } from '@codemirror/state';
-import { oneDark } from '@codemirror/theme-one-dark';
-import { getEffectiveTheme, getThemeMode } from '../theme';
+import { minervaSurfaceTheme, minervaSyntaxHighlighting } from './minerva-highlight';
 
-/** oneDark in dark mode, an empty base in light/contrast — `minervaEditorTheme`
- *  layers the shared tokens on top either way. */
+/** The token-driven surface chrome + shared syntax highlight (#1117), replacing
+ *  the old `oneDark` (dark) / empty (light) split. One palette for every theme;
+ *  `minervaEditorTheme` layers the gutter / active-line tokens on top. Kept as a
+ *  function so it can be reconfigured through the theme compartment on a theme
+ *  swap (a no-op for the `var()`-based colors, which re-skin live). */
 export function cmTheme(): Extension {
-  return getEffectiveTheme(getThemeMode()) === 'dark' ? oneDark : [];
+  return [minervaSurfaceTheme(), minervaSyntaxHighlighting()];
 }
 
 /** Minerva-specific gutter + active-line styling per IMPLEMENTATION.md §8.2.
- *  Layered on top of `cmTheme()` so both dark oneDark and the empty light base
- *  inherit the same tokens. */
+ *  Layered on top of `cmTheme()`'s token-driven surface + highlight. */
 export function minervaEditorTheme(): Extension {
   return EditorView.theme({
     '.cm-gutters': {

--- a/src/renderer/lib/editor/minerva-highlight.ts
+++ b/src/renderer/lib/editor/minerva-highlight.ts
@@ -1,0 +1,148 @@
+/**
+ * The single token-driven CodeMirror highlight + surface theme (#1117).
+ *
+ * Replaces the off-the-shelf `oneDark` theme, which ignored every design token
+ * and dropped a cold `#282c34` slab with `#c678dd`/`#61afef`/`#98c379` syntax
+ * colors into the warm "Honey" chrome. One `HighlightStyle`, shared by the note
+ * editor (`editor-theme.ts`) and the query panel (`QueryPanel.svelte`), keeps
+ * every code surface on the same palette.
+ *
+ * Colors are `var(--token)` references, not resolved hex. CodeMirror's
+ * `HighlightStyle`/`EditorView.theme` emit their rules through a StyleModule —
+ * plain CSS the browser resolves at paint — so `var(--iris)` re-skins live on a
+ * theme swap with no rebuild, exactly as `minervaEditorTheme()`'s `var(--bg)`
+ * gutters already do. (The theme-change hooks still reconfigure their
+ * compartments; with `var()` colors that's simply a no-op for the palette.)
+ *
+ * Palette (tokens defined per theme in global.css, AA-verified on --bg-inset in
+ * dark/light/contrast): iris keywords, honey/accent functions & headings, sage
+ * strings, rust numbers/atoms, faint-italic comments, muted operators &
+ * punctuation.
+ */
+
+import { EditorView } from '@codemirror/view';
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+import type { Extension } from '@codemirror/state';
+
+/** The shared token-driven highlight style. Stable (colors are `var()`), so a
+ *  single instance serves every editor and re-skins via the CSS cascade. */
+export const minervaHighlightStyle = HighlightStyle.define([
+  // Keywords & control flow → iris.
+  {
+    tag: [
+      t.keyword,
+      t.controlKeyword,
+      t.operatorKeyword,
+      t.definitionKeyword,
+      t.moduleKeyword,
+      t.modifier,
+      t.self,
+    ],
+    color: 'var(--iris)',
+  },
+  // Types, classes, namespaces, markup tags → iris (structural, like keywords).
+  {
+    tag: [t.typeName, t.className, t.namespace, t.tagName],
+    color: 'var(--iris)',
+  },
+  // Functions, definitions, labels → honey (accent).
+  {
+    tag: [
+      t.function(t.variableName),
+      t.function(t.propertyName),
+      t.definition(t.function(t.variableName)),
+      t.labelName,
+      t.macroName,
+    ],
+    color: 'var(--accent)',
+  },
+  // Plain identifiers → body text.
+  {
+    tag: [t.variableName, t.propertyName, t.attributeName],
+    color: 'var(--text)',
+  },
+  // Strings, regexps, links → sage.
+  {
+    tag: [t.string, t.special(t.string), t.regexp, t.link, t.url],
+    color: 'var(--sage)',
+  },
+  // Numbers, booleans, atoms, escapes → rust.
+  {
+    tag: [t.number, t.integer, t.float, t.bool, t.atom, t.null, t.escape, t.character],
+    color: 'var(--rust)',
+  },
+  // Comments → faint italic.
+  {
+    tag: [t.comment, t.lineComment, t.blockComment, t.docComment],
+    color: 'var(--text-faint)',
+    fontStyle: 'italic',
+  },
+  // Operators, punctuation, brackets, meta → muted.
+  {
+    tag: [
+      t.operator,
+      t.derefOperator,
+      t.arithmeticOperator,
+      t.logicOperator,
+      t.compareOperator,
+      t.bitwiseOperator,
+      t.punctuation,
+      t.separator,
+      t.bracket,
+      t.squareBracket,
+      t.paren,
+      t.brace,
+      t.meta,
+      t.annotation,
+    ],
+    color: 'var(--text-muted)',
+  },
+  // Markdown inline structure.
+  { tag: t.heading, color: 'var(--accent)', fontWeight: '600' },
+  { tag: t.strong, fontWeight: '600' },
+  { tag: t.emphasis, fontStyle: 'italic' },
+  { tag: t.strikethrough, textDecoration: 'line-through' },
+  // Errors → rust (a signal color, not alarm red, per the UI philosophy).
+  { tag: t.invalid, color: 'var(--rust)' },
+]);
+
+/** The shared highlighter extension for any CodeMirror instance. Non-fallback,
+ *  so it wins over basicSetup's `defaultHighlightStyle` (which is registered as
+ *  a fallback and only fills tags this style doesn't map). */
+export function minervaSyntaxHighlighting(): Extension {
+  return syntaxHighlighting(minervaHighlightStyle);
+}
+
+/** Token-driven surface chrome (background, cursor, selection, matches) that
+ *  `oneDark` used to supply. Layered under `minervaEditorTheme()`'s gutter /
+ *  active-line rules. Shared by the note editor and the query panel. */
+export function minervaSurfaceTheme(): Extension {
+  return EditorView.theme({
+    '&': {
+      color: 'var(--text)',
+      backgroundColor: 'var(--bg)',
+    },
+    '.cm-content': {
+      caretColor: 'var(--accent)',
+    },
+    '.cm-cursor, .cm-dropCursor': {
+      borderLeftColor: 'var(--accent)',
+    },
+    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection':
+      {
+        backgroundColor: 'color-mix(in oklch, var(--accent) 22%, transparent)',
+      },
+    '.cm-selectionMatch': {
+      backgroundColor: 'color-mix(in oklch, var(--accent) 16%, transparent)',
+    },
+    '&.cm-focused .cm-matchingBracket, .cm-matchingBracket': {
+      backgroundColor: 'color-mix(in oklch, var(--accent) 20%, transparent)',
+      color: 'inherit',
+      outline: '1px solid color-mix(in oklch, var(--accent) 40%, transparent)',
+    },
+    '.cm-nonmatchingBracket': {
+      backgroundColor: 'color-mix(in oklch, var(--rust) 22%, transparent)',
+    },
+  });
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -87,6 +87,12 @@
   --accent:        oklch(0.500 0.150 65);
   --accent-dim:    oklch(0.620 0.105 65);
   --accent-ink:    #ffffff;
+  /* Signal hues — darkened for this theme so they clear WCAG AA (4.5:1) on the
+     white --bg-inset when used as syntax colors (#1117). Without these, they'd
+     inherit the dark theme's light values and fail contrast on white. */
+  --sage:          oklch(0.440 0.080 148);
+  --rust:          oklch(0.500 0.140 38);
+  --iris:          oklch(0.450 0.110 280);
   /* Contrast theme keeps its dark title bar over a light body */
   --bg-titlebar:           #3a3a4a;
   --titlebar-text:         #ffffff;

--- a/src/renderer/styles/hljs-minerva.css
+++ b/src/renderer/styles/hljs-minerva.css
@@ -1,0 +1,94 @@
+/*
+ * Token-driven highlight.js theme for rendered code fences (#1117).
+ *
+ * Replaces `highlight.js/styles/github-dark.min.css`, whose cold GitHub palette
+ * ignored every design token. Mirrors the CodeMirror `minervaHighlightStyle`
+ * mapping so preview fences, the note editor, and the query panel all read the
+ * same: iris keywords, honey/accent functions, sage strings, rust numbers,
+ * faint-italic comments, muted operators & punctuation. Colors are `var()`
+ * tokens, so fences re-skin live across dark / light / contrast — and the fence
+ * background stays whatever Preview's `pre`/`code` rules set (var(--bg-inset)).
+ */
+
+.hljs {
+  color: var(--text);
+  background: transparent;
+}
+
+/* Comments → faint italic. */
+.hljs-comment,
+.hljs-quote {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+/* Keywords, types, markup tags → iris. */
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-type,
+.hljs-tag,
+.hljs-name,
+.hljs-meta .hljs-keyword {
+  color: var(--iris);
+}
+
+/* Functions, definitions, object keys, headings → honey (accent). */
+.hljs-title,
+.hljs-title.function_,
+.hljs-title.class_,
+.hljs-built_in,
+.hljs-attr,
+.hljs-attribute,
+.hljs-section {
+  color: var(--accent);
+}
+
+/* Plain identifiers → body text. */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-subst,
+.hljs-params {
+  color: var(--text);
+}
+
+/* Strings, regexps, links, additions → sage. */
+.hljs-string,
+.hljs-regexp,
+.hljs-link,
+.hljs-addition,
+.hljs-meta .hljs-string {
+  color: var(--sage);
+}
+
+/* Numbers, literals, atoms, deletions → rust. */
+.hljs-number,
+.hljs-literal,
+.hljs-symbol,
+.hljs-deletion {
+  color: var(--rust);
+}
+
+/* Meta, operators, punctuation, bullets → muted. */
+.hljs-meta,
+.hljs-operator,
+.hljs-punctuation,
+.hljs-bullet,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-comment .hljs-doctag {
+  color: var(--text-muted);
+}
+
+/* Documentation tags read as annotations, not prose. */
+.hljs-doctag {
+  color: var(--iris);
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: 600;
+}

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -34,12 +34,13 @@ const KNOWN_WELCOME = new Set<string>([
   // Clean: --text-faint was lifted to WCAG AA, so no tolerated violations here.
 ]);
 const KNOWN_WORKSPACE = new Set<string>([
-  // Remaining color-contrast is EDITOR-INTERNAL only: CodeMirror's oneDark
-  // theme syntax colors (e.g. its red #e06c75 at 4.38:1) + our link-type badge
-  // decorations (--text-faint) layered on oneDark's #282c34 background. The app
-  // chrome's faint text was lifted to AA (the welcome test enforces it, no
-  // allowlist there). Making the editor fully AA means retuning/replacing the
-  // oneDark theme — its own change; tracked as follow-up.
+  // Remaining color-contrast is EDITOR-INTERNAL only. The oneDark theme was
+  // replaced with the token-driven minervaHighlightStyle (#1117) — every syntax
+  // color is AA-verified on --bg-inset in all three themes — but axe may still
+  // flag editor-internal decorations (e.g. link-type badges) or the honey
+  // function color, which is AA on --bg-inset but 4.33:1 (AA-large) on the
+  // editor's --bg surface in light mode. Kept tolerated pending an editor a11y
+  // sweep; the app chrome's faint text is enforced by the welcome test.
   'color-contrast',
   // CodeMirror's `.cm-scroller` (tabindex=-1); its `.cm-content` editable IS
   // keyboard-focusable, so this axe finding is a known CM quirk, not a real trap.

--- a/tests/renderer/editor-theme.test.ts
+++ b/tests/renderer/editor-theme.test.ts
@@ -6,7 +6,7 @@
  * builds without throwing — catching a broken `EditorView.theme(...)` spec.
  */
 import { describe, it, expect } from 'vitest';
-import { minervaEditorTheme, fontSizeTheme } from '../../src/renderer/lib/editor/editor-theme';
+import { cmTheme, minervaEditorTheme, fontSizeTheme } from '../../src/renderer/lib/editor/editor-theme';
 
 describe('editor-theme builders (#672)', () => {
   it('minervaEditorTheme builds an extension', () => {
@@ -16,6 +16,10 @@ describe('editor-theme builders (#672)', () => {
   it('fontSizeTheme builds an extension for a given size', () => {
     expect(fontSizeTheme(16)).toBeTruthy();
   });
-  // cmTheme reads the theme mode (localStorage/matchMedia) so it's exercised via
-  // the app at runtime, not here — these two are the env-free pure builders.
+
+  // After #1117 cmTheme is env-free (token-driven surface + shared highlight,
+  // no theme-mode read), so it can build here without a DOM.
+  it('cmTheme builds the token-driven surface + highlight', () => {
+    expect(cmTheme()).toBeTruthy();
+  });
 });

--- a/tests/renderer/minerva-highlight.test.ts
+++ b/tests/renderer/minerva-highlight.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Smoke coverage for the single token-driven highlight (#1117), which replaced
+ * the oneDark theme across the note editor + query panel. These return opaque
+ * CodeMirror extensions, so we pin that each builds without throwing and that
+ * the shared HighlightStyle actually maps the palette tokens (a regression that
+ * emptied the spec would still "build", so we assert the token colors too).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  minervaHighlightStyle,
+  minervaSyntaxHighlighting,
+  minervaSurfaceTheme,
+} from '../../src/renderer/lib/editor/minerva-highlight';
+
+describe('minerva-highlight (#1117)', () => {
+  it('exposes a HighlightStyle and extension builders', () => {
+    expect(minervaHighlightStyle).toBeTruthy();
+    expect(minervaSyntaxHighlighting()).toBeTruthy();
+    expect(minervaSurfaceTheme()).toBeTruthy();
+  });
+
+  it('drives syntax colors from design tokens, not hardcoded hex', () => {
+    // HighlightStyle.define compiles the spec into a StyleModule; its rules
+    // carry the color declarations. The palette must be var(--token) so it
+    // re-skins per theme — and must never fall back to oneDark's hex slabs.
+    const css = JSON.stringify(minervaHighlightStyle.module?.getRules() ?? '');
+    expect(css).toContain('var(--iris)');
+    expect(css).toContain('var(--accent)');
+    expect(css).toContain('var(--sage)');
+    expect(css).toContain('var(--rust)');
+    expect(css).toContain('var(--text-faint)');
+    expect(css).not.toContain('#282c34');
+  });
+});


### PR DESCRIPTION
The design-review round-2 "single highest-impact fix" (`reports/design-review-2.md` §7). Replaces the off-the-shelf `oneDark` CodeMirror theme — a cold-blue palette that ignored every design token, dropping a `#282c34` slab with `#c678dd`/`#61afef`/`#98c379` syntax colors into the warm "Honey" paper chrome — with **one** token-driven `HighlightStyle` shared across the note editor, the query panel, and rendered code fences.

## Approach
- **New `src/renderer/lib/editor/minerva-highlight.ts`** — the single source of truth: `minervaHighlightStyle`, `minervaSyntaxHighlighting()`, and `minervaSurfaceTheme()` (background / cursor / selection chrome oneDark used to supply).
- **Colors are `var(--token)`, not resolved hex.** CodeMirror emits `HighlightStyle`/`EditorView.theme` rules through a StyleModule (plain CSS), so `var(--iris)` re-skins **live** on a theme swap — exactly as `minervaEditorTheme()`'s `var(--bg)` gutters already do. This is simpler than the probe-and-rebuild the plan sketched (which assumed CM needs concrete colors); the theme-change hooks still reconfigure their compartments, which is just a no-op for `var()` colors. Palette: iris keywords, honey/accent functions & headings, sage strings, rust numbers/atoms, faint-italic comments, muted operators & punctuation.
- **`editor-theme.ts`** — `cmTheme()` drops the oneDark branch and returns `[minervaSurfaceTheme(), minervaSyntaxHighlighting()]`; now env-free (no theme-mode read).
- **`QueryPanel.svelte`** — drops oneDark and its two bespoke SPARQL `HighlightStyle`s for the shared highlight + surface theme.
- **`Preview.svelte`** — code fences swap `highlight.js/styles/github-dark.min.css` for a token-driven `hljs-minerva.css` mirroring the same palette (fence background already `var(--bg-inset)`).
- **`global.css`** — the contrast theme now defines `--sage`/`--rust`/`--iris` (they were inheriting the dark theme's *light* values → would fail on white).
- **Removed `@codemirror/theme-one-dark`** from package.json + lockfile (no imports remain).

## Why the minerva highlight wins
`basicSetup` registers `syntaxHighlighting(defaultHighlightStyle, { fallback: true })` — a fallback that only fills unmapped tags. The minerva highlight is non-fallback, so it wins for every tag it maps, exactly as oneDark did.

## AA contrast
Every syntax color is AA-verified (≥ 4.5:1) on `--bg-inset` in all three themes (min 5.24:1). Verified with an oklch→sRGB→WCAG script:

| token | dark | light | contrast |
|---|---|---|---|
| iris | 7.00 | 5.87 | 7.68 |
| accent | 9.70 | 4.59 | 6.21 |
| sage | 7.28 | 6.63 | 7.48 |
| rust | 5.97 | 5.55 | 6.40 |
| comment (faint) | 5.42 | 5.40 | 5.63 |

Note: the note-editor content surface is `var(--bg)` (per the plan), where the honey **function** color is 4.33:1 in light mode — AA-large (>3:1) but just under AA-normal. The e2e a11y allowlist keeps `color-contrast` tolerated for editor internals (comment updated); the fence surface (`--bg-inset`) is fully AA.

## Verification
- `pnpm lint` clean; 1046 renderer + publish tests pass.
- New/updated unit tests assert the palette resolves to `var(--token)` and never oneDark hex.
- Publish/export exporters keep their own standalone hljs CSS (separate artifact, out of scope, untouched).
- Recommend a visual pass: open a note with code + a query tab in dark / light / contrast — warm palette everywhere, no `#282c34` box.

Closes #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)