### PR TITLE
Add thoughtbase.md — a user-authored guide injected into conversations

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -19,6 +19,7 @@ import type { Proposal } from '../llm/approval';
 import { orderRefactors } from '../notebase/reorg';
 import * as conversation from '../llm/conversation';
 import { currentDateContext } from '../llm/date-context';
+import { readThoughtbaseDoc, thoughtbaseDocPromptBlock } from '../llm/thoughtbase-doc';
 import type { ContextBundle, ConversationMessage } from '../../shared/types';
 import {
   formatComputeResultAsContext,
@@ -71,12 +72,20 @@ const DEFAULT_CONVERSATION_SYSTEM_PROMPT = [
   'Answer in GitHub-flavored markdown. When you reference a note, cite its relative path so the user can open it.',
 ].join('\n');
 
-function buildConversationSystemPrompt(
+async function buildConversationSystemPrompt(
   userSystem: string | undefined,
   contextBundle: ContextBundle,
   currentNotePath?: string,
-): string {
+  rootPath?: string | null,
+): Promise<string> {
   const parts = [DEFAULT_CONVERSATION_SYSTEM_PROMPT];
+  // The thoughtbase's own conventions doc (thoughtbase.md), when present, sits
+  // right after the base instructions as authoritative project context —
+  // foundational, before the per-turn/session context below.
+  const thoughtbaseBlock = thoughtbaseDocPromptBlock(rootPath ? await readThoughtbaseDoc(rootPath) : null);
+  if (thoughtbaseBlock) {
+    parts.push('', thoughtbaseBlock);
+  }
   // Dynamic per-turn context follows the static prompt. Within one session
   // (same day, same open note) it's stable, so the cached system block still
   // hits across turns; it only re-caches when the date or open note changes.
@@ -226,10 +235,11 @@ export function registerConversation(): void {
         .filter(m => m.role !== 'system')
         .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }));
 
-      const effectiveSystem = buildConversationSystemPrompt(
+      const effectiveSystem = await buildConversationSystemPrompt(
         systemPrompt ?? conv.systemPrompt,
         conv.contextBundle,
         currentNotePath,
+        rootPath,
       );
 
       if (!rootPath) {

--- a/src/main/llm/thoughtbase-doc.ts
+++ b/src/main/llm/thoughtbase-doc.ts
@@ -1,0 +1,41 @@
+/**
+ * `thoughtbase.md` — the thoughtbase's own guide.
+ *
+ * A user-authored, plain-English file at the project root describing the
+ * thoughtbase's structure, intent, and conventions — analogous to CLAUDE.md for
+ * Claude Code. When present, its contents are injected into every conversation's
+ * system prompt so the assistant understands how this thoughtbase is organized
+ * and how the user wants it worked within. Entirely opt-in: no file, no effect.
+ */
+import * as notebaseFs from '../notebase/fs';
+import { THOUGHTBASE_DOC_FILENAME } from '../../shared/thoughtbase';
+
+export { THOUGHTBASE_DOC_FILENAME };
+
+/**
+ * Read `thoughtbase.md` from the project root. Returns the trimmed contents, or
+ * `null` when the file is absent, empty/whitespace, or unreadable. Read fresh on
+ * each conversation turn so a user's edits take effect on their next message.
+ */
+export async function readThoughtbaseDoc(rootPath: string): Promise<string | null> {
+  try {
+    const content = (await notebaseFs.readFile(rootPath, THOUGHTBASE_DOC_FILENAME)).trim();
+    return content.length > 0 ? content : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format the thoughtbase doc as a labeled system-prompt block, or `''` when
+ * there's nothing to inject. Kept pure (no I/O) so the prompt wording is
+ * unit-testable independent of the filesystem read.
+ */
+export function thoughtbaseDocPromptBlock(doc: string | null): string {
+  if (!doc) return '';
+  return [
+    `The following is this thoughtbase's own guide (${THOUGHTBASE_DOC_FILENAME}), written by the user to describe its structure, intent, and conventions. Treat it as authoritative context for how this thoughtbase is organized and how the user wants you to work within it:`,
+    '',
+    doc,
+  ].join('\n');
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -221,6 +221,11 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
         accelerator: 'CmdOrCtrl+Shift+W',
         click: () => send(Channels.MENU_CLOSE_PROJECT),
       }),
+      gate({
+        label: 'Edit Thoughtbase Guide…',
+        toolTip: 'Open thoughtbase.md — the plain-English guide (structure, intent, conventions) shown to the assistant at the start of every conversation. Created from a template if it doesn\'t exist yet.',
+        click: () => send(Channels.MENU_EDIT_THOUGHTBASE_DOC),
+      }),
       { type: 'separator' },
 
       // Everyday note actions.

--- a/src/main/notebase/indexable-files.ts
+++ b/src/main/notebase/indexable-files.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { THOUGHTBASE_DOC_FILENAME } from '../../shared/thoughtbase';
 
 /**
  * Canonical set of file extensions that Minerva indexes + lists as
@@ -13,5 +14,9 @@ import path from 'node:path';
 export const INDEXABLE_EXTS: ReadonlySet<string> = new Set(['.md', '.ttl', '.csv', '.py']);
 
 export function isIndexable(relativePath: string): boolean {
+  // The thoughtbase guide (thoughtbase.md) is meta, not knowledge — it feeds the
+  // conversation system prompt, not the graph/search. Keep it out of every index
+  // (it still lists + edits like any file; listing ≠ indexing, see fs.listFiles).
+  if (path.basename(relativePath) === THOUGHTBASE_DOC_FILENAME) return false;
   return INDEXABLE_EXTS.has(path.extname(relativePath).toLowerCase());
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -459,6 +459,9 @@ contextBridge.exposeInMainWorld('api', {
     onNewNote: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_NEW_NOTE, () => cb());
     },
+    onEditThoughtbaseDoc: (cb: () => void) => {
+      ipcRenderer.on(Channels.MENU_EDIT_THOUGHTBASE_DOC, () => cb());
+    },
     onSave: (cb: () => void) => {
       ipcRenderer.on(Channels.MENU_SAVE, () => cb());
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -84,6 +84,7 @@
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { ENTRYPOINT_TAG } from '../shared/entrypoint';
   import { WELCOME_NOTE_PATH, welcomeNoteContent } from '../shared/welcome-note';
+  import { THOUGHTBASE_DOC_FILENAME, THOUGHTBASE_DOC_TEMPLATE } from '../shared/thoughtbase';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
   import { findRunnableFences, RUNNABLE_LANGUAGE_SET } from '../shared/compute/fences';
   import { loadFormatSettings } from './lib/formatter/settings';
@@ -518,6 +519,25 @@
   }
 
   /**
+   * Open the thoughtbase guide (thoughtbase.md), creating it from a template
+   * when it doesn't exist yet. The guide is a plain-English description of the
+   * thoughtbase, injected into every conversation's system prompt. It's an
+   * ordinary root file — excluded only from indexing — so we just open it.
+   */
+  async function handleEditThoughtbaseDoc(): Promise<void> {
+    if (!notebase.meta) return;
+    try {
+      if (!(await api.notebase.fileExists(THOUGHTBASE_DOC_FILENAME))) {
+        await api.notebase.writeFile(THOUGHTBASE_DOC_FILENAME, THOUGHTBASE_DOC_TEMPLATE);
+        await notebase.refresh();
+      }
+      await editor.openFile(THOUGHTBASE_DOC_FILENAME);
+    } catch (e) {
+      console.warn('[thoughtbase] open/create guide failed:', e);
+    }
+  }
+
+  /**
    * Check whether the just-opened thoughtbase should trigger the
    * onboarding modal. Called from every project-open path (the
    * `project:opened` event AND the in-window New/Open/Open-Recent
@@ -607,6 +627,7 @@
     openProject: () => { void handleOpenThoughtbase(); },
     newProject: () => { void handleNewThoughtbase(); },
     closeProject: () => { notebase.close(); editor.clear(); },
+    editThoughtbaseGuide: () => { void handleEditThoughtbaseDoc(); },
     print: () => window.print(),
     saveAsTemplate: () => { void handleSaveAsTemplate(); },
     insertTemplate: () => { void handleInsertTemplate(); },
@@ -1070,6 +1091,7 @@
 
     // Listen for menu events from main process
     api.menu.onNewNote(() => handleNewNote());
+    api.menu.onEditThoughtbaseDoc(() => { void handleEditThoughtbaseDoc(); });
     api.menu.onSave(() => handleSave());
     api.menu.onSaveAsTemplate(() => { void handleSaveAsTemplate(); });
     api.menu.onInsertTemplate(() => { void handleInsertTemplate(); });

--- a/src/renderer/lib/command-palette/registry.ts
+++ b/src/renderer/lib/command-palette/registry.ts
@@ -34,6 +34,7 @@ export interface CommandDeps {
   openProject(): void;
   newProject(): void;
   closeProject(): void;
+  editThoughtbaseGuide(): void;
   print(): void;
   saveAsTemplate(): void;
   // ── Edit ──
@@ -109,6 +110,8 @@ export function buildCommandRegistry(deps: CommandDeps): Command[] {
     { id: 'file.closeProject', title: 'Close Thoughtbase', category: 'File',
       keybinding: formatAccelerator('CmdOrCtrl+Shift+W'),
       enabled: hasProject, run: () => deps.closeProject() },
+    { id: 'file.editThoughtbaseGuide', title: 'Edit Thoughtbase Guide…', category: 'File',
+      keybinding: null, enabled: hasProject, run: () => deps.editThoughtbaseGuide() },
     { id: 'file.print', title: 'Print…', category: 'File',
       keybinding: null, enabled: hasNote, run: () => deps.print() },
     { id: 'file.saveAsTemplate', title: 'Save as Template…', category: 'File',

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -673,6 +673,7 @@ export interface SkillsApi {
 
 export interface MenuApi {
   onNewNote(cb: () => void): void;
+  onEditThoughtbaseDoc(cb: () => void): void;
   onSave(cb: () => void): void;
   onSaveAsTemplate(cb: () => void): void;
   onInsertTemplate(cb: () => void): void;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -152,6 +152,7 @@ export const Channels = {
   MENU_OPEN_IN_DEFAULT: 'menu:openInDefault',
   MENU_OPEN_IN_TERMINAL: 'menu:openInTerminal',
   MENU_NEW_NOTE: 'menu:newNote',
+  MENU_EDIT_THOUGHTBASE_DOC: 'menu:editThoughtbaseDoc',
   MENU_SAVE_AS_TEMPLATE: 'menu:saveAsTemplate',
   MENU_INSERT_TEMPLATE: 'menu:insertTemplate',
   MENU_SAVE: 'menu:save',

--- a/src/shared/thoughtbase.ts
+++ b/src/shared/thoughtbase.ts
@@ -1,0 +1,40 @@
+/**
+ * `thoughtbase.md` — the thoughtbase's own guide.
+ *
+ * A user-authored, plain-English file at the project root describing the
+ * thoughtbase's structure, intent, and conventions — analogous to CLAUDE.md for
+ * Claude Code. When present, its contents are injected into every conversation's
+ * system prompt (see `main/llm/thoughtbase-doc.ts`). Shared here so main
+ * (injection, indexing exclusion) and the renderer (the "Edit Thoughtbase
+ * Guide" affordance) agree on the one filename.
+ */
+
+/** Root-relative filename of the thoughtbase guide. */
+export const THOUGHTBASE_DOC_FILENAME = 'thoughtbase.md';
+
+/** Starter content written when the user opens the guide for a thoughtbase that
+ *  doesn't have one yet. HTML comments explain each section without cluttering
+ *  what the assistant reads once the user fills it in. */
+export const THOUGHTBASE_DOC_TEMPLATE = `# Thoughtbase Guide
+
+<!--
+This file describes your thoughtbase — its structure, intent, and conventions —
+in plain English. Its contents are shown to the AI assistant at the start of
+every conversation, so it understands how this thoughtbase is organized and how
+you want it to work within it. Edit freely; delete the file to opt out.
+-->
+
+## What this thoughtbase is for
+
+<!-- A sentence or two on the purpose or domain of this thoughtbase. -->
+
+## Structure & conventions
+
+<!-- How notes are organized (folders, tags, naming), and any conventions the
+     assistant should follow — e.g. "prefer wiki-links over tags", or "file new
+     claims under notes/claims/". -->
+
+## Working preferences
+
+<!-- How you'd like the assistant to respond or file things in this thoughtbase. -->
+`;

--- a/tests/main/llm/thoughtbase-doc.test.ts
+++ b/tests/main/llm/thoughtbase-doc.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  readThoughtbaseDoc,
+  thoughtbaseDocPromptBlock,
+  THOUGHTBASE_DOC_FILENAME,
+} from '../../../src/main/llm/thoughtbase-doc';
+
+describe('readThoughtbaseDoc', () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-thoughtbase-'));
+  });
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns the trimmed contents when the file exists', async () => {
+    await fs.writeFile(path.join(root, THOUGHTBASE_DOC_FILENAME), '\n# My thoughtbase\n\nConventions here.\n', 'utf-8');
+    expect(await readThoughtbaseDoc(root)).toBe('# My thoughtbase\n\nConventions here.');
+  });
+
+  it('returns null when the file is absent (opt-in)', async () => {
+    expect(await readThoughtbaseDoc(root)).toBeNull();
+  });
+
+  it('returns null for an empty / whitespace-only file', async () => {
+    await fs.writeFile(path.join(root, THOUGHTBASE_DOC_FILENAME), '   \n\t\n', 'utf-8');
+    expect(await readThoughtbaseDoc(root)).toBeNull();
+  });
+});
+
+describe('thoughtbaseDocPromptBlock', () => {
+  it('is empty when there is nothing to inject', () => {
+    expect(thoughtbaseDocPromptBlock(null)).toBe('');
+    expect(thoughtbaseDocPromptBlock('')).toBe('');
+  });
+
+  it('labels the block and includes the doc contents verbatim', () => {
+    const block = thoughtbaseDocPromptBlock('Prefer wiki-links over tags.');
+    expect(block).toContain(THOUGHTBASE_DOC_FILENAME);
+    expect(block).toContain('written by the user');
+    expect(block).toContain('Prefer wiki-links over tags.');
+    // The contents come last so the model reads the label, then the doc.
+    expect(block.trimEnd().endsWith('Prefer wiki-links over tags.')).toBe(true);
+  });
+});

--- a/tests/main/notebase/indexable-files.test.ts
+++ b/tests/main/notebase/indexable-files.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { isIndexable } from '../../../src/main/notebase/indexable-files';
+import { THOUGHTBASE_DOC_FILENAME } from '../../../src/shared/thoughtbase';
+
+describe('isIndexable', () => {
+  it('indexes the first-class note/data extensions', () => {
+    expect(isIndexable('notes/idea.md')).toBe(true);
+    expect(isIndexable('data.csv')).toBe(true);
+    expect(isIndexable('graph.ttl')).toBe(true);
+    expect(isIndexable('run.py')).toBe(true);
+  });
+
+  it('skips unknown extensions', () => {
+    expect(isIndexable('photo.png')).toBe(false);
+    expect(isIndexable('notes.txt')).toBe(false);
+  });
+
+  it('excludes the thoughtbase guide (meta, not a knowledge node)', () => {
+    expect(isIndexable(THOUGHTBASE_DOC_FILENAME)).toBe(false);
+    // Excluded by basename, wherever it sits.
+    expect(isIndexable('anything/thoughtbase.md')).toBe(false);
+    // A differently-named markdown note is still indexed.
+    expect(isIndexable('thoughts.md')).toBe(true);
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -151,6 +151,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onCloseProject",
     "onCycleTheme",
     "onEditSavedQueries",
+    "onEditThoughtbaseDoc",
     "onExport",
     "onFind",
     "onFindInNotes",

--- a/tests/renderer/command-palette/registry.test.ts
+++ b/tests/renderer/command-palette/registry.test.ts
@@ -14,7 +14,7 @@ import { buildCommandRegistry, type CommandDeps } from '../../../src/renderer/li
 // command is enabled unless a test overrides them.
 function makeDeps(overrides: Partial<CommandDeps> = {}): CommandDeps {
   const actionNames = [
-    'newNote', 'save', 'openProject', 'newProject', 'closeProject', 'print',
+    'newNote', 'save', 'openProject', 'newProject', 'closeProject', 'editThoughtbaseGuide', 'print',
     'saveAsTemplate', 'insertTemplate', 'dictate', 'find', 'findReplace', 'findInNotes',
     'replaceInNotes', 'gotoLine', 'sortLines', 'toggleSidebar', 'toggleRightSidebar',
     'togglePreview', 'toggleConversations', 'newConversation', 'setTheme', 'fontIncrease', 'fontDecrease',
@@ -41,7 +41,7 @@ describe('buildCommandRegistry', () => {
     const ids = buildCommandRegistry(makeDeps()).map((c) => c.id);
     expect(ids).toEqual([
       'file.newNote', 'file.save', 'file.openProject', 'file.newProject',
-      'file.closeProject', 'file.print', 'file.saveAsTemplate', 'edit.insertTemplate',
+      'file.closeProject', 'file.editThoughtbaseGuide', 'file.print', 'file.saveAsTemplate', 'edit.insertTemplate',
       'edit.dictate',
       'edit.find', 'edit.findReplace', 'edit.findInNotes', 'edit.replaceInNotes',
       'edit.gotoLine', 'edit.sortLines', 'view.toggleSidebar', 'view.toggleRightSidebar',
@@ -110,6 +110,7 @@ describe('buildCommandRegistry', () => {
     const wiring: Record<string, keyof CommandDeps> = {
       'file.newNote': 'newNote', 'file.save': 'save', 'file.openProject': 'openProject',
       'file.newProject': 'newProject', 'file.closeProject': 'closeProject',
+      'file.editThoughtbaseGuide': 'editThoughtbaseGuide',
       'file.print': 'print', 'file.saveAsTemplate': 'saveAsTemplate',
       'edit.insertTemplate': 'insertTemplate', 'edit.dictate': 'dictate', 'edit.find': 'find',
       'edit.findReplace': 'findReplace', 'edit.findInNotes': 'findInNotes',


### PR DESCRIPTION
## What & why

Adds support for a user-editable **`thoughtbase.md`** at the project root — analogous to CLAUDE.md for Claude Code. It's a plain-English description of the thoughtbase's structure, intent, and conventions, and its contents are presented to the assistant at the start of every conversation so it understands how the thoughtbase is organized and how the user wants it worked within.

## Core: injection

- **`shared/thoughtbase.ts`** — the single source of truth for the filename (`thoughtbase.md`) and a starter template.
- **`main/llm/thoughtbase-doc.ts`** — `readThoughtbaseDoc()` (opt-in: `null` when absent/empty/unreadable) + `thoughtbaseDocPromptBlock()` (labels it as the user's authoritative guide).
- **`register-conversation.ts`** — `buildConversationSystemPrompt()` (now async) injects the block right after the base instructions. This is the single point every conversation's `system` funnels through — plain "Ask a Question" *and* skill-driven — so one change covers both. Read **fresh each turn**, so editing the guide mid-conversation takes effect on the next message.

## Extension 1: discoverability

- **File ▸ "Edit Thoughtbase Guide…"** (and a matching command-palette entry) open `thoughtbase.md`, **creating it from the template** when it doesn't exist yet. New `MENU_EDIT_THOUGHTBASE_DOC` channel + preload/client wiring; handler in `App.svelte`.

## Extension 2: excluded from indexing

- **`isIndexable()`** now returns false for `thoughtbase.md` (by basename), keeping it out of the graph, search, and vector indexes — it's meta, not a knowledge node. It still **lists in the sidebar and edits like any file** (listing ≠ indexing, per #1130), and stays openable via the menu/command above.

## Testing

- `thoughtbase-doc.test.ts` — read (trim/absent/whitespace) + block formatting.
- `indexable-files.test.ts` — exclusion by basename; other `.md` still indexed.
- Updated command-palette registry test (id-order + dispatch) and the preload surface snapshot for the one new method.
- Full suite: **4144 passing**; `pnpm lint` clean (also enforced by the pre-push hook).

**Verification caveat:** I can't drive a live Anthropic request here, so the prompt injection is covered by the module unit tests + type-checked wiring + the passing conversation-send suite rather than observing a real prompt.

## Design notes
- **"On conversation entry" → injected every turn** (fresh read). It's present from the first message and reflects edits immediately, since the system prompt was already rebuilt per-send.
- **All-index exclusion** (graph + search + vectors) rather than graph-only — best matches "not a knowledge node," and keeps the change to one idiomatic line in `isIndexable`. A differently-named `.md` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)