### PR TITLE
Learning ▸ "Ask a Question" replaces View ▸ "New Conversation"

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -465,10 +465,7 @@ function buildViewMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
         accelerator: 'CmdOrCtrl+Shift+K',
         click: () => send(Channels.MENU_TOGGLE_CONVERSATIONS),
       }),
-      gate({
-        label: 'New Conversation',
-        click: () => send(Channels.MENU_NEW_CONVERSATION),
-      }),
+      // "New Conversation" moved to Learning ▸ "Ask a Question" (buildToolMenus).
       gate({
         label: 'Cycle Preview Mode',
         accelerator: 'CmdOrCtrl+Shift+P',
@@ -642,12 +639,23 @@ function buildToolMenus(gate: Gate): Electron.MenuItemConstructorOptions[] {
       // last). Otherwise stay flat — current behavior for ungrouped
       // categories (Learning, Research).
       const groups = groupToolsByGroup(tools);
-      const submenu: Electron.MenuItemConstructorOptions[] = hasNamedGroups(groups)
+      const toolItems: Electron.MenuItemConstructorOptions[] = hasNamedGroups(groups)
         ? groups.map((g) => ({
             label: g.label ?? 'General',
             submenu: g.tools.map(mkItem),
           }))
         : tools.map(mkItem);
+      // "Ask a Question" opens a plain conversation — the same action the View
+      // menu used to call "New Conversation". It lives atop Learning as the
+      // simplest thinking tool. Needs no note (just a thoughtbase), so it gates
+      // like the rest of the project-only items.
+      const submenu = id === 'learning'
+        ? [
+            gate({ label: 'Ask a Question', click: () => send(Channels.MENU_NEW_CONVERSATION) }),
+            { type: 'separator' as const },
+            ...toolItems,
+          ]
+        : toolItems;
       return {
         label: CATEGORIES.find((c) => c.id === id)!.label,
         submenu,

--- a/src/renderer/lib/command-palette/registry.ts
+++ b/src/renderer/lib/command-palette/registry.ts
@@ -146,8 +146,6 @@ export function buildCommandRegistry(deps: CommandDeps): Command[] {
       keybinding: null, enabled: hasNote, run: () => deps.togglePreview() },
     { id: 'view.toggleConversations', title: 'Toggle Conversations', category: 'View',
       keybinding: null, enabled: true, run: () => deps.toggleConversations() },
-    { id: 'view.newConversation', title: 'New Conversation', category: 'View',
-      keybinding: null, enabled: hasProject, run: () => deps.newConversation() },
     // One directly-selectable entry per theme, so each is searchable and a
     // click jumps straight to it (#1139). The active mode is marked.
     ...THEME_MODES.map((m) => ({
@@ -164,6 +162,9 @@ export function buildCommandRegistry(deps: CommandDeps): Command[] {
       keybinding: null, enabled: true, run: () => deps.fontDecrease() },
     { id: 'view.fontReset', title: 'Reset Font Size', category: 'View',
       keybinding: null, enabled: true, run: () => deps.fontReset() },
+    // ── Learning ── (opens a plain conversation; the Learning menu's "Ask a Question")
+    { id: 'learning.askQuestion', title: 'Ask a Question', category: 'Learning',
+      keybinding: null, enabled: hasProject, run: () => deps.newConversation() },
     // ── Navigate ──
     { id: 'nav.quickOpen', title: 'Go to…', category: 'Navigate',
       keybinding: formatAccelerator('CmdOrCtrl+P'),

--- a/tests/renderer/command-palette/registry.test.ts
+++ b/tests/renderer/command-palette/registry.test.ts
@@ -45,9 +45,9 @@ describe('buildCommandRegistry', () => {
       'edit.dictate',
       'edit.find', 'edit.findReplace', 'edit.findInNotes', 'edit.replaceInNotes',
       'edit.gotoLine', 'edit.sortLines', 'view.toggleSidebar', 'view.toggleRightSidebar',
-      'view.togglePreview', 'view.toggleConversations', 'view.newConversation',
+      'view.togglePreview', 'view.toggleConversations',
       'view.theme.dark', 'view.theme.light', 'view.theme.contrast', 'view.theme.system',
-      'view.fontIncrease', 'view.fontDecrease', 'view.fontReset', 'nav.quickOpen',
+      'view.fontIncrease', 'view.fontDecrease', 'view.fontReset', 'learning.askQuestion', 'nav.quickOpen',
       'nav.back', 'nav.forward', 'refactor.rename', 'refactor.move', 'refactor.copy',
       'refactor.extract', 'refactor.splitHere', 'refactor.splitByHeading',
       'refactor.autoTag', 'refactor.autoLink', 'refactor.autoLinkInbound',
@@ -116,7 +116,7 @@ describe('buildCommandRegistry', () => {
       'edit.replaceInNotes': 'replaceInNotes', 'edit.gotoLine': 'gotoLine',
       'edit.sortLines': 'sortLines', 'view.toggleSidebar': 'toggleSidebar',
       'view.toggleRightSidebar': 'toggleRightSidebar', 'view.togglePreview': 'togglePreview',
-      'view.toggleConversations': 'toggleConversations', 'view.newConversation': 'newConversation',
+      'view.toggleConversations': 'toggleConversations', 'learning.askQuestion': 'newConversation',
       // view.theme.* all dispatch to setTheme with distinct args — asserted
       // separately below, so they're excluded from the 1:1 run loop.
       'view.theme.dark': 'setTheme', 'view.theme.light': 'setTheme',


### PR DESCRIPTION
## What & why

Moves the "open a plain conversation" action out of the **View** menu and into **Learning** as the simplest thinking tool, renamed **"Ask a Question"**.

- **`menu.ts`** — dropped "New Conversation" from the View submenu; added a static "Ask a Question" item at the top of the Learning submenu (with a separator before the skill tools). It sends the same `MENU_NEW_CONVERSATION` channel, so behavior is identical, and is gated project-only like the old item.
- **`command-palette/registry.ts`** — the palette mirror moved the same way: `view.newConversation` / "New Conversation" / *View* → `learning.askQuestion` / "Ask a Question" / *Learning* (same `run`).
- **`registry.test.ts`** — updated the id-order and dispatch assertions.

No skill/tool engine involved — this is a deliberately trivial move+rename. Internal channel/handler names (`MENU_NEW_CONVERSATION`, `newConversation`, `onNewConversation`) are unchanged. The conversations-panel "+ New Conversation" button is a separate affordance and is left as-is.

## Testing
- `pnpm test` — 4129 passing; `pnpm lint` clean (also enforced by the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)