### PR TITLE
Hoist rebuildAliasMap out of the per-note full-index loop (#1106)

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -375,6 +375,21 @@ export function addOntologyToStore(state: GraphState): void {
 
 // ── Indexing ────────────────────────────────────────────────────────────────
 
+export interface IndexNoteOptions {
+  /**
+   * Skip the per-note `rebuildAliasMap` call (perf #1106). `rebuildAliasMap`
+   * is O(N) in the project's total note count, so calling it once per note
+   * during a full `indexAllNotes` walk is O(N²) — at 5,000 notes, tens of
+   * millions of wasted inner iterations. `indexAllNotes` already runs a
+   * complete alias pre-pass (`walkAndCollectAliases`) before this loop starts
+   * and rebuilds once more after it ends, so the per-note rebuild here is
+   * pure redundancy in that path. The incremental single-note path (a save,
+   * a rename, a merge, …) still needs it — that path never runs the pre-pass
+   * or a trailing rebuild, so skipping it there would leave `aliasMap` stale.
+   */
+  skipAliasRebuild?: boolean;
+}
+
 // indexNote is an async-by-contract public API: callers `await` it across
 // the project (ipc, write-pipeline, watchers, rename), and we want the
 // freedom to add real async work later without rippling out a signature
@@ -384,6 +399,7 @@ export async function indexNote(
   ctx: ProjectContext,
   relativePath: string,
   content: string,
+  opts: IndexNoteOptions = {},
 ): Promise<{ headingRenameCandidate?: HeadingRenameCandidate }> {
   checkLLMWriteGuard('indexNote');
   const state = getState(ctx);
@@ -490,7 +506,7 @@ export async function indexNote(
   } else {
     state.aliasesPerNote.delete(relativePath);
   }
-  rebuildAliasMap(state);
+  if (!opts.skipAliasRebuild) rebuildAliasMap(state);
   for (const alias of validAliases) {
     store.add(subject, MINERVA('hasAlias'), $rdf.lit(alias), graph);
   }
@@ -1190,6 +1206,11 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
 
   let count = 0;
   await walkAndIndex(rootPath, rootPath);
+  // Each indexNote call above skipped its own rebuild (perf #1106) — the
+  // pre-pass already left aliasMap correct, but rebuild once more here as a
+  // cheap (O(N), not O(N²)) guarantee rather than relying on the pre-pass
+  // and the main pass never diverging.
+  rebuildAliasMap(state);
   count += await walkAndIndexSources(ctx, rootPath);
   count += await walkAndIndexExcerpts(ctx, rootPath);
   // graph.ttl is a cold snapshot now (#348). The release / quit path
@@ -1207,7 +1228,7 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
       } else if (isIndexable(entry.name)) {
         const relativePath = path.relative(root, fullPath);
         const content = await fs.readFile(fullPath, 'utf-8');
-        await indexNote(ctx, relativePath, content);
+        await indexNote(ctx, relativePath, content, { skipAliasRebuild: true });
         count++;
       }
     }

--- a/tests/main/graph/aliases.test.ts
+++ b/tests/main/graph/aliases.test.ts
@@ -19,6 +19,7 @@ import os from 'node:os';
 import {
   initGraph,
   indexNote,
+  indexAllNotes,
   queryGraph,
   getAliasMap,
 } from '../../../src/main/graph/index';
@@ -159,5 +160,50 @@ describe('frontmatter aliases (#469)', () => {
       '',
     ].join('\n'));
     expect(Object.keys(getAliasMap(ctx)).sort()).toEqual(['foo']);
+  });
+
+  describe('full-index path (perf #1106 — skips the per-note rebuild)', () => {
+    it('produces the same alias map as the incremental path, including collisions', async () => {
+      // Same three scenarios as the incremental tests above, but all planted
+      // on disk and indexed via indexAllNotes — the path that now skips
+      // rebuildAliasMap per note and relies on the pre-pass + one rebuild
+      // after the main walk instead.
+      await fsp.writeFile(
+        path.join(root, 'kennedy.md'),
+        ['---', 'aliases:', '  - JFK', '---', '# Kennedy', ''].join('\n'),
+        'utf-8',
+      );
+      // A real note named JFK.md should beat the alias above.
+      await fsp.writeFile(path.join(root, 'JFK.md'), '# Some other JFK note\n', 'utf-8');
+      // Duplicate alias claim: alphabetically-first path wins.
+      await fsp.writeFile(
+        path.join(root, 'b.md'),
+        ['---', 'aliases:', '  - shared', '---', '# B'].join('\n'),
+        'utf-8',
+      );
+      await fsp.writeFile(
+        path.join(root, 'a.md'),
+        ['---', 'aliases:', '  - shared', '---', '# A'].join('\n'),
+        'utf-8',
+      );
+      // A link that should resolve through an alias planted in the same pass.
+      await fsp.writeFile(path.join(root, 'essays.md'), '# Essays\n\nSee [[shared]].\n', 'utf-8');
+
+      const count = await indexAllNotes(ctx);
+      expect(count).toBe(5);
+
+      const map = getAliasMap(ctx);
+      expect(map.jfk).toBeUndefined(); // real JFK.md file wins over the alias
+      expect(map.shared).toBe('a.md'); // alphabetically-first path wins
+
+      // The `shared` alias resolves to a.md, not left dangling as literal text.
+      const r = await queryGraph(ctx, `
+        SELECT ?subject ?target WHERE {
+          ?subject <https://minerva.dev/ontology#references> ?target .
+        }
+      `);
+      const rows = r.results as Array<{ subject: string; target: string }>;
+      expect(rows.some((row) => row.target.endsWith('/a'))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
`indexNote` unconditionally called `rebuildAliasMap` — O(N) in the project's total note count — on every note. During `indexAllNotes`'s main walk this made the alias-map work O(N²): N notes each triggering an O(N) rebuild, on top of the complete alias pre-pass (`walkAndCollectAliases`) that already runs before the walk starts.

Adds an `IndexNoteOptions` param (`skipAliasRebuild`) that `indexAllNotes` passes for its own per-note `indexNote` calls, plus one final rebuild after the main walk as a cheap (O(N), not O(N²)) correctness safeguard. The incremental single-note path (save, rename, merge, …) is unchanged — it never runs the pre-pass, so it still needs its own rebuild every call.

Closes #1106.

## Test plan
- [x] Added a test exercising the full-index path directly (`aliases.test.ts` previously only covered `indexNote`'s incremental path) — same collision behaviors (title beats alias, alphabetical tiebreak) proven correct with the skip+final-rebuild path
- [x] Measured the actual improvement by temporarily reverting the fix and re-running the same scenario: at N=3200 notes, the old code took 3.6s (1.14ms/note, climbing with N — the O(N²) signature) vs. 1.6s (0.52ms/note, flat) with the fix — a 2.2x speedup at this scale, widening further toward the issue's stated 5,000-note freeze
- [x] Full suite: `pnpm test` — 432 files / 4069 tests passing
- [x] `pnpm lint` — clean

Note: the issue's "Dependencies" section mentions a companion full-index benchmark; that's tracked separately as #1109 (still open) rather than bundled into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)