### PR TITLE
Debounce the search-index persist off the save hot path (#1107)

### DIFF
--- a/src/main/notebase/write-pipeline.ts
+++ b/src/main/notebase/write-pipeline.ts
@@ -12,7 +12,10 @@
  *   3. re-run graph indexing (returns a heading-rename candidate if the
  *      edit looks like a rename of an anchored heading)
  *   4. re-run search indexing
- *   5. persist the search index (graph.ttl is a cold snapshot, #348)
+ *   5. schedule a debounced search-index persist (perf #1107 — like
+ *      graph.ttl's cold-snapshot posture, #348, but on a short timer rather
+ *      than only at release/quit, since the search index isn't otherwise
+ *      flushed on a rebuild trigger)
  *   6. broadcast NOTEBASE_REWRITTEN so open editors refresh
  *   7. broadcast NOTEBASE_HEADING_RENAME_SUGGESTED if step 3 surfaced a
  *      rename candidate
@@ -48,8 +51,8 @@ export interface WritePipelineOpts {
    *     broadcast for every touched path at the end of its loop.
    */
   suppressRewrittenBroadcast?: boolean;
-  /** Skip search.persist. Used by batch callers that will persist once
-   *  after the loop. */
+  /** Skip scheduling search.persist. Used by batch callers that will
+   *  persist once after the loop. */
   skipPersist?: boolean;
 }
 
@@ -73,7 +76,10 @@ export async function writeAndReindex(
   // model. No-op when the vector store isn't initialized; resilient internally.
   if (relativePath.endsWith('.md')) void vectors.indexNote(ctx, relativePath, content);
   if (!opts.skipPersist) {
-    await search.persist(ctx);
+    // Debounced, not immediate (perf #1107) — persist serializes the whole
+    // index, not just this note, so doing it synchronously on every save
+    // would put an O(corpus-bytes) write on the hot path of every autosave.
+    search.schedulePersist(ctx);
   }
   if (!opts.suppressRewrittenBroadcast) {
     hooks.broadcastRewritten(rootPath, [relativePath]);

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -8,10 +8,37 @@ import { createProjectStore } from '../project-store';
 interface SearchState {
   rootPath: string;
   provider: SearchProvider;
+  /** Pending debounced-persist timer (perf #1107), or null if none scheduled. */
+  persistTimer: ReturnType<typeof setTimeout> | null;
 }
 
-// Pure MiniSearch state — nothing to close on dispose, so no dispose hook.
-const store = createProjectStore<SearchState>();
+/**
+ * How long to wait after the last `schedulePersist` call before actually
+ * writing the index to disk (perf #1107). `persist` serializes the entire
+ * MiniSearch index — O(total corpus bytes), not O(the one changed note) — so
+ * calling it synchronously on every save (the old behavior) meant a
+ * multi-megabyte JSON.stringify + write on every ~1s autosave tick in a large
+ * vault. This coalesces a burst of saves into one write after things go
+ * quiet. A crash before the timer fires loses only index freshness, not
+ * data — the index is fully reconstructible via `indexAllNotes`.
+ */
+let persistDebounceMs = 3000;
+
+/** Test-only: shrink the debounce window instead of waiting out the real one. */
+export function _setPersistDebounceMsForTests(ms: number): void {
+  persistDebounceMs = ms;
+}
+
+// Dispose clears any pending debounce timer so it can't fire after the
+// project's state (and possibly the whole process, on the last window) is
+// gone. persist() itself already cancels the timer on every explicit call
+// (release/quit paths persist synchronously before disposing), so this is a
+// defensive backstop, not the primary flush path.
+const store = createProjectStore<SearchState>({
+  dispose: (state) => {
+    if (state.persistTimer) clearTimeout(state.persistTimer);
+  },
+});
 
 function getState(ctx: ProjectContext): SearchState | null {
   return store.get(ctx);
@@ -21,7 +48,7 @@ function getState(ctx: ProjectContext): SearchState | null {
 function getOrCreateState(ctx: ProjectContext): SearchState {
   let state = store.get(ctx);
   if (!state) {
-    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider() };
+    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider(), persistTimer: null };
     store.set(ctx, state);
   }
   return state;
@@ -90,7 +117,32 @@ export function search(ctx: ProjectContext, query: string, opts?: { limit?: numb
 export async function persist(ctx: ProjectContext): Promise<void> {
   const state = getState(ctx);
   if (!state) return;
+  if (state.persistTimer) {
+    clearTimeout(state.persistTimer);
+    state.persistTimer = null;
+  }
   await state.provider.save(indexPath(state));
+}
+
+/**
+ * Debounced counterpart to `persist` (perf #1107) — arms (or re-arms) a timer
+ * to persist after the debounce window elapses with no further calls, instead
+ * of writing immediately. This is what the per-save write path calls;
+ * anything that needs an on-disk guarantee right now (project release, app
+ * quit, a manual rebuild) should keep calling `persist` directly.
+ */
+export function schedulePersist(ctx: ProjectContext): void {
+  const state = getState(ctx);
+  if (!state) return;
+  if (state.persistTimer) clearTimeout(state.persistTimer);
+  state.persistTimer = setTimeout(async () => {
+    state.persistTimer = null;
+    try {
+      await state.provider.save(indexPath(state));
+    } catch (err) {
+      console.warn(`[search] debounced persist failed for ${state.rootPath}:`, err);
+    }
+  }, persistDebounceMs);
 }
 
 /** Simple title extraction matching what the graph parser does */

--- a/tests/main/search/index.test.ts
+++ b/tests/main/search/index.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Debounced search-index persistence (perf #1107).
+ *
+ * `persist` serializes the whole MiniSearch index — O(total corpus bytes),
+ * not O(the one changed note) — so the per-save write path now calls
+ * `schedulePersist` (a debounced, coalescing wrapper) instead of `persist`
+ * directly. These tests pin that contract: no immediate write, one write
+ * after the quiet period, repeated calls coalesce to a single write, and an
+ * explicit `persist()` still forces an immediate write (the release/quit
+ * paths keep calling that).
+ *
+ * Uses `_setPersistDebounceMsForTests` to shrink the real debounce window
+ * rather than mocking time — `schedulePersist`'s timer callback does real
+ * `fs` I/O, which doesn't resolve on vitest's fake-timer clock (it settles
+ * via libuv's real thread pool), so faking `setTimeout` here would just
+ * trade a slow test for a flaky one.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  initSearch,
+  indexNote,
+  persist,
+  schedulePersist,
+  disposeProject,
+  _setPersistDebounceMsForTests,
+} from '../../../src/main/search/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+const DEBOUNCE_MS = 50;
+
+function indexFilePath(root: string): string {
+  return path.join(root, '.minerva', 'search-index.json');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+describe('search index persistence (perf #1107)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-search-persist-'));
+    fs.mkdirSync(path.join(root, '.minerva'), { recursive: true });
+    ctx = projectContext(root);
+    await initSearch(ctx);
+    _setPersistDebounceMsForTests(DEBOUNCE_MS);
+  });
+
+  afterEach(() => {
+    _setPersistDebounceMsForTests(3000);
+    disposeProject(ctx);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('schedulePersist does not write immediately', () => {
+    indexNote(ctx, 'a.md', '# A\nbody');
+    schedulePersist(ctx);
+    expect(fs.existsSync(indexFilePath(root))).toBe(false);
+  });
+
+  it('schedulePersist writes after the debounce delay elapses', async () => {
+    indexNote(ctx, 'a.md', '# A\nbody');
+    schedulePersist(ctx);
+
+    await sleep(DEBOUNCE_MS / 2);
+    expect(fs.existsSync(indexFilePath(root))).toBe(false);
+
+    await sleep(DEBOUNCE_MS);
+    expect(fs.existsSync(indexFilePath(root))).toBe(true);
+    const written = JSON.parse(fs.readFileSync(indexFilePath(root), 'utf-8'));
+    expect(JSON.stringify(written)).toContain('a.md');
+  });
+
+  it('repeated schedulePersist calls within the window coalesce into one write', async () => {
+    indexNote(ctx, 'a.md', '# A\nbody');
+    schedulePersist(ctx);
+    await sleep(DEBOUNCE_MS / 2);
+    // A second save comes in before the first would have fired — this
+    // should push the write out again rather than let the first fire.
+    indexNote(ctx, 'b.md', '# B\nbody');
+    schedulePersist(ctx);
+    await sleep(DEBOUNCE_MS / 2);
+    expect(fs.existsSync(indexFilePath(root))).toBe(false);
+
+    await sleep(DEBOUNCE_MS);
+    expect(fs.existsSync(indexFilePath(root))).toBe(true);
+    const written = JSON.parse(fs.readFileSync(indexFilePath(root), 'utf-8'));
+    // Both notes made it into the single, coalesced write.
+    expect(JSON.stringify(written)).toContain('a.md');
+    expect(JSON.stringify(written)).toContain('b.md');
+  });
+
+  it('persist() forces an immediate write and cancels a pending scheduled one', async () => {
+    indexNote(ctx, 'a.md', '# A\nbody');
+    schedulePersist(ctx);
+    expect(fs.existsSync(indexFilePath(root))).toBe(false);
+
+    await persist(ctx);
+    expect(fs.existsSync(indexFilePath(root))).toBe(true);
+    const firstWrite = fs.statSync(indexFilePath(root)).mtimeMs;
+
+    // The debounced timer that was pending before persist() ran should have
+    // been cancelled — waiting past its original deadline must not fire a
+    // second, redundant write.
+    await sleep(DEBOUNCE_MS * 2);
+    expect(fs.statSync(indexFilePath(root)).mtimeMs).toBe(firstWrite);
+  });
+});


### PR DESCRIPTION
## Summary
`writeAndReindex` called `search.persist` synchronously on every save (unless `skipPersist`) — `persist` serializes the entire MiniSearch index (title + content copies of every document), an O(total corpus bytes) `JSON.stringify` + disk write, not O(the one changed note). In a large vault this put a multi-megabyte write on every ~1s autosave tick.

Adds `schedulePersist`: a debounced wrapper (3s trailing debounce, coalescing a burst of saves into one write after things go quiet). `write-pipeline.ts` now calls that instead of `persist` directly. `persist()` itself cancels any pending debounce timer before writing, so the existing release/project-close and app-quit paths (which need an immediate, guaranteed on-disk write) can't race with a stale debounced write firing after them. A crash before the timer fires loses only index freshness, not data — the index is fully reconstructible via `indexAllNotes`.

Closes #1107.

## Grounding
Found a stale comment along the way (not changed — out of scope, unrelated subsystem): `project-context.ts` already claimed "the on-disk graph is already up to date through the debounced persist that runs while the window is open," but that's describing `graph.ttl`'s cold-snapshot strategy (#348), which is a different mechanism (never written on save at all, only at specific triggers) — not an actual debounce. Left it alone since it's about graph, not search, and unrelated to this fix.

## Test plan
- [x] New test file `tests/main/search/index.test.ts` (didn't exist before) — covers no-immediate-write, write-after-debounce-elapses, multiple-calls-coalesce-into-one-write, and `persist()` forcing an immediate write while cancelling any pending timer
- [x] Manual burst simulation: 10 saves 300ms apart — 10 real writes under the old behavior collapse to 1 under the new one
- [x] Full suite: `pnpm test` — 433 files / 4073 tests passing
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)