### PR TITLE
cli: headless read access — query/sql/search/semantic/read (#1149)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,58 @@
+# Minerva CLI
+
+Headless, scriptable access to a thoughtbase — the first slice of the Substrate
+epic (#1145 → #1149). It reuses the exact `ctx`-based core the app uses (that
+core is Electron-free), so an external agent or a shell script can query your
+knowledge graph and notes without the app running.
+
+> **Status: read-only, first cut.** `query`, `search`, `read`. Writes (through the
+> approval gate) and an MCP subcommand are later children of the epic.
+
+## Build & run
+
+```sh
+pnpm cli:build                     # → .vite/build/cli.js (standalone Node bundle)
+node .vite/build/cli.js <command> [args] [--project <path>]
+```
+
+`pnpm cli` builds then runs in one step. The bundle externalizes node_modules, so
+it resolves heavy/native deps (rdflib, comunica, DuckDB, onnxruntime) from the
+repo's `node_modules` at runtime — no separate install.
+
+## Commands
+
+| Command | Purpose | Output |
+|---|---|---|
+| `query <sparql>` | SPARQL over the knowledge graph (standard prefixes auto-injected) | `{ columns, results }` |
+| `search <text>` | Full-text search over notes (`--limit <n>`, default 20) | `{ query, hits }` |
+| `read <relative-path>` | A note's raw markdown | `{ path, content }` |
+
+Global options: `--project <path>` (thoughtbase root, default: cwd), `--help`.
+
+Every result is **grounded** — query bindings carry node IRIs, search hits carry
+the note path, read echoes the path — and printed as JSON on stdout so it pipes
+into `jq` or feeds an agent directly.
+
+```sh
+# What do I already know about photosynthesis?
+node .vite/build/cli.js search photosynthesis --project ~/vault | jq '.hits[].relativePath'
+
+# Every note with a title, alphabetized.
+node .vite/build/cli.js query \
+  'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title' \
+  --project ~/vault
+```
+
+## Exit codes
+
+`0` success · `1` a core/query error (e.g. malformed SPARQL) · `2` a usage error
+(unknown command, missing argument, bad `--project`). Errors print to stderr.
+
+## Design
+
+All logic is one pure function — `runCli(argv, { cwd })` in `src/cli/run.ts` —
+returning `{ stdout, stderr, code }` without touching `process` or Electron. The
+executable entry (`src/cli/main.ts`) is a thin write-and-exit shell, and the
+forthcoming MCP subcommand will wrap the same function. That's why the whole
+surface is testable under vitest (`tests/cli/run.test.ts`) with no spawned
+process.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,8 +5,8 @@ epic (#1145 → #1149). It reuses the exact `ctx`-based core the app uses (that
 core is Electron-free), so an external agent or a shell script can query your
 knowledge graph and notes without the app running.
 
-> **Status: read-only, first cut.** `query`, `search`, `read`. Writes (through the
-> approval gate) and an MCP subcommand are later children of the epic.
+> **Status: read-only.** `query`, `sql`, `search`, `semantic`, `read`. Writes
+> (through the approval gate) and an MCP subcommand are later children of the epic.
 
 ## Build & run
 
@@ -24,10 +24,16 @@ repo's `node_modules` at runtime — no separate install.
 | Command | Purpose | Output |
 |---|---|---|
 | `query <sparql>` | SPARQL over the knowledge graph (standard prefixes auto-injected) | `{ columns, results }` |
+| `sql <sql>` | DuckDB SQL over the vault's CSV tables (registered by derived name) | `{ columns, rows }` |
 | `search <text>` | Full-text search over notes (`--limit <n>`, default 20) | `{ query, hits }` |
+| `semantic <text>` | Embeddings search over notes (`--limit <n>`) | `{ query, hits }` |
 | `read <relative-path>` | A note's raw markdown | `{ path, content }` |
 
 Global options: `--project <path>` (thoughtbase root, default: cwd), `--help`.
+
+`semantic` covers only content the app has already embedded; against a vault that
+was never opened in the app it returns no hits (with a `note` saying so). `sql`
+integer columns come back as JSON numbers (DuckDB BigInt is handled).
 
 Every result is **grounded** — query bindings carry node IRIs, search hits carry
 the note path, read echoes the path — and printed as JSON on stdout so it pipes

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "prepare": "git config core.hooksPath .githooks || true",
     "dev": "electron-forge start",
+    "cli:build": "vite build --config vite.cli.config.ts",
+    "cli": "pnpm cli:build && node .vite/build/cli.js",
     "build": "electron-forge make",
     "package": "electron-forge package",
     "release:tag": "node scripts/tag-release.mjs",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Executable entry for the Minerva CLI (#1149, epic #1145 — Substrate).
+ *
+ * A thin shell over `runCli`: parse argv, run, write, exit. Every bit of logic
+ * lives in `./run` so it stays testable without spawning a process. Built as a
+ * standalone Node bundle via `vite.cli.config.ts` → `.vite/build/cli.js`.
+ */
+import { runCli } from './run';
+
+async function main(): Promise<void> {
+  const result = await runCli(process.argv.slice(2), { cwd: process.cwd() });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.code);
+}
+
+void main();

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,169 @@
+/**
+ * The Minerva CLI (#1149, epic #1145 — Substrate).
+ *
+ * `runCli` is the whole command surface as one pure async function: it takes an
+ * argv slice + a working directory and returns { stdout, stderr, code } without
+ * touching `process` or Electron. That keeps it fully testable under vitest and
+ * lets the thin executable entry (`./main.ts`) — and, later, the MCP subcommand
+ * (#1146) — wrap the same logic.
+ *
+ * This is the READ half of CLI parity: `query` (SPARQL), `search` (full-text),
+ * and `read` (a note's markdown). It reuses the exact `ctx`-based core the app
+ * uses — the audit for epic #1145 confirmed that core is Electron-free — by
+ * constructing a ProjectContext from a directory and running the same
+ * init → index → query path the app runs on project open.
+ *
+ * Every result is *grounded*: query bindings carry node IRIs, search hits carry
+ * the note path, read echoes the path. Output is JSON on stdout so it pipes to
+ * jq and can be handed straight to an agent.
+ */
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import * as graph from '../main/graph/index';
+import * as search from '../main/search/index';
+import { readFile } from '../main/notebase/fs';
+import { projectContext, type ProjectContext } from '../main/project-context-types';
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export const HELP = `minerva — headless access to a Minerva thoughtbase (#1149)
+
+Usage:
+  minerva <command> [args] [--project <path>]
+
+Commands:
+  query <sparql>        Run a SPARQL query against the knowledge graph.
+  search <text>         Full-text search over notes.        [--limit <n>]
+  read <relative-path>  Print a note's raw markdown.
+
+Options:
+  --project <path>      Thoughtbase root (default: current directory).
+  --limit <n>           Max results for search (default: 20).
+  --help, -h            Show this help.
+
+Results are JSON on stdout, grounded with node IRIs / note paths so the output
+pipes into jq or feeds an agent directly.`;
+
+interface ParsedArgs {
+  command: string | undefined;
+  positionals: string[];
+  project: string | undefined;
+  limit: number | undefined;
+  help: boolean;
+}
+
+/** Hand-rolled parse — no dependency, and the surface is tiny. Recognises the
+ *  global `--project`/`--limit` value flags and `--help`; everything else is a
+ *  positional (so a SPARQL query with stray dashes survives). */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  let project: string | undefined;
+  let limit: number | undefined;
+  let help = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--project' || arg === '-p') {
+      project = argv[++i];
+    } else if (arg.startsWith('--project=')) {
+      project = arg.slice('--project='.length);
+    } else if (arg === '--limit') {
+      limit = Number(argv[++i]);
+    } else if (arg.startsWith('--limit=')) {
+      limit = Number(arg.slice('--limit='.length));
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  return { command: positionals.shift(), positionals, project, limit, help };
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+/** A directory is required and must exist; a missing `.minerva` is fine —
+ *  indexing just rebuilds from the `.md` files and an empty tree yields empty
+ *  results rather than an error. */
+async function resolveProjectRoot(project: string | undefined, cwd: string): Promise<string> {
+  const root = path.resolve(cwd, project ?? '.');
+  const stat = await fs.stat(root).catch(() => null);
+  if (!stat || !stat.isDirectory()) {
+    throw new UsageError(`Not a directory: ${root}`);
+  }
+  return root;
+}
+
+/** A CLI-level error whose message is meant for the user (exit code 2), as
+ *  opposed to an unexpected throw (exit code 1). */
+class UsageError extends Error {}
+
+async function runQuery(ctx: ProjectContext, sparql: string): Promise<CliResult> {
+  if (!sparql.trim()) throw new UsageError('query: a SPARQL string is required.');
+  await graph.initGraph(ctx);
+  await graph.indexAllNotes(ctx);
+  const { results, columns, error } = await graph.queryGraph(ctx, sparql);
+  if (error) return { stdout: '', stderr: `SPARQL error: ${error}\n`, code: 1 };
+  return { stdout: json({ columns, results }), stderr: '', code: 0 };
+}
+
+async function runSearch(ctx: ProjectContext, text: string, limit: number | undefined): Promise<CliResult> {
+  if (!text.trim()) throw new UsageError('search: a query string is required.');
+  // `indexAllNotes` persists the MiniSearch index into `.minerva/`; a running
+  // app always has that dir, but a headless first run against a fresh vault may
+  // not — create it so the index write doesn't ENOENT. Derived cache only, so
+  // writing it during a read is safe (it just warms what the app would build).
+  await fs.mkdir(path.join(ctx.rootPath, '.minerva'), { recursive: true });
+  await search.initSearch(ctx);
+  await search.indexAllNotes(ctx);
+  const hits = search.search(ctx, text, limit ? { limit } : undefined);
+  return { stdout: json({ query: text, hits }), stderr: '', code: 0 };
+}
+
+async function runRead(ctx: ProjectContext, relativePath: string): Promise<CliResult> {
+  if (!relativePath) throw new UsageError('read: a relative note path is required.');
+  const content = await readFile(ctx.rootPath, relativePath);
+  return { stdout: json({ path: relativePath, content }), stderr: '', code: 0 };
+}
+
+/**
+ * Run one CLI invocation. Never throws for expected conditions — usage problems
+ * return code 2, core errors code 1, success code 0 — so the executable entry is
+ * a thin "write + exit" shell.
+ */
+export async function runCli(argv: string[], opts: { cwd: string }): Promise<CliResult> {
+  const args = parseArgs(argv);
+
+  if (args.help || !args.command) {
+    return { stdout: `${HELP}\n`, stderr: '', code: args.command ? 0 : args.help ? 0 : 2 };
+  }
+
+  try {
+    const root = await resolveProjectRoot(args.project, opts.cwd);
+    const ctx = projectContext(root);
+
+    switch (args.command) {
+      case 'query':
+        return await runQuery(ctx, args.positionals.join(' '));
+      case 'search':
+        return await runSearch(ctx, args.positionals.join(' '), args.limit);
+      case 'read':
+        return await runRead(ctx, args.positionals[0] ?? '');
+      default:
+        return { stdout: '', stderr: `Unknown command: ${args.command}\n\n${HELP}\n`, code: 2 };
+    }
+  } catch (err) {
+    if (err instanceof UsageError) {
+      return { stdout: '', stderr: `${err.message}\n`, code: 2 };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { stdout: '', stderr: `Error: ${message}\n`, code: 1 };
+  }
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -21,6 +21,10 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import * as graph from '../main/graph/index';
 import * as search from '../main/search/index';
+import * as tables from '../main/sources/tables';
+import * as vectors from '../main/embeddings/vector-store';
+import type { ChunkEmbedder } from '../main/embeddings/vector-store';
+import { getSharedEmbedder } from '../main/embeddings/shared-embedder';
 import { readFile } from '../main/notebase/fs';
 import { projectContext, type ProjectContext } from '../main/project-context-types';
 
@@ -30,6 +34,13 @@ export interface CliResult {
   code: number;
 }
 
+export interface RunOptions {
+  cwd: string;
+  /** Injectable embedder for `semantic`, so tests can run against a fake instead
+   *  of loading the real WASM model. Defaults to the shared model embedder. */
+  embedder?: ChunkEmbedder;
+}
+
 export const HELP = `minerva — headless access to a Minerva thoughtbase (#1149)
 
 Usage:
@@ -37,16 +48,19 @@ Usage:
 
 Commands:
   query <sparql>        Run a SPARQL query against the knowledge graph.
+  sql <sql>             Run a DuckDB SQL query over the vault's CSV tables.
   search <text>         Full-text search over notes.        [--limit <n>]
+  semantic <text>       Semantic (embeddings) search over notes.  [--limit <n>]
   read <relative-path>  Print a note's raw markdown.
 
 Options:
   --project <path>      Thoughtbase root (default: current directory).
-  --limit <n>           Max results for search (default: 20).
+  --limit <n>           Max results for search/semantic (default: 20).
   --help, -h            Show this help.
 
 Results are JSON on stdout, grounded with node IRIs / note paths so the output
-pipes into jq or feeds an agent directly.`;
+pipes into jq or feeds an agent directly. Semantic search covers only content the
+app has already embedded.`;
 
 interface ParsedArgs {
   command: string | undefined;
@@ -85,8 +99,25 @@ export function parseArgs(argv: string[]): ParsedArgs {
   return { command: positionals.shift(), positionals, project, limit, help };
 }
 
+// DuckDB returns BigInt for integer columns (SQL command), which JSON.stringify
+// can't serialize. Keep safe integers as numbers; stringify larger ids to avoid
+// precision loss. See the DuckDB BigInt serialization gotcha.
+function bigintSafeReplacer(_key: string, v: unknown): unknown {
+  if (typeof v !== 'bigint') return v;
+  return v >= BigInt(Number.MIN_SAFE_INTEGER) && v <= BigInt(Number.MAX_SAFE_INTEGER)
+    ? Number(v)
+    : v.toString();
+}
+
 function json(value: unknown): string {
-  return `${JSON.stringify(value, null, 2)}\n`;
+  return `${JSON.stringify(value, bigintSafeReplacer, 2)}\n`;
+}
+
+/** The app always has a `.minerva/` dir; a headless first run against a fresh
+ *  vault may not, and the index-building commands persist there. Derived cache
+ *  only, so creating it during a read is safe. */
+async function ensureMinervaDir(root: string): Promise<void> {
+  await fs.mkdir(path.join(root, '.minerva'), { recursive: true });
 }
 
 /** A directory is required and must exist; a missing `.minerva` is fine —
@@ -116,15 +147,45 @@ async function runQuery(ctx: ProjectContext, sparql: string): Promise<CliResult>
 
 async function runSearch(ctx: ProjectContext, text: string, limit: number | undefined): Promise<CliResult> {
   if (!text.trim()) throw new UsageError('search: a query string is required.');
-  // `indexAllNotes` persists the MiniSearch index into `.minerva/`; a running
-  // app always has that dir, but a headless first run against a fresh vault may
-  // not — create it so the index write doesn't ENOENT. Derived cache only, so
-  // writing it during a read is safe (it just warms what the app would build).
-  await fs.mkdir(path.join(ctx.rootPath, '.minerva'), { recursive: true });
+  // `indexAllNotes` persists the MiniSearch index into `.minerva/`, so the dir
+  // must exist first (a headless first run may not have it).
+  await ensureMinervaDir(ctx.rootPath);
   await search.initSearch(ctx);
   await search.indexAllNotes(ctx);
   const hits = search.search(ctx, text, limit ? { limit } : undefined);
   return { stdout: json({ query: text, hits }), stderr: '', code: 0 };
+}
+
+async function runSql(ctx: ProjectContext, sql: string): Promise<CliResult> {
+  if (!sql.trim()) throw new UsageError('sql: a SQL string is required.');
+  await ensureMinervaDir(ctx.rootPath);
+  await tables.initTablesDb(ctx);
+  // Register the vault's CSV tables so they're queryable by their derived names.
+  await tables.registerAllCsvs(ctx);
+  const result = await tables.runQuery(ctx, sql);
+  if (!result.ok) return { stdout: '', stderr: `SQL error: ${result.error}\n`, code: 1 };
+  return { stdout: json({ columns: result.columns, rows: result.rows }), stderr: '', code: 0 };
+}
+
+async function runSemantic(
+  ctx: ProjectContext,
+  text: string,
+  limit: number | undefined,
+  embedder: ChunkEmbedder,
+): Promise<CliResult> {
+  if (!text.trim()) throw new UsageError('semantic: a query string is required.');
+  await ensureMinervaDir(ctx.rootPath);
+  await vectors.init(ctx, { embedder });
+  const hits = await vectors.searchRelated(ctx, text, limit ? { limit } : {});
+  const out: Record<string, unknown> = { query: text, hits };
+  if (hits.length === 0) {
+    // Semantic search only covers already-embedded content; a vault the app has
+    // never opened/embedded yields nothing. Say so rather than look broken.
+    out.note =
+      'No embedded content matched. Semantic search covers notes already embedded ' +
+      'by the app; a vault that has never been embedded returns no hits.';
+  }
+  return { stdout: json(out), stderr: '', code: 0 };
 }
 
 async function runRead(ctx: ProjectContext, relativePath: string): Promise<CliResult> {
@@ -138,7 +199,7 @@ async function runRead(ctx: ProjectContext, relativePath: string): Promise<CliRe
  * return code 2, core errors code 1, success code 0 — so the executable entry is
  * a thin "write + exit" shell.
  */
-export async function runCli(argv: string[], opts: { cwd: string }): Promise<CliResult> {
+export async function runCli(argv: string[], opts: RunOptions): Promise<CliResult> {
   const args = parseArgs(argv);
 
   if (args.help || !args.command) {
@@ -152,8 +213,12 @@ export async function runCli(argv: string[], opts: { cwd: string }): Promise<Cli
     switch (args.command) {
       case 'query':
         return await runQuery(ctx, args.positionals.join(' '));
+      case 'sql':
+        return await runSql(ctx, args.positionals.join(' '));
       case 'search':
         return await runSearch(ctx, args.positionals.join(' '), args.limit);
+      case 'semantic':
+        return await runSemantic(ctx, args.positionals.join(' '), args.limit, opts.embedder ?? getSharedEmbedder());
       case 'read':
         return await runRead(ctx, args.positionals[0] ?? '');
       default:

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The headless CLI read surface (#1149, epic #1145 — Substrate).
+ *
+ * Exercises `runCli` end-to-end against a real temp thoughtbase — the same
+ * `ctx`-based core the app uses, proving an external process can query the graph
+ * and notes without Electron. Asserts the grounded JSON shape (node IRIs / note
+ * paths) and the exit-code contract (0 ok / 1 core error / 2 usage).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { runCli, parseArgs } from '../../src/cli/run';
+
+let root: string;
+
+beforeAll(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-'));
+  await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+  await fsp.writeFile(
+    path.join(root, 'notes', 'photosynthesis.md'),
+    '---\ntitle: Photosynthesis\ntags: [biology, energy]\n---\n\n' +
+      'Photosynthesis converts light into chemical energy. See [[chlorophyll]].\n',
+    'utf-8',
+  );
+  await fsp.writeFile(
+    path.join(root, 'notes', 'chlorophyll.md'),
+    '# Chlorophyll\n\nThe green pigment that absorbs light for photosynthesis.\n',
+    'utf-8',
+  );
+});
+
+afterAll(async () => {
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('parseArgs', () => {
+  it('pulls out command, positionals, and global flags', () => {
+    const a = parseArgs(['search', 'green', 'pigment', '--project', '/x', '--limit', '5']);
+    expect(a.command).toBe('search');
+    expect(a.positionals).toEqual(['green', 'pigment']);
+    expect(a.project).toBe('/x');
+    expect(a.limit).toBe(5);
+  });
+
+  it('supports --flag=value form and -h', () => {
+    const a = parseArgs(['read', 'notes/x.md', '--project=/y']);
+    expect(a.project).toBe('/y');
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+
+  it('leaves dashless SPARQL positionals intact', () => {
+    const a = parseArgs(['query', 'SELECT ?s WHERE { ?s ?p ?o }']);
+    expect(a.command).toBe('query');
+    expect(a.positionals).toEqual(['SELECT ?s WHERE { ?s ?p ?o }']);
+  });
+});
+
+describe('runCli read commands (#1149)', () => {
+  it('query returns grounded SPARQL bindings as JSON (exit 0)', async () => {
+    const r = await runCli(
+      ['query', 'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title'],
+      { cwd: root },
+    );
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    const out = JSON.parse(r.stdout);
+    expect(out.columns).toContain('title');
+    const titles = out.results.map((row: Record<string, string>) => row.title);
+    expect(titles).toContain('Photosynthesis');
+  });
+
+  it('search returns note-path-grounded hits (exit 0)', async () => {
+    const r = await runCli(['search', 'pigment'], { cwd: root });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.query).toBe('pigment');
+    const paths = out.hits.map((h: { relativePath: string }) => h.relativePath);
+    expect(paths).toContain('notes/chlorophyll.md');
+  });
+
+  it('search honours --limit', async () => {
+    const r = await runCli(['search', 'photosynthesis', '--limit', '1'], { cwd: root });
+    const out = JSON.parse(r.stdout);
+    expect(out.hits.length).toBeLessThanOrEqual(1);
+  });
+
+  it('search works on a fresh vault with no pre-existing .minerva (ENOENT guard)', async () => {
+    // A dedicated temp dir so no earlier command created `.minerva/` first —
+    // this is the ordering that broke the built bundle before runSearch ensured
+    // the dir exists.
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-fresh-'));
+    try {
+      await fsp.writeFile(path.join(fresh, 'seed.md'), '# Seed\n\nA lonely note about mitochondria.\n', 'utf-8');
+      const r = await runCli(['search', 'mitochondria'], { cwd: fresh });
+      expect(r.code).toBe(0);
+      expect(r.stderr).toBe('');
+      const out = JSON.parse(r.stdout);
+      expect(out.hits.map((h: { relativePath: string }) => h.relativePath)).toContain('seed.md');
+    } finally {
+      await fsp.rm(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it('read echoes the path and returns the raw markdown (exit 0)', async () => {
+    const r = await runCli(['read', 'notes/chlorophyll.md'], { cwd: root });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.path).toBe('notes/chlorophyll.md');
+    expect(out.content).toContain('green pigment');
+  });
+});
+
+describe('runCli contract', () => {
+  it('no command prints help with usage exit code 2', async () => {
+    const r = await runCli([], { cwd: root });
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain('Usage:');
+  });
+
+  it('--help is a clean exit 0', async () => {
+    const r = await runCli(['--help'], { cwd: root });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('Commands:');
+  });
+
+  it('unknown command is a usage error (exit 2)', async () => {
+    const r = await runCli(['frobnicate'], { cwd: root });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('Unknown command');
+  });
+
+  it('a missing project directory is a usage error (exit 2)', async () => {
+    const r = await runCli(['search', 'x', '--project', '/no/such/dir/here'], { cwd: root });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('Not a directory');
+  });
+
+  it('read of a traversal path is refused, not a crash', async () => {
+    const r = await runCli(['read', '../../etc/passwd'], { cwd: root });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/Error:/);
+  });
+
+  it('a malformed SPARQL query surfaces as a core error (exit 1)', async () => {
+    const r = await runCli(['query', 'THIS IS NOT SPARQL'], { cwd: root });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('SPARQL error');
+  });
+});

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -12,6 +12,31 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { runCli, parseArgs } from '../../src/cli/run';
+import * as store from '../../src/main/embeddings/vector-store';
+import type { ChunkEmbedder } from '../../src/main/embeddings/vector-store';
+import { MODEL } from '../../src/main/embeddings/embedder';
+import { projectContext } from '../../src/main/project-context-types';
+
+/** Deterministic hashing embedder — no WASM model load. Mirrors the stub the
+ *  embeddings suite uses so `semantic` is testable fast. */
+function fakeEmbedder(): ChunkEmbedder {
+  return {
+    dim: MODEL.dim,
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      return texts.map((t) => {
+        const v = new Float32Array(MODEL.dim);
+        for (const w of t.toLowerCase().split(/\W+/).filter(Boolean)) {
+          let h = 0;
+          for (const ch of w) h = (h * 31 + ch.charCodeAt(0)) >>> 0;
+          v[h % MODEL.dim] += 1;
+        }
+        const n = Math.hypot(...v);
+        if (n > 0) for (let i = 0; i < MODEL.dim; i++) v[i] /= n;
+        return v;
+      });
+    },
+  };
+}
 
 let root: string;
 
@@ -27,6 +52,12 @@ beforeAll(async () => {
   await fsp.writeFile(
     path.join(root, 'notes', 'chlorophyll.md'),
     '# Chlorophyll\n\nThe green pigment that absorbs light for photosynthesis.\n',
+    'utf-8',
+  );
+  // A CSV table for the `sql` command (registered under the derived name `plants`).
+  await fsp.writeFile(
+    path.join(root, 'plants.csv'),
+    'name,height_cm\nfern,40\nmoss,3\n',
     'utf-8',
   );
 });
@@ -84,6 +115,53 @@ describe('runCli read commands (#1149)', () => {
     const r = await runCli(['search', 'photosynthesis', '--limit', '1'], { cwd: root });
     const out = JSON.parse(r.stdout);
     expect(out.hits.length).toBeLessThanOrEqual(1);
+  });
+
+  it('sql queries CSV tables and serializes DuckDB BigInt counts (exit 0)', async () => {
+    const r = await runCli(['sql', 'SELECT COUNT(*) AS n FROM plants'], { cwd: root });
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    const out = JSON.parse(r.stdout);
+    // COUNT(*) comes back as a DuckDB BIGINT — the JSON replacer must turn it into
+    // a plain number, not throw.
+    expect(out.rows[0].n).toBe(2);
+  });
+
+  it('semantic returns embedding-ranked hits via an injected embedder (exit 0)', async () => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-sem-'));
+    const ctx = projectContext(vault);
+    try {
+      await fsp.writeFile(path.join(vault, 'green.md'), '# Green\n\nchlorophyll is a green pigment\n', 'utf-8');
+      // Populate the store with the fake embedder, then let runCli's init no-op
+      // and reuse it (init is idempotent per rootPath).
+      await store.init(ctx, { embedder: fakeEmbedder() });
+      await store.indexNote(ctx, 'green.md', 'chlorophyll is a green pigment');
+      const r = await runCli(['semantic', 'green pigment'], { cwd: vault, embedder: fakeEmbedder() });
+      expect(r.code).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.hits.map((h: { ref: string }) => h.ref)).toContain('green.md');
+    } finally {
+      await store.dispose(ctx);
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  it('semantic on an un-embedded vault returns empty hits with a note, not an error', async () => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-noembed-'));
+    const ctx = projectContext(vault);
+    try {
+      await fsp.writeFile(path.join(vault, 'a.md'), '# A\n\nsome text\n', 'utf-8');
+      // Pre-init with the fake embedder so no real WASM model loads; store is empty.
+      await store.init(ctx, { embedder: fakeEmbedder() });
+      const r = await runCli(['semantic', 'anything'], { cwd: vault, embedder: fakeEmbedder() });
+      expect(r.code).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.hits).toEqual([]);
+      expect(out.note).toMatch(/embedded/i);
+    } finally {
+      await store.dispose(ctx);
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
   });
 
   it('search works on a fresh vault with no pre-existing .minerva (ENOENT guard)', async () => {
@@ -147,5 +225,11 @@ describe('runCli contract', () => {
     const r = await runCli(['query', 'THIS IS NOT SPARQL'], { cwd: root });
     expect(r.code).toBe(1);
     expect(r.stderr).toContain('SPARQL error');
+  });
+
+  it('a malformed SQL query surfaces as a core error (exit 1)', async () => {
+    const r = await runCli(['sql', 'SELECT * FROM no_such_table'], { cwd: root });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('SQL error');
   });
 });

--- a/vite.cli.config.ts
+++ b/vite.cli.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig } from 'vite';
+import { execSync } from 'node:child_process';
+
+/**
+ * Standalone Node build of the headless CLI (#1149, epic #1145 — Substrate).
+ *
+ * `ssr: true` externalizes node builtins + everything in node_modules and
+ * bundles only our own `src/**`, so the emitted `cli.js` is small and resolves
+ * heavy/native deps (rdflib, comunica, DuckDB, onnxruntime) from node_modules at
+ * runtime — the same way the app does. The explicit `external` list additionally
+ * pins the native packages that must never be bundled (mirrors
+ * vite.main.config) and adds `electron`: the read core imports it transitively
+ * (notebase/fs's picker, llm/settings), but the CLI never calls those, so in
+ * plain Node `require('electron')` harmlessly yields the binary-path string.
+ *
+ * Build:  vite build --config vite.cli.config.ts   (→ .vite/build/cli.js)
+ * Run:    node .vite/build/cli.js query "SELECT ..." --project /path/to/vault
+ */
+function gitCommit(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+export default defineConfig({
+  define: {
+    __APP_COMMIT__: JSON.stringify(gitCommit()),
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString().slice(0, 10)),
+  },
+  build: {
+    ssr: true,
+    outDir: '.vite/build',
+    emptyOutDir: false,
+    rollupOptions: {
+      input: 'src/cli/main.ts',
+      output: { entryFileNames: 'cli.js', format: 'cjs' },
+      external: [
+        'electron',
+        'canvas',
+        /^@duckdb\/node-bindings/,
+        'vega',
+        'vega-lite',
+        'sql.js',
+        /^onnxruntime-web/,
+        /^onnxruntime-common/,
+      ],
+    },
+  },
+});


### PR DESCRIPTION
First slice of the Substrate epic (#1145) — the **read half** of CLI parity (#1149). A headless CLI so an external agent or shell script can query a thoughtbase **without the app running**.

## Why this was cheap
The epic audit found the read core (`queryGraph`, `search`, `readFile`) is **Electron-free** and `ctx`-based. So this is *exposure*, not new query logic: the CLI constructs a `ProjectContext` from a directory and runs the same `init → index → query` path the app runs on project open.

## Commands
| Command | Purpose | Output |
|---|---|---|
| `query <sparql>` | SPARQL over the graph (prefixes auto-injected) | `{ columns, results }` |
| `search <text>` | Full-text search (`--limit <n>`) | `{ query, hits }` |
| `read <relative-path>` | A note's raw markdown | `{ path, content }` |

Global `--project <path>` (default cwd), `--help`. Every result is **grounded** (node IRIs / note paths) and printed as JSON on stdout, so it pipes into `jq` or feeds an agent directly.

```sh
pnpm cli:build
node .vite/build/cli.js query 'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title }' --project ~/vault
```

## Shape
- **`src/cli/run.ts`** — the whole surface as one pure `runCli(argv, {cwd}) → {stdout, stderr, code}`, no `process`/Electron touch, so it's fully testable and the forthcoming MCP subcommand (#1146) wraps the *same* function.
- **`src/cli/main.ts`** — thin write-and-exit executable entry.
- **`vite.cli.config.ts`** — standalone Node bundle (`ssr: true` externalizes node_modules; mirrors main's native-dep list; adds `electron` so the transitive `import {dialog}` resolves to a harmless path-string in plain Node). 131 KB, deps resolved from `node_modules` at runtime.
- Exit-code contract: `0` ok / `1` core error / `2` usage.

## Verification
- Ran **end-to-end from the built bundle** against a temp vault — all three commands return correct grounded output.
- **14 vitest cases** including a fresh-vault search **ENOENT guard**: `runSearch` ensures `.minerva/` exists before the index write, so a headless first run doesn't depend on the app having created the dir (this bit the raw bundle before the fix; the shared-temp test masked it).
- `pnpm lint` clean.

## Scope
Read-only, first cut. Writes-through-the-gate (#1147) and the MCP subcommand (#1146) are later children — `runCli` is deliberately the reusable seam for both. `sql`/`semantic` read commands are a small follow-up (they add DuckDB/onnxruntime init).

Docs: `docs/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)