### PR TITLE
docs-grounding: extract & chunk website/docs into indexable text

### DIFF
--- a/scripts/lib/extract-docs-corpus.mjs
+++ b/scripts/lib/extract-docs-corpus.mjs
@@ -1,0 +1,178 @@
+/**
+ * Extraction for the help-docs corpus (#1283, part of #1154's epic:docs-grounding).
+ *
+ * Turns the user-facing docs site (`website/docs/*.html`) into indexable text
+ * chunks — one per `<h2>` section, plus a preamble chunk (h1 + lede) per page —
+ * so the in-app assistant can ground "how do I…" answers in Minerva's real
+ * documentation instead of guessing from training-data priors about a product
+ * it's never seen.
+ *
+ * Every docs page shares one template (verified across all 76 pages): content
+ * lives entirely inside `<main class="docs-content">`, is headed by an `<h1>`
+ * + `<p class="lede">`, and is split into `<h2 id="...">` sections — chrome
+ * (`<nav>`, `<aside class="docs-nav">`, `<footer>`) lives outside `<main>` and
+ * is never touched by scoping extraction there. `.crumbs`/`.pager` are the two
+ * bits of navigation noise that live *inside* `<main>`, so those are removed
+ * explicitly. `.shot` screenshot-placeholder captions are also dropped: they
+ * mostly restate the surrounding prose ("Screenshot — X: a rendered note
+ * showing Y") in service of a not-yet-taken screenshot, so keeping them would
+ * dilute a chunk's embedding without adding real instructional content.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseHTML } from 'linkedom';
+
+const DEFAULT_MAX_CHARS = 1000;
+const NOISE_SELECTORS = ['.crumbs', '.pager', '.shot'];
+
+/**
+ * Extract indexable chunks from one docs page's HTML.
+ * Pure — no filesystem access — so it's directly unit-testable against fixtures.
+ *
+ * @param {string} html
+ * @param {string} sourcePage e.g. "notes-links.html"
+ * @param {{ maxChars?: number }} [opts]
+ * @returns {{ id: string, sourcePage: string, pageTitle: string, heading: string, text: string }[]}
+ */
+export function extractPageChunks(html, sourcePage, opts = {}) {
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  const { document } = parseHTML(html);
+  const main = document.querySelector('main.docs-content');
+  if (!main) return [];
+
+  for (const selector of NOISE_SELECTORS) {
+    main.querySelectorAll(selector).forEach((el) => el.remove());
+  }
+
+  const pageTitle = elementText(main.querySelector('h1'));
+
+  const chunks = [];
+  let heading = '';
+  let sectionId = null; // null while in the preamble (before the first h2)
+  let blocks = [];
+
+  const flush = () => {
+    const text = blocks.filter(Boolean).join('\n\n');
+    blocks = [];
+    if (!text) return;
+    const id = sectionId ? `${sourcePage}#${sectionId}` : sourcePage;
+    for (const piece of splitLong(text, maxChars)) {
+      chunks.push({ id, sourcePage, pageTitle, heading, text: piece });
+    }
+  };
+
+  for (const child of Array.from(main.children)) {
+    if (child.tagName === 'H1') continue; // captured separately as pageTitle
+    if (child.tagName === 'H2') {
+      flush();
+      heading = elementText(child);
+      sectionId = child.getAttribute('id') || slugify(heading);
+      continue;
+    }
+    blocks.push(...blockPieces(child));
+  }
+  flush();
+
+  return chunks;
+}
+
+/**
+ * Text piece(s) for one top-level content element. `.deflist`/`.doc-cards`
+ * containers and `<ul>`/`<ol>` lists are expanded into one piece per
+ * row/card/item — their natural paragraph-equivalent boundaries — rather than
+ * one opaque blob for the whole container. Otherwise a long list (e.g. a
+ * 12-row typed-link table, or a 14-card hub page) collapses into a single
+ * "paragraph" that `splitLong` can only hard-slice mid-word when it overflows
+ * `maxChars`, instead of packing whole rows/items up to the limit.
+ */
+function blockPieces(el) {
+  if (el.matches?.('.deflist')) {
+    return Array.from(el.querySelectorAll('.row')).map(joinChildren).filter(Boolean);
+  }
+  if (el.matches?.('.doc-cards')) {
+    return Array.from(el.querySelectorAll('.doc-card')).map(joinChildren).filter(Boolean);
+  }
+  if (el.tagName === 'UL' || el.tagName === 'OL') {
+    return Array.from(el.querySelectorAll('li')).map(elementText).filter(Boolean);
+  }
+  const text = elementText(el);
+  return text ? [text] : [];
+}
+
+/** Join a `.row`/`.doc-card`'s direct children (e.g. `.k`+`.v`, or `.icon`+
+ *  `h3`+`p`) with an explicit space. Adjacent block-level children with no
+ *  whitespace text node between them in the source (compact/minified markup)
+ *  would otherwise run together via plain `.textContent` — this doesn't
+ *  depend on incidental source formatting. */
+function joinChildren(el) {
+  return Array.from(el.children).map(elementText).filter(Boolean).join(' ');
+}
+
+/**
+ * Extract chunks from every `*.html` page in a docs directory (i.e.
+ * `website/docs`). Touches the filesystem — the I/O counterpart to
+ * {@link extractPageChunks}, used by the build-time embedding script.
+ *
+ * @param {string} docsDir
+ * @param {{ maxChars?: number }} [opts]
+ */
+export function extractDocsCorpus(docsDir, opts = {}) {
+  const files = fs.readdirSync(docsDir).filter((f) => f.endsWith('.html')).sort();
+  const chunks = [];
+  for (const file of files) {
+    const html = fs.readFileSync(path.join(docsDir, file), 'utf-8');
+    chunks.push(...extractPageChunks(html, file, opts));
+  }
+  return chunks;
+}
+
+function elementText(el) {
+  return (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Sub-split an over-long section on blank-line (paragraph) boundaries, packing
+ *  paragraphs up to `maxChars`. Mirrors `src/main/embeddings/chunk.ts`'s
+ *  `splitLong`, adapted for a text blob already joined with `\n\n` per
+ *  top-level block (a row/item/paragraph — see `blockPieces`) rather than
+ *  markdown lines. A single over-long paragraph is packed by sentence instead
+ *  of hard-sliced by character count, so a long lede/prose paragraph never
+ *  gets cut mid-word — only a single run-on *sentence* longer than `maxChars`
+ *  (essentially never, in hand-written docs prose) falls back to a raw slice. */
+function splitLong(text, maxChars) {
+  if (text.length <= maxChars) return [text];
+  const paras = text.split(/\n\n+/);
+  const out = [];
+  let buf = '';
+  const push = () => { if (buf) { out.push(buf); buf = ''; } };
+  const pack = (piece) => {
+    if (buf.length + piece.length + 1 > maxChars) push();
+    buf = buf ? `${buf} ${piece}` : piece;
+  };
+  for (const para of paras) {
+    if (para.length <= maxChars) {
+      if (buf.length + para.length + 2 > maxChars) push();
+      buf = buf ? `${buf}\n\n${para}` : para;
+      continue;
+    }
+    push();
+    for (const sentence of para.split(/(?<=[.!?])\s+/)) {
+      if (sentence.length > maxChars) {
+        push();
+        for (let i = 0; i < sentence.length; i += maxChars) out.push(sentence.slice(i, i + maxChars));
+        continue;
+      }
+      pack(sentence);
+    }
+    push();
+  }
+  push();
+  return out;
+}

--- a/tests/scripts/extract-docs-corpus.test.ts
+++ b/tests/scripts/extract-docs-corpus.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+// @ts-expect-error -- plain JS build-time module, no .d.ts
+import { extractPageChunks as extractPageChunksImpl, extractDocsCorpus as extractDocsCorpusImpl } from '../../scripts/lib/extract-docs-corpus.mjs';
+
+interface DocChunk {
+  id: string;
+  sourcePage: string;
+  pageTitle: string;
+  heading: string;
+  text: string;
+}
+
+const extractPageChunks = extractPageChunksImpl as (
+  html: string,
+  sourcePage: string,
+  opts?: { maxChars?: number },
+) => DocChunk[];
+const extractDocsCorpus = extractDocsCorpusImpl as (docsDir: string, opts?: { maxChars?: number }) => DocChunk[];
+
+const PAGE_SHELL = (main: string) => `<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body>
+<nav>Decoy nav content — should never appear in a chunk.</nav>
+<div class="docs">
+  <aside class="docs-nav">Decoy sidebar content — should never appear in a chunk.</aside>
+  <main class="docs-content">
+${main}
+  </main>
+</div>
+<footer>Decoy footer content — should never appear in a chunk.</footer>
+</body>
+</html>`;
+
+describe('extractPageChunks', () => {
+  it('captures the h1 + lede preamble as its own chunk with a bare page id', () => {
+    const html = PAGE_SHELL(`
+      <p class="crumbs">Decoy crumb — should never appear in a chunk.</p>
+      <h1>Widgets</h1>
+      <p class="lede">Widgets do the thing.</p>
+      <h2 id="basics">Basics</h2>
+      <p>Basic body.</p>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html');
+    const preamble = chunks.find((c: DocChunk) => c.id === 'widgets.html');
+    expect(preamble).toBeTruthy();
+    expect(preamble!.heading).toBe('');
+    expect(preamble!.pageTitle).toBe('Widgets');
+    expect(preamble!.text).toBe('Widgets do the thing.');
+  });
+
+  it('chunks each h2 section under a page.html#anchor id', () => {
+    const html = PAGE_SHELL(`
+      <h1>Widgets</h1>
+      <p class="lede">Lede.</p>
+      <h2 id="basics">Basics</h2>
+      <p>Basic body.</p>
+      <h2 id="advanced">Advanced</h2>
+      <p>Advanced body.</p>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html');
+    const ids = chunks.map((c: DocChunk) => c.id);
+    expect(ids).toEqual(['widgets.html', 'widgets.html#basics', 'widgets.html#advanced']);
+    expect(chunks[1].heading).toBe('Basics');
+    expect(chunks[1].text).toBe('Basic body.');
+    expect(chunks[2].heading).toBe('Advanced');
+    expect(chunks[2].text).toBe('Advanced body.');
+  });
+
+  it('falls back to a slugified id when an h2 has none', () => {
+    const html = PAGE_SHELL(`
+      <h1>Widgets</h1>
+      <p class="lede">Lede.</p>
+      <h2>No Id Here!</h2>
+      <p>Body.</p>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html');
+    expect(chunks[1].id).toBe('widgets.html#no-id-here');
+  });
+
+  it('expands a .deflist into one piece per row, not one opaque blob', () => {
+    const html = PAGE_SHELL(`
+      <h1>Widgets</h1>
+      <p class="lede">Lede.</p>
+      <h2 id="types">Types</h2>
+      <div class="deflist">
+        <div class="row"><div class="k">alpha</div><div class="v">The alpha type.</div></div>
+        <div class="row"><div class="k">beta</div><div class="v">The beta type.</div></div>
+      </div>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html');
+    const section = chunks.filter((c: DocChunk) => c.id === 'widgets.html#types');
+    // Both rows fit comfortably under maxChars, so they land in one chunk —
+    // but joined with a paragraph break, not flattened into one run-on string.
+    expect(section).toHaveLength(1);
+    expect(section[0].text).toContain('alpha The alpha type.');
+    expect(section[0].text).toContain('beta The beta type.');
+    expect(section[0].text).toMatch(/alpha The alpha type\.\n\nbeta The beta type\./);
+  });
+
+  it('expands .doc-cards and <ul>/<ol> into per-item pieces the same way', () => {
+    const html = PAGE_SHELL(`
+      <h1>Hub</h1>
+      <p class="lede">Lede.</p>
+      <h2 id="cards">Cards</h2>
+      <div class="doc-cards">
+        <a class="doc-card" href="a.html"><h3>A</h3><p>About A.</p></a>
+        <a class="doc-card" href="b.html"><h3>B</h3><p>About B.</p></a>
+      </div>
+      <h2 id="list">List</h2>
+      <ul>
+        <li>First gotcha.</li>
+        <li>Second gotcha.</li>
+      </ul>
+    `);
+    const chunks = extractPageChunks(html, 'hub.html');
+    const cards = chunks.find((c: DocChunk) => c.id === 'hub.html#cards')!;
+    expect(cards.text).toContain('A About A.');
+    expect(cards.text).toContain('B About B.');
+    const list = chunks.find((c: DocChunk) => c.id === 'hub.html#list')!;
+    expect(list.text).toBe('First gotcha.\n\nSecond gotcha.');
+  });
+
+  it('excludes nav/aside/footer chrome and in-main .crumbs/.pager/.shot noise', () => {
+    const html = PAGE_SHELL(`
+      <p class="crumbs">Decoy crumb — should never appear in a chunk.</p>
+      <h1>Widgets</h1>
+      <p class="lede">Lede.</p>
+      <h2 id="basics">Basics</h2>
+      <p>Real body text.</p>
+      <div class="shot wide">
+        <div class="icon">🔧</div>
+        <div class="k">Screenshot — Basics</div>
+        <div class="d">Decoy screenshot caption — should never appear in a chunk.</div>
+      </div>
+      <div class="pager">Decoy pager — should never appear in a chunk.</div>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html');
+    const allText = chunks.map((c: DocChunk) => c.text).join(' ');
+    expect(allText).toContain('Real body text.');
+    for (const decoy of ['Decoy nav', 'Decoy sidebar', 'Decoy footer', 'Decoy crumb', 'Decoy screenshot caption', 'Decoy pager']) {
+      expect(allText).not.toContain(decoy);
+    }
+  });
+
+  it('returns no chunks for a page with no main.docs-content (defensive)', () => {
+    expect(extractPageChunks('<html><body>no main here</body></html>', 'weird.html')).toEqual([]);
+  });
+
+  it('splits an over-long section by packing whole rows/sentences, never mid-word', () => {
+    const rows = Array.from({ length: 20 }, (_, i) =>
+      `<div class="row"><div class="k">type-${i}</div><div class="v">A fairly descriptive explanation of type number ${i} and what it is used for in practice, written out at reasonable length.</div></div>`,
+    ).join('\n');
+    const html = PAGE_SHELL(`
+      <h1>Widgets</h1>
+      <p class="lede">Lede.</p>
+      <h2 id="types">Types</h2>
+      <div class="deflist">${rows}</div>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html', { maxChars: 300 });
+    const section = chunks.filter((c: DocChunk) => c.id === 'widgets.html#types');
+    expect(section.length).toBeGreaterThan(1);
+    for (const chunk of section) {
+      expect(chunk.text.length).toBeLessThanOrEqual(300);
+      // No hard mid-word cut: every piece boundary should read as one or more
+      // complete "key value" rows, never truncated mid-token.
+      expect(chunk.text.trim()).toMatch(/^type-\d+ .*[.]$/s);
+    }
+  });
+
+  it('hard-slices only as a last resort, for a single sentence longer than maxChars', () => {
+    const longSentence = 'x'.repeat(50) + ' word '.repeat(50) + 'end.';
+    // The extractor collapses whitespace the same way the browser's own
+    // `.textContent` reads it, so the expected value is normalized the same
+    // way rather than compared against the raw double-spaced input literal.
+    const normalized = longSentence.replace(/\s+/g, ' ').trim();
+    const html = PAGE_SHELL(`
+      <h1>Widgets</h1>
+      <p class="lede">Lede.</p>
+      <h2 id="basics">Basics</h2>
+      <p>${longSentence}</p>
+    `);
+    const chunks = extractPageChunks(html, 'widgets.html', { maxChars: 50 });
+    const section = chunks.filter((c: DocChunk) => c.id === 'widgets.html#basics');
+    expect(section.length).toBeGreaterThan(1);
+    // Reassembling the pieces recovers the original text losslessly.
+    expect(section.map((c: DocChunk) => c.text).join('')).toBe(normalized);
+  });
+});
+
+describe('extractDocsCorpus', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-corpus-test-'));
+    fs.writeFileSync(
+      path.join(dir, 'a.html'),
+      PAGE_SHELL('<h1>A</h1><p class="lede">Lede A.</p><h2 id="x">X</h2><p>Body A.</p>'),
+    );
+    fs.writeFileSync(
+      path.join(dir, 'b.html'),
+      PAGE_SHELL('<h1>B</h1><p class="lede">Lede B.</p><h2 id="y">Y</h2><p>Body B.</p>'),
+    );
+    // A non-html file must be ignored.
+    fs.writeFileSync(path.join(dir, 'docs.css'), 'body { color: red; }');
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('aggregates chunks across every html page, ignoring non-html files', () => {
+    const chunks = extractDocsCorpus(dir);
+    const sourcePages = [...new Set(chunks.map((c: DocChunk) => c.sourcePage))].sort();
+    expect(sourcePages).toEqual(['a.html', 'b.html']);
+    expect(chunks.some((c: DocChunk) => c.text === 'Lede A.')).toBe(true);
+    expect(chunks.some((c: DocChunk) => c.text === 'Lede B.')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- First stage of epic:docs-grounding (#1154): a pure extraction module (`scripts/lib/extract-docs-corpus.mjs`) that turns `website/docs/*.html` into text chunks ready for embedding — one chunk per `<h2>` section (`id: page.html#anchor`), plus a preamble chunk (h1 + lede, `id: page.html`) per page.
- Closes #1283.
- Audited all 76 docs pages first, per the note that we control this markup: every page already has `<main class="docs-content">`, every `<h2>` already has a stable, non-duplicated `id`, and `.shot`/`.crumbs`/`.pager`/`.deflist`/`.doc-cards` are used consistently everywhere — so **no docs-page changes were needed**, only extraction-side handling of the existing structure. `.shot` captions are dropped (mostly-redundant screenshot-placeholder text); `.crumbs`/`.pager` are stripped as in-main navigation noise.
- Found and fixed two real chunking bugs against the actual corpus, not just the unit tests:
  - A naive whole-container `.textContent` flatten on `.deflist`/`.doc-cards`/`<ul>`/`<ol>` produced hard mid-word slices once a list-heavy section exceeded the 1000-char cap (e.g. `notes-links.html`'s 12-row typed-link table splitting mid-word inside "knowledge-base file. quote Quotes"). Fixed by exploding each container into its natural row/card/item pieces before packing, and packing the fallback overflow path by sentence rather than raw character count.
  - Adjacent block-level elements with no whitespace text node between them in the source would run together without a separator (an incidental-formatting dependency). Fixed by explicitly space-joining a row/card's direct children.
- Verified against the full real corpus in addition to the unit tests: 76 pages → 501 chunks, max chunk length 998, zero remaining hard-slices.

## Test plan
- [x] `pnpm lint` passes (verified via pre-push hook)
- [x] New unit tests (`tests/scripts/extract-docs-corpus.test.ts`, 10 cases) cover preamble chunking, per-section ids, deflist/doc-cards/list expansion, chrome exclusion, id-fallback slugification, long-section splitting (row-packing and sentence-fallback), and the filesystem-aggregation wrapper
- [x] Manually ran extraction against the real `website/docs/` corpus and inspected output for clean boundaries (no hard mid-word slices)