### PR TITLE
feat: live backlinks + semantic-search query blocks (#1137, #1128)

### DIFF
--- a/src/main/ipc/register-links.ts
+++ b/src/main/ipc/register-links.ts
@@ -3,6 +3,7 @@ import { Channels } from '../../shared/channels';
 import * as notebaseFs from '../notebase/fs';
 import * as graph from '../graph/index';
 import * as vectors from '../embeddings/vector-store';
+import type { RefKind } from '../embeddings/vector-store';
 import { topRelatedNotes, markAlreadyLinked } from '../embeddings/related';
 import { projectContext } from '../project-context-types';
 import { withRootPathOr } from './helpers';
@@ -35,6 +36,36 @@ export function registerLinks(): void {
     ]);
     return { enabled: true, notes: markAlreadyLinked(ranked, linked) };
   }));
+
+  // Free-text semantic search for the live `:::query-semantic` block (#1128).
+  // Embeds the block's query text at request time (searchRelated does the
+  // embed) and ranks the corpus — read-only, nothing is written. `excludePath`
+  // drops the host note from its own results; `kinds` restricts the corpus.
+  ipcMain.handle(
+    Channels.EMBEDDINGS_SEARCH_TEXT,
+    withRootPathOr<[string, { limit?: number; kinds?: readonly RefKind[]; excludePath?: string }?], RelatedNotesResult | Promise<RelatedNotesResult>>(
+      { enabled: false, notes: [] },
+      async (rootPath, query: string, opts): Promise<RelatedNotesResult> => {
+        const ctx = projectContext(rootPath);
+        if (!vectors.isEnabled(ctx) || !query.trim()) return { enabled: false, notes: [] };
+        const n = Math.min(Math.max(Math.floor(opts?.limit ?? 8), 1), 25);
+        const hits = await vectors.searchRelated(ctx, query, {
+          limit: n * 5,
+          ...(opts?.kinds && opts.kinds.length > 0 ? { kinds: opts.kinds } : {}),
+          ...(opts?.excludePath ? { exclude: { kind: 'note' as const, ref: opts.excludePath } } : {}),
+        });
+        const ranked = topRelatedNotes(hits, {
+          limit: n,
+          titleOf: (h) => {
+            if (h.kind === 'source') return graph.sourceTitle(ctx, h.ref);
+            if (h.kind === 'excerpt') return 'Excerpt';
+            return graph.noteTitle(ctx, h.ref);
+          },
+        });
+        return { enabled: true, notes: ranked };
+      },
+    ),
+  );
   // Links
   ipcMain.handle(Channels.LINKS_OUTGOING, withRootPathOr([], (rootPath, relativePath: string) =>
     graph.outgoingLinks(projectContext(rootPath), relativePath)));

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -131,6 +131,8 @@ contextBridge.exposeInMainWorld('api', {
       subscribeIpc(Channels.EMBEDDINGS_BACKFILL_PROGRESS, cb),
     related: (relativePath: string, limit?: number) =>
       ipcRenderer.invoke(Channels.EMBEDDINGS_RELATED, relativePath, limit),
+    searchText: (query: string, opts?: { limit?: number; kinds?: readonly ('note' | 'source' | 'excerpt')[]; excludePath?: string }) =>
+      ipcRenderer.invoke(Channels.EMBEDDINGS_SEARCH_TEXT, query, opts),
   },
   tables: {
     query: (sql: string) => ipcRenderer.invoke(Channels.TABLES_QUERY, sql),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1459,6 +1459,7 @@
                         {numberedHeadings}
                         getNotePaths={() => flattenNotePaths(notebase.files)}
                         getAliases={() => aliasEntries}
+                        revision={graphRevision}
                         onNavigate={handleNavigate}
                         onTagSelect={handleTagSelect}
                         onOpenSource={handleOpenSource}

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1178,17 +1178,22 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             return;
         }
 
-        // Semantic block (#1128): embed the block's free-text query and rank the
-        // corpus. Read-only vector search over the on-device index.
+        // Semantic block (#1128): rank the corpus by similarity. With a free-text
+        // body, embed that query; with an empty body, fall back to "related to
+        // THIS note" (the sidebar's stored-vector path). Read-only.
         if (type === 'semantic') {
-            if (!query) { el.innerHTML = buildSemanticHtml([], config); return; }
+            const q = (query ?? '').trim();
             el.innerHTML = '<span class="query-loading">Loading...</span>';
             try {
-                const result = await api.embeddings.searchText(query, {
-                    limit: 25,
-                    kinds: semanticKinds(config),
-                    ...(notePath ? { excludePath: notePath } : {}),
-                });
+                const result = q
+                    ? await api.embeddings.searchText(q, {
+                        limit: 25,
+                        kinds: semanticKinds(config),
+                        ...(notePath ? { excludePath: notePath } : {}),
+                    })
+                    : notePath
+                        ? await api.embeddings.related(notePath, 25)
+                        : { enabled: false, notes: [] };
                 const notes = result.enabled ? selectSemanticNotes(result.notes, config) : [];
                 el.innerHTML = buildSemanticHtml(notes, config);
             } catch (e) {

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -53,6 +53,8 @@
         buildNotePreviewMissing
     } from '../preview/cite-meta';
     import { makeNotePreviewFetcher } from '../editor/note-preview';
+    import { selectBacklinks, buildBacklinksHtml, semanticKinds, selectSemanticNotes, buildSemanticHtml } from '../preview/live-blocks';
+    import { getLinkBundle } from '../sidebar-link-bundle';
     import {
         findSourceFenceBefore,
         renderComputeOutput,
@@ -139,6 +141,10 @@
          *  Without them the hover preview is simply inert. */
         getNotePaths?: () => string[];
         getAliases?: () => readonly { alias: string; relativePath: string }[];
+        /** Graph revision — bumped on any index change. The live query-block
+         *  family (backlinks / semantic, #1137/#1128) re-runs when it changes,
+         *  so a block reflects links/embeddings added elsewhere. */
+        revision?: number;
     }
 
     let {
@@ -161,6 +167,7 @@
         numberedHeadings = false,
         getNotePaths,
         getAliases,
+        revision = 0,
     }: Props = $props();
 
     // Wiki-link hover preview (#1132) — reuses the editor's async fetcher +
@@ -926,6 +933,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     // After render, find query-block placeholders and execute queries
     $effect(() => {
         rendered; // track dependency on rendered HTML
+        revision; // re-run live blocks (backlinks/semantic) on graph changes (#1137/#1128)
 
         // Destroy previous chart instances before re-rendering
         activeCharts.forEach(c => c.destroy());
@@ -1148,13 +1156,47 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     async function executeQueryBlock(el: HTMLElement) {
         const query = el.dataset.query;
         const type = el.dataset.type;
-        if (!query) return;
 
         let config: Record<string, string> = {};
         try {
             config = JSON.parse(el.dataset.config ?? '{}');
         } catch { /* ignore */
         }
+
+        // Backlinks block (#1137): no query body — "who links to THIS note". Sits
+        // ahead of the `!query` guard. Direct IPC (deduped, title-enriched,
+        // typed rows), not a SPARQL preset. Read-only; nothing is written.
+        if (type === 'backlinks') {
+            if (!notePath) { el.innerHTML = buildBacklinksHtml([], config); return; }
+            try {
+                const bundle = await getLinkBundle(notePath, revision);
+                el.innerHTML = buildBacklinksHtml(selectBacklinks(bundle.backlinks, config), config);
+            } catch {
+                el.innerHTML = buildBacklinksHtml([], config);
+            }
+            return;
+        }
+
+        // Semantic block (#1128): embed the block's free-text query and rank the
+        // corpus. Read-only vector search over the on-device index.
+        if (type === 'semantic') {
+            if (!query) { el.innerHTML = buildSemanticHtml([], config); return; }
+            el.innerHTML = '<span class="query-loading">Loading...</span>';
+            try {
+                const result = await api.embeddings.searchText(query, {
+                    limit: 25,
+                    kinds: semanticKinds(config),
+                    ...(notePath ? { excludePath: notePath } : {}),
+                });
+                const notes = result.enabled ? selectSemanticNotes(result.notes, config) : [];
+                el.innerHTML = buildSemanticHtml(notes, config);
+            } catch {
+                el.innerHTML = buildSemanticHtml([], config);
+            }
+            return;
+        }
+
+        if (!query) return;
 
         const language = config.language === 'sql' ? 'sql' : 'sparql';
         // Cache key pairs (language, query) so a SQL query and a SPARQL query that
@@ -2318,6 +2360,41 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         color: var(--text-muted);
         font-size: 13px;
         font-style: italic;
+    }
+
+    /* Live query-block family: backlinks badges + semantic snippets (#1137/#1128). */
+    .preview :global(.query-link-badge) {
+        display: inline-block;
+        margin-left: 6px;
+        font-size: 9px;
+        font-weight: 600;
+        color: var(--bg);
+        padding: 1px 4px;
+        border-radius: 3px;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        vertical-align: middle;
+    }
+    .preview :global(.semantic-block li) {
+        padding: 6px 0;
+    }
+    .preview :global(.semantic-section) {
+        font-size: 11px;
+        color: var(--text-faint);
+        margin-top: 1px;
+    }
+    .preview :global(.semantic-snippet) {
+        font-size: 12px;
+        color: var(--text-muted);
+        margin-top: 2px;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+    .preview :global(.semantic-nonnote) {
+        color: var(--text);
     }
 
     .preview :global(.query-empty) {

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1171,7 +1171,8 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             try {
                 const bundle = await getLinkBundle(notePath, revision);
                 el.innerHTML = buildBacklinksHtml(selectBacklinks(bundle.backlinks, config), config);
-            } catch {
+            } catch (e) {
+                console.warn('[query-backlinks] failed:', e);
                 el.innerHTML = buildBacklinksHtml([], config);
             }
             return;
@@ -1190,7 +1191,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
                 });
                 const notes = result.enabled ? selectSemanticNotes(result.notes, config) : [];
                 el.innerHTML = buildSemanticHtml(notes, config);
-            } catch {
+            } catch (e) {
+                // A silent empty state hid the common cause here — a preload
+                // addition (api.embeddings.searchText) needs a full app restart,
+                // not just Cmd-R. Surface it so it's diagnosable.
+                console.warn('[query-semantic] failed:', e);
                 el.innerHTML = buildSemanticHtml([], config);
             }
             return;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -164,6 +164,11 @@ export interface EmbeddingsApi {
   onBackfillProgress(cb: (p: { done: number; total: number; running: boolean }) => void): void;
   /** Notes semantically related to `relativePath`, for the Related panel (#838). */
   related(relativePath: string, limit?: number): Promise<import('../../../shared/types').RelatedNotesResult>;
+  /** Free-text semantic search for the live `:::query-semantic` block (#1128). */
+  searchText(
+    query: string,
+    opts?: { limit?: number; kinds?: readonly ('note' | 'source' | 'excerpt')[]; excludePath?: string },
+  ): Promise<import('../../../shared/types').RelatedNotesResult>;
 }
 
 export interface TagsApi {

--- a/src/renderer/lib/preview/live-blocks.ts
+++ b/src/renderer/lib/preview/live-blocks.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure config + HTML builders for the live query-block family that renders in
+ * the Preview pane:
+ *   - `:::query-backlinks` — the notes that wiki-link to the current note (#1137)
+ *   - `:::query-semantic`  — notes semantically similar to free query text (#1128)
+ *
+ * The block plumbing (parse → execute → inject) lives in Preview.svelte; the
+ * data fetch is a direct IPC. These string-only builders keep the selection +
+ * markup logic unit-testable, mirroring `cite-meta.ts`. Both are read-only —
+ * nothing is written back to the note or graph.
+ */
+import { escapeHtml, escapeAttr } from './text';
+import type { Backlink, RelatedNote } from '../../../shared/types';
+
+function clampLimit(raw: string | undefined, fallback: number, max = 50): number {
+  const n = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(n) ? Math.min(Math.max(n, 1), max) : fallback;
+}
+
+function titleHtmlFor(config: Record<string, string>): string {
+  return config.title ? `<h4 class="query-title">${escapeHtml(config.title)}</h4>` : '';
+}
+
+// ── Backlinks block (#1137) ─────────────────────────────────────────────────
+
+/** Apply the block's `linkType` filter and `limit` to the note's backlinks. */
+export function selectBacklinks(rows: Backlink[], config: Record<string, string>): Backlink[] {
+  let out = rows;
+  if (config.linkType) {
+    const wanted = new Set(config.linkType.split(',').map((s) => s.trim()).filter(Boolean));
+    if (wanted.size > 0) out = out.filter((b) => wanted.has(b.linkType));
+  }
+  return out.slice(0, clampLimit(config.limit, 25));
+}
+
+export function buildBacklinksHtml(rows: Backlink[], config: Record<string, string>): string {
+  const titleHtml = titleHtmlFor(config);
+  if (rows.length === 0) return `${titleHtml}<p class="query-empty">No backlinks yet</p>`;
+  const items = rows.map((b) => {
+    // Show the typed-link badge (cite/quote/supports/…) like the sidebar panel.
+    const badge = b.linkLabel
+      ? `<span class="query-link-badge" style="background:${escapeAttr(b.linkColor)}">${escapeHtml(b.linkLabel)}</span>`
+      : '';
+    const label = escapeHtml(b.sourceTitle || b.source);
+    return `<li><a class="wiki-link" data-target="${escapeAttr(b.source)}">${label}</a>${badge}</li>`;
+  });
+  return `${titleHtml}<ul class="query-result-list backlinks-block">${items.join('')}</ul>`;
+}
+
+// ── Semantic block (#1128) ──────────────────────────────────────────────────
+
+/** Which corpus kinds the block queries. Defaults to notes (the clickable case);
+ *  `kind: source|excerpt|all` overrides. */
+export function semanticKinds(config: Record<string, string>): readonly ('note' | 'source' | 'excerpt')[] {
+  const raw = (config.kind ?? 'note').toLowerCase();
+  if (raw === 'all') return ['note', 'source', 'excerpt'];
+  return raw.split(',').map((s) => s.trim()).filter((k): k is 'note' | 'source' | 'excerpt' =>
+    k === 'note' || k === 'source' || k === 'excerpt');
+}
+
+/** Apply the block's `threshold` (min cosine similarity) and `limit`. */
+export function selectSemanticNotes(notes: RelatedNote[], config: Record<string, string>): RelatedNote[] {
+  const threshold = Number.parseFloat(config.threshold ?? '');
+  const filtered = Number.isFinite(threshold) ? notes.filter((n) => n.score >= threshold) : notes;
+  return filtered.slice(0, clampLimit(config.limit, 8));
+}
+
+export function buildSemanticHtml(notes: RelatedNote[], config: Record<string, string>): string {
+  const titleHtml = titleHtmlFor(config);
+  if (notes.length === 0) return `${titleHtml}<p class="query-empty">No related notes</p>`;
+  const showSnippet = config.snippet !== 'false' && config.snippet !== 'off';
+  const items = notes.map((n) => {
+    // Note hits are navigable wiki-links; source/excerpt hits show their title.
+    const head = n.kind === 'note'
+      ? `<a class="wiki-link" data-target="${escapeAttr(n.ref)}">${escapeHtml(n.title)}</a>`
+      : `<span class="semantic-nonnote">${escapeHtml(n.title)}</span>`;
+    const section = n.sectionHeading
+      ? `<div class="semantic-section">${escapeHtml(n.sectionHeading)}</div>` : '';
+    const snippet = showSnippet && n.snippet
+      ? `<div class="semantic-snippet">${escapeHtml(n.snippet)}</div>` : '';
+    return `<li>${head}${section}${snippet}</li>`;
+  });
+  return `${titleHtml}<ul class="query-result-list semantic-block">${items.join('')}</ul>`;
+}

--- a/src/renderer/lib/preview/live-blocks.ts
+++ b/src/renderer/lib/preview/live-blocks.ts
@@ -58,27 +58,33 @@ export function semanticKinds(config: Record<string, string>): readonly ('note' 
     k === 'note' || k === 'source' || k === 'excerpt');
 }
 
-/** Apply the block's `threshold` (min cosine similarity) and `limit`. */
+/** Apply the block's `kind` filter, `threshold` (min cosine similarity), and
+ *  `limit`. The kind filter runs client-side so the empty-query path (which
+ *  reuses the all-kinds "related to this note" IPC) honors it too. */
 export function selectSemanticNotes(notes: RelatedNote[], config: Record<string, string>): RelatedNote[] {
+  const kinds = new Set<string>(semanticKinds(config));
+  let out = notes.filter((n) => kinds.has(n.kind));
   const threshold = Number.parseFloat(config.threshold ?? '');
-  const filtered = Number.isFinite(threshold) ? notes.filter((n) => n.score >= threshold) : notes;
-  return filtered.slice(0, clampLimit(config.limit, 8));
+  if (Number.isFinite(threshold)) out = out.filter((n) => n.score >= threshold);
+  return out.slice(0, clampLimit(config.limit, 8));
 }
 
 export function buildSemanticHtml(notes: RelatedNote[], config: Record<string, string>): string {
   const titleHtml = titleHtmlFor(config);
   if (notes.length === 0) return `${titleHtml}<p class="query-empty">No related notes</p>`;
-  const showSnippet = config.snippet !== 'false' && config.snippet !== 'off';
+  // `compact: true` → just the link (no section heading, no snippet).
+  const compact = config.compact === 'true' || config.compact === 'on';
+  const showSnippet = !compact && config.snippet !== 'false' && config.snippet !== 'off';
   const items = notes.map((n) => {
     // Note hits are navigable wiki-links; source/excerpt hits show their title.
     const head = n.kind === 'note'
       ? `<a class="wiki-link" data-target="${escapeAttr(n.ref)}">${escapeHtml(n.title)}</a>`
       : `<span class="semantic-nonnote">${escapeHtml(n.title)}</span>`;
-    const section = n.sectionHeading
+    const section = !compact && n.sectionHeading
       ? `<div class="semantic-section">${escapeHtml(n.sectionHeading)}</div>` : '';
     const snippet = showSnippet && n.snippet
       ? `<div class="semantic-snippet">${escapeHtml(n.snippet)}</div>` : '';
     return `<li>${head}${section}${snippet}</li>`;
   });
-  return `${titleHtml}<ul class="query-result-list semantic-block">${items.join('')}</ul>`;
+  return `${titleHtml}<ul class="query-result-list semantic-block"${compact ? ' data-compact="1"' : ''}>${items.join('')}</ul>`;
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -108,6 +108,9 @@ export const Channels = {
   EMBEDDINGS_BACKFILL_PROGRESS: 'embeddings:backfillProgress',
   /** Notes semantically related to a note, for the Related sidebar panel (#838). */
   EMBEDDINGS_RELATED: 'embeddings:related',
+  // Free-text semantic search — embeds arbitrary query text and ranks the
+  // corpus (the live `:::query-semantic` block, #1128).
+  EMBEDDINGS_SEARCH_TEXT: 'embeddings:searchText',
   /** Snapshot of the live graph's predicates + classes for SPARQL autocomplete (#198). */
   GRAPH_SCHEMA_FOR_COMPLETION: 'graph:schemaForCompletion',
   GRAPH_SOURCE_DETAIL: 'graph:sourceDetail',

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -68,6 +68,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "csl:removeLocale",
   "csl:removeStyle",
   "embeddings:related",
+  "embeddings:searchText",
   "excerpt:getNoteFolder",
   "excerpt:setNoteFolder",
   "export:csv",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -101,6 +101,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
   "embeddings": [
     "onBackfillProgress",
     "related",
+    "searchText",
   ],
   "export": [
     "csv",

--- a/tests/renderer/preview/live-blocks.test.ts
+++ b/tests/renderer/preview/live-blocks.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Live query-block builders (#1137 backlinks, #1128 semantic) — selection
+ * (filter/limit/threshold/kind) + read-only HTML. Pure string functions.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  selectBacklinks,
+  buildBacklinksHtml,
+  semanticKinds,
+  selectSemanticNotes,
+  buildSemanticHtml,
+} from '../../../src/renderer/lib/preview/live-blocks';
+import type { Backlink, RelatedNote } from '../../../src/shared/types';
+
+const bl = (over: Partial<Backlink>): Backlink => ({
+  source: 'notes/a.md', sourceTitle: 'A', linkType: 'references', linkLabel: '', linkColor: '#888', ...over,
+});
+const rn = (over: Partial<RelatedNote>): RelatedNote => ({
+  kind: 'note', ref: 'notes/x.md', title: 'X', sectionHeading: '', snippet: '', score: 0.9, ...over,
+});
+
+describe('backlinks block (#1137)', () => {
+  it('filters by linkType and honors limit', () => {
+    const rows = [bl({ source: '1.md', linkType: 'cite' }), bl({ source: '2.md', linkType: 'references' }), bl({ source: '3.md', linkType: 'cite' })];
+    expect(selectBacklinks(rows, { linkType: 'cite' }).map((b) => b.source)).toEqual(['1.md', '3.md']);
+    expect(selectBacklinks(rows, { limit: '2' })).toHaveLength(2);
+  });
+
+  it('renders navigable rows with a typed badge, escaping content', () => {
+    const html = buildBacklinksHtml([bl({ source: 'notes/b.md', sourceTitle: 'B & <C>', linkType: 'cite', linkLabel: 'cites', linkColor: '#e78284' })], {});
+    expect(html).toContain('data-target="notes/b.md"');
+    expect(html).toContain('B &amp; &lt;C&gt;');
+    expect(html).toContain('class="query-link-badge" style="background:#e78284"');
+    expect(html).toContain('>cites<');
+  });
+
+  it('quiet empty state, plus optional title', () => {
+    expect(buildBacklinksHtml([], {})).toContain('No backlinks yet');
+    expect(buildBacklinksHtml([], { title: 'Linked from' })).toContain('<h4 class="query-title">Linked from</h4>');
+  });
+});
+
+describe('semantic block (#1128)', () => {
+  it('defaults to notes; `all` spans every kind', () => {
+    expect(semanticKinds({})).toEqual(['note']);
+    expect(semanticKinds({ kind: 'all' })).toEqual(['note', 'source', 'excerpt']);
+    expect(semanticKinds({ kind: 'source' })).toEqual(['source']);
+  });
+
+  it('applies threshold and limit', () => {
+    const notes = [rn({ ref: '1.md', score: 0.9 }), rn({ ref: '2.md', score: 0.5 }), rn({ ref: '3.md', score: 0.8 })];
+    expect(selectSemanticNotes(notes, { threshold: '0.75' }).map((n) => n.ref)).toEqual(['1.md', '3.md']);
+    expect(selectSemanticNotes(notes, { limit: '1' })).toHaveLength(1);
+  });
+
+  it('renders note hits as wiki-links with section + snippet; snippet:off hides it', () => {
+    const notes = [rn({ ref: 'notes/r.md', title: 'Result', sectionHeading: 'Intro', snippet: 'a snippet' })];
+    const html = buildSemanticHtml(notes, {});
+    expect(html).toContain('class="wiki-link" data-target="notes/r.md"');
+    expect(html).toContain('Intro');
+    expect(html).toContain('a snippet');
+    expect(buildSemanticHtml(notes, { snippet: 'off' })).not.toContain('a snippet');
+  });
+
+  it('non-note hits are not navigable', () => {
+    const html = buildSemanticHtml([rn({ kind: 'source', ref: 'src-1', title: 'A Paper' })], {});
+    expect(html).toContain('semantic-nonnote');
+    expect(html).not.toContain('wiki-link');
+  });
+
+  it('quiet empty state', () => {
+    expect(buildSemanticHtml([], {})).toContain('No related notes');
+  });
+});

--- a/tests/renderer/preview/live-blocks.test.ts
+++ b/tests/renderer/preview/live-blocks.test.ts
@@ -53,6 +53,23 @@ describe('semantic block (#1128)', () => {
     expect(selectSemanticNotes(notes, { limit: '1' })).toHaveLength(1);
   });
 
+  it('filters by kind — default is note-only; kind:all keeps everything', () => {
+    // The empty-query path reuses the all-kinds "related to this note" IPC, so
+    // the kind filter runs client-side here.
+    const notes = [rn({ ref: '1.md' }), rn({ kind: 'source', ref: 'src-1' })];
+    expect(selectSemanticNotes(notes, {}).map((n) => n.ref)).toEqual(['1.md']);
+    expect(selectSemanticNotes(notes, { kind: 'all' })).toHaveLength(2);
+  });
+
+  it('compact mode renders only the link (no section / snippet)', () => {
+    const notes = [rn({ ref: 'notes/r.md', title: 'R', sectionHeading: 'Sec', snippet: 'snip' })];
+    const html = buildSemanticHtml(notes, { compact: 'true' });
+    expect(html).toContain('data-target="notes/r.md"');
+    expect(html).not.toContain('semantic-section');
+    expect(html).not.toContain('Sec');
+    expect(html).not.toContain('snip');
+  });
+
   it('renders note hits as wiki-links with section + snippet; snippet:off hides it', () => {
     const notes = [rn({ ref: 'notes/r.md', title: 'Result', sectionHeading: 'Intro', snippet: 'a snippet' })];
     const html = buildSemanticHtml(notes, {});


### PR DESCRIPTION
Closes #1137. Closes #1128.

Two siblings in one PR — both are new *live-block surfaces* over existing infrastructure, and they share so much of the `:::query-*` machinery (parse → `executeQueryBlock` → inject, the reactive re-run, the empty-state) that separate PRs would mostly duplicate each other. Both are **read-only** — nothing is written to the note or graph.

## Syntax decision (resolves #1128's open question)
The **directive family**, not a ```` ```search ```` fence. `:::query-backlinks` and `:::query-semantic` slot beside the existing `:::query-list` / `:::query-table` blocks and **parse for free** (the directive parser already matches `:::query-<word>`). One consistent story: SPARQL / SQL / semantic / backlinks live blocks. Doing them together made this the obvious call.

## Backlinks block (#1137) — nearly free
A `backlinks` branch in `executeQueryBlock` (ahead of the `!query` guard, since it has no body) calls the existing `getLinkBundle(notePath, revision)` — the deduped, title-enriched, typed `Backlink[]` the sidebar already uses — and renders the notes that link here as a list with their **typed-link badges** (cite/quote/supports/…). Direct IPC, not a SPARQL-with-substitution preset. Config: `title`, `limit`, `linkType` filter.

## Semantic block (#1128) — a thin IPC over the on-device embedder
`searchRelated(ctx, query)` already embeds a *string* at query time, so the "new infrastructure" is just a channel: **`EMBEDDINGS_SEARCH_TEXT`** embeds the block's free text and ranks the corpus via the same `topRelatedNotes` path as the Related panel. Renders title + section heading + optional snippet; note hits are navigable wiki-links. Config: `limit`, `threshold` (min cosine similarity), `snippet` on/off, `kind` (note/source/excerpt/all). The host note is excluded from its own results.

## Live refresh
Preview now takes the graph **`revision`** and re-runs the live blocks when it bumps, so a block reflects links / embeddings added *elsewhere*, not just on the note's own edit. (SPARQL/SQL blocks re-run too but hit their cache, so behavior is unchanged.) Below-threshold / no-backlinks → a **quiet empty state**, never an error.

## Acceptance criteria
**#1137:** ✅ renders backlinks as a linked list · ✅ typed-link badges · ✅ `title`/`limit`/`linkType` · ✅ refreshes on graph change · ✅ quiet empty · ✅ read-only
**#1128:** ✅ free-text query → top matches by cosine similarity · ✅ `limit`/`threshold`/`snippet`/`kind`, self-excluded · ✅ quiet below-threshold · ✅ refreshes on re-render/index update · ✅ read-only
Both: ✅ `pnpm lint` + `pnpm test` (3976).

## Testing
Pure selection + HTML builders live in `preview/live-blocks.ts` (mirroring `cite-meta.ts`) and are unit-tested: linkType/limit/threshold/kind filtering, navigable rows + escaped typed badge, snippet on/off, non-note non-navigable, and the quiet empties. Snapshots updated for the new channel/method.

> The Preview injection + DuckDB/embedder query aren't unit-testable end-to-end (mounted component + native index); worth a quick manual pass — drop `:::query-backlinks` and a `:::query-semantic` block in a note and preview it. Semantic requires the embedding index enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)