### PR TITLE
Behavior setting: "Open Conversations on project load"

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -29,6 +29,11 @@
     type BreadcrumbsSettings,
   } from '../breadcrumbs/settings';
   import {
+    getConversationsSettings,
+    setConversationsSettings,
+    type ConversationsSettings,
+  } from '../conversations/settings';
+  import {
     getFormatSettings,
     setFormatSettings,
     resetFormatToHouseStyle,
@@ -131,6 +136,12 @@
   function patchBreadcrumbs(patch: Partial<BreadcrumbsSettings>): void {
     breadcrumbs = { ...breadcrumbs, ...patch };
     setBreadcrumbsSettings(patch);
+  }
+
+  let conversations = $state<ConversationsSettings>({ ...getConversationsSettings() });
+  function patchConversations(patch: Partial<ConversationsSettings>): void {
+    conversations = { ...conversations, ...patch };
+    setConversationsSettings(patch);
   }
 
   // Formatter settings (#154). Mirror the persisted map into local state so
@@ -525,6 +536,21 @@
               Append the current section's heading chain to the breadcrumbs bar above
               the editor when the cursor sits inside a section. Updates as the cursor
               moves between sections.
+            </p>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input
+                type="checkbox"
+                checked={conversations.openOnLoad}
+                onchange={(e) => patchConversations({ openOnLoad: e.currentTarget.checked })}
+              />
+              Open Conversations on project load
+            </label>
+            <p class="hint">
+              Show the Conversations panel automatically each time a thoughtbase opens.
+              Off by default — the panel launches hidden and you toggle it with
+              ⌘/Ctrl+Shift+K.
             </p>
           </div>
           <div class="field">

--- a/src/renderer/lib/conversations/settings.ts
+++ b/src/renderer/lib/conversations/settings.ts
@@ -1,0 +1,50 @@
+/**
+ * Conversations-panel behavior settings.
+ *
+ * Mirrors the synchronous-snapshot pattern used by sidebar/settings.ts —
+ * a tiny wrapper around localStorage that the SettingsDialog writes through
+ * and the conversations store reads from on project load.
+ */
+
+export interface ConversationsSettings {
+  /** Open the Conversations panel automatically on project load. Default off,
+   *  preserving the "launch hidden, toggle with ⌘/Ctrl+Shift+K" behavior. */
+  openOnLoad: boolean;
+}
+
+export const DEFAULT_CONVERSATIONS_SETTINGS: ConversationsSettings = {
+  openOnLoad: false,
+};
+
+const STORAGE_KEY = 'conversationsSettings';
+
+function readFromStorage(): ConversationsSettings {
+  try {
+    if (typeof localStorage === 'undefined') return { ...DEFAULT_CONVERSATIONS_SETTINGS };
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_CONVERSATIONS_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<ConversationsSettings> | null;
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_CONVERSATIONS_SETTINGS };
+    return { ...DEFAULT_CONVERSATIONS_SETTINGS, ...parsed };
+  } catch {
+    return { ...DEFAULT_CONVERSATIONS_SETTINGS };
+  }
+}
+
+let settings: ConversationsSettings = readFromStorage();
+
+export function getConversationsSettings(): ConversationsSettings {
+  return settings;
+}
+
+export function setConversationsSettings(patch: Partial<ConversationsSettings>): ConversationsSettings {
+  settings = { ...settings, ...patch };
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }
+  return settings;
+}
+
+export function __resetConversationsSettingsForTests(): void {
+  settings = readFromStorage();
+}

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -1,4 +1,5 @@
 import { api } from '../ipc/client';
+import { getConversationsSettings } from '../conversations/settings';
 import type {
   Conversation,
   ContextBundle,
@@ -297,12 +298,13 @@ async function init(): Promise<void> {
   ensureSubscriptions();
   try {
     const ui = await api.conversations.loadUIState();
-    // Always launch hidden — even if the user closed the app with the
-    // panel visible. The intent is that the panel doesn't shove the
-    // editor up unexpectedly on every launch; the user toggles when
-    // they want it (Cmd/Ctrl+Shift+K). Persisted height + last-active
-    // tab still apply when they re-open.
-    visible = false;
+    // Launch hidden by default — the panel shouldn't shove the editor up
+    // unexpectedly on every launch; the user toggles when they want it
+    // (Cmd/Ctrl+Shift+K). The persisted `visible` is deliberately ignored.
+    // The "Open Conversations on project load" behavior setting opts into
+    // showing it on load instead. Persisted height + last-active tab still
+    // apply either way.
+    visible = getConversationsSettings().openOnLoad;
     height = ui.height || DEFAULT_HEIGHT;
     // Restore tab list from the canonical store: any active conversation is
     // an open tab. No parallel "open tabs" persisted list — the status field

--- a/tests/renderer/conversations-settings.test.ts
+++ b/tests/renderer/conversations-settings.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Conversations behavior settings — the "Open Conversations on project load"
+ * boolean. Guards the DEFAULTS merge so a blob persisted before the field
+ * existed still reads its default rather than `undefined`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getConversationsSettings,
+  setConversationsSettings,
+  __resetConversationsSettingsForTests,
+} from '../../src/renderer/lib/conversations/settings';
+
+// The renderer harness only sets up a partial localStorage stub (missing
+// clear), so install a clean in-memory one — same approach as editor-settings.
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+      get length() { return store.size; },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+describe('conversations settings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetConversationsSettingsForTests();
+  });
+
+  it('defaults openOnLoad to false (preserves launch-hidden behavior)', () => {
+    expect(getConversationsSettings().openOnLoad).toBe(false);
+  });
+
+  it('round-trips openOnLoad through localStorage', () => {
+    setConversationsSettings({ openOnLoad: true });
+    expect(getConversationsSettings().openOnLoad).toBe(true);
+    // Survives a fresh read of the persisted blob.
+    __resetConversationsSettingsForTests();
+    expect(getConversationsSettings().openOnLoad).toBe(true);
+  });
+
+  it('fills openOnLoad for a blob stored before the field existed', () => {
+    localStorage.setItem('conversationsSettings', JSON.stringify({}));
+    __resetConversationsSettingsForTests();
+    expect(getConversationsSettings().openOnLoad).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Adds an app-global **Behavior** toggle — **"Open Conversations on project load"** — that shows the Conversations panel automatically each time a thoughtbase opens, instead of today's always-launch-hidden behavior. **Off by default**, so existing behavior is unchanged unless the user opts in.

## Changes
- **`src/renderer/lib/conversations/settings.ts`** (new) — a `ConversationsSettings { openOnLoad }` localStorage module, default `false`, mirroring the `sidebar/settings.ts` snapshot pattern (with a `__resetForTests` hook).
- **`conversations.svelte.ts`** — `init()` now sets `visible = getConversationsSettings().openOnLoad` instead of hardcoding `false`. This is the single authoritative load-time visibility decision (reached via `store.reset()` on every project open — both in-window and new-window, since `ConversationsPanel` is `{#key rootPath}`-remounted). The `if (initialized) return` guard means it only fires on load, so a manual close still sticks until the next project load. The persisted `visible` stays ignored, as before.
- **`SettingsDialog.svelte`** — a write-through checkbox in the Behaviors tab, next to the sidebar/breadcrumbs toggles.

## Notes
- **Takes effect on the next project load**, matching the setting's name — toggling it mid-session doesn't pop the panel open on the already-loaded project (the user can still toggle manually with ⌘/Ctrl+Shift+K).
- **App-global** (localStorage), like the other Behaviors settings — not per-project.

## Testing
- `tests/renderer/conversations-settings.test.ts` — default, round-trip, and the forward-compat DEFAULTS merge.
- Full suite: **4132 passing**; `pnpm lint` clean (also enforced by the pre-push hook).

Verification caveat: the panel-opens-on-load behavior itself isn't driveable end-to-end in this environment (Electron), so it's covered by the unit test + a two-line policy swap in a well-understood load path rather than a live observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)