### PR TITLE
Editor status bar: dictation mic button

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -45,6 +45,7 @@
   import { formatAccelerator } from './lib/command-palette/format-accelerator';
   import DictationIndicator from './lib/components/DictationIndicator.svelte';
   import { toggleEditorDictation } from './lib/editor/dictation';
+  import { getVoiceStore } from './lib/voice/voice.svelte';
   import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import PublishDialog from './lib/components/PublishDialog.svelte';
@@ -113,6 +114,7 @@
   const toolPanel = getToolPanelStore();
   const conversationsStore = getConversationsStore();
   const bookmarkStore = getBookmarksStore();
+  const voice = getVoiceStore();
   // Position-bearing bookmarks are resolved per pane at the Editor mount via
   // `collectBookmarksForPath(bookmarkStore.tree, <that pane's file>)` (#813),
   // so each split pane shows its own file's gutter flags (#756).
@@ -1673,6 +1675,9 @@
               rightSidebarVisible = true;
               rightSidebar?.showPanel('backlinks');
             }}
+            onToggleDictation={() => { void toggleEditorDictation(editorComponent?.getView() ?? null); }}
+            dictationActive={voice.surface === 'editor' && voice.busy}
+            dictationDisabled={editor.viewMode === 'preview'}
           />
           <ToolPanel
             bind:this={toolPanelComponent}

--- a/src/renderer/lib/components/StatusBar.svelte
+++ b/src/renderer/lib/components/StatusBar.svelte
@@ -31,6 +31,14 @@
     onShowBacklinks?: () => void;
     /** Semantic-index backfill progress (#836); null hides the indicator. */
     backfill?: { done: number; total: number } | null;
+    /** Toggle voice dictation into the editor — same action as the right-click
+     *  "Dictate" and ⌘⇧V. */
+    onToggleDictation: () => void;
+    /** True while dictation is capturing for the editor; highlights the mic. */
+    dictationActive?: boolean;
+    /** True when the pane shows preview only (no editor to dictate into) — the
+     *  mic greys out. */
+    dictationDisabled?: boolean;
   }
 
   let {
@@ -39,6 +47,7 @@
     isDirty = false, hasActiveNote = false,
     onGotoLine, onSelectTheme, onShowInspections, onShowBacklinks,
     backfill = null,
+    onToggleDictation, dictationActive = false, dictationDisabled = false,
   }: Props = $props();
 
   let themeMenuOpen = $state(false);
@@ -90,6 +99,20 @@
     {/if}
   </div>
   <div class="status-right">
+    <button
+      class="status-item clickable mic"
+      class:active={dictationActive}
+      onclick={onToggleDictation}
+      disabled={dictationDisabled}
+      aria-pressed={dictationActive}
+      aria-label="Dictate"
+      title={dictationDisabled
+        ? 'Dictation isn’t available while previewing'
+        : dictationActive ? 'Stop dictation (Cmd+Shift+V)' : 'Dictate — voice to text (Cmd+Shift+V)'}
+    >
+      <Icon name="mic" size={12} />
+    </button>
+    <span class="rule" aria-hidden="true"></span>
     {#if backfill}
       <span class="status-item faint" title="Building semantic search index in the background">
         <Icon name="sparkle" size={12} />
@@ -196,6 +219,21 @@
   }
   .status-item.clickable:hover {
     color: var(--text);
+  }
+
+  /* Dictation mic (#voice): accent while capturing, greyed + inert while the
+     pane is showing preview (nothing to dictate into). */
+  .status-item.clickable.mic.active,
+  .status-item.clickable.mic.active:hover {
+    color: var(--accent);
+  }
+  .status-item.clickable.mic:disabled {
+    color: var(--text-faint);
+    cursor: default;
+    opacity: 0.5;
+  }
+  .status-item.clickable.mic:disabled:hover {
+    color: var(--text-faint);
   }
 
   /* Mono cells get tabular-nums so digit columns line up — L47 · C23,


### PR DESCRIPTION
Adds a **microphone button to the editor's bottom info-bar** that toggles voice dictation — the same action as the right-click **Dictate** and **⌘⇧V**.

## Behaviour
- **Toggles dictation** into the focused editor (reuses `toggleEditorDictation(view)` — no new dictation logic).
- **Highlights** in the accent colour while capturing (bound to the voice store: `surface === 'editor' && busy`).
- **Greys out (disabled)** when the pane is showing **preview only** (`viewMode === 'preview'`) — there's no editor to dictate into. Stays enabled in **source** and **split** (`editor-preview`) modes, where the editor is present.

Placed at the start of the status-bar's right cluster. The bar only renders for note tabs, so the mic is inherently editor-scoped. `mic` icon already existed (the composer uses it).

## Design note
I grey the mic only on **pure preview**, not split — dictation genuinely works in split (the editor is mounted), so disabling it there would kill a working affordance. Easy to widen to "any time preview is visible" if you'd prefer the stricter reading.

## Testing
- `pnpm lint` clean; full suite green except the pre-existing unrelated `help-docs-corpus-staleness` failure (uncommitted local `website/docs` edits, not in this branch).
- Verification caveat: this is a visual UI addition and I can't drive the Electron UI here, so it's covered by typecheck + logic review (the underlying dictation path is already tested/shipped) rather than a live screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)