### PR TITLE
main: introduce createProjectStore<T> per-project state registry (#1085)

### DIFF
--- a/src/main/embeddings/vector-store.ts
+++ b/src/main/embeddings/vector-store.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import type { ProjectContext } from '../project-context-types';
+import { createProjectStore } from '../project-store';
 import { MODEL } from './embedder';
 import { chunkMarkdown } from './chunk';
 
@@ -63,7 +64,17 @@ interface StoreState {
   lock: Promise<unknown>;
 }
 
-const states = new Map<string, StoreState>();
+// Dispose waits for any in-flight indexing (the per-project lock) to settle,
+// then closes the persisted DuckDB. The store removes the state before running
+// this hook, so a concurrent call sees the project already gone — preserving
+// the original delete-first-then-close ordering.
+const store = createProjectStore<StoreState>({
+  dispose: async (state) => {
+    try { await state.lock; } catch { /* ignore */ }
+    try { state.connection.closeSync(); } catch { /* already closed */ }
+    try { state.instance.closeSync(); } catch { /* already closed */ }
+  },
+});
 const TABLE = 'note_chunks';
 
 function defaultDbPath(rootPath: string): string {
@@ -71,7 +82,7 @@ function defaultDbPath(rootPath: string): string {
 }
 
 export async function init(ctx: ProjectContext, opts: VectorStoreInit): Promise<void> {
-  if (states.has(ctx.rootPath)) return;
+  if (store.has(ctx)) return;
   const dbPath = opts.dbPath ?? defaultDbPath(ctx.rootPath);
   await fs.mkdir(path.dirname(dbPath), { recursive: true });
 
@@ -103,22 +114,17 @@ export async function init(ctx: ProjectContext, opts: VectorStoreInit): Promise<
        updated_at      TIMESTAMP NOT NULL
      )`,
   );
-  states.set(ctx.rootPath, {
+  store.set(ctx, {
     instance, connection, embedder: opts.embedder, model: MODEL.name, lock: Promise.resolve(),
   });
 }
 
 export function isEnabled(ctx: ProjectContext): boolean {
-  return states.has(ctx.rootPath);
+  return store.has(ctx);
 }
 
 export async function dispose(ctx: ProjectContext): Promise<void> {
-  const state = states.get(ctx.rootPath);
-  if (!state) return;
-  states.delete(ctx.rootPath);
-  try { await state.lock; } catch { /* ignore */ }
-  try { state.connection.closeSync(); } catch { /* already closed */ }
-  try { state.instance.closeSync(); } catch { /* already closed */ }
+  await store.dispose(ctx);
 }
 
 // ── Indexing ────────────────────────────────────────────────────────────────
@@ -129,7 +135,7 @@ export async function dispose(ctx: ProjectContext): Promise<void> {
  * over. Transactional. Resilient — failures log, leaving prior rows intact.
  */
 export async function indexChunks(ctx: ProjectContext, kind: RefKind, ref: string, content: string): Promise<void> {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) return;
   return runLocked(state, async () => {
     try {
@@ -167,7 +173,7 @@ export const indexExcerpt = (ctx: ProjectContext, excerptId: string, text: strin
   indexChunks(ctx, 'excerpt', excerptId, text);
 
 export async function removeRef(ctx: ProjectContext, kind: RefKind, ref: string): Promise<void> {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) return;
   return runLocked(state, async () => {
     try { await deleteRef(state, kind, ref); }
@@ -182,7 +188,7 @@ export const removeExcerpt = (ctx: ProjectContext, excerptId: string) => removeR
 /** The refs of `kind` already embedded under the current model — the backfill's
  *  per-kind skip set (#836/#839). */
 export async function embeddedRefs(ctx: ProjectContext, kind: RefKind): Promise<Set<string>> {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) return new Set();
   const reader = await state.connection.runAndReadAll(
     `SELECT DISTINCT ref_id FROM ${TABLE} WHERE kind = ${lit(kind)} AND embedding_model = ${lit(state.model)}`,
@@ -196,7 +202,7 @@ export async function embeddedRefs(ctx: ProjectContext, kind: RefKind): Promise<
 export const embeddedNotePaths = (ctx: ProjectContext) => embeddedRefs(ctx, 'note');
 
 export async function clear(ctx: ProjectContext): Promise<void> {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) return;
   return runLocked(state, async () => { await state.connection.run(`DELETE FROM ${TABLE}`); });
 }
@@ -208,7 +214,7 @@ export async function searchRelated(
   query: string | Float32Array,
   opts: SearchOptions = {},
 ): Promise<RelatedHit[]> {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) return [];
   const vec = typeof query === 'string' ? (await state.embedder.embed([query]))[0] : query;
   if (!vec) return [];
@@ -233,7 +239,7 @@ export async function relatedToRef(
   ref: string,
   opts: SearchOptions = {},
 ): Promise<RelatedHit[]> {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) return [];
   const model = lit(state.model);
   const kc = kindClause(opts.kinds, 't.');
@@ -256,7 +262,7 @@ export const relatedToNote = (ctx: ProjectContext, notePath: string, opts: Searc
 // ── internals ───────────────────────────────────────────────────────────────
 
 export function _connectionForTest(ctx: ProjectContext): DuckDBConnection {
-  const state = states.get(ctx.rootPath);
+  const state = store.get(ctx);
   if (!state) throw new Error('vector store not initialized');
   return state.connection;
 }

--- a/src/main/graph/state.ts
+++ b/src/main/graph/state.ts
@@ -17,6 +17,7 @@ import { performance } from 'node:perf_hooks';
 import * as uriHelpers from './uri-helpers';
 import type { LinkType } from '../../shared/link-types';
 import type { ProjectContext } from '../project-context-types';
+import { createProjectStore } from '../project-store';
 
 // ── Comunica engine (process-wide; stateless across projects) ────────────────
 
@@ -181,25 +182,27 @@ export interface GraphState {
 // read/write path — rdflib IndexedFormula mutation, `invalidate()`, and the
 // on-demand N3 rebuild in `queryGraph` — runs synchronously on the Electron
 // main thread, one IPC handler at a time. That single-threaded serialization is
-// precisely what lets this Map and the mutable store stay lock-free: no two
-// writes, and no write racing the rebuild, can ever interleave. A write nulls
-// `n3Cache` and the very next query rebuilds it before anyone reads it. If any
-// of this ever moves off the main thread (e.g. the O(n) rebuild into a worker,
-// #1088), that invariant breaks and real synchronization becomes necessary.
-const states = new Map<string, GraphState>();
+// precisely what lets this store and the mutable IndexedFormula stay lock-free:
+// no two writes, and no write racing the rebuild, can ever interleave. A write
+// nulls `n3Cache` and the very next query rebuilds it before anyone reads it. If
+// any of this ever moves off the main thread (e.g. the O(n) rebuild into a
+// worker, #1088), that invariant breaks and real synchronization becomes
+// necessary. The rdflib IndexedFormula holds no OS handle, so there's no dispose
+// hook — teardown just drops the state (#1085).
+const store = createProjectStore<GraphState>();
 
 export function getState(ctx: ProjectContext): GraphState | null {
-  return states.get(ctx.rootPath) ?? null;
+  return store.get(ctx);
 }
 
 /** Register a freshly-built state for a project. */
 export function setState(ctx: ProjectContext, state: GraphState): void {
-  states.set(ctx.rootPath, state);
+  store.set(ctx, state);
 }
 
 /** Tear down a project's graph state. Called by ProjectContext on last release. */
 export function deleteState(ctx: ProjectContext): void {
-  states.delete(ctx.rootPath);
+  void store.dispose(ctx);
 }
 
 export function invalidate(state: GraphState): void {

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -19,6 +19,7 @@ import { abortBackfill } from './embeddings/backfill';
 import * as healthChecks from './graph/health-checks';
 import * as conversation from './llm/conversation';
 import { projectContext, type ProjectContext } from './project-context-types';
+import { disposeAllProjectStores } from './project-store';
 
 interface ProjectRecord {
   ctx: ProjectContext;
@@ -120,10 +121,10 @@ export async function releaseProject(rootPath: string, winId: number): Promise<v
   } catch (err) {
     console.warn(`[project-context] final persist failed for ${rootPath}:`, err);
   }
-  tables.disposeProject(rec.ctx);
-  search.disposeProject(rec.ctx);
-  graph.disposeProject(rec.ctx);
-  await vectors.dispose(rec.ctx); // flush + close the embeddings DB (#835)
+  // Tear down every per-project store — graph, search, tables, and the vector
+  // store's embeddings DB (#835) — by iterating the registry instead of naming
+  // each (#1085). Disposal has no cross-store ordering dependency, unlike init.
+  await disposeAllProjectStores(rec.ctx);
   projects.delete(rootPath);
 }
 

--- a/src/main/project-store.ts
+++ b/src/main/project-store.ts
@@ -1,0 +1,72 @@
+/**
+ * A per-project state slot (#1085).
+ *
+ * Every stateful subsystem — graph, search, tables, vectors — held one value
+ * per open project in its own `Map<string, TState>` keyed by `rootPath`, and
+ * re-declared the same get / set / has / delete + dispose boilerplate. This
+ * centralizes that map and its lifecycle in one place, and self-registers so the
+ * orchestrator (`project-context.ts`) can tear a project down by iterating the
+ * registry instead of naming each subsystem.
+ *
+ * A store owns the map only. Each subsystem keeps its own `init` — the
+ * signatures genuinely diverge (some take options, some are async, some open a
+ * DuckDB) — and calls `set` once it has built the state. Init ORDER stays the
+ * orchestrator's job: the deliberate `indexAllNotes`-before-`registerAllCsvs`
+ * sequencing (#337) is a cross-store dependency a generic store must not own.
+ * Disposal, by contrast, has no cross-store ordering dependency — each store
+ * closes only its own resources — so `disposeAllProjectStores` can run them in
+ * any order.
+ */
+
+import type { ProjectContext } from './project-context-types';
+
+export interface ProjectStore<T> {
+  /** The state for this project, or null if it was never initialized. */
+  get(ctx: ProjectContext): T | null;
+  /** Whether this project has state — the idempotent-init guard. */
+  has(ctx: ProjectContext): boolean;
+  /** Register freshly-built state for this project. */
+  set(ctx: ProjectContext, state: T): void;
+  /**
+   * Run the dispose hook (if any) and drop the state. Idempotent — a second
+   * call, or a call for a project that was never initialized, is a no-op. The
+   * state is removed from the map BEFORE the (possibly async) hook runs, so a
+   * re-entrant lookup during teardown sees it already gone — matching the
+   * delete-then-close ordering the vector store relied on.
+   */
+  dispose(ctx: ProjectContext): Promise<void>;
+  /** rootPaths currently held — for diagnostics / tests. */
+  keys(): string[];
+}
+
+const registry: Array<ProjectStore<unknown>> = [];
+
+export function createProjectStore<T>(opts?: {
+  /** Cleanup run before the state is dropped (close DB handles, await locks). */
+  dispose?: (state: T, ctx: ProjectContext) => void | Promise<void>;
+}): ProjectStore<T> {
+  const map = new Map<string, T>();
+  const store: ProjectStore<T> = {
+    get: (ctx) => map.get(ctx.rootPath) ?? null,
+    has: (ctx) => map.has(ctx.rootPath),
+    set: (ctx, state) => { map.set(ctx.rootPath, state); },
+    async dispose(ctx) {
+      const state = map.get(ctx.rootPath);
+      if (state === undefined) return;
+      map.delete(ctx.rootPath);
+      if (opts?.dispose) await opts.dispose(state, ctx);
+    },
+    keys: () => [...map.keys()],
+  };
+  registry.push(store);
+  return store;
+}
+
+/**
+ * Dispose every registered store for a project. Called by `project-context` on
+ * a project's last release, AFTER the final persist. Order-independent (see the
+ * module comment), so the registry's registration order is fine.
+ */
+export async function disposeAllProjectStores(ctx: ProjectContext): Promise<void> {
+  for (const store of registry) await store.dispose(ctx);
+}

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -3,16 +3,28 @@ import fs from 'node:fs/promises';
 import type { SearchProvider, SearchResult } from './types';
 import { MiniSearchProvider } from './minisearch-provider';
 import type { ProjectContext } from '../project-context-types';
+import { createProjectStore } from '../project-store';
 
 interface SearchState {
   rootPath: string;
   provider: SearchProvider;
 }
 
-const states = new Map<string, SearchState>();
+// Pure MiniSearch state — nothing to close on dispose, so no dispose hook.
+const store = createProjectStore<SearchState>();
 
 function getState(ctx: ProjectContext): SearchState | null {
-  return states.get(ctx.rootPath) ?? null;
+  return store.get(ctx);
+}
+
+/** Return the project's search state, creating an empty one if absent. */
+function getOrCreateState(ctx: ProjectContext): SearchState {
+  let state = store.get(ctx);
+  if (!state) {
+    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider() };
+    store.set(ctx, state);
+  }
+  return state;
 }
 
 function indexPath(state: SearchState): string {
@@ -20,24 +32,16 @@ function indexPath(state: SearchState): string {
 }
 
 export async function initSearch(ctx: ProjectContext): Promise<void> {
-  let state = states.get(ctx.rootPath);
-  if (!state) {
-    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider() };
-    states.set(ctx.rootPath, state);
-  }
+  const state = getOrCreateState(ctx);
   await state.provider.load(indexPath(state));
 }
 
 export function disposeProject(ctx: ProjectContext): void {
-  states.delete(ctx.rootPath);
+  void store.dispose(ctx);
 }
 
 export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
-  let state = states.get(ctx.rootPath);
-  if (!state) {
-    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider() };
-    states.set(ctx.rootPath, state);
-  }
+  const state = getOrCreateState(ctx);
   state.provider.clear();
 
   let count = 0;
@@ -55,7 +59,7 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
         const relativePath = path.relative(root, fullPath);
         const content = await fs.readFile(fullPath, 'utf-8');
         const title = extractTitle(content) ?? path.basename(relativePath, '.md');
-        state!.provider.index(relativePath, title, content);
+        state.provider.index(relativePath, title, content);
         count++;
       }
     }

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -4,6 +4,7 @@ import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
 import type { ProjectContext } from '../project-context-types';
+import { createProjectStore } from '../project-store';
 import { loadCsvSchema, buildReadCsvSql } from './csv-schema';
 
 interface TablesState {
@@ -16,10 +17,17 @@ interface TablesState {
   tableToPath: Map<string, string>;
 }
 
-const states = new Map<string, TablesState>();
+// Dispose closes the in-memory DuckDB (connection then instance) before the
+// state is dropped. closeSync is synchronous, so `disposeProject` stays sync.
+const store = createProjectStore<TablesState>({
+  dispose: (state) => {
+    try { state.connection.closeSync(); } catch { /* already closed */ }
+    try { state.instance.closeSync(); } catch { /* already closed */ }
+  },
+});
 
 function getState(ctx: ProjectContext): TablesState | null {
-  return states.get(ctx.rootPath) ?? null;
+  return store.get(ctx);
 }
 
 export type QueryResult =
@@ -35,10 +43,10 @@ export interface TableInfo {
 
 /** Open an in-memory DuckDB for the given project. Idempotent per project. */
 export async function initTablesDb(ctx: ProjectContext): Promise<void> {
-  if (states.has(ctx.rootPath)) return;
+  if (store.has(ctx)) return;
   const instance = await DuckDBInstance.create(':memory:');
   const connection = await instance.connect();
-  states.set(ctx.rootPath, {
+  store.set(ctx, {
     rootPath: ctx.rootPath,
     instance,
     connection,
@@ -48,11 +56,9 @@ export async function initTablesDb(ctx: ProjectContext): Promise<void> {
 }
 
 export function disposeProject(ctx: ProjectContext): void {
-  const state = states.get(ctx.rootPath);
-  if (!state) return;
-  try { state.connection.closeSync(); } catch { /* already closed */ }
-  try { state.instance.closeSync(); } catch { /* already closed */ }
-  states.delete(ctx.rootPath);
+  // The DuckDB close runs synchronously inside the store's dispose hook, so
+  // this stays a sync teardown even though `dispose` returns a promise.
+  void store.dispose(ctx);
 }
 
 /**
@@ -363,5 +369,5 @@ export async function listTables(ctx: ProjectContext): Promise<TableInfo[]> {
 
 /** Exposed for tests. */
 export function _isOpen(ctx: ProjectContext): boolean {
-  return states.has(ctx.rootPath);
+  return store.has(ctx);
 }


### PR DESCRIPTION
Closes #1085.

## What

`graph/state.ts`, `search/index.ts`, `sources/tables.ts`, and `embeddings/vector-store.ts` each declared their own `Map<string, XState>` keyed by `rootPath` plus a near-identical get / set / has / dispose. This centralizes that into `createProjectStore<T>` and lets `project-context.ts` tear a project down by iterating a registry instead of naming each store.

### New `src/main/project-store.ts`
`createProjectStore<T>({ dispose? })` → `{ get, has, set, dispose, keys }`, self-registering for `disposeAllProjectStores(ctx)`. A store owns the map only; each subsystem keeps its own `init` (the signatures genuinely diverge — vectors takes options, tables/vectors open a DuckDB). `dispose` removes the state **before** running the optional cleanup hook, preserving the vector store's original delete-then-close-under-lock ordering.

### Migrated subsystems (4)
- **graph**, **search** — pure in-memory state, no dispose hook. Public `disposeProject` signatures unchanged. Search's duplicated get-or-create is deduped.
- **tables**, **vectors** — pass a dispose hook that closes their DuckDB (`closeSync`; vectors also awaits its in-flight lock first).

### Orchestrator
`releaseProject` swaps its four explicit `*.disposeProject(...)` / `vectors.dispose(...)` calls for one `await disposeAllProjectStores(ctx)`. The deliberate **`indexAllNotes`-before-`registerAllCsvs` init sequencing (#337) is untouched** — init order stays the orchestrator's job; only disposal (which has no cross-store ordering dependency) is registry-driven.

## Scope note — conversation excluded

`llm/conversation.ts` is **not** migrated despite the issue listing it: it uses a single-active-project singleton (`activeRootPath` / `conversationsDir`), not a per-project `Map`, so the store abstraction doesn't apply. The four genuine per-project state maps are graph/search/tables/vectors.

## Verification

- [x] Per-project `Map<string, X>` boilerplate removed from each of the 4 subsystems
- [x] `project-context.ts` iterates the registry rather than naming each store
- [x] Init/dispose ordering preserved (#337 sequencing intact; delete-then-close for the vector store)
- [x] `pnpm lint` passes; full `pnpm test` (4043) green, incl. the acquire/release ref-count lifecycle test

🤖 Generated with [Claude Code](https://claude.com/claude-code)