### PR TITLE
docs site: add the Viewing options documentation section

### DIFF
--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Font Size &amp; Zoom</title>
+<meta name="description" content="Two separate ways to make text bigger or smaller in Minerva — the editor's own font-size setting, and whole-window zoom on the entire UI — and how they interact." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-view-modes.html" class="sub">View modes</a>
+    <a href="viewing-options-themes.html" class="sub">Themes</a>
+    <a href="viewing-options-font-size-zoom.html" class="sub active">Font size &amp; zoom</a>
+    <a href="viewing-options-split-panes-windows.html" class="sub">Split panes &amp; windows</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="viewing-options.html">Viewing options</a><span class="sep">/</span>Font size &amp; zoom</p>
+
+    <h1>Font size &amp; zoom</h1>
+    <p class="lede">Minerva has two separate controls for making text bigger or smaller, and they don't do the same thing. <b>Editor font size</b> resizes only the text inside the CodeMirror source editor. <b>Zoom</b> scales the entire window — sidebar, toolbar, dialogs, and the editor along with everything else. They're independent settings that happen to compound, since zoom scales the whole rendered page including whatever the editor's own font size is currently set to.</p>
+
+    <h2 id="mechanisms">The two mechanisms</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Editor font size</div>
+        <div class="v">Resizes text in the <a href="editor.html">source editor</a> only — the sidebar, toolbar, and dialogs stay the same size. <kbd>⌘</kbd><kbd>⇧</kbd><kbd>=</kbd> / <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>=</kbd> increases it, <kbd>⌘</kbd><kbd>⇧</kbd><kbd>-</kbd> / <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>-</kbd> decreases it, in steps of 1px each press (View → Increase/Decrease Editor Font Size, <code>src/main/menu.ts:482-491</code>). View → Reset Editor Font Size has no default shortcut. Ranges from 10px to 24px, default 14px (<code>src/renderer/lib/editor/font-size.ts:10-12</code>), and persists across restarts in <code>localStorage</code> under <code>editorFontSize</code> (<code>src/renderer/lib/components/Editor.svelte:253-254</code>). There's no Settings-panel slider for it — the menu items and shortcuts are the only way to change it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Zoom</div>
+        <div class="v">Scales the whole window's UI — everything renders bigger or smaller together, not just the editor. <kbd>⌘</kbd><kbd>+</kbd> / <kbd>Ctrl</kbd><kbd>+</kbd> zooms in, <kbd>⌘</kbd><kbd>-</kbd> / <kbd>Ctrl</kbd><kbd>-</kbd> zooms out, <kbd>⌘</kbd><kbd>0</kbd> / <kbd>Ctrl</kbd><kbd>0</kbd> resets to actual size (View → Actual Size / <em>(unlabeled zoom in/out)</em>, <code>src/main/menu.ts:478-480</code>). These are Electron's built-in <code>resetZoom</code> / <code>zoomIn</code> / <code>zoomOut</code> menu roles, which drive <code>webContents</code>'s zoom factor directly — Minerva doesn't implement its own zoom logic or clamp it to a custom range.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔍</div>
+      <div class="k">Screenshot — View menu, zoom &amp; font size section</div>
+      <div class="d">The View menu open, scrolled to the lower section showing "Actual Size", the unlabeled zoom in/out items, and below a separator "Increase Editor Font Size", "Decrease Editor Font Size", and "Reset Editor Font Size" — illustrating that these are two adjacent but distinct groups of commands.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">They compound, not replace</span>
+      <p>Zoom scales the entire rendered page, and the editor's font size is just a CSS pixel value on that page — so zooming in on a window where you've already bumped the editor font up to 20px gives you 20px text rendered at, say, 110% larger again. If text looks too big, check both controls rather than assuming one setting reset the other.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Zoom resets every launch; editor font size doesn't.</b> Editor font size is saved to <code>localStorage</code> and survives restarts. Zoom is Electron's in-memory <code>webContents</code> zoom factor — Minerva doesn't persist it anywhere, so a zoomed window goes back to 100% the next time you open the app.</li>
+      <li><b>Zoom has no reset shortcut for the editor specifically.</b> <kbd>⌘</kbd><kbd>0</kbd> resets whole-window zoom to 100%; it does not touch your editor font-size setting. To get the editor back to its default 14px, use View → Reset Editor Font Size.</li>
+      <li><b>Editor font size is clamped, zoom isn't (by Minerva).</b> The editor setting can't go below 10px or above 24px — the menu commands simply stop moving it further once you hit either end. Zoom uses Chromium's own built-in limits, which are much wider and not something Minerva restricts.</li>
+      <li><b>No Settings-panel control for either.</b> Both are menu commands (with keyboard shortcuts) rather than fields in <a href="settings.html">Settings</a> — there's nothing to type a specific pixel size or zoom percentage into.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="viewing-options-themes.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Themes</span>
+      </a>
+      <a class="next" href="viewing-options-split-panes-windows.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Split panes &amp; windows →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Split Panes &amp; Windows</title>
+<meta name="description" content="Splitting the editor into multiple panes — each with its own tabs and view mode — moving tabs between them, and when to open a whole new window instead." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-view-modes.html" class="sub">View modes</a>
+    <a href="viewing-options-themes.html" class="sub">Themes</a>
+    <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
+    <a href="viewing-options-split-panes-windows.html" class="sub active">Split panes &amp; windows</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="viewing-options.html">Viewing options</a><span class="sep">/</span>Split panes &amp; windows</p>
+
+    <h1>Split panes &amp; windows</h1>
+    <p class="lede">A single tab strip is fine until you want to see two notes at once — a source next to the claim it supports, or an outline next to the section you're drafting from it. Minerva gives you two ways to do that: split the current window into multiple <b>panes</b>, each with its own tabs and its own <a href="viewing-options-view-modes.html">view mode</a>; or open an entirely separate <b>window</b>. They solve different problems, and knowing which one you want saves a few seconds of fighting the layout.</p>
+
+    <h2 id="panes">Panes and groups</h2>
+    <p>Internally, a pane is called a <b>group</b> — an independent unit owning its own tab strip, active tab, and view mode (<code>EditorGroup</code>, <code>src/renderer/lib/stores/editor.svelte.ts:100-105</code>). A window with no splits is just one group. The panes themselves are arranged in a recursive layout tree of horizontal/vertical splits with fractional sizes, so you can split a pane that's already inside a split (<code>LayoutNode</code>, <code>src/renderer/lib/editor/layout-tree.ts:12-27</code>); dragging the hairline between two panes resizes just that pair.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Split right</div>
+        <div class="v"><kbd>⌘</kbd><kbd>\</kbd> (<kbd>Ctrl</kbd><kbd>\</kbd> on Windows/Linux), the split-pane icon button in a pane's toolbar, or <b>View → Split Editor Right</b>. Splits the focused pane horizontally, adding a new empty pane to its right and focusing it (<code>editor.splitGroup(groupId, 'horizontal')</code>, <code>src/renderer/lib/stores/editor.svelte.ts:253-262</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Split down</div>
+        <div class="v"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>\</kbd> (<kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>\</kbd>), the toolbar's split-down button, or <b>View → Split Editor Down</b>. Same as Split Right but stacks the new pane vertically, below the focused one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Drag a tab to an edge</div>
+        <div class="v">Press and drag a tab toward the left, right, top, or bottom edge of any pane; a preview shows where it'll land. Dropping on an edge band splits that pane along the matching axis and moves the tab into the new sub-pane — dragging to the left or right edge splits horizontally, top or bottom splits vertically (<code>dropZoneFromFraction</code> / <code>splitForZone</code>, <code>src/renderer/lib/editor/drop-zone.ts:13-46</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Focus next / previous pane</div>
+        <div class="v"><kbd>⌘</kbd><kbd>⌥</kbd><kbd>→</kbd> / <kbd>⌘</kbd><kbd>⌥</kbd><kbd>←</kbd> (<kbd>Ctrl</kbd><kbd>Alt</kbd>), or <b>View → Focus Next/Previous Group</b>. Cycles focus through panes in left-to-right visual order, wrapping at the ends.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close pane</div>
+        <div class="v"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>W</kbd> or <b>View → Close Group</b>. Closes every tab in the focused pane and collapses it out of the layout tree, rebalancing the remaining split.</div>
+      </div>
+    </div>
+
+    <h2 id="moving-tabs">Moving tabs between panes</h2>
+    <p>Once you have more than one pane, a tab can move between them two ways:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Drag to center</div>
+        <div class="v">Drag a tab and drop it in the middle of another pane (including onto its tab bar) rather than on an edge — this moves the tab into that pane without creating a new split, the same "move here" gesture VS Code uses.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move to Other Group</div>
+        <div class="v">Right-click a tab for its context menu. With exactly one other pane open it's a single-click <b>Move to Other Group</b>; with more than two panes it expands into a submenu listing each by position (Group 1, Group 2, …) so you can pick the destination (<code>TabBar.svelte:174-180</code>).</div>
+      </div>
+    </div>
+
+    <p>A file, source, or PDF can only be open in one pane at a time — Minerva won't let you open the same note twice into two panes as separate buffers, since that would race two copies against each other on save. Trying to open something that's already open elsewhere just refocuses the pane it's already in.</p>
+
+    <h2 id="view-mode">Each pane keeps its own view mode</h2>
+    <p>View mode — <a href="viewing-options-view-modes.html">Source, Preview, or Editor + Preview</a> — lives on the group, not on the note or the window. Split a pane and the new one inherits the splitting pane's mode so the split feels continuous, but from that point the two are independent: switch one pane to Preview and the other stays in Source, and each remembers its own mode as you switch which note is open in it.</p>
+
+    <div class="shot wide">
+      <div class="icon">🪟</div>
+      <div class="k">Screenshot — Two panes, two view modes</div>
+      <div class="d">The editor split vertically into two side-by-side panes via Split Right. The left pane shows a note in Source mode with raw markdown and an open wiki-link; the right pane shows a different note in Preview mode, fully rendered. Each pane has its own tab strip and toolbar above it, with the right pane's "Preview" button highlighted as active and the left pane's "Source" button highlighted instead.</div>
+    </div>
+
+    <h2 id="windows">Opening a new window</h2>
+    <p><b>File → New Window</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd>) opens a second, completely blank Minerva window with no project loaded — you then open a thoughtbase into it the same way you would the first window. It is not tied to whatever project is open in the window you triggered it from.</p>
+
+    <div class="box">
+      <span class="label">Same project, or a different one — your choice</span>
+      <p>A new window can open the <em>same</em> thoughtbase as another open window, or a completely different one. When two windows point at the same project's root path, Minerva shares one underlying project context between them — the graph, search index, tables, and embeddings are initialized once and reference-counted across acquiring windows, not duplicated (<code>acquireProject</code>, <code>src/main/project-context.ts:52-96</code>). A note saved in one window is written to disk and re-indexed once; the other window's file watcher picks up the change and reflects it, same as if the file had changed from outside the app.</p>
+    </div>
+
+    <h2 id="which">Split pane or new window?</h2>
+    <p>Both let you look at two things at once — the difference is scope and independence:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Prefer a split</div>
+        <div class="v">You're working within one project and want two views alongside each other on one screen — a source next to the note citing it, an outline next to a draft, or the same note in Source and Preview. Panes share the window's size, menu, and focus.</div>
+      </div>
+      <div class="row">
+        <div class="k">Prefer a new window</div>
+        <div class="v">You want a second, independently movable and resizable surface — across two monitors, for example — or you want to have <em>two different projects</em> open at once. A window is also the only way to get a fully separate set of panes: splitting only subdivides the window you're already in.</div>
+      </div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Closing a pane's last tab collapses the pane.</b> Close every tab in a split pane (one at a time, or via Close All) and the now-empty pane collapses out of the layout tree automatically, handing its space back to its sibling — you don't end up staring at a blank pane. The one exception is a window with a single pane and no split: that one stays, showing its normal empty "no file open" state, since a window always keeps at least one pane.</li>
+      <li><b>A new window starts blank, not cloned.</b> New Window never copies the current window's open tabs, panes, or project — it's a fresh window exactly like the one you'd get from launching the app again. If you want the same project open a second time, you open it again from the new window's File menu (or Recent Thoughtbases).</li>
+      <li><b>Same project across windows means shared state, not synced UI.</b> The graph and indexes are shared and stay consistent, but each window's panes, tabs, and view modes are independent — closing a pane in one window has no effect on the other.</li>
+      <li><b>Drag vs. click targets differ by pixel region.</b> The edge bands that trigger a split are the outer quarter of a pane on each side; the inner half plus the entire tab bar is the "move without splitting" zone. If a drag keeps splitting when you meant to move a tab into a pane, drop closer to its center or onto its tab bar instead.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="viewing-options-font-size-zoom.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Font size &amp; zoom</span>
+      </a>
+      <a class="next" href="editor.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Editor →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Themes</title>
+<meta name="description" content="Minerva ships Dark, Light, and High Contrast themes plus a System option, switched instantly from Settings, the status bar, or a shortcut — a whole-app appearance choice, not a per-note one." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-view-modes.html" class="sub">View modes</a>
+    <a href="viewing-options-themes.html" class="sub active">Themes</a>
+    <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
+    <a href="viewing-options-split-panes-windows.html" class="sub">Split panes &amp; windows</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="viewing-options.html">Viewing options</a><span class="sep">/</span>Themes</p>
+
+    <h1>Themes</h1>
+    <p class="lede">Minerva ships three appearance themes — Dark, Light, and High Contrast — plus a System option that follows your OS setting. Switching is instant: pick one from Settings, the status bar, or a shortcut, and the whole app repaints immediately. There's no restart, and no per-note override — theme is a whole-app setting.</p>
+
+    <h2 id="themes">The themes</h2>
+    <p>Every theme is a set of CSS custom properties (<code>--bg</code>, <code>--text</code>, <code>--accent</code>, <code>--border</code>, and related tokens) defined in <code>src/renderer/styles/global.css</code>. The default tier lives on <code>:root</code>; the other two are keyed off a <code>data-theme</code> attribute on <code>&lt;html&gt;</code>, so switching is a single attribute swap rather than a stylesheet reload.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Dark <span style="color:var(--text-faint);font-weight:400;">(default)</span></div>
+        <div class="v">Minerva's default look — a warm, Catppuccin-inspired dark palette ("Honey"): ink-toned backgrounds, soft warm-white text, and a honeyed amber accent. Defined on <code>:root</code> with no <code>data-theme</code> attribute set.</div>
+      </div>
+      <div class="row">
+        <div class="k">Light</div>
+        <div class="v">The same warm palette inverted onto a pale paper background, with darker text and a deeper amber accent — reads like the dark theme's daytime twin rather than a generic light mode. <code>[data-theme="light"]</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k">High Contrast</div>
+        <div class="v">A stark black-on-white palette with a dark title bar retained over the light body. Signal colors (sage, rust, iris) and highlight tints are individually darkened so every combination clears WCAG AA (4.5:1). Built for maximum legibility, not aesthetics. <code>[data-theme="contrast"]</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k">System</div>
+        <div class="v">Not a fourth palette — it follows your OS light/dark setting, resolving to Dark or Light and updating live if you change your OS appearance while Minerva is open. This is the default on a fresh install.</div>
+      </div>
+    </div>
+
+    <h2 id="switching">Switching themes</h2>
+    <p>Three equivalent ways to change the theme, all reading from and writing to the same list so labels never drift between surfaces:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Settings → Appearance</div>
+        <div class="v">Open Settings and select the <b>Appearance</b> tab, then choose a theme from the <b>Theme</b> dropdown. The change applies live as you pick — no "Apply" or "OK" step needed, and no restart.</div>
+      </div>
+      <div class="row">
+        <div class="k">Status bar</div>
+        <div class="v">Click the theme label in the status bar to open a small picker listing all four options; click one to switch immediately.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
+        <div class="v">Cycles through Dark → Light → High Contrast → System → Dark, without opening any menu.</div>
+      </div>
+    </div>
+
+    <p>Your choice is stored in <code>localStorage</code>, so it's per-machine — it isn't part of the project and doesn't travel with the notebase or sync between devices.</p>
+
+    <div class="shot wide">
+      <div class="icon">🎨</div>
+      <div class="k">Screenshot — Theme picker in Settings</div>
+      <div class="d">The Settings dialog's Appearance tab, showing the "Theme" field with its dropdown open over the four options (Dark, Light, High Contrast, System) and the hint line below it noting the status-bar picker and the ⌘⇧T shortcut; the content-font field sits directly beneath.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Whole-app, not per-note.</b> There's no way to pin one note or window to a different theme — every open window reflects the same stored preference.</li>
+      <li><b>"System" isn't a distinct palette.</b> It's an auto-selector that resolves to the Dark or Light token set depending on your OS appearance, and updates live if the OS setting changes while Minerva is running.</li>
+      <li><b>No custom CSS override.</b> Themes are fixed token sets shipped with the app; there's currently no user stylesheet or theme-editing surface to define your own.</li>
+      <li><b>Exports don't inherit your theme.</b> HTML and PDF exports (<code>src/main/publish/exporters/note-html/style.ts</code>) use their own fixed, print-friendly light stylesheet, independent of whichever app theme is active — a note exported while you're in High Contrast or Dark looks the same as one exported in Light.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="viewing-options-view-modes.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← View modes</span>
+      </a>
+      <a class="next" href="viewing-options-font-size-zoom.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Font size &amp; zoom →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — View Modes</title>
+<meta name="description" content="The three ways to view a note in Minerva — Source, Preview, and side-by-side Editor+Preview — and how to switch between them with the toolbar buttons or the cycle shortcut." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-view-modes.html" class="sub active">View modes</a>
+    <a href="viewing-options-themes.html" class="sub">Themes</a>
+    <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
+    <a href="viewing-options-split-panes-windows.html" class="sub">Split panes &amp; windows</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="viewing-options.html">Viewing options</a><span class="sep">/</span>View modes</p>
+
+    <h1>View modes</h1>
+    <p class="lede">Every open note has a view mode: raw markdown in the editor, the rendered read-only page, or both side by side. It's a per-pane setting — a <a href="viewing-options-split-panes-windows.html">split pane</a> can show one note in Source while another shows a different note in Preview — and switching modes never touches the file on disk, so it's a free, reversible way to look at the same content differently.</p>
+
+    <h2 id="modes">The three modes</h2>
+    <p>The mode lives on the pane (called a "group" internally), not on the note itself — reopen a note later and it comes back in whatever mode that pane was last set to, not whatever mode it was in when you closed it (<code>src/renderer/lib/stores/editor.svelte.ts:576</code> — <code>setViewMode(mode, groupId)</code> sets it per group).</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Source</div>
+        <div class="v">The raw <code>.md</code> text in the CodeMirror editor — what you'll want for anything mechanical: fixing a wiki-link, editing frontmatter, working inside a code fence. Labeled <b>Source</b> on the toolbar.</div>
+      </div>
+      <div class="row">
+        <div class="k">Preview</div>
+        <div class="v">The fully rendered, read-only page — headings, callouts, math, diagrams, charts, and embedded media all render live. Labeled <b>Preview</b> on the toolbar.</div>
+      </div>
+      <div class="row">
+        <div class="k">Editor + Preview</div>
+        <div class="v">Source on the left, rendered Preview on the right, in the same pane. Internally this is the <code>editor-preview</code> mode; the toolbar calls it <b>Side by side</b>.</div>
+      </div>
+    </div>
+
+    <p>These three are exactly the values of the <code>ViewMode</code> union — <code>'source' | 'preview' | 'editor-preview'</code> (<code>src/renderer/lib/stores/editor.svelte.ts:92</code>). A plain-text file (no markdown rendering — see <a href="notes.html">Notes</a>) skips the toggle entirely and only shows Source, since a Preview of plain text would just be an empty pane.</p>
+
+    <div class="shot wide">
+      <div class="icon">🪟</div>
+      <div class="k">Screenshot — Editor + Preview split mode</div>
+      <div class="d">A note pane in "Side by side" mode: the CodeMirror source editor on the left with raw markdown and an open code fence, and the rendered Preview pane on the right showing the same content formatted, separated by a hairline divider. The toolbar above shows Source / Side by side / Preview with "Side by side" highlighted as active.</div>
+    </div>
+
+    <h2 id="switching">Switching modes</h2>
+    <p>Two ways to change a pane's mode, both acting on the same underlying <code>editor.setViewMode()</code> / <code>editor.cycleViewMode()</code> calls:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Toolbar buttons</div>
+        <div class="v">Three buttons above the note — <b>Source</b>, <b>Side by side</b>, <b>Preview</b> — jump straight to that mode regardless of what it's currently showing. Each calls <code>editor.setViewMode('source' | 'editor-preview' | 'preview', groupId)</code> directly (<code>src/renderer/App.svelte:1360-1372</code>); there's no cycling involved, so you can go from Source straight to Preview without passing through the split view.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cycle shortcut — <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
+        <div class="v">Steps the active pane through the three modes in order: <b>Source → Preview → Editor + Preview → Source</b> (<code>cycleViewMode()</code>, <code>src/renderer/lib/stores/editor.svelte.ts:580-585</code>). Bound globally as <kbd>Cmd</kbd><kbd>Shift</kbd><kbd>P</kbd> / <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>P</kbd> (<code>src/renderer/lib/keymap/handle-keydown.ts:52-55</code>) and also reachable from the View menu as <b>Cycle Preview Mode</b> (<code>src/main/menu.ts:428-432</code>).</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Why ⌘P was taken already</span>
+      <p>Minerva binds <kbd>⌘</kbd><kbd>P</kbd> to <a href="navigation-quick-switch.html">Quick switch</a> rather than a preview toggle, unlike some other markdown editors — so the cycle shortcut adds <kbd>⇧</kbd> instead. See <a href="navigation-command-palette.html">Command palette</a> for the related <kbd>⌘</kbd><kbd>K</kbd> binding.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>No scroll sync in Side by side.</b> The source and preview panes scroll independently — scrolling one does not move the other. Each pane just remembers its own scroll position for restoring the note later (<code>src/renderer/lib/components/Editor.svelte:932-933</code>); they aren't linked to each other.</li>
+      <li><b>Cursor and scroll position survive a mode switch.</b> Toggling between Source, Preview, and Side by side doesn't remount the editor — it's only swapping which pane(s) are visible around it — so your cursor offset and scroll position in the source editor are exactly where you left them when you switch back to Source.</li>
+      <li><b>The mode belongs to the pane, not the note.</b> Split your window into two panes, put one in Preview and one in Source, and that assignment sticks per pane even as you switch which note is open in it.</li>
+      <li><b>Plain-text files have no toggle.</b> A file that Minerva treats as plain text (not markdown) has nothing to render, so the Source/Side by side/Preview toolbar doesn't appear for it at all — you're always in Source for those.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="viewing-options.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Viewing options</span>
+      </a>
+      <a class="next" href="viewing-options-themes.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Themes →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/viewing-options.html
+++ b/website/docs/viewing-options.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Viewing Options</title>
+<meta name="description" content="How you view a note in Minerva: the three view modes, appearance themes, font size and zoom, and splitting panes or opening new windows." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html" class="active">Viewing options</a>
+    <a href="viewing-options-view-modes.html" class="sub">View modes</a>
+    <a href="viewing-options-themes.html" class="sub">Themes</a>
+    <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
+    <a href="viewing-options-split-panes-windows.html" class="sub">Split panes &amp; windows</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Viewing options</p>
+
+    <h1>Viewing options</h1>
+    <p class="lede">How a note looks on screen is separate from what's in it. Four independent controls shape that: which view mode a pane shows a note in, which color theme the whole app wears, how large the text renders, and how many notes you can see at once across panes and windows. None of these touch a note's content — they're all about how you're looking at it right now.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
+        <div class="v"><a href="viewing-options-view-modes.html"><b>View modes</b></a> — cycle a pane through Source, Preview, and side-by-side.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
+        <div class="v"><a href="viewing-options-themes.html"><b>Themes</b></a> — cycle Dark, Light, High Contrast, and System.</div>
+      </div>
+      <div class="row">
+        <div class="k">several</div>
+        <div class="v"><a href="viewing-options-font-size-zoom.html"><b>Font size &amp; zoom</b></a> — resize editor text and the whole window independently — they compound.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>\</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd></div>
+        <div class="v"><a href="viewing-options-split-panes-windows.html"><b>Split panes &amp; windows</b></a> — split the current window, or open a new one entirely.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="viewing-options-view-modes.html">
+        <span class="em">🔄</span>
+        <h3>View modes</h3>
+        <p>Source, Preview, or both side by side — a per-pane setting.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-themes.html">
+        <span class="em">🎨</span>
+        <h3>Themes</h3>
+        <p>Dark, Light, High Contrast, or follow the OS — switches instantly.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-font-size-zoom.html">
+        <span class="em">🔠</span>
+        <h3>Font size &amp; zoom</h3>
+        <p>Two separate controls for bigger text, and they compound.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-split-panes-windows.html">
+        <span class="em">🪟</span>
+        <h3>Split panes &amp; windows</h3>
+        <p>See two notes at once — split the window, or open a new one.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="navigation-back-forward.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Back / forward</span>
+      </a>
+      <a class="next" href="viewing-options-view-modes.html">
+        <span class="dir">Next</span>
+        <span class="ttl">View modes →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Viewing options hub page (`viewing-options.html`) plus four full sub-pages: View modes, Themes, Font size & zoom, and Split panes & windows — closing out epic #1197 and its four children.
- **Restructured from the original plan**, same reasoning as Navigation (#1274), Left sidebar (#1275), and Right sidebar (#1277): one shared page with four subsections doesn't fit the real depth once each is properly documented. Issue #1197 and all four children were updated on GitHub to reflect the new per-page targets before this was built.
- Corrections made after verifying against source rather than trusting the issue text:
  - **Themes**: four modes ship (Dark, Light, High Contrast, System-follows-OS), not an assumed two or three; switching is instant with no restart, and exported HTML/PDF always uses a fixed light stylesheet regardless of the active theme.
  - **View modes**: the real menu command is labeled "Cycle Preview Mode," not "Toggle Preview"; there's no scroll-sync between split panes, and cursor position survives a mode switch.
  - **Font size & zoom**: editor font size and window zoom are independent mechanisms that compound multiplicatively rather than one overriding the other; editor font size has no Settings-panel control at all, it's menu/shortcut only.
  - **Split panes & windows**: view mode is confirmed genuinely per-pane; drag-to-split uses a 25%-edge detection zone (center, including the whole tab strip, always just moves — never splits); windows on the same project share one refcounted graph/search/tables store but each runs its own independent file watcher.
- Since the sidebar only expands the section you're currently in, this batch is purely additive — no existing pages needed changes.

Closes #1197, #1255, #1256, #1257, #1258.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 5 pages
- [x] Visually reviewed each page in a browser