### PR TITLE
feat: series-filing skills group into a directory with sort-ordered names (#1141)

### DIFF
--- a/src/main/llm/tools/propose-notes.ts
+++ b/src/main/llm/tools/propose-notes.ts
@@ -139,7 +139,19 @@ export const proposeNotes: NotebaseTool = {
       'links. Bad: `[[stop-1]]` while the file is `notes/.../Sets, Functions, ' +
       'and the Need for Types.md`. Good: `[[Sets, Functions, and the Need for ' +
       'Types]]`. Prefer paths without commas/punctuation in the basename if you ' +
-      'can — they\'re easier to link to.',
+      'can — they\'re easier to link to.\n' +
+      '\n' +
+      'Grouping & ordering: put the whole bundle (parent index + every child) in ' +
+      'ONE new directory named for the topic, e.g. "notes/group-theory-journey/…", ' +
+      'so it stays together instead of scattering among unrelated notes. When the ' +
+      'children form an ORDERED series (a learning path, sequential steps), prefix ' +
+      'their basenames with a zero-padded number so they sort into reading order — ' +
+      '"Step 01: …", "Step 02: …" (zero-pad: "Step 01", not "Step 1", or a 10th+ ' +
+      'step mis-sorts), with the intro/overview named to sort first (e.g. ' +
+      '"Introduction"). Do NOT number unordered bundles — a glossary or a set of ' +
+      'claims should stay alphabetical, which is the right order there. A numeric ' +
+      'prefix is part of the basename, so the parent\'s [[…]] links must include it ' +
+      'exactly (the wiki-link rule above still applies).',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/main/skills/stock/create-learning-journey.md
+++ b/src/main/skills/stock/create-learning-journey.md
@@ -26,6 +26,8 @@ After the first journey, iterate with the user. They may want more stops, fewer,
 
 When the user is happy with the structure and wants it filed as notes, call the propose_notes tool with a bundle: one parent index note (the journey overview, with wiki-links to each child) plus one child note per stop (its content fleshed out). The user reviews the bundle as an inline card. Do NOT paste the same content inline in chat — the card is the deliverable.
 
+File the whole bundle into ONE new directory named for the journey, e.g. `notes/group-theory-journey/`, so the index and every stop stay grouped. This is an ordered path, so name the stops to sort into reading order: give each a zero-padded `Step NN: <title>` basename (`Step 01: Semigroups`, `Step 02: Groups`, … — `Step 01`, not `Step 1`, or a 10th stop mis-sorts), and name the overview so it sorts first (e.g. `Introduction`). The parent's `[[…]]` links must match those exact basenames, prefix included.
+
 Use web search when a stop is a term you need to look up for accuracy.
 
 ## Note{{#if note.title}} — {{note.title}}{{/if}}
@@ -43,5 +45,7 @@ Once the destination is clear, propose a numbered journey of 3–8 stops. For ea
 After the first journey, iterate with the user. They may want more stops, fewer, a different starting assumption, or to skip/merge specific stops.
 
 When the user is happy with the structure and wants it filed as notes, call the propose_notes tool with a bundle: one parent index note (the journey overview, with wiki-links to each child) plus one child note per stop (its content fleshed out). The user reviews the bundle as an inline card. Do NOT paste the same content inline in chat — the card is the deliverable.
+
+File the whole bundle into ONE new directory named for the journey, e.g. `notes/group-theory-journey/`, so the index and every stop stay grouped. This is an ordered path, so name the stops to sort into reading order: give each a zero-padded `Step NN: <title>` basename (`Step 01: Semigroups`, `Step 02: Groups`, … — `Step 01`, not `Step 1`, or a 10th stop mis-sorts), and name the overview so it sorts first (e.g. `Introduction`). The parent's `[[…]]` links must match those exact basenames, prefix included.
 
 Use web search when a stop is a term you need to look up for accuracy.{{/if}}

--- a/src/main/skills/stock/decompose-into-claims.md
+++ b/src/main/skills/stock/decompose-into-claims.md
@@ -47,7 +47,7 @@ If the passage genuinely yields no claims (purely descriptive, only questions, o
 
 ### Parent decomposition note
 
-Path: `notes/decomposition-of-<source-stem>.md` (use the source note's basename, slugified).
+Path: `notes/claims/<source-stem>/00-decomposition.md` — the index lives in the same `notes/claims/<source-stem>/` directory as its claim notes (the `00` prefix sorts it above the numbered claims).
 
 ```markdown
 ---
@@ -68,7 +68,7 @@ A breakdown of [[<source-note-stem>]] into its individual claims.
 
 ### Child claim notes (one per claim)
 
-Path: `notes/claims/<source-stem>-<n>-<short-claim-slug>.md` — pick a basename that's stable, kebab-case, and ideally uses no punctuation (CRITICAL wiki-link rule applies — the parent's links must match these basenames identically).
+Path: `notes/claims/<source-stem>/<nn>-<short-claim-slug>.md` — file this source's claims together in their own `notes/claims/<source-stem>/` directory (the parent index goes there too), and zero-pad the number (`01`, `02`, … `10`) so they sort in extraction order rather than `1, 10, 2`. Pick a basename that's stable, kebab-case, and ideally uses no punctuation (CRITICAL wiki-link rule applies — the parent's links must match these basenames identically).
 
 ````markdown
 ---

--- a/src/main/skills/stock/decompose.md
+++ b/src/main/skills/stock/decompose.md
@@ -26,6 +26,7 @@ You are decomposing a long note into a parent index note plus 2–7 focused chil
 4. **Build the bundle.** Call `propose_notes` ONCE with:
    - **One parent note.** Body is a 1–3 paragraph orientation framing what the note is about and how the children relate. Do NOT inline the children's prose — point at them via `[[basename]]` wiki-links using the children's exact basenames.
    - **One child note per topic.** Title in 2–6 words, title-case. Body preserves the source's voice with minor tidying only — no heavy rewriting. No frontmatter required.
+   - **One directory for the set.** File the parent and all children into a new directory named for the source (e.g. `notes/<source-slug>/`) so the decomposition stays grouped instead of scattering. If the children have a natural reading order (the source was sequential), give them a zero-padded `NN — <title>` basename so they sort that way; if the split is purely topical with no inherent order, plain titles are fine — don't force numbering.
 5. **Wiki-links.** Wiki-link resolution is exact-match on basename. Spell each `[[Other Note Name]]` IDENTICALLY to the OTHER payload's `relativePath` minus the trailing `.md`. Pick basenames you're willing to use as link targets unchanged — prefer simple names without commas/punctuation.
 6. **End the turn.** After `propose_notes` returns, end with one short acknowledgement sentence ("Drafted N notes for review.") and stop. Do not repeat the contents inline.
 

--- a/src/main/skills/stock/define-terms.md
+++ b/src/main/skills/stock/define-terms.md
@@ -25,7 +25,7 @@ Use web lookup when you need a canonical definition. After the first glossary, i
 
 When the user wants the glossary filed, call the propose_notes tool with the bundle. Two reasonable shapes:
 - One note containing all terms as a glossary (cleanest for short lists).
-- One parent index + one note per term (when terms warrant their own pages).
+- One parent index + one note per term (when terms warrant their own pages). File the parent and all term notes into one directory named for the glossary (e.g. `notes/<glossary-slug>/`) so they stay grouped. A glossary is unordered — name term notes by the term itself and let them sort alphabetically; do NOT add numeric prefixes.
 
 The user reviews the bundle as an inline card. Don't paste the contents inline in chat too — the card is the deliverable.
 
@@ -44,6 +44,6 @@ Use web lookup when you need a canonical definition. After the first glossary, i
 
 When the user wants the glossary filed, call the propose_notes tool with the bundle. Two reasonable shapes:
 - One note containing all terms as a glossary (cleanest for short lists).
-- One parent index + one note per term (when terms warrant their own pages).
+- One parent index + one note per term (when terms warrant their own pages). File the parent and all term notes into one directory named for the glossary (e.g. `notes/<glossary-slug>/`) so they stay grouped. A glossary is unordered — name term notes by the term itself and let them sort alphabetically; do NOT add numeric prefixes.
 
 The user reviews the bundle as an inline card. Don't paste the contents inline in chat too — the card is the deliverable.{{/if}}

--- a/src/main/skills/stock/explain-like-im.md
+++ b/src/main/skills/stock/explain-like-im.md
@@ -35,7 +35,7 @@ Tune your explanation to the audience level the user specified. Keep it accurate
 
 After the first explanation, iterate with the user — different angle, different slice, a specific point in more depth.
 
-If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough.
+If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough. When you split into per-section children, file the parent index and all sections into one new directory named for the topic (e.g. `notes/<topic-slug>/`); and since an explanation's sections usually build in order, give them a zero-padded `Step NN: <title>` basename (`Step 01`, `Step 02`, …) so they sort in reading order, with the overview named to sort first (e.g. `Introduction`). The parent's `[[…]]` links must match those exact basenames.
 
 Audience: {{param.audience}}.
 
@@ -47,6 +47,6 @@ Because no note is open, your first response should be a short clarifying questi
 
 Tune your explanation to the audience level the user specified. Keep it accurate — simplify without falsifying. Use analogies, narrative, or concrete examples as the audience demands. You have web tools available; use them when a canonical example or external framing would help.
 
-If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough.
+If the user wants the explanation filed as a new note (or split into a parent index plus per-section children), call the propose_notes tool with the bundle. Don't paste the same content inline as well — the inline review card is enough. When you split into per-section children, file the parent index and all sections into one new directory named for the topic (e.g. `notes/<topic-slug>/`); and since an explanation's sections usually build in order, give them a zero-padded `Step NN: <title>` basename (`Step 01`, `Step 02`, …) so they sort in reading order, with the overview named to sort first (e.g. `Introduction`). The parent's `[[…]]` links must match those exact basenames.
 
 Audience: {{param.audience}}.{{/if}}


### PR DESCRIPTION
Closes #1141.

## Problem

Skills that file a *series* of notes — Create Learning Journey, and the same bundle pattern in Decompose / Decompose into Claims / Define Terms / Explain Like I'm… — gave the model no guidance on **where** the notes go or **how they're named**. Result: a parent index + children scattered among unrelated notes, and stop names like "Semigroups" / "Groups" / "Abelian groups" sorting alphabetically into meaningless order.

## Fix (prompt-only)

`propose_notes` already accepts subdirectory paths (`notes/foo/bar.md`), so no code change is needed — just prompting.

- **Shared `propose_notes` tool description** — the general rule, so even series filed outside these skills benefit: put the whole bundle in one new topic directory; for an **ordered** series, zero-pad numeric basename prefixes (`Step 01: …`, overview sorts first) so it reads in sequence; **do not** number unordered bundles. Numeric prefixes are part of the basename, so parent `[[…]]` links must include them (ties into the existing wiki-link rule).
- **create-learning-journey** & **explain-like-im** — dedicated directory + zero-padded `Step NN:` ordering (both are inherently ordered; explanation sections usually build).
- **decompose** — dedicated directory; number **only** when the children have a natural reading order, else plain topical titles (a purely topical split has no inherent sequence).
- **decompose-into-claims** — file a source's claims *and* their index in `notes/claims/<source-stem>/` with zero-padded numbers, instead of scattering them across a shared `notes/claims/` where `1, 10, 2` mis-sorts.
- **define-terms** — dedicated directory but explicitly **keep alphabetical**: a glossary is unordered, so no numeric prefixes (per the issue's watch-out).

## Watch-outs honored

- Zero-pad emphasized everywhere (`Step 01`, not `Step 1`) so 10+ items sort right.
- Consistency with the wiki-link rule: prefixes are part of the basename the parent must link to exactly — called out in each edit.
- No forced numbering on non-series bundles (glossary stays alphabetical; topical decompose stays unnumbered unless naturally sequential).

## Testing

Prompt-only. `skills-parse` / `skills-compile` / `learning-tools` / `propose-notes-tool` / `decompose-into-claims-tool` suites pass (47); `pnpm lint` clean. Behavior itself is model-driven and not unit-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)