### PR TITLE
Don't decrypt the API key when reading settings for display

### DIFF
--- a/src/main/ipc/register-tools.ts
+++ b/src/main/ipc/register-tools.ts
@@ -8,8 +8,8 @@ import { pickAndImportSkill, removeUserSkill, revealSkillsFolder, type ImportedS
 import { getMenuConfig, saveMenuConfig } from '../skills/menu-config-store';
 import { toSkillInfo, type SkillCatalogInfo } from '../../shared/skills/types';
 import type { MenuConfig } from '../../shared/skills/menu-config';
-import { getSettings, saveSettings, getApiKeyStorage } from '../llm/settings';
-import type { ToolExecutionRequest, LLMSettings } from '../../shared/tools/types';
+import { getSettingsForDisplay, saveSettings, getApiKeyStorage } from '../llm/settings';
+import type { ToolExecutionRequest, LLMSettingsUpdate } from '../../shared/tools/types';
 import { winFromEvent } from './helpers';
 
 export function registerTools(): void {
@@ -89,9 +89,10 @@ export function registerTools(): void {
     await revealSkillsFolder();
   });
 
-  ipcMain.handle(Channels.TOOL_GET_SETTINGS, () => getSettings());
+  // Display read: no decrypt, so opening settings never prompts the keychain.
+  ipcMain.handle(Channels.TOOL_GET_SETTINGS, () => getSettingsForDisplay());
 
-  ipcMain.handle(Channels.TOOL_SET_SETTINGS, (_e, settings: LLMSettings) => saveSettings(settings));
+  ipcMain.handle(Channels.TOOL_SET_SETTINGS, (_e, update: LLMSettingsUpdate) => saveSettings(update));
 
   ipcMain.handle(Channels.TOOL_GET_KEY_STORAGE, () => getApiKeyStorage());
 }

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import type { LLMSettings, WebSettings, ApiKeyStorage } from '../../shared/tools/types';
+import type { LLMSettings, LLMSettingsView, LLMSettingsUpdate, WebSettings, ApiKeyStorage } from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
 import { encryptSecret, decryptSecret, isEncrypted, secretEncryptionAvailable } from '../secret-storage';
@@ -67,10 +67,58 @@ export async function getSettings(): Promise<LLMSettings> {
   }
 }
 
-export async function saveSettings(settings: LLMSettings): Promise<void> {
-  // Encrypt the API key at rest (#1326); everything else is non-sensitive.
-  // Reading back through `getSettings` decrypts it transparently.
-  const onDisk = { ...settings, apiKey: encryptSecret(settings.apiKey ?? '') };
+/**
+ * Display-only settings for the settings panel / model picker. Same as
+ * `getSettings` but WITHOUT decrypting the API key — reading settings to show
+ * the model, effort, or a set/unset badge must never prompt the OS keychain.
+ * The plaintext key is only ever materialized by the API-call path
+ * (`getSettings`). `hasApiKey` reports whether a key is configured (stored, or
+ * via the env var) using the raw stored value — no decrypt.
+ */
+export async function getSettingsForDisplay(): Promise<LLMSettingsView> {
+  try {
+    const raw = await fs.readFile(settingsPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
+    const effort = resolveEffortSetting(parsed.effort);
+    const hasApiKey = typeof parsed.apiKey === 'string'
+      ? parsed.apiKey.length > 0
+      : !!process.env.ANTHROPIC_API_KEY;
+    return {
+      model: resolveModel(parsed.model),
+      web: resolveWeb(parsed.web),
+      ...(effort ? { effort } : {}),
+      hasApiKey,
+    };
+  } catch {
+    return {
+      model: DEFAULT_MODEL,
+      web: { ...DEFAULT_WEB_SETTINGS },
+      hasApiKey: !!process.env.ANTHROPIC_API_KEY,
+    };
+  }
+}
+
+/** Read the raw stored apiKey string (encrypted or legacy plaintext) without
+ *  decrypting, so a save that doesn't touch the key can preserve it verbatim. */
+async function readStoredApiKey(): Promise<string> {
+  try {
+    const raw = await fs.readFile(settingsPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
+    return typeof parsed.apiKey === 'string' ? parsed.apiKey : '';
+  } catch {
+    return '';
+  }
+}
+
+export async function saveSettings(update: LLMSettingsUpdate): Promise<void> {
+  // apiKey is tri-state (#1326): a provided string is encrypted at rest (''
+  // clears); an OMITTED apiKey preserves the stored value verbatim — no decrypt
+  // and no re-encrypt, so saving unrelated settings never touches the keychain.
+  const { apiKey: providedKey, ...rest } = update;
+  const apiKey = providedKey === undefined
+    ? await readStoredApiKey()
+    : encryptSecret(providedKey);
+  const onDisk = { ...rest, apiKey };
   await fs.writeFile(settingsPath(), JSON.stringify(onDisk, null, 2), 'utf-8');
 }
 

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -9,7 +9,7 @@
   } from '../appearance/settings';
   import { getThemeMode, setThemeMode, THEME_MODES, type ThemeMode } from '../theme';
   import { api } from '../ipc/client';
-  import type { LLMSettings } from '../../../shared/tools/types';
+  import type { LLMSettingsUpdate } from '../../../shared/tools/types';
   import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
   import { CONFIRM_REGISTRY, confirmRegistryEntry } from '../confirm-keys';
   import {
@@ -250,8 +250,6 @@
   let clearApiKey = $state(false);
   let keyStorage = $state<import('../../../shared/tools/types').ApiKeyStorage | null>(null);
 
-  // Keep the dialog's own copy of saved LLM settings for Done-time diffing.
-  let loadedLlm: LLMSettings | null = null;
   let toolModelOverrides = $state<Record<string, string>>({});
 
   // Compute (#374): the Python-interpreter panel now lives in
@@ -260,10 +258,9 @@
   onMount(async () => {
     try {
       const s = await api.tools.getSettings();
-      loadedLlm = s;
       model = s.model;
       effort = s.effort;
-      apiKeyStatus = s.apiKey ? 'set' : 'unset';
+      apiKeyStatus = s.hasApiKey ? 'set' : 'unset';
       try {
         keyStorage = await api.tools.getKeyStorage();
       } catch (e) {
@@ -342,14 +339,10 @@
     setFontFamily(fontFamily);
     onThemeChanged();
 
-    // Web + AI — build new LLMSettings and save
-    const newApiKey = clearApiKey
-      ? ''
-      : apiKeyInput
-        ? apiKeyInput
-        : loadedLlm?.apiKey ?? '';
-    const next: LLMSettings = {
-      apiKey: newApiKey,
+    // Web + AI — build the settings update and save. The apiKey is tri-state:
+    // clear → '', a typed value → that key, otherwise OMIT it so main preserves
+    // the stored key without decrypting (the dialog never held the plaintext).
+    const next: LLMSettingsUpdate = {
       model,
       web: {
         enabled: webEnabled,
@@ -358,6 +351,7 @@
       },
       ...(effort ? { effort } : {}),
       ...(Object.keys(toolModelOverrides).length > 0 ? { toolModelOverrides } : {}),
+      ...(clearApiKey ? { apiKey: '' } : apiKeyInput ? { apiKey: apiKeyInput } : {}),
     };
     try {
       await api.tools.setSettings(next);

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,5 +1,5 @@
 import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState } from '../../../shared/types';
-import type { ToolExecutionRequest, ToolExecutionResult, LLMSettings, ConversationToolPayload } from '../../../shared/tools/types';
+import type { ToolExecutionRequest, ToolExecutionResult, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
 import type { ThemeMode } from '../../../shared/theme';
 
@@ -652,8 +652,8 @@ export interface ToolsApi {
   prepareConversation(request: ToolExecutionRequest): Promise<ConversationToolPayload>;
   cancel(): Promise<void>;
   onStream(cb: (chunk: string) => void): void;
-  getSettings(): Promise<LLMSettings>;
-  setSettings(settings: LLMSettings): Promise<void>;
+  getSettings(): Promise<import('../../../shared/tools/types').LLMSettingsView>;
+  setSettings(update: import('../../../shared/tools/types').LLMSettingsUpdate): Promise<void>;
   getKeyStorage(): Promise<import('../../../shared/tools/types').ApiKeyStorage>;
   onInvoke(cb: (toolId: string) => void): void;
 }

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -266,6 +266,36 @@ export interface LLMSettings {
   toolModelOverrides?: Record<string, string>;
 }
 
+/**
+ * Display-only view of LLM settings, returned by the read IPC. Deliberately
+ * omits the plaintext `apiKey` so reading settings for the settings panel /
+ * model picker never decrypts the stored secret (which would prompt the OS
+ * keychain). Callers that need set/unset use `hasApiKey`; the plaintext key is
+ * only ever materialized on the main-process API-call path.
+ */
+export interface LLMSettingsView {
+  model: string;
+  web?: WebSettings;
+  effort?: import('./effort').Effort;
+  toolModelOverrides?: Record<string, string>;
+  /** Whether a usable key is configured (stored, or via ANTHROPIC_API_KEY). */
+  hasApiKey: boolean;
+}
+
+/**
+ * Settings-save payload. Same as LLMSettings minus the special apiKey handling:
+ * `apiKey` is optional and tri-state — a non-empty string sets a new key, `''`
+ * clears it, and **omitting it keeps the stored key untouched** (so a save that
+ * doesn't touch the key neither decrypts nor re-encrypts it).
+ */
+export interface LLMSettingsUpdate {
+  apiKey?: string;
+  model: string;
+  web?: WebSettings;
+  effort?: import('./effort').Effort;
+  toolModelOverrides?: Record<string, string>;
+}
+
 /** Source-scoped tools (#103) live in the Source viewer; everything else is
  *  note-scoped. Applied identically by the menu, the editor right-click, the
  *  command palette, and the Source viewer's actions list. */

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -22,16 +22,17 @@ vi.mock('electron', () => ({
   },
   safeStorage: {
     isEncryptionAvailable: () => true,
-    encryptString: (s: string) => Buffer.from('FAKEENC:' + s, 'utf-8'),
-    decryptString: (buf: Buffer) => {
+    encryptString: vi.fn((s: string) => Buffer.from('FAKEENC:' + s, 'utf-8')),
+    decryptString: vi.fn((buf: Buffer) => {
       const s = buf.toString('utf-8');
       if (!s.startsWith('FAKEENC:')) throw new Error('bad ciphertext');
       return s.slice('FAKEENC:'.length);
-    },
+    }),
   },
 }));
 
-import { getSettings, saveSettings, getApiKeyStorage } from '../../../src/main/llm/settings';
+import { safeStorage } from 'electron';
+import { getSettings, getSettingsForDisplay, saveSettings, getApiKeyStorage } from '../../../src/main/llm/settings';
 import type { LLMSettings } from '../../../src/shared/tools/types';
 
 const settingsFile = () => path.join(tempDir, 'llm-settings.json');
@@ -44,6 +45,7 @@ const base: LLMSettings = {
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-llm-settings-'));
   delete process.env.ANTHROPIC_API_KEY;
+  vi.clearAllMocks();
 });
 afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
@@ -80,6 +82,48 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
     // An explicitly-cleared key stays cleared (matches the pre-#1326 `??` chain).
     fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: '', model: 'claude-sonnet-5' }));
     expect((await getSettings()).apiKey).toBe('');
+  });
+
+  describe('display read + keep-on-save never touch the keychain', () => {
+    it('getSettingsForDisplay reports a key without decrypting it', async () => {
+      await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
+      vi.clearAllMocks();
+      const view = await getSettingsForDisplay();
+      expect(view.hasApiKey).toBe(true);
+      expect(view.model).toBe('claude-sonnet-5');
+      expect((view as { apiKey?: string }).apiKey).toBeUndefined(); // no plaintext leaks out
+      expect(safeStorage.decryptString).not.toHaveBeenCalled();
+    });
+
+    it('getSettingsForDisplay: hasApiKey false when cleared, true from env', async () => {
+      fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: '', model: 'claude-sonnet-5' }));
+      expect((await getSettingsForDisplay()).hasApiKey).toBe(false);
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-env';
+      fs.writeFileSync(settingsFile(), JSON.stringify({ model: 'claude-sonnet-5' }));
+      expect((await getSettingsForDisplay()).hasApiKey).toBe(true);
+    });
+
+    it('saving without an apiKey preserves the stored key verbatim, no decrypt/encrypt', async () => {
+      await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
+      const encrypted = JSON.parse(fs.readFileSync(settingsFile(), 'utf-8')).apiKey as string;
+      vi.clearAllMocks();
+      // A settings save that doesn't touch the key omits apiKey entirely.
+      await saveSettings({ model: 'claude-opus-4-8', web: base.web });
+      const after = JSON.parse(fs.readFileSync(settingsFile(), 'utf-8'));
+      expect(after.apiKey).toBe(encrypted);       // byte-for-byte preserved
+      expect(after.model).toBe('claude-opus-4-8'); // the actual edit landed
+      expect(safeStorage.decryptString).not.toHaveBeenCalled();
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      // And the key still decrypts for the API-call path.
+      expect((await getSettings()).apiKey).toBe('sk-ant-secret');
+    });
+
+    it('an explicit empty apiKey clears the stored key', async () => {
+      await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
+      await saveSettings({ model: base.model, web: base.web, apiKey: '' });
+      expect(JSON.parse(fs.readFileSync(settingsFile(), 'utf-8')).apiKey).toBe('');
+      expect((await getSettingsForDisplay()).hasApiKey).toBe(false);
+    });
   });
 
   describe('getApiKeyStorage — settings-panel indicator (#1326)', () => {


### PR DESCRIPTION
## Problem

Opening the Settings dialog (and saving unrelated settings) prompted the macOS keychain, because `getSettings()` unconditionally decrypts the stored Anthropic key via `safeStorage`, and the settings dialog + conversations panel both call it just to read the model / effort / a set-or-unset badge. Decrypting a secret should only happen when the secret is actually **used**, not to display settings.

## Fix

Split "read for display" from "use the key":

- **`shared/tools/types.ts`** — two new shapes:
  - `LLMSettingsView` — display read: `model` / `web` / `effort` + `hasApiKey: boolean`, **no plaintext key**.
  - `LLMSettingsUpdate` — save payload: `apiKey` is tri-state — a string **sets**, `''` **clears**, and **omitting it keeps** the stored key.
- **`main/llm/settings.ts`**
  - `getSettingsForDisplay()` (new) — computes `hasApiKey` from the raw stored value; **no decrypt**.
  - `saveSettings(update)` — when `apiKey` is omitted, preserves the stored value **verbatim** (no decrypt, no re-encrypt); otherwise encrypts the provided key.
  - Internal `getSettings()` still decrypts, and is used only on the API-call path (`provider` / `executor` / `auto-tag` / `auto-link`).
- **IPC** — `TOOL_GET_SETTINGS` → `getSettingsForDisplay`; `TOOL_SET_SETTINGS` → `LLMSettingsUpdate`. Client types updated.
- **`SettingsDialog.svelte`** — reads `hasApiKey` for the set/unset badge; the save omits `apiKey` unless the user cleared or typed one (dropped the old `loadedLlm` plaintext round-trip).

Net: the keychain prompts **only** when you enter/clear a key (encrypt) or make a request (decrypt) — matching expectations.

## Trade-off (touches the #1326 migration timing)

Previously a **legacy plaintext** key opportunistically re-encrypted on *any* settings save (a side effect of the old decrypt-and-round-trip). Now an unrelated save preserves it as-is; a legacy key migrates to encrypted only when the user re-enters it. This is the correct behavior for "don't touch the keychain on unrelated saves," and legacy plaintext configs are rare post-#1326.

## Testing

- `tests/main/llm/settings.test.ts` (now 11): `getSettingsForDisplay` reports `hasApiKey` and **asserts `decryptString` is never called** and no plaintext leaks; saving without `apiKey` preserves the stored blob byte-for-byte with **no decrypt/encrypt** (and the key still decrypts afterward for API calls); explicit `''` clears. Existing encryption/migration tests still pass.
- Full suite: **4133 passing**; `pnpm lint` clean (also enforced by the pre-push hook).

Verified manually: after a clean dev-app restart, opening Settings no longer prompts the keychain (an earlier lingering prompt was a stale-main-process / dev-signature artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)