### PR TITLE
cli: stdio MCP server — query the thoughtbase from agent clients (#1146)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,8 +5,9 @@ epic (#1145 → #1149). It reuses the exact `ctx`-based core the app uses (that
 core is Electron-free), so an external agent or a shell script can query your
 knowledge graph and notes without the app running.
 
-> **Status: read-only.** `query`, `sql`, `search`, `semantic`, `read`. Writes
-> (through the approval gate) and an MCP subcommand are later children of the epic.
+> **Status: read-only.** `query`, `sql`, `search`, `semantic`, `read`, and `mcp`
+> (a stdio MCP server exposing the reads to agent clients). Writes — through the
+> approval gate — are a later child of the epic (#1147).
 
 ## Build & run
 
@@ -48,6 +49,35 @@ node .vite/build/cli.js query \
   'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title' \
   --project ~/vault
 ```
+
+## MCP server
+
+`minerva mcp [--project <path>]` starts a [Model Context Protocol](https://modelcontextprotocol.io)
+server over stdio, exposing the read commands as tools so any MCP client — Claude
+Desktop, a coding agent, an editor — can query the thoughtbase. It speaks
+newline-delimited JSON-RPC 2.0 and stays running until stdin closes.
+
+Tools: `query_graph`, `sql_query`, `search_notes`, `semantic_search`, `read_note`
+— each returning the same grounded JSON as the matching CLI command.
+
+Point an MCP client at it (the client launches it as a subprocess):
+
+```json
+{
+  "mcpServers": {
+    "minerva": {
+      "command": "node",
+      "args": ["/path/to/minerva/.vite/build/cli.js", "mcp", "--project", "/path/to/vault"]
+    }
+  }
+}
+```
+
+The server inits each modality once and stays warm across tool calls. Because
+that init is a point-in-time snapshot, a long-running server serves results as of
+startup — restart it to pick up external edits (the write-coordination caveat in
+`docs/vision/substrate-mcp-plan.md`). Read-only: writes will arrive as
+approval-gated proposals in a later child (#1147).
 
 ## Exit codes
 

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -1,0 +1,113 @@
+/**
+ * The read Engine (#1146/#1149, epic #1145 — Substrate).
+ *
+ * The single source of truth for "init the project, then run a read": the CLI
+ * (one-shot) and the MCP server (long-lived) both drive it. Each modality's init
+ * — graph index, full-text index, DuckDB tables, vector store — runs at most
+ * once and is memoized, so a one-shot CLI run pays only for the modality it uses
+ * and a persistent MCP server stays warm across tool calls.
+ *
+ * Results are a discriminated `ExecResult` so callers can format them their own
+ * way (CLI → JSON + exit code; MCP → tool result). Every result is grounded:
+ * query bindings carry node IRIs, search hits carry note paths, read echoes the
+ * path.
+ *
+ * NOTE (write coordination): init is a point-in-time snapshot. A server that
+ * outlives edits to the vault serves stale results until restarted — the caveat
+ * flagged in docs/vision/substrate-mcp-plan.md. Acceptable for the read MVP.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as graph from '../main/graph/index';
+import * as search from '../main/search/index';
+import * as tables from '../main/sources/tables';
+import * as vectors from '../main/embeddings/vector-store';
+import type { ChunkEmbedder } from '../main/embeddings/vector-store';
+import { getSharedEmbedder } from '../main/embeddings/shared-embedder';
+import { readFile } from '../main/notebase/fs';
+import type { ProjectContext } from '../main/project-context-types';
+
+export type ExecResult = { ok: true; data: unknown } | { ok: false; error: string };
+
+export interface Engine {
+  query(sparql: string): Promise<ExecResult>;
+  sql(sql: string): Promise<ExecResult>;
+  search(text: string, limit?: number): Promise<ExecResult>;
+  semantic(text: string, limit?: number): Promise<ExecResult>;
+  read(relativePath: string): Promise<ExecResult>;
+}
+
+export interface EngineOptions {
+  /** Injectable embedder for `semantic` so tests avoid the real WASM model.
+   *  Resolved lazily — the shared embedder is only constructed if `semantic`
+   *  actually runs. */
+  embedder?: ChunkEmbedder | undefined;
+}
+
+const SEMANTIC_EMPTY_NOTE =
+  'No embedded content matched. Semantic search covers notes already embedded ' +
+  'by the app; a vault that has never been embedded returns no hits.';
+
+export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Engine {
+  const ensureMinervaDir = () => fs.mkdir(path.join(ctx.rootPath, '.minerva'), { recursive: true });
+
+  // Memoized per-modality init — the `??=` makes each block run exactly once.
+  let graphReady: Promise<void> | undefined;
+  let searchReady: Promise<void> | undefined;
+  let tablesReady: Promise<void> | undefined;
+  let vectorsReady: Promise<void> | undefined;
+
+  const ensureGraph = () => (graphReady ??= (async () => {
+    await graph.initGraph(ctx);
+    await graph.indexAllNotes(ctx);
+  })());
+  const ensureSearch = () => (searchReady ??= (async () => {
+    await ensureMinervaDir();
+    await search.initSearch(ctx);
+    await search.indexAllNotes(ctx);
+  })());
+  const ensureTables = () => (tablesReady ??= (async () => {
+    await ensureMinervaDir();
+    await tables.initTablesDb(ctx);
+    await tables.registerAllCsvs(ctx);
+  })());
+  const ensureVectors = () => (vectorsReady ??= (async () => {
+    await ensureMinervaDir();
+    await vectors.init(ctx, { embedder: opts.embedder ?? getSharedEmbedder() });
+  })());
+
+  return {
+    async query(sparql) {
+      await ensureGraph();
+      const { results, columns, error } = await graph.queryGraph(ctx, sparql);
+      return error ? { ok: false, error } : { ok: true, data: { columns, results } };
+    },
+    async sql(sql) {
+      await ensureTables();
+      const result = await tables.runQuery(ctx, sql);
+      return result.ok
+        ? { ok: true, data: { columns: result.columns, rows: result.rows } }
+        : { ok: false, error: result.error };
+    },
+    async search(text, limit) {
+      await ensureSearch();
+      const hits = search.search(ctx, text, limit ? { limit } : undefined);
+      return { ok: true, data: { query: text, hits } };
+    },
+    async semantic(text, limit) {
+      await ensureVectors();
+      const hits = await vectors.searchRelated(ctx, text, limit ? { limit } : {});
+      const data: Record<string, unknown> = { query: text, hits };
+      if (hits.length === 0) data.note = SEMANTIC_EMPTY_NOTE;
+      return { ok: true, data };
+    },
+    async read(relativePath) {
+      try {
+        const content = await readFile(ctx.rootPath, relativePath);
+        return { ok: true, data: { path: relativePath, content } };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}

--- a/src/cli/json.ts
+++ b/src/cli/json.ts
@@ -1,0 +1,18 @@
+/**
+ * BigInt-safe JSON for the CLI + MCP layers (#1149/#1146).
+ *
+ * DuckDB returns BigInt for integer columns, which `JSON.stringify` can't
+ * serialize. Safe integers become plain numbers; anything outside the safe range
+ * becomes a string to avoid silent precision loss. Shared so the CLI (pretty
+ * stdout) and the MCP server (compact tool-result text) format identically.
+ */
+export function bigintSafeReplacer(_key: string, v: unknown): unknown {
+  if (typeof v !== 'bigint') return v;
+  return v >= BigInt(Number.MIN_SAFE_INTEGER) && v <= BigInt(Number.MAX_SAFE_INTEGER)
+    ? Number(v)
+    : v.toString();
+}
+
+export function jsonStringify(value: unknown, pretty = false): string {
+  return JSON.stringify(value, bigintSafeReplacer, pretty ? 2 : undefined);
+}

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -1,0 +1,226 @@
+/**
+ * A minimal MCP server over stdio (#1146, epic #1145 — Substrate).
+ *
+ * The headline of the substrate vision: any external agent in the user's fleet —
+ * a coding agent, a browser agent, Claude Desktop — can query the thoughtbase
+ * through one protocol. This wraps the read `Engine` as MCP tools. It's a thin
+ * envelope: the Engine already does the work; this speaks the wire.
+ *
+ * Hand-rolled rather than pulling in the MCP SDK — the read-only surface is a
+ * handful of JSON-RPC 2.0 methods over newline-delimited stdio, and keeping it
+ * dependency-free keeps the CLI bundle lean and the protocol handling testable
+ * as a pure function. `handleMcpMessage` is that pure core; `runMcpServer` is the
+ * stdio plumbing around it.
+ *
+ * Read-only by construction. Writes are a later child (#1147) and go through the
+ * approval gate — an external agent proposes, the human confirms.
+ */
+import * as readline from 'node:readline';
+import { createEngine, type Engine, type EngineOptions, type ExecResult } from './engine';
+import { jsonStringify } from './json';
+import { projectContext } from '../main/project-context-types';
+
+/** Protocol version we speak. We echo the client's requested version when it
+ *  sends one (lenient), falling back to this. */
+const PROTOCOL_VERSION = '2025-06-18';
+const SERVER_INFO = { name: 'minerva', version: '0.1.2' };
+
+interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface JsonSchema {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required?: string[];
+}
+
+interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  run(engine: Engine, args: Record<string, unknown>): Promise<ExecResult>;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
+
+/** The read tools, one per Engine method. Names + schemas are what an external
+ *  agent sees; results are grounded JSON so the agent can attribute. */
+export const MCP_TOOLS: McpTool[] = [
+  {
+    name: 'query_graph',
+    description:
+      'Run a SPARQL query against the thoughtbase knowledge graph. Standard prefixes ' +
+      '(minerva, thought, dc, rdf, rdfs, xsd, csvw, prov …) are auto-injected. Returns ' +
+      'bindings grounded with node IRIs.',
+    inputSchema: {
+      type: 'object',
+      properties: { sparql: { type: 'string', description: 'A SPARQL query string.' } },
+      required: ['sparql'],
+    },
+    run: (engine, args) => engine.query(str(args.sparql)),
+  },
+  {
+    name: 'sql_query',
+    description:
+      "Run a DuckDB SQL query over the vault's CSV tables (each CSV is registered under a " +
+      'name derived from its path). Returns rows.',
+    inputSchema: {
+      type: 'object',
+      properties: { sql: { type: 'string', description: 'A DuckDB SQL query string.' } },
+      required: ['sql'],
+    },
+    run: (engine, args) => engine.sql(str(args.sql)),
+  },
+  {
+    name: 'search_notes',
+    description: 'Full-text search over notes. Hits are grounded with the note path.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'Search text.' },
+        limit: { type: 'number', description: 'Max results (default 20).' },
+      },
+      required: ['text'],
+    },
+    run: (engine, args) => engine.search(str(args.text), num(args.limit)),
+  },
+  {
+    name: 'semantic_search',
+    description:
+      'Semantic (embeddings) search over notes — finds conceptually related content, not ' +
+      'just keyword matches. Covers only notes the app has already embedded.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'Query text.' },
+        limit: { type: 'number', description: 'Max results (default 20).' },
+      },
+      required: ['text'],
+    },
+    run: (engine, args) => engine.semantic(str(args.text), num(args.limit)),
+  },
+  {
+    name: 'read_note',
+    description: "Read a note's raw markdown by its vault-relative path.",
+    inputSchema: {
+      type: 'object',
+      properties: { relative_path: { type: 'string', description: 'Vault-relative note path.' } },
+      required: ['relative_path'],
+    },
+    run: (engine, args) => engine.read(str(args.relative_path)),
+  },
+];
+
+/**
+ * Handle one JSON-RPC message. Pure over the injected engine: returns the
+ * response object to send, or `null` for notifications (which get no reply).
+ * This is the whole protocol surface, so it's the whole thing worth testing.
+ */
+export async function handleMcpMessage(
+  msg: JsonRpcMessage,
+  engine: Engine,
+): Promise<JsonRpcResponse | null> {
+  const id = msg.id ?? null;
+  const ok = (result: unknown): JsonRpcResponse => ({ jsonrpc: '2.0', id, result });
+  const fail = (code: number, message: string): JsonRpcResponse => ({
+    jsonrpc: '2.0',
+    id,
+    error: { code, message },
+  });
+
+  switch (msg.method) {
+    case 'initialize': {
+      const requested = str(msg.params?.protocolVersion);
+      return ok({
+        protocolVersion: requested || PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      });
+    }
+    // Notifications — no response.
+    case 'notifications/initialized':
+    case 'initialized':
+      return null;
+    case 'ping':
+      return ok({});
+    case 'tools/list':
+      return ok({
+        tools: MCP_TOOLS.map(({ name, description, inputSchema }) => ({ name, description, inputSchema })),
+      });
+    case 'tools/call': {
+      const name = str(msg.params?.name);
+      const tool = MCP_TOOLS.find((t) => t.name === name);
+      if (!tool) return fail(-32602, `Unknown tool: ${name}`);
+      const args = (msg.params?.arguments as Record<string, unknown>) ?? {};
+      const result = await tool.run(engine, args);
+      // Tool-level failures are reported as an MCP tool result with isError,
+      // NOT a JSON-RPC error — the call itself succeeded; the tool returned a
+      // problem the agent should see and can recover from.
+      return result.ok
+        ? ok({ content: [{ type: 'text', text: jsonStringify(result.data, true) }] })
+        : ok({ content: [{ type: 'text', text: result.error }], isError: true });
+    }
+    default:
+      // An unrecognised notification (no id) is ignored; an unrecognised request
+      // gets a proper "method not found".
+      if (id === null && msg.id === undefined) return null;
+      return fail(-32601, `Method not found: ${msg.method ?? '(none)'}`);
+  }
+}
+
+/**
+ * Run the stdio MCP server over a project until the input stream closes. Reads
+ * newline-delimited JSON-RPC from stdin, writes responses to stdout. Messages are
+ * processed in order (a serial chain) so responses never interleave. Defaults to
+ * the real process streams; tests inject their own.
+ */
+export async function runMcpServer(
+  root: string,
+  opts: EngineOptions & {
+    input?: NodeJS.ReadableStream;
+    output?: NodeJS.WritableStream;
+  } = {},
+): Promise<void> {
+  const engine = createEngine(projectContext(root), { embedder: opts.embedder });
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+
+  const write = (obj: JsonRpcResponse) => output.write(`${jsonStringify(obj)}\n`);
+
+  await new Promise<void>((resolve) => {
+    // Serialize handling so out-of-order async completions can't interleave
+    // writes; ids still let clients correlate, but ordered output is tidier.
+    let chain: Promise<void> = Promise.resolve();
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      chain = chain.then(async () => {
+        let msg: JsonRpcMessage;
+        try {
+          msg = JSON.parse(trimmed) as JsonRpcMessage;
+        } catch {
+          write({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } });
+          return;
+        }
+        const response = await handleMcpMessage(msg, engine);
+        if (response) write(response);
+      });
+    });
+    rl.on('close', () => {
+      void chain.then(resolve);
+    });
+  });
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,17 +1,17 @@
 /**
  * The Minerva CLI (#1149, epic #1145 — Substrate).
  *
- * `runCli` is the whole command surface as one pure async function: it takes an
- * argv slice + a working directory and returns { stdout, stderr, code } without
- * touching `process` or Electron. That keeps it fully testable under vitest and
- * lets the thin executable entry (`./main.ts`) — and, later, the MCP subcommand
- * (#1146) — wrap the same logic.
+ * `runCli` is the whole command surface as one async function: it takes an argv
+ * slice + a working directory and returns { stdout, stderr, code } without
+ * touching `process`. That keeps it testable and lets the thin executable entry
+ * (`./main.ts`) wrap it. The read work itself lives in the shared `Engine`
+ * (`./engine`), which the MCP subcommand (`./mcp`, #1146) drives too.
  *
- * This is the READ half of CLI parity: `query` (SPARQL), `search` (full-text),
- * and `read` (a note's markdown). It reuses the exact `ctx`-based core the app
- * uses — the audit for epic #1145 confirmed that core is Electron-free — by
- * constructing a ProjectContext from a directory and running the same
- * init → index → query path the app runs on project open.
+ * READ surface: `query` (SPARQL), `sql` (DuckDB), `search` (full-text),
+ * `semantic` (embeddings), `read` (a note's markdown), and `mcp` (a stdio MCP
+ * server exposing those as tools to agent clients). It reuses the exact
+ * `ctx`-based core the app uses — the audit for epic #1145 confirmed that core
+ * is Electron-free.
  *
  * Every result is *grounded*: query bindings carry node IRIs, search hits carry
  * the note path, read echoes the path. Output is JSON on stdout so it pipes to
@@ -19,14 +19,11 @@
  */
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import * as graph from '../main/graph/index';
-import * as search from '../main/search/index';
-import * as tables from '../main/sources/tables';
-import * as vectors from '../main/embeddings/vector-store';
 import type { ChunkEmbedder } from '../main/embeddings/vector-store';
-import { getSharedEmbedder } from '../main/embeddings/shared-embedder';
-import { readFile } from '../main/notebase/fs';
-import { projectContext, type ProjectContext } from '../main/project-context-types';
+import { projectContext } from '../main/project-context-types';
+import { createEngine, type Engine, type ExecResult } from './engine';
+import { jsonStringify } from './json';
+import { runMcpServer } from './mcp';
 
 export interface CliResult {
   stdout: string;
@@ -52,6 +49,8 @@ Commands:
   search <text>         Full-text search over notes.        [--limit <n>]
   semantic <text>       Semantic (embeddings) search over notes.  [--limit <n>]
   read <relative-path>  Print a note's raw markdown.
+  mcp                   Start a stdio MCP server exposing the read tools to
+                        agent clients (Claude Desktop, coding agents, …).
 
 Options:
   --project <path>      Thoughtbase root (default: current directory).
@@ -99,25 +98,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   return { command: positionals.shift(), positionals, project, limit, help };
 }
 
-// DuckDB returns BigInt for integer columns (SQL command), which JSON.stringify
-// can't serialize. Keep safe integers as numbers; stringify larger ids to avoid
-// precision loss. See the DuckDB BigInt serialization gotcha.
-function bigintSafeReplacer(_key: string, v: unknown): unknown {
-  if (typeof v !== 'bigint') return v;
-  return v >= BigInt(Number.MIN_SAFE_INTEGER) && v <= BigInt(Number.MAX_SAFE_INTEGER)
-    ? Number(v)
-    : v.toString();
-}
-
 function json(value: unknown): string {
-  return `${JSON.stringify(value, bigintSafeReplacer, 2)}\n`;
-}
-
-/** The app always has a `.minerva/` dir; a headless first run against a fresh
- *  vault may not, and the index-building commands persist there. Derived cache
- *  only, so creating it during a read is safe. */
-async function ensureMinervaDir(root: string): Promise<void> {
-  await fs.mkdir(path.join(root, '.minerva'), { recursive: true });
+  return `${jsonStringify(value, true)}\n`;
 }
 
 /** A directory is required and must exist; a missing `.minerva` is fine —
@@ -136,62 +118,12 @@ async function resolveProjectRoot(project: string | undefined, cwd: string): Pro
  *  opposed to an unexpected throw (exit code 1). */
 class UsageError extends Error {}
 
-async function runQuery(ctx: ProjectContext, sparql: string): Promise<CliResult> {
-  if (!sparql.trim()) throw new UsageError('query: a SPARQL string is required.');
-  await graph.initGraph(ctx);
-  await graph.indexAllNotes(ctx);
-  const { results, columns, error } = await graph.queryGraph(ctx, sparql);
-  if (error) return { stdout: '', stderr: `SPARQL error: ${error}\n`, code: 1 };
-  return { stdout: json({ columns, results }), stderr: '', code: 0 };
-}
-
-async function runSearch(ctx: ProjectContext, text: string, limit: number | undefined): Promise<CliResult> {
-  if (!text.trim()) throw new UsageError('search: a query string is required.');
-  // `indexAllNotes` persists the MiniSearch index into `.minerva/`, so the dir
-  // must exist first (a headless first run may not have it).
-  await ensureMinervaDir(ctx.rootPath);
-  await search.initSearch(ctx);
-  await search.indexAllNotes(ctx);
-  const hits = search.search(ctx, text, limit ? { limit } : undefined);
-  return { stdout: json({ query: text, hits }), stderr: '', code: 0 };
-}
-
-async function runSql(ctx: ProjectContext, sql: string): Promise<CliResult> {
-  if (!sql.trim()) throw new UsageError('sql: a SQL string is required.');
-  await ensureMinervaDir(ctx.rootPath);
-  await tables.initTablesDb(ctx);
-  // Register the vault's CSV tables so they're queryable by their derived names.
-  await tables.registerAllCsvs(ctx);
-  const result = await tables.runQuery(ctx, sql);
-  if (!result.ok) return { stdout: '', stderr: `SQL error: ${result.error}\n`, code: 1 };
-  return { stdout: json({ columns: result.columns, rows: result.rows }), stderr: '', code: 0 };
-}
-
-async function runSemantic(
-  ctx: ProjectContext,
-  text: string,
-  limit: number | undefined,
-  embedder: ChunkEmbedder,
-): Promise<CliResult> {
-  if (!text.trim()) throw new UsageError('semantic: a query string is required.');
-  await ensureMinervaDir(ctx.rootPath);
-  await vectors.init(ctx, { embedder });
-  const hits = await vectors.searchRelated(ctx, text, limit ? { limit } : {});
-  const out: Record<string, unknown> = { query: text, hits };
-  if (hits.length === 0) {
-    // Semantic search only covers already-embedded content; a vault the app has
-    // never opened/embedded yields nothing. Say so rather than look broken.
-    out.note =
-      'No embedded content matched. Semantic search covers notes already embedded ' +
-      'by the app; a vault that has never been embedded returns no hits.';
-  }
-  return { stdout: json(out), stderr: '', code: 0 };
-}
-
-async function runRead(ctx: ProjectContext, relativePath: string): Promise<CliResult> {
-  if (!relativePath) throw new UsageError('read: a relative note path is required.');
-  const content = await readFile(ctx.rootPath, relativePath);
-  return { stdout: json({ path: relativePath, content }), stderr: '', code: 0 };
+/** Format an Engine result as a CliResult: success → pretty JSON + code 0;
+ *  failure → `<prefix>: <error>` on stderr + code 1. */
+function format(result: ExecResult, errorPrefix: string): CliResult {
+  return result.ok
+    ? { stdout: json(result.data), stderr: '', code: 0 }
+    : { stdout: '', stderr: `${errorPrefix}: ${result.error}\n`, code: 1 };
 }
 
 /**
@@ -208,19 +140,33 @@ export async function runCli(argv: string[], opts: RunOptions): Promise<CliResul
 
   try {
     const root = await resolveProjectRoot(args.project, opts.cwd);
-    const ctx = projectContext(root);
+
+    // The MCP server is long-lived and owns its own IO; it doesn't fit the
+    // request/response shape, so it's handled before the engine dispatch.
+    if (args.command === 'mcp') {
+      await runMcpServer(root, { embedder: opts.embedder });
+      return { stdout: '', stderr: '', code: 0 };
+    }
+
+    const engine: Engine = createEngine(projectContext(root), { embedder: opts.embedder });
+    const rest = args.positionals.join(' ');
 
     switch (args.command) {
       case 'query':
-        return await runQuery(ctx, args.positionals.join(' '));
+        if (!rest.trim()) throw new UsageError('query: a SPARQL string is required.');
+        return format(await engine.query(rest), 'SPARQL error');
       case 'sql':
-        return await runSql(ctx, args.positionals.join(' '));
+        if (!rest.trim()) throw new UsageError('sql: a SQL string is required.');
+        return format(await engine.sql(rest), 'SQL error');
       case 'search':
-        return await runSearch(ctx, args.positionals.join(' '), args.limit);
+        if (!rest.trim()) throw new UsageError('search: a query string is required.');
+        return format(await engine.search(rest, args.limit), 'Error');
       case 'semantic':
-        return await runSemantic(ctx, args.positionals.join(' '), args.limit, opts.embedder ?? getSharedEmbedder());
+        if (!rest.trim()) throw new UsageError('semantic: a query string is required.');
+        return format(await engine.semantic(rest, args.limit), 'Error');
       case 'read':
-        return await runRead(ctx, args.positionals[0] ?? '');
+        if (!args.positionals[0]) throw new UsageError('read: a relative note path is required.');
+        return format(await engine.read(args.positionals[0]), 'Error');
       default:
         return { stdout: '', stderr: `Unknown command: ${args.command}\n\n${HELP}\n`, code: 2 };
     }

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The stdio MCP server (#1146, epic #1145 — Substrate).
+ *
+ * Two layers: `handleMcpMessage` (the pure JSON-RPC protocol surface, driven by a
+ * real Engine over a temp vault) and `runMcpServer` (the stdio plumbing, driven
+ * over in-memory streams). Together they prove an external agent can complete the
+ * initialize → tools/list → tools/call handshake and get grounded results —
+ * without a live client.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { PassThrough } from 'node:stream';
+import { handleMcpMessage, runMcpServer, MCP_TOOLS } from '../../src/cli/mcp';
+import { createEngine } from '../../src/cli/engine';
+import { projectContext } from '../../src/main/project-context-types';
+
+let root: string;
+const engine = () => createEngine(projectContext(root));
+
+beforeAll(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-mcp-'));
+  await fsp.writeFile(
+    path.join(root, 'photosynthesis.md'),
+    '---\ntitle: Photosynthesis\n---\n\nConverts light to chemical energy.\n',
+    'utf-8',
+  );
+  await fsp.writeFile(path.join(root, 'plants.csv'), 'name,height_cm\nfern,40\nmoss,3\n', 'utf-8');
+});
+
+afterAll(async () => {
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('handleMcpMessage — handshake & discovery', () => {
+  it('initialize echoes the requested protocol version and advertises tools', async () => {
+    const r = await handleMcpMessage(
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } },
+      engine(),
+    );
+    expect(r?.id).toBe(1);
+    const result = r?.result as Record<string, unknown>;
+    expect(result.protocolVersion).toBe('2025-06-18');
+    expect(result.capabilities).toEqual({ tools: {} });
+    expect((result.serverInfo as { name: string }).name).toBe('minerva');
+  });
+
+  it('tools/list returns every read tool with a JSON-Schema input', async () => {
+    const r = await handleMcpMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, engine());
+    const tools = (r?.result as { tools: { name: string; inputSchema: unknown }[] }).tools;
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      ['query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
+    );
+    for (const t of tools) expect(t.inputSchema).toHaveProperty('type', 'object');
+  });
+
+  it('the initialized notification gets no response', async () => {
+    const r = await handleMcpMessage({ jsonrpc: '2.0', method: 'notifications/initialized' }, engine());
+    expect(r).toBeNull();
+  });
+
+  it('an unknown request method is method-not-found (-32601)', async () => {
+    const r = await handleMcpMessage({ jsonrpc: '2.0', id: 9, method: 'no/such/method' }, engine());
+    expect(r?.error?.code).toBe(-32601);
+  });
+});
+
+describe('handleMcpMessage — tools/call', () => {
+  async function call(name: string, args: Record<string, unknown>) {
+    return handleMcpMessage(
+      { jsonrpc: '2.0', id: 7, method: 'tools/call', params: { name, arguments: args } },
+      engine(),
+    );
+  }
+
+  it('query_graph returns grounded SPARQL bindings as text content', async () => {
+    const r = await call('query_graph', {
+      sparql: 'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title }',
+    });
+    const content = (r?.result as { content: { type: string; text: string }[] }).content;
+    expect(content[0].type).toBe('text');
+    const parsed = JSON.parse(content[0].text);
+    expect(parsed.results.map((row: Record<string, string>) => row.title)).toContain('Photosynthesis');
+  });
+
+  it('sql_query returns rows (DuckDB BigInt serialized safely)', async () => {
+    const r = await call('sql_query', { sql: 'SELECT COUNT(*) AS n FROM plants' });
+    const content = (r?.result as { content: { text: string }[] }).content;
+    expect(JSON.parse(content[0].text).rows[0].n).toBe(2);
+  });
+
+  it('read_note returns the markdown, grounded with the path', async () => {
+    const r = await call('read_note', { relative_path: 'photosynthesis.md' });
+    const parsed = JSON.parse((r?.result as { content: { text: string }[] }).content[0].text);
+    expect(parsed.path).toBe('photosynthesis.md');
+    expect(parsed.content).toContain('chemical energy');
+  });
+
+  it('a tool failure is an MCP tool result with isError, not a JSON-RPC error', async () => {
+    const r = await call('query_graph', { sparql: 'THIS IS NOT SPARQL' });
+    expect(r?.error).toBeUndefined();
+    const result = r?.result as { content: { text: string }[]; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBeTruthy();
+  });
+
+  it('an unknown tool name is rejected (-32602)', async () => {
+    const r = await call('destroy_everything', {});
+    expect(r?.error?.code).toBe(-32602);
+  });
+});
+
+describe('MCP_TOOLS metadata', () => {
+  it('every tool marks its required inputs', () => {
+    for (const t of MCP_TOOLS) {
+      expect(Array.isArray(t.inputSchema.required)).toBe(true);
+      expect(t.inputSchema.required!.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('runMcpServer over stdio streams', () => {
+  it('completes a full initialize → tools/call handshake and closes on stdin end', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const chunks: Buffer[] = [];
+    output.on('data', (c: Buffer) => chunks.push(c));
+
+    const done = runMcpServer(root, { input, output });
+
+    input.write(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }) + '\n');
+    input.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+    input.write(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'read_note', arguments: { relative_path: 'photosynthesis.md' } },
+      }) + '\n',
+    );
+    input.end();
+    await done;
+
+    const lines = Buffer.concat(chunks).toString('utf-8').trim().split('\n').filter(Boolean);
+    const responses = lines.map((l) => JSON.parse(l));
+    // Two responses (initialize id 1, tools/call id 2); the notification got none.
+    expect(responses.map((r) => r.id)).toEqual([1, 2]);
+    expect(responses[0].result.serverInfo.name).toBe('minerva');
+    const parsed = JSON.parse(responses[1].result.content[0].text);
+    expect(parsed.content).toContain('chemical energy');
+  });
+
+  it('a malformed line yields a JSON-RPC parse error, not a crash', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const chunks: Buffer[] = [];
+    output.on('data', (c: Buffer) => chunks.push(c));
+
+    const done = runMcpServer(root, { input, output });
+    input.write('{ not valid json\n');
+    input.end();
+    await done;
+
+    const resp = JSON.parse(Buffer.concat(chunks).toString('utf-8').trim());
+    expect(resp.error.code).toBe(-32700);
+  });
+});


### PR DESCRIPTION
The **headline** of the Substrate epic (#1145): any external agent in the user's fleet — Claude Desktop, a coding agent, an editor — can query the thoughtbase through one protocol. `minerva mcp` starts a Model Context Protocol server over stdio, exposing the read surface as MCP tools.

Builds directly on the CLI read work (#1149): `runCli` was designed as the reusable seam, and this is the envelope over it.

## Tools
`query_graph` · `sql_query` · `search_notes` · `semantic_search` · `read_note` — each returns the same **grounded** JSON as the matching CLI command (node IRIs / note paths).

## Structure
The read work is factored into a shared, memoized **Engine** so the CLI (one-shot) and the MCP server (long-lived) drive the *exact same core*:

- **`src/cli/engine.ts`** — `createEngine(ctx)`; each modality's init (graph / search / tables / vectors) runs **once** and is memoized, so a persistent server stays warm across tool calls. Returns discriminated `ExecResult`s; callers format.
- **`src/cli/mcp.ts`** — hand-rolled MCP over **newline-delimited JSON-RPC 2.0** (no SDK dependency — the read-only surface is a handful of methods, and staying dependency-free keeps the bundle lean and the protocol testable). `handleMcpMessage` is a **pure, fully-tested** protocol core; `runMcpServer` is the stdio plumbing (serialized so responses never interleave). Tool failures surface as MCP tool results with `isError`, not JSON-RPC errors.
- **`src/cli/json.ts`** — shared BigInt-safe JSON (CLI pretty, MCP compact).
- **`run.ts`** refactored to delegate to the Engine — behaviour unchanged, its 18 tests pass as-is — and dispatch the `mcp` command.

## Why hand-rolled, not the SDK
The read-only surface is `initialize` / `tools/list` / `tools/call` / `ping` over stdio. Hand-rolling ~200 lines avoids a heavy ESM dependency (and its CJS-bundle interop), keeps the 130 KB CLI bundle lean, and makes the whole protocol a pure function I can test exhaustively.

## Verification
- **End-to-end from the built bundle**: drove `node .vite/build/cli.js mcp` with a real `initialize → tools/list → tools/call` session over stdio (`sql_query`, `read_note`) and validated the newline-delimited JSON-RPC output with `jq` — correct grounded results, clean framing.
- **30 vitest cases** across CLI + MCP: the pure handler (handshake, discovery, tools/call, unknown-method/-tool, notifications) and the stdio server over in-memory streams (full handshake + malformed-line `-32700`).
- Full suite **4026** green; `pnpm lint` clean.

## Client config
```json
{ "mcpServers": { "minerva": {
  "command": "node",
  "args": ["/path/to/minerva/.vite/build/cli.js", "mcp", "--project", "/path/to/vault"]
}}}
```

## Scope
Read-only by construction. Writes are #1147 — external agents *propose* through the approval gate, the human confirms. The memoized init is a point-in-time snapshot (a long-running server serves as-of-startup until restarted) — the write-coordination caveat from the plan, acceptable for the read MVP.

Docs: `docs/cli.md` MCP section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)