### PR TITLE
design: render minervaMark iris/pupil in honey, not muted text (#1121 follow-up)

### DIFF
--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -150,13 +150,16 @@ export const ICONS = {
     '<path d="M8.5 4 13 8 8.5 12z" fill="currentColor" stroke="none"/>',
 
   // ── Brand ─────────────────────────────────────────────────────────
-  // A crop of the app owl's eye looking back (#1121): outer socket ring,
-  // honey (accent) iris fill, dark pupil, catchlight. Inherits currentColor so
-  // it takes the accent in the title bar and the muted tone elsewhere.
+  // A crop of the app owl's eye looking back (#1121): honey (accent) socket
+  // ring, translucent honey iris, solid honey pupil, white catchlight. Colors
+  // are `var(--accent)` directly, NOT `currentColor` (#1121 follow-up): <Icon>
+  // maps its `color` prop to the SVG `stroke`, so `fill="currentColor"` would
+  // resolve to the inherited (muted) text color and the iris/pupil would render
+  // grey instead of honey.
   minervaMark:
-    '<circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.4"/>' +
-    '<circle cx="8" cy="8" r="4.2" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.2"/>' +
-    '<circle cx="8" cy="8" r="1.7" fill="currentColor" stroke="none"/>' +
+    '<circle cx="8" cy="8" r="7" stroke="var(--accent)" stroke-width="1.4"/>' +
+    '<circle cx="8" cy="8" r="4.2" fill="var(--accent)" fill-opacity="0.28" stroke="var(--accent)" stroke-width="1.2"/>' +
+    '<circle cx="8" cy="8" r="1.7" fill="var(--accent)" stroke="none"/>' +
     '<circle cx="7.2" cy="7.2" r="0.6" fill="#fff" fill-opacity="0.7" stroke="none"/>',
 } as const;
 


### PR DESCRIPTION
Follow-up to #1121 (merged in #1123). The owl-eye redraw shipped, but in the app it renders **muted grey, not honey** — so it was unclear the fix had landed.

## Why it was grey
Every circle in `minervaMark` set `stroke`/`fill="currentColor"`. `<Icon>` maps its `color` prop to the SVG **`stroke`**, but `currentColor` resolves to the inherited CSS **`color`** — the breadcrumb's muted text — so the per-circle `stroke="currentColor"` *overrode* the accent, and the fills picked up the muted text color. Net: the whole mark rendered in the title-bar text color, honey nowhere.

## Fix (option 1)
Point the socket ring, iris, and pupil at `var(--accent)` directly; the catchlight stays white. `var()` resolves in these SVG presentation attributes in Chromium — the same mechanism that already colors stroke-only icons through the `color` prop (e.g. the `forward` icon rendered via `stroke="var(--accent)"`).

Result — the intended honey eye (rendered here from the actual SVG):

- **Before:** honey nowhere — muted-grey ring + grey iris.
- **After:** honey socket ring, translucent honey iris, solid honey pupil, white catchlight.

Renders in the two call sites — the title bar breadcrumb (14px) and the onboarding brand panel (64px) — and still re-skins per theme (light/contrast accent).

## Verification
- `pnpm lint` clean.
- Rasterized the SVG at 200px and 14px to confirm it reads as a honey eye (no code path change; registry string only).
- No test asserts the mark markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)