### PR TITLE
Add search_help tool over the docs corpus (#1286)

### DIFF
--- a/src/main/llm/tools/registry.ts
+++ b/src/main/llm/tools/registry.ts
@@ -4,6 +4,7 @@ import type { NotebaseTool, ToolContext, ToolCallbacks, ToolResult } from './typ
 import { searchNotes } from './search-notes';
 import { readNote } from './read-note';
 import { searchRelated } from './search-related';
+import { searchHelp } from './search-help';
 import { queryGraph } from './query-graph';
 import { listNotes } from './list-notes';
 import { proposeNoteRename } from './propose-note-rename';
@@ -31,6 +32,7 @@ const DEFAULT_TOOLS: NotebaseTool[] = [
   searchNotes,
   readNote,
   searchRelated,
+  searchHelp,
   queryGraph,
   listNotes,
   proposeNoteRename,

--- a/src/main/llm/tools/search-help.ts
+++ b/src/main/llm/tools/search-help.ts
@@ -1,0 +1,61 @@
+import { searchHelpDocs, WEAK_MATCH_THRESHOLD } from '../../help-docs/search';
+import type { HelpHit } from '../../help-docs/search';
+import type { NotebaseTool } from './types';
+
+async function runSearchHelp(input: unknown): Promise<string> {
+  const { query, limit } = input as { query?: string; limit?: number };
+  if (typeof query !== 'string' || !query.trim()) {
+    throw new Error('query is required');
+  }
+  const n = Math.min(Math.max(Math.floor(limit ?? 5), 1), 20);
+  const { hits, weakMatch } = await searchHelpDocs(query.trim(), n);
+
+  if (hits.length === 0) {
+    return `No help docs are available (the corpus has not been built for this checkout).`;
+  }
+
+  const body = hits.map((h: HelpHit, i: number) => {
+    const snippet = h.text.replace(/\s+/g, ' ').trim().slice(0, 400);
+    return `${i + 1}. ${h.pageTitle} > ${h.heading} (${h.sourcePage}, similarity ${h.score.toFixed(2)})\n   ${snippet}`;
+  }).join('\n');
+
+  if (!weakMatch) return body;
+  return (
+    `WEAK MATCH — the closest result still scored below the confidence threshold ` +
+    `(${WEAK_MATCH_THRESHOLD}). The docs may not actually describe this; say so plainly ` +
+    `rather than presenting the result below as a confident answer.\n${body}`
+  );
+}
+
+export const searchHelp: NotebaseTool = {
+  definition: {
+    name: 'search_help',
+    description:
+      'Semantic search over Minerva\'s own user-facing documentation ' +
+      '(website/docs) — the actual product, not general knowledge about ' +
+      'markdown apps. Call this before answering any "how do I…" or "what ' +
+      'does X do in Minerva" question, since training data has never seen ' +
+      'this specific app and can be confidently wrong. Each result names the ' +
+      'source page, section, and a similarity score; a WEAK MATCH prefix means ' +
+      'the docs likely don\'t cover this — say so instead of falling back to ' +
+      'general knowledge. Use search_notes/search_related for the user\'s own ' +
+      'notes, not this tool.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Free-text description of what to find, matched by meaning.',
+        },
+        limit: {
+          type: 'integer',
+          description: 'Maximum number of results to return. Defaults to 5.',
+          minimum: 1,
+          maximum: 20,
+        },
+      },
+      required: ['query'],
+    },
+  },
+  run: async (_ctx, input) => ({ content: await runSearchHelp(input), isError: false }),
+};

--- a/src/main/llm/tools/search-related.ts
+++ b/src/main/llm/tools/search-related.ts
@@ -88,7 +88,8 @@ export const searchRelated: NotebaseTool = {
       'Choosing among the search tools: use search_related for "find things ' +
       'like / about this" by meaning; use search_notes for exact keywords or ' +
       'phrases; use query_graph for structural questions (links, tags, types, ' +
-      'claims). They complement each other — combine when unsure.',
+      'claims); use search_help for questions about Minerva itself rather than ' +
+      'the user\'s own thoughtbase. They complement each other — combine when unsure.',
     input_schema: {
       type: 'object',
       properties: {

--- a/tests/main/llm/search-help-tool.test.ts
+++ b/tests/main/llm/search-help-tool.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HelpSearchResult } from '../../../src/main/help-docs/search';
+
+// The search/rank/weakMatch logic itself is exercised (with a real embedder)
+// by tests/main/help-docs/search.test.ts. Here we isolate the tool's own
+// responsibility — input validation, result formatting, and the WEAK MATCH
+// prefix — from searchHelpDocs, which needs a corpus + embedder and would
+// otherwise force these tests to touch the model.
+const searchHelpDocsMock = vi.fn<(query: string, limit?: number) => Promise<HelpSearchResult>>();
+vi.mock('../../../src/main/help-docs/search', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/main/help-docs/search')>(
+    '../../../src/main/help-docs/search',
+  );
+  return { ...actual, searchHelpDocs: (query: string, limit?: number) => searchHelpDocsMock(query, limit) };
+});
+
+import { executeNotebaseTool } from '../../../src/main/llm/tools';
+
+const hit = (id: string, score: number) => ({
+  id, sourcePage: id, pageTitle: id, heading: 'Overview', text: `Help text for ${id}.`, score,
+});
+
+describe('search_help tool (#1286)', () => {
+  beforeEach(() => { searchHelpDocsMock.mockReset(); });
+
+  it('errors when query is missing', async () => {
+    const out = await executeNotebaseTool({ rootPath: '/irrelevant' }, 'search_help', {});
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/query/);
+    expect(searchHelpDocsMock).not.toHaveBeenCalled();
+  });
+
+  it('reports plainly when no corpus is available', async () => {
+    searchHelpDocsMock.mockResolvedValue({ hits: [], weakMatch: true });
+    const out = await executeNotebaseTool({ rootPath: '/irrelevant' }, 'search_help', { query: 'anything' });
+    expect(out.isError).toBe(false);
+    expect(out.content).toMatch(/no help docs|not available/i);
+  });
+
+  it('returns ranked hits with page, heading, and similarity score, passing the limit through', async () => {
+    searchHelpDocsMock.mockResolvedValue({
+      hits: [hit('notes-links.html', 0.62), hit('finance.html', 0.4)],
+      weakMatch: false,
+    });
+    const out = await executeNotebaseTool({ rootPath: '/irrelevant' }, 'search_help', {
+      query: 'wikilink syntax note',
+      limit: 2,
+    });
+    expect(out.isError).toBe(false);
+    expect(searchHelpDocsMock).toHaveBeenCalledWith('wikilink syntax note', 2);
+    expect(out.content).toContain('notes-links.html');
+    expect(out.content).toMatch(/similarity 0\.62/);
+    expect(out.content.indexOf('notes-links.html')).toBeLessThan(out.content.indexOf('finance.html'));
+    expect(out.content).not.toMatch(/^WEAK MATCH/);
+  });
+
+  it('prefixes a WEAK MATCH warning when the closest hit is below the confidence threshold', async () => {
+    searchHelpDocsMock.mockResolvedValue({ hits: [hit('unrelated.html', 0.15)], weakMatch: true });
+    const out = await executeNotebaseTool({ rootPath: '/irrelevant' }, 'search_help', {
+      query: 'the boiling point of tungsten',
+    });
+    expect(out.isError).toBe(false);
+    expect(out.content).toMatch(/^WEAK MATCH/);
+    expect(out.content).toContain('unrelated.html');
+  });
+
+  it('clamps limit to the 1-20 range', async () => {
+    searchHelpDocsMock.mockResolvedValue({ hits: [], weakMatch: true });
+    await executeNotebaseTool({ rootPath: '/irrelevant' }, 'search_help', { query: 'x', limit: 999 });
+    expect(searchHelpDocsMock).toHaveBeenCalledWith('x', 20);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/main/llm/tools/search-help.ts` — the `search_help` conversation tool, modeled on `search-notes.ts`/`search-related.ts`. Validates `query`, clamps `limit` to 1-20, calls `searchHelpDocs` (#1285), and formats hits as `page > heading (sourcePage, similarity N.NN)` with a snippet. When `weakMatch` is true, prefixes the response with a `WEAK MATCH` warning naming the confidence threshold, so the model can't just quietly present a bad match as good.
- Registers it in `DEFAULT_TOOLS` (`registry.ts`), alongside `search_notes`/`search_related`/`query_graph`.
- Updates `search_related`'s own "choosing among the search tools" guidance to mention `search_help`, keeping the triad's tool descriptions internally consistent.
- No `TOOL_CALLBACK_KEYS` change needed — it's a pure read tool with no draft/callback.

Part of epic #1154 (`epic:docs-grounding`). Closes #1286. System-prompt guidance that actually tells the model to call this tool proactively (and to admit when the docs don't cover something) is #1287, not this PR.

## Test plan
- [x] `tests/main/llm/search-help-tool.test.ts` (5 new tests) — mocks `searchHelpDocs` to isolate the tool's own responsibility (validation, formatting, WEAK MATCH prefix, limit clamping) from the ranking/embedding logic already covered by #1285's test suite
- [x] Full suite: `pnpm test` — 431 files / 4066 tests passing
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)