### PR TITLE
provenance: attribute + surface the fleet's contributions (#1151)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,13 @@ cat draft.md | node .vite/build/cli.js propose-note notes/idea.md --by cli --pro
 `mcp:<client-name>` from the initialize handshake. The note body comes from
 **stdin**, so it composes with anything upstream.
 
+**Provenance for the fleet.** Every proposal is attributed by `proposedBy`, so the
+graph is an audit log of who contributed what. In Minerva, the Proposals panel
+labels external agents distinctly from the built-in AI, and the *Contributions by
+agent* stock query (Graph → Query) groups proposals by proposer. Attribution
+survives a graph reindex, so a proposal filed while the app is closed still shows
+up (and stays attributed) once it reopens.
+
 > **Coordination caveat.** A proposal is persisted into `.minerva/graph.ttl`. If
 > Minerva has the same vault open, both processes rewrite that file, so it's
 > last-writer-wins — file proposals when the app isn't actively editing the graph,

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -1141,10 +1141,34 @@ function ensureProject(state: GraphState): void {
   }
 }
 
+/**
+ * Statements describing every `thought:Proposal` in the store. Proposals are the
+ * review queue's source of truth and are NOT rebuilt from notes, so a
+ * from-scratch reindex must carry them across the reset — otherwise the queue
+ * empties on every rebuild and a CLI/MCP-filed proposal (persisted in graph.ttl)
+ * would be dropped the moment the app next indexes, before the user ever sees it
+ * (#1151, epic #1145 — substrate/fleet provenance).
+ */
+function captureProposalStatements(store: $rdf.IndexedFormula): $rdf.Statement[] {
+  const out: $rdf.Statement[] = [];
+  for (const typed of store.statementsMatching(undefined, RDF('type'), THOUGHT('Proposal'))) {
+    // Proposals are flat records — every triple on the proposal subject.
+    out.push(...store.statementsMatching(typed.subject, undefined, undefined));
+  }
+  return out;
+}
+
+function restoreProposalStatements(store: $rdf.IndexedFormula, stmts: $rdf.Statement[]): void {
+  for (const st of stmts) store.add(st.subject, st.predicate, st.object);
+}
+
 export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
   const state = getState(ctx);
   if (!state) return 0;
   const { rootPath } = state;
+
+  // Carry proposals across the from-scratch reset below (see the helper's note).
+  const preservedProposals = captureProposalStatements(state.store);
 
   // Reset and rebuild from scratch with ontology
   state.store = $rdf.graph();
@@ -1155,6 +1179,7 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
   state.indexedNotePaths.clear();
 
   ensureProject(state);
+  restoreProposalStatements(state.store, preservedProposals);
 
   // Two-pass build (#469): the first walk just reads frontmatter
   // aliases so the alias map is fully populated before any link gets

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -2,6 +2,7 @@
   import { api } from '../../ipc/client';
   import { onMount } from 'svelte';
   import Ribbon from './Ribbon.svelte';
+  import { describeProposer } from '../../../../shared/provenance';
 
   type NotePayload = { kind: 'note'; relativePath: string; content: string };
   type TriplesPayload = { kind: 'graph-triples'; turtle: string; affectsNodeUris: string[] };
@@ -251,6 +252,7 @@
   {:else}
     <div class="proposal-list">
       {#each shown() as p}
+        {@const by = describeProposer(p.proposedBy)}
         <button
           class="proposal-item"
           class:selected={selectedUri === p.uri}
@@ -259,7 +261,9 @@
           <span class="proposal-meta">
             <span class="proposal-status status-{p.status}">{p.status}</span>
             <span class="proposal-type">{p.operationType.replace(/_/g, ' ')}</span>
-            <span class="proposal-by">{p.proposedBy}</span>
+            <span class="proposal-by" class:external={by.external} title={p.proposedBy}>
+              {#if by.external}<span class="by-tag">agent</span>{/if}{by.label}
+            </span>
           </span>
           <span class="proposal-note">{p.note}</span>
           <span class="proposal-effects" title="What approving this proposal will create">
@@ -420,9 +424,33 @@
   }
   .proposal-by {
     margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     font-family: var(--font-mono);
     font-size: 10px;
     color: var(--text-faint);
+    max-width: 12em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* A contribution from a fleet agent (MCP client / CLI), not Minerva's own AI —
+     surfaced so the reviewer sees at a glance who proposed it (#1151). */
+  .proposal-by.external {
+    color: var(--accent);
+  }
+  .by-tag {
+    font-family: var(--font-sans, inherit);
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0 4px;
+    border-radius: 3px;
+    background: var(--bg-button, var(--bg-elev));
+    color: var(--accent);
+    border: 1px solid var(--accent);
   }
 
   .proposal-note {

--- a/src/shared/provenance.ts
+++ b/src/shared/provenance.ts
@@ -1,0 +1,54 @@
+/**
+ * Human-readable attribution for a proposal's `proposedBy` stamp (#1151, epic
+ * #1145 — Substrate: provenance for the fleet).
+ *
+ * Every proposal carries a free-form `thought:proposedBy` string. Minerva's own
+ * AI writes `llm:*` (`llm:conversation:<id>`, `llm:auto-tag`, …); external fleet
+ * agents write `mcp:<client>` (an MCP client, named from its initialize
+ * handshake) or `cli` (the headless CLI / scripts). This turns that convention
+ * into a legible label plus an internal-vs-external distinction, so the review
+ * queue and audit views can show *who* contributed *what* — the whole point of
+ * "the graph is the audit log of the entourage's contributions."
+ */
+export type ProposerKind = 'internal' | 'external' | 'cli' | 'unknown';
+
+export interface ProposerInfo {
+  /** The raw `proposedBy` stamp, verbatim. */
+  raw: string;
+  kind: ProposerKind;
+  /** The specific agent/source, e.g. 'claude-code', 'Minerva AI', 'CLI'. */
+  agent: string;
+  /** Short label for display. */
+  label: string;
+  /** True for anything outside Minerva's own AI — i.e. a fleet member. */
+  external: boolean;
+}
+
+const MCP_PREFIX = 'mcp:';
+const LLM_PREFIX = 'llm:';
+
+export function describeProposer(proposedBy: string | null | undefined): ProposerInfo {
+  const raw = proposedBy ?? '';
+
+  // External MCP client — `mcp:<client-name>`, the name from its initialize
+  // handshake (e.g. `mcp:claude-code`, `mcp:browser-agent`).
+  if (raw.startsWith(MCP_PREFIX)) {
+    const agent = raw.slice(MCP_PREFIX.length).trim() || 'unknown';
+    return { raw, kind: 'external', agent, label: agent, external: true };
+  }
+
+  // The headless CLI / scripts.
+  if (raw === 'cli' || raw.startsWith('cli:')) {
+    return { raw, kind: 'cli', agent: 'CLI', label: 'CLI', external: true };
+  }
+
+  // Minerva's built-in AI — `llm:conversation:<id>`, `llm:auto-tag`, …
+  if (raw.startsWith(LLM_PREFIX)) {
+    return { raw, kind: 'internal', agent: 'Minerva AI', label: 'Minerva AI', external: false };
+  }
+
+  // Anything else (an empty stamp, a test harness like `e2e`): show as-is, and
+  // don't claim it's a fleet agent.
+  const shown = raw || 'unknown';
+  return { raw, kind: 'unknown', agent: shown, label: shown, external: false };
+}

--- a/src/shared/stock-queries.ts
+++ b/src/shared/stock-queries.ts
@@ -243,6 +243,19 @@ SELECT ?proposal ?note ?operationType ?proposedBy ?proposedAt WHERE {
 ORDER BY ?proposedAt`,
   },
   {
+    name: 'Contributions by agent',
+    description: "Every proposal grouped by who proposed it — the fleet audit log (mcp:… are external agents, llm:… is Minerva's own AI)",
+    language: 'sparql',
+    query: `${PREFIXES}
+SELECT ?proposedBy ?status (COUNT(?proposal) AS ?count) WHERE {
+  ?proposal rdf:type thought:Proposal .
+  ?proposal thought:proposedBy ?proposedBy .
+  ?proposal thought:proposalStatus ?status .
+}
+GROUP BY ?proposedBy ?status
+ORDER BY ?proposedBy ?status`,
+  },
+  {
     name: 'Conversation history',
     description: 'All recorded conversations with their status and trigger',
     language: 'sparql',

--- a/tests/main/graph/proposals-survive-reindex.test.ts
+++ b/tests/main/graph/proposals-survive-reindex.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Proposals survive a full reindex (#1151, epic #1145 — Substrate).
+ *
+ * `indexAllNotes` rebuilds the graph store from scratch. Proposals aren't derived
+ * from notes — they live only in graph.ttl and the live store — so the rebuild
+ * must carry them across, or the review queue empties on every reindex and any
+ * CLI/MCP-filed proposal is dropped before the user ever reviews it. This is the
+ * last mile that makes external (fleet) proposals actually reach Minerva.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import * as graph from '../../../src/main/graph/index';
+import * as approval from '../../../src/main/llm/approval';
+import { projectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+
+afterEach(async () => {
+  if (root) await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('proposals survive indexAllNotes (#1151)', () => {
+  it('a persisted proposal is still in the queue after an app-style reopen', async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-reindex-'));
+    const ctx = projectContext(root);
+
+    // File a proposal (as the CLI/MCP propose path does) and persist to graph.ttl.
+    await graph.initGraph(ctx);
+    await graph.withLLMContext(() =>
+      approval.proposeWrite(ctx, {
+        operationType: 'component_creation',
+        payloads: [{ kind: 'note', relativePath: 'x.md', content: '# X\n\nbody' }],
+        note: 'from an external agent',
+        proposedBy: 'mcp:claude-code',
+      }),
+    );
+    await graph.persistGraph(ctx);
+    graph.disposeProject(ctx);
+
+    // Simulate an app open: initGraph (load snapshot) THEN indexAllNotes (rebuild).
+    await graph.initGraph(ctx);
+    await graph.indexAllNotes(ctx);
+
+    const proposals = await approval.listProposals(ctx);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.proposedBy).toBe('mcp:claude-code');
+    expect(proposals[0]!.status).toBe('pending');
+  });
+
+  it('a session proposal survives a manual rebuild (indexAllNotes again)', async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-reindex2-'));
+    const ctx = projectContext(root);
+    await graph.initGraph(ctx);
+    await graph.indexAllNotes(ctx);
+    await graph.withLLMContext(() =>
+      approval.proposeWrite(ctx, {
+        operationType: 'component_creation',
+        payloads: [{ kind: 'note', relativePath: 'y.md', content: '# Y\n\nbody' }],
+        note: 'session proposal',
+        proposedBy: 'llm:conversation:abc',
+      }),
+    );
+    // A manual "rebuild graph" must not silently drop the pending proposal.
+    await graph.indexAllNotes(ctx);
+    const proposals = await approval.listProposals(ctx);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.proposedBy).toBe('llm:conversation:abc');
+  });
+});

--- a/tests/shared/provenance.test.ts
+++ b/tests/shared/provenance.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Fleet-provenance attribution (#1151). Pins the mapping from a proposal's
+ * `proposedBy` stamp to a legible, internal-vs-external label.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeProposer } from '../../src/shared/provenance';
+
+describe('describeProposer', () => {
+  it('names an external MCP client from its handshake name', () => {
+    const info = describeProposer('mcp:claude-code');
+    expect(info.kind).toBe('external');
+    expect(info.agent).toBe('claude-code');
+    expect(info.label).toBe('claude-code');
+    expect(info.external).toBe(true);
+  });
+
+  it('falls back to "unknown" for an unnamed MCP client', () => {
+    const info = describeProposer('mcp:');
+    expect(info.kind).toBe('external');
+    expect(info.agent).toBe('unknown');
+    expect(info.external).toBe(true);
+  });
+
+  it('labels the headless CLI as external', () => {
+    expect(describeProposer('cli')).toMatchObject({ kind: 'cli', label: 'CLI', external: true });
+  });
+
+  it('collapses every llm:* stamp to the internal Minerva AI', () => {
+    for (const raw of ['llm:conversation:abc123', 'llm:auto-tag', 'llm:auto-link-inbound']) {
+      const info = describeProposer(raw);
+      expect(info.kind).toBe('internal');
+      expect(info.label).toBe('Minerva AI');
+      expect(info.external).toBe(false);
+    }
+  });
+
+  it('shows an unrecognised stamp as-is, not flagged external', () => {
+    expect(describeProposer('e2e')).toMatchObject({ kind: 'unknown', label: 'e2e', external: false });
+  });
+
+  it('handles an empty / missing stamp without throwing', () => {
+    expect(describeProposer('')).toMatchObject({ label: 'unknown', external: false });
+    expect(describeProposer(null)).toMatchObject({ label: 'unknown', external: false });
+    expect(describeProposer(undefined)).toMatchObject({ label: 'unknown', external: false });
+  });
+
+  it('preserves the raw stamp for search / tooltips', () => {
+    expect(describeProposer('mcp:browser-agent').raw).toBe('mcp:browser-agent');
+  });
+});


### PR DESCRIPTION
The **closer** for the Substrate epic (#1145): the thoughtbase becomes an audit log of *which agent contributed what*. Every proposal is already stamped `proposedBy` (#1147 — `mcp:<client>`, `cli`, vs internal `llm:*`); this makes that attribution **legible, queryable, and durable**.

## What ships
- **`shared/provenance.ts` `describeProposer()`** — a pure mapping from a `proposedBy` stamp to a legible label + internal/external distinction (`mcp:`/`cli` → external fleet agent; `llm:*` → Minerva AI). Fully unit-tested.
- **ProposalsPanel** renders it: external contributions get an **"agent" tag + accent** so the reviewer sees *who* proposed *what* at approval time — not a raw `mcp:claude-code` string.
- **Stock query "Contributions by agent"** — groups proposals by proposer + status: the fleet audit log, sibling to the existing "Pending proposals".

## The last-mile fix that makes it real
While building this I found a gap that quietly hollowed out the whole propose→review loop: **`indexAllNotes` wiped proposals.** It rebuilds the graph store from notes, and proposals aren't note-derived — so every reindex (each project open, every manual rebuild) emptied the review queue, and a CLI/MCP-filed proposal was dropped before the user ever saw it. A probe confirmed it (`before: 1, after: 0`).

`indexAllNotes` now **captures and restores proposal records across the reset**. Without this, #1147 and this issue were both facades — external proposals never reached Minerva, and any audit log was erased on reindex.

## Verification
End-to-end from the built bundle: two agents (`cli`, `mcp:claude-code`) proposed notes, then the *Contributions by agent* query — run **after** the reindex it triggers — returned both, attributed:
```
cli              —  1 pending
mcp:claude-code  —  1 pending
```
**47 tests**: `describeProposer` (external/internal/cli/unknown/empty), `proposals-survive-reindex` (app-reopen **and** manual-rebuild paths), cli/mcp. Full suite **4043** green; `pnpm lint` clean.

## Epic #1145 — complete
This is the last child. The substrate is real end-to-end: an external agent can query the thoughtbase (#1146/#1149), pull a context slice (#1150), and propose back through the gate (#1147) — attributed, reviewable, and durable (#1151) — with the conversation layer provider-agnostic underneath (#1148).

Docs: `docs/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)