### PR TITLE
Add/Remove Property menu items; all four in the editor right-click too

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -886,7 +886,7 @@
   const {
     handleExtractSelection, handleSplitByHeading, handleSplitHere,
     handleAutoLink, handleAutoLinkInbound, handleAutoLinkInboundApply, handleAutoLinkApply,
-    handleAddTag, handleRemoveTag, handleToggleEntrypoint,
+    handleAddTag, handleRemoveTag, handleAddProperty, handleRemoveProperty, handleToggleEntrypoint,
     handleFormat, handleBibliography, handleAutoTag, handleAutoTagApply,
   } = createRefactorOps(refactorOpsCtx);
 
@@ -1327,6 +1327,8 @@
           onDelete={handleDelete}
           onAddTag={handleAddTag}
           onRemoveTag={handleRemoveTag}
+          onAddProperty={handleAddProperty}
+          onRemoveProperty={handleRemoveProperty}
           onFormat={() => handleFormat()}
           onRename={handleRename}
           onMerge={handleMerge}
@@ -1518,6 +1520,10 @@
                           onAutoLink={() => void handleAutoLink(note.relativePath)}
                           onAutoLinkInbound={() => void handleAutoLinkInbound(note.relativePath)}
                           onFormatCurrentNote={() => handleFormat()}
+                          onAddTagCurrentNote={() => void handleAddTag(note.relativePath, false, { targetOnly: true })}
+                          onRemoveTagCurrentNote={() => void handleRemoveTag(note.relativePath, false, { targetOnly: true })}
+                          onAddPropertyCurrentNote={() => void handleAddProperty(note.relativePath, false, { targetOnly: true })}
+                          onRemovePropertyCurrentNote={() => void handleRemoveProperty(note.relativePath, false, { targetOnly: true })}
                           onUploadError={(message) => {
                             void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
                           }}

--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -30,6 +30,11 @@ import {
   removeTagsFromContent,
   extractTagsFromContent,
 } from '../../../shared/refactor/auto-tag';
+import {
+  setPropertyInContent,
+  removePropertyFromContent,
+  extractPropertyKeysFromContent,
+} from '../../../shared/refactor/frontmatter-properties';
 import { expandSelectionToNoteFiles } from '../sidebar-tree-utils';
 import { ENTRYPOINT_TAG } from '../../../shared/entrypoint';
 import { CONFIRM_KEYS } from '../confirm-keys';
@@ -280,8 +285,10 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
    * operation should touch. Returns null when nothing applies — the
    * caller surfaces the "no .md files" dialog.
    */
-  function bulkTagTargets(fallbackPath?: string, fallbackIsDir?: boolean): string[] | null {
-    const sel = ctx.getSidebar()?.getSelectionPaths() ?? [];
+  function bulkTagTargets(fallbackPath?: string, fallbackIsDir?: boolean, ignoreSelection = false): string[] | null {
+    // The editor right-click acts on the note being edited, so it passes
+    // `ignoreSelection` to bypass any sidebar multi-selection.
+    const sel = ignoreSelection ? [] : (ctx.getSidebar()?.getSelectionPaths() ?? []);
     if (sel.length > 0) {
       return expandSelectionToNoteFiles(new Set(sel), notebase.files);
     }
@@ -301,9 +308,9 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
    * (mergeTagsIntoContent handles that). Per-batch: failures are
    * collected into a summary instead of aborting.
    */
-  async function handleAddTag(targetPath?: string, targetIsDir?: boolean) {
+  async function handleAddTag(targetPath?: string, targetIsDir?: boolean, opts?: { targetOnly?: boolean }) {
     if (!notebase.meta) return;
-    const targets = bulkTagTargets(targetPath, targetIsDir);
+    const targets = bulkTagTargets(targetPath, targetIsDir, opts?.targetOnly);
     if (targets === null || targets.length === 0) {
       await showConfirm(
         'The selection contains no .md files to tag.',
@@ -356,9 +363,9 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
    * tags it can plausibly remove). Per-note removal is
    * case-insensitive.
    */
-  async function handleRemoveTag(targetPath?: string, targetIsDir?: boolean) {
+  async function handleRemoveTag(targetPath?: string, targetIsDir?: boolean, opts?: { targetOnly?: boolean }) {
     if (!notebase.meta) return;
-    const targets = bulkTagTargets(targetPath, targetIsDir);
+    const targets = bulkTagTargets(targetPath, targetIsDir, opts?.targetOnly);
     if (targets === null || targets.length === 0) {
       await showConfirm(
         'The selection contains no .md files to tag.',
@@ -469,6 +476,130 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
       msg += `\n\nFailed (${failures.length}):\n${head}${tail}`;
     }
     await showConfirm(msg, CONFIRM_KEYS.bulkTagComplete, 'OK');
+  }
+
+  /**
+   * Add (or update) a frontmatter property across the selection (or a single
+   * target from the editor menu). Prompts for the key — autocompleted from the
+   * thoughtbase's frontmatter-key vocabulary — then a value, and upserts
+   * `key: value` into each note. `tags` is routed to Add Tag instead.
+   */
+  async function handleAddProperty(targetPath?: string, targetIsDir?: boolean, opts?: { targetOnly?: boolean }) {
+    if (!notebase.meta) return;
+    const targets = bulkTagTargets(targetPath, targetIsDir, opts?.targetOnly);
+    if (targets === null || targets.length === 0) {
+      await showConfirm('The selection contains no .md files to edit.', CONFIRM_KEYS.bulkTagNoSelection, 'OK');
+      return;
+    }
+
+    let keyVocab: string[] = [];
+    try { keyVocab = (await api.graph.frontmatterKeys()).filter((k) => k !== 'tags'); }
+    catch { /* vocab is a nicety; the prompt still works without it */ }
+
+    const noun = `${targets.length} note${targets.length === 1 ? '' : 's'}`;
+    const rawKey = await showPrompt(`Add property to ${noun} — name:`, { suggestions: keyVocab });
+    if (!rawKey) return;
+    const key = rawKey.trim();
+    if (!key) return;
+    if (key === 'tags') {
+      await showConfirm('Tags have their own action — use "Add Tag" instead.', CONFIRM_KEYS.bulkPropertyFailed, 'OK');
+      return;
+    }
+    const value = await showPrompt(`Value for "${key}":`);
+    if (value === null) return; // cancelled (empty string is allowed)
+
+    const changedPaths: string[] = [];
+    const failures: Array<{ path: string; error: string }> = [];
+    for (const path of targets) {
+      try {
+        const content = await api.notebase.readFile(path);
+        const { content: next, changed } = setPropertyInContent(content, key, value);
+        if (changed) {
+          await api.notebase.writeFile(path, next);
+          changedPaths.push(path);
+        }
+      } catch (err) {
+        failures.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    await syncOpenTabsToDisk(changedPaths);
+    await reportBulkPropertySummary('Add', key, targets.length, changedPaths.length, failures);
+  }
+
+  /**
+   * Remove a frontmatter property across the selection (or the editor's note).
+   * Prompts with the union of property keys actually present, so it only offers
+   * something removable.
+   */
+  async function handleRemoveProperty(targetPath?: string, targetIsDir?: boolean, opts?: { targetOnly?: boolean }) {
+    if (!notebase.meta) return;
+    const targets = bulkTagTargets(targetPath, targetIsDir, opts?.targetOnly);
+    if (targets === null || targets.length === 0) {
+      await showConfirm('The selection contains no .md files to edit.', CONFIRM_KEYS.bulkTagNoSelection, 'OK');
+      return;
+    }
+
+    const keySet = new Set<string>();
+    const readFailures: Array<{ path: string; error: string }> = [];
+    const cache = new Map<string, string>();
+    for (const path of targets) {
+      try {
+        const content = await api.notebase.readFile(path);
+        cache.set(path, content);
+        for (const k of extractPropertyKeysFromContent(content)) keySet.add(k);
+      } catch (err) {
+        readFailures.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+    if (keySet.size === 0) {
+      await showConfirm(
+        'None of the selected notes have properties to remove.',
+        CONFIRM_KEYS.bulkPropertyNoKeysOnSelection,
+        'OK',
+      );
+      return;
+    }
+    const noun = `${targets.length} note${targets.length === 1 ? '' : 's'}`;
+    const rawKey = await showPrompt(`Remove property from ${noun}:`, { suggestions: [...keySet].sort() });
+    if (!rawKey) return;
+    const key = rawKey.trim();
+    if (!key) return;
+
+    const changedPaths: string[] = [];
+    const failures: Array<{ path: string; error: string }> = [...readFailures];
+    for (const path of targets) {
+      if (!cache.has(path)) continue;
+      try {
+        const { content: next, removed } = removePropertyFromContent(cache.get(path)!, key);
+        if (removed) {
+          await api.notebase.writeFile(path, next);
+          changedPaths.push(path);
+        }
+      } catch (err) {
+        failures.push({ path, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    await syncOpenTabsToDisk(changedPaths);
+    await reportBulkPropertySummary('Remove', key, targets.length, changedPaths.length, failures);
+  }
+
+  async function reportBulkPropertySummary(
+    op: 'Add' | 'Remove',
+    key: string,
+    total: number,
+    changed: number,
+    failures: Array<{ path: string; error: string }>,
+  ): Promise<void> {
+    const verb = op === 'Add' ? 'set' : 'removed';
+    let msg = `${verb} "${key}" on ${changed} of ${total} note${total === 1 ? '' : 's'}.`;
+    if (failures.length > 0) {
+      const head = failures.slice(0, 5).map((f) => `• ${f.path}: ${f.error}`).join('\n');
+      const tail = failures.length > 5 ? `\n…and ${failures.length - 5} more` : '';
+      msg += `\n\nFailed (${failures.length}):\n${head}${tail}`;
+    }
+    await showConfirm(msg, CONFIRM_KEYS.bulkPropertyComplete, 'OK');
   }
 
   /**
@@ -630,7 +761,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
   return {
     handleExtractSelection, handleSplitByHeading, handleSplitHere,
     handleAutoLink, handleAutoLinkInbound, handleAutoLinkInboundApply, handleAutoLinkApply,
-    handleAddTag, handleRemoveTag, handleToggleEntrypoint,
+    handleAddTag, handleRemoveTag, handleAddProperty, handleRemoveProperty, handleToggleEntrypoint,
     handleFormat, handleBibliography, handleAutoTag, handleAutoTagApply,
   };
 }

--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -61,7 +61,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
   const dialogs = getDialogStore();
   const busy = getBusyStore();
   const flow = getRefactorFlowStore();
-  const { showPrompt, showConfirm } = dialogs;
+  const { showPrompt, showConfirm, showAddPropertyDialog } = dialogs;
 
   /**
    * After a renderer-initiated bulk write (tag add/remove, entrypoint toggle),
@@ -494,19 +494,19 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
 
     let keyVocab: string[] = [];
     try { keyVocab = (await api.graph.frontmatterKeys()).filter((k) => k !== 'tags'); }
-    catch { /* vocab is a nicety; the prompt still works without it */ }
+    catch { /* vocab is a nicety; the dialog still works without it */ }
 
     const noun = `${targets.length} note${targets.length === 1 ? '' : 's'}`;
-    const rawKey = await showPrompt(`Add property to ${noun} — name:`, { suggestions: keyVocab });
-    if (!rawKey) return;
-    const key = rawKey.trim();
+    // Name + value on one panel (not two sequential prompts).
+    const entered = await showAddPropertyDialog(`Add property to ${noun}`, keyVocab);
+    if (!entered) return;
+    const key = entered.name.trim();
     if (!key) return;
     if (key === 'tags') {
       await showConfirm('Tags have their own action — use "Add Tag" instead.', CONFIRM_KEYS.bulkPropertyFailed, 'OK');
       return;
     }
-    const value = await showPrompt(`Value for "${key}":`);
-    if (value === null) return; // cancelled (empty string is allowed)
+    const value = entered.value;
 
     const changedPaths: string[] = [];
     const failures: Array<{ path: string; error: string }> = [];

--- a/src/renderer/lib/components/AddPropertyDialog.svelte
+++ b/src/renderer/lib/components/AddPropertyDialog.svelte
@@ -1,0 +1,241 @@
+<script lang="ts">
+  /**
+   * Add-Property dialog — collects a frontmatter property's name AND value on
+   * one panel (vs. two sequential prompts). Mirrors PromptDialog's chrome; the
+   * name field autocompletes from the thoughtbase's frontmatter-key vocabulary.
+   */
+  import type { AddPropertyResult } from '../stores/dialogs.svelte';
+
+  interface Props {
+    message: string;
+    keySuggestions: string[];
+    onConfirm: (value: AddPropertyResult) => void;
+    onCancel: () => void;
+  }
+
+  let { message, keySuggestions, onConfirm, onCancel }: Props = $props();
+
+  let name = $state('');
+  let value = $state('');
+  let nameEl = $state<HTMLInputElement>();
+  let valueEl = $state<HTMLInputElement>();
+  const listId = `add-property-keys-${Math.random().toString(36).slice(2, 9)}`;
+
+  const canConfirm = $derived(name.trim().length > 0);
+  function submit() {
+    if (canConfirm) onConfirm({ name: name.trim(), value });
+  }
+
+  function onOverlayKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+  function onNameKeydown(e: KeyboardEvent) {
+    // Enter on the name field advances to value rather than submitting, so the
+    // value isn't skipped by a reflexive Enter.
+    if (e.key === 'Enter') { e.preventDefault(); valueEl?.focus(); }
+  }
+  function onValueKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') { e.preventDefault(); submit(); }
+  }
+
+  $effect(() => { nameEl?.focus(); });
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onkeydown={onOverlayKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="add-property-title">
+    <header class="card-header">
+      <div class="eyebrow">Property</div>
+      <h2 class="title" id="add-property-title">{message}</h2>
+    </header>
+
+    <div class="body">
+      <label class="field">
+        <span class="field-label">Name</span>
+        <input
+          bind:this={nameEl}
+          bind:value={name}
+          onkeydown={onNameKeydown}
+          type="text"
+          class="input"
+          list={keySuggestions.length > 0 ? listId : undefined}
+          autocomplete="off"
+          placeholder="e.g. status"
+        />
+        {#if keySuggestions.length > 0}
+          <datalist id={listId}>
+            {#each keySuggestions as s}
+              <option value={s}></option>
+            {/each}
+          </datalist>
+        {/if}
+      </label>
+      <label class="field">
+        <span class="field-label">Value</span>
+        <input
+          bind:this={valueEl}
+          bind:value
+          onkeydown={onValueKeydown}
+          type="text"
+          class="input"
+          autocomplete="off"
+          placeholder="e.g. draft"
+        />
+      </label>
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↵ next / confirm</span>
+      <span class="footer-actions">
+        <button class="btn secondary" onclick={onCancel}>Cancel</button>
+        <button class="btn primary" disabled={!canConfirm} onclick={submit}>
+          Add
+          <span class="btn-kbd">↵</span>
+        </button>
+      </span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    width: 460px;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+  }
+
+  .card-header {
+    padding: 20px 24px 0;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+    color: var(--text);
+  }
+
+  .body {
+    padding: 14px 24px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .field-label {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .input {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    outline: none;
+  }
+  .input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    border-radius: 0 0 12px 12px;
+  }
+  .kbd-hint {
+    margin-right: auto;
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+  }
+  .footer-actions {
+    display: inline-flex;
+    gap: 8px;
+  }
+
+  .btn {
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12.5px;
+    font-family: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .secondary {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .secondary:hover {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  .primary {
+    background: var(--accent);
+    color: var(--accent-ink);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover:not(:disabled) {
+    opacity: 0.92;
+  }
+  .primary:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .btn-kbd {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    opacity: 0.7;
+  }
+</style>

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -10,6 +10,7 @@
   import SnippetPickerDialog from './SnippetPickerDialog.svelte';
   import ConfirmDialog from './ConfirmDialog.svelte';
   import OpenTargetDialog from './OpenTargetDialog.svelte';
+  import AddPropertyDialog from './AddPropertyDialog.svelte';
   import { getDialogStore } from '../stores/dialogs.svelte';
 
   const dialogs = getDialogStore();
@@ -58,5 +59,14 @@
     onThisWindow={() => dialogs.resolveOpenTarget('this')}
     onNewWindow={() => dialogs.resolveOpenTarget('new')}
     onCancel={() => dialogs.resolveOpenTarget('cancel')}
+  />
+{/if}
+
+{#if dialogs.addProperty}
+  <AddPropertyDialog
+    message={dialogs.addProperty.message}
+    keySuggestions={dialogs.addProperty.keySuggestions}
+    onConfirm={(v) => dialogs.confirmAddProperty(v)}
+    onCancel={() => dialogs.cancelAddProperty()}
   />
 {/if}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -128,6 +128,12 @@
     onAutoLink?: () => void;
     onAutoLinkInbound?: () => void;
     onFormatCurrentNote?: () => void;
+    /** Frontmatter metadata actions on the note being edited (mirrors the
+     *  sidebar's tag menu). */
+    onAddTagCurrentNote?: () => void;
+    onRemoveTagCurrentNote?: () => void;
+    onAddPropertyCurrentNote?: () => void;
+    onRemovePropertyCurrentNote?: () => void;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
     /** Live list of Sources for `[[cite::…]]` autocomplete. */
@@ -196,6 +202,10 @@
     onAutoLink,
     onAutoLinkInbound,
     onFormatCurrentNote,
+    onAddTagCurrentNote,
+    onRemoveTagCurrentNote,
+    onAddPropertyCurrentNote,
+    onRemovePropertyCurrentNote,
     getNotePaths,
     getSources,
     getAliases,
@@ -1166,6 +1176,26 @@
           </div>
         </div>
       {/each}
+    {/if}
+    {#if onAddTagCurrentNote || onRemoveTagCurrentNote || onAddPropertyCurrentNote || onRemovePropertyCurrentNote}
+      <div class="separator"></div>
+      <div class="submenu-item" onmouseenter={adjustSubmenu}>
+        <span class="submenu-trigger">Metadata<Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          {#if onAddTagCurrentNote}
+            <button onclick={() => handleMenuAction(() => onAddTagCurrentNote?.())}>Add Tag&hellip;</button>
+          {/if}
+          {#if onRemoveTagCurrentNote}
+            <button onclick={() => handleMenuAction(() => onRemoveTagCurrentNote?.())}>Remove Tag&hellip;</button>
+          {/if}
+          {#if onAddPropertyCurrentNote}
+            <button onclick={() => handleMenuAction(() => onAddPropertyCurrentNote?.())}>Add Property&hellip;</button>
+          {/if}
+          {#if onRemovePropertyCurrentNote}
+            <button onclick={() => handleMenuAction(() => onRemovePropertyCurrentNote?.())}>Remove Property&hellip;</button>
+          {/if}
+        </div>
+      </div>
     {/if}
     <div class="separator"></div>
     {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onMerge || onAutoTag || onAutoLink || onAutoLinkInbound}

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -59,6 +59,8 @@
     onDelete: (relativePath: string, isDirectory: boolean) => void;
     onAddTag?: ((relativePath: string, isDirectory: boolean) => void) | undefined;
     onRemoveTag?: ((relativePath: string, isDirectory: boolean) => void) | undefined;
+    onAddProperty?: ((relativePath: string, isDirectory: boolean) => void) | undefined;
+    onRemoveProperty?: ((relativePath: string, isDirectory: boolean) => void) | undefined;
     /** Format the current sidebar selection (every .md under the selected
      *  files/folders, recursing into directories). The handler reads the
      *  selection itself; the right-clicked item is promoted into it before
@@ -85,7 +87,7 @@
     onExternalDrop?: ((destDirectory: string, files: FileList) => void) | undefined;
   }
 
-  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, focusedPath, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onFormat, onContextMenuTarget, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onExternalDrop }: Props = $props();
+  let { files, activeFilePath, depth = 0, canPaste = false, expanded, selection, focusedPath, onToggleDir, onItemClick, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onContextMenuTarget, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onExternalDrop }: Props = $props();
 
   let contextMenu = $state<{ x: number; y: number; dir: string; target?: string | undefined; targetIsDir?: boolean | undefined; targetIsEntrypoint?: boolean | null } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
@@ -238,6 +240,8 @@
             {onDelete}
             {onAddTag}
             {onRemoveTag}
+            {onAddProperty}
+            {onRemoveProperty}
             {onFormat}
             {onContextMenuTarget}
             {onRename}
@@ -338,7 +342,7 @@
           <button onclick={() => { void api.shell.openInTerminal(contextMenu!.target); contextMenu = null; }}>Open in Terminal</button>
         </div>
       </div>
-      {#if onAddTag || onRemoveTag || onFormat}
+      {#if onAddTag || onRemoveTag || onAddProperty || onRemoveProperty || onFormat}
         <div class="separator"></div>
         {#if onAddTag}
           <button onclick={() => { onAddTag(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
@@ -348,6 +352,16 @@
         {#if onRemoveTag}
           <button onclick={() => { onRemoveTag(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
             Remove Tag…
+          </button>
+        {/if}
+        {#if onAddProperty}
+          <button onclick={() => { onAddProperty(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
+            Add Property…
+          </button>
+        {/if}
+        {#if onRemoveProperty}
+          <button onclick={() => { onRemoveProperty(contextMenu!.target!, contextMenu!.targetIsDir!); contextMenu = null; }}>
+            Remove Property…
           </button>
         {/if}
         {#if onFormat}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -56,6 +56,8 @@
     onDelete: (relativePath: string, isDirectory: boolean) => void;
     onAddTag?: (relativePath: string, isDirectory: boolean) => void;
     onRemoveTag?: (relativePath: string, isDirectory: boolean) => void;
+    onAddProperty?: (relativePath: string, isDirectory: boolean) => void;
+    onRemoveProperty?: (relativePath: string, isDirectory: boolean) => void;
     onFormat?: (relativePath: string, isDirectory: boolean) => void;
     onRename: (relativePath: string) => void;
     onMerge?: (relativePath: string) => void;
@@ -78,7 +80,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -604,6 +606,8 @@
               {onDelete}
               {onAddTag}
               {onRemoveTag}
+              {onAddProperty}
+              {onRemoveProperty}
               {onFormat}
               onContextMenuTarget={handleContextMenuTarget}
               {onRename}

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -37,6 +37,9 @@ export const CONFIRM_KEYS = {
   bulkTagComplete: 'bulk-tag-complete',
   bulkTagNoSelection: 'bulk-tag-no-selection',
   bulkTagNoTagsOnSelection: 'bulk-tag-no-tags-on-selection',
+  bulkPropertyFailed: 'bulk-property-failed',
+  bulkPropertyComplete: 'bulk-property-complete',
+  bulkPropertyNoKeysOnSelection: 'bulk-property-no-keys-on-selection',
   formatFailed: 'format-failed',
   formatComplete: 'format-complete',
   formatAllConfirm: 'format-all-confirm',
@@ -218,6 +221,24 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Remove Tag: selection has no tags',
     description:
       'Shown when Remove Tag is invoked on a selection whose notes have no frontmatter tags — there is nothing to remove.',
+  },
+  {
+    key: CONFIRM_KEYS.bulkPropertyComplete,
+    title: 'Add/Remove Property complete',
+    description:
+      'Summary dialog after an Add Property / Remove Property operation finishes (counts of notes changed and any per-note failures).',
+  },
+  {
+    key: CONFIRM_KEYS.bulkPropertyFailed,
+    title: 'Add/Remove Property failed',
+    description:
+      'Shown when a property operation fails outright (e.g. fetching the frontmatter-key vocabulary errored before the loop started).',
+  },
+  {
+    key: CONFIRM_KEYS.bulkPropertyNoKeysOnSelection,
+    title: 'Remove Property: selection has no properties',
+    description:
+      'Shown when Remove Property is invoked on a selection whose notes have no frontmatter properties — there is nothing to remove.',
   },
   {
     key: CONFIRM_KEYS.formatFailed,

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -44,12 +44,24 @@ export interface OpenTargetState {
   message: string;
   resolve: (value: OpenTargetChoice) => void;
 }
+/** Name + value collected on one panel by the "Add Property" dialog. */
+export interface AddPropertyResult {
+  name: string;
+  value: string;
+}
+export interface AddPropertyState {
+  message: string;
+  /** Frontmatter-key vocabulary for the name field's autocomplete. */
+  keySuggestions: string[];
+  resolve: (value: AddPropertyResult | null) => void;
+}
 
 let prompt = $state<PromptState | null>(null);
 let newNote = $state<NewNoteState | null>(null);
 let snippet = $state<SnippetPickerState | null>(null);
 let confirm = $state<ConfirmState | null>(null);
 let openTarget = $state<OpenTargetState | null>(null);
+let addProperty = $state<AddPropertyState | null>(null);
 
 export function getDialogStore() {
   const confirmSuppression = getConfirmSuppressionStore();
@@ -97,6 +109,11 @@ export function getDialogStore() {
     return new Promise((resolve) => { snippet = { templates, resolve }; });
   }
 
+  /** Collect a frontmatter property's name + value on a single panel. */
+  function showAddPropertyDialog(message: string, keySuggestions: string[]): Promise<AddPropertyResult | null> {
+    return new Promise((resolve) => { addProperty = { message, keySuggestions, resolve }; });
+  }
+
   /** Pure open-target prompt — always shows. App.svelte wraps this with the
    *  "no project open → 'this'" shortcut, which is app logic, not dialog logic. */
   function askOpenTarget(message: string): Promise<OpenTargetChoice> {
@@ -124,16 +141,21 @@ export function getDialogStore() {
     const r = openTarget?.resolve; openTarget = null; r?.(choice);
   }
 
+  function confirmAddProperty(value: AddPropertyResult) { const r = addProperty?.resolve; addProperty = null; r?.(value); }
+  function cancelAddProperty() { const r = addProperty?.resolve; addProperty = null; r?.(null); }
+
   return {
     get prompt() { return prompt; },
     get newNote() { return newNote; },
     get snippet() { return snippet; },
     get confirm() { return confirm; },
     get openTarget() { return openTarget; },
+    get addProperty() { return addProperty; },
     showPrompt,
     showNewNoteDialog,
     showConfirm,
     showSnippetPicker,
+    showAddPropertyDialog,
     askOpenTarget,
     confirmPrompt,
     cancelPrompt,
@@ -144,6 +166,8 @@ export function getDialogStore() {
     confirmConfirm,
     cancelConfirm,
     resolveOpenTarget,
+    confirmAddProperty,
+    cancelAddProperty,
   };
 }
 
@@ -154,4 +178,5 @@ export function __resetDialogsForTests(): void {
   snippet = null;
   confirm = null;
   openTarget = null;
+  addProperty = null;
 }

--- a/src/shared/refactor/frontmatter-properties.ts
+++ b/src/shared/refactor/frontmatter-properties.ts
@@ -1,0 +1,91 @@
+/**
+ * Frontmatter *property* (arbitrary key/value) manipulation, mirroring the
+ * tag-specific helpers in `auto-tag.ts`. Powers the sidebar / editor
+ * "Add Property" / "Remove Property" menu actions.
+ *
+ * A property is any frontmatter key other than `tags` (which has its own
+ * Add/Remove Tag actions). Values are written as string scalars — the menu
+ * flow is a text prompt; richer typing lives in the Properties panel.
+ */
+import YAML from 'yaml';
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+function parseFrontmatterObject(content: string): { fm: Record<string, unknown>; match: RegExpMatchArray } | null {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return null;
+  let parsed: unknown;
+  try { parsed = YAML.parse(match[1]!); } catch { return null; }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return { fm: parsed as Record<string, unknown>, match };
+}
+
+/**
+ * Frontmatter property keys present on the note — every key except `tags`.
+ * Used by Remove Property's autocomplete so it only offers keys that are
+ * actually there.
+ */
+export function extractPropertyKeysFromContent(content: string): string[] {
+  const parsed = parseFrontmatterObject(content);
+  if (!parsed) return [];
+  return Object.keys(parsed.fm).filter((k) => k !== 'tags');
+}
+
+export interface SetPropertyResult {
+  content: string;
+  /** False when the key was already set to this exact string (no write needed). */
+  changed: boolean;
+}
+
+/**
+ * Upsert `key: value` into the note's frontmatter, creating the block when the
+ * note has none. `value` is stored as a string scalar (YAML quotes it as
+ * needed — so a `[[wiki-link]]` value survives round-trip). No-op when the key
+ * already holds the same string.
+ */
+export function setPropertyInContent(content: string, key: string, value: string): SetPropertyResult {
+  const match = content.match(FRONTMATTER_RE);
+  let fm: Record<string, unknown> = {};
+  if (match) {
+    try {
+      const parsed: unknown = YAML.parse(match[1]!);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        fm = parsed as Record<string, unknown>;
+      }
+    } catch { /* malformed frontmatter — overwrite */ }
+  }
+  if (fm[key] === value) return { content, changed: false };
+  fm[key] = value;
+  const yamlBlock = YAML.stringify(fm).trimEnd();
+  const rendered = `---\n${yamlBlock}\n---\n`;
+  const body = match ? content.slice(match[0].length) : content;
+  const separator = body.startsWith('\n') || body === '' ? '' : '\n';
+  return { content: rendered + separator + body, changed: true };
+}
+
+export interface RemovePropertyResult {
+  content: string;
+  /** False when the key wasn't present. */
+  removed: boolean;
+}
+
+/**
+ * Remove `key` from the note's frontmatter. If the block becomes empty it's
+ * dropped entirely (same rationale as `removeTagsFromContent`). No-op when the
+ * key isn't present.
+ */
+export function removePropertyFromContent(content: string, key: string): RemovePropertyResult {
+  const parsed = parseFrontmatterObject(content);
+  if (!parsed) return { content, removed: false };
+  const { fm, match } = parsed;
+  if (!(key in fm)) return { content, removed: false };
+  delete fm[key];
+  const body = content.slice(match[0].length);
+  if (Object.keys(fm).length === 0) {
+    return { content: body.replace(/^\n+/, ''), removed: true };
+  }
+  const yamlBlock = YAML.stringify(fm).trimEnd();
+  const rendered = `---\n${yamlBlock}\n---\n`;
+  const separator = body.startsWith('\n') || body === '' ? '' : '\n';
+  return { content: rendered + separator + body, removed: true };
+}

--- a/tests/shared/refactor/frontmatter-properties.test.ts
+++ b/tests/shared/refactor/frontmatter-properties.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractPropertyKeysFromContent,
+  setPropertyInContent,
+  removePropertyFromContent,
+} from '../../../src/shared/refactor/frontmatter-properties';
+
+describe('setPropertyInContent', () => {
+  it('creates a frontmatter block when the note has none', () => {
+    const { content, changed } = setPropertyInContent('# Note\n\nBody', 'status', 'draft');
+    expect(changed).toBe(true);
+    // A blank line separates the new block from the body (same as mergeTagsIntoContent).
+    expect(content).toBe('---\nstatus: draft\n---\n\n# Note\n\nBody');
+  });
+
+  it('adds a key alongside existing frontmatter, preserving the rest', () => {
+    const src = '---\ntitle: T\ntags:\n  - a\n---\n# Note';
+    const { content } = setPropertyInContent(src, 'status', 'draft');
+    expect(content).toContain('title: T');
+    expect(content).toContain('status: draft');
+    expect(content).toContain('- a'); // tags untouched
+  });
+
+  it('overwrites an existing key and is a no-op when unchanged', () => {
+    const src = '---\nstatus: draft\n---\n# N';
+    expect(setPropertyInContent(src, 'status', 'final').content).toContain('status: final');
+    const same = setPropertyInContent(src, 'status', 'draft');
+    expect(same.changed).toBe(false);
+    expect(same.content).toBe(src);
+  });
+
+  it('quotes a wiki-link value so it survives YAML round-trip', () => {
+    const { content } = setPropertyInContent('# N', 'about', '[[some-note]]');
+    // Quoted → not eaten into a nested array on re-parse.
+    expect(content).toMatch(/about: "\[\[some-note\]\]"|about: '\[\[some-note\]\]'/);
+  });
+});
+
+describe('removePropertyFromContent', () => {
+  it('removes a key, keeping the other frontmatter', () => {
+    const src = '---\ntitle: T\nstatus: draft\n---\n# N';
+    const { content, removed } = removePropertyFromContent(src, 'status');
+    expect(removed).toBe(true);
+    expect(content).toContain('title: T');
+    expect(content).not.toContain('status');
+  });
+
+  it('drops the whole block when the last key is removed', () => {
+    const { content, removed } = removePropertyFromContent('---\nstatus: draft\n---\n# N', 'status');
+    expect(removed).toBe(true);
+    expect(content).toBe('# N');
+  });
+
+  it('is a no-op for an absent key', () => {
+    const src = '---\ntitle: T\n---\n# N';
+    expect(removePropertyFromContent(src, 'missing')).toEqual({ content: src, removed: false });
+  });
+});
+
+describe('extractPropertyKeysFromContent', () => {
+  it('lists frontmatter keys but excludes tags', () => {
+    const src = '---\ntitle: T\nstatus: draft\ntags:\n  - a\n---\n# N';
+    expect(extractPropertyKeysFromContent(src).sort()).toEqual(['status', 'title']);
+  });
+
+  it('returns [] when there is no frontmatter', () => {
+    expect(extractPropertyKeysFromContent('# N')).toEqual([]);
+  });
+});


### PR DESCRIPTION
The left-sidebar right-click had **Add Tag** / **Remove Tag**. This adds parallel **Add Property** / **Remove Property**, and surfaces **all four** (tags + properties) in the **editor** right-click menu.

## Changes

- **`shared/refactor/frontmatter-properties.ts`** (new) — `setPropertyInContent` (upsert `key: value`, creating the block if absent), `removePropertyFromContent` (drops an empty block), `extractPropertyKeysFromContent` (keys except `tags`). Mirrors `auto-tag.ts`'s YAML round-trip; values are stored as string scalars (so a `[[wiki-link]]` value survives quoting). Unit-tested.
- **`refactor-ops`** — `handleAddProperty` (prompts for the key, autocompleted from the thoughtbase's frontmatter-key vocabulary, then a value) and `handleRemoveProperty` (prompts from the keys actually present on the selection). Reuses the bulk-tag machinery (targets, per-note read/write, open-tab resync, summary dialog).
- **`bulkTagTargets` gains `ignoreSelection`** — the editor menu acts on the note being edited, not a stray sidebar multi-selection. The two tag handlers accept the same option.
- **`FileTree` / `Sidebar`** — Add Property… / Remove Property… items alongside the tag ones.
- **`Editor`** — a new **"Metadata"** submenu (Add/Remove Tag, Add/Remove Property), wired to the note's own path with `targetOnly`.
- **`confirm-keys`** — `bulkProperty*` summary/failure keys.

## Notes / decisions
- **Editor grouping:** the four go under a **"Metadata" submenu** rather than four top-level items — the editor menu is already submenu-heavy (Highlight, Link, Paragraph, Elements, Refactor), so this keeps it tidy. Easy to flatten to top-level if you'd prefer.
- **`tags` is routed away** from Add Property (it has its own action) to avoid clobbering the tag array with a scalar.
- Property writes reload open tabs, so the right-sidebar **Properties panel** reflects the change immediately.

## Testing
- `tests/shared/refactor/frontmatter-properties.test.ts` (9): create/overwrite/no-op, wiki-link quoting, remove + empty-block drop, key extraction excluding tags.
- `pnpm lint` clean; `confirm-keys` contract test passes with the new keys. Full suite green except the pre-existing unrelated `help-docs-corpus-staleness` failure (uncommitted local `website/docs` edits, not in this branch).
- Verification caveat: the menus themselves are visual; I can't drive the Electron UI here, so coverage is the util tests + typecheck + reuse of the already-shipped tag-handler path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)