### PR TITLE
Parse Table: <caption> onto ParsedTable (#1356)

### DIFF
--- a/src/main/graph/parser.ts
+++ b/src/main/graph/parser.ts
@@ -1,5 +1,6 @@
 import YAML from 'yaml';
 import { splitAnchor } from '../../shared/slug';
+import { slugifyTableName } from '../../shared/table-name';
 
 export interface ParsedLink {
   /** Bare target path/id with any `#anchor` stripped. */
@@ -15,6 +16,17 @@ export interface ParsedLink {
 export interface ParsedTable {
   headers: string[];
   rows: string[][];
+  /**
+   * Raw human caption from a Pandoc-style `Table: <caption>` line directly
+   * above the table (#1356). Only present when such a line exists; uncaptioned
+   * tables stay graph-only and are never SQL-registered.
+   */
+  caption?: string;
+  /**
+   * `caption` sanitized to a DuckDB-safe SQL identifier via `slugifyTableName`.
+   * Present iff `caption` is. This is the name the table is `SELECT`-able by.
+   */
+  name?: string;
 }
 
 /** A frontmatter value after YAML parsing — preserves type info the indexer needs. */
@@ -253,10 +265,29 @@ function extractTables(content: string): ParsedTable[] {
     }
 
     if (headers.length > 0 && rows.length > 0) {
-      tables.push({ headers, rows });
+      const caption = captionAbove(lines, i);
+      if (caption) {
+        tables.push({ headers, rows, caption, name: slugifyTableName(caption) });
+      } else {
+        tables.push({ headers, rows });
+      }
     }
     i = j;
   }
 
   return tables;
+}
+
+// Pandoc-style `Table: <caption>` line directly above a table's header row
+// (#1356). Case-insensitive; one blank line between the caption and the table
+// is allowed. Returns the trimmed caption text, or null when there's no caption.
+const TABLE_CAPTION_RE = /^Table:\s*(.+)$/i;
+
+function captionAbove(lines: string[], headerIndex: number): string | null {
+  let above = lines[headerIndex - 1]?.trim();
+  if (above === '') above = lines[headerIndex - 2]?.trim(); // skip one blank line
+  if (!above) return null;
+  const m = above.match(TABLE_CAPTION_RE);
+  const caption = m?.[1]?.trim();
+  return caption ? caption : null;
 }

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
+import { slugifyTableName } from '../../shared/table-name';
 import type { ProjectContext } from '../project-context-types';
 import { createProjectStore } from '../project-store';
 import { loadCsvSchema, buildReadCsvSql } from './csv-schema';
@@ -113,17 +114,9 @@ export async function runQuery(ctx: ProjectContext, sql: string): Promise<QueryR
  * Identifiers that would start with a digit get a `t_` prefix.
  */
 export function deriveTableName(relativePath: string): string {
-  const withoutExt = relativePath.replace(/\.csv$/i, '');
-  // Separator-ish characters collapse to a single underscore; anything else
-  // non-alphanumeric just drops out.
-  let name = withoutExt
-    .replace(/[/\\.\-\s]+/g, '_')
-    .replace(/[^a-zA-Z0-9_]/g, '')
-    .replace(/_+/g, '_')
-    .replace(/^_+|_+$/g, '');
-  if (!name) name = 'table';
-  if (/^[0-9]/.test(name)) name = 't_' + name;
-  return name;
+  // Strip the CSV extension, then apply the shared identifier sanitizer so the
+  // CSV and markdown-table (#1356) paths agree on names + collide in one namespace.
+  return slugifyTableName(relativePath.replace(/\.csv$/i, ''));
 }
 
 /**

--- a/src/shared/table-name.ts
+++ b/src/shared/table-name.ts
@@ -1,0 +1,27 @@
+/**
+ * Sanitize an arbitrary string into a DuckDB-safe SQL table identifier.
+ *
+ * Shared by the CSV pipeline (`deriveTableName`, which strips the `.csv`
+ * extension first) and the markdown-table caption path (#1356), so a
+ * `Table: <caption>` line and a `foo.csv` filename derive names by the same
+ * rules and can be checked for collisions in one namespace.
+ *
+ * Rules (case-preserving, matching the original `deriveTableName` core):
+ * - Separator-ish characters (`/ \ . - whitespace`) collapse to a single `_`.
+ * - Any other non-`[A-Za-z0-9_]` character drops out.
+ * - Runs of `_` collapse; leading/trailing `_` are trimmed.
+ * - An empty result falls back to `table`.
+ * - A digit-leading identifier gets a `t_` prefix (SQL idents can't start with a digit).
+ *
+ * `Q3 Sales` → `Q3_Sales`; `2024-experiment` → `t_2024_experiment`.
+ */
+export function slugifyTableName(raw: string): string {
+  let name = raw
+    .replace(/[/\\.\-\s]+/g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!name) name = 'table';
+  if (/^[0-9]/.test(name)) name = 't_' + name;
+  return name;
+}

--- a/tests/main/graph/parser.test.ts
+++ b/tests/main/graph/parser.test.ts
@@ -473,4 +473,50 @@ describe('table extraction', () => {
     const result = parseMarkdown(md);
     expect(result.tables[0].rows[0]).toEqual(['foo', 'bar']);
   });
+
+  // ── Table: <caption> parsing (#1356) ─────────────────────────────────────
+  it('leaves caption/name undefined for an uncaptioned table', () => {
+    const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].caption).toBeUndefined();
+    expect(result.tables[0].name).toBeUndefined();
+  });
+
+  it('parses a caption line directly above the table', () => {
+    const md = 'Table: Q3 Sales\n| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].caption).toBe('Q3 Sales');
+    expect(result.tables[0].name).toBe('Q3_Sales');
+  });
+
+  it('allows one blank line between the caption and the table', () => {
+    const md = 'Table: Revenue\n\n| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].caption).toBe('Revenue');
+    expect(result.tables[0].name).toBe('Revenue');
+  });
+
+  it('is case-insensitive on the Table: prefix', () => {
+    const md = 'table: Foo\n| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].caption).toBe('Foo');
+  });
+
+  it('sanitizes a digit-leading caption to a valid SQL identifier', () => {
+    const md = 'Table: 2024 Experiment\n| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].name).toBe('t_2024_Experiment');
+  });
+
+  it('ignores a Table: line not followed by a table', () => {
+    const md = 'Table: Orphan caption\n\nJust a paragraph, no table.';
+    const result = parseMarkdown(md);
+    expect(result.tables).toEqual([]);
+  });
+
+  it('does not attach a preceding paragraph as a caption', () => {
+    const md = 'Some intro text\n| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].caption).toBeUndefined();
+  });
 });

--- a/tests/shared/table-name.test.ts
+++ b/tests/shared/table-name.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { slugifyTableName } from '../../src/shared/table-name';
+
+describe('slugifyTableName', () => {
+  it('collapses separators (spaces, slashes, dots, hyphens) to single underscores', () => {
+    expect(slugifyTableName('Q3 Sales')).toBe('Q3_Sales');
+    expect(slugifyTableName('notes/data/experiment')).toBe('notes_data_experiment');
+    expect(slugifyTableName('a - b . c')).toBe('a_b_c');
+  });
+
+  it('preserves case (matches CSV deriveTableName behavior)', () => {
+    expect(slugifyTableName('MixedCase')).toBe('MixedCase');
+  });
+
+  it('drops non-identifier characters', () => {
+    expect(slugifyTableName('sales$ (2024)!')).toBe('sales_2024');
+  });
+
+  it('prefixes a digit-leading name with t_', () => {
+    expect(slugifyTableName('2024-experiment')).toBe('t_2024_experiment');
+  });
+
+  it('trims leading/trailing underscores and collapses runs', () => {
+    expect(slugifyTableName('__a___b__')).toBe('a_b');
+  });
+
+  it('falls back to "table" when nothing usable remains', () => {
+    expect(slugifyTableName('!!!')).toBe('table');
+    expect(slugifyTableName('   ')).toBe('table');
+  });
+});


### PR DESCRIPTION
**Epic #1355 · Ticket 1 of 6** (foundational)

Gives embedded markdown tables an optional name so they can be addressed in SQL.

## What
- **New `src/shared/table-name.ts`** — extracts `deriveTableName`'s core into a shared `slugifyTableName(raw)` so the CSV and markdown-table paths sanitize names by the same rules and collide in one namespace. Case-preserving (matches existing CSV behavior), digit-leading → `t_`, non-ident chars → `_`.
- **`sources/tables.ts`** — `deriveTableName` now strips `.csv` then delegates to `slugifyTableName`. No behavior change for CSVs.
- **`graph/parser.ts`** — `extractTables` detects a Pandoc-style `Table: <caption>` line directly above a table's header row (case-insensitive, one blank line allowed) and carries `caption` (raw) + `name` (sanitized) on `ParsedTable`. **Opt-in**: uncaptioned tables are unchanged and stay graph-only.

## Tests
- `tests/shared/table-name.test.ts` — sanitizer rules (separators, case, digit-leading, fallback).
- `tests/main/graph/parser.test.ts` — caption present/absent, blank-line variant, case-insensitivity, digit-leading sanitization, a `Table:` line not followed by a table is ignored, a preceding paragraph is not mistaken for a caption.

Confirmed design: `Table: <caption>` syntax, opt-in. Uncaptioned tables untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)