### PR TITLE
Wire up website download/GitHub/Releases/License links; add MIT license

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@
 # exercised by CI (a maker regression stayed invisible until release day), and
 # there was no tag→downloadable-build flow.
 #
+# Also uploads a stable-named DMG copy (Minerva-mac-arm64.dmg, no version in the
+# name) alongside the version-stamped original, so the website's download button
+# can link to a URL that never changes across releases (see "Collect artifacts").
+#
 # Signing + notarization (#959): when the Apple secrets below are configured,
 # the "Prepare macOS signing" step imports the Developer ID cert into a throwaway
 # keychain and exports the App Store Connect API-key env vars, so forge.config.ts
@@ -121,6 +125,18 @@ jobs:
         run: |
           mkdir -p dist-artifacts
           find out/make -type f \( -name '*.dmg' -o -name '*.zip' \) -exec cp {} dist-artifacts/ \;
+
+          # Stable-named copy of the DMG (#1300-adjacent: website download link),
+          # alongside the version-stamped original. The versioned name changes
+          # every release, so the website can't link to it directly — this fixed
+          # name lets it link to a URL that never changes:
+          #   .../releases/latest/download/Minerva-mac-arm64.dmg
+          # which GitHub always redirects to whatever's currently published.
+          dmg="$(find dist-artifacts -maxdepth 1 -name '*.dmg' | head -n1)"
+          if [ -n "$dmg" ]; then
+            cp "$dmg" dist-artifacts/Minerva-mac-arm64.dmg
+          fi
+
           echo "Collected:"
           ls -la dist-artifacts
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dave Griffith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -203,4 +203,4 @@ src/
 
 ## License
 
-Private — not yet licensed for distribution.
+MIT — see [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "minerva",
   "version": "0.1.2",
   "private": true,
+  "license": "MIT",
   "engines": {
     "node": ">=24"
   },

--- a/website/about.html
+++ b/website/about.html
@@ -126,7 +126,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/features.html
+++ b/website/features.html
@@ -401,7 +401,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -51,7 +51,7 @@
       <a href="getting-started.html" class="active hide-sm">Getting Started</a>
       <a href="about.html" class="hide-sm">About</a>
       <a href="privacy.html" class="hide-sm">Privacy</a>
-      <a href="#" class="navcta">Download</a>
+      <a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg" class="navcta">Download</a>
     </div>
   </div>
 </nav>
@@ -70,7 +70,7 @@
     <p class="lede">Minerva doesn't drop you in front of a blank page. Tell it what you want to think about, and it builds you a starting structure to grow from.</p>
 
     <div class="steps">
-      <div class="step"><div class="n"></div><div><h3>Install and open</h3><p><a href="#"><b>Download Minerva for macOS</b></a> — or <a href="#">build it from source</a>. Drag it to Applications and launch. No account, no sign-up, no cloud; it runs entirely on your machine. The app is signed and notarized by Apple, so it opens without security warnings.</p></div></div>
+      <div class="step"><div class="n"></div><div><h3>Install and open</h3><p><a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg"><b>Download Minerva for macOS (Apple Silicon)</b></a> — or <a href="#">build it from source</a>. Drag it to Applications and launch. No account, no sign-up, no cloud; it runs entirely on your machine. The app is signed and notarized by Apple, so it opens without security warnings.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Tell it what you're exploring</h3><p>The opening wizard asks what you want to build a thoughtbase <em>of</em>, who it's for, and how deep to go. A research topic, a book you're studying, a decision you're working through — anything.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Get a starting map, not a blank page</h3><p>Minerva generates an overview set of linked notes to orient you — the antidote to the blank canvas. Every note is yours to keep, rewrite, or delete.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Think, and let it hold the structure</h3><p>Write, ask, link, cite. When the AI suggests a claim or a source, you review and approve it. Your thoughtbase grows into a real map of what you know — and it's plain files on your disk the whole time.</p></div></div>
@@ -103,9 +103,9 @@
       <div class="note">A local-first desktop workspace for thinking with AI.</div>
     </div>
     <div class="cols">
-      <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="#">Download</a></div>
+      <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -209,9 +209,9 @@
       </div>
       <div class="col">
         <h4>Source</h4>
-        <a href="#">GitHub</a>
-        <a href="#">Releases</a>
-        <a href="#">License</a>
+        <a href="https://github.com/dgriffith/ide-for-thought">GitHub</a>
+        <a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a>
+        <a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a>
       </div>
     </div>
   </div>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -102,7 +102,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- The website's Download, GitHub, Releases, and License links were all `href="#"` stubs, never wired up after the signing/notarization/auto-update pipeline (epic #958) shipped real signed builds.
- `release.yml` now also uploads a stable-named DMG copy (`Minerva-mac-arm64.dmg`, no version in the name) alongside the version-stamped original, so the website can link to `.../releases/latest/download/Minerva-mac-arm64.dmg` — a URL that never changes across releases, no client-side JS/API calls needed. Backfilled onto the existing `v0.1.2` release (verified: same SHA-256 as the original, and the stable URL 302s correctly) so the link works today instead of only from the next tagged release onward.
- Wires the Download button/nav-CTA/footer link on `getting-started.html` to that URL, labeled "Apple Silicon" since x64/universal is deliberately out of scope for now (#962).
- Wires the footer GitHub/Releases links across all five marketing pages to the real repo/releases URLs.
- Adds an MIT `LICENSE`, `"license": "MIT"` in `package.json`, and wires the footer License links to it. Updates `README.md`'s License section, which previously read "Private — not yet licensed for distribution."

## Test plan
- [x] Validated `release.yml` YAML syntax (Ruby's YAML parser) and bash-syntax-checked the new artifact-collection logic
- [x] Functionally tested the collect-artifacts logic against a fake `out/make` directory — confirms it produces both the versioned DMG and the stable-named copy
- [x] Confirmed the live stable URL (`.../releases/latest/download/Minerva-mac-arm64.dmg`) resolves via `curl -I` — 302s to `.../releases/download/v0.1.2/Minerva-mac-arm64.dmg`
- [x] Verified all `href="#"` Download/GitHub/Releases/License stubs are gone across `index.html`, `about.html`, `features.html`, `privacy.html`, `getting-started.html`
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)