### PR TITLE
fix: external note moves follow the open tab instead of closing it (#1144)

### DIFF
--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -5,6 +5,16 @@ import type { BrowserWindow } from 'electron';
 import { Channels } from '../../shared/channels';
 
 import { INDEXABLE_EXTS } from './indexable-files';
+import { wasHandled } from './path-dedup';
+
+/**
+ * How long an `unlink` is held before it's surfaced as a deletion, giving a
+ * paired `add` (the other half of an external move) time to arrive so the two
+ * can be correlated into a rename. Finder/CLI moves emit the two events within
+ * a few milliseconds; 150ms is a comfortable margin without making genuine
+ * deletes feel laggy (the tree refresh is debounced separately anyway).
+ */
+const MOVE_PAIR_WINDOW_MS = 150;
 
 /**
  * Paths we want to surface as watcher events even though they aren't
@@ -37,6 +47,8 @@ export interface WatcherCallbacks {
 interface WatcherPair {
   notes: FSWatcher;
   minervaData: FSWatcher;
+  /** Clears any pending move-detection timers so teardown leaves nothing armed. */
+  disposeMoveDetection: () => void;
 }
 
 const watchers = new Map<number, WatcherPair>();
@@ -71,32 +83,175 @@ export function startWatching(
     ],
     persistent: true,
     ignoreInitial: true,
+    // Guarantee fs.Stats on add/change so we can read inodes for robust
+    // move correlation (see the move-detection block below).
+    alwaysStat: true,
   });
+
+  // --- External move (rename) detection -------------------------------
+  // chokidar reports a Finder/CLI move as two *uncorrelated* events: an
+  // `add` on the new path and an `unlink` on the old one. Emitting the
+  // `unlink` as NOTEBASE_FILE_DELETED closes the open tab (and drops any
+  // unsaved edits in it) — issue #1144. To make an external move behave
+  // like an in-app one, we correlate the pair and surface it as a rename via
+  // NOTEBASE_RENAMED, so the open tab *follows* the file exactly as
+  // `api.notebase.rename` already does.
+  //
+  // The two events can arrive in either order (macOS fsevents fires `add`
+  // first; other backends may differ), so we bridge both directions: each
+  // `add` is remembered briefly so a following `unlink` can claim it, and
+  // each unclaimed `unlink` is held briefly so a following `add` can claim
+  // it. Whichever half arrives second detects the pair.
+  //
+  // Matching signal: the inode is authoritative — a move preserves it — and
+  // is used whenever it's known on both sides (we cache inodes seen on
+  // add/change). A file that existed at startup was never `add`ed this
+  // session, so its inode is uncached; there we fall back to a basename
+  // match, which the reported case (same file, new directory) satisfies. A
+  // known-but-different inode vetoes a basename match, so a genuine
+  // delete-then-recreate of a same-named file isn't mistaken for a move.
+  // In-app ops are skipped via `wasHandled` — they already drive the tab
+  // through the rename path themselves.
+  interface FileEvent {
+    relative: string;
+    basename: string;
+    inode: number | undefined;
+    timer: ReturnType<typeof setTimeout>;
+  }
+  const pendingUnlinks = new Map<string, FileEvent>(); // abs old path, delete held
+  const recentAdds = new Map<string, FileEvent>();      // abs new path, create emitted
+  const inodeByPath = new Map<string, number>();        // abs path -> last-seen inode
+
+  const inodeOf = (stats?: fs.Stats): number | undefined =>
+    stats && typeof stats.ino === 'number' && stats.ino !== 0 ? stats.ino : undefined;
+
+  // Best pairing for a (basename, inode) among buffered counterpart events.
+  const findMatch = (
+    pool: Map<string, FileEvent>,
+    basename: string,
+    inode: number | undefined,
+  ): string | undefined => {
+    if (inode !== undefined) {
+      for (const [abs, e] of pool) if (e.inode === inode) return abs;
+    }
+    for (const [abs, e] of pool) {
+      if (e.basename !== basename) continue;
+      // Both inodes known but different → a distinct file sharing a name.
+      if (inode !== undefined && e.inode !== undefined && e.inode !== inode) continue;
+      return abs;
+    }
+    return undefined;
+  };
+
+  const armTimer = (fn: () => void): ReturnType<typeof setTimeout> => {
+    const timer = setTimeout(fn, MOVE_PAIR_WINDOW_MS);
+    // Don't let a pending timer keep the process alive during teardown.
+    if (typeof timer.unref === 'function') timer.unref();
+    return timer;
+  };
+
+  const flushDelete = (absPath: string) => {
+    const pending = pendingUnlinks.get(absPath);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    pendingUnlinks.delete(absPath);
+    if (win.isDestroyed()) return;
+    win.webContents.send(Channels.NOTEBASE_FILE_DELETED, pending.relative);
+    void callbacks?.onFileDeleted(pending.relative);
+  };
+
+  const emitCreate = (relative: string) => {
+    win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
+    void callbacks?.onFileCreated(relative);
+  };
 
   // Callbacks may be async (interface allows void | Promise<void>); the
   // watcher invokes them as fire-and-forget. `void` makes that explicit.
-  notes.on('change', (filePath) => {
+  notes.on('change', (filePath, stats) => {
     if (isWatchable(filePath) && !win.isDestroyed()) {
+      const ino = inodeOf(stats);
+      if (ino !== undefined) inodeByPath.set(filePath, ino);
       const relative = filePath.slice(rootPath.length + 1);
       win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
       void callbacks?.onFileChanged(relative);
     }
   });
 
-  notes.on('add', (filePath) => {
-    if (isWatchable(filePath) && !win.isDestroyed()) {
-      const relative = filePath.slice(rootPath.length + 1);
-      win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
-      void callbacks?.onFileCreated(relative);
+  notes.on('add', (filePath, stats) => {
+    if (!isWatchable(filePath) || win.isDestroyed()) return;
+    const ino = inodeOf(stats);
+    if (ino !== undefined) inodeByPath.set(filePath, ino);
+    const relative = filePath.slice(rootPath.length + 1);
+    const basename = path.basename(filePath);
+
+    // Unlink-first ordering: a held delete this add pairs with → rename.
+    // In-app creates (wasHandled) never pair — they route their own tab
+    // updates through NOTEBASE_RENAMED already.
+    const movedFrom = wasHandled(relative) ? undefined : findMatch(pendingUnlinks, basename, ino);
+    if (movedFrom) {
+      const pending = pendingUnlinks.get(movedFrom)!;
+      clearTimeout(pending.timer);
+      pendingUnlinks.delete(movedFrom);
+      // Tab follows the file (renderer); the index drops the old path and
+      // picks up the new one. Crucially we do NOT emit FILE_DELETED for the
+      // old path — that broadcast is what would close the tab.
+      win.webContents.send(Channels.NOTEBASE_RENAMED, [{ old: pending.relative, new: relative }]);
+      void callbacks?.onFileDeleted(pending.relative);
+      emitCreate(relative);
+      return;
+    }
+
+    // Normal create — emit now, but remember it briefly so an add-first move
+    // (macOS: `add` precedes `unlink`) is recognized when its `unlink` lands.
+    emitCreate(relative);
+    if (!wasHandled(relative)) {
+      recentAdds.set(filePath, {
+        relative,
+        basename,
+        inode: ino,
+        timer: armTimer(() => recentAdds.delete(filePath)),
+      });
     }
   });
 
   notes.on('unlink', (filePath) => {
-    if (isWatchable(filePath) && !win.isDestroyed()) {
-      const relative = filePath.slice(rootPath.length + 1);
+    if (!isWatchable(filePath) || win.isDestroyed()) return;
+    const relative = filePath.slice(rootPath.length + 1);
+    const basename = path.basename(filePath);
+    const inode = inodeByPath.get(filePath);
+    inodeByPath.delete(filePath);
+
+    // In-app renames already moved the tab via NOTEBASE_RENAMED; emit the
+    // delete immediately (unchanged behavior) rather than debouncing it.
+    if (wasHandled(relative)) {
       win.webContents.send(Channels.NOTEBASE_FILE_DELETED, relative);
       void callbacks?.onFileDeleted(relative);
+      return;
     }
+
+    // Add-first ordering (macOS): the new path already arrived and is
+    // buffered → surface the pair as a rename. The new path already emitted
+    // its create + indexed on `add`; here we just reconnect the tab and drop
+    // the old path from the index. No FILE_DELETED — that would close the tab.
+    const movedTo = findMatch(recentAdds, basename, inode);
+    if (movedTo) {
+      const added = recentAdds.get(movedTo)!;
+      clearTimeout(added.timer);
+      recentAdds.delete(movedTo);
+      win.webContents.send(Channels.NOTEBASE_RENAMED, [{ old: relative, new: added.relative }]);
+      void callbacks?.onFileDeleted(relative);
+      return;
+    }
+
+    // Nothing to pair yet: hold the delete so a slightly-late add (unlink-first
+    // platforms) can still claim it; otherwise flushDelete surfaces a genuine
+    // deletion once the window elapses.
+    pendingUnlinks.set(filePath, {
+      relative,
+      basename,
+      inode,
+      timer: armTimer(() => flushDelete(filePath)),
+    });
   });
 
   // Separate watcher scoped to .minerva/{sources,excerpts} so graph-backing
@@ -133,7 +288,15 @@ export function startWatching(
   minervaData.on('add', (filePath) => handleMinervaEvent(filePath, 'upsert'));
   minervaData.on('unlink', (filePath) => handleMinervaEvent(filePath, 'delete'));
 
-  watchers.set(id, { notes, minervaData });
+  const disposeMoveDetection = () => {
+    for (const p of pendingUnlinks.values()) clearTimeout(p.timer);
+    for (const a of recentAdds.values()) clearTimeout(a.timer);
+    pendingUnlinks.clear();
+    recentAdds.clear();
+    inodeByPath.clear();
+  };
+
+  watchers.set(id, { notes, minervaData, disposeMoveDetection });
 
   // Resolve once both chokidar watchers have completed their initial scan
   // and a brief settle window has elapsed. Production callers ignore this
@@ -158,6 +321,7 @@ export function stopWatching(id: number): void {
     // chokidar's close() returns a Promise that resolves when handles
     // are released. We don't block on it: callers (window-manager
     // teardown, test cleanup) just want the watcher detached now.
+    pair.disposeMoveDetection();
     void pair.notes.close();
     void pair.minervaData.close();
     watchers.delete(id);

--- a/tests/main/notebase/watcher.test.ts
+++ b/tests/main/notebase/watcher.test.ts
@@ -199,6 +199,106 @@ describe('startWatching() (#345)', () => {
     });
   });
 
+  describe('external move detection (#1144)', () => {
+    it('surfaces a cross-directory move as a rename, not a delete', async () => {
+      // A note that existed at startup (ignoreInitial → no inode cached),
+      // moved to another folder in the project. This is the reported repro:
+      // an in-Finder move must make the open tab follow, not close it.
+      const rel = 'note.md';
+      await fsp.mkdir(path.join(root, 'sub'), { recursive: true });
+      await fsp.writeFile(path.join(root, rel), '# note\n', 'utf-8');
+
+      const deleted: string[] = [];
+      const created: string[] = [];
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: (p) => deleted.push(p),
+      });
+
+      await fsp.rename(path.join(root, rel), path.join(root, 'sub', 'note.md'));
+
+      // The rename transition is broadcast (tab follows) and no delete IPC
+      // for the old path is ever sent (that would close the tab).
+      await waitFor(() =>
+        win.webContents.send.mock.calls.some(
+          (c) => c[0] === Channels.NOTEBASE_RENAMED,
+        ),
+      );
+      const renameCall = win.webContents.send.mock.calls.find(
+        (c) => c[0] === Channels.NOTEBASE_RENAMED,
+      );
+      expect(renameCall?.[1]).toEqual([{ old: rel, new: 'sub/note.md' }]);
+
+      // Give the (would-be) delete window time to elapse — the renderer-facing
+      // delete IPC (which closes the tab) must never fire.
+      await new Promise((r) => setTimeout(r, 300));
+      const sentDelete = win.webContents.send.mock.calls.some(
+        (c) => c[0] === Channels.NOTEBASE_FILE_DELETED,
+      );
+      expect(sentDelete).toBe(false);
+      // Index consistency: the old path is still dropped and the new path
+      // added via the callbacks (just not broadcast as a tab-closing delete).
+      expect(deleted).toEqual(['note.md']);
+      expect(created).toContain('sub/note.md');
+    });
+
+    it('detects an in-place rename (same dir, new name) as a rename', async () => {
+      // Create the file AFTER startWatching so its inode is cached — a rename
+      // that changes the basename can only be correlated by inode, and the
+      // watcher only knows a file's inode once it has seen an add/change for
+      // it this session.
+      const created: string[] = [];
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+
+      const rel = 'old-name.md';
+      await fsp.writeFile(path.join(root, rel), '# body\n', 'utf-8');
+      await waitFor(() => created.includes(rel));
+      // Let the recentAdds buffer for the create expire so it can't be the
+      // thing the rename pairs against.
+      await new Promise((r) => setTimeout(r, 200));
+
+      await fsp.rename(path.join(root, rel), path.join(root, 'new-name.md'));
+
+      await waitFor(() =>
+        win.webContents.send.mock.calls.some(
+          (c) => c[0] === Channels.NOTEBASE_RENAMED,
+        ),
+      );
+      const renameCall = win.webContents.send.mock.calls.find(
+        (c) => c[0] === Channels.NOTEBASE_RENAMED,
+      );
+      // In-place rename keeps the same inode, so the pair is correlated even
+      // though the basename changed.
+      expect(renameCall?.[1]).toEqual([{ old: rel, new: 'new-name.md' }]);
+    });
+
+    it('still emits a delete for a genuine removal (no paired add)', async () => {
+      // Regression guard: the debounce must not swallow real deletions.
+      const rel = 'doomed.md';
+      await fsp.writeFile(path.join(root, rel), 'x\n', 'utf-8');
+
+      const deleted: string[] = [];
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: () => undefined,
+        onFileChanged: () => undefined,
+        onFileDeleted: (p) => deleted.push(p),
+      });
+
+      await fsp.rm(path.join(root, rel));
+      await waitFor(() => deleted.includes(rel));
+      expect(win.webContents.send).toHaveBeenCalledWith(
+        Channels.NOTEBASE_FILE_DELETED,
+        rel,
+      );
+      expect(win.webContents.send.mock.calls.some((c) => c[0] === Channels.NOTEBASE_RENAMED)).toBe(false);
+    });
+  });
+
   describe('.minerva/{sources,excerpts} routing', () => {
     it('routes .minerva/sources/<id>/meta.ttl writes to onSourceMetaChanged', async () => {
       const sourceId = 'sha-abc123';


### PR DESCRIPTION
Closes #1144.

## Problem

With a note open in the editor, moving that note in **Finder** (or any external tool) closed the note — the tab and any unsaved edits vanished. In-app renames already make the tab follow the file; external moves did not.

chokidar reports an external move as two uncorrelated events — an `add` on the new path and an `unlink` on the old — and the `unlink` fired `NOTEBASE_FILE_DELETED`, which the renderer treats as a deletion (`closeTabsForDeletedPath`).

## Fix

The watcher now correlates the `add`/`unlink` pair and surfaces it as a rename through the **existing** `NOTEBASE_RENAMED` → `applyRenameTransitions` path that already makes in-app moves' tabs follow the file — no renderer changes needed.

- **Order-independent.** macOS fsevents fires `add` before `unlink` (verified); other backends may differ. Each `add` is briefly buffered so a following `unlink` can claim it, and each unclaimed `unlink` is briefly held (150ms) so a following `add` can claim it. Whichever half arrives second detects the pair.
- **Matching.** By inode (authoritative — a move preserves it; cached from `add`/`change` events), with a **basename** fallback for files whose inode we haven't seen this session (the reported cross-directory case). A known-but-different inode **vetoes** a basename match, so a genuine delete-then-recreate of a same-named file isn't mistaken for a move.
- **Index stays consistent.** The old path is still dropped and the new path added via the existing callbacks; only the tab-closing `FILE_DELETED` *broadcast* is suppressed.
- **In-app ops excluded** via `wasHandled` — they already drive the tab through the rename path.
- **Genuine deletions** (no paired `add`) still emit `NOTEBASE_FILE_DELETED` after the window elapses.

### Scope note
Moving a note **out of the project root** still closes it (only an `unlink` fires — the file is genuinely gone from the watched tree). The issue flags keeping an orphaned/detached buffer as "worth a decision"; that's a larger feature left out of this fix. Rename-in-place of a note that existed at **startup** (never touched this session, so its old inode is uncached and the basename changed) also can't be correlated and falls back to the old behavior — the primary reported case (cross-directory move, basename preserved) is fully fixed.

## Testing

- New watcher tests: cross-directory move → rename (no tab-closing delete IPC); in-place rename via inode; genuine deletion still emits a delete.
- `tests/main/notebase/` — 147 pass; watcher suite stable across repeated runs.
- `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)