### PR TITLE
fix: tell the assistant today's date in the conversation prompt (#1138)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -18,6 +18,7 @@ import * as approval from '../llm/approval';
 import type { Proposal } from '../llm/approval';
 import { orderRefactors } from '../notebase/reorg';
 import * as conversation from '../llm/conversation';
+import { currentDateContext } from '../llm/date-context';
 import type { ContextBundle, ConversationMessage } from '../../shared/types';
 import {
   formatComputeResultAsContext,
@@ -73,6 +74,10 @@ function buildConversationSystemPrompt(
   currentNotePath?: string,
 ): string {
   const parts = [DEFAULT_CONVERSATION_SYSTEM_PROMPT];
+  // Dynamic per-turn context follows the static prompt. Within one session
+  // (same day, same open note) it's stable, so the cached system block still
+  // hits across turns; it only re-caches when the date or open note changes.
+  parts.push('', currentDateContext());
   if (contextBundle.notePath) {
     parts.push('', `The user started this conversation from the note: ${contextBundle.notePath}`);
   }

--- a/src/main/llm/date-context.ts
+++ b/src/main/llm/date-context.ts
@@ -1,0 +1,26 @@
+/**
+ * A one-line "today is …" context for the conversation system prompt so the
+ * model dates notes correctly and can resolve relative dates ("tomorrow",
+ * "last week", "next Friday"). Without it the model guesses, usually landing
+ * in its training-cutoff era (#1138).
+ *
+ * A pure leaf module (only `Intl` + `Date`) so it's unit-testable without
+ * pulling the conversation registrar's electron/llm import graph.
+ */
+
+/**
+ * @param now       The moment to describe. Defaults to `new Date()` and is
+ *                  computed per turn by the caller, so long-lived / resumed
+ *                  conversations always reflect the real current date.
+ * @param timeZone  IANA zone; defaults to the host's resolved zone. The
+ *                  weekday is included so day-relative phrasing resolves, and
+ *                  the zone disambiguates "today" across the date line.
+ */
+export function currentDateContext(
+  now: Date = new Date(),
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+): string {
+  const iso = now.toLocaleDateString('en-CA', { timeZone }); // YYYY-MM-DD
+  const weekday = now.toLocaleDateString('en-US', { timeZone, weekday: 'long' });
+  return `Today's date is ${weekday}, ${iso} (${timeZone}). Use it to resolve relative dates ("today", "tomorrow", "last week") and whenever you name or date a note.`;
+}

--- a/tests/main/llm/date-context.test.ts
+++ b/tests/main/llm/date-context.test.ts
@@ -1,0 +1,31 @@
+/**
+ * The conversation system prompt injects today's date so the model dates notes
+ * correctly and can resolve relative dates (#1138). This pins the format and
+ * the per-turn / timezone behavior of `currentDateContext`.
+ */
+import { describe, it, expect } from 'vitest';
+import { currentDateContext } from '../../../src/main/llm/date-context';
+
+describe('currentDateContext (#1138)', () => {
+  it('formats weekday, ISO date, and timezone for a fixed instant', () => {
+    // 2026-07-10 12:00 UTC → 07:00 in Chicago (CDT, UTC-5), still July 10.
+    const line = currentDateContext(new Date('2026-07-10T12:00:00Z'), 'America/Chicago');
+    expect(line).toBe(
+      "Today's date is Friday, 2026-07-10 (America/Chicago). Use it to resolve " +
+        'relative dates ("today", "tomorrow", "last week") and whenever you name or date a note.',
+    );
+  });
+
+  it('resolves the calendar date in the given timezone, not UTC', () => {
+    // 23:30 UTC on the 10th is already the 11th in Tokyo (UTC+9).
+    const instant = new Date('2026-07-10T23:30:00Z');
+    expect(currentDateContext(instant, 'Asia/Tokyo')).toContain('2026-07-11');
+    expect(currentDateContext(instant, 'America/Chicago')).toContain('2026-07-10');
+  });
+
+  it('names the timezone it was given', () => {
+    expect(currentDateContext(new Date('2026-01-02T12:00:00Z'), 'Europe/London')).toContain(
+      '(Europe/London)',
+    );
+  });
+});


### PR DESCRIPTION
Closes #1138.

## Problem

The conversation system prompt never told the model what today's date is. Notes involving dates ("log today's entry", "file tomorrow's standup", "what did I do last week") came out wrong — the model guessed, usually landing in its training-cutoff era — and relative dates couldn't be resolved at all.

## Fix

`buildConversationSystemPrompt` now injects a line like:

> Today's date is Friday, 2026-07-10 (America/Chicago). Use it to resolve relative dates ("today", "tomorrow", "last week") and whenever you name or date a note.

- **Per-turn.** The builder runs on every `CONVERSATION_SEND`, so `new Date()` there is naturally per-turn — long-lived and resumed conversations stay accurate.
- **Weekday + IANA zone.** The weekday lets the model resolve day-relative phrasing ("next Friday"); the timezone disambiguates "today" across the date line and dates notes in the user's local calendar, not UTC.
- **Caching.** The line sits in the dynamic tail of the single, cached system block. Within one session — same day, same open note — it's stable, so the prompt cache still hits across turns; it only re-caches when the date or open note changes (the block already varied per-turn via the open-note path, so this adds negligible busting). Correctness beats a marginal cache hit here anyway.

## Notes

- The formatter is a pure leaf module (`src/main/llm/date-context.ts`, only `Intl` + `Date`) so it's unit-testable without pulling the registrar's electron/llm import graph.
- **Compaction** (`COMPACT_SYSTEM_PROMPT`) is deliberately left untouched — it condenses existing history rather than filing dated content, so it isn't the reported failure mode.

## Testing

- New `date-context.test.ts`: exact format for a fixed instant; calendar date resolves in the given zone not UTC (Tokyo rolls to the 11th while Chicago is still the 10th); names the given zone.
- `tests/main/llm` + `tests/main/ipc` — 227 pass. `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)