### PR TITLE
Conversations: label the assistant turn "Minerva"

### DIFF
--- a/src/renderer/lib/components/conversations/MessageList.svelte
+++ b/src/renderer/lib/components/conversations/MessageList.svelte
@@ -90,6 +90,13 @@
     return `${t.id}:${msgIndex}:${ci}`;
   }
 
+  /** Display name for a message's sender. The assistant turn is presented as
+   *  "Minerva" (the app) in the conversation UI; the underlying message role is
+   *  still `assistant` — this only relabels what the user sees. */
+  function roleLabel(role: string): string {
+    return role === 'assistant' ? 'Minerva' : role;
+  }
+
   /** Note this conversation cites *into*: its anchor note, else whatever the
    *  editor currently shows. Null when there's nowhere to record the edge. */
   function citeTargetPath(t: TabRuntime): string | null {
@@ -130,7 +137,7 @@
   {#if msg.role !== 'system'}
     <div class="msg {msg.role}">
       <div class="msg-role">
-        <span>{msg.role}</span>
+        <span>{roleLabel(msg.role)}</span>
         {#if msg.role === 'assistant'}
           {@const turnCost = formatTurnCost(msg)}
           {#if turnCost}
@@ -168,7 +175,7 @@
 
   {#if tab.streaming}
     <div class="msg assistant streaming">
-      <div class="msg-role">assistant</div>
+      <div class="msg-role">{roleLabel('assistant')}</div>
       {#if tab.streamedChunks}
         <!-- Stream the assistant's partial text through markdown-it so tool-call
              indicators (`_🔍 …_`) and any markdown the model emits mid-stream


### PR DESCRIPTION
## What & why

In the conversation panel, the AI's turns were labeled **"assistant"**. Rename that display label to **"Minerva"** (the app's name).

## Change

`MessageList.svelte` — a small `roleLabel()` helper maps the `assistant` role to `"Minerva"` for display; other roles (e.g. `user`) are shown as-is. Applied to both the finalized message label and the streaming-turn label.

**Display-only.** The underlying message `role` stays `assistant` everywhere it matters — the Anthropic API payload, persisted conversation JSON, and the graph transcript are all unchanged. This purely relabels what the user sees.

## Testing
- `pnpm lint` clean.
- Full suite passes except one **pre-existing, unrelated** failure in `help-docs-corpus-staleness.test.ts`, caused by uncommitted local edits to `website/docs/*.html` that are not part of this branch (verified: stashing this change leaves that test still failing). This commit contains only `MessageList.svelte`, so CI on the branch is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)