### PR TITLE
docs site: add the Thinking tools documentation section

### DIFF
--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Managing &amp; Authoring Skills</title>
+<meta name="description" content="How to enable, disable, reassign, and reorder skills from Settings — and where to go when you're ready to write your own." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
+    <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
+    <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-managing-authoring.html" class="sub active">Managing &amp; authoring</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>Managing &amp; authoring</p>
+
+    <h1>Managing &amp; authoring</h1>
+    <p class="lede">Every skill — stock or your own — can be turned off, moved to a different menu, or reordered from <b>Settings → Skills</b>. The changes are per-machine, take effect immediately, and never require editing a file by hand.</p>
+
+    <h2 id="settings">Managing skills from Settings</h2>
+    <p>Open <b>Settings → Skills</b> and each of the three menus — Learning, Research, Analysis — lists its skills as rows, stock and user skills together. Every row carries an enable checkbox, up/down reorder buttons, and a menu dropdown, so the whole surface is a working control panel, not a JSON file you're expected to open in an editor.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Enable / disable</div>
+        <div class="v">The checkbox on each row hides a skill from every surface — menu, command palette, and slash commands — without deleting its file. Stock skills can't be removed outright, so this is how you turn one off; a disabled row stays visible in Settings (dimmed) so you can find it again later.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reassign to a different menu</div>
+        <div class="v">The dropdown on each row moves that skill into a different one of the three fixed menus, overriding whatever menu the skill's own frontmatter declares. Useful when a skill you use constantly is buried in Analysis but you'd rather reach it from Learning.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reorder within a menu</div>
+        <div class="v">The ↑ / ↓ buttons move a skill up or down within its current menu's list. Order here is the order it appears in the actual menu, the command palette, and the slash-command list.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧰</div>
+      <div class="k">Screenshot — Settings → Skills panel</div>
+      <div class="d">The Skills settings panel with the Learning, Research, and Analysis sections stacked, each listing its skill rows: an enable checkbox, the skill name and source tag (stock or user), reorder arrows, and a menu-reassignment dropdown per row.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Where this lives on disk</span>
+      <p>These per-machine overrides are persisted to <code>~/.minerva/menu-config.json</code>. You never need to open that file — Settings is a full read/write interface for it — but if you're curious, it's a small JSON object mapping skill IDs to an enabled flag and a menu override, plus an explicit ordering array per menu. A skill with no entry there is enabled, in its declared menu, and sorted after any explicitly-ordered skills, so a fresh install needs no config file at all and newly added skills just slot in.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Changes apply immediately — no restart.</b> Toggling, reassigning, or reordering a skill updates the menu bar, the command palette, and the slash-command list right away. The Settings panel writes optimistically (the UI reflects the change before the save round-trip finishes), so the effect is visible before you've even closed the dialog.</li>
+      <li><b>It's per-machine, not per-project.</b> <code>menu-config.json</code> lives under your home directory, not inside a project's <code>.minerva/</code> folder — so the same overrides follow you across every thoughtbase you open on that machine, but don't travel with the project itself if you open it on another computer.</li>
+      <li><b>A bad hand-edit degrades quietly, not fatally.</b> If you do go poking at the file directly and leave it malformed, Minerva drops whatever it can't parse and falls back to defaults for the rest rather than failing to start — but there's no reason to hand-edit it when Settings does the same job with immediate visual feedback.</li>
+    </ul>
+
+    <p>Ready to write your own skill instead of just rearranging the stock ones? The full authoring reference — frontmatter fields, the template language, tool wiring, and a worked example — lives at <code>docs/authoring-skills.md</code> in the repo. This page won't duplicate it; start there.</p>
+
+    <div class="pager">
+      <a class="prev" href="thinking-tools-three-menus.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← The three menus</span>
+      </a>
+      <a class="next" href="settings.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Settings →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Running a Skill</title>
+<meta name="description" content="What actually happens when you invoke a thinking tool from the Learning, Research, or Analysis menu — how it gathers context, runs, and almost always ends with a proposal to review rather than a direct write." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
+    <a href="thinking-tools-running-a-skill.html" class="sub active">Running a skill</a>
+    <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>Running a skill</p>
+
+    <h1>Running a skill</h1>
+    <p class="lede">Pick a skill from the Learning, Research, or Analysis menu (or the editor's right-click menu) and Minerva gathers whatever context that skill declared it needs from the note you're in, then runs it. Almost every stock skill hands its result to you as a <a href="conversations-propose-review-approve.html">reviewable proposal</a> — nothing lands in your notes or the graph without a keystroke from you.</p>
+
+    <h2 id="invoke">From menu click to running</h2>
+    <p>A skill is just a registered thinking tool, so invoking one from a menu, the editor's right-click, or the command palette all funnel through the same path: the click sends the tool's id over the <code>tool:invoke</code> IPC channel, the renderer gathers exactly the context fields that skill's <code>context:</code> frontmatter declared (the current note's full text, your current selection, a claim under the cursor, related or tagged notes, or — for Source-scoped skills — the active source's metadata and body), and then runs it.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">1. Gather context</div>
+        <div class="v">Only what the skill asked for is collected — a skill that lists <code>fullNote</code> gets the current note's text and path; one that lists <code>selectedText</code> gets your highlighted passage; one that lists <code>claimUnderCursor</code> resolves the <code>thought:Claim</code> at your cursor. Nothing is sent that the skill didn't declare it needs.</div>
+      </div>
+      <div class="row">
+        <div class="k">2. Ask for parameters (if any)</div>
+        <div class="v">A skill can declare a small parameters form — a dropdown, a text field, or a note picker — that opens as a dialog before anything runs. Excavate's "Analysis depth" (Quick / Standard / Deep) is a stock example. Skills with no parameters skip straight to running.</div>
+      </div>
+      <div class="row">
+        <div class="k">3. Run</div>
+        <div class="v">Most stock skills open a new <a href="conversations.html">conversation</a> seeded with a system prompt and an auto-fired first message built from your context — you watch it think and respond like any other conversation. A handful of skills (marked for direct output) instead run in a compact bottom panel with a streaming "Thinking…" view and no chat back-and-forth.</div>
+      </div>
+      <div class="row">
+        <div class="k">4. Land as a proposal</div>
+        <div class="v">When a skill's work involves writing to your notes or graph — filing a claim, proposing linked evidence, drafting a source summary, rewriting a note — it calls a tool like <code>propose_claims</code> or <code>propose_source_properties</code>, which files a <code>thought:Proposal</code> through the approval engine. Nothing is written until you approve it.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">The trust principle still applies</span>
+      <p>A skill is a prompt template, not a shortcut around the approval engine. Whatever conversation a skill opens is bound by the same rule as a conversation you started yourself: <b>the LLM proposes, the human confirms.</b> See <a href="conversations-propose-review-approve.html">The propose, review, approve loop</a> for how the approval tiers work and <a href="right-sidebar-proposals.html">Proposals</a> for how to review and act on what a skill files.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧭</div>
+      <div class="k">Screenshot — Invoking a skill and its resulting proposal</div>
+      <div class="d">Split view: the Research menu open with a skill highlighted (e.g. "Propose Summary") on the left, and the Proposals panel on the right showing the pending card it filed — the abstract and TL;DR payloads collapsed, ready to expand and review.</div>
+    </div>
+
+    <h2 id="output-modes">Where the result actually shows up</h2>
+    <p>What you see after a skill runs depends on its <code>outputMode</code>, set by whoever authored it:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Open a conversation</div>
+        <div class="v">The default for nearly every stock skill. The menu click opens a new conversation tab pinned to your current note, with the skill's system prompt and first message already in place. You read the model's reasoning as it comes in, same as any chat — and if the skill's job is to propose a graph change, that proposal appears the same way any conversation-filed proposal does: as a pending card, reviewable from the <a href="right-sidebar-proposals.html">Proposals panel</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Direct output panel</div>
+        <div class="v">A small number of skills (Excavate is a stock example) run in a bottom dock instead of opening a conversation: a streaming "Thinking…" view, then the finished text with <b>Save as Note</b>, <b>Append to Current</b>, and <b>Copy</b> buttons. This is a separate, older mechanism from the proposal system — choosing "Save as Note" writes the file immediately rather than filing a <code>thought:Proposal</code>. The explicit button click is still your confirmation step; it's just a different one than the diff-and-approve flow.</div>
+      </div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>A skill can refuse to run before it ever reaches the model.</b> If a skill declares <code>requiresSelection</code> and you haven't highlighted anything, the menu item fails fast with a message telling you to select text first — the right-click menu hides the entry entirely in that case. Other skills check their context at prompt-build time instead: a claim-scoped skill invoked with no <code>thought:Claim</code> under the cursor throws a specific, readable error ("right-click on a claim line first") rather than sending an empty prompt to the model.</li>
+      <li><b>Running a skill over a note with nothing relevant in it doesn't error — it just produces a thin result.</b> A source-summarizing skill invoked with no extracted body text says so plainly in its first message rather than fabricating a summary; other skills without that guard will still run and the model will do its best with sparse input, which usually means a proposal not worth approving. Reviewing the diff before you approve is what catches this, not the tool refusing to run.</li>
+      <li><b>The skill only sees the context it declared, not everything about the note.</b> A skill listing only <code>selectedText</code> never sees the rest of the note, even though you invoked it while that note was open — if a skill seems to be ignoring context you'd expect it to use, check what its <code>context:</code> list actually requests (see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>).</li>
+      <li><b>Cancel stops the run, not the proposal.</b> The direct-output panel has a Cancel button while it's streaming, which stops that call. A skill running as a conversation is cancelled the same way any conversation send is — but if the model already made its tool call before you cancelled, whatever it proposed is still sitting in the Proposals panel; cancelling doesn't retract a proposal already filed. Reject it there if you don't want it.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="thinking-tools-what-they-are.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← What thinking tools are</span>
+      </a>
+      <a class="next" href="thinking-tools-three-menus.html">
+        <span class="dir">Next</span>
+        <span class="ttl">The three menus →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — The Three Menus</title>
+<meta name="description" content="Learning, Research, and Analysis each hold a different kind of skill, and how a skill's optional group field turns a long menu into nested submenus." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
+    <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
+    <a href="thinking-tools-three-menus.html" class="sub active">The three menus</a>
+    <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>The three menus</p>
+
+    <h1>The three menus</h1>
+    <p class="lede">Every skill declares exactly one menu — <code>Learning</code>, <code>Research</code>, or <code>Analysis</code> — in its frontmatter, and that's the only thing that decides where it shows up in the menu bar (and in the command palette's grouping). The three aren't enforced categories with different capabilities; they're a rough division of labor: Learning helps you understand something already in front of you, Research goes out and gathers or files new material, Analysis operates on a claim or argument you already have. A skill's <code>menu:</code> field is just a label — nothing about <code>outputMode</code>, tool access, or approval tier changes based on which one it picks.</p>
+
+    <h2 id="menus">What belongs where</h2>
+    <p>The order in the menu bar itself — Learning, then Research, then Analysis — is deliberate: it reads top-down as a workflow, read-and-understand first, then go gather or file material, then operate across what you've collected (<code>src/main/menu.ts</code>, the comment above <code>buildToolMenus()</code>). A couple of real stock skills per menu, with the actual frontmatter fields that place them:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Learning</div>
+        <div class="v">Skills that work on something you already have open — explain it, expand it, quiz you on it. <b>Deep Dive on Term</b> (<code>src/main/skills/stock/deep-dive.md</code>) expands a selected word or phrase into a fuller explanation at a chosen depth, using the surrounding note as context. <b>Explain Like I'm…</b> (<code>src/main/skills/stock/explain-like-im.md</code>) and <b>Quiz Me</b> (<code>src/main/skills/stock/quiz-me.md</code>) are the same shape: no new material comes in from outside, the skill just changes how you're engaging with what's already there.</div>
+      </div>
+      <div class="row">
+        <div class="k">Research</div>
+        <div class="v">Skills that go get something — from the web, from your existing notes, or from a source you're reading — and hand it back as a draft to file. <b>Find Sources</b> (<code>src/main/skills/stock/find-sources.md</code>) assembles a candidate reading list from web search and your existing notes; it explicitly doesn't ingest anything itself — "You pick which to actually read; ingest the keepers through Ingest URL / Identifier." <b>Extract Key Claims</b> (<code>src/main/skills/stock/extract-key-claims.md</code>) mines a source for <code>thought:Claim</code> notes anchored back to the passage they came from. <b>Check Facts</b> (<code>src/main/skills/stock/check-facts.md</code>) verifies a specific claim against outside evidence.</div>
+      </div>
+      <div class="row">
+        <div class="k">Analysis</div>
+        <div class="v">Skills that operate on a claim, argument, or note you already have, teasing out structure, tension, or a stronger version of it. <b>Steelman</b> (<code>src/main/skills/stock/steelman.md</code>) constructs the strongest possible version of an opposing argument. <b>Find Tensions</b> (<code>src/main/skills/stock/find-tensions.md</code>) compares two notes for where they disagree. <b>Doublecrux</b> and <b>Murphyjitsu</b> are the same family — this is Minerva's largest menu by a wide margin, roughly 30 of the ~50 stock skills, which is exactly why it's the one that needed grouping.</div>
+      </div>
+    </div>
+
+    <h2 id="grouping">Thematic grouping within a menu</h2>
+    <p>A skill's frontmatter can carry an optional <code>group:</code> field — a short thematic label like <code>Disagreement</code>, <code>Verification</code>, or <code>Data</code>. When at least one skill in a menu sets a <code>group</code>, that menu stops rendering as a flat list and becomes a set of nested submenus instead, one per group name, in first-appearance order (which follows the menu config's ordering). Skills that don't set a group collect into a trailing <code>General</code> bucket rather than disappearing. <b>Steelman</b> and <b>Doublecrux</b> both set <code>group: Disagreement</code>; <b>Find Sources</b> sets <code>group: Discovery</code>; <b>Check Facts</b>, <b>Date / Scope Check</b>, and <b>Find Primary Sources</b> all set <code>group: Verification</code>.</p>
+
+    <div class="box">
+      <span class="label">Flat until someone sets a group — where this is enforced</span>
+      <p>The partitioning is pure logic in <code>groupToolsByGroup()</code> (<code>src/shared/tools/grouping.ts</code>): it buckets tools by their <code>group</code> field in a <code>Map</code> keyed by first appearance, collects ungrouped tools separately, and — critically — "if no tool in the list declares a group, the result is a single null-labelled bucket." <code>hasNamedGroups()</code> checks whether any bucket has a non-null label. <code>buildToolMenus()</code> in <code>src/main/menu.ts</code> (lines 593–608) calls both: when <code>hasNamedGroups()</code> is false it renders <code>tools.map(mkItem)</code> directly as a flat list; only when it's true does it wrap each bucket in a <code>submenu</code> entry, labelled from <code>g.label</code> or falling back to <code>'General'</code> for the trailing bucket. No stock skill in Learning or Research sets a <code>group</code> today, so both stay flat — Analysis is the only menu with named groups (Disagreement, Verification, Discovery, Data, Semantic, Pattern, Motivation, Planning, Diagnostic, Generation, Organization, Mining, Decomposition, Summarize, Argumentation), which is also why it's the menu large enough to need the split. The same <code>groupToolsByGroup()</code> call is the one place this logic lives — the renderer's own copy of the registry and the Settings → Skills UI both read the same <code>group</code> field, so a skill you group yourself behaves identically everywhere it appears.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗃️</div>
+      <div class="k">Screenshot — Analysis menu with a nested group open</div>
+      <div class="d">The menu bar's Analysis menu open, showing named submenus (Disagreement, Verification, Semantic, Pattern, General) instead of a flat list, with the Disagreement submenu expanded to reveal Steelman, Find Tensions, and Doublecrux.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The menu is just a label, not a capability tier.</b> Nothing about a skill's <code>outputMode</code>, tool access, or approval tier is derived from which of the three menus it's in — <code>menu:</code> only controls where it's discoverable. A Research skill and a Learning skill can both open a conversation, write a note, or call the same tools; there's no sandboxing by category.</li>
+      <li><b>A skill can't belong to more than one menu.</b> <code>menu:</code> takes a single value. If a skill feels like it straddles two categories, pick the one that describes what triggers you to reach for it, not what it technically does under the hood.</li>
+      <li><b>Adding a group to one skill doesn't just nest that skill.</b> Because grouping is a menu-wide decision (<code>hasNamedGroups()</code> flips for the whole category), setting <code>group:</code> on a single skill in an otherwise-flat menu immediately restructures every other skill in that menu into the trailing <code>General</code> bucket. If you're authoring a skill for Learning or Research today, adding a group is a visible change to the whole menu, not a local one.</li>
+      <li><b>Source-scoped skills never appear in these menus at all.</b> A skill with <code>scope: source</code> is excluded from Learning/Research/Analysis and the editor's right-click menu regardless of what <code>menu:</code> it declares — it only shows up in the Source viewer's Tools menu. See <a href="thinking-tools-what-they-are.html">What thinking tools are</a> for that split.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="thinking-tools-running-a-skill.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Running a skill</span>
+      </a>
+      <a class="next" href="thinking-tools-managing-authoring.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Managing &amp; authoring →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — What Thinking Tools Are</title>
+<meta name="description" content="A thinking tool is a skill — a markdown file with YAML frontmatter and a template prompt body — not a hardcoded feature, and every one you see in the Learning, Research, and Analysis menus is one." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="thinking-tools-what-they-are.html" class="sub active">What thinking tools are</a>
+    <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
+    <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>What thinking tools are</p>
+
+    <h1>What thinking tools are</h1>
+    <p class="lede">Every entry in the <b>Learning</b>, <b>Research</b>, and <b>Analysis</b> menus is a <b>skill</b> — a markdown file with a block of YAML frontmatter and a prompt body, not a feature built into the app. Minerva reads skill files at startup, and what they declare (a name, which menu they belong to, what context they need) is what you see on the menu. There is no separate, hardcoded catalog of tools to fall back on: the file <i>is</i> the tool.</p>
+
+    <h2 id="not-hardcoded">A skill, not a hardcoded tool</h2>
+    <p>Earlier versions of Minerva shipped roughly 35 individual tools as TypeScript code — one file per tool, each wired by hand into a menu, the command palette, and the conversation engine. That registry is gone. Every one of those tools is now a skill file: plain markdown, readable and editable like any note, requiring no rebuild of the app to change. Here's the frontmatter and opening lines of a real stock skill, <code>src/main/skills/stock/add-term-to-glossary.md</code>:</p>
+
+    <pre><code>---
+id: learning.add-term-to-glossary
+name: Add Term to Glossary
+description: Add one term to the existing glossary, matching its conventions
+menu: Learning
+outputMode: openConversation
+context: [selectedText, fullNote]
+slashCommand: /add-term-to-glossary
+model: claude-sonnet-5
+web: true
+firstMessage: "{{#if selection}}Add \"{{selection | trim}}\" to the glossary.{{/if}}"
+---
+You add a single term to the user's **existing** glossary, matching the
+conventions already in use.</code></pre>
+
+    <p>The frontmatter is declarative — which menu (<code>Learning</code>), what triggers it (a <code>/add-term-to-glossary</code> slash command, a menu click), what context to gather before running (the current selection and the active note). The body underneath is the actual prompt, written in a small non-executing template language (<code>{{selection}}</code>, <code>{{#if note}}…{{/if}}</code>) so one file adapts to whether a note is open or something is selected, instead of shipping separate code paths for each case. Minerva turns this into a running tool through a fixed pipeline, all under <code>src/main/skills/</code>: <code>parse.ts</code> reads the frontmatter and body, <code>loader.ts</code> assembles the full catalog, <code>compile.ts</code> turns each valid skill into a <code>ThinkingToolDef</code>, and <code>register.ts</code> adds it to the shared tool registry the menu bar, command palette, and conversation engine all read from. The renderer never sees the prompt text itself — it gets a serializable <code>SkillInfo</code> summary via <code>api.skills.list()</code> and builds its own copy of the registry from that.</p>
+
+    <h2 id="stock-vs-user">Stock skills vs. user skills</h2>
+    <p>Skills come from two places, and the distinction matters for what you can change:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Location</div>
+        <div class="v"><b>Stock:</b> <code>src/main/skills/stock/*.md</code>, bundled into the app at build time via Vite's <code>import.meta.glob</code> — around 50 files today, covering the default Learning, Research, and Analysis catalog. <b>User:</b> <code>~/.minerva/skills/</code> on your machine — either a bare <code>my-skill.md</code> file or a folder with a <code>SKILL.md</code> inside it (the folder form is for a skill that ships assets alongside its prompt). User skills apply across every thoughtbase you open on that machine, not just one project.</div>
+      </div>
+      <div class="row">
+        <div class="k">Loaded when</div>
+        <div class="v">Stock skills are embedded at build time — they ship inside the app itself, no filesystem read required. User skills are read from disk at runtime, on app startup, and again whenever you hit <b>Reload</b> in Settings → Skills after editing a file by hand.</div>
+      </div>
+      <div class="row">
+        <div class="k">Can it override?</div>
+        <div class="v">No. Stock loads first and claims every id it defines; a user skill whose <code>id</code> collides with a stock skill is rejected outright rather than replacing it — user skills are <b>additive only</b>. To change how a stock skill behaves, disable it in Settings → Skills and author your own from scratch (copying the stock file as a starting point is the normal way to do this).</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Additive, not overriding — where this is enforced</span>
+      <p>The rule lives in <code>src/main/skills/loader.ts</code>. <code>loadSkillCatalog()</code> loads stock skills first and inserts them into an id-keyed map (lines 98–104); it then loads user skills and, for each one, checks whether its id already exists in that map (lines 105–115). If the existing entry came from stock, the user skill is rejected with the error <code>id "…" is already a stock skill; user skills can't override stock</code> — it never reaches the catalog. The same file's header comment states the invariant directly: "User skills are additive only: a user skill whose id collides with a stock skill is rejected (it can't shadow stock)." A rejected skill doesn't take down the rest of your catalog, either — parsing is error-isolated per file, so one bad or colliding skill is reported (Settings → Skills lists load errors) while every other skill loads normally.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧠</div>
+      <div class="k">Screenshot — A thinking-tools menu open</div>
+      <div class="d">The menu bar's Analysis menu open, showing a flat list of skill entries (Steelman, Find Tensions, Murphyjitsu, Doublecrux, Antithesize) each with its short description beneath the name, matching the card layout skills declare via `name` and `description` in frontmatter.</div>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="thinking-tools.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Thinking tools</span>
+      </a>
+      <a class="next" href="thinking-tools-running-a-skill.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Running a skill →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Thinking Tools</title>
+<meta name="description" content="The Learning, Research, and Analysis skills: what they are, running one, the three menus, and managing or authoring your own." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html" class="active">Thinking tools</a>
+    <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
+    <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
+    <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
+    <a href="settings.html">Settings</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Thinking tools</p>
+
+    <h1>Thinking tools</h1>
+    <p class="lede">The Learning, Research, and Analysis menus are structured thinking moves you run over the note you're looking at — steelman an argument, extract its claims, quiz yourself on it, check a fact. Every one is a <b>skill</b>: a markdown file, not a hardcoded feature, which is why the set you get is yours to enable, reassign, or extend.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-what-they-are.html"><b>What thinking tools are</b></a> — markdown files with YAML frontmatter, not built-in features.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-running-a-skill.html"><b>Running a skill</b></a> — pick one from a menu; it runs and hands back a proposal to review.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-three-menus.html"><b>The three menus</b></a> — Learning, Research, Analysis, and how skills group within each.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-managing-authoring.html"><b>Managing &amp; authoring</b></a> — enable, reassign, reorder from Settings, or write your own.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Still the trust principle</span>
+      <p>A skill's output is a candidate, not a graph write. Every stock skill that produces a change files it through the approval engine — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thinking-tools-what-they-are.html">
+        <span class="em">📄</span>
+        <h3>What thinking tools are</h3>
+        <p>Skills are markdown files, not built-in features — stock and user, side by side.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-running-a-skill.html">
+        <span class="em">▶️</span>
+        <h3>Running a skill</h3>
+        <p>Pick one from a menu; it runs and hands back a proposal to review.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-three-menus.html">
+        <span class="em">🗂️</span>
+        <h3>The three menus</h3>
+        <p>Learning, Research, Analysis — and how skills group within each.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-managing-authoring.html">
+        <span class="em">🛠️</span>
+        <h3>Managing &amp; authoring</h3>
+        <p>Enable, reassign, reorder from Settings — and how to write your own.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="conversations-propose-review-approve.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← The propose → review → approve loop</span>
+      </a>
+      <a class="next" href="thinking-tools-what-they-are.html">
+        <span class="dir">Next</span>
+        <span class="ttl">What thinking tools are →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Thinking tools hub page (`thinking-tools.html`) plus four full sub-pages: What thinking tools are, Running a skill, The three menus, and Managing & authoring — closing out epic #1202 and its four children.
- **Restructured from the original plan**, same reasoning as every prior section in this series.
- Grounded in the real skills system rather than the issue text alone:
  - **What thinking tools are**: pulled a real frontmatter example from `add-term-to-glossary.md`, and confirmed the loader rejects any user skill whose `id` collides with a stock one (actual error message quoted on the page).
  - **The three menus**: empirically verified — not assumed — that Learning and Research currently have zero grouped skills (genuinely flat), while Analysis has 14 distinct groups across roughly 30 grouped skills.
  - **Managing & authoring**: confirmed all three Settings → Skills controls (enable/disable, reassign menu, reorder) are real live UI backed by `~/.minerva/menu-config.json`, applying immediately with no restart — not something requiring hand-edited JSON.
  - **Running a skill**: confirmed the output funnels into the same propose → review → approve loop documented in the Conversations section, cross-linked rather than re-derived.
- Since the sidebar only expands the section you're currently in, this batch is purely additive — no existing pages needed changes.

Closes #1202, #1207, #1209, #1210, #1211.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 5 pages
- [x] Visually reviewed each page in a browser