### PR TITLE
docs site: add the Right sidebar documentation section

### DIFF
--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Backlinks</title>
+<meta name="description" content="The Backlinks panel lists every note that links to the one you're viewing, grouped by link type or sorted alphabetically, with a click to jump straight to the source." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub active">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Backlinks</p>
+
+    <h1>Backlinks</h1>
+    <p class="lede">The <b>Backlinks</b> panel lists every note that links to the one you currently have open — the incoming side of the link graph, as opposed to the note's own <a href="right-sidebar-outgoing-links.html">outgoing links</a>. It's driven entirely by the graph index, so the list updates as soon as another note's link is saved, without you touching the current note at all.</p>
+
+    <div class="box">
+      <span class="label">How a backlink gets here</span>
+      <p>This page is about the panel's own UI — grouping, sorting, and click behavior. For how wiki-links resolve to a target, what the twelve typed-link predicates mean, and how a link gets indexed into the graph as a triple in the first place, see <a href="notes-links.html#backlinks">Notes → Links → Backlinks</a>.</p>
+    </div>
+
+    <h2 id="layout">Reading the panel</h2>
+    <p>Each row is a source note that links to the current one, with a small notes icon and the source note's title — never its raw file path, though the path is available as the row's tooltip. A header line above the list gives a running total: <i>"N linked mentions"</i>. If a note links to the current one more than once (say, via two different typed links), each link is its own row — the count is mentions, not distinct notes.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Filter box</div>
+        <div class="v">Typing into the ribbon's search field narrows the list to source notes whose title or path contains the query, live as you type. It searches only what's already loaded for the current note — it isn't a project-wide search.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sort: By type (default)</div>
+        <div class="v">Rows are grouped into collapsible sections, one per link type, each with a colored square and mono-cased label (e.g. <code>SUPPORTS</code>, <code>REFERENCES</code>) matching that type's color from <a href="notes-links.html">typed links</a>, plus a count. Click a group header — or its chevron — to collapse or expand it; the ribbon's collapse-all / expand-all buttons act on every group at once.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sort: Alphabetical</div>
+        <div class="v">Switching the sort dropdown to "Alphabetical" drops the type grouping entirely and lists every backlink as one flat list, ordered by source note title. Each row instead carries its own small colored badge showing that link's type, since the grouping that would otherwise convey it is gone.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a row</div>
+        <div class="v">Opens the source note in the editor. This is real navigation, not a preview — the current note's own panel state (search text, sort choice, collapsed groups) is left as you had it, ready for when you navigate back.</div>
+      </div>
+      <div class="row">
+        <div class="k">Drag a row</div>
+        <div class="v">A backlink row can be picked up and dropped the same way a sidebar file can — useful for dragging a source note into a note body as a new link, or into another drop target that accepts a note reference.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔗</div>
+      <div class="k">Screenshot — Backlinks panel, grouped by type</div>
+      <div class="d">The right-sidebar Backlinks panel with the sort dropdown set to "By type," showing two expanded type groups — each with a colored square, mono type label, and count — and one collapsed group, above a flat row of ungrouped backlinks; the ribbon's filter field, sort selector, and expand/collapse-all buttons are visible at the top.</div>
+    </div>
+
+    <h2 id="empty">No backlinks</h2>
+    <p>A note with nothing pointing at it shows <i>"No backlinks found"</i> in place of the list — this is expected for a new note, a leaf note, or anything you haven't linked to yet, not an error state. If backlinks exist but your filter text doesn't match any of them, the message changes to <i>"No matches"</i> instead, so you can tell at a glance whether the panel is empty because nothing links here or because your search is too narrow.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The panel only knows about the graph, not the disk.</b> A link that hasn't been saved yet — still sitting in an unsaved editor buffer — isn't indexed, so it won't appear as a backlink anywhere until the source note is saved.</li>
+      <li><b>Same source, multiple rows.</b> If a note links to the current one through more than one typed link, it shows up once per link, not deduplicated into a single row — the mention count in the header reflects this.</li>
+      <li><b>Collapsed-group state doesn't persist across notes.</b> Switching to a different note resets which type groups are collapsed; it isn't remembered per-note.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Right sidebar</span>
+      </a>
+      <a class="next" href="right-sidebar-outgoing-links.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Outgoing links →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Bookmarks (Note)</title>
+<meta name="description" content="The right sidebar's Bookmarks panel is the same project-wide bookmark store as the left sidebar's Bookmarks panel, filtered down to a flat list of just the current note's bookmarks." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub active">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Bookmarks</p>
+
+    <h1>Bookmarks</h1>
+    <p class="lede">The right sidebar's Bookmarks panel shows the bookmarks that belong to the note you're currently looking at — a flat list, no folders. It isn't a separate bookmarking system: it reads the exact same project-wide bookmark store as the <a href="left-sidebar.html">left sidebar</a>'s <a href="left-sidebar-bookmarks.html">Bookmarks panel</a>, just filtered down to one file and rendered without the tree.</p>
+
+    <div class="box">
+      <span class="label">Same store, different view</span>
+      <p>There is one bookmark store in the whole app. The left sidebar's <code>BookmarksPanel.svelte</code> renders its full folder tree, unfiltered, with search, drag-and-drop, and folder management. This panel — a distinct component also named <code>BookmarksPanel.svelte</code>, at <code>right-sidebar/BookmarksPanel.svelte</code> — flattens that same tree and filters it down to whatever bookmarks (whole-note, section, or line) target the active note. Neither creates, folders, nor persists anything independently; both read and write through <code>getBookmarksStore()</code>, so a rename or delete in one view is instantly reflected in the other. For how bookmarks are created, how folders and drag-to-reorder work, the <code>Bookmark</code> data shape, and the <code>.minerva/bookmarks.json</code> persistence model, see <a href="left-sidebar-bookmarks.html">the left sidebar's Bookmarks page</a> — this page only covers what's different about the note-scoped view.</p>
+    </div>
+
+    <h2 id="what-shows">What shows up here</h2>
+    <p>The panel takes the active note's relative path and keeps only the bookmarks whose <code>relativePath</code> matches it, discarding the left sidebar's folder structure entirely in the process — a bookmark filed three folders deep on the left shows up here as a plain row, with no indication of which folder it lives in. Switch notes and the list recomputes immediately, since it's a derived filter over the shared store rather than a separate fetch.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">No active note</div>
+        <div class="v">Shows "No active note" — there's nothing to scope the list to.</div>
+      </div>
+      <div class="row">
+        <div class="k">Active note, no bookmarks</div>
+        <div class="v">Shows "No bookmarks for this note", distinct from the left sidebar's empty state ("No bookmarks yet"), which only appears when the entire project has zero bookmarks.</div>
+      </div>
+      <div class="row">
+        <div class="k">Whole-note, section, and line bookmarks</div>
+        <div class="v">All three kinds appear side by side, using the same icon convention as the left sidebar: an outline glyph for a section anchor, a dot for a line (cursor-offset) bookmark, and a plain bookmark glyph for a whole-note bookmark.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔖</div>
+      <div class="k">Screenshot — Right sidebar Bookmarks panel scoped to the active note</div>
+      <div class="d">The right sidebar's Bookmarks panel showing a short flat list of three bookmarks for the open note — one whole-note, one section (outline icon), one line (dot icon) — each row with a name on the left and a small delete (×) button that fades in on hover at the right; no folders, no search field, no "+ Folder" button.</div>
+    </div>
+
+    <h2 id="actions">What you can do from here</h2>
+    <p>This view is deliberately thin. Clicking a row opens the bookmark exactly like the left sidebar does — a section anchor scrolls to that heading, a line bookmark jumps to its stored cursor offset, and a whole-note bookmark just opens the file (a no-op here, since it's already open). The only other action is the per-row delete button, which removes the bookmark from the shared store outright. There's no rename, no drag-to-reorder, no new-folder button, and no way to create a bookmark from this panel — creation only happens from the editor, preview, or tab context menu's <b>Bookmark This Note</b> / <b>Bookmark Section</b> / <b>Bookmark Line</b> commands, the same as for the left sidebar.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Deleting here deletes everywhere.</b> Because both panels point at the same store, removing a bookmark from this list removes it from the left sidebar's tree too — there's no per-view "hide" that leaves the underlying bookmark intact.</li>
+      <li><b>Line bookmarks can still drift.</b> A line bookmark's position is a static character offset captured at creation time, so later edits to the note can shift what that offset now points at. This is the same acknowledged tradeoff documented on <a href="left-sidebar-bookmarks.html">the left sidebar's Bookmarks page</a> — it applies here too, since it's the identical stored data, just filtered.</li>
+      <li><b>Folder placement is invisible here.</b> If you're trying to find which folder a bookmark lives in so you can move or reorganize it, this panel can't help — switch to the left sidebar's tree view for that.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-heading-graph.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Heading graph</span>
+      </a>
+      <a class="next" href="conversations.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Conversations →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Citations</title>
+<meta name="description" content="The Citations panel lists every source the current note cites or quotes, grouped one row per source with occurrence counts and quoted excerpts, so you can jump straight to the source you referenced." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub active">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Citations</p>
+
+    <h1>Citations</h1>
+    <p class="lede">The Citations panel lists every source the current note cites or quotes — one row per source, with a byline, an occurrence count, and (when the note quotes it) the specific excerpts pulled in. It's a bibliography for the note you're looking at, built from its <code>[[cite::…]]</code> and <code>[[quote::…]]</code> links rather than typed by hand.</p>
+
+    <h2 id="how-it-works">How it works</h2>
+    <p>The panel groups every <a href="notes-links.html#types"><code>cite</code> and <code>quote</code> typed link</a> in the note by the source it resolves to, so a source cited three times and quoted twice appears once, with both counts on the same row. It reads the note's own indexed <code>thought:cites</code> / <code>thought:quotes</code> edges to find which sources are in play, then re-scans the live editor buffer to count occurrences — so the counts track what you're typing, not just the last save. Edits are debounced before the panel re-queries, so fast typing doesn't trigger a query per keystroke.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Source row</div>
+        <div class="v">Shows the source's title in italic and a byline (author, or "author and author," or "author et al." for three or more, plus the year when known) — the same metadata as the source's own entry. A chip on the right splits the count into cites and quotes, e.g. <code>3</code> cites and <code>2″</code> quotes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a source row</div>
+        <div class="v">Opens that source's own tab — the same detail view described in <a href="left-sidebar-sources.html">Left sidebar → Sources</a> — scrolled to the top.</div>
+      </div>
+      <div class="row">
+        <div class="k">Expand a source</div>
+        <div class="v">A disclosure triangle appears on any source the note actually quotes. Expanding it lists each quoted excerpt underneath, with a truncated preview of the quoted text and its locator (a page number, page range, or other location text) when the source has one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click an excerpt</div>
+        <div class="v">Opens the source scrolled to that excerpt, rather than just to the top of the source — useful for jumping straight back to the passage you quoted in a long PDF or web capture.</div>
+      </div>
+      <div class="row">
+        <div class="k">Search and sort</div>
+        <div class="v">The ribbon's search field filters by source title, source ID, author name, or quoted text — so you can find the source you cited by searching for a phrase you remember quoting. Sort between "Most cited" (the default) and alphabetical by title.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">📚</div>
+      <div class="k">Screenshot — Citations panel with an expanded source</div>
+      <div class="d">The right sidebar's Citations panel listing several cited sources as italic titles with author/year bylines and cite/quote count chips; one row is expanded to show two quoted excerpts indented beneath it with a locator like "p. 42" next to each.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>A citation key that doesn't resolve still gets a row.</b> If a <code>[[cite::id]]</code> or <code>[[quote::id]]</code> points at a source ID with no matching entry in the graph, that source is skipped entirely — it never enters the group set, so it won't show up as a broken row. Only sources the graph can actually resolve are listed, whether or not they have a title.</li>
+      <li><b>A resolved source with no title reads as "uncited."</b> If the source exists in the graph but has no title yet (a stub, or metadata still being fetched), its row shows the raw source ID in place of a title, in a warning color, with "N references · uncited" instead of a byline. It's still clickable — the warning is about missing metadata, not a broken link.</li>
+      <li><b>Bibliography blocks don't inflate the count.</b> Notes that embed a rendered bibliography block don't have their citation counts doubled by it — the panel strips that block before counting, so the numbers reflect inline <code>cite</code>/<code>quote</code> links only.</li>
+      <li><b>No citations, no rows.</b> A note with no <code>cite</code> or <code>quote</code> links shows a plain "No citations in this note" message — this panel only covers the source/excerpt typed links, not plain <code>references</code> links to other notes (see <a href="right-sidebar-backlinks.html">Backlinks</a> for those).</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-proposals.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Proposals</span>
+      </a>
+      <a class="next" href="right-sidebar-tags.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Tags →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Footnotes Panel</title>
+<meta name="description" content="The Footnotes panel lists every footnote in the current note, lets you jump between a reference and its definition, and flags footnotes that are defined but unused or referenced but undefined." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub active">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Footnotes</p>
+
+    <h1>Footnotes</h1>
+    <p class="lede">The <b>Footnotes</b> panel lists every footnote defined or referenced in the current note and lets you jump straight to where it's used — a quick index for notes with more than a couple of asides, and a linter that catches footnotes left dangling in either direction.</p>
+
+    <div class="box">
+      <span class="label">Syntax lives on its own page</span>
+      <p>This page is about the panel's own UI — search, rows, and the two stale-footnote flags. For the <code>[^label]</code> reference/definition syntax, how footnotes render in preview, and click-to-jump navigation in the source editor, see <a href="notes-footnotes.html">Notes → Footnotes</a>.</p>
+    </div>
+
+    <h2 id="layout">Reading the panel</h2>
+    <p>Each row shows a footnote's label and a one-line preview of its body. Rows for defined footnotes appear in source order — the order their definitions occur in the file, not the order they're referenced. Typing into the ribbon's search field narrows the list to footnotes whose label or body text contains the query, live as you type; this searches only the current note, not the whole project.</p>
+    <p><b>Click a row</b> to scroll the editor to that footnote's first in-text reference — the same jump-to-use behavior as clicking a definition in the source editor. If a footnote has no reference at all (see below), the click instead lands on the definition itself, since there's no reference to jump to.</p>
+
+    <h2 id="stale">Stale-footnote flags</h2>
+    <p>The panel doubles as a linter for the two ways a footnote can go out of sync — each renders as its own row with a small mono caption under the body preview:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Defined · never used</div>
+        <div class="v">A <code>[^label]: …</code> definition that no <code>[^label]</code> reference points at anywhere in the note. Shown muted, since it isn't broken — just unreferenced. Clicking it jumps to the definition.</div>
+      </div>
+      <div class="row">
+        <div class="k">Referenced · not defined</div>
+        <div class="v">A <code>[^label]</code> in the body text with no matching definition anywhere in the file. Clicking it takes you to the dangling reference so you can write the missing definition. If the same missing label is referenced more than once, it's still one row — clicking jumps to the first occurrence.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗂️</div>
+      <div class="k">Screenshot — Footnotes panel, search and stale flags</div>
+      <div class="d">The right-sidebar Footnotes panel with the ribbon's search field focused and text entered, filtering the list to a handful of matching rows below — one row flagged "DEFINED · NEVER USED" in a muted style and one flagged "REFERENCED · NOT DEFINED," alongside ordinary rows showing a label and body preview.</div>
+    </div>
+
+    <h2 id="empty">No footnotes, no matches</h2>
+    <p>A note with no footnotes at all shows <i>"No footnotes"</i> in place of the list. If the note has footnotes but none match the current search text, the message changes to <i>"No matches"</i> instead, so you can tell at a glance whether the panel is empty because the note has nothing to show or because your filter is too narrow.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Row order follows definitions, not references.</b> The panel lists definitions in the order they appear in the file, then any undefined-reference rows after — it isn't ordered by where footnotes first appear as superscripts in the rendered note.</li>
+      <li><b>One row per label, not per use.</b> A footnote referenced several times in the text still gets a single row; clicking it always jumps to the first reference.</li>
+      <li><b>The panel reflects saved content.</b> Like the rest of the right sidebar, it's driven by the current note's content — a footnote you just typed shows up as soon as it's part of the note text the panel is reading, but a stale flag won't resolve until the fix (a new definition, or a new reference) is actually in place.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-related.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Related</span>
+      </a>
+      <a class="next" href="right-sidebar-tables.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Tables →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Heading Graph</title>
+<meta name="description" content="The Heading graph panel renders the current note's headings as an interactive node-and-edge tree — the same data as the Outline panel, laid out spatially instead of as a list, so you can see a note's shape at a glance." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub active">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Heading graph</p>
+
+    <h1>Heading graph</h1>
+    <p class="lede">The Heading graph panel draws the current note's headings as a spatial tree — a root node for the note itself, with each heading connected to whichever shallower heading precedes it — rather than the flat, indented list the <a href="right-sidebar-outline.html">Outline</a> panel shows. Same source data, a different shape: useful when you want to see how a long note branches at a glance instead of scanning a list top to bottom.</p>
+
+    <h2 id="how-it-works">How it works</h2>
+    <p>The panel re-derives its graph from the note's raw text on every change, the same way Outline does — there's no separate refresh step. It reuses the identical heading parser (<code>extractHeadings</code>) that powers Outline and the editor's breadcrumb chain, so the two panels never disagree about what counts as a heading or how deep it's nested. That flat list is then reshaped into nodes and edges: a heading's parent is the nearest preceding heading of a shallower level, or a synthetic root node (labeled with the note's title) if none exists. The graph is rendered on a shared Cytoscape canvas — the same one that draws a note's link-neighborhood graph elsewhere in Minerva — laid out here with a top-down <code>breadthfirst</code> layout so the root sits above its headings and each branch reads as a tidy hierarchy rather than a force-directed tangle.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Node</div>
+        <div class="v">One heading (or the synthetic root, standing in for the note's title). Depth in the tree drives its styling, so H2s and H3s read as visually distinct tiers rather than same-size boxes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Edge</div>
+        <div class="v">A pure nesting relationship — "this heading is the nearest shallower heading above that one." Edges track heading <em>depth</em> only; they don't represent wiki-links, references, or any other relationship that might happen to appear inside a heading's text.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a node</div>
+        <div class="v">Scrolls the editor to that heading's line, the same destination Outline's click-to-scroll lands on. A toolbar toggle switches between two click models: click-to-open (single click navigates immediately) and click-to-select (single click selects; double-click or Enter navigates) — one shared setting, so the choice you make here also applies to the note's link-neighborhood graph elsewhere in Minerva.</div>
+      </div>
+      <div class="row">
+        <div class="k">Pan / zoom</div>
+        <div class="v">Standard canvas gestures — drag to pan, scroll or pinch to zoom. The view re-fits automatically when the sidebar is resized.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🕸️</div>
+      <div class="k">Screenshot — Heading graph for a multi-section note</div>
+      <div class="d">The right sidebar's Heading graph panel showing a root node labeled with the note's title, branching into several H2 nodes, two of which have their own H3 children one level further out, laid out top-down with connecting edges; a small toolbar above the canvas shows the click-to-open / click-to-select toggle in its default state.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Not a link graph</span>
+      <p>It's easy to expect "graph" here to mean cross-links — headings connected because one references another by name or wiki-link. It doesn't: every edge is strictly a nesting relationship derived from heading levels, identical in substance to what Outline's indentation already encodes. A wiki-link typed inside a heading's own text doesn't add an edge to anything; the graph never looks at heading content, only at heading level and document order.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No headings, no graph.</b> A note with no headings shows a plain "No headings to map" message instead of a lone root node — there's nothing to lay out.</li>
+      <li><b>Completely flat documents still branch tidily.</b> A note that only ever uses one heading level (say, every heading is an H2) doesn't collapse into a single connected line — each of those headings attaches directly to the root, so the graph reads as one hub with several spokes rather than a chain.</li>
+      <li><b>Very few headings can look sparse.</b> A note with one or two headings renders a root with one or two children and not much else — Outline's compact list is the more legible choice at that scale; the graph earns its keep on notes with real branching structure.</li>
+      <li><b>Very many headings get crowded.</b> On a note with dozens of headings, the top-down layout can grow wide and require noticeable panning and zooming to read a single branch. Outline's scrollable list stays more compact for that case.</li>
+      <li><b>Duplicate heading text is fine.</b> Two headings with identical text still get separate nodes, each wired to its own line — nothing here is keyed by text.</li>
+    </ul>
+
+    <h2 id="contrast">Heading graph vs. Outline</h2>
+    <p>Both panels are views onto the exact same parsed heading list, kept in lockstep by sharing the same underlying extraction — they will never show different headings or different nesting for the same note. The difference is purely presentational:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="right-sidebar-outline.html">Outline</a></div>
+        <div class="v">A flat, indented, collapsible list. Denser and faster to scan top to bottom, with a filter field for jumping straight to a heading by text. The better default for most notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Heading graph</div>
+        <div class="v">An interactive, pannable node-and-edge tree. Better for seeing the overall shape of a note's structure at a glance — how many major sections, how deep each one nests — at the cost of taking up more visual space per heading.</div>
+      </div>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-tables.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Tables</span>
+      </a>
+      <a class="next" href="right-sidebar-bookmarks.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Bookmarks →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-inspections.html
+++ b/website/docs/right-sidebar-inspections.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Inspections</title>
+<meta name="description" content="The Inspections panel: project-wide epistemic health checks against the knowledge graph — implemented and running, but not currently reachable in the UI." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Inspections</p>
+
+    <h1>Inspections</h1>
+    <p class="lede">Inspections is a battery of epistemic health checks that run against your <em>whole project's</em> knowledge graph — not just the open note — and surface structural or evidentiary problems in your claims, grounds, and warrants: unsupported claims, missing warrants, contradictions between established claims, broken links, and a handful of source-hygiene checks. Every result is a read-only flag. Nothing here writes to the graph, and nothing goes through the Proposal/approval system — it's diagnostics, not authorship.</p>
+
+    <div class="box">
+      <span class="label">Not currently in the UI</span>
+      <p>This panel's tab was deliberately removed from the right sidebar before the v1.0 release — the feature wasn't ready for general use. The engine behind it keeps running: <code>health-checks.ts</code> still executes its checks on a schedule, and the panel component itself is untouched. There's no setting to bring the tab back; that only happens in a future release. This page documents the panel as it exists in the code, for whenever the tab returns.</p>
+    </div>
+
+    <h2 id="what-it-checks">What it actually checks</h2>
+    <p>The checks are a fixed, hardcoded list in <code>src/main/graph/health-checks.ts</code> — not a general query builder and not user-configurable. Each one is a SPARQL query against <code>.minerva/graph.ttl</code>, run in parallel by <code>runAllChecks()</code>:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Unsupported claim</div>
+        <div class="v">A <code>thought:Claim</code> with no other node <code>thought:supports</code>-ing it — a claim asserted with no grounds behind it at all.</div>
+      </div>
+      <div class="row">
+        <div class="k">Missing warrant</div>
+        <div class="v">A claim that has <code>thought:Grounds</code> supporting it but no <code>thought:Warrant</code> connecting the grounds to the claim — evidence exists, but the reasoning link explaining why it counts is absent.</div>
+      </div>
+      <div class="row">
+        <div class="k">Missing backing</div>
+        <div class="v">A warrant with no <code>thought:Backing</code> behind it — the reasoning link exists, but nothing justifies trusting the warrant itself.</div>
+      </div>
+      <div class="row">
+        <div class="k">Contradiction</div>
+        <div class="v">Two claims both marked <code>thought:hasStatus thought:established</code> that rebut each other — two things the graph currently treats as settled, disagreeing.</div>
+      </div>
+      <div class="row">
+        <div class="k">Source hygiene</div>
+        <div class="v">A cluster of checks unrelated to the claim/grounds/warrant structure: stale notes, malformed DOIs, sources missing metadata, aged-out stubs, sources that are cited but never actually read, duplicate sources sharing a DOI or URL, and broken wiki-links, anchors, or citation keys.</div>
+      </div>
+    </div>
+
+    <h2 id="running">How it runs</h2>
+    <p>Checks run automatically once when a project opens, and again every five minutes after that. The panel's own <b>Run</b> button forces an immediate pass rather than waiting for the next scheduled sweep. There's no write path anywhere in this code — it only reads the graph, so running an inspection can't trigger the LLM write-guard or the approval engine, because nothing is written.</p>
+
+    <div class="shot wide">
+      <div class="icon">🔬</div>
+      <div class="k">Screenshot — Inspections panel</div>
+      <div class="d">The right-sidebar Inspections panel showing a list of flagged results across several check types — an unsupported claim, a missing warrant, and a broken wiki-link — each with a short description and a Run button in the panel toolbar.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Clicking a result doesn't navigate.</b> Unlike Backlinks, Outline, or every other panel that jumps you to a location, clicking an inspection result opens a new conversation pre-seeded with that inspection's message — the intended next step is to discuss and resolve it with the AI, not just to look at where it is.</li>
+      <li><b>Plain prose produces nothing.</b> A note with no <code>thought:Claim</code>/<code>Grounds</code>/<code>Warrant</code> structure at all won't fail any check — it simply won't generate any rows, since none of the checks have anything to fire against.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-heading-graph.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Heading graph</span>
+      </a>
+      <a class="next" href="right-sidebar-bookmarks.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Bookmarks →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Outgoing Links</title>
+<meta name="description" content="The Outgoing links panel lists every note the current note points to — the inverse of Backlinks — grouped by link type, with broken targets flagged and one click to jump to a resolved note." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub active">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Outgoing links</p>
+
+    <h1>Outgoing links</h1>
+    <p class="lede">The Outgoing links panel lists every <a href="notes-links.html">wiki-link</a> the current note contains — the notes it points to, not the notes pointing at it. It's the mirror image of <a href="right-sidebar-backlinks.html">Backlinks</a>: same grouped-by-type layout, same click-to-jump behavior, but read in the opposite direction.</p>
+
+    <h2 id="contents">What's in the list</h2>
+    <p>Every wiki-link in the current note's source becomes one row, sourced from the same coalesced link-bundle fetch that feeds Backlinks — switching tabs doesn't cost a second IPC round-trip for a note that has both panels open. Each row shows the target note's resolved title, not the raw link text you typed.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Resolved link</div>
+        <div class="v">A quiet document icon, the target note's title, and — when sorted alphabetically rather than by type — a small colored badge naming the link type. Click the row to open that note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Broken link</div>
+        <div class="v">A warning icon in place of the document icon, and the title rendered in a rust tint instead of the normal text color. The row still appears (so you can see and fix the target) but clicking it does nothing — there's nowhere to navigate to. See <a href="notes-links.html#resolving">how a target resolves</a> for why a link might fail to match any note.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Grouped by type, same as Backlinks</span>
+      <p>By default, rows are grouped under a header per <a href="notes-links.html#types">link type</a> — a colored square, the type's label, and a count — matching the color a typed link renders in inside the note itself. Switch the sort control to <b>Alphabetical</b> to flatten everything into one title-sorted list with an inline type badge on each row instead of a group header. Group headers are individually collapsible, or use the toolbar's expand/collapse-all buttons; collapse state only applies in the by-type sort.</p>
+    </div>
+
+    <p>The toolbar also has a filter field — narrows the list to targets whose title or path contains the typed text — and an "open as graph" button that visualizes the current note's link neighborhood instead of listing it as rows.</p>
+
+    <div class="shot wide">
+      <div class="icon">➡️</div>
+      <div class="k">Screenshot — Outgoing links panel</div>
+      <div class="d">The right sidebar's Outgoing links tab for a note with several typed links, showing collapsible type-grouped sections (References, Supports, Cites) with colored squares and counts, one row with a rust warning icon and tint for a broken target, and the toolbar's filter field, sort selector, and expand/collapse/graph buttons.</div>
+    </div>
+
+    <h2 id="cite-quote">Links to sources</h2>
+    <p><code>cite</code> and <code>quote</code> links point at a bibliography-style source rather than another note in your knowledge base — see <a href="notes-links.html#types">typed links</a>. The Outgoing links panel doesn't distinguish that case visually: it resolves every target as if it were a note path, so a <code>cite</code> or <code>quote</code> link to a source shows up as an unresolved, rust-tinted row rather than as a distinct "external reference" entry. To browse citations to sources specifically, use the <a href="right-sidebar-citations.html">Citations</a> panel instead.</p>
+
+    <h2 id="empty">No outgoing links</h2>
+    <p>A note with no wiki-links in its body shows "No outgoing links" in the panel body. If a filter is active and nothing matches it, the message changes to "No matches" instead — so an empty result reads differently depending on whether the note is actually link-free or your filter is just too narrow.</p>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-backlinks.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Backlinks</span>
+      </a>
+      <a class="next" href="right-sidebar-outline.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Outline →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Outline</title>
+<meta name="description" content="The Outline panel renders a live, collapsible heading tree for the current note — H1 through H6 — so you can scan a long note's structure at a glance and click any heading to jump the editor there." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub active">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Outline</p>
+
+    <h1>Outline</h1>
+    <p class="lede">The Outline panel renders every heading in the current note — <code>#</code> through <code>######</code> — as a collapsible tree, indented to match heading depth, so you can scan a long note's structure without scrolling through it. Click any heading to move the editor's cursor there and scroll it into view.</p>
+
+    <h2 id="how-it-works">How it works</h2>
+    <p>The panel re-parses the note's raw text on every change and rebuilds the tree from scratch — there's no separate "refresh" step and no stale state to worry about. Headings are recognized with a plain ATX-style match (a run of 1–6 <code>#</code> characters, a space, then the heading text); Setext-style headings (text underlined with <code>===</code> or <code>---</code>) aren't recognized, because Minerva notes don't use that form. The same parser also powers the editor's cursor-aware breadcrumb chain above the note, so the two stay in lockstep by construction rather than by convention.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Nesting</div>
+        <div class="v">A heading is indented under whichever shallower heading precedes it — <code>##</code> nests under the last <code>#</code>, <code>###</code> nests under the last <code>##</code>, and so on. A heading with no shallower heading above it (or a document that only uses one level) sits flush at the root.</div>
+      </div>
+      <div class="row">
+        <div class="k">Collapse / expand</div>
+        <div class="v">Any heading with subheadings gets a disclosure triangle. Click it to fold that branch, or use the ribbon's expand-all / collapse-all buttons to act on the whole tree at once. A heading with no children shows a blank spacer instead of a triangle — nothing to toggle.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter</div>
+        <div class="v">The ribbon's search field filters headings by text as you type. Filtering ignores the collapsed state of any ancestor — a match stays visible even inside a folded branch — but it doesn't re-nest results into their own mini-tree; each match still renders at its normal indent depth.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click-to-scroll</div>
+        <div class="v">Clicking a heading (not its disclosure triangle) places the editor's cursor at the start of that heading's line and scrolls it to the vertical center of the view. It's a real cursor placement, the same as jumping to a search result — not a transient visual highlight — so you can start typing right away.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗒️</div>
+      <div class="k">Screenshot — Outline panel for a multi-heading note</div>
+      <div class="d">The right sidebar's Outline panel open on a note with several H2 sections, one of them expanded to show nested H3 subheadings indented beneath it and a sibling H2 collapsed to a single triangle-prefixed row; the ribbon's filter field and expand-all/collapse-all buttons sit above the tree.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No headings, no tree.</b> A note with no <code>#</code>-style headings shows a plain "No headings" message in place of the list — there's nothing to scan and nothing to click.</li>
+      <li><b>Duplicate heading text is fine.</b> The panel doesn't require unique heading text; two sections both titled "Notes" show up as two separate rows, each jumping to its own line. Nothing here is keyed by text — every row is tied to the line the heading actually appears on.</li>
+      <li><b>Long headings truncate, they don't wrap.</b> A heading whose text is wider than the sidebar is cut off with an ellipsis rather than wrapping to a second line, to keep every row a single scannable line height.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-outgoing-links.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Outgoing links</span>
+      </a>
+      <a class="next" href="right-sidebar-properties.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Properties →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Properties</title>
+<meta name="description" content="The Properties panel in Minerva's right sidebar: a structured, type-aware editor for a note's frontmatter — add, edit, and remove keys without hand-editing YAML." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub active">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Properties</p>
+
+    <h1>Properties</h1>
+    <p class="lede">The Properties panel is the right sidebar's structured editor for a note's <a href="notes-frontmatter.html">frontmatter</a>: the same YAML block, presented as a list of typed rows you can edit, add to, or remove from without touching a <code>---</code> fence. It's an alternative surface, not a separate data store — every change here is a rewrite of the note's actual frontmatter, and every hand-edit in the source view shows up here the moment the file reflows.</p>
+
+    <h2 id="where">Where it lives</h2>
+    <p>Properties is one of the panels under the <b>Note</b> group in the right sidebar, alongside Outline, Footnotes, Tags, and Tables — the panels that describe the active note itself, as opposed to how it connects to other notes. Switching tabs or notes just re-renders the same panel against whatever note is currently active; there's no per-note panel state to lose track of.</p>
+
+    <p>The component is <code>PropertiesPanel.svelte</code> (<code>src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte</code>), wired into <code>RightSidebar.svelte</code> at the <code>properties</code> panel id. It's given the editor's current buffer content and a callback to push edits back — it has no independent notion of "the file," only whatever content it's handed.</p>
+
+    <h2 id="writeback">How an edit reaches the file</h2>
+    <p>Every control in the panel — renaming a key, typing a new string, toggling a checkbox, adding a chip — funnels through one function that parses the note's existing frontmatter into a YAML document, applies a single mutation (set a key, delete a key, rename a key), and re-serializes the whole block (<code>PropertiesPanel.svelte:209-240</code>). The result replaces the frontmatter block in the editor buffer via <code>onContentChange</code>, exactly as if you'd typed the change yourself in the source view.</p>
+
+    <p>Because the panel always works from the real, parsed YAML document rather than a shadow copy, edits round-trip cleanly:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Key order</div>
+        <div class="v">Preserved. Editing an existing key's value mutates that key in place; only a brand-new key is appended at the end. Reordering isn't a supported gesture from the panel — drag the lines around in the source editor if you want a specific order.</div>
+      </div>
+      <div class="row">
+        <div class="k">Comments</div>
+        <div class="v">Preserved on untouched lines, because the panel parses with the <code>yaml</code> library's document API (which retains comments as part of the AST) rather than a parse-to-plain-object-and-restringify round trip. A comment attached to the exact key you edit can still be displaced by re-serialization — the guarantee is for the block as a whole, not line-for-line stability on every touched key.</div>
+      </div>
+      <div class="row">
+        <div class="k">Typing debounce</div>
+        <div class="v">Text and number fields don't write on every keystroke. Each keystroke updates a local draft immediately (so the input never stutters) and flushes to the buffer 250&nbsp;ms after you stop typing, or immediately on blur (<code>PropertiesPanel.svelte:299-307</code>). Checkboxes, dates, chips, and the key-rename field commit immediately — there's no debounce to wait out on those.</div>
+      </div>
+    </div>
+
+    <h2 id="editing">Editing, adding, and removing properties</h2>
+    <p>Each row is <code>[type icon, key, value control, × button]</code>. The value control is chosen from the same shape-detection rules covered in <a href="notes-frontmatter.html#values">Frontmatter → Value shapes</a> — this page only covers the parts of that interaction that aren't about the value's shape.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Renaming a key</div>
+        <div class="v">The key itself is a text input, not just a label. Typing a new name and blurring (or tabbing away) renames the key in place, keeping its value and position. Renaming to a key that's empty, or unchanged, is a no-op.</div>
+      </div>
+      <div class="row">
+        <div class="k">Removing a property</div>
+        <div class="v">Hover a row to reveal a × button at its right edge; click it to delete that key. If deleting the last remaining key leaves the frontmatter block empty, Minerva drops the entire <code>---</code>…<code>---</code> block from the note rather than leave a blank, technically-malformed fence pair behind (<code>PropertiesPanel.svelte:230-235</code>) — the note reverts to having no frontmatter at all, same as if you'd never added it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Adding a new key</div>
+        <div class="v">An "Add property…" row sits at the bottom of the list (or, for a note with no frontmatter yet, in the middle of the empty state) with an autocomplete field. Typing a name and pressing Enter — or clicking the adjacent + button — inserts the key with an empty string value and focuses its new value input immediately, so you can type the value with no extra click.</div>
+      </div>
+      <div class="row">
+        <div class="k">Autocomplete suggestions</div>
+        <div class="v">The dropdown suggests keys already in use elsewhere in the project first, then falls back to canonical keys the note doesn't have yet — filtered so a key already present on this note never appears twice. A handful of canonical keys are also offered as quick-add pill chips just below the add row, for one-click insertion without typing a name at all.</div>
+      </div>
+      <div class="row">
+        <div class="k">Starting from zero</div>
+        <div class="v">A note with no frontmatter block shows an empty-state prompt instead of a row list. Adding the first property here does double duty: it creates the <code>---</code>…<code>---</code> block and inserts the key in one step (<code>PropertiesPanel.svelte:211-218</code>) — there's no separate "create frontmatter" action to find first.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Custom keys work exactly the same</span>
+      <p>Adding a key that isn't on Minerva's canonical list isn't a degraded path — it's indexed and editable identically, just rendered with a muted key color instead of the accent used for recognized keys. See <a href="notes-frontmatter.html#custom">Frontmatter → Custom keys</a> for how an arbitrary key becomes a queryable graph triple.</p>
+    </div>
+
+    <h2 id="invalid">Invalid input on a typed field</h2>
+    <p>The panel declines bad input rather than writing something broken into the file:</p>
+
+    <ul>
+      <li><b>Number fields</b> ignore a blank or non-numeric value on commit — the underlying YAML key is simply left unchanged until you type something that parses as a finite number.</li>
+      <li><b>The wiki-link picker</b> discards an edit if you clear the target field entirely, reverting to the chip view rather than writing an empty link.</li>
+      <li><b>A YAML-shaped value</b> (a nested object, or a list with mixed or non-string items) has no structured editor at all — the panel shows it as read-only preformatted text with a note to edit it in source, rather than attempt a lossy round trip through a control that can't represent it.</li>
+    </ul>
+
+    <p>None of this is enforced with a confirmation dialog or a validation error banner — an unparseable number field just doesn't commit, silently, the same way a professional spreadsheet ignores a keystroke that doesn't belong in a numeric cell. The one visible error state is at the block level: if the frontmatter YAML doesn't parse at all (a bad indent, an unclosed quote), the whole panel shows the parse error and disables structured editing until the source is fixed — see <a href="notes-frontmatter.html#syntax">Frontmatter → The frontmatter block</a>.</p>
+
+    <div class="shot wide">
+      <div class="icon">🗂️</div>
+      <div class="k">Screenshot — Properties panel mid-edit</div>
+      <div class="d">The right sidebar's Note group with the Properties tab active: a row list showing a few canonical rows (title, tags as chips, created as a date picker) and one custom key in muted styling, the cursor focused in a freshly-added empty value field with the row highlighted, and the "Add property…" autocomplete row with its canonical-key suggestion chips visible beneath the list.</div>
+    </div>
+
+    <h2 id="related">Properties vs. hand-editing YAML</h2>
+    <p>Nothing the panel does is exclusive to it — every mutation is a plain rewrite of the same frontmatter block you could edit by hand in the source view, and the two stay in sync automatically because the panel re-parses the buffer's content on every change, regardless of where that change came from. Use the panel when you want quick, mistake-resistant edits to a known shape of data (toggle a boolean, pick a date, add a tag chip); drop into source editing for anything the panel renders as read-only YAML, for reordering keys, or for writing a value shape the panel doesn't have a control for yet.</p>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-outline.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Outline</span>
+      </a>
+      <a class="next" href="right-sidebar-proposals.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Proposals →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Proposals</title>
+<meta name="description" content="The Proposals panel is where the Trust Principle lives in the UI: every AI-originated graph write waits here as a diffable, single-keystroke approve/reject decision before it touches your notes." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub active">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Proposals</p>
+
+    <h1>Proposals</h1>
+    <p class="lede">The Proposals panel is where <b>the LLM proposes, the human confirms</b> — the most important design decision in Minerva — becomes a screen you actually look at. Every graph write an AI operation wants to make waits here as a reviewable card until you approve or reject it; nothing lands in <code>.minerva/graph.ttl</code> on the strength of a model's say-so alone.</p>
+
+    <h2 id="what">What shows up here</h2>
+    <p>A proposal is a <code>thought:Proposal</code> node created by the approval engine (<code>src/main/llm/approval.ts</code>) whenever an LLM operation's approval tier is <code>requires_approval</code> — new claims, evidence links, component creation, note refactors/deletes, in-place note rewrites, and proposed source properties all file this way by default. Each card bundles one or more <b>payloads</b> — a new note, a block of graph triples, or both — that apply atomically: approve lands the whole bundle, reject discards the whole bundle, never half of one.</p>
+
+    <div class="box">
+      <span class="label">Not scoped to the open note</span>
+      <p>Unlike every other panel in the right sidebar, Proposals is not filtered to the file you currently have open — <code>ProposalsPanel.svelte</code> is handed only a <code>revision</code> counter to know when to refresh, not an <code>activeFilePath</code>. It lists every proposal in the project regardless of which note is active, with a status-tab filter (<b>All / Pending / Approved / Rejected</b>) defaulting to <b>All</b> so the panel doubles as an audit trail — most everyday AI operations (auto-tag, auto-link) are actually <code>autonomous</code> or <code>notify_only</code> tier and apply immediately with nothing to review, so a panel that only ever showed "Pending" would look empty most of the time.</p>
+    </div>
+
+    <h2 id="review">Reviewing a proposal</h2>
+    <p>Click a card to expand it. Each payload is a separate collapsible row — click one to preview its actual content: a note's full text, or the raw Turtle for a graph-triples payload. This is the diff view: you're reading exactly what will be written, not a paraphrase of it, before you decide.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Approve — <kbd>y</kbd></div>
+        <div class="v">Applies the proposal's full payload bundle via the approval engine's <code>approveProposal()</code> and flips its status to <code>approved</code>. The keystroke only fires while a card is expanded (selected) — <code>handleKeydown</code> checks <code>selectedUri</code> first. A success banner reports exactly what landed (note paths included, up to three, then "+N more").</div>
+      </div>
+      <div class="row">
+        <div class="k">Reject — <kbd>n</kbd></div>
+        <div class="v">Calls <code>rejectProposal()</code>, which flips status to <code>rejected</code> and applies nothing. The proposal node stays in the graph as a rejected record — rejecting doesn't delete it, so the audit trail shows what the AI suggested even when you turned it down.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close — <kbd>s</kbd> / <kbd>Esc</kbd></div>
+        <div class="v">Collapses the expanded card without changing anything. Pure UI state, not a decision.</div>
+      </div>
+      <div class="row">
+        <div class="k">Status tabs</div>
+        <div class="v">All / Pending / Approved / Rejected, filtering the list client-side by the proposal's stored status. Search and a Newest-first / By-type sort sit above the tabs for finding one proposal in a long history.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗳️</div>
+      <div class="k">Screenshot — Reviewing a pending proposal</div>
+      <div class="d">The Proposals panel with the Pending tab selected and one card expanded: the status pill, operation type, and proposer badge at the top; an expanded graph-triples payload row showing raw Turtle for a new claim; and the Approve (y) / Reject (n) / Close (s) button row at the bottom of the card.</div>
+    </div>
+
+    <h2 id="tiers">Why some AI writes never appear here</h2>
+    <p>Not every LLM operation is a proposal. The approval engine classifies each operation type into one of three tiers, and only <code>requires_approval</code> ever creates a card you review:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>requires_approval</code></div>
+        <div class="v">New claims, evidence links, component creation, note refactors and deletes, note rewrites, source-property proposals. Filed as a pending <code>thought:Proposal</code> and held until you act on it.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>notify_only</code></div>
+        <div class="v">Confidence updates, status changes. Applied immediately, but still recorded as an already-<code>approved</code> proposal — so it shows up here under the Approved tab as a record of what happened, not a decision to make.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>autonomous</code></div>
+        <div class="v">Tag additions, staleness flags. Applied immediately with no proposal node at all — nothing to find in this panel, at any status.</div>
+      </div>
+    </div>
+
+    <p>One escalation cuts across all three: any write that touches a node already marked <code>thought:hasStatus thought:established</code> is forced up to <code>requires_approval</code> regardless of its own tier, so the AI can't quietly re-tag or re-flag something you've already vetted.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>"Expiry" isn't a background timer.</b> CLAUDE.md describes proposals as auto-expiring after "a configurable window," and every proposal does carry an <code>autoExpires</code> timestamp — seven days out by default (<code>write.expiryDays ?? 7</code> in <code>approval.ts</code>). But nothing sweeps the graph on a schedule to enforce it: <code>expireProposals()</code> only flips overdue pending proposals to <code>expired</code> when something actually calls it (wired to the <code>proposal:expire</code> IPC channel). A stale pending proposal past its window will keep showing as <b>Pending</b> in the panel — not silently vanish — until that check runs.</li>
+      <li><b>Approve and Reject are no-ops on anything but a pending proposal.</b> Both buttons are disabled once a card is already <code>approved</code>, <code>rejected</code>, or <code>expired</code> (tooltip reads "Already {status}"), and the underlying IPC calls return <code>false</code> for the same reason rather than erroring — the panel surfaces that as "may already be approved/rejected, or its payload has gone stale."</li>
+      <li><b>Approving with an empty payload bundle throws, not silently succeeds.</b> <code>approveProposal()</code> deliberately refuses to flip status on a proposal with zero payloads — that shape means something upstream filed the proposal wrong, and the engine would rather surface the bug than approve a no-op.</li>
+      <li><b>Editing or deleting the target note first doesn't invalidate the proposal.</b> A <code>note</code> payload writes to a <code>relativePath</code> at approval time, resolved fresh (suffixed <code>-2</code>, <code>-3</code>, … on a collision); a <code>graph-triples</code> payload merges Turtle into the store regardless of what's since changed on disk. If the note you were editing when a proposal was filed has since moved or been deleted, approving still applies the bundle against the project as it is <i>now</i>, which can land somewhere you don't expect — review the expanded payload preview rather than assuming it still matches what prompted the proposal.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-properties.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Properties</span>
+      </a>
+      <a class="next" href="right-sidebar-citations.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Citations →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Related</title>
+<meta name="description" content="The Related panel surfaces notes, sources, and excerpts that are semantically similar to the one you're viewing, ranked by embedding similarity — distinct from the explicit, authored connections in Backlinks and Outgoing links." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub active">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Related</p>
+
+    <h1>Related</h1>
+    <p class="lede">The <b>Related</b> panel suggests notes, sources, and quoted excerpts that read like the one you're viewing — without either side having to link to the other. It's computed entirely from semantic embedding similarity, not from anything you've written or linked, which makes it the one right-sidebar panel that surfaces connections you never authored.</p>
+
+    <div class="box">
+      <span class="label">Implicit, not explicit</span>
+      <p><a href="right-sidebar-backlinks.html">Backlinks</a> and <a href="right-sidebar-outgoing-links.html">Outgoing links</a> both read the knowledge graph — they only ever show connections that exist because a wiki-link was typed somewhere. Related reads a separate vector store instead: it has no idea whether two notes link to each other, only whether their text is close in meaning. A note can be full of related suggestions while having zero backlinks, and a heavily-linked note can have nothing related if nothing else in the project resembles its content.</p>
+    </div>
+
+    <h2 id="how-it-works">How ranking works</h2>
+    <p>Every note, source body, and quoted excerpt in the project is split into sections and embedded into a 384-dimension vector using a local model — <code>all-MiniLM-L6-v2</code>, run fully offline through onnxruntime-web (WASM), not a cloud API and not transformers.js. Embedding happens automatically as you save; there's no separate "reindex" command to remember to run. The panel then ranks every other item by cosine similarity to the current note's own stored sections, taking each candidate's single best-matching section, and lists the closest matches first.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">What's ranked</div>
+        <div class="v">Semantic similarity only — cosine distance between embedding vectors. There's no graph-proximity component (shared tags, shared links, or folder location don't factor in at all); two notes can be textually similar despite never having been linked, tagged alike, or filed near each other.</div>
+      </div>
+      <div class="row">
+        <div class="k">What's compared</div>
+        <div class="v">The current note's stored section vectors against every other indexed note, source body, and highlighted excerpt in the project — three corpora in one ranked list, distinguished by a small kind icon on each row.</div>
+      </div>
+      <div class="row">
+        <div class="k">Similarity score</div>
+        <div class="v">Shown as a short bar next to each title rather than a raw number, with the exact percentage in its tooltip. It's a deliberately quiet affordance — a muted bar, not a scary red/green gauge — since a low score isn't a problem to fix, just a weaker match.</div>
+      </div>
+    </div>
+
+    <h2 id="reading">Reading a row</h2>
+    <p>Each result shows a kind icon, the title, the similarity bar, the heading of the best-matching section (when the source has headings), and a short snippet of the matching text. Clicking a note or excerpt row navigates straight to that section; clicking a source opens the source viewer. A row can also be picked up and dragged into the editor to insert a wiki-link, the same as dragging a file from the sidebar.</p>
+
+    <div class="box">
+      <span class="label">Suggesting a link</span>
+      <p>A related note that scores highly (above roughly 45% similarity) and isn't already linked to the current note in either direction gets a subtle left-edge accent plus a small link button — a low-key nudge that this might be worth an explicit link, not a demand. Clicking it inserts a <code>[[wiki-link]]</code> under a "See also" heading; the × next to it dismisses the suggestion for that specific note pair, remembered locally so it doesn't keep resurfacing. A note that's already linked via Backlinks or Outgoing links can still appear here — being related and being linked aren't mutually exclusive — it simply won't get the suggest affordance.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧭</div>
+      <div class="k">Screenshot — Related panel with a link suggestion</div>
+      <div class="d">The right sidebar's Related panel listing several results — a mix of note and source kind icons, each with a muted similarity bar, a section-heading breadcrumb, and a two-line snippet — with the top row showing the faint left-edge accent and link/dismiss buttons that mark an unlinked, high-similarity suggestion.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>A brand-new note has nothing to compare yet.</b> Related depends on the note's own content already being embedded; a note you just created and haven't saved with any real text yet won't have a meaningful vector, so the panel reads as empty rather than showing weak or irrelevant matches.</li>
+      <li><b>A small project may not have enough to suggest.</b> With only a handful of notes, or notes that don't overlap in subject matter, "No related notes found" is a normal, expected result — it isn't a sign anything is broken.</li>
+      <li><b>Indexing takes a moment on a project that's new to semantic search.</b> The first time embeddings are enabled for a thoughtbase, a background backfill has to embed the existing corpus; until that finishes, the panel shows an indexing message rather than treating an empty result as final.</li>
+      <li><b>Semantic search can be unavailable entirely.</b> If the vector store isn't initialized for the current project, the panel says so plainly instead of pretending there are no matches.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-tags.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Tags</span>
+      </a>
+      <a class="next" href="right-sidebar-footnotes.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Footnotes →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Tables (Note)</title>
+<meta name="description" content="The right sidebar's Tables panel scans the current note's SQL fences for table references and lets you open a SELECT * query against any that are registered — it's the SQL/DuckDB pipeline, not a markdown-table or CSVW browser." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub active">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Tables</p>
+
+    <h1>Tables</h1>
+    <p class="lede">The right sidebar's Tables panel is not a markdown-table browser. It scans the current note's <code>```sql</code> fences for table references and shows you, per note, which of those names are actually registered — the same registration the <a href="left-sidebar-tables.html">left sidebar's Tables panel</a> maintains for every <code>.csv</code> file in the project. Click a row to open a <code>SELECT *</code> against it in a new query tab.</p>
+
+    <div class="box">
+      <span class="label">Not the CSVW panel it sounds like</span>
+      <p>It would be reasonable to guess that a right-sidebar, per-note "Tables" panel lists the <a href="notes-tables.html">markdown tables</a> in the current note — the ones extracted into the graph as CSVW. It doesn't. This panel is part of the SQL/DuckDB pipeline: it reads SQL fences, not pipe tables, and its rows link to registered <code>.csv</code> files, not to CSVW <code>csvw:Table</code> nodes in the graph. If you want to see a note's markdown tables, look at the note itself in preview; if you want their extracted triples, use Graph &gt; Query. See <a href="notes-tables.html#gotchas">the Tables &amp; CSV gotchas</a> for the graph side, and <a href="left-sidebar-tables.html">Left sidebar — Tables</a> for the project-wide version of this same DuckDB registry.</p>
+    </div>
+
+    <h2 id="contents">What's in the list</h2>
+    <p>The panel scans the current note's source for fenced blocks marked <code>```sql</code> (or a query-directive fence carrying <code>language: sql</code> metadata) and pulls out every name that follows a <code>FROM</code>, <code>JOIN</code>, or <code>INTO</code> keyword. Each distinct name becomes one row, sorted alphabetically. This is a lightweight scan, not a SQL parser — it's tuned for the common shapes and can over-report on more complex queries (CTEs with aliases, derived tables), which is why the next check matters.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Registered row</div>
+        <div class="v">A tables icon, the table's name in monospace, and its row count × column count in a muted stat line. The whole row is clickable and opens <code>SELECT * FROM &lt;name&gt;</code> in a new query tab. Hovering also reveals a right-aligned <b>SELECT *</b> button that does the same thing — a discoverable shortcut to the row's default click behavior, not a second action.</div>
+      </div>
+      <div class="row">
+        <div class="k">Unregistered row</div>
+        <div class="v">A warning icon and the name in a rust tint, with "not registered" in place of the row/column stat. This is a name your SQL fence references that doesn't match any <code>.csv</code> currently registered in the project — typically a typo, or a file that hasn't been added yet. The row isn't clickable; there's no query to run against a table that doesn't exist.</div>
+      </div>
+    </div>
+
+    <p>A search field at the top filters the list by name. If the note has no SQL fences at all, the panel reads "No tables referenced."</p>
+
+    <div class="shot wide">
+      <div class="icon">🗂️</div>
+      <div class="k">Screenshot — Tables panel for a note with SQL fences</div>
+      <div class="d">The right sidebar's Tables tab for a note containing two ```sql code fences: a resolved row for "sessions" showing "1,204 × 6" with a tables icon and, on hover, a right-aligned SELECT * button; and an unregistered row for "sesssions" (a typo) shown with a warning icon, rust-tinted name, and "not registered" in place of a row/column stat.</div>
+    </div>
+
+    <h2 id="relationship">How this relates to the left sidebar's Tables panel</h2>
+    <p>Both panels read from the same underlying registry — the project's registered <code>.csv</code> files, queryable as DuckDB tables. The difference is scope and direction:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Left sidebar</div>
+        <div class="v">Every registered table in the project, independent of any note. Browsing-first: filter, click to query, right-click for more (open the CSV, reveal in Finder, copy the name). See <a href="left-sidebar-tables.html">Left sidebar — Tables</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Right sidebar (this panel)</div>
+        <div class="v">Only the table names the current note's own SQL fences reference, cross-checked against that same registry. Note-first: it answers "which of the tables this note's queries depend on actually exist?" rather than "what tables do I have?"</div>
+      </div>
+    </div>
+
+    <p>Neither panel edits or registers tables directly — registration happens by dropping a <code>.csv</code> file into the project, which Minerva picks up automatically.</p>
+
+    <h2 id="empty">No SQL fences</h2>
+    <p>A note with no <code>```sql</code> fences (or query-directive fences) shows "No tables referenced," the same empty state as a note that has SQL fences with no <code>FROM</code>/<code>JOIN</code>/<code>INTO</code> clause. If a search filter is active and nothing matches, the list itself is simply empty under the count line rather than swapping to a distinct "no matches" message.</p>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-footnotes.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Footnotes</span>
+      </a>
+      <a class="next" href="right-sidebar-heading-graph.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Heading graph →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Tags (Note)</title>
+<meta name="description" content="The right sidebar's Tags panel is a read-only, hierarchical view of the tags on the current note only — distinct from the left sidebar's flat, project-wide Tags panel, and it doesn't add or remove tags itself." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub active">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="right-sidebar.html">Right sidebar</a><span class="sep">/</span>Tags</p>
+
+    <h1>Tags</h1>
+    <p class="lede">The right sidebar's Tags panel shows the tags that appear <b>on the current note</b> — nothing else in the project — arranged as a hierarchy so a tag like <code>#project/minerva/docs</code> renders as nested rows instead of one long string. It's a read view: this panel doesn't add or remove tags itself. To change what a note is tagged with, you edit the note.</p>
+
+    <div class="box">
+      <span class="label">Not the same panel as the left sidebar's Tags</span>
+      <p>Minerva has two panels that both say "Tags," and they do genuinely different jobs:</p>
+      <p><a href="left-sidebar-tags.html">Left sidebar → Tags</a> is flat and project-wide — every tag used anywhere in the thoughtbase, alphabetical, with a count. It's for browsing the whole project's vocabulary and jumping to any note carrying a given tag, regardless of what you currently have open.</p>
+      <p>This panel, in the <b>right</b> sidebar, is scoped to whatever note is open in the active tab. It only ever lists tags that are actually present in that note's content — no other tag in the project shows up here at all — and it renders them as a tree rather than a flat list (<code>TagsPanel.svelte</code>, right-sidebar variant). Switch tabs and the panel's contents change with it; it is not a filtered view of the left sidebar's list, it's a different query answering a different question ("what does <i>this</i> note carry?" vs. "what tags exist?").</p>
+    </div>
+
+    <h2 id="hierarchy">Reading the tree</h2>
+    <p>A tag with slashes in it — <code>#area/health</code>, <code>#project/minerva/docs</code> — is treated as a path, and the panel builds a tree out of every such path across the note's tags. Segments are synthesized as parent rows even if nothing in the project is tagged with that exact shorter form: a note tagged only <code>#foo/bar/baz</code> still shows <code>foo</code> and <code>foo/bar</code> as rows above it, because they're implied ancestors, not because anyone tagged a note with just <code>#foo</code>.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Expand / collapse</div>
+        <div class="v">Click the chevron on any row with children to fold or unfold that branch. Expand state persists locally (per-machine, not per-project) so the tree looks the same the next time you open the panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a leaf tag</div>
+        <div class="v">Shows every note and source tagged with that <i>exact</i> tag in a "TAGGED #…" section below the tree — not just the current note. This is how the panel doubles as a jumping-off point: the tag you see here is scoped to the current note, but clicking it surfaces every other note in the project that shares it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a parent tag</div>
+        <div class="v">Shows every note and source tagged at-or-under that prefix — "TAGGED UNDER #…" — a superset of clicking each child leaf individually. Useful for a broad sweep, e.g. every note under <code>#area/health</code> regardless of how deep the specific tag goes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Accent marker</div>
+        <div class="v">A row for a tag literally present on the current note is tinted with the accent color, distinguishing it from a synthesized ancestor row that exists only to hold the tree together.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter field</div>
+        <div class="v">The ribbon's search box filters the tree by substring. A match keeps its ancestor chain visible even if a parent branch was previously collapsed, so you can see where in the hierarchy the hit lives.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🏷️</div>
+      <div class="k">Screenshot — Tags panel for a note tagged under a hierarchy</div>
+      <div class="d">The right sidebar's Tags panel open on a note carrying a nested tag, showing an expanded tree with a synthesized parent row and an accent-tinted leaf row for the tag actually on the note, and a "TAGGED #…" section beneath the tree listing other notes and sources that share that same tag.</div>
+    </div>
+
+    <h2 id="add-remove">Adding and removing a tag</h2>
+    <p>There's no input field or delete control in this panel — it only reads. A tag is added to or removed from a note the same way any other content changes: by editing the note itself. Minerva recognizes tags written two ways, and this panel shows both together without distinguishing which form a given tag used:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Inline <code>#hashtag</code></div>
+        <div class="v">Type <code>#tagname</code> anywhere in the note's body. It's picked up as a tag the next time the note is saved and re-indexed — no special syntax beyond the leading <code>#</code> and a valid tag character to follow it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Frontmatter <code>tags:</code> list</div>
+        <div class="v">Add or remove an entry in the YAML <code>tags:</code> array at the top of the note. Many notes carry tags only this way, with nothing typed inline — the panel merges both sources so neither is treated as more authoritative.</div>
+      </div>
+      <div class="row">
+        <div class="k">Removing a tag</div>
+        <div class="v">Delete the <code>#hashtag</code> text or the frontmatter list entry and save. There's no separate "untag" action — the panel simply stops showing a tag once the note no longer contains it in either form.</div>
+      </div>
+    </div>
+
+    <p>The panel re-reads the active note's content reactively, so a save that adds or removes a tag updates the tree immediately — no manual refresh. For the mechanics of how tags are extracted and indexed into the knowledge graph (the shared parsing that both this panel and the left sidebar's rely on), see <a href="left-sidebar-tags.html">Left sidebar → Tags</a>.</p>
+
+    <h2 id="graph">How this feeds the rest of the app</h2>
+    <p>Every tag on a note is indexed into <code>.minerva/graph.ttl</code> the moment the note is saved, the same as titles, wiki-links, and frontmatter metadata generally. That indexing is what makes both Tags panels, tag-based <a href="../features.html">SPARQL</a> queries, and the auto-tag skill's "don't repeat an existing tag" check all possible — this panel is simply the narrowest lens onto that same graph data, filtered down to one note.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No tags in the note, no tree.</b> A note with no tags at all — inline or frontmatter — shows a plain "No tags in this note" message instead of an empty tree.</li>
+      <li><b>A code block's <code>#</code> doesn't count.</b> Text inside fenced or inline code is stripped before the panel looks for <code>#hashtag</code> matches, so a shell comment or a Markdown heading marker inside a code span won't accidentally show up as a tag.</li>
+      <li><b>Ancestor rows aren't "real" tags.</b> A synthesized parent segment (e.g. <code>foo</code> above a note tagged only <code>foo/bar</code>) exists to make the tree readable, not because the project has a tag called exactly that — don't expect it to appear in the left sidebar's project-wide list unless some note is tagged with that shorter form directly.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-citations.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Citations</span>
+      </a>
+      <a class="next" href="right-sidebar-related.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Related →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Right Sidebar</title>
+<meta name="description" content="The right sidebar's panels: Backlinks, Outgoing links, Outline, Properties, Proposals, Citations, Tags, Related, Footnotes, Tables, Heading graph, and Bookmarks." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html" class="active">Right sidebar</a>
+    <a href="right-sidebar-backlinks.html" class="sub">Backlinks</a>
+    <a href="right-sidebar-outgoing-links.html" class="sub">Outgoing links</a>
+    <a href="right-sidebar-outline.html" class="sub">Outline</a>
+    <a href="right-sidebar-properties.html" class="sub">Properties</a>
+    <a href="right-sidebar-proposals.html" class="sub">Proposals</a>
+    <a href="right-sidebar-citations.html" class="sub">Citations</a>
+    <a href="right-sidebar-tags.html" class="sub">Tags</a>
+    <a href="right-sidebar-related.html" class="sub">Related</a>
+    <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-tables.html" class="sub">Tables</a>
+    <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
+    <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Right sidebar</p>
+
+    <h1>Right sidebar</h1>
+    <p class="lede">The right sidebar is context about the note in front of you — twelve panels, each answering a different question about it. What links here? What does it link to? What's its shape? What's pending review? What does it cite? None of them edit your prose directly; they're lenses on the graph, the frontmatter, and the AI review queue, all pointed at whatever you're currently looking at.</p>
+
+    <div class="box">
+      <span class="label">One exception</span>
+      <p>Every panel below is scoped to the note you have open — except <a href="right-sidebar-proposals.html">Proposals</a>, which is project-wide by design: pending AI writes aren't naturally a per-note concern, so it shows you everything regardless of which note is active.</p>
+    </div>
+
+    <h2 id="glance">The twelve panels</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="right-sidebar-backlinks.html">Backlinks</a></div>
+        <div class="v">Notes that link to this one — the incoming side of the graph.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-outgoing-links.html">Outgoing links</a></div>
+        <div class="v">Every wiki-link this note makes — the outgoing side.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-outline.html">Outline</a></div>
+        <div class="v">A collapsible heading tree, for scanning a long note fast.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-properties.html">Properties</a></div>
+        <div class="v">Frontmatter as editable typed rows, instead of raw YAML.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-proposals.html">Proposals</a></div>
+        <div class="v">Approve or reject pending AI writes, one keystroke at a time.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-citations.html">Citations</a></div>
+        <div class="v">Every source this note cites or quotes, with excerpts.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-tags.html">Tags</a></div>
+        <div class="v">This note's own tags, shown as a hierarchy — read-only.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-related.html">Related</a></div>
+        <div class="v">Notes that read alike, found by semantic similarity.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-footnotes.html">Footnotes</a></div>
+        <div class="v">Every footnote in this note, plus a linter for dangling ones.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-tables.html">Tables</a></div>
+        <div class="v">Which SQL-referenced tables this note mentions actually exist.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-heading-graph.html">Heading graph</a></div>
+        <div class="v">The same headings as Outline, drawn as a spatial tree.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-bookmarks.html">Bookmarks</a></div>
+        <div class="v">This note's bookmarks, filtered from the project-wide list.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="right-sidebar-backlinks.html">
+        <span class="em">↙️</span>
+        <h3>Backlinks</h3>
+        <p>Every note that links here — the incoming side.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-outgoing-links.html">
+        <span class="em">↗️</span>
+        <h3>Outgoing links</h3>
+        <p>Every link this note makes — the outgoing side.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-outline.html">
+        <span class="em">📑</span>
+        <h3>Outline</h3>
+        <p>A collapsible heading tree for scanning a long note fast.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-properties.html">
+        <span class="em">🎛️</span>
+        <h3>Properties</h3>
+        <p>Edit frontmatter as typed rows instead of raw YAML.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-proposals.html">
+        <span class="em">🤝</span>
+        <h3>Proposals</h3>
+        <p>Approve or reject pending AI writes, one keystroke at a time.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-citations.html">
+        <span class="em">📖</span>
+        <h3>Citations</h3>
+        <p>Every source this note cites or quotes, with excerpts.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-tags.html">
+        <span class="em">🌿</span>
+        <h3>Tags</h3>
+        <p>This note's own tags, shown as a hierarchy — read-only.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-related.html">
+        <span class="em">🧲</span>
+        <h3>Related</h3>
+        <p>Notes that read alike, found by semantic similarity.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-footnotes.html">
+        <span class="em">📎</span>
+        <h3>Footnotes</h3>
+        <p>Every footnote in this note, and a linter for dangling ones.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-tables.html">
+        <span class="em">🧾</span>
+        <h3>Tables</h3>
+        <p>Which SQL-referenced tables in this note actually exist.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-heading-graph.html">
+        <span class="em">🌐</span>
+        <h3>Heading graph</h3>
+        <p>The same headings as Outline, drawn as a spatial tree.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-bookmarks.html">
+        <span class="em">📌</span>
+        <h3>Bookmarks</h3>
+        <p>This note's bookmarks, filtered from the global list.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="left-sidebar-bookmarks.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Bookmarks</span>
+      </a>
+      <a class="next" href="right-sidebar-backlinks.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Backlinks →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Right sidebar hub page (`right-sidebar.html`) plus twelve full sub-pages: Backlinks, Outgoing links, Outline, Properties, Proposals, Citations, Tags, Related, Footnotes, Tables, Heading graph, and Bookmarks — closing out epic #1200 and its thirteen children (see note on Inspections below).
- **Restructured from the original plan**, same reasoning as Navigation (#1274) and Left sidebar (#1275): the epic and its children originally called for one shared `right-sidebar.html` page with thirteen subsections, which doesn't fit the real depth of thirteen distinct panels. Issue #1200 and all thirteen children were updated on GitHub to reflect the new per-page targets before this was built.
- Every claim is verified against the actual source rather than assumed from the issue text — and several issue assumptions turned out to be wrong:
  - **Proposals** and **Inspections** are project-wide, not scoped to the open note like every other panel.
  - **Right-sidebar Tags** is read-only — no add/remove capability exists despite the issue explicitly claiming otherwise — and is a distinct, hierarchical component from the left sidebar's flat, project-wide Tags panel.
  - **Right-sidebar Tables** is DuckDB-backed, not a CSVW/markdown-table browser, matching its left-sidebar namesake — this independently corroborates a fact `notes-tables.html` (an earlier PR) already recorded.
  - **Proposals**' documented "auto-expire" behavior isn't enforced by any running timer — the sweep exists but nothing calls it.
  - **Inspections** breaks the click-to-navigate convention every other panel follows — clicking a result opens a conversation instead.
- **Inspections is a special case**: its tab was deliberately pulled from the app's UI before v1.0 (issue #786), though the backing engine (`health-checks.ts`) and component are fully intact. To mirror that, its doc page (`right-sidebar-inspections.html`) exists on disk with a clear "not currently in the UI" note, but is unlinked from the hub, the sidebar nav, and the main pager chain (which now runs Heading graph → Bookmarks directly) — the same "keep it, don't surface it" choice the app itself made.

Closes #1200, #1206, #1216, #1217, #1218, #1219, #1220, #1228, #1229, #1230, #1231, #1232, #1233, #1234.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 14 pages, including the Inspections gap
- [x] Visually reviewed each page in a browser