### PR TITLE
Perf: defer preview highlight + batch cite/quote IPC + cache transclusions (#1114)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -57,7 +57,7 @@
         tableToCsv,
         outputToMarkdownClipboard
     } from '../preview/compute-output-render';
-    import { applyCslMarkers, resolveCiteLabel, resolveQuoteLabel, type CitationRenderDeps } from '../preview/citation-render';
+    import { applyCslMarkers, resolveCiteQuoteLabels, type CitationRenderDeps } from '../preview/citation-render';
     import { executeQueryBlock, type QueryBlockDeps } from '../preview/query-blocks';
 
     interface Props {
@@ -201,6 +201,16 @@
     const citeMetaCache = new Map<string, CiteMeta>();
     const quoteMetaCache = new Map<string, QuoteMeta>();
 
+    // Rendered-transclusion cache (perf #1114): `${rel}\u0000${embed}` → the
+    // md.render output for that embed's sliced body. Each host re-render rebuilds
+    // the whole preview DOM, so without this every `![[embed]]` re-ran a readFile
+    // IPC + a full md.render on every keystroke-debounced render. Keyed by the
+    // resolved target + embed directive (both project-global, like the other
+    // caches), and cleared on `revision` so a save to an embedded note refreshes
+    // it (see the effect below). Loop/depth checks still run per pass — only the
+    // read+parse of an unchanged body is skipped.
+    const transclusionRenderCache = new Map<string, string>();
+
     const QUERY_PREFIXES = `PREFIX minerva: <https://minerva.dev/ontology#>
 PREFIX thought: <https://minerva.dev/ontology/thought#>
 PREFIX dc: <http://purl.org/dc/terms/>
@@ -221,15 +231,14 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         html: true,
         linkify: true,
         typographer: true,
-        highlight(str: string, lang: string) {
-            if (lang && hljs.getLanguage(lang)) {
-                try {
-                    return hljs.highlight(str, {language: lang}).value;
-                } catch { /* fall through */
-                }
-            }
-            return '';
-        },
+        // No synchronous `highlight` (perf #1114). hljs.highlight is O(code
+        // size) and, inside md.render, runs on the critical debounced-render
+        // path — a large note with many/large fences blocks the main thread
+        // before anything paints. Instead markdown-it emits plain escaped code
+        // carrying its `language-…` class, and `highlightCodeBlocks()` applies
+        // hljs to each block in a post-render pass (off the critical path,
+        // after paint). Output is identical — the same hljs span markup — just
+        // computed later.
     });
     // Disable setext (underline) headings. Minerva is ATX-only by convention —
     // the heading extractor deliberately skips `text\n---` — and leaving lheading
@@ -565,6 +574,48 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     const imageDataUrlCache = new Map<string, string>();
 
     /**
+     * Deferred syntax highlighting (perf #1114). markdown-it now emits plain
+     * escaped code with a `language-…` class (no synchronous hljs on the render
+     * path); this post-render pass applies hljs to each not-yet-highlighted
+     * block. `data-hl` guards against re-highlighting on a revision-only re-run
+     * of the post-render effect. Output matches the old inline highlight exactly
+     * — the same `hljs.highlight(code, {language}).value` markup — just off the
+     * critical path. Unknown languages are left as escaped plain text (as before).
+     * Blocks are highlighted in `requestIdleCallback` chunks so a note with many
+     * large fences yields to input between batches instead of one long task.
+     */
+    function highlightCodeBlocks(): void {
+        const root = previewEl;
+        if (!root) return;
+        const blocks = Array.from(
+            root.querySelectorAll<HTMLElement>('pre > code[class*="language-"]:not([data-hl])'),
+        );
+        if (blocks.length === 0) return;
+
+        const highlightOne = (code: HTMLElement): void => {
+            code.dataset.hl = '1';
+            const langClass = Array.from(code.classList).find((c) => c.startsWith('language-'));
+            const lang = langClass?.slice('language-'.length);
+            if (!lang || !hljs.getLanguage(lang)) return;
+            try {
+                // textContent is the raw source (markdown-it escaped it into text
+                // nodes), which is exactly what hljs.highlight expects.
+                code.innerHTML = hljs.highlight(code.textContent ?? '', { language: lang }).value;
+            } catch { /* leave the escaped plain text in place */ }
+        };
+
+        const CHUNK = 12;
+        const idle = window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 0));
+        let i = 0;
+        const pump = (): void => {
+            const end = Math.min(i + CHUNK, blocks.length);
+            for (; i < end; i++) highlightOne(blocks[i]!);
+            if (i < blocks.length) idle(pump);
+        };
+        pump();
+    }
+
+    /**
      * Post-render hydration: walk every `.local-image[data-rel]`
      * placeholder, fetch the asset bytes via the binary IPC, and
      * inline as a data URL. Cached so re-renders are O(1) per image.
@@ -673,26 +724,33 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
                     continue;
                 }
 
-                let fileContent: string;
-                try {
-                    fileContent = await api.notebase.readFile(rel);
-                } catch {
-                    notice(ph, `Could not read “${target.path}”`, 'transclusion-missing');
-                    continue;
-                }
+                // Skip the readFile + slice + md.render for an unchanged embed
+                // (perf #1114): reuse the cached body HTML. The cache is cleared
+                // on `revision`, so a save to the embedded note re-renders it.
+                const cacheKey = `${rel}\u0000${embed}`;
+                let html = transclusionRenderCache.get(cacheKey);
+                if (html === undefined) {
+                    let fileContent: string;
+                    try {
+                        fileContent = await api.notebase.readFile(rel);
+                    } catch {
+                        notice(ph, `Could not read “${target.path}”`, 'transclusion-missing');
+                        continue;
+                    }
 
-                const slice = sliceTransclusion(fileContent, target);
-                if (!slice.ok) {
-                    notice(ph, slice.reason ?? 'Embedded content unavailable', 'transclusion-missing');
-                    continue;
-                }
+                    const slice = sliceTransclusion(fileContent, target);
+                    if (!slice.ok) {
+                        notice(ph, slice.reason ?? 'Embedded content unavailable', 'transclusion-missing');
+                        continue;
+                    }
 
-                renderPathOverride = rel;
-                let html: string;
-                try {
-                    html = md.render(slice.text);
-                } finally {
-                    renderPathOverride = null;
+                    renderPathOverride = rel;
+                    try {
+                        html = md.render(slice.text);
+                    } finally {
+                        renderPathOverride = null;
+                    }
+                    transclusionRenderCache.set(cacheKey, html);
                 }
 
                 const label = target.heading ? `${target.path} › ${target.heading}`
@@ -715,14 +773,14 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         root.querySelectorAll<HTMLElement>('.transclusion[data-embed]:not([data-resolved])')
             .forEach((ph) => notice(ph, 'Transclusion nested too deep', 'transclusion-loop'));
 
-        // Embedded fragments carry their own images / charts / cards / cite links —
-        // run the same post-render battery over the freshly injected subtree.
+        // Embedded fragments carry their own images / charts / cards / cite links /
+        // code fences — run the same post-render battery over the freshly injected
+        // subtree. The `data-hl` guard means the highlight pass only touches the
+        // newly-injected fences, not the host's already-highlighted ones.
         if (injected) {
+            highlightCodeBlocks();
             void hydrateLocalImages();
-            const cites = root.querySelectorAll('.cite-link');
-            cites.forEach((el) => resolveCiteLabel(citeDeps(), el as HTMLElement));
-            const quotes = root.querySelectorAll('.quote-link');
-            quotes.forEach((el) => resolveQuoteLabel(citeDeps(), el as HTMLElement));
+            void resolveCiteQuoteLabels(citeDeps());
             void hydrateMermaidBlocks(root);
             void hydrateVegaBlocks(root, content);
             hydrateCardCallouts(root);
@@ -945,6 +1003,17 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         return { notePath, revision, queryCache, queryPrefixes: QUERY_PREFIXES, activeCharts };
     }
 
+    // Drop cached transclusion bodies whenever the graph changes (perf #1114).
+    // `revision` bumps on any note save/index — including an embedded note — so
+    // this is exactly when a cached embed body could be stale. Pure host typing
+    // doesn't bump revision, so the cache still absorbs keystroke re-renders.
+    // Runs before the post-render effect's rAF, so hydrateTransclusions sees the
+    // cleared cache.
+    $effect(() => {
+        revision;
+        transclusionRenderCache.clear();
+    });
+
     // After render, find query-block placeholders and execute queries
     $effect(() => {
         rendered; // track dependency on rendered HTML
@@ -955,12 +1024,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         activeCharts = [];
 
         requestAnimationFrame(() => {
+            // Syntax-highlight fences off the critical render path (#1114).
+            highlightCodeBlocks();
             const blocks = previewEl?.querySelectorAll('.query-block');
             blocks?.forEach((el) => executeQueryBlock(queryDeps(), el as HTMLElement));
-            const cites = previewEl?.querySelectorAll('.cite-link');
-            cites?.forEach((el) => resolveCiteLabel(citeDeps(), el as HTMLElement));
-            const quotes = previewEl?.querySelectorAll('.quote-link');
-            quotes?.forEach((el) => resolveQuoteLabel(citeDeps(), el as HTMLElement));
+            void resolveCiteQuoteLabels(citeDeps());
             // CSL marker pass — runs in parallel with the per-element
             // metadata fetches. Citeproc-rendered markers replace the
             // raw cite/quote display text per the project's CSL style.

--- a/src/renderer/lib/preview/citation-render.ts
+++ b/src/renderer/lib/preview/citation-render.ts
@@ -77,36 +77,60 @@ export async function applyCslMarkers(deps: CitationRenderDeps): Promise<void> {
   deps.setBibliographyEntries(response.bibliography);
 }
 
-export async function resolveCiteLabel(deps: CitationRenderDeps, el: HTMLElement): Promise<void> {
-  const sourceId = el.dataset.sourceId;
-  if (!sourceId) return;
+/**
+ * Resolve hover-tooltip metadata for a whole batch of `.cite-link` elements in
+ * ONE IPC round-trip (perf #1114). The former per-element resolver issued a
+ * separate `api.graph.query` for each link, so a citation-heavy note fired N
+ * SPARQL round-trips on every re-render. Cached ids are applied immediately; the
+ * uncached remainder is fetched with a single `VALUES ?sid { … }` query, grouped
+ * back per source, and cached. On query failure the uncached links are left as
+ * their rendered source-id, retried on the next render (matching the old
+ * per-element fall-through).
+ */
+export async function resolveCiteLabels(deps: CitationRenderDeps, els: HTMLElement[]): Promise<void> {
+  const uncached = new Map<string, HTMLElement[]>();
+  for (const el of els) {
+    const id = el.dataset.sourceId;
+    if (!id || !el.querySelector('.link-display')) continue;
+    const cached = deps.citeMetaCache.get(id);
+    if (cached) { applyCiteMeta(el, cached); continue; }
+    const group = uncached.get(id);
+    if (group) group.push(el); else uncached.set(id, [el]);
+  }
+  if (uncached.size === 0) return;
 
-  const displayEl = el.querySelector<HTMLSpanElement>('.link-display');
-  if (!displayEl) return;
-
-  const cached = deps.citeMetaCache.get(sourceId);
-  if (cached) {
-    applyCiteMeta(el, cached);
-    return;
+  const values = [...uncached.keys()].map((id) => `"${id.replace(/"/g, '\\"')}"`).join(' ');
+  const sparql = `PREFIX bibo: <http://purl.org/ontology/bibo/>
+      SELECT ?sid ?title ?creator ?issued ?doi ?uri WHERE {
+        VALUES ?sid { ${values} }
+        ?src minerva:sourceId ?sid .
+        OPTIONAL { ?src dc:title ?title }
+        OPTIONAL { ?src dc:creator ?creator }
+        OPTIONAL { ?src dc:issued ?issued }
+        OPTIONAL { ?src bibo:doi ?doi }
+        OPTIONAL { ?src bibo:uri ?uri }
+      }`;
+  let rows: Array<Record<string, string>>;
+  try {
+    const response = await api.graph.query(deps.queryPrefixes + sparql);
+    rows = response.results as Array<Record<string, string>>;
+  } catch {
+    return; // leave uncached links as-is; next render retries.
   }
 
-  try {
-    const idEsc = sourceId.replace(/"/g, '\\"');
-    const sparql = `PREFIX bibo: <http://purl.org/ontology/bibo/>
-        SELECT ?title ?creator ?issued ?doi ?uri WHERE {
-          ?src minerva:sourceId "${idEsc}" .
-          OPTIONAL { ?src dc:title ?title }
-          OPTIONAL { ?src dc:creator ?creator }
-          OPTIONAL { ?src dc:issued ?issued }
-          OPTIONAL { ?src bibo:doi ?doi }
-          OPTIONAL { ?src bibo:uri ?uri }
-        }`;
-    const response = await api.graph.query(deps.queryPrefixes + sparql);
-    const meta = collapseCiteRows(response.results as Array<Record<string, string>>);
-    deps.citeMetaCache.set(sourceId, meta);
-    applyCiteMeta(el, meta);
-  } catch {
-    // Fall back to the source-id already rendered.
+  // Group rows by source id — a source with multiple creators yields one row
+  // each, and `collapseCiteRows` folds them into a single CiteMeta.
+  const rowsById = new Map<string, Array<Record<string, string>>>();
+  for (const row of rows) {
+    const sid = row.sid;
+    if (sid == null) continue;
+    const group = rowsById.get(sid);
+    if (group) group.push(row); else rowsById.set(sid, [row]);
+  }
+  for (const [id, targets] of uncached) {
+    const meta = collapseCiteRows(rowsById.get(id) ?? []);
+    deps.citeMetaCache.set(id, meta);
+    for (const el of targets) applyCiteMeta(el, meta);
   }
 }
 
@@ -117,50 +141,88 @@ function applyCiteMeta(el: HTMLElement, meta: CiteMeta): void {
   el.dataset.tooltipPayload = JSON.stringify(meta);
 }
 
-export async function resolveQuoteLabel(deps: CitationRenderDeps, el: HTMLElement): Promise<void> {
-  const excerptId = el.dataset.excerptId;
-  if (!excerptId) return;
+/** Build a QuoteMeta from one SPARQL result row (excerpt + owning source). */
+function quoteMetaFromRow(row: Record<string, string> | undefined): QuoteMeta {
+  return row ? {
+    ...(row.citedText !== undefined ? { citedText: row.citedText } : {}),
+    ...(row.sourceTitle !== undefined ? { sourceTitle: row.sourceTitle } : {}),
+    ...(row.sourceCreator !== undefined ? { sourceCreator: row.sourceCreator } : {}),
+    ...(row.sourceIssued !== undefined ? { sourceYear: row.sourceIssued.slice(0, 4) } : {}),
+    ...(row.page !== undefined ? { page: row.page } : {}),
+    ...(row.pageRange !== undefined ? { pageRange: row.pageRange } : {}),
+    ...(row.locationText !== undefined ? { locationText: row.locationText } : {}),
+  } : {};
+}
 
-  const displayEl = el.querySelector<HTMLSpanElement>('.link-display');
-  if (!displayEl) return;
-
-  const cached = deps.quoteMetaCache.get(excerptId);
-  if (cached) {
-    applyQuoteMeta(el, cached);
-    return;
+/**
+ * Batched counterpart to `resolveCiteLabels` for `.quote-link` elements (perf
+ * #1114): resolve every uncached excerpt's tooltip metadata in ONE IPC round-
+ * trip via `VALUES ?eid { … }` instead of one query per link. First row per
+ * excerpt wins (mirrors the old `LIMIT 1`).
+ */
+export async function resolveQuoteLabels(deps: CitationRenderDeps, els: HTMLElement[]): Promise<void> {
+  const uncached = new Map<string, HTMLElement[]>();
+  for (const el of els) {
+    const id = el.dataset.excerptId;
+    if (!id || !el.querySelector('.link-display')) continue;
+    const cached = deps.quoteMetaCache.get(id);
+    if (cached) { applyQuoteMeta(el, cached); continue; }
+    const group = uncached.get(id);
+    if (group) group.push(el); else uncached.set(id, [el]);
   }
+  if (uncached.size === 0) return;
 
+  const values = [...uncached.keys()].map((id) => `"${id.replace(/"/g, '\\"')}"`).join(' ');
+  const sparql = `SELECT ?eid ?citedText ?sourceTitle ?sourceCreator ?sourceIssued ?page ?pageRange ?locationText WHERE {
+      VALUES ?eid { ${values} }
+      ?ex minerva:excerptId ?eid .
+      OPTIONAL { ?ex thought:citedText ?citedText }
+      OPTIONAL { ?ex thought:page ?page }
+      OPTIONAL { ?ex thought:pageRange ?pageRange }
+      OPTIONAL { ?ex thought:locationText ?locationText }
+      OPTIONAL {
+        ?ex thought:fromSource ?src .
+        OPTIONAL { ?src dc:title ?sourceTitle }
+        OPTIONAL { ?src dc:creator ?sourceCreator }
+        OPTIONAL { ?src dc:issued ?sourceIssued }
+      }
+    }`;
+  let rows: Array<Record<string, string>>;
   try {
-    const idEsc = excerptId.replace(/"/g, '\\"');
-    const sparql = `SELECT ?citedText ?sourceTitle ?sourceCreator ?sourceIssued ?page ?pageRange ?locationText WHERE {
-        ?ex minerva:excerptId "${idEsc}" .
-        OPTIONAL { ?ex thought:citedText ?citedText }
-        OPTIONAL { ?ex thought:page ?page }
-        OPTIONAL { ?ex thought:pageRange ?pageRange }
-        OPTIONAL { ?ex thought:locationText ?locationText }
-        OPTIONAL {
-          ?ex thought:fromSource ?src .
-          OPTIONAL { ?src dc:title ?sourceTitle }
-          OPTIONAL { ?src dc:creator ?sourceCreator }
-          OPTIONAL { ?src dc:issued ?sourceIssued }
-        }
-      } LIMIT 1`;
     const response = await api.graph.query(deps.queryPrefixes + sparql);
-    const row = response.results[0] as Record<string, string> | undefined;
-    const meta: QuoteMeta = row ? {
-      ...(row.citedText !== undefined ? { citedText: row.citedText } : {}),
-      ...(row.sourceTitle !== undefined ? { sourceTitle: row.sourceTitle } : {}),
-      ...(row.sourceCreator !== undefined ? { sourceCreator: row.sourceCreator } : {}),
-      ...(row.sourceIssued !== undefined ? { sourceYear: row.sourceIssued.slice(0, 4) } : {}),
-      ...(row.page !== undefined ? { page: row.page } : {}),
-      ...(row.pageRange !== undefined ? { pageRange: row.pageRange } : {}),
-      ...(row.locationText !== undefined ? { locationText: row.locationText } : {}),
-    } : {};
-    deps.quoteMetaCache.set(excerptId, meta);
-    applyQuoteMeta(el, meta);
+    rows = response.results as Array<Record<string, string>>;
   } catch {
-    // Fall back to the excerpt-id already rendered.
+    return; // leave uncached links as-is; next render retries.
   }
+
+  // Keep the first row per excerpt id (old behavior: LIMIT 1).
+  const rowById = new Map<string, Record<string, string>>();
+  for (const row of rows) {
+    const eid = row.eid;
+    if (eid != null && !rowById.has(eid)) rowById.set(eid, row);
+  }
+  for (const [id, targets] of uncached) {
+    const meta = quoteMetaFromRow(rowById.get(id));
+    deps.quoteMetaCache.set(id, meta);
+    for (const el of targets) applyQuoteMeta(el, meta);
+  }
+}
+
+/**
+ * One-shot post-render enrichment for every cite + quote link in the preview
+ * (perf #1114). Replaces the former per-element `forEach(resolveCiteLabel)` /
+ * `forEach(resolveQuoteLabel)` fan-out with two batched queries (cites, quotes)
+ * that run concurrently.
+ */
+export async function resolveCiteQuoteLabels(deps: CitationRenderDeps): Promise<void> {
+  const root = deps.previewEl;
+  if (!root) return;
+  const cites = Array.from(root.querySelectorAll<HTMLElement>('.cite-link'));
+  const quotes = Array.from(root.querySelectorAll<HTMLElement>('.quote-link'));
+  await Promise.all([
+    resolveCiteLabels(deps, cites),
+    resolveQuoteLabels(deps, quotes),
+  ]);
 }
 
 function applyQuoteMeta(el: HTMLElement, meta: QuoteMeta): void {

--- a/tests/renderer/preview/citation-render-batch.test.ts
+++ b/tests/renderer/preview/citation-render-batch.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Batched cite/quote hydration (perf #1114). The former per-element resolvers
+ * issued one `api.graph.query` per `.cite-link` / `.quote-link`; these tests pin
+ * that a whole batch now resolves in a SINGLE IPC round-trip, that metadata is
+ * applied to every link, and that a re-run served from cache issues no IPC.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const queryMock = vi.fn();
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { graph: { query: (sparql: string) => queryMock(sparql) } },
+}));
+
+import {
+  resolveCiteLabels,
+  resolveQuoteLabels,
+  type CitationRenderDeps,
+} from '../../../src/renderer/lib/preview/citation-render';
+import type { CiteMeta, QuoteMeta } from '../../../src/renderer/lib/preview/cite-meta';
+
+function makeDeps(): CitationRenderDeps {
+  const root = document.createElement('div');
+  return {
+    previewEl: root,
+    citeMetaCache: new Map<string, CiteMeta>(),
+    quoteMetaCache: new Map<string, QuoteMeta>(),
+    queryPrefixes: '',
+    setBibliographyEntries: () => {},
+  };
+}
+
+/** A `.cite-link` element with the `.link-display` span the resolver requires. */
+function citeLink(sourceId: string): HTMLElement {
+  const el = document.createElement('span');
+  el.className = 'cite-link';
+  el.dataset.sourceId = sourceId;
+  const disp = document.createElement('span');
+  disp.className = 'link-display';
+  el.appendChild(disp);
+  return el;
+}
+
+function quoteLink(excerptId: string): HTMLElement {
+  const el = document.createElement('span');
+  el.className = 'quote-link';
+  el.dataset.excerptId = excerptId;
+  const disp = document.createElement('span');
+  disp.className = 'link-display';
+  el.appendChild(disp);
+  return el;
+}
+
+beforeEach(() => queryMock.mockReset());
+
+describe('resolveCiteLabels (batched, #1114)', () => {
+  it('resolves N cite links in a single IPC call', async () => {
+    queryMock.mockResolvedValue({
+      results: [
+        { sid: 's1', title: 'First', creator: 'Ada', issued: '2020-01-01' },
+        { sid: 's2', title: 'Second', creator: 'Bob', issued: '2021-06-01' },
+      ],
+    });
+    const deps = makeDeps();
+    const els = [citeLink('s1'), citeLink('s2'), citeLink('s1')]; // s1 twice
+
+    await resolveCiteLabels(deps, els);
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    // One VALUES query carrying both distinct ids.
+    const sparql = queryMock.mock.calls[0]![0] as string;
+    expect(sparql).toContain('VALUES ?sid');
+    expect(sparql).toContain('"s1"');
+    expect(sparql).toContain('"s2"');
+
+    // Every element (including the duplicate s1) got tooltip metadata.
+    for (const el of els) {
+      expect(el.dataset.tooltipKind).toBe('cite');
+    }
+    const meta1 = JSON.parse(els[0]!.dataset.tooltipPayload!) as CiteMeta;
+    expect(meta1.title).toBe('First');
+    expect(meta1.creators).toEqual(['Ada']);
+    expect(meta1.year).toBe('2020');
+    // The duplicate points at the same source.
+    expect(JSON.parse(els[2]!.dataset.tooltipPayload!).title).toBe('First');
+  });
+
+  it('serves cached ids without any IPC on a second pass', async () => {
+    queryMock.mockResolvedValue({ results: [{ sid: 's1', title: 'First', creator: 'Ada' }] });
+    const deps = makeDeps();
+
+    await resolveCiteLabels(deps, [citeLink('s1')]);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+
+    // A fresh element for the same, now-cached source → no new query.
+    await resolveCiteLabels(deps, [citeLink('s1')]);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not query when there are no cite links', async () => {
+    await resolveCiteLabels(makeDeps(), []);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveQuoteLabels (batched, #1114)', () => {
+  it('resolves N quote links in a single IPC call', async () => {
+    queryMock.mockResolvedValue({
+      results: [
+        { eid: 'e1', citedText: 'quote one', sourceTitle: 'Src', page: '3' },
+        { eid: 'e2', citedText: 'quote two' },
+      ],
+    });
+    const deps = makeDeps();
+    const els = [quoteLink('e1'), quoteLink('e2')];
+
+    await resolveQuoteLabels(deps, els);
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const sparql = queryMock.mock.calls[0]![0] as string;
+    expect(sparql).toContain('VALUES ?eid');
+    const meta1 = JSON.parse(els[0]!.dataset.tooltipPayload!) as QuoteMeta;
+    expect(meta1.citedText).toBe('quote one');
+    expect(meta1.page).toBe('3');
+    expect(JSON.parse(els[1]!.dataset.tooltipPayload!).citedText).toBe('quote two');
+  });
+});


### PR DESCRIPTION
Addresses #1114 (finding M2) — the **safe subset** agreed with the author. The worker/incremental whole-doc render is deferred to its own follow-up (the issue itself says measure-first + coordinate with the #1087 split); everything here is contained and reviewable.

Four Preview hot paths, all moved off the critical debounced-render path:

## 1. Deferred syntax highlighting
`hljs.highlight` ran **synchronously inside `md.render`**, so a large note with many/large fences blocked the main renderer thread before anything painted. markdown-it now emits plain escaped code carrying its `language-…` class, and a new `highlightCodeBlocks()` applies hljs in a post-render `requestIdleCallback` pass (12-block chunks), guarded by `data-hl` so a revision-only re-run skips already-highlighted blocks. **Output is byte-identical** to the old inline highlight (same `hljs.highlight(code, {language}).value` markup) — just computed after paint. Unknown languages stay escaped plain text, as before.

## 2. Batched cite/quote hydration
`resolveCiteLabel`/`resolveQuoteLabel` each fired their own `api.graph.query` SPARQL **per link**, so a citation-heavy note issued N IPC round-trips per re-render (the issue's headline case). `resolveCiteLabels`/`resolveQuoteLabels` now collect every uncached id and resolve them in **one `VALUES` query each** (cites + quotes run concurrently via `resolveCiteQuoteLabels`). Cached ids apply with zero IPC; on query failure links are left as-is and retried next render (matching the old per-element fall-through). `applyCslMarkers` was already batched and is untouched.

## 3. Transclusion render cache
Each host re-render rebuilds the whole preview DOM, so every `![[embed]]` re-ran a `readFile` IPC + a full `md.render` on **every keystroke-debounced render**. A per-embed cache keyed by resolved-path + embed directive reuses the rendered body. It's cleared on `revision`, so a **save** to an embedded note refreshes it, while pure host typing (no save) is fully absorbed. Loop/depth checks still run per pass — only the read+parse of an *unchanged* body is skipped.

## 4. Sidebar `countFiles` — verified already-satisfied (no change)
`notesCount` is `$derived(countFiles(files))`, and `notebase.files` is reassigned only by `listFiles()` on **structural** tree changes (create/delete/rename/move) — never on a save (only `onFileCreated`/`onFileDeleted` schedule a refresh). So the Svelte 5 derived already recomputes only when the tree actually changes; the automated report over-flagged it (same pattern as #1108). Documented rather than adding gratuitous code.

## Success criteria
- [x] Large-note Preview render no longer blocks the main thread synchronously (highlight deferred to a post-render idle pass)
- [x] Post-render cite/quote hydration uses a single batched IPC call (one `VALUES` query each)
- [x] Transclusion hydration doesn't re-parse the whole embed per `![[…]]` unnecessarily (per-embed cache, revision-invalidated)
- [x] Sidebar file-count no longer recomputed via full walk on every tree change (already gated by the derived; verified)
- [x] `pnpm lint` and `pnpm test` pass (4105 tests; +4 new)
- [ ] Worker/incremental whole-doc render — **deferred to a follow-up** (out of the agreed scope)

## Tests
New `citation-render-batch` suite (jsdom): N cite/quote links resolve in a **single** IPC call, metadata reaches every link (including a duplicate source id), a cached second pass issues **no** IPC, and an empty set issues none.

## Not verified at runtime
The deferred-highlight flash-of-plain-code and transclusion-cache freshness are visual/timing behaviors jsdom can't exercise — worth an eyeball in a real long note with fences + citations + embeds. Happy to drive the app and capture it if you'd like.

## Coordination
Touches `Preview.svelte` — coordinate with the #1087 arch split. Isolated to the render/hydration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
