### PR TITLE
cli/mcp: propose notes through the approval gate (#1147)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,9 +5,10 @@ epic (#1145 → #1149). It reuses the exact `ctx`-based core the app uses (that
 core is Electron-free), so an external agent or a shell script can query your
 knowledge graph and notes without the app running.
 
-> **Status: read-only.** `query`, `sql`, `search`, `semantic`, `read`, and `mcp`
-> (a stdio MCP server exposing the reads to agent clients). Writes — through the
-> approval gate — are a later child of the epic (#1147).
+> **Status: read + propose.** `query`, `sql`, `search`, `semantic`, `read`,
+> `propose-note`, and `mcp` (a stdio MCP server exposing them to agent clients).
+> Proposals go through the approval gate — they never touch the vault until a
+> human approves them in Minerva.
 
 ## Build & run
 
@@ -29,6 +30,7 @@ repo's `node_modules` at runtime — no separate install.
 | `search <text>` | Full-text search over notes (`--limit <n>`, default 20) | `{ query, hits }` |
 | `semantic <text>` | Embeddings search over notes (`--limit <n>`) | `{ query, hits }` |
 | `read <relative-path>` | A note's raw markdown | `{ path, content }` |
+| `propose-note <path>` | File a new note (body on **stdin**) as a pending proposal (`--by <id>`) | `{ status, proposalUri, … }` |
 
 Global options: `--project <path>` (thoughtbase root, default: cwd), `--help`.
 
@@ -50,6 +52,27 @@ node .vite/build/cli.js query \
   --project ~/vault
 ```
 
+## Proposing (writes go through the gate)
+
+External agents never write the vault directly. `propose-note` files a note as a
+**pending proposal** through Minerva's approval engine — the same gate the
+built-in AI uses — stamped with provenance. Nothing lands until a human reviews
+and approves it in Minerva's Proposals panel.
+
+```sh
+cat draft.md | node .vite/build/cli.js propose-note notes/idea.md --by cli --project ~/vault
+```
+
+`--by <id>` records who proposed it (default `cli`); MCP clients are stamped
+`mcp:<client-name>` from the initialize handshake. The note body comes from
+**stdin**, so it composes with anything upstream.
+
+> **Coordination caveat.** A proposal is persisted into `.minerva/graph.ttl`. If
+> Minerva has the same vault open, both processes rewrite that file, so it's
+> last-writer-wins — file proposals when the app isn't actively editing the graph,
+> and expect the app to surface them after its next reindex. A running-app-aware
+> write path is future work (see `docs/vision/substrate-mcp-plan.md`).
+
 ## MCP server
 
 `minerva mcp [--project <path>]` starts a [Model Context Protocol](https://modelcontextprotocol.io)
@@ -58,7 +81,8 @@ Desktop, a coding agent, an editor — can query the thoughtbase. It speaks
 newline-delimited JSON-RPC 2.0 and stays running until stdin closes.
 
 Tools: `query_graph`, `sql_query`, `search_notes`, `semantic_search`, `read_note`
-— each returning the same grounded JSON as the matching CLI command.
+(reads, grounded JSON) and `propose_note` (files a pending proposal stamped
+`mcp:<client-name>` — see *Proposing* above).
 
 Point an MCP client at it (the client launches it as a subprocess):
 
@@ -76,8 +100,8 @@ Point an MCP client at it (the client launches it as a subprocess):
 The server inits each modality once and stays warm across tool calls. Because
 that init is a point-in-time snapshot, a long-running server serves results as of
 startup — restart it to pick up external edits (the write-coordination caveat in
-`docs/vision/substrate-mcp-plan.md`). Read-only: writes will arrive as
-approval-gated proposals in a later child (#1147).
+`docs/vision/substrate-mcp-plan.md`). Writes are limited to `propose_note`, which
+is gated: an agent proposes, a human approves.
 
 ## Exit codes
 

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -24,10 +24,20 @@ import * as tables from '../main/sources/tables';
 import * as vectors from '../main/embeddings/vector-store';
 import type { ChunkEmbedder } from '../main/embeddings/vector-store';
 import { getSharedEmbedder } from '../main/embeddings/shared-embedder';
+import * as approval from '../main/llm/approval';
 import { readFile } from '../main/notebase/fs';
 import type { ProjectContext } from '../main/project-context-types';
 
 export type ExecResult = { ok: true; data: unknown } | { ok: false; error: string };
+
+export interface ProposeNoteInput {
+  relativePath: string;
+  content: string;
+  /** One-line summary for the review queue; defaulted from the path if absent. */
+  note?: string | undefined;
+  /** Provenance — who proposed this. e.g. 'cli' or 'mcp:claude-code'. */
+  proposedBy: string;
+}
 
 export interface Engine {
   query(sparql: string): Promise<ExecResult>;
@@ -35,6 +45,9 @@ export interface Engine {
   search(text: string, limit?: number): Promise<ExecResult>;
   semantic(text: string, limit?: number): Promise<ExecResult>;
   read(relativePath: string): Promise<ExecResult>;
+  /** File a NEW note as a pending proposal through the approval gate. Never
+   *  writes the vault directly — a human approves it in Minerva. */
+  proposeNote(input: ProposeNoteInput): Promise<ExecResult>;
 }
 
 export interface EngineOptions {
@@ -108,6 +121,51 @@ export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Eng
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
+    },
+
+    async proposeNote(input) {
+      const rel = input.relativePath?.trim();
+      if (!rel) return { ok: false, error: 'A relative note path is required.' };
+      if (typeof input.content !== 'string' || !input.content.trim()) {
+        return { ok: false, error: 'Note content is required.' };
+      }
+
+      // Load the on-disk snapshot fresh — NOT the read path's `indexAllNotes`
+      // store, which resets to note-derived triples and would drop existing
+      // proposals — so filing preserves everything already in graph.ttl. Then
+      // invalidate the read memo so a later query re-indexes against the store
+      // we're about to mutate.
+      await graph.initGraph(ctx);
+      graphReady = undefined;
+
+      const summary = input.note?.trim() || `Proposed note: ${rel}`;
+      // Route through the approval gate exactly like the internal AI does, and in
+      // LLM context so a regression that wrote directly (bypassing proposeWrite)
+      // would trip the write guard. The proposal lands PENDING — never applied
+      // here — so nothing touches the vault until a human approves it.
+      const proposal = await graph.withLLMContext(() =>
+        approval.proposeWrite(ctx, {
+          operationType: 'component_creation',
+          payloads: [{ kind: 'note', relativePath: rel, content: input.content }],
+          note: summary,
+          proposedBy: input.proposedBy,
+        }),
+      );
+      await graph.persistGraph(ctx);
+
+      return {
+        ok: true,
+        data: {
+          status: 'pending',
+          proposalUri: proposal?.uri ?? null,
+          relativePath: rel,
+          proposedBy: input.proposedBy,
+          note: summary,
+          message:
+            'Filed as a pending proposal. It is NOT written to the vault until a ' +
+            'human reviews and approves it in Minerva (Proposals panel).',
+        },
+      };
     },
   };
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,8 +8,19 @@
  */
 import { runCli } from './run';
 
+/** Read all of stdin (the `propose-note` note body). Returns '' at a TTY, so an
+ *  interactive invocation without a pipe doesn't hang waiting for input. */
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
 async function main(): Promise<void> {
-  const result = await runCli(process.argv.slice(2), { cwd: process.cwd() });
+  const argv = process.argv.slice(2);
+  const stdin = argv[0] === 'propose-note' ? await readStdin() : undefined;
+  const result = await runCli(argv, { cwd: process.cwd(), stdin });
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   process.exit(result.code);

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -45,11 +45,23 @@ interface JsonSchema {
   required?: string[];
 }
 
+/** Per-connection state. `clientName` is captured from the initialize handshake
+ *  so propose provenance can record WHICH agent proposed (decision #2 of the
+ *  substrate plan: `mcp:<client-id>`). */
+export interface McpSession {
+  clientName?: string;
+}
+
+interface ToolRunOptions {
+  /** Provenance stamp for write tools, e.g. `mcp:claude-code`. */
+  proposedBy: string;
+}
+
 interface McpTool {
   name: string;
   description: string;
   inputSchema: JsonSchema;
-  run(engine: Engine, args: Record<string, unknown>): Promise<ExecResult>;
+  run(engine: Engine, args: Record<string, unknown>, opts: ToolRunOptions): Promise<ExecResult>;
 }
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
@@ -121,6 +133,30 @@ export const MCP_TOOLS: McpTool[] = [
     },
     run: (engine, args) => engine.read(str(args.relative_path)),
   },
+  {
+    name: 'propose_note',
+    description:
+      'Propose a NEW note for the thoughtbase. IMPORTANT: this does NOT write to the ' +
+      "vault — it files a PENDING proposal that the user reviews and approves in Minerva's " +
+      'Proposals panel. The proposal is stamped with your agent identity for provenance. ' +
+      'Use this to contribute findings back to the user\'s knowledge graph safely.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        relative_path: { type: 'string', description: 'Vault-relative path for the new note, e.g. notes/idea.md.' },
+        content: { type: 'string', description: 'The note markdown (may include frontmatter).' },
+        note: { type: 'string', description: 'Optional one-line summary shown in the review queue.' },
+      },
+      required: ['relative_path', 'content'],
+    },
+    run: (engine, args, opts) =>
+      engine.proposeNote({
+        relativePath: str(args.relative_path),
+        content: str(args.content),
+        note: str(args.note) || undefined,
+        proposedBy: opts.proposedBy,
+      }),
+  },
 ];
 
 /**
@@ -131,6 +167,7 @@ export const MCP_TOOLS: McpTool[] = [
 export async function handleMcpMessage(
   msg: JsonRpcMessage,
   engine: Engine,
+  session: McpSession = {},
 ): Promise<JsonRpcResponse | null> {
   const id = msg.id ?? null;
   const ok = (result: unknown): JsonRpcResponse => ({ jsonrpc: '2.0', id, result });
@@ -142,6 +179,9 @@ export async function handleMcpMessage(
 
   switch (msg.method) {
     case 'initialize': {
+      // Capture the client's name for propose provenance.
+      const clientInfo = msg.params?.clientInfo as { name?: string } | undefined;
+      if (clientInfo?.name) session.clientName = clientInfo.name;
       const requested = str(msg.params?.protocolVersion);
       return ok({
         protocolVersion: requested || PROTOCOL_VERSION,
@@ -164,7 +204,9 @@ export async function handleMcpMessage(
       const tool = MCP_TOOLS.find((t) => t.name === name);
       if (!tool) return fail(-32602, `Unknown tool: ${name}`);
       const args = (msg.params?.arguments as Record<string, unknown>) ?? {};
-      const result = await tool.run(engine, args);
+      // Provenance for any write tool: `mcp:<client>` (decision #2 of the plan).
+      const proposedBy = `mcp:${session.clientName ?? 'unknown'}`;
+      const result = await tool.run(engine, args, { proposedBy });
       // Tool-level failures are reported as an MCP tool result with isError,
       // NOT a JSON-RPC error — the call itself succeeded; the tool returned a
       // problem the agent should see and can recover from.
@@ -194,6 +236,7 @@ export async function runMcpServer(
   } = {},
 ): Promise<void> {
   const engine = createEngine(projectContext(root), { embedder: opts.embedder });
+  const session: McpSession = {};
   const input = opts.input ?? process.stdin;
   const output = opts.output ?? process.stdout;
   const rl = readline.createInterface({ input, crlfDelay: Infinity });
@@ -215,7 +258,7 @@ export async function runMcpServer(
           write({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } });
           return;
         }
-        const response = await handleMcpMessage(msg, engine);
+        const response = await handleMcpMessage(msg, engine, session);
         if (response) write(response);
       });
     });

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -36,6 +36,9 @@ export interface RunOptions {
   /** Injectable embedder for `semantic`, so tests can run against a fake instead
    *  of loading the real WASM model. Defaults to the shared model embedder. */
   embedder?: ChunkEmbedder;
+  /** Note content piped on stdin — how `propose-note` receives the body (the
+   *  executable entry reads it; kept as data so `runCli` stays process-free). */
+  stdin?: string | undefined;
 }
 
 export const HELP = `minerva — headless access to a Minerva thoughtbase (#1149)
@@ -49,12 +52,15 @@ Commands:
   search <text>         Full-text search over notes.        [--limit <n>]
   semantic <text>       Semantic (embeddings) search over notes.  [--limit <n>]
   read <relative-path>  Print a note's raw markdown.
-  mcp                   Start a stdio MCP server exposing the read tools to
-                        agent clients (Claude Desktop, coding agents, …).
+  propose-note <path>   File a NEW note (body on stdin) as a pending proposal
+                        for review in Minerva.               [--by <client-id>]
+  mcp                   Start a stdio MCP server exposing the read + propose
+                        tools to agent clients (Claude Desktop, coding agents…).
 
 Options:
   --project <path>      Thoughtbase root (default: current directory).
   --limit <n>           Max results for search/semantic (default: 20).
+  --by <client-id>      Provenance for propose-note (default: cli).
   --help, -h            Show this help.
 
 Results are JSON on stdout, grounded with node IRIs / note paths so the output
@@ -66,6 +72,7 @@ interface ParsedArgs {
   positionals: string[];
   project: string | undefined;
   limit: number | undefined;
+  by: string | undefined;
   help: boolean;
 }
 
@@ -76,6 +83,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   let project: string | undefined;
   let limit: number | undefined;
+  let by: string | undefined;
   let help = false;
 
   for (let i = 0; i < argv.length; i++) {
@@ -90,12 +98,16 @@ export function parseArgs(argv: string[]): ParsedArgs {
       limit = Number(argv[++i]);
     } else if (arg.startsWith('--limit=')) {
       limit = Number(arg.slice('--limit='.length));
+    } else if (arg === '--by') {
+      by = argv[++i];
+    } else if (arg.startsWith('--by=')) {
+      by = arg.slice('--by='.length);
     } else {
       positionals.push(arg);
     }
   }
 
-  return { command: positionals.shift(), positionals, project, limit, help };
+  return { command: positionals.shift(), positionals, project, limit, by, help };
 }
 
 function json(value: unknown): string {
@@ -167,6 +179,21 @@ export async function runCli(argv: string[], opts: RunOptions): Promise<CliResul
       case 'read':
         if (!args.positionals[0]) throw new UsageError('read: a relative note path is required.');
         return format(await engine.read(args.positionals[0]), 'Error');
+      case 'propose-note': {
+        const rel = args.positionals[0];
+        if (!rel) throw new UsageError('propose-note: a relative note path is required.');
+        const content = opts.stdin ?? '';
+        if (!content.trim()) {
+          throw new UsageError(
+            'propose-note: pipe the note content on stdin, e.g. ' +
+              '`cat note.md | minerva propose-note notes/idea.md`.',
+          );
+        }
+        return format(
+          await engine.proposeNote({ relativePath: rel, content, proposedBy: args.by ?? 'cli' }),
+          'Error',
+        );
+      }
       default:
         return { stdout: '', stderr: `Unknown command: ${args.command}\n\n${HELP}\n`, code: 2 };
     }

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -51,7 +51,7 @@ describe('handleMcpMessage — handshake & discovery', () => {
     const r = await handleMcpMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, engine());
     const tools = (r?.result as { tools: { name: string; inputSchema: unknown }[] }).tools;
     expect(tools.map((t) => t.name).sort()).toEqual(
-      ['query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
+      ['propose_note', 'query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
     );
     for (const t of tools) expect(t.inputSchema).toHaveProperty('type', 'object');
   });
@@ -109,6 +109,70 @@ describe('handleMcpMessage — tools/call', () => {
   it('an unknown tool name is rejected (-32602)', async () => {
     const r = await call('destroy_everything', {});
     expect(r?.error?.code).toBe(-32602);
+  });
+});
+
+describe('handleMcpMessage — propose_note (write through the gate)', () => {
+  it('files a PENDING proposal stamped mcp:<client>, without writing the note', async () => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-mcp-propose-'));
+    try {
+      const eng = createEngine(projectContext(vault));
+      const session: { clientName?: string } = {};
+      // The initialize handshake carries the client name → propose provenance.
+      await handleMcpMessage(
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: { clientInfo: { name: 'claude-code' } } },
+        eng,
+        session,
+      );
+      const r = await handleMcpMessage(
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: {
+            name: 'propose_note',
+            arguments: { relative_path: 'ideas/spark.md', content: '# Spark\n\nA proposed idea.\n' },
+          },
+        },
+        eng,
+        session,
+      );
+      const result = r?.result as { content: { text: string }[]; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const out = JSON.parse(result.content[0].text);
+      expect(out.status).toBe('pending');
+      expect(out.proposedBy).toBe('mcp:claude-code');
+      expect(out.proposalUri).toBeTruthy();
+      // Pending — the note is NOT written to the vault.
+      expect(fs.existsSync(path.join(vault, 'ideas', 'spark.md'))).toBe(false);
+      // The proposal IS persisted to graph.ttl for the app's review queue.
+      const ttl = await fsp.readFile(path.join(vault, '.minerva', 'graph.ttl'), 'utf-8');
+      expect(ttl).toContain('Proposal');
+      expect(ttl).toContain('claude-code');
+    } finally {
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  it('stamps mcp:unknown when the client sent no name', async () => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-mcp-anon-'));
+    try {
+      const eng = createEngine(projectContext(vault));
+      const r = await handleMcpMessage(
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'propose_note', arguments: { relative_path: 'x.md', content: 'body' } },
+        },
+        eng,
+        {},
+      );
+      const out = JSON.parse((r?.result as { content: { text: string }[] }).content[0].text);
+      expect(out.proposedBy).toBe('mcp:unknown');
+    } finally {
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -190,6 +190,53 @@ describe('runCli read commands (#1149)', () => {
   });
 });
 
+describe('runCli propose-note (#1147 — write through the gate)', () => {
+  it('files a pending proposal, stamped, without writing the note file', async () => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-propose-'));
+    try {
+      const r = await runCli(['propose-note', 'notes/idea.md', '--by', 'cli'], {
+        cwd: vault,
+        stdin: '# Idea\n\nA proposed thought.\n',
+      });
+      expect(r.code).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.status).toBe('pending');
+      expect(out.proposedBy).toBe('cli');
+      expect(out.proposalUri).toBeTruthy();
+      // Pending → the note is NOT written.
+      expect(fs.existsSync(path.join(vault, 'notes', 'idea.md'))).toBe(false);
+      // The proposal is persisted for the app's review queue.
+      const ttl = await fsp.readFile(path.join(vault, '.minerva', 'graph.ttl'), 'utf-8');
+      expect(ttl).toContain('Proposal');
+      expect(ttl).toMatch(/pending/);
+    } finally {
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  it('requires the note body on stdin (exit 2)', async () => {
+    const r = await runCli(['propose-note', 'notes/x.md'], { cwd: root, stdin: '' });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('stdin');
+  });
+
+  it('a second proposal does not clobber the first (persistence safety)', async () => {
+    // The core risk of the whole propose path: filing #2 re-loads graph.ttl,
+    // so #1 must survive. Guards the initGraph → proposeWrite → persistGraph
+    // design against a store-reset regression.
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-propose2-'));
+    try {
+      await runCli(['propose-note', 'a.md'], { cwd: vault, stdin: '# A\n\nbody a\n' });
+      await runCli(['propose-note', 'b.md'], { cwd: vault, stdin: '# B\n\nbody b\n' });
+      const ttl = await fsp.readFile(path.join(vault, '.minerva', 'graph.ttl'), 'utf-8');
+      expect(ttl).toContain('Proposed note: a.md');
+      expect(ttl).toContain('Proposed note: b.md');
+    } finally {
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('runCli contract', () => {
   it('no command prints help with usage exit code 2', async () => {
     const r = await runCli([], { cwd: root });


### PR DESCRIPTION
The capability that makes the whole substrate vision **safe**: external agents (CLI + MCP clients) can contribute to the thoughtbase — but only as **pending proposals** through the same approval engine the built-in AI uses. Nothing touches the vault until a human approves it in Minerva's Proposals panel. *The LLM proposes, the human confirms* — extended to the whole fleet.

## What ships
- **Engine `proposeNote`** — files via `approval.proposeWrite` (`component_creation` → `requires_approval` → **pending**, never applied here). Wrapped in `withLLMContext`, so a regression that wrote directly (bypassing the gate) trips the fatal-under-test **write guard** — the trust invariant is enforced, not hoped for.
- **CLI `propose-note <path>`** — note body on **stdin**, `--by <id>` provenance (default `cli`). `cat draft.md | minerva propose-note notes/idea.md --by cli`.
- **MCP `propose_note` tool** — stamped `mcp:<client-name>`, captured from the `initialize` handshake. This realizes the plan's fleet-provenance design: the graph records *which agent* proposed *what*.
- The note file is **not** written and no note-content triples are added — only the pending proposal record persists to `graph.ttl` for the review queue, which the existing ProposalsPanel already renders (no new review UI needed).

## The persistence-safety crux
The read path's `indexAllNotes` **resets** the graph store — running it before a propose would drop existing proposals. So `proposeNote` deliberately uses `initGraph` (load the on-disk snapshot) → `proposeWrite` → `persistGraph`, and invalidates the read memo. The real risk is **clobbering**: filing proposal #2 re-loads `graph.ttl`, so #1 must survive. Guarded two ways:
- a **regression test** (two CLI proposals; both summaries present in `graph.ttl`), and
- **end-to-end across processes**: a CLI proposal survived an MCP proposal filed by a *separate* `minerva mcp` process → **2 pending proposals** in `graph.ttl`, each with the right `proposedBy` (`cli`, `mcp:browser-agent`).

## Coordination caveat (documented)
A proposal persists into `.minerva/graph.ttl`; if the app has the same vault open, both processes rewrite that file (last-writer-wins). Documented in `docs/cli.md` — file proposals when the app isn't actively editing; a running-app-aware write path is future work (per the plan).

## Verification
- E2E from the built bundle: CLI `propose-note` (pending, `proposedBy: cli`, note **not** written) and MCP `propose_note` (`proposedBy: mcp:browser-agent`).
- **35 cli/mcp tests**: pending + not-written + stamped + no-clobber + stdin contract + `mcp:unknown` fallback + tools/list now 6.
- Full suite **4031** green (write guard satisfied under the fatal test runner); `pnpm lint` clean.

## Scope
`propose-note` only (the wired `note` payload). Sources and richer primitives are follow-ups. Reads unchanged.

Docs: `docs/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)