### PR TITLE
skills: break the type-only cycle skills/types.ts ↔ menu-config.ts (#1091)

### DIFF
--- a/src/shared/skills/menu-config.ts
+++ b/src/shared/skills/menu-config.ts
@@ -21,25 +21,12 @@
  */
 
 import { type SkillMenu, SKILL_MENUS } from './types';
+import type { MenuConfig, MenuItemLike, SkillSetting } from './types';
 
-/** Per-skill override. Both fields are explicit once the user touches a skill. */
-export interface SkillSetting {
-  enabled: boolean;
-  menu: SkillMenu;
-}
-
-export interface MenuConfig {
-  /** id → override. Absent id = enabled, declared menu. */
-  skills: Record<string, SkillSetting>;
-  /** menu → ordered skill ids. Ids absent from the array sort last (appended). */
-  order: Record<SkillMenu, string[]>;
-}
-
-/** Minimal item shape the ordering functions need (SkillDef and SkillInfo both fit). */
-export interface MenuItemLike {
-  id: string;
-  menu: SkillMenu;
-}
+// The config type shapes moved to the leaf `types.ts` to break the type-only
+// cycle (#1091); re-exported here so existing `from './menu-config'` importers
+// keep working unchanged.
+export type { MenuConfig, MenuItemLike, SkillSetting } from './types';
 
 export function emptyMenuConfig(): MenuConfig {
   return {

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -15,11 +15,35 @@ import type {
   ToolParameter,
   ToolScope,
 } from '../tools/types';
-import type { MenuConfig } from './menu-config';
 
 export type SkillMenu = 'Learning' | 'Research' | 'Analysis';
 
 export const SKILL_MENUS: readonly SkillMenu[] = ['Learning', 'Research', 'Analysis'];
+
+// ── Menu config (#630) ───────────────────────────────────────────────────────
+// The per-machine menu-config shapes live here, in the leaf type module, rather
+// than in `menu-config.ts` (which holds the pure logic that operates on them).
+// `menu-config.ts` already imports SkillMenu from here; defining these types
+// here too removes the type-only back-edge that formed a cycle (#1091).
+
+/** Per-skill override. Both fields are explicit once the user touches a skill. */
+export interface SkillSetting {
+  enabled: boolean;
+  menu: SkillMenu;
+}
+
+export interface MenuConfig {
+  /** id → override. Absent id = enabled, declared menu. */
+  skills: Record<string, SkillSetting>;
+  /** menu → ordered skill ids. Ids absent from the array sort last (appended). */
+  order: Record<SkillMenu, string[]>;
+}
+
+/** Minimal item shape the ordering functions need (SkillDef and SkillInfo both fit). */
+export interface MenuItemLike {
+  id: string;
+  menu: SkillMenu;
+}
 
 /** Skill `menu:` (display-cased) ↔ the registry's lowercase ToolCategory. */
 export function menuToCategory(menu: SkillMenu): ToolCategory {


### PR DESCRIPTION
Closes #1091.

## What

`shared/skills/types.ts` imported `MenuConfig` (type-only) from `menu-config.ts`, which imports `SkillMenu`/`SKILL_MENUS` from `types.ts` — a type-only circular dependency. It's erased at compile so there's no runtime cycle, but it was the **only** cycle madge reported across the 592-module graph.

The three config shapes (`MenuConfig`, `SkillSetting`, `MenuItemLike`) only depend on `SkillMenu`, which already lives in `types.ts`. Moving them there removes the back-edge cleanly:

- **`types.ts`** (leaf) now defines the config shapes alongside `SkillMenu`; no longer imports `menu-config.ts`.
- **`menu-config.ts`** keeps the pure logic, imports the types back, and re-exports them so every existing `from './menu-config'` importer (client.ts, register-tools.ts, tests) is unchanged.

## Verification

- [x] `madge --circular` reports **no circular dependency** across the project (was 1)
- [x] `pnpm lint` passes
- [x] menu-config + SkillsSettings tests pass; full `pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)