### PR TITLE
ipc: standardize window-needing handlers on withRootPathWin (#1092)

### DIFF
--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -52,6 +52,25 @@ export function withRootPathOr<A extends unknown[], R>(
   };
 }
 
+/**
+ * Like {@link withRootPath}, but also hands the handler its {@link BrowserWindow}.
+ * The many handlers that resolve a project and then broadcast a change back to
+ * the renderer (or open a dialog anchored to the window) still need the event;
+ * #990's `withRootPath` dropped it, so those handlers kept hand-rolling the
+ * `rootPathFromEvent(e)` + `if (!rootPath) throw` guard. This finishes that
+ * consolidation for the window-needing handlers (#1092). Throws "No project
+ * open" when there's no project — same contract as `withRootPath`.
+ */
+export function withRootPathWin<A extends unknown[], R>(
+  fn: (rootPath: string, win: BrowserWindow, ...args: A) => R,
+): (e: Electron.IpcMainInvokeEvent, ...args: A) => R {
+  return (e, ...args) => {
+    const rootPath = rootPathFromEvent(e);
+    if (!rootPath) throw new Error('No project open');
+    return fn(rootPath, winFromEvent(e), ...args);
+  };
+}
+
 export async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
   if (!isIndexable(relativePath)) return;
   const content = await notebaseFs.readFile(rootPath, relativePath);

--- a/src/main/ipc/register-bibliography.ts
+++ b/src/main/ipc/register-bibliography.ts
@@ -23,7 +23,7 @@ import {
   USER_LOCALES_DIR,
 } from '../publish/csl/user-assets';
 import { renderInlineCitations, type InlineCiteRequest, type InlineCiteResponse } from '../citations/render-inline';
-import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr, hooks } from './helpers';
+import { rootPathFromEvent, withRootPath, withRootPathOr, withRootPathWin, hooks } from './helpers';
 
 export function registerBibliography(): void {
   // Bibliography (#113)
@@ -67,10 +67,7 @@ export function registerBibliography(): void {
       filePath: l.filePath,
     }));
   }));
-  ipcMain.handle(Channels.CSL_IMPORT_STYLE, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-    const win = winFromEvent(e);
+  ipcMain.handle(Channels.CSL_IMPORT_STYLE, withRootPathWin(async (rootPath, win) => {
     const result = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
       filters: [{ name: 'CSL style', extensions: ['csl', 'xml'] }],
@@ -90,11 +87,8 @@ export function registerBibliography(): void {
     const destPath = path.join(destDir, `${id}.csl`);
     await fs.writeFile(destPath, xml, 'utf-8');
     return { id, label: extractStyleTitle(xml) ?? id, filePath: destPath };
-  });
-  ipcMain.handle(Channels.CSL_IMPORT_LOCALE, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-    const win = winFromEvent(e);
+  }));
+  ipcMain.handle(Channels.CSL_IMPORT_LOCALE, withRootPathWin(async (rootPath, win) => {
     const result = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
       filters: [{ name: 'CSL locale', extensions: ['xml'] }],
@@ -114,7 +108,7 @@ export function registerBibliography(): void {
     const destPath = path.join(destDir, `${id}.xml`);
     await fs.writeFile(destPath, xml, 'utf-8');
     return { id, filePath: destPath };
-  });
+  }));
   ipcMain.handle(Channels.CSL_REMOVE_STYLE, withRootPath(async (rootPath, id: string) => {
     if (!/^[a-z0-9_-]+$/i.test(id)) throw new Error('Invalid style id.');
     const target = path.join(rootPath, USER_STYLES_DIR, `${id}.csl`);

--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -10,7 +10,7 @@ import {
   removePublishTarget,
   type PublishTarget,
 } from '../project-config';
-import { rootPathFromEvent, winFromEvent, withRootPath } from './helpers';
+import { withRootPath, withRootPathWin } from './helpers';
 
 export function registerPublish(): void {
   // ── Publication (#282) ─────────────────────────────────────────────────────
@@ -83,15 +83,12 @@ export function registerPublish(): void {
     };
   }));
 
-  ipcMain.handle(Channels.PUBLISH_RUN_EXPORT, async (e, args: Omit<publish.RunExportInput, 'outputDir'> & { outputDir?: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.PUBLISH_RUN_EXPORT, withRootPathWin(async (rootPath, win, args: Omit<publish.RunExportInput, 'outputDir'> & { outputDir?: string }) => {
     let outputDir = args.outputDir;
     // When the renderer doesn't pass an outputDir, open a directory
     // picker here. Parents the dialog to the invoking window so it
     // behaves as a modal rather than a floating sheet.
     if (!outputDir) {
-      const win = winFromEvent(e);
       const result = await dialog.showOpenDialog(win, {
         properties: ['openDirectory', 'createDirectory'],
         title: 'Choose export destination',
@@ -101,7 +98,7 @@ export function registerPublish(): void {
       outputDir = result.filePaths[0]!;
     }
     return await publish.runExport(rootPath, { ...args, outputDir });
-  });
+  }));
 
   // ── Publish → git remote (#254) ────────────────────────────────────────────
 

--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog } from 'electron';
+import { ipcMain, dialog, BrowserWindow } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
@@ -39,7 +39,7 @@ import { importBibtex } from '../sources/import-bibtex';
 import { importZoteroRdf } from '../sources/import-zotero-rdf';
 import { getExcerptNoteFolder, setExcerptNoteFolder } from '../project-config';
 import { createExcerpt } from '../sources/create-excerpt';
-import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr, reindexFile, persistIndexes } from './helpers';
+import { withRootPath, withRootPathOr, withRootPathWin, reindexFile, persistIndexes } from './helpers';
 
 export function registerSources(): void {
   ipcMain.handle(Channels.SOURCES_INGEST_URL, withRootPath(async (rootPath, url: string) => {
@@ -70,39 +70,30 @@ export function registerSources(): void {
     return await mineSourceReferences(rootPath, sourceId);
   }));
 
-  ipcMain.handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, async (e, params: { sourceId: string; refs: ParsedReference[] }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, withRootPathWin(async (rootPath, win, params: { sourceId: string; refs: ParsedReference[] }) => {
     const result = await createReferenceStubs(rootPath, params.sourceId, params.refs);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
     return result;
-  });
+  }));
 
   ipcMain.handle(Channels.SOURCES_RESOLVE_STUB, withRootPath(async (rootPath, sourceId: string) => {
     return await resolveStub(rootPath, sourceId, { fetchImpl: privilegedFetch });
   }));
 
-  ipcMain.handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, async (e, params: { sourceId: string; doi: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, withRootPathWin(async (rootPath, win, params: { sourceId: string; doi: string }) => {
     const ok = await applyStubResolution(rootPath, params.sourceId, params.doi, { fetchImpl: privilegedFetch });
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
     return { ok };
-  });
+  }));
 
   ipcMain.handle(Channels.INGEST_GET_SETTINGS, () => getIngestSettings());
   ipcMain.handle(Channels.INGEST_SET_SETTINGS, (_e, settings: IngestSettings) =>
     saveIngestSettings(settings),
   );
 
-  ipcMain.handle(Channels.SOURCES_IMPORT_BIBTEX, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-    const win = winFromEvent(e);
+  ipcMain.handle(Channels.SOURCES_IMPORT_BIBTEX, withRootPathWin(async (rootPath, win) => {
     const result = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
       filters: [{ name: 'BibTeX', extensions: ['bib', 'bibtex'] }],
@@ -117,12 +108,9 @@ export function registerSources(): void {
         }
       },
     });
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_IMPORT_ZOTERO_RDF, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-    const win = winFromEvent(e);
+  ipcMain.handle(Channels.SOURCES_IMPORT_ZOTERO_RDF, withRootPathWin(async (rootPath, win) => {
     const result = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
       filters: [{ name: 'Zotero RDF', extensions: ['rdf', 'xml'] }],
@@ -137,12 +125,9 @@ export function registerSources(): void {
         }
       },
     });
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_INGEST_FILE, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
-    const win = winFromEvent(e);
+  ipcMain.handle(Channels.SOURCES_INGEST_FILE, withRootPathWin(async (rootPath, win) => {
     const result = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
       filters: [
@@ -158,7 +143,7 @@ export function registerSources(): void {
     await reindexFile(rootPath, `.minerva/sources/${ingested.sourceId}/meta.ttl`);
     await persistIndexes(rootPath);
     return ingested;
-  });
+  }));
 
   // Read the raw PDF bytes of a previously-persisted source, for the
   // renderer-side OCR worker (#95).
@@ -185,39 +170,30 @@ export function registerSources(): void {
   // Finalise a scanned-PDF ingest: the renderer has run OCR and hands
   // back the per-page text. We rewrite body.md + stamp meta.ttl with
   // extractionMethod "ocr" (#95).
-  ipcMain.handle(Channels.SOURCES_FINISH_PDF_OCR, async (e, sourceId: string, pages: string[]) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_FINISH_PDF_OCR, withRootPathWin(async (rootPath, win, sourceId: string, pages: string[]) => {
     await finishPdfOcrIngest(rootPath, sourceId, pages);
     await reindexFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
-  });
+  }));
 
   ipcMain.handle(Channels.SOURCES_LIST_ALL, withRootPathOr([], (rootPath) =>
     graph.listAllSources(projectContext(rootPath))));
 
-  ipcMain.handle(Channels.SOURCES_DELETE, async (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_DELETE, withRootPathWin(async (rootPath, win, sourceId: string) => {
     const result = await deleteSource(rootPath, sourceId);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) {
       win.webContents.send(Channels.SOURCES_CHANGED);
       win.webContents.send(Channels.EXCERPTS_CHANGED);
     }
     return result;
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_MERGE, async (e, params: { srcId: string; destId: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_MERGE, withRootPathWin(async (rootPath, win, params: { srcId: string; destId: string }) => {
     try {
       const result = await mergeSources(rootPath, params.srcId, params.destId);
       await persistIndexes(rootPath);
-      const win = winFromEvent(e);
       if (!win.isDestroyed()) {
         win.webContents.send(Channels.SOURCES_CHANGED);
         win.webContents.send(Channels.EXCERPTS_CHANGED);
@@ -233,63 +209,45 @@ export function registerSources(): void {
       }
       throw err;
     }
-  });
+  }));
 
   // ── Reading queue (#116) ──────────────────────────────────────────────────
-  ipcMain.handle(Channels.SOURCES_SET_READ_STATUS, async (e, params: { sourceId: string; status: ReadStatus | null }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_SET_READ_STATUS, withRootPathWin(async (rootPath, win, params: { sourceId: string; status: ReadStatus | null }) => {
     await setSourceReadStatus(rootPath, params.sourceId, params.status);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_SET_TITLE, async (e, params: { sourceId: string; title: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_SET_TITLE, withRootPathWin(async (rootPath, win, params: { sourceId: string; title: string }) => {
     await setSourceTitle(rootPath, params.sourceId, params.title);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_ADD_TAG, async (e, params: { sourceId: string; tag: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_ADD_TAG, withRootPathWin(async (rootPath, win, params: { sourceId: string; tag: string }) => {
     await addSourceTag(rootPath, params.sourceId, params.tag);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_REMOVE_TAG, async (e, params: { sourceId: string; tag: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_REMOVE_TAG, withRootPathWin(async (rootPath, win, params: { sourceId: string; tag: string }) => {
     await removeSourceTag(rootPath, params.sourceId, params.tag);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_SET_READ_DUE_BY, async (e, params: { sourceId: string; dueBy: string | null }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_SET_READ_DUE_BY, withRootPathWin(async (rootPath, win, params: { sourceId: string; dueBy: string | null }) => {
     await setSourceReadDueBy(rootPath, params.sourceId, params.dueBy);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
-  });
+  }));
 
-  ipcMain.handle(Channels.SOURCES_STRIP_UPSTREAM_TAGS, async (e, sourceId: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.SOURCES_STRIP_UPSTREAM_TAGS, withRootPathWin(async (rootPath, win, sourceId: string) => {
     const result = await stripUpstreamTags(rootPath, sourceId);
     await persistIndexes(rootPath);
-    const win = winFromEvent(e);
     if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
     return result;
-  });
+  }));
 
   ipcMain.handle(Channels.SOURCES_QUEUE_MEMBERS, withRootPathOr([], (rootPath, view: ReadingQueueView) => {
     const ctx = projectContext(rootPath);
@@ -299,8 +257,7 @@ export function registerSources(): void {
   }));
 
   // ── Collections (#470) ────────────────────────────────────────────────────
-  const broadcastCollectionsChanged = (e: Electron.IpcMainInvokeEvent) => {
-    const win = winFromEvent(e);
+  const broadcastCollectionsChanged = (win: BrowserWindow) => {
     if (!win.isDestroyed()) win.webContents.send(Channels.COLLECTIONS_CHANGED);
   };
 
@@ -308,70 +265,52 @@ export function registerSources(): void {
     return await loadCollections(rootPath);
   }));
 
-  ipcMain.handle(Channels.COLLECTIONS_CREATE, async (e, args: { name: string; parent?: string | null }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_CREATE, withRootPathWin(async (rootPath, win, args: { name: string; parent?: string | null }) => {
     const result = await createCollection(rootPath, args);
-    broadcastCollectionsChanged(e);
+    broadcastCollectionsChanged(win);
     return result;
-  });
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_RENAME, async (e, args: { id: string; name: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_RENAME, withRootPathWin(async (rootPath, win, args: { id: string; name: string }) => {
     await renameCollection(rootPath, args.id, args.name);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_DELETE, async (e, id: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_DELETE, withRootPathWin(async (rootPath, win, id: string) => {
     await deleteCollection(rootPath, id);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_ADD_SOURCE, async (e, args: { collectionId: string; sourceId: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_ADD_SOURCE, withRootPathWin(async (rootPath, win, args: { collectionId: string; sourceId: string }) => {
     await addSourceToCollection(rootPath, args.collectionId, args.sourceId);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_REMOVE_SOURCE, async (e, args: { collectionId: string; sourceId: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_REMOVE_SOURCE, withRootPathWin(async (rootPath, win, args: { collectionId: string; sourceId: string }) => {
     await removeSourceFromCollection(rootPath, args.collectionId, args.sourceId);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_CREATE_SMART, async (e, args: { name: string; predicate: SmartCollectionPredicate }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_CREATE_SMART, withRootPathWin(async (rootPath, win, args: { name: string; predicate: SmartCollectionPredicate }) => {
     const result = await createSmartCollection(rootPath, args);
-    broadcastCollectionsChanged(e);
+    broadcastCollectionsChanged(win);
     return result;
-  });
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_RENAME_SMART, async (e, args: { id: string; name: string }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_RENAME_SMART, withRootPathWin(async (rootPath, win, args: { id: string; name: string }) => {
     await renameSmartCollection(rootPath, args.id, args.name);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_DELETE_SMART, async (e, id: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_DELETE_SMART, withRootPathWin(async (rootPath, win, id: string) => {
     await deleteSmartCollection(rootPath, id);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
-  ipcMain.handle(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, async (e, args: { id: string; predicate: SmartCollectionPredicate }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) throw new Error('No project open');
+  ipcMain.handle(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, withRootPathWin(async (rootPath, win, args: { id: string; predicate: SmartCollectionPredicate }) => {
     await updateSmartCollectionPredicate(rootPath, args.id, args.predicate);
-    broadcastCollectionsChanged(e);
-  });
+    broadcastCollectionsChanged(win);
+  }));
 
   ipcMain.handle(Channels.COLLECTIONS_SMART_MEMBERS, withRootPathOr<[string], SourceMetadata[] | Promise<SourceMetadata[]>>([], async (rootPath, id: string) => {
     const data = await loadCollections(rootPath);


### PR DESCRIPTION
Closes #1092.

## Context

#990 collapsed the hand-rolled `rootPathFromEvent(e)` + `if (!rootPath) throw` guard into `withRootPath`/`withRootPathOr` — but only for handlers whose **only** use of the event was resolving the project. When I swept every remaining hand-rolled site, all of them also need the event (to broadcast a change back to the renderer, or to anchor a native dialog to the window). `withRootPath` drops `e`, so it couldn't apply and the guard stayed. There were **zero** remaining handlers where the plain helper fits.

## Change

Add **`withRootPathWin`** — same "there must be a project" contract as `withRootPath`, but it also hands the handler its `BrowserWindow`. Then convert the 26 window-needing handlers:

- **register-sources.ts (23)** — reference stubs, stub resolution, BibTeX/Zotero/file ingest dialogs, PDF-OCR finish, delete, merge, the reading-queue mutators (read-status/title/tags/due-by/strip), and all Collections handlers (`broadcastCollectionsChanged` now takes the `win`).
- **register-bibliography.ts (2)** — CSL style/locale import dialogs.
- **register-publish.ts (1)** — `PUBLISH_RUN_EXPORT`.

## Intentionally left alone

- **register-queries.ts** — `LIST`/`SAVE`/`MOVE` pass a *nullable* rootPath straight through so global saved-queries work with **no project open**. A helper that throws or short-circuits would break that. (The issue cited this file, but its handlers aren't the throw-guard pattern.)
- **register-bibliography `BIBLIOGRAPHY_LIST_STYLES`** — deliberately falls back to the bundled style set when no project is open.
- **The 3 `CONVERSATION_FILE_*` handlers** — left to the #1089 branch (which edits the same lines) to avoid a merge conflict; they can convert once that lands.

## Verification

- [x] No `if (!rootPath) throw` remains where a helper applies (only the 3 conversation handlers, deferred)
- [x] `pnpm lint` passes; full `pnpm test` (4043) green
- [x] Net −51 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)