### PR TITLE
feat: show all files in the tree; plain-text + "no preview" renderers (#1130)

### DIFF
--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
 import type { NoteFile, NotebaseMeta } from '../../shared/types';
-import { INDEXABLE_EXTS } from './indexable-files';
 
 const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
 
@@ -49,7 +48,10 @@ async function readDirectory(dirPath: string, rootPath: string): Promise<NoteFil
         isDirectory: true,
         children,
       });
-    } else if (INDEXABLE_EXTS.has(path.extname(entry.name))) {
+    } else {
+      // List every file, not just indexable ones (#1130) — hiding unknown
+      // extensions made files a user put in their project silently vanish.
+      // Indexing stays gated on INDEXABLE_EXTS elsewhere; listing ≠ indexing.
       // mtime drives the "2h / 5d / 1mo" stamp on each file row in the
       // sidebar (§5.3 of the 2026-05 design review). One extra stat per
       // file at listing time; for typical thoughtbase sizes this is

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -150,6 +150,15 @@ export function startWatching(
     return timer;
   };
 
+  // The tree now lists every file (#1130), so the watcher surfaces IPC (tree
+  // refresh) and runs move-detection (open tabs following external moves) for
+  // ALL files. Graph/search indexing stays gated on `isWatchable` — listing a
+  // `.txt` must not drag it into the knowledge graph. These helpers apply that
+  // gate to just the index callbacks; the IPC sends around them are unconditional.
+  const indexChanged = (relative: string) => { if (isWatchable(relative)) void callbacks?.onFileChanged(relative); };
+  const indexCreated = (relative: string) => { if (isWatchable(relative)) void callbacks?.onFileCreated(relative); };
+  const indexDeleted = (relative: string) => { if (isWatchable(relative)) void callbacks?.onFileDeleted(relative); };
+
   const flushDelete = (absPath: string) => {
     const pending = pendingUnlinks.get(absPath);
     if (!pending) return;
@@ -157,28 +166,25 @@ export function startWatching(
     pendingUnlinks.delete(absPath);
     if (win.isDestroyed()) return;
     win.webContents.send(Channels.NOTEBASE_FILE_DELETED, pending.relative);
-    void callbacks?.onFileDeleted(pending.relative);
+    indexDeleted(pending.relative);
   };
 
   const emitCreate = (relative: string) => {
     win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
-    void callbacks?.onFileCreated(relative);
+    indexCreated(relative);
   };
 
-  // Callbacks may be async (interface allows void | Promise<void>); the
-  // watcher invokes them as fire-and-forget. `void` makes that explicit.
   notes.on('change', (filePath, stats) => {
-    if (isWatchable(filePath) && !win.isDestroyed()) {
-      const ino = inodeOf(stats);
-      if (ino !== undefined) inodeByPath.set(filePath, ino);
-      const relative = filePath.slice(rootPath.length + 1);
-      win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
-      void callbacks?.onFileChanged(relative);
-    }
+    if (win.isDestroyed()) return;
+    const ino = inodeOf(stats);
+    if (ino !== undefined) inodeByPath.set(filePath, ino);
+    const relative = filePath.slice(rootPath.length + 1);
+    win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
+    indexChanged(relative);
   });
 
   notes.on('add', (filePath, stats) => {
-    if (!isWatchable(filePath) || win.isDestroyed()) return;
+    if (win.isDestroyed()) return;
     const ino = inodeOf(stats);
     if (ino !== undefined) inodeByPath.set(filePath, ino);
     const relative = filePath.slice(rootPath.length + 1);
@@ -196,7 +202,7 @@ export function startWatching(
       // picks up the new one. Crucially we do NOT emit FILE_DELETED for the
       // old path — that broadcast is what would close the tab.
       win.webContents.send(Channels.NOTEBASE_RENAMED, [{ old: pending.relative, new: relative }]);
-      void callbacks?.onFileDeleted(pending.relative);
+      indexDeleted(pending.relative);
       emitCreate(relative);
       return;
     }
@@ -215,7 +221,7 @@ export function startWatching(
   });
 
   notes.on('unlink', (filePath) => {
-    if (!isWatchable(filePath) || win.isDestroyed()) return;
+    if (win.isDestroyed()) return;
     const relative = filePath.slice(rootPath.length + 1);
     const basename = path.basename(filePath);
     const inode = inodeByPath.get(filePath);
@@ -225,7 +231,7 @@ export function startWatching(
     // delete immediately (unchanged behavior) rather than debouncing it.
     if (wasHandled(relative)) {
       win.webContents.send(Channels.NOTEBASE_FILE_DELETED, relative);
-      void callbacks?.onFileDeleted(relative);
+      indexDeleted(relative);
       return;
     }
 
@@ -239,7 +245,7 @@ export function startWatching(
       clearTimeout(added.timer);
       recentAdds.delete(movedTo);
       win.webContents.send(Channels.NOTEBASE_RENAMED, [{ old: relative, new: added.relative }]);
-      void callbacks?.onFileDeleted(relative);
+      indexDeleted(relative);
       return;
     }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1349,23 +1349,27 @@
                       title="Recompute all cells (top to bottom, stops on error)"
                     ><Icon name="run-all" size={12} /></button>
                   {/if}
-                  <div class="view-toggle">
-                    <button
-                      class:active={group.viewMode === 'source'}
-                      onclick={() => editor.setViewMode('source', groupId)}
-                      title="Source (Cmd+Shift+P to cycle)"
-                    >Source</button>
-                    <button
-                      class:active={group.viewMode === 'editor-preview'}
-                      onclick={() => editor.setViewMode('editor-preview', groupId)}
-                      title="Source + preview side by side"
-                    >Side by side</button>
-                    <button
-                      class:active={group.viewMode === 'preview'}
-                      onclick={() => editor.setViewMode('preview', groupId)}
-                      title="Preview"
-                    >Preview</button>
-                  </div>
+                  {#if !note.plainText}
+                    <!-- A plain-text file has no rendered preview (#1130) — the
+                         source/preview toggle would offer empty views. -->
+                    <div class="view-toggle">
+                      <button
+                        class:active={group.viewMode === 'source'}
+                        onclick={() => editor.setViewMode('source', groupId)}
+                        title="Source (Cmd+Shift+P to cycle)"
+                      >Source</button>
+                      <button
+                        class:active={group.viewMode === 'editor-preview'}
+                        onclick={() => editor.setViewMode('editor-preview', groupId)}
+                        title="Source + preview side by side"
+                      >Side by side</button>
+                      <button
+                        class:active={group.viewMode === 'preview'}
+                        onclick={() => editor.setViewMode('preview', groupId)}
+                        title="Preview"
+                      >Preview</button>
+                    </div>
+                  {/if}
                   <button
                     class="nav-btn"
                     onclick={() => editor.splitGroup(groupId, 'horizontal')}
@@ -1388,8 +1392,8 @@
                     title="Toggle Right Sidebar (Cmd+Shift+B)"
                   ><Icon name="outline" size={12} /></button>
                 </div>
-                <div class="editor-content" class:editor-preview={group.viewMode === 'editor-preview'}>
-                  {#if group.viewMode === 'source' || group.viewMode === 'editor-preview'}
+                <div class="editor-content" class:editor-preview={group.viewMode === 'editor-preview' && !note.plainText}>
+                  {#if note.plainText || group.viewMode === 'source' || group.viewMode === 'editor-preview'}
                     <div class="editor-panel">
                       {#key groupId + ':' + note.relativePath}
                         <Editor
@@ -1397,6 +1401,7 @@
                           groupId={groupId}
                           filePath={note.relativePath}
                           content={note.content}
+                          plainText={note.plainText ?? false}
                           initialHistory={note.historyJson}
                           searchQuery={pendingSearchQuery}
                           onContentChange={(text) => editor.setContent(text, groupId)}
@@ -1443,7 +1448,7 @@
                       {/key}
                     </div>
                   {/if}
-                  {#if group.viewMode === 'preview' || group.viewMode === 'editor-preview'}
+                  {#if !note.plainText && (group.viewMode === 'preview' || group.viewMode === 'editor-preview')}
                     <div class="preview-panel">
                       <Preview
                         bind:this={previewComponents[groupId]}
@@ -1520,6 +1525,22 @@
                     onOpenNote={(p) => handleFileSelect(p)}
                   />
                 {/key}
+              {:else if active?.type === 'unsupported'}
+                <!-- No in-app renderer for this file type (#1130). A calm panel
+                     (not an error, per the UI philosophy) with escape hatches to
+                     the OS. Capture primitives, not the reactive tab, so the
+                     button handlers can't read a stale path. -->
+                {@const relPath = active.relativePath}
+                {@const extLabel = active.ext ? `${active.ext} files` : 'this file type'}
+                <div class="no-file no-preview">
+                  <p>No preview for {extLabel}</p>
+                  <p class="no-preview-name">{active.fileName}</p>
+                  <div class="no-preview-actions">
+                    <button onclick={() => void api.shell.revealFile(relPath)}>Reveal in Finder</button>
+                    <button onclick={() => void api.shell.openInDefault(relPath)}>Open with default app</button>
+                    <button onclick={() => void navigator.clipboard.writeText(relPath)}>Copy path</button>
+                  </div>
+                </div>
               {:else if editor.groups.length > 1}
                 <!-- A freshly split pane is empty until a note lands in it.
                      It has no tab bar, so offer a way back out (#817). -->
@@ -2028,6 +2049,36 @@
     cursor: pointer;
   }
   .empty-pane-close:hover {
+    border-color: var(--accent);
+  }
+
+  /* "No preview for .xyz" panel (#1130) — reuses the calm .no-file empty-state
+     look; no danger styling (per the UI philosophy). */
+  .no-preview {
+    flex-direction: column;
+    gap: 4px;
+  }
+  .no-preview-name {
+    font-size: 12px !important;
+    color: var(--text-faint) !important;
+    font-family: var(--font-mono);
+  }
+  .no-preview-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .no-preview-actions button {
+    padding: 4px 12px;
+    font-size: 12px;
+    color: var(--text);
+    background: var(--bg-button);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .no-preview-actions button:hover {
     border-color: var(--accent);
   }
 

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -141,6 +141,15 @@
      */
     onUploadError?: (message: string) => void;
     /**
+     * Plain-text mode (#1130): a non-markdown text file. Turns OFF the
+     * markdown-specific extensions — markdown language + syntax highlight,
+     * frontmatter fold, wiki-link/tag autocomplete + decorations, compute
+     * cells, footnote/highlight decorations, format-on-paste, image-paste
+     * upload — leaving a plain editable/saveable code buffer. Default false
+     * keeps every markdown caller unchanged.
+     */
+    plainText?: boolean;
+    /**
      * Run-cell handler (#373). When supplied, replaces the direct
      * `api.compute.runCell` call. App.svelte injects a trust-gated
      * variant that prompts on first Python execution per thoughtbase.
@@ -191,6 +200,7 @@
     initialHistory,
     onUploadError,
     onRunCell,
+    plainText = false,
   }: Props = $props();
 
   // Tools-for-Thought submenus, built to match the native main menu exactly
@@ -448,18 +458,22 @@
     basicSetup,
     // Give the `role="textbox"` content DOM an accessible name (#1005 a11y) —
     // CodeMirror's editable div is otherwise unlabeled (axe aria-input-field-name).
-    EditorView.contentAttributes.of({ 'aria-label': 'Note editor' }),
-    markdown({ codeLanguages: languages }),
-    // Pin the frontmatter fold's gutter arrow to line 1 by claiming the
-    // foldable range there ourselves. Without this, the markdown
-    // language's syntactic fold detection picks line 2 for the YAML
-    // body, so toggling the fold makes the arrow jump between lines —
-    // and a click-to-collapse from the expanded state leaves line 1 of
-    // the YAML visible.
-    foldService.of((state, lineStart) => {
-      if (lineStart !== 0) return null;
-      return findFrontmatterFoldRange(state.doc);
-    }),
+    EditorView.contentAttributes.of({ 'aria-label': plainText ? 'Text editor' : 'Note editor' }),
+    // Markdown language + frontmatter fold are markdown-only (#1130). A
+    // plain-text file gets a plain editable buffer with no md syntax layer.
+    ...(plainText ? [] : [
+      markdown({ codeLanguages: languages }),
+      // Pin the frontmatter fold's gutter arrow to line 1 by claiming the
+      // foldable range there ourselves. Without this, the markdown
+      // language's syntactic fold detection picks line 2 for the YAML
+      // body, so toggling the fold makes the arrow jump between lines —
+      // and a click-to-collapse from the expanded state leaves line 1 of
+      // the YAML visible.
+      foldService.of((state, lineStart) => {
+        if (lineStart !== 0) return null;
+        return findFrontmatterFoldRange(state.doc);
+      }),
+    ]),
     themeCompartment.of(cmTheme()),
     minervaEditorTheme(),
     search({
@@ -479,32 +493,36 @@
       '.cm-gutter.cm-lineNumbers': { display: 'none !important' },
     })),
     whitespaceCompartment.of(initSettings.showWhitespace ? highlightWhitespace() : []),
-    linkDecorations({
-      onOpenNote: (target: string) => {
-        if (onNavigate) onNavigate(target);
-      },
-      onOpenSource: (sourceId: string) => {
-        if (onOpenSource) onOpenSource(sourceId);
-      },
-      onOpenExcerpt: (excerptId: string) => {
-        if (onOpenExcerpt) onOpenExcerpt(excerptId);
-      },
-      onOpenExternal: (url: string) => {
-        void api.shell.openExternal(url);
-      },
-    }),
-    bookmarkGutterExtension(),
-    computeCellsExtension({
-      runCell: (language, code) => (
-        onRunCell
-          ? onRunCell(language, code, filePath)
-          : api.compute.runCell(language, code, filePath)
-      ),
-      runAllRef,
-    }),
-    footnotePreview(),
-    footnoteDecorations(),
-    highlightDecorations(),
+    // Markdown-only rendering layers (#1130): wiki-link/URL decorations,
+    // bookmark gutter, runnable compute cells, footnote + highlight decorations.
+    ...(plainText ? [] : [
+      linkDecorations({
+        onOpenNote: (target: string) => {
+          if (onNavigate) onNavigate(target);
+        },
+        onOpenSource: (sourceId: string) => {
+          if (onOpenSource) onOpenSource(sourceId);
+        },
+        onOpenExcerpt: (excerptId: string) => {
+          if (onOpenExcerpt) onOpenExcerpt(excerptId);
+        },
+        onOpenExternal: (url: string) => {
+          void api.shell.openExternal(url);
+        },
+      }),
+      bookmarkGutterExtension(),
+      computeCellsExtension({
+        runCell: (language, code) => (
+          onRunCell
+            ? onRunCell(language, code, filePath)
+            : api.compute.runCell(language, code, filePath)
+        ),
+        runAllRef,
+      }),
+      footnotePreview(),
+      footnoteDecorations(),
+      highlightDecorations(),
+    ]),
     EditorView.domEventHandlers({
       // Snapshot the selection at the very start of a right-click, before
       // any built-in handling can collapse it. Then, when the click is
@@ -549,6 +567,7 @@
       // Without stopPropagation an image drop fires both handlers and
       // the import path rejects the JPEG with "doesn't ingest *.jpeg".
       dragover: (e) => {
+        if (plainText) return false; // no image-upload / format-on-paste in plain text
         if (e.dataTransfer && hasImageFiles(e.dataTransfer)) {
           e.preventDefault();
           e.stopPropagation();
@@ -558,6 +577,7 @@
         return false;
       },
       drop: (e, v) => {
+        if (plainText) return false;
         if (!e.dataTransfer || !hasImageFiles(e.dataTransfer)) return false;
         e.preventDefault();
         e.stopPropagation();
@@ -569,6 +589,7 @@
       // → Cmd+V workflow and any other clipboard image source. Non-
       // image clipboard contents (text / html) fall through.
       paste: (e, v) => {
+        if (plainText) return false; // native paste — no image upload, no markdown reformat
         const items = e.clipboardData?.items;
         if (items) {
           const files = imageFilesFromClipboard(items);
@@ -850,7 +871,8 @@
       defaultKeymap: false,
     });
 
-    const allExtensions = [...extensions, appKeymap, updateListener, completion];
+    // Wiki-link / tag autocomplete is markdown-only (#1130).
+    const allExtensions = [...extensions, appKeymap, updateListener, ...(plainText ? [] : [completion])];
 
     // When the caller passes a history snapshot AND its serialised doc
     // still matches the current content, restore the undo/redo stacks

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -7,6 +7,7 @@
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import { extractTagsFromContent } from '../../../shared/refactor/auto-tag';
+  import { fileCapability } from '../../../shared/file-capability';
   import { ENTRYPOINT_TAG } from '../../../shared/entrypoint';
   import type { IconName } from './icons/registry';
 
@@ -23,8 +24,11 @@
       case '.csv': return 'tables';
       case '.ttl': return 'graph';
       case '.py':  return 'code';
-      default:     return 'notes';
     }
+    // Now that the tree lists every file (#1130), disambiguate the newly-shown
+    // types by capability: plain-text/code files get the code glyph; everything
+    // else (markdown and unsupported binaries) falls back to the page icon.
+    return fileCapability(name) === 'plaintext' ? 'code' : 'notes';
   }
 
   interface Props {

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -114,7 +114,9 @@
               ? `PDF: ${sourceTabLabel(tab.sourceId)}`
               : tab.type === 'graph'
                 ? `Graph: ${tab.relativePath}`
-                : `Source: ${sourceTabLabel(tab.sourceId)}`}
+                : tab.type === 'unsupported'
+                  ? tab.relativePath
+                  : `Source: ${sourceTabLabel(tab.sourceId)}`}
       >
         <!-- Leading slot: dirty pip OR type icon. The pip wins when the
              note is dirty so the visual cue can't be missed (§7.2). -->
@@ -138,6 +140,7 @@
           {:else if tab.type === 'query'}{tab.title}
           {:else if tab.type === 'pdf'}{sourceTabLabel(tab.sourceId)} (PDF)
           {:else if tab.type === 'graph'}{(tab.relativePath.split('/').pop() ?? tab.relativePath).replace(/\.md$/, '')} (Graph)
+          {:else if tab.type === 'unsupported'}{tab.fileName}
           {:else}{sourceTabLabel(tab.sourceId)}{/if}
         </span>
       </button>

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -1,5 +1,6 @@
 import { api } from '../ipc/client';
 import type { TabSession, SavedTab, SavedGroup, LayoutSession } from '../../../shared/types';
+import { fileCapability, extensionOf } from '../../../shared/file-capability';
 import { normalizeSqlRows, unionColumns } from '../editor/sql-result';
 import {
   type LayoutNode,
@@ -19,6 +20,10 @@ export interface NoteTab {
   fileName: string;
   content: string;
   savedContent: string;
+  /** True when opened in plain-text mode — a non-markdown text file (#1130).
+   *  Drives the Editor's plain-text mode (markdown behaviors off). Omitted for
+   *  markdown files. */
+  plainText?: boolean | undefined;
   cursorOffset?: number | undefined;
   scrollTop?: number | undefined;
   /**
@@ -69,7 +74,15 @@ export interface GraphTab {
   depth: number;
 }
 
-export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab;
+export interface UnsupportedTab {
+  type: 'unsupported';
+  relativePath: string;
+  fileName: string;
+  /** Lowercased extension (with dot) or '' — drives the "no preview for `.xyz`" copy. */
+  ext: string;
+}
+
+export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab | UnsupportedTab;
 
 /**
  * Source / preview view mode. `'editor-preview'` = source editor + rendered
@@ -98,6 +111,7 @@ function isQuery(tab: Tab): tab is QueryTab { return tab.type === 'query'; }
 function isSource(tab: Tab): tab is SourceTab { return tab.type === 'source'; }
 function isPdf(tab: Tab): tab is PdfTab { return tab.type === 'pdf'; }
 function isGraph(tab: Tab): tab is GraphTab { return tab.type === 'graph'; }
+function isUnsupported(tab: Tab): tab is UnsupportedTab { return tab.type === 'unsupported'; }
 
 let queryCounter = 0;
 let groupCounter = 0;
@@ -407,7 +421,7 @@ export function getEditorStore() {
     // already open anywhere, focus that pane + tab rather than spawning a second
     // live buffer (which would race to last-write-wins on save). This holds for
     // every caller — sidebar, wiki-link, search, split-open.
-    const found = locateTab((t) => isNote(t) && t.relativePath === relativePath);
+    const found = locateTab((t) => (isNote(t) || isUnsupported(t)) && t.relativePath === relativePath);
     if (found) {
       focusExistingTab(found);
       return;
@@ -415,14 +429,28 @@ export function getEditorStore() {
 
     const grp = resolveGroup(groupId);
     activeGroupId = grp.id;
-    const text = await api.notebase.readFile(relativePath);
     const fileName = relativePath.split('/').pop() ?? '';
+    const capability = fileCapability(relativePath);
+
+    // A file with no renderer (binary / unknown type) must NOT be read as text
+    // — that would slurp megabytes of garbage into a string (#1130). Route it
+    // to a calm "no preview" tab instead.
+    if (capability === 'unsupported') {
+      const tab: UnsupportedTab = { type: 'unsupported', relativePath, fileName, ext: extensionOf(relativePath) };
+      grp.tabs.push(tab);
+      grp.activeIndex = grp.tabs.length - 1;
+      schedulePersistTabs();
+      return;
+    }
+
+    const text = await api.notebase.readFile(relativePath);
     const tab: NoteTab = {
       type: 'note',
       relativePath,
       fileName,
       content: text,
       savedContent: text,
+      ...(capability === 'plaintext' ? { plainText: true } : {}),
     };
     grp.tabs.push(tab);
     grp.activeIndex = grp.tabs.length - 1;
@@ -455,11 +483,14 @@ export function getEditorStore() {
     const byOld = new Map(transitions.map((t) => [t.old, t.new]));
     let touched = false;
     for (const tab of allTabs()) {
-      if (!isNote(tab)) continue;
+      // Note tabs (markdown + plain-text) and unsupported-file tabs both carry a
+      // relativePath that must follow a move (#1130).
+      if (!isNote(tab) && !isUnsupported(tab)) continue;
       const newPath = byOld.get(tab.relativePath);
       if (newPath && newPath !== tab.relativePath) {
         tab.relativePath = newPath;
         tab.fileName = newPath.split('/').pop() ?? '';
+        if (isUnsupported(tab)) tab.ext = extensionOf(newPath);
         touched = true;
       }
     }
@@ -568,9 +599,12 @@ export function getEditorStore() {
       return {
         type: 'note',
         relativePath: t.relativePath,
+        ...(t.plainText ? { plainText: true } : {}),
         ...(t.cursorOffset !== undefined ? { cursorOffset: t.cursorOffset } : {}),
         ...(t.scrollTop !== undefined ? { scrollTop: t.scrollTop } : {}),
       };
+    } else if (isUnsupported(t)) {
+      return { type: 'unsupported', relativePath: t.relativePath };
     } else if (isQuery(t)) {
       return { type: 'query', title: t.title, query: t.query, language: t.language };
     } else if (isPdf(t)) {
@@ -619,12 +653,16 @@ export function getEditorStore() {
           fileName,
           content: text,
           savedContent: text,
+          ...(saved.plainText ? { plainText: true } : {}),
           cursorOffset: saved.cursorOffset,
           scrollTop: saved.scrollTop,
         };
       } catch {
         return null; // file deleted since last session
       }
+    } else if (saved.type === 'unsupported') {
+      const fileName = saved.relativePath.split('/').pop() ?? '';
+      return { type: 'unsupported', relativePath: saved.relativePath, fileName, ext: extensionOf(saved.relativePath) };
     } else if (saved.type === 'query') {
       queryCounter++;
       return {
@@ -913,7 +951,7 @@ export function getEditorStore() {
       // Walk in reverse so each splice doesn't disturb pending indexes.
       for (let i = grp.tabs.length - 1; i >= 0; i--) {
         const t = grp.tabs[i]!;
-        if (isNote(t) && isUnder(t.relativePath)) {
+        if ((isNote(t) || isUnsupported(t)) && isUnder(t.relativePath)) {
           grp.tabs.splice(i, 1);
           if (i === grp.activeIndex) {
             grp.activeIndex = -1;

--- a/src/shared/file-capability.ts
+++ b/src/shared/file-capability.ts
@@ -1,0 +1,71 @@
+/**
+ * How Minerva can render a file, keyed by extension (#1130).
+ *
+ * The project tree lists every file now, so clicking one must route to the
+ * right viewer — or say "no preview" instead of slurping a binary as text.
+ * This is the single source of truth both the editor host and the file tree
+ * consult, so the icon a row shows and the view it opens can't drift.
+ *
+ *  - `markdown`   — the full note editor (markdown extensions on). The files
+ *                   that already opened there — `.md`, plus `.ttl`/`.csv`/`.py`
+ *                   — keep doing so, unchanged.
+ *  - `plaintext`  — the editor in plain-text/code mode (markdown behaviors off):
+ *                   editable + saveable, but no section numbers, wiki-link
+ *                   autocomplete, format-on-paste, footnote/highlight decorations.
+ *  - `unsupported`— no in-app renderer (binaries, unknown types). The host shows
+ *                   a calm "no preview" panel with open-externally affordances,
+ *                   and never reads the file as text.
+ */
+export type FileCapability = 'markdown' | 'plaintext' | 'unsupported';
+
+/** Files that open in the full markdown note editor (unchanged from before). */
+const MARKDOWN_EXTS: ReadonlySet<string> = new Set(['.md', '.ttl', '.csv', '.py']);
+
+/**
+ * Plainly-textual files that open in plain-text mode. An allowlist (rather than
+ * "anything not known-binary") so an unknown extension defaults to `unsupported`
+ * and we never read a binary blob into a string.
+ */
+const PLAINTEXT_EXTS: ReadonlySet<string> = new Set([
+  '.txt', '.text', '.log', '.json', '.jsonl', '.ndjson', '.geojson',
+  '.xml', '.yaml', '.yml', '.toml', '.ini', '.cfg', '.conf', '.properties', '.env',
+  '.csv.schema.yaml', // paired CSV schema sidecar, edited as text
+  '.css', '.scss', '.sass', '.less',
+  '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.svelte', '.vue',
+  '.html', '.htm', '.svg', '.rss', '.atom',
+  '.sh', '.bash', '.zsh', '.fish', '.ps1', '.bat',
+  '.sql', '.graphql', '.gql',
+  '.rs', '.go', '.java', '.kt', '.swift', '.dart', '.scala', '.groovy', '.gradle',
+  '.c', '.h', '.hpp', '.hh', '.cpp', '.cc', '.cxx', '.m', '.mm',
+  '.rb', '.php', '.pl', '.pm', '.lua', '.r', '.jl', '.hs', '.ml', '.ex', '.exs', '.clj', '.erl',
+  '.tex', '.bib', '.rst', '.org', '.adoc', '.asciidoc',
+  '.diff', '.patch', '.gitignore', '.gitattributes', '.editorconfig', '.dockerignore',
+  '.makefile', '.mk', '.cmake', '.tf', '.tfvars', '.proto',
+]);
+
+/** Lowercased extension including the leading dot, or '' when there is none. */
+export function extensionOf(pathOrName: string): string {
+  const base = pathOrName.split('/').pop() ?? pathOrName;
+  const dot = base.lastIndexOf('.');
+  // A leading-dot name with no other dot (".gitignore") is treated as an
+  // extension so those config files still read as plain text.
+  if (dot <= 0) return dot === 0 ? base.toLowerCase() : '';
+  return base.slice(dot).toLowerCase();
+}
+
+export function fileCapability(pathOrName: string): FileCapability {
+  const lower = (pathOrName.split('/').pop() ?? pathOrName).toLowerCase();
+  // Double-extension sidecar (`<stem>.csv.schema.yaml`) is a plain-text edit.
+  if (lower.endsWith('.csv.schema.yaml')) return 'plaintext';
+  const ext = extensionOf(pathOrName);
+  if (MARKDOWN_EXTS.has(ext)) return 'markdown';
+  if (PLAINTEXT_EXTS.has(ext)) return 'plaintext';
+  return 'unsupported';
+}
+
+/** True when a file opens in an editable text buffer (markdown or plain text) —
+ *  i.e. it is safe to `readFile` it as a string. `unsupported` files must not
+ *  be read as text (they may be large binaries). */
+export function isTextEditable(pathOrName: string): boolean {
+  return fileCapability(pathOrName) !== 'unsupported';
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -190,6 +190,15 @@ export interface SavedNoteTab {
   relativePath: string;
   cursorOffset?: number;
   scrollTop?: number;
+  /** True for a file opened in plain-text mode (#1130); omitted for markdown. */
+  plainText?: boolean;
+}
+
+/** A file with no in-app renderer (binary / unknown type), shown as a calm
+ *  "no preview" panel. Not read as text. (#1130) */
+export interface SavedUnsupportedTab {
+  type: 'unsupported';
+  relativePath: string;
 }
 
 export interface SavedQueryTab {
@@ -221,7 +230,7 @@ export interface SavedGraphTab {
   depth?: number;
 }
 
-export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab | SavedGraphTab;
+export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab | SavedGraphTab | SavedUnsupportedTab;
 
 /** Legacy flat session: one group's tabs + active index. Superseded by
  *  {@link LayoutSession} (#816); still read on load and migrated to a single

--- a/tests/main/notebase/fs.test.ts
+++ b/tests/main/notebase/fs.test.ts
@@ -85,8 +85,9 @@ describe('listFiles', () => {
     await fsp.writeFile(path.join(root, 'README.md'), '# readme\n');
     await fsp.writeFile(path.join(root, 'data.csv'), 'a,b\n1,2\n');
     await fsp.writeFile(path.join(root, 'ontology.ttl'), '@prefix x: <x:> .\n');
-    // Non-indexable: must be filtered out.
+    // Non-indexable: now LISTED (#1130) though still not indexed.
     await fsp.writeFile(path.join(root, 'image.png'), 'fake');
+    await fsp.writeFile(path.join(root, 'notes.txt'), 'plain text\n');
     // Hidden dir: must be filtered out.
     await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
     await fsp.writeFile(path.join(root, '.minerva', 'graph.ttl'), '@prefix x: <x:> .\n');
@@ -119,17 +120,17 @@ describe('listFiles', () => {
     expect(names).not.toContain('.minerva');
   });
 
-  it('only includes indexable file types (.md, .ttl, .csv)', async () => {
+  it('lists all files, including non-indexable types (#1130)', async () => {
     const files = await listFiles(root);
-    function checkLeaves(items: typeof files) {
-      for (const f of items) {
-        if (!f.isDirectory) {
-          expect(f.name).toMatch(/\.(md|ttl|csv)$/);
-        }
-        if (f.children) checkLeaves(f.children);
-      }
-    }
-    checkLeaves(files);
+    const names = files.map((f) => f.name);
+    // Previously hidden non-indexable files are now surfaced in the tree.
+    expect(names).toContain('image.png');
+    expect(names).toContain('notes.txt');
+    // Indexable files still listed too.
+    expect(names).toContain('data.csv');
+    expect(names).toContain('ontology.ttl');
+    // Hidden dirs stay filtered.
+    expect(names).not.toContain('.minerva');
   });
 
   it('includes nested files', async () => {

--- a/tests/main/notebase/watcher.test.ts
+++ b/tests/main/notebase/watcher.test.ts
@@ -141,7 +141,7 @@ describe('startWatching() (#345)', () => {
       expect(created.sort()).toEqual(['a.md', 'b.ttl', 'c.csv']);
     });
 
-    it('ignores non-indexable extensions like .png and .json', async () => {
+    it('refreshes the tree for non-indexable files but does NOT index them (#1130)', async () => {
       const created: string[] = [];
       await startWatching(root, win as unknown as BrowserWindow, winId, {
         onFileCreated: (p) => created.push(p),
@@ -150,13 +150,20 @@ describe('startWatching() (#345)', () => {
       });
 
       await fsp.writeFile(path.join(root, 'image.png'), 'fake', 'utf-8');
-      await fsp.writeFile(path.join(root, 'config.json'), '{}', 'utf-8');
-      // Plant something we DO care about so we know the watcher is alive.
+      await fsp.writeFile(path.join(root, 'notes.txt'), 'plain', 'utf-8');
+      // Plant something indexable so we know the watcher is alive.
       await fsp.writeFile(path.join(root, 'real.md'), '# r\n', 'utf-8');
 
       await waitFor(() => created.includes('real.md'));
-      // .png / .json must not have invoked the callback, even though they
-      // landed in the watched tree.
+      // The tree-refresh IPC fires for EVERY file, so the sidebar updates
+      // when a .png / .txt is created (#1130).
+      await waitFor(() =>
+        win.webContents.send.mock.calls.some(
+          (c) => c[0] === Channels.NOTEBASE_FILE_CREATED && c[1] === 'notes.txt',
+        ),
+      );
+      expect(win.webContents.send).toHaveBeenCalledWith(Channels.NOTEBASE_FILE_CREATED, 'image.png');
+      // ...but the INDEX callback only ran for the indexable file — listing ≠ indexing.
       expect(created).toEqual(['real.md']);
     });
 

--- a/tests/shared/file-capability.test.ts
+++ b/tests/shared/file-capability.test.ts
@@ -1,0 +1,48 @@
+/**
+ * File-capability lookup (#1130) — the single source of truth for how the tree
+ * lists a file's icon and how the editor host routes it. A binary must map to
+ * `unsupported` so it's never read as text.
+ */
+import { describe, it, expect } from 'vitest';
+import { fileCapability, isTextEditable, extensionOf } from '../../src/shared/file-capability';
+
+describe('fileCapability (#1130)', () => {
+  it('routes the existing editor types to markdown', () => {
+    for (const p of ['note.md', 'data.csv', 'graph.ttl', 'helpers.py', 'notes/deep/x.MD']) {
+      expect(fileCapability(p), p).toBe('markdown');
+    }
+  });
+
+  it('routes plainly-textual types to plaintext', () => {
+    for (const p of ['a.txt', 'b.log', 'c.json', 'd.yaml', 'e.css', 'f.js', 'g.html', 'h.xml', 'notes/i.TS']) {
+      expect(fileCapability(p), p).toBe('plaintext');
+    }
+  });
+
+  it('routes binaries / unknown types to unsupported', () => {
+    for (const p of ['image.png', 'photo.JPG', 'archive.zip', 'doc.docx', 'movie.mp4', 'font.woff2', 'mystery']) {
+      expect(fileCapability(p), p).toBe('unsupported');
+    }
+  });
+
+  it('treats a leading-dot config file as plain text (.gitignore)', () => {
+    expect(fileCapability('.gitignore')).toBe('plaintext');
+    expect(fileCapability('.editorconfig')).toBe('plaintext');
+  });
+
+  it('handles the double-extension CSV schema sidecar as plain text', () => {
+    expect(fileCapability('data.csv.schema.yaml')).toBe('plaintext');
+  });
+
+  it('isTextEditable is true for everything but unsupported', () => {
+    expect(isTextEditable('a.md')).toBe(true);
+    expect(isTextEditable('a.txt')).toBe(true);
+    expect(isTextEditable('a.png')).toBe(false);
+  });
+
+  it('extensionOf lowercases and includes the dot', () => {
+    expect(extensionOf('notes/Foo.MD')).toBe('.md');
+    expect(extensionOf('noext')).toBe('');
+    expect(extensionOf('.gitignore')).toBe('.gitignore');
+  });
+});


### PR DESCRIPTION
Closes #1130.

The sidebar silently hid any file whose extension wasn't in a small allowlist, so files a user put in their project just **vanished**. Now the tree lists every file, and every file opens to *something* — never markdown-garbage, never a slurped binary.

## The core decouple
`INDEXABLE_EXTS` drove three concerns at once. Split them — **listing ≠ indexing**:
- **`fs.ts readDirectory`** lists all files (hidden `.`/`IGNORED_DIRS` still filtered).
- **Watcher**: the tree-refresh IPC *and* external-move detection now fire for **every** file (so creating/renaming/deleting a `.txt` refreshes the sidebar, and an open plain-text tab follows an external move), while graph/search **indexing stays gated on `INDEXABLE_EXTS`** — a listed `.txt` is *not* dragged into the graph.

## Capability lookup (one source of truth)
New shared `file-capability.ts`: `ext → 'markdown' | 'plaintext' | 'unsupported'`, consulted by both the file tree (row icons) and the editor host (routing), so they can't drift.

## Don't slurp binaries
`openFile` dispatches on capability. An `unsupported` file (binary/unknown) opens a tab **without `readFile`** — no reading megabytes of garbage into a string and rendering it as markdown.

## "No preview" panel
A calm editor-host branch (no danger styling, per the UI philosophy): *"No preview for `.xyz` files"* + **Reveal in Finder** / **Open with default app** / **Copy path**.

## Plain-text renderer
`.txt` and siblings (`.log/.json/.xml/.yaml/.css/.js/.html/…`) open in the editor's new **plain-text mode** — markdown-specific extensions off (md syntax + highlight, frontmatter fold, wiki-link/tag autocomplete + decorations, compute cells, footnote/highlight decorations, format-on-paste, image-paste upload). Editable + saveable through the existing note path. The Source/Preview toggle is hidden (nothing to preview).
- **`.html`**: raw source (design-question option **a**). A sandboxed *rendered* preview is a separate, security-scoped follow-up.

## Model
New `UnsupportedTab` + `NoteTab.plainText`, round-tripped through session restore, close-on-delete, and follow-on-rename.

## Unchanged / out of scope
`.md`/`.csv`/`.ttl`/`.py` and source/pdf/graph tabs are **byte-for-byte unchanged** — `plainText` defaults false, so the markdown extension set is identical. **Images** route to the "no preview" panel (open-externally); a standalone image viewer is out of scope, as is sandboxed HTML and indexing the newly-shown types.

## Acceptance criteria — all met
- [x] Tree shows files of any extension (hidden/ignored still filtered)
- [x] No-renderer file → calm "no preview" panel with reveal/open/copy
- [x] Binary is not read as text into a note buffer
- [x] `.txt` (+ siblings) open editable in plain-text mode; edits save
- [x] Create/rename/delete of a non-indexable file refreshes the sidebar
- [x] Graph indexing unchanged (newly-visible types not indexed)
- [x] Existing types + source/pdf/graph render as before
- [x] `pnpm lint` + `pnpm test` pass (3952 tests)

## Testing
- `file-capability.test.ts`: markdown/plaintext/unsupported routing (binaries → unsupported, `.gitignore` → plaintext, `.csv.schema.yaml` sidecar).
- `fs.test.ts`: lists non-indexable files (`image.png`, `notes.txt`), still filters `.minerva`.
- `watcher.test.ts`: a `.txt`/`.png` fires the tree-refresh IPC but does **not** invoke the index callback.

> Notes: (1) the 3 `state_referenced_locally` warnings on `plainText` in Editor.svelte are the intentional per-instance capture (the editor is keyed per file, so it can't change without remount) — CLAUDE.md documents these as non-fatal. (2) This is a UI-heavy change; worth a quick manual pass (open a `.txt`, a `.png`, a `.md`) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)