### PR TITLE
Perf: virtualize the conversation message list rendering (#1112)

### DIFF
--- a/src/renderer/lib/components/conversations/MessageList.svelte
+++ b/src/renderer/lib/components/conversations/MessageList.svelte
@@ -51,7 +51,16 @@
 
   function scrollToBottom() {
     requestAnimationFrame(() => {
-      if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
+      if (!scrollEl) return;
+      scrollEl.scrollTop = scrollEl.scrollHeight;
+      // Second pass (#1112): with `content-visibility` render-virtualization the
+      // bottom turns may have used their intrinsic-size *estimate* on the first
+      // pass. Scrolling there brings them on-screen so they render at their real
+      // height; re-pin to the now-accurate scrollHeight on the next frame so we
+      // always land flush at the bottom instead of a few pixels short.
+      requestAnimationFrame(() => {
+        if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
+      });
     });
   }
 
@@ -223,7 +232,25 @@
     flex-direction: column;
     gap: 10px;
   }
-  .msg { display: flex; flex-direction: column; gap: 2px; }
+  .msg {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    /* Render-virtualization for long transcripts (perf #1112). A several-
+       hundred-message research conversation mounts thousands of DOM nodes
+       (rendered markdown, citations, diffs); `content-visibility: auto` lets
+       Chromium skip layout + paint for the off-screen turns so scroll and
+       per-append cost stay bounded by the visible window instead of the whole
+       history. Crucially the nodes stay in the DOM, so scroll-to-bottom,
+       jump-to-message, and cross-message text selection keep working unchanged
+       — this virtualizes rendering, not the node list.
+       `contain-intrinsic-size: auto <fallback>` makes Chromium remember each
+       turn's real height after its first render (so the scrollbar settles
+       instead of drifting as you scroll up); the 4rem fallback only sizes turns
+       that have never been on-screen yet. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 4rem;
+  }
   .msg-role {
     font-size: 10px;
     font-weight: 600;


### PR DESCRIPTION
Closes #1112.

## Problem

`MessageList.svelte` renders the full transcript — `{#each tab.conversation.messages as msg, i}` — with no windowing. A long LLM conversation (hundreds of turns, each with rendered markdown, citations, and diff cards) mounts thousands of DOM nodes, and every reflow lays out and paints the entire list. This is the one renderer hot path whose DOM cost grows with a single session's activity rather than vault size, so a long research conversation degrades scroll and input latency in the panel.

## Approach

Use Chromium's native render-virtualization rather than a hand-rolled JS virtual scroller. For a variable-height transcript that must preserve scroll-to-bottom, jump-to-message, and cross-message text selection, `content-visibility: auto` is the right lever: off-screen turns skip layout + paint while **staying in the DOM**, so scroll and per-append cost stay bounded by the visible window — and every existing behavior is preserved for free because the nodes are still there. This virtualizes *rendering*, not the node list, which keeps the change contained (matching the issue's Low–Med risk rating) instead of a variable-height virtual scroller that would fight the interleaved draft cards, the streaming trailer, and the selection logic.

- `content-visibility: auto` + `contain-intrinsic-size: auto 4rem` on `.msg`. The `auto` keyword makes Chromium remember each turn's real height after its first render, so the scrollbar settles as you scroll up instead of drifting; the 4rem fallback only sizes turns never yet on-screen.
- **Scroll-to-bottom guard:** the one behavior content-visibility can perturb is landing short when the final turn renders taller than its intrinsic-size estimate. `scrollToBottom()` now re-pins on a second `requestAnimationFrame`, after the bottom turns have entered the viewport and rendered at true height, so it always lands flush.

Electron 43 (Chromium 136) fully supports the property and the last-remembered-size form.

## Success criteria
- [x] Message list renders only the visible window (Chromium skips layout/paint for off-screen turns)
- [x] Scroll and append latency stay bounded by the visible window, not history length
- [x] Scroll-to-bottom / navigation behaviors preserved (nodes stay mounted; scroll-to-bottom re-pinned)
- [x] Rendered markdown / proposals / diffs still display correctly (unchanged markup)
- [x] `pnpm lint` and `pnpm test` pass

## Verification note

Lint + the conversation renderer suites pass. The behavioral win (flat scroll/paint in a several-hundred-message conversation) and scroll-to-bottom flush-landing are visual/layout properties jsdom can't exercise — worth an eyeball in a real long conversation. Happy to drive the app and capture it if you'd like.

## Coordination
Touches `MessageList.svelte` (already extracted from `ConversationsPanel` under the #1087 arch split); this change is isolated to that component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)