### PR TITLE
Thinking tools that run without a note, and gray out unavailable menu items

### DIFF
--- a/src/main/ipc/register-app.ts
+++ b/src/main/ipc/register-app.ts
@@ -1,7 +1,8 @@
-import { ipcMain, app } from 'electron';
+import { ipcMain, app, BrowserWindow } from 'electron';
 import { Channels } from '../../shared/channels';
-import { getMenuShortcuts, setMenuThemeMode } from '../menu';
+import { getMenuShortcuts, setMenuThemeMode, setMenuEditorState } from '../menu';
 import type { ThemeMode } from '../../shared/theme';
+import type { MenuEditorState } from '../../shared/types';
 
 // Injected by vite.main.config.ts `define` at build time — a packaged app has
 // no git to query at runtime, so the commit + date are baked in.
@@ -36,4 +37,11 @@ export function registerApp(): void {
   // The renderer owns the theme (localStorage); it reports changes so the
   // native View → Theme submenu can show the active radio (#1139).
   ipcMain.on(Channels.MENU_REPORT_THEME, (_e, mode: ThemeMode) => setMenuThemeMode(mode));
+
+  // The renderer owns note/selection state; it reports flips so the native menu
+  // can gray out note/selection-only items for the reporting window.
+  ipcMain.on(Channels.MENU_REPORT_EDITOR_STATE, (e, state: MenuEditorState) => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    if (win) setMenuEditorState(win.id, state);
+  });
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { registerIpcHandlers } from './ipc';
-import { buildMenu, rebuildMenu } from './menu';
-import { createWindow, openProjectInWindow, setMenuRebuilder } from './window-manager';
+import { buildMenu, rebuildMenu, clearMenuEditorState } from './menu';
+import { createWindow, openProjectInWindow, setMenuRebuilder, setMenuStateCleaner } from './window-manager';
 import { appIconPath } from './app-icon';
 import { loadSession } from './session';
 import { registerBuiltinExecutors } from './compute/executors';
@@ -41,6 +41,7 @@ void app.whenReady().then(async () => {
   // `rebuildMenu` directly. Registered before any window is created so the
   // focus/project-change rebuild triggers are wired from the first window.
   setMenuRebuilder(rebuildMenu);
+  setMenuStateCleaner(clearMenuEditorState);
   // macOS dev dock icon (#805). A packaged .app gets its icon from the bundle
   // (packagerConfig.icon); an unpackaged `electron-forge start` shows the stock
   // Electron icon unless we set the dock icon here.

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -15,7 +15,8 @@ import { restartKernel as restartPythonKernel, interruptKernel as interruptPytho
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
 import { groupToolsByGroup, hasNamedGroups } from '../shared/tools/grouping';
-import { isSourceScoped } from '../shared/tools/types';
+import { isSourceScoped, toolRequiresNote, toolRequiresSelection } from '../shared/tools/types';
+import type { MenuEditorState } from '../shared/types';
 import {
   checkForUpdatesNow,
   isUpdateDownloaded,
@@ -40,12 +41,42 @@ export function setMenuThemeMode(mode: ThemeMode): void {
   rebuildMenu();
 }
 
+// Per-window editor gating state, mirrored from each renderer. Keyed by
+// window id like `getRootPath(winId)` so a focus switch shows the right window's
+// enablement; `rebuildMenu` reads the focused window's entry.
+const editorStateByWin = new Map<number, MenuEditorState>();
+
+/** Renderer → main: record a window's note/selection state and refresh the menu
+ *  if that window is focused (its state is what's on screen). Deduped so a
+ *  no-op report costs no rebuild. */
+export function setMenuEditorState(winId: number, state: MenuEditorState): void {
+  const prev = editorStateByWin.get(winId);
+  if (prev && prev.hasEditor === state.hasEditor && prev.hasNote === state.hasNote && prev.hasSelection === state.hasSelection) return;
+  editorStateByWin.set(winId, state);
+  if (BrowserWindow.getFocusedWindow()?.id === winId) rebuildMenu();
+}
+
+/** Drop a window's editor state when it closes (called from window-manager). */
+export function clearMenuEditorState(winId: number): void {
+  editorStateByWin.delete(winId);
+}
+
 export function buildMenu(_win?: BrowserWindow): void {
   rebuildMenu();
 }
 
-/** Enablement gate applied to items that require an open thoughtbase. */
-type Gate = <T extends Electron.MenuItemConstructorOptions>(item: T) => T;
+/** Per-item preconditions beyond "a thoughtbase is open". */
+interface GateReq {
+  /** Needs any editor tab open (note/query/source) — e.g. pane commands. */
+  editor?: boolean;
+  /** Needs a note tab active. */
+  note?: boolean;
+  /** Needs a non-empty text selection (implies `note`). */
+  selection?: boolean;
+}
+/** Enablement gate. `gate(item)` requires only an open thoughtbase (the common
+ *  case); pass a `GateReq` to also require a note and/or selection. */
+type Gate = <T extends Electron.MenuItemConstructorOptions>(item: T, req?: GateReq) => T;
 
 export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
   const isMac = process.platform === 'darwin';
@@ -56,7 +87,20 @@ export function rebuildMenu(): Electron.MenuItemConstructorOptions[] {
   // tracks the focused window's state.
   const focusedWin = BrowserWindow.getFocusedWindow();
   const hasProject = focusedWin ? getRootPath(focusedWin.id) !== null : false;
-  const gate: Gate = (item) => ({ ...item, enabled: hasProject && (item.enabled ?? true) });
+  // Note/selection state is renderer-owned; the focused window reports it via
+  // MENU_REPORT_EDITOR_STATE. Absent (window never reported) ⇒ treat as none.
+  const editorState = focusedWin ? editorStateByWin.get(focusedWin.id) : undefined;
+  const hasEditor = editorState?.hasEditor ?? false;
+  const hasNote = editorState?.hasNote ?? false;
+  const hasSelection = editorState?.hasSelection ?? false;
+  const gate: Gate = (item, req) => {
+    const ok =
+      hasProject &&
+      (!req?.editor || hasEditor) &&
+      (!req?.note || hasNote) &&
+      (!req?.selection || hasSelection);
+    return { ...item, enabled: ok && (item.enabled ?? true) };
+  };
 
   // rebuildMenu is the assembly line: each top-level menu is produced by its
   // own builder (below), sharing `gate` (project-enablement) and the
@@ -189,11 +233,11 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
         label: 'Save',
         accelerator: 'CmdOrCtrl+S',
         click: () => send(Channels.MENU_SAVE),
-      }),
+      }, { note: true }),
       gate({
         label: 'Save as Template…',
         click: () => send(Channels.MENU_SAVE_AS_TEMPLATE),
-      }),
+      }, { note: true }),
       { type: 'separator' },
 
       // Ingest / Import — bringing external things in.
@@ -235,7 +279,7 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
       gate({
         label: 'Print…',
         click: () => send(Channels.MENU_PRINT),
-      }),
+      }, { note: true }),
       gate({
         label: 'Print to PDF…',
         click: async () => {
@@ -255,7 +299,7 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
             await fs.writeFile(result.filePath, data);
           }
         },
-      }),
+      }, { note: true }),
       { type: 'separator' },
       {
         label: 'Open In',
@@ -264,11 +308,11 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
             label: 'Reveal in Finder',
             accelerator: 'CmdOrCtrl+Shift+R',
             click: () => send(Channels.SHELL_REVEAL_FILE),
-          }),
+          }, { note: true }),
           gate({
             label: 'Open in Default App',
             click: () => send(Channels.MENU_OPEN_IN_DEFAULT),
-          }),
+          }, { note: true }),
           gate({
             label: 'Open in Terminal',
             click: () => send(Channels.MENU_OPEN_IN_TERMINAL),
@@ -361,12 +405,12 @@ function buildEditMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
         label: 'Find',
         accelerator: 'CmdOrCtrl+F',
         click: () => send(Channels.MENU_FIND),
-      }),
+      }, { note: true }),
       gate({
         label: 'Find and Replace',
         accelerator: 'CmdOrCtrl+H',
         click: () => send(Channels.MENU_FIND_REPLACE),
-      }),
+      }, { note: true }),
       gate({
         label: 'Find in Notes…',
         accelerator: 'CmdOrCtrl+Shift+F',
@@ -381,12 +425,12 @@ function buildEditMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
       gate({
         label: 'Insert Template…',
         click: () => send(Channels.MENU_INSERT_TEMPLATE),
-      }),
+      }, { note: true }),
       { type: 'separator' },
       gate({
         label: 'Sort Lines',
         click: () => send(Channels.MENU_SORT_LINES),
-      }),
+      }, { note: true }),
       ...(!isMac
         ? [
             { type: 'separator' as const },
@@ -429,7 +473,7 @@ function buildViewMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
         label: 'Cycle Preview Mode',
         accelerator: 'CmdOrCtrl+Shift+P',
         click: () => send(Channels.MENU_TOGGLE_PREVIEW),
-      }),
+      }, { note: true }),
       { type: 'separator' },
       // Editor split — pane focus & layout commands (#814).
       gate({
@@ -446,17 +490,17 @@ function buildViewMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
         label: 'Focus Next Group',
         accelerator: 'CmdOrCtrl+Alt+Right',
         click: () => send(Channels.MENU_FOCUS_NEXT_GROUP),
-      }),
+      }, { editor: true }),
       gate({
         label: 'Focus Previous Group',
         accelerator: 'CmdOrCtrl+Alt+Left',
         click: () => send(Channels.MENU_FOCUS_PREV_GROUP),
-      }),
+      }, { editor: true }),
       gate({
         label: 'Close Group',
         accelerator: 'CmdOrCtrl+Shift+W',
         click: () => send(Channels.MENU_CLOSE_GROUP),
-      }),
+      }, { editor: true }),
       { type: 'separator' },
       {
         label: 'Theme',
@@ -530,7 +574,7 @@ function buildNavigateMenu(gate: Gate): Electron.MenuItemConstructorOptions {
         label: 'Go to Line',
         accelerator: 'CmdOrCtrl+G',
         click: () => send(Channels.MENU_GOTO_LINE),
-      }),
+      }, { note: true }),
     ],
   };
 }
@@ -540,18 +584,18 @@ function buildRefactorMenu(gate: Gate): Electron.MenuItemConstructorOptions {
   return {
     label: 'Refactor',
     submenu: [
-      gate({ label: 'Rename…', click: () => send(Channels.MENU_REFACTOR_RENAME) }),
-      gate({ label: 'Move…', click: () => send(Channels.MENU_REFACTOR_MOVE) }),
-      gate({ label: 'Copy…', click: () => send(Channels.MENU_REFACTOR_COPY) }),
+      gate({ label: 'Rename…', click: () => send(Channels.MENU_REFACTOR_RENAME) }, { note: true }),
+      gate({ label: 'Move…', click: () => send(Channels.MENU_REFACTOR_MOVE) }, { note: true }),
+      gate({ label: 'Copy…', click: () => send(Channels.MENU_REFACTOR_COPY) }, { note: true }),
       { type: 'separator' },
-      gate({ label: 'Extract Selection to New Note', click: () => send(Channels.MENU_REFACTOR_EXTRACT) }),
-      gate({ label: 'Split Note Here', click: () => send(Channels.MENU_REFACTOR_SPLIT_HERE) }),
-      gate({ label: 'Split by Heading…', click: () => send(Channels.MENU_REFACTOR_SPLIT_BY_HEADING) }),
+      gate({ label: 'Extract Selection to New Note', click: () => send(Channels.MENU_REFACTOR_EXTRACT) }, { note: true, selection: true }),
+      gate({ label: 'Split Note Here', click: () => send(Channels.MENU_REFACTOR_SPLIT_HERE) }, { note: true }),
+      gate({ label: 'Split by Heading…', click: () => send(Channels.MENU_REFACTOR_SPLIT_BY_HEADING) }, { note: true }),
       { type: 'separator' },
-      gate({ label: 'Auto-tag', click: () => send(Channels.MENU_REFACTOR_AUTOTAG) }),
-      gate({ label: 'Auto-link outbound…', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) }),
-      gate({ label: 'Auto-link inbound…', click: () => send(Channels.MENU_REFACTOR_AUTOLINK_INBOUND) }),
-      gate({ label: 'Decompose Note…', click: () => send(Channels.MENU_REFACTOR_DECOMPOSE) }),
+      gate({ label: 'Auto-tag', click: () => send(Channels.MENU_REFACTOR_AUTOTAG) }, { note: true }),
+      gate({ label: 'Auto-link outbound…', click: () => send(Channels.MENU_REFACTOR_AUTOLINK) }, { note: true }),
+      gate({ label: 'Auto-link inbound…', click: () => send(Channels.MENU_REFACTOR_AUTOLINK_INBOUND) }, { note: true }),
+      gate({ label: 'Decompose Note…', click: () => send(Channels.MENU_REFACTOR_DECOMPOSE) }, { note: true }),
       { type: 'separator' },
       // Deterministic markdown normalisation (issue #152 epic). Nested
       // under Refactor so the title bar stays lean.
@@ -565,7 +609,7 @@ function buildRefactorMenu(gate: Gate): Electron.MenuItemConstructorOptions {
         label: 'Insert/Update Bibliography',
         toolTip: 'Render a References section listing every source the active note cites, in the project’s configured CSL style.',
         click: () => send(Channels.MENU_BIBLIOGRAPHY),
-      }),
+      }, { note: true }),
     ],
   };
 }
@@ -585,11 +629,14 @@ function buildToolMenus(gate: Gate): Electron.MenuItemConstructorOptions[] {
     .filter((id) => getToolsByCategory(id).some((t) => !isSourceScoped(t)))
     .map((id) => {
       const tools = getToolsByCategory(id).filter((t) => !isSourceScoped(t));
-      const mkItem = (tool: typeof tools[number]) => gate({
-        label: tool.name,
-        toolTip: tool.description,
-        click: () => send(Channels.TOOL_INVOKE, tool.id),
-      });
+      const mkItem = (tool: typeof tools[number]) => gate(
+        {
+          label: tool.name,
+          toolTip: tool.description,
+          click: () => send(Channels.TOOL_INVOKE, tool.id),
+        },
+        { note: toolRequiresNote(tool), selection: toolRequiresSelection(tool) },
+      );
       // Thematic sub-grouping (#525): when any tool in the category declares
       // a `group`, render one nested submenu per group (ungrouped → General,
       // last). Otherwise stay flat — current behavior for ungrouped

--- a/src/main/skills/compile.ts
+++ b/src/main/skills/compile.ts
@@ -44,6 +44,7 @@ export function compileSkill(skill: SkillDef): ThinkingToolDef {
     def.buildSystemPrompt = (ctx) => render(skill.body, ctx);
     def.buildFirstMessage = (ctx) => render(skill.firstMessage, ctx);
   }
+  if (skill.requiresNote !== undefined) def.requiresNote = skill.requiresNote;
   if (skill.group) def.group = skill.group;
   if (skill.scope && skill.scope !== 'note') def.scope = skill.scope;
   if (skill.model) def.preferredModel = skill.model;

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -157,6 +157,10 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
   const web = fm.web === undefined ? false : Boolean(fm.web);
   const model = asString(fm.model);
   const requiresSelection = Boolean(fm.requiresSelection);
+  // Tri-state: undefined ⇒ derive from context; explicit false must survive
+  // (a plain Boolean() would collapse it), so a skill can opt out of the note
+  // requirement even while listing `context:[fullNote]`.
+  const requiresNote = fm.requiresNote === undefined ? undefined : Boolean(fm.requiresNote);
   const outputNotePrefix = asString(fm.outputNotePrefix);
   const group = asString(fm.group);
 
@@ -199,6 +203,7 @@ export function parseSkill(content: string, source: SkillSource, filePath: strin
     ...(slashCommand !== undefined ? { slashCommand } : {}),
     ...(outputNotePrefix !== undefined ? { outputNotePrefix } : {}),
     requiresSelection,
+    ...(requiresNote !== undefined ? { requiresNote } : {}),
     firstMessage,
     body,
     source,

--- a/src/main/skills/stock/create-learning-journey.md
+++ b/src/main/skills/stock/create-learning-journey.md
@@ -5,6 +5,10 @@ description: Design an ordered learning path ending at mastery
 menu: Learning
 outputMode: openConversation
 context: [fullNote]
+# Uses the note's topic when one is open, but works from a user-named topic
+# otherwise — so it must stay available with no note (overrides the fullNote
+# derivation that would otherwise mark it note-required).
+requiresNote: false
 slashCommand: /learning-journey
 model: claude-opus-4-8
 web: true

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -34,6 +34,13 @@ export function setMenuRebuilder(fn: () => void): void {
   menuRebuilder = fn;
 }
 
+// Same one-way-edge rationale as `menuRebuilder`: drop a closed window's
+// reported note/selection state from the menu module's per-window map.
+let menuStateCleaner: ((winId: number) => void) | null = null;
+export function setMenuStateCleaner(fn: (winId: number) => void): void {
+  menuStateCleaner = fn;
+}
+
 interface WindowContext {
   rootPath: string | null;
   graphStore: typeof graph | null;
@@ -133,6 +140,7 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
     }
     const heldRoot = contexts.get(win.id)?.rootPath ?? null;
     contexts.delete(win.id);
+    menuStateCleaner?.(win.id);
     if (heldRoot) {
       // Fire-and-forget: window's already gone; the release just disposes
       // shared state if this was the last acquirer.

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,7 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { Channels } from '../shared/channels';
 import { invoke } from './typed-invoke';
-import type { SearchInNotesOptions, ReplaceInNotesOptions } from '../shared/types';
+import type { SearchInNotesOptions, ReplaceInNotesOptions, MenuEditorState } from '../shared/types';
 import type { ThemeMode } from '../shared/theme';
 
 /**
@@ -484,6 +484,7 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.on(Channels.MENU_SET_THEME, (_e, mode: ThemeMode) => cb(mode));
     },
     reportTheme: (mode: ThemeMode) => ipcRenderer.send(Channels.MENU_REPORT_THEME, mode),
+    reportEditorState: (state: MenuEditorState) => ipcRenderer.send(Channels.MENU_REPORT_EDITOR_STATE, state),
     onSplitRight: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SPLIT_RIGHT, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -38,7 +38,7 @@
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
-  import type { SafeDeleteBlocker } from '../shared/types';
+  import type { SafeDeleteBlocker, MenuEditorState } from '../shared/types';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
@@ -222,6 +222,27 @@
   const previewComponent = $derived(previewComponents[editor.activeGroupId]);
   let toolPanelComponent = $state<ToolPanel>();
   let cursorInfo = $state<CursorInfo>({ line: 1, column: 1, selectionLength: 0, wordCount: 0 });
+
+  // Report note/selection state to main so the native menu can gray out
+  // note/selection-only items (the command palette already gates reactively;
+  // the native menu had no such signal). `cursorInfo` follows the focused pane's
+  // editor, so it doubles as the selection source. Report only on boolean flip —
+  // cursor moves and selection-length changes that don't cross empty↔non-empty
+  // send nothing, so the native menu isn't rebuilt on every keystroke. Main
+  // dedupes again as a backstop.
+  let lastEditorStateReport: MenuEditorState | null = null;
+  $effect(() => {
+    const hasEditor = !!editor.activeTab;
+    const hasNote = editor.activeTab?.type === 'note';
+    const hasSelection = hasNote && cursorInfo.selectionLength > 0;
+    if (
+      lastEditorStateReport?.hasEditor === hasEditor &&
+      lastEditorStateReport?.hasNote === hasNote &&
+      lastEditorStateReport?.hasSelection === hasSelection
+    ) return;
+    lastEditorStateReport = { hasEditor, hasNote, hasSelection };
+    api.menu.reportEditorState(lastEditorStateReport);
+  });
 
   // Drag-tab-to-split (#817) — pointer-based, NOT HTML5 DnD. A macOS native
   // drag enters a nested run-loop that suspends the page's reactivity queue, so

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -67,7 +67,7 @@
   }
 
   import { getToolInfosByCategory } from '../tools/tool-registry';
-  import { isSourceScoped, type ThinkingToolInfo } from '../../../shared/tools/types';
+  import { isSourceScoped, toolRequiresSelection, type ThinkingToolInfo } from '../../../shared/tools/types';
   import { groupToolsByGroup, hasNamedGroups } from '../../../shared/tools/grouping';
 
   interface Props {
@@ -1031,7 +1031,7 @@
 {/if}
 
 {#snippet toolButton(tool: ThinkingToolInfo)}
-  {@const needsSelection = !!tool.requiresSelection && !contextMenu?.hasSelection}
+  {@const needsSelection = toolRequiresSelection(tool) && !contextMenu?.hasSelection}
   {@const needsClaim = (tool.context?.includes('claimUnderCursor') ?? false) && !contextMenu?.claimUri}
   <button
     onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
 import type { ThemeMode } from '../../../shared/theme';
@@ -682,6 +682,7 @@ export interface MenuApi {
   onCycleTheme(cb: () => void): void;
   onSetTheme(cb: (mode: ThemeMode) => void): void;
   reportTheme(mode: ThemeMode): void;
+  reportEditorState(state: MenuEditorState): void;
   onSplitRight(cb: () => void): void;
   onSplitDown(cb: () => void): void;
   onFocusNextGroup(cb: () => void): void;

--- a/src/renderer/lib/tools/tool-registry.ts
+++ b/src/renderer/lib/tools/tool-registry.ts
@@ -29,6 +29,7 @@ export function skillInfoToToolDef(info: SkillInfo): ThinkingToolDef {
     ...(info.model !== undefined ? { preferredModel: info.model } : {}),
     web: { defaultEnabled: info.web },
     requiresSelection: info.requiresSelection,
+    ...(info.requiresNote !== undefined ? { requiresNote: info.requiresNote } : {}),
     buildPrompt: () => '', // never invoked in the renderer
   };
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -165,6 +165,9 @@ export const Channels = {
   MENU_SET_THEME: 'menu:setTheme',
   // Renderer → main: report the current theme so the menu's radio reflects it.
   MENU_REPORT_THEME: 'menu:reportTheme',
+  // Renderer → main: report editor gating state (is a note active, is there a
+  // selection) so the native menu can gray out note/selection-only items.
+  MENU_REPORT_EDITOR_STATE: 'menu:reportEditorState',
   // Editor split — focus & pane commands (#814)
   MENU_SPLIT_RIGHT: 'menu:splitRight',
   MENU_SPLIT_DOWN: 'menu:splitDown',

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -84,6 +84,9 @@ export interface SkillDef {
   slashCommand?: string;
   outputNotePrefix?: string;
   requiresSelection: boolean;
+  /** Explicit override of the "needs a note" derivation (see
+   *  `toolRequiresNote`). Omit to derive from `context` / `requiresSelection`. */
+  requiresNote?: boolean;
   /** Auto-fired first user message (template). Empty = let the user start. */
   firstMessage: string;
   /** Prompt body (template) — system prompt or one-shot prompt. */
@@ -110,6 +113,8 @@ export interface SkillInfo {
   slashCommand?: string | undefined;
   outputNotePrefix?: string | undefined;
   requiresSelection: boolean;
+  /** See SkillDef.requiresNote. */
+  requiresNote?: boolean | undefined;
   source: SkillSource;
 }
 
@@ -151,6 +156,7 @@ export function toSkillInfo(s: SkillDef): SkillInfo {
     slashCommand: s.slashCommand,
     outputNotePrefix: s.outputNotePrefix,
     requiresSelection: s.requiresSelection,
+    requiresNote: s.requiresNote,
     source: s.source,
   };
 }

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -159,6 +159,14 @@ export interface ThinkingToolDef {
   /** When true, the tool refuses to run without a non-empty `ctx.selectedText`. The editor right-click hides it, the menu-bar entry fails fast with a clear error. */
   requiresSelection?: boolean;
   /**
+   * Whether the tool needs a note open to be useful. Absent = derived from
+   * `context` (any note/selection requirement ⇒ needs a note) OR
+   * `requiresSelection`. Set it explicitly to override the derivation — e.g.
+   * Create Learning Journey lists `context:[fullNote]` to use the note's topic
+   * when one is open, but sets `requiresNote: false` so it stays invokable with
+   * no note. Consumed via `toolRequiresNote` to gray out menu entries. */
+  requiresNote?: boolean;
+  /**
    * Template-scoped tools the agent should have access to in this
    * conversation, on top of the default toolset. Today the only entry
    * is `'ask_user'` — declare it when the prompt needs to collect a
@@ -187,6 +195,8 @@ export interface ThinkingToolInfo {
   preferredModel?: string;
   web?: ToolWebHint;
   requiresSelection?: boolean;
+  /** See ThinkingToolDef.requiresNote. */
+  requiresNote?: boolean;
 }
 
 export interface ToolExecutionRequest {
@@ -261,6 +271,39 @@ export interface LLMSettings {
  *  command palette, and the Source viewer's actions list. */
 export function isSourceScoped(tool: { scope?: ToolScope }): boolean {
   return tool.scope === 'source';
+}
+
+/** Context requirements that can only be satisfied with a note open. */
+const NOTE_CONTEXTS: readonly ContextRequirement[] = [
+  'fullNote',
+  'selectedText',
+  'selectionRange',
+  'relatedNotes',
+  'taggedNotes',
+  'claimUnderCursor',
+];
+
+/**
+ * Whether a tool needs a note open to be useful. `requiresNote` overrides when
+ * set; otherwise a selection requirement or any note-reading `context` entry
+ * implies it. Whole-thoughtbase tools (empty `context`, e.g. Find Correlations)
+ * derive to false and stay available with no note. Shared by the native menu,
+ * the editor right-click, and the command palette so all three agree. */
+export function toolRequiresNote(
+  tool: Pick<ThinkingToolInfo, 'context' | 'requiresSelection' | 'requiresNote'>,
+): boolean {
+  if (tool.requiresNote !== undefined) return tool.requiresNote;
+  if (tool.requiresSelection) return true;
+  return tool.context.some((c) => NOTE_CONTEXTS.includes(c));
+}
+
+/** Whether a tool needs a non-empty text selection (a stricter gate than
+ *  `toolRequiresNote`). Selection ⇒ note, so a `requiresSelection` tool is also
+ *  reported by `toolRequiresNote`. */
+export function toolRequiresSelection(
+  tool: Pick<ThinkingToolInfo, 'requiresSelection'>,
+): boolean {
+  return !!tool.requiresSelection;
 }
 
 export const DEFAULT_WEB_SETTINGS: WebSettings = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,6 +15,18 @@ export interface NotebaseMeta {
   name: string;
 }
 
+/** Renderer → main editor gating state (`MENU_REPORT_EDITOR_STATE`). Drives the
+ *  native menu's enablement of note/selection/editor-only items. */
+export interface MenuEditorState {
+  /** Any editor tab is open (note, query, or source). Gates pane commands whose
+   *  accelerators must keep firing for non-note tabs too. */
+  hasEditor: boolean;
+  /** A note tab is active (as opposed to a query/source tab, or none). */
+  hasNote: boolean;
+  /** The active note editor has a non-empty text selection. */
+  hasSelection: boolean;
+}
+
 export interface SearchInNotesOptions {
   pattern: string;
   caseSensitive: boolean;

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -100,6 +100,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "links:externalInbound",
   "links:neighborhood",
   "links:outgoing",
+  "menu:reportEditorState",
   "menu:reportTheme",
   "notebase:close",
   "notebase:copy",

--- a/tests/main/skills-compile.test.ts
+++ b/tests/main/skills-compile.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { compileSkill } from '../../src/main/skills/compile';
+import { parseSkill } from '../../src/main/skills/parse';
 import { buildConversationPayload } from '../../src/main/tools/executor';
 import { getTool, registerTool, unregisterTool } from '../../src/shared/tools/registry';
+import { toolRequiresNote } from '../../src/shared/tools/types';
 import type { SkillDef } from '../../src/shared/skills/types';
 
 function skill(overrides: Partial<SkillDef> = {}): SkillDef {
@@ -94,6 +98,29 @@ describe('compiled skill through the conversation payload builder', () => {
       { context: {} },
     );
     expect(payload.model).toBeUndefined();
+  });
+});
+
+describe('requiresNote', () => {
+  it('derives from context by default and the explicit override wins', () => {
+    // Default: context:[fullNote] ⇒ needs a note.
+    expect(toolRequiresNote(compileSkill(skill({ context: ['fullNote'] })))).toBe(true);
+    // Whole-thoughtbase tool (no context) ⇒ available with no note.
+    expect(toolRequiresNote(compileSkill(skill({ context: [] })))).toBe(false);
+    // Override: reads the note when present but stays available without one.
+    expect(toolRequiresNote(compileSkill(skill({ context: ['fullNote'], requiresNote: false })))).toBe(false);
+  });
+
+  it('keeps the stock Create Learning Journey available with no note (regression guard)', () => {
+    // The reported bug: "To create a learning journey you have to have a note
+    // open." The stock skill declares context:[fullNote] but must opt out.
+    const md = fs.readFileSync(
+      path.join(__dirname, '../../src/main/skills/stock/create-learning-journey.md'),
+      'utf-8',
+    );
+    const { skill: parsed, errors } = parseSkill(md, 'stock', 'stock/create-learning-journey.md');
+    expect(errors).toEqual([]);
+    expect(toolRequiresNote(compileSkill(parsed!))).toBe(false);
   });
 });
 

--- a/tests/main/skills-parse.test.ts
+++ b/tests/main/skills-parse.test.ts
@@ -49,6 +49,22 @@ Body here {{selection}}`;
     expect(skill!.context).toEqual([]);
   });
 
+  it('reads requiresNote as tri-state (absent → undefined, explicit false preserved)', () => {
+    const base = (extra: string) => `---
+name: T
+description: d
+menu: Learning
+outputMode: openConversation
+context: [fullNote]
+${extra}---
+body`;
+    // Absent: left undefined so the requiresNote derivation (from context) applies.
+    expect(parseSkill(base(''), 'stock', 'x.md').skill!.requiresNote).toBeUndefined();
+    // Explicit false must survive (the create-learning-journey opt-out).
+    expect(parseSkill(base('requiresNote: false\n'), 'stock', 'x.md').skill!.requiresNote).toBe(false);
+    expect(parseSkill(base('requiresNote: true\n'), 'stock', 'x.md').skill!.requiresNote).toBe(true);
+  });
+
   it('honors an explicit id', () => {
     const c = `---
 id: learning.summarize

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -206,6 +206,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onTogglePreview",
     "onToggleRightSidebar",
     "onToggleSidebar",
+    "reportEditorState",
     "reportTheme",
   ],
   "notebase": [

--- a/tests/shared/tool-requirements.test.ts
+++ b/tests/shared/tool-requirements.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { toolRequiresNote, toolRequiresSelection } from '../../src/shared/tools/types';
+import type { ContextRequirement } from '../../src/shared/tools/types';
+
+/** Minimal shape the helpers Pick from. */
+function tool(o: { context?: ContextRequirement[]; requiresSelection?: boolean; requiresNote?: boolean }) {
+  return { context: o.context ?? [], requiresSelection: o.requiresSelection, requiresNote: o.requiresNote };
+}
+
+describe('toolRequiresNote', () => {
+  it('is false for whole-thoughtbase tools with no context', () => {
+    expect(toolRequiresNote(tool({ context: [] }))).toBe(false);
+  });
+
+  it('is true when the context reads the note', () => {
+    expect(toolRequiresNote(tool({ context: ['fullNote'] }))).toBe(true);
+    expect(toolRequiresNote(tool({ context: ['selectedText'] }))).toBe(true);
+    expect(toolRequiresNote(tool({ context: ['claimUnderCursor'] }))).toBe(true);
+  });
+
+  it('is false for source-only context (source tools are note-independent)', () => {
+    expect(toolRequiresNote(tool({ context: ['sourceMetadata', 'sourceBody'] }))).toBe(false);
+  });
+
+  it('is true when a selection is required (selection ⇒ note)', () => {
+    expect(toolRequiresNote(tool({ context: [], requiresSelection: true }))).toBe(true);
+  });
+
+  it('lets an explicit requiresNote:false override the fullNote derivation', () => {
+    // The create-learning-journey case: reads the note when present, but stays
+    // invokable with none.
+    expect(toolRequiresNote(tool({ context: ['fullNote'], requiresNote: false }))).toBe(false);
+  });
+
+  it('lets an explicit requiresNote:true override an empty context', () => {
+    expect(toolRequiresNote(tool({ context: [], requiresNote: true }))).toBe(true);
+  });
+});
+
+describe('toolRequiresSelection', () => {
+  it('mirrors requiresSelection', () => {
+    expect(toolRequiresSelection(tool({ requiresSelection: true }))).toBe(true);
+    expect(toolRequiresSelection(tool({}))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

User report: *"To create a learning journey you have to have a note open."* The `create-learning-journey` skill already branched on `{{#if note}}`, so the skill was fine — the surrounding **menu UX** was the problem. This generalizes into two policy changes.

### 1. Declarative tool requirements
- Added `requiresNote?` to the tool/skill types plus shared pure helpers `toolRequiresNote()` / `toolRequiresSelection()` (in `src/shared/tools/types.ts`, next to `isSourceScoped` so the native menu, editor right-click, and command palette share one definition).
- A tool needs a note when its `context` reads the note (`fullNote`, `selectedText`, …) or it requires a selection; whole-thoughtbase tools (empty `context` — Find Correlations, Find Outliers, Generate Visualizations, Organize by Topic, Tidy Filenames) don't.
- An explicit `requiresNote` overrides the derivation. **Create Learning Journey** sets `requiresNote: false` — it uses the note's topic when present but stays invokable with none. Guarded by a test that reads the real stock skill file.
- Plumbed tri-state through `parse.ts` → `compile.ts` → both process registries.

### 2. Gray out menu items whose precondition is missing
The native menu only knew `hasProject`, so Save / Find / Refactor / every thinking tool stayed clickable (then no-op'd/errored) with no note. Now:
- New `MENU_REPORT_EDITOR_STATE` channel reports the focused window's `{ hasEditor, hasNote, hasSelection }` (mirrors the existing `MENU_REPORT_THEME` pattern). Reported **flip-only** (a selection growing 3→40 chars doesn't re-report) with a main-side dedupe, so the native menu isn't rebuilt on every keystroke. Per-window state, cleared on window close.
- The `gate` helper gained per-item `{ editor?, note?, selection? }` preconditions. `gate(item)` stays project-only (zero churn for ~40 items). Applied `{ note: true }` across File/Edit/View/Navigate/Refactor; `{ note, selection }` to Extract Selection; and `toolRequiresNote`/`toolRequiresSelection` to every thinking-tool item.
- **Focus Next/Prev Group** and **Close Group** gate on `hasEditor` (any editor tab), *not* `hasNote` — because a disabled menu item's accelerator stops firing, and those pane commands must keep working when a query/source tab is active in a split.

The command palette already gated correctly (reactive `hasNote()` getters); the editor right-click now shares `toolRequiresSelection`.

**Deliberately left project-only** (flagged during review): Format (documents a sidebar-multi-select workflow), Find in Notes / Replace in Notes / Export (cross-note or scope-picking), Open in Terminal (falls back to project root), and Split Editor Right/Down.

## Testing
- `tests/shared/tool-requirements.test.ts` — the helpers across all cases incl. the override.
- Extended `skills-parse.test.ts` (tri-state `requiresNote`) and `skills-compile.test.ts` (derivation + a **regression guard** reading the stock Create Learning Journey → `toolRequiresNote === false`).
- Updated two contract snapshots (preload surface + registered channels) for the one new method/channel.
- Full suite: **4129 passing**; `pnpm lint` clean (also enforced by the pre-push hook).

## Verification limitation
Native menu `enabled` state isn't DOM-observable, and a full e2e launch needs `build:e2e` + a display — not feasible in this environment. Coverage is the unit/integration suite + typecheck; the state bridge is a direct copy of the working theme-report path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)