### PR TITLE
Extract command-registry + keymap dep tables from App.svelte (#1084)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -42,12 +42,13 @@
   import type { SafeDeleteBlocker, MenuEditorState } from '../shared/types';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
-  import { buildCommandRegistry, type CommandDeps } from './lib/command-palette/registry';
+  import { buildCommandRegistry } from './lib/command-palette/registry';
+  import { createCommandKeymap, type CommandKeymapCtx } from './lib/app/command-keymap';
   import { formatAccelerator } from './lib/command-palette/format-accelerator';
   import DictationIndicator from './lib/components/DictationIndicator.svelte';
   import { toggleEditorDictation } from './lib/editor/dictation';
   import { getVoiceStore } from './lib/voice/voice.svelte';
-  import { handleKeydown, type KeymapDeps } from './lib/keymap/handle-keydown';
+  import { handleKeydown } from './lib/keymap/handle-keydown';
   import ExportDialog from './lib/components/ExportDialog.svelte';
   import PublishDialog from './lib/components/PublishDialog.svelte';
   import AboutDialog from './lib/components/AboutDialog.svelte';
@@ -455,62 +456,59 @@
    *  so while the palette is closed the derived depends solely on
    *  `showCommandPalette` and navigation no longer touches it.
    */
-  const commandDeps: CommandDeps = {
-    hasProject: () => !!notebase.meta,
-    hasNote: () => !!editor.activeFilePath,
-    hasActiveNoteTab: () => editor.activeTab?.type === 'note',
-    canGoBack: () => nav.canGoBack,
-    canGoForward: () => nav.canGoForward,
+  // The command-palette + global-keymap dependency tables live in
+  // ./lib/app/command-keymap.ts (#1084). The factory pulls the stores itself
+  // (predicates, active-note guards, close-project, font dance) and takes the
+  // App-local ops handlers + focused-pane editor ref + UI-chrome $state via ctx.
+  // Both tables are fully typed, so a mis-wired binding is a compile error.
+  const { commandDeps, keymapDeps } = createCommandKeymap({
+    getEditorComponent: () => editorComponent,
     newNote: () => { void handleNewNote(); },
     save: () => { void handleSave(); },
     openProject: () => { void handleOpenThoughtbase(); },
     newProject: () => { void handleNewThoughtbase(); },
-    closeProject: () => { notebase.close(); editor.clear(); },
     editThoughtbaseGuide: () => { void handleEditThoughtbaseDoc(); },
-    print: () => window.print(),
     saveAsTemplate: () => { void handleSaveAsTemplate(); },
     insertTemplate: () => { void handleInsertTemplate(); },
-    dictate: () => { void toggleEditorDictation(editorComponent?.getView() ?? null); },
-    find: () => editorComponent?.openFind(),
-    findReplace: () => editorComponent?.openFindReplace(),
-    findInNotes: () => { findInNotesMode = 'find'; },
-    replaceInNotes: () => { findInNotesMode = 'replace'; },
-    gotoLine: () => { showGotoLine = true; },
-    sortLines: () => editorComponent?.runSortLines(),
-    toggleSidebar: () => { sidebarVisible = !sidebarVisible; },
-    toggleRightSidebar: () => { rightSidebarVisible = !rightSidebarVisible; },
-    togglePreview: () => cycleViewMode(),
-    toggleConversations: () => conversationsStore.toggle(),
-    newConversation: () => { void newConversation(); },
-    setTheme: (mode) => handleSelectTheme(mode),
-    currentTheme: () => themeLabel,
-    fontIncrease: () => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; },
-    fontDecrease: () => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; },
-    fontReset: () => { editorComponent?.resetFontSize(); editorFontSize = 14; },
-    quickOpen: () => { void refreshSourcesCache(); void refreshSavedQueriesCache(); showGotoNote = true; },
-    navBack: () => { void handleNavBack(); },
-    navForward: () => { void handleNavForward(); },
-    renameActive: () => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); },
-    moveActive: () => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); },
-    copyActive: () => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); },
     extractSelection: () => { void handleExtractSelection(); },
     splitHere: () => { void handleSplitHere(); },
     splitByHeading: () => { void handleSplitByHeading(); },
-    autoTagActive: () => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); },
-    autoLinkActive: () => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); },
-    autoLinkInboundActive: () => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); },
-    decomposeActive: () => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); },
     format: () => { void handleFormat(); },
+    bibliography: () => { void handleBibliography(); },
+    newConversation: () => { void newConversation(); },
+    openConversation: () => { void openConversation(); },
     ingestUrl: () => { void handleIngestUrlAsSource(); },
     ingestIdentifier: () => { void handleIngestIdentifier(); },
     ingestFile: () => { void handleIngestFileAsSource(); },
     importBibtex: () => { void handleImportBibtex(); },
     importZoteroRdf: () => { void handleImportZoteroRdf(); },
-    bibliography: () => { void handleBibliography(); },
-    newQuery: () => editor.openQuery(),
-    editSavedQueries: () => { showEditSavedQueries = true; },
-    openSettings: () => { showSettings = true; },
-  };
+    navBack: () => { void handleNavBack(); },
+    navForward: () => { void handleNavForward(); },
+    rename: (p) => { void handleRename(p); },
+    move: (p) => { void handleMoveWithPrompt(p); },
+    copy: (p) => { void handleCopyWithPrompt(p); },
+    autoTag: (p) => { void handleAutoTag(p); },
+    autoLink: (p) => { void handleAutoLink(p); },
+    autoLinkInbound: (p) => { void handleAutoLinkInbound(p); },
+    decompose: (p) => { void handleDecompose(p); },
+    selectTheme: (mode) => handleSelectTheme(mode),
+    cycleTheme: () => handleCycleTheme(),
+    getThemeLabel: () => themeLabel,
+    cycleViewMode: () => cycleViewMode(),
+    refreshSourcesCache: () => { void refreshSourcesCache(); },
+    refreshSavedQueriesCache: () => { void refreshSavedQueriesCache(); },
+    getEditorFontSize: () => editorFontSize,
+    setEditorFontSize: (n) => { editorFontSize = n; },
+    setFindInNotesMode: (mode) => { findInNotesMode = mode; },
+    setShowGotoLine: (v) => { showGotoLine = v; },
+    setShowGotoNote: (v) => { showGotoNote = v; },
+    toggleQuickOpen: () => { showGotoNote = !showGotoNote; },
+    setShowEditSavedQueries: (v) => { showEditSavedQueries = v; },
+    setShowSettings: (v) => { showSettings = v; },
+    toggleSidebar: () => { sidebarVisible = !sidebarVisible; },
+    toggleRightSidebar: () => { rightSidebarVisible = !rightSidebarVisible; },
+    toggleCommandPalette: () => { showCommandPalette = !showCommandPalette; },
+  } satisfies CommandKeymapCtx);
   const commands = $derived<Command[]>(
     showCommandPalette ? buildCommandRegistry(commandDeps) : [],
   );
@@ -808,26 +806,6 @@
   function cycleViewMode() {
     editor.cycleViewMode();
   }
-
-  // Global keyboard shortcuts live in lib/keymap/handle-keydown.ts (#670);
-  // this object injects the state predicates + actions they dispatch to.
-  const keymapDeps: KeymapDeps = {
-    hasProject: () => !!notebase.meta,
-    hasActiveTab: () => !!editor.activeTab,
-    hasActiveIndex: () => editor.activeIndex >= 0,
-    toggleCommandPalette: () => { showCommandPalette = !showCommandPalette; },
-    navBack: () => { void handleNavBack(); },
-    navForward: () => { void handleNavForward(); },
-    cyclePreview: () => cycleViewMode(),
-    toggleRightSidebar: () => { rightSidebarVisible = !rightSidebarVisible; },
-    cycleTheme: () => handleCycleTheme(),
-    newNote: () => { void handleNewNote(); },
-    closeActiveTab: () => { editor.closeTab(editor.activeIndex); },
-    toggleQuickOpen: () => { showGotoNote = !showGotoNote; },
-    openGotoLine: () => { showGotoLine = true; },
-    newQuery: () => editor.openQuery(),
-    openConversation: () => { void openConversation(); },
-  };
 
   onMount(() => {
     initTheme();

--- a/src/renderer/lib/app/command-keymap.ts
+++ b/src/renderer/lib/app/command-keymap.ts
@@ -1,0 +1,202 @@
+/**
+ * Command-palette registry + global-keymap dependency tables, extracted from
+ * App.svelte (#1084). These two objects (`CommandDeps` / `KeymapDeps`) are the
+ * app's action surface — the wiring from every command / shortcut to the store
+ * call, ops handler, or UI-state mutation it triggers.
+ *
+ * Both interfaces are fully typed, so tsc enforces that every field is present
+ * and correctly shaped — a mis-wired binding here is a compile error, not a
+ * silent runtime break (which is why this lifts out safely where the untyped
+ * `api.menu.on*` wiring does not).
+ *
+ * The factory pulls the singleton stores internally, so the store-derived
+ * predicates (`hasProject`, `canGoBack`, …), the active-note guards
+ * (`renameActive` → guarded `rename(path)`), `closeProject`, `newQuery`,
+ * `toggleConversations`, and the font-size dance live here as real logic.
+ * Everything the factory can't reach — App-local ops handlers, the focused
+ * pane's editor ref, the theme label, and the UI-chrome `$state` — arrives via
+ * `ctx`. App keeps the `commands` `$derived` (a rune must stay in the component)
+ * and passes `commandDeps` into it.
+ */
+import { getNotebaseStore } from '../stores/notebase.svelte';
+import { getEditorStore } from '../stores/editor.svelte';
+import { getNavigationStore } from '../stores/navigation.svelte';
+import { getConversationsStore } from '../stores/conversations.svelte';
+import { toggleEditorDictation } from '../editor/dictation';
+import type { EditorView } from '@codemirror/view';
+import type { ThemeMode } from '../theme';
+import type { CommandDeps } from '../command-palette/registry';
+import type { KeymapDeps } from '../keymap/handle-keydown';
+
+/** Minimal structural view of the focused pane's Editor instance — only the
+ *  methods the command table drives. */
+interface EditorRef {
+  getView(): EditorView | undefined;
+  openFind(): void;
+  openFindReplace(): void;
+  runSortLines(): void;
+  changeFontSize(delta: number): void;
+  currentFontSize(): number;
+  resetFontSize(): void;
+}
+
+export interface CommandKeymapCtx {
+  /** The focused pane's editor instance (App-owned `$derived` ref). */
+  getEditorComponent: () => EditorRef | undefined;
+
+  // App-local / other-cluster handlers, invoked as-is.
+  newNote: () => void;
+  save: () => void;
+  openProject: () => void;
+  newProject: () => void;
+  editThoughtbaseGuide: () => void;
+  saveAsTemplate: () => void;
+  insertTemplate: () => void;
+  extractSelection: () => void;
+  splitHere: () => void;
+  splitByHeading: () => void;
+  format: () => void;
+  bibliography: () => void;
+  newConversation: () => void;
+  openConversation: () => void;
+  ingestUrl: () => void;
+  ingestIdentifier: () => void;
+  ingestFile: () => void;
+  importBibtex: () => void;
+  importZoteroRdf: () => void;
+  navBack: () => void;
+  navForward: () => void;
+
+  // Active-note handlers — the factory supplies the guarded path.
+  rename: (path: string) => void;
+  move: (path: string) => void;
+  copy: (path: string) => void;
+  autoTag: (path: string) => void;
+  autoLink: (path: string) => void;
+  autoLinkInbound: (path: string) => void;
+  decompose: (path: string) => void;
+
+  // Theme — the label + surface re-tint stay in App.
+  selectTheme: (mode: ThemeMode) => void;
+  cycleTheme: () => void;
+  getThemeLabel: () => ThemeMode;
+
+  // View-mode cycle + the palette's backing caches.
+  cycleViewMode: () => void;
+  refreshSourcesCache: () => void;
+  refreshSavedQueriesCache: () => void;
+
+  // Editor font size (App `$state`, also read by the status bar).
+  getEditorFontSize: () => number;
+  setEditorFontSize: (n: number) => void;
+
+  // UI chrome / dialog visibility (App `$state`).
+  setFindInNotesMode: (mode: 'find' | 'replace') => void;
+  setShowGotoLine: (v: boolean) => void;
+  setShowGotoNote: (v: boolean) => void;
+  toggleQuickOpen: () => void;
+  setShowEditSavedQueries: (v: boolean) => void;
+  setShowSettings: (v: boolean) => void;
+  toggleSidebar: () => void;
+  toggleRightSidebar: () => void;
+  toggleCommandPalette: () => void;
+}
+
+export function createCommandKeymap(ctx: CommandKeymapCtx): {
+  commandDeps: CommandDeps;
+  keymapDeps: KeymapDeps;
+} {
+  const notebase = getNotebaseStore();
+  const editor = getEditorStore();
+  const nav = getNavigationStore();
+  const conversationsStore = getConversationsStore();
+
+  const commandDeps: CommandDeps = {
+    hasProject: () => !!notebase.meta,
+    hasNote: () => !!editor.activeFilePath,
+    hasActiveNoteTab: () => editor.activeTab?.type === 'note',
+    canGoBack: () => nav.canGoBack,
+    canGoForward: () => nav.canGoForward,
+    newNote: ctx.newNote,
+    save: ctx.save,
+    openProject: ctx.openProject,
+    newProject: ctx.newProject,
+    closeProject: () => { notebase.close(); editor.clear(); },
+    editThoughtbaseGuide: ctx.editThoughtbaseGuide,
+    print: () => window.print(),
+    saveAsTemplate: ctx.saveAsTemplate,
+    insertTemplate: ctx.insertTemplate,
+    dictate: () => { void toggleEditorDictation(ctx.getEditorComponent()?.getView() ?? null); },
+    find: () => ctx.getEditorComponent()?.openFind(),
+    findReplace: () => ctx.getEditorComponent()?.openFindReplace(),
+    findInNotes: () => ctx.setFindInNotesMode('find'),
+    replaceInNotes: () => ctx.setFindInNotesMode('replace'),
+    gotoLine: () => ctx.setShowGotoLine(true),
+    sortLines: () => ctx.getEditorComponent()?.runSortLines(),
+    toggleSidebar: ctx.toggleSidebar,
+    toggleRightSidebar: ctx.toggleRightSidebar,
+    togglePreview: ctx.cycleViewMode,
+    toggleConversations: () => conversationsStore.toggle(),
+    newConversation: ctx.newConversation,
+    setTheme: (mode) => ctx.selectTheme(mode),
+    currentTheme: () => ctx.getThemeLabel(),
+    fontIncrease: () => {
+      const ec = ctx.getEditorComponent();
+      ec?.changeFontSize(1);
+      ctx.setEditorFontSize(ec?.currentFontSize() ?? ctx.getEditorFontSize());
+    },
+    fontDecrease: () => {
+      const ec = ctx.getEditorComponent();
+      ec?.changeFontSize(-1);
+      ctx.setEditorFontSize(ec?.currentFontSize() ?? ctx.getEditorFontSize());
+    },
+    fontReset: () => { ctx.getEditorComponent()?.resetFontSize(); ctx.setEditorFontSize(14); },
+    quickOpen: () => {
+      ctx.refreshSourcesCache();
+      ctx.refreshSavedQueriesCache();
+      ctx.setShowGotoNote(true);
+    },
+    navBack: ctx.navBack,
+    navForward: ctx.navForward,
+    renameActive: () => { if (editor.activeFilePath) ctx.rename(editor.activeFilePath); },
+    moveActive: () => { if (editor.activeFilePath) ctx.move(editor.activeFilePath); },
+    copyActive: () => { if (editor.activeFilePath) ctx.copy(editor.activeFilePath); },
+    extractSelection: ctx.extractSelection,
+    splitHere: ctx.splitHere,
+    splitByHeading: ctx.splitByHeading,
+    autoTagActive: () => { if (editor.activeFilePath) ctx.autoTag(editor.activeFilePath); },
+    autoLinkActive: () => { if (editor.activeFilePath) ctx.autoLink(editor.activeFilePath); },
+    autoLinkInboundActive: () => { if (editor.activeFilePath) ctx.autoLinkInbound(editor.activeFilePath); },
+    decomposeActive: () => { if (editor.activeFilePath) ctx.decompose(editor.activeFilePath); },
+    format: ctx.format,
+    ingestUrl: ctx.ingestUrl,
+    ingestIdentifier: ctx.ingestIdentifier,
+    ingestFile: ctx.ingestFile,
+    importBibtex: ctx.importBibtex,
+    importZoteroRdf: ctx.importZoteroRdf,
+    bibliography: ctx.bibliography,
+    newQuery: () => editor.openQuery(),
+    editSavedQueries: () => ctx.setShowEditSavedQueries(true),
+    openSettings: () => ctx.setShowSettings(true),
+  };
+
+  const keymapDeps: KeymapDeps = {
+    hasProject: () => !!notebase.meta,
+    hasActiveTab: () => !!editor.activeTab,
+    hasActiveIndex: () => editor.activeIndex >= 0,
+    toggleCommandPalette: ctx.toggleCommandPalette,
+    navBack: ctx.navBack,
+    navForward: ctx.navForward,
+    cyclePreview: ctx.cycleViewMode,
+    toggleRightSidebar: ctx.toggleRightSidebar,
+    cycleTheme: ctx.cycleTheme,
+    newNote: ctx.newNote,
+    closeActiveTab: () => { editor.closeTab(editor.activeIndex); },
+    toggleQuickOpen: ctx.toggleQuickOpen,
+    openGotoLine: () => ctx.setShowGotoLine(true),
+    newQuery: () => editor.openQuery(),
+    openConversation: ctx.openConversation,
+  };
+
+  return { commandDeps, keymapDeps };
+}

--- a/tests/renderer/app/command-keymap.test.ts
+++ b/tests/renderer/app/command-keymap.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Behavioral net for the command-palette + keymap dependency tables extracted
+ * from App.svelte (#1084). Mocks the four stores the factory pulls internally
+ * and the dictation helper. Verifies the real logic the module owns — the
+ * store-derived predicates, the active-note guards, close-project, the
+ * font-size dance, quick-open, and that the ctx handlers are dispatched — not
+ * merely that the objects have the right keys (tsc already guarantees that).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const notebase = { meta: null as unknown, close: vi.fn() };
+  const editor = {
+    activeFilePath: null as string | null,
+    activeTab: undefined as unknown,
+    activeIndex: -1,
+    clear: vi.fn(),
+    closeTab: vi.fn(),
+    openQuery: vi.fn(),
+  };
+  const nav = { canGoBack: false, canGoForward: false };
+  const conversations = { toggle: vi.fn() };
+  const toggleEditorDictation = vi.fn();
+  return { notebase, editor, nav, conversations, toggleEditorDictation };
+});
+
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+vi.mock('../../../src/renderer/lib/stores/navigation.svelte', () => ({ getNavigationStore: () => h.nav }));
+vi.mock('../../../src/renderer/lib/stores/conversations.svelte', () => ({ getConversationsStore: () => h.conversations }));
+vi.mock('../../../src/renderer/lib/editor/dictation', () => ({ toggleEditorDictation: h.toggleEditorDictation }));
+
+import { createCommandKeymap, type CommandKeymapCtx } from '../../../src/renderer/lib/app/command-keymap';
+
+// A spy for every ctx member so each binding's dispatch can be asserted.
+function makeCtx() {
+  const editorComponent = {
+    getView: vi.fn(() => undefined),
+    openFind: vi.fn(),
+    openFindReplace: vi.fn(),
+    runSortLines: vi.fn(),
+    changeFontSize: vi.fn(),
+    currentFontSize: vi.fn(() => 17),
+    resetFontSize: vi.fn(),
+  };
+  let editorFontSize = 14;
+  const spies = {
+    newNote: vi.fn(), save: vi.fn(), openProject: vi.fn(), newProject: vi.fn(),
+    editThoughtbaseGuide: vi.fn(), saveAsTemplate: vi.fn(), insertTemplate: vi.fn(),
+    extractSelection: vi.fn(), splitHere: vi.fn(), splitByHeading: vi.fn(),
+    format: vi.fn(), bibliography: vi.fn(), newConversation: vi.fn(), openConversation: vi.fn(),
+    ingestUrl: vi.fn(), ingestIdentifier: vi.fn(), ingestFile: vi.fn(),
+    importBibtex: vi.fn(), importZoteroRdf: vi.fn(), navBack: vi.fn(), navForward: vi.fn(),
+    rename: vi.fn(), move: vi.fn(), copy: vi.fn(), autoTag: vi.fn(), autoLink: vi.fn(),
+    autoLinkInbound: vi.fn(), decompose: vi.fn(),
+    selectTheme: vi.fn(), cycleTheme: vi.fn(), cycleViewMode: vi.fn(),
+    refreshSourcesCache: vi.fn(), refreshSavedQueriesCache: vi.fn(),
+    setFindInNotesMode: vi.fn(), setShowGotoLine: vi.fn(), setShowGotoNote: vi.fn(),
+    toggleQuickOpen: vi.fn(), setShowEditSavedQueries: vi.fn(), setShowSettings: vi.fn(),
+    toggleSidebar: vi.fn(), toggleRightSidebar: vi.fn(), toggleCommandPalette: vi.fn(),
+    setEditorFontSize: vi.fn((n: number) => { editorFontSize = n; }),
+  };
+  const ctx: CommandKeymapCtx = {
+    getEditorComponent: () => editorComponent,
+    getThemeLabel: () => 'dark',
+    getEditorFontSize: () => editorFontSize,
+    ...spies,
+  };
+  return { ctx, editorComponent, spies, getFontSize: () => editorFontSize };
+}
+
+let built: ReturnType<typeof makeCtx>;
+let commandDeps: ReturnType<typeof createCommandKeymap>['commandDeps'];
+let keymapDeps: ReturnType<typeof createCommandKeymap>['keymapDeps'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.notebase.meta = null;
+  h.editor.activeFilePath = null;
+  h.editor.activeTab = undefined;
+  h.editor.activeIndex = -1;
+  h.nav.canGoBack = false;
+  h.nav.canGoForward = false;
+  built = makeCtx();
+  ({ commandDeps, keymapDeps } = createCommandKeymap(built.ctx));
+});
+
+describe('store-derived predicates', () => {
+  it('read live store state at call time', () => {
+    expect(commandDeps.hasProject()).toBe(false);
+    h.notebase.meta = { rootPath: '/p' };
+    expect(commandDeps.hasProject()).toBe(true);
+
+    h.editor.activeFilePath = 'a.md';
+    expect(commandDeps.hasNote()).toBe(true);
+    h.editor.activeTab = { type: 'note' };
+    expect(commandDeps.hasActiveNoteTab()).toBe(true);
+
+    h.nav.canGoBack = true;
+    expect(commandDeps.canGoBack()).toBe(true);
+    expect(commandDeps.canGoForward()).toBe(false);
+  });
+});
+
+describe('active-note guards', () => {
+  it('renameActive dispatches ctx.rename with the active path', () => {
+    h.editor.activeFilePath = 'notes/x.md';
+    commandDeps.renameActive();
+    expect(built.spies.rename).toHaveBeenCalledWith('notes/x.md');
+  });
+
+  it('decomposeActive is a no-op when nothing is active', () => {
+    h.editor.activeFilePath = null;
+    commandDeps.decomposeActive();
+    expect(built.spies.decompose).not.toHaveBeenCalled();
+  });
+
+  it('autoLinkInboundActive guards then dispatches', () => {
+    h.editor.activeFilePath = 'y.md';
+    commandDeps.autoLinkInboundActive();
+    expect(built.spies.autoLinkInbound).toHaveBeenCalledWith('y.md');
+  });
+});
+
+describe('store actions owned by the factory', () => {
+  it('closeProject closes the notebase and clears the editor', () => {
+    commandDeps.closeProject();
+    expect(h.notebase.close).toHaveBeenCalled();
+    expect(h.editor.clear).toHaveBeenCalled();
+  });
+
+  it('toggleConversations toggles the conversations store', () => {
+    commandDeps.toggleConversations();
+    expect(h.conversations.toggle).toHaveBeenCalled();
+  });
+
+  it('newQuery opens a query tab', () => {
+    commandDeps.newQuery();
+    expect(h.editor.openQuery).toHaveBeenCalled();
+  });
+});
+
+describe('editor-ref driven commands', () => {
+  it('dictate targets the focused pane view', () => {
+    commandDeps.dictate();
+    expect(built.editorComponent.getView).toHaveBeenCalled();
+    expect(h.toggleEditorDictation).toHaveBeenCalledWith(null);
+  });
+
+  it('find / findReplace / sortLines reach the editor component', () => {
+    commandDeps.find();
+    commandDeps.findReplace();
+    commandDeps.sortLines();
+    expect(built.editorComponent.openFind).toHaveBeenCalled();
+    expect(built.editorComponent.openFindReplace).toHaveBeenCalled();
+    expect(built.editorComponent.runSortLines).toHaveBeenCalled();
+  });
+
+  it('fontIncrease bumps the editor and mirrors its reported size back to App state', () => {
+    commandDeps.fontIncrease();
+    expect(built.editorComponent.changeFontSize).toHaveBeenCalledWith(1);
+    expect(built.spies.setEditorFontSize).toHaveBeenCalledWith(17);
+  });
+
+  it('fontReset resets to 14', () => {
+    commandDeps.fontReset();
+    expect(built.editorComponent.resetFontSize).toHaveBeenCalled();
+    expect(built.spies.setEditorFontSize).toHaveBeenCalledWith(14);
+  });
+});
+
+describe('UI-chrome commands', () => {
+  it('quickOpen refreshes the palette caches and opens goto-note', () => {
+    commandDeps.quickOpen();
+    expect(built.spies.refreshSourcesCache).toHaveBeenCalled();
+    expect(built.spies.refreshSavedQueriesCache).toHaveBeenCalled();
+    expect(built.spies.setShowGotoNote).toHaveBeenCalledWith(true);
+  });
+
+  it('findInNotes / replaceInNotes set the mode', () => {
+    commandDeps.findInNotes();
+    expect(built.spies.setFindInNotesMode).toHaveBeenCalledWith('find');
+    commandDeps.replaceInNotes();
+    expect(built.spies.setFindInNotesMode).toHaveBeenCalledWith('replace');
+  });
+
+  it('setTheme forwards to ctx.selectTheme; currentTheme reads the label', () => {
+    commandDeps.setTheme('light');
+    expect(built.spies.selectTheme).toHaveBeenCalledWith('light');
+    expect(commandDeps.currentTheme()).toBe('dark');
+  });
+});
+
+describe('keymapDeps', () => {
+  it('closeActiveTab closes the active index', () => {
+    h.editor.activeIndex = 3;
+    keymapDeps.closeActiveTab();
+    expect(h.editor.closeTab).toHaveBeenCalledWith(3);
+  });
+
+  it('shares wiring with the command table (navBack, toggleQuickOpen, cyclePreview)', () => {
+    keymapDeps.navBack();
+    keymapDeps.toggleQuickOpen();
+    keymapDeps.cyclePreview();
+    expect(built.spies.navBack).toHaveBeenCalled();
+    expect(built.spies.toggleQuickOpen).toHaveBeenCalled();
+    expect(built.spies.cycleViewMode).toHaveBeenCalled();
+  });
+
+  it('hasActiveIndex reflects the editor store', () => {
+    h.editor.activeIndex = -1;
+    expect(keymapDeps.hasActiveIndex()).toBe(false);
+    h.editor.activeIndex = 0;
+    expect(keymapDeps.hasActiveIndex()).toBe(true);
+  });
+});


### PR DESCRIPTION
Second slice of the App.svelte god-component breakup (#1084), following [#1368](https://github.com/dgriffith/ide-for-thought/pull/1368).

## What moved
Lifts the **`CommandDeps` and `KeymapDeps` tables** — the app's action surface, mapping every command / shortcut to its store call, ops handler, or UI-state mutation — into `src/renderer/lib/app/command-keymap.ts` via a `createCommandKeymap(ctx)` factory, matching the `*-ops` pattern.

The factory **pulls the singleton stores itself**, so the genuinely-logical parts live in the module, not just passthrough:
- store-derived predicates (`hasProject`, `hasNote`, `canGoBack`, …)
- active-note guards (`renameActive` → guarded `rename(path)`, likewise move/copy/autoTag/autoLink/autoLinkInbound/decompose)
- `closeProject`, `newQuery`, `toggleConversations`, `closeActiveTab`
- the font-size dance (`fontIncrease/Decrease/Reset` reconciling the editor's reported size back into App state)

Only what the factory can't reach — App-local ops handlers, the focused-pane editor ref, the theme label, and the UI-chrome `$state` — arrives via `ctx`.

## Why this one is safe to move (vs. the deferred IPC wiring)
Both tables are **fully typed** (`CommandDeps` / `KeymapDeps`), so a missing or mis-shaped binding is a **compile error**. That's the opposite of the untyped `api.menu.on*` statements, where a mis-wire is a silent runtime break — which is why IPC wiring stays its own later slice.

## Reactivity
App keeps the `commands` `$derived` (a rune must stay in the component) and passes `commandDeps` into it. That line is **byte-identical**; the getter closures still read the same reactive sources synchronously inside the derived, so the [#1108](https://github.com/dgriffith/ide-for-thought/issues/1108) palette-gating (registry rebuilt only while the palette is open) is preserved.

## Impact
- `App.svelte`: **−22 LOC** (net; ~75 lines of dep tables + logic moved out, ~40-line typed ctx wiring stays)
- New `tests/renderer/app/command-keymap.test.ts` (17 cases): predicates read live store state, guards gate + dispatch, font dance, quick-open, keymap wiring
- `pnpm lint` (tsc + svelte-check + eslint) clean; full suite **4228 passed**

No e2e covers the palette, so the reactivity argument above is the guarantee; behavior is otherwise identical (same closures, relocated behind a typed factory).

## Staging
PR 2 of #1084. Remaining: IPC/menu event wiring, then the App controller shrink to render-only. Toward #1084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)