### PR TITLE
Perf: stop holding full note bodies in the search provider (#1111)

### DIFF
--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -113,7 +113,7 @@ export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Eng
     },
     async search(text, limit) {
       await ensureSearch();
-      const hits = search.search(ctx, text, limit ? { limit } : undefined);
+      const hits = await search.search(ctx, text, limit ? { limit } : undefined);
       return { ok: true, data: { query: text, hits } };
     },
     async semantic(text, limit) {
@@ -141,7 +141,7 @@ export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Eng
       // the link neighborhood + note content grounding.
       await ensureSearch();
       await ensureGraph();
-      const hits = search.search(ctx, t, { limit: n });
+      const hits = await search.search(ctx, t, { limit: n });
       const notes = await Promise.all(
         hits.map(async (h) => {
           let content = '';

--- a/src/main/ipc/register-queries.ts
+++ b/src/main/ipc/register-queries.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 import { Channels } from '../../shared/channels';
 import { projectContext } from '../project-context-types';
 import * as search from '../search/index';
+import type { SearchResult } from '../search/types';
 import * as savedQueries from '../saved-queries';
 import { rebuildMenu } from '../menu';
 import { rootPathFromEvent, withRootPathOr } from './helpers';
@@ -57,6 +58,6 @@ export function registerQueries(): void {
   });
 
   // Search
-  ipcMain.handle(Channels.SEARCH_QUERY, withRootPathOr([], (rootPath, query: string) =>
+  ipcMain.handle(Channels.SEARCH_QUERY, withRootPathOr(Promise.resolve<SearchResult[]>([]), (rootPath, query: string) =>
     search.search(projectContext(rootPath), query)));
 }

--- a/src/main/llm/tools/search-notes.ts
+++ b/src/main/llm/tools/search-notes.ts
@@ -2,12 +2,12 @@ import * as search from '../../search/index';
 import { projectContext } from '../../project-context-types';
 import type { NotebaseTool, ToolContext } from './types';
 
-function runSearch(ctx: ToolContext, input: unknown): string {
+async function runSearch(ctx: ToolContext, input: unknown): Promise<string> {
   const { query, limit } = input as { query: string; limit?: number };
   if (typeof query !== 'string' || !query.trim()) {
     throw new Error('query is required');
   }
-  const results = search.search(projectContext(ctx.rootPath), query, { limit: limit ?? 10 });
+  const results = await search.search(projectContext(ctx.rootPath), query, { limit: limit ?? 10 });
   if (results.length === 0) {
     return `No results for "${query}".`;
   }
@@ -44,5 +44,5 @@ export const searchNotes: NotebaseTool = {
       required: ['query'],
     },
   },
-  run: (ctx, input) => ({ content: runSearch(ctx, input), isError: false }),
+  run: async (ctx, input) => ({ content: await runSearch(ctx, input), isError: false }),
 };

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -48,7 +48,7 @@ function getState(ctx: ProjectContext): SearchState | null {
 function getOrCreateState(ctx: ProjectContext): SearchState {
   let state = store.get(ctx);
   if (!state) {
-    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider(), persistTimer: null };
+    state = { rootPath: ctx.rootPath, provider: new MiniSearchProvider(ctx.rootPath), persistTimer: null };
     store.set(ctx, state);
   }
   return state;
@@ -108,9 +108,9 @@ export function removeNote(ctx: ProjectContext, relativePath: string): void {
   state.provider.remove(relativePath);
 }
 
-export function search(ctx: ProjectContext, query: string, opts?: { limit?: number }): SearchResult[] {
+export function search(ctx: ProjectContext, query: string, opts?: { limit?: number }): Promise<SearchResult[]> {
   const state = getState(ctx);
-  if (!state) return [];
+  if (!state) return Promise.resolve([]);
   return state.provider.search(query, opts);
 }
 

--- a/src/main/search/minisearch-provider.ts
+++ b/src/main/search/minisearch-provider.ts
@@ -1,15 +1,33 @@
 import MiniSearch from 'minisearch';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import type { SearchProvider, SearchResult } from './types';
 
 const SNIPPET_RADIUS = 60; // characters of context around match
 
+/**
+ * Cap on the recently-read-body cache (perf #1111). Bounds snippet reads at
+ * O(cap × note size) instead of O(vault) — a handful of note bodies, not the
+ * whole corpus. Sized to comfortably cover one result page so paging through
+ * or re-running the same query stays off disk.
+ */
+const SNIPPET_CACHE_MAX = 100;
+
 export class MiniSearchProvider implements SearchProvider {
   private engine: MiniSearch;
-  /** Keep raw content for snippet extraction — MiniSearch doesn't store fields by default */
-  private docs = new Map<string, { title: string; content: string }>();
+  private readonly rootPath: string;
+  /**
+   * Bounded LRU of recently-read note bodies, used only for snippet extraction
+   * (perf #1111). MiniSearch doesn't store field bodies, so snippets are read
+   * from disk on demand rather than from a parallel full-corpus map — the note
+   * is already on disk. Insertion order is recency (re-inserted on hit); the
+   * oldest entry is evicted once `size` exceeds `SNIPPET_CACHE_MAX`, so resident
+   * memory stays bounded regardless of vault size.
+   */
+  private snippetCache = new Map<string, string>();
 
-  constructor() {
+  constructor(rootPath: string) {
+    this.rootPath = rootPath;
     this.engine = MiniSearchProvider.createEngine();
   }
 
@@ -28,64 +46,91 @@ export class MiniSearchProvider implements SearchProvider {
 
   index(relativePath: string, title: string, content: string): void {
     // MiniSearch requires remove-then-add to update
-    if (this.docs.has(relativePath)) {
+    if (this.engine.has(relativePath)) {
       this.engine.discard(relativePath);
     }
     this.engine.add({ relativePath, title, content });
-    this.docs.set(relativePath, { title, content });
+    // Body changed on disk — drop any stale cached copy.
+    this.snippetCache.delete(relativePath);
   }
 
   remove(relativePath: string): void {
-    if (this.docs.has(relativePath)) {
+    if (this.engine.has(relativePath)) {
       this.engine.discard(relativePath);
-      this.docs.delete(relativePath);
     }
+    this.snippetCache.delete(relativePath);
   }
 
-  search(query: string, opts?: { limit?: number }): SearchResult[] {
+  async search(query: string, opts?: { limit?: number }): Promise<SearchResult[]> {
     if (!query.trim()) return [];
 
     const limit = opts?.limit ?? 50;
-    const raw = this.engine.search(query);
+    const raw = this.engine.search(query) as Array<{ id: string; title?: string; score: number }>;
 
-    return raw.slice(0, limit).map((hit: { id: string; title?: string; score: number }) => {
-      const doc = this.docs.get(hit.id);
-      const snippet = doc ? extractSnippet(doc.content, query) : '';
-      return {
-        relativePath: hit.id,
-        title: hit.title ?? doc?.title ?? hit.id,
-        snippet,
-        score: hit.score,
-      };
-    });
+    // Snippets are only needed for the visible page, so read bodies for just
+    // the top `limit` hits. Reads run concurrently; the LRU keeps repeated
+    // (e.g. per-keystroke) searches over the same notes off disk.
+    return Promise.all(
+      raw.slice(0, limit).map(async (hit) => {
+        const body = await this.readBody(hit.id);
+        return {
+          relativePath: hit.id,
+          title: hit.title ?? hit.id,
+          snippet: body ? extractSnippet(body, query) : '',
+          score: hit.score,
+        };
+      }),
+    );
+  }
+
+  /**
+   * Read a note body for snippet extraction, via the bounded LRU. A miss reads
+   * from disk and caches; a file that's since moved or been deleted resolves to
+   * null so the result still surfaces (title + score) without a snippet.
+   */
+  private async readBody(relativePath: string): Promise<string | null> {
+    const cached = this.snippetCache.get(relativePath);
+    if (cached !== undefined) {
+      // Refresh recency: re-insert so it becomes the most-recently-used.
+      this.snippetCache.delete(relativePath);
+      this.snippetCache.set(relativePath, cached);
+      return cached;
+    }
+    try {
+      const body = await fs.readFile(path.join(this.rootPath, relativePath), 'utf-8');
+      this.snippetCache.set(relativePath, body);
+      if (this.snippetCache.size > SNIPPET_CACHE_MAX) {
+        const oldest = this.snippetCache.keys().next().value;
+        if (oldest !== undefined) this.snippetCache.delete(oldest);
+      }
+      return body;
+    } catch {
+      return null;
+    }
   }
 
   clear(): void {
     this.engine = MiniSearchProvider.createEngine();
-    this.docs.clear();
+    this.snippetCache.clear();
   }
 
   async save(destPath: string): Promise<void> {
-    const data = {
-      index: this.engine.toJSON(),
-      docs: Object.fromEntries(this.docs),
-    };
+    // Persist the index only — note bodies live on disk and are read on demand
+    // for snippets (perf #1111), so the JSON no longer duplicates the corpus.
+    const data = { index: this.engine.toJSON() };
     await fs.writeFile(destPath, JSON.stringify(data), 'utf-8');
   }
 
   async load(srcPath: string): Promise<void> {
     try {
       const raw = await fs.readFile(srcPath, 'utf-8');
-      const data = JSON.parse(raw) as { index: unknown; docs: Record<string, { title: string; content: string }> };
+      const data = JSON.parse(raw) as { index: unknown };
       this.engine = MiniSearch.loadJSON(JSON.stringify(data.index), {
         fields: ['title', 'content'],
         storeFields: ['title'],
         idField: 'relativePath',
       });
-      this.docs.clear();
-      for (const [key, val] of Object.entries(data.docs)) {
-        this.docs.set(key, val);
-      }
+      this.snippetCache.clear();
     } catch {
       // No persisted index or corrupt — start fresh
       this.clear();

--- a/src/main/search/types.ts
+++ b/src/main/search/types.ts
@@ -16,8 +16,9 @@ export interface SearchProvider {
   /** Remove a document from the index */
   remove(relativePath: string): void;
 
-  /** Search the index, returning ranked results */
-  search(query: string, opts?: { limit?: number }): SearchResult[];
+  /** Search the index, returning ranked results. Async because snippets are
+   *  read from disk on demand rather than held in memory (perf #1111). */
+  search(query: string, opts?: { limit?: number }): Promise<SearchResult[]>;
 
   /** Persist the index to disk */
   save(destPath: string): Promise<void>;

--- a/tests/main/notebase/write-pipeline.test.ts
+++ b/tests/main/notebase/write-pipeline.test.ts
@@ -77,7 +77,7 @@ describe('writeAndReindex (#341)', () => {
     expect((r.results as Array<{ t: string }>)[0].t).toBe('Foo');
 
     // Step 4: search indexed (full-text query hits).
-    const hits = runSearch(ctx, 'body');
+    const hits = await runSearch(ctx, 'body');
     expect(hits.some((h) => h.relativePath === 'foo.md')).toBe(true);
 
     // Step 6: rewritten broadcast went out for this path.

--- a/tests/main/search/minisearch-provider.test.ts
+++ b/tests/main/search/minisearch-provider.test.ts
@@ -1,79 +1,100 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 import { MiniSearchProvider } from '../../../src/main/search/minisearch-provider';
 
+// The provider reads note bodies from disk on demand for snippet extraction
+// (perf #1111), so tests back each indexed note with a real file under a temp
+// root. `write` both creates the file and indexes it, mirroring how the search
+// layer feeds the provider (index.ts reads the file, then calls `index`).
+let root: string;
+
 function createProvider(): MiniSearchProvider {
-  return new MiniSearchProvider();
+  return new MiniSearchProvider(root);
 }
+
+function write(p: MiniSearchProvider, relativePath: string, title: string, content: string): void {
+  const full = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf-8');
+  p.index(relativePath, title, content);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minisearch-provider-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
 
 describe('MiniSearchProvider', () => {
   describe('index and search', () => {
-    it('finds an indexed document', () => {
+    it('finds an indexed document', async () => {
       const p = createProvider();
-      p.index('note.md', 'My Note', 'This is some content');
-      const results = p.search('content');
+      write(p, 'note.md', 'My Note', 'This is some content');
+      const results = await p.search('content');
       expect(results).toHaveLength(1);
       expect(results[0].relativePath).toBe('note.md');
     });
 
-    it('finds by title', () => {
+    it('finds by title', async () => {
       const p = createProvider();
-      p.index('note.md', 'Architecture', 'Body text');
-      const results = p.search('Architecture');
+      write(p, 'note.md', 'Architecture', 'Body text');
+      const results = await p.search('Architecture');
       expect(results).toHaveLength(1);
     });
 
-    it('title matches rank higher than content matches', () => {
+    it('title matches rank higher than content matches', async () => {
       const p = createProvider();
-      p.index('a.md', 'Architecture Overview', 'Some unrelated body');
-      p.index('b.md', 'Other Note', 'The architecture is described here');
-      const results = p.search('architecture');
+      write(p, 'a.md', 'Architecture Overview', 'Some unrelated body');
+      write(p, 'b.md', 'Other Note', 'The architecture is described here');
+      const results = await p.search('architecture');
       expect(results[0].relativePath).toBe('a.md');
     });
 
-    it('supports prefix search', () => {
+    it('supports prefix search', async () => {
       const p = createProvider();
-      p.index('note.md', 'Deployment', 'Deploy the application');
-      const results = p.search('dep');
+      write(p, 'note.md', 'Deployment', 'Deploy the application');
+      const results = await p.search('dep');
       expect(results.length).toBeGreaterThan(0);
     });
 
-    it('returns empty for empty query', () => {
+    it('returns empty for empty query', async () => {
       const p = createProvider();
-      p.index('note.md', 'Test', 'Content');
-      expect(p.search('')).toEqual([]);
-      expect(p.search('  ')).toEqual([]);
+      write(p, 'note.md', 'Test', 'Content');
+      expect(await p.search('')).toEqual([]);
+      expect(await p.search('  ')).toEqual([]);
     });
 
-    it('respects limit option', () => {
+    it('respects limit option', async () => {
       const p = createProvider();
       for (let i = 0; i < 20; i++) {
-        p.index(`note-${i}.md`, `Note ${i}`, 'Common content word');
+        write(p, `note-${i}.md`, `Note ${i}`, 'Common content word');
       }
-      const results = p.search('content', { limit: 5 });
+      const results = await p.search('content', { limit: 5 });
       expect(results.length).toBeLessThanOrEqual(5);
     });
   });
 
   describe('update', () => {
-    it('re-indexes a document on second index call', () => {
+    it('re-indexes a document on second index call', async () => {
       const p = createProvider();
-      p.index('note.md', 'Old Title', 'Old content');
-      p.index('note.md', 'New Title', 'New content');
-      const results = p.search('New Title');
+      write(p, 'note.md', 'Old Title', 'Old content');
+      write(p, 'note.md', 'New Title', 'New content');
+      const results = await p.search('New Title');
       expect(results).toHaveLength(1);
       expect(results[0].title).toBe('New Title');
     });
   });
 
   describe('remove', () => {
-    it('removes a document from search results', () => {
+    it('removes a document from search results', async () => {
       const p = createProvider();
-      p.index('note.md', 'Test', 'Content');
+      write(p, 'note.md', 'Test', 'Content');
       p.remove('note.md');
-      expect(p.search('Test')).toEqual([]);
+      expect(await p.search('Test')).toEqual([]);
     });
 
     it('is a no-op for non-existent document', () => {
@@ -83,50 +104,75 @@ describe('MiniSearchProvider', () => {
   });
 
   describe('clear', () => {
-    it('empties all documents', () => {
+    it('empties all documents', async () => {
       const p = createProvider();
-      p.index('a.md', 'A', 'Content A');
-      p.index('b.md', 'B', 'Content B');
+      write(p, 'a.md', 'A', 'Content A');
+      write(p, 'b.md', 'B', 'Content B');
       p.clear();
-      expect(p.search('Content')).toEqual([]);
+      expect(await p.search('Content')).toEqual([]);
     });
   });
 
   describe('snippets', () => {
-    it('includes context around the matched term', () => {
+    it('includes context around the matched term', async () => {
       const p = createProvider();
       const body = 'The quick brown fox jumps over the lazy dog. ' +
         'Architecture is the foundation of every system. ' +
         'More text follows after this point.';
-      p.index('note.md', 'Test', body);
-      const results = p.search('Architecture');
+      write(p, 'note.md', 'Test', body);
+      const results = await p.search('Architecture');
       expect(results[0].snippet).toContain('Architecture');
+    });
+
+    it('finds a match deep in the body (read from disk, not a truncated preview)', async () => {
+      const p = createProvider();
+      const body = 'x'.repeat(5000) + ' needle-in-haystack ' + 'y'.repeat(5000);
+      write(p, 'note.md', 'Test', body);
+      const results = await p.search('needle-in-haystack');
+      expect(results[0].snippet).toContain('needle-in-haystack');
+    });
+
+    it('still surfaces a result (sans snippet) when the file is gone from disk', async () => {
+      const p = createProvider();
+      write(p, 'note.md', 'Test', 'Content about architecture');
+      fs.rmSync(path.join(root, 'note.md'));
+      const results = await p.search('architecture');
+      expect(results).toHaveLength(1);
+      expect(results[0].snippet).toBe('');
     });
   });
 
   describe('save and load', () => {
     it('round-trips through a file', async () => {
       const p = createProvider();
-      p.index('note.md', 'Saved Note', 'Persistent content');
+      write(p, 'note.md', 'Saved Note', 'Persistent content');
 
-      const tmpFile = path.join(os.tmpdir(), `minisearch-test-${Date.now()}.json`);
-      try {
-        await p.save(tmpFile);
+      const tmpFile = path.join(root, 'index.json');
+      await p.save(tmpFile);
 
-        const p2 = createProvider();
-        await p2.load(tmpFile);
-        const results = p2.search('Persistent');
-        expect(results).toHaveLength(1);
-        expect(results[0].relativePath).toBe('note.md');
-      } finally {
-        fs.unlinkSync(tmpFile);
-      }
+      const p2 = createProvider();
+      await p2.load(tmpFile);
+      const results = await p2.search('Persistent');
+      expect(results).toHaveLength(1);
+      expect(results[0].relativePath).toBe('note.md');
+    });
+
+    it('persisted JSON does not embed note bodies', async () => {
+      const p = createProvider();
+      write(p, 'note.md', 'Secret Title', 'UNIQUEBODYTOKEN should not be serialized');
+
+      const tmpFile = path.join(root, 'index.json');
+      await p.save(tmpFile);
+      const written = fs.readFileSync(tmpFile, 'utf-8');
+      // The inverted index holds terms, but the raw body text must not be
+      // stored verbatim — that was the O(vault) duplication #1111 removed.
+      expect(written).not.toContain('UNIQUEBODYTOKEN should not be serialized');
     });
 
     it('load handles missing file gracefully', async () => {
       const p = createProvider();
-      await p.load('/tmp/nonexistent-file-' + Date.now() + '.json');
-      expect(p.search('anything')).toEqual([]);
+      await p.load(path.join(root, 'nonexistent.json'));
+      expect(await p.search('anything')).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Closes #1111.

## Problem

MiniSearch doesn't store field bodies, so `MiniSearchProvider` kept a parallel `docs` Map of **every note's full content** purely so `search()` could extract a query-context snippet. That's an O(total vault bytes) permanent allocation resident in the main process for the project's lifetime — on top of MiniSearch's inverted index and the rdflib store — and `save()` serialized it verbatim into `.minerva/search-index.json`, duplicating the whole corpus on disk.

## Fix

Read snippet bodies **from disk on demand** — the note is already on disk.

- **`docs` Map removed entirely.** MiniSearch v7's `has(id)` covers the remove-then-add and `remove()` membership checks the Map previously served; `title` was already in `storeFields` and comes back on the hit.
- **Bounded LRU** (`SNIPPET_CACHE_MAX = 100` recently-read bodies) keeps repeated per-keystroke searches over the same notes off disk without pinning the corpus in memory. Only the visible page's bodies are read, and concurrently. Re-index/remove evict the stale cache entry; a file that's since moved/deleted resolves to no-snippet (the result still surfaces with title + score).
- **`save()` persists the index only**, so the on-disk JSON no longer duplicates bodies (compounds with the #1107 debounce). `load()` reads only `.index`, so pre-existing index files still load.

## Async ripple

`search()` now returns `Promise<SearchResult[]>` (it does disk I/O). Every caller already sits on an async boundary and now awaits: the `SEARCH_QUERY` IPC handler, the compute-RPC dispatch (`notes.search`), the `search_notes` LLM tool, and the CLI engine.

## Tests

Provider unit tests now back each note with a real file under a temp root. Added coverage:
- a match **deep past any preview window** is still snippeted — proves the on-demand disk read rather than a truncated stored field;
- a result still surfaces (empty snippet) when its file has vanished from disk;
- the persisted JSON contains **no verbatim body text**.

## Success criteria
- [x] `docs` Map no longer holds full note bodies (removed entirely)
- [x] Snippet extraction works (on-demand disk read + LRU)
- [x] Persisted search JSON no longer duplicates full bodies
- [x] Main-process resident memory for search is index-only (plus a bounded ≤100-body snippet cache)
- [x] `pnpm lint` and `pnpm test` pass (4101 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)