### PR TITLE
Security L3: DOMPurify pass on mermaid diagram SVG before innerHTML (#1331)

### DIFF
--- a/src/renderer/lib/compute-output-sanitize.ts
+++ b/src/renderer/lib/compute-output-sanitize.ts
@@ -14,9 +14,13 @@
 
 import DOMPurify from 'dompurify';
 
-const FORBID_TAGS = ['script', 'iframe', 'object', 'embed', 'form'];
+// The script/injection surface forbidden across every DOMPurify pass in the
+// renderer — reused by the diagram-SVG sanitiser (#1331) so there is a single
+// source of truth for "what a library must never be able to emit into the host
+// page." Exported rather than duplicated.
+export const FORBID_TAGS = ['script', 'iframe', 'object', 'embed', 'form'];
 
-const FORBID_ATTR = [
+export const FORBID_ATTR = [
   'onerror',
   'onload',
   'onclick',

--- a/src/renderer/lib/compute-output-sanitize.ts
+++ b/src/renderer/lib/compute-output-sanitize.ts
@@ -14,13 +14,9 @@
 
 import DOMPurify from 'dompurify';
 
-// The script/injection surface forbidden across every DOMPurify pass in the
-// renderer — reused by the diagram-SVG sanitiser (#1331) so there is a single
-// source of truth for "what a library must never be able to emit into the host
-// page." Exported rather than duplicated.
-export const FORBID_TAGS = ['script', 'iframe', 'object', 'embed', 'form'];
+const FORBID_TAGS = ['script', 'iframe', 'object', 'embed', 'form'];
 
-export const FORBID_ATTR = [
+const FORBID_ATTR = [
   'onerror',
   'onload',
   'onclick',

--- a/src/renderer/lib/markdown/mermaid-renderer.ts
+++ b/src/renderer/lib/markdown/mermaid-renderer.ts
@@ -16,6 +16,7 @@
 
 import { getEffectiveTheme, getThemeMode } from '../theme';
 import { normalizeColor } from '../utils/oklch';
+import { sanitizeDiagramSvg } from './sanitize-diagram-svg';
 
 type MermaidApi = {
   initialize: (config: Record<string, unknown>) => void;
@@ -126,7 +127,10 @@ export async function hydrateMermaidBlocks(root: HTMLElement): Promise<void> {
     try {
       const id = `mermaid-${++counter}`;
       const { svg, bindFunctions } = await api.render(id, source);
-      el.innerHTML = svg;
+      // Defense in depth behind CSP (#1331): scrub the library-generated SVG
+      // before it hits the DOM. bindFunctions runs after and re-queries the
+      // sanitised nodes by id/class (both preserved), so interactivity survives.
+      el.innerHTML = sanitizeDiagramSvg(svg);
       el.setAttribute('data-mermaid-rendered', 'ok');
       if (bindFunctions) bindFunctions(el);
     } catch (err) {

--- a/src/renderer/lib/markdown/sanitize-diagram-svg.ts
+++ b/src/renderer/lib/markdown/sanitize-diagram-svg.ts
@@ -1,0 +1,39 @@
+/**
+ * Defense-in-depth sanitisation for library-generated diagram SVG (#1331, L3).
+ *
+ * Mermaid renders a diagram to an SVG *string* that the renderer injects via
+ * `innerHTML` (`mermaid-renderer.ts`). Today the only thing between a malicious
+ * ```mermaid source and DOM injection is the app CSP (no `unsafe-inline` in
+ * `script-src`) plus mermaid's own output being well-formed. This adds an
+ * explicit DOMPurify pass as a second, independent layer, so a mermaid
+ * sanitisation bypass or a future CSP regression can't turn diagram source into
+ * an executing `<script>` or inline event handler.
+ *
+ * (Vega does NOT need this: vega-embed builds the chart with safe DOM
+ * construction — createElementNS/setAttribute via its SVG renderer — never
+ * `innerHTML` of a generated string, and runs expressions through the CSP-safe
+ * AST interpreter (`ast: true`). The only `innerHTML` in the Vega renderer is
+ * app-controlled, already-escaped error/notice HTML.)
+ *
+ * Config mirrors `sanitizeComputeOutputHtml`: DOMPurify's default HTML+SVG
+ * allowlist minus the script/handler surface. That allowlist keeps everything
+ * this app's mermaid actually emits — it runs with `securityLevel: 'strict'`, so
+ * node labels are SVG `<text>` (not `<foreignObject>` HTML), and the `<style>`,
+ * `<path>`, `<g>`, ids, classes and inline styles all survive, including the
+ * ids/classes mermaid's post-render `bindFunctions` re-queries. `USE_PROFILES`
+ * is intentionally omitted — see the note in compute-output-sanitize.ts.
+ *
+ * (DOMPurify's default drops `<foreignObject>` HTML content, which would matter
+ * only if mermaid were switched to `htmlLabels`/non-strict — revisit the config
+ * here if that ever happens.)
+ */
+
+import DOMPurify from 'dompurify';
+import { FORBID_TAGS, FORBID_ATTR } from '../compute-output-sanitize';
+
+export function sanitizeDiagramSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, {
+    FORBID_TAGS,
+    FORBID_ATTR,
+  });
+}

--- a/src/renderer/lib/markdown/sanitize-diagram-svg.ts
+++ b/src/renderer/lib/markdown/sanitize-diagram-svg.ts
@@ -4,36 +4,61 @@
  * Mermaid renders a diagram to an SVG *string* that the renderer injects via
  * `innerHTML` (`mermaid-renderer.ts`). Today the only thing between a malicious
  * ```mermaid source and DOM injection is the app CSP (no `unsafe-inline` in
- * `script-src`) plus mermaid's own output being well-formed. This adds an
- * explicit DOMPurify pass as a second, independent layer, so a mermaid
- * sanitisation bypass or a future CSP regression can't turn diagram source into
- * an executing `<script>` or inline event handler.
+ * `script-src`) plus mermaid's own output. This adds an explicit, independent
+ * scrub of the markup before it hits the DOM, so a mermaid sanitisation bypass
+ * or a future CSP regression can't turn diagram source into an executing
+ * `<script>` or inline event handler. CSP stays the primary control; this is the
+ * second layer.
  *
- * (Vega does NOT need this: vega-embed builds the chart with safe DOM
+ * Why not DOMPurify (as used for compute output): DOMPurify's allowlist strips
+ * `<foreignObject>` HTML content, and mermaid v11 renders node labels as HTML
+ * inside `<foreignObject>` — so a DOMPurify pass silently deletes every diagram
+ * label. Instead this parses the SVG the same way the browser will when it's
+ * assigned to `innerHTML` (the HTML parser, where `<foreignObject>` is an HTML
+ * integration point so labels survive) and removes only the actual injection
+ * surface: script/embed elements, SMIL animation elements (mermaid diagrams are
+ * static; these are a known animate-to-script vector), `on*` handler attributes,
+ * and `javascript:` / `vbscript:` / `data:text/html` URLs. Everything legitimate
+ * — `<text>`/`<foreignObject>` labels, `<style>`, `<path>`, ids, classes, inline
+ * styles, the ids/classes mermaid's post-render `bindFunctions` re-queries — is
+ * preserved untouched.
+ *
+ * (Vega needs no equivalent: vega-embed builds the chart with safe DOM
  * construction — createElementNS/setAttribute via its SVG renderer — never
- * `innerHTML` of a generated string, and runs expressions through the CSP-safe
- * AST interpreter (`ast: true`). The only `innerHTML` in the Vega renderer is
- * app-controlled, already-escaped error/notice HTML.)
- *
- * Config mirrors `sanitizeComputeOutputHtml`: DOMPurify's default HTML+SVG
- * allowlist minus the script/handler surface. That allowlist keeps everything
- * this app's mermaid actually emits — it runs with `securityLevel: 'strict'`, so
- * node labels are SVG `<text>` (not `<foreignObject>` HTML), and the `<style>`,
- * `<path>`, `<g>`, ids, classes and inline styles all survive, including the
- * ids/classes mermaid's post-render `bindFunctions` re-queries. `USE_PROFILES`
- * is intentionally omitted — see the note in compute-output-sanitize.ts.
- *
- * (DOMPurify's default drops `<foreignObject>` HTML content, which would matter
- * only if mermaid were switched to `htmlLabels`/non-strict — revisit the config
- * here if that ever happens.)
+ * `innerHTML` of a generated string, and `ast: true` keeps expressions off
+ * `new Function`.)
  */
 
-import DOMPurify from 'dompurify';
-import { FORBID_TAGS, FORBID_ATTR } from '../compute-output-sanitize';
+/** Elements never legitimately present in a static rendered diagram. */
+const FORBIDDEN_ELEMENTS = [
+  'script', 'iframe', 'object', 'embed', 'form',
+  // SMIL animation can retarget an href to a script URL; mermaid output is
+  // static, so these are pure attack surface.
+  'animate', 'animatetransform', 'animatemotion', 'set',
+];
+
+/** URL schemes that must never survive on href / xlink:href / src. */
+const UNSAFE_URI_RE = /^\s*(?:javascript|vbscript|data:text\/html)/i;
+const URI_ATTRS = new Set(['href', 'xlink:href', 'src']);
 
 export function sanitizeDiagramSvg(svg: string): string {
-  return DOMPurify.sanitize(svg, {
-    FORBID_TAGS,
-    FORBID_ATTR,
-  });
+  // Parse as HTML — the same parser the browser uses for `el.innerHTML = …`, so
+  // `<foreignObject>` HTML labels are namespaced correctly and preserved.
+  const doc = new DOMParser().parseFromString(svg, 'text/html');
+  const container = doc.body;
+
+  container.querySelectorAll(FORBIDDEN_ELEMENTS.join(',')).forEach((el) => el.remove());
+
+  for (const el of container.querySelectorAll('*')) {
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith('on')) {
+        el.removeAttribute(attr.name);
+      } else if (URI_ATTRS.has(name) && UNSAFE_URI_RE.test(attr.value)) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return container.innerHTML;
 }

--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -293,6 +293,12 @@ export async function hydrateVegaBlocks(root: HTMLElement, noteContent = ''): Pr
     }
 
     try {
+      // No DOMPurify pass here (#1331): vega-embed builds the chart with safe
+      // DOM construction (createElementNS/setAttribute via its SVG renderer),
+      // never innerHTML of a generated string, and `ast: true` below keeps
+      // expressions off `new Function`. The only innerHTML in this file is the
+      // app-controlled, already-escaped error/notice HTML. See
+      // sanitize-diagram-svg.ts for the mermaid counterpart that does need it.
       const { view } = await embed(el, spec, {
         mode,
         renderer: 'svg',

--- a/tests/renderer/markdown/sanitize-diagram-svg.test.ts
+++ b/tests/renderer/markdown/sanitize-diagram-svg.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Defense-in-depth sanitisation for mermaid-generated diagram SVG (#1331, L3).
+ *
+ * jsdom rather than happy-dom for the same reason as the compute-output test:
+ * DOMPurify v3's element-table detection matches Chromium closely under jsdom,
+ * so the real sanitiser code path is exercised. Verifies the L3 call-out — a
+ * `<script>` / inline handler smuggled into diagram SVG is stripped — while the
+ * SVG shape and the ids/classes mermaid's post-render bindFunctions relies on
+ * survive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sanitizeDiagramSvg } from '../../../src/renderer/lib/markdown/sanitize-diagram-svg';
+
+describe('sanitizeDiagramSvg (#1331)', () => {
+  it('strips a <script> smuggled into the SVG', () => {
+    const evil = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><g class="node"><rect/></g></svg>';
+    const out = sanitizeDiagramSvg(evil);
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('alert');
+    expect(out).toContain('<rect');
+  });
+
+  it('strips inline event-handler attributes on diagram nodes', () => {
+    const out = sanitizeDiagramSvg('<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="alert(1)" onload="steal()"/></svg>');
+    expect(out).not.toContain('onclick');
+    expect(out).not.toContain('onload');
+    expect(out).not.toContain('alert');
+    expect(out).toContain('<rect');
+  });
+
+  it('preserves the SVG structure, text labels, ids and classes bindFunctions re-queries', () => {
+    // Mirrors strict-mode mermaid output: SVG <text> labels (not foreignObject),
+    // <style>, ids/classes, inline styles.
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" id="mermaid-1">'
+      + '<style>.node{fill:red}</style>'
+      + '<g class="node clickable" id="node-a"><rect x="0" y="0" width="10" height="10" style="fill:blue"/>'
+      + '<text class="nodeLabel">Hello Label</text></g><path class="edge" d="M0 0 L10 10"/></svg>';
+    const out = sanitizeDiagramSvg(svg);
+    expect(out).toContain('id="mermaid-1"');
+    expect(out).toContain('id="node-a"');
+    expect(out).toContain('class="node clickable"');
+    expect(out).toContain('<style');
+    expect(out).toContain('<path');
+    expect(out).toContain('Hello Label'); // node label text survives
+    expect(out).toContain('style="fill:blue"');
+  });
+
+  it('drops a javascript: href on a clickable node link', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><a xlink:href="javascript:alert(1)"><rect/></a></svg>';
+    const out = sanitizeDiagramSvg(svg);
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('<rect');
+  });
+});

--- a/tests/renderer/markdown/sanitize-diagram-svg.test.ts
+++ b/tests/renderer/markdown/sanitize-diagram-svg.test.ts
@@ -3,12 +3,11 @@
  *
  * Defense-in-depth sanitisation for mermaid-generated diagram SVG (#1331, L3).
  *
- * jsdom rather than happy-dom for the same reason as the compute-output test:
- * DOMPurify v3's element-table detection matches Chromium closely under jsdom,
- * so the real sanitiser code path is exercised. Verifies the L3 call-out — a
- * `<script>` / inline handler smuggled into diagram SVG is stripped — while the
- * SVG shape and the ids/classes mermaid's post-render bindFunctions relies on
- * survive.
+ * Verifies the L3 call-out — a `<script>` / inline handler / `javascript:` URL
+ * smuggled into diagram SVG is stripped — while the diagram content mermaid
+ * actually emits survives, crucially the HTML node labels mermaid v11 renders
+ * inside `<foreignObject>` (a DOMPurify allowlist pass would delete those; the
+ * regression this guards against).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -31,9 +30,25 @@ describe('sanitizeDiagramSvg (#1331)', () => {
     expect(out).toContain('<rect');
   });
 
-  it('preserves the SVG structure, text labels, ids and classes bindFunctions re-queries', () => {
-    // Mirrors strict-mode mermaid output: SVG <text> labels (not foreignObject),
-    // <style>, ids/classes, inline styles.
+  it('drops a javascript: href on a clickable node link', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><a xlink:href="javascript:alert(1)"><rect/></a></svg>';
+    const out = sanitizeDiagramSvg(svg);
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('<rect');
+  });
+
+  it('removes SMIL animation elements (animate-to-script vector)', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect>'
+      + '<set attributeName="href" to="javascript:alert(1)"/>'
+      + '<animate attributeName="x" values="javascript:alert(2)"/></rect></svg>';
+    const out = sanitizeDiagramSvg(svg);
+    expect(out).not.toContain('<set');
+    expect(out).not.toContain('<animate');
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('<rect');
+  });
+
+  it('preserves SVG <text> labels, <style>, ids, classes and inline styles', () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg" id="mermaid-1">'
       + '<style>.node{fill:red}</style>'
       + '<g class="node clickable" id="node-a"><rect x="0" y="0" width="10" height="10" style="fill:blue"/>'
@@ -44,14 +59,31 @@ describe('sanitizeDiagramSvg (#1331)', () => {
     expect(out).toContain('class="node clickable"');
     expect(out).toContain('<style');
     expect(out).toContain('<path');
-    expect(out).toContain('Hello Label'); // node label text survives
+    expect(out).toContain('Hello Label');
     expect(out).toContain('style="fill:blue"');
   });
 
-  it('drops a javascript: href on a clickable node link', () => {
-    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><a xlink:href="javascript:alert(1)"><rect/></a></svg>';
+  it('preserves mermaid v11 foreignObject HTML labels (the regression #1331 guards)', () => {
+    // Mermaid v11 renders node labels as HTML inside <foreignObject>. This must
+    // survive sanitisation — a DOMPurify allowlist pass deletes it, blanking
+    // every diagram label.
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><g class="node">'
+      + '<foreignObject width="80" height="20">'
+      + '<div xmlns="http://www.w3.org/1999/xhtml" class="nodeLabel"><span class="nodeLabel">Order Service</span></div>'
+      + '</foreignObject></g></svg>';
     const out = sanitizeDiagramSvg(svg);
-    expect(out).not.toContain('javascript:');
-    expect(out).toContain('<rect');
+    expect(out.toLowerCase()).toContain('foreignobject');
+    expect(out).toContain('Order Service');
+    expect(out).toContain('class="nodeLabel"');
+  });
+
+  it('strips a <script> hidden inside a foreignObject label', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject>'
+      + '<div xmlns="http://www.w3.org/1999/xhtml">safe<script>alert(1)</script></div>'
+      + '</foreignObject></svg>';
+    const out = sanitizeDiagramSvg(svg);
+    expect(out).toContain('safe');
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('alert');
   });
 });


### PR DESCRIPTION
Closes #1331 (security finding L3).

## Problem

The mermaid renderer assigns **library-generated SVG via `innerHTML`** (`mermaid-renderer.ts:129`), relying on mermaid's own output plus the app CSP (no `unsafe-inline` in `script-src`) — no independent sanitize pass. Residual risk: a mermaid sanitisation bypass or a future CSP regression turns a malicious ```mermaid source into DOM injection.

## Fix

Scrub the SVG string before it hits the DOM, as an independent defense-in-depth layer behind CSP.

**Approach: targeted denylist scrub, not a DOMPurify allowlist.** DOMPurify (used for compute output) strips `<foreignObject>` HTML content, and **mermaid v11 renders node labels as HTML inside `<foreignObject>`** — so a DOMPurify pass silently blanks every diagram label. (This was caught in review after a first DOMPurify-based cut; my "strict mode emits `<text>`" reading was wrong — the `getBBox` I saw is mermaid's temporary text-measurement pass, not the final labels.)

Instead `sanitizeDiagramSvg` parses the SVG with the **same HTML parser the browser uses for `innerHTML`** (so `<foreignObject>` is an HTML integration point and its labels survive) and removes only the real injection surface:
- `script` / `iframe` / `object` / `embed` / `form` elements
- SMIL animation elements (`animate` / `animateTransform` / `animateMotion` / `set`) — mermaid diagrams are static, and these are a known animate-to-script vector
- `on*` handler attributes
- `javascript:` / `vbscript:` / `data:text/html` URLs on `href` / `xlink:href` / `src`

Everything legitimate passes through untouched: `<foreignObject>` + `<text>` labels, `<style>`, `<path>`, ids, classes, inline styles — including the ids/classes mermaid's post-render `bindFunctions` re-queries (it runs after and binds the scrubbed nodes). This is the "safe DOM construction" option the finding also lists, and unlike an allowlist it can't silently delete legitimate diagram content.

## Vega — no change needed, documented in place

The issue also named the Vega renderer, but it already uses safe DOM construction: `vega-embed` builds the chart via its SVG renderer (`createElementNS`/`setAttribute`), never `innerHTML` of a generated string, and `ast: true` keeps expressions off `new Function`. Every `innerHTML` in that file is app-controlled, already-escaped error/notice HTML. Added a pointer comment at the `embed()` call.

## Success criteria
- [x] Explicit sanitize pass on the mermaid `innerHTML` path (defense in depth behind CSP)
- [x] Vega verified to use safe DOM construction; documented
- [x] **No rendering regression** — mermaid v11 `<foreignObject>` HTML labels preserved (regression-tested), along with `<text>`, styles, ids/classes, and `bindFunctions` targets
- [x] `pnpm lint` and `pnpm test` pass (4115 tests; +7 new)

## Tests
`sanitize-diagram-svg` suite (jsdom): strips a smuggled `<script>` (incl. one hidden inside a foreignObject label), strips inline `on*` handlers, drops a `javascript:` node-link href, removes SMIL animation elements, and **preserves mermaid v11 `<foreignObject>` HTML labels** + `<text>` labels + `<style>` + ids/classes/styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
