### PR TITLE
shared: hoist draft note into a ConversationToolDraft base (#1090)

### DIFF
--- a/src/shared/conversation-claims-drafts.ts
+++ b/src/shared/conversation-claims-drafts.ts
@@ -18,7 +18,7 @@
  * Drafts live in renderer memory and drop when the tab closes.
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 
 export type ClaimKind = 'factual' | 'evaluative' | 'definitional' | 'predictive';
 
@@ -45,9 +45,7 @@ export interface DraftClaim {
   quoteFound: boolean;
 }
 
-export interface ConversationClaimsDraft extends ConversationDraftBase {
-  /** Bundle-level "why I'm proposing these" note from the LLM. */
-  note: string;
+export interface ConversationClaimsDraft extends ConversationToolDraft {
   /** The source the claims were extracted from. */
   sourceId: string;
   claims: DraftClaim[];

--- a/src/shared/conversation-draft-base.ts
+++ b/src/shared/conversation-draft-base.ts
@@ -2,8 +2,9 @@
  * Fields every conversation draft carries (#980). Mid-conversation the LLM emits
  * a draft over a `Channels.CONVERSATION_*_DRAFT` channel; the renderer buckets
  * it by `conversationId`, keys it by `draftId`, and files it on Approve. Each
- * draft kind extends this base with its own payload-specific fields (and most,
- * but not compute, add a one-line `note`).
+ * draft kind extends this base with its own payload-specific fields. Compute
+ * extends this directly; every other kind extends {@link ConversationToolDraft}
+ * to pick up the shared `note`.
  */
 export interface ConversationDraftBase {
   /** Stable id wiring Approve/Reject back to the cached bundle; also the render key. */
@@ -12,4 +13,27 @@ export interface ConversationDraftBase {
   conversationId: string;
   /** ISO timestamp when the draft was created. */
   createdAt: string;
+}
+
+/**
+ * Base for every *tool* draft — i.e. every draft kind except compute. All of
+ * them carry the LLM's one-line rationale for the proposed action, so `note` is
+ * defined once here rather than repeated on each kind (#1090). Compute is the
+ * exception: its card shows the code + result, not a rationale line, so it
+ * extends {@link ConversationDraftBase} directly. Kind-specific fields (the
+ * payload list and any pre-apply outcome/problem shapes) are added by each
+ * extending interface.
+ *
+ * Result-shape convention: the payload/outcome collections deliberately stay
+ * per-kind rather than hiding behind a generic `<Payload, Outcome>`. The field
+ * *names* diverge by intent (`payloads` / `sources` / `claims` / `updates` /
+ * `items`), and single-outcome kinds (note-body, source-property) don't share a
+ * shape with the many-outcome kinds (sources, reorg). A draft card reads its own
+ * kind's field directly; nothing accesses payloads polymorphically across kinds,
+ * so a common generic would add ceremony without removing real duplication.
+ */
+export interface ConversationToolDraft extends ConversationDraftBase {
+  /** The LLM's one-line rationale for this draft ("why I'm proposing this"),
+   *  shown on the card header. */
+  note: string;
 }

--- a/src/shared/conversation-drafts.ts
+++ b/src/shared/conversation-drafts.ts
@@ -19,7 +19,7 @@
  * dialog closes. Persistence across reload is a follow-up.
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 
 export interface DraftNotePayload {
   kind: 'note';
@@ -30,9 +30,7 @@ export interface DraftNotePayload {
 
 export type DraftPayload = DraftNotePayload;
 
-export interface ConversationDraft extends ConversationDraftBase {
-  /** One-line description the LLM provided when calling propose_notes ("why I'm proposing this"). */
-  note: string;
+export interface ConversationDraft extends ConversationToolDraft {
   payloads: DraftPayload[];
 }
 

--- a/src/shared/conversation-note-body-drafts.ts
+++ b/src/shared/conversation-note-body-drafts.ts
@@ -14,11 +14,9 @@
  * NOTEBASE_REWRITTEN so an open editor reloads the new content.
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 
-export interface ConversationNoteBodyDraft extends ConversationDraftBase {
-  /** One-line summary for the card header (e.g. "Fill out notes/stub.md"). */
-  note: string;
+export interface ConversationNoteBodyDraft extends ConversationToolDraft {
   /** Thoughtbase-relative path of the existing note being rewritten. */
   relativePath: string;
   /** The note's current full content (frontmatter + body), for the diff's

--- a/src/shared/conversation-property-drafts.ts
+++ b/src/shared/conversation-property-drafts.ts
@@ -20,7 +20,7 @@
  * tab closes — same lifecycle as note/source drafts.
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 import type { PropertyPatch } from './refactor/frontmatter-patch';
 
 /** A single per-note frontmatter patch. */
@@ -33,9 +33,7 @@ export interface PropertyUpdate {
   properties: PropertyPatch;
 }
 
-export interface ConversationPropertyDraft extends ConversationDraftBase {
-  /** Bundle-level "why I'm proposing this" note from the LLM. */
-  note: string;
+export interface ConversationPropertyDraft extends ConversationToolDraft {
   updates: PropertyUpdate[];
 }
 

--- a/src/shared/conversation-refactor-drafts.ts
+++ b/src/shared/conversation-refactor-drafts.ts
@@ -12,7 +12,7 @@
  * `note-refactor` proposal (#911).
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 
 /** One note whose content changes if the refactor is applied — carried so the
  *  review card can show the diff without recomputing the plan. */
@@ -25,9 +25,7 @@ export interface RefactorAffectedNote {
   isMoved: boolean;
 }
 
-export interface ConversationRefactorDraft extends ConversationDraftBase {
-  /** One-line description ("Move a.md → b/a.md"). */
-  note: string;
+export interface ConversationRefactorDraft extends ConversationToolDraft {
   fromPath: string;
   toPath: string;
   /** The dry-run blast radius — every note whose links would be rewritten. */
@@ -48,8 +46,7 @@ export interface ReorgDraftItem {
  * which files them as one ordered note-refactor bundle (atomic — partial failure
  * rolls the whole bundle back).
  */
-export interface ConversationReorgDraft extends ConversationDraftBase {
-  note: string;
+export interface ConversationReorgDraft extends ConversationToolDraft {
   items: ReorgDraftItem[];
   /** Plan-level problems surfaced before apply (collisions, cycles, skips). */
   warnings: string[];
@@ -76,8 +73,7 @@ export interface DeleteDraftItem {
  * git, per the project's "delete is a normal operation" stance, but it is
  * always gated on explicit approval).
  */
-export interface ConversationDeleteDraft extends ConversationDraftBase {
-  note: string;
+export interface ConversationDeleteDraft extends ConversationToolDraft {
   items: DeleteDraftItem[];
   /** Per-note problems surfaced before apply (missing file, not a note). */
   warnings: string[];

--- a/src/shared/conversation-source-drafts.ts
+++ b/src/shared/conversation-source-drafts.ts
@@ -25,7 +25,7 @@
  * when the conversation tab closes. Persistence is a follow-up.
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 
 /**
  * One proposed source. Exactly one of `identifier` / `url` is present;
@@ -39,9 +39,7 @@ export interface DraftSource {
   url?: string;
 }
 
-export interface ConversationSourceDraft extends ConversationDraftBase {
-  /** Bundle-level "why I'm proposing these" note from the LLM. */
-  note: string;
+export interface ConversationSourceDraft extends ConversationToolDraft {
   sources: DraftSource[];
 }
 

--- a/src/shared/conversation-source-property-drafts.ts
+++ b/src/shared/conversation-source-property-drafts.ts
@@ -19,11 +19,9 @@
  * closes — same lifecycle as note / source / property drafts.
  */
 
-import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ConversationToolDraft } from './conversation-draft-base';
 
-export interface ConversationSourcePropertyDraft extends ConversationDraftBase {
-  /** Bundle-level "why I'm proposing this" note from the LLM. */
-  note: string;
+export interface ConversationSourcePropertyDraft extends ConversationToolDraft {
   /** The source whose meta.ttl is being patched. */
   sourceId: string;
   /** Proposed formal abstract (`dc:abstract`). Omitted when not proposed. */


### PR DESCRIPTION
Closes #1090.

## What

Every conversation draft *except* compute carries the LLM's one-line rationale, but `note: string` was declared inline on all **9** draft interfaces across 7 files. Add a `ConversationToolDraft` base (`extends ConversationDraftBase` + `note`) and have those 9 extend it, so `note` is defined once:

`ConversationDraft`, `ConversationClaimsDraft`, `ConversationNoteBodyDraft`, `ConversationPropertyDraft`, `ConversationSourceDraft`, `ConversationSourcePropertyDraft`, `ConversationRefactorDraft`, `ConversationReorgDraft`, `ConversationDeleteDraft`.

Compute keeps extending `ConversationDraftBase` directly (its card shows code + result, not a rationale). The `*Input` tool-parse types (`ProposeNotesInput`, `ProposeClaimsInput`, …) keep their own `note` — that's the shape the model produces, a separate concern from the cached/rendered draft.

## On the generic `<Payload, Outcome>`

The issue floated a generic base. I didn't force it: the payload field *names* diverge by intent (`payloads` / `sources` / `claims` / `updates` / `items`) and single-outcome kinds (note-body, source-property) don't share a shape with the many-outcome kinds (sources, reorg). Nothing accesses payloads polymorphically across kinds, so a generic would add ceremony without removing real duplication. That single-vs-many convention is now **documented on the base** instead (the issue explicitly allowed this).

## Verification

- [x] `note` defined once; removed from all 9 draft interfaces
- [x] Purely type-level — no runtime change
- [x] `pnpm lint` passes; llm + renderer tests (1281) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)