### PR TITLE
llm: provider-abstraction seam for the conversation layer (#1148)

### DIFF
--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -1,5 +1,9 @@
-import Anthropic from '@anthropic-ai/sdk';
-import { getSettings } from './settings';
+import { getProvider } from './provider';
+import type {
+  ChatMessage,
+  ProviderMessage,
+  ProviderToolResult,
+} from './provider/types';
 import {
   buildConversationTools,
   executeNotebaseTool,
@@ -8,8 +12,6 @@ import {
 } from './tools';
 import type { Citation, TurnUsage } from '../../shared/types';
 import { resolveEffort, type Effort } from '../../shared/tools/effort';
-import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
-import { MISSING_API_KEY_MARKER } from '../../shared/llm-errors';
 import type { ConversationDraft } from '../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../shared/conversation-source-drafts';
 import type { ConversationPropertyDraft } from '../../shared/conversation-property-drafts';
@@ -127,10 +129,7 @@ export function toToolCallbacks(callbacks?: StreamCallbacks): ToolCallbacks {
   return out;
 }
 
-export interface ChatMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
+export type { ChatMessage } from './provider/types';
 
 export interface CompleteOptions {
   system?: string;
@@ -156,7 +155,7 @@ export interface CompleteOptions {
 
 export interface CompleteWithToolsOptions {
   system: string;
-  messages: Anthropic.MessageParam[];
+  messages: ChatMessage[];
   toolContext: ToolContext;
   callbacks?: StreamCallbacks;
   /** Hard cap on tool-use iterations. Defaults to 10. */
@@ -198,57 +197,17 @@ export interface CompleteWithToolsResult {
   containerExpiresAt?: string;
 }
 
-async function getClient(): Promise<{
-  client: Anthropic;
-  model: string;
-  web: NonNullable<Awaited<ReturnType<typeof getSettings>>['web']>;
-  effort: Effort | undefined;
-}> {
-  const settings = await getSettings();
-  if (!settings.apiKey) {
-    // Message starts with MISSING_API_KEY_MARKER so the renderer can
-    // detect this specific failure across IPC and surface an actionable
-    // "Open Settings" dialog instead of the silent log message that was
-    // the only feedback before. See `shared/llm-errors.ts`.
-    throw new Error(
-      `${MISSING_API_KEY_MARKER}. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.`,
-    );
-  }
-  return {
-    client: new Anthropic({ apiKey: settings.apiKey }),
-    model: settings.model,
-    web: settings.web ?? { ...DEFAULT_WEB_SETTINGS },
-    effort: settings.effort,
-  };
-}
-
-/**
- * Build the `output_config` to attach to a Messages call for a given
- * (model, override) pair, or `undefined` to omit it. Effort is resolved from
- * the per-call override over the global default, then clamped to what the model
- * supports — Haiku gets nothing (sending effort 400s); `xhigh` only survives on
- * Opus. Returned as a partial so callers can spread it onto the params.
- */
-function outputConfigFor(
-  model: string,
-  override: Effort | undefined,
-  globalDefault: Effort | undefined,
-): { output_config: { effort: Effort } } | undefined {
-  const effort = resolveEffort(model, override, globalDefault);
-  return effort ? { output_config: { effort } } : undefined;
-}
-
 /**
  * Single-shot completion. Preserves the original API used by the Thinking
  * Tools executor and conversation slash commands — no tool use, streaming
- * controlled by the caller.
+ * controlled by the caller. All provider specifics live behind `provider`.
  */
 export async function complete(
   prompt: string,
   callbacksOrOptions?: StreamCallbacks | CompleteOptions,
 ): Promise<string> {
   let system: string | undefined;
-  let messages: Anthropic.MessageParam[];
+  let messages: ChatMessage[];
   let callbacks: StreamCallbacks | undefined;
   let modelOverride: string | undefined;
   let effortOverride: Effort | undefined;
@@ -264,39 +223,31 @@ export async function complete(
     modelOverride = opts.model;
     effortOverride = opts.effort;
     onUsage = opts.onUsage;
-    messages = (opts.messages ?? [{ role: 'user', content: prompt }]);
+    messages = opts.messages ?? [{ role: 'user', content: prompt }];
   } else {
     messages = [{ role: 'user', content: prompt }];
   }
 
-  const { client, model: defaultModel, effort: defaultEffort } = await getClient();
+  const { provider, model: defaultModel, effort: defaultEffort } = await getProvider();
   const model = modelOverride ?? defaultModel;
-  const outputConfig = outputConfigFor(model, effortOverride, defaultEffort);
+  const effort = resolveEffort(model, effortOverride, defaultEffort);
 
-  if (!callbacks) {
-    const response = await client.messages.create({
+  // `const` (not the outer `let`) so TS keeps the narrowing inside the closure.
+  const cb = callbacks;
+  const result = await provider.complete(
+    {
       model,
-      max_tokens: 16000,
-      ...(system ? { system } : {}),
-      ...outputConfig,
+      system,
       messages,
-    });
-    if (onUsage) onUsage(addUsage(emptyUsage(), response.usage), model);
-    return extractText(response.content);
-  }
-
-  const stream = client.messages.stream({
-    model,
-    max_tokens: 64000,
-    ...(system ? { system } : {}),
-    ...outputConfig,
-    messages,
-  }, { signal: callbacks.signal });
-
-  stream.on('text', (delta) => callbacks.onChunk(delta));
-  const finalMessage = await stream.finalMessage();
-  if (onUsage) onUsage(addUsage(emptyUsage(), finalMessage.usage), model);
-  return extractText(finalMessage.content);
+      effort,
+      // Streaming callers historically got a larger budget than one-shots.
+      maxTokens: cb ? 64000 : 16000,
+      signal: cb?.signal,
+    },
+    cb ? (delta) => cb.onChunk(delta) : undefined,
+  );
+  if (onUsage) onUsage(result.usage, model);
+  return result.text;
 }
 
 /**
@@ -311,28 +262,15 @@ export async function complete(
 export async function completeWithTools(
   options: CompleteWithToolsOptions,
 ): Promise<CompleteWithToolsResult> {
-  const { client, model: defaultModel, web, effort: defaultEffort } = await getClient();
+  const { provider, model: defaultModel, web, effort: defaultEffort } = await getProvider();
   const model = options.model ?? defaultModel;
-  const outputConfig = outputConfigFor(model, options.effort, defaultEffort);
+  const effort = resolveEffort(model, options.effort, defaultEffort);
   const { toolContext, callbacks, maxIterations = 10 } = options;
-  const messages: Anthropic.MessageParam[] = [...options.messages];
 
-  const system: Anthropic.TextBlockParam[] = [
-    {
-      type: 'text',
-      text: options.system,
-      cache_control: { type: 'ephemeral' },
-    },
-  ];
-
-  const tools = buildConversationTools({
-    web: {
-      enabled: web.enabled,
-      allowedDomains: web.allowedDomains,
-      blockedDomains: web.blockedDomains,
-    },
-    extraTools: options.extraTools,
-  });
+  // Client-side tools only; server-side web tools are added inside the provider
+  // from `web`. History is opaque to this loop — the provider owns its shape.
+  const tools = buildConversationTools({ extraTools: options.extraTools });
+  const history: ProviderMessage[] = provider.ingestHistory(options.messages);
 
   const textPieces: string[] = [];
   const citationMap = new Map<string, Citation>();
@@ -340,17 +278,11 @@ export async function completeWithTools(
   // only the final iteration's usage would under-report tool-heavy turns by
   // however many tool round-trips it took to get there (#820).
   const usage = emptyUsage();
-  // Code-execution sandbox id, threaded across iterations AND across
-  // turns of the same conversation. The newer web_search_20260209 /
-  // web_fetch_20260209 tools surface as `server_tool_use` blocks of
-  // type `code_execution`; once the API spins up a container, every
-  // subsequent request whose `messages` history still references
-  // those tool-use blocks must echo `container: <id>` back or the API
-  // 400s with "container_id is required when there are pending tool
-  // uses generated by code execution with tools." Seeded from the
-  // caller (Conversation.containerId) so the next turn picks up where
-  // the prior turn left off; captured fresh on every iteration so the
-  // most-recent id wins.
+  // Code-execution sandbox id, threaded across iterations AND across turns of
+  // the same conversation (see CompleteWithToolsOptions.initialContainerId). The
+  // provider echoes it back on each request and reports the latest id in the
+  // turn result; we keep the most-recent non-null so an intermediate
+  // non-code-execution turn doesn't drop a still-live sandbox.
   let containerId: string | null = options.initialContainerId ?? null;
   let containerExpiresAt: string | null = null;
 
@@ -364,119 +296,66 @@ export async function completeWithTools(
   const MAX_CONSECUTIVE_ERROR_ITERS = 3;
   let consecutiveAllErrorIters = 0;
 
+  // Surface a tool call as a live "🔍 Searching…" indicator the moment the model
+  // emits it — pushed inline into the transcript and streamed to the UI. The
+  // provider fires this exactly once per block (client- or server-side).
+  const onToolCallStart = (name: string, input: unknown): void => {
+    const indicator = `\n\n_${formatToolCall(name, input)}…_\n\n`;
+    textPieces.push(indicator);
+    if (callbacks) callbacks.onChunk(indicator);
+  };
+
   for (let iteration = 0; iteration < maxIterations; iteration++) {
-    const streamParams: Anthropic.MessageStreamParams = {
-      model,
-      max_tokens: 64000,
-      system,
-      tools,
-      messages,
-      ...outputConfig,
-    };
-    if (containerId) streamParams.container = containerId;
-    // Per-iteration diagnostic so the "container_id is required" 400s
-    // are easy to root-cause. Logs iteration number, whether we're
-    // passing a container, and a histogram of block types in the
-    // accumulated messages array — code_execution / server_tool_use
-    // here without a container is the smoking gun.
     if (process.env.MINERVA_LLM_DEBUG) {
-      const blockHist: Record<string, number> = {};
-      for (const m of messages) {
-        if (typeof m.content === 'string') continue;
-        for (const b of m.content) {
-          const t = (b as { type?: string }).type ?? '?';
-          blockHist[t] = (blockHist[t] ?? 0) + 1;
-        }
-      }
       console.log(
-        `[llm] iter=${iteration} container=${containerId ?? 'null'} ` +
-        `messageCount=${messages.length} blocks=${JSON.stringify(blockHist)}`,
+        `[llm] iter=${iteration} container=${containerId ?? 'null'} historyLength=${history.length}`,
       );
     }
-    const stream = client.messages.stream(
-      streamParams,
-      { signal: callbacks?.signal },
+
+    const turn = await provider.runTurn(
+      {
+        model,
+        system: options.system,
+        history,
+        tools,
+        web,
+        effort,
+        maxTokens: 64000,
+        containerId,
+        signal: callbacks?.signal,
+      },
+      {
+        onTextDelta: callbacks ? (delta) => callbacks.onChunk(delta) : undefined,
+        onToolCallStart,
+      },
     );
 
-    // Track which tool-use blocks we've already surfaced as live
-    // indicators so the post-finalMessage iteration below doesn't
-    // double-push them. The contentBlock event fires the moment the
-    // model finishes emitting a tool-use block (before the API
-    // executes the server tool / before our client-side dispatch
-    // runs), so users see "🔍 Searching the web for X" *during* the
-    // wait rather than after the iteration completes.
-    const liveEmittedToolUseIds = new Set<string>();
-    stream.on('contentBlock', (block) => {
-      if (block.type !== 'tool_use' && block.type !== 'server_tool_use') return;
-      const indicator = `\n\n_${formatToolCall(block.name, block.input)}…_\n\n`;
-      textPieces.push(indicator);
-      if (callbacks) callbacks.onChunk(indicator);
-      liveEmittedToolUseIds.add(block.id);
-    });
-
-    if (callbacks) {
-      stream.on('text', (delta) => callbacks.onChunk(delta));
+    sumUsage(usage, turn.usage);
+    history.push(turn.assistantMessage);
+    // Hold on to the container so the next iteration can reuse it; don't clear
+    // it when a later turn reports none.
+    if (turn.containerId) {
+      containerId = turn.containerId;
+      containerExpiresAt = turn.containerExpiresAt ?? null;
     }
 
-    const message = await stream.finalMessage();
-    addUsage(usage, message.usage);
-    messages.push({ role: 'assistant', content: message.content });
-    // Hold on to the container so the next iteration of this same
-    // agent turn can reuse it. Don't clear if a later iteration's
-    // response has `container: null` — the sandbox can persist across
-    // intermediate non-code-execution turns and the API still wants
-    // the id echoed.
-    if (message.container?.id) {
-      containerId = message.container.id;
-      containerExpiresAt = message.container.expires_at ?? null;
-    }
-
-    for (const block of message.content) {
-      if (block.type === 'text') {
-        textPieces.push(block.text);
-        collectCitations(block, citationMap);
-      } else if (block.type === 'server_tool_use' && !liveEmittedToolUseIds.has(block.id)) {
-        // Fallback path — if the SDK didn't fire `contentBlock` for
-        // this block for some reason, recover the indicator here.
-        const indicator = `\n\n_${formatToolCall(block.name, block.input)}…_\n\n`;
-        textPieces.push(indicator);
-        if (callbacks) callbacks.onChunk(indicator);
-      }
+    if (turn.text) textPieces.push(turn.text);
+    for (const c of turn.citations) {
+      if (!citationMap.has(c.url)) citationMap.set(c.url, c);
     }
 
     // Server-side tool loop (e.g. web_search) can hit its internal iteration
-    // cap and return pause_turn. The API expects us to re-send the same
-    // conversation so it can resume where it left off — no extra user message.
-    if (message.stop_reason === 'pause_turn') {
-      continue;
-    }
+    // cap and pause; re-send the same conversation so it resumes — no extra
+    // user message.
+    if (turn.stopReason === 'pause') continue;
+    if (turn.stopReason !== 'tool_use') break;
+    // Stopped for tool_use but only server-side blocks (which we don't execute)
+    // — nothing to run, so stop rather than loop forever.
+    if (turn.toolCalls.length === 0) break;
 
-    if (message.stop_reason !== 'tool_use') {
-      break;
-    }
-
-    const toolUses = message.content.filter(
-      (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use',
-    );
-
-    // If the model stopped for tool_use but only emitted server_tool_use
-    // blocks (which we don't execute), we'd loop forever. Guard against it.
-    if (toolUses.length === 0) break;
-
-    const toolResults: Anthropic.ToolResultBlockParam[] = [];
-    for (const use of toolUses) {
+    const toolResults: ProviderToolResult[] = [];
+    for (const use of turn.toolCalls) {
       console.log(`[conv] tool call: ${use.name}`, JSON.stringify(use.input).slice(0, 200));
-      // Indicator was already streamed live via the `contentBlock`
-      // listener above (and pushed to textPieces) the moment the model
-      // finished emitting this tool-use block — i.e. before the wait
-      // for our local executor. Re-push only if the live emit somehow
-      // missed it (SDK version drift, etc.), so the persisted transcript
-      // still carries the indicator inline.
-      if (!liveEmittedToolUseIds.has(use.id)) {
-        const indicator = `\n\n_${formatToolCall(use.name, use.input)}…_\n\n`;
-        textPieces.push(indicator);
-        if (callbacks) callbacks.onChunk(indicator);
-      }
       const { content, isError } = await executeNotebaseTool(
         toolContext,
         use.name,
@@ -486,18 +365,13 @@ export async function completeWithTools(
       if (isError) {
         console.warn(`[conv] tool ${use.name} returned error:`, content.slice(0, 300));
       }
-      toolResults.push({
-        type: 'tool_result',
-        tool_use_id: use.id,
-        content,
-        ...(isError ? { is_error: true } : {}),
-      });
+      toolResults.push({ toolUseId: use.id, content, isError });
     }
 
-    messages.push({ role: 'user', content: toolResults });
+    history.push(provider.toolResultMessage(toolResults));
 
     // Track runs of all-error iterations and bail out of a wedged retry loop.
-    const allErrored = toolResults.length > 0 && toolResults.every((r) => r.is_error);
+    const allErrored = toolResults.length > 0 && toolResults.every((r) => r.isError);
     consecutiveAllErrorIters = allErrored ? consecutiveAllErrorIters + 1 : 0;
     if (consecutiveAllErrorIters >= MAX_CONSECUTIVE_ERROR_ITERS) {
       console.warn(`[conv] aborting after ${consecutiveAllErrorIters} consecutive all-error tool iterations`);
@@ -519,45 +393,20 @@ export async function completeWithTools(
   };
 }
 
-function collectCitations(
-  block: Anthropic.TextBlock,
-  acc: Map<string, Citation>,
-): void {
-  if (!block.citations) return;
-  for (const c of block.citations) {
-    if (c.type !== 'web_search_result_location') continue;
-    if (!c.url) continue;
-    if (acc.has(c.url)) continue;
-    acc.set(c.url, {
-      url: c.url,
-      ...(c.title != null ? { title: c.title } : {}),
-      citedText: c.cited_text,
-    });
-  }
-}
-
 function emptyUsage(): TurnUsage {
   return { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
 }
 
 /**
- * Fold one API response's `usage` into a running per-turn total. Kept distinct
- * by token kind (plain input vs cache read vs cache write) so #821 can price
- * each at its own rate. Mutates and returns `acc` for terse call sites in the
- * agentic loop.
+ * Fold one turn's usage into a running per-turn total, kept distinct by token
+ * kind (plain input vs cache read vs cache write) so #821 can price each at its
+ * own rate. The provider already reduced the raw API usage to `TurnUsage`; this
+ * just sums across the agentic loop's iterations. Mutates and returns `acc`.
  */
-function addUsage(acc: TurnUsage, usage: Anthropic.Usage | undefined): TurnUsage {
-  if (!usage) return acc;
-  acc.inputTokens += usage.input_tokens ?? 0;
-  acc.outputTokens += usage.output_tokens ?? 0;
-  acc.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
-  acc.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+function sumUsage(acc: TurnUsage, turn: TurnUsage): TurnUsage {
+  acc.inputTokens += turn.inputTokens;
+  acc.outputTokens += turn.outputTokens;
+  acc.cacheCreationTokens += turn.cacheCreationTokens;
+  acc.cacheReadTokens += turn.cacheReadTokens;
   return acc;
-}
-
-function extractText(content: Anthropic.ContentBlock[]): string {
-  return content
-    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
-    .map((b) => b.text)
-    .join('');
 }

--- a/src/main/llm/provider/anthropic.ts
+++ b/src/main/llm/provider/anthropic.ts
@@ -1,0 +1,223 @@
+/**
+ * The Anthropic implementation of the provider seam (#1148).
+ *
+ * This is the ONLY file under `src/main/llm/` that imports `@anthropic-ai/sdk`
+ * (alongside the settings module, which only reads model ids). Everything
+ * Claude-specific — the client, message/tool-result block shapes, streaming
+ * events, `output_config.effort`, server-side web tools, code-execution
+ * `container` ids, usage-field names, and web-search citations — is translated
+ * to and from the neutral types in `./types` here. The agentic loop in
+ * `../index.ts` sees none of it.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import type { Citation, TurnUsage } from '../../../shared/types';
+import type { Effort } from '../../../shared/tools/effort';
+import type {
+  ChatMessage,
+  CompletionRequest,
+  CompletionResult,
+  LLMProvider,
+  ProviderMessage,
+  ProviderToolResult,
+  StopReason,
+  ToolSpec,
+  TurnHooks,
+  TurnRequest,
+  TurnResult,
+  WebToolSettings,
+} from './types';
+
+/** `output_config` for a resolved effort, or `undefined` to omit it. Effort has
+ *  already been clamped to the model by the caller; a falsy value means the
+ *  model doesn't take one (e.g. Haiku), so we send nothing. */
+function outputConfigFor(
+  effort: Effort | undefined,
+): { output_config: { effort: Effort } } | undefined {
+  return effort ? { output_config: { effort } } : undefined;
+}
+
+/**
+ * Server-side tools run on Anthropic's infrastructure — we declare them in the
+ * request and the API executes queries/fetches and returns structured
+ * citations. Version _20260209 bundles dynamic filtering. `allowed_domains` /
+ * `blocked_domains` pass through per user setting (mutually exclusive from the
+ * model's perspective, but the API accepts either independently).
+ */
+function buildWebTools(web: WebToolSettings): Anthropic.Messages.ToolUnion[] {
+  const webSearch: Anthropic.Messages.WebSearchTool20260209 = {
+    type: 'web_search_20260209',
+    name: 'web_search',
+  };
+  const webFetch: Anthropic.Messages.WebFetchTool20260209 = {
+    type: 'web_fetch_20260209',
+    name: 'web_fetch',
+  };
+  if (web.allowedDomains && web.allowedDomains.length > 0) {
+    webSearch.allowed_domains = web.allowedDomains;
+    webFetch.allowed_domains = web.allowedDomains;
+  } else if (web.blockedDomains && web.blockedDomains.length > 0) {
+    webSearch.blocked_domains = web.blockedDomains;
+    webFetch.blocked_domains = web.blockedDomains;
+  }
+  return [webSearch, webFetch];
+}
+
+function emptyUsage(): TurnUsage {
+  return { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+}
+
+/** Fold one API response's `usage` into a running total, kept distinct by token
+ *  kind (plain vs cache-read vs cache-write) so #821 can price each separately. */
+function foldUsage(acc: TurnUsage, usage: Anthropic.Usage | undefined): TurnUsage {
+  if (!usage) return acc;
+  acc.inputTokens += usage.input_tokens ?? 0;
+  acc.outputTokens += usage.output_tokens ?? 0;
+  acc.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
+  acc.cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+  return acc;
+}
+
+function extractText(content: Anthropic.ContentBlock[]): string {
+  return content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+function collectCitations(content: Anthropic.ContentBlock[]): Citation[] {
+  const acc = new Map<string, Citation>();
+  for (const block of content) {
+    if (block.type !== 'text' || !block.citations) continue;
+    for (const c of block.citations) {
+      if (c.type !== 'web_search_result_location' || !c.url || acc.has(c.url)) continue;
+      acc.set(c.url, {
+        url: c.url,
+        ...(c.title != null ? { title: c.title } : {}),
+        citedText: c.cited_text,
+      });
+    }
+  }
+  return [...acc.values()];
+}
+
+function mapStopReason(reason: Anthropic.Message['stop_reason']): StopReason {
+  if (reason === 'pause_turn') return 'pause';
+  if (reason === 'tool_use') return 'tool_use';
+  return 'end';
+}
+
+export class AnthropicProvider implements LLMProvider {
+  readonly id = 'anthropic';
+  private readonly client: Anthropic;
+
+  constructor(apiKey: string) {
+    this.client = new Anthropic({ apiKey });
+  }
+
+  // History entries are Anthropic message params under the hood; the loop only
+  // ever holds them as opaque `ProviderMessage`s.
+  ingestHistory(messages: ChatMessage[]): ProviderMessage[] {
+    return messages.map((m) => ({ role: m.role, content: m.content })) as unknown as ProviderMessage[];
+  }
+
+  toolResultMessage(results: ProviderToolResult[]): ProviderMessage {
+    const content: Anthropic.ToolResultBlockParam[] = results.map((r) => ({
+      type: 'tool_result',
+      tool_use_id: r.toolUseId,
+      content: r.content,
+      ...(r.isError ? { is_error: true } : {}),
+    }));
+    return { role: 'user', content } as unknown as ProviderMessage;
+  }
+
+  private buildTools(specs: ToolSpec[], web: WebToolSettings): Anthropic.Messages.ToolUnion[] {
+    // ToolSpec is structurally an Anthropic.Tool (name/description/input_schema).
+    const tools: Anthropic.Messages.ToolUnion[] = specs.map((s) => s as Anthropic.Tool);
+    if (web.enabled) tools.push(...buildWebTools(web));
+    return tools;
+  }
+
+  async runTurn(req: TurnRequest, hooks: TurnHooks): Promise<TurnResult> {
+    const system: Anthropic.TextBlockParam[] = [
+      { type: 'text', text: req.system, cache_control: { type: 'ephemeral' } },
+    ];
+    const streamParams: Anthropic.MessageStreamParams = {
+      model: req.model,
+      max_tokens: req.maxTokens,
+      system,
+      tools: this.buildTools(req.tools, req.web),
+      messages: req.history as unknown as Anthropic.MessageParam[],
+      ...outputConfigFor(req.effort),
+    };
+    if (req.containerId) streamParams.container = req.containerId;
+
+    const stream = this.client.messages.stream(streamParams, { signal: req.signal });
+
+    // Fire onToolCallStart the moment the model finishes a tool-use block, so the
+    // indicator streams *during* the wait for our executor / the server tool.
+    const emitted = new Set<string>();
+    stream.on('contentBlock', (block) => {
+      if (block.type !== 'tool_use' && block.type !== 'server_tool_use') return;
+      emitted.add(block.id);
+      hooks.onToolCallStart?.(block.name, block.input);
+    });
+    if (hooks.onTextDelta) stream.on('text', (delta) => hooks.onTextDelta!(delta));
+
+    const message = await stream.finalMessage();
+
+    // Fallback for any tool-use block the streaming event missed (SDK drift),
+    // so the indicator still appears exactly once.
+    for (const block of message.content) {
+      if (
+        (block.type === 'tool_use' || block.type === 'server_tool_use') &&
+        !emitted.has(block.id)
+      ) {
+        hooks.onToolCallStart?.(block.name, block.input);
+      }
+    }
+
+    const toolCalls = message.content
+      .filter((b): b is Anthropic.ToolUseBlock => b.type === 'tool_use')
+      .map((b) => ({ id: b.id, name: b.name, input: b.input }));
+
+    return {
+      assistantMessage: { role: 'assistant', content: message.content } as unknown as ProviderMessage,
+      text: extractText(message.content),
+      toolCalls,
+      citations: collectCitations(message.content),
+      usage: foldUsage(emptyUsage(), message.usage),
+      stopReason: mapStopReason(message.stop_reason),
+      ...(message.container?.id ? { containerId: message.container.id } : {}),
+      ...(message.container?.expires_at ? { containerExpiresAt: message.container.expires_at } : {}),
+    };
+  }
+
+  async complete(
+    req: CompletionRequest,
+    onDelta?: (delta: string) => void,
+  ): Promise<CompletionResult> {
+    const messages = req.messages as Anthropic.MessageParam[];
+    const base = {
+      model: req.model,
+      ...(req.system ? { system: req.system } : {}),
+      ...outputConfigFor(req.effort),
+      messages,
+    };
+
+    if (!onDelta) {
+      const response = await this.client.messages.create(
+        { ...base, max_tokens: req.maxTokens },
+        req.signal ? { signal: req.signal } : undefined,
+      );
+      return { text: extractText(response.content), usage: foldUsage(emptyUsage(), response.usage) };
+    }
+
+    const stream = this.client.messages.stream(
+      { ...base, max_tokens: req.maxTokens },
+      { signal: req.signal },
+    );
+    stream.on('text', (delta) => onDelta(delta));
+    const finalMessage = await stream.finalMessage();
+    return { text: extractText(finalMessage.content), usage: foldUsage(emptyUsage(), finalMessage.usage) };
+  }
+}

--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Provider factory — the single place the conversation layer resolves *which*
+ * model provider to use (#1148). Today there is one; when a second ships, it
+ * branches here on a settings field and nothing above this line changes.
+ */
+import { getSettings } from '../settings';
+import { MISSING_API_KEY_MARKER } from '../../../shared/llm-errors';
+import { DEFAULT_WEB_SETTINGS } from '../../../shared/tools/types';
+import type { Effort } from '../../../shared/tools/effort';
+import { AnthropicProvider } from './anthropic';
+import type { LLMProvider, WebToolSettings } from './types';
+
+export type { LLMProvider } from './types';
+
+export interface ResolvedProvider {
+  provider: LLMProvider;
+  /** The default model for this provider, from settings. */
+  model: string;
+  web: WebToolSettings;
+  /** Global default reasoning effort, before per-call override/clamping. */
+  effort: Effort | undefined;
+}
+
+/**
+ * Build the configured provider plus the settings the caller threads into each
+ * request (model, web tools, default effort). Throws the marker error the
+ * renderer detects when no API key is set, so the "Open Settings" affordance
+ * still fires exactly as before.
+ */
+export async function getProvider(): Promise<ResolvedProvider> {
+  const settings = await getSettings();
+  if (!settings.apiKey) {
+    throw new Error(
+      `${MISSING_API_KEY_MARKER}. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.`,
+    );
+  }
+  // Single provider today. A second provider is a new `case` here keyed off a
+  // settings field — see docs/vision/substrate-mcp.md → Internal agnosticism.
+  const provider = new AnthropicProvider(settings.apiKey);
+  return {
+    provider,
+    model: settings.model,
+    web: settings.web ?? { ...DEFAULT_WEB_SETTINGS },
+    effort: settings.effort,
+  };
+}

--- a/src/main/llm/provider/types.ts
+++ b/src/main/llm/provider/types.ts
@@ -1,0 +1,150 @@
+/**
+ * The provider seam (#1148, epic #1145 — Substrate).
+ *
+ * Everything in this file is provider-neutral. The conversation layer — the
+ * agentic loop in `../index.ts`, tool dispatch, the approval gate, and the
+ * skills that compile into tools — talks to the `LLMProvider` interface and
+ * these neutral types, never to `@anthropic-ai/sdk` directly. All Claude-
+ * specific translation lives behind a single implementation (`./anthropic.ts`).
+ *
+ * This is the *seam*, not multi-provider support: today there is exactly one
+ * implementation. Its job is to make sure adding a second provider later is
+ * "write one more implementation of this interface" rather than "rewrite the
+ * gate." See `docs/vision/substrate-mcp.md` → *Internal agnosticism*.
+ */
+import type { Citation, TurnUsage } from '../../../shared/types';
+import type { Effort } from '../../../shared/tools/effort';
+
+/**
+ * A provider-neutral tool declaration — the JSON-Schema shape the model sees.
+ * The field names mirror the common wire form (`input_schema`); each provider's
+ * implementation adapts them to its own API as needed. Structurally identical to
+ * what the tool files under `../tools/` already emit, so introducing this type
+ * cost them no changes.
+ */
+export interface ToolSpec {
+  name: string;
+  description?: string;
+  input_schema: {
+    type: 'object';
+    properties?: Record<string, unknown> | undefined;
+    required?: string[] | undefined;
+    [key: string]: unknown;
+  };
+}
+
+/** Server-side web search/fetch settings, if the provider supports them. */
+export interface WebToolSettings {
+  enabled: boolean;
+  allowedDomains?: string[] | undefined;
+  blockedDomains?: string[] | undefined;
+}
+
+/**
+ * An opaque native conversation-history entry. The agentic loop treats these as
+ * black boxes — only the provider constructs them (`ingestHistory`,
+ * `toolResultMessage`, `TurnResult.assistantMessage`) and only the provider
+ * reads them (`runTurn`). Branded so a raw object can't be smuggled in where a
+ * provider-owned message is expected.
+ */
+export type ProviderMessage = { readonly __brand: 'ProviderMessage' };
+
+/** A neutral chat turn used to seed a conversation before the loop runs. */
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** A client-side tool call the loop must execute against the tool registry. */
+export interface ProviderToolCall {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/** The outcome of executing one tool call, fed back to the model next turn. */
+export interface ProviderToolResult {
+  toolUseId: string;
+  content: string;
+  isError: boolean;
+}
+
+export interface TurnHooks {
+  /** Fired as assistant text streams in (drives the live typing in the UI). */
+  onTextDelta?: ((delta: string) => void) | undefined;
+  /**
+   * Fired once per tool-use block the model emits (client- or server-side),
+   * before execution — drives the live "🔍 Searching…" indicators. The provider
+   * de-duplicates: exactly one call per block, whether it surfaced mid-stream or
+   * only in the final message.
+   */
+  onToolCallStart?: ((name: string, input: unknown) => void) | undefined;
+}
+
+export interface TurnRequest {
+  model: string;
+  system: string;
+  /** Native history — seeded by `ingestHistory`, grown via prior turns. */
+  history: ProviderMessage[];
+  tools: ToolSpec[];
+  web: WebToolSettings;
+  /** Already resolved + clamped to the model; the provider just applies it. */
+  effort?: Effort | undefined;
+  maxTokens: number;
+  /** Code-execution sandbox id to echo back when the history references one. */
+  containerId?: string | null | undefined;
+  signal?: AbortSignal | undefined;
+}
+
+/** Why the model stopped: neutral over provider-specific stop-reason strings. */
+export type StopReason = 'end' | 'tool_use' | 'pause';
+
+export interface TurnResult {
+  /** Append to `history` before the next turn. */
+  assistantMessage: ProviderMessage;
+  /** The turn's assistant text (final blocks joined), for the transcript. */
+  text: string;
+  /** Client-side tool calls for the loop to execute; empty when none. */
+  toolCalls: ProviderToolCall[];
+  citations: Citation[];
+  /** This single turn's token usage; the loop sums across turns. */
+  usage: TurnUsage;
+  stopReason: StopReason;
+  containerId?: string | undefined;
+  containerExpiresAt?: string | undefined;
+}
+
+export interface CompletionRequest {
+  model: string;
+  system?: string | undefined;
+  messages: ChatMessage[];
+  effort?: Effort | undefined;
+  maxTokens: number;
+  signal?: AbortSignal | undefined;
+}
+
+export interface CompletionResult {
+  text: string;
+  usage: TurnUsage;
+}
+
+/**
+ * The provider boundary. Adding a second model provider means implementing this
+ * interface; the gate, the skills, the tool dispatch, and the agentic loop stay
+ * exactly as they are.
+ */
+export interface LLMProvider {
+  /** Stable id for provenance/logging, e.g. `"anthropic"`. */
+  readonly id: string;
+  /** Convert neutral seed history into native message objects. */
+  ingestHistory(messages: ChatMessage[]): ProviderMessage[];
+  /** Wrap executed tool results as a native user-role message. */
+  toolResultMessage(results: ProviderToolResult[]): ProviderMessage;
+  /** Run ONE streaming model call, returning a neutral structured result. */
+  runTurn(req: TurnRequest, hooks: TurnHooks): Promise<TurnResult>;
+  /** Single-shot completion; streams via `onDelta` when provided. */
+  complete(
+    req: CompletionRequest,
+    onDelta?: (delta: string) => void,
+  ): Promise<CompletionResult>;
+}

--- a/src/main/llm/tools/registry.ts
+++ b/src/main/llm/tools/registry.ts
@@ -1,5 +1,5 @@
-import type Anthropic from '@anthropic-ai/sdk';
 import type { ConversationToolKey } from '../../../shared/conversation-tools';
+import type { ToolSpec } from '../provider/types';
 import type { NotebaseTool, ToolContext, ToolCallbacks, ToolResult } from './types';
 import { searchNotes } from './search-notes';
 import { readNote } from './read-note';
@@ -54,7 +54,7 @@ export const NOTEBASE_TOOL_REGISTRY: Record<string, NotebaseTool> = Object.fromE
   DEFAULT_TOOLS.map((t) => [t.definition.name, t]),
 );
 
-export const NOTEBASE_TOOLS: Anthropic.Tool[] = DEFAULT_TOOLS.map((t) => t.definition);
+export const NOTEBASE_TOOLS: ToolSpec[] = DEFAULT_TOOLS.map((t) => t.definition);
 
 /**
  * Dispatch table for `executeNotebaseTool`. Same as the default registry plus
@@ -65,65 +65,23 @@ const DISPATCH: Record<string, NotebaseTool> = {
   [askUser.definition.name]: askUser,
 };
 
-const TEMPLATE_TOOL_REGISTRY: Record<ConversationToolKey, Anthropic.Tool> = {
+const TEMPLATE_TOOL_REGISTRY: Record<ConversationToolKey, ToolSpec> = {
   ask_user: askUser.definition,
 };
 
-/**
- * Server-side tools run on Anthropic's infrastructure — we just declare them
- * in the request and the API executes queries/fetches and returns structured
- * citations. Version _20260209 bundles dynamic filtering (Claude filters
- * results with code before they hit its context window).
- *
- * `allowed_domains` / `blocked_domains` are passed through per user setting;
- * they're mutually exclusive from the model's perspective but the API accepts
- * either independently.
- */
-export function buildWebTools(opts: {
-  allowedDomains?: string[] | undefined;
-  blockedDomains?: string[] | undefined;
-}): Anthropic.Messages.ToolUnion[] {
-  const webSearch: Anthropic.Messages.WebSearchTool20260209 = {
-    type: 'web_search_20260209',
-    name: 'web_search',
-  };
-  if (opts.allowedDomains && opts.allowedDomains.length > 0) {
-    webSearch.allowed_domains = opts.allowedDomains;
-  } else if (opts.blockedDomains && opts.blockedDomains.length > 0) {
-    webSearch.blocked_domains = opts.blockedDomains;
-  }
-  const webFetch: Anthropic.Messages.WebFetchTool20260209 = {
-    type: 'web_fetch_20260209',
-    name: 'web_fetch',
-  };
-  if (opts.allowedDomains && opts.allowedDomains.length > 0) {
-    webFetch.allowed_domains = opts.allowedDomains;
-  } else if (opts.blockedDomains && opts.blockedDomains.length > 0) {
-    webFetch.blocked_domains = opts.blockedDomains;
-  }
-  return [webSearch, webFetch];
-}
-
 export interface ConversationToolOptions {
-  web: {
-    enabled: boolean;
-    allowedDomains?: string[];
-    blockedDomains?: string[];
-  };
   /** Template-scoped tools to add on top of the default set. */
   extraTools?: ConversationToolKey[] | undefined;
 }
 
-export function buildConversationTools(
-  opts: ConversationToolOptions,
-): Anthropic.Messages.ToolUnion[] {
-  const tools: Anthropic.Messages.ToolUnion[] = [...NOTEBASE_TOOLS];
-  if (opts.web.enabled) {
-    tools.push(...buildWebTools({
-      allowedDomains: opts.web.allowedDomains,
-      blockedDomains: opts.web.blockedDomains,
-    }));
-  }
+/**
+ * The neutral client-side toolset for a conversation: the default notebase
+ * tools plus any template-scoped extras. Server-side web tools are NOT here —
+ * they're provider-specific (they run on the provider's infrastructure) and are
+ * added inside the provider from the request's web settings (#1148).
+ */
+export function buildConversationTools(opts: ConversationToolOptions): ToolSpec[] {
+  const tools: ToolSpec[] = [...NOTEBASE_TOOLS];
   if (opts.extraTools) {
     const seen = new Set<string>();
     for (const key of opts.extraTools) {

--- a/src/main/llm/tools/types.ts
+++ b/src/main/llm/tools/types.ts
@@ -1,4 +1,4 @@
-import type Anthropic from '@anthropic-ai/sdk';
+import type { ToolSpec } from '../provider/types';
 import type { ConversationDraft } from '../../../shared/conversation-drafts';
 import type { ConversationSourceDraft } from '../../../shared/conversation-source-drafts';
 import type { ConversationPropertyDraft } from '../../../shared/conversation-property-drafts';
@@ -74,6 +74,6 @@ export interface ToolResult {
 }
 
 export interface NotebaseTool {
-  definition: Anthropic.Tool;
+  definition: ToolSpec;
   run(ctx: ToolContext, input: unknown, callbacks: ToolCallbacks): Promise<ToolResult> | ToolResult;
 }

--- a/src/main/publish/exporters/static-site/index.ts
+++ b/src/main/publish/exporters/static-site/index.ts
@@ -27,6 +27,7 @@ import type { Exporter, ExportOutput, ExportPlanFile } from '../../types';
 import { loadSiteConfig, type SiteConfig } from './site-config';
 import { buildSiteIndex, noteUrl, sourceUrl, collectCitedSources } from './site-data';
 import { extractPublish } from './publish-meta';
+import { buildSidebarTree } from './sidebar';
 import {
   renderNotePage,
   renderTagCloud,
@@ -59,6 +60,10 @@ export const staticSiteExporter: Exporter = {
     }
 
     const index = buildSiteIndex(notes);
+    // Structure sidebar (#1133): built from the EXPORTED note set (post-filter),
+    // so it never links to a note that was withheld. Attached to config and
+    // threaded into every page's shell.
+    config.sidebarTree = buildSidebarTree(notes.map((n) => ({ relativePath: n.relativePath, title: n.title })));
     const files: ExportOutput['files'] = [];
 
     // Custom site stylesheet (#1135): if the project ships `.minerva/site.css`,

--- a/src/main/publish/exporters/static-site/render.ts
+++ b/src/main/publish/exporters/static-site/render.ts
@@ -297,11 +297,14 @@ function renderSidebar(config: SiteConfig, rootRelative: string, currentPath: st
   return `<aside class="site-sidebar">${brand}<nav class="site-tree">${renderTreeNodes(tree, currentPath, rootRelative)}</nav></aside>`;
 }
 
-function renderTreeNodes(nodes: SidebarNode[], currentPath: string, rootRelative: string): string {
+function renderTreeNodes(nodes: SidebarNode[], currentPath: string, rootRelative: string, prefix = ''): string {
   const items = nodes.map((n) => {
     if (n.children) {
+      const folderPath = prefix ? `${prefix}/${n.name}` : n.name;
       const open = subtreeContains(n.children, currentPath) ? ' open' : '';
-      return `<li class="tree-folder"><details${open}><summary>${escapeHtml(n.name)}</summary>${renderTreeNodes(n.children, currentPath, rootRelative)}</details></li>`;
+      // `data-path` is a stable id so search.js can persist the open/closed
+      // state across page loads (#1133) — navigating keeps expanded folders open.
+      return `<li class="tree-folder"><details data-path="${escapeAttr(folderPath)}"${open}><summary>${escapeHtml(n.name)}</summary>${renderTreeNodes(n.children, currentPath, rootRelative, folderPath)}</details></li>`;
     }
     const current = n.path === currentPath ? ' aria-current="page"' : '';
     return `<li class="tree-note"><a href="${escapeAttr(`${rootRelative}${noteUrl(n.path!)}`)}"${current}>${escapeHtml(n.name)}</a></li>`;

--- a/src/main/publish/exporters/static-site/render.ts
+++ b/src/main/publish/exporters/static-site/render.ts
@@ -17,6 +17,7 @@ import type { SiteConfig } from './site-config';
 import { noteUrl, type SiteIndex } from './site-data';
 import { renderFootnotesSection } from '../note-html';
 import { extractPublish, type PublishMeta } from './publish-meta';
+import { type SidebarNode, subtreeContains } from './sidebar';
 
 export interface RenderPageInput {
   note: ExportPlanFile;
@@ -76,6 +77,7 @@ export async function renderNotePage(input: RenderPageInput): Promise<string> {
     pageTitle: note.title,
     bodyHtml: `<article>${bodyWithBroken}${backlinksHtml}</article>${sidebar}`,
     nav,
+    currentPath: note.relativePath,
     ...(headExtra ? { headExtra } : {}),
     ...(bodyStyle ? { bodyStyle } : {}),
   });
@@ -279,18 +281,50 @@ interface ShellInput {
   /** Per-note background, validated to a safe CSS color/token (#1136). Applied
    *  as an inline style on `<body>`. */
   bodyStyle?: string;
+  /** relativePath of the note this page renders, so the structure sidebar can
+   *  highlight it and open its folder path (#1133). Empty for section pages. */
+  currentPath?: string;
+}
+
+/** The left structure sidebar (#1133) — site brand (links home) + the folder/
+ *  note tree, with the current note highlighted and its ancestors expanded.
+ *  Rendered from the tree the exporter attached to `config` (built from the
+ *  exported note set, so exclusions are respected). Empty when no tree. */
+function renderSidebar(config: SiteConfig, rootRelative: string, currentPath: string): string {
+  const tree = config.sidebarTree;
+  if (!tree || tree.length === 0) return '';
+  const brand = `<a class="site-brand" href="${escapeAttr(`${rootRelative}index.html`)}">${escapeHtml(config.title)}</a>`;
+  return `<aside class="site-sidebar">${brand}<nav class="site-tree">${renderTreeNodes(tree, currentPath, rootRelative)}</nav></aside>`;
+}
+
+function renderTreeNodes(nodes: SidebarNode[], currentPath: string, rootRelative: string): string {
+  const items = nodes.map((n) => {
+    if (n.children) {
+      const open = subtreeContains(n.children, currentPath) ? ' open' : '';
+      return `<li class="tree-folder"><details${open}><summary>${escapeHtml(n.name)}</summary>${renderTreeNodes(n.children, currentPath, rootRelative)}</details></li>`;
+    }
+    const current = n.path === currentPath ? ' aria-current="page"' : '';
+    return `<li class="tree-note"><a href="${escapeAttr(`${rootRelative}${noteUrl(n.path!)}`)}"${current}>${escapeHtml(n.name)}</a></li>`;
+  });
+  return `<ul>${items.join('')}</ul>`;
 }
 
 function shell(input: ShellInput): string {
   const { config, rootRelative, pageTitle, bodyHtml, nav } = input;
   const headExtra = input.headExtra ?? '';
   const bodyStyleAttr = input.bodyStyle ? ` style="${escapeAttr(input.bodyStyle)}"` : '';
+  const sidebar = renderSidebar(config, rootRelative, input.currentPath ?? '');
   const navLink = (present: boolean, href: string, label: string): string =>
     present ? `\n  <a href="${escapeAttr(`${rootRelative}${href}`)}">${label}</a>` : '';
   const links =
     navLink(nav.hasTags, 'tags/index.html', 'Tags') +
     navLink(nav.hasReferences, 'references.html', 'References') +
     navLink(nav.hasSources, 'sources/index.html', 'Sources');
+  // The sidebar-toggle checkbox precedes .site-layout so the CSS-only
+  // `:checked ~ .site-layout .site-sidebar` reveal works on narrow screens.
+  const toggle = sidebar
+    ? '\n  <label for="site-sidebar-toggle" class="sidebar-toggle" aria-label="Toggle structure sidebar">☰</label>'
+    : '';
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -302,14 +336,18 @@ function shell(input: ShellInput): string {
   }${headExtra}
 </head>
 <body data-search-root="${escapeAttr(rootRelative)}"${bodyStyleAttr}>
-<nav class="site-nav">
+<nav class="site-nav">${toggle}
   <a class="site-title" href="${rootRelative}index.html">${escapeHtml(config.title)}</a>${links}
   <input class="site-search" type="search" placeholder="Search notes…" autocomplete="off">
 </nav>
 <div id="search-results" class="hidden"></div>
+<input type="checkbox" id="site-sidebar-toggle" class="sidebar-toggle-cb" hidden>
+<div class="site-layout">
+${sidebar}
 <main class="page">
 ${bodyHtml}
 </main>
+</div>
 <script src="${rootRelative}search.js" defer></script>
 </body>
 </html>`;

--- a/src/main/publish/exporters/static-site/search-script.ts
+++ b/src/main/publish/exporters/static-site/search-script.ts
@@ -71,4 +71,32 @@ export const SITE_SEARCH_SCRIPT = `(function() {
   function escapeAttr(s) { return escapeHtml(s); }
 
   input.addEventListener('input', function(e) { render(e.target.value.trim()); });
+})();
+
+// Structure-sidebar folder state (#1133): persist which folders are expanded so
+// navigating between notes keeps them open, instead of collapsing back to just
+// the current note's path on every page load. The server still opens the
+// current note's ancestors; we only ADD folders the user had expanded, never
+// force-close.
+(function() {
+  'use strict';
+  var KEY = 'minerva-site-tree';
+  var tree = document.querySelector('.site-tree');
+  if (!tree || !window.localStorage) return;
+  var open;
+  try { open = JSON.parse(localStorage.getItem(KEY) || '[]'); } catch (e) { open = []; }
+  var openSet = {};
+  for (var i = 0; i < open.length; i++) openSet[open[i]] = true;
+  var folders = tree.querySelectorAll('details[data-path]');
+  function save() {
+    var out = [];
+    for (var j = 0; j < folders.length; j++) {
+      if (folders[j].open) out.push(folders[j].getAttribute('data-path'));
+    }
+    try { localStorage.setItem(KEY, JSON.stringify(out)); } catch (e) {}
+  }
+  for (var k = 0; k < folders.length; k++) {
+    if (openSet[folders[k].getAttribute('data-path')]) folders[k].open = true;
+    folders[k].addEventListener('toggle', save);
+  }
 })();`;

--- a/src/main/publish/exporters/static-site/search-script.ts
+++ b/src/main/publish/exporters/static-site/search-script.ts
@@ -73,20 +73,22 @@ export const SITE_SEARCH_SCRIPT = `(function() {
   input.addEventListener('input', function(e) { render(e.target.value.trim()); });
 })();
 
-// Structure-sidebar folder state (#1133): persist which folders are expanded so
-// navigating between notes keeps them open, instead of collapsing back to just
-// the current note's path on every page load. The server still opens the
-// current note's ancestors; we only ADD folders the user had expanded, never
-// force-close.
+// Structure-sidebar folder state (#1133): make the tree "sticky" across page
+// loads so navigating between notes keeps folders open instead of collapsing
+// back to just the current note's path. On each page the server opens the
+// current note's ancestors; we restore any folders the reader had open and then
+// re-save the union — so a folder stays open as you browse away from it, and
+// only a manual collapse closes it. localStorage-less browsers just get the
+// per-page default expansion.
 (function() {
   'use strict';
   var KEY = 'minerva-site-tree';
   var tree = document.querySelector('.site-tree');
   if (!tree || !window.localStorage) return;
-  var open;
-  try { open = JSON.parse(localStorage.getItem(KEY) || '[]'); } catch (e) { open = []; }
+  var stored;
+  try { stored = JSON.parse(localStorage.getItem(KEY) || '[]'); } catch (e) { stored = []; }
   var openSet = {};
-  for (var i = 0; i < open.length; i++) openSet[open[i]] = true;
+  for (var i = 0; i < stored.length; i++) openSet[stored[i]] = true;
   var folders = tree.querySelectorAll('details[data-path]');
   function save() {
     var out = [];
@@ -99,4 +101,8 @@ export const SITE_SEARCH_SCRIPT = `(function() {
     if (openSet[folders[k].getAttribute('data-path')]) folders[k].open = true;
     folders[k].addEventListener('toggle', save);
   }
+  // Persist the current open set — INCLUDING the server-opened current-note
+  // path, whose HTML \`open\` attribute fires no toggle event — so those folders
+  // stay open once you navigate elsewhere.
+  save();
 })();`;

--- a/src/main/publish/exporters/static-site/sidebar.ts
+++ b/src/main/publish/exporters/static-site/sidebar.ts
@@ -1,0 +1,65 @@
+/**
+ * Structure sidebar for the static-site exporter (#1133).
+ *
+ * Builds a folder/note tree for the left navigation from the EXPORTED note set —
+ * NOT a raw filesystem listing — so it respects the same exclusions the pages
+ * do (private / excludeTags / excludeFolders). A note that was withheld never
+ * shows up as a link. Pure + string-only so the grouping is unit-testable; the
+ * HTML rendering (which needs escaping) lives in render.ts.
+ */
+
+export interface SidebarNode {
+  /** Folder name, or the note's display title for a leaf. */
+  name: string;
+  /** relativePath for a note leaf; absent for a folder. */
+  path?: string;
+  /** Child nodes for a folder; absent for a note leaf. */
+  children?: SidebarNode[];
+}
+
+/**
+ * Group notes into a nested folder tree by their relativePath segments. Each
+ * level is ordered folders-first then alphabetically (by folder name / note
+ * title) — the sidebar's natural reading order, matching the app's file tree.
+ */
+export function buildSidebarTree(notes: ReadonlyArray<{ relativePath: string; title: string }>): SidebarNode[] {
+  const root: SidebarNode[] = [];
+  const folders = new Map<string, SidebarNode>(); // path-prefix → folder node
+
+  for (const note of notes) {
+    const parts = note.relativePath.split('/');
+    parts.pop(); // filename — the leaf's display uses the title, not the file name
+    let level = root;
+    let prefix = '';
+    for (const folder of parts) {
+      prefix = prefix ? `${prefix}/${folder}` : folder;
+      let node = folders.get(prefix);
+      if (!node) {
+        node = { name: folder, children: [] };
+        folders.set(prefix, node);
+        level.push(node);
+      }
+      level = node.children!;
+    }
+    level.push({ name: note.title, path: note.relativePath });
+  }
+
+  sortLevel(root);
+  return root;
+}
+
+function sortLevel(nodes: SidebarNode[]): void {
+  nodes.sort((a, b) => {
+    const aFolder = a.children !== undefined;
+    const bFolder = b.children !== undefined;
+    if (aFolder !== bFolder) return aFolder ? -1 : 1; // folders first
+    return a.name.localeCompare(b.name);
+  });
+  for (const n of nodes) if (n.children) sortLevel(n.children);
+}
+
+/** Whether a folder subtree contains the note at `path` — used to auto-expand
+ *  the ancestor folders of the current page. */
+export function subtreeContains(nodes: SidebarNode[], path: string): boolean {
+  return nodes.some((n) => (n.path === path) || (n.children ? subtreeContains(n.children, path) : false));
+}

--- a/src/main/publish/exporters/static-site/site-config.ts
+++ b/src/main/publish/exporters/static-site/site-config.ts
@@ -9,6 +9,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import type { SidebarNode } from './sidebar';
 
 export interface SiteConfig {
   /** Site title shown in the nav header and `<title>` of every page. */
@@ -27,6 +28,10 @@ export interface SiteConfig {
    *  `.minerva/site.css` that the exporter copied + linked (#1135). Set by the
    *  exporter after detecting the file, not by `loadSiteConfig`. */
   hasCustomCss?: boolean;
+  /** Runtime-only (not persisted): the left structure-sidebar tree, built from
+   *  the EXPORTED note set so exclusions are respected (#1133). Set by the
+   *  exporter, threaded into every page's shell. */
+  sidebarTree?: SidebarNode[];
 }
 
 const DEFAULTS: Omit<SiteConfig, 'title'> = {

--- a/src/main/publish/exporters/static-site/style.ts
+++ b/src/main/publish/exporters/static-site/style.ts
@@ -20,27 +20,29 @@
 
 export const STATIC_SITE_STYLE = `
 :root {
-  --fg: #1a1a1a;
-  --fg-muted: #5a5a5a;
-  --fg-faint: #8a8a8a;
-  --bg: #fdfdfa;
-  --bg-elev: #f4f3ee;
-  --accent: #2563eb;
-  --border: #e5e3dc;
-  --code-bg: #f5f4ef;
-  --strike: #b00020;
+  /* Calm, warm "reading" defaults — soft ink on warm paper, a muted slate-blue
+     link rather than an electric one. All overridable via .minerva/site.css. */
+  --fg: #2b2a27;
+  --fg-muted: #6b6862;
+  --fg-faint: #97948d;
+  --bg: #fbf9f3;
+  --bg-elev: #f2efe7;
+  --accent: #47698e;
+  --border: #e7e3d9;
+  --code-bg: #f2efe7;
+  --strike: #a8574c;
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --fg: #e8e6df;
-    --fg-muted: #b0aea7;
-    --fg-faint: #888680;
-    --bg: #1d1d1b;
-    --bg-elev: #262624;
-    --accent: #6ea8fe;
-    --border: #353330;
-    --code-bg: #2a2a28;
-    --strike: #ef9a9a;
+    --fg: #e6e3da;
+    --fg-muted: #a9a69d;
+    --fg-faint: #7d7a72;
+    --bg: #1c1c1a;
+    --bg-elev: #262523;
+    --accent: #93b1d1;
+    --border: #34322e;
+    --code-bg: #262523;
+    --strike: #d69b93;
   }
 }
 * { box-sizing: border-box; }
@@ -50,11 +52,12 @@ body {
   background: var(--bg);
   color: var(--fg);
   font-family: Georgia, "Iowan Old Style", "Palatino Linotype", serif;
-  line-height: 1.6;
+  line-height: 1.65;
   -webkit-font-smoothing: antialiased;
 }
-a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 0.06em; }
-a:hover { text-decoration-thickness: 0.12em; }
+/* Softer links: muted color + a light, offset underline rather than a stark one. */
+a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 0.05em; text-underline-offset: 0.16em; text-decoration-color: var(--border); }
+a:hover { text-decoration-color: var(--accent); }
 
 /* Top nav */
 nav.site-nav {
@@ -91,7 +94,7 @@ nav.site-nav input.site-search {
 /* ── Structure sidebar layout (#1133) ─────────────────────────────────────── */
 .site-layout {
   display: grid;
-  grid-template-columns: var(--sidebar-width, 16em) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width, 15em) minmax(0, 1fr);
   align-items: start;
 }
 .site-sidebar {
@@ -151,8 +154,9 @@ nav.site-nav input.site-search {
 @media (max-width: 720px) {
   .page { grid-template-columns: 1fr; }
 }
-@media (max-width: 900px) {
-  /* Sidebar folds to a toggle so the note stays readable. */
+@media (max-width: 640px) {
+  /* Only on genuinely narrow screens does the sidebar fold to a toggle, so the
+     note stays readable; typical windows keep the two-column reading layout. */
   .site-layout { grid-template-columns: 1fr; }
   .site-sidebar { display: none; position: static; max-height: none; border-right: none; border-bottom: 1px solid var(--border); }
   .sidebar-toggle-cb:checked ~ .site-layout .site-sidebar { display: block; }

--- a/src/main/publish/exporters/static-site/style.ts
+++ b/src/main/publish/exporters/static-site/style.ts
@@ -88,6 +88,57 @@ nav.site-nav input.site-search {
   min-width: 160px;
 }
 
+/* ── Structure sidebar layout (#1133) ─────────────────────────────────────── */
+.site-layout {
+  display: grid;
+  grid-template-columns: var(--sidebar-width, 16em) minmax(0, 1fr);
+  align-items: start;
+}
+.site-sidebar {
+  position: sticky;
+  top: 3.1em; /* clears the sticky top nav */
+  max-height: calc(100vh - 3.1em);
+  overflow-y: auto;
+  padding: 1.4em 0.9em;
+  border-right: 1px solid var(--border);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  font-size: 0.88em;
+}
+.site-brand {
+  display: block;
+  font-weight: 700;
+  font-size: 1.08em;
+  color: var(--fg);
+  text-decoration: none;
+  margin-bottom: 1em;
+}
+.site-tree ul { list-style: none; margin: 0; padding-left: 0.85em; }
+.site-tree > ul { padding-left: 0; }
+.site-tree li { margin: 0.1em 0; }
+.site-tree a {
+  display: block;
+  padding: 0.12em 0.4em;
+  border-radius: 3px;
+  color: var(--fg-muted);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.site-tree a:hover { color: var(--fg); background: var(--bg-elev); }
+.site-tree a[aria-current="page"] { color: var(--fg); font-weight: 700; background: var(--bg-elev); }
+.site-tree summary {
+  cursor: pointer;
+  padding: 0.12em 0.4em;
+  color: var(--fg);
+  font-weight: 600;
+}
+.site-tree summary:hover { background: var(--bg-elev); border-radius: 3px; }
+
+/* Sidebar toggle — a hamburger shown only on narrow screens. CSS-only. */
+.sidebar-toggle { display: none; cursor: pointer; user-select: none; font-size: 1.1em; color: var(--fg-muted); }
+.sidebar-toggle:hover { color: var(--fg); }
+
 /* Page layout */
 .page {
   max-width: 60em;
@@ -99,6 +150,13 @@ nav.site-nav input.site-search {
 }
 @media (max-width: 720px) {
   .page { grid-template-columns: 1fr; }
+}
+@media (max-width: 900px) {
+  /* Sidebar folds to a toggle so the note stays readable. */
+  .site-layout { grid-template-columns: 1fr; }
+  .site-sidebar { display: none; position: static; max-height: none; border-right: none; border-bottom: 1px solid var(--border); }
+  .sidebar-toggle-cb:checked ~ .site-layout .site-sidebar { display: block; }
+  .sidebar-toggle { display: inline-block; }
 }
 article { min-width: 0; }
 aside.note-meta {

--- a/tests/main/llm/provider-seam.test.ts
+++ b/tests/main/llm/provider-seam.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The provider seam invariant (#1148, epic #1145 — Substrate).
+ *
+ * The whole point of the seam is that the conversation layer — the agentic loop,
+ * tool dispatch, the approval gate, the skills — talks to the `LLMProvider`
+ * interface, never to Claude directly. That property is only true if exactly one
+ * file imports `@anthropic-ai/sdk`. If a future change reaches for the SDK from
+ * the loop or a tool again (the easy, tempting shortcut), this test fails so the
+ * regression is caught at CI rather than discovered when a second provider is
+ * attempted and the "clean seam" turns out to have quietly rotted.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../..');
+const srcRoot = path.join(repoRoot, 'src');
+
+/** Recursively collect every .ts file under a directory. */
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+// Match a real import/require of the SDK, not a passing mention in a comment
+// (types.ts, for instance, names it in prose while importing nothing from it).
+const SDK_IMPORT = /(?:from|require\()\s*['"]@anthropic-ai\/sdk['"]/;
+// The single sanctioned home of the SDK. Everything Claude-specific lives here.
+const SANCTIONED = path.join('src', 'main', 'llm', 'provider', 'anthropic.ts');
+
+describe('provider seam (#1148)', () => {
+  const importers = collectTsFiles(srcRoot)
+    .filter((f) => SDK_IMPORT.test(fs.readFileSync(f, 'utf-8')))
+    .map((f) => path.relative(repoRoot, f))
+    .sort();
+
+  it('confines the Anthropic SDK to the single provider implementation', () => {
+    expect(importers).toEqual([SANCTIONED]);
+  });
+
+  it('does not let the SDK leak into tool definitions or the agentic loop', () => {
+    // Belt-and-braces: name the two files that used to import the SDK, so a
+    // reader of a failure sees *where* the seam broke, not just a count.
+    expect(importers).not.toContain(path.join('src', 'main', 'llm', 'index.ts'));
+    expect(importers).not.toContain(path.join('src', 'main', 'llm', 'tools', 'registry.ts'));
+    expect(importers).not.toContain(path.join('src', 'main', 'llm', 'tools', 'types.ts'));
+  });
+});

--- a/tests/main/publish/sidebar.test.ts
+++ b/tests/main/publish/sidebar.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Structure-sidebar tree (#1133). Pins the folder grouping, folders-first
+ * ordering, and the ancestor-containment check that drives auto-expansion.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSidebarTree, subtreeContains } from '../../../src/main/publish/exporters/static-site/sidebar';
+
+describe('buildSidebarTree (#1133)', () => {
+  it('groups notes into a nested folder tree, folders before notes, alpha-sorted', () => {
+    const tree = buildSidebarTree([
+      { relativePath: 'zebra.md', title: 'Zebra' },
+      { relativePath: 'notes/beta.md', title: 'Beta' },
+      { relativePath: 'notes/alpha.md', title: 'Alpha' },
+      { relativePath: 'apple.md', title: 'Apple' },
+    ]);
+    // Top level: folder "notes" first, then notes Apple, Zebra.
+    expect(tree.map((n) => n.name)).toEqual(['notes', 'Apple', 'Zebra']);
+    expect(tree[0]!.children!.map((n) => n.name)).toEqual(['Alpha', 'Beta']);
+    // Leaves carry the note path; the folder carries none.
+    expect(tree[0]!.path).toBeUndefined();
+    expect(tree[1]!.path).toBe('apple.md');
+  });
+
+  it('nests deep folders', () => {
+    const tree = buildSidebarTree([{ relativePath: 'a/b/c/deep.md', title: 'Deep' }]);
+    expect(tree[0]!.name).toBe('a');
+    expect(tree[0]!.children![0]!.children![0]!.children![0]!.path).toBe('a/b/c/deep.md');
+  });
+});
+
+describe('subtreeContains', () => {
+  it('finds a note anywhere in a folder subtree (drives ancestor auto-expand)', () => {
+    const tree = buildSidebarTree([
+      { relativePath: 'a/b/target.md', title: 'T' },
+      { relativePath: 'x/other.md', title: 'O' },
+    ]);
+    expect(subtreeContains(tree, 'a/b/target.md')).toBe(true);
+    expect(subtreeContains(tree[0]!.children!, 'a/b/target.md')).toBe(true); // inside "a"
+    expect(subtreeContains(tree.filter((n) => n.name === 'x'), 'a/b/target.md')).toBe(false);
+  });
+});

--- a/tests/main/publish/static-site.test.ts
+++ b/tests/main/publish/static-site.test.ts
@@ -449,11 +449,16 @@ describe('static-site link + nav fixes (live GitHub Pages bugs)', () => {
     expect(inner).toContain('>Top</a>');
     // Current note highlighted; its folder auto-expanded.
     expect(inner).toContain('aria-current="page"');
-    expect(inner).toMatch(/<details open><summary>topic<\/summary>/);
+    expect(inner).toMatch(/<details data-path="topic" open><summary>topic<\/summary>/);
     // A page outside that folder does NOT force it open.
     const top = String(output.files.find((f) => f.path === 'top.html')!.contents);
     expect(top).toContain('<aside class="site-sidebar">');
-    expect(top).toMatch(/<details><summary>topic<\/summary>/); // collapsed
+    expect(top).toMatch(/<details data-path="topic"><summary>topic<\/summary>/); // collapsed
+    // The shipped script persists expanded-folder state across page loads so
+    // navigating doesn't collapse the sibling folders the reader opened (#1133).
+    const js = String(output.files.find((f) => f.path === 'search.js')!.contents);
+    expect(js).toContain('minerva-site-tree');
+    expect(js).toContain("details[data-path]");
   });
 
   it('sidebar lists ONLY exported notes — excluded/private never appear (#1133)', async () => {

--- a/tests/main/publish/static-site.test.ts
+++ b/tests/main/publish/static-site.test.ts
@@ -436,6 +436,41 @@ describe('static-site link + nav fixes (live GitHub Pages bugs)', () => {
     expect(html).toContain('href="fancy.css"');
   });
 
+  it('renders a structure sidebar on every page, current note highlighted + folder expanded (#1133)', async () => {
+    await fsp.mkdir(path.join(root, 'topic'), { recursive: true });
+    await fsp.writeFile(path.join(root, 'topic', 'inner.md'), '---\ntitle: Inner\n---\n# Inner\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'top.md'), '---\ntitle: Top\n---\n# Top\n', 'utf-8');
+
+    const output = await runExporter(staticSiteExporter, await resolvePlan(root, { kind: 'project' }));
+    const inner = String(output.files.find((f) => f.path === 'topic/inner.html')!.contents);
+    expect(inner).toContain('<aside class="site-sidebar">');
+    // Sidebar links to both notes, resolving from this page's depth.
+    expect(inner).toContain('href="../top.html"');
+    expect(inner).toContain('>Top</a>');
+    // Current note highlighted; its folder auto-expanded.
+    expect(inner).toContain('aria-current="page"');
+    expect(inner).toMatch(/<details open><summary>topic<\/summary>/);
+    // A page outside that folder does NOT force it open.
+    const top = String(output.files.find((f) => f.path === 'top.html')!.contents);
+    expect(top).toContain('<aside class="site-sidebar">');
+    expect(top).toMatch(/<details><summary>topic<\/summary>/); // collapsed
+  });
+
+  it('sidebar lists ONLY exported notes — excluded/private never appear (#1133)', async () => {
+    await fsp.mkdir(path.join(root, '.minerva'), { recursive: true });
+    await fsp.writeFile(path.join(root, '.minerva/site-config.json'), JSON.stringify({ excludeTags: ['secret'] }), 'utf-8');
+    await fsp.writeFile(path.join(root, 'public.md'), '---\ntitle: Public\n---\n# Public\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'hidden.md'), '---\ntitle: Hidden\nprivate: true\n---\n# Hidden\n', 'utf-8');
+    await fsp.writeFile(path.join(root, 'tagged.md'), '---\ntitle: Tagged\ntags: [secret]\n---\n# Tagged\n', 'utf-8');
+
+    const output = await runExporter(staticSiteExporter, await resolvePlan(root, { kind: 'project' }));
+    const html = String(output.files.find((f) => f.path === 'public.html')!.contents);
+    const sidebar = html.slice(html.indexOf('<aside class="site-sidebar">'), html.indexOf('</aside>'));
+    expect(sidebar).toContain('>Public</a>');
+    expect(sidebar).not.toContain('Hidden');
+    expect(sidebar).not.toContain('Tagged');
+  });
+
   it('with baseUrl empty, absolute-URL OG tags are cleanly omitted (#1136)', async () => {
     await fsp.writeFile(path.join(root, 'card.md'),
       '---\ntitle: Card\ndescription: blurb\npublish:\n  image: https://ex.com/c.png\n---\n# Card\n', 'utf-8');


### PR DESCRIPTION
Closes #1148 — the one **pre-launch** child of the Substrate epic (#1145).

## Why now
The conversation layer was welded to `@anthropic-ai/sdk`: the agentic loop, the tool schemas, and streaming all referenced `Anthropic.*` types directly. Per the epic, a Claude-only conversation layer quietly contradicts the "thinking, learning, and building **with AI**" tagline — but the load-bearing argument is **business continuity**: a tool holding a person's life's thinking shouldn't be knockable out of its core feature by one provider's bad week. This guardrail is cheap now and only gets more expensive as more subsystems pile onto the current shape.

## What this is (and isn't)
A **clean seam, not multi-provider support.** No second provider is wired up. The deliverable is an architecture that doesn't foreclose one.

## The shape
- **`src/main/llm/provider/types.ts`** — provider-neutral `LLMProvider` interface + neutral request/result/tool/message types. The loop, tool dispatch, and the approval gate talk to *this*.
- **`src/main/llm/provider/anthropic.ts`** — the **sole** importer of the SDK. Owns client construction, streaming, `output_config.effort`, server-side web tools, code-execution `container` ids, usage folding, web-search citations, and tool-result blocks.
- **`src/main/llm/provider/index.ts`** — `getProvider()` factory; the single place a future provider selection would branch.
- **`index.ts`** — the agentic loop is now provider-agnostic: opaque `ProviderMessage[]` history, `runTurn`, neutral tool orchestration. **−193 lines net** across the touched files.
- Tool definitions swap `Anthropic.Tool` → a structurally-identical neutral `ToolSpec`, so the **~20 tool files change not at all**.

## Boundary decision
The seam sits at the **raw completion call + tool-schema shape** (one of the epic's open questions). The persisted conversation format was already the neutral `{role, content}` `ConversationMessage`, so nothing in conversation persistence or IPC had to change.

## Verification
- Behavior-preserving: the SDK-mocking **dispatch-loop regression test passes unchanged**, and the **full suite (3994 tests)** is green.
- New **`provider-seam.test.ts`** pins the invariant — *exactly one file imports the SDK* — so a future re-coupling of the loop to Claude fails CI rather than being discovered when a second provider is attempted.
- `pnpm lint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)