### PR TITLE
feat: direct theme selection in status bar, palette, and View menu (#1139)

### DIFF
--- a/src/main/ipc/register-app.ts
+++ b/src/main/ipc/register-app.ts
@@ -1,6 +1,7 @@
 import { ipcMain, app } from 'electron';
 import { Channels } from '../../shared/channels';
-import { getMenuShortcuts } from '../menu';
+import { getMenuShortcuts, setMenuThemeMode } from '../menu';
+import type { ThemeMode } from '../../shared/theme';
 
 // Injected by vite.main.config.ts `define` at build time — a packaged app has
 // no git to query at runtime, so the commit + date are baked in.
@@ -31,4 +32,8 @@ export function registerApp(): void {
 
   // Keyboard-shortcut reference for the Help menu (#804).
   ipcMain.handle(Channels.APP_GET_SHORTCUTS, () => getMenuShortcuts());
+
+  // The renderer owns the theme (localStorage); it reports changes so the
+  // native View → Theme submenu can show the active radio (#1139).
+  ipcMain.on(Channels.MENU_REPORT_THEME, (_e, mode: ThemeMode) => setMenuThemeMode(mode));
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, shell, dialog, BrowserWindow } from 'electron';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
+import { THEME_MODES, type ThemeMode } from '../shared/theme';
 import { getRecentProjects } from './recent-projects';
 import { createWindow, openProjectInWindow, getRootPath, broadcastBackfillProgress } from './window-manager';
 import { runBackfill } from './embeddings/backfill';
@@ -25,6 +26,18 @@ import {
 function send(channel: string, ...args: unknown[]) {
   const win = BrowserWindow.getFocusedWindow();
   if (win) win.webContents.send(channel, ...args);
+}
+
+// Current theme, mirrored from the renderer (which owns it in localStorage) so
+// the View → Theme submenu can show the active radio (#1139). Defaults to the
+// renderer's own default; corrected the moment the renderer reports on mount.
+let currentThemeMode: ThemeMode = 'dark';
+
+/** Renderer → main: record the active theme and refresh the menu's radio. */
+export function setMenuThemeMode(mode: ThemeMode): void {
+  if (mode === currentThemeMode) return;
+  currentThemeMode = mode;
+  rebuildMenu();
 }
 
 export function buildMenu(_win?: BrowserWindow): void {
@@ -446,7 +459,18 @@ function buildViewMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
       }),
       { type: 'separator' },
       {
-        label: 'Cycle Theme (Dark/Light/Contrast/System)',
+        label: 'Theme',
+        submenu: THEME_MODES.map((m) => ({
+          label: m.label,
+          type: 'radio' as const,
+          checked: currentThemeMode === m.value,
+          click: () => send(Channels.MENU_SET_THEME, m.value),
+        })),
+      },
+      {
+        // ⌘⇧T keeps cycling for power users; the submenu above is for
+        // direct selection (#1139).
+        label: 'Cycle Theme',
         accelerator: 'CmdOrCtrl+Shift+T',
         click: () => send(Channels.MENU_CYCLE_THEME),
       },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { Channels } from '../shared/channels';
 import { invoke } from './typed-invoke';
 import type { SearchInNotesOptions, ReplaceInNotesOptions } from '../shared/types';
+import type { ThemeMode } from '../shared/theme';
 
 /**
  * Subscribe to an IPC channel and forward the typed payload to `cb`.
@@ -476,6 +477,10 @@ contextBridge.exposeInMainWorld('api', {
     onCycleTheme: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_CYCLE_THEME, () => cb());
     },
+    onSetTheme: (cb: (mode: ThemeMode) => void) => {
+      ipcRenderer.on(Channels.MENU_SET_THEME, (_e, mode: ThemeMode) => cb(mode));
+    },
+    reportTheme: (mode: ThemeMode) => ipcRenderer.send(Channels.MENU_REPORT_THEME, mode),
     onSplitRight: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SPLIT_RIGHT, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -65,7 +65,7 @@
   import type { OnboardingAnswers } from './lib/components/OnboardingDialog.svelte';
   import { api } from './lib/ipc/client';
   import { getNavigationStore } from './lib/stores/navigation.svelte';
-  import { initTheme, cycleTheme, getThemeMode } from './lib/theme';
+  import { initTheme, cycleTheme, getThemeMode, setThemeMode, type ThemeMode } from './lib/theme';
   import { getEditorSettings, saveEditorSettings } from './lib/editor/settings';
   import {
     slugifyForPath,
@@ -562,7 +562,8 @@
     togglePreview: () => cycleViewMode(),
     toggleConversations: () => conversationsStore.toggle(),
     newConversation: () => { void newConversation(); },
-    cycleTheme: () => handleCycleTheme(),
+    setTheme: (mode) => handleSelectTheme(mode),
+    currentTheme: () => themeLabel,
     fontIncrease: () => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; },
     fontDecrease: () => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; },
     fontReset: () => { editorComponent?.resetFontSize(); editorFontSize = 14; },
@@ -834,13 +835,27 @@
     openFileSelect: (p) => { void handleFileSelect(p); },
   } satisfies ConversationOpsCtx);
 
-  function handleCycleTheme() {
-    themeLabel = cycleTheme();
+  // Re-tint every canvas/CodeMirror surface that can't pick up the CSS
+  // custom-property change on its own. Shared by cycle (⌘⇧T) and direct pick.
+  function applyThemeToSurfaces() {
     editorComponent?.updateTheme();
     queryPanelComponent?.updateTheme();
     previewComponent?.updateTheme();
     neighborhoodGraphComponent?.updateTheme();
     rightSidebar?.updateTheme();
+  }
+
+  function handleCycleTheme() {
+    themeLabel = cycleTheme();
+    applyThemeToSurfaces();
+    api.menu.reportTheme(themeLabel);
+  }
+
+  function handleSelectTheme(mode: ThemeMode) {
+    setThemeMode(mode);
+    themeLabel = mode;
+    applyThemeToSurfaces();
+    api.menu.reportTheme(themeLabel);
   }
 
   async function handleSwitchTab(index: number, groupId?: string) {
@@ -950,6 +965,9 @@
 
   onMount(() => {
     initTheme();
+    // Tell main the current theme so the native View → Theme radio starts
+    // in sync with what the renderer loaded from localStorage (#1139).
+    api.menu.reportTheme(themeLabel);
     initAppearance();
 
     // Pull skill metadata loaded by main (#625) into the renderer registry so
@@ -994,6 +1012,7 @@
     api.menu.onSaveAsTemplate(() => { void handleSaveAsTemplate(); });
     api.menu.onInsertTemplate(() => { void handleInsertTemplate(); });
     api.menu.onCycleTheme(() => handleCycleTheme());
+    api.menu.onSetTheme((mode) => handleSelectTheme(mode));
     api.menu.onFontIncrease(() => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
     api.menu.onFontDecrease(() => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
     api.menu.onFontReset(() => { editorComponent?.resetFontSize(); editorFontSize = 14; });
@@ -1540,7 +1559,7 @@
             isDirty={editor.isDirty}
             hasActiveNote={editor.activeTab?.type === 'note'}
             onGotoLine={() => { showGotoLine = true; }}
-            onCycleTheme={handleCycleTheme}
+            onSelectTheme={handleSelectTheme}
             onShowInspections={() => { rightSidebarVisible = true; }}
             onShowBacklinks={() => {
               rightSidebarVisible = true;

--- a/src/renderer/lib/command-palette/registry.ts
+++ b/src/renderer/lib/command-palette/registry.ts
@@ -18,6 +18,7 @@
  */
 import type { Command } from './types';
 import { formatAccelerator } from './format-accelerator';
+import { THEME_MODES, type ThemeMode } from '../theme';
 
 /** Dependencies the command registry needs from the host component. */
 export interface CommandDeps {
@@ -50,7 +51,11 @@ export interface CommandDeps {
   togglePreview(): void;
   toggleConversations(): void;
   newConversation(): void;
-  cycleTheme(): void;
+  /** Directly select a theme (#1139). One palette entry per mode. */
+  setTheme(mode: ThemeMode): void;
+  /** Current mode, so the active entry can be marked. Read at build time,
+   *  so it must be a getter for the palette's `$derived` to re-track it. */
+  currentTheme(): ThemeMode;
   fontIncrease(): void;
   fontDecrease(): void;
   fontReset(): void;
@@ -143,8 +148,16 @@ export function buildCommandRegistry(deps: CommandDeps): Command[] {
       keybinding: null, enabled: true, run: () => deps.toggleConversations() },
     { id: 'view.newConversation', title: 'New Conversation', category: 'View',
       keybinding: null, enabled: hasProject, run: () => deps.newConversation() },
-    { id: 'view.cycleTheme', title: 'Cycle Theme', category: 'View',
-      keybinding: null, enabled: true, run: () => deps.cycleTheme() },
+    // One directly-selectable entry per theme, so each is searchable and a
+    // click jumps straight to it (#1139). The active mode is marked.
+    ...THEME_MODES.map((m) => ({
+      id: `view.theme.${m.value}`,
+      title: `Theme: ${m.label}${deps.currentTheme() === m.value ? ' (current)' : ''}`,
+      category: 'View',
+      keybinding: null,
+      enabled: true,
+      run: () => deps.setTheme(m.value),
+    })),
     { id: 'view.fontIncrease', title: 'Increase Font Size', category: 'View',
       keybinding: null, enabled: true, run: () => deps.fontIncrease() },
     { id: 'view.fontDecrease', title: 'Decrease Font Size', category: 'View',

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -7,7 +7,7 @@
     FONT_FAMILY_PRESETS,
     type FontFamilyPreset,
   } from '../appearance/settings';
-  import { getThemeMode, setThemeMode, type ThemeMode } from '../theme';
+  import { getThemeMode, setThemeMode, THEME_MODES, type ThemeMode } from '../theme';
   import { api } from '../ipc/client';
   import type { LLMSettings } from '../../../shared/tools/types';
   import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
@@ -205,13 +205,6 @@
     id: id as FontFamilyPreset,
     label: def.label,
   }));
-
-  const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
-    { value: 'dark', label: 'Dark' },
-    { value: 'light', label: 'Light' },
-    { value: 'contrast', label: 'High Contrast' },
-    { value: 'system', label: 'System' },
-  ];
 
   // Privileged sites now live in SitesSettings.svelte (self-contained panel).
 
@@ -477,7 +470,7 @@
           <div class="field">
             <label for="theme">Theme</label>
             <select id="theme" bind:value={theme}>
-              {#each THEME_OPTIONS as opt}
+              {#each THEME_MODES as opt}
                 <option value={opt.value}>{opt.label}</option>
               {/each}
             </select>

--- a/src/renderer/lib/components/StatusBar.svelte
+++ b/src/renderer/lib/components/StatusBar.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import type { CursorInfo } from './Editor.svelte';
   import Icon from './Icon.svelte';
+  import { THEME_MODES, type ThemeMode } from '../theme';
+  import { installDismissOnClickOutside } from '../dismiss-menu';
 
   interface Props {
     cursor: CursorInfo;
     fontSize: number;
-    theme: string;
+    /** Current theme mode — drives both the status-bar label and the
+     *  checked item in the picker. */
+    theme: ThemeMode;
     inspectionCount?: number;
     /** Number of incoming wiki-links to the active note (#472). 0
      *  hides the item entirely — keeps the bar tidy for unlinked
@@ -19,7 +23,8 @@
      *  cue entirely when no editable file is open. */
     hasActiveNote?: boolean;
     onGotoLine: () => void;
-    onCycleTheme: () => void;
+    /** Pick a theme directly (#1139) — replaces the old blind cycle on click. */
+    onSelectTheme: (mode: ThemeMode) => void;
     onShowInspections?: () => void;
     /** Click handler for the backlink-count item — App reveals + focuses
      *  the right-sidebar Backlinks panel. */
@@ -32,9 +37,34 @@
     cursor, fontSize, theme,
     inspectionCount = 0, backlinkCount = 0,
     isDirty = false, hasActiveNote = false,
-    onGotoLine, onCycleTheme, onShowInspections, onShowBacklinks,
+    onGotoLine, onSelectTheme, onShowInspections, onShowBacklinks,
     backfill = null,
   }: Props = $props();
+
+  let themeMenuOpen = $state(false);
+  let themeMenuEl = $state<HTMLDivElement>();
+
+  function toggleThemeMenu() {
+    themeMenuOpen = !themeMenuOpen;
+    if (themeMenuOpen) {
+      installDismissOnClickOutside(() => { themeMenuOpen = false; }, '.theme-wrap');
+    }
+  }
+
+  function pickTheme(mode: ThemeMode) {
+    onSelectTheme(mode);
+    themeMenuOpen = false;
+  }
+
+  // Focus the checked item when the picker opens so it's keyboard-drivable.
+  $effect(() => {
+    if (themeMenuOpen && themeMenuEl) {
+      themeMenuEl.querySelector<HTMLButtonElement>('[aria-checked="true"]')?.focus();
+    }
+  });
+
+  const themeLabels: Record<ThemeMode, string> =
+    Object.fromEntries(THEME_MODES.map((m) => [m.value, m.label])) as Record<ThemeMode, string>;
 </script>
 
 <div class="status-bar">
@@ -88,7 +118,36 @@
     <span class="status-item faint">·</span>
     <span class="status-item faint nums">{fontSize}px</span>
     <span class="status-item faint">·</span>
-    <button class="status-item faint clickable" onclick={onCycleTheme} title="Cycle Theme (Cmd+Shift+T)">{theme}</button>
+    <div class="theme-wrap">
+      <button
+        class="status-item faint clickable"
+        onclick={toggleThemeMenu}
+        title="Theme — click to pick (Cmd+Shift+T cycles)"
+        aria-haspopup="menu"
+        aria-expanded={themeMenuOpen}
+      >{themeLabels[theme]}</button>
+      {#if themeMenuOpen}
+        <div
+          class="theme-menu"
+          role="menu"
+          tabindex="-1"
+          bind:this={themeMenuEl}
+          onkeydown={(e) => { if (e.key === 'Escape') { themeMenuOpen = false; } }}
+        >
+          {#each THEME_MODES as mode (mode.value)}
+            <button
+              role="menuitemradio"
+              aria-checked={theme === mode.value}
+              class="theme-menu-item"
+              onclick={() => pickTheme(mode.value)}
+            >
+              <span class="check">{#if theme === mode.value}<Icon name="check" size={11} color="var(--accent)" />{/if}</span>
+              {mode.label}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
     <span class="status-item faint">·</span>
     <span class="status-item faint">Markdown</span>
   </div>
@@ -152,6 +211,51 @@
     width: 1px;
     height: 11px;
     background: var(--border);
+    flex-shrink: 0;
+  }
+
+  /* Theme picker — a small popup that opens upward from the status bar. */
+  .theme-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+  .theme-menu {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    right: 0;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 140px;
+    display: flex;
+    flex-direction: column;
+  }
+  .theme-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 12px 6px 8px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .theme-menu-item:hover,
+  .theme-menu-item:focus-visible {
+    background: var(--bg-button);
+    outline: none;
+  }
+  .theme-menu-item .check {
+    display: inline-flex;
+    width: 12px;
     flex-shrink: 0;
   }
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,6 +1,7 @@
 import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
+import type { ThemeMode } from '../../../shared/theme';
 
 export interface NotebaseApi {
   open(): Promise<NotebaseMeta | null>;
@@ -673,6 +674,8 @@ export interface MenuApi {
   onTogglePreview(cb: () => void): void;
   onQuickOpen(cb: () => void): void;
   onCycleTheme(cb: () => void): void;
+  onSetTheme(cb: (mode: ThemeMode) => void): void;
+  reportTheme(mode: ThemeMode): void;
   onSplitRight(cb: () => void): void;
   onSplitDown(cb: () => void): void;
   onFocusNextGroup(cb: () => void): void;

--- a/src/renderer/lib/theme.ts
+++ b/src/renderer/lib/theme.ts
@@ -1,4 +1,9 @@
-export type ThemeMode = 'dark' | 'light' | 'contrast' | 'system';
+// ThemeMode + THEME_MODES live in shared/ so the native menu (main process)
+// and the renderer draw from one list. Re-exported here so existing
+// `../theme` imports keep working.
+import type { ThemeMode } from '../../shared/theme';
+export { THEME_MODES } from '../../shared/theme';
+export type { ThemeMode };
 
 const STORAGE_KEY = 'themeMode';
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -158,6 +158,10 @@ export const Channels = {
   MENU_TOGGLE_CONVERSATIONS: 'menu:toggleConversations',
   MENU_NEW_CONVERSATION: 'menu:newConversation',
   MENU_CYCLE_THEME: 'menu:cycleTheme',
+  // Direct theme selection from the native View → Theme submenu (#1139).
+  MENU_SET_THEME: 'menu:setTheme',
+  // Renderer → main: report the current theme so the menu's radio reflects it.
+  MENU_REPORT_THEME: 'menu:reportTheme',
   // Editor split — focus & pane commands (#814)
   MENU_SPLIT_RIGHT: 'menu:splitRight',
   MENU_SPLIT_DOWN: 'menu:splitDown',

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,0 +1,13 @@
+/**
+ * Theme modes shared across processes. The renderer's status-bar picker,
+ * command palette, and Settings → Appearance, plus the native View → Theme
+ * submenu, all draw from this one list so labels can't drift between surfaces.
+ */
+export type ThemeMode = 'dark' | 'light' | 'contrast' | 'system';
+
+export const THEME_MODES: { value: ThemeMode; label: string }[] = [
+  { value: 'dark', label: 'Dark' },
+  { value: 'light', label: 'Light' },
+  { value: 'contrast', label: 'High Contrast' },
+  { value: 'system', label: 'System' },
+];

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -99,6 +99,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "links:externalInbound",
   "links:neighborhood",
   "links:outgoing",
+  "menu:reportTheme",
   "notebase:close",
   "notebase:copy",
   "notebase:createFile",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -196,6 +196,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onReplaceInNotes",
     "onSave",
     "onSaveAsTemplate",
+    "onSetTheme",
     "onShortcuts",
     "onSortLines",
     "onSplitDown",
@@ -204,6 +205,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onTogglePreview",
     "onToggleRightSidebar",
     "onToggleSidebar",
+    "reportTheme",
   ],
   "notebase": [
     "clearRecent",

--- a/tests/renderer/command-palette/registry.test.ts
+++ b/tests/renderer/command-palette/registry.test.ts
@@ -17,7 +17,7 @@ function makeDeps(overrides: Partial<CommandDeps> = {}): CommandDeps {
     'newNote', 'save', 'openProject', 'newProject', 'closeProject', 'print',
     'saveAsTemplate', 'insertTemplate', 'dictate', 'find', 'findReplace', 'findInNotes',
     'replaceInNotes', 'gotoLine', 'sortLines', 'toggleSidebar', 'toggleRightSidebar',
-    'togglePreview', 'toggleConversations', 'newConversation', 'cycleTheme', 'fontIncrease', 'fontDecrease',
+    'togglePreview', 'toggleConversations', 'newConversation', 'setTheme', 'fontIncrease', 'fontDecrease',
     'fontReset', 'quickOpen', 'navBack', 'navForward', 'renameActive', 'moveActive',
     'copyActive', 'extractSelection', 'splitHere', 'splitByHeading', 'autoTagActive',
     'autoLinkActive', 'autoLinkInboundActive', 'decomposeActive', 'format', 'ingestUrl',
@@ -30,6 +30,7 @@ function makeDeps(overrides: Partial<CommandDeps> = {}): CommandDeps {
     hasActiveNoteTab: () => true,
     canGoBack: () => true,
     canGoForward: () => true,
+    currentTheme: () => 'dark',
   } as Record<string, unknown>;
   for (const name of actionNames) deps[name] = vi.fn();
   return { ...deps, ...overrides } as CommandDeps;
@@ -44,7 +45,8 @@ describe('buildCommandRegistry', () => {
       'edit.dictate',
       'edit.find', 'edit.findReplace', 'edit.findInNotes', 'edit.replaceInNotes',
       'edit.gotoLine', 'edit.sortLines', 'view.toggleSidebar', 'view.toggleRightSidebar',
-      'view.togglePreview', 'view.toggleConversations', 'view.newConversation', 'view.cycleTheme',
+      'view.togglePreview', 'view.toggleConversations', 'view.newConversation',
+      'view.theme.dark', 'view.theme.light', 'view.theme.contrast', 'view.theme.system',
       'view.fontIncrease', 'view.fontDecrease', 'view.fontReset', 'nav.quickOpen',
       'nav.back', 'nav.forward', 'refactor.rename', 'refactor.move', 'refactor.copy',
       'refactor.extract', 'refactor.splitHere', 'refactor.splitByHeading',
@@ -115,7 +117,10 @@ describe('buildCommandRegistry', () => {
       'edit.sortLines': 'sortLines', 'view.toggleSidebar': 'toggleSidebar',
       'view.toggleRightSidebar': 'toggleRightSidebar', 'view.togglePreview': 'togglePreview',
       'view.toggleConversations': 'toggleConversations', 'view.newConversation': 'newConversation',
-      'view.cycleTheme': 'cycleTheme',
+      // view.theme.* all dispatch to setTheme with distinct args — asserted
+      // separately below, so they're excluded from the 1:1 run loop.
+      'view.theme.dark': 'setTheme', 'view.theme.light': 'setTheme',
+      'view.theme.contrast': 'setTheme', 'view.theme.system': 'setTheme',
       'view.fontIncrease': 'fontIncrease', 'view.fontDecrease': 'fontDecrease',
       'view.fontReset': 'fontReset', 'nav.quickOpen': 'quickOpen', 'nav.back': 'navBack',
       'nav.forward': 'navForward', 'refactor.rename': 'renameActive',
@@ -136,9 +141,28 @@ describe('buildCommandRegistry', () => {
     // that forgot a dispatch assertion).
     expect(new Set(cmds.map((c) => c.id))).toEqual(new Set(Object.keys(wiring)));
     for (const cmd of cmds) {
+      // Theme entries share one dep (setTheme) with distinct args; covered below.
+      if (cmd.id.startsWith('view.theme.')) continue;
       cmd.run();
       const depMethod = deps[wiring[cmd.id]] as ReturnType<typeof vi.fn>;
       expect(depMethod, `command ${cmd.id} should call deps.${wiring[cmd.id]}`).toHaveBeenCalledTimes(1);
     }
+  });
+
+  it('each theme command selects its own mode via setTheme (#1139)', () => {
+    const deps = makeDeps();
+    const cmds = buildCommandRegistry(deps);
+    const byId = (id: string) => cmds.find((c) => c.id === id)!;
+    byId('view.theme.light').run();
+    byId('view.theme.system').run();
+    expect(deps.setTheme).toHaveBeenNthCalledWith(1, 'light');
+    expect(deps.setTheme).toHaveBeenNthCalledWith(2, 'system');
+  });
+
+  it('marks the current theme in the entry title', () => {
+    const cmds = buildCommandRegistry(makeDeps({ currentTheme: () => 'contrast' }));
+    const byId = (id: string) => cmds.find((c) => c.id === id)!;
+    expect(byId('view.theme.contrast').title).toBe('Theme: High Contrast (current)');
+    expect(byId('view.theme.dark').title).toBe('Theme: Dark');
   });
 });


### PR DESCRIPTION
Closes #1139.

## Problem

Theme switching was a blind four-way **cycle** (dark → light → contrast → system) everywhere it was discoverable — the status-bar click, ⌘⇧T, the command palette's "Cycle Theme", and the native View menu. Getting to the theme you wanted meant clicking repeatedly and watching the whole UI reflow each step. The only direct picker was buried in Settings → Appearance.

## Fix

Every discoverable surface now offers **direct selection**:

- **Status bar** — clicking the theme label opens a small popup menu (opens upward) listing Dark / Light / High Contrast / System with the current one checked. `role=menu` / `menuitemradio`, Escape + click-outside dismiss, focuses the active item on open.
- **Command palette** — the single "Cycle Theme" entry becomes one searchable entry per mode (`Theme: Dark`, `Theme: Light`, …), the active one marked `(current)`.
- **Native View menu** — "Cycle Theme" becomes a **Theme** submenu of radio items reflecting the active theme. *(This is the piece the first pass missed.)*

**⌘⇧T still cycles** — kept for power users, on both the shortcut and a "Cycle Theme" item beside the submenu, exactly as the issue suggested.

### How the native-menu checkmark stays in sync
The renderer owns the theme (localStorage); the main process can't read it. So the renderer **reports** its theme to main — on mount and on every change (cycle or pick) — via a new `menu:reportTheme` channel. Main records it and rebuilds the menu, so the radio reflects reality no matter which surface changed it.

### Consolidation
`ThemeMode` + `THEME_MODES` move to `src/shared/theme.ts` so the native menu (main) and the renderer draw from **one list**. `SettingsDialog`'s duplicate `THEME_OPTIONS` is dropped in favor of it, ending the "Contrast" vs "High Contrast" label drift between surfaces.

## Testing

- New registry tests: four `view.theme.*` entries, each dispatches `setTheme` with its own mode; active entry marked `(current)`.
- Snapshots updated: preload bridge (`onSetTheme` / `reportTheme`) and the IPC registration contract (`menu:reportTheme`).
- Full suite green (3936 tests); `pnpm lint` clean.

> Note: the View-menu change is in the **main** process — a running `pnpm dev` needs a restart (not just HMR) to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)