### PR TITLE
registerMarkdownTable: materialize captioned note tables into DuckDB (#1357)

### DIFF
--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -1,9 +1,13 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
+import { parseMarkdown, type ParsedTable } from '../graph/parser';
 import { slugifyTableName } from '../../shared/table-name';
+import { serializeCsv } from '../../shared/csv-parse';
 import type { ProjectContext } from '../project-context-types';
 import { createProjectStore } from '../project-store';
 import { loadCsvSchema, buildReadCsvSql } from './csv-schema';
@@ -16,6 +20,18 @@ interface TablesState {
   pathToTable: Map<string, string>;
   /** tableName → relativePath, so we can detect + warn on collisions. */
   tableToPath: Map<string, string>;
+  /**
+   * notePath → the captioned markdown tables registered from that note (#1357).
+   * A note can hold several captioned tables; `tableIndex` is the position in
+   * the note's full `parsed.tables` list (captioned or not), matching the
+   * graph's positional `…/table/<index>` addressing.
+   */
+  noteTables: Map<string, { name: string; tableIndex: number }[]>;
+  /**
+   * tableName → notePath. Shares the identifier namespace with `tableToPath`
+   * so a markdown table can't collide with a CSV (or another note table).
+   */
+  tableToNote: Map<string, string>;
 }
 
 // Dispose closes the in-memory DuckDB (connection then instance) before the
@@ -54,6 +70,8 @@ export async function initTablesDb(ctx: ProjectContext): Promise<void> {
     connection,
     pathToTable: new Map(),
     tableToPath: new Map(),
+    noteTables: new Map(),
+    tableToNote: new Map(),
   });
 }
 
@@ -170,6 +188,13 @@ export type RegisterCsvResult =
   | { ok: true }
   | { ok: false; reason: 'collision'; collision: CsvTableCollision }
   | { ok: false; reason: 'inactive' }
+  | { ok: false; reason: 'error'; error: unknown };
+
+export type RegisterTableResult =
+  | { ok: true; name: string }
+  | { ok: false; reason: 'collision'; collision: CsvTableCollision }
+  | { ok: false; reason: 'inactive' }
+  | { ok: false; reason: 'uncaptioned' }
   | { ok: false; reason: 'error'; error: unknown };
 
 /**
@@ -321,6 +346,124 @@ export async function unregisterCsv(ctx: ProjectContext, relativePath: string): 
   pathToTable.delete(relativePath);
   tableToPath.delete(tableName);
   unindexCsvTable(ctx, tableName);
+}
+
+// ── Markdown tables (#1357) ─────────────────────────────────────────────────
+
+/**
+ * Materialize a captioned markdown table into the shared DuckDB as a real
+ * TABLE (not a VIEW — an embedded table has no backing file to `read_csv`
+ * lazily). The rows are serialized to CSV text and loaded through DuckDB's
+ * CSV sniffer so **type inference matches the standalone-`.csv` path** (a
+ * numeric column comes back numeric).
+ *
+ * Opt-in: only tables carrying a `name` (from a `Table: <caption>` line, #1356)
+ * are registered; uncaptioned tables stay graph-only and return `uncaptioned`.
+ *
+ * Names share one identifier namespace with CSV tables and other note tables,
+ * so a clash is skipped + surfaced via the same collision toast (#354). CSV
+ * tables win — callers register all CSVs before note tables (see #1358).
+ *
+ * Precondition: the caller has already dropped this note's prior tables (via
+ * `unregisterNoteTables`) — `reregisterNoteTables` does this. A lingering
+ * entry for `notePath` therefore means a sibling table in the same note
+ * already claimed the name (two identical captions), which is also skipped.
+ */
+export async function registerMarkdownTable(
+  ctx: ProjectContext,
+  notePath: string,
+  table: ParsedTable,
+  tableIndex: number,
+): Promise<RegisterTableResult> {
+  const state = getState(ctx);
+  if (!state) return { ok: false, reason: 'inactive' };
+  const { rootPath, connection, tableToPath, tableToNote, noteTables } = state;
+  const tableName = table.name;
+  if (!tableName) return { ok: false, reason: 'uncaptioned' };
+
+  const existingPath = tableToPath.get(tableName) ?? tableToNote.get(tableName);
+  if (existingPath) {
+    console.warn(
+      `[tables] Table name collision: '${tableName}' from note '${notePath}' ` +
+      `is already used by '${existingPath}'. Skipping the markdown table. ` +
+      `Rename the 'Table:' caption to disambiguate.`,
+    );
+    const collision = { tableName, existingPath, attemptedPath: notePath };
+    // A same-note duplicate (both paths identical) is a user typo, not a
+    // cross-source clash — skip it quietly rather than firing a confusing toast.
+    if (existingPath !== notePath) emitCollision(rootPath, collision);
+    return { ok: false, reason: 'collision', collision };
+  }
+
+  // Round-trip the cells through a temp CSV so DuckDB's sniffer types them.
+  const csvText = serializeCsv(table.headers, table.rows);
+  const tmpPath = path.join(os.tmpdir(), `minerva-mdtable-${crypto.randomUUID()}.csv`);
+  try {
+    await fs.writeFile(tmpPath, csvText, 'utf-8');
+    const escaped = tmpPath.replace(/'/g, "''");
+    // header=true: we always emit a header row, so don't leave it to sniffing.
+    // null_padding=true: tolerate short rows in a hand-written markdown table.
+    await connection.run(
+      `CREATE OR REPLACE TABLE "${tableName}" AS SELECT * FROM ` +
+      `read_csv_auto('${escaped}', header=true, null_padding=true)`,
+    );
+    const entries = noteTables.get(notePath) ?? [];
+    entries.push({ name: tableName, tableIndex });
+    noteTables.set(notePath, entries);
+    tableToNote.set(tableName, notePath);
+    return { ok: true, name: tableName };
+  } catch (err) {
+    console.warn(
+      `[tables] Failed to register markdown table '${tableName}' from ` +
+      `'${notePath}': ` + (err instanceof Error ? err.message : String(err)),
+    );
+    return { ok: false, reason: 'error', error: err };
+  } finally {
+    await fs.rm(tmpPath, { force: true }).catch(() => { /* best-effort cleanup */ });
+  }
+}
+
+/** Drop every DuckDB table registered from a note. No-op if none were. */
+export async function unregisterNoteTables(ctx: ProjectContext, notePath: string): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  const { connection, noteTables, tableToNote } = state;
+  const entries = noteTables.get(notePath);
+  if (!entries) return;
+  for (const { name } of entries) {
+    try {
+      await connection.run(`DROP TABLE IF EXISTS "${name}"`);
+    } catch { /* table may already be gone */ }
+    tableToNote.delete(name);
+  }
+  noteTables.delete(notePath);
+}
+
+/**
+ * Re-parse a note and re-register its captioned tables: drop the note's prior
+ * tables, then register each captioned one afresh. This is the entry the file
+ * watcher + boot sweep call (#1358); a note edit can add/remove/rename a
+ * caption or change rows, so a full drop-then-register keeps DuckDB in sync.
+ */
+export async function reregisterNoteTables(
+  ctx: ProjectContext,
+  notePath: string,
+  content: string,
+): Promise<{ count: number; collisions: CsvTableCollision[] }> {
+  const state = getState(ctx);
+  if (!state) return { count: 0, collisions: [] };
+  await unregisterNoteTables(ctx, notePath);
+  const parsed = parseMarkdown(content);
+  let count = 0;
+  const collisions: CsvTableCollision[] = [];
+  for (let i = 0; i < parsed.tables.length; i++) {
+    const table = parsed.tables[i]!;
+    if (!table.name) continue; // uncaptioned → graph-only, skip SQL registration
+    const result = await registerMarkdownTable(ctx, notePath, table, i);
+    if (result.ok) count++;
+    else if (result.reason === 'collision') collisions.push(result.collision);
+  }
+  return { count, collisions };
 }
 
 /**

--- a/src/shared/csv-parse.ts
+++ b/src/shared/csv-parse.ts
@@ -50,6 +50,21 @@ export function parseCsv(text: string): ParsedCsv {
   };
 }
 
+/**
+ * Serialize headers + rows to RFC-4180 CSV text (comma-delimited, `\n`
+ * line breaks). A field is quoted only when it contains a comma, a double
+ * quote, or a line break; embedded quotes are doubled. Used by the
+ * markdown-table → DuckDB path (#1357) to hand a captioned table's cells to
+ * DuckDB's CSV sniffer so type inference matches the standalone-`.csv` path.
+ */
+export function serializeCsv(headers: string[], rows: string[][]): string {
+  const esc = (field: string): string =>
+    /[",\r\n]/.test(field) ? '"' + field.replace(/"/g, '""') + '"' : field;
+  const lines = [headers.map(esc).join(',')];
+  for (const row of rows) lines.push(row.map(esc).join(','));
+  return lines.join('\n');
+}
+
 function splitRecords(text: string): string[][] {
   const out: string[][] = [];
   let cur: string[] = [];

--- a/tests/main/sources/tables-markdown.test.ts
+++ b/tests/main/sources/tables-markdown.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  initTablesDb,
+  disposeProject,
+  runQuery,
+  registerCsv,
+  registerMarkdownTable,
+  unregisterNoteTables,
+  reregisterNoteTables,
+  onCsvTableCollision,
+} from '../../../src/main/sources/tables';
+import { projectContext } from '../../../src/main/project-context-types';
+import type { ParsedTable } from '../../../src/main/graph/parser';
+
+let rootPath: string;
+let ctx: ReturnType<typeof projectContext>;
+
+beforeAll(async () => {
+  rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-mdtable-test-'));
+  ctx = projectContext(rootPath);
+  await initTablesDb(ctx);
+});
+
+afterAll(async () => {
+  disposeProject(ctx);
+  await fs.rm(rootPath, { recursive: true, force: true });
+});
+
+function table(caption: string, headers: string[], rows: string[][]): ParsedTable {
+  // Mirror what the parser produces for a captioned table.
+  const name = caption.replace(/\s+/g, '_');
+  return { headers, rows, caption, name };
+}
+
+describe('registerMarkdownTable (#1357)', () => {
+  it('materializes rows with inferred types (numbers as numbers)', async () => {
+    const t = table('sales', ['item', 'amount'], [['a', '10'], ['b', '20']]);
+    const res = await registerMarkdownTable(ctx, 'notes/q3.md', t, 0);
+    expect(res.ok).toBe(true);
+
+    const sum = await runQuery(ctx, 'SELECT sum(amount) AS total FROM sales');
+    expect(sum.ok).toBe(true);
+    // DuckDB infers `amount` as an integer column and sums to a BigInt.
+    if (sum.ok) expect(Number(sum.rows[0]!.total)).toBe(30);
+
+    const shape = await runQuery(ctx, "SELECT data_type FROM information_schema.columns WHERE table_name = 'sales' AND column_name = 'amount'");
+    if (shape.ok) expect(String(shape.rows[0]!.data_type)).toMatch(/INT|BIGINT/i);
+  });
+
+  it('skips an uncaptioned table', async () => {
+    const res = await registerMarkdownTable(ctx, 'notes/x.md', { headers: ['a'], rows: [['1']] }, 0);
+    expect(res).toEqual({ ok: false, reason: 'uncaptioned' });
+  });
+
+  it('re-registering a note replaces its tables cleanly', async () => {
+    const md = 'Table: metrics\n| k | v |\n|---|---|\n| x | 1 |\n| y | 2 |';
+    const first = await reregisterNoteTables(ctx, 'notes/m.md', md);
+    expect(first.count).toBe(1);
+    let r = await runQuery(ctx, 'SELECT count(*) AS n FROM metrics');
+    if (r.ok) expect(Number(r.rows[0]!.n)).toBe(2);
+
+    // Edit: fewer rows, same caption.
+    const edited = 'Table: metrics\n| k | v |\n|---|---|\n| z | 9 |';
+    await reregisterNoteTables(ctx, 'notes/m.md', edited);
+    r = await runQuery(ctx, 'SELECT count(*) AS n FROM metrics');
+    if (r.ok) expect(Number(r.rows[0]!.n)).toBe(1);
+  });
+
+  it('removes the table when the caption is dropped on edit', async () => {
+    await reregisterNoteTables(ctx, 'notes/drop.md', 'Table: gone\n| a | b |\n|---|---|\n| 1 | 2 |');
+    expect((await runQuery(ctx, 'SELECT * FROM gone')).ok).toBe(true);
+
+    await reregisterNoteTables(ctx, 'notes/drop.md', '| a | b |\n|---|---|\n| 1 | 2 |'); // no caption
+    expect((await runQuery(ctx, 'SELECT * FROM gone')).ok).toBe(false);
+  });
+
+  it('unregisterNoteTables drops every table for a note', async () => {
+    const md = 'Table: t_one\n| a | c |\n|---|---|\n| 1 | 2 |\n\nText\n\nTable: t_two\n| b | d |\n|---|---|\n| 2 | 3 |';
+    await reregisterNoteTables(ctx, 'notes/multi.md', md);
+    expect((await runQuery(ctx, 'SELECT * FROM t_one')).ok).toBe(true);
+    expect((await runQuery(ctx, 'SELECT * FROM t_two')).ok).toBe(true);
+
+    await unregisterNoteTables(ctx, 'notes/multi.md');
+    expect((await runQuery(ctx, 'SELECT * FROM t_one')).ok).toBe(false);
+    expect((await runQuery(ctx, 'SELECT * FROM t_two')).ok).toBe(false);
+  });
+
+  it('detects a collision with a CSV table and skips the markdown table', async () => {
+    // Register a CSV named `revenue`.
+    await fs.writeFile(path.join(rootPath, 'revenue.csv'), 'x,y\n1,2\n', 'utf-8');
+    const csv = await registerCsv(ctx, 'revenue.csv');
+    expect(csv.ok).toBe(true);
+
+    const collisions: unknown[] = [];
+    const unsub = onCsvTableCollision(rootPath, (c) => collisions.push(c));
+    const res = await registerMarkdownTable(
+      ctx,
+      'notes/clash.md',
+      table('revenue', ['a'], [['9']]),
+      0,
+    );
+    unsub();
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('collision');
+    expect(collisions).toHaveLength(1);
+    // CSV wins — the table still resolves to the CSV's columns, not the note's.
+    const cols = await runQuery(ctx, "SELECT column_name FROM information_schema.columns WHERE table_name = 'revenue' ORDER BY ordinal_position");
+    if (cols.ok) expect(cols.rows.map((r) => r.column_name)).toEqual(['x', 'y']);
+  });
+
+  it('skips a same-note duplicate caption without firing a cross-source toast', async () => {
+    const collisions: unknown[] = [];
+    const unsub = onCsvTableCollision(rootPath, (c) => collisions.push(c));
+    const md = 'Table: dup\n| a | c |\n|---|---|\n| 1 | 2 |\n\nTable: dup\n| b | d |\n|---|---|\n| 2 | 3 |';
+    const out = await reregisterNoteTables(ctx, 'notes/dup.md', md);
+    unsub();
+    expect(out.count).toBe(1); // only the first `dup` registers
+    expect(collisions).toHaveLength(0); // same-note dup is quiet
+  });
+});


### PR DESCRIPTION
**Epic #1355 · Ticket 2 of 6** (core; builds on #1356)

A `registerCsv` sibling that pushes a captioned markdown table's rows into the same in-memory DuckDB connection the CSVs use.

## What
- **`serializeCsv(headers, rows)`** in `src/shared/csv-parse.ts` — RFC-4180 CSV text (none existed in main before).
- **`registerMarkdownTable(ctx, notePath, table, tableIndex)`** in `sources/tables.ts`:
  - **Materialized** (`CREATE OR REPLACE TABLE … AS SELECT * FROM read_csv_auto(tmp, header=true, null_padding=true)`) — an embedded table has no backing file to `read_csv` lazily. Rows round-trip through a temp CSV so **type inference matches the standalone-`.csv` path** (numeric column sums numerically).
  - Opt-in: only tables with a `name` (from #1356's `Table:` caption) register; uncaptioned → `uncaptioned`, stay graph-only.
  - New `noteTables` / `tableToNote` state maps share the identifier namespace with `tableToPath`, so a markdown table can't collide with a CSV or another note table. **CSV wins** (callers register CSVs first, #1358); the clash is skipped + surfaced via the existing collision toast. A same-note duplicate caption is skipped quietly.
- **`unregisterNoteTables`** drops every table for a note; **`reregisterNoteTables`** re-parses + drops-then-registers (the entry the watcher + boot sweep call in #1358).

## Tests
`tests/main/sources/tables-markdown.test.ts` — type inference, uncaptioned skip, edit-replaces-cleanly, caption-drop removal, multi-table unregister, CSV collision (CSV wins + toast fires), same-note duplicate (quiet skip).

No graph changes here — the `minerva:fromNote` graph overlay is #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)