### PR TITLE
New thoughtbase: welcome note + clearer empty-panel hint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Minerva is a desktop markdown IDE built with Electron + Svelte 5 + TypeScript. It manages knowledge bases backed by an RDF graph and git. The codebase repo name is `miranda` but the app is called **Minerva**.
+Minerva is a desktop markdown IDE built with Electron + Svelte 5 + TypeScript. It manages knowledge bases backed by an RDF graph. (Git is only an opt-in *publish* target — see `src/main/git/` — not automatic version control; thoughtbases are not git-backed yet.) The codebase repo name is `miranda` but the app is called **Minerva**.
 
 ## Commands
 
@@ -20,7 +20,7 @@ with `git push --no-verify` (or `SKIP_HOOKS=1 git push`).
 
 Three-process Electron app with strict context isolation:
 
-- **Main** (`src/main/`) — Node.js process. File I/O, git, graph indexing, menus, window management. All file access goes through `notebase/fs.ts` which enforces path traversal protection.
+- **Main** (`src/main/`) — Node.js process. File I/O, git publishing, graph indexing, menus, window management. All file access goes through `notebase/fs.ts` which enforces path traversal protection.
 - **Preload** (`src/preload/preload.ts`) — Bridges main and renderer via `contextBridge`. The renderer accesses everything through `window.api`.
 - **Renderer** (`src/renderer/`) — Svelte 5 UI. State managed with runes (`$state`, `$effect`, `$derived`). Two stores: `notebase.svelte.ts` (project/files) and `editor.svelte.ts` (active file/content).
 
@@ -34,7 +34,7 @@ This project uses **Svelte 5 runes** — not Svelte 4 syntax. Use `$state`, `$de
 ### UI & UX Philosophy
 This is a **professional tool**. Design accordingly:
 
-- **No danger styling.** Don't color destructive actions in red. Deleting a note is a normal operation, not a scary one — especially with git backing every project.
+- **No danger styling.** Don't color destructive actions in red. Deleting a note is a normal operation, not a scary one.
 - **Respect the user.** Every confirmation dialog must include a "Don't ask again" checkbox. Use `showConfirm(message, key, label)` in App.svelte — the `key` parameter allows each dialog type to be independently suppressed via localStorage.
 - **Stay out of the way.** Prefer keyboard shortcuts and contextual actions (right-click menus) over modal UI. Don't add warnings, toasts, or interstitials unless absolutely necessary.
 - **No hand-holding.** Don't add validation that prevents the user from doing what they asked. Don't add "are you sure?" unless there's genuine data loss risk — and even then, make it dismissable.

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -42,6 +42,7 @@
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
+  import { formatAccelerator } from './lib/command-palette/format-accelerator';
   import DictationIndicator from './lib/components/DictationIndicator.svelte';
   import { toggleEditorDictation } from './lib/editor/dictation';
   import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
@@ -82,6 +83,7 @@
   import { sectionAnchorAt } from './lib/markdown/headings';
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
+  import { WELCOME_NOTE_PATH, welcomeNoteContent } from '../shared/welcome-note';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
   import { findRunnableFences, RUNNABLE_LANGUAGE_SET } from '../shared/compute/fences';
   import { loadFormatSettings } from './lib/formatter/settings';
@@ -465,6 +467,32 @@
     if (dontAskAgain) {
       try { await api.notebase.setOnboardingDismissed(true); }
       catch (e) { console.warn('[onboarding] persist dismiss failed:', e); }
+    }
+    // Dismissing onboarding (button, Escape, or click-away) leaves an empty
+    // thoughtbase with nothing to open. Seed a welcoming default note so the
+    // user lands on real prose instead of the bare editor placeholder. Only
+    // when still empty — accepting onboarding takes a different path and never
+    // reaches here, so this fires exactly for "declined onboarding". `entrypoint`
+    // (baked into the body) makes it the note that auto-opens on later loads.
+    await maybeSeedWelcomeNote();
+  }
+
+  /**
+   * Write + open the welcome note when the thoughtbase has no notes yet.
+   * Guarded on emptiness so it never clobbers an existing note or duplicates
+   * itself. `writeFile` routes through the main-process write pipeline, which
+   * indexes the new note (graph + search) exactly like any other save.
+   */
+  async function maybeSeedWelcomeNote(): Promise<void> {
+    if (!notebase.meta) return;
+    if (countNotes(notebase.files) > 0) return;
+    const isMac = /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '');
+    try {
+      await api.notebase.writeFile(WELCOME_NOTE_PATH, welcomeNoteContent(isMac));
+      await notebase.refresh();
+      await editor.openFile(WELCOME_NOTE_PATH);
+    } catch (e) {
+      console.warn('[onboarding] welcome note seed failed:', e);
     }
   }
 
@@ -1569,7 +1597,7 @@
                 </div>
               {:else}
                 <div class="no-file">
-                  <p>Select a note from the sidebar</p>
+                  <p>Press {formatAccelerator('CmdOrCtrl+N')} to create a new note</p>
                 </div>
               {/if}
               {#if draggingTab && dropTarget?.groupId === groupId}

--- a/src/shared/welcome-note.ts
+++ b/src/shared/welcome-note.ts
@@ -1,0 +1,48 @@
+/**
+ * The welcoming default note offered when someone declines the onboarding
+ * modal on an empty thoughtbase. Onboarding is the primary greeting —
+ * this note is the fallback so a user who dismisses the modal lands on real
+ * prose instead of a bare "Press ⌘N to create a new note" panel. It is never
+ * created when the user engages onboarding.
+ *
+ * Pure + Electron-free so both the renderer (which writes it) and tests can
+ * import it.
+ */
+
+/** Relative path of the welcome note. */
+export const WELCOME_NOTE_PATH = 'Welcome.md';
+
+/**
+ * Build the welcome note body. `isMac` picks the platform-correct shortcut
+ * glyph for the inline "new note" hint. The block-sequence `tags:` matches
+ * what the app itself writes (via YAML.stringify), so the indexer parses it
+ * reliably; the `entrypoint` tag makes this the thoughtbase's designated
+ * starting surface, which the renderer re-opens on later empty-editor loads.
+ */
+export function welcomeNoteContent(isMac: boolean): string {
+  const newNote = isMac ? '⌘N' : 'Ctrl+N';
+  return `---
+tags:
+  - entrypoint
+---
+
+# Welcome to your thoughtbase
+
+This is Minerva — a workshop for thinking in writing. You're reading your first
+note. Edit it, or delete it once you've found your footing; every note is a plain
+Markdown file on disk that you fully own.
+
+A few ways in:
+
+- **Press ${newNote} to create a new note.** That's the same shortcut whenever you
+  want a fresh page.
+- **Connect ideas with \`[[wiki-links]]\`.** Type \`[[\` and start naming another
+  note — Minerva weaves the links into a knowledge graph you can query.
+- **Label with tags and frontmatter.** Titles, tags, and links are all indexed;
+  the \`entrypoint\` tag above is what marks this as your starting note.
+- **Ask questions of your notes.** Open a conversation to explore or challenge what
+  you've written — nothing lands in your graph without your approval.
+
+When you're ready, press ${newNote} and start writing.
+`;
+}

--- a/tests/shared/welcome-note.test.ts
+++ b/tests/shared/welcome-note.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { parse as parseYAML } from 'yaml';
+import { WELCOME_NOTE_PATH, welcomeNoteContent } from '../../src/shared/welcome-note';
+
+describe('welcomeNoteContent', () => {
+  it('lands at Welcome.md', () => {
+    expect(WELCOME_NOTE_PATH).toBe('Welcome.md');
+  });
+
+  it('carries a parseable entrypoint tag so the note auto-opens', () => {
+    const body = welcomeNoteContent(true);
+    const fm = body.match(/^---\n([\s\S]*?)\n---/);
+    expect(fm).not.toBeNull();
+    const parsed = parseYAML(fm![1]!) as { tags?: string[] };
+    expect(parsed.tags).toEqual(['entrypoint']);
+  });
+
+  it('uses the mac glyph on darwin and Ctrl elsewhere', () => {
+    expect(welcomeNoteContent(true)).toContain('⌘N');
+    expect(welcomeNoteContent(true)).not.toContain('Ctrl+N');
+    expect(welcomeNoteContent(false)).toContain('Ctrl+N');
+    expect(welcomeNoteContent(false)).not.toContain('⌘N');
+  });
+
+  it('greets the reader', () => {
+    expect(welcomeNoteContent(true)).toContain('Welcome to your thoughtbase');
+  });
+});


### PR DESCRIPTION
## What & why

A brand-new thoughtbase opened on an empty editor whose only cue was **"Select a note from the sidebar"** — but there were no notes to select. Two fixes:

1. **Empty-panel hint.** The placeholder now reads **"Press ⌘N to create a new note"** (platform-aware — `Ctrl N` on Windows/Linux — via the existing `formatAccelerator` helper).

2. **Welcome note on onboarding decline.** The `onboarding.dismissed` flag is *per-project*, so a new thoughtbase always shows the onboarding modal. When the user **declines** it (button, Esc, or click-away) on an empty thoughtbase, we now seed and open a welcoming default note (`src/shared/welcome-note.ts`), tagged `entrypoint` so it becomes the designated starting surface and auto-opens on later empty-editor loads.

| Modal action | Outcome |
|---|---|
| **Declines** | Welcome note created + opened |
| **Accepts** ("use it") | Onboarding conversation starts — **no** welcome note |

Onboarding stays the primary greeting; the welcome note is purely the fallback for people who dismiss it. Guarded on emptiness so it never clobbers or duplicates. It routes through `api.notebase.writeFile` (the normal write pipeline), so it's indexed like any other save — no new IPC/preload surface.

3. **CLAUDE.md correction.** Thoughtbases are **not git-backed yet** (git is only an opt-in *publish* target under `src/main/git/`). Dropped the "backed by an RDF graph and git" and "git backing every project" claims, and refined the main-process bullet to "git publishing." The welcome-note copy likewise makes no git promise.

## Testing

- `pnpm lint` clean (0 errors); ran again by the pre-push hook.
- New `tests/shared/welcome-note.test.ts` (4 tests, passing) — asserts the `entrypoint` tag parses, platform glyphs, path, and greeting.
- Not driven end-to-end: the modal→decline flow sits behind the native directory picker + an Electron modal, so that path is covered by logic review + unit tests rather than a live run.

## Notes for review

- The `entrypoint` tag means the welcome note re-opens on later empty-editor loads and shows an entrypoint badge in the sidebar — intended, but easy to drop if you'd prefer an ordinary note.
- Because it hangs off the decline handler, declining onboarding on *any* empty thoughtbase (not only a freshly created one) seeds the note. Consistent with "if they dismiss onboarding," but can be scoped strictly to creation if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)