### PR TITLE
Backlinks panel: surface frontmatter links

### DIFF
--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -642,35 +642,67 @@ export function findNotesLinkingTo(ctx: ProjectContext, targetRelativePath: stri
   return [...seen];
 }
 
+/** Muted badge colour for frontmatter (key-typed) backlinks, so they read as
+ *  first-class but stay visually distinct from the typed-body-link vocabulary. */
+const FRONTMATTER_LINK_COLOR = '#9399b2';
+
+/** Humanize a predicate's local name into a badge label: `seeAlso`→"See Also",
+ *  `meta-related`→"Related", `subject`→"Subject", `wasDerivedFrom`→"Was Derived From". */
+function humanizePredicateLocal(local: string): string {
+  const key = local.startsWith('meta-') ? local.slice('meta-'.length) : local;
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .trim()
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
 export function backlinks(ctx: ProjectContext, relativePath: string): Backlink[] {
   const state = getState(ctx);
   if (!state) return [];
   const { store } = state;
 
-  const targetBase = noteUri(state, relativePath).value;
+  const targetSym = noteUri(state, relativePath);
+  const targetBase = targetSym.value;
   const results: Backlink[] = [];
 
+  const push = (sourceNode: $rdf.NamedNode, linkType: string, linkLabel: string, linkColor: string) => {
+    const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
+    const sourcePath = pathStmts[0]?.object.value ?? '';
+    if (!sourcePath.endsWith('.md')) return; // only note sources (skip folders/tags/claims)
+    const titleStmts = store.statementsMatching(sourceNode, DC('title'), undefined);
+    results.push({
+      source: sourcePath,
+      sourceTitle: titleStmts[0]?.object.value ?? sourceNode.value,
+      linkType, linkLabel, linkColor,
+    });
+  };
+
+  // Pass 1 — typed body links (exact + anchored target IRI). These own the
+  // richest badges (per-type label + colour from the link-type registry).
+  const typedPredIris = new Set<string>();
   for (const lt of LINK_TYPES) {
     if (lt.targetKind && lt.targetKind !== 'note') continue;
-    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
-    for (const st of stmts) {
+    typedPredIris.add(linkPredicate(lt).value);
+    for (const st of store.statementsMatching(undefined, linkPredicate(lt), undefined)) {
       const objValue = st.object.value;
       if (objValue !== targetBase && !objValue.startsWith(`${targetBase}#`)) continue;
-      const sourceNode = st.subject;
-      const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
-      const titleStmts = store.statementsMatching(sourceNode, DC('title'), undefined);
-
-      const sourcePath = pathStmts[0]?.object.value ?? '';
-      if (!sourcePath) continue;
-
-      results.push({
-        source: sourcePath,
-        sourceTitle: titleStmts[0]?.object.value ?? sourceNode.value,
-        linkType: lt.name,
-        linkLabel: lt.label,
-        linkColor: lt.color,
-      });
+      if (st.subject.equals(targetSym)) continue; // a note doesn't backlink itself
+      push(st.subject as $rdf.NamedNode, lt.name, lt.label, lt.color);
     }
+  }
+
+  // Pass 2 — every OTHER inbound edge at the note: frontmatter key-typed links
+  // (`about:`→dc:subject, `see-also:`→thought:seeAlso, custom `meta-*` keys, …).
+  // Object-indexed so it's cheap; a derived label + neutral colour keeps
+  // frontmatter links first-class in the panel instead of invisible. Predicates
+  // already surfaced by pass 1 and the note's own self-statements are skipped.
+  for (const st of store.statementsMatching(undefined, undefined, targetSym)) {
+    if (typedPredIris.has(st.predicate.value)) continue;
+    if (st.subject.equals(targetSym)) continue;
+    const iri = st.predicate.value;
+    const local = iri.slice(Math.max(iri.lastIndexOf('#'), iri.lastIndexOf('/')) + 1);
+    push(st.subject as $rdf.NamedNode, iri, humanizePredicateLocal(local), FRONTMATTER_LINK_COLOR);
   }
 
   return results;

--- a/tests/main/graph/frontmatter-backlinks.test.ts
+++ b/tests/main/graph/frontmatter-backlinks.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Backlinks panel surfaces frontmatter-originated links (broad option): every
+ * inbound frontmatter edge shows up, with a label derived from the predicate
+ * and a neutral colour that distinguishes it from typed body links.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, backlinks } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('backlinks — frontmatter links (broad)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fm-backlinks-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    await indexNote(ctx, 'a.md', '# A');
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('surfaces body AND frontmatter inbound links, labelled by their predicate', async () => {
+    await indexNote(ctx, 'body.md', '# Body\n\n[[a]]');
+    await indexNote(ctx, 'about.md', '---\nabout: "[[a]]"\n---\n# About\n');       // dc:subject
+    await indexNote(ctx, 'see.md', '---\nsee-also: "[[a]]"\n---\n# See\n');        // thought:seeAlso
+    await indexNote(ctx, 'custom.md', '---\nrelated: "[[a]]"\n---\n# Custom\n');   // minerva:meta-related
+
+    const bySrc = new Map(backlinks(ctx, 'a.md').map((b) => [b.source, b]));
+
+    // Body link keeps its typed badge.
+    expect(bySrc.get('body.md')?.linkLabel).toBe('References');
+    // Frontmatter links now appear (previously invisible), labelled from the key.
+    expect(bySrc.get('about.md')?.linkLabel).toBe('Subject');
+    expect(bySrc.get('see.md')?.linkLabel).toBe('See Also');
+    expect(bySrc.get('custom.md')?.linkLabel).toBe('Related');
+    // …with a neutral colour that reads distinctly from the typed body link.
+    expect(bySrc.get('custom.md')?.linkColor).not.toBe(bySrc.get('body.md')?.linkColor);
+  });
+
+  it('never lists a note as its own backlink (body or frontmatter self-link)', async () => {
+    await indexNote(ctx, 'self.md', '---\nrelated: "[[self]]"\n---\n# Self\n\n[[self]]');
+    expect(backlinks(ctx, 'self.md').map((b) => b.source)).not.toContain('self.md');
+  });
+
+  it('only lists note sources — not source/tag/other nodes', async () => {
+    // A plain integer property doesn't create an inbound edge; a wiki-link does.
+    await indexNote(ctx, 'nolink.md', '---\nrating: 5\n---\n# NoLink\n');
+    expect(backlinks(ctx, 'a.md').map((b) => b.source)).not.toContain('nolink.md');
+  });
+});


### PR DESCRIPTION
Item #3 off the frontmatter-link-parity list — **option (a), broad**.

## The gap

`backlinks()` iterated **only the 12 `LINK_TYPES` predicates**, so every frontmatter-originated edge was **invisible** in the Backlinks panel: `about:`→`dc:subject`, `see-also:`→`thought:seeAlso`, custom keys→`minerva:meta-*`, and (once #1351 lands) typed frontmatter values. Frontmatter links were second-class — safe-delete counted them, but the panel never showed them.

## The fix

A second, **object-indexed** pass in `backlinks()` over every *other* inbound edge at the note. Each gets:
- a **label derived from the predicate's local name** — `seeAlso`→"See Also", `meta-related`→"Related", `subject`→"Subject", `wasDerivedFrom`→"Was Derived From";
- a **neutral badge colour** so frontmatter links read as first-class but stay visually distinct from the typed body-link palette.

`BacklinksPanel` already groups by `linkType` and renders whatever `linkColor`/`linkLabel` it's handed, so **no UI change was needed**. Only note sources are surfaced (source/tag/claim nodes are filtered out).

Also fixed an inconsistency: both passes now skip **self-links** (a note linking to itself no longer lists itself — pass 1 previously did).

## Testing
- New `tests/main/graph/frontmatter-backlinks.test.ts`: body + `about`/`see-also`/custom-key frontmatter links all surface with the right labels and a distinct colour; self-links excluded; non-link properties don't create phantom sources.
- Full suite green except the pre-existing unrelated `help-docs-corpus-staleness` failure (uncommitted local `website/docs` edits, not in this branch).

## Status of the list
- ✅ #1/#2/#4 — type + anchor parity + equivalent RDF (PR #1351)
- ✅ #3 — this PR
- ⏭️ #5 (stretch) — frontmatter links clickable/hoverable in preview (bigger feature: frontmatter is stripped before render). Recommend a separate epic; happy to scope it if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)