### PR TITLE
Add runtime search over the help-docs corpus (#1285)

### DIFF
--- a/src/main/help-docs/corpus-store.ts
+++ b/src/main/help-docs/corpus-store.ts
@@ -1,0 +1,82 @@
+/**
+ * Loads the precomputed help-docs corpus (#1285, epic:docs-grounding, #1154).
+ *
+ * The corpus is a static, project-independent asset built ahead of time by
+ * `scripts/build-help-corpus.mjs` (#1284) into `resources/help-docs/corpus.json`
+ * — one process-global load, cached for the app's lifetime, mirroring
+ * `shared-embedder.ts`'s singleton and its dev/packaged path resolution.
+ */
+
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { MODEL } from '../embeddings/embedder';
+
+export interface HelpDocChunk {
+  id: string;
+  sourcePage: string;
+  pageTitle: string;
+  heading: string;
+  text: string;
+  vector: number[];
+}
+
+interface CorpusFile {
+  model: string;
+  dim: number;
+  generatedAt: string;
+  chunks: HelpDocChunk[];
+}
+
+let cached: HelpDocChunk[] | null = null;
+
+function corpusPath(resourcesBaseOverride?: string): string {
+  const resourcesBase = resourcesBaseOverride ?? (app?.isPackaged
+    ? path.join(process.resourcesPath, 'resources')
+    : path.join(process.cwd(), 'resources'));
+  return path.join(resourcesBase, 'help-docs', 'corpus.json');
+}
+
+/**
+ * Load (and cache) the help-docs corpus. Returns `[]` — never throws — if the
+ * file is missing (not yet built, e.g. a fresh checkout before `pnpm predev`
+ * has run) or was built against a different embedding model than the one this
+ * build of the app ships (a model upgrade would otherwise silently compare
+ * vectors from two incompatible embedding spaces).
+ */
+export function getHelpDocsCorpus(resourcesBaseOverride?: string): HelpDocChunk[] {
+  if (cached) return cached;
+
+  const file = corpusPath(resourcesBaseOverride);
+  if (!fs.existsSync(file)) {
+    console.warn(`[help-docs] corpus not found at ${file} — run "pnpm fetch:help-corpus"`);
+    cached = [];
+    return cached;
+  }
+
+  let parsed: CorpusFile;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as CorpusFile;
+  } catch (err) {
+    console.warn(`[help-docs] corpus at ${file} is not valid JSON — ignoring: ${(err as Error).message}`);
+    cached = [];
+    return cached;
+  }
+
+  if (parsed.model !== MODEL.name || parsed.dim !== MODEL.dim) {
+    console.warn(
+      `[help-docs] corpus was built with model "${parsed.model}" (dim ${parsed.dim}), ` +
+      `but this app ships "${MODEL.name}" (dim ${MODEL.dim}) — ignoring stale corpus`,
+    );
+    cached = [];
+    return cached;
+  }
+
+  cached = parsed.chunks;
+  return cached;
+}
+
+/** Test-only: force the next `getHelpDocsCorpus()` call to reload from disk. */
+export function resetHelpDocsCorpusCache(): void {
+  cached = null;
+}

--- a/src/main/help-docs/search.ts
+++ b/src/main/help-docs/search.ts
@@ -1,0 +1,77 @@
+/**
+ * Similarity search over the help-docs corpus (#1285, epic:docs-grounding, #1154).
+ *
+ * Embeds the query with the same process-global embedder singleton the
+ * thoughtbase's own semantic search uses (`shared-embedder.ts` — no second
+ * model load) unless a caller injects its own (tests: the shared singleton is
+ * worker-thread-backed and needs a built `embed-worker.js`, so tests pass a
+ * directly-instantiated `createWasmEmbedder()` instead — same pattern as
+ * `cli/engine.ts`'s `opts.embedder ?? getSharedEmbedder(...)`). Then
+ * brute-force cosine-ranks it against the corpus loaded by `corpus-store.ts`.
+ * Brute force is deliberate: at ~500 chunks (~230-460 KB of vectors) this is
+ * sub-millisecond, and simpler than a second DuckDB instance for a corpus this
+ * small, static, and read-only.
+ *
+ * `weakMatch` is the honest-degrade signal #1154 is actually about: a search
+ * with no confidence signal (like `search-related.ts`'s tool) lets a bad
+ * match get presented as if it were a good one. Here, the caller still gets
+ * the closest hit(s) even when `weakMatch` is true — the point isn't to
+ * withhold results, it's to tell the caller (ultimately the model) that they
+ * shouldn't be trusted as a confident answer.
+ */
+
+import { getSharedEmbedder } from '../embeddings/shared-embedder';
+import type { EmbedderService } from '../embeddings/embedder-service';
+import { cosineSimilarity } from '../embeddings/pooling';
+import { getHelpDocsCorpus } from './corpus-store';
+
+export interface HelpHit {
+  id: string;
+  sourcePage: string;
+  pageTitle: string;
+  heading: string;
+  text: string;
+  score: number;
+}
+
+export interface HelpSearchResult {
+  hits: HelpHit[];
+  weakMatch: boolean;
+}
+
+/**
+ * Cosine-similarity floor below which even the best hit shouldn't be
+ * presented as a confident answer. A starting estimate (not yet tuned
+ * against real query traffic against the real corpus — see #1287): a quick
+ * manual check found genuinely out-of-scope queries scoring ~0.29-0.32
+ * against this corpus, and genuinely in-scope ones ~0.43-0.63, so 0.35 sits
+ * in the gap between them.
+ */
+export const WEAK_MATCH_THRESHOLD = 0.35;
+
+export async function searchHelpDocs(
+  query: string,
+  topK = 5,
+  embedder: Pick<EmbedderService, 'embed'> = getSharedEmbedder(),
+): Promise<HelpSearchResult> {
+  const corpus = getHelpDocsCorpus();
+  if (corpus.length === 0) return { hits: [], weakMatch: true };
+
+  const [queryVector] = await embedder.embed([query]);
+  if (!queryVector) return { hits: [], weakMatch: true };
+
+  const hits: HelpHit[] = corpus
+    .map((c) => ({
+      id: c.id,
+      sourcePage: c.sourcePage,
+      pageTitle: c.pageTitle,
+      heading: c.heading,
+      text: c.text,
+      score: cosineSimilarity(queryVector, c.vector),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK);
+
+  const weakMatch = hits.length === 0 || hits[0]!.score < WEAK_MATCH_THRESHOLD;
+  return { hits, weakMatch };
+}

--- a/tests/main/help-docs/corpus-store.test.ts
+++ b/tests/main/help-docs/corpus-store.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getHelpDocsCorpus, resetHelpDocsCorpusCache } from '../../../src/main/help-docs/corpus-store';
+import { MODEL } from '../../../src/main/embeddings/embedder';
+
+let dir: string;
+
+function writeCorpus(contents: unknown): void {
+  fs.mkdirSync(path.join(dir, 'help-docs'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'help-docs', 'corpus.json'),
+    typeof contents === 'string' ? contents : JSON.stringify(contents),
+  );
+}
+
+const chunk = (id: string) => ({
+  id,
+  sourcePage: 'notes.html',
+  pageTitle: 'Notes',
+  heading: 'Overview',
+  text: 'Some help text.',
+  vector: [0, 0, 0],
+});
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-help-docs-'));
+  resetHelpDocsCorpusCache();
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  resetHelpDocsCorpusCache();
+});
+
+describe('corpus-store', () => {
+  it('loads a valid corpus matching the shipped embedding model', () => {
+    writeCorpus({
+      model: MODEL.name,
+      dim: MODEL.dim,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      chunks: [chunk('notes.html'), chunk('notes.html#links')],
+    });
+
+    const chunks = getHelpDocsCorpus(dir);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]!.id).toBe('notes.html');
+  });
+
+  it('returns [] without throwing when the corpus file is missing', () => {
+    expect(getHelpDocsCorpus(dir)).toEqual([]);
+  });
+
+  it('returns [] without throwing when the corpus file is malformed JSON', () => {
+    writeCorpus('{ not valid json');
+    expect(getHelpDocsCorpus(dir)).toEqual([]);
+  });
+
+  it('returns [] and ignores a corpus built against a different embedding model', () => {
+    writeCorpus({
+      model: 'some-other-model',
+      dim: 123,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      chunks: [chunk('notes.html')],
+    });
+
+    expect(getHelpDocsCorpus(dir)).toEqual([]);
+  });
+
+  it('caches the loaded corpus across calls until reset', () => {
+    writeCorpus({
+      model: MODEL.name,
+      dim: MODEL.dim,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      chunks: [chunk('notes.html')],
+    });
+
+    expect(getHelpDocsCorpus(dir)).toHaveLength(1);
+
+    // Overwriting the file on disk shouldn't matter — the cache should win.
+    writeCorpus({
+      model: MODEL.name,
+      dim: MODEL.dim,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      chunks: [chunk('notes.html'), chunk('notes.html#links')],
+    });
+    expect(getHelpDocsCorpus(dir)).toHaveLength(1);
+
+    resetHelpDocsCorpusCache();
+    expect(getHelpDocsCorpus(dir)).toHaveLength(2);
+  });
+});

--- a/tests/main/help-docs/search.test.ts
+++ b/tests/main/help-docs/search.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getHelpDocsCorpus, resetHelpDocsCorpusCache } from '../../../src/main/help-docs/corpus-store';
+import { modelDir, MODEL } from '../../../src/main/embeddings/embedder';
+import type { Embedder } from '../../../src/main/embeddings/embedder';
+
+describe('searchHelpDocs (no corpus)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-help-search-empty-'));
+    resetHelpDocsCorpusCache();
+    // Prime the module-level cache to [] via the override, so searchHelpDocs's
+    // own no-args getHelpDocsCorpus() call (it never threads an override
+    // through) hits this cached empty result instead of falling through to
+    // whatever real corpus.json happens to exist in this checkout's
+    // resources/help-docs/ (e.g. already built by `pnpm fetch:help-corpus`).
+    getHelpDocsCorpus(dir);
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    resetHelpDocsCorpusCache();
+  });
+
+  it('honestly degrades — empty hits, weakMatch true — without touching the embedder', async () => {
+    const { searchHelpDocs } = await import('../../../src/main/help-docs/search');
+    // No embedder is passed and none is stubbed — if the empty-corpus
+    // short-circuit didn't fire, this would throw trying to spawn the
+    // worker-backed shared embedder (no built embed-worker.js under vitest).
+    const result = await searchHelpDocs('how do I make a link', 5);
+    expect(result).toEqual({ hits: [], weakMatch: true });
+  });
+});
+
+// Real model inference — needs the bundled weights staged by
+// scripts/fetch-embedding-model.mjs. Skip (don't fail) when they're absent so a
+// no-network checkout still passes the rest of the suite.
+const haveModel = fs.existsSync(path.join(modelDir(), 'onnx', 'model_quantized.onnx'));
+const d = haveModel ? describe : describe.skip;
+
+d('searchHelpDocs (real embedder, synthetic corpus)', () => {
+  let corpusDir: string;
+  let embedder: Embedder;
+
+  beforeAll(async () => {
+    corpusDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-help-search-synth-'));
+
+    const { createWasmEmbedder } = await import('../../../src/main/embeddings/wasm-embedder');
+    embedder = await createWasmEmbedder();
+
+    const texts = [
+      'Link a note to another with [[wikilink]] syntax to connect related ideas.',
+      'The graph view shows notes as nodes and links as edges between them.',
+      'Quarterly revenue and earnings reports exceeded analyst forecasts.',
+    ];
+    const vectors = await embedder.embed(texts);
+    fs.mkdirSync(path.join(corpusDir, 'help-docs'), { recursive: true });
+    fs.writeFileSync(
+      path.join(corpusDir, 'help-docs', 'corpus.json'),
+      JSON.stringify({
+        model: MODEL.name,
+        dim: MODEL.dim,
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        chunks: [
+          { id: 'notes-links.html', sourcePage: 'notes-links.html', pageTitle: 'Links', heading: 'Linking notes', text: texts[0], vector: Array.from(vectors[0]!) },
+          { id: 'navigation-graph.html', sourcePage: 'navigation-graph.html', pageTitle: 'Graph view', heading: 'Graph view', text: texts[1], vector: Array.from(vectors[1]!) },
+          { id: 'unrelated.html', sourcePage: 'unrelated.html', pageTitle: 'Unrelated', heading: 'Unrelated', text: texts[2], vector: Array.from(vectors[2]!) },
+        ],
+      }),
+    );
+  }, 60_000);
+  afterAll(async () => {
+    await embedder?.dispose();
+    fs.rmSync(corpusDir, { recursive: true, force: true });
+    resetHelpDocsCorpusCache();
+  });
+
+  // searchHelpDocs() calls getHelpDocsCorpus() with no override, relying on the
+  // module cache — re-prime it before every test in this block, since other
+  // test files (and the "no corpus" block above) reset/repopulate that same
+  // process-wide cache.
+  beforeEach(() => {
+    resetHelpDocsCorpusCache();
+    getHelpDocsCorpus(corpusDir);
+  });
+
+  it('ranks the semantically closest chunk first, with a confident (non-weak) match', async () => {
+    const { searchHelpDocs } = await import('../../../src/main/help-docs/search');
+    const { hits, weakMatch } = await searchHelpDocs('how do I link one note to another?', 2, embedder);
+
+    expect(hits).toHaveLength(2);
+    expect(hits[0]!.id).toBe('notes-links.html');
+    expect(hits[0]!.score).toBeGreaterThan(hits[1]!.score);
+    expect(weakMatch).toBe(false);
+  });
+
+  it('flags weakMatch when the closest hit still scores below the threshold', async () => {
+    const { searchHelpDocs, WEAK_MATCH_THRESHOLD } = await import('../../../src/main/help-docs/search');
+    const { hits, weakMatch } = await searchHelpDocs('what is the boiling point of tungsten?', 1, embedder);
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBeLessThan(WEAK_MATCH_THRESHOLD);
+    expect(weakMatch).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/main/help-docs/corpus-store.ts` — lazy-loaded, process-global cache for `resources/help-docs/corpus.json` (#1284), rejecting a corpus built against a different embedding model than the one this build ships.
- Adds `src/main/help-docs/search.ts` — `searchHelpDocs(query, topK?, embedder?)` brute-force cosine-ranks a query against the loaded corpus, returning `{hits, weakMatch}`. `weakMatch` fires when even the best hit scores below `WEAK_MATCH_THRESHOLD` (0.35, a starting estimate — real tuning deferred to #1287) — the honest-degrade signal #1154 needs, still returning the closest hit(s) so a caller can present them as an unconfident guess rather than nothing.
- `searchHelpDocs` accepts an optional injectable embedder (default: the process-wide `getSharedEmbedder()` singleton), mirroring the existing `opts.embedder ?? getSharedEmbedder(...)` idiom in `src/cli/engine.ts` — needed because the shared singleton is worker-thread-backed and requires a built `embed-worker.js`, unavailable under vitest (same reason `embedder-service.test.ts` only covers its non-spawning plumbing).

Part of epic #1154 (`epic:docs-grounding`). Closes #1285.

## Test plan
- [x] `npx vitest run tests/main/help-docs/` — 8 new tests (corpus-store: valid load, missing file, malformed JSON, model/dim mismatch, caching; search: no-corpus short-circuit without touching the embedder, real-embedder ranking + weakMatch true/false against a synthetic corpus) — all passing
- [x] Full suite: `pnpm test` — 430 files / 4061 tests passing
- [x] `pnpm lint` — clean
- [x] Manual end-to-end sanity check against the real built corpus: an in-scope query ("how do I make a link that says this note supports another one?") scored 0.57 (non-weak); a genuinely out-of-scope query scored 0.15 (weakMatch: true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)