### PR TITLE
Graph parity: schema overlay + note join-back for markdown SQL tables (#1360)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -42,11 +42,12 @@ export type {
 // — it's internal-only.
 export {
   indexNote, indexCsvTable, unindexCsvTable, unindexAllCsvTables,
+  indexMarkdownTable, unindexMarkdownTable, unindexAllNoteTables,
   removeNote, indexSource, removeSource, parseSourceIdFromPath,
   indexExcerpt, removeExcerpt, excerptIdsForSource, parseExcerptIdFromPath,
   indexAllNotes,
 } from './indexers';
-export type { CsvTableColumn, CsvTableShape, HeadingRenameCandidate } from './indexers';
+export type { CsvTableColumn, CsvTableShape, MarkdownTableShape, HeadingRenameCandidate } from './indexers';
 import { addOntologyToStore } from './indexers';
 
 /** Tear down a project's graph state. Called by ProjectContext on last release. */

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -610,6 +610,12 @@ function indexTable(
   const tableUri = $rdf.sym(`${noteNode.value}/table/${tableIndex}`);
   store.add(tableUri, RDF('type'), CSVW('Table'), graph);
   store.add(tableUri, CSVW('inNote'), noteNode, graph);
+  // A captioned table (#1360) labels its in-note node with the human caption.
+  // The SQL name + typed schema live on the separate DuckDB overlay node
+  // (indexMarkdownTable), which links back here via minerva:fromTable — so the
+  // in-note node deliberately does NOT carry minerva:tableName (that would make
+  // two nodes answer to one name). Uncaptioned tables are unchanged.
+  if (table.caption) store.add(tableUri, RDFS('label'), $rdf.lit(table.caption), graph);
 
   // Columns
   const colNodes: $rdf.NamedNode[] = [];
@@ -755,21 +761,116 @@ export function unindexCsvTable(ctx: ProjectContext, tableName: string): void {
 /**
  * Drop every CSV-registered table's triples. Used at the start of a
  * full rescan so triples for CSVs deleted while the app was closed
- * don't persist. Identifies them via `minerva:tableName`, which
- * markdown-embedded csvw:Table nodes don't carry — those stay.
+ * don't persist. Identifies them via `minerva:fromFile` — a predicate
+ * unique to CSV overlays. Markdown-table overlays carry `minerva:fromNote`
+ * instead (indexMarkdownTable) and the in-note csvw:Table nodes carry
+ * neither, so both are left untouched.
  */
 export function unindexAllCsvTables(ctx: ProjectContext): void {
   checkLLMWriteGuard('unindexAllCsvTables');
+  removeTableGraphsBy(ctx, MINERVA('fromFile'));
+}
+
+// ── Markdown-table DuckDB overlay (#1360) ───────────────────────────────────
+
+/**
+ * Shape of a captioned markdown table registered into DuckDB, passed in from
+ * the tables module (which owns the DuckDB-inferred column types). Mirrors
+ * `CsvTableShape` but keyed to the source note + its in-note table index.
+ */
+export interface MarkdownTableShape {
+  tableName: string;
+  notePath: string;
+  tableIndex: number;
+  caption: string;
+  columns: CsvTableColumn[];
+}
+
+/**
+ * Write the CSVW + OWL schema overlay for a captioned markdown table, the
+ * graph-parity twin of `indexCsvTable` (#1360). The in-note `indexTable`
+ * node keeps the untyped rows/cells; this overlay adds the typed, named,
+ * OWL-class view SPARQL consumers get for CSVs. The named graph equals the
+ * table URI, so re-indexing is a clean wipe-and-replace.
+ *
+ * Join-back mirrors the CSV `minerva:fromFile` bridge: `minerva:fromNote`
+ * points at the source note and `minerva:fromTable` at the in-note CSVW node,
+ * so overlay ↔ rows ↔ note all connect. Since a markdown table can't share a
+ * name with a CSV (collision detection blocks it), their table URIs never clash.
+ */
+export function indexMarkdownTable(ctx: ProjectContext, shape: MarkdownTableShape): void {
+  checkLLMWriteGuard('indexMarkdownTable');
   const state = getState(ctx);
   if (!state) return;
   invalidate(state);
   const { store } = state;
-  // Snapshot subjects before removing — rdflib's statementsMatching
-  // returns a live reference into the store, so removing triples while
-  // iterating drops subsequent matches.
+  const tableNode = tableUri(state, shape.tableName);
+  const graph = tableNode;
+  const schema = $rdf.sym(`${tableNode.value}/schema`);
+  const note = noteUri(state, shape.notePath);
+  const inNoteTable = $rdf.sym(`${note.value}/table/${shape.tableIndex}`);
+
+  store.removeMatches(undefined, undefined, undefined, graph);
+
+  store.add(tableNode, RDF('type'), CSVW('Table'), graph);
+  store.add(tableNode, RDF('type'), OWL('Class'), graph);
+  store.add(tableNode, RDFS('label'), $rdf.lit(shape.caption), graph);
+  store.add(tableNode, CSVW('tableSchema'), schema, graph);
+  store.add(tableNode, MINERVA('tableName'), $rdf.lit(shape.tableName), graph);
+  store.add(tableNode, MINERVA('relativePath'), $rdf.lit(shape.notePath), graph);
+  store.add(tableNode, MINERVA('fromNote'), note, graph);
+  store.add(tableNode, MINERVA('fromTable'), inNoteTable, graph);
+
+  store.add(schema, RDF('type'), CSVW('Schema'), graph);
+  for (const col of shape.columns) {
+    const colUri = $rdf.sym(`${tableNode.value}/column/${encodeURIComponent(col.name)}`);
+    const xsdType = xsdForDuckDbType(col.duckdbType);
+    store.add(schema, CSVW('column'), colUri, graph);
+    store.add(colUri, RDF('type'), CSVW('Column'), graph);
+    store.add(colUri, RDF('type'), OWL('DatatypeProperty'), graph);
+    store.add(colUri, CSVW('name'), $rdf.lit(col.name), graph);
+    store.add(colUri, CSVW('columnIndex'), $rdf.lit(String(col.index), undefined, XSD('integer')), graph);
+    store.add(colUri, CSVW('datatype'), xsdType, graph);
+    store.add(colUri, RDFS('label'), $rdf.lit(col.name), graph);
+    store.add(colUri, RDFS('domain'), tableNode, graph);
+    store.add(colUri, RDFS('range'), xsdType, graph);
+  }
+}
+
+/** Remove a markdown table's overlay triples (entire named graph). */
+export function unindexMarkdownTable(ctx: ProjectContext, tableName: string): void {
+  checkLLMWriteGuard('unindexMarkdownTable');
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  state.store.removeMatches(undefined, undefined, undefined, tableUri(state, tableName));
+}
+
+/**
+ * Drop every markdown-table overlay's triples. Identifies them via
+ * `minerva:fromNote` (unique to markdown overlays). Called at the start of a
+ * full note-table rescan so overlays for notes deleted while the app was
+ * closed don't persist.
+ */
+export function unindexAllNoteTables(ctx: ProjectContext): void {
+  checkLLMWriteGuard('unindexAllNoteTables');
+  removeTableGraphsBy(ctx, MINERVA('fromNote'));
+}
+
+/**
+ * Wipe the named graph of every subject bearing `marker`. Shared by the CSV
+ * and markdown full-rescan cleaners. Snapshots subjects first — rdflib's
+ * statementsMatching returns a live view, so removing while iterating would
+ * drop subsequent matches.
+ */
+function removeTableGraphsBy(ctx: ProjectContext, marker: ReturnType<typeof MINERVA>): void {
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
   const subjects: $rdf.NamedNode[] = [];
   const seen = new Set<string>();
-  for (const st of store.statementsMatching(undefined, MINERVA('tableName'), undefined)) {
+  for (const st of store.statementsMatching(undefined, marker, undefined)) {
     if (seen.has(st.subject.value)) continue;
     seen.add(st.subject.value);
     subjects.push(st.subject as $rdf.NamedNode);

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import YAML from 'yaml';
 import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
-import { indexCsvTable, unindexCsvTable, unindexAllCsvTables, type CsvTableColumn } from '../graph/index';
+import {
+  indexCsvTable, unindexCsvTable, unindexAllCsvTables,
+  indexMarkdownTable, unindexMarkdownTable, unindexAllNoteTables,
+  type CsvTableColumn,
+} from '../graph/index';
 import { parseMarkdown, type ParsedTable } from '../graph/parser';
 import { slugifyTableName } from '../../shared/table-name';
 import { serializeCsv } from '../../shared/csv-parse';
@@ -418,6 +422,10 @@ export async function registerMarkdownTable(
     entries.push({ name: tableName, tableIndex, caption: table.caption ?? tableName });
     noteTables.set(notePath, entries);
     tableToNote.set(tableName, notePath);
+    // Mirror the CSV path's graph overlay so SPARQL sees a typed, named table
+    // node joined back to the note (#1360). Non-fatal — the table is queryable
+    // via SQL even if the graph write is skipped.
+    await indexMarkdownTableShape(ctx, notePath, tableName, tableIndex, table.caption ?? tableName);
     return { ok: true, name: tableName };
   } catch (err) {
     console.warn(
@@ -442,8 +450,47 @@ export async function unregisterNoteTables(ctx: ProjectContext, notePath: string
       await connection.run(`DROP TABLE IF EXISTS "${name}"`);
     } catch { /* table may already be gone */ }
     tableToNote.delete(name);
+    unindexMarkdownTable(ctx, name); // drop the graph overlay too (#1360)
   }
   noteTables.delete(notePath);
+}
+
+/**
+ * Fetch column names + DuckDB types from information_schema for a registered
+ * markdown table and write the graph-parity overlay (#1360). Mirrors
+ * `indexCsvTableShape`; failures log but don't throw — the table is still
+ * SQL-queryable even if the graph entry didn't land.
+ */
+async function indexMarkdownTableShape(
+  ctx: ProjectContext,
+  notePath: string,
+  tableName: string,
+  tableIndex: number,
+  caption: string,
+): Promise<void> {
+  const state = getState(ctx);
+  if (!state) return;
+  const safeName = tableName.replace(/'/g, "''");
+  try {
+    const reader = await state.connection.runAndReadAll(
+      `SELECT column_name, data_type, ordinal_position ` +
+      `FROM information_schema.columns ` +
+      `WHERE table_name = '${safeName}' AND table_schema = 'main' ` +
+      `ORDER BY ordinal_position`,
+    );
+    const rows = reader.getRowObjectsJS() as Record<string, unknown>[];
+    const columns: CsvTableColumn[] = rows.map((r) => ({
+      name: String(r.column_name),
+      duckdbType: String(r.data_type),
+      index: Number(r.ordinal_position) - 1,
+    }));
+    indexMarkdownTable(ctx, { tableName, notePath, tableIndex, caption, columns });
+  } catch (err) {
+    console.warn(
+      `[tables] Failed to index markdown table '${tableName}' into graph: ` +
+      (err instanceof Error ? err.message : String(err)),
+    );
+  }
 }
 
 /**
@@ -532,9 +579,12 @@ export async function registerAllNoteTables(ctx: ProjectContext): Promise<{ coun
   const state = getState(ctx);
   if (!state) return { count: 0, collisions: [] };
   const { rootPath } = state;
-  // Drop any note tables from a previous sweep so a note deleted while the app
-  // was closed (or since the last "Rebuild All Indexes") doesn't linger — the
-  // walk below only revisits notes that still exist.
+  // Wipe stale markdown-table overlays up front (mirrors registerAllCsvs) so a
+  // note deleted while the app was closed doesn't linger in the graph; each
+  // registered table rewrites its own overlay below.
+  unindexAllNoteTables(ctx);
+  // Drop any DuckDB note tables from a previous sweep too — the walk below only
+  // revisits notes that still exist.
   for (const notePath of [...state.noteTables.keys()]) {
     await unregisterNoteTables(ctx, notePath);
   }

--- a/tests/main/graph/markdown-table-indexing.test.ts
+++ b/tests/main/graph/markdown-table-indexing.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  indexMarkdownTable,
+  unindexMarkdownTable,
+  unindexAllNoteTables,
+  indexCsvTable,
+  unindexAllCsvTables,
+  indexNote,
+  queryGraph,
+} from '../../../src/main/graph/index';
+import { type ProjectContext } from '../../../src/main/project-context-types';
+import { useGraphProject } from '../../helpers/temp-project';
+
+describe('indexMarkdownTable — graph parity overlay (#1360)', () => {
+  const project = useGraphProject('minerva-md-table-test-');
+  let ctx: ProjectContext;
+  beforeEach(() => { ctx = project.ctx; });
+
+  function indexBarzoom() {
+    indexMarkdownTable(ctx, {
+      tableName: 'barzoom',
+      notePath: 'notes/report.md',
+      tableIndex: 0,
+      caption: 'Barzoom',
+      columns: [
+        { name: 'foo', duckdbType: 'INTEGER', index: 0 },
+        { name: 'bar', duckdbType: 'VARCHAR', index: 1 },
+      ],
+    });
+  }
+
+  it('emits csvw:Table + owl:Class labelled by the caption', async () => {
+    indexBarzoom();
+    const { results } = await queryGraph(ctx, `
+      SELECT ?type ?label WHERE {
+        ?t minerva:tableName "barzoom" ;
+           rdfs:label ?label ;
+           a ?type .
+      }
+    `);
+    const rows = results as Array<{ type: string; label: string }>;
+    expect(rows.map((r) => r.type)).toContain('http://www.w3.org/ns/csvw#Table');
+    expect(rows.map((r) => r.type)).toContain('http://www.w3.org/2002/07/owl#Class');
+    expect(rows[0]!.label).toBe('Barzoom');
+  });
+
+  it('joins back to the source note and the in-note table node', async () => {
+    indexBarzoom();
+    const { results } = await queryGraph(ctx, `
+      SELECT ?note ?tbl WHERE {
+        ?t minerva:tableName "barzoom" ;
+           minerva:fromNote ?note ;
+           minerva:fromTable ?tbl .
+      }
+    `);
+    const rows = results as Array<{ note: string; tbl: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.note).toContain('notes/report'); // noteUri strips the .md
+    expect(rows[0]!.tbl).toContain('/table/0');
+  });
+
+  it('types each column as owl:DatatypeProperty with an xsd range', async () => {
+    indexBarzoom();
+    const { results } = await queryGraph(ctx, `
+      SELECT ?name ?range WHERE {
+        ?t minerva:tableName "barzoom" ;
+           csvw:tableSchema ?s .
+        ?s csvw:column ?c .
+        ?c a owl:DatatypeProperty ; csvw:name ?name ; rdfs:range ?range .
+      } ORDER BY ?name
+    `);
+    const rows = results as Array<{ name: string; range: string }>;
+    const foo = rows.find((r) => r.name === 'foo')!;
+    expect(foo.range).toBe('http://www.w3.org/2001/XMLSchema#integer');
+  });
+
+  it('the CSV rescan wipe leaves markdown overlays intact (and vice versa)', async () => {
+    indexBarzoom();
+    indexCsvTable(ctx, {
+      tableName: 'sales',
+      relativePath: 'sales.csv',
+      columns: [{ name: 'x', duckdbType: 'INTEGER', index: 0 }],
+    });
+
+    // Wiping CSV overlays must not touch the markdown one.
+    unindexAllCsvTables(ctx);
+    let r = await queryGraph(ctx, `SELECT ?t WHERE { ?t minerva:tableName "barzoom" }`);
+    expect(r.results).toHaveLength(1);
+    r = await queryGraph(ctx, `SELECT ?t WHERE { ?t minerva:tableName "sales" }`);
+    expect(r.results).toHaveLength(0);
+
+    // And wiping note overlays must not touch a CSV one.
+    indexCsvTable(ctx, {
+      tableName: 'sales',
+      relativePath: 'sales.csv',
+      columns: [{ name: 'x', duckdbType: 'INTEGER', index: 0 }],
+    });
+    unindexAllNoteTables(ctx);
+    r = await queryGraph(ctx, `SELECT ?t WHERE { ?t minerva:tableName "barzoom" }`);
+    expect(r.results).toHaveLength(0);
+    r = await queryGraph(ctx, `SELECT ?t WHERE { ?t minerva:tableName "sales" }`);
+    expect(r.results).toHaveLength(1);
+  });
+
+  it('unindexMarkdownTable removes a single overlay', async () => {
+    indexBarzoom();
+    unindexMarkdownTable(ctx, 'barzoom');
+    const r = await queryGraph(ctx, `SELECT ?t WHERE { ?t minerva:tableName "barzoom" }`);
+    expect(r.results).toHaveLength(0);
+  });
+
+  it('labels the in-note CSVW node with the caption (via indexNote)', async () => {
+    await indexNote(ctx, 'notes/report.md', 'Table: Barzoom\n| Foo | Bar |\n|-----|-----|\n| 1 | 2 |');
+    const { results } = await queryGraph(ctx, `
+      SELECT ?label WHERE {
+        ?t a csvw:Table ; csvw:inNote ?n ; rdfs:label ?label .
+      }
+    `);
+    expect((results as Array<{ label: string }>).map((r) => r.label)).toContain('Barzoom');
+  });
+});


### PR DESCRIPTION
**Epic #1355 · Ticket 5 of 6** (parity polish; builds on #1357)

Brings the graph representation of a SQL-registered markdown table in line with CSVs. Implements **option (a)** from the epic — backward-compatible.

## What
- The in-note `indexTable` node **keeps its untyped CSVW rows/cells** (SPARQL over markdown cells still works), and is now labelled with the human caption (`rdfs:label`).
- **`indexMarkdownTable`** writes the typed, named, OWL-class **overlay** at the table URI (own named graph), mirroring `indexCsvTable`, with the join-back bridge:
  - `minerva:fromNote` → the source note (twin of the CSV `minerva:fromFile`)
  - `minerva:fromTable` → the in-note CSVW node — so **overlay ↔ rows ↔ note all connect**.
- **Wipe-by-predicate isolation:** `unindexAllCsvTables` now keys on `minerva:fromFile` (was `minerva:tableName`) and `unindexAllNoteTables` on `minerva:fromNote`, via a shared `removeTableGraphsBy` helper — a CSV rescan never clobbers markdown overlays and vice-versa.
- `tables.ts` writes the overlay after registering (`indexMarkdownTableShape`, twin of `indexCsvTableShape`), drops it in `unregisterNoteTables`, and full-wipes stale overlays at the start of `registerAllNoteTables`. Graph writes stay **non-fatal** — the table is SQL-queryable even if the graph write is skipped.

Since a markdown table can't share a name with a CSV (collision detection blocks it), their table URIs never clash.

## Tests
`tests/main/graph/markdown-table-indexing.test.ts` — overlay type/label, `fromNote`/`fromTable` join-back, typed columns, the CSV-wipe/note-wipe isolation property (each leaves the other intact), single unindex, and the in-note node's caption label via `indexNote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)