### PR TITLE
docs site: add the Conversations documentation section

### DIFF
--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Chatting with the AI</title>
+<meta name="description" content="How a conversation starts, why the AI reads your thoughtbase through tools instead of a dumped-in context blob, and what a streaming reply with a web citation looks like." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="conversations-chatting.html" class="sub active">Chatting with the AI</a>
+    <a href="conversations-drafts.html" class="sub">Drafts</a>
+    <a href="conversations-propose-review-approve.html" class="sub">The propose → review → approve loop</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="conversations.html">Conversations</a><span class="sep">/</span>Chatting with the AI</p>
+
+    <h1>Chatting with the AI</h1>
+    <p class="lede">The conversations panel is a two-pane, mail-style chat: a list of open conversation tabs on the left, the active transcript and composer on the right. The model doesn't get your whole thoughtbase stuffed into its context on every turn — it gets a small set of tools and decides for itself when to search your notes, query the graph, or look something up on the web.</p>
+
+    <h2 id="opening">Opening a conversation</h2>
+    <p>The panel lives beneath the editor and stays hidden until you ask for it — it's not a permanent fixture of the workspace. Every path into it lands on the same two-pane view:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Toggle the panel</div>
+        <div class="v"><b>View → Toggle Conversations</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd>) shows or hides the panel without touching any open conversation. Hiding it doesn't archive anything — your tabs are still there when you bring it back.</div>
+      </div>
+      <div class="row">
+        <div class="k">New conversation</div>
+        <div class="v">The <b>+</b> button in the conversation list, <b>View → New Conversation</b>, or the toolbar's <b>New Conversation</b> button above the editor. This starts a <i>freeform</i> conversation — no note attached, regardless of what's open in the editor.</div>
+      </div>
+      <div class="row">
+        <div class="k">Ask about this note</div>
+        <div class="v">Right-click a tab in the editor's tab bar → <b>Ask About This...</b>. This opens a new conversation whose <code>contextBundle.notePath</code> is set to that note, shown as a "From:" origin chip in the conversation's context rail — the note-scoped counterpart to a blank New Conversation.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close a tab</div>
+        <div class="v">The × on a tab, with a confirm dialog — "Close this conversation? You won't be able to reopen it." — because closing <i>archives</i> the conversation rather than merely hiding the tab. There's no reopen UI for an archived conversation, which is why the confirm exists even under the "don't add warnings" house rule.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">A conversation's note origin isn't a lock-in</span>
+      <p>The context rail shows two things side by side when they differ: <b>From:</b> the note the conversation was started against, and <b>Active:</b> the note currently open in the editor, if you've since switched files. Both are passed to the model on every turn as plain sentences in the system prompt — "the user started this conversation from…" / "the note currently open in the editor is…" — so it can resolve "this note" against whichever one you mean, without the conversation being pinned to a single file for its whole lifetime.</p>
+    </div>
+
+    <h2 id="scoping">How the AI is scoped to your thoughtbase</h2>
+    <p>There is no step where Minerva serializes your graph, or the active note's full text, into the prompt on every turn. Instead the assistant is handed a fixed set of tools and a system prompt that tells it when to reach for each one — the model decides what it actually needs, per turn:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>search_notes</code></div>
+        <div class="v">Full-text search across the thoughtbase. The model's first move for "what have I written about X."</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>read_note</code></div>
+        <div class="v">Reads one specific note by its relative path — typically a path <code>search_notes</code> or a citation just surfaced.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>query_graph</code></div>
+        <div class="v">Runs a SPARQL query against <code>.minerva/graph.ttl</code> for structural questions — what links to what, which notes share a tag, which claims cite a source. Standard prefixes are auto-injected, same as a <code>```sparql</code> cell in a note.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>describe_graph_schema</code></div>
+        <div class="v">Fetches the full ontology TTL so the model can check class/predicate names before guessing at a non-trivial query.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>web_search</code> / <code>web_fetch</code></div>
+        <div class="v">For facts, current events, or documentation outside the thoughtbase — <code>web_fetch</code> reads a specific URL in full, typically one <code>web_search</code> just turned up.</div>
+      </div>
+    </div>
+
+    <p>The only always-on context is a few lines of plain text folded into the system prompt on every turn (<code>buildConversationSystemPrompt</code> in <code>src/main/ipc/register-conversation.ts</code>): today's date, the conversation's origin note path if any, and the currently-open editor note path if it differs. None of that is note <i>content</i> — just enough for the model to know which path "this note" refers to before it decides whether to go read it.</p>
+
+    <div class="box">
+      <span class="label">The trust principle still governs what comes back</span>
+      <p>Reading your notes and graph is unrestricted — the read tools have no approval gate, because reading changes nothing. But the two write tools available in conversation, <code>propose_notes</code> and <code>propose_sources</code>, only ever produce inline draft cards with Approve/Discard. Nothing the model reads or reasons about turns into a graph write on its own say-so — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+    </div>
+
+    <h2 id="sending">Sending a message</h2>
+    <p>The composer is a plain textarea: <kbd>⏎</kbd> sends, <kbd>⇧</kbd><kbd>⏎</kbd> inserts a newline. Typing a leading <code>/</code> opens a filtered menu of built-in commands (like <code>/compact</code>, which summarizes older turns once a thread gets long) and any skill that declared a slash command — picking one runs it exactly as if you'd chosen it from a menu. A mic button next to Send drives local, on-device dictation into the composer when voice input is enabled.</p>
+    <p>Your message is echoed into the transcript immediately, before the model has replied — the send call can take anywhere from a second to tens of seconds, and without that optimistic insert your own message would appear to vanish from the composer with nothing to show for it.</p>
+
+    <h2 id="streaming">Streaming responses</h2>
+    <p>Replies stream in token-by-token, not all at once. Each chunk arrives over the <code>conversation:stream</code> IPC channel and is appended to a running buffer as it comes in; a three-dot "thinking" indicator sits at the head of the reply and stays visible through any mid-turn pause — including the gap while the model is blocked on a tool call between chunks of text — so the panel never looks stalled. The partial buffer is rendered through the same markdown pipeline as a finished message, so formatting doesn't visibly "snap" into place once the turn completes.</p>
+    <p>While a reply is streaming, the composer disables and its Send button becomes <b>Cancel</b>, which aborts the in-flight turn.</p>
+
+    <h2 id="citations">Referenced notes and citations</h2>
+    <p>A citation in a conversation is a <b>web source</b>, not a link back into your graph. When the model uses <code>web_search</code>, each result it draws on becomes a numbered footnote under that assistant message — title, host, and the exact passage cited — and clicking one opens the URL in your default browser. There's a "cite" action next to each one that ingests the source into your Sources library and weaves a citation marker into whichever note the conversation is anchored to (its origin note, or the active editor note if it's freeform), the same mechanism as citing from anywhere else in Minerva.</p>
+    <p>References to your own notes work differently: the model just writes the relative path in its prose ("see <code>research/thesis.md</code>") per the system prompt's instruction to cite what it reads, rendered as plain markdown text — there's no separate "sources used" sidebar for thoughtbase reads, because reading a note doesn't need an approval trail or a footnote the way an external claim does.</p>
+
+    <div class="shot wide">
+      <div class="icon">💬</div>
+      <div class="k">Screenshot — An active conversation, mid-reply</div>
+      <div class="d">The conversations panel with the tab list on the left; the context rail showing "From: research/thesis.md" and a model picker; a streaming assistant message with the thinking-dots indicator still visible beneath the partial markdown text; and, on the completed message above it, a numbered footnote citation with title, host, and a "cite" action.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The model picker and effort picker are per-conversation, not per-message.</b> Changing the model on an existing tab only affects turns from that point forward; if the conversation had a reasoning-effort override the new model doesn't support, it's silently clamped to the nearest level it does (or cleared, for a model with no effort levels at all) rather than erroring on the next send.</li>
+      <li><b>Closing a tab is one-way.</b> There's a confirm dialog, but there is no "reopen last closed conversation" — once archived, a conversation only resurfaces as an entry in whatever surface lists archived conversations, not back in the tab strip.</li>
+      <li><b>A conversation's citations are exclusively from <code>web_search</code>.</b> If the model never calls that tool during a turn, the message carries no citations at all, even if it extensively read and referenced your own notes via <code>search_notes</code>/<code>read_note</code>.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="conversations.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Conversations</span>
+      </a>
+      <a class="next" href="conversations-drafts.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Drafts →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Drafts</title>
+<meta name="description" content="A draft card is the AI's not-yet-submitted proposal inline in the conversation — accept it as-is or discard it, and see exactly how Approve turns it into an already-approved thought:Proposal." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="conversations-chatting.html" class="sub">Chatting with the AI</a>
+    <a href="conversations-drafts.html" class="sub active">Drafts</a>
+    <a href="conversations-propose-review-approve.html" class="sub">The propose → review → approve loop</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="conversations.html">Conversations</a><span class="sep">/</span>Drafts</p>
+
+    <h1>Drafts</h1>
+    <p class="lede">A draft card is what the AI hands back instead of writing anything: a not-yet-submitted candidate — a note, a set of tags, a claim, a rewrite — sitting inline in the conversation transcript, waiting for you to accept it or throw it away. Nothing it describes exists in your project until you say so.</p>
+
+    <h2 id="when">When a draft card appears</h2>
+    <p>A draft card shows up whenever a conversation tool produces something that would change your project. Ask the AI to file a new note and you get a note draft; ask it to summarize a source, tag a batch of files, extract claims from a paper, rename or reorganize notes, rewrite a note body, or generate a runnable code cell, and you get the matching card type — <code>DraftCard</code>, <code>ComputeDraftCard</code>, <code>RefactorDraftCard</code>, <code>ReorgDraftCard</code>, <code>DeleteDraftCard</code>, or <code>NoteBodyDraftCard</code> (<code>src/renderer/lib/components/conversations/DraftCards.svelte</code>). Each card is anchored to the assistant turn that produced it and renders directly under that message — you don't have to go looking for it in a separate panel.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Accept</div>
+        <div class="v">Files the draft exactly as shown. Labeled per card type — "Approve &amp; file" for notes, "Approve &amp; ingest" for sources, "Approve &amp; apply" for property/tag patches — and replaces the card with a compact, persistent "Filed:" line linking to whatever landed.</div>
+      </div>
+      <div class="row">
+        <div class="k">Edit</div>
+        <div class="v">Only the compute-cell draft is actually editable before it runs: <code>ComputeDraftCard</code> keeps its own edit buffer, and Run/Insert send your edited code (falling back to the AI's original if you didn't touch it) rather than the draft's stored text. Every other draft type — note, source, property, source-property, claims, refactor, reorg, delete, note-body rewrite — has no in-card editing. You're deciding on exactly what the AI produced.</div>
+      </div>
+      <div class="row">
+        <div class="k">Discard</div>
+        <div class="v">Drops the card from the conversation's draft list with no further action — no proposal is ever created, nothing is written, and there's no undo beyond asking the AI to try again.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Draft vs. proposal</span>
+      <p>A <b>draft</b> only exists in the renderer's conversation state — it's never touched the knowledge graph. A <b>proposal</b> is a <code>thought:Proposal</code> node the approval engine has actually written to <code>.minerva/graph.ttl</code>. Clicking Accept on a draft card is the moment one becomes the other: the main process calls <code>approval.proposeWrite()</code> to file the proposal, then immediately calls <code>approval.approveProposal()</code> on it, because you already made the accept/discard call at the card — a second pending state in the <a href="right-sidebar-proposals.html">Proposals panel</a> would just be busywork. Every draft type resolves this way (<code>src/main/ipc/register-conversation.ts</code>, e.g. the note-draft handler at <code>CONVERSATION_FILE_DRAFT</code>: propose, then approve, in the same handler), so the trust principle still holds — the write still goes through the approval engine, it just doesn't linger in a pending state you have to separately clear. For the mechanics of reviewing a proposal that isn't auto-approved this way — the diff view, the Approve/Reject keystrokes, the tier table — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a> and <a href="right-sidebar-proposals.html">Proposals</a>.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗒️</div>
+      <div class="k">Screenshot — A draft card awaiting a decision</div>
+      <div class="d">A note draft card inline in the conversation transcript: the bold headline ("2 notes"), the AI's one-line rationale, an expandable list of the proposed note paths with a collapsed preview, and the Approve &amp; file / Discard button row along the bottom edge.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>"Accept" doesn't mean "unreviewed."</b> Because Accept immediately approves the resulting proposal, a filed draft won't show up under the Proposals panel's Pending tab — it lands directly in Approved, same as a <code>notify_only</code>-tier write. If you want a record of what an AI conversation has filed, look under Approved, not Pending.</li>
+      <li><b>Discarding is final, not a rejection record.</b> Unlike rejecting a proposal in the Proposals panel — which keeps a <code>rejected</code> node in the graph as an audit trail — discarding a draft card never created a graph node to begin with, so there's nothing left behind to show the AI once suggested it.</li>
+      <li><b>The compute draft's "edit" is a local buffer, not a re-prompt.</b> Editing the code in a compute card changes only what gets executed or inserted; it doesn't send your edit back to the model or change the conversation transcript. If you want the AI to reconsider its approach, ask again rather than relying on your edit to inform its next turn.</li>
+      <li><b>Refactor, reorg, and delete drafts can be partial.</b> <code>ReorgDraftCard</code> and <code>DeleteDraftCard</code> let you select a subset of the proposed items before accepting — accept only applies to what's checked, the rest of the card's suggestions are silently dropped, not held over as a smaller draft.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="conversations-chatting.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Chatting with the AI</span>
+      </a>
+      <a class="next" href="conversations-propose-review-approve.html">
+        <span class="dir">Next</span>
+        <span class="ttl">The propose → review → approve loop →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — The Propose, Review, Approve Loop</title>
+<meta name="description" content="Why every AI-originated graph write in Minerva files as a reviewable thought:Proposal instead of landing directly — the Trust Principle, the three approval tiers, and the diff view you check before you approve." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="conversations-chatting.html" class="sub">Chatting with the AI</a>
+    <a href="conversations-drafts.html" class="sub">Drafts</a>
+    <a href="conversations-propose-review-approve.html" class="sub active">The propose → review → approve loop</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="conversations.html">Conversations</a><span class="sep">/</span>Propose, review, approve</p>
+
+    <h1>The propose, review, approve loop</h1>
+    <p class="lede">Minerva talks to a graph-backed knowledge base, and the one design decision that makes that safe is simple to state and easy to underestimate: the model never gets to write to it directly. Every AI-originated change to <code>.minerva/graph.ttl</code> — a new claim, a rewritten note, a proposed source summary — has to pass through a single choke point, the approval engine, before it becomes real.</p>
+
+    <div class="box">
+      <span class="label">The Trust Principle</span>
+      <p><b>The LLM proposes, the human confirms.</b> Conversation output is evidence to be evaluated and filed, not an authoritative update to the graph. This is the most important design decision in Minerva — not a safety feature bolted on afterward, but the reason the approval engine (<code>src/main/llm/approval.ts</code>) exists at all.</p>
+    </div>
+
+    <h2 id="why">Why proposals exist</h2>
+    <p>An LLM is a source of claims about your notes, not an editor with commit rights. Treating its output as evidence means every graph mutation it wants to make is a <i>suggestion</i> until you look at it — so wrong claims, bad links, and hallucinated components stay quarantined as pending records instead of silently becoming part of what you know. The mechanism for that quarantine is a node type: <code>thought:Proposal</code>, with a <code>thought:proposalStatus</code> of <code>thought:pending</code>, <code>thought:approved</code>, <code>thought:rejected</code>, or <code>thought:expired</code>.</p>
+
+    <p>Internally, every LLM apply path funnels through one function, <code>proposeWrite()</code>, which takes an <code>operationType</code> (what kind of change this is) and a bundle of <code>payloads</code> (what it would actually write). What happens next depends entirely on that operation's approval tier.</p>
+
+    <h2 id="tiers">The three approval tiers</h2>
+    <p>Every <code>OperationType</code> the LLM can emit maps to exactly one tier in a policy table (<code>DEFAULT_POLICY</code> in <code>approval.ts</code>, lines 46–65). The tier decides whether <code>proposeWrite()</code> files a pending proposal, applies the write immediately and just logs it, or applies it with no record at all:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>requires_approval</code></div>
+        <div class="v">New claims (<code>new_claim</code>), evidence links (<code>evidence_link</code>), component creation (<code>component_creation</code>), note moves/renames (<code>note_refactor</code>), note deletes (<code>note_delete</code>), in-place note rewrites (<code>note_rewrite</code>), and proposed source properties (<code>source_properties</code>). <code>proposeWrite()</code> writes a <code>thought:Proposal</code> with status <code>pending</code> and stops there — nothing is applied until you act on it.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>notify_only</code></div>
+        <div class="v">Confidence updates (<code>confidence_update</code>) and status changes (<code>status_change</code>). The bundle is applied immediately via <code>applyBundle()</code>, but a <code>thought:Proposal</code> is still written — filed straight in as <code>approved</code> — so the change leaves an audit trail even though nobody reviewed it beforehand.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>autonomous</code></div>
+        <div class="v">Tag additions (<code>tag_addition</code>) and staleness flags (<code>staleness_flag</code>). Applied immediately with no proposal node written at all — <code>proposeWrite()</code> returns <code>null</code>. Low-stakes enough that even an audit-trail entry isn't worth it.</div>
+      </div>
+    </div>
+
+    <p>One override cuts across all three. Before dispatching on tier, <code>proposeWrite()</code> checks whether any node the bundle touches (<code>affectsNodeUris</code>) already carries <code>thought:hasStatus thought:established</code> — a SPARQL <code>ASK</code>-style lookup (<code>anyNodeEstablished()</code>, <code>approval.ts</code> lines 91–101). If so, the tier is forced up to <code>requires_approval</code> regardless of what the operation type's own policy says. A <code>tag_addition</code> against an ordinary note applies silently; the same <code>tag_addition</code> against a note you've marked established gets queued for your review instead. Once you've vetted something, the model can't quietly touch it again without asking.</p>
+
+    <h2 id="diff">The diff view</h2>
+    <p>A pending proposal isn't a one-line description you have to trust — it's the literal payload bundle waiting to be applied, and reviewing it means reading that payload directly. Each payload in the bundle carries enough to reconstruct exactly what will land:</p>
+
+    <ul>
+      <li>A <code>note</code> payload carries the full <code>content</code> of the file that would be created (plus the <code>relativePath</code> it would be filed at) — you read the whole note, not a summary of it.</li>
+      <li>A <code>graph-triples</code> payload carries the raw Turtle that would be merged into the store, along with the <code>affectsNodeUris</code> it introduces — the same triples the trust-integrity query later checks for approval provenance.</li>
+      <li>A <code>note-rewrite</code> payload carries the full replacement <code>content</code> for an existing note; approval captures the prior content as a pre-image first, so the operation is reversible even though what you're shown is the new version.</li>
+      <li>A <code>note-delete</code> or <code>note-refactor</code> payload names the <code>path</code> (or <code>fromPath</code>/<code>toPath</code>) being removed or moved.</li>
+    </ul>
+
+    <p>A proposal can bundle more than one payload, and the bundle is atomic: approving applies every payload in order, rejecting discards all of them, never half. This is the same mechanism <a href="right-sidebar-proposals.html">the Proposals panel</a> renders as an expandable card per payload — that page documents the panel's UI in detail (the status tabs, the keyboard shortcuts, the project-wide scope); this page is about what makes the payload trustworthy to read in the first place: it's the actual write, not a paraphrase of it.</p>
+
+    <div class="shot wide">
+      <div class="icon">🔍</div>
+      <div class="k">Screenshot — Diff view for a pending proposal</div>
+      <div class="d">A pending proposal card expanded in the Proposals panel: the operation type and proposer badge at the top, one payload row expanded to show the raw Turtle for a new claim's graph-triples payload, and a second collapsed row for the note payload it's attached to — the reviewer can inspect either before deciding.</div>
+    </div>
+
+    <h2 id="decide">Approving and rejecting</h2>
+    <p>Once you've read the payload, the decision is one keystroke: <kbd>y</kbd> to approve, <kbd>n</kbd> to reject, both handled by <code>approveProposal()</code> / <code>rejectProposal()</code> in <code>approval.ts</code>. Approving applies the bundle and flips status to <code>approved</code>; rejecting flips status to <code>rejected</code> and applies nothing, but the proposal node itself stays in the graph either way — reviewed history, not a queue you empty. See <a href="right-sidebar-proposals.html">Proposals</a> for the full keystroke reference, the status-tab filtering, and what the panel shows you while a card is collapsed.</p>
+
+    <h2 id="expiry">Auto-expiry</h2>
+    <p>Every proposal is stamped with an <code>autoExpires</code> timestamp at creation — seven days out by default (<code>write.expiryDays ?? 7</code>), configurable per write. There is a real function that enforces it, <code>expireProposals()</code>, which walks every still-<code>pending</code> proposal past its <code>autoExpires</code> date and flips it to <code>expired</code>.</p>
+
+    <p>What doesn't exist is anything that calls that function on a schedule. <code>expireProposals()</code> is wired to a single IPC channel, <code>proposal:expire</code>, exposed on <code>window.api</code> as <code>api.proposals.expire()</code> — but nothing in the renderer currently invokes it, and there's no timer in main running it in the background. In practice a proposal past its expiry window doesn't flip itself to <code>expired</code>; it just keeps showing as <b>Pending</b> until something calls that IPC method, which nothing currently does. Treat <code>autoExpires</code> as a recorded intent rather than a guarantee — <a href="right-sidebar-proposals.html">Proposals</a> covers this same finding from the panel's side, in its Gotchas section.</p>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>"Applied immediately" still isn't invisible.</b> <code>notify_only</code> operations write to the graph before you ever see them, but they still leave an <code>approved</code> proposal behind — check the Approved tab in the Proposals panel if you want to know what an autonomous-feeling AI action actually did.</li>
+      <li><b><code>autonomous</code> operations leave nothing to audit through proposals.</b> Tag additions and staleness flags never create a <code>thought:Proposal</code> at all. If you want a record of every graph write regardless of tier, the <a href="right-sidebar-proposals.html">Proposals</a> panel won't show these — you'd need to look at the graph directly.</li>
+      <li><b>Escalation is per-write, not per-conversation.</b> The established-node check runs against the specific <code>affectsNodeUris</code> a given bundle touches, computed fresh on every <code>proposeWrite()</code> call — there's no session-level flag that makes an entire conversation more cautious once it brushes an established node once.</li>
+      <li><b>Approving a bundle with zero payloads throws rather than silently succeeding.</b> That's a deliberate refusal in <code>approveProposal()</code> — an empty bundle means something upstream filed the proposal incorrectly, and the engine surfaces that as a bug instead of a no-op approval.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="conversations-drafts.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Drafts</span>
+      </a>
+      <a class="next" href="thinking-tools.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Thinking tools →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Conversations</title>
+<meta name="description" content="Chatting with the AI about your notes, draft cards, and the propose → review → approve loop that keeps the human in control of the knowledge graph." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html" class="active">Conversations</a>
+    <a href="conversations-chatting.html" class="sub">Chatting with the AI</a>
+    <a href="conversations-drafts.html" class="sub">Drafts</a>
+    <a href="conversations-propose-review-approve.html" class="sub">The propose → review → approve loop</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Conversations</p>
+
+    <h1>Conversations</h1>
+    <p class="lede">Conversations is where you think alongside the AI instead of just editing prose by hand. You chat, it reads your notes through tools it calls itself, and when it wants to change something — a new claim, a rewritten note, a tag — it hands you a draft instead of just doing it. Everything past that point runs through one rule: the model proposes, you confirm. Nothing lands in the graph until you say so.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd></div>
+        <div class="v"><a href="conversations-chatting.html"><b>Chatting with the AI</b></a> — open the panel, start a conversation, watch it search your notes as it goes.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="conversations-drafts.html"><b>Drafts</b></a> — a not-yet-submitted candidate sitting in the transcript, yours to accept or discard.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="conversations-propose-review-approve.html"><b>The propose → review → approve loop</b></a> — why nothing the AI produces writes to the graph on its own.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">The trust principle</span>
+      <p>Conversation outputs are evidence to be evaluated and filed, not authoritative updates to the graph. It's the single most important design decision in Minerva — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a> for the full picture.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="conversations-chatting.html">
+        <span class="em">💭</span>
+        <h3>Chatting with the AI</h3>
+        <p>Tab-based conversations, scoped by tools the model calls itself.</p>
+      </a>
+      <a class="doc-card" href="conversations-drafts.html">
+        <span class="em">📝</span>
+        <h3>Drafts</h3>
+        <p>Not-yet-submitted candidates you can accept or discard.</p>
+      </a>
+      <a class="doc-card" href="conversations-propose-review-approve.html">
+        <span class="em">🔁</span>
+        <h3>The propose → review → approve loop</h3>
+        <p>The trust principle: the model proposes, you confirm.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="right-sidebar-bookmarks.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Bookmarks</span>
+      </a>
+      <a class="next" href="conversations-chatting.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Chatting with the AI →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Conversations hub page (`conversations.html`) plus three full sub-pages: Chatting with the AI, Drafts, and The propose → review → approve loop — closing out epic #1201 and its three children.
- **Restructured from the original plan**, same reasoning as every prior section in this series.
- Every claim verified against source rather than trusting the issue text:
  - **Chatting with the AI**: context scoping is agentic — the model gets tools (`search_notes`, `read_note`, `query_graph`, `web_search`, etc.) and decides per-turn what to fetch, in a loop capped at 10 iterations, rather than the whole thoughtbase being dumped into context. Citations only ever come from web search results, never from thoughtbase note reads.
  - **Drafts**: independently confirmed every draft type — note, refactor, reorg, delete, properties, claims — routes through `proposeWrite()` then `approveProposal()`, with no bypass of the Trust Principle found anywhere. An explicit code comment explains why an accepted draft auto-approves rather than creating a second pending review card.
  - **The propose → review → approve loop**: independently re-derived (not just cited) `right-sidebar-proposals.html`'s finding that proposal auto-expiry isn't enforced by any running timer — confirmed clean via a fresh grep of the renderer and main process. Also nails down the real approval-tier trigger conditions and the established-node escalation rule.
- Since the sidebar only expands the section you're currently in, this batch is purely additive — no existing pages needed changes.

Closes #1201, #1204, #1205, #1208.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 4 pages
- [x] Visually reviewed each page in a browser