### PR TITLE
Security M3: route shell:* IPC handlers through assertSafePath (#1328)

### DIFF
--- a/src/main/ipc/register-shell.ts
+++ b/src/main/ipc/register-shell.ts
@@ -2,6 +2,7 @@ import { ipcMain, shell, dialog } from 'electron';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { Channels } from '../../shared/channels';
+import { assertSafePath } from '../notebase/fs';
 import { winFromEvent, withRootPathOr } from './helpers';
 
 export function registerShell(): void {
@@ -19,21 +20,28 @@ export function registerShell(): void {
     }
   });
 
-  // Shell
+  // Shell. All three resolve renderer-supplied relative paths through
+  // `assertSafePath` before handing them to `shell.*` / `spawn`, so a
+  // `../` escape can't launch or reveal a file outside the project root —
+  // the same path-traversal invariant `fs.ts` enforces (#1328). A
+  // traversal attempt throws, which rejects the invoke and performs no
+  // shell action.
   ipcMain.handle(Channels.SHELL_REVEAL_FILE, withRootPathOr(undefined, (rootPath, relativePath?: string) => {
     const fullPath = relativePath
-      ? path.join(rootPath, relativePath)
+      ? assertSafePath(rootPath, relativePath)
       : rootPath;
     shell.showItemInFolder(fullPath);
   }));
 
   ipcMain.handle(Channels.SHELL_OPEN_IN_DEFAULT, withRootPathOr(undefined, (rootPath, relativePath: string) => {
-    void shell.openPath(path.join(rootPath, relativePath));
+    void shell.openPath(assertSafePath(rootPath, relativePath));
   }));
 
   ipcMain.handle(Channels.SHELL_OPEN_IN_TERMINAL, withRootPathOr(undefined, (rootPath, relativePath?: string) => {
+    // Validate the full path is in-root, then open its containing dir —
+    // dirname of an in-root path is itself in-root.
     const dir = relativePath
-      ? path.join(rootPath, path.dirname(relativePath))
+      ? path.dirname(assertSafePath(rootPath, relativePath))
       : rootPath;
     // Use spawn with explicit args (no shell) so a filename containing
     // shell metacharacters can't inject. Detached + unref so closing the

--- a/tests/main/ipc/register-shell.test.ts
+++ b/tests/main/ipc/register-shell.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Shell-handler path-traversal guard (#1328).
+ *
+ * `SHELL_REVEAL_FILE`, `SHELL_OPEN_IN_DEFAULT`, and `SHELL_OPEN_IN_TERMINAL`
+ * take a renderer-supplied `relativePath` and hand it to `shell.*` / `spawn`.
+ * They must route it through `assertSafePath` first so a `../` escape can't
+ * reveal, open, or spawn a terminal at a location outside the project root.
+ *
+ * This drives the real `registerShell()` with the real `assertSafePath`
+ * (electron + `spawn` + the project-scoping helper are the only mocks), then
+ * invokes each captured handler with a safe path (must act on the in-root
+ * resolution) and a traversal path (must throw + perform no shell action).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+
+// A deliberately non-existent root: `assertSafePath`'s realpath step falls back
+// to the input when the prefix doesn't exist, so the resolution stays
+// deterministic without touching the filesystem.
+const ROOT = '/minerva-shell-guard-root-8f3a';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+const { handlers, shellCalls, spawnCalls } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  shellCalls: { reveal: [] as string[], openPath: [] as string[] },
+  spawnCalls: [] as unknown[][],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { handlers.set(channel, fn); } },
+  shell: {
+    showItemInFolder: (p: string) => { shellCalls.reveal.push(p); },
+    openPath: (p: string) => { shellCalls.openPath.push(p); return Promise.resolve(''); },
+    openExternal: () => Promise.resolve(),
+  },
+  dialog: { showSaveDialog: () => Promise.resolve({ canceled: true }) },
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    spawnCalls.push(args);
+    return { unref() {}, once() {} };
+  },
+}));
+
+// Inject a fixed project root and bypass the BrowserWindow lookup — the guard
+// under test is `assertSafePath(root, rel)`, not the project-scoping wrapper.
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  winFromEvent: () => ({}),
+  withRootPathOr:
+    <A extends unknown[], R>(_fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+    (_e: unknown, ...args: A) => fn(ROOT, ...args),
+}));
+
+import { registerShell } from '../../../src/main/ipc/register-shell';
+import { Channels } from '../../../src/shared/channels';
+
+registerShell();
+
+beforeEach(() => {
+  shellCalls.reveal = [];
+  shellCalls.openPath = [];
+  spawnCalls.length = 0;
+});
+
+const TRAVERSAL = '../../../../etc/passwd';
+
+describe('shell handlers — path-traversal guard (#1328)', () => {
+  it('SHELL_REVEAL_FILE reveals an in-root file and rejects traversal', () => {
+    const h = handlers.get(Channels.SHELL_REVEAL_FILE)!;
+    h({}, 'notes/a.md');
+    expect(shellCalls.reveal).toEqual([path.resolve(ROOT, 'notes/a.md')]);
+
+    expect(() => h({}, TRAVERSAL)).toThrow(/traversal/i);
+    expect(shellCalls.reveal).toHaveLength(1); // no second (escaping) reveal
+  });
+
+  it('SHELL_OPEN_IN_DEFAULT opens an in-root file and rejects traversal', () => {
+    const h = handlers.get(Channels.SHELL_OPEN_IN_DEFAULT)!;
+    h({}, 'sub/dir/file.pdf');
+    expect(shellCalls.openPath).toEqual([path.resolve(ROOT, 'sub/dir/file.pdf')]);
+
+    expect(() => h({}, TRAVERSAL)).toThrow(/traversal/i);
+    expect(shellCalls.openPath).toHaveLength(1); // the escaping open never fired
+  });
+
+  it('SHELL_OPEN_IN_TERMINAL spawns for an in-root path and rejects traversal', () => {
+    const h = handlers.get(Channels.SHELL_OPEN_IN_TERMINAL)!;
+    h({}, 'notes/a.md');
+    expect(spawnCalls).toHaveLength(1); // a terminal was spawned
+
+    expect(() => h({}, TRAVERSAL)).toThrow(/traversal/i);
+    expect(spawnCalls).toHaveLength(1); // no terminal spawned outside the root
+  });
+
+  it('reveal with no relativePath falls back to the root itself (no traversal)', () => {
+    const h = handlers.get(Channels.SHELL_REVEAL_FILE)!;
+    h({});
+    expect(shellCalls.reveal).toEqual([ROOT]);
+  });
+});


### PR DESCRIPTION
Closes #1328.

## Problem
Three shell handlers built paths with a bare `path.join(rootPath, relativePath)`, skipping the codebase's own path-traversal invariant (`assertSafePath`, "always use it" — CLAUDE.md, enforced across `fs.ts`):

- `SHELL_REVEAL_FILE` — `register-shell.ts:23-28`
- `SHELL_OPEN_IN_DEFAULT` — `:30-32`
- `SHELL_OPEN_IN_TERMINAL` — `:34-60`

A `relativePath` of `../../../…` escapes the root. `SHELL_OPEN_IN_DEFAULT` would then open an arbitrary out-of-project file with its OS default handler (on macOS, opening an `.app`/script by path can execute it); the others reveal or launch a terminal at an arbitrary location. `relativePath` currently comes from the renderer's file tree / tab menus, so this is primarily a defense-in-depth / invariant-consistency gap — but a renderer bug or a future feature routing note-derived paths here would make it a real traversal-to-launch primitive.

## Fix
Route all three through `assertSafePath(rootPath, relativePath)` before `shell.showItemInFolder` / `shell.openPath` / `spawn`. For the terminal handler, validate the full file path is in-root, then take its `dirname` (dirname of an in-root path is itself in-root). A traversal attempt throws, which rejects the invoke and performs **no** shell action.

Note: command injection was never the issue here — the terminal handler already spawns with explicit args and no shell. This closes the **path-scope** gap only.

## Tests
New `tests/main/ipc/register-shell.test.ts` drives the real handlers with the real `assertSafePath` (only electron / `spawn` / the project-scoping helper are mocked):
- in-root paths act on the resolved location (reveal / openPath / spawn);
- `../../../../etc/passwd` throws for all three and performs no shell action;
- reveal with no `relativePath` falls back to the root itself.

Full suite green; `pnpm lint` clean.

## Scope
Addresses **M3** only. Remaining review items stay their own issues: M1 (#1326), M2 (#1327), L1–L6 (#1329–#1334). H1 (#1325) already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)