### PR TITLE
docs site: complete the Notes documentation section

### DIFF
--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -52,6 +52,20 @@
 
     <h4>Using Minerva</h4>
     <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Callouts &amp; Cards</title>
+<meta name="description" content="Callout blocks in Minerva notes: the blockquote and bare-paragraph syntax that triggers one, the 14 built-in kinds, collapsible callouts, and how a [!card] callout differs from a plain one." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub active">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Callouts &amp; cards</p>
+
+    <h1>Callouts &amp; cards</h1>
+    <p class="lede">A callout turns an ordinary blockquote into a titled, colored box — a note, a tip, a warning-equivalent, a flashcard. The syntax is Obsidian's <code>[!type]</code> convention: a blockquote whose first line names a kind. Minerva also accepts a lenient bare form with no leading <code>&gt;</code>, and one kind — <code>card</code> — renders as a front/back flashcard instead of a plain note box.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>A callout's marker line is <code>[!type]</code>, optionally followed by <code>+</code> or <code>-</code> to make it collapsible, and an optional custom title. Everything after the marker line — inside the blockquote — is the callout body.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>&gt; [!type]</code></div>
+        <div class="v"><b>Standard form.</b> A blockquote whose first line is <code>[!type]</code>. Every following <code>&gt;</code>-prefixed line is the body. This is the same syntax Obsidian and GitHub use.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[!type]</code></div>
+        <div class="v"><b>Bare form (lenient extension).</b> A top-level paragraph starting with <code>[!type]</code> becomes a callout even without the leading <code>&gt;</code>. It always renders non-collapsible — there's no blockquote container to attach a disclosure to. Only fires at the top level; a <code>[!type]</code> line nested inside a list or another blockquote is left alone.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; [!type]+</code></div>
+        <div class="v"><b>Collapsible, default-expanded.</b> Renders as a <code>&lt;details open&gt;</code>/<code>&lt;summary&gt;</code> pair instead of a plain <code>&lt;div&gt;</code>, so it's keyboard-operable and starts open.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; [!type]-</code></div>
+        <div class="v"><b>Collapsible, default-collapsed.</b> Same as above but starts closed — the body is hidden until clicked.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; [!type] Custom title</code></div>
+        <div class="v"><b>Custom title.</b> Text after the marker (and fold flag) replaces the kind's default title in the title bar. Whitespace here is restricted to spaces/tabs, so a title can't accidentally swallow the body's first line.</div>
+      </div>
+    </div>
+
+    <p>A complete example, plus the bare form:</p>
+<pre><code>&gt; [!warning] Before you continue
+&gt; This rewrites every note's frontmatter in place. Commit first.
+
+&gt; [!tip]-
+&gt; Collapsed by default — click to expand.
+
+[!note]
+No leading &gt; required — this still becomes a callout.</code></pre>
+
+    <h2 id="kinds">Supported kinds</h2>
+    <p>Fourteen kinds are recognized by name; each has a default icon, a default title (used when you don't supply a custom one), and a color drawn from the existing palette — nothing new, no red/danger styling. An unrecognized kind (e.g. <code>[!random]</code>) still renders as a callout: it falls back to a generic dot icon and the accent color, with the kind name capitalized as its title.</p>
+
+    <div class="deflist">
+      <div class="row"><div class="k"><code>note</code></div><div class="v">Default title "Note". Accent-colored.</div></div>
+      <div class="row"><div class="k"><code>info</code></div><div class="v">Default title "Info". Iris-colored.</div></div>
+      <div class="row"><div class="k"><code>tip</code></div><div class="v">Default title "Tip". Sage-colored.</div></div>
+      <div class="row"><div class="k"><code>success</code></div><div class="v">Default title "Success". Sage-colored, checkmark icon.</div></div>
+      <div class="row"><div class="k"><code>question</code></div><div class="v">Default title "Question". Accent-colored, "?" icon.</div></div>
+      <div class="row"><div class="k"><code>warning</code></div><div class="v">Default title "Warning". The warmest tone in the set (an amber/rust shade, not red) with a triangle icon — Minerva's stand-in for danger styling.</div></div>
+      <div class="row"><div class="k"><code>failure</code></div><div class="v">Default title "Failure". Same warm tone as <code>warning</code>, "✗" icon.</div></div>
+      <div class="row"><div class="k"><code>danger</code></div><div class="v">Default title "Danger". Same warm tone as <code>warning</code> — Minerva has no separate red danger color, per house style.</div></div>
+      <div class="row"><div class="k"><code>bug</code></div><div class="v">Default title "Bug". Iris-colored.</div></div>
+      <div class="row"><div class="k"><code>example</code></div><div class="v">Default title "Example". Iris-colored.</div></div>
+      <div class="row"><div class="k"><code>quote</code></div><div class="v">Default title "Quote". Muted-text colored rather than an accent — reads as a citation, not an alert.</div></div>
+      <div class="row"><div class="k"><code>abstract</code></div><div class="v">Default title "Abstract". Iris-colored.</div></div>
+      <div class="row"><div class="k"><code>todo</code></div><div class="v">Default title "Todo". Accent-colored, checkbox icon.</div></div>
+      <div class="row"><div class="k"><code>card</code></div><div class="v">Default title "Card". Renders as a flashcard rather than a plain note box — see below.</div></div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗒️</div>
+      <div class="k">Screenshot — Callout kinds in preview</div>
+      <div class="d">A rendered note stacking three blocks top to bottom: a "Note" callout in the accent color with its pencil icon, a "Warning" callout in the warm amber tone with its triangle icon (no red anywhere), and below them a "Card" callout showing its front-side prompt text above a dashed divider with a collapsed "Show answer" disclosure.</div>
+    </div>
+
+    <h2 id="cards">Card-style callouts</h2>
+    <p><code>[!card]</code> is syntactically an ordinary callout — same marker, same blockquote body — but it's treated differently once inside: an <code>&lt;hr&gt;</code> (a <code>---</code> line) in the body splits it into a front and a back, the way a flashcard's prompt and answer are two separate things. Minerva's preview hydrates this after render by moving everything after the divider into a collapsed <b>Show answer</b> disclosure, so the front stands alone until you choose to reveal the back — the divider itself is replaced by the disclosure's summary line.</p>
+    <p>A card without a <code>---</code> divider is left untouched — it just renders as a front with no answer to reveal, same as a malformed or front-only card.</p>
+    <p>A card's title line also has one more piece of machinery: a trailing <code>^id</code> block-id (used to anchor the card for spaced-repetition review) is stripped from the displayed title, leaving only the deck name you wrote — or the default "Card" title if the marker line held nothing but an id.</p>
+
+<pre><code>&gt; [!card] Biology deck
+&gt; What organelle produces most of a cell's ATP?
+&gt; ---
+&gt; The mitochondrion.</code></pre>
+
+    <div class="box">
+      <span class="label">Unrecognized kinds still work</span>
+      <p>A kind that isn't in the built-in list doesn't fail to render — it becomes a callout styled with the accent color and a generic dot icon, titled with the capitalized kind name (or your custom title, if you supplied one). This makes ad hoc kinds safe to use for personal conventions.</p>
+    </div>
+
+    <h2 id="nesting">Nesting and nuances</h2>
+    <ul>
+      <li><b>Nesting works for free.</b> A callout inside a callout is just a nested blockquote — Minerva's core render rule walks every <code>blockquote_open</code> token independently, so nested callouts need no special-case syntax.</li>
+      <li><b>Bare callouts can't collapse.</b> Because the lenient no-<code>&gt;</code> form has no blockquote container, <code>+</code>/<code>-</code> fold flags on a bare <code>[!type]</code> line are meaningless — collapsibility requires the standard blockquote form.</li>
+      <li><b>Kind names are case-insensitive.</b> <code>[!Warning]</code> and <code>[!warning]</code> resolve to the same kind; the stored kind is always lowercased.</li>
+      <li><b>Collapsible callouts render as <code>&lt;details&gt;</code>.</b> That means keyboard operability (focus, <kbd>Enter</kbd>/<kbd>Space</kbd> to toggle) comes from the browser, not from custom script.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-links.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Links</span>
+      </a>
+      <a class="next" href="notes-math.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Math →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Charts</title>
+<meta name="description" content="Embedding Vega and Vega-Lite charts in Minerva notes: the vega-lite and vega fence syntax, the JSON spec format, live data from SPARQL/SQL/tables/cells, and how charts render inline." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub active">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Charts</p>
+
+    <h1>Charts</h1>
+    <p class="lede">Put a <a href="https://vega.github.io/vega-lite/">Vega-Lite</a> or <a href="https://vega.github.io/vega/">Vega</a> JSON spec in a fenced code block and the preview renders it as a live, interactive chart — hover for tooltips, use the built-in menu to export a PNG or SVG. Data can be inlined in the spec, or bound to a SPARQL query, a DuckDB table, or a compute cell's output, so a chart can track the graph or a dataset instead of a frozen snapshot.</p>
+
+    <h2 id="syntax">The <code>vega-lite</code> and <code>vega</code> fences</h2>
+    <p>A chart is a fenced code block whose language is <code>vega-lite</code> or <code>vega</code>, containing a JSON chart specification. Both fences render through the same engine — <a href="https://github.com/vega/vega-embed">vega-embed</a> compiles and draws either — so the only difference is which spec dialect you're writing.</p>
+
+<pre><code>```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": { "values": [
+    { "category": "A", "value": 28 },
+    { "category": "B", "value": 55 },
+    { "category": "C", "value": 43 },
+    { "category": "D", "value": 91 }
+  ] },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}
+```</code></pre>
+
+    <p>To insert one, right-click in the editor and choose <b>Elements → Chart…</b>. The submenu offers Bar, Line, Area, Scatter, Time Series, and Pie — each drops a complete, valid, inline-data spec with the cursor already inside the data array, so the first edit is just replacing the sample values. <b>From SPARQL</b>, <b>From Table</b>, and <b>From Cell</b> scaffold a data-bound chart instead (see below); <b>Empty Block</b> drops a bare <code>```vega-lite</code> fence for writing a spec from scratch.</p>
+
+    <h2 id="dialects">Vega-Lite vs. Vega</h2>
+    <p>Minerva tells the two dialects apart by the fence's language tag, not by inspecting the JSON — a <code>```vega</code> fence is always compiled as full Vega, a <code>```vega-lite</code> fence always as Vega-Lite.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>```vega-lite</code></div>
+        <div class="v"><b>Vega-Lite — the concise, declarative form.</b> You describe data, a mark type, and encodings; Vega-Lite works out axes, scales, and legends. This is what every Insert-menu scaffold produces, and what you want for ordinary bar/line/area/scatter/pie charts.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>```vega</code></div>
+        <div class="v"><b>Full Vega — the low-level grammar.</b> You specify scales, axes, and marks explicitly. Reach for it only when a chart needs something Vega-Lite's higher-level vocabulary can't express.</div>
+      </div>
+    </div>
+
+    <h2 id="rendering">How it renders</h2>
+    <p>The chart renders inline as an SVG, sized to the width of the note column — a spec's own <code>width</code>/<code>height</code> are honored, but the drawing scales to fit rather than overflowing into a horizontal scrollbar. It's genuinely interactive: hover a mark for a tooltip, and an "⋯" menu in the corner offers PNG/SVG export and viewing the spec (raw and compiled). While a chart is being drawn the block shows a brief "Rendering chart…" placeholder.</p>
+
+    <p>Chart colors follow the current theme automatically — background, axis lines, gridlines, and the default category palette are drawn from the same tokens as the rest of the UI, so a chart looks at home in dark, light, or high-contrast mode without any styling in the spec. An explicit color in your spec's own encoding still wins.</p>
+
+    <div class="shot wide">
+      <div class="icon">📊</div>
+      <div class="d">A rendered note showing a vega-lite bar chart fenced block: the chart drawn as an SVG bar chart sized to the note column width, a tooltip visible on a hovered bar, and the "⋯" export menu in the corner of the chart block.</div>
+    </div>
+
+    <h2 id="data">Sourcing data</h2>
+    <p>The ordinary way to supply data is inline, in the spec's own <code>data.values</code> array, as in the example above. For a chart that should track something else in the project, Minerva also recognizes four binding forms in place of <code>values</code> — each resolves to rows just before the chart renders:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>"data": { "sparql": "…" }</code></div>
+        <div class="v">Runs the query against the project's knowledge graph; each result row becomes a data point.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>"data": { "sql": "…" }</code></div>
+        <div class="v">Runs the query against registered DuckDB tables.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>"data": { "table": "name" }</code></div>
+        <div class="v">Shorthand for <code>SELECT * FROM name</code> against a registered table.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>"data": { "cell": "cell-id" }</code></div>
+        <div class="v">Reads the stored tabular output of a compute cell elsewhere in the note. The cell must have been run at least once — an unrun cell has no output to read.</div>
+      </div>
+    </div>
+
+    <p>A data-bound chart gets a refresh (⟳) button on its fence toolbar that inline charts don't need — click it to re-run the query and redraw without editing the note, useful after the graph or a table has changed. Values coming back from SPARQL are strings; Minerva coerces any column that's numeric in every row to a number first, so quantitative encodings (sums, axes, sorting) behave rather than sorting "10" before "9".</p>
+
+    <div class="box">
+      <span class="label">Inline data only — no remote URLs</span>
+      <p>A Vega/Vega-Lite spec can normally point <code>data</code> at a <code>url</code> to fetch a file or a network resource. Minerva refuses that: a note can arrive from an import, the clipper, or someone else's shared vault, so a chart spec is untrusted input, and rendering it must not make an arbitrary network or filesystem request. A spec with a <code>url</code> anywhere in it renders a "Remote data disabled" notice instead of a chart — inline <code>data.values</code>, or one of the SPARQL/SQL/table/cell bindings above, are the only supported sources.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Invalid JSON fails the whole block.</b> If the fence body doesn't parse as JSON, the chart is replaced with an inline "Vega error" showing the parse error — fix the syntax and it re-renders. A structurally valid spec that Vega-Lite/Vega itself rejects (unknown mark type, missing required encoding, and so on) surfaces the same way, with the library's own error message.</li>
+      <li><b>Fence language picks the dialect, not the JSON.</b> Pasting a full Vega spec into a <code>```vega-lite</code> fence (or vice versa) doesn't auto-detect — it just gets compiled by the wrong engine and fails. Match the fence tag to the spec you're writing.</li>
+      <li><b>A <code>url</code> anywhere in the spec blocks the whole chart</b>, even nested inside a layer or transform — not just at the top level. See the callout above.</li>
+      <li><b>Cell-bound charts need the cell to have run.</b> <code>data.cell</code> reads a stored output block from earlier in the note; if that compute cell hasn't been executed yet (or its last run errored), the chart shows "Chart data unavailable" instead of drawing empty axes.</li>
+      <li><b>Sizing follows the note column, not the spec's raw pixel size.</b> A wide fixed-width spec doesn't force a horizontal scrollbar — it scales down to fit. If a chart looks cramped, that's usually the note column, not the spec.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-diagrams.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Diagrams</span>
+      </a>
+      <a class="next" href="notes-code.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Code &amp; compute cells →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Code &amp; Compute Cells</title>
+<meta name="description" content="Code fences in Minerva notes: plain syntax-highlighted blocks versus runnable sparql, sql, and python cells, how to run them, and where their output lands in the note." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub active">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Code &amp; compute cells</p>
+
+    <h1>Code &amp; compute cells</h1>
+    <p class="lede">Every fenced code block in a note gets syntax highlighting. A handful of languages get more than that: mark a fence <code>sparql</code>, <code>sql</code>, or <code>python</code> and it becomes a runnable cell — a small ▶ appears, and running it writes the result back into the note as an output block sitting right under the code. The rest of the note stays a normal, portable markdown file the whole time.</p>
+
+    <h2 id="syntax">Plain fences vs. runnable fences</h2>
+    <p>The distinction is entirely the language tag on the opening fence. Everything else about the fence — the triple backticks, the indentation, how it looks in preview — is identical.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">```<i>lang</i></div>
+        <div class="v"><b>Plain fence.</b> Any language your syntax highlighter recognizes — <code>js</code>, <code>rust</code>, <code>bash</code>, <code>yaml</code>, and so on — renders with color highlighting and nothing else. There's no fixed list to check against: if it's not one of the three runnable tags below, Minerva highlights it and leaves it alone.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>```sparql</code></div>
+        <div class="v"><b>Runnable.</b> Runs against the current project's knowledge graph — the same engine behind the Query panel. Returns a table of variable bindings.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>```sql</code></div>
+        <div class="v"><b>Runnable.</b> Runs against the project's DuckDB instance — the same connection behind CSV/table sources. Returns a table of rows.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>```python</code></div>
+        <div class="v"><b>Runnable.</b> Executes in a persistent local Python process, one per project. Also matches the <code>py</code> and <code>python3</code> aliases. Returns text, a pandas table, JSON, an inline image (matplotlib, PIL), or rich HTML, depending on what the cell produces.</div>
+      </div>
+    </div>
+
+    <p>An unlabeled fence — bare ``` ``` with no language at all — is always plain. Minerva only turns on the run affordance when it recognizes the tag.</p>
+
+    <h2 id="running">Running a cell</h2>
+    <p>A runnable fence gets a small toolbar in both the source editor and the rendered preview:</p>
+    <ul>
+      <li><b>Click ▶</b> — on the fence's gutter marker in the editor, or the toolbar button in preview. The icon swaps to a muted <code>…</code> while the cell runs.</li>
+      <li><b><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Enter</kbd></b> (or <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>Enter</kbd>) — runs the fence the cursor is currently inside, from the editor.</li>
+      <li><b>Recompute all</b> — the toolbar button above the note re-runs every runnable fence top to bottom, stopping at the first error. It only appears when the note has at least one runnable fence.</li>
+    </ul>
+    <p>Editor and preview stay in sync either way: a run from the preview's ▶ button routes through the same trust gate and writes the same doc edit as a run from the editor gutter, so the fence and its output look identical regardless of which surface triggered the run.</p>
+
+    <h2 id="output">Where output goes</h2>
+    <p>A cell's result is written into the note itself, as an <code>output</code> fence immediately below the source fence — not a floating panel that disappears when you close the note. Re-running a cell replaces its existing output block in place. What that block renders as depends on the result's shape: a table for SPARQL bindings, SQL rows, or a pandas DataFrame; preformatted text; pretty-printed JSON; an inline image; or sanitized HTML for something like a Seaborn plot's rich repr. A failed cell — a SPARQL syntax error, a bad SQL statement, a Python exception — writes an error block instead, styled distinctly from a normal result, with the interpreter's message.</p>
+
+    <div class="shot wide">
+      <div class="icon">▶</div>
+      <div class="k">Screenshot — Runnable cell with output</div>
+      <div class="d">A note in preview showing a python fence with its ▶/Recompute toolbar, followed immediately by its rendered output block — a small table (a pandas DataFrame) with a "Showing N of M rows" truncation footer beneath it.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Large results are capped, not dropped</span>
+      <p>Table output — from SQL, SPARQL, or a DataFrame — is capped at a fixed row count per cell. When a result is truncated the output block shows "Showing <i>N</i> of <i>M</i> rows" so you know there's more data than you're seeing, rather than silently hiding it. Narrow the query if you need the rest.</p>
+    </div>
+
+    <h2 id="python">Python specifics</h2>
+    <p>The Python kernel is a real local process — the same permissions as Minerva itself, not a browser sandbox. It can read and write files, make network requests, and import anything installed in the interpreter Minerva is configured to use (Settings → Compute). Because of that, Minerva asks for confirmation once per project before running any Python cell; declining leaves the cell unrun until you approve it or re-run it later. There's no per-cell red warning styling — it's a single one-time prompt, and approving it is remembered for the rest of the project.</p>
+    <p>Cells in the same note share a namespace: a variable or import from one Python cell is visible to a later cell in that note, in run order. Cells in different notes never share state. SQL and SPARQL fences have no such state to share — each run is an independent query.</p>
+
+    <h2 id="trust">Approval and the knowledge graph</h2>
+    <p>Running a fence yourself — clicking ▶, pressing the shortcut, or using Recompute all — is a direct action you took, so it executes immediately with no approval step, the same way typing in a note doesn't ask for approval. Fences you write and run are ordinary local computation, not an AI-originated change, so the approval engine (the review step that gates AI proposals before they reach the graph) doesn't apply to them.</p>
+    <p>Both engines run the query you wrote, in full: a <code>sparql</code> fence executes through the same SPARQL engine as the Query panel, and a <code>sql</code> fence executes through the same DuckDB connection as your table sources. Every stock example is a read (<code>SELECT</code>, a graph pattern), and that's the intended use — but nothing in the compute shell parses your query to reject a write statement first. Treat a runnable fence with the same care as running a query in the Query panel itself. The SQL side has a natural backstop: that DuckDB connection is an in-memory instance rebuilt from your CSV sources each time the project opens, not a persisted database, so nothing a <code>sql</code> fence does to it outlives the session.</p>
+    <p>The one place a compute cell touches the graph on its own is unrelated to what the cell does: when the AI proposes a cell inside a conversation (rather than you writing one directly in a note) and you click Run on that proposal, Minerva records a <code>thought:ComputeProposal</code> audit entry — what ran, when, and that it was already approved by your click. That's provenance for a thing you just confirmed, not a new claim awaiting review, so it isn't queued through the pending-proposal flow the way an AI-proposed claim or link would be.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The runnable list is exactly three languages.</b> <code>sparql</code>, <code>sql</code>, and <code>python</code> (plus the <code>py</code> / <code>python3</code> aliases for the last one). Everything else — including close cousins like <code>graphql</code> or <code>bash</code> — is highlighted only; there's no way to make an arbitrary language executable from within a note.</li>
+      <li><b>Case matters in spirit, not literally.</b> The language tag is matched case-insensitively, so <code>SPARQL</code> and <code>Sql</code> still get the run affordance — but stick to lowercase; it's what every stock example and the highlighter both expect.</li>
+      <li><b>An output block isn't free-standing.</b> It's tied to the fence directly above it. Insert a paragraph or heading between a source fence and its output block and Minerva can no longer tell they're related — re-running writes a fresh block instead of replacing the orphaned one.</li>
+      <li><b>Declining the Python trust prompt doesn't block SPARQL or SQL.</b> The prompt only gates Python's arbitrary-process execution — a <code>sparql</code> or <code>sql</code> fence always runs when you click ▶, whatever the query says. Write cells the way you'd write anything you're about to run yourself.</li>
+      <li><b>Recompute all stops on the first error.</b> It's a top-to-bottom re-run, not a best-effort sweep — fix the failing cell and run again to continue past it.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-charts.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Charts</span>
+      </a>
+      <a class="next" href="notes-tables.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Tables &amp; CSV →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Diagrams</title>
+<meta name="description" content="Mermaid diagrams in Minerva notes: the mermaid fence syntax, which diagram types render, how the app's theme colors carry into the diagram, and what happens when a diagram has a syntax error." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub active">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Diagrams</p>
+
+    <h1>Diagrams</h1>
+    <p class="lede">A <code>mermaid</code> fence renders as a live diagram wherever it appears in a note — flowcharts, sequence diagrams, and anything else <a href="https://mermaid.js.org" target="_blank" rel="noopener">Mermaid</a>'s own syntax supports. Minerva doesn't restrict which Mermaid diagram types you can draw; it hands your fence content straight to the Mermaid library and draws whatever comes back as inline SVG, recolored to match the note around it.</p>
+
+    <h2 id="syntax">The <code>mermaid</code> fence</h2>
+    <p>A diagram is a fenced code block whose language is <code>mermaid</code>. Everything inside the fence is Mermaid's own diagram-definition language — Minerva doesn't parse or validate it beyond handing it to the renderer.</p>
+
+<pre><code>```mermaid
+flowchart LR
+  A[Draft] --> B{Reviewed?}
+  B -- yes --> C[Published]
+  B -- no --> A
+```</code></pre>
+
+    <p>To insert one, right-click in the editor and choose <b>Elements → Mermaid Diagram</b> — it drops an empty fence with the cursor inside, ready for a diagram definition.</p>
+
+    <h2 id="types">Diagram types</h2>
+    <p>The fence renderer (<code>renderMermaidFence</code> in <code>Preview.svelte</code>) does no type-checking on the content — it escapes the fence body and hands it to Mermaid's <code>render()</code> call as-is, in <code>mermaid-renderer.ts</code>. That means any diagram type Mermaid itself understands works in a Minerva note: flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, and the rest of Mermaid's grammar. Two of the most common are worth a quick reference:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>flowchart</code></div>
+        <div class="v"><b>Flowchart.</b> Nodes and directional edges — <code>LR</code> (left-to-right), <code>TD</code> (top-down), and the other Mermaid layout directions all work.
+<pre><code>```mermaid
+flowchart TD
+  Start --> Decision{OK?}
+  Decision -->|yes| End
+  Decision -->|no| Start
+```</code></pre>
+        </div>
+      </div>
+      <div class="row">
+        <div class="k"><code>sequenceDiagram</code></div>
+        <div class="v"><b>Sequence diagram.</b> Participants and the messages passed between them, in order.
+<pre><code>```mermaid
+sequenceDiagram
+  Alice->>Bob: Question
+  Bob-->>Alice: Answer
+```</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <h2 id="rendering">How it renders</h2>
+    <p>In preview, the fence becomes a bordered block with a collapse toggle in its toolbar — the same convention as other fence types — and the diagram itself renders as inline SVG below it. Rendering is lazy: Minerva dynamic-imports the Mermaid library the first time a diagram needs drawing, rather than bundling it into the app's startup path.</p>
+
+    <div class="shot wide">
+      <div class="icon">🗺️</div>
+      <div class="k">Screenshot — Mermaid flowchart in preview</div>
+      <div class="d">A rendered note with a mermaid-fence flowchart: a small decision-branch diagram drawn as SVG, sitting inside a bordered fence block with a collapse toggle in its toolbar, colors matching the surrounding dark theme.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Theme colors carry into the diagram</span>
+      <p>Minerva initializes Mermaid on the <code>base</code> theme and overrides its variables with the app's own Catppuccin tokens — background, text, borders, node fill, and accent all come from the same CSS custom properties the rest of the note uses. Switch Minerva's theme (dark, light, or contrast) and diagrams redraw to match; there's no separate diagram theme to configure.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>A syntax error renders inline, not as raw text.</b> If Mermaid can't parse the fence content, the block shows a small "Mermaid error" panel with the underlying error message in place of the diagram — the rest of the note keeps rendering normally. Fix the definition and the diagram appears in its place.</li>
+      <li><b>Re-rendering is idempotent.</b> A diagram block is marked once it's rendered, so re-running the preview's hydration pass (for example after an unrelated edit elsewhere in the note) doesn't redraw diagrams that already succeeded.</li>
+      <li><b>No live player, no external calls.</b> Rendering happens entirely locally through the bundled Mermaid library — nothing about a diagram's content is sent anywhere.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-math.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Math</span>
+      </a>
+      <a class="next" href="notes-charts.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Charts →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Frontmatter</title>
+<meta name="description" content="YAML frontmatter in Minerva notes: the --- delimited block, the recognized keys and their value shapes, how frontmatter feeds the graph index and the right-sidebar Properties panel, and common YAML pitfalls." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub active">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Frontmatter</p>
+
+    <h1>Frontmatter</h1>
+    <p class="lede">Frontmatter is a block of YAML at the top of a note, fenced by <code>---</code> lines, that carries structured metadata the prose itself doesn't. Minerva parses it three ways at once: a handful of keys drive the app directly (a note's title, its tags), everything else becomes a graph triple on the note, and the whole block renders as an editable property list in the right sidebar — so the YAML, the graph, and the panel are always three views of the same data.</p>
+
+    <h2 id="syntax">The frontmatter block</h2>
+    <p>A note's frontmatter must be the very first thing in the file: an opening <code>---</code> on line one, a closing <code>---</code> on its own line below, and valid YAML in between.</p>
+
+<pre><code>---
+title: The Attention Schema
+tags: [neuroscience, consciousness]
+created: 2024-03-01
+---
+
+The body of the note starts here.</code></pre>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>---</code></div>
+        <div class="v"><b>Opening fence.</b> Must be the first line of the file — nothing, not even a blank line, can come before it. Minerva only recognizes frontmatter that starts at byte zero.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>key: value</code></div>
+        <div class="v"><b>A property.</b> Standard YAML mapping syntax. Order is preserved when Minerva rewrites the block, and comments in the YAML survive edits made from the source editor.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>---</code> (closing)</div>
+        <div class="v"><b>Closing fence.</b> A second line containing only <code>---</code>. Everything between the fences is parsed as one YAML document; everything after the closing fence is the note body.</div>
+      </div>
+    </div>
+
+    <p>If the YAML between the fences doesn't parse — a bad indent, an unclosed quote — the Properties panel shows the parse error and disables structured editing until you fix it in the source editor. The rest of the app degrades gracefully: a note with unparseable frontmatter still opens, indexes its links and body tags, and falls back to its filename for a title.</p>
+
+    <h2 id="keys">Recognized keys</h2>
+    <p>Minerva ships with a set of <b>canonical</b> keys it understands well enough to map onto a specific graph predicate or a specific piece of app behavior. A generous set of aliases map onto the same canonical keys — write <code>author</code> or <code>authors</code> and both land as the same predicate as <code>creator</code>. You are not limited to this list — see <a href="#custom">Custom keys</a> below.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>title</code></div>
+        <div class="v"><b>String.</b> Becomes the note's title everywhere in the app — sidebar, tab, backlinks, graph queries — overriding the first-<code>H1</code> fallback. Indexed as <code>dc:title</code>, not as a generic metadata triple.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>tags</code></div>
+        <div class="v"><b>List of strings.</b> Merged with any inline <code>#tag</code> tags found in the note body into one tag set. A tag that only exists in frontmatter is indexed exactly like a body tag.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>aliases</code> <span style="opacity:.6">(alias: <code>alias</code>)</span></div>
+        <div class="v"><b>List of strings</b> (a single string also works). Alternate names this note resolves under for <code>[[wiki-links]]</code> — see <a href="notes-links.html#resolving">Links → How a target resolves</a>. Aliases containing <code>[</code>, <code>]</code>, <code>|</code>, <code>#</code>, or a newline are silently dropped, since they couldn't be written as a working <code>[[alias]]</code> anyway.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>creator</code> <span style="opacity:.6">(aliases: <code>author</code>, <code>authors</code>)</span></div>
+        <div class="v"><b>String.</b> Dublin Core author/creator.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>description</code>, <code>abstract</code></div>
+        <div class="v"><b>String.</b> Dublin Core description fields — a summary distinct from the note body.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>publisher</code>, <code>subject</code></div>
+        <div class="v"><b>String.</b> Dublin Core publisher and subject.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>language</code> <span style="opacity:.6">(alias: <code>lang</code>)</span></div>
+        <div class="v"><b>String.</b> Dublin Core language.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>about</code></div>
+        <div class="v"><b>String</b> (typically a <code>[[wiki-link]]</code>). Declares which source or note this note is <em>about</em> — maps onto the same predicate as <code>subject</code>, so the two are interchangeable.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>created</code>, <code>modified</code></div>
+        <div class="v"><b>Date</b> (<code>YYYY-MM-DD</code>) or datetime. Dublin Core timestamps. Note <code>modified</code> here is distinct from the file's actual on-disk mtime, which the graph indexer tracks separately regardless of frontmatter.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>issued</code> <span style="opacity:.6">(aliases: <code>date</code>, <code>year</code>)</span></div>
+        <div class="v"><b>Date, datetime, or number.</b> Publication date of the underlying source.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>doi</code>, <code>isbn</code></div>
+        <div class="v"><b>String.</b> Bibliographic identifiers (BIBO).</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>uri</code> <span style="opacity:.6">(alias: <code>url</code>)</span></div>
+        <div class="v"><b>String.</b> Bibliographic URI/URL of the source.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>pages</code> <span style="opacity:.6">(alias: <code>pageRange</code>)</span>, <code>volume</code>, <code>issue</code>, <code>numPages</code></div>
+        <div class="v"><b>String or number.</b> Bibliographic locators.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>inContainer</code></div>
+        <div class="v"><b>String</b> (typically a <code>[[wiki-link]]</code>). schema.org container reference — the journal, book, or site a source appears in.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>accessedAt</code>, <code>archivedAt</code></div>
+        <div class="v"><b>Date or datetime.</b> When a web source was accessed or archived — used by the source-tracking Research tools.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>supports</code>, <code>rebuts</code></div>
+        <div class="v"><b>String</b> (a <code>[[wiki-link]]</code> to a claim). Argumentation edges — materializes a <code>thought:supports</code> or <code>thought:rebuts</code> triple from this note to the target claim, same relationship a typed <code>[[supports::…]]</code> link expresses inline.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>claim-kind</code> <span style="opacity:.6">(alias: <code>claimKind</code>)</span>, <code>source-text</code> <span style="opacity:.6">(alias: <code>sourceText</code>)</span></div>
+        <div class="v"><b>String.</b> Claim-mining metadata written by the Decompose-into-Claims tool.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>extracted-by</code> <span style="opacity:.6">(alias: <code>extractedBy</code>)</span>, <code>extracted-from</code> <span style="opacity:.6">(alias: <code>extractedFrom</code>)</span></div>
+        <div class="v"><b>String.</b> Provenance for LLM-extracted claims — which tool or model produced this note, and what note or excerpt it was extracted from.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>decomposes</code></div>
+        <div class="v"><b>String</b> (a <code>[[wiki-link]]</code>). Points a decomposition note back at the source note it breaks down.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>confidence</code> <span style="opacity:.6">(alias: <code>confidenceValue</code>)</span></div>
+        <div class="v"><b>Number, 0.0–1.0.</b> Per-claim confidence score.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>term</code>, <code>disambiguation</code></div>
+        <div class="v"><b>String.</b> Glossary-note metadata: the term itself and a disambiguating note for when a term name collides.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>seeAlso</code> <span style="opacity:.6">(alias: <code>see-also</code>)</span></div>
+        <div class="v"><b>List of <code>[[wiki-links]]</code>.</b> Related glossary terms.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>derived_from</code></div>
+        <div class="v"><b>String</b> (a <code>[[wiki-link]]</code>). PROV-O provenance for a note derived from another — maps to <code>prov:wasDerivedFrom</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>derived_at</code>, <code>derived_from_cell</code></div>
+        <div class="v"><b>Datetime / string.</b> Companion provenance fields written alongside <code>derived_from</code> for compute-cell-derived notes.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Aliases get rewritten, not preserved</span>
+      <p>Aliases exist so you aren't penalized for a natural spelling (<code>author</code> instead of <code>creator</code>), not as a second permanent form. Minerva's formatter canonicalizes frontmatter keys when it formats a note — an alias you typed gets rewritten to its canonical form on save. Write whichever one you want in the moment; don't expect the alias spelling to stick around.</p>
+    </div>
+
+    <h2 id="custom">Custom keys</h2>
+    <p>Any key outside the canonical list is not rejected or dropped — it's indexed as-is. Minerva turns it into a graph triple using a generated predicate of the form <code>minerva:meta-&lt;key&gt;</code>, so a project-specific field like <code>status: draft</code> becomes a real, queryable edge even though Minerva has no built-in opinion about what <code>status</code> means. The Properties panel shows custom keys the same way it shows canonical ones — full editing, just without the accent-colored key and without appearing in the canonical-key quick-add suggestions.</p>
+    <p>One key is the exception: a <code>publish:</code> block (used by the static-site publishing feature) is deliberately excluded from graph indexing — it's a nested object of publication directives, not metadata about the note itself.</p>
+
+    <h2 id="values">Value shapes</h2>
+    <p>The Properties panel infers a type-specific editor from each value's YAML shape — a checkbox for booleans, a chip list for string arrays, a date picker for anything matching <code>YYYY-MM-DD</code>, a clickable chip for a single <code>[[wiki-link]]</code> value, and a raw YAML view (read-only in the panel, editable in source) for anything shaped like a nested object or a mixed-type list.</p>
+
+    <div class="shot wide">
+      <div class="icon">🗒️</div>
+      <div class="k">Screenshot — Properties panel</div>
+      <div class="d">The right-sidebar Properties panel open on a note with a mix of frontmatter: a "title" string row, a "tags" row rendered as removable chips, a "created" row with a date-picker input, a "confidence" row rendered as a number field, an "about" row rendered as a clickable wiki-link chip, and one custom key (e.g. "status: draft") shown with a muted, non-accent key color and a plain string input, plus the "+ Add property" row with a few canonical-key suggestion chips beneath it.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The opening fence must be line one.</b> A blank line, a comment, or any character before the first <code>---</code> means Minerva doesn't treat the block as frontmatter at all — it's read as ordinary note text instead.</li>
+      <li><b>Indentation is significant.</b> Frontmatter is YAML, so it inherits YAML's indentation rules. A misaligned nested value is a parse error, not a best-effort guess — and a parse error disables the structured Properties editor until it's fixed in source.</li>
+      <li><b>Unquoted values can silently change type.</b> <code>date: 2024-03-01</code> parses as a date, not a string; <code>version: 1.0</code> parses as a number; <code>enabled: yes</code> parses as a boolean, not the string <code>"yes"</code>. If you want a literal string that happens to look like something else, quote it: <code>version: "1.0"</code>.</li>
+      <li><b>A bracketed wiki-link in a list-like key gets eaten by YAML.</b> Writing <code>about: [[sources/foo]]</code> looks like a wiki-link, but bare <code>[…]</code> is YAML's array syntax — the outer brackets start a list and the inner brackets start a nested list, so YAML parses it as a one-element array containing a one-element array containing the string <code>sources/foo</code>. Minerva specifically detects this exact shape and recovers the intended <code>[[sources/foo]]</code> wiki-link, but any messier variant (a real multi-item list, extra text around the brackets) is left as whatever YAML actually parsed. When a value is meant to be a wiki-link, it's safest to quote it — <code>about: "[[sources/foo]]"</code> — so YAML never sees it as array syntax in the first place.</li>
+      <li><b>Nested objects don't reach the graph.</b> A frontmatter value that's a mapping (not a scalar or a flat list) has no obvious predicate to materialize, so the indexer drops it rather than guess. The Properties panel still shows it — as read-only YAML — so it isn't invisible, just not queryable.</li>
+      <li><b><code>modified:</code> in frontmatter isn't the file's real mtime.</b> The graph's <code>dc:modified</code> triple is sourced from the file's actual on-disk modification time, independent of anything you write under a <code>modified:</code> key. Use the canonical key if you want to record something else — a "content last reviewed" date, for instance — without it conflicting with the real timestamp.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-rdf.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Turtle / RDF</span>
+      </a>
+      <a class="next" href="navigation.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Navigation →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Highlights</title>
+<meta name="description" content="Highlighting text in Minerva notes: the ==highlighted== and ==color:highlighted== syntax, the five-color palette, and how highlights render as a tinted span in both the source editor and preview." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub active">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Highlights</p>
+
+    <h1>Highlights</h1>
+    <p class="lede">Wrap text in double equals signs and Minerva marks it as highlighted — a tinted inline span, the same idea as a highlighter pen on paper. It's a lightweight way to flag a passage as important while you're reading or drafting, without committing to a claim, a link, or any other structured markup.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>The marker is <code>==</code> on both sides of the text. An optional color name before the text picks from a small built-in palette; leave it off for the default tint.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>==text==</code></div>
+        <div class="v"><b>Highlight.</b> Marks the enclosed text with the default tint.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>==color:text==</code></div>
+        <div class="v"><b>Colored highlight.</b> <code>color</code> must be one of <code>yellow</code>, <code>green</code>, <code>blue</code>, <code>pink</code>, or <code>orange</code>. Anything else isn't recognized as a color prefix and is treated as part of the highlighted text instead — so <code>==Pythagorean: a²+b²==</code> highlights the whole string rather than guessing at a color.</div>
+      </div>
+      <div class="row">
+        <div class="k">no space inside</div>
+        <div class="v"><b>Whitespace guard.</b> A space or tab right after the opening <code>==</code> or right before the closing <code>==</code> stops the match — same rule as <code>**bold**</code> and <code>~~strikethrough~~</code>. This keeps a run of prose like <code>x == y == z</code> from accidentally turning into a highlight.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>===</code></div>
+        <div class="v"><b>Not a delimiter.</b> Three or more consecutive equals signs — in either direction — are never read as a highlight marker, so ASCII rules and similar runs of <code>=</code> are left alone.</div>
+      </div>
+    </div>
+
+    <p>A short example:</p>
+<pre><code>The migration is safe as long as ==the backfill runs before the
+NOT NULL constraint is added==. Everything else is cosmetic.
+
+Flagged for review: ==orange:re-check this once the index rebuild finishes==.</code></pre>
+
+    <h2 id="rendering">How highlights render</h2>
+    <p>A highlight becomes a <code>&lt;mark&gt;</code> element wherever it appears — an inline tinted span, not a block. In the rendered preview this shows as a soft color wash behind the text, sized to the palette color you chose (or the default accent tint if you didn't choose one).</p>
+
+    <div class="shot wide">
+      <div class="icon">🖍️</div>
+      <div class="k">Screenshot — Highlighted text in preview</div>
+      <div class="d">A rendered paragraph mid-sentence with two inline highlighted spans: one with the default tint around a short phrase, and one with the yellow palette color around a different phrase later in the same paragraph — both shown as a soft color wash behind the text, inline with the surrounding prose.</div>
+    </div>
+
+    <p>In the source editor, the same span is painted with a matching tint while you type — the <code>==</code> delimiters stay visible rather than being hidden, which is the convention Minerva uses for inline markup generally (it matches how <code>*emphasis*</code> and <code>~~strikethrough~~</code> are shown). You can see exactly what you wrote, decorated in place.</p>
+
+    <div class="box">
+      <span class="label">The color is themeable</span>
+      <p>Highlight tints are defined as CSS custom properties per theme, not fixed colors — the same five palette names (<code>yellow</code>, <code>green</code>, <code>blue</code>, <code>pink</code>, <code>orange</code>) resolve to different underlying values in Honey, Light, and Contrast, so a highlight stays legible and on-palette no matter which theme you're using. The editor and preview both derive their tint from the same source, so a highlight looks the same intensity in both places.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Other inline formatting nests fine.</b> The text inside <code>==…==</code> is re-parsed as regular inline markdown, so <code>==**bold**==</code>, <code>==[[wiki-link]]==</code>, and similar combinations work as you'd expect — the highlight wraps around the other formatting rather than blocking it.</li>
+      <li><b>Bold can wrap a highlight too.</b> <code>**==highlighted==**</code> resolves outermost-in — the bold applies around the highlighted span — so both directions of nesting are supported.</li>
+      <li><b>Unrecognized color prefixes aren't stripped.</b> Only the five palette names count as a color. <code>==note:remember this==</code> isn't read as a <code>note</code>-colored highlight — the whole thing, prefix included, is just the highlighted text.</li>
+      <li><b>An empty color prefix falls back to plain.</b> <code>==yellow:==</code> has no body left after the color name, so it isn't treated as a valid highlight with an empty label — it's left uncolored so you can still see what you wrote.</li>
+      <li><b>Highlights are inline-only.</b> A newline inside the marker ends the match before it closes — a highlight can't span multiple lines or wrap a whole paragraph.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-footnotes.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Footnotes</span>
+      </a>
+      <a class="next" href="notes-tasks.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Task lists →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Links</title>
+<meta name="description" content="Wiki-links in Minerva notes: the [[target|alias]] syntax, heading and block anchors, the 12 typed link types, how a link target resolves, and how links feed backlinks in the graph." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub active">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Links</p>
+
+    <h1>Links</h1>
+    <p class="lede">Wiki-links are how notes connect to each other. Wrap a note title in double brackets and Minerva turns it into a live link — resolved, rendered, and indexed into the knowledge graph. Beyond a plain reference, a link can carry a <b>type</b>: <em>supports</em>, <em>rebuts</em>, <em>depends on</em>, and nine others that describe the shape of the relationship, not just its existence.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>The full form is <code>[[type::target#anchor|display]]</code> — every part after the target is optional.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>[[target]]</code></div>
+        <div class="v"><b>Basic link.</b> <code>target</code> is a note title or filename. An untyped link is a <b>References</b> link — the default, catch-all type.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[target|display]]</code></div>
+        <div class="v"><b>Display text.</b> Everything after <code>|</code> is shown in place of the raw target — useful when the note title is long or reads awkwardly inline.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[target#Heading]]</code></div>
+        <div class="v"><b>Heading anchor.</b> Points at a specific heading in the target note rather than the top of the file.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[target^blockid]]</code></div>
+        <div class="v"><b>Block anchor.</b> Points at a specific block. The <code>^</code> is part of the syntax and isn't stripped when Minerva writes the anchor into the graph.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[type::target]]</code></div>
+        <div class="v"><b>Typed link.</b> <code>type</code> must start with a lowercase letter (e.g. <code>supports</code>, <code>depends-on</code>) — see the full list below. It goes <em>before</em> the target, separated by <code>::</code>.</div>
+      </div>
+    </div>
+
+    <p>Anchors and display text combine with a type prefix in any order you'd expect:</p>
+
+<pre><code>This claim is well established.[[supports::experiment-log#Trial 4]]
+
+See [[depends-on::auth-redesign|the redesign proposal]] before touching this.</code></pre>
+
+    <h2 id="types">Typed links</h2>
+    <p>A typed link renders in its type's color in preview, so the shape of a note's connections is visible at a glance without opening the backlinks panel. Twelve types are built in:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>references</code></div>
+        <div class="v"><b>References.</b> General-purpose "points at" link. The default when no type is given.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>supports</code></div>
+        <div class="v"><b>Supports.</b> This note backs up the claim in the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>rebuts</code></div>
+        <div class="v"><b>Rebuts.</b> This note argues against the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>load-bearing-for</code></div>
+        <div class="v"><b>Load-bearing for.</b> Flags the target as critically dependent on the analysis in this note — a high-leverage link worth double-checking if this note turns out to be wrong.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>expands</code></div>
+        <div class="v"><b>Expands.</b> This note elaborates on or goes deeper into the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>depends-on</code></div>
+        <div class="v"><b>Depends On.</b> This note requires the target to hold.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>implements</code></div>
+        <div class="v"><b>Implements.</b> This note is a concrete realization of an idea or spec described in the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>alternative-to</code></div>
+        <div class="v"><b>Alternative To.</b> This note proposes a different approach to the same problem as the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>supersedes</code></div>
+        <div class="v"><b>Supersedes.</b> This note replaces the target — a signal the target may be stale.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>related-to</code></div>
+        <div class="v"><b>Related To.</b> A loose, non-directional relation — useful when a link matters but none of the sharper types fit.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>cite</code></div>
+        <div class="v"><b>Cites.</b> Points at a <em>source</em> rather than a note — the target is a bibliography-style reference, not another knowledge-base file.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>quote</code></div>
+        <div class="v"><b>Quotes.</b> Points at a specific excerpt anchored in a source, for a direct quotation rather than a general citation.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔗</div>
+      <div class="k">Screenshot — Typed links in preview</div>
+      <div class="d">A rendered note with several inline wiki-links in different colors — a green "supports" link, a red "rebuts" link, and a default-blue untyped link — each underlined in its type's color.</div>
+    </div>
+
+    <h2 id="resolving">How a target resolves</h2>
+    <p>Minerva tries a target against your notes in order and stops at the first match:</p>
+    <ol>
+      <li>Exact file path.</li>
+      <li>Filename, case-sensitive.</li>
+      <li>A note's <code>aliases:</code> frontmatter, case-insensitive.</li>
+      <li>Filename, case-insensitive and slugified — punctuation and spacing don't have to match exactly.</li>
+      <li>Full path, slugified.</li>
+      <li>A unique tail of a nested path (so <code>[[raft]]</code> can resolve to <code>journey/raft.md</code>).</li>
+    </ol>
+    <p>The same resolver drives graph indexing, click-to-navigate in preview, and the hover preview — a link goes to the same place everywhere it's shown.</p>
+
+    <div class="box">
+      <span class="label">Ambiguous targets</span>
+      <p>If more than one note could satisfy a given step above, Minerva takes the first one it finds and doesn't warn you. Keep filenames distinct, or lean on <code>aliases:</code> frontmatter to make the intended target unambiguous.</p>
+    </div>
+
+    <p>In the source editor, clicking a link navigates to it; <kbd>⌘</kbd>-click (or <kbd>Ctrl</kbd>-click) places the cursor inside it to edit, the same convention as footnotes.</p>
+
+    <h2 id="backlinks">Backlinks</h2>
+    <p>Every link is indexed into the graph as a triple from the source note to the resolved target, using a predicate specific to its type — an untyped link becomes a <code>references</code> triple, a <code>[[supports::x]]</code> link becomes a <code>supports</code> triple, and so on. The right sidebar's <b>Backlinks</b> panel queries the graph for every note that links to the one you're viewing, and shows each with its link type's label and color, so you can tell at a glance whether an incoming note supports, rebuts, or merely references the current one.</p>
+
+    <div class="shot">
+      <div class="icon">↩️</div>
+      <div class="k">Screenshot — Backlinks panel</div>
+      <div class="d">The right-sidebar Backlinks panel listing several notes that link to the current one, each row showing the source note's title and a colored badge for its link type (e.g. "SUPPORTS", "RELATED TO").</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Links inside code don't count.</b> A <code>[[...]]</code> written inside a fenced code block or inline <code>`code`</code> span is left as literal text — it's never indexed or rendered as a link.</li>
+      <li><b>No nested brackets.</b> A link ends at the first <code>]]</code> it finds, so a literal <code>]</code> inside a target or display string will truncate the link early rather than being escaped.</li>
+      <li><b>Unresolved links don't stand out.</b> A target that doesn't match any note still gets indexed — as a link to a not-yet-existing file — but it renders the same as a resolved one. Clicking it won't create the missing note; it'll fail to open. Check the Backlinks panel or graph query results if you suspect a link isn't landing where you expect.</li>
+      <li><b>Frontmatter links are plainer.</b> A wiki-link written as a frontmatter value (e.g. in a custom property) only supports <code>[[target]]</code> and <code>[[target|display]]</code> — no type prefix, no anchor. Frontmatter values are treated as bare references.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Notes</span>
+      </a>
+      <a class="next" href="notes-callouts.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Callouts &amp; cards →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Math</title>
+<meta name="description" content="Math in Minerva notes: the $…$ inline and $$…$$ block delimiters, how both render through KaTeX, and gotchas around malformed LaTeX and math inside tables." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub active">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Math</p>
+
+    <h1>Math</h1>
+    <p class="lede">Minerva renders LaTeX math wherever it appears in a note — inline in a sentence or as its own centered display equation — using the same <code>$…$</code> / <code>$$…$$</code> convention as Pandoc and most markdown-flavored notes apps. Rendering happens through <a href="https://katex.org/" target="_blank" rel="noopener">KaTeX</a>, so it's fast and works offline: no server round-trip, no network dependency.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>Wrap LaTeX in single dollar signs for inline math, doubled dollar signs for a block display equation.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>$…$</code></div>
+        <div class="v"><b>Inline.</b> Renders in place, mid-sentence. Example: <code>the update rule is $\theta_{t+1} = \theta_t - \eta \nabla L(\theta_t)$.</code></div>
+      </div>
+      <div class="row">
+        <div class="k"><code>$$…$$</code></div>
+        <div class="v"><b>Block.</b> Renders as its own centered display equation. Example: <code>$$\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}$$</code></div>
+      </div>
+    </div>
+
+    <p>A block equation can open and close on one line, or span several — the closing <code>$$</code> just needs to end its own line:</p>
+
+<pre><code>$$
+P(A \mid B) = \frac{P(B \mid A)\,P(A)}{P(B)}
+$$</code></pre>
+
+    <div class="shot wide">
+      <div class="icon">∑</div>
+      <div class="k">Screenshot — Rendered math in preview</div>
+      <div class="d">A rendered note showing a sentence with an inline equation (θ update rule) in normal running text, followed by a bordered, centered block equation (the Bayes' rule example above) rendered by KaTeX in its own card below the paragraph.</div>
+    </div>
+
+    <h2 id="rendering">How math renders</h2>
+    <p>Inline math renders directly in the flow of text at normal size. Block math renders inside a bordered card — the same visual treatment as a code block — with the equation centered and the card scrolling horizontally if the equation is too wide to fit.</p>
+    <p>A <code>$$…$$</code> pair written mid-paragraph (not at the start of a line) still renders in display mode, just without its own card — useful for a one-off large equation you don't want to break out of the sentence.</p>
+
+    <div class="box">
+      <span class="label">Malformed LaTeX doesn't break the preview</span>
+      <p>An equation KaTeX can't parse renders as an inline error span showing the raw source, rather than failing the whole note's preview. Hovering the error span shows KaTeX's parse error as a tooltip, so you can see exactly what's wrong without leaving the note.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Unsupported LaTeX commands.</b> Minerva renders whatever KaTeX supports — a large but not complete subset of LaTeX math. A command from a package KaTeX doesn't implement will render as the error span described above rather than being silently dropped.</li>
+      <li><b>No space right after the opening <code>$</code> or before the closing <code>$</code>.</b> This is intentional, so ordinary prose mentioning money — "cost: $5 today, $50 tomorrow" — doesn't get swept into a math span. <code>$x+1$</code> is math; <code>$ x+1 $</code> is not. Digits right after the opening <code>$</code> are fine (<code>$0.6&lt;z&lt;4$</code> works), just not whitespace.</li>
+      <li><b>No blank line inside inline math.</b> An unescaped line break inside a <code>$…$</code> span ends the match instead of continuing it — keep inline math on one line. Block <code>$$…$$</code> math is fine spanning multiple lines.</li>
+      <li><b>Escaping a literal dollar sign.</b> Write <code>\$</code> to show a literal dollar sign next to math-like content without triggering inline math.</li>
+      <li><b>Math inside code fences and inline code is left alone.</b> A <code>$…$</code> written inside a fenced code block or inline <code>`code`</code> span is shown as literal text, never rendered as math.</li>
+      <li><b>Table cells render math normally.</b> A markdown table cell goes through the same inline-rendering pipeline as body text, so <code>$…$</code> works unescaped inside a cell — no special escaping needed beyond the rules above.</li>
+      <li><b>Note frontmatter is not rendered as markdown.</b> The YAML frontmatter block is stripped out before the note body is rendered, so <code>$…$</code> in a frontmatter value is shown as plain text in the frontmatter panel, not as math. (The Source viewer's title and abstract fields are the exception — see <a href="notes-frontmatter.html">Frontmatter</a> for where properties do and don't get markdown treatment.)</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-callouts.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Callouts &amp; cards</span>
+      </a>
+      <a class="next" href="notes-diagrams.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Diagrams →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Turtle / RDF</title>
+<meta name="description" content="Embedding raw Turtle in a Minerva note: the ```turtle fence that marks a block for graph indexing, the this: self-reference prefix, and how the triples merge into .minerva/graph.ttl." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub active">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Turtle / RDF</p>
+
+    <h1>Turtle / RDF</h1>
+    <p class="lede">Most of the knowledge graph is built for you — titles, tags, links, frontmatter, and table data are all extracted automatically as you write. But sometimes you know the relationship you want to assert more precisely than any auto-extraction could infer it. A fenced <code>turtle</code> block lets you drop hand-authored triples straight into a note; Minerva parses them on save and merges them into <code>.minerva/graph.ttl</code> alongside everything it extracted on its own.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>Mark a block with the <code>turtle</code> language tag. Anything inside is parsed as Turtle, not rendered as a code sample:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>```turtle</code></div>
+        <div class="v"><b>Opening fence.</b> The language tag must be exactly <code>turtle</code> — lowercase, no aliases like <code>ttl</code> or <code>rdf</code> are recognized. A block with any other tag (or no tag) is left as an ordinary code block and never reaches the graph.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>this:</code></div>
+        <div class="v"><b>Self-reference prefix.</b> Stands for the current note's own IRI. Use it as the subject when the triple is about the note itself — the common case.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>```</code></div>
+        <div class="v"><b>Closing fence.</b> Same as any fenced code block. Everything between the fences is handed to the Turtle parser verbatim.</div>
+      </div>
+    </div>
+
+    <p>A short, realistic example — typing a note as a glossary term and linking it to a broader concept:</p>
+
+<pre><code>```turtle
+this: a thought:Term ;
+    thought:hasStatus thought:established ;
+    minerva:relatesTo &lt;https://minerva.dev/ontology#Provenance&gt; .
+```</code></pre>
+
+    <p>On save, this block contributes three triples — all with <code>this:</code> resolved to the note's own IRI — into the note's slice of the graph, right next to the title, tags, and links Minerva extracted from the rest of the file.</p>
+
+    <div class="shot wide">
+      <div class="icon">🐢</div>
+      <div class="k">Screenshot — Turtle block in the editor</div>
+      <div class="d">The source editor showing a note with regular markdown body text above and below a fenced ```turtle code block, the block syntax-highlighted distinctly from surrounding prose, containing a few hand-authored triples using the `this:` subject and a `thought:` predicate.</div>
+    </div>
+
+    <h2 id="prefixes">Prefixes</h2>
+    <p>You don't need to declare the standard prefixes yourself. Minerva prepends them to the block before parsing — the same fixed set used everywhere else in the graph: <code>minerva</code>, <code>thought</code>, <code>dc</code>, <code>rdf</code>, <code>rdfs</code>, <code>xsd</code>, <code>csvw</code>, <code>owl</code>, <code>prov</code>, <code>bibo</code>, and <code>schema</code>, plus <code>this:</code> for the note itself. Write <code>thought:Term</code> or <code>dc:title</code> directly, with no <code>@prefix</code> line of your own.</p>
+
+    <div class="box">
+      <span class="label">Redeclaring a prefix</span>
+      <p>If your block already declares a prefix Minerva would otherwise inject — your own <code>@prefix dc: …</code>, say, or a custom <code>@prefix ex: &lt;https://example.org/&gt; .</code> — yours wins. Minerva only fills in prefixes the block doesn't already define, so you're free to point a standard prefix somewhere else or add prefixes of your own for IRIs outside the standard set.</p>
+    </div>
+
+    <h2 id="indexing">How it merges into the graph</h2>
+    <p>Every note has its own named graph in the store, keyed by the note's IRI — this is what lets Minerva cleanly drop and rebuild a single note's triples on reindex without touching anyone else's. A <code>turtle</code> block doesn't get a graph of its own: its triples land in that same per-note named graph, mixed in with the title, tags, links, and frontmatter triples Minerva generated automatically. There's no separate namespace or provenance marker distinguishing a hand-authored triple from an extracted one — once it's in the graph, it's just a triple in this note's graph.</p>
+    <p>Re-editing the block and saving again re-parses and replaces it, same as any other change to the note: reindexing clears the note's entire named graph first, then rebuilds it from scratch.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The tag is exactly <code>turtle</code>.</b> <code>```ttl</code> and <code>```rdf</code> are not recognized — the block just renders as a plain code sample and none of its content reaches the parser.</li>
+      <li><b>A malformed block doesn't break the note.</b> If a block fails to parse — a stray bracket, a missing period, an undeclared prefix you didn't mean to leave off — Minerva logs the error and skips that block. Every other part of the note (and any other <code>turtle</code> blocks in the same file) still indexes normally.</li>
+      <li><b>A skipped block fails quietly in the UI.</b> There's no inline squiggle or banner marking a block as broken — check the main process console if triples you expected aren't showing up in a query.</li>
+      <li><b>Blank nodes are fine.</b> <code>_:x</code>-style blank nodes work as you'd expect for structure you don't need to address from outside the block.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-tasks.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Task lists</span>
+      </a>
+      <a class="next" href="notes-frontmatter.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Frontmatter →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Tables &amp; CSV</title>
+<meta name="description" content="Markdown tables in Minerva notes: standard pipe-delimited syntax and alignment markers, and how every table on a note is extracted into the knowledge graph as CSVW triples during indexing." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub active">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Tables &amp; CSV</p>
+
+    <h1>Tables &amp; CSV</h1>
+    <p class="lede">Markdown tables render the way you'd expect — a header row, an alignment row, and as many data rows as you like. What's less obvious is that every table in a note is also read as data: on each save, Minerva parses its rows and columns into the knowledge graph using CSVW, the W3C vocabulary for describing tabular data. You don't opt in — a table is always both a formatted block in your text and a small dataset in the graph.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>Minerva uses standard GFM (GitHub-Flavored Markdown) pipe tables. A leading and trailing <code>|</code> on each row is conventional but not load-bearing for rendering — what matters is the separator row between the header and the data.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>| A | B |</code></div>
+        <div class="v"><b>Header row.</b> One line, cells separated by <code>|</code>. Becomes the column names for both rendering and graph extraction.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>|---|---|</code></div>
+        <div class="v"><b>Separator row.</b> Required immediately after the header. Marks where the header ends and data begins — without it, the lines above and below are just a paragraph, not a table.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>:---</code></div>
+        <div class="v"><b>Left-align</b> the column (also the default with no colon).</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>---:</code></div>
+        <div class="v"><b>Right-align</b> the column — handy for numeric data.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>:---:</code></div>
+        <div class="v"><b>Center-align</b> the column.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>| a \| b |</code></div>
+        <div class="v"><b>Escaped pipe.</b> A backslash before a pipe inside a cell renders it as a literal <code>|</code> instead of a column break.</div>
+      </div>
+    </div>
+
+    <p>A short example:</p>
+<pre><code>| Trial | Condition | Effect size |
+|:------|:---------:|------------:|
+| 1     | control   |        0.12 |
+| 2     | treatment |        0.61 |
+| 3     | treatment |        0.58 |</code></pre>
+
+    <div class="shot wide">
+      <div class="icon">📊</div>
+      <div class="k">Screenshot — Rendered table in preview</div>
+      <div class="d">The rendered preview of the trial/condition/effect-size table above: a bordered table with a bold header row, the first column left-aligned, the second column centered, and the numeric third column right-aligned.</div>
+    </div>
+
+    <p>Rendering is unmodified GFM — the same table syntax you'd write for GitHub. There's no support for merged or spanned cells (no colspan/rowspan); each cell is exactly one row by one column.</p>
+
+    <h2 id="csvw">How tables become CSVW</h2>
+    <p>On every index pass, Minerva walks each note's parsed tables and writes them into <code>.minerva/graph.ttl</code> using <a href="https://www.w3.org/ns/csvw#" target="_blank" rel="noopener">CSVW</a> — the real W3C namespace, not a Minerva-specific one. Each table becomes a <code>csvw:Table</code> linked to its note with <code>csvw:inNote</code>; each header becomes a <code>csvw:Column</code> with a <code>csvw:name</code> and <code>csvw:columnIndex</code>; each data row becomes a <code>csvw:Row</code>; and each row/column intersection becomes a <code>csvw:Cell</code> carrying the cell's value. <code>csvw</code> is one of the prefixes auto-injected into every query, so you can reach this data from Graph &gt; Query without declaring the namespace yourself.</p>
+
+    <div class="box">
+      <span class="label">Every table, no opt-in</span>
+      <p>There's no caption, id, or frontmatter flag that marks a table as "graph-worthy." Any syntactically valid table — header row, separator row, at least one data row — is extracted automatically. A table with a header and separator but zero data rows is the one exception: it's dropped silently, both from rendering as a meaningful table and from the graph. There's no way to write a markdown table that's decorative-only and keep it out of the graph; if you don't want tabular content indexed, it can't be a markdown table.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Alignment is display-only.</b> The <code>:---</code> / <code>---:</code> / <code>:---:</code> markers control text alignment in preview and nowhere else — that information isn't captured when a table is extracted into the graph. A SPARQL query over a table's cells can't tell you which columns were right-aligned.</li>
+      <li><b>Escaped pipes render correctly but don't extract correctly.</b> Preview handles <code>\|</code> as a literal pipe character inside a cell. The graph indexer's table parser doesn't — it splits naively on every <code>|</code>, so a cell written as <code>a \| b</code> shows up as one cell in preview but as extra, misaligned cells in the CSVW triples. Avoid literal pipes in cell content if you plan to query that table.</li>
+      <li><b>Tables inside code fences aren't extracted.</b> A pipe table written as an example inside a fenced code block renders as code, not a table, and is correctly excluded from graph indexing.</li>
+      <li><b>This isn't the CSV/DuckDB pipeline.</b> The right sidebar's <b>Tables</b> panel lists tables referenced by <code>```sql</code> fences and registered <code>.csv</code> files in your project — a separate, SQL-oriented feature. It doesn't show markdown tables or CSVW data. The only way to see a markdown table's extracted triples today is a graph query.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-code.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Code &amp; compute cells</span>
+      </a>
+      <a class="next" href="notes-images.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Images →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Task Lists</title>
+<meta name="description" content="Task lists in Minerva notes: the - [ ] / - [x] checkbox syntax, clicking a rendered checkbox to toggle it, and how the change writes back to the markdown source." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub active">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="notes.html">Notes</a><span class="sep">/</span>Task lists</p>
+
+    <h1>Task lists</h1>
+    <p class="lede">A list item that starts with <code>[ ]</code> or <code>[x]</code> renders as a live checkbox instead of a bullet. Click it in preview and Minerva flips the state and writes the change straight back to the markdown source — no separate "done" field, no dialog. The checkbox <em>is</em> the source of truth.</p>
+
+    <h2 id="syntax">Syntax</h2>
+    <p>A task item is an ordinary list item — bulleted or numbered — whose text begins with a checkbox marker and a space:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>- [ ] text</code></div>
+        <div class="v"><b>Unchecked.</b> Renders an empty checkbox. The list marker can be <code>-</code>, <code>*</code>, <code>+</code>, or an ordered marker like <code>1.</code> — all four work.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>- [x] text</code></div>
+        <div class="v"><b>Checked.</b> Renders a checked checkbox. Uppercase <code>[X]</code> also counts as checked — Minerva accepts either case on read, but always writes lowercase <code>x</code> back when it toggles a box.</div>
+      </div>
+      <div class="row">
+        <div class="k">indented item</div>
+        <div class="v"><b>Nested task.</b> Indent a task item under another to make it a sub-task. Nesting is ordinary markdown list nesting — Minerva doesn't track any parent/child relationship between the two, so checking the parent doesn't cascade to its children.</div>
+      </div>
+    </div>
+
+    <p>A space must follow the closing bracket — <code>- [ ]foo</code> (no space) isn't recognized and renders as a literal bracket pair, not a checkbox. An empty task item, <code>- [ ]</code> with nothing after it, is valid and toggles like any other.</p>
+
+<pre><code>- [ ] Draft the outline
+- [x] Circulate for feedback
+- [ ] Incorporate comments
+  - [x] Section 2 rewrite
+  - [ ] Section 4 rewrite
+- [ ] Final pass</code></pre>
+
+    <div class="shot wide">
+      <div class="icon">☑️</div>
+      <div class="k">Screenshot — Rendered task list</div>
+      <div class="d">A rendered note showing a bulleted task list with a mix of checked and unchecked boxes, including one top-level item with an indented sub-item beneath it (one checked, one unchecked) to show that nesting renders correctly.</div>
+    </div>
+
+    <h2 id="toggling">Clicking a checkbox</h2>
+    <p>In preview, every rendered checkbox is a real, clickable <code>&lt;input type="checkbox"&gt;</code>. Clicking one flips just that line in the note's markdown — <code>[ ]</code> becomes <code>[x]</code> or vice versa — leaving the rest of the line, and every other line, untouched. The edit lands in the editor's in-memory buffer immediately and then follows the normal auto-save path: it's written to disk about a second later (sooner if you save manually), the same debounced write every other edit in the note goes through.</p>
+    <p>Because the write goes through the ordinary file-save call, it triggers the ordinary file-write pipeline — including the graph re-index. There's no special-cased fast path for checkboxes; toggling one is treated exactly like typing the same character change by hand.</p>
+
+    <div class="box">
+      <span class="label">What actually changes on disk</span>
+      <p>Only the checkbox character on the matched line changes — the list marker, any indentation, and the rest of the item's text are preserved byte-for-byte. If the line doesn't match the task-item pattern (for example, the click somehow lands on a checkbox whose line was edited out from under it), nothing is written.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No cascading.</b> Checking a parent task doesn't check its nested sub-tasks, and checking every sub-task doesn't check the parent. Each checkbox is an independent toggle on its own line.</li>
+      <li><b>Ordered-list task items work too.</b> <code>1. [ ] item</code> is recognized the same as a bulleted one — useful if you want a numbered procedure where steps can also be marked done.</li>
+      <li><b>Case is normalized on write.</b> Reading treats <code>[x]</code> and <code>[X]</code> as equally checked, but a toggle always writes lowercase <code>x</code> — an existing <code>[X]</code> becomes <code>[ ]</code> when unchecked, not back to <code>[X]</code>.</li>
+      <li><b>The save is debounced, not instant.</b> The checkbox flips visually the moment you click it, but the write to disk (and the graph re-index that follows) happens on the same short delay as any other keystroke. A manual save flushes it immediately.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="notes-highlights.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Highlights</span>
+      </a>
+      <a class="next" href="notes-rdf.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Turtle / RDF →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Notes</title>
+<meta name="description" content="What a note is in Minerva, how the note lifecycle works — create, rename, move, delete — how every save feeds the knowledge graph, and a map of everything you can put inside a note." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html" class="active">Notes</a>
+    <a href="notes-links.html" class="sub">Links</a>
+    <a href="notes-callouts.html" class="sub">Callouts &amp; cards</a>
+    <a href="notes-math.html" class="sub">Math</a>
+    <a href="notes-diagrams.html" class="sub">Diagrams</a>
+    <a href="notes-charts.html" class="sub">Charts</a>
+    <a href="notes-code.html" class="sub">Code &amp; compute cells</a>
+    <a href="notes-tables.html" class="sub">Tables &amp; CSV</a>
+    <a href="notes-images.html" class="sub">Images</a>
+    <a href="notes-media.html" class="sub">Media</a>
+    <a href="notes-footnotes.html" class="sub">Footnotes</a>
+    <a href="notes-highlights.html" class="sub">Highlights</a>
+    <a href="notes-tasks.html" class="sub">Task lists</a>
+    <a href="notes-rdf.html" class="sub">Turtle / RDF</a>
+    <a href="notes-frontmatter.html" class="sub">Frontmatter</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Notes</p>
+
+    <h1>Notes</h1>
+    <p class="lede">A note is a plain <code>.md</code> file — nothing more. It can live anywhere in your project's folder tree, no dedicated "notes" directory required, and it can optionally start with a block of YAML <a href="notes-frontmatter.html">frontmatter</a> carrying structured metadata. Everything else — links, formatting, embedded content — is markdown written in a text editor, which is what makes a Minerva project just a folder of files you can open, edit, and back up with anything else that understands plain text.</p>
+
+    <h2 id="lifecycle">The note lifecycle</h2>
+    <p>Notes are managed from the sidebar tree, the command palette, or the File menu:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Create</div>
+        <div class="v"><b>File → New Note</b> (<kbd>⌘</kbd><kbd>N</kbd>), or "New Note" from the command palette. A dialog asks for a name and, optionally, a starting template — there's no silent "Untitled" default and no auto-numbering to dodge a collision, so pick a name that doesn't already exist.</div>
+      </div>
+      <div class="row">
+        <div class="k">Rename</div>
+        <div class="v">From the note's context menu in the sidebar. Prompts for a new name with the current one pre-filled. Renaming also rewrites every <a href="notes-links.html">wiki-link</a> elsewhere in the project that pointed at the old name, so incoming links don't go stale.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move</div>
+        <div class="v">Drag the note to a different folder in the sidebar tree.</div>
+      </div>
+      <div class="row">
+        <div class="k">Delete</div>
+        <div class="v">From the note's context menu in the sidebar. Minerva checks first whether anything outside the project still links to the file; if it's clear, you get a plain confirmation — "Delete note &quot;name&quot;?" — with a "don't ask again" option. No red styling: deleting a note is a normal operation, especially with git backing every project.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗂️</div>
+      <div class="k">Screenshot — Note lifecycle actions</div>
+      <div class="d">The left sidebar's file tree with a right-click context menu open on a note showing Rename, Move, and Delete, alongside the New Note dialog prompting for a name and template.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Every save updates the graph</span>
+      <p>There's no separate "index" or "sync" step. The moment you save a note, Minerva parses it and immediately re-indexes it into <code>.minerva/graph.ttl</code> — extracting the title, tags, wiki-links, frontmatter metadata, any embedded <a href="notes-rdf.html">Turtle blocks</a>, and <a href="notes-tables.html">table</a> data. The knowledge graph is always a live reflection of what's on disk, not a snapshot you have to remember to refresh.</p>
+    </div>
+
+    <h2 id="contents">What you can put in a note</h2>
+    <p>Beyond prose, a note can embed any of the following. Each has its own page with the exact syntax, how it renders, and any gotchas to know about:</p>
+
+    <div class="doc-cards">
+      <a class="doc-card" href="notes-links.html">
+        <span class="em">🔗</span>
+        <h3>Links</h3>
+        <p>Wiki-links, typed relationships, and how they build the backlink graph.</p>
+      </a>
+      <a class="doc-card" href="notes-callouts.html">
+        <span class="em">💡</span>
+        <h3>Callouts &amp; cards</h3>
+        <p>Titled note, tip, and warning-style boxes, plus front/back flashcard callouts.</p>
+      </a>
+      <a class="doc-card" href="notes-math.html">
+        <span class="em">∫</span>
+        <h3>Math</h3>
+        <p>Inline and display equations, rendered with KaTeX.</p>
+      </a>
+      <a class="doc-card" href="notes-diagrams.html">
+        <span class="em">🔀</span>
+        <h3>Diagrams</h3>
+        <p>Flowcharts, sequence diagrams, and anything else Mermaid draws.</p>
+      </a>
+      <a class="doc-card" href="notes-charts.html">
+        <span class="em">📊</span>
+        <h3>Charts</h3>
+        <p>Interactive Vega and Vega-Lite charts, live in the note.</p>
+      </a>
+      <a class="doc-card" href="notes-code.html">
+        <span class="em">🧮</span>
+        <h3>Code &amp; compute cells</h3>
+        <p>Syntax-highlighted code, plus runnable SPARQL, SQL, and Python cells.</p>
+      </a>
+      <a class="doc-card" href="notes-tables.html">
+        <span class="em">📋</span>
+        <h3>Tables &amp; CSV</h3>
+        <p>Markdown tables that double as structured data via CSVW.</p>
+      </a>
+      <a class="doc-card" href="notes-images.html">
+        <span class="em">🖼️</span>
+        <h3>Images</h3>
+        <p>Drag, paste, or link images — stored right alongside your notes.</p>
+      </a>
+      <a class="doc-card" href="notes-media.html">
+        <span class="em">🎬</span>
+        <h3>Media</h3>
+        <p>YouTube videos as click-to-open poster cards, no embedded player.</p>
+      </a>
+      <a class="doc-card" href="notes-footnotes.html">
+        <span class="em">🦶</span>
+        <h3>Footnotes</h3>
+        <p>Asides and citations that collect at the bottom of the note.</p>
+      </a>
+      <a class="doc-card" href="notes-highlights.html">
+        <span class="em">🖍️</span>
+        <h3>Highlights</h3>
+        <p>Mark a passage as important with a tinted inline span.</p>
+      </a>
+      <a class="doc-card" href="notes-tasks.html">
+        <span class="em">☑️</span>
+        <h3>Task lists</h3>
+        <p>Checkboxes that toggle in preview and write straight back to source.</p>
+      </a>
+      <a class="doc-card" href="notes-rdf.html">
+        <span class="em">🐢</span>
+        <h3>Turtle / RDF</h3>
+        <p>Hand-author graph triples directly inside a note.</p>
+      </a>
+      <a class="doc-card" href="notes-frontmatter.html">
+        <span class="em">🏷️</span>
+        <h3>Frontmatter</h3>
+        <p>YAML metadata that drives the app and feeds the graph.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="../getting-started.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Getting started</span>
+      </a>
+      <a class="next" href="notes-links.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Links →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Notes overview hub page (`notes.html`) plus the eleven remaining content-type pages: Links, Callouts & cards, Math, Diagrams, Charts, Code & compute cells, Tables & CSV, Highlights, Task lists, Turtle/RDF, and Frontmatter.
- Together with the previously-merged Images, Media, and Footnotes pages, this completes the entire "Notes" doc section (parent #1195, epic #1194).
- Every syntax/behavior claim is verified against the actual source (link resolution, callout kinds, Mermaid pass-through, Vega data bindings, KaTeX delimiters, task-toggle write-back, Turtle prefix injection, frontmatter key mapping, compute-cell trust model, etc.) rather than guessed.
- Wires the full prev/next pager chain end-to-end: Overview → Getting started → Notes → Links → Callouts & cards → Math → Diagrams → Charts → Code & compute cells → Tables & CSV → Images → Media → Footnotes → Highlights → Task lists → Turtle/RDF → Frontmatter → Navigation.
- Updates `index.html`'s sidebar (previously missing the Notes sub-list) so every docs page now shares the identical left nav.

Closes #1239, #1240, #1241, #1242, #1243, #1244, #1245, #1246, #1264, #1265, #1266, #1267.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every new page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 16 docs pages
- [x] Visually reviewed each page in a browser