### PR TITLE
docs site: add the Settings documentation section

### DIFF
--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: AI</title>
+<meta name="description" content="The AI tab of Settings: choosing a default model and reasoning effort, entering and clearing your Anthropic API key, and where per-skill model overrides actually live." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub active">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>AI</p>
+
+    <h1>AI</h1>
+    <p class="lede">The default model and reasoning effort every new conversation starts with, your Anthropic API key, and voice dictation. Per-skill model overrides live on the separate <a href="settings-skills.html">Skills</a> tab, not here — this tab only sets the fallback everything else defers to.</p>
+
+    <h2 id="model">Default model and effort</h2>
+    <p>These two dropdowns set the defaults a new conversation opens with. Both are just starting points — the per-conversation model and effort pickers in the conversation panel's context rail override them for that one tab, and neither dropdown here touches a conversation already in progress.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Default model</div>
+        <div class="v">A fixed list, not a live query against Anthropic — Claude Fable 5, Claude Opus 4.8, Claude Sonnet 5, Claude Sonnet 4.6, and Claude Haiku 4.5. Sonnet 4.6 stays listed alongside its successor, Sonnet 5, purely so anyone who had it selected doesn't get silently reset to a different model on upgrade.</div>
+      </div>
+      <div class="row">
+        <div class="k">Default reasoning effort</div>
+        <div class="v">"Model default" (send no preference), Low, Medium, High, Extra, or Max. Higher effort lets the model think longer before answering. Support is model-gated: Haiku 4.5 accepts no effort control at all, Sonnet 4.6 and Sonnet 5 top out at Max, and "Extra" only exists for Opus 4.8 and Fable 5.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Only the levels a model supports are ever sent</span>
+      <p>The dropdown here doesn't hide unsupported levels for you — it's a single global default, not model-aware. The gating happens downstream: the per-conversation effort picker only offers what the conversation's current model actually accepts, and if a saved default or a conversation override doesn't apply to the model in play, it's silently clamped to the nearest level that model supports rather than sent as-is and rejected by the API.</p>
+    </div>
+
+    <h2 id="apikey">API key</h2>
+    <p>A password-style field for your Anthropic API key, plus a status line above it that reflects what's already stored — not a live validation check. On open, the panel shows <b>Loading…</b> until the saved settings arrive, then <b>✓ API key saved</b> if one is on file or <b>No API key set</b> if it isn't. Minerva never round-trips the stored key to check it still works; "saved" means present, not verified.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Entering a key</div>
+        <div class="v">Typing into the field doesn't save immediately — like the model and effort defaults, it's held until you click <b>Done</b> on the dialog. The field's placeholder changes to "Type to replace existing key" once a key is already saved, and the saved value itself is never displayed back — copy, cut, and right-click are all disabled on the field so there's nothing to accidentally expose over your shoulder or leak into a clipboard manager.</div>
+      </div>
+      <div class="row">
+        <div class="k">Clearing a key</div>
+        <div class="v">A <b>Clear saved key</b> link appears once a key is set. Clicking it doesn't delete anything immediately — it flips a pending "will clear on save" state (the status line updates to say so, the input disables) with a <b>Cancel clear</b> link right below it to back out before you commit. The key is only actually removed when you click Done.</div>
+      </div>
+      <div class="row">
+        <div class="k">Environment variable fallback</div>
+        <div class="v">Setting <code>ANTHROPIC_API_KEY</code> in your environment works without ever touching this field — Minerva falls back to it whenever no key is stored in settings. A key you type here and save takes precedence over the environment variable.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Where this lives on disk</span>
+      <p>The model, effort, and API key are all one record, written to <code>llm-settings.json</code> in your Electron user-data directory (not inside the project's <code>.minerva/</code> folder, and not synced anywhere) — so this is a per-machine setting, same as the Skills and Behaviors tabs. It's saved as one unit when you click Done on the Settings dialog, not per-field as you edit.</p>
+    </div>
+
+    <h2 id="tools">Tool preferences</h2>
+    <p>This tab doesn't have its own tool-preference controls. Per-skill model overrides — pointing a specific skill at a cheaper or more capable model than the global default — are configured on the <a href="settings-skills.html">Skills</a> tab instead, which reads the same default-model value set here as its fallback for any skill without an explicit override.</p>
+
+    <h2 id="voice">Voice dictation</h2>
+    <p>Below the API key sits an unrelated pair of controls: an <b>Enable voice dictation</b> checkbox and a voice-model dropdown. Unlike everything above, these save immediately to <code>localStorage</code> as you change them — dictation runs entirely on-device (local Whisper, via a renderer worker) and never touches your Anthropic key or the main-process settings file, so there's no reason to defer it to the dialog's Done button. The model (tens of megabytes) downloads once on first use; your audio never leaves the machine.</p>
+
+    <div class="shot wide">
+      <div class="icon">🤖</div>
+      <div class="k">Screenshot — Settings → AI tab</div>
+      <div class="d">The AI settings panel: a "Default model" dropdown and a "Default reasoning effort" dropdown with its model-gating hint text beneath; below that the API key section showing the "✓ API key saved" status line, a masked password field with a "Clear saved key" link; and at the bottom the voice dictation checkbox with its model dropdown.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Nothing here saves until you click Done.</b> The model, effort, API key entry, and pending clear are all held in the dialog's local state and only written together when you close the dialog with Done — clicking Cancel, or closing the window, discards all of it, including a pending key clear.</li>
+      <li><b>Changing the model or clearing the key doesn't touch conversations already open.</b> Each conversation tab tracks its own model (defaulting from this setting only when it was created), so switching the default here has no retroactive effect on an in-progress tab. Clearing the API key here and clicking Done will, however, make the very next message you send in <i>any</i> conversation fail — there's no separate per-conversation key.</li>
+      <li><b>"API key saved" is a presence check, not a working-key check.</b> An expired, revoked, or mistyped key still shows <b>✓ API key saved</b> — the status only reflects that something is stored, not that Anthropic will accept it. A bad key surfaces as a failed request the next time you actually send a message.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-compute.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Compute</span>
+      </a>
+      <a class="next" href="settings-skills.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Skills →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Appearance</title>
+<meta name="description" content="The Appearance tab in Settings: pick a theme and choose the font used for the markdown editor and preview — the two whole-app looks-and-feel controls Minerva exposes." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub active">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Appearance</p>
+
+    <h1>Appearance</h1>
+    <p class="lede">Two controls live on this tab: which theme the whole app uses, and which font the markdown editor and preview render in. Both apply live as you change them — there's no "Apply" step, and neither setting travels with a project; they're stored per-machine.</p>
+
+    <h2 id="theme">Theme</h2>
+    <p>The <b>Theme</b> dropdown offers Dark, Light, High Contrast, and System. This tab is just one of three equivalent places to change it — the status bar and the <kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd> shortcut cycle the same setting. The mechanics — what each theme looks like, how System tracks your OS, where the preference is stored — are covered in full on the <a href="viewing-options-themes.html">Themes</a> page; this tab is just the Settings-dialog surface for picking one.</p>
+
+    <h2 id="content-font">Content font</h2>
+    <p>The <b>Content font</b> dropdown changes the typeface used for note text — in both the CodeMirror editor and the rendered preview. It does not touch the app's own interface: menus, sidebar labels, dialog text, and every other piece of chrome stay on the system UI font regardless of what you pick here. The setting writes a single CSS custom property, <code>--content-font-family</code>, which the editor's <code>.cm-content</code> and the preview pane both read; everything else in the app never references that variable, which is what keeps the two scopes separate.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Minerva default (Plex)</div>
+        <div class="v">No override — content falls back to Minerva's own monospace stack (IBM Plex Mono and friends). The default look, unchanged.</div>
+      </div>
+      <div class="row">
+        <div class="k">System Sans</div>
+        <div class="v"><code>-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif</code> — your OS's UI sans, for a prose-first reading feel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Serif</div>
+        <div class="v"><code>Georgia, "Times New Roman", Cambria, serif</code> — a book-like serif for long-form notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Monospace</div>
+        <div class="v"><code>ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, monospace</code> — a generic monospace stack that takes whichever of those faces is installed.</div>
+      </div>
+      <div class="row">
+        <div class="k">JetBrains Mono</div>
+        <div class="v">Named preference for JetBrains Mono specifically, falling back through standard monospace faces if it isn't installed.</div>
+      </div>
+      <div class="row">
+        <div class="k">Berkeley Mono</div>
+        <div class="v">Named preference for Berkeley Mono (and its <code>TX-02</code> alias), same fallback pattern.</div>
+      </div>
+      <div class="row">
+        <div class="k">System mono</div>
+        <div class="v"><code>ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace</code> — your OS's default monospace face instead of Plex Mono.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔤</div>
+      <div class="k">Screenshot — Settings → Appearance tab</div>
+      <div class="d">The Settings dialog's Appearance tab, showing the "Theme" dropdown at top and the "Content font" dropdown below it with its options open (Minerva default, System Sans, Serif, Monospace, JetBrains Mono, Berkeley Mono, System mono), each hint line visible beneath its field.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>The named mono presets don't install fonts.</b> Picking "JetBrains Mono" or "Berkeley Mono" only sets a font-family preference — if that face isn't already installed on your system, the browser falls through to the next name in the stack (ultimately Menlo/SFMono-Regular), so the note pane will silently keep looking like the fallback rather than the one you chose.</li>
+      <li><b>Chrome is never affected.</b> If you're expecting a "reading font" that also restyles the sidebar or menus, that's not what this control does — it's scoped to <code>--content-font-family</code>, which only the editor content and preview read. The rest of the UI always uses the system font.</li>
+      <li><b>Per-machine, not per-project.</b> Like theme, the content font is stored in <code>localStorage</code> — it's a preference for this install of Minerva, not something that travels with the notebase or syncs to another device.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-editor.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Editor</span>
+      </a>
+      <a class="next" href="settings-behaviors.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Behaviors →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Behaviors</title>
+<meta name="description" content="The Behaviors tab of Settings: sidebar auto-reveal, breadcrumb heading chains, and the per-dialog list that lets you re-enable any confirmation you've told Minerva to stop asking about." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub active">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Behaviors</p>
+
+    <h1>Behaviors</h1>
+    <p class="lede">Two small app-wide toggles, plus a control panel for every confirmation dialog you've ever told Minerva to stop asking about. Nothing here changes what Minerva can do — it only changes how much it interrupts you while doing it.</p>
+
+    <h2 id="toggles">Behavior toggles</h2>
+    <p>These two checkboxes sit at the top of the tab and take effect immediately — no restart, no reopening the current note.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Auto-reveal active file in sidebar</div>
+        <div class="v">When the active editor changes, scroll the matching row into view in the Notes panel and expand its parent folders. It never collapses anything you've already opened by hand — it only ever reveals, never rearranges the tree around you.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show heading chain in breadcrumbs</div>
+        <div class="v">Appends the current section's heading chain to the breadcrumbs bar above the editor when the cursor sits inside a section, updating live as the cursor moves. See <a href="navigation-breadcrumbs.html">Breadcrumbs</a> for how the chain itself is built and what it looks like.</div>
+      </div>
+    </div>
+
+    <h2 id="confirmations">Confirmation dialogs</h2>
+    <p>Every <code>showConfirm(...)</code> call site in Minerva is registered once, up front, in a single list (<code>CONFIRM_REGISTRY</code>) — a title, a description, and a stable key. The Behaviors tab renders that registry as one checkbox per dialog: checked means the dialog still asks, unchecked means you've suppressed it. Unchecking a row here does exactly what ticking "Don't ask again" does the moment the dialog appears — there's no separate suppression mechanism to learn.</p>
+
+    <p>Because the list is generated from the registry rather than hand-maintained on this page, it grows every time a new confirmation is added to the app — deletes, collisions, batch-operation summaries, LLM-tool failures, and more all show up as their own row with their own independent switch. Suppressing one dialog never silences another, even when two dialogs cover similar-sounding situations (for instance, a failed save is a different key from a failed format, so muting one leaves the other asking).</p>
+
+    <div class="shot wide">
+      <div class="icon">🔕</div>
+      <div class="k">Screenshot — Settings → Behaviors, confirmation dialogs list</div>
+      <div class="d">The Behaviors tab scrolled to the Confirmation dialogs section: the "auto-reveal" and "heading chain" toggles above, then a long checklist of dialog rows, each with a bolded title, a checkbox, and a one-line description underneath — Delete file or folder, Close conversation, Format batch complete, and so on, all independently checked or unchecked.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Leftover keys from older builds</span>
+      <p>Suppressed dialogs are stored in <code>localStorage</code> as a flat set of keys, with no reference back to the registry. If a build removes or renames a confirmation, a key you suppressed in an older version can outlive the dialog it belonged to. Rather than silently drop that key — which would make it impossible to ever undo — the Behaviors tab diffs the stored set against the current registry and lists anything it doesn't recognize under its own "Unknown confirmation" rows, showing the raw key instead of a friendly title. Unchecking one of those is the only way to clear it; there's no bulk "clean up" action.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>A few dialogs hide the checkbox entirely.</b> The first-run Python trust prompt and the "no API key configured" prompt both omit "Don't ask again" on purpose — Python trust is scoped per-project (recorded in <code>.minerva/config.json</code>, not per-machine localStorage), and the missing-key prompt is the thing that tells you LLM features are blocked, so silencing it would just return you to a confusing silent failure. Both still get a row here for completeness, but toggling the Python-trust row has no effect since suppression was never how that one worked.</li>
+      <li><b>Suppression is per-machine.</b> The underlying <code>localStorage</code> set doesn't travel with the project — reopening the same thoughtbase on another computer asks every dialog again until you re-suppress it there too.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-appearance.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Appearance</span>
+      </a>
+      <a class="next" href="settings-notes.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Notes →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Bibliography</title>
+<meta name="description" content="The Bibliography tab in Settings — choosing a CSL citation style, importing additional styles and locales, and how the setting feeds Refactor → Insert/Update Bibliography." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub active">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Bibliography</p>
+
+    <h1>Bibliography</h1>
+    <p class="lede">The Bibliography tab in <b>Settings</b> picks the CSL (Citation Style Language) style Minerva renders your bibliography in, and lets you import additional styles or locales beyond the bundled set. It's the only setting behind <b>Refactor → Insert/Update Bibliography</b> — there's no separate citation formatting anywhere else, and no live connection to a reference manager. Bringing in an existing library — Zotero, BibTeX, or otherwise — is a one-time file import from the Sources panel, covered in <a href="left-sidebar-sources.html#adding">Left sidebar → Sources</a>, along with the <code>[[cite::id]]</code> / <code>[[quote::id]]</code> link syntax that actually produces a citation.</p>
+
+    <h2 id="settings">Settings</h2>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Citation style</div>
+        <div class="v">Dropdown. Default <b>APA (7th edition)</b>. Choose from six bundled CSL styles — APA, MLA (9th edition), Chicago (author–date), Chicago (notes &amp; bibliography), IEEE, and Vancouver (NLM citation-sequence) — plus anything you've imported yourself (labeled "(imported)" in the list). Stored per-project in <code>.minerva/config.json</code>, so different thoughtbases can follow different style guides. This is the style <b>Refactor → Insert/Update Bibliography</b> renders with; there's no per-note override.</div>
+      </div>
+      <div class="row">
+        <div class="k">Imported styles</div>
+        <div class="v">Drop a <code>.csl</code> file into <code>.minerva/csl-styles/</code>, or use the <b>Import .csl style…</b> button to pick one with a file dialog. Either way it shows up in the Citation style dropdown above (and in the export dialog's style picker) immediately — no restart. Each imported style is listed here with a <b>Remove</b> action. The <a href="https://www.zotero.org/styles">Zotero Style Repository</a> publishes 10,000+ open CSL styles if the bundled six don't match what you need.</div>
+      </div>
+      <div class="row">
+        <div class="k">Imported locales</div>
+        <div class="v">Optional. The only bundled locale is <b>en-US</b> — it supplies the translated terms citeproc renders into a citation or bibliography entry (things like "and", "ed.", "no date", month names), not sort order, which each CSL style defines on its own. Import a CSL locale XML file via <b>Import locale .xml…</b> to render in another language; official locales live at <a href="https://github.com/citation-style-language/locales">github.com/citation-style-language/locales</a>. Imported locales land in <code>.minerva/csl-locales/</code> and are listed here with a <b>Remove</b> action. There's no picker to select which locale is active — Minerva always renders with en-US unless you're using a style that hardcodes a different one internally.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">📖</div>
+      <div class="k">Screenshot — Settings → Bibliography tab</div>
+      <div class="d">The Bibliography tab of the Settings dialog: the Citation style dropdown (APA selected, with imported styles marked "(imported)" further down the list), the Imported styles section showing an empty state and an "Import .csl style…" button with the Zotero Style Repository link in its hint text, and the Imported locales section below it with its own import button and locales.citation-style-language.org link.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">This tab formats citations — it doesn't create them</span>
+      <p>Nothing here writes a citation into a note. You cite a source with <code>[[cite::sourceId]]</code> or quote a saved excerpt with <code>[[quote::excerptId]]</code> in the note body, then run <b>Refactor → Insert/Update Bibliography</b> to scan the note for those links and render a <code>## References</code> section in the style configured on this tab. Re-running it is idempotent — it replaces its own previously-rendered block (tracked by an HTML comment pair) without disturbing any prose you've added around it, so it's safe to run again after adding more citations.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Styles and locales live in separate directories.</b> An imported <code>.csl</code> file goes in <code>.minerva/csl-styles/</code>; an imported locale XML goes in <code>.minerva/csl-locales/</code> — dropping one in the other's folder means it's silently never picked up.</li>
+      <li><b>The style choice is per-project, not global.</b> Switching thoughtbases can mean switching bibliography styles too — check this tab if a freshly-opened project's References section renders differently than you expected.</li>
+      <li><b>An imported style or locale with the same id as a bundled one wins.</b> Project files always take precedence over the bundled set on a filename collision, so you can override, say, <code>apa.csl</code> with your own variant without touching app source — but it also means a badly-named import can silently shadow a built-in style.</li>
+      <li><b>No live reference-manager connection.</b> There's no Zotero or Mendeley account to sign into here — building up a library happens once, via <b>File → Import BibTeX…</b> / <b>Import Zotero RDF…</b> or one-at-a-time ingest in the Sources panel. See <a href="left-sidebar-sources.html">Left sidebar → Sources</a> for those flows.</li>
+      <li><b>A cited id citeproc can't resolve doesn't block the rest.</b> Insert/Update Bibliography still renders every entry it can; unresolved ids are surfaced separately rather than failing the whole command.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-formatter.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Formatter</span>
+      </a>
+      <a class="next" href="settings-web.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Web →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Clipper</title>
+<meta name="description" content="The Clipper tab of Settings: enabling the browser-clipper loopback server, pairing a browser extension with the one-time pairing code, and regenerating it." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub active">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Clipper</p>
+
+    <h1>Clipper</h1>
+    <p class="lede">A companion browser extension can send the page you're reading straight into Minerva as a Source. This tab turns that path on, and shows the one-time pairing code the extension needs to talk to it. Everything here takes effect immediately — there's no separate "apply" step.</p>
+
+    <h2 id="enable">Enable browser clipper</h2>
+    <p>The checkbox starts (or stops) a small HTTP server bound to <code>127.0.0.1</code> the moment you toggle it — not when you close the dialog. Turning it on issues a secret the first time one doesn't already exist; turning it off tears the server down entirely, so nothing is listening on this machine unless the checkbox is checked <i>and</i> a thoughtbase is open.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Enable browser clipper</div>
+        <div class="v">Off by default. Checking it starts the loopback server right away; unchecking it stops the server right away. Because a stop/restart is triggered on every change to this tab (including Regenerate, below), an already-running clip in flight in the browser can fail if it lands mid-restart — rare in practice, since the restart is near-instant.</div>
+      </div>
+      <div class="row">
+        <div class="k">Listening port</div>
+        <div class="v">Shown next to the pairing code once the server is running. Minerva prefers a fixed port (41599) so the extension doesn't need reconfiguring across restarts, but falls back to an OS-assigned ephemeral port if something else on the machine is already using it — the pairing code always carries whichever port is actually live, so pairing still works either way.</div>
+      </div>
+    </div>
+
+    <h2 id="pairing">The pairing code</h2>
+    <p>Once enabled and running, a masked field shows the pairing code — <b>Reveal</b> swaps it to plain text, <b>Copy</b> puts it on the clipboard. Paste it into the browser extension once; the extension decodes it into the port and a shared secret and uses that secret on every subsequent request, in a header the loopback server checks with a constant-time comparison before it will process anything.</p>
+
+    <div class="box">
+      <span class="label">What's actually in the code</span>
+      <p>The pairing code isn't the raw secret — it's the port and secret together, JSON-encoded and then base64url'd into one opaque string, so there's exactly one thing to copy-paste rather than two fields to fill in separately in the extension. Decoding is symmetric: the same encode/decode pair is shared between the app and the extension, so a change to the format only has to happen in one place.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔌</div>
+      <div class="k">Screenshot — Settings → Clipper, pairing code revealed</div>
+      <div class="d">The Clipper tab with "Enable browser clipper" checked: below it, the Pairing code field showing the revealed base64url token, Reveal (toggled to "Hide") and Copy buttons beside it, a hint naming the listening port, and below that the "Regenerate code" button with its invalidation warning.</div>
+    </div>
+
+    <h2 id="regenerate">Regenerate code</h2>
+    <p><b>Regenerate code</b> rotates the shared secret on the server side and persists the new one — it's not a cosmetic reshuffle of the display. The old secret stops being accepted the instant the server restarts with the new config, so any browser extension still holding the previous pairing code starts getting rejected on its next request. There's no grace period and no way to un-rotate; re-pairing means opening Settings again, copying the new code, and pasting it into the extension.</p>
+
+    <h2 id="no-project">When no thoughtbase is open</h2>
+    <p>The server itself only runs while a thoughtbase is open — a clip needs somewhere to write the resulting Source. If you enable the clipper before opening one, the tab shows a hint instead of a pairing code:</p>
+
+    <div class="box">
+      <span class="label">Fallback hint</span>
+      <p>"Open a thoughtbase to start the clipper and reveal its pairing code." The checkbox stays checked (the setting itself is saved), but the port and pairing-code fields don't appear until a project is actually open. Even a request that reaches the endpoint while no thoughtbase is open is answered, just with an error rather than a write — the ingest route responds <code>503 No thoughtbase open</code> rather than silently dropping the clip.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Regenerating breaks the currently-paired extension.</b> This is the main surprise: rotating the code isn't additive. The moment you click Regenerate, the extension's stored secret is worthless, and its next clip attempt fails until you paste the fresh code into it.</li>
+      <li><b>The setting is per-machine, not per-project.</b> Like the rest of Settings' local config, enable state and the secret live under your user data directory, not inside the thoughtbase's <code>.minerva/</code> folder — so pairing done on one computer doesn't travel with the project to another.</li>
+      <li><b>The secret survives ordinary restarts.</b> Quitting and reopening Minerva (or closing and reopening a thoughtbase) keeps the same secret, so a paired extension keeps working without you needing to re-pair — only an explicit Regenerate, or hand-editing the on-disk config, invalidates it.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-sources.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Sources</span>
+      </a>
+      <a class="next" href="settings-compute.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Compute →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Compute</title>
+<meta name="description" content="The Compute settings tab: selecting and probing the Python interpreter Minerva runs code cells with, and where the execution trust prompt actually lives." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub active">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Compute</p>
+
+    <h1>Compute</h1>
+    <p class="lede">The Compute tab is one thing: which Python interpreter Minerva runs your <code>python</code> cells with. There's no separate trust switch to configure here — the one-time consent prompt for running Python at all lives at the point you actually run a cell, not in Settings. See <a href="notes-code.html">Code &amp; compute cells</a> for the fence syntax, how output is written back into a note, and the full execution-trust model.</p>
+
+    <h2 id="interpreter">Python interpreter</h2>
+    <p>This tab has a single field: a path to a Python executable. It's a per-machine override, not a per-project one — every thoughtbase you open on this computer shares whatever interpreter you set here.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Python interpreter path</div>
+        <div class="v">A text field for the path to the Python binary Minerva should invoke — for example <code>/Users/you/.minerva-venv/bin/python</code>. Left empty, Minerva resolves an interpreter in order: the <code>MINERVA_PYTHON</code> environment variable, then <code>python3</code> on <code>$PATH</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Browse…</div>
+        <div class="v">Opens a native file picker to select the interpreter binary instead of typing a path. Selecting a file probes it immediately, so you see right away whether it's runnable.</div>
+      </div>
+      <div class="row">
+        <div class="k">Probe</div>
+        <div class="v">Runs <code>python --version</code> against whichever path is currently in the field (or, if the field is empty, against whatever the resolver would currently pick) and reports the result inline — the resolved version string on success, or the interpreter's own error text on failure. Probing doesn't save anything; it's a dry run.</div>
+      </div>
+      <div class="row">
+        <div class="k">Save</div>
+        <div class="v">Writes the current path as the per-machine override. Disabled when the field matches what's already saved, so it only lights up once there's an actual change to persist.</div>
+      </div>
+      <div class="row">
+        <div class="k">Save &amp; Restart Kernel</div>
+        <div class="v">Saves the path and restarts the persistent Python process immediately, so the very next cell you run picks up the new interpreter. Restarting wipes the kernel's namespace — variables and imports from earlier cells in any open note are gone, the same as if you'd started a fresh Minerva session.</div>
+      </div>
+      <div class="row">
+        <div class="k">Clear override</div>
+        <div class="v">Empties the saved path, returning to the <code>MINERVA_PYTHON</code> / <code>python3</code> resolution order above. Only appears once a path has been saved.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🐍</div>
+      <div class="k">Screenshot — Settings → Compute tab</div>
+      <div class="d">The Compute settings panel: the Python interpreter path field with Browse and Probe buttons beside it, a probe-result strip beneath showing a resolved version string and path, and the Save / Save &amp; Restart Kernel / Clear override row underneath.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Where the trust prompt actually is</span>
+      <p>The tab's sub-line in the Settings menu reads "Python interpreter · trust," but there's no toggle for it here — the trust model isn't a setting you configure in advance, it's a one-time confirmation dialog that appears the first time you run a Python cell in a given project. Declining leaves the cell unrun until you approve it later; approving is remembered for the rest of that project. That prompt, what it gates, and why SPARQL and SQL fences skip it entirely, are covered in <a href="notes-code.html#trust">Code &amp; compute cells — Approval and the knowledge graph</a>. This page is only about which interpreter binary gets used once that trust is in place.</p>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>A saved path that stops existing fails at run time, not save time.</b> Saving doesn't validate the path — Probe does, but Save doesn't require a successful probe first. If an interpreter gets uninstalled, moved, or was on a drive that's no longer mounted, the saved override stays in place and the next cell run simply fails with the interpreter's own error text in the output block. Come back to this tab, Probe to confirm, and Browse to a valid binary.</li>
+      <li><b>It's per-machine, so it doesn't travel with the project.</b> Open the same thoughtbase on another computer and it resolves the interpreter fresh on that machine — the environment variable or <code>python3</code> on that machine's <code>PATH</code>, unless you set an override there too. A project's notes never encode which interpreter produced their output.</li>
+      <li><b>Restarting the kernel is a real reset.</b> Any variable, DataFrame, or import built up across a note's Python cells is gone after Save &amp; Restart Kernel. If you need that state, re-run the note's cells from the top afterward rather than assuming Minerva carries anything forward.</li>
+      <li><b>Probing the empty field probes the resolver, not "nothing."</b> With the path field blank, Probe still runs against whatever <code>MINERVA_PYTHON</code> or <code>python3</code> would resolve to — so a failed probe on an empty field usually means neither of those is set up, not that probing was skipped.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-clipper.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Clipper</span>
+      </a>
+      <a class="next" href="settings-ai.html">
+        <span class="dir">Next</span>
+        <span class="ttl">AI →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Editor</title>
+<meta name="description" content="The Editor tab in Settings — tab size, word wrap, line numbers, whitespace, frontmatter collapsing, and numbered section headings, with their defaults." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub active">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Editor</p>
+
+    <h1>Editor</h1>
+    <p class="lede">The Editor tab in <b>Settings</b> holds the handful of preferences that change how the markdown editor and its preview behave while you type — tab size, wrapping, line numbers, whitespace visibility, frontmatter collapsing, and numbered section headings. These are per-machine editing preferences, distinct from the <a href="editor.html">Editor</a> doc section, which covers the editing surface itself rather than its settings.</p>
+
+    <h2 id="settings">Settings</h2>
+    <p>Six fields, all with sensible defaults — most people never need to open this tab:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Tab size</div>
+        <div class="v">Number input, range 1–8. Default <b>2</b>. Controls how many spaces a tab or auto-indent inserts.</div>
+      </div>
+      <div class="row">
+        <div class="k">Word wrap</div>
+        <div class="v">Checkbox. Default <b>on</b>. Long lines wrap to fit the editor width instead of scrolling horizontally.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show line numbers</div>
+        <div class="v">Checkbox. Default <b>on</b>. Toggles the gutter running down the left edge of the editor.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show whitespace</div>
+        <div class="v">Checkbox. Default <b>off</b>. Renders spaces and tabs as visible marks — useful for chasing down stray trailing whitespace or mixed indentation.</div>
+      </div>
+      <div class="row">
+        <div class="k">Always collapse frontmatter</div>
+        <div class="v">Checkbox. Default <b>off</b>. Automatically folds the YAML <a href="notes-frontmatter.html">frontmatter</a> block at the top of a note when it's opened, instead of leaving it expanded.</div>
+      </div>
+      <div class="row">
+        <div class="k">Numbered section headings</div>
+        <div class="v">Checkbox. Default <b>off</b>. Prefixes each H2 in the <b>preview</b> with a "§ 01" section numeral — H1 and H3+ are untouched, and the raw markdown source is untouched too, since the numeral is a rendered decoration, not text written into the file. Best for long-form essays; leave off for journals and lists.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">⚙️</div>
+      <div class="k">Screenshot — Settings → Editor tab</div>
+      <div class="d">The Editor tab of the Settings dialog: the Tab size number field followed by checkbox rows for Word wrap, Show line numbers, Show whitespace, Always collapse frontmatter, and Numbered section headings, the last two with their explanatory hint text visible beneath the label.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Preview-only, not source</span>
+      <p>Numbered section headings is purely a rendering choice: it changes what the preview pane shows, via a CSS counter on the H2 elements, and never rewrites the note's markdown. Turning it off again removes the numerals from the preview immediately — there's nothing in the file to clean up either way.</p>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="settings.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Settings</span>
+      </a>
+      <a class="next" href="settings-appearance.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Appearance →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Formatter</title>
+<meta name="description" content="The Formatter tab in Settings — the on-by-default house style, opt-in rules by category, the Restore house style button, and how rule toggles apply the next time you format." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub active">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Formatter</p>
+
+    <h1>Formatter</h1>
+    <p class="lede">The Formatter tab in <b>Settings</b> lists every deterministic markdown normalization Minerva knows how to apply — trailing-whitespace cleanup, frontmatter tidying, footnote conventions, and more — each as its own checkbox with a title and a plain-language description. Formatting itself runs on demand, from <b>Refactor ▸ Format</b>, not automatically on every save; this tab only controls which rules fire the next time you run it.</p>
+
+    <h2 id="model">House style, and everything else opt-in</h2>
+    <p>Rules aren't all-on or all-off together. Minerva ships a curated <b>house style</b> — a subset chosen because each rule is safe and uncontroversial: it tidies whitespace, list markers, frontmatter shape, or Minerva's own link hygiene without ever changing the meaning of your prose, your heading levels, or the words you wrote. House-style rules are <b>on by default</b>. Every other rule — anything opinionated enough that it could surprise a writer, like heading capitalization, smart-ellipsis substitution, or spelling autocorrect — is <b>off by default</b> and stays off until you check its box.</p>
+
+    <p>Toggling any rule, in either direction, writes an explicit override; a rule with no override falls back to whether it's in the house-style set. Overrides are stored per-project in <code>.minerva/formatter.json</code>, so they travel with the thoughtbase — open the project on another machine and you get the same formatting behavior, not a fresh set of per-machine defaults.</p>
+
+    <div class="box">
+      <span class="label">"Restore house style"</span>
+      <p>The button above the rule list clears every explicit enable/disable override in one step, so each rule falls back to the curated default — house-style rules on, everything else off. It's disabled when you're already at house style (no overrides to clear), and it doesn't ask for confirmation — there's nothing destructive about it, since your notes aren't touched until you next run Format. One thing it deliberately leaves alone: per-rule <em>configuration</em>. If you'd changed a rule's own setting — for instance, how many consecutive blank lines to allow — that value survives a restore. The button resets <em>which</em> rules run, not how the ones you've tuned are configured.</p>
+    </div>
+
+    <h2 id="categories">Rule categories</h2>
+    <p>Rules are grouped into six categories, applied in this order — structural passes first, so later rules see an already-normalized document shape. A handful of real examples from each:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">YAML frontmatter</div>
+        <div class="v">Structural tidying of the YAML block — no value rewrites beyond de-duplication. <b>Compact frontmatter</b> (house style) strips leading and trailing blank lines inside the block. <b>Dedupe YAML array values</b> (house style) collapses <code>tags: [a, a, b]</code> to <code>tags: [a, b]</code>, first occurrence wins. <b>Sort frontmatter keys</b> (opt-in) imposes a consistent key order.</div>
+      </div>
+      <div class="row">
+        <div class="k">Headings</div>
+        <div class="v"><b>Heading increment</b> (opt-in) clamps an out-of-order jump — H1 straight to H3 — down to the previous level plus one; the document's first heading is always accepted as-is. <b>Capitalize headings</b> (opt-in) applies a chosen case style (title case, sentence case, or lowercase) with a configurable list of proper nouns to preserve verbatim.</div>
+      </div>
+      <div class="row">
+        <div class="k">Content</div>
+        <div class="v"><b>Proper ellipsis</b> (opt-in) collapses three consecutive dots (<code>...</code>) into a single <code>…</code> character. <b>Wrap bare URLs</b> (opt-in) turns a bare <code>https://…</code> into an angle-bracket or link form. <b>Auto-correct common misspellings</b> (opt-in) runs a small, deliberately conservative starter dictionary — extendable via a per-rule config rather than expected to catch everything out of the box.</div>
+      </div>
+      <div class="row">
+        <div class="k">Footnotes</div>
+        <div class="v"><b>Footnote reference after punctuation</b> (opt-in) moves a reference marker that lands before sentence-ending punctuation to after it: <code>word[^1].</code> → <code>word.[^1]</code>. <b>Move footnotes to the bottom</b> (opt-in) collects every <code>[^name]: …</code> definition, continuation lines included, and re-emits them as a single block at the document's end, in document order.</div>
+      </div>
+      <div class="row">
+        <div class="k">Spacing</div>
+        <div class="v"><b>Trailing whitespace</b> (house style) strips trailing spaces and tabs from every line, leaving code fences, frontmatter, and math untouched. <b>Collapse consecutive blank lines</b> (house style) caps runs of blank lines at a configurable maximum — default 1.</div>
+      </div>
+      <div class="row">
+        <div class="k">Minerva-specific</div>
+        <div class="v"><b>Canonical wiki-link extension</b> (house style) enforces one style for wiki-link targets, always with <code>.md</code> or always without — typed links like <code>[[cite::…]]</code> are left alone since they target sources, not files. <b>Unique heading slugs</b> (house style) suffixes a duplicate heading anchor (<code>Overview</code> + <code>Overview</code> → <code>Overview</code> + <code>Overview 2</code>) and cascades the rename into any incoming <code>[[note#old-slug]]</code> links.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧹</div>
+      <div class="k">Screenshot — Settings → Formatter tab</div>
+      <div class="d">The Formatter tab: the intro paragraph explaining house style, a "Restore house style" button (dimmed, at house style) with its hint text, then the six category headings — YAML frontmatter, Headings, Content, Footnotes, Spacing, Minerva-specific — each expanded into a checklist of rule rows, a checkbox plus title plus description per row, with a mix of checked (house style) and unchecked (opt-in) boxes visible.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Formatting is on demand, not on save.</b> There's no background pass that rewrites a note the moment you save it. Rules only run when you invoke <b>Refactor ▸ Format</b> — on the active note, or on every <code>.md</code> file under whatever you've selected in the left sidebar (multi-select with <kbd>⌘</kbd>-click, <kbd>⇧</kbd>-click, or <kbd>⌘</kbd><kbd>A</kbd>). Toggling a rule in Settings changes nothing about notes already on disk; it only changes what happens the <em>next</em> time you run Format.</li>
+      <li><b>Nothing is retroactive.</b> Following on from the above: a note you formatted last week under an old rule set stays exactly as it was written. There's no "re-format everything" prompt triggered by a settings change — if you want the new rule set applied project-wide, select the whole tree in the sidebar and run Format yourself.</li>
+      <li><b>It's global, not per-note.</b> There's no frontmatter flag or per-file switch to exempt a single note from formatting — the rule set in this tab applies uniformly to whatever you run Format over. If a note needs different handling, leave it out of your sidebar selection when you invoke the command.</li>
+      <li><b>Ignore the tab list's "On-save rules" subtitle.</b> The Settings sidebar's own tab listing labels this section "On-save rules" — that's a holdover from an earlier design and doesn't match current behavior. Nothing runs on save; go by the on-demand behavior described above.</li>
+      <li><b>Restoring house style doesn't touch per-rule configuration.</b> Clearing your on/off overrides is not the same as clearing everything — a tuned value like a custom blank-line maximum persists across a restore. Only the enabled/disabled state resets.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-notes.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Notes</span>
+      </a>
+      <a class="next" href="settings-bibliography.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Bibliography →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Notes</title>
+<meta name="description" content="The Notes tab in Settings — where refactored notes and excerpt notes land by default, the folder and filename template tokens, and the link and body templates that wrap them." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub active">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Notes</p>
+
+    <h1>Notes</h1>
+    <p class="lede">The Notes tab in <b>Settings</b> controls where the note-creating commands file what they create — <b>Extract Selection</b>, <b>Split Here</b>, and <b>Split by Heading</b> (the <em>Refactoring</em> subsection), and <b>New note from excerpt</b> (the <em>Excerpt notes</em> subsection) — plus the templates that shape what gets written into the new note and left behind in the source.</p>
+
+    <h2 id="refactoring">Refactoring</h2>
+    <p>These settings apply to the three note-splitting commands. They're per-machine preferences, not part of a project — Minerva keeps them in your browser profile's local storage, so they follow you across every thoughtbase you open on this machine but don't travel with a project to another computer.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Destination for new notes</div>
+        <div class="v">Dropdown with three options: <b>Same folder as source note</b> (default), <b>Thoughtbase root</b>, or <b>Custom folder (template)</b>. Applies to Extract Selection, Split Here, and Split by Heading alike.</div>
+      </div>
+      <div class="row">
+        <div class="k">Custom folder template</div>
+        <div class="v">Only shown when destination is <b>Custom folder (template)</b>. A text field for a project-relative path built from tokens, e.g. <code>notes/{{date:YYYY}}/{{date:MM}}</code>. Left blank, it resolves to the thoughtbase root.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filename prefix</div>
+        <div class="v">Text field, empty by default. Prepended to every refactored note's generated filename, using the same token syntax as the folder template — e.g. <code>{{date:YYYYMMDDHHmm}}-</code> for a Zettelkasten-style timestamp prefix.</div>
+      </div>
+      <div class="row">
+        <div class="k">Normalize heading levels in extracted notes</div>
+        <div class="v">Checkbox, off by default. When the extracted body's shallowest heading is H2 or deeper, shifts every heading up so it becomes H1. Only touches the new note's body — the source note is never rewritten.</div>
+      </div>
+      <div class="row">
+        <div class="k">Transclude by default</div>
+        <div class="v">Checkbox, off by default. When on, refactor commands leave behind <code>![[new-note]]</code> in the source instead of <code>[[new-note]]</code>, so the preview inlines the extracted content rather than just linking to it. Disabled (greyed out) whenever a link template is set below, since the template takes over that decision.</div>
+      </div>
+      <div class="row">
+        <div class="k">Link template</div>
+        <div class="v">Multi-line text field, empty by default. What to put in the source note in place of the extracted content. Blank means Minerva falls back to a plain wiki-link, or a transclusion if the toggle above is on. Precedence is: link template, if set, always wins over the transclude toggle.</div>
+      </div>
+      <div class="row">
+        <div class="k">Refactored note template</div>
+        <div class="v">Multi-line text field, empty by default. Wraps the body of every note these commands create. Blank means the extracted content is used as-is, unwrapped.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🗒️</div>
+      <div class="k">Screenshot — Settings → Notes tab, Refactoring</div>
+      <div class="d">The Refactoring subsection of the Notes settings tab: the Destination dropdown with Custom folder selected and its revealed folder-template field, the Filename prefix field, the Normalize heading levels and Transclude by default checkboxes with their hint text, and the Link template and Refactored note template textareas below.</div>
+    </div>
+
+    <h3 id="tokens">Template tokens</h3>
+    <p>The destination template, filename prefix, link template, and refactored-note template all share one token syntax. A token is anything inside double braces:</p>
+
+    <pre><code>{{date}}               ISO date (YYYY-MM-DD) in local time
+{{date:FORMAT}}        Custom date format — FORMAT is built from YYYY, MM, DD, HH, mm, ss
+{{title}}              The source note's title
+{{source}}             The source note's project-relative path
+{{new_note_title}}     The new (extracted) note's title
+{{new_note_content}}   The new note's raw body — only available in the refactored-note template</code></pre>
+
+    <p>Not every template accepts every token — <code>{{new_note_content}}</code> only makes sense in the refactored-note template, since it's the one place the extracted body is available to insert. The destination and filename-prefix templates realistically only need <code>{{date:…}}</code> and <code>{{title}}</code>, but all six are recognized wherever a template field appears.</p>
+
+    <div class="box">
+      <span class="label">Unknown tokens render as nothing</span>
+      <p>A token Minerva doesn't recognize — a typo, or one borrowed from the wrong field — quietly resolves to an empty string rather than raising an error or leaving the literal <code>{{…}}</code> in the output. That keeps a mistyped token from leaking brace characters into a filename, but it also means a silently-wrong template just produces a slightly-off result with no warning. The one template with a real failure mode is the <b>refactored-note template</b>: it wraps the extracted body wherever <code>{{new_note_content}}</code> appears, so a template that omits that token entirely discards the extracted content — the new note is created from the template text alone, with nothing to show for the selection you just extracted.</p>
+    </div>
+
+    <h2 id="excerpt-notes">Excerpt notes</h2>
+    <p>A single setting, separate from Refactoring because it's stored differently: this one is per-project, not per-machine.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Default destination folder</div>
+        <div class="v">Text field, placeholder "(project root)". The project-relative folder where <b>New note from excerpt</b> lands. Leave it blank and excerpts land at the thoughtbase root; the folder is created automatically on the first write if it doesn't already exist.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Where this lives on disk</span>
+      <p>Unlike the Refactoring settings above, the excerpt destination folder is stored in the project itself, at <code>.minerva/config.json</code>, under an <code>excerpt.noteFolder</code> key. That makes it a project convention rather than a personal one — it travels with the project if you sync or git-track <code>.minerva/</code>, the same way <a href="left-sidebar.html">bookmarks</a> do. It's telling Minerva where excerpts belong within <em>this</em> project's structure, not expressing a personal habit the way the Refactoring defaults do.</p>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="settings-behaviors.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Behaviors</span>
+      </a>
+      <a class="next" href="settings-formatter.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Formatter →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Skills</title>
+<meta name="description" content="The Skills tab in Settings — importing your own skill files and setting a per-skill model override, with the enable/reorder/reassign mechanics covered separately in Thinking tools." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub active">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Skills</p>
+
+    <h1>Skills</h1>
+    <p class="lede">The Skills tab in <b>Settings</b> is where a skill catalog gets managed — but enabling, disabling, reassigning between menus, and reordering are already covered in full at <a href="thinking-tools-managing-authoring.html">Thinking tools → Managing &amp; authoring</a>. This page covers the two things that live here and nowhere else: importing your own skill file into the catalog, and setting a per-skill model override.</p>
+
+    <h2 id="import">Importing a skill</h2>
+    <p>The <b>Import skill…</b> button at the top of the tab opens a native file picker that accepts either a single <code>.md</code> file or a folder containing a <code>SKILL.md</code> (the same two shapes described in <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a> — a bare file or a Claude-style skill folder). Whatever you pick is validated and, if it passes, copied into <code>~/.minerva/skills/</code>.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">What gets checked</div>
+        <div class="v">Before anything is copied, Minerva parses the file's YAML frontmatter and rejects it outright if required fields — <code>name</code>, <code>description</code>, a valid <code>menu</code>, a recognized <code>outputMode</code> — are missing or malformed. A folder without a <code>SKILL.md</code> inside it is rejected the same way. Nothing lands in your skills folder until the file is confirmed valid.</div>
+      </div>
+      <div class="row">
+        <div class="k">Colliding with a stock skill</div>
+        <div class="v">User skills are additive only — they can never shadow a built-in one. If the id you're importing matches a stock skill's id, the import is rejected before the copy happens, and Settings shows the reason inline: a built-in skill already uses that id, and the fix is to disable the stock one and give yours a different id.</div>
+      </div>
+      <div class="row">
+        <div class="k">Colliding with another user skill</div>
+        <div class="v">Same rejection, different message: you already have a skill using that id. Rename the id in the file's frontmatter and try again.</div>
+      </div>
+      <div class="row">
+        <div class="k">Canceling the picker</div>
+        <div class="v">Dismissing the file picker without choosing anything is a silent no-op — no error, nothing imported, nothing to dismiss.</div>
+      </div>
+      <div class="row">
+        <div class="k">On success</div>
+        <div class="v">The skill catalog reloads and the native menu rebuilds immediately — your import shows up in its declared menu (or wherever <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>'s reassignment moves it) without restarting Minerva.</div>
+      </div>
+    </div>
+
+    <p>Two adjacent buttons round out the row: <b>Reveal skills folder</b> opens <code>~/.minerva/skills/</code> in your OS file manager (creating it first if it doesn't exist yet), and <b>Reload</b> re-scans that folder without going through the import dialog — useful after hand-editing or dropping a file in directly.</p>
+
+    <div class="box">
+      <span class="label">A rejected import still shows you why</span>
+      <p>Every rejection reason above — bad frontmatter, a missing <code>SKILL.md</code>, a stock or user id collision, a filename that already exists in the folder — surfaces as the exact underlying message in an inline message beneath the button row, not a generic "import failed." You never have to guess which of the several validation checks tripped.</p>
+    </div>
+
+    <h2 id="model-overrides">Per-skill model override</h2>
+    <p>Each skill row carries a model picker alongside its menu-reassignment dropdown. Left on its default option, the skill runs on whatever model it would have used anyway — its own <code>model:</code> frontmatter preference if it declares one, otherwise the AI tab's global default model. Picking a specific model here pins that one skill to it, regardless of what the AI tab's default is set to.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Default option label</div>
+        <div class="v">The picker's empty option is never a bare "Default model" — it names whichever model would actually apply, e.g. "Default · Claude Sonnet 5", so you're not guessing what "default" resolves to for that particular skill.</div>
+      </div>
+      <div class="row">
+        <div class="k">Resolution order</div>
+        <div class="v">A skill invocation resolves its model as: this override, if set → the skill's own <code>model:</code> preference, if it declares one → the AI tab's global default model. The override set here always wins over a skill's own stated preference.</div>
+      </div>
+      <div class="row">
+        <div class="k">Storage</div>
+        <div class="v">Overrides are keyed by skill id in a single map alongside the API key, the global default model, and the effort setting — the same <a href="settings-ai.html">AI tab</a> settings object, saved together when you close the Settings dialog. It's machine-global, like <code>menu-config.json</code>: the same overrides apply no matter which thoughtbase you have open, but they don't travel with a project to another computer.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🧩</div>
+      <div class="k">Screenshot — Settings → Skills panel, import + model override</div>
+      <div class="d">The Skills settings panel: the Import skill… / Reveal skills folder / Reload button row at top, and below it a skill row expanded to show its model picker set to a specific model (not the "Default · …" option) alongside the existing enable checkbox, reorder arrows, and menu dropdown.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Overrides don't survive a restart yet.</b> The override map is written to disk correctly when you close Settings, but the setting isn't read back on the next load — so a per-skill model choice quietly reverts to "Default" the next time you reopen Minerva (or the Settings dialog after a reload). Re-set it if a skill seems to have forgotten its pinned model; nothing else in your settings is affected.</li>
+      <li><b>The override is per-skill, not per-menu or per-category.</b> Two skills that share a menu can run on two different models; there's no bulk "set this menu to Haiku" control, only the per-row picker.</li>
+      <li><b>Importing doesn't create an override.</b> A freshly imported skill has no entry in the override map — it runs on its own <code>model:</code> preference or the global default until you explicitly pick something for it.</li>
+    </ul>
+
+    <p>For enabling, disabling, reassigning a skill to a different menu, or reordering it within one — the mechanics that make up the rest of this tab — see <a href="thinking-tools-managing-authoring.html">Thinking tools → Managing &amp; authoring</a>.</p>
+
+    <div class="pager">
+      <a class="prev" href="settings-ai.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← AI</span>
+      </a>
+      <span></span>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Sources</title>
+<meta name="description" content="The Sources settings tab: importing upstream subject taxonomies as namespaced tags on identifier ingest, and granting privileged sites a cookie-authenticated fetch session." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub active">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Sources</p>
+
+    <h1>Sources</h1>
+    <p class="lede">The <b>Sources</b> tab in Settings covers two things that only apply to identifier-based ingest and authenticated fetches — not the Sources panel itself. For what a source is, how collections and the reading queue work, and the ways you get a source into a project, see <a href="left-sidebar-sources.html">Left sidebar → Sources</a>. This page is just the two settings: importing upstream subject tags, and privileged sites.</p>
+
+    <h2 id="ingest">Ingest</h2>
+    <p>A single toggle, on by default, that controls whether identifier ingest brings along the source API's own subject taxonomy:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Import upstream subject tags on source ingest</div>
+        <div class="v">When on, ingesting by DOI, arXiv id, or PMID (<b>File → Ingest Identifier…</b>) applies the subject terms that API surfaces as namespaced tags on the new source — CrossRef's disciplinary subject taxonomy as <code>crossref/…</code>, arXiv's category codes as <code>arxiv/…</code>, and PubMed's MeSH descriptor headings as <code>mesh/…</code>. Turning it off doesn't touch tags already applied to existing sources; it only stops new ones from being added on future ingests. A source's right-click "Strip upstream tags" removes them after the fact, one source at a time.</div>
+      </div>
+    </div>
+
+    <p>Each namespace prefix identifies which API produced the tag, and the subject string is slugified (lowercased, non-alphanumerics collapsed to hyphens) to fit the tag panel's naming rules. Real examples produced by the ingest adapters:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>crossref/sociology</code></div>
+        <div class="v">From CrossRef's <code>subject</code> array on a DOI lookup — its broad disciplinary taxonomy (e.g. "Computer Science Applications" becomes <code>computer-science-applications</code> the same way; "Sociology" becomes <code>sociology</code> unchanged, which is the simplest case of the same slug rule).</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>arxiv/cs-lg</code></div>
+        <div class="v">From an arXiv entry's category terms — the primary category first, then any additional ones on the entry. The API's dotted form (<code>cs.LG</code>) can't survive the tag slugger's rules, so the dot becomes a hyphen: <code>cs.LG</code> → <code>cs-lg</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>mesh/genetics</code></div>
+        <div class="v">From PubMed's MeSH heading list on a PMID lookup — one tag per top-level descriptor name (qualifiers are ignored, since a single MeSH heading can carry several).</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Only three upstream namespaces exist</span>
+      <p>CrossRef, arXiv, and PubMed/MeSH are the only identifier-ingest sources Minerva talks to, so <code>crossref/…</code>, <code>arxiv/…</code>, and <code>mesh/…</code> are the complete set of namespaces this toggle can produce — there's no per-namespace control, just the one switch for all upstream tagging. URL and file ingest never produce these tags; only DOI / arXiv id / PMID lookups carry a source-side subject taxonomy to import.</p>
+    </div>
+
+    <h2 id="privileged-sites">Privileged sites</h2>
+    <p>A list of domains you've logged in to inside Minerva, so ingest fetches to those domains carry your session instead of hitting the page as an anonymous visitor. This is for institutional access and paid subscriptions — a paywalled article that renders fully once you're logged in.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Add site</div>
+        <div class="v">Enter a domain (e.g. <code>arxiv.org</code>) and an optional label, then <b>Add</b>. Each site gets its own dedicated, persistent Electron session partition — cookies for one privileged site never mix with another's, or with Minerva's own browsing.</div>
+      </div>
+      <div class="row">
+        <div class="k">Login</div>
+        <div class="v">Opens a plain browser window (no Minerva UI or APIs injected) pointed at the site's domain, using that site's partition. Log in as you normally would, then close the window — Minerva records the login time and keeps the session cookies in that partition for future fetches.</div>
+      </div>
+      <div class="row">
+        <div class="k">Logout</div>
+        <div class="v">Clears the partition's cookies and storage, and resets the recorded login time to "never." The site stays in your list; you'd just need to log in again before it grants anything.</div>
+      </div>
+      <div class="row">
+        <div class="k">Remove</div>
+        <div class="v">Deletes the site from the list and clears its partition's storage — same cookie wipe as Logout, plus the entry itself is gone.</div>
+      </div>
+    </div>
+
+    <p>What "privileged" actually grants: every ingest path — URL ingest, identifier ingest, and reference-stub resolution — routes its fetch through a privileged-site-aware wrapper. If the URL being fetched matches a configured site's domain (or a subdomain of it), the request goes through that site's authenticated session partition instead of a plain anonymous fetch; otherwise it falls back to a normal fetch. It has nothing to do with the browser clipper's trust model or with any kind of auto-ingestion — it only changes which cookies, if any, an ingest fetch carries.</p>
+
+    <div class="shot wide">
+      <div class="icon">🔐</div>
+      <div class="k">Screenshot — Settings → Sources tab</div>
+      <div class="d">The Sources settings tab showing the Ingest subsection with the "Import upstream subject tags on source ingest" checkbox and its hint text listing the three namespace examples, and the Privileged sites subsection below it with the add-site form (domain and label fields) and a configured site row showing its label, domain, last-login timestamp, and Login/Logout/Remove buttons.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Longest-domain-suffix wins when sites overlap.</b> If you've added both a parent and a subdomain (unlikely, but possible), the fetch matches whichever configured domain is the more specific hostname suffix — not necessarily the one you added first.</li>
+      <li><b>Both settings are per-machine, not per-project.</b> Like the rest of the Settings dialog's ingest-adjacent panels, the upstream-tags toggle and the privileged-sites list live under your home directory (Electron's <code>userData</code>), so they follow you across every project you open on this machine but don't travel with the project itself.</li>
+      <li><b>Turning the tag toggle off is not retroactive.</b> It only changes what happens on the next identifier ingest — tags already on existing sources stay until you strip them manually, one source at a time, from that source's right-click menu.</li>
+      <li><b>A privileged site only helps if the fetch actually goes through Minerva.</b> It authenticates ingest-time fetches (URL ingest, identifier ingest, stub resolution) — it doesn't log the browser clipper in, and it doesn't make a paywalled site auto-ingest anything on its own.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-web.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Web</span>
+      </a>
+      <a class="next" href="settings-clipper.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Clipper →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings: Web</title>
+<meta name="description" content="The Web tab in Settings: the master switch for web access in conversations, and the allowed/blocked domain lists that scope where web_search and web_fetch can go." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub active">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="settings.html">Settings</a><span class="sep">/</span>Web</p>
+
+    <h1>Web</h1>
+    <p class="lede">Three controls live on this tab, and they only matter to conversations: a master switch for web access, and two domain lists that scope where <code>web_search</code> and <code>web_fetch</code> are allowed to go once that switch is on. See <a href="conversations-chatting.html">Chatting with the AI</a> for what those two tools actually do and how their results show up as citations — this page is just the Settings surface that governs them.</p>
+
+    <h2 id="controls">The three settings</h2>
+    <p>All three are per-machine, take effect on the next conversation turn, and require no restart.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Enable web access for conversations</div>
+        <div class="v">The master switch. On, the assistant may call <code>web_search</code> and <code>web_fetch</code> when it judges a turn needs something outside your thoughtbase. Off, neither tool is offered to the model at all — it's not that a call is blocked or refused, the tool definitions simply aren't in the request the model sees, so it has no way to attempt one. On by default for a fresh install.</div>
+      </div>
+      <div class="row">
+        <div class="k">Allowed domains</div>
+        <div class="v">A textarea, one domain per line (e.g. <code>arxiv.org</code>). Empty by default. If it holds any entries, web searches and fetches are restricted to just those domains — an allowlist, not a suggestion. Leave it blank to search the whole web.</div>
+      </div>
+      <div class="row">
+        <div class="k">Blocked domains</div>
+        <div class="v">Same format, one domain per line. Excludes the listed domains from results — but only when the allowlist above is empty. As soon as you put anything in Allowed domains, Blocked domains stops having any effect, because Minerva sends the API one filter or the other, never both at once.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Allowlist wins outright</span>
+      <p>The precedence isn't a merge or an intersection — it's a straight either/or. Minerva checks the allowed-domains list first: non-empty, and that becomes the domain filter sent with both <code>web_search</code> and <code>web_fetch</code>, full stop. Only when the allowlist is empty does it fall back to sending the blocked-domains list instead. A blocklist you'd carefully built up goes silently inert the moment you add even one entry to Allowed domains — there's no warning for this, so if web results suddenly seem to be missing sources you expected, check whether Allowed domains has something in it.</p>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🌐</div>
+      <div class="k">Screenshot — Settings → Web tab</div>
+      <div class="d">The Settings dialog's Web tab: the "Enable web access for conversations" checkbox at top with its hint line about web_search/web_fetch beneath it, followed by the "Allowed domains" textarea (placeholder "One domain per line (e.g. arxiv.org)") and its hint, then the "Blocked domains" textarea (placeholder "One domain per line") and its hint noting it's ignored when an allowlist is set.</div>
+    </div>
+
+    <h2 id="gotchas">Gotchas</h2>
+    <ul>
+      <li><b>Turning web access off disables both textareas.</b> They gray out along with the rest of the tab's controls rather than just becoming inert — a visual confirmation that nothing typed into them matters while the master switch is off, not just a functional one.</li>
+      <li><b>The blocklist doesn't layer on top of the allowlist.</b> If you want to allow a broad set of sites except a couple of bad ones, that combination isn't expressible here — Allowed domains and Blocked domains are mutually exclusive from the model's perspective, matching how the underlying web tools accept one filter or the other, never both.</li>
+      <li><b>This setting doesn't touch anything outside conversations.</b> Citing a source into your library, fetching a page from the Clipper, and other web-touching features elsewhere in Minerva aren't gated by this toggle — it only governs whether the assistant can call <code>web_search</code>/<code>web_fetch</code> mid-conversation.</li>
+    </ul>
+
+    <div class="pager">
+      <a class="prev" href="settings-bibliography.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Bibliography</span>
+      </a>
+      <a class="next" href="settings-sources.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Sources →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Settings</title>
+<meta name="description" content="Everything you can tune in Minerva: Editor, Appearance, Behaviors, Notes, Formatter, Bibliography, Web, Sources, Clipper, Compute, AI, and Skills." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html" class="active">Settings</a>
+    <a href="settings-editor.html" class="sub">Editor</a>
+    <a href="settings-appearance.html" class="sub">Appearance</a>
+    <a href="settings-behaviors.html" class="sub">Behaviors</a>
+    <a href="settings-notes.html" class="sub">Notes</a>
+    <a href="settings-formatter.html" class="sub">Formatter</a>
+    <a href="settings-bibliography.html" class="sub">Bibliography</a>
+    <a href="settings-web.html" class="sub">Web</a>
+    <a href="settings-sources.html" class="sub">Sources</a>
+    <a href="settings-clipper.html" class="sub">Clipper</a>
+    <a href="settings-compute.html" class="sub">Compute</a>
+    <a href="settings-ai.html" class="sub">AI</a>
+    <a href="settings-skills.html" class="sub">Skills</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Settings</p>
+
+    <h1>Settings</h1>
+    <p class="lede">Twelve tabs, each a different corner of how Minerva behaves. Some are about the editor itself, some about the AI, some about where things get filed or fetched from. None of it is per-note — everything here is per-machine or per-project, and most of it applies the moment you change it, no restart required.</p>
+
+    <h2 id="glance">The twelve tabs</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="settings-editor.html">Editor</a></div>
+        <div class="v">Tab size, wrapping, line numbers, and other editing preferences.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-appearance.html">Appearance</a></div>
+        <div class="v">Theme and content font — both apply live, per machine.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-behaviors.html">Behaviors</a></div>
+        <div class="v">App-wide toggles, plus re-enabling any dialog you silenced.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-notes.html">Notes</a></div>
+        <div class="v">Where new notes from refactoring and excerpts land.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-formatter.html">Formatter</a></div>
+        <div class="v">Every markdown normalization rule, individually toggleable.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-bibliography.html">Bibliography</a></div>
+        <div class="v">Citation style, locale, and importing more of each.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-web.html">Web</a></div>
+        <div class="v">Master switch and domain lists for <code>web_search</code> and <code>web_fetch</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-sources.html">Sources</a></div>
+        <div class="v">Upstream tag import and per-site fetch privileges.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-clipper.html">Clipper</a></div>
+        <div class="v">Turn on the browser extension and see its pairing code.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-compute.html">Compute</a></div>
+        <div class="v">Which Python interpreter runs your compute cells.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-ai.html">AI</a></div>
+        <div class="v">Default model, effort, API key, and voice dictation.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-skills.html">Skills</a></div>
+        <div class="v">Import skills and set per-skill model overrides.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="settings-editor.html">
+        <span class="em">📃</span>
+        <h3>Editor</h3>
+        <p>Tab size, wrapping, line numbers, and other editing preferences.</p>
+      </a>
+      <a class="doc-card" href="settings-appearance.html">
+        <span class="em">🪞</span>
+        <h3>Appearance</h3>
+        <p>Theme and content font — both apply live, per machine.</p>
+      </a>
+      <a class="doc-card" href="settings-behaviors.html">
+        <span class="em">🧩</span>
+        <h3>Behaviors</h3>
+        <p>App-wide toggles, plus re-enabling any dialog you silenced.</p>
+      </a>
+      <a class="doc-card" href="settings-notes.html">
+        <span class="em">🗒️</span>
+        <h3>Notes</h3>
+        <p>Where new notes from refactoring and excerpts land.</p>
+      </a>
+      <a class="doc-card" href="settings-formatter.html">
+        <span class="em">🧹</span>
+        <h3>Formatter</h3>
+        <p>Every markdown normalization rule, individually toggleable.</p>
+      </a>
+      <a class="doc-card" href="settings-bibliography.html">
+        <span class="em">📜</span>
+        <h3>Bibliography</h3>
+        <p>Citation style, locale, and importing more of each.</p>
+      </a>
+      <a class="doc-card" href="settings-web.html">
+        <span class="em">🌍</span>
+        <h3>Web</h3>
+        <p>Master switch and domain lists for AI web access.</p>
+      </a>
+      <a class="doc-card" href="settings-sources.html">
+        <span class="em">🎫</span>
+        <h3>Sources</h3>
+        <p>Upstream tag import and per-site fetch privileges.</p>
+      </a>
+      <a class="doc-card" href="settings-clipper.html">
+        <span class="em">✂️</span>
+        <h3>Clipper</h3>
+        <p>Turn on the browser extension and see its pairing code.</p>
+      </a>
+      <a class="doc-card" href="settings-compute.html">
+        <span class="em">🐍</span>
+        <h3>Compute</h3>
+        <p>Which Python interpreter runs your compute cells.</p>
+      </a>
+      <a class="doc-card" href="settings-ai.html">
+        <span class="em">🤖</span>
+        <h3>AI</h3>
+        <p>Default model, effort, API key, and voice dictation.</p>
+      </a>
+      <a class="doc-card" href="settings-skills.html">
+        <span class="em">🎚️</span>
+        <h3>Skills</h3>
+        <p>Import skills and set per-skill model overrides.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="thinking-tools-managing-authoring.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Managing &amp; authoring</span>
+      </a>
+      <a class="next" href="settings-editor.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Editor →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the Settings hub page (`settings.html`) plus twelve full sub-pages, one per tab: Editor, Appearance, Behaviors, Notes, Formatter, Bibliography, Web, Sources, Clipper, Compute, AI, and Skills — closing out epic #1203 and its twelve children, and with it **the entire docs-site epic #1194**.
- **Restructured from the original plan**, same reasoning as every prior section in this series.
- Found and documented **three internal UI inconsistencies** where a settings tab's own label promises something the tab doesn't actually do:
  - Appearance's sub-label reads "Theme · font · density" but no density control is rendered.
  - Compute's sub-label reads "Python interpreter · trust" but there's no trust UI in that component — the real one-time consent prompt lives at first-cell-execution time, elsewhere in the app.
  - The Formatter tab's own sidebar metadata says "On-save rules," directly contradicting its own body copy — formatting is on-demand only via Refactor → Format, never triggered by save.
- Found **a real application bug**, out of scope to fix in this PR but documented as a gotcha: `getSettings()` in `src/main/llm/settings.ts` never reads back `toolModelOverrides` from the saved JSON file, so per-skill model overrides silently vanish on the next app load even though saving writes them correctly. Verified via code reading and a scratch script; no existing issue tracks it.
- Other corrections after verifying against source: only three upstream tag namespaces exist for source ingestion (`crossref`/`arxiv`/`mesh`, a closed set); there's no live Zotero/Mendeley connection anywhere, library-building is one-time file import only; six bundled CSL citation styles ship, not just APA; the real note-template token list is six tokens, not three; and Refactoring settings are per-machine `localStorage` while Excerpt-notes destination is per-project `.minerva/config.json` — kept distinct rather than conflated.
- Since the sidebar only expands the section you're currently in, this batch is purely additive — no existing pages needed changes.

Closes #1203, #1235, #1236, #1237, #1238, #1250, #1251, #1252, #1253, #1254, #1268, #1269, #1270.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] Every page's HTML tags balance (scripted check)
- [x] Sidebar `active` state and pager prev/next links verified consistent across all 13 pages
- [x] Visually reviewed each page in a browser