### PR TITLE
Frontmatter wiki-links: type + anchor parity with body links

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -21,6 +21,7 @@ import { parseMarkdown, type ParsedTable, type FrontmatterValue } from './parser
 import { getLinkType, type LinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
 import { resolveWikiLinkTarget } from '../../shared/wiki-link-resolver';
+import { parseWikiInner } from '../../shared/wiki-link';
 import { slugify } from '../../shared/slug';
 import { parseCsv } from '../../shared/csv-parse';
 import { isIndexable } from '../notebase/indexable-files';
@@ -203,71 +204,75 @@ function resolveFrontmatterPredicate(key: string) {
   }
 }
 
-/** Match [[target]] or [[target|display]] (no typed-link prefix — values are bare refs). */
-const FRONTMATTER_WIKILINK_RE = /^\[\[([^[\]\n|]+)(?:\|[^\]]+)?\]\]$/;
+/** Whole frontmatter value that is a single wiki-link — `[[…]]` and nothing
+ *  else. The inner is then parsed by the shared body grammar (`parseWikiInner`)
+ *  so type prefixes and anchors are honoured, not swept into the target. */
+const WHOLE_WIKILINK_RE = /^\[\[([^\]\n]+?)\]\]$/;
 
 /**
- * Turn a typed frontmatter scalar into an rdflib term.
- * - `"[[notes/foo]]"` → note URI (so backlinks work)
- * - `42`              → xsd:integer literal
- * - `3.14`            → xsd:decimal literal
- * - `true`/`false`    → xsd:boolean literal
- * - `Date`            → xsd:dateTime literal
- * - `"2024-01-15"`    → xsd:date literal (ISO-date shape)
- * - other string      → plain string literal
+ * Turn a frontmatter scalar into a graph edge — `{ predicate, term }`. The
+ * caller supplies `keyPredicate` (derived from the frontmatter key); a value
+ * with its own typed wiki-link overrides it.
+ *
+ * Wiki-link values are parsed with the SAME grammar as body links so a
+ * frontmatter link renders IDENTICALLY to a body one (same predicate, same
+ * anchored target IRI):
+ * - `[[supports::x]]` — the link's own `type::` wins, mapped through
+ *   `LINK_TYPES` exactly like a body `[[supports::x]]`, overriding `keyPredicate`.
+ * - `[[x#heading]]` / `[[x#^block]]` — the anchor resolves + appends via the
+ *   shared `resolveLinkTarget`, just as in the body.
+ * - `[[x]]` / `[[x|display]]` — untyped: keeps `keyPredicate` (the
+ *   frontmatter-key-as-type feature); the display alias is cosmetic and dropped.
+ * - `[[sources/<id>]]` — the actual source node (#474 convention), untyped.
+ *
+ * Non-link scalars keep `keyPredicate`: `42`→xsd:integer, `3.14`→xsd:decimal,
+ * `true`→xsd:boolean, `Date`/ISO shapes→xsd:date(Time)/gYear, a bare `https://…`
+ * →an IRI node, everything else→a plain string literal.
  */
-function frontmatterValueToTerm(
+function frontmatterValueToEdge(
   value: Exclude<FrontmatterValue, null | FrontmatterValue[]>,
-  projectBaseUri: string,
-  rc?: LinkResolveCtx,
+  state: GraphState,
+  keyPredicate: ReturnType<typeof resolveFrontmatterPredicate>,
+  rc: LinkResolveCtx,
 ) {
-  if (value instanceof Date) {
-    return $rdf.lit(value.toISOString(), undefined, XSD('dateTime'));
-  }
-  if (typeof value === 'boolean') {
-    return $rdf.lit(String(value), undefined, XSD('boolean'));
-  }
+  type Term = ReturnType<typeof resolveLinkTarget> | ReturnType<typeof $rdf.lit>;
+  const plain = (term: Term) => ({ predicate: keyPredicate, term });
+
+  if (value instanceof Date) return plain($rdf.lit(value.toISOString(), undefined, XSD('dateTime')));
+  if (typeof value === 'boolean') return plain($rdf.lit(String(value), undefined, XSD('boolean')));
   if (typeof value === 'number') {
     const datatype = Number.isInteger(value) ? 'integer' : 'decimal';
-    return $rdf.lit(String(value), undefined, XSD(datatype));
+    return plain($rdf.lit(String(value), undefined, XSD(datatype)));
   }
-  // Strings: try wiki-link first, then date shapes, then plain.
-  const wiki = value.match(FRONTMATTER_WIKILINK_RE);
-  if (wiki && projectBaseUri) {
-    const target = wiki[1]!.trim();
-    // `[[sources/<id>]]` materialises as the actual source URI rather
-    // than a phantom note path (#474). Lets `about: [[sources/foo]]`
-    // become a real edge from this note to the foo source, queryable
-    // alongside the cite/quote backlinks the source detail collects.
-    if (target.startsWith('sources/')) {
-      const sourceId = target.slice('sources/'.length);
-      if (sourceId) return $rdf.sym(uriHelpers.sourceUri(projectBaseUri, sourceId));
+
+  // Whole-value wiki-link → parse with the body grammar for full parity.
+  const inner = state.baseUri ? value.match(WHOLE_WIKILINK_RE) : null;
+  if (inner) {
+    const link = parseWikiInner(inner[1]!);
+    // #474: a bare `[[sources/<id>]]` edges to the actual source node. A typed
+    // `[[cite::<id>]]` reaches a source through resolveLinkTarget's targetKind.
+    if (!link.type && link.target.startsWith('sources/')) {
+      const sourceId = link.target.slice('sources/'.length);
+      if (sourceId) return plain(sourceUri(state, sourceId));
     }
-    // Resolve like navigation / body links (#1142) so a frontmatter
-    // `see-also: [[Term]]` edges to the real glossary/Term.md, not a phantom
-    // root Term.md. Falls back to the literal path (for a not-yet-created note).
-    const noteRel = (rc && resolveWikiLinkTarget(target, rc.files, rc.aliases))
-      || (target.endsWith('.md') ? target : `${target}.md`);
-    return $rdf.sym(uriHelpers.noteUri(projectBaseUri, noteRel));
+    // getLinkType falls back to `references` for untyped/unknown types — same as
+    // the body path — so an untyped link resolves as a note. The predicate,
+    // though, only switches to the link type when one was written explicitly;
+    // otherwise the frontmatter key stays authoritative.
+    const linkType = getLinkType(link.type ?? 'references');
+    const predicate = link.type ? linkPredicate(linkType) : keyPredicate;
+    const anchor = link.anchor ? link.anchor.slice(1) : undefined; // parseWikiInner keeps the leading '#'
+    return { predicate, term: resolveLinkTarget(state, linkType, link.target, rc, anchor) };
   }
-  // Bare absolute URI → IRI node. Lets a frontmatter key like
-  // `supports: https://minerva.dev/c/claim-…` materialise as a real
-  // graph edge to that node, rather than as an opaque string literal.
-  // The tail check excludes whitespace so we don't mis-classify a
-  // longer string that happens to start with a URL.
-  if (/^https?:\/\/\S+$/.test(value)) {
-    return $rdf.sym(value);
-  }
-  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return $rdf.lit(value, undefined, XSD('date'));
-  }
-  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) {
-    return $rdf.lit(value, undefined, XSD('dateTime'));
-  }
-  if (/^\d{4}$/.test(value)) {
-    return $rdf.lit(value, undefined, XSD('gYear'));
-  }
-  return $rdf.lit(value);
+
+  // Bare absolute URI → IRI node (e.g. `supports: https://minerva.dev/c/claim-…`).
+  // The tail check excludes whitespace so a longer string that merely starts
+  // with a URL isn't mis-classified.
+  if (/^https?:\/\/\S+$/.test(value)) return plain($rdf.sym(value));
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return plain($rdf.lit(value, undefined, XSD('date')));
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) return plain($rdf.lit(value, undefined, XSD('dateTime')));
+  if (/^\d{4}$/.test(value)) return plain($rdf.lit(value, undefined, XSD('gYear')));
+  return plain($rdf.lit(value));
 }
 
 /**
@@ -408,7 +413,7 @@ export async function indexNote(
   // store; flag the N3 mirror as stale once, at the boundary, instead
   // of after every internal store.add.
   invalidate(state);
-  const { store, baseUri, headingsPerNote } = state;
+  const { store, headingsPerNote } = state;
 
   const subject = noteUri(state, relativePath);
   const graph = subject; // named graph = note URI, for clean removal on re-index
@@ -528,10 +533,12 @@ export async function indexNote(
     // publishing directives (#1136) — a publication concern, kept out of the
     // graph (and it's an object, not a materialisable scalar anyway).
     if (key === 'title' || key === 'tags' || key === 'publish') continue;
-    const predicate = resolveFrontmatterPredicate(key);
+    const keyPredicate = resolveFrontmatterPredicate(key);
     for (const v of flattenFrontmatterScalars(value)) {
-      const term = frontmatterValueToTerm(v, baseUri, linkCtx);
-      if (term) store.add(subject, predicate, term, graph);
+      // A typed wiki-link value (`[[supports::x]]`) overrides keyPredicate with
+      // its own type; everything else stays under the key's predicate.
+      const edge = frontmatterValueToEdge(v, state, keyPredicate, linkCtx);
+      if (edge) store.add(subject, edge.predicate, edge.term, graph);
     }
   }
 

--- a/tests/main/graph/frontmatter-link-parity.test.ts
+++ b/tests/main/graph/frontmatter-link-parity.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Frontmatter wiki-links reach parity with body wiki-links: type prefixes
+ * (`[[supports::x]]`) and anchors (`[[x#heading]]`) are honoured and render the
+ * SAME RDF a body link would, instead of being flattened to a bare reference.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+async function targetsUnder(ctx: ProjectContext, src: string, predicateQName: string): Promise<string[]> {
+  const { results } = await queryGraph(ctx, `
+    SELECT ?t WHERE { ?note minerva:relativePath "${src}" ; ${predicateQName} ?t . }
+  `);
+  return (results as Array<{ t: string }>).map((r) => r.t);
+}
+
+describe('frontmatter ↔ body wiki-link parity', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fm-parity-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    await indexNote(ctx, 'a.md', '# A\n\n## Intro\n\nbody');
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('a typed frontmatter link renders the same triple as a body link', async () => {
+    await indexNote(ctx, 'body.md', '# Body\n\nSee [[supports::a]].');
+    await indexNote(ctx, 'fm.md', '---\nrelated: "[[supports::a]]"\n---\n# FM\n');
+
+    // Both emit minerva:supports → a.md.
+    const bodyT = await targetsUnder(ctx, 'body.md', 'minerva:supports');
+    const fmT = await targetsUnder(ctx, 'fm.md', 'minerva:supports');
+    expect(bodyT.length).toBe(1);
+    expect(fmT).toEqual(bodyT); // byte-identical target IRI → equivalent RDF
+
+    // The explicit type wins over the key: nothing lands under the key predicate.
+    expect(await targetsUnder(ctx, 'fm.md', 'minerva:meta-related')).toEqual([]);
+  });
+
+  it('a frontmatter link anchor resolves + appends exactly like a body link', async () => {
+    await indexNote(ctx, 'body.md', '# Body\n\n[[a#intro]]');
+    await indexNote(ctx, 'fm.md', '---\nrelated: "[[a#intro]]"\n---\n# FM\n');
+
+    const [bodyT] = await targetsUnder(ctx, 'body.md', 'minerva:references');
+    // Untyped → keeps the key predicate, but the anchored target matches the body.
+    const [fmT] = await targetsUnder(ctx, 'fm.md', 'minerva:meta-related');
+    expect(bodyT).toMatch(/note\/a#intro$/);
+    expect(fmT).toBe(bodyT);
+  });
+
+  it('a typed frontmatter link overrides the key-derived predicate', async () => {
+    await indexNote(ctx, 'fm.md', '---\nabout: "[[rebuts::a]]"\n---\n# FM\n');
+    // about → dc:subject normally, but rebuts:: wins.
+    expect((await targetsUnder(ctx, 'fm.md', 'minerva:rebuts')).length).toBe(1);
+    expect(await targetsUnder(ctx, 'fm.md', 'dc:subject')).toEqual([]);
+  });
+
+  it('an untyped frontmatter link still keeps the key predicate (about → dc:subject)', async () => {
+    await indexNote(ctx, 'fm.md', '---\nabout: "[[a]]"\n---\n# FM\n');
+    const { results } = await queryGraph(ctx, `
+      SELECT ?p WHERE { ?note minerva:relativePath "fm.md" ; dc:subject ?t . ?t minerva:relativePath ?p . }
+    `);
+    expect((results as Array<{ p: string }>).map((r) => r.p)).toEqual(['a.md']);
+  });
+
+  it('preserves the bare [[sources/<id>]] source convention (#474)', async () => {
+    await indexNote(ctx, 'fm.md', '---\nabout: "[[sources/foo]]"\n---\n# FM\n');
+    const [t] = await targetsUnder(ctx, 'fm.md', 'dc:subject');
+    expect(t).toMatch(/source\/foo$/);
+  });
+});


### PR DESCRIPTION
First item off the frontmatter-link-parity list. Brings **frontmatter** `[[…]]` values to parity with **body** links, and renders them **equivalently in the RDF graph**.

## The gap

Frontmatter link values went through a bespoke reduced regex (`FRONTMATTER_WIKILINK_RE`) that captured only a bare target. A `::` or `#` inside `[[…]]` got swept into the "target" string and then failed to resolve — so a typed or anchored frontmatter link was effectively **broken**, not just plain.

## The fix

`frontmatterValueToEdge` (replacing `frontmatterValueToTerm`) parses a frontmatter link value with the **shared body grammar** (`parseWikiInner`) and resolves it through the body's own `resolveLinkTarget`:

- **`[[supports::x]]`** — the value's own `type::` wins, mapped through `LINK_TYPES` exactly like a body `[[supports::x]]` → **same predicate**, overriding the key-derived one.
- **`[[x#heading]]` / `[[x#^block]]`** — the anchor resolves and appends to the target IRI, exactly as in the body.
- **`[[x]]` / `[[x|display]]`** — untyped: keeps the frontmatter key's predicate (the key-as-type feature is unchanged); the display alias is cosmetic and dropped.
- **`[[sources/<id>]]`** — the #474 source convention is preserved.

**Equivalent RDF, guaranteed:** `noteUri(state,…)` is byte-identical to the prior `uriHelpers.noteUri(baseUri,…)`, so existing (untyped) links produce the exact same triples; only the previously-broken typed/anchored cases change. A test asserts a body `[[supports::a]]` and a frontmatter `related: "[[supports::a]]"` produce the identical `minerva:supports → a.md` triple.

Rename/link-rewrite already handled typed/anchored frontmatter links (it runs the shared parser over the whole file), so that path needed no change.

## Testing
- New `tests/main/graph/frontmatter-link-parity.test.ts` (5): type-prefix equivalence, anchor equivalence, type overrides key, untyped keeps key, `[[sources/…]]` preserved.
- Existing frontmatter / anchor / parser / cite tests still green.
- Full suite passes except one **pre-existing, unrelated** failure in `help-docs-corpus-staleness.test.ts` (from uncommitted local `website/docs/*.html` edits, not in this branch).

## Follow-ups on the list
- **#3 Backlinks panel** surfaces frontmatter links (`backlinks()` scans only `LINK_TYPES` predicates today) — next PR.
- **#5 (stretch)** frontmatter links clickable in preview.
- The `notes-links.html` "Frontmatter links are plainer" gotcha is now outdated and should be revised (leaving to you, since you're editing the docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)