### PR TITLE
fix: pre-fill the rename dialog with the current filename (#1143)

### DIFF
--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -430,7 +430,10 @@ export function createNoteOps(ctx: NoteOpsCtx) {
   async function handleRename(relativePath: string) {
     if (!notebase.meta) return;
     const oldName = relativePath.split('/').pop()!;
-    const rawNewName = await showPrompt('New name:');
+    // Seed the field with the current name so the user can tweak it instead
+    // of retyping from scratch; pre-select just the stem so typing replaces
+    // the name while the extension stays visible (#1143).
+    const rawNewName = await showPrompt('New name:', { initial: oldName, selectStem: true });
     if (!rawNewName || rawNewName === oldName) return;
     // Preserve the old extension when the user didn't include one. A file
     // that drops its .md / .ttl suffix falls out of the indexed set and

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -20,6 +20,7 @@
     message={dialogs.prompt.message}
     suggestions={dialogs.prompt.suggestions ?? []}
     initial={dialogs.prompt.initial ?? ''}
+    selectStem={dialogs.prompt.selectStem ?? false}
     onConfirm={(v) => dialogs.confirmPrompt(v)}
     onCancel={() => dialogs.cancelPrompt()}
   />

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -14,9 +14,14 @@
     /** Optional pre-seeded value (e.g. Rename) — the input opens
      *  populated with this string, fully selected. */
     initial?: string;
+    /** When true, pre-select only the filename stem (text before the last
+     *  dot) rather than the whole value, so typing replaces the name but
+     *  visibly keeps the extension. Used by Rename. Falls back to a full
+     *  select when `initial` has no extension. */
+    selectStem?: boolean;
   }
 
-  let { message, onConfirm, onCancel, suggestions = [], initial = '' }: Props = $props();
+  let { message, onConfirm, onCancel, suggestions = [], initial = '', selectStem = false }: Props = $props();
   // Intentional one-time seed from `initial`; dialog is short-lived and keyed.
   // svelte-ignore state_referenced_locally
   let value = $state(initial);
@@ -35,9 +40,13 @@
 
   $effect(() => {
     inputEl?.focus();
-    // Pre-select the seeded value so the user can type to replace
-    // it but Tab/Enter to accept as-is.
-    if (initial) inputEl?.select();
+    if (!initial || !inputEl) return;
+    // Pre-select the seeded value so the user can type to replace it but
+    // Tab/Enter to accept as-is. For Rename, select only the stem (before
+    // the last dot) so the extension stays visible and untouched.
+    const dot = initial.lastIndexOf('.');
+    if (selectStem && dot > 0) inputEl.setSelectionRange(0, dot);
+    else inputEl.select();
   });
 </script>
 

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -21,6 +21,7 @@ export interface PromptState {
   message: string;
   suggestions?: string[] | undefined;
   initial?: string | undefined;
+  selectStem?: boolean | undefined;
   resolve: (value: string | null) => void;
 }
 export interface NewNoteState {
@@ -55,7 +56,7 @@ export function getDialogStore() {
 
   function showPrompt(
     message: string,
-    initialOrOptions?: string | { suggestions?: string[]; initial?: string },
+    initialOrOptions?: string | { suggestions?: string[]; initial?: string; selectStem?: boolean },
   ): Promise<string | null> {
     // Two overloads to keep call sites readable. New callers pass
     // (message, "current name") for Rename-style flows; existing
@@ -64,7 +65,13 @@ export function getDialogStore() {
       ? { initial: initialOrOptions }
       : (initialOrOptions ?? {});
     return new Promise((resolve) => {
-      prompt = { message, suggestions: opts.suggestions, initial: opts.initial, resolve };
+      prompt = {
+        message,
+        suggestions: opts.suggestions,
+        initial: opts.initial,
+        selectStem: opts.selectStem,
+        resolve,
+      };
     });
   }
 

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -81,6 +81,15 @@ describe('handleRename', () => {
     await ops.handleRename('foo.md');
     expect(h.api.notebase.rename).not.toHaveBeenCalled();
   });
+
+  it('seeds the prompt with the current name and selects the stem (#1143)', async () => {
+    h.dialog.showPrompt.mockResolvedValue('renamed');
+    await ops.handleRename('notes/foo.md');
+    expect(h.dialog.showPrompt).toHaveBeenCalledWith('New name:', {
+      initial: 'foo.md',
+      selectStem: true,
+    });
+  });
 });
 
 describe('handleNewNote', () => {


### PR DESCRIPTION
Closes #1143.

## Problem

Renaming a file popped a "New name:" prompt with an **empty** field, forcing the user to retype the whole name just to tweak it (fix a typo, add a word).

## Fix

Seed the field with the current name and pre-select only the **stem** (the text before the last dot), so typing replaces the name while the extension stays visible, and Enter accepts it as-is. This mirrors Finder-style rename.

`handleRename` now calls:
```ts
await showPrompt('New name:', { initial: oldName, selectStem: true });
```

`selectStem` is a new, generic option threaded through `showPrompt` → `PromptState` → `DialogHost` → `PromptDialog`. When set, the dialog selects `[0, lastDot)` via `setSelectionRange` instead of selecting the whole value (falling back to a full select when the seed has no extension). Only Rename opts in; every other prompt is unchanged.

The existing extension-preservation logic (`handleRename` re-appends the old extension if the user omits one) is untouched, so accepting the pre-filled name or typing a bare stem both behave correctly.

### Scope note
`handleCopyWithPrompt` has the same empty-field pattern, but seeding it with the source name would produce an immediate copy-to-same-path cancel on Enter — worse UX — so I left it out, as the issue anticipated (copy-to-same-dir needs a *different* name).

## Testing

- New `note-ops` test asserts the prompt is seeded with the current name + `selectStem: true`; existing rename tests (extension preservation, cancel/unchanged) still pass.
- `note-ops` / `dialogs` / a11y dialog suites — 26 pass.
- `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)