### PR TITLE
docs site: add the Left sidebar documentation section

### DIFF
--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Bookmarks</title>
+<meta name="description" content="The Bookmarks panel saves whole-note, section, or exact-line locations in a folder tree of your own making, and jumps straight back to them — including a raw character offset that isn't remapped if you edit heavily above it." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="left-sidebar-notes-tree.html" class="sub">Notes tree</a>
+    <a href="left-sidebar-sources.html" class="sub">Sources</a>
+    <a href="left-sidebar-tags.html" class="sub">Tags</a>
+    <a href="left-sidebar-tables.html" class="sub">Tables</a>
+    <a href="left-sidebar-bookmarks.html" class="sub active">Bookmarks</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="left-sidebar.html">Left sidebar</a><span class="sep">/</span>Bookmarks</p>
+
+    <h1>Bookmarks</h1>
+    <p class="lede">The Bookmarks tab is a folder tree of saved locations you name and organize yourself — a whole note, a section under a heading, or an exact line. Click any entry and Minerva opens the note and jumps straight to that spot. Unlike <a href="left-sidebar-notes-tree.html">Notes</a> or <a href="left-sidebar-tags.html">Tags</a>, this tree isn't derived from the project — every node in it exists because you put it there.</p>
+
+    <h2 id="creating">Creating a bookmark</h2>
+    <p>There's no keybinding for it — bookmarks are created from context menus, in three flavors depending on what you right-click and where the cursor is:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Bookmark This Note</div>
+        <div class="v">Whole-file bookmark. Available from the editor's right-click menu, the tab bar's context menu, and a note's context menu in the <a href="left-sidebar-notes-tree.html">Notes tree</a>. Stores just the note's path — no offset, no anchor — and opens like clicking the note anywhere else.</div>
+      </div>
+      <div class="row">
+        <div class="k">Bookmark Section</div>
+        <div class="v">Editor right-click menu only. Bookmarks the nearest heading at or above the cursor, named after the heading text. If the cursor isn't inside any section, Minerva tells you so and stops — "No section heading above the cursor to bookmark. Place the cursor inside a section first."</div>
+      </div>
+      <div class="row">
+        <div class="k">Bookmark Line</div>
+        <div class="v">Editor right-click menu only. Bookmarks the exact cursor position as a character offset. The name is auto-derived from the line's trimmed text (truncated at 60 characters with an ellipsis), or "Line <var>N</var>" if the line is blank.</div>
+      </div>
+    </div>
+
+    <p>New bookmarks land at the root of the tree. From there, drag one onto a folder row to file it — or right-click any folder to create a new one first via <b>+ Folder</b> in the panel header.</p>
+
+    <div class="shot wide">
+      <div class="icon">🔖</div>
+      <div class="k">Screenshot — Bookmarks panel with a mixed tree</div>
+      <div class="d">The left sidebar's Bookmarks tab showing a "+ Folder" button in the header, a search field, and a tree with one open folder containing a section bookmark (outline icon) and a line bookmark (dot icon), plus a whole-note bookmark (filled bookmark icon) at the root — each row showing its name on top and its relative path below in a smaller monospace font.</div>
+    </div>
+
+    <h2 id="storage">What's stored, and where</h2>
+    <p>Each bookmark is one of three kinds, distinguished by which optional fields it carries on top of a name and a target path:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Whole-note</div>
+        <div class="v">Just <code>relativePath</code>. Neither <code>cursorOffset</code> nor <code>anchor</code> is set.</div>
+      </div>
+      <div class="row">
+        <div class="k">Section</div>
+        <div class="v"><code>anchor</code> — a heading slug, the same one <code>[[note#slug]]</code> wiki-links resolve against. Selecting it opens the note and scrolls to that heading, the same navigation path a wiki-link to that anchor would take.</div>
+      </div>
+      <div class="row">
+        <div class="k">Line</div>
+        <div class="v"><code>cursorOffset</code> — a raw character offset into the file's plain-text content, captured at creation time. This is the "saved character offset" the bookmark jumps back to.</div>
+      </div>
+    </div>
+
+    <p>The whole tree — folders and bookmarks together, in <code>BookmarkNode[]</code> form — is written to <code>.minerva/bookmarks.json</code> in the project root, debounced 500ms after any change. It's a plain project file alongside <code>.minerva/graph.ttl</code>, not an entry in the knowledge graph itself: bookmarks aren't queryable via SPARQL, and creating one doesn't touch <code>graph.ttl</code>. Because the file lives inside the project folder, bookmarks travel with the project across machines if you sync or git-track <code>.minerva/</code>, and they're shared by everyone with access to that folder — there's no per-user or per-device bookmark set.</p>
+
+    <h2 id="selecting">Selecting a bookmark</h2>
+    <p>Clicking a bookmark row routes by kind: a section bookmark opens the note and scrolls to its anchor; a line bookmark opens the note and restores the cursor to its saved offset; a whole-note bookmark just opens the note. Line bookmarks use a different jump primitive than <a href="navigation-search.html">Search</a> results — Search hands off a line/column pair to <code>gotoLineColumn()</code>, while a line bookmark hands off a raw character offset to the editor's <code>restorePosition(offset)</code>, which clamps the offset to the document's current length, places the cursor there, and scrolls it to the vertical center of the view. Functionally the destination looks the same either way — cursor placed, view centered, ready to type — the two panels just start from different units (line+column vs. a single offset).</p>
+
+    <div class="box">
+      <span class="label">A line bookmark's offset doesn't track edits between sessions</span>
+      <p>The number stored in <code>cursorOffset</code> is a snapshot from the moment you created the bookmark — it is <em>not</em> re-derived from the note's current content when you select it later. If you insert or delete a large amount of text above the bookmarked line after saving, the offset no longer points at the same character, and the bookmark can land you a few lines off, or mid-word. (There is a live position-mapping mechanism, but it only runs inside the editor's in-memory CodeMirror state while a file stays open in the current session — it resets the moment the tab closes or the app restarts, since only the raw offset is what's actually persisted to <code>bookmarks.json</code>.) Renaming or moving the note itself is safe — the bookmark's <code>relativePath</code> is rewritten automatically to follow it — and renaming the heading a section bookmark points at is also safe, since its slug is retargeted to match. It's specifically heavy edits <em>above</em> a line bookmark's position that can cause drift.</p>
+    </div>
+
+    <h2 id="managing">Renaming, moving, and deleting</h2>
+    <p>Right-click any bookmark or folder for <b>Rename</b> and <b>Delete</b>. Renaming only changes the label shown in the tree — it has no effect on what the bookmark points at. Reordering and filing is drag-and-drop: drag a bookmark onto a folder to move it inside, or onto the tree's empty background to move it back to the root. Deleting a folder deletes everything nested inside it — there's no separate "empty the folder first" step, and no confirmation dialog either; a bookmark is a pointer to a note, not the note itself, so removing one is low-stakes.</p>
+
+    <p>The panel header also has a search field (filters the tree to bookmarks and folders whose name matches, keeping a matching folder visible even if none of its children match) and expand-all / collapse-all controls for the folder tree.</p>
+
+    <div class="pager">
+      <a class="prev" href="left-sidebar-tables.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Tables</span>
+      </a>
+      <a class="next" href="right-sidebar.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Right sidebar →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Notes Tree</title>
+<meta name="description" content="The Notes panel's file tree: how it displays your project's folder structure, the header's live note count, and how creating, renaming, and moving notes are exposed as tree-specific UI." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="left-sidebar-notes-tree.html" class="sub active">Notes tree</a>
+    <a href="left-sidebar-sources.html" class="sub">Sources</a>
+    <a href="left-sidebar-tags.html" class="sub">Tags</a>
+    <a href="left-sidebar-tables.html" class="sub">Tables</a>
+    <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="left-sidebar.html">Left sidebar</a><span class="sep">/</span>Notes tree</p>
+
+    <h1>Notes tree</h1>
+    <p class="lede">The <b>Notes</b> tab is the left sidebar's default panel — the file/folder tree that mirrors your project's directory structure on disk. This page covers the panel itself as a piece of UI: the header controls, how the tree displays folders and files, and how creating, renaming, and moving notes are exposed here specifically. For the underlying concepts — what a note is, the full lifecycle, everything you can embed in one — see <a href="notes.html">Notes</a>.</p>
+
+    <h2 id="header">The panel header</h2>
+    <p>Above the tree sits a header with the panel title and a count on the right, then a row of three small tool buttons once the project has at least one note:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Note count</div>
+        <div class="v">A plain number next to the "Notes" title — no icon, no label, just a tabular-numeral count. It's a recursive file count, not a top-level one: every file anywhere in the tree, folders excluded, counted depth-first. It's a derived value, so it updates live the instant a note is created, deleted, or moved — there's no separate refresh step.</div>
+      </div>
+      <div class="row">
+        <div class="k">Expand all / Collapse all</div>
+        <div class="v">Two toolbar buttons above the tree. Expand All opens every folder in the project at once, regardless of current state; Collapse All folds everything shut. Both act on the whole tree, not just the visible portion.</div>
+      </div>
+      <div class="row">
+        <div class="k">Auto-reveal active file</div>
+        <div class="v">A toggle button (pressed = on) that keeps the tree in sync with whatever note is open in the editor: switching files expands every ancestor folder and scrolls the row into view automatically. It only reveals — clicking a folder to open or close it never re-triggers a reveal, so manually browsing the tree doesn't fight with whatever you have open elsewhere.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">The project name is a row, not a header</span>
+      <p>If the sidebar has a project name to show, it renders as a synthetic root row above the real tree — with its own folder icon and disclosure arrow — rather than as a section heading. It behaves like any other folder row (click to expand/collapse) but sits outside the multi-selection and drag-and-drop model, so it can't be accidentally selected, deleted, or dragged.</p>
+    </div>
+
+    <h2 id="tree">Reading the tree</h2>
+    <p>Folders and files are interleaved in a single hierarchical list, indented by depth. A few things about how it's populated and displayed are worth knowing:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Empty folders</div>
+        <div class="v">Shown, not filtered out. An empty folder is a normal, visible row you can expand (to see nothing) or drop a file into — Minerva doesn't hide directories just because they're currently empty.</div>
+      </div>
+      <div class="row">
+        <div class="k">Every file type</div>
+        <div class="v">The tree lists every file in the project, not just <code>.md</code> notes — <code>.csv</code> tables, <code>.ttl</code> Turtle/RDF, <code>.py</code> compute cells, and plain-text or code files each get a distinct row icon. Anything else falls back to the default note-page icon, since a curated notebase is almost always markdown-adjacent rather than an arbitrary binary.</div>
+      </div>
+      <div class="row">
+        <div class="k">Modified time</div>
+        <div class="v">File rows show a relative timestamp ("3h ago") on the right when the file has a known modification time. Folder rows don't carry one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Expand / collapse</div>
+        <div class="v">Only the disclosure chevron toggles a folder open or shut. Clicking the rest of the row selects the folder without touching its expanded state — so you can select a folder (to delete it, tag it, and so on) without it springing open or shut underneath you.</div>
+      </div>
+      <div class="row">
+        <div class="k">Keyboard navigation</div>
+        <div class="v">Click the tree (or Tab into it) to give it keyboard focus, then <kbd>↑</kbd>/<kbd>↓</kbd> move a cursor through the currently visible rows — respecting collapsed folders — without opening anything. <kbd>Enter</kbd> opens the focused file or toggles the focused folder. <kbd>⌘</kbd><kbd>↓</kbd>/<kbd>⌘</kbd><kbd>↑</kbd> expand/collapse the focused folder in place. <kbd>Space</kbd> toggles the focused row into/out of the selection. <kbd>⌘</kbd><kbd>A</kbd> selects every visible row; <kbd>Esc</kbd> clears the selection.</div>
+      </div>
+      <div class="row">
+        <div class="k">Multi-select</div>
+        <div class="v"><kbd>⌘</kbd>-click toggles a row in or out of the selection without opening it; <kbd>Shift</kbd>-click selects a contiguous range in visible order. A selection-count badge ("3 of 42 selected") appears above the tree once anything beyond a single row is selected, with a "clear" link. Right-clicking a row that's already part of the selection keeps the whole selection intact — so Delete or a tag action from the context menu applies to everything selected, not just the row you clicked.</div>
+      </div>
+    </div>
+
+    <h2 id="create">Creating notes and folders from the panel</h2>
+    <p>Right-clicking empty space in the tree (or the project-root row) opens a menu with just two entries: <b>New Note</b> and <b>New Folder</b>. Right-clicking an existing folder gets the same two entries at the top, scoped to create inside that folder rather than at the project root. New Note here opens the same naming dialog described in <a href="notes.html#lifecycle">Notes → The note lifecycle</a>; New Folder is the sidebar-specific counterpart — there's no File-menu or command-palette equivalent for creating a folder, only this context menu.</p>
+
+    <h2 id="rename-move">Renaming and moving</h2>
+    <p>Right-clicking a note or folder opens a fuller context menu: Cut, Copy, Paste (when something's on the clipboard), New Note, New Folder, then a separator before Rename, Merge into… (notes only), Copy Path, Bookmark and Toggle Entrypoint (notes only), an Open In submenu (Reveal in Finder / Open in Default App / Open in Terminal), Add Tag…, Remove Tag…, Format, and finally Delete.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Rename</div>
+        <div class="v">Context menu → Rename. Same prompt-with-prefilled-name behavior as described in the note lifecycle — wiki-links elsewhere in the project are rewritten to match.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move (drag)</div>
+        <div class="v">Every row is natively draggable. Drag a file or folder onto a target folder row to move it there; drop on empty space below the tree (or on the root row) to move it to the project root. Dropping a file straight into the editor — rather than onto a folder — inserts a resolving wiki-link instead of moving it; that's a different drag payload from a folder-to-folder move.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move (Cut / Paste)</div>
+        <div class="v">Context menu → Cut on the source, then Paste on the destination folder's context menu. Functionally the same move as dragging, useful when the source and destination aren't both scrolled into view at once.</div>
+      </div>
+      <div class="row">
+        <div class="k">Copy</div>
+        <div class="v">Context menu → Copy, then Paste elsewhere — duplicates rather than moves.</div>
+      </div>
+      <div class="row">
+        <div class="k">External drops</div>
+        <div class="v">Dragging files in from Finder (or another app) onto the tree imports them into the project at the drop location, rather than being treated as an internal move.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗂️</div>
+      <div class="k">Screenshot — Notes tree with context menu open</div>
+      <div class="d">The left sidebar's Notes panel: header showing the "Notes" title and a note count on the right, the Expand All / Collapse All / Auto-reveal toolbar below it, and the file tree beneath with a folder expanded to show a mix of notes and an empty subfolder. A right-click context menu is open on a note row, showing Cut, Copy, New Note, New Folder, a separator, then Rename, Copy Path, Bookmark, an Open In submenu, Add Tag…, Remove Tag…, Format, and Delete.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Deleting is a plain confirmation, not a warning</span>
+      <p>Delete from this menu follows the same rule as everywhere else in Minerva: no red styling, just a plain "Delete note &quot;name&quot;?" confirmation with a "don't ask again" option, backed by the fact that git has your history regardless. See <a href="notes.html#lifecycle">Notes → The note lifecycle</a> for the link-check Minerva runs first.</p>
+    </div>
+
+    <h2 id="empty-project">No notes yet</h2>
+    <p>A brand-new project with zero files shows a plain "No notes yet" message in place of the tree — the toolbar (Expand All / Collapse All / Auto-reveal) doesn't render at all until there's at least one file, since there's nothing yet for those controls to act on. Right-clicking the empty state still opens the New Note / New Folder menu, so an empty project isn't a dead end.</p>
+
+    <div class="pager">
+      <a class="prev" href="left-sidebar.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Left sidebar</span>
+      </a>
+      <a class="next" href="left-sidebar-sources.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Sources →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Sources</title>
+<meta name="description" content="The Sources panel: browsing collections and the reading queue, opening a source to view its metadata and body, capturing new sources by URL/DOI/file/clipper, and how sources connect to notes via cite and quote links." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="left-sidebar-notes-tree.html" class="sub">Notes tree</a>
+    <a href="left-sidebar-sources.html" class="sub active">Sources</a>
+    <a href="left-sidebar-tags.html" class="sub">Tags</a>
+    <a href="left-sidebar-tables.html" class="sub">Tables</a>
+    <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="left-sidebar.html">Left sidebar</a><span class="sep">/</span>Sources</p>
+
+    <h1>Sources</h1>
+    <p class="lede">The <b>Sources</b> tab (labeled <code>sites</code> internally, rendered by <code>SourcesPanel.svelte</code>) is Minerva's reference manager: a captured web page, PDF, or bibliography entry, with its own metadata, a markdown body, and excerpts you can cite from your notes. It sits alongside the notes tree as a second first-class content type — not a bookmark list, a working bibliography.</p>
+
+    <h2 id="what-is-a-source">What a source is</h2>
+    <p>A source is metadata plus an extracted body, stored as plain files at <code>.minerva/sources/&lt;sourceId&gt;/</code> — never inside your notes tree. Each source directory holds <code>meta.ttl</code> (Turtle metadata: title, creators, year, publisher, DOI, tags, and more), <code>body.md</code> (the extracted content, rendered and editable the same way a note is), and, when the original was a web page or PDF, <code>original.html</code> or <code>original.pdf</code> alongside it for re-extraction or offline reference. The source id itself is derived from content or identifier — a URL hash, a DOI, a file hash — never a human-readable slug, which is why every row and header shows a computed display title rather than the id.</p>
+
+    <div class="box">
+      <span class="label">Source vs. note</span>
+      <p>A source is not a note with different frontmatter — it's a distinct RDF class (<code>thought:Source</code>, with subtypes like <code>thought:WebPage</code>, <code>thought:Article</code>, and <code>thought:PDFSource</code>) living outside the notebase file tree. You can still write a note <em>about</em> a source — the source detail view has a "New note about this source" action that pre-fills <code>about: [[sources/&lt;id&gt;]]</code> frontmatter — but the source's own body and metadata are edited from the Sources panel, not the notes tree.</p>
+    </div>
+
+    <h2 id="browsing">Browsing the panel</h2>
+    <p>The panel stacks three sections above the flat source list, each acting as a filter scope:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Collections</div>
+        <div class="v">A nested, expandable tree of manual collections (you assign sources to them by hand) and <b>smart collections</b> — saved queries that populate automatically from a predicate you define. Each row shows a live member count. Selecting a collection scopes the list below to its members.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reading queue</div>
+        <div class="v">A collapsible section with four built-in views — <b>Unread</b>, <b>Reading</b>, <b>Due this week</b>, and <b>Recently finished</b> — each with a live count, driven by the per-source read status and due date rather than anything you curate manually.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter field</div>
+        <div class="v">A single text box above the list. It matches against the displayed title, the byline (creators), the year, and the source id — whichever collection or queue view is currently selected. There's no separate sort control; order comes from however the backend returns the list.</div>
+      </div>
+    </div>
+
+    <p>Each row in the flat list (<code>SourceListItem.svelte</code>) shows:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Title</div>
+        <div class="v">The computed display title — the real <code>dc:title</code> if one was extracted, otherwise a cleaned-up form of the source URL. Rendered in the same italic display face used for citations.</div>
+      </div>
+      <div class="row">
+        <div class="k">Status dot</div>
+        <div class="v">A small glyph next to the title if a reading status is set (unread / reading / read / skipped) — absent for sources with no status.</div>
+      </div>
+      <div class="row">
+        <div class="k">Byline</div>
+        <div class="v">Creators, then year, then a due-date stamp if one is set — whichever of those three are present, joined with a middle dot. An overdue due date is styled distinctly from one still upcoming.</div>
+      </div>
+    </div>
+
+    <p>There's no favicon or domain column — this is a bibliography list, not a browser-style bookmark manager. Clicking a row opens the source's detail view in a tab, the same way clicking a note opens it in the editor. Right-clicking gives you rename, add tag, add/remove collection membership, set reading status or due date, copy DOI, mine references, merge into another source, and delete.</p>
+
+    <h2 id="adding">Getting sources in</h2>
+    <p>Nothing is captured automatically — every source starts from an explicit action:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Panel "+" button</div>
+        <div class="v">Next to the filter field. Prompts for a URL, DOI, arXiv id, or PubMed id and figures out which it is, then ingests it. The fastest path when you're already looking at the panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">File → Ingest URL as Source… <span style="white-space:nowrap"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>I</kbd></span></div>
+        <div class="v">Fetches the page, runs Mozilla Readability to extract the article content, and converts it to markdown. Re-running this on a URL you've already ingested merges any newly-found metadata into the existing <code>meta.ttl</code> without touching your edited <code>body.md</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k">File → Ingest Identifier… <span style="white-space:nowrap"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>D</kbd></span></div>
+        <div class="v">Looks up a DOI, arXiv id, or PubMed id and pulls structured bibliographic metadata, fetching an open-access PDF where one exists.</div>
+      </div>
+      <div class="row">
+        <div class="k">File → Ingest File as Source…</div>
+        <div class="v">Local-file picker. PDFs go through text-layer extraction (or a two-step OCR flow if the PDF has no text layer); HTML files go through the same Readability path as a URL; plain markdown/text files are stored verbatim.</div>
+      </div>
+      <div class="row">
+        <div class="k">File → Import BibTeX… / Import Zotero RDF…</div>
+        <div class="v">Bulk import from an existing bibliography export — for bringing an established reference library into a project in one pass rather than one source at a time.</div>
+      </div>
+      <div class="row">
+        <div class="k">Browser clipper</div>
+        <div class="v">A companion browser extension pairs with Minerva over a local, secret-gated loopback connection (paired and rotated from Settings → Browser Clipper) and sends the current page straight into the same ingest pipeline — for capturing while you're reading in the browser, without switching to the app first.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Ingest needs the network</span>
+      <p>URL, identifier, and clipper capture all fetch live over the network — there's no offline queue that retries later. Local-file ingest is the only path that works without a connection. There's also no "refresh" action on an existing source: re-ingesting a URL merges fresh metadata but leaves the body alone, specifically so edits you've made to <code>body.md</code> survive.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">📚</div>
+      <div class="k">Screenshot — Sources panel with detail view open</div>
+      <div class="d">The left sidebar's Sources panel showing the Collections tree, the collapsed Reading queue section, and a filtered list of a few source rows (title, status dot, and creator/year byline), next to an open source detail tab showing its title, byline, tag chips, a metadata block (Publisher, DOI, Source id, reading-status buttons), an abstract, and its rendered markdown body.</div>
+    </div>
+
+    <h2 id="detail">Opening a source</h2>
+    <p>Clicking a row opens <code>SourceDetail.svelte</code> in a tab — the same tab strip a note uses. The header shows the subtype (Article, Web Page, PDF, and so on — with a "STUB" marker for a reference-mined placeholder that hasn't been resolved yet), the title, the byline, and editable tag chips. Below that, a metadata block lists whatever fields are present — Publisher, DOI (a clickable external link), URL, the raw source id, reading-status buttons (Unread / Reading / Read / Skipped — click the active one again to clear it), and a due-date picker. Action buttons cover Open original PDF (when one was captured), Rename source, and Delete source.</p>
+
+    <p>If the source has an abstract, it renders above the body. The body itself — <code>body.md</code> — renders through the same markdown preview a note uses, and has its own <b>Edit body</b> toggle that swaps in a plain-text editor for direct changes. Selecting text inside the rendered body opens a small context menu to save it as an <b>excerpt</b> — a separately stored, precisely anchored quotation you can later cite by id. A density gutter along the body's scrollbar marks where existing excerpts fall. Further down, a References section lists any sources this one cites (including unresolved stubs created by reference-mining), and a "Referenced from" section lists notes that cite or quote this source — both clickable.</p>
+
+    <div class="box">
+      <span class="label">Deletion has no undo dialog trapdoor — it has git</span>
+      <p>Deleting a source removes its excerpts and its entire <code>.minerva/sources/&lt;id&gt;/</code> directory in one pass. The confirmation reads plainly — "Delete source &quot;name&quot;? Any excerpts from this source will also be removed." — with no red styling and a "don't ask again" option, same as deleting a note. Wiki-links or cite/quote links pointing at the deleted source become dead links; recovery is what git is for.</p>
+    </div>
+
+    <h2 id="citations">Sources, notes, and citations</h2>
+    <p>A source is cited from a note using the typed wiki-link syntax, not through any UI in this panel: <code>[[cite::sourceId]]</code> points at a source as a bibliography-style reference, and <code>[[quote::excerptId]]</code> points at a specific excerpt for a direct quotation. Both are indexed into the graph the same way any typed link is, which is what powers the "Referenced from" list on the detail view above. See <a href="notes-links.html">Notes → Links</a> for the full typed-link mechanics and how targets resolve — this page covers the panel you browse and capture sources from, not the citation syntax itself.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No favicon, no domain, no browser-bookmark styling.</b> The row and header UI are built around bibliographic fields (creators, year, publisher, DOI) — if what you want is a lightweight bookmark list, see <a href="left-sidebar-bookmarks.html">Bookmarks</a> instead.</li>
+      <li><b>Renaming a source only changes its title, not its id.</b> <code>Rename source</code> upserts <code>dc:title</code> in <code>meta.ttl</code>; the on-disk directory and the id any citations resolve against stay exactly as they were.</li>
+      <li><b>Encrypted PDFs are rejected outright</b> during ingest, with a clean error rather than a partial/garbled capture.</li>
+      <li><b>Scanned PDFs need an OCR step before they have a body.</b> A PDF with no text layer ingests immediately (metadata and <code>original.pdf</code> are saved), but <code>body.md</code> stays empty until you run — or explicitly skip — the OCR pass Minerva offers.</li>
+      <li><b>Merging two sources is manual and irreversible on the losing side.</b> The merge picker warns that excerpts and citations of the source being merged away move to the target, then the original is removed.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="left-sidebar-notes-tree.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Notes tree</span>
+      </a>
+      <a class="next" href="left-sidebar-tags.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Tags →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Tables Panel</title>
+<meta name="description" content="The left sidebar's Tables panel: every CSV in your project registered as a queryable DuckDB view, with row/column counts, a click-to-query shortcut, and a context menu to open the raw file." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="left-sidebar-notes-tree.html" class="sub">Notes tree</a>
+    <a href="left-sidebar-sources.html" class="sub">Sources</a>
+    <a href="left-sidebar-tags.html" class="sub">Tags</a>
+    <a href="left-sidebar-tables.html" class="sub active">Tables</a>
+    <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="left-sidebar.html">Left sidebar</a><span class="sep">/</span>Tables</p>
+
+    <h1>Tables</h1>
+    <p class="lede">The Tables panel lists every <code>.csv</code> file in your project as a queryable table. Each one is registered as a live DuckDB view the moment it appears on disk — the panel isn't a browser for markdown tables or their <a href="notes-tables.html">CSVW</a> triples, it's a directory of your project's actual CSV data, ready to query with SQL.</p>
+
+    <div class="box">
+      <span class="label">Not the same "tables" as the Notes &amp; Tables page</span>
+      <p><a href="notes-tables.html">Tables &amp; CSV</a> covers markdown pipe tables written inside a note and how each one is extracted into <code>.minerva/graph.ttl</code> as CSVW triples on save. This panel is unrelated: it only ever lists standalone <code>.csv</code> files sitting in your project folder. A markdown table inside a note's prose never appears here, and a CSV file's rows never appear as a markdown table anywhere — the two pipelines don't intersect except that both eventually write shape information (columns, types) into the same graph.</p>
+    </div>
+
+    <h2 id="registration">How a CSV gets here</h2>
+    <p>On project open, Minerva walks the project folder and registers every <code>.csv</code> file it finds as an in-memory DuckDB view — the view is lazy, so DuckDB re-reads the file from disk on every query rather than caching stale content. The file watcher keeps this live afterward: adding, editing, or deleting a <code>.csv</code> anywhere in the project registers, re-registers, or drops its view automatically, and the panel refreshes to match. There's no import step and no dialog — drop a CSV in the folder and it's queryable.</p>
+
+    <p>The SQL identifier for a table is derived from its path by default (slashes and punctuation become underscores — <code>notes/data/2024-experiment.csv</code> becomes <code>notes_data_2024_experiment</code>), but you can pin an explicit name. A companion markdown note in the same folder with a matching filename stem (<code>experiment.csv</code> ↔ <code>experiment.md</code>) can set <code>table_name:</code> in its frontmatter to override the derived name — useful for giving a table a shorter or more memorable identifier than its path would produce.</p>
+
+    <div class="box">
+      <span class="label">Two CSVs, one name</span>
+      <p>If two different CSVs would derive the same table name, the second one is skipped rather than silently replacing the first's view — you'll see a toast pointing at the conflict, and the fix is a <code>table_name:</code> override on one of the companion notes to disambiguate. The skipped file's data simply isn't queryable until you resolve the collision.</p>
+    </div>
+
+    <h2 id="panel">What each row shows</h2>
+    <p>The panel is a flat, alphabetically-sorted list (by file path) with a filter field above it that matches against both the table name and the file's relative path as you type.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Table name</div>
+        <div class="v">The SQL identifier — the derived or overridden name described above — shown in monospace as the row's primary label.</div>
+      </div>
+      <div class="row">
+        <div class="k">Row / column counts</div>
+        <div class="v">A live count queried straight from DuckDB — <code>3 rows · 5 cols</code>, for example — not a cached figure from when the file was first registered.</div>
+      </div>
+      <div class="row">
+        <div class="k">File path (on hover)</div>
+        <div class="v">The CSV's project-relative path isn't printed in the row itself, but it's the row's tooltip — hover to confirm which file a given table name maps to.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧮</div>
+      <div class="k">Screenshot — Tables panel with several registered CSVs</div>
+      <div class="d">The left sidebar's Tables tab showing a filter field followed by a handful of rows — each a monospace table name like <code>notes_data_2024_experiment</code> over a smaller row/column count line, with one row's right-click context menu open showing Query (SELECT *), Copy Table Name, Open CSV, and Reveal in Finder.</div>
+    </div>
+
+    <h2 id="clicking">Clicking a table</h2>
+    <p>Clicking a row doesn't open the CSV file or jump anywhere in a note — it opens a new SQL query tab pre-filled with <code>SELECT * FROM &lt;table name&gt;</code> against that table, so you land straight on its data. From there it's an ordinary compute-cell-style query surface: edit the SQL, re-run it, and it executes against the same in-memory DuckDB instance the panel itself is backed by.</p>
+
+    <p>Right-clicking a row opens a context menu with four actions:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Query (SELECT *)</div>
+        <div class="v">Same action as a left click — opens the query tab.</div>
+      </div>
+      <div class="row">
+        <div class="k">Copy Table Name</div>
+        <div class="v">Copies the SQL identifier to the clipboard, for referencing the table in a query you're already writing elsewhere (a compute cell, for instance).</div>
+      </div>
+      <div class="row">
+        <div class="k">Open CSV</div>
+        <div class="v">This is "opening the underlying CSV" — it opens the raw <code>.csv</code> file itself as a file tab, the same as selecting it in the notes tree. There's no separate export or view-as-table step; you're looking at the plain-text file on disk.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reveal in Finder</div>
+        <div class="v">Shows the CSV file in the OS file browser.</div>
+      </div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Empty project shows a hint, not a blank pane.</b> With no CSVs registered, the panel reads "No tables yet. Drop a CSV into the thoughtbase." instead of an empty list.</li>
+      <li><b>A table with no header row is still queryable, just awkwardly.</b> DuckDB's CSV auto-detection infers a header when it can; if a file genuinely has none, columns come back as generic auto-generated names rather than anything meaningful. There's no markdown-style caption concept here at all — a CSV file has no title beyond its filename and derived table name.</li>
+      <li><b>Reads are live, but registration needs the watcher (or a rebuild) to notice a brand-new file.</b> Editing an already-registered CSV is reflected immediately — the DuckDB view re-reads on every query. Adding a new <code>.csv</code> or renaming one relies on the file watcher to register it, which is normally instant; if a table you expect doesn't show up, <b>Query → Rebuild All Indexes</b> forces a full re-scan of every CSV in the project.</li>
+      <li><b>This is a separate DuckDB instance from any per-note compute cells.</b> The panel and its query tabs share one in-memory database per project — every registered CSV is queryable from any query you open, and none of it touches <code>.minerva/graph.ttl</code> directly (only column names and types are mirrored into the graph, not row data).</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="left-sidebar-tags.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Tags</span>
+      </a>
+      <a class="next" href="left-sidebar-bookmarks.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Bookmarks →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Tags</title>
+<meta name="description" content="The left sidebar's Tags panel: a flat, alphabetical chip list of every tag from frontmatter and inline #tag syntax, with per-tag note/source counts and click-to-filter results." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="left-sidebar-notes-tree.html" class="sub">Notes tree</a>
+    <a href="left-sidebar-sources.html" class="sub">Sources</a>
+    <a href="left-sidebar-tags.html" class="sub active">Tags</a>
+    <a href="left-sidebar-tables.html" class="sub">Tables</a>
+    <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="left-sidebar.html">Left sidebar</a><span class="sep">/</span>Tags</p>
+
+    <h1>Tags</h1>
+    <p class="lede">The Tags panel is a flat, alphabetical list of every tag in your project — pulled from frontmatter and from inline <code>#tag</code> text alike — rendered as chips you click to see what carries that tag. It's a browsing and filtering tool, not an editor: tags themselves are added and removed from a note's own text or its Properties panel, not from here.</p>
+
+    <h2 id="sources">Where tags come from</h2>
+    <p>A tag can be written two ways, and both land in the same place. Minerva doesn't distinguish a "frontmatter tag" from a "body tag" once they're indexed — they're merged into one deduplicated set per note and written to the graph as identical <code>minerva:hasTag</code> edges.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Frontmatter list</div>
+        <div class="v"><code>tags: [neuroscience, consciousness]</code> in the YAML block at the top of a note. See <a href="notes-frontmatter.html#keys">Frontmatter — Recognized keys</a> for the full value shape.</div>
+      </div>
+      <div class="row">
+        <div class="k">Inline <code>#tag</code></div>
+        <div class="v">Anywhere in the note body, a <code>#</code> at the start of a line or after whitespace, immediately followed by a letter — <code>#draft</code>, <code>#project/ui</code>. It stops at the next character that isn't a letter, digit, underscore, hyphen, or slash.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Why <code># Heading</code> doesn't become a tag</span>
+      <p>An ATX heading like <code># Heading</code> or <code>## Subheading</code> has a space between the <code>#</code> and the text, and the tag pattern requires a letter <em>immediately</em> after the <code>#</code> — so ordinary headings are never mistaken for tags. Write <code>#tag</code> with no space to tag something; write <code>#&nbsp;Heading</code> with a space for a heading. Tags inside fenced or inline code spans are also ignored — code is stripped from the note before tag extraction runs, so a <code>#</code> in a code sample never pollutes your tag list.</p>
+    </div>
+
+    <h2 id="panel">What the panel shows</h2>
+    <p>Tags render as a wrapped grid of chips, sorted alphabetically by tag name — not by frequency, recency, or anything else. Each chip's label is the tag name prefixed with <code>#</code>, followed by a count.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Count</div>
+        <div class="v">The number next to a tag's name is how many notes (and, if the <b>sources</b> toggle is on, sources) carry it — hovering a chip shows the exact breakdown, e.g. "3 notes, 1 source." A note or source is only counted once per tag even if the tag appears many times in its body.</div>
+      </div>
+      <div class="row">
+        <div class="k">Chip size</div>
+        <div class="v">Tags in the top quartile by combined note+source count render slightly larger than the rest — a quick visual cue for which tags dominate the project, recomputed automatically as the tag list changes. It's a sizing hint only; it doesn't change sort order or behavior.</div>
+      </div>
+      <div class="row">
+        <div class="k">Accent tags</div>
+        <div class="v"><code>entrypoint</code> and <code>open-question</code> always render in the accent color, regardless of their count — Minerva treats these two as navigationally significant rather than ordinary labels.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sources toggle</div>
+        <div class="v">A checkbox above the tag list, on by default, that includes tagged sources alongside tagged notes — in both the displayed counts and in a selected tag's results below. Turning it off narrows everything to notes only.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🏷️</div>
+      <div class="k">Screenshot — Tags panel with a tag selected</div>
+      <div class="d">The left sidebar's Tags tab: a wrapped row of pill-shaped tag chips of mixed size sorted alphabetically, one chip (e.g. #neuroscience) shown in its active/pressed state, with a "Tagged #neuroscience" section beneath listing matching note titles and a couple of source rows marked with a small SRC badge — the "sources" checkbox above the chip grid shown checked.</div>
+    </div>
+
+    <h2 id="selecting">Selecting a tag</h2>
+    <p>Clicking a chip is the panel's only interaction — there's no separate search box for the tag list itself. It queries the graph for every note and source carrying that exact tag and lists their titles directly beneath the chip grid, under a "Tagged #name" header. Clicking a listed note opens it in the editor; clicking a listed source opens the source viewer.</p>
+
+    <p>Only one tag can be active at a time — selecting a chip doesn't add to a running filter, it replaces whichever tag was previously selected. Clicking the already-active chip again deselects it and clears the results, which is also how you back out of a tag filter entirely.</p>
+
+    <div class="box">
+      <span class="label">This filters a results list, not the notes tree</span>
+      <p>Selecting a tag doesn't change what's visible in the <a href="left-sidebar-notes-tree.html">Notes tree</a> panel — the two are independent. It produces its own flat list of matching titles inside the Tags panel itself; switch to the Notes tab and the full, unfiltered tree is exactly as you left it.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No tag hierarchy in this panel.</b> The <code>/</code> in a tag like <code>project/ui</code> is valid syntax and is stored and matched as a literal tag string — but this panel shows it as one flat chip alongside every other tag, not as a nested tree with parent/child rollup. (A nested-tag tree does exist elsewhere, in the right sidebar's Properties-adjacent tags view — a different panel from the one described on this page.)</li>
+      <li><b>Selecting a tag is an exact match, not a prefix match.</b> Selecting <code>project</code> shows only notes tagged exactly <code>#project</code> — notes tagged only <code>#project/ui</code> won't appear in its results.</li>
+      <li><b>Empty project shows a hint, not a blank pane.</b> With no tags indexed anywhere, the panel reads "No tags yet" instead of an empty grid.</li>
+      <li><b>The panel doesn't add or remove tags.</b> To tag a note, edit its frontmatter or type <code>#tag</code> in the body (or use the Properties panel's tag chips in the right sidebar); the Tags panel only ever reads what's already indexed.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="left-sidebar-sources.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Sources</span>
+      </a>
+      <a class="next" href="left-sidebar-tables.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Tables →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Left Sidebar</title>
+<meta name="description" content="The left sidebar's five panels: the Notes tree, Sources, Tags, Tables, and Bookmarks — what each one shows and how to work with it." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html" class="active">Left sidebar</a>
+    <a href="left-sidebar-notes-tree.html" class="sub">Notes tree</a>
+    <a href="left-sidebar-sources.html" class="sub">Sources</a>
+    <a href="left-sidebar-tags.html" class="sub">Tags</a>
+    <a href="left-sidebar-tables.html" class="sub">Tables</a>
+    <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Left sidebar</p>
+
+    <h1>Left sidebar</h1>
+    <p class="lede">The left sidebar is the workspace rail — five panels behind five tabs, each a different lens on your project. The Notes tree is the file system; Sources is a reference manager sitting alongside it; Tags and Tables are two different ways to browse data extracted from your notes; Bookmarks is a set of places you've marked yourself. Switch between them by clicking a tab icon at the top of the sidebar.</p>
+
+    <h2 id="glance">The five panels</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="left-sidebar-notes-tree.html">Notes tree</a></div>
+        <div class="v">The default panel — your project's folder structure, and where you create, rename, and move notes.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-sources.html">Sources</a></div>
+        <div class="v">Captured web pages, PDFs, and bibliography entries, separate from your notes but citable from them.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-tags.html">Tags</a></div>
+        <div class="v">A flat, alphabetical list of every tag in the project — from frontmatter and inline <code>#tag</code> text alike.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-tables.html">Tables</a></div>
+        <div class="v">Every <code>.csv</code> file in the project, registered as a live, queryable table.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-bookmarks.html">Bookmarks</a></div>
+        <div class="v">Places you've saved yourself — a whole note, a section, or an exact line — organized in your own folders.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="left-sidebar-notes-tree.html">
+        <span class="em">🌳</span>
+        <h3>Notes tree</h3>
+        <p>The file/folder tree — create, rename, and move notes.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-sources.html">
+        <span class="em">📚</span>
+        <h3>Sources</h3>
+        <p>Captured references you can cite from your notes.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-tags.html">
+        <span class="em">#️⃣</span>
+        <h3>Tags</h3>
+        <p>Every tag in the project, frontmatter and inline alike.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-tables.html">
+        <span class="em">🗄️</span>
+        <h3>Tables</h3>
+        <p>Every CSV in the project, ready to query with DuckDB.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-bookmarks.html">
+        <span class="em">🔖</span>
+        <h3>Bookmarks</h3>
+        <p>Saved locations — a note, a section, or an exact line.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="editor.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Editor</span>
+      </a>
+      <a class="next" href="left-sidebar-notes-tree.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Notes tree →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Left sidebar hub page (`left-sidebar.html`) plus five full sub-pages: Notes tree, Sources, Tags, Tables, and Bookmarks — closing out epic #1199 and its five children.
- **Restructured from the original plan**, same reasoning as the Navigation section (PR #1274): the epic and its children originally called for one shared `left-sidebar.html` page with five subsections, which doesn't fit the real depth of five distinct panels. Issue #1199 and all five children were updated on GitHub to reflect the new per-page targets before this was built.
- Every claim is verified against the actual source rather than assumed from the issue text — and several issue assumptions turned out to be wrong:
  - **Tables panel** is a DuckDB browser over every `.csv` file in the project — clicking a row opens a `SELECT * FROM <table>` query tab, not a browser for markdown-table CSVW data as the issue assumed. This lines up with what `notes-tables.html` (from the Notes section PR) already found: there's no dedicated CSVW browser panel.
  - **Tags panel** click populates an inline results list within the panel itself, not a filter on the Notes tree as assumed — and it's a distinct, flat component from a separate hierarchical Tags panel that lives in the *right* sidebar (out of scope here, explicitly flagged to avoid future confusion).
  - **Bookmarks** store a static character offset that can drift if text above the bookmark is later edited — a tradeoff the code's own comments acknowledge, not a bug, but worth documenting.
- Since the sidebar now only expands the section you're currently viewing (merged in PR #1274), this batch is purely additive — none of the 23 existing docs pages needed changes.

Closes #1199, #1259, #1260, #1261, #1262, #1263.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every new page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 6 new pages
- [x] Confirmed no pre-existing pages required changes (sidebar collapse-by-section already handles this)
- [x] Visually reviewed each page in a browser