### PR TITLE
design: § numbered headings as an editor setting, not frontmatter (#1120 follow-up)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -66,6 +66,7 @@
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
   import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
+  import { getEditorSettings, saveEditorSettings } from './lib/editor/settings';
   import {
     slugifyForPath,
     flattenNotePaths,
@@ -315,6 +316,9 @@
   }
   let editorFontSize = $state(parseInt(localStorage.getItem('editorFontSize') ?? '14', 10));
   let themeLabel = $state(getThemeMode());
+  // §-numeral heading setting (#1120), mirrored reactively so every Preview
+  // re-skins the moment it's toggled in Settings → Editor.
+  let numberedHeadings = $state(getEditorSettings().numberedHeadings);
   // Generic modal dialogs (prompt / confirm / new-note / snippet / open-target)
   // live in the dialog store (#670); destructure the imperative `show*` helpers
   // so the many call sites read unchanged. <DialogHost> renders the state.
@@ -1426,6 +1430,7 @@
                         bind:this={previewComponents[groupId]}
                         content={note.content}
                         notePath={note.relativePath}
+                        {numberedHeadings}
                         onNavigate={handleNavigate}
                         onTagSelect={handleTagSelect}
                         onOpenSource={handleOpenSource}
@@ -1460,6 +1465,7 @@
                   <SourceDetail
                     sourceId={active.sourceId}
                     highlightExcerptId={active.highlightExcerptId}
+                    {numberedHeadings}
                     onNavigate={handleNavigate}
                     onShowConfirm={showConfirm}
                     onShowPrompt={showPrompt}
@@ -1768,7 +1774,15 @@
   {/if}
   {#if showSettings}
     <SettingsDialog
-      onApplyEditor={(s) => editorComponent?.applySettings(s)}
+      onApplyEditor={(s) => {
+        // applySettings both persists and live-reconfigures the editor, but it
+        // no-ops when no editor view is mounted (e.g. Done pressed on a source
+        // tab). Persist here too so preview-only settings like numberedHeadings
+        // survive regardless, and mirror the value so open previews react now.
+        saveEditorSettings(s);
+        editorComponent?.applySettings(s);
+        numberedHeadings = s.numberedHeadings;
+      }}
       onThemeChanged={() => {
         themeLabel = getThemeMode();
         editorComponent?.updateTheme();

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -123,6 +123,14 @@
          * DOI links open externally like any other link.
          */
         onDoiClick?: (doi: string) => void;
+        /**
+         * §-numeral opt-in (#1120). When true, rendered H2s get a
+         * decimal-leading-zero "§ 01" section numeral. Driven by the
+         * `numberedHeadings` editor setting (Settings → Editor), off by
+         * default — only long-form/essay notes want it, so it isn't forced on
+         * every journal or list.
+         */
+        numberedHeadings?: boolean;
     }
 
     let {
@@ -142,17 +150,8 @@
         onRunCell,
         onApplyCellOutputEdit,
         onDoiClick,
+        numberedHeadings = false,
     }: Props = $props();
-
-    // §-numeral opt-in (#1120). The decimal-leading-zero "§ 01" H2 counter
-    // only makes sense for long-form/essay notes, so it's gated on a
-    // `numbered: true` frontmatter flag rather than firing on every note
-    // (a journal or grocery list shouldn't grow section numerals). A
-    // targeted regex over the frontmatter block is enough for one boolean.
-    const numbered = $derived.by(() => {
-        const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1];
-        return fm ? /^\s*numbered:\s*true\s*$/m.test(fm) : false;
-    });
 
     // Per-fence collapse state, keyed by the fence's opening line in the
     // source markdown. Survives doc-edit re-renders (line numbers may
@@ -1737,7 +1736,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 <!-- svelte-ignore a11y_mouse_events_have_key_events -->
 <div
         class="preview"
-        class:numbered
+        class:numbered={numberedHeadings}
         bind:this={previewEl}
         onclick={handleClick}
         oncontextmenu={handlePreviewContextMenu}
@@ -1937,9 +1936,9 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
     /* Heading scale per IMPLEMENTATION.md §8.1. H1/H2/H3 in the display
        serif. The § numeral eyebrow (rendered via a CSS counter) is opt-in
-       per note (#1120): only `.preview.numbered` — set from a
-       `numbered: true` frontmatter flag — resets/increments the counter and
-       shows the "§ 01" prefix. The serif H2 itself stays unconditional. */
+       (#1120): only `.preview.numbered` — added when the `numberedHeadings`
+       editor setting is on — resets/increments the counter and shows the
+       "§ 01" prefix. The serif H2 itself stays unconditional. */
     .preview.numbered {
         counter-reset: h2;
     }

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -462,6 +462,16 @@
               Automatically folds the YAML frontmatter block at the top of a note when it's opened.
             </p>
           </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" bind:checked={editor.numberedHeadings} />
+              Numbered section headings
+            </label>
+            <p class="hint">
+              Prefixes each H2 in the preview with a "§ 01" section numeral. Best for long-form
+              essays; leave off for journals and lists.
+            </p>
+          </div>
 
         {:else if activeTab === 'appearance'}
           <div class="field">

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -68,13 +68,16 @@
      *  the note menus; since this source is the active tab, gatherContext
      *  picks up its body/metadata. */
     onInvokeTool?: (toolId: string) => void;
+    /** Mirror of the `numberedHeadings` editor setting (#1120), forwarded to
+     *  the source body's Preview so it agrees with note previews. */
+    numberedHeadings?: boolean;
   }
 
   let {
     sourceId, highlightExcerptId, onNavigate, onShowConfirm, onShowPrompt, onDeleted,
     onCreateAboutNote, onOpenReference, onResolveStub, onOpenPdf,
     onCreateNoteFromExcerpt, onAppendExcerptToCurrent, canAppendToCurrent = false,
-    onInvokeTool,
+    onInvokeTool, numberedHeadings = false,
   }: Props = $props();
   let resolving = $state(false);
   let appendFlashId = $state<string | null>(null);
@@ -572,7 +575,7 @@
             bind:this={bodyViewEl}
             oncontextmenu={handleBodyContextMenu}
           >
-            <Preview content={bodyContent} onNavigate={onNavigate} />
+            <Preview content={bodyContent} onNavigate={onNavigate} {numberedHeadings} />
             {#if detail && detail.excerpts.length > 0}
               <ExcerptDensityGutter
                 host={bodyViewEl ?? null}

--- a/src/renderer/lib/editor/settings.ts
+++ b/src/renderer/lib/editor/settings.ts
@@ -4,6 +4,10 @@ export interface EditorSettings {
   lineNumbers: boolean;
   showWhitespace: boolean;
   alwaysCollapseFrontmatter: boolean;
+  /** Prefix rendered H2s with a "§ 01" section numeral in the preview (#1120).
+   *  Off by default — only long-form/essay notes want it, so it's a setting
+   *  rather than firing on every journal or list. */
+  numberedHeadings: boolean;
 }
 
 const STORAGE_KEY = 'editorSettings';
@@ -14,6 +18,7 @@ const DEFAULTS: EditorSettings = {
   lineNumbers: true,
   showWhitespace: false,
   alwaysCollapseFrontmatter: false,
+  numberedHeadings: false,
 };
 
 export function getEditorSettings(): EditorSettings {

--- a/tests/renderer/editor-settings.test.ts
+++ b/tests/renderer/editor-settings.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Editor settings persistence (#1120 added `numberedHeadings`). The key
+ * guarantee is the DEFAULTS merge: a user whose stored `editorSettings`
+ * predates a new field still reads its default rather than `undefined`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getEditorSettings, saveEditorSettings } from '../../src/renderer/lib/editor/settings';
+
+// Clean in-memory localStorage — the renderer harness only sets up a partial
+// stub (same approach as command-palette.test.ts).
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+      get length() { return store.size; },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+describe('editor settings', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('defaults numberedHeadings to false', () => {
+    expect(getEditorSettings().numberedHeadings).toBe(false);
+  });
+
+  it('round-trips numberedHeadings through localStorage', () => {
+    saveEditorSettings({ ...getEditorSettings(), numberedHeadings: true });
+    expect(getEditorSettings().numberedHeadings).toBe(true);
+  });
+
+  it('fills numberedHeadings for settings stored before the field existed', () => {
+    // Simulate an older persisted blob with no numberedHeadings key.
+    localStorage.setItem(
+      'editorSettings',
+      JSON.stringify({ tabSize: 4, wordWrap: false, lineNumbers: true, showWhitespace: false, alwaysCollapseFrontmatter: false }),
+    );
+    const s = getEditorSettings();
+    expect(s.tabSize).toBe(4);
+    expect(s.numberedHeadings).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #1120 (merged in #1123). That change gated the "§ 01" H2 numeral on a `numbered: true` **frontmatter** flag; per feedback, this makes it a **Settings → Editor** toggle instead — a project-wide preference rather than per-note YAML.

## Changes
- **`editor/settings.ts`** — new `numberedHeadings` field on `EditorSettings` (default `false`).
- **`SettingsDialog.svelte`** — "Numbered section headings" checkbox under the **Editor** panel, with a hint ("Best for long-form essays; leave off for journals and lists").
- **`Preview.svelte`** — dropped the frontmatter regex/derived; now takes a `numberedHeadings` prop that drives the `.preview.numbered` class. The serif H2 itself stays unconditional.
- **`App.svelte`** — mirrors the setting in reactive `$state`, threads it to every note `Preview` and to `SourceDetail` (→ its body `Preview`), and updates it on Settings apply so open previews re-skin immediately.
- **Persistence robustness** — App also calls `saveEditorSettings(s)` directly, because `Editor.applySettings` early-returns (no save) when no editor view is mounted (e.g. Done pressed while on a source/query tab). Without this the toggle would apply for the session but not persist across restart.

## Verification
- `pnpm lint` clean (tsc + svelte-check + eslint).
- 1028 renderer tests pass, including a new `editor-settings` test covering the default, the round-trip, and the **DEFAULTS back-compat merge** (users with an `editorSettings` blob saved before the field existed still read `false`, not `undefined`).
- Toggle off → H2s render plain; toggle on → "§ 01…" returns, live across open note + source previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)