### PR TITLE
feat: wiki-link hover preview in the editor (#1131)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -44,6 +44,7 @@
     type BookmarkRef,
   } from '../editor/bookmark-gutter';
   import { footnotePreview } from '../editor/footnote-preview';
+  import { linkPreview } from '../editor/link-preview';
   import { footnoteDecorations } from '../editor/footnote-decorations';
   import { linkCompletionSource } from '../editor/link-autocomplete';
   import { planBlockLink } from '../editor/block-link';
@@ -524,6 +525,11 @@
         runAllRef,
       }),
       footnotePreview(),
+      linkPreview({
+        getNotePaths: () => getNotePaths?.() ?? [],
+        getAliases: () => getAliases?.() ?? [],
+        readNote: (p) => api.notebase.readFile(p),
+      }),
       footnoteDecorations(),
       highlightDecorations(),
     ]),

--- a/src/renderer/lib/editor/link-preview.ts
+++ b/src/renderer/lib/editor/link-preview.ts
@@ -1,0 +1,80 @@
+/**
+ * CodeMirror hover tooltip that previews a `[[wiki-link]]`'s target note when
+ * the user hovers it in the editor (#1131). Mirrors `footnote-preview.ts`; the
+ * one new muscle is async content — a link's target lives in ANOTHER file, so
+ * the tooltip returns a placeholder synchronously and fills it once the cached
+ * read resolves.
+ *
+ * Only plain note links preview here. Typed links (`cite::`, `quote::`) are out
+ * of scope (a richer source/excerpt card is a follow-on, #1071).
+ */
+import type { Extension } from '@codemirror/state';
+import { hoverTooltip, type Tooltip } from '@codemirror/view';
+import { parseWikiInner } from './link-decorations';
+import { makeNotePreviewFetcher, type NotePreviewDeps } from './note-preview';
+
+// Local copy (fresh lastIndex per scan; never shared) — matches the WIKI_RE in
+// link-decorations.ts.
+const WIKI_RE = /\[\[([^[\]\n]+)\]\]/g;
+
+export function linkPreview(deps: NotePreviewDeps): Extension {
+  const fetchPreview = makeNotePreviewFetcher(deps);
+
+  return hoverTooltip((view, pos): Tooltip | null => {
+    const line = view.state.doc.lineAt(pos);
+    const text = line.text;
+    const col = pos - line.from;
+
+    // Find a `[[…]]` span that contains the hover position.
+    WIKI_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    let hit: { start: number; end: number; inner: string } | null = null;
+    while ((m = WIKI_RE.exec(text)) !== null) {
+      const start = m.index;
+      const end = m.index + m[0].length;
+      if (col >= start && col <= end) {
+        hit = { start, end, inner: m[1]! };
+        break;
+      }
+    }
+    if (!hit) return null;
+
+    const { target, linkType } = parseWikiInner(hit.inner);
+    // Skip typed links (cite::/quote::…) and empty targets — plain notes only.
+    if (linkType || !target) return null;
+
+    return {
+      pos: line.from + hit.start,
+      end: line.from + hit.end,
+      above: true,
+      create: () => {
+        const dom = document.createElement('div');
+        dom.className = 'cm-link-preview loading';
+        dom.textContent = '…';
+        void fetchPreview(target).then((preview) => {
+          if (!preview) {
+            dom.className = 'cm-link-preview missing';
+            dom.textContent = `“${target}” not found`;
+            return;
+          }
+          dom.className = 'cm-link-preview';
+          dom.textContent = '';
+          const titleEl = document.createElement('div');
+          titleEl.className = 'title';
+          titleEl.textContent = preview.title;
+          const body = document.createElement('div');
+          body.className = 'body';
+          body.textContent = preview.snippet || '(empty note)';
+          dom.append(titleEl, body);
+        }).catch(() => {
+          dom.className = 'cm-link-preview missing';
+          dom.textContent = `“${target}” not found`;
+        });
+        return { dom };
+      },
+    };
+  }, {
+    // Match the footnote-preview feel — short delay, no hideOnChange.
+    hoverTime: 250,
+  });
+}

--- a/src/renderer/lib/editor/note-preview.ts
+++ b/src/renderer/lib/editor/note-preview.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared async note-preview fetcher for wiki-link hover popovers (#1131 editor,
+ * #1132 Preview pane). Given a wiki-link target it resolves the note, reads it
+ * (behind a short per-path TTL cache so rapid re-hovers don't re-hit IPC), and
+ * returns a title + a truncated opening/section snippet. Returns null when the
+ * target doesn't resolve — callers show a quiet "not found", never an error.
+ *
+ * Pure of any surface: the editor extension and the Preview tooltip both drive
+ * it with the same three dependencies.
+ */
+import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
+import { parseTransclusionTarget, sliceTransclusion } from '../../../shared/transclusion';
+
+export interface NotePreview {
+  /** Resolved relativePath of the target note. */
+  path: string;
+  /** Display title — frontmatter `title`, else the first H1, else the stem. */
+  title: string;
+  /** Truncated opening (or the referenced `#heading` / `^block` section). */
+  snippet: string;
+}
+
+export interface NotePreviewDeps {
+  /** Live list of note relativePaths (for target resolution). */
+  getNotePaths: () => string[];
+  /** Live frontmatter alias entries, so `[[alias]]` resolves like navigation. */
+  getAliases?: () => readonly { alias: string; relativePath: string }[];
+  readNote: (path: string) => Promise<string>;
+}
+
+const CACHE_TTL_MS = 5000;
+const MAX_LINES = 8;
+const MAX_CHARS = 260;
+
+export function makeNotePreviewFetcher(deps: NotePreviewDeps) {
+  const cache = new Map<string, Promise<string>>();
+  function readCached(path: string): Promise<string> {
+    let p = cache.get(path);
+    if (!p) {
+      p = deps.readNote(path);
+      cache.set(path, p);
+      // Evict a rejected read at once (transient failure can retry) and any
+      // read after the TTL (the file may have changed).
+      p.catch(() => cache.delete(path));
+      setTimeout(() => cache.delete(path), CACHE_TTL_MS);
+    }
+    return p;
+  }
+
+  return async function fetchPreview(target: string): Promise<NotePreview | null> {
+    const parsed = parseTransclusionTarget(target); // { path, heading?, blockId? }
+    const files = deps.getNotePaths().map((relativePath) => ({ relativePath, isDirectory: false }));
+    const aliases = Object.fromEntries(
+      (deps.getAliases?.() ?? []).map((a) => [a.alias.toLowerCase(), a.relativePath]),
+    );
+    const resolved = resolveWikiLinkTarget(parsed.path, files, aliases);
+    if (!resolved) return null;
+
+    let content: string;
+    try {
+      content = await readCached(resolved);
+    } catch {
+      return null;
+    }
+
+    let slice = sliceTransclusion(content, parsed);
+    // A missing heading/block falls back to the note's opening rather than a
+    // terse "not found" — the opening is the more useful preview.
+    if (!slice.ok && (parsed.heading || parsed.blockId)) {
+      slice = sliceTransclusion(content, { path: parsed.path });
+    }
+    const title = noteTitle(content, resolved);
+    return { path: resolved, title, snippet: truncate(dropLeadingH1(slice.text, title)) };
+  };
+}
+
+function noteTitle(content: string, path: string): string {
+  const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (fm) {
+    const t = fm[1]!.match(/^title:\s*(.+)$/m);
+    if (t) return t[1]!.trim().replace(/^["']|["']$/g, '');
+  }
+  const body = stripFrontmatter(content);
+  const h1 = body.match(/^#\s+(.+)$/m);
+  if (h1) return h1[1]!.trim();
+  return path.split('/').pop()!.replace(/\.md$/i, '');
+}
+
+/** Drop a leading `# Title` line when it just repeats the title shown above. */
+function dropLeadingH1(text: string, title: string): string {
+  const lines = text.split('\n');
+  if (lines[0] && /^#\s+/.test(lines[0]) && lines[0].replace(/^#\s+/, '').trim() === title) {
+    return lines.slice(1).join('\n').trim();
+  }
+  return text;
+}
+
+function truncate(text: string): string {
+  const allLines = text.split('\n');
+  let out = allLines.slice(0, MAX_LINES).join('\n').trim();
+  let clipped = allLines.length > MAX_LINES;
+  if (out.length > MAX_CHARS) {
+    out = out.slice(0, MAX_CHARS).replace(/\s+\S*$/, '');
+    clipped = true;
+  }
+  return clipped ? `${out}…` : out;
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -573,3 +573,38 @@ mark.hl-orange { background: color-mix(in oklch, var(--hl-orange) 30%, transpare
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
 }
+
+/* Wiki-link hover preview (#1131) — clones the footnote-tooltip look. */
+.cm-tooltip:has(.cm-link-preview) {
+  background: var(--bg-button);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  max-width: 360px;
+}
+.cm-link-preview {
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text);
+}
+.cm-link-preview .title {
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.cm-link-preview .body {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-muted);
+}
+.cm-link-preview.loading {
+  color: var(--text-faint);
+}
+.cm-link-preview.missing {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 11px;
+}

--- a/tests/renderer/editor/note-preview.test.ts
+++ b/tests/renderer/editor/note-preview.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared wiki-link preview fetcher (#1131 / #1132). Pins resolution, snippet
+ * extraction (opening vs `#heading` section), the title source order, quiet
+ * not-found, and the per-path read cache.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { makeNotePreviewFetcher, type NotePreviewDeps } from '../../../src/renderer/lib/editor/note-preview';
+
+const NOTES: Record<string, string> = {
+  'notes/topic.md': [
+    '---',
+    'title: The Topic',
+    '---',
+    '',
+    '# The Topic',
+    '',
+    'Opening paragraph explaining the topic.',
+    '',
+    '## Section A',
+    '',
+    'Details about section A.',
+  ].join('\n'),
+  'notes/plain.md': '# Plain Note\n\nJust an H1 and a line.',
+};
+
+function makeDeps(overrides: Partial<NotePreviewDeps> = {}): { deps: NotePreviewDeps; read: ReturnType<typeof vi.fn> } {
+  const read = vi.fn((p: string) => {
+    const c = NOTES[p];
+    return c !== undefined ? Promise.resolve(c) : Promise.reject(new Error('ENOENT'));
+  });
+  return {
+    read,
+    deps: {
+      getNotePaths: () => Object.keys(NOTES),
+      readNote: read,
+      ...overrides,
+    },
+  };
+}
+
+describe('makeNotePreviewFetcher (#1131/#1132)', () => {
+  it('previews a note: title + opening snippet (leading H1 dropped)', async () => {
+    const { deps } = makeDeps();
+    const preview = await makeNotePreviewFetcher(deps)('notes/topic');
+    expect(preview).not.toBeNull();
+    expect(preview!.path).toBe('notes/topic.md');
+    expect(preview!.title).toBe('The Topic'); // from frontmatter
+    expect(preview!.snippet).toContain('Opening paragraph');
+    expect(preview!.snippet.startsWith('# ')).toBe(false); // H1 duplicate stripped
+  });
+
+  it('previews the referenced #heading section, not the whole note', async () => {
+    const { deps } = makeDeps();
+    const preview = await makeNotePreviewFetcher(deps)('notes/topic#Section A');
+    expect(preview!.snippet).toContain('Details about section A');
+    expect(preview!.snippet).not.toContain('Opening paragraph');
+  });
+
+  it('falls back to the H1 for the title when there is no frontmatter title', async () => {
+    const { deps } = makeDeps();
+    const preview = await makeNotePreviewFetcher(deps)('notes/plain');
+    expect(preview!.title).toBe('Plain Note');
+  });
+
+  it('returns null for an unresolved target (quiet not-found)', async () => {
+    const { deps } = makeDeps();
+    expect(await makeNotePreviewFetcher(deps)('notes/ghost')).toBeNull();
+  });
+
+  it('caches the read — repeated hovers do not re-hit IPC', async () => {
+    const { deps, read } = makeDeps();
+    const fetch = makeNotePreviewFetcher(deps);
+    await fetch('notes/topic');
+    await fetch('notes/topic#Section A');
+    await fetch('notes/topic');
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1131.

Hover a `[[wiki-link]]` in the editor for ~250ms → a floating popover previews the target note's title + opening. Extends the footnote hover-tooltip pattern to wiki-links. The one genuinely new muscle vs. footnotes: a footnote's body is in the same buffer (sync), but a link's content is in **another file** (async read + cache).

## Shared helper (built here; #1132 reuses it)
`note-preview.ts` is the async-fetch + snippet helper the sibling Preview-pane ticket (#1132) will share:
- Resolves the target via the same navigation resolver as click-nav.
- Reads it behind a **5s per-path TTL cache**, so rapid re-hovers don't re-hit IPC.
- Slices a snippet with `sliceTransclusion`: `[[note#heading]]` / `[[note^block]]` preview **that section**; a bare `[[note]]` previews the opening (leading `# H1` dropped since the title renders above). Title = frontmatter `title`, else first H1, else filename stem.

## Editor extension
`link-preview.ts` is a CodeMirror `hoverTooltip` mirroring `footnote-preview.ts`, registered right alongside it. It finds the `[[…]]` span under the cursor (WIKI_RE + `parseWikiInner`), returns a placeholder DOM synchronously, and fills it when the cached read resolves.
- **Unresolved** target → quiet "not found" (italic/muted), never an error or empty box.
- A **missing heading** falls back to the note opening (more useful than a terse miss).
- **Typed links** (`cite::`/`quote::`) are skipped — a richer source/excerpt card is a follow-on (#1071).

Styling clones `.cm-footnote-tooltip`.

## Acceptance criteria
- [x] Hovering a resolvable `[[link]]` shows the target's opening after ~250ms
- [x] Content fetched once and cached; re-hovers don't re-hit IPC
- [x] `[[note#heading]]` previews that section, not the whole note
- [x] Unresolved link → quiet "not found"
- [x] Matches footnote-preview look/dismiss; footnote preview still works (separate `hoverTooltip`, returns null for non-links)
- [x] `pnpm lint` + `pnpm test` pass (3965)

## Testing
`note-preview.test.ts` pins the shared fetcher: note/`#heading` snippet, title source order (frontmatter → H1 → stem), quiet not-found, and the read cache (**one** IPC read across three hovers of the same target).

> The CodeMirror hover interaction itself isn't unit-testable (it's the same proven `hoverTooltip` mechanism as footnotes); worth a quick manual hover pass. The 4 `state_referenced_locally` warnings are the pre-existing `plainText` capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)