### PR TITLE
feat: wiki-link hover preview in the Preview pane (#1132)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1457,6 +1457,8 @@
                         content={note.content}
                         notePath={note.relativePath}
                         {numberedHeadings}
+                        getNotePaths={() => flattenNotePaths(notebase.files)}
+                        getAliases={() => aliasEntries}
                         onNavigate={handleNavigate}
                         onTagSelect={handleTagSelect}
                         onOpenSource={handleOpenSource}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -48,8 +48,11 @@
         collapseCiteRows,
         buildCiteTooltip,
         buildQuoteTooltip,
-        buildFootnoteTooltip
+        buildFootnoteTooltip,
+        buildNotePreviewTooltip,
+        buildNotePreviewMissing
     } from '../preview/cite-meta';
+    import { makeNotePreviewFetcher } from '../editor/note-preview';
     import {
         findSourceFenceBefore,
         renderComputeOutput,
@@ -131,6 +134,11 @@
          * every journal or list.
          */
         numberedHeadings?: boolean;
+        /** Live note-path list + frontmatter aliases, for the wiki-link hover
+         *  preview (#1132) — resolves a hovered `[[link]]` to a note to read.
+         *  Without them the hover preview is simply inert. */
+        getNotePaths?: () => string[];
+        getAliases?: () => readonly { alias: string; relativePath: string }[];
     }
 
     let {
@@ -151,7 +159,19 @@
         onApplyCellOutputEdit,
         onDoiClick,
         numberedHeadings = false,
+        getNotePaths,
+        getAliases,
     }: Props = $props();
+
+    // Wiki-link hover preview (#1132) — reuses the editor's async fetcher +
+    // per-path read cache. A monotonic token cancels a stale async result when
+    // the pointer has since left or moved to another link.
+    const notePreviewFetcher = makeNotePreviewFetcher({
+        getNotePaths: () => getNotePaths?.() ?? [],
+        getAliases: () => getAliases?.() ?? [],
+        readNote: (p) => api.notebase.readFile(p),
+    });
+    let hoverToken = 0;
 
     // Per-fence collapse state, keyed by the fence's opening line in the
     // source markdown. Survives doc-edit re-renders (line numbers may
@@ -1692,6 +1712,27 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             }
             return;
         }
+        // Wiki-link hover (#1132): unlike cite/quote (whose metadata is on the
+        // element), a note's content is in another file — resolve + cached-read
+        // + snippet, then fill. Async, so guard against the pointer having moved
+        // on before the read resolves.
+        const wiki = target.closest<HTMLElement>('.wiki-link');
+        if (wiki) {
+            const linkTarget = wiki.dataset.target;
+            if (!linkTarget || !getNotePaths) return;
+            const token = ++hoverToken;
+            void notePreviewFetcher(linkTarget).then((preview) => {
+                if (token !== hoverToken) return; // superseded by another hover / mouseout
+                tooltipHtml = preview
+                    ? buildNotePreviewTooltip(preview.title, preview.snippet)
+                    : buildNotePreviewMissing(linkTarget);
+                tooltipVisible = true;
+                positionTooltip(wiki);
+            }).catch(() => {
+                if (token === hoverToken) tooltipVisible = false;
+            });
+            return;
+        }
         const el = target.closest<HTMLElement>('.cite-link, .quote-link');
         if (!el) return;
         const kind = el.dataset.tooltipKind;
@@ -1709,11 +1750,12 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
     function handleMouseOut(e: MouseEvent) {
         const target = e.target as HTMLElement | null;
-        const leaving = target?.closest<HTMLElement>('.cite-link, .quote-link, .footnote-ref');
+        const leaving = target?.closest<HTMLElement>('.cite-link, .quote-link, .footnote-ref, .wiki-link');
         if (!leaving) return;
         // relatedTarget can be null when cursor leaves the window — dismiss anyway
         const to = e.relatedTarget as Node | null;
         if (to && leaving.contains(to)) return;
+        hoverToken++; // cancel any in-flight wiki-link fetch (#1132)
         tooltipVisible = false;
     }
 
@@ -1895,6 +1937,21 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         font-size: 12px;
         color: var(--text-muted);
         font-family: var(--font-mono);
+    }
+
+    /* Wiki-link hover preview (#1132) — the target note's opening snippet. */
+    .cite-tooltip :global(.tt-note-body) {
+        color: var(--text-muted);
+        font-size: 12px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 12em;
+        overflow: hidden;
+    }
+    .cite-tooltip :global(.tt-note-missing) {
+        color: var(--text-muted);
+        font-style: italic;
+        font-size: 12px;
     }
 
     .cite-tooltip :global(.tt-quote) {

--- a/src/renderer/lib/preview/cite-meta.ts
+++ b/src/renderer/lib/preview/cite-meta.ts
@@ -84,6 +84,20 @@ export function buildQuoteTooltip(meta: QuoteMeta): string {
   return parts.join('') || `<div class="tt-meta">No excerpt metadata available</div>`;
 }
 
+/** Wiki-link hover preview (#1132): a note's title + opening/section snippet.
+ *  Mirrors the cite/quote builders' pure-HTML-string shape. */
+export function buildNotePreviewTooltip(title: string, snippet: string): string {
+  const parts: string[] = [];
+  if (title) parts.push(`<div class="tt-title">${escapeHtml(title)}</div>`);
+  parts.push(`<div class="tt-note-body">${escapeHtml(snippet || '(empty note)')}</div>`);
+  return parts.join('');
+}
+
+/** Quiet "not found" for an unresolved wiki-link (#1132). */
+export function buildNotePreviewMissing(target: string): string {
+  return `<div class="tt-note-missing">“${escapeHtml(target)}” not found</div>`;
+}
+
 export function formatFullByline(creators: string[], year?: string): string {
   const who = creators.length === 0 ? ''
     : creators.length <= 3 ? creators.join(', ')

--- a/tests/renderer/preview/cite-meta.test.ts
+++ b/tests/renderer/preview/cite-meta.test.ts
@@ -9,6 +9,8 @@ import {
   buildCiteTooltip,
   buildQuoteTooltip,
   buildFootnoteTooltip,
+  buildNotePreviewTooltip,
+  buildNotePreviewMissing,
   type CiteMeta,
 } from '../../../src/renderer/lib/preview/cite-meta';
 
@@ -98,5 +100,22 @@ describe('buildFootnoteTooltip', () => {
     expect(html).not.toContain('footnote-backref');
     expect(html).not.toContain('↩');
     expect(html.startsWith('<div class="tt-footnote">')).toBe(true);
+  });
+});
+
+describe('buildNotePreviewTooltip (#1132)', () => {
+  it('renders title + snippet with escaped HTML', () => {
+    const html = buildNotePreviewTooltip('The <b>Topic</b>', 'a & b < c');
+    expect(html).toContain('<div class="tt-title">The &lt;b&gt;Topic&lt;/b&gt;</div>');
+    expect(html).toContain('<div class="tt-note-body">a &amp; b &lt; c</div>');
+  });
+  it('shows an empty-note placeholder when the snippet is blank', () => {
+    expect(buildNotePreviewTooltip('T', '')).toContain('(empty note)');
+  });
+  it('buildNotePreviewMissing is a quiet not-found', () => {
+    const html = buildNotePreviewMissing('ghost');
+    expect(html).toContain('tt-note-missing');
+    expect(html).toContain('ghost');
+    expect(html).toContain('not found');
   });
 });


### PR DESCRIPTION
Closes #1132. The Preview-pane sibling of #1131 (editor), reusing the shared fetcher it built.

Hover a `[[wiki-link]]` in the rendered Preview → a floating popover previews the target note's title + opening, positioned like the cite/quote tooltips.

## The crux — an async branch in a sync tooltip system
The existing `.cite-tooltip` fills **instantly from `data-` attributes**; a wiki-link's content lives in **another file**. So `handleMouseOver` grows a `.wiki-link` branch that resolves → cached-reads → fills, guarded by a **monotonic hover token** so a result that resolves after the pointer has left (or moved to another link) is discarded. `handleMouseOut` bumps the token to cancel any in-flight fetch.

## Reuse (most of it)
- **`note-preview.ts`** — the shared async-fetch + snippet helper from #1131 (resolve via the navigation resolver, 5s per-path read cache, `sliceTransclusion` snippet). So `[[note#heading]]` previews that section and re-hovers don't re-hit IPC, for free.
- App passes Preview the same `getNotePaths` / `getAliases` it already gives the Editor.
- New pure HTML builders `buildNotePreviewTooltip` / `buildNotePreviewMissing` mirror the cite/quote builders in `cite-meta.ts`; styling extends `.cite-tooltip`.

## Doesn't disturb anything
The new branch sits ahead of the cite/quote branch and returns early, so existing cite/quote/footnote hovers and wiki-link **click-navigation** are untouched. Typed `cite::`/`quote::` links render as `.cite-link`/`.quote-link` (not `.wiki-link`), so they keep their own tooltips.

## Acceptance criteria
- [x] Hovering a resolvable `[[link]]` shows the target's opening content
- [x] Fetched once and cached; re-hovers don't re-hit IPC (shared cache)
- [x] `[[note#heading]]` previews that section
- [x] Existing cite/quote/footnote tooltips + wiki-link click-nav unaffected
- [x] Unresolved link → quiet "not found"
- [x] `pnpm lint` + `pnpm test` pass (3968)

## Testing
New `cite-meta` tests for the HTML builders (escaping, empty-note placeholder, quiet not-found). The shared fetcher (resolution, section snippet, cache) is already pinned by #1131's `note-preview.test.ts`.

> The mouseover interaction itself isn't unit-testable (DOM + async in a mounted Preview); worth a quick manual hover pass in the Preview pane. The 4 `state_referenced_locally` warnings are the pre-existing `plainText` capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)