### PR TITLE
docs site: add the Editor documentation section

### DIFF
--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Keyboard Shortcuts</title>
+<meta name="description" content="A complete reference of Minerva's editor keyboard shortcuts — formatting, file and editing commands, and navigation — gathered in one place and cross-linked to their dedicated pages." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+    <a href="editor-writing-surface.html" class="sub">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub active">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>Keyboard shortcuts</p>
+
+    <h1>Keyboard shortcuts</h1>
+    <p class="lede">Every shortcut the editor answers to, gathered in one reference: inline formatting, file and editing commands, and the navigation shortcuts documented in depth elsewhere. All bindings live in <code>src/renderer/lib/editor/command-registry.ts</code> (formatting and text commands, dispatched through CodeMirror's keymap) and <code>src/renderer/lib/keymap/handle-keydown.ts</code> (app-level navigation, bound at the window). On Windows and Linux, <kbd>⌘</kbd> becomes <kbd>Ctrl</kbd> and <kbd>⌥</kbd> becomes <kbd>Alt</kbd> — every combo below follows that swap unless noted.</p>
+
+    <h2 id="formatting">Formatting</h2>
+    <p>Inline and insert commands from <code>COMMAND_REGISTRY</code>. Toggle commands wrap or unwrap the current selection — pressing the same shortcut again on already-formatted text removes the markers. See <a href="editor-markdown-formatting.html">Markdown formatting</a> for the underlying syntax each one produces.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>B</kbd></div>
+        <div class="v">Toggle <b>bold</b> — wraps the selection in <code>**…**</code>, or drops the cursor between a fresh pair of markers with nothing selected.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>I</kbd></div>
+        <div class="v">Toggle <i>italic</i> — wraps the selection in <code>*…*</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>E</kbd></div>
+        <div class="v">Toggle inline <code>code</code> — wraps the selection in backticks.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>X</kbd></div>
+        <div class="v">Toggle strikethrough — wraps the selection in <code>~~…~~</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Y</kbd></div>
+        <div class="v">Toggle <a href="notes-highlights.html">highlight</a>, cycling color on repeat presses — yellow → green → blue → pink → orange → plain (unwrapped). Y is mnemonic for yellow, the default color. <code>Mod-Shift-H</code> was the more obvious pick but was already claimed by the menu's Replace-in-Notes accelerator, so this shortcut uses Y instead.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v">Insert a markdown link — <code>[selected text](url)</code>, or <code>[](url)</code> with the cursor in the brackets if nothing's selected. This is the editor's insert-link command, distinct from the app-level <a href="navigation-command-palette.html">command palette</a>'s <kbd>⌘</kbd><kbd>K</kbd> — the palette only opens when the editor isn't the one capturing the keystroke first.</div>
+      </div>
+    </div>
+
+    <p>Headings, quotes, lists, task lists, tables, horizontal rules, footnotes, wiki-links, and typed links are all reachable from the editor's Insert/Format menus and the command palette, but ship with no default key binding (<code>defaultKey: ''</code> in the registry) — there's simply nothing to press for them yet.</p>
+
+    <div class="box">
+      <span class="label">Shortcuts are user-remappable</span>
+      <p>Every entry in <code>COMMAND_REGISTRY</code> can be rebound from Settings — overrides are stored in <code>localStorage</code> and merged over the defaults at startup (<code>resolveKeyBindings()</code>). The bindings on this page are what you get out of the box; check Settings if a combo doesn't match what you're seeing.</p>
+    </div>
+
+    <h2 id="file-and-editing">File &amp; editing</h2>
+    <p>Saving, undo/redo, and text manipulation commands.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>S</kbd></div>
+        <div class="v">Save now. Minerva <a href="notes.html">autosaves</a> on a debounced ~1000ms timer, so this isn't strictly necessary to avoid losing work — but it's not a no-op either: it flushes any pending autosave and writes immediately, then refreshes tags, the right sidebar, and backlink/alias caches on the spot rather than waiting for the timer.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>Z</kbd></div>
+        <div class="v">Undo, via CodeMirror's standard history keymap (bundled in <code>basicSetup</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Z</kbd></div>
+        <div class="v">Redo.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>D</kbd></div>
+        <div class="v">Duplicate line — with no selection, copies the current line directly beneath itself; with a selection, duplicates the whole selected region.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌥</kbd><kbd>↑</kbd> / <kbd>⌥</kbd><kbd>↓</kbd></div>
+        <div class="v">Extend or shrink the selection outward/inward through a sequence of enclosing scopes — word, bracket/quote pair, line, sentence, paragraph, heading section, whole document — remembering each step so shrinking retraces exactly what extending grew.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>U</kbd></div>
+        <div class="v">Toggle case of the selection (or the word under the cursor with nothing selected): all-lowercase → UPPERCASE → Title Case → lowercase.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>J</kbd></div>
+        <div class="v">Join lines — merges the current line with the next (or every line in a multi-line selection) into one, separated by a single space. This binding doesn't swap to <kbd>⌘</kbd> on Windows/Linux — it's <code>Ctrl-Shift-j</code> in the registry on every platform.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>V</kbd></div>
+        <div class="v">Start or stop <a href="editor-voice-dictation.html">voice dictation</a> into the editor at the cursor.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>F</kbd></div>
+        <div class="v">Open CodeMirror's built-in search panel, scoped to the current editor tab only. Not the same as project-wide search — see the gotcha below.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>H</kbd></div>
+        <div class="v">Open the same panel with replace enabled, scoped to the current tab.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">⌘F / ⌘H are per-tab, not project-wide</span>
+      <p>These open CodeMirror's own search panel inside whichever note is focused. For a search across every file in the project, use <a href="navigation-search.html">Find in Notes…</a> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd>) instead — same underlying idea, much larger scope. If a search you expect to span the whole project is only turning up matches in the file you already have open, you pressed the un-shifted version.</p>
+    </div>
+
+    <h2 id="navigation">Navigation</h2>
+    <p>Shortcuts that move you around the app rather than editing text. Each one has its own page with the full mechanics — this is just the complete list in one place, so you don't have to go hunting across the docs for a shortcut you half-remember.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v">Open the <a href="navigation-command-palette.html">command palette</a> — a do-anything launcher over commands and actions.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>P</kbd></div>
+        <div class="v"><a href="navigation-quick-switch.html">Quick switch</a> — jump to any note, source, or query by name.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd></div>
+        <div class="v"><a href="navigation-search.html">Find in Notes…</a> — project-wide search across every file's actual content.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>[</kbd> / <kbd>⌘</kbd><kbd>]</kbd></div>
+        <div class="v"><a href="navigation-back-forward.html">Back / Forward</a> through your navigation history.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
+        <div class="v">Cycle the active pane's <a href="viewing-options-view-modes.html">view mode</a> — Source → Preview → Editor + Preview → Source.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>\</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>\</kbd></div>
+        <div class="v"><a href="viewing-options-split-panes-windows.html">Split the editor</a> right or down.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd></div>
+        <div class="v"><a href="viewing-options-split-panes-windows.html">New window</a> — opens a second, blank Minerva window.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>N</kbd></div>
+        <div class="v"><a href="notes.html">New Note</a> — prompts for a name and, optionally, a starting template.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>G</kbd></div>
+        <div class="v">Go to line, when a note is focused.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Q</kbd></div>
+        <div class="v">New query tab, when a project is open.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>I</kbd></div>
+        <div class="v">Open a <a href="conversations.html">conversation</a> with the assistant.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>B</kbd></div>
+        <div class="v">Toggle the <a href="right-sidebar.html">right sidebar</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
+        <div class="v">Cycle the <a href="viewing-options-themes.html">theme</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>W</kbd></div>
+        <div class="v">Close the active tab, when one is open.</div>
+      </div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>⌘P is Quick switch, not a preview toggle.</b> Unlike some other markdown editors, Minerva reserves <kbd>⌘</kbd><kbd>P</kbd> for <a href="navigation-quick-switch.html">Quick switch</a>. Cycling the preview mode is <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> instead, matching the Linear / VS Code convention rather than Obsidian's.</li>
+      <li><b>Join Lines doesn't follow the Cmd/Ctrl swap.</b> It's bound as <code>Ctrl-Shift-j</code> in <code>COMMAND_REGISTRY</code> on every platform, including macOS — the one formatting/editing shortcut on this page that isn't <kbd>⌘</kbd> on Mac.</li>
+      <li><b>⌘F/⌘H vs ⌘⇧F/⌘⇧H.</b> The un-shifted pair searches only the current tab (CodeMirror's own panel); the shifted pair searches the whole project (<a href="navigation-search.html">Find in Notes…</a>). Easy to reach for the wrong one out of habit from a single-file editor.</li>
+      <li><b>Most paragraph-level formatting has no default key.</b> Headings, quotes, lists, task lists, tables, horizontal rules, and footnote insertion are registry commands with an empty <code>defaultKey</code> — reach them from the Insert/Format menus, the command palette, or bind your own key in Settings.</li>
+      <li><b>Every shortcut is remappable.</b> If a combo on this page doesn't do what's described, check Settings for a user override before assuming the docs are stale.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="editor-markdown-formatting.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Markdown formatting</span>
+      </a>
+      <a class="next" href="editor-link-autocomplete.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Link autocomplete →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Link Autocomplete</title>
+<meta name="description" content="How typing [[ suggests matching notes and aliases as you type, how to filter and accept an entry, and what actually happens when the typed text doesn't match anything." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+    <a href="editor-writing-surface.html" class="sub">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub active">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>Link autocomplete</p>
+
+    <h1>Link autocomplete</h1>
+    <p class="lede">Typing <code>[[</code> opens a suggestion list of notes and aliases, filtered as you keep typing. It saves you from remembering exact filenames — and from a typo quietly producing a link to nowhere. This page covers the trigger, the filtering, and — verified directly against the completion source, not assumed — exactly what happens when nothing matches.</p>
+
+    <h2 id="trigger">Triggering the list</h2>
+    <p>The popup isn't tied to the single act of typing <code>[[</code> — it re-evaluates on every keystroke while your cursor sits inside an unclosed pair. Start a link, and the list stays open and refiltering as you type, narrows and reorders as you add characters, and disappears once you type the closing <code>]]</code> or leave the link.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Trigger</div>
+        <div class="v">Typing <code>[[</code> anywhere in a note opens the list. It stays live on every subsequent keystroke as long as the cursor is inside an open pair — there's no separate "re-trigger" gesture, it's continuous.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter</div>
+        <div class="v">Whatever you type after <code>[[</code> narrows the list. Filtering is CodeMirror's built-in fuzzy matcher — a subsequence match, case-insensitive — not a Minerva-specific search, so out-of-order characters can still match (e.g. <code>mtg</code> can match <code>Meeting Notes</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Select</div>
+        <div class="v">Arrow keys move through the list; clicking an entry also works. <kbd>Esc</kbd> dismisses the popup without changing anything you've typed.</div>
+      </div>
+      <div class="row">
+        <div class="k">Accept</div>
+        <div class="v"><kbd>Tab</kbd> or <kbd>Enter</kbd> accepts the highlighted entry, inserting its title or alias in place of what you'd typed so far. Accepting never inserts brackets — you already typed <code>[[</code>, and Minerva doesn't auto-close <code>]]</code> for you.</div>
+      </div>
+      <div class="row">
+        <div class="k">No match</div>
+        <div class="v">If nothing in your notes matches, the list shows no items — there's no "Create new note" entry. See <a href="#gotchas">Gotchas</a> for the verified detail.</div>
+      </div>
+    </div>
+
+    <p>The list draws from two sources at once: every note's path (title, effectively) and any <code>aliases:</code> frontmatter entries across the project, so an alias you've defined is just as reachable as the note's real filename. A note path ranks slightly above a matching alias when both match the same typed text, so the canonical name wins ties. Typing <code>type::</code> first (e.g. <code>supports::</code>) also offers the twelve <a href="notes-links.html#types">link types</a> as completions before you get to the target text, and <code>cite::</code> switches the whole list over to your indexed sources instead of notes.</p>
+
+    <div class="shot wide">
+      <div class="icon">🔎</div>
+      <div class="k">Screenshot — Link autocomplete open</div>
+      <div class="d">The editor mid-line with an unclosed [[Mee typed, a completion popup open beneath the cursor listing filtered matches such as "Meeting Notes" and "Meeting Prep", one entry highlighted, with a note-path icon beside each.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Typing text that matches no note does not create anything — the list is simply empty.</b> The completion source builds its option list strictly from existing note paths, aliases, headings, block ids, or sources, depending on which part of the link you're typing — there's no branch anywhere that synthesizes a "create new note" option from your typed text. If you finish typing a target that matches nothing and close the brackets yourself, you're left with a plain unresolved <code>[[...]]</code> link, exactly as if you'd typed it without ever seeing a suggestion. This mirrors the click-navigation behavior documented in <a href="navigation-wiki-links.html#gotchas">Navigation → Wiki-links</a> — an unresolved target is a quiet no-op there too, not an auto-create — so the two code paths agree even though they're independent.</li>
+      <li><b>Closing the brackets yourself has no special effect.</b> Autocomplete is purely an insert-before-you-finish-typing convenience. Typing the closing <code>]]</code> just ends the phase the popup was tracking; nothing is validated, created, or written at that moment.</li>
+      <li><b>Accepting mid-word eats the leftover tail, not just what's before the cursor.</b> If you're editing inside an existing link — say the cursor sits in the middle of <code>[[No|te]]</code> — accepting a suggestion also removes the contiguous run of word characters right after the cursor, so you get a clean <code>[[Notebook]]</code> instead of <code>[[Notebooknote]]</code>. It stops at the first non-word character, so it won't reach past a <code>]</code> or a <code>,</code>.</li>
+      <li><b>The popup closes at <code>|</code>.</b> Once you type the display-text separator, completion stops offering target suggestions — everything after <code>|</code> is free text, same as writing <code>[[target|display]]</code> by hand. See <a href="notes-links.html#syntax">Links → Syntax</a>.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="editor-keyboard-shortcuts.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Keyboard shortcuts</span>
+      </a>
+      <a class="next" href="editor-voice-dictation.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Voice dictation →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Markdown Formatting</title>
+<meta name="description" content="A quick-reference table of every markdown syntax Minerva renders — basics like headers and lists in full, plus a one-line pointer to the dedicated page for anything more elaborate." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+    <a href="editor-writing-surface.html" class="sub">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub active">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>Markdown formatting</p>
+
+    <h1>Markdown formatting</h1>
+    <p class="lede">Minerva renders standard markdown, plus a set of extensions for research and knowledge work. This page is a scannable reference — syntax on the left, what it renders as on the right — not a tutorial. The basics are covered in full below; anything more elaborate links out to its own page with the complete syntax and behavior.</p>
+
+    <h2 id="basics">The basics</h2>
+    <p>Headers, emphasis, lists, blockquotes, and inline code follow standard CommonMark, with one deliberate deviation noted below.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code># … ######</code></div>
+        <div class="v">Headings, level 1 through 6 — <code># H1</code>, <code>## H2</code>, and so on. Minerva is <b>ATX-only</b>: the underline style (<code>Heading\n---</code>) is deliberately disabled, so a line followed by a row of dashes stays plain text rather than becoming a heading. Every rendered heading gets a stable id for <a href="notes-links.html">wiki-link</a> anchors like <code>[[note#heading]]</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>**bold**</code> / <code>__bold__</code></div>
+        <div class="v">Both delimiters work — <b>bold text</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>*italic*</code> / <code>_italic_</code></div>
+        <div class="v">Both delimiters work — <em>italic text</em>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>- item</code> / <code>* item</code> / <code>1. item</code></div>
+        <div class="v">Unordered lists (either <code>-</code> or <code>*</code>) and ordered lists (any number followed by <code>.</code>). Indent a nested item by four spaces to sublist it. A list item starting with <code>[ ]</code> or <code>[x]</code> becomes an interactive checkbox instead — see <a href="notes-tasks.html">Task lists</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; quoted text</code></div>
+        <div class="v">A blockquote, indented and set off with a rule along the left edge. Prefix the first line with <code>[!type]</code> — <code>[!note]</code>, <code>[!tip]</code>, <code>[!warning]</code>, <code>[!card]</code>, and more — and it becomes a titled, colored callout instead of a plain quote. See <a href="notes-callouts.html">Callouts &amp; cards</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>---</code></div>
+        <div class="v">A horizontal rule, as long as it sits on its own line with a blank line before and after. The one exception: three dashes as the very first line of the file instead opens a YAML <a href="notes-frontmatter.html">frontmatter</a> block, closed by a matching <code>---</code> further down.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>`inline code`</code></div>
+        <div class="v">Monospaced <code>inline code</code>, no syntax highlighting.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>```lang … ```</code></div>
+        <div class="v">A fenced code block, syntax-highlighted by language. Fence a block <code>sparql</code>, <code>sql</code>, or <code>python</code> and it becomes a runnable cell with its result written back into the note. See <a href="notes-code.html">Code &amp; compute cells</a>.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">✍️</div>
+      <div class="k">Screenshot — Basic markdown rendered in Preview</div>
+      <div class="d">A note's Preview pane showing an H2 heading, a paragraph with bold and italic phrases, an unordered list with a nested sub-item, a blockquote, a horizontal rule, and an inline code span, all rendered together to show how the basics look side by side.</div>
+    </div>
+
+    <h2 id="more">Everything else</h2>
+    <p>These have their own page with full syntax, rendering details, and any gotchas — this row is just a pointer:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="notes-links.html">Links &amp; wiki-links</a></div>
+        <div class="v"><code>[[Note Title]]</code> resolves and renders as a live link into the knowledge graph; standard <code>[text](url)</code> links also work. Links can carry a relationship type, like <em>supports</em> or <em>rebuts</em>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-images.html">Images</a></div>
+        <div class="v">Standard <code>![alt](path)</code> syntax. PNG, JPEG, GIF, WebP, SVG, and AVIF render inline and can be clicked to enlarge.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-tables.html">Tables</a></div>
+        <div class="v">Standard pipe-delimited markdown tables — header row, alignment row, data rows. Every table is also parsed into the graph as CSVW structured data on save.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-footnotes.html">Footnotes</a></div>
+        <div class="v">An inline <code>[^id]</code> marker paired with a <code>[^id]: definition</code> anywhere in the file, collected at the bottom of the note.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-highlights.html">Highlights</a></div>
+        <div class="v">Wrap text in <code>==double equals==</code> for a tinted inline highlight span.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-tasks.html">Task lists</a></div>
+        <div class="v">A list item starting with <code>[ ]</code> or <code>[x]</code> renders as a clickable checkbox that writes its state straight back to the source.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-math.html">Math</a></div>
+        <div class="v"><code>$inline$</code> and <code>$$display$$</code> LaTeX, rendered with KaTeX — the same convention as Pandoc.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-diagrams.html">Diagrams</a></div>
+        <div class="v">A <code>```mermaid</code> fence renders as a live diagram — flowcharts, sequence diagrams, and anything else Mermaid draws.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-charts.html">Charts</a></div>
+        <div class="v">A Vega or Vega-Lite JSON spec in a fenced code block renders as an interactive chart, optionally bound to a live SPARQL query or dataset.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-callouts.html">Callouts &amp; cards</a></div>
+        <div class="v">A blockquote whose first line is <code>[!type]</code> becomes a titled note/tip/warning-style box; <code>[!card]</code> renders as a front/back flashcard.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-rdf.html">Turtle / RDF</a></div>
+        <div class="v">A <code>```turtle</code> fence lets you hand-author graph triples directly in a note; Minerva merges them into <code>.minerva/graph.ttl</code> on save.</div>
+      </div>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="editor-writing-surface.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← The writing surface</span>
+      </a>
+      <a class="next" href="editor-keyboard-shortcuts.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Keyboard shortcuts →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Voice Dictation</title>
+<meta name="description" content="Dictate straight into a note with an on-device Whisper model — no audio ever leaves your machine — and how it relates to the composer's separate mic button." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+    <a href="editor-writing-surface.html" class="sub">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub active">Voice dictation</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>Voice dictation</p>
+
+    <h1>Voice dictation</h1>
+    <p class="lede">Dictate into the note you're editing, and Minerva transcribes it with a local Whisper model running entirely on your machine — no audio, and nothing but the one-time model download, ever crosses the network. Trigger it from the keyboard, the command palette, or the editor's right-click menu; the transcript lands right at your cursor.</p>
+
+    <div class="box">
+      <span class="label">Two mic buttons, one engine</span>
+      <p>The Conversations composer has its own inline mic for dictating a chat message, and the editor has this separate entry point for dictating into a note. Both drive the same recorder and the same Whisper worker — Minerva just tracks which surface asked for it (<code>voice</code> vs. <code>editor</code>), so only the button that started a recording lights up while it runs. This page covers the editor path; see <a href="conversations.html">Conversations</a> for the composer's.</p>
+    </div>
+
+    <h2 id="how-it-runs">How it runs on-device</h2>
+    <p>Dictation never calls out to a cloud speech-to-text API. Recording, decoding, and transcription all happen inside the renderer:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Capture</div>
+        <div class="v">A <code>getUserMedia</code> microphone stream is recorded with <code>MediaRecorder</code>. Dictation is click-to-toggle, not continuously streamed — the whole clip is captured first, then handed off for transcription in a single pass.</div>
+      </div>
+      <div class="row">
+        <div class="k">Transcription</div>
+        <div class="v">The recorded clip is decoded, downmixed, and resampled to 16 kHz mono, then sent to a Whisper model (<code>@huggingface/transformers</code>) running in a dedicated Web Worker — off the UI thread, so a multi-second transcription doesn't stall the editor. The worker runs on the WASM (<code>onnxruntime-web</code>) backend, never the native binary.</div>
+      </div>
+      <div class="row">
+        <div class="k">Model download</div>
+        <div class="v">The chosen Whisper model's weights are fetched from the Hugging Face hub the first time dictation is used, then cached by the browser's Cache API — every dictation after that loads from cache with no network round-trip. Only the model file is ever fetched; your recorded audio is passed directly to the worker and never leaves the process.</div>
+      </div>
+      <div class="row">
+        <div class="k">Model choice</div>
+        <div class="v">Three English-only Whisper variants are available in Settings — Tiny (~25MB, fastest, least accurate), Base (~50MB, the default), and Small (~180MB, slowest, most accurate). Switching models in Settings downloads and caches the new one on next use; the old model's worker is dropped rather than kept alongside it.</div>
+      </div>
+    </div>
+
+    <h2 id="using-it">Starting and stopping</h2>
+    <p>Three entry points all funnel into the same toggle — the first trigger starts recording, the second stops it and inserts the transcript:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Shortcut — <kbd>⌘</kbd><kbd>⇧</kbd><kbd>V</kbd></div>
+        <div class="v">Starts recording at the cursor. Press it again to stop and insert the transcribed text at that same cursor position — even if focus moved to the floating recording indicator while you were speaking.</div>
+      </div>
+      <div class="row">
+        <div class="k">Right-click menu</div>
+        <div class="v">Editor context menu → <b>Dictate…</b>, alongside <b>Ask About This...</b> and <b>Bookmark This Note</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Command palette</div>
+        <div class="v">Search for <b>Dictate (Voice to Text)</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k">While recording</div>
+        <div class="v">A floating pill at the bottom of the window shows <b>Listening…</b> with <b>Insert</b> and <b>Cancel</b> buttons, plus the shortcut reminder. <kbd>Esc</kbd> cancels without inserting anything. During transcription the pill switches to <b>Transcribing…</b>; on first use (or after switching models) it shows model-download progress as a percentage instead.</div>
+      </div>
+      <div class="row">
+        <div class="k">Text insertion</div>
+        <div class="v">The transcript is inserted at wherever your cursor was when you started recording. Minerva adds a leading space automatically when joining onto a preceding word, so dictating after existing text doesn't run the two together.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🎙️</div>
+      <div class="k">Screenshot — Dictating into the editor</div>
+      <div class="d">A note in the editor mid-dictation: the cursor sits in the body text, and the floating recording pill at the bottom of the window shows a pulsing "Listening…" indicator with the ⌘⇧V hint and Insert/Cancel buttons.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>First use downloads a model.</b> The first time you dictate (or the first time after switching models in Settings), Minerva fetches the model file before it can transcribe — the default Base model is roughly 50MB. The floating pill shows download progress; every dictation after that is instant, served from the browser cache.</li>
+      <li><b>Microphone permission is asked once by the OS.</b> The first recording attempt triggers the normal macOS/Windows microphone permission prompt. If it's denied, the pill reports it plainly rather than failing silently; you'll need to grant microphone access to Minerva in your system settings before trying again.</li>
+      <li><b>English only.</b> All three bundled Whisper variants are English-only models — there's no language picker, and accuracy on other languages will be poor to unusable.</li>
+      <li><b>A very short clip is treated as a no-op.</b> Toggling dictation on and immediately off again (under roughly a fifth of a second of audio) inserts nothing rather than erroring — useful if you trigger the shortcut by accident.</li>
+      <li><b>It's a whole-clip transcription, not live streaming.</b> Minerva records the entire dictation first and transcribes it as one pass when you stop, so there's no word-by-word text appearing as you speak — the transcript arrives all at once, right after you stop.</li>
+      <li><b>One microphone at a time.</b> Recording is a single shared engine — starting a dictation in the editor while the composer's mic is active (or vice versa) isn't a supported combination; only one surface can be recording at once.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="editor-link-autocomplete.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Link autocomplete</span>
+      </a>
+      <a class="next" href="left-sidebar.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Left sidebar →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/editor-writing-surface.html
+++ b/website/docs/editor-writing-surface.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — The Writing Surface</title>
+<meta name="description" content="How Minerva's Source editor renders markdown live inline as you type — styled headers, emphasis, and links in place of raw syntax — and how the pane relates to the file on disk." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+    <a href="editor-writing-surface.html" class="sub active">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>The writing surface</p>
+
+    <h1>The writing surface</h1>
+    <p class="lede">The Source pane isn't a plain textarea with a monospace font bolted on. It's a single CodeMirror surface that understands markdown as you type — headers, emphasis, and links render styled in place, in the same pane you're editing, rather than staying inert characters until you switch to Preview. This page is about that pane's own character. For how Source relates to Preview and Side by side as separate view modes, see <a href="viewing-options-view-modes.html">View modes</a>.</p>
+
+    <h2 id="live-rendering">What "live inline rendering" means</h2>
+    <p>Minerva parses the buffer with <code>@codemirror/lang-markdown</code> and applies a token-driven highlight style directly on top of it (<code>src/renderer/lib/components/Editor.svelte:470</code>, <code>src/renderer/lib/editor/minerva-highlight.ts</code>). A heading line isn't just gray text with a <code>#</code> in front — the whole line is styled bold and in the accent color the moment CodeMirror recognizes it as a heading. Bold and italic spans pick up real <code>font-weight</code> and <code>font-style</code> the moment you close the <code>**</code> or <code>_</code>. Wiki-links and URLs get a soft rounded chip and become clickable (<code>src/renderer/lib/editor/link-decorations.ts:165-173</code>).</p>
+
+    <p>The important distinction from Obsidian-style "live preview" editors: Minerva never hides the markdown delimiters. The <code>#</code>, <code>**</code>, <code>==</code>, and <code>[[</code>/<code>]]</code> stay on screen, styled through, rather than disappearing until your cursor lands nearby. A comment in the highlight-span source states the convention directly: <i>"We don't hide the <code>==</code> delimiters — keeping them visible is the convention for inline markup... the user can see exactly what they wrote"</i> (<code>src/renderer/lib/editor/highlight-decorations.ts:6-9</code>). There's no cursor-triggered reveal because nothing is ever concealed — what you see is always the literal file content, styled, not a rendered substitute.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Headers</div>
+        <div class="v">Styled bold, in the accent color, as soon as the line parses as a heading. The <code>#</code> markers stay visible as part of the line (<code>t.heading</code>, <code>minerva-highlight.ts:102</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Bold / italic / strikethrough</div>
+        <div class="v"><code>**bold**</code>, <code>_italic_</code>, and <code>~~struck~~</code> render with real weight, slant, or a line-through the moment the span closes — the asterisks, underscores, and tildes stay visible, just styled along with the text (<code>minerva-highlight.ts:103-105</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Highlights — <code>==text==</code></div>
+        <div class="v">A tinted background matching the same color the Preview pane uses, painted live while typing. Delimiters are intentionally not hidden (<code>src/renderer/lib/editor/highlight-decorations.ts</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Wiki-links &amp; URLs</div>
+        <div class="v">A soft accent-tinted chip, no underline, cursor turns into a pointer on hover — a mark decoration, not a widget, so the caret can still move through the link text to edit it (<code>src/renderer/lib/editor/link-decorations.ts:178-194</code>). Hovering one briefly also pops a preview tooltip of the target note (<code>src/renderer/lib/editor/link-preview.ts</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Footnote refs &amp; definitions</div>
+        <div class="v"><code>[^label]</code> renders underlined and clickable, jumping between a reference and its definition on click; hovering a reference pops a tooltip of the definition body (<code>src/renderer/lib/editor/footnote-decorations.ts</code>, <code>footnote-preview.ts</code>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Runnable code fences</div>
+        <div class="v">A ▶ run marker appears in the gutter next to any executable fence (SPARQL, SQL, Python); results write back into the note as a companion <code>```output</code> block right below the fence, not into a separate panel (<code>src/renderer/lib/editor/compute-cells.ts</code>).</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">✍️</div>
+      <div class="k">Screenshot — Live inline rendering in the Source pane</div>
+      <div class="d">The Source editor showing a heading rendered bold in the accent color with its "#" still visible, a bold span with its "**" markers intact, and a wiki-link rendered as a rounded accent-tinted chip — with the text cursor visibly resting inside the bold span to show that the raw "**" characters remain on screen rather than disappearing while editing.</div>
+    </div>
+
+    <h2 id="not-a-textarea">Not a textarea, and not a second copy of the file</h2>
+    <p>Two things follow from the pane being CodeMirror rather than a bare <code>&lt;textarea&gt;</code>: it understands markdown structure well enough to fold the frontmatter block, match brackets, and drive autocomplete — see <a href="editor-link-autocomplete.html">Link autocomplete</a> — and it renders through <a href="viewing-options-themes.html">theme</a> tokens, so switching themes re-skins the editor's syntax colors along with everything else, live, with no rebuild.</p>
+
+    <div class="box">
+      <span class="label">The pane is the file, not a preview of it</span>
+      <p>What you're looking at in Source is the exact text of the <code>.md</code> file on disk, styled — not a separate rendering pass like Preview's. There's no intermediate "draft" state: every keystroke is the buffer, and every save re-indexes it into the knowledge graph immediately, the same as any other edit. See <a href="notes.html#lifecycle">Notes</a> for how saves feed <code>.minerva/graph.ttl</code>.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Plain-text files skip all of this.</b> A file Minerva treats as plain text (not markdown) gets the bare editing buffer with no markdown language, no link/footnote/highlight decorations, and no compute-cell gutter — <code>Editor.svelte:467-535</code> gates the entire markdown rendering stack behind a markdown check.</li>
+      <li><b>Delimiters are never hidden.</b> If you're coming from an editor that conceals <code>**</code>/<code>#</code>/<code>[[…]]</code> until the cursor is nearby, expect Minerva's Source pane to look "busier" — that's deliberate, so what you see always matches what's actually in the file.</li>
+      <li><b>Links are marks, not widgets.</b> The chip styling on a wiki-link doesn't replace the text with something else — you can still click into the middle of <code>[[Some Note]]</code> and edit the target directly, because the brackets and text are still real, editable characters underneath the styling.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="editor.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Editor</span>
+      </a>
+      <a class="next" href="editor-markdown-formatting.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Markdown formatting →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Editor</title>
+<meta name="description" content="The writing surface: how markdown renders live in the editor, formatting syntax, keyboard shortcuts, link autocomplete, and voice dictation." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html" class="active">Editor</a>
+    <a href="editor-writing-surface.html" class="sub">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Editor</p>
+
+    <h1>Editor</h1>
+    <p class="lede">The editor is a single writing surface, not a split raw-text-and-preview view — markdown renders styled in place as you type, in the same pane you're editing. This section covers that surface itself, the formatting syntax it understands, every keyboard shortcut it answers to, the <code>[[</code> autocomplete that helps you link notes without memorizing filenames, and voice dictation for when you'd rather talk than type.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="editor-writing-surface.html"><b>The writing surface</b></a> — how live inline rendering works, and what it deliberately doesn't hide.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="editor-markdown-formatting.html"><b>Markdown formatting</b></a> — a syntax reference table, linking out to the deep dives.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="editor-keyboard-shortcuts.html"><b>Keyboard shortcuts</b></a> — every binding the editor answers to, in one place.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[</code></div>
+        <div class="v"><a href="editor-link-autocomplete.html"><b>Link autocomplete</b></a> — a filtered suggestion list of notes and aliases as you type.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>V</kbd></div>
+        <div class="v"><a href="editor-voice-dictation.html"><b>Voice dictation</b></a> — local, on-device transcription into the note.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="editor-writing-surface.html">
+        <span class="em">🖋️</span>
+        <h3>The writing surface</h3>
+        <p>A single pane where markdown renders styled in place as you type.</p>
+      </a>
+      <a class="doc-card" href="editor-markdown-formatting.html">
+        <span class="em">🔤</span>
+        <h3>Markdown formatting</h3>
+        <p>A syntax reference — what renders as what, linking to the deep dives.</p>
+      </a>
+      <a class="doc-card" href="editor-keyboard-shortcuts.html">
+        <span class="em">⌨️</span>
+        <h3>Keyboard shortcuts</h3>
+        <p>Every binding the editor answers to, gathered in one place.</p>
+      </a>
+      <a class="doc-card" href="editor-link-autocomplete.html">
+        <span class="em">🔮</span>
+        <h3>Link autocomplete</h3>
+        <p>Type <code>[[</code> and get a filtered list of notes and aliases.</p>
+      </a>
+      <a class="doc-card" href="editor-voice-dictation.html">
+        <span class="em">🎙️</span>
+        <h3>Voice dictation</h3>
+        <p>Local, on-device transcription — nothing leaves your machine.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="viewing-options-split-panes-windows.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Split panes &amp; windows</span>
+      </a>
+      <a class="next" href="editor-writing-surface.html">
+        <span class="dir">Next</span>
+        <span class="ttl">The writing surface →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Editor hub page (`editor.html`) plus five full sub-pages: The writing surface, Markdown formatting, Keyboard shortcuts, Link autocomplete, and Voice dictation — closing out epic #1198 and its five children.
- **Restructured from the original plan**, same reasoning as every prior section in this series (Navigation #1274, Left sidebar #1275, Right sidebar #1277, Viewing options #1278): one shared page with five subsections doesn't fit the real depth.
- Corrections made after verifying against source rather than trusting the issue text:
  - **The writing surface**: no Obsidian-style syntax-hiding exists — markdown delimiters (`**`, `==`, etc.) stay visible by deliberate design, confirmed by an explicit code comment, not an oversight.
  - **Markdown formatting**: setext-style headings (`Text\n---`) are disabled specifically because they'd collide with `[!card]` flashcard parsing.
  - **Keyboard shortcuts**: Cmd/Ctrl+S is a real "flush autosave immediately" action, not a no-op; join-lines is hardcoded to `Ctrl-Shift-J` even on Mac, breaking the usual ⌘ convention.
  - **Link autocomplete**: non-matching typed text never creates a note — confirmed via an independent code path, consistent with the same finding for click-navigation in `notes-links.html`/`navigation-wiki-links.html`.
  - **Voice dictation**: corrected a stale assumption of mine — editor dictation (not just the conversation composer) has fully shipped, verified via its real keybinding, right-click menu entry, and command-palette command all wired to working code.
- Since the sidebar only expands the section you're currently in, this batch is purely additive — no existing pages needed changes.

Closes #1198, #1212, #1213, #1214, #1221, #1222.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 6 pages
- [x] Visually reviewed each page in a browser