### PR TITLE
Security M1: encrypt API key + clipper secret at rest via safeStorage, with settings indicator (#1326)

### DIFF
--- a/src/main/clipper/clipper-config.ts
+++ b/src/main/clipper/clipper-config.ts
@@ -14,6 +14,7 @@ import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
+import { encryptSecret, decryptSecret } from '../secret-storage';
 
 export interface ClipperConfig {
   enabled: boolean;
@@ -40,7 +41,10 @@ export async function getClipperConfig(): Promise<ClipperConfig> {
     const parsed = JSON.parse(raw) as Partial<ClipperConfig>;
     return {
       enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : DEFAULT_CLIPPER_CONFIG.enabled,
-      secret: typeof parsed.secret === 'string' ? parsed.secret : DEFAULT_CLIPPER_CONFIG.secret,
+      // Decrypt the secret at rest (#1326); a legacy plaintext secret passes
+      // through unchanged, so existing pairings keep working and re-encrypt on
+      // the next write.
+      secret: typeof parsed.secret === 'string' ? decryptSecret(parsed.secret) : DEFAULT_CLIPPER_CONFIG.secret,
     };
   } catch {
     return { ...DEFAULT_CLIPPER_CONFIG };
@@ -48,7 +52,11 @@ export async function getClipperConfig(): Promise<ClipperConfig> {
 }
 
 async function saveClipperConfig(config: ClipperConfig): Promise<void> {
-  await fs.writeFile(configPath(), JSON.stringify(config, null, 2), 'utf-8');
+  // The in-memory ClipperConfig.secret stays plaintext for consumers (the
+  // loopback endpoint's constant-time compare); only the on-disk copy is
+  // encrypted (#1326).
+  const onDisk: ClipperConfig = { ...config, secret: encryptSecret(config.secret) };
+  await fs.writeFile(configPath(), JSON.stringify(onDisk, null, 2), 'utf-8');
 }
 
 /** Set the enable flag. Enabling issues a secret if none exists yet. */

--- a/src/main/ipc/register-tools.ts
+++ b/src/main/ipc/register-tools.ts
@@ -8,7 +8,7 @@ import { pickAndImportSkill, removeUserSkill, revealSkillsFolder, type ImportedS
 import { getMenuConfig, saveMenuConfig } from '../skills/menu-config-store';
 import { toSkillInfo, type SkillCatalogInfo } from '../../shared/skills/types';
 import type { MenuConfig } from '../../shared/skills/menu-config';
-import { getSettings, saveSettings } from '../llm/settings';
+import { getSettings, saveSettings, getApiKeyStorage } from '../llm/settings';
 import type { ToolExecutionRequest, LLMSettings } from '../../shared/tools/types';
 import { winFromEvent } from './helpers';
 
@@ -92,4 +92,6 @@ export function registerTools(): void {
   ipcMain.handle(Channels.TOOL_GET_SETTINGS, () => getSettings());
 
   ipcMain.handle(Channels.TOOL_SET_SETTINGS, (_e, settings: LLMSettings) => saveSettings(settings));
+
+  ipcMain.handle(Channels.TOOL_GET_KEY_STORAGE, () => getApiKeyStorage());
 }

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import type { LLMSettings, WebSettings } from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
+import { encryptSecret, decryptSecret } from '../secret-storage';
 
 const DEFAULT_MODEL = 'claude-sonnet-5';
 
@@ -43,8 +44,16 @@ export async function getSettings(): Promise<LLMSettings> {
     const raw = await fs.readFile(settingsPath(), 'utf-8');
     const parsed = JSON.parse(raw) as Partial<LLMSettings>;
     const effort = resolveEffortSetting(parsed.effort);
+    // Decrypt the stored key (#1326). `decryptSecret` passes a legacy
+    // plaintext value through unchanged, so pre-encryption configs keep
+    // working. Only fall back to the env var when the field is absent —
+    // an explicitly-cleared ('') key stays cleared, matching the prior
+    // `?? env ?? ''` semantics.
+    const apiKey = typeof parsed.apiKey === 'string'
+      ? decryptSecret(parsed.apiKey)
+      : (process.env.ANTHROPIC_API_KEY ?? '');
     return {
-      apiKey: parsed.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '',
+      apiKey,
       model: resolveModel(parsed.model),
       web: resolveWeb(parsed.web),
       ...(effort ? { effort } : {}),
@@ -59,5 +68,8 @@ export async function getSettings(): Promise<LLMSettings> {
 }
 
 export async function saveSettings(settings: LLMSettings): Promise<void> {
-  await fs.writeFile(settingsPath(), JSON.stringify(settings, null, 2), 'utf-8');
+  // Encrypt the API key at rest (#1326); everything else is non-sensitive.
+  // Reading back through `getSettings` decrypts it transparently.
+  const onDisk = { ...settings, apiKey: encryptSecret(settings.apiKey ?? '') };
+  await fs.writeFile(settingsPath(), JSON.stringify(onDisk, null, 2), 'utf-8');
 }

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -1,10 +1,10 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import type { LLMSettings, WebSettings } from '../../shared/tools/types';
+import type { LLMSettings, WebSettings, ApiKeyStorage } from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
-import { encryptSecret, decryptSecret } from '../secret-storage';
+import { encryptSecret, decryptSecret, isEncrypted, secretEncryptionAvailable } from '../secret-storage';
 
 const DEFAULT_MODEL = 'claude-sonnet-5';
 
@@ -72,4 +72,22 @@ export async function saveSettings(settings: LLMSettings): Promise<void> {
   // Reading back through `getSettings` decrypts it transparently.
   const onDisk = { ...settings, apiKey: encryptSecret(settings.apiKey ?? '') };
   await fs.writeFile(settingsPath(), JSON.stringify(onDisk, null, 2), 'utf-8');
+}
+
+/**
+ * Report how the stored API key is protected at rest, for the settings UI
+ * (#1326). `available` reflects the machine's secure-storage capability;
+ * `encrypted` reflects the actual on-disk form of the currently-stored key
+ * (a legacy plaintext key reads back `encrypted: false` until it's re-saved).
+ */
+export async function getApiKeyStorage(): Promise<ApiKeyStorage> {
+  let encrypted = false;
+  try {
+    const raw = await fs.readFile(settingsPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
+    encrypted = typeof parsed.apiKey === 'string' && parsed.apiKey.length > 0 && isEncrypted(parsed.apiKey);
+  } catch {
+    // No settings file yet — nothing stored, so nothing encrypted.
+  }
+  return { available: secretEncryptionAvailable(), encrypted };
 }

--- a/src/main/secret-storage.ts
+++ b/src/main/secret-storage.ts
@@ -37,6 +37,16 @@ function encryptionAvailable(): boolean {
 }
 
 /**
+ * Whether OS-backed secure storage is usable on this machine — i.e. whether a
+ * secret written now would actually be encrypted at rest. Surfaced to the UI so
+ * the settings panel can tell the user the truth rather than claiming security
+ * unconditionally (#1326).
+ */
+export function secretEncryptionAvailable(): boolean {
+  return encryptionAvailable();
+}
+
+/**
  * Encode a secret for on-disk storage. Empty in → empty out. Encrypts when
  * `safeStorage` is available; otherwise returns the plaintext unchanged (same
  * as the pre-#1326 behavior).

--- a/src/main/secret-storage.ts
+++ b/src/main/secret-storage.ts
@@ -1,0 +1,77 @@
+/**
+ * At-rest encryption for the handful of secrets Minerva persists under
+ * `userData` — the Anthropic API key (`llm-settings.json`) and the
+ * browser-clipper shared secret (`clipper-config.json`) (#1326).
+ *
+ * Values are wrapped with Electron `safeStorage` (Keychain on macOS, DPAPI on
+ * Windows, libsecret/kwallet on Linux) and tagged with a version prefix so the
+ * read path can tell an encrypted value from a legacy plaintext one. That tag
+ * is what makes the migration **backward-compatible**: an existing plaintext
+ * config still decrypts (returned verbatim), and the value is re-stored
+ * encrypted the next time its config is written.
+ *
+ * When `safeStorage` is unavailable (e.g. Linux with no keyring, or before the
+ * app is `ready`) we fall back to storing plaintext — encryption at rest is a
+ * hardening measure, not a boundary that should ever cost the user their API
+ * key, and this preserves the prior behavior exactly.
+ */
+import { safeStorage } from 'electron';
+
+/**
+ * Marks a `safeStorage`-encrypted, base64-encoded value. A real Anthropic key
+ * (`sk-ant-…`) or a hex clipper secret never begins with this, so its absence
+ * unambiguously means "legacy plaintext" — the basis for the migration.
+ */
+const ENC_PREFIX = 'enc:v1:';
+
+function encryptionAvailable(): boolean {
+  try {
+    return (
+      typeof safeStorage?.isEncryptionAvailable === 'function' &&
+      safeStorage.isEncryptionAvailable()
+    );
+  } catch {
+    // isEncryptionAvailable can throw before the app is ready on some platforms.
+    return false;
+  }
+}
+
+/**
+ * Encode a secret for on-disk storage. Empty in → empty out. Encrypts when
+ * `safeStorage` is available; otherwise returns the plaintext unchanged (same
+ * as the pre-#1326 behavior).
+ */
+export function encryptSecret(plain: string): string {
+  if (!plain) return '';
+  if (!encryptionAvailable()) return plain;
+  try {
+    return ENC_PREFIX + safeStorage.encryptString(plain).toString('base64');
+  } catch {
+    // Never lose the user's secret to a transient encryption failure — the
+    // worst case degrades to the old plaintext-at-rest behavior.
+    return plain;
+  }
+}
+
+/**
+ * Decode a stored secret, transparently handling both the encrypted
+ * (`enc:v1:` prefix) and legacy plaintext forms. Returns '' when an encrypted
+ * value can't be decrypted (e.g. the OS keychain entry was rotated or the
+ * profile moved machines) rather than surfacing ciphertext to a caller that
+ * expects a usable key.
+ */
+export function decryptSecret(stored: string): string {
+  if (!stored) return '';
+  if (!stored.startsWith(ENC_PREFIX)) return stored; // legacy plaintext
+  const b64 = stored.slice(ENC_PREFIX.length);
+  try {
+    return safeStorage.decryptString(Buffer.from(b64, 'base64'));
+  } catch {
+    return '';
+  }
+}
+
+/** True when a stored value is in the encrypted (tagged) form. */
+export function isEncrypted(stored: string): boolean {
+  return stored.startsWith(ENC_PREFIX);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -416,6 +416,7 @@ contextBridge.exposeInMainWorld('api', {
     onStream: (cb: (chunk: string) => void) => subscribeIpc(Channels.TOOL_STREAM, cb),
     getSettings: () => ipcRenderer.invoke(Channels.TOOL_GET_SETTINGS),
     setSettings: (settings: unknown) => ipcRenderer.invoke(Channels.TOOL_SET_SETTINGS, settings),
+    getKeyStorage: () => ipcRenderer.invoke(Channels.TOOL_GET_KEY_STORAGE),
     onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
   },
   skills: {

--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -12,6 +12,7 @@
    */
   import { MODEL_OPTIONS } from '../../../shared/tools/models';
   import { EFFORT_LEVELS, type Effort } from '../../../shared/tools/effort';
+  import type { ApiKeyStorage } from '../../../shared/tools/types';
   import { voiceSettings, VOICE_MODEL_OPTIONS } from '../voice/voice-settings.svelte';
 
   interface Props {
@@ -20,6 +21,8 @@
     apiKeyInput: string;
     clearApiKey: boolean;
     apiKeyStatus: 'unknown' | 'set' | 'unset';
+    /** At-rest storage status of the saved key (#1326). Null while loading. */
+    keyStorage: ApiKeyStorage | null;
   }
 
   let {
@@ -28,7 +31,12 @@
     apiKeyInput = $bindable(),
     clearApiKey = $bindable(),
     apiKeyStatus,
+    keyStorage,
   }: Props = $props();
+
+  // The saved key is protected at rest only when it's actually encrypted on
+  // disk — reflect that literally, don't claim security we don't have.
+  const keyEncrypted = $derived(apiKeyStatus === 'set' && !clearApiKey && keyStorage?.encrypted === true);
 
   // '' in the <select> means "no override → built-in default"; map to/from
   // the optional `effort` prop.
@@ -67,6 +75,8 @@
       Loading…
     {:else if clearApiKey}
       API key will be cleared on save
+    {:else if keyEncrypted}
+      🔒 API key saved — encrypted at rest
     {:else if apiKeyStatus === 'set'}
       ✓ API key saved
     {:else}
@@ -90,8 +100,17 @@
     disabled={clearApiKey}
   />
   <p class="hint">
-    Keys are stored in your user data directory. The saved value is never displayed back.
-    You can also set <code>ANTHROPIC_API_KEY</code> as an environment variable.
+    {#if keyStorage?.available}
+      Your key is encrypted at rest with your operating system's secure storage
+      (Keychain on macOS, Credential Manager on Windows, libsecret on Linux).
+    {:else if keyStorage}
+      No system secure store is available here, so the key is saved as plain text
+      in your user data directory.
+    {:else}
+      The key is stored in your user data directory.
+    {/if}
+    The saved value is never displayed back. You can also set
+    <code>ANTHROPIC_API_KEY</code> as an environment variable.
   </p>
   {#if apiKeyStatus === 'set' && !clearApiKey}
     <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -248,6 +248,7 @@
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');
   let clearApiKey = $state(false);
+  let keyStorage = $state<import('../../../shared/tools/types').ApiKeyStorage | null>(null);
 
   // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
   let loadedLlm: LLMSettings | null = null;
@@ -263,6 +264,11 @@
       model = s.model;
       effort = s.effort;
       apiKeyStatus = s.apiKey ? 'set' : 'unset';
+      try {
+        keyStorage = await api.tools.getKeyStorage();
+      } catch (e) {
+        console.error('[settings] failed to load key storage status:', e);
+      }
       const web = s.web ?? { enabled: true, allowedDomains: [], blockedDomains: [] };
       webEnabled = web.enabled;
       allowedDomainsText = web.allowedDomains.join('\n');
@@ -864,6 +870,7 @@
             bind:apiKeyInput
             bind:clearApiKey
             {apiKeyStatus}
+            {keyStorage}
           />
         {/if}
       </section>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -654,6 +654,7 @@ export interface ToolsApi {
   onStream(cb: (chunk: string) => void): void;
   getSettings(): Promise<LLMSettings>;
   setSettings(settings: LLMSettings): Promise<void>;
+  getKeyStorage(): Promise<import('../../../shared/tools/types').ApiKeyStorage>;
   onInvoke(cb: (toolId: string) => void): void;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -397,6 +397,8 @@ export const Channels = {
   TOOL_CANCEL: 'tool:cancel',
   TOOL_GET_SETTINGS: 'tool:getSettings',
   TOOL_SET_SETTINGS: 'tool:setSettings',
+  /** At-rest storage status of the API key, for the settings panel (#1326). */
+  TOOL_GET_KEY_STORAGE: 'tool:getKeyStorage',
   /** Prepare the system prompt + first message + model for a conversational tool. */
   TOOL_PREPARE_CONVERSATION: 'tool:prepareConversation',
 

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -221,6 +221,22 @@ export interface WebSettings {
   blockedDomains: string[];
 }
 
+/**
+ * At-rest storage status for the Anthropic API key (#1326), surfaced to the
+ * AI settings panel so it can indicate — honestly — whether the key is
+ * encrypted. Read-only; not part of the saved settings payload.
+ */
+export interface ApiKeyStorage {
+  /** OS secure storage (Electron safeStorage) is usable on this machine. */
+  available: boolean;
+  /**
+   * The persisted key is encrypted at rest (safeStorage-tagged form). False
+   * when no key is stored yet, or it's a legacy plaintext value not re-saved
+   * since encryption landed, or secure storage is unavailable.
+   */
+  encrypted: boolean;
+}
+
 export interface LLMSettings {
   apiKey: string;
   model: string;

--- a/tests/main/clipper/clipper-config.test.ts
+++ b/tests/main/clipper/clipper-config.test.ts
@@ -18,6 +18,16 @@ vi.mock('electron', () => ({
       return tempDir;
     },
   },
+  // Reversible fake so the secret's at-rest encryption path (#1326) is exercised.
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (s: string) => Buffer.from('FAKEENC:' + s, 'utf-8'),
+    decryptString: (buf: Buffer) => {
+      const s = buf.toString('utf-8');
+      if (!s.startsWith('FAKEENC:')) throw new Error('bad ciphertext');
+      return s.slice('FAKEENC:'.length);
+    },
+  },
 }));
 
 import {
@@ -68,4 +78,30 @@ it('ensureClipperSecret generates once, then is stable', async () => {
   const s1 = await ensureClipperSecret();
   expect(s1).toMatch(/^[0-9a-f]{64}$/);
   expect(await ensureClipperSecret()).toBe(s1);
+});
+
+it('encrypts the secret at rest but keeps it plaintext in memory (#1326)', async () => {
+  const cfg = await setClipperEnabled(true);
+  // In-memory secret stays plaintext hex for the loopback compare.
+  expect(cfg.secret).toMatch(/^[0-9a-f]{64}$/);
+  // On-disk copy is encrypted, not the raw hex.
+  const onDisk = fs.readFileSync(path.join(tempDir, 'clipper-config.json'), 'utf-8');
+  expect(onDisk).not.toContain(cfg.secret);
+  expect((JSON.parse(onDisk).secret as string).startsWith('enc:v1:')).toBe(true);
+  // Round-trips back to the same plaintext on read.
+  expect((await getClipperConfig()).secret).toBe(cfg.secret);
+});
+
+it('reads a legacy plaintext secret unchanged, then re-encrypts on next write (#1326)', async () => {
+  const legacy = 'a'.repeat(64);
+  fs.writeFileSync(
+    path.join(tempDir, 'clipper-config.json'),
+    JSON.stringify({ enabled: true, secret: legacy }),
+  );
+  // Legacy plaintext still resolves.
+  expect((await getClipperConfig()).secret).toBe(legacy);
+  // A write (rotate) migrates the file to encrypted form.
+  await setClipperEnabled(false);
+  const onDisk = fs.readFileSync(path.join(tempDir, 'clipper-config.json'), 'utf-8');
+  expect((JSON.parse(onDisk).secret as string).startsWith('enc:v1:')).toBe(true);
 });

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -210,6 +210,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "templates:saveAs",
   "tool:cancel",
   "tool:execute",
+  "tool:getKeyStorage",
   "tool:getSettings",
   "tool:prepareConversation",
   "tool:setSettings",

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -1,0 +1,84 @@
+/**
+ * LLM settings — API key at-rest encryption + backward compatibility (#1326).
+ *
+ * `saveSettings` encrypts the Anthropic key on disk; `getSettings` decrypts it
+ * transparently and still reads pre-encryption (plaintext) configs. Stubs
+ * `app.getPath('userData')` to a temp dir and mocks `safeStorage` with a
+ * reversible fake (mirrors clipper-config.test).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+let tempDir: string;
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected getPath(${name})`);
+      return tempDir;
+    },
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (s: string) => Buffer.from('FAKEENC:' + s, 'utf-8'),
+    decryptString: (buf: Buffer) => {
+      const s = buf.toString('utf-8');
+      if (!s.startsWith('FAKEENC:')) throw new Error('bad ciphertext');
+      return s.slice('FAKEENC:'.length);
+    },
+  },
+}));
+
+import { getSettings, saveSettings } from '../../../src/main/llm/settings';
+import type { LLMSettings } from '../../../src/shared/tools/types';
+
+const settingsFile = () => path.join(tempDir, 'llm-settings.json');
+const base: LLMSettings = {
+  apiKey: '',
+  model: 'claude-sonnet-5',
+  web: { enabled: false, allowedDomains: [], blockedDomains: [] },
+};
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-llm-settings-'));
+  delete process.env.ANTHROPIC_API_KEY;
+});
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('llm settings — API key at-rest encryption (#1326)', () => {
+  it('reads a legacy plaintext apiKey unchanged (backward compat)', async () => {
+    fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: 'sk-ant-legacy', model: 'claude-sonnet-5' }));
+    expect((await getSettings()).apiKey).toBe('sk-ant-legacy');
+  });
+
+  it('encrypts the apiKey on save and decrypts it on read', async () => {
+    await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
+    const onDisk = fs.readFileSync(settingsFile(), 'utf-8');
+    expect(onDisk).not.toContain('sk-ant-secret');
+    expect((JSON.parse(onDisk).apiKey as string).startsWith('enc:v1:')).toBe(true);
+    expect((await getSettings()).apiKey).toBe('sk-ant-secret');
+  });
+
+  it('migrates a legacy plaintext key to encrypted on the next save', async () => {
+    fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: 'sk-ant-old', model: 'claude-sonnet-5' }));
+    const loaded = await getSettings();
+    expect(loaded.apiKey).toBe('sk-ant-old');
+    await saveSettings(loaded);
+    const onDisk = fs.readFileSync(settingsFile(), 'utf-8');
+    expect(onDisk).not.toContain('sk-ant-old');
+    expect((JSON.parse(onDisk).apiKey as string).startsWith('enc:v1:')).toBe(true);
+  });
+
+  it('falls back to the env var when apiKey is absent, but respects an explicit empty', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-env';
+    fs.writeFileSync(settingsFile(), JSON.stringify({ model: 'claude-sonnet-5' }));
+    expect((await getSettings()).apiKey).toBe('sk-ant-env');
+    // An explicitly-cleared key stays cleared (matches the pre-#1326 `??` chain).
+    fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: '', model: 'claude-sonnet-5' }));
+    expect((await getSettings()).apiKey).toBe('');
+  });
+});

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -31,7 +31,7 @@ vi.mock('electron', () => ({
   },
 }));
 
-import { getSettings, saveSettings } from '../../../src/main/llm/settings';
+import { getSettings, saveSettings, getApiKeyStorage } from '../../../src/main/llm/settings';
 import type { LLMSettings } from '../../../src/shared/tools/types';
 
 const settingsFile = () => path.join(tempDir, 'llm-settings.json');
@@ -80,5 +80,24 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
     // An explicitly-cleared key stays cleared (matches the pre-#1326 `??` chain).
     fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: '', model: 'claude-sonnet-5' }));
     expect((await getSettings()).apiKey).toBe('');
+  });
+
+  describe('getApiKeyStorage — settings-panel indicator (#1326)', () => {
+    it('reports available + not-encrypted when no key is stored', async () => {
+      expect(await getApiKeyStorage()).toEqual({ available: true, encrypted: false });
+    });
+
+    it('reports encrypted after a key is saved', async () => {
+      await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
+      expect(await getApiKeyStorage()).toEqual({ available: true, encrypted: true });
+    });
+
+    it('reports NOT-encrypted for a legacy plaintext key until it is re-saved', async () => {
+      fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: 'sk-ant-legacy', model: 'claude-sonnet-5' }));
+      expect(await getApiKeyStorage()).toEqual({ available: true, encrypted: false });
+      // Re-saving migrates it to encrypted, which the indicator then reflects.
+      await saveSettings(await getSettings());
+      expect(await getApiKeyStorage()).toEqual({ available: true, encrypted: true });
+    });
   });
 });

--- a/tests/main/secret-storage.test.ts
+++ b/tests/main/secret-storage.test.ts
@@ -1,0 +1,73 @@
+/**
+ * At-rest secret encryption (#1326).
+ *
+ * Wraps Electron `safeStorage` behind a version-tagged encode/decode so the
+ * read path can distinguish an encrypted value from a legacy plaintext one —
+ * the property that makes the migration backward-compatible. The real
+ * `safeStorage` needs an Electron runtime + OS keychain, so we mock it with a
+ * reversible fake and a toggleable availability flag.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = vi.hoisted(() => ({ available: true }));
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => state.available,
+    encryptString: (s: string) => Buffer.from('FAKEENC:' + s, 'utf-8'),
+    decryptString: (buf: Buffer) => {
+      const s = buf.toString('utf-8');
+      if (!s.startsWith('FAKEENC:')) throw new Error('bad ciphertext');
+      return s.slice('FAKEENC:'.length);
+    },
+  },
+}));
+
+import { encryptSecret, decryptSecret, isEncrypted } from '../../src/main/secret-storage';
+
+beforeEach(() => {
+  state.available = true;
+});
+
+describe('secret-storage (#1326)', () => {
+  it('round-trips through safeStorage and never exposes the plaintext', () => {
+    const key = 'sk-ant-abc123';
+    const enc = encryptSecret(key);
+    expect(enc).not.toBe(key);
+    expect(enc.startsWith('enc:v1:')).toBe(true);
+    expect(enc).not.toContain(key); // ciphertext, not the key
+    expect(isEncrypted(enc)).toBe(true);
+    expect(decryptSecret(enc)).toBe(key);
+  });
+
+  it('reads a legacy plaintext value unchanged (backward compat)', () => {
+    expect(decryptSecret('sk-ant-legacy')).toBe('sk-ant-legacy');
+    expect(isEncrypted('sk-ant-legacy')).toBe(false);
+  });
+
+  it('handles empty strings on both paths', () => {
+    expect(encryptSecret('')).toBe('');
+    expect(decryptSecret('')).toBe('');
+  });
+
+  it('falls back to plaintext when encryption is unavailable', () => {
+    state.available = false;
+    const enc = encryptSecret('sk-ant-xyz');
+    expect(enc).toBe('sk-ant-xyz');
+    expect(isEncrypted(enc)).toBe(false);
+    expect(decryptSecret(enc)).toBe('sk-ant-xyz');
+  });
+
+  it('returns empty string when a tagged value cannot be decrypted', () => {
+    const undecryptable = 'enc:v1:' + Buffer.from('not-real-ciphertext').toString('base64');
+    expect(decryptSecret(undecryptable)).toBe('');
+  });
+
+  // Guards the tag-collision assumption: the sentinel prefix must not appear at
+  // the start of a plausible real secret, or a plaintext value would be
+  // mistaken for ciphertext.
+  it('the encrypted prefix does not collide with real secret shapes', () => {
+    expect('sk-ant-api03-xyz'.startsWith('enc:v1:')).toBe(false);
+    expect('a'.repeat(64).startsWith('enc:v1:')).toBe(false);
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -362,6 +362,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
   "tools": [
     "cancel",
     "execute",
+    "getKeyStorage",
     "getSettings",
     "onInvoke",
     "onStream",


### PR DESCRIPTION
Closes #1326.

## Problem
Two secrets were persisted as **plaintext JSON** under `userData`, with `safeStorage` used nowhere in the tree:
- the Anthropic API key — `llm-settings.json` (`llm/settings.ts:62`)
- the browser-clipper shared secret — `clipper-config.json`

Any local process, backup/cloud sync, or other user on a shared machine could lift them.

## Fix
New `src/main/secret-storage.ts` wraps Electron `safeStorage` (Keychain on macOS, DPAPI on Windows, libsecret/kwallet on Linux) behind a tiny `encryptSecret` / `decryptSecret` pair using a **version-tagged** on-disk format (`enc:v1:` + base64).

- `saveSettings` / `saveClipperConfig` encrypt the secret before writing.
- `getSettings` / `getClipperConfig` decrypt it transparently.
- **In-memory and IPC shapes are unchanged** — the renderer still sends/receives a plaintext `apiKey`, and the clipper's loopback constant-time compare still sees a plaintext hex secret.

## Backward compatible by construction
The `enc:v1:` tag lets the read path tell an encrypted value from a legacy plaintext one:

- A pre-existing **plaintext** key/secret has no tag → returned verbatim → keeps working.
- On the **next write**, the value is re-stored encrypted (lazy migration).
- `getSettings` preserves the exact prior `?? env ?? ''` semantics: an explicitly-cleared (`''`) key stays cleared; only an **absent** field falls back to `ANTHROPIC_API_KEY`.
- If `safeStorage` is **unavailable** (Linux without a keyring, or before `app` is ready), it degrades to the old plaintext behavior rather than ever losing the user's key.
- If a tagged value **can't** be decrypted (keychain rotated / profile moved machines), the reader returns `''` instead of surfacing ciphertext.

## Settings-panel indicator (follow-up commit)
The AI settings panel now tells the user — **honestly** — how the key is protected:

- New `tool:getKeyStorage` IPC returns `{ available, encrypted }`: `available` = the machine's `safeStorage` capability; `encrypted` = the *actual on-disk form* of the stored key (a legacy plaintext key reads `false` until re-saved).
- Shows **"🔒 API key saved — encrypted at rest"** only when the stored key is genuinely encrypted. The hint states where/how the key lives — encrypted via the OS secure store when available, or plainly noting plaintext-in-userData when no secure store exists.
- It never claims security it doesn't have: on a box without a keyring, or for a not-yet-migrated legacy key, the lock does not appear.

Wiring: `TOOL_GET_KEY_STORAGE` channel + `getApiKeyStorage()` + `ApiKeyStorage` shared type + preload/client method; `SettingsDialog` loads it on mount and passes it to `AiSettings`. Preload + IPC-registration snapshots updated.

## Not touched (deliberately)
`privileged-sites.json` holds only domain / label / timestamps. The actual site **cookies live in Electron persistent partitions** (Chromium-managed, OS-encrypted at rest), not in that JSON — so there's no plaintext secret there to wrap.

## Tests
- `secret-storage.test.ts`: round-trip (never exposes plaintext), legacy-plaintext passthrough, empty-string handling, unavailable→plaintext fallback, undecryptable→`''`, prefix-collision guard.
- `settings.test.ts` (new): encrypt-on-save/decrypt-on-read, read-legacy-plaintext, migrate-on-next-save, env-fallback-vs-explicit-empty, and `getApiKeyStorage` (no-key / encrypted / legacy-until-resaved).
- `clipper-config.test.ts` (extended): encrypt-at-rest while plaintext-in-memory, read-legacy-plaintext + re-encrypt-on-write.
- **Full suite: 4095 passing**; `pnpm lint` clean.

## Scope
Addresses **M1** only. Remaining: M2 (#1327), L1–L6 (#1329–#1334). H1 (#1325) and M3 (#1328) already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)