### PR TITLE
cli/mcp: context handoff — a thoughtbase slice for agents (#1150)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,7 @@ repo's `node_modules` at runtime — no separate install.
 | `search <text>` | Full-text search over notes (`--limit <n>`, default 20) | `{ query, hits }` |
 | `semantic <text>` | Embeddings search over notes (`--limit <n>`) | `{ query, hits }` |
 | `read <relative-path>` | A note's raw markdown | `{ path, content }` |
+| `context <topic>` | A task-relevant slice: matching notes + link neighborhood + content (`--limit <n>`) | `{ topic, noteCount, notes[] }` |
 | `propose-note <path>` | File a new note (body on **stdin**) as a pending proposal (`--by <id>`) | `{ status, proposalUri, … }` |
 
 Global options: `--project <path>` (thoughtbase root, default: cwd), `--help`.
@@ -50,6 +51,21 @@ node .vite/build/cli.js search photosynthesis --project ~/vault | jq '.hits[].re
 node .vite/build/cli.js query \
   'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title' \
   --project ~/vault
+```
+
+## Context handoff
+
+`context <topic>` (MCP tool `gather_context`) is the one command that isn't a
+single lookup: it assembles a **task-relevant slice** an agent seeds its own
+context with. It full-text-retrieves the matching notes and expands each along the
+graph — its backlinks (what references it) and outgoing links (what it references)
+— returning each note's content plus that neighborhood as one bundle. A coding
+agent grounds itself in your design notes before writing; a browser agent checks
+what you already concluded before re-researching.
+
+```sh
+node .vite/build/cli.js context "retrieval augmented generation" --limit 5 --project ~/vault \
+  | jq '.notes[] | {path, backlinks: [.backlinks[].source]}'
 ```
 
 ## Proposing (writes go through the gate)
@@ -81,8 +97,9 @@ Desktop, a coding agent, an editor — can query the thoughtbase. It speaks
 newline-delimited JSON-RPC 2.0 and stays running until stdin closes.
 
 Tools: `query_graph`, `sql_query`, `search_notes`, `semantic_search`, `read_note`
-(reads, grounded JSON) and `propose_note` (files a pending proposal stamped
-`mcp:<client-name>` — see *Proposing* above).
+(reads, grounded JSON), `gather_context` (a topic slice — see *Context handoff*),
+and `propose_note` (files a pending proposal stamped `mcp:<client-name>` — see
+*Proposing* above).
 
 Point an MCP client at it (the client launches it as a subprocess):
 

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -45,6 +45,10 @@ export interface Engine {
   search(text: string, limit?: number): Promise<ExecResult>;
   semantic(text: string, limit?: number): Promise<ExecResult>;
   read(relativePath: string): Promise<ExecResult>;
+  /** Assemble a task-relevant slice of the thoughtbase for a topic: the matching
+   *  notes plus their link neighborhood and full content, as one bundle an
+   *  external agent can seed its own context with (#1150). */
+  context(topic: string, limit?: number): Promise<ExecResult>;
   /** File a NEW note as a pending proposal through the approval gate. Never
    *  writes the vault directly — a human approves it in Minerva. */
   proposeNote(input: ProposeNoteInput): Promise<ExecResult>;
@@ -121,6 +125,50 @@ export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Eng
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
+    },
+
+    async context(topic, limit) {
+      const t = topic?.trim();
+      if (!t) return { ok: false, error: 'A topic is required.' };
+      const n = limit && limit > 0 ? limit : 5;
+      // Full-text retrieval (reliable, no model load), then expand each hit along
+      // its graph edges. Both indexes are needed: search for retrieval, graph for
+      // the link neighborhood + note content grounding.
+      await ensureSearch();
+      await ensureGraph();
+      const hits = search.search(ctx, t, { limit: n });
+      const notes = await Promise.all(
+        hits.map(async (h) => {
+          let content = '';
+          try {
+            content = await readFile(ctx.rootPath, h.relativePath);
+          } catch {
+            // A hit whose file vanished between index and read — skip its body,
+            // keep the neighborhood.
+          }
+          return {
+            path: h.relativePath,
+            title: h.title,
+            score: h.score,
+            snippet: h.snippet,
+            content,
+            // "Linked from" — notes that reference this one.
+            backlinks: graph.backlinks(ctx, h.relativePath).map((b) => ({
+              source: b.source,
+              sourceTitle: b.sourceTitle,
+              linkType: b.linkType,
+            })),
+            // "Links to" — what this note references.
+            outgoingLinks: graph.outgoingLinks(ctx, h.relativePath).map((o) => ({
+              target: o.target,
+              targetTitle: o.targetTitle,
+              linkType: o.linkType,
+              exists: o.exists,
+            })),
+          };
+        }),
+      );
+      return { ok: true, data: { topic: t, noteCount: notes.length, notes } };
     },
 
     async proposeNote(input) {

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -134,6 +134,24 @@ export const MCP_TOOLS: McpTool[] = [
     run: (engine, args) => engine.read(str(args.relative_path)),
   },
   {
+    name: 'gather_context',
+    description:
+      'Assemble a task-relevant SLICE of the thoughtbase for a topic — the matching notes ' +
+      'plus their link neighborhood (what links to them, what they link to) and full ' +
+      'content — as one bundle to seed your own context. Use this before researching or ' +
+      "writing, to ground yourself in what the user already knows. Prefer this over " +
+      'several separate reads when you need a topic overview.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        topic: { type: 'string', description: 'The topic / question to gather context about.' },
+        limit: { type: 'number', description: 'Max notes in the slice (default 5).' },
+      },
+      required: ['topic'],
+    },
+    run: (engine, args) => engine.context(str(args.topic), num(args.limit)),
+  },
+  {
     name: 'propose_note',
     description:
       'Propose a NEW note for the thoughtbase. IMPORTANT: this does NOT write to the ' +

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -52,6 +52,8 @@ Commands:
   search <text>         Full-text search over notes.        [--limit <n>]
   semantic <text>       Semantic (embeddings) search over notes.  [--limit <n>]
   read <relative-path>  Print a note's raw markdown.
+  context <topic>       Assemble a relevant slice — matching notes + their link
+                        neighborhood + content — as agent context.  [--limit <n>]
   propose-note <path>   File a NEW note (body on stdin) as a pending proposal
                         for review in Minerva.               [--by <client-id>]
   mcp                   Start a stdio MCP server exposing the read + propose
@@ -179,6 +181,9 @@ export async function runCli(argv: string[], opts: RunOptions): Promise<CliResul
       case 'read':
         if (!args.positionals[0]) throw new UsageError('read: a relative note path is required.');
         return format(await engine.read(args.positionals[0]), 'Error');
+      case 'context':
+        if (!rest.trim()) throw new UsageError('context: a topic is required.');
+        return format(await engine.context(rest, args.limit), 'Error');
       case 'propose-note': {
         const rel = args.positionals[0];
         if (!rel) throw new UsageError('propose-note: a relative note path is required.');

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -51,7 +51,7 @@ describe('handleMcpMessage — handshake & discovery', () => {
     const r = await handleMcpMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, engine());
     const tools = (r?.result as { tools: { name: string; inputSchema: unknown }[] }).tools;
     expect(tools.map((t) => t.name).sort()).toEqual(
-      ['propose_note', 'query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
+      ['gather_context', 'propose_note', 'query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
     );
     for (const t of tools) expect(t.inputSchema).toHaveProperty('type', 'object');
   });
@@ -109,6 +109,17 @@ describe('handleMcpMessage — tools/call', () => {
   it('an unknown tool name is rejected (-32602)', async () => {
     const r = await call('destroy_everything', {});
     expect(r?.error?.code).toBe(-32602);
+  });
+
+  it('gather_context returns a slice: matching notes with content and neighborhood', async () => {
+    const r = await call('gather_context', { topic: 'photosynthesis' });
+    const parsed = JSON.parse((r?.result as { content: { text: string }[] }).content[0].text);
+    expect(parsed.topic).toBe('photosynthesis');
+    const hit = parsed.notes.find((n: { path: string }) => n.path === 'photosynthesis.md');
+    expect(hit).toBeTruthy();
+    expect(hit.content).toContain('chemical energy');
+    expect(Array.isArray(hit.backlinks)).toBe(true);
+    expect(Array.isArray(hit.outgoingLinks)).toBe(true);
   });
 });
 

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -190,6 +190,49 @@ describe('runCli read commands (#1149)', () => {
   });
 });
 
+describe('runCli context (#1150 — thoughtbase slice for handoff)', () => {
+  it('assembles matching notes with content + link neighborhood (both directions)', async () => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-context-'));
+    try {
+      await fsp.mkdir(path.join(vault, 'notes'), { recursive: true });
+      await fsp.writeFile(
+        path.join(vault, 'notes', 'energy.md'),
+        '# Energy\n\nCellular energy comes from [[mitochondria]].\n',
+        'utf-8',
+      );
+      await fsp.writeFile(
+        path.join(vault, 'notes', 'mitochondria.md'),
+        '# Mitochondria\n\nThe powerhouse of the cell.\n',
+        'utf-8',
+      );
+      const r = await runCli(['context', 'mitochondria'], { cwd: vault });
+      expect(r.code).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.topic).toBe('mitochondria');
+      expect(out.noteCount).toBeGreaterThan(0);
+
+      const mito = out.notes.find((n: { path: string }) => n.path === 'notes/mitochondria.md');
+      expect(mito).toBeTruthy();
+      expect(mito.content).toContain('powerhouse');
+      // energy.md links [[mitochondria]] → appears as a backlink of mitochondria.
+      expect(mito.backlinks.map((b: { source: string }) => b.source)).toContain('notes/energy.md');
+
+      const energy = out.notes.find((n: { path: string }) => n.path === 'notes/energy.md');
+      if (energy) {
+        // …and mitochondria appears among energy's outgoing links.
+        expect(energy.outgoingLinks.map((o: { target: string }) => o.target)).toContain('notes/mitochondria.md');
+      }
+    } finally {
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  it('requires a topic (exit 2)', async () => {
+    const r = await runCli(['context'], { cwd: root });
+    expect(r.code).toBe(2);
+  });
+});
+
 describe('runCli propose-note (#1147 — write through the gate)', () => {
   it('files a pending proposal, stamped, without writing the note file', async () => {
     const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-propose-'));


### PR DESCRIPTION
The distinction from plain Read (#1146): *Read* answers one question; **context handoff** assembles a coherent, task-relevant **slice** an external agent seeds its own context with. A coding agent grounds itself in the user's design notes before writing; a browser agent checks what the user already concluded before re-researching.

## What ships
`context <topic>` (CLI) / `gather_context` (MCP tool):
1. Full-text-retrieves the notes matching the topic.
2. Expands each along the graph — **backlinks** (what references it) + **outgoing links** (what it references).
3. Returns each note's **content** plus that neighborhood as one grounded bundle: `{ topic, noteCount, notes: [{ path, title, score, snippet, content, backlinks, outgoingLinks }] }`.

Composed entirely from existing primitives — `search.search` + `graph.backlinks`/`graph.outgoingLinks` + `readFile`. No new core, exactly as the plan predicted (this is expansion of the read layer, not new machinery).

## Design choice: full-text retrieval
Retrieval is full-text (reliable, fast, **no embedding-model load**); the graph-neighborhood expansion is the distinctive value over a plain read. Semantic-augmented retrieval is a clean future add (the primitive is already there) but would cost a model load per call — not worth it for the default.

## Verification
End-to-end from the built bundle (CLI + MCP over stdio): a slice for `"mitochondria"` correctly surfaced the note **plus its backlink** from `energy.md`, and `energy.md`'s **outgoing links** to both neighbors:
```
• notes/mitochondria.md  ⟵backlinks:[notes/energy.md]  ⟶links:[]
• notes/energy.md        ⟵backlinks:[]  ⟶links:[notes/mitochondria.md, notes/electron-transport-chain.md]
```
**38 cli/mcp tests** (bidirectional neighborhood assertion, topic-required contract, MCP tool + `tools/list` now 7); full suite **4034** green; `pnpm lint` clean.

Docs: `docs/cli.md` (Context handoff section).

## Substrate epic
Leaves only **#1151** (fleet provenance — an audit view over the `mcp:` `proposedBy` namespace; storage already exists from #1147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)