### PR TITLE
a11y: bring the editor to WCAG AA, enforce color-contrast in the axe net (#1080)

### DIFF
--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -448,6 +448,12 @@
     font-variant-numeric: tabular-nums;
     flex-shrink: 0;
   }
+  /* On a selected row the accent tint warms/darkens the background enough that
+     the faint timestamp falls below WCAG AA (3.16:1 on the active-selected row);
+     lift it to full-strength text there, which clears AA in every theme (#1080). */
+  .tree-item.selected .mtime {
+    color: var(--text);
+  }
 
   .context-menu {
     position: fixed;

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -441,16 +441,20 @@
   }
 
   /* Modified-time stamp on file rows (§5.3) — right-aligned, mono. */
+  /* Muted, not faint (#1080): --text-faint is only ~4.6:1 on a plain row and
+     drops to 4.18:1 once the row lightens on :hover (--text 4% tint) — below
+     WCAG AA. --text-muted clears AA on both (5.1–5.6:1). */
   .mtime {
     font-family: var(--font-mono);
     font-size: 10.5px;
-    color: var(--text-faint);
+    color: var(--text-muted);
     font-variant-numeric: tabular-nums;
     flex-shrink: 0;
   }
-  /* On a selected row the accent tint warms/darkens the background enough that
-     the faint timestamp falls below WCAG AA (3.16:1 on the active-selected row);
-     lift it to full-strength text there, which clears AA in every theme (#1080). */
+  /* Accent-tinted rows (open file / tree selection) warm the background enough
+     that even --text-muted falls below AA (3.8:1 on the active-selected row);
+     lift the timestamp to full-strength text there — AA in every theme. */
+  .tree-item.active .mtime,
   .tree-item.selected .mtime {
     color: var(--text);
   }

--- a/src/renderer/lib/editor/editor-theme.ts
+++ b/src/renderer/lib/editor/editor-theme.ts
@@ -24,7 +24,9 @@ export function cmTheme(): Extension {
 export function minervaEditorTheme(): Extension {
   return EditorView.theme({
     '.cm-gutters': {
-      backgroundColor: 'var(--bg)',
+      // Match the content surface (--bg-inset, #1080) so the gutter and code
+      // area read as one panel rather than a two-tone seam.
+      backgroundColor: 'var(--bg-inset)',
       border: 'none',
       color: 'var(--text-faint)',
       fontFamily: 'var(--font-mono)',

--- a/src/renderer/lib/editor/minerva-highlight.ts
+++ b/src/renderer/lib/editor/minerva-highlight.ts
@@ -121,7 +121,12 @@ export function minervaSurfaceTheme(): Extension {
   return EditorView.theme({
     '&': {
       color: 'var(--text)',
-      backgroundColor: 'var(--bg)',
+      // The code surface is --bg-inset, not --bg (#1080): it's the background
+      // every syntax color is AA-verified against, and in light mode the honey
+      // function color clears 4.5:1 on --bg-inset (4.59) but not on the lighter
+      // --bg (4.33). It also matches Preview's code-fence background, so editor
+      // and rendered fences read identically.
+      backgroundColor: 'var(--bg-inset)',
     },
     '.cm-content': {
       caretColor: 'var(--accent)',

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -34,14 +34,11 @@ const KNOWN_WELCOME = new Set<string>([
   // Clean: --text-faint was lifted to WCAG AA, so no tolerated violations here.
 ]);
 const KNOWN_WORKSPACE = new Set<string>([
-  // Remaining color-contrast is EDITOR-INTERNAL only. The oneDark theme was
-  // replaced with the token-driven minervaHighlightStyle (#1117) — every syntax
-  // color is AA-verified on --bg-inset in all three themes — but axe may still
-  // flag editor-internal decorations (e.g. link-type badges) or the honey
-  // function color, which is AA on --bg-inset but 4.33:1 (AA-large) on the
-  // editor's --bg surface in light mode. Kept tolerated pending an editor a11y
-  // sweep; the app chrome's faint text is enforced by the welcome test.
-  'color-contrast',
+  // color-contrast is now ENFORCED (#1080): the oneDark editor theme was
+  // replaced with the token-driven minervaHighlightStyle (#1117), and the code
+  // surface + gutters moved to --bg-inset, where every syntax color and the
+  // --text-faint gutter/decoration text clear WCAG AA (4.5:1). This spec runs
+  // in the default (dark) theme, so a regression here fails CI.
   // CodeMirror's `.cm-scroller` (tabindex=-1); its `.cm-content` editable IS
   // keyboard-focusable, so this axe finding is a known CM quirk, not a real trap.
   'scrollable-region-focusable',


### PR DESCRIPTION
Closes #1080 — the remaining piece of the #1005 a11y sweep. Builds on #1117 (oneDark → token-driven `minervaHighlightStyle`).

## The gap #1117 left
#1117 made the syntax palette AA-*verifiable*, but the editor **content surface** was `var(--bg)`, and there the honey **function** color is only **4.33:1** in light mode. So AA wasn't actually met on the surface the text sits on.

## Fix
- **Editor surface + gutters → `var(--bg-inset)`** (`minerva-highlight.ts`, `editor-theme.ts`). That's the background every syntax color is AA-verified against (≥**4.59:1** in dark/light/contrast) and the one Preview's code fences already use, so the editor and rendered fences now read identically. Gutters move too, to avoid a two-tone seam.
- **Removed `color-contrast` from `KNOWN_WORKSPACE`** in `a11y.spec.ts` — it's now **enforced**; a regression fails CI.

## Removing the allowlist surfaced a real (non-editor) bug
With `color-contrast` no longer tolerated, the axe pass caught a previously-hidden sidebar violation the old "editor-internal only" comment had wrong: the file-tree **`.mtime` timestamp** (`--text-faint`) on a **selected** row's accent-tinted background was **3.16:1**. On that background only `--text` (8.88) and `--accent` (5.66) clear AA — `--text-muted` (3.84) doesn't — so I lift `.tree-item.selected .mtime` to `--text` (AA in every theme).

## Verification
Ran the real-browser axe pass (`pnpm build:e2e` + Playwright):

```
✓ welcome screen: no NEW serious a11y violations
✓ workspace (sidebar + editor): no NEW serious a11y violations
  (only tolerated: scrollable-region-focusable — the known CM `.cm-scroller` quirk)
```

`pnpm lint` clean; 1028 renderer unit tests pass. The e2e runs in the default (dark) theme and gates on serious+critical; syntax AA in light/contrast is verified by the contrast math (all ≥4.59:1 on `--bg-inset`).

## Known residual (documented, out of scope)
The wiki-link **chip** renders `--accent` text on an `--accent` tint, ~**4.16:1 in light mode**. This isn't editor *syntax* (which is what #1080 targeted) and isn't caught by the dark-theme axe pass — it's an intrinsic property of the light `--accent` token for small text (even untinted it's 4.59, and any tint pushes it under), and it affects accent-colored small text app-wide. Best fixed by a dedicated darker "accent-for-text" token or a light-`--accent` retune — a separate change with broader blast radius. Flagging rather than silently expanding scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)