### PR TITLE
Tables panel + TableInfo: source-aware listing (CSV file vs note) (#1359)

### DIFF
--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -26,7 +26,7 @@ interface TablesState {
    * the note's full `parsed.tables` list (captioned or not), matching the
    * graph's positional `…/table/<index>` addressing.
    */
-  noteTables: Map<string, { name: string; tableIndex: number }[]>;
+  noteTables: Map<string, { name: string; tableIndex: number; caption: string }[]>;
   /**
    * tableName → notePath. Shares the identifier namespace with `tableToPath`
    * so a markdown table can't collide with a CSV (or another note table).
@@ -53,9 +53,16 @@ export type QueryResult =
 
 export interface TableInfo {
   name: string;
+  /** CSV file path for `source: 'csv'`; the source note's path for `'note'`. */
   relativePath: string;
   columns: string[];
   rowCount: number;
+  /** Where the table came from — a standalone `.csv` file or a note's `Table:` caption (#1359). */
+  source: 'csv' | 'note';
+  /** Note tables only: the raw human caption, to label the row + jump to the table. */
+  caption?: string;
+  /** Note tables only: position in the note's `parsed.tables` list. */
+  tableIndex?: number;
 }
 
 /** Open an in-memory DuckDB for the given project. Idempotent per project. */
@@ -408,7 +415,7 @@ export async function registerMarkdownTable(
       `read_csv_auto('${escaped}', header=true, null_padding=true)`,
     );
     const entries = noteTables.get(notePath) ?? [];
-    entries.push({ name: tableName, tableIndex });
+    entries.push({ name: tableName, tableIndex, caption: table.caption ?? tableName });
     noteTables.set(notePath, entries);
     tableToNote.set(tableName, notePath);
     return { ok: true, name: tableName };
@@ -563,24 +570,42 @@ export async function registerAllNoteTables(ctx: ProjectContext): Promise<{ coun
   return { count, collisions };
 }
 
-/** Every registered CSV's table name, relative path, column names, and row count. */
+/** Row count + ordered column names for a registered table, via DuckDB. */
+async function tableShape(ctx: ProjectContext, name: string): Promise<{ columns: string[]; rowCount: number }> {
+  const countR = await runQuery(ctx, `SELECT COUNT(*) AS n FROM "${name}"`);
+  const colsR = await runQuery(ctx,
+    `SELECT column_name FROM information_schema.columns ` +
+    `WHERE table_name = '${name.replace(/'/g, "''")}' AND table_schema = 'main' ` +
+    `ORDER BY ordinal_position`,
+  );
+  return {
+    rowCount: countR.ok ? Number(countR.rows[0]?.n ?? 0) : 0,
+    columns: colsR.ok ? colsR.rows.map((r) => String(r.column_name)) : [],
+  };
+}
+
+/**
+ * Every registered table — standalone `.csv` files and captioned markdown
+ * tables (#1359) — with its name, source, relative path, columns, and row
+ * count. Both kinds live in one DuckDB connection, so this is the single
+ * source of truth the Tables panel and SQL autocomplete read.
+ */
 export async function listTables(ctx: ProjectContext): Promise<TableInfo[]> {
   const state = getState(ctx);
   if (!state) return [];
   const out: TableInfo[] = [];
   for (const [relativePath, name] of state.pathToTable.entries()) {
-    const quoted = `"${name}"`;
-    const countR = await runQuery(ctx, `SELECT COUNT(*) AS n FROM ${quoted}`);
-    const colsR = await runQuery(ctx,
-      `SELECT column_name FROM information_schema.columns ` +
-      `WHERE table_name = '${name.replace(/'/g, "''")}' AND table_schema = 'main' ` +
-      `ORDER BY ordinal_position`,
-    );
-    const rowCount = countR.ok ? Number(countR.rows[0]?.n ?? 0) : 0;
-    const columns = colsR.ok ? colsR.rows.map((r) => String(r.column_name)) : [];
-    out.push({ name, relativePath, columns, rowCount });
+    const { columns, rowCount } = await tableShape(ctx, name);
+    out.push({ name, relativePath, columns, rowCount, source: 'csv' });
   }
-  out.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  for (const [notePath, entries] of state.noteTables.entries()) {
+    for (const { name, tableIndex, caption } of entries) {
+      const { columns, rowCount } = await tableShape(ctx, name);
+      out.push({ name, relativePath: notePath, columns, rowCount, source: 'note', caption, tableIndex });
+    }
+  }
+  // Group by file, then by name so multiple tables in one note order stably.
+  out.sort((a, b) => a.relativePath.localeCompare(b.relativePath) || a.name.localeCompare(b.name));
   return out;
 }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1345,6 +1345,7 @@
           onMineReferences={handleMineReferences}
           onTableClick={(name) => editor.openQuery(`SELECT * FROM ${name}`, 'sql')}
           onOpenCsv={(rel) => handleFileSelect(rel)}
+          onOpenNote={(rel) => handleFileSelect(rel)}
           onExternalDrop={handleExternalDrop}
           canPaste={clipboard.current !== null}
         />

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -76,11 +76,12 @@
     onMineReferences?: (source: import('../../../shared/types').SourceMetadata) => Promise<void>;
     onTableClick?: (tableName: string) => void;
     onOpenCsv?: (relativePath: string) => void;
+    onOpenNote?: (relativePath: string) => void;
     onExternalDrop?: (destDirectory: string, files: FileList) => void;
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -635,8 +636,8 @@
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {...(onSourceSelect !== undefined ? { onSourceSelect } : {})} />
     {:else if activePanel === 'tables'}
-      {#if onTableClick && onOpenCsv}
-        <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} />
+      {#if onTableClick && onOpenCsv && onOpenNote}
+        <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} {onOpenNote} />
       {/if}
     {:else if activePanel === 'bookmarks'}
       {#if onShowPrompt}

--- a/src/renderer/lib/components/TablesPanel.svelte
+++ b/src/renderer/lib/components/TablesPanel.svelte
@@ -7,9 +7,10 @@
   interface Props {
     onTableClick: (tableName: string) => void;
     onOpenCsv: (relativePath: string) => void;
+    onOpenNote: (relativePath: string) => void;
   }
 
-  let { onTableClick, onOpenCsv }: Props = $props();
+  let { onTableClick, onOpenCsv, onOpenNote }: Props = $props();
 
   let tables = $state<TableInfo[]>([]);
   let filter = $state('');
@@ -52,7 +53,7 @@
 
 <div class="tables-panel">
   {#if tables.length === 0}
-    <div class="empty">No tables yet. Drop a CSV into the thoughtbase.</div>
+    <div class="empty">No tables yet. Drop a CSV into the thoughtbase, or add a <code>Table:</code> caption above a markdown table.</div>
   {:else}
     <div class="filter-row">
       <input
@@ -68,10 +69,13 @@
           class="table-item"
           onclick={() => onTableClick(t.name)}
           oncontextmenu={(e) => handleContextMenu(e, t)}
-          title={t.relativePath}
+          title={t.source === 'note' ? `${t.caption} — ${t.relativePath}` : t.relativePath}
         >
-          <div class="table-name">{t.name}</div>
-          <div class="table-meta">{t.rowCount} {t.rowCount === 1 ? 'row' : 'rows'} · {t.columns.length} {t.columns.length === 1 ? 'col' : 'cols'}</div>
+          <div class="table-name">
+            {t.name}
+            <span class="source-tag" class:note={t.source === 'note'}>{t.source}</span>
+          </div>
+          <div class="table-meta">{t.rowCount} {t.rowCount === 1 ? 'row' : 'rows'} · {t.columns.length} {t.columns.length === 1 ? 'col' : 'cols'}{#if t.source === 'note'} · {t.relativePath}{/if}</div>
         </button>
       {/each}
       {#if visible.length === 0}
@@ -95,9 +99,15 @@
       Copy Table Name
     </button>
     <div class="separator"></div>
-    <button onclick={() => { onOpenCsv(contextMenu!.table.relativePath); contextMenu = null; }}>
-      Open CSV
-    </button>
+    {#if contextMenu.table.source === 'note'}
+      <button onclick={() => { onOpenNote(contextMenu!.table.relativePath); contextMenu = null; }}>
+        Open Note
+      </button>
+    {:else}
+      <button onclick={() => { onOpenCsv(contextMenu!.table.relativePath); contextMenu = null; }}>
+        Open CSV
+      </button>
+    {/if}
     <button onclick={() => { void api.shell.revealFile(contextMenu!.table.relativePath); contextMenu = null; }}>
       Reveal in Finder
     </button>
@@ -167,6 +177,23 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .source-tag {
+    font-family: var(--font-sans);
+    font-weight: 400;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    background: var(--bg-button);
+    border-radius: 3px;
+    padding: 0 4px;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+  .source-tag.note {
+    color: var(--accent);
   }
 
   .table-meta {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -143,9 +143,16 @@ export type TablesQueryResult =
 
 export interface TableInfo {
   name: string;
+  /** CSV file path for `source: 'csv'`; the source note's path for `'note'`. */
   relativePath: string;
   columns: string[];
   rowCount: number;
+  /** Where the table came from — a standalone `.csv` file or a note's `Table:` caption (#1359). */
+  source: 'csv' | 'note';
+  /** Note tables only: the raw human caption. */
+  caption?: string;
+  /** Note tables only: position in the note's table list. */
+  tableIndex?: number;
 }
 
 export interface TablesApi {

--- a/tests/main/sources/note-tables-lifecycle.test.ts
+++ b/tests/main/sources/note-tables-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   runQuery,
   registerAllCsvs,
   registerAllNoteTables,
+  listTables,
   onCsvTableCollision,
 } from '../../../src/main/sources/tables';
 import { projectContext } from '../../../src/main/project-context-types';
@@ -61,6 +62,26 @@ describe('registerAllNoteTables (#1358)', () => {
     // `sales` still resolves to the CSV's columns, not the note's.
     const cols = await runQuery(ctx, "SELECT column_name FROM information_schema.columns WHERE table_name = 'sales' ORDER BY ordinal_position");
     if (cols.ok) expect(cols.rows.map((r) => r.column_name)).toEqual(['x', 'y']);
+  });
+
+  it('listTables labels tables by source (csv file vs note) with caption + index', async () => {
+    await write('data.csv', 'x,y\n1,2\n');
+    await write('report.md', 'Table: findings\n| metric | value |\n|--------|-------|\n| n | 5 |');
+    await registerAllCsvs(ctx);
+    await registerAllNoteTables(ctx);
+
+    const tables = await listTables(ctx);
+    const csv = tables.find((t) => t.name === 'data');
+    const note = tables.find((t) => t.name === 'findings');
+
+    expect(csv?.source).toBe('csv');
+    expect(csv?.caption).toBeUndefined();
+
+    expect(note?.source).toBe('note');
+    expect(note?.relativePath).toBe('report.md');
+    expect(note?.caption).toBe('findings');
+    expect(note?.tableIndex).toBe(0);
+    expect(note?.columns).toEqual(['metric', 'value']);
   });
 
   it('drops a note table on a subsequent sweep after the note is deleted', async () => {

--- a/tests/main/sources/tables-csv.test.ts
+++ b/tests/main/sources/tables-csv.test.ts
@@ -277,8 +277,8 @@ describe('CSV pipeline: register / list / unregister (#233)', () => {
 
     const a = tables.find((t) => t.name === 'a');
     const b = tables.find((t) => t.name === 'nested_b');
-    expect(a).toEqual({ name: 'a', relativePath: 'a.csv', columns: ['x', 'y'], rowCount: 2 });
-    expect(b).toEqual({ name: 'nested_b', relativePath: 'nested/b.csv', columns: ['p', 'q', 'r'], rowCount: 1 });
+    expect(a).toEqual({ name: 'a', relativePath: 'a.csv', columns: ['x', 'y'], rowCount: 2, source: 'csv' });
+    expect(b).toEqual({ name: 'nested_b', relativePath: 'nested/b.csv', columns: ['p', 'q', 'r'], rowCount: 1, source: 'csv' });
   });
 
   it('returns a structured collision result when two CSVs derive the same table name (#354)', async () => {


### PR DESCRIPTION
**Epic #1355 · Ticket 4 of 6** (UI; builds on #1357/#1358)

The left-sidebar Tables panel assumed every table is a CSV file ("Open CSV"). Note tables have no `.csv` file — their path is a note, and a note can hold several tables.

## What
- **`TableInfo`** (both mirrored defs — `sources/tables.ts` + `renderer/lib/ipc/client.ts`) gains `source: 'csv' | 'note'` plus, for note tables, `caption` + `tableIndex`.
- **`listTables`** enumerates the `noteTables` maps alongside CSVs from the same connection. A shared `tableShape()` helper removes the count/columns duplication.
- **Tables panel** (`TablesPanel.svelte`): each row shows a source tag; a note row's context action is **Open Note** (new `onOpenNote` prop, wired Sidebar → App → `handleFileSelect`) instead of Open CSV. CSV rows unchanged. Multiple tables per note render as distinct rows. Empty-state copy now mentions the `Table:` caption.
- **SQL autocomplete**: no change needed — `QueryPanel.refreshSqlSchema` already builds from `api.tables.list()`, so note tables appear automatically (verified in code).

## Tests
- `note-tables-lifecycle.test.ts` — `listTables` labels by source with caption/index/columns for a note table and `source: 'csv'` for a CSV.
- `tables-csv.test.ts` — existing exact-shape assertions updated for the new `source` field.

Lint clean; preload-bridge snapshot unaffected (no new `window.api` method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)