### PR TITLE
Lifecycle: register/unregister note tables on open, save, delete (#1358)

### DIFF
--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -92,6 +92,8 @@ export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Eng
     await ensureMinervaDir();
     await tables.initTablesDb(ctx);
     await tables.registerAllCsvs(ctx);
+    // Captioned markdown tables register after CSVs — CSV wins on a name clash.
+    await tables.registerAllNoteTables(ctx);
   })());
   const ensureVectors = () => (vectorsReady ??= (async () => {
     await ensureMinervaDir();

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -342,6 +342,8 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
             search.indexAllNotes(ctx),
           ]);
           await tables.registerAllCsvs(ctx);
+          // Note tables after CSVs — CSV wins on a shared name (#1358).
+          await tables.registerAllNoteTables(ctx);
           if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
         },
       }),

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -82,6 +82,9 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
         search.indexAllNotes(ctx),
       ]);
       await tables.registerAllCsvs(ctx);
+      // Captioned markdown tables register after CSVs so a name shared by both
+      // resolves deterministically — CSV wins, note table is skipped (#1358).
+      await tables.registerAllNoteTables(ctx);
       // Re-project conversation JSON into the graph after notes are
       // indexed (so contextNote IRIs resolve against a populated note
       // namespace). Also self-heals stale relative-path triples from

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -449,9 +449,13 @@ export async function reregisterNoteTables(
   ctx: ProjectContext,
   notePath: string,
   content: string,
-): Promise<{ count: number; collisions: CsvTableCollision[] }> {
+): Promise<{ count: number; collisions: CsvTableCollision[]; changed: boolean }> {
   const state = getState(ctx);
-  if (!state) return { count: 0, collisions: [] };
+  if (!state) return { count: 0, collisions: [], changed: false };
+  // Whether the note owned any tables before this pass — combined with the new
+  // count/collisions below, lets the watcher skip a TABLES_CHANGED broadcast
+  // when an ordinary (caption-less) note is saved.
+  const hadBefore = state.noteTables.has(notePath);
   await unregisterNoteTables(ctx, notePath);
   const parsed = parseMarkdown(content);
   let count = 0;
@@ -463,7 +467,7 @@ export async function reregisterNoteTables(
     if (result.ok) count++;
     else if (result.reason === 'collision') collisions.push(result.collision);
   }
-  return { count, collisions };
+  return { count, collisions, changed: hadBefore || count > 0 || collisions.length > 0 };
 }
 
 /**
@@ -501,6 +505,57 @@ export async function registerAllCsvs(ctx: ProjectContext): Promise<{ count: num
         const result = await registerCsv(ctx, rel);
         if (result.ok) count++;
         else if (result.reason === 'collision') collisions.push(result.collision);
+      }
+    }
+  }
+  await walk(rootPath);
+  return { count, collisions };
+}
+
+/**
+ * Scan the thoughtbase on project open and register every captioned markdown
+ * table (#1358). Mirrors `registerAllCsvs`'s walker. **Must run after
+ * `registerAllCsvs`** so a CSV and a note table that derive the same name
+ * resolve deterministically — the CSV wins and the note table is skipped.
+ *
+ * Returns the count of registered tables plus collisions (routed to the same
+ * toast as CSV collisions).
+ */
+export async function registerAllNoteTables(ctx: ProjectContext): Promise<{ count: number; collisions: CsvTableCollision[] }> {
+  const state = getState(ctx);
+  if (!state) return { count: 0, collisions: [] };
+  const { rootPath } = state;
+  // Drop any note tables from a previous sweep so a note deleted while the app
+  // was closed (or since the last "Rebuild All Indexes") doesn't linger — the
+  // walk below only revisits notes that still exist.
+  for (const notePath of [...state.noteTables.keys()]) {
+    await unregisterNoteTables(ctx, notePath);
+  }
+  let count = 0;
+  const collisions: CsvTableCollision[] = [];
+  async function walk(dirPath: string) {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+        const rel = path.relative(rootPath, fullPath);
+        let content: string;
+        try {
+          content = await fs.readFile(fullPath, 'utf-8');
+        } catch {
+          continue;
+        }
+        const result = await reregisterNoteTables(ctx, rel, content);
+        count += result.count;
+        collisions.push(...result.collisions);
       }
     }
   }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -385,6 +385,11 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(projectCtx, relativePath, content);
         search.indexNote(projectCtx, relativePath, content);
+        // Captioned markdown tables in the note re-register in DuckDB (#1358).
+        if (relativePath.toLowerCase().endsWith('.md')) {
+          const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
+          if (r.changed && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+        }
         debouncedPersist();
       } catch (err) {
         // Usually a race (file deleted between events), but log so real bugs
@@ -413,6 +418,10 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         const content = await notebaseFs.readFile(rootPath, relativePath);
         await graph.indexNote(projectCtx, relativePath, content);
         search.indexNote(projectCtx, relativePath, content);
+        if (relativePath.toLowerCase().endsWith('.md')) {
+          const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
+          if (r.changed && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+        }
         debouncedPersist();
       } catch (err) {
         console.warn(`[watcher] indexing failed for ${relativePath}:`, err);
@@ -435,6 +444,12 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       try {
         search.removeNote(projectCtx, relativePath);
         graph.removeNote(projectCtx, relativePath);
+        // Drop any DuckDB tables the deleted note owned (#1358). A rename
+        // surfaces as delete+create, so the create half re-registers them.
+        if (relativePath.toLowerCase().endsWith('.md')) {
+          await tables.unregisterNoteTables(projectCtx, relativePath);
+          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+        }
       } catch (err) {
         console.warn(`[watcher] removeNote failed for ${relativePath}:`, err);
       }

--- a/tests/main/sources/note-tables-lifecycle.test.ts
+++ b/tests/main/sources/note-tables-lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  initTablesDb,
+  disposeProject,
+  runQuery,
+  registerAllCsvs,
+  registerAllNoteTables,
+  onCsvTableCollision,
+} from '../../../src/main/sources/tables';
+import { projectContext } from '../../../src/main/project-context-types';
+
+let rootPath: string;
+let ctx: ReturnType<typeof projectContext>;
+
+beforeEach(async () => {
+  rootPath = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-note-lifecycle-'));
+  ctx = projectContext(rootPath);
+  await initTablesDb(ctx);
+});
+
+afterEach(async () => {
+  disposeProject(ctx);
+  await fs.rm(rootPath, { recursive: true, force: true });
+});
+
+async function write(rel: string, content: string): Promise<void> {
+  const abs = path.join(rootPath, rel);
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, content, 'utf-8');
+}
+
+describe('registerAllNoteTables (#1358)', () => {
+  it('registers captioned tables from notes across subdirectories', async () => {
+    await write('top.md', 'Table: budget\n| item | cost |\n|------|------|\n| pens | 3 |\n| ink | 7 |');
+    await write('sub/nested.md', 'Table: crew\n| who | age |\n|-----|-----|\n| ana | 30 |');
+    await write('plain.md', '| a | b |\n|---|---|\n| 1 | 2 |'); // uncaptioned → skipped
+
+    const out = await registerAllNoteTables(ctx);
+    expect(out.count).toBe(2);
+
+    const budget = await runQuery(ctx, 'SELECT sum(cost) AS total FROM budget');
+    if (budget.ok) expect(Number(budget.rows[0]!.total)).toBe(10);
+    expect((await runQuery(ctx, 'SELECT * FROM crew')).ok).toBe(true);
+  });
+
+  it('lets a CSV win a name shared with a note table (CSV registered first)', async () => {
+    await write('sales.csv', 'x,y\n1,2\n');
+    await write('note.md', 'Table: sales\n| a | b |\n|---|---|\n| 9 | 9 |');
+
+    await registerAllCsvs(ctx);
+    const collisions: unknown[] = [];
+    const unsub = onCsvTableCollision(rootPath, (c) => collisions.push(c));
+    const out = await registerAllNoteTables(ctx);
+    unsub();
+
+    expect(out.collisions).toHaveLength(1);
+    expect(collisions).toHaveLength(1);
+    // `sales` still resolves to the CSV's columns, not the note's.
+    const cols = await runQuery(ctx, "SELECT column_name FROM information_schema.columns WHERE table_name = 'sales' ORDER BY ordinal_position");
+    if (cols.ok) expect(cols.rows.map((r) => r.column_name)).toEqual(['x', 'y']);
+  });
+
+  it('drops a note table on a subsequent sweep after the note is deleted', async () => {
+    await write('temp.md', 'Table: ephemeral\n| a | b |\n|---|---|\n| 1 | 2 |');
+    await registerAllNoteTables(ctx);
+    expect((await runQuery(ctx, 'SELECT * FROM ephemeral')).ok).toBe(true);
+
+    await fs.rm(path.join(rootPath, 'temp.md'));
+    await registerAllNoteTables(ctx);
+    expect((await runQuery(ctx, 'SELECT * FROM ephemeral')).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
**Epic #1355 · Ticket 3 of 6** (core parity lands here; builds on #1357)

Wires markdown-table registration into the same lifecycle the CSV path uses, so note tables stay in sync with edits. **This is where end-to-end SQL parity actually works** — open a project or edit a note and its captioned tables are `SELECT`-able.

## What
- **`registerAllNoteTables(ctx)`** — walks `.md` notes, registers captioned tables. Added to all three boot sweeps: `project-context.ts:84`, `cli/engine.ts`, `menu.ts` reindex — **sequenced after `registerAllCsvs`** so a CSV and note table sharing a name resolve deterministically (CSV wins). It first drops note tables from a prior sweep, so a note deleted while the app was closed doesn't linger.
- **Watcher** (`window-manager.ts`) — the `.md` branches of `onFileChanged`/`onFileCreated` call `tables.reregisterNoteTables`; `onFileDeleted` calls `unregisterNoteTables`. A rename surfaces as delete+create, so it's covered. The existing `.csv`-only guards are untouched — this adds a parallel `.md` path.
- `reregisterNoteTables` now returns `changed`, so the watcher only broadcasts `TABLES_CHANGED` when a note actually has/had captioned tables — not on every ordinary note save.
- `graph/` still never imports DuckDB (re-parse happens in the tables module).

## Tests
`tests/main/sources/note-tables-lifecycle.test.ts` — sweep registers across subdirs (uncaptioned skipped), CSV-wins precedence + collision reported, and stale-cleanup (deleted note's table dropped on next sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)