### PR TITLE
Extract main↔renderer IPC/menu wiring from App.svelte (#1084)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -16,7 +16,7 @@
   import type { CursorInfo } from './lib/components/Editor.svelte';
   import Preview from './lib/components/Preview.svelte';
   import SourceDetail from './lib/components/SourceDetail.svelte';
-  import { onMount, tick } from 'svelte';
+  import { onMount } from 'svelte';
   import { getNotebaseStore } from './lib/stores/notebase.svelte';
   import { getEditorStore } from './lib/stores/editor.svelte';
   import { getBusyStore } from './lib/stores/busy.svelte';
@@ -30,6 +30,7 @@
   import { createTemplateOps, type TemplateOpsCtx } from './lib/app/template-ops';
   import { createConversationOps, type ConversationOpsCtx } from './lib/app/conversation-ops';
   import { createProjectOps, type ProjectOpsCtx } from './lib/app/project-ops';
+  import { registerAppIpc, type IpcWiringCtx } from './lib/app/ipc-wiring';
   import DialogHost from './lib/components/DialogHost.svelte';
   import { getDialogStore } from './lib/stores/dialogs.svelte';
   import { getLinkDrag } from './lib/stores/link-drag.svelte';
@@ -76,7 +77,6 @@
     lineBookmarkName,
   } from './lib/app/text-helpers';
   import { initAppearance } from './lib/appearance/settings';
-  import { getToolPanelStore } from './lib/stores/tool-panel.svelte';
   import { getConversationsStore } from './lib/stores/conversations.svelte';
   import { getBookmarksStore, collectBookmarksForPath } from './lib/stores/bookmarks.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
@@ -84,10 +84,7 @@
   import { isMissingApiKeyError } from '../shared/llm-errors';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
   import { findRunnableFences, RUNNABLE_LANGUAGE_SET } from '../shared/compute/fences';
-  import { loadFormatSettings } from './lib/formatter/settings';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
-  import { registerSkillInfos } from './lib/tools/tool-registry';
-  import { applyMenuConfig } from '../shared/skills/menu-config';
 
 
   const notebase = getNotebaseStore();
@@ -107,7 +104,6 @@
     if (t) lastNotePath = t.relativePath;
   });
   const nav = getNavigationStore();
-  const toolPanel = getToolPanelStore();
   const conversationsStore = getConversationsStore();
   const bookmarkStore = getBookmarksStore();
   const voice = getVoiceStore();
@@ -755,54 +751,6 @@
     void sidebar?.revealFile(relativePath);
   }
 
-  // Refresh tags when notebase opens
-  const originalOpen = notebase.open;
-  notebase.open = async () => {
-    const result = await originalOpen();
-    setTimeout(() => {
-      sidebar?.refreshTags();
-      sidebar?.refreshSources();
-      sidebar?.refreshTables();
-      void refreshSourcesCache();
-    }, 100);
-    return result;
-  };
-
-  // Main broadcasts when the sources watcher reindexes or removes a source.
-  // Refresh the sidebar Sources panel AND the editor autocomplete cache so
-  // newly-ingested sources become reachable without a manual reload.
-  api.sources.onChanged(() => {
-    sidebar?.refreshSources();
-    void refreshSourcesCache();
-  });
-
-  // Main broadcasts after the initial CSV scan and on every register/unregister
-  // from the watcher — keeps the sidebar Tables panel in lockstep.
-  api.tables.onChanged(() => {
-    sidebar?.refreshTables();
-  });
-
-  // Semantic-index backfill progress (#836): a quiet status-bar indicator while
-  // the corpus embeds in the background. Cleared on completion (running:false).
-  api.embeddings.onBackfillProgress((p) => {
-    embeddingProgress = p.running && p.total > 0 ? { done: p.done, total: p.total } : null;
-  });
-
-  // CSV table-name collision (#354): two CSVs would land on the
-  // same DuckDB table name; the second was skipped. Show a
-  // suppressible toast pointing at `table_name:` as the fix.
-  api.tables.onNameCollision((collision) => {
-    void showConfirm(
-      `Two CSVs would use the same DuckDB table name "${collision.tableName}":\n\n` +
-      `  • ${collision.existingPath}  (active)\n` +
-      `  • ${collision.attemptedPath}  (skipped)\n\n` +
-      `Add \`table_name: <unique-name>\` to a companion .md alongside one of them to disambiguate.`,
-      CONFIRM_KEYS.tableNameCollision,
-      'OK',
-      { hideDontAskAgain: false },
-    );
-  });
-
   function cycleViewMode() {
     editor.cycleViewMode();
   }
@@ -814,236 +762,71 @@
     api.menu.reportTheme(themeLabel);
     initAppearance();
 
-    // Pull skill metadata loaded by main (#625) into the renderer registry so
-    // the tool panel / command palette / slash commands see skills alongside
-    // hardcoded tools. Fire-and-forget — skills enrich the menus when ready.
-    void (async () => {
-      try {
-        const cat = await api.skills.list();
-        // Apply the per-machine menu config (#630): only enabled skills, in
-        // their effective menu and configured order, reach the palette / slash.
-        registerSkillInfos(applyMenuConfig(cat.skills, cat.config));
-      } catch (err) {
-        console.warn('[skills] failed to load skill list:', err);
-      }
-    })();
-
-    // Auto-save
-    editor.onAutoSaved = () => {
-      sidebar?.refreshTags();
-      rightSidebar?.refresh();
-      graphRevision++;
-      void refreshBacklinkCount();
-      void refreshAliasMap();
-    };
-    window.addEventListener('beforeunload', () => {
-      // Capture current editor state before persisting — the Editor
-      // only saves on unmount, which hasn't happened yet on window close
-      if (editor.activeFilePath && editorComponent) {
-        editor.saveEditorState(
-          editor.activeFilePath,
-          editorComponent.getOffset(),
-          editorComponent.getView()?.scrollDOM.scrollTop ?? 0,
-        );
-      }
-      editor.flushAutoSave();
-      editor.persistTabs();
-    });
-
-    // Listen for menu events from main process
-    api.menu.onNewNote(() => handleNewNote());
-    api.menu.onEditThoughtbaseDoc(() => { void handleEditThoughtbaseDoc(); });
-    api.menu.onSave(() => handleSave());
-    api.menu.onSaveAsTemplate(() => { void handleSaveAsTemplate(); });
-    api.menu.onInsertTemplate(() => { void handleInsertTemplate(); });
-    api.menu.onCycleTheme(() => handleCycleTheme());
-    api.menu.onSetTheme((mode) => handleSelectTheme(mode));
-    api.menu.onFontIncrease(() => { editorComponent?.changeFontSize(1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
-    api.menu.onFontDecrease(() => { editorComponent?.changeFontSize(-1); editorFontSize = editorComponent?.currentFontSize() ?? editorFontSize; });
-    api.menu.onFontReset(() => { editorComponent?.resetFontSize(); editorFontSize = 14; });
-    api.menu.onToggleSidebar(() => { sidebarVisible = !sidebarVisible; });
-    api.menu.onToggleRightSidebar(() => { rightSidebarVisible = !rightSidebarVisible; });
-    api.menu.onToggleConversations(() => conversationsStore.toggle());
-    api.menu.onNewConversation(() => { void newConversation(); });
-    api.menu.onTogglePreview(() => cycleViewMode());
-    // Editor split — pane focus & layout commands (#814).
-    api.menu.onSplitRight(() => editor.splitGroup(editor.activeGroupId, 'horizontal'));
-    api.menu.onSplitDown(() => editor.splitGroup(editor.activeGroupId, 'vertical'));
-    api.menu.onFocusNextGroup(() => editor.focusNextGroup());
-    api.menu.onFocusPrevGroup(() => editor.focusPreviousGroup());
-    api.menu.onCloseGroup(() => editor.closeActiveGroup());
-    api.menu.onOpenProject(() => handleOpenThoughtbase());
-    api.menu.onNewProject(() => handleNewThoughtbase());
-    api.menu.onOpenRecentProject((p) => handleOpenRecentThoughtbase(p));
-    api.menu.onCloseProject(() => {
-      notebase.close();
-      editor.clear();
-    });
-    api.menu.onClearRecent(() => api.notebase.clearRecent());
-    api.menu.onNavBack(() => handleNavBack());
-    api.menu.onNavForward(() => handleNavForward());
-    api.menu.onGotoLine(() => { if (editor.activeTab) showGotoLine = true; });
-    api.menu.onQuickOpen(() => {
-      // Lazily refresh the palette's source + query backing data so
-      // its scope chip counts are fresh when the user opens it.
-      void refreshSourcesCache();
-      void refreshSavedQueriesCache();
-      showGotoNote = true;
-    });
-    api.menu.onNewQuery(() => editor.openQuery());
-    api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
-    api.menu.onEditSavedQueries(() => { showEditSavedQueries = true; });
-    api.menu.onSortLines(() => editorComponent?.runSortLines());
-    api.menu.onFind(() => editorComponent?.openFind());
-    api.menu.onFindReplace(() => editorComponent?.openFindReplace());
-    api.menu.onFindInNotes(() => { findInNotesMode = 'find'; });
-    api.menu.onReplaceInNotes(() => { findInNotesMode = 'replace'; });
-    api.menu.onPrint(() => window.print());
-    api.menu.onAbout(() => { showAbout = true; });
-    api.menu.onShortcuts(() => { showShortcuts = true; });
-    api.menu.onOpenInDefault(() => { if (editor.activeFilePath) void api.shell.openInDefault(editor.activeFilePath); });
-    api.menu.onOpenInTerminal(() => { void api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
-    api.menu.onOpenSettings(() => { showSettings = true; });
-
-    // Refactor menu (issue #172)
-    api.menu.onRefactorRename(() => { if (editor.activeFilePath) void handleRename(editor.activeFilePath); });
-    api.menu.onRefactorMove(() => { if (editor.activeFilePath) void handleMoveWithPrompt(editor.activeFilePath); });
-    api.menu.onRefactorCopy(() => { if (editor.activeFilePath) void handleCopyWithPrompt(editor.activeFilePath); });
-    api.menu.onRefactorExtract(() => handleExtractSelection());
-    api.menu.onRefactorSplitHere(() => handleSplitHere());
-    api.menu.onRefactorSplitByHeading(() => handleSplitByHeading());
-    api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) void handleAutoTag(editor.activeFilePath); });
-    api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) void handleAutoLink(editor.activeFilePath); });
-    api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) void handleAutoLinkInbound(editor.activeFilePath); });
-    api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) void handleDecompose(editor.activeFilePath); });
-
-    // Format menu (issue #153)
-    api.menu.onFormat(() => handleFormat());
-
-    // Insert/Update Bibliography (#113)
-    api.menu.onBibliography(() => { void handleBibliography(); });
-
-    // Ingest URL (#93)
-    api.menu.onIngestUrl(() => handleIngestUrlAsSource());
-    api.menu.onIngestIdentifier(() => handleIngestIdentifier());
-    api.menu.onIngestFile(() => handleIngestFileAsSource());
-    api.menu.onImportBibtex(() => handleImportBibtex());
-    api.menu.onImportZoteroRdf(() => handleImportZoteroRdf());
-    api.menu.onExport((groupId) => { exportDialogGroup = groupId; });
-    api.menu.onPublish(() => { publishDialogOpen = true; });
-
-    // Progress updates during a bulk import — rewrites the busy-overlay
-    // label in place so the user sees running counts on large imports.
-    // One handler per stream; both funnel into the same busyLabel so the
-    // user doesn't care which import is running.
-    const progressToBusyLabel = ({ done, total, currentTitle }: { done: number; total: number; currentTitle: string }) => {
-      if (busy.label) {
-        const short = currentTitle.length > 60 ? currentTitle.slice(0, 57) + '…' : currentTitle;
-        busy.setLabel(`Importing ${done}/${total}: ${short}`);
-      }
-    };
-    api.sources.onImportBibtexProgress(progressToBusyLabel);
-    api.sources.onImportZoteroRdfProgress(progressToBusyLabel);
-
-    // External file changes (watcher-driven) — refresh the sidebar so files
-    // added / deleted in Finder show up without a restart. Debounced because
-    // the watcher also fires for internal ops that already called refresh(),
-    // and a burst of watcher events (e.g. ingesting a source tree) shouldn't
-    // produce a burst of listFiles round-trips.
-    let treeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-    const scheduleTreeRefresh = () => {
-      if (treeRefreshTimer) clearTimeout(treeRefreshTimer);
-      treeRefreshTimer = setTimeout(() => {
-        treeRefreshTimer = null;
-        void notebase.refresh();
-      }, 200);
-    };
-    api.notebase.onFileCreated(scheduleTreeRefresh);
-    api.notebase.onFileDeleted((deletedPath) => {
-      editor.closeTabsForDeletedPath(deletedPath);
-      scheduleTreeRefresh();
-    });
-
-    // Notebase rename/rewrite notifications from main — keep open tabs
-    // consistent with disk so the next auto-save doesn't overwrite a
-    // link rewrite silently.
-    api.notebase.onRenamed((transitions) => {
-      editor.applyRenameTransitions(transitions);
-      bookmarkStore.applyRenameTransitions(transitions);
-    });
-    api.notebase.onRewritten(async (paths) => {
-      for (const p of paths) {
-        if (editor.isPathDirty(p)) {
-          const keepDisk = await showConfirm(
-            `"${p}" was updated on disk by a link rewrite. Discard your unsaved edits and load the new version?`,
-            CONFIRM_KEYS.rewriteConflict,
-            'Load disk',
-          );
-          if (!keepDisk) continue;
-        }
-        await editor.reloadTabFromDisk(p);
-      }
-    });
-
-    api.notebase.onHeadingRenameSuggested(async (candidate) => {
-      // Keep the user's own section bookmarks pointing at the renamed
-      // heading (#755). Local metadata, no content mutation — do it
-      // unconditionally, even when nothing links to the heading.
-      bookmarkStore.retargetSectionAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
-      // Only offer to rewrite OTHER notes' incoming links when some exist.
-      const n = candidate.incomingLinkCount;
-      if (n === 0) return;
-      const msg =
-        `The heading "${candidate.oldText}" in ${candidate.relativePath} looks like it was renamed ` +
-        `to "${candidate.newText}". Update ${n} incoming link${n === 1 ? '' : 's'}?`;
-      const ok = await showConfirm(msg, CONFIRM_KEYS.headingRenameSuggestion, 'Update links');
-      if (!ok) return;
-      await api.notebase.renameAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
-    });
-
-    // Tools for Thought — stream listener (once)
-    api.tools.onStream((chunk) => {
-      toolPanel.appendChunk(chunk);
-    });
-
-    api.tools.onInvoke((toolId) => handleToolInvoke(toolId));
-
-    api.menu.onProjectOpened(async (meta) => {
-      await notebase.openPath(meta.rootPath);
-      await editor.restoreTabs();
-      await bookmarkStore.load();
-      await loadFormatSettings();
-      sidebar?.refreshTags();
-      sidebar?.refreshSources();
-      sidebar?.refreshTables();
-      await refreshSourcesCache();
-      await refreshAliasMap();
-      // Inspections hidden for v1.0: count polling disabled so the status-bar
-      // badge stays hidden (inspectionCount stays 0). Restore the
-      // setTimeout/setInterval(refreshInspectionCount) to re-enable.
-      // Restore cursor/scroll for every pane's active note tab after the
-      // split layout has rendered and each pane's Editor has mounted (#816 —
-      // restore is now multi-group, not just the focused pane).
-      await tick();
-      requestAnimationFrame(() => {
-        for (const grp of editor.groups) {
-          const noteTab = editor.noteTabForGroup(grp.id);
-          if (noteTab?.cursorOffset != null) {
-            editorComponents[grp.id]?.restorePosition(noteTab.cursorOffset, noteTab.scrollTop);
-          }
-        }
-      });
-
-      // Offer the onboarding journey on empty thoughtbases. Files have
-      // already been loaded by `notebase.openPath` above, so the count
-      // is current. Helper is shared with the in-window New/Open paths.
-      await maybeShowOnboarding();
-      // Auto-open any `entrypoint`-tagged notes when restoreTabs left
-      // the editor with no note tabs. Runs after the onboarding check
-      // because an empty thoughtbase has no entrypoints anyway, but
-      // ordering doesn't matter beyond that.
-      await maybeOpenEntrypoints();
-    });
+    // All main↔renderer event wiring — the native-menu command bindings, the
+    // sources/tables/embeddings/notebase-watcher/tools broadcasts, import
+    // progress, the auto-save + beforeunload lifecycle hooks, the notebase.open
+    // refresh patch, and the project-open restore flow — lives in
+    // ./lib/app/ipc-wiring.ts (#1084). Stores are pulled there; App bridges its
+    // ops handlers, component refs, and UI-chrome $state via ctx.
+    registerAppIpc({
+      getEditorComponent: () => editorComponent,
+      getEditorComponents: () => editorComponents,
+      getSidebar: () => sidebar,
+      getRightSidebar: () => rightSidebar,
+      bumpGraphRevision: () => { graphRevision++; },
+      getEditorFontSize: () => editorFontSize,
+      setEditorFontSize: (n) => { editorFontSize = n; },
+      toggleSidebar: () => { sidebarVisible = !sidebarVisible; },
+      toggleRightSidebar: () => { rightSidebarVisible = !rightSidebarVisible; },
+      setShowGotoLine: (v) => { showGotoLine = v; },
+      setShowGotoNote: (v) => { showGotoNote = v; },
+      setShowEditSavedQueries: (v) => { showEditSavedQueries = v; },
+      setShowAbout: (v) => { showAbout = v; },
+      setShowShortcuts: (v) => { showShortcuts = v; },
+      setShowSettings: (v) => { showSettings = v; },
+      setPublishDialogOpen: (v) => { publishDialogOpen = v; },
+      setFindInNotesMode: (m) => { findInNotesMode = m; },
+      setExportDialogGroup: (g) => { exportDialogGroup = g; },
+      setEmbeddingProgress: (p) => { embeddingProgress = p; },
+      refreshSourcesCache: () => refreshSourcesCache(),
+      refreshAliasMap: () => refreshAliasMap(),
+      refreshSavedQueriesCache: () => { void refreshSavedQueriesCache(); },
+      refreshBacklinkCount: () => { void refreshBacklinkCount(); },
+      newNote: () => { void handleNewNote(); },
+      editThoughtbaseGuide: () => { void handleEditThoughtbaseDoc(); },
+      save: () => { void handleSave(); },
+      saveAsTemplate: () => { void handleSaveAsTemplate(); },
+      insertTemplate: () => { void handleInsertTemplate(); },
+      cycleTheme: () => handleCycleTheme(),
+      selectTheme: (mode) => handleSelectTheme(mode),
+      openThoughtbase: () => { void handleOpenThoughtbase(); },
+      newThoughtbase: () => { void handleNewThoughtbase(); },
+      openRecentThoughtbase: (p) => { void handleOpenRecentThoughtbase(p); },
+      navBack: () => { void handleNavBack(); },
+      navForward: () => { void handleNavForward(); },
+      rename: (p) => { void handleRename(p); },
+      move: (p) => { void handleMoveWithPrompt(p); },
+      copy: (p) => { void handleCopyWithPrompt(p); },
+      extractSelection: () => { void handleExtractSelection(); },
+      splitHere: () => { void handleSplitHere(); },
+      splitByHeading: () => { void handleSplitByHeading(); },
+      autoTag: (p) => { void handleAutoTag(p); },
+      autoLink: (p) => { void handleAutoLink(p); },
+      autoLinkInbound: (p) => { void handleAutoLinkInbound(p); },
+      decompose: (p) => { void handleDecompose(p); },
+      format: () => { void handleFormat(); },
+      bibliography: () => { void handleBibliography(); },
+      ingestUrl: () => { void handleIngestUrlAsSource(); },
+      ingestIdentifier: () => { void handleIngestIdentifier(); },
+      ingestFile: () => { void handleIngestFileAsSource(); },
+      importBibtex: () => { void handleImportBibtex(); },
+      importZoteroRdf: () => { void handleImportZoteroRdf(); },
+      toolInvoke: (id) => { void handleToolInvoke(id); },
+      newConversation: () => { void newConversation(); },
+      cycleViewMode: () => cycleViewMode(),
+      maybeShowOnboarding: () => maybeShowOnboarding(),
+      maybeOpenEntrypoints: () => maybeOpenEntrypoints(),
+    } satisfies IpcWiringCtx);
   });
 
   /** Count .md notes anywhere in the tree (recursive over folder

--- a/src/renderer/lib/app/ipc-wiring.ts
+++ b/src/renderer/lib/app/ipc-wiring.ts
@@ -1,0 +1,419 @@
+/**
+ * Main↔renderer event wiring extracted from App.svelte (#1084). Registers every
+ * `api.*.on*` subscription — the native-menu command bindings, the sources /
+ * tables / embeddings / notebase-watcher / tools broadcasts, the bulk-import
+ * progress streams, and the `project:opened` restore flow — plus the two
+ * lifecycle hooks (`editor.onAutoSaved`, `beforeunload`), the notebase.open
+ * refresh patch, and the skills-catalog load.
+ *
+ * Bodies are verbatim from App.svelte; the substitutions are mechanical:
+ * singleton stores are pulled here (so all `editor.*` / `notebase.*` /
+ * `bookmarkStore.*` / `busy.*` / `toolPanel.*` calls and `showConfirm` are
+ * direct), while App-owned pieces — the ops handlers, the focused-pane editor
+ * ref, the per-group editor map, the sidebar refs, and the UI-chrome `$state` —
+ * arrive through `ctx`.
+ *
+ * IMPORTANT: unlike the typed CommandDeps / KeymapDeps tables (command-keymap.ts),
+ * the `api.menu.on*` callbacks are untyped `() => void`, so a transposed binding
+ * would be a silent runtime break. The paired table-driven test
+ * (ipc-wiring.test.ts) captures every registration and asserts each dispatches
+ * to the right action — that test IS the safety net here.
+ *
+ * Called once from App's onMount. The four subscriptions + the notebase.open
+ * patch used to run at script-init; moving them to onMount is safe because main
+ * only broadcasts them after a project is open (post-mount).
+ */
+import { tick } from 'svelte';
+import { api } from '../ipc/client';
+import { getNotebaseStore } from '../stores/notebase.svelte';
+import { getEditorStore } from '../stores/editor.svelte';
+import { getBusyStore } from '../stores/busy.svelte';
+import { getToolPanelStore } from '../stores/tool-panel.svelte';
+import { getConversationsStore } from '../stores/conversations.svelte';
+import { getBookmarksStore } from '../stores/bookmarks.svelte';
+import { getDialogStore } from '../stores/dialogs.svelte';
+import { CONFIRM_KEYS } from '../confirm-keys';
+import { loadFormatSettings } from '../formatter/settings';
+import { registerSkillInfos } from '../tools/tool-registry';
+import { applyMenuConfig } from '../../../shared/skills/menu-config';
+import type { EditorView } from '@codemirror/view';
+import type { ThemeMode } from '../theme';
+
+/** Focused-pane editor methods the wiring drives (font, find, sort, and the
+ *  beforeunload state capture). */
+interface EditorRef {
+  getOffset(): number;
+  getView(): EditorView | undefined;
+  changeFontSize(delta: number): void;
+  currentFontSize(): number;
+  resetFontSize(): void;
+  runSortLines(): void;
+  openFind(): void;
+  openFindReplace(): void;
+}
+
+/** Sidebar panels refreshed on watcher / open events. */
+interface SidebarRef {
+  refreshTags(): void;
+  refreshSources(): void;
+  refreshTables(): void;
+}
+
+export interface IpcWiringCtx {
+  // Component refs (App-owned; resolve at callback time).
+  getEditorComponent: () => EditorRef | undefined;
+  getEditorComponents: () => Record<string, { restorePosition(offset: number, scrollTop?: number): void } | undefined>;
+  getSidebar: () => SidebarRef | undefined;
+  getRightSidebar: () => { refresh(): void } | undefined;
+
+  // UI-chrome `$state` mutators.
+  bumpGraphRevision: () => void;
+  getEditorFontSize: () => number;
+  setEditorFontSize: (n: number) => void;
+  toggleSidebar: () => void;
+  toggleRightSidebar: () => void;
+  setShowGotoLine: (v: boolean) => void;
+  setShowGotoNote: (v: boolean) => void;
+  setShowEditSavedQueries: (v: boolean) => void;
+  setShowAbout: (v: boolean) => void;
+  setShowShortcuts: (v: boolean) => void;
+  setShowSettings: (v: boolean) => void;
+  setPublishDialogOpen: (v: boolean) => void;
+  setFindInNotesMode: (m: 'find' | 'replace') => void;
+  setExportDialogGroup: (g: string) => void;
+  setEmbeddingProgress: (p: { done: number; total: number } | null) => void;
+
+  // App-local refreshers (they write App `$state`, not store state). The two
+  // awaited by the project-open flow return promises so that ordering is kept.
+  refreshSourcesCache: () => Promise<void>;
+  refreshAliasMap: () => Promise<void>;
+  refreshSavedQueriesCache: () => void;
+  refreshBacklinkCount: () => void;
+
+  // Ops handlers + App-local flows (fire-and-forget; some return promises).
+  newNote: () => void;
+  editThoughtbaseGuide: () => void;
+  save: () => void;
+  saveAsTemplate: () => void;
+  insertTemplate: () => void;
+  cycleTheme: () => void;
+  selectTheme: (mode: ThemeMode) => void;
+  openThoughtbase: () => void;
+  newThoughtbase: () => void;
+  openRecentThoughtbase: (rootPath: string) => void;
+  navBack: () => void;
+  navForward: () => void;
+  rename: (path: string) => void;
+  move: (path: string) => void;
+  copy: (path: string) => void;
+  extractSelection: () => void;
+  splitHere: () => void;
+  splitByHeading: () => void;
+  autoTag: (path: string) => void;
+  autoLink: (path: string) => void;
+  autoLinkInbound: (path: string) => void;
+  decompose: (path: string) => void;
+  format: () => void;
+  bibliography: () => void;
+  ingestUrl: () => void;
+  ingestIdentifier: () => void;
+  ingestFile: () => void;
+  importBibtex: () => void;
+  importZoteroRdf: () => void;
+  toolInvoke: (toolId: string) => void;
+  newConversation: () => void;
+  cycleViewMode: () => void;
+  maybeShowOnboarding: () => Promise<void>;
+  maybeOpenEntrypoints: () => Promise<void>;
+}
+
+export function registerAppIpc(ctx: IpcWiringCtx): void {
+  const notebase = getNotebaseStore();
+  const editor = getEditorStore();
+  const busy = getBusyStore();
+  const toolPanel = getToolPanelStore();
+  const conversationsStore = getConversationsStore();
+  const bookmarkStore = getBookmarksStore();
+  const { showConfirm } = getDialogStore();
+
+  // Pull skill metadata loaded by main (#625) into the renderer registry so
+  // the tool panel / command palette / slash commands see skills alongside
+  // hardcoded tools. Fire-and-forget — skills enrich the menus when ready.
+  void (async () => {
+    try {
+      const cat = await api.skills.list();
+      // Apply the per-machine menu config (#630): only enabled skills, in
+      // their effective menu and configured order, reach the palette / slash.
+      registerSkillInfos(applyMenuConfig(cat.skills, cat.config));
+    } catch (err) {
+      console.warn('[skills] failed to load skill list:', err);
+    }
+  })();
+
+  // Auto-save
+  editor.onAutoSaved = () => {
+    ctx.getSidebar()?.refreshTags();
+    ctx.getRightSidebar()?.refresh();
+    ctx.bumpGraphRevision();
+    ctx.refreshBacklinkCount();
+    void ctx.refreshAliasMap();
+  };
+  window.addEventListener('beforeunload', () => {
+    // Capture current editor state before persisting — the Editor
+    // only saves on unmount, which hasn't happened yet on window close
+    const editorComponent = ctx.getEditorComponent();
+    if (editor.activeFilePath && editorComponent) {
+      editor.saveEditorState(
+        editor.activeFilePath,
+        editorComponent.getOffset(),
+        editorComponent.getView()?.scrollDOM.scrollTop ?? 0,
+      );
+    }
+    editor.flushAutoSave();
+    editor.persistTabs();
+  });
+
+  // Refresh tags when notebase opens
+  const originalOpen = notebase.open;
+  notebase.open = async () => {
+    const result = await originalOpen();
+    setTimeout(() => {
+      ctx.getSidebar()?.refreshTags();
+      ctx.getSidebar()?.refreshSources();
+      ctx.getSidebar()?.refreshTables();
+      void ctx.refreshSourcesCache();
+    }, 100);
+    return result;
+  };
+
+  // Main broadcasts when the sources watcher reindexes or removes a source.
+  // Refresh the sidebar Sources panel AND the editor autocomplete cache so
+  // newly-ingested sources become reachable without a manual reload.
+  api.sources.onChanged(() => {
+    ctx.getSidebar()?.refreshSources();
+    void ctx.refreshSourcesCache();
+  });
+
+  // Main broadcasts after the initial CSV scan and on every register/unregister
+  // from the watcher — keeps the sidebar Tables panel in lockstep.
+  api.tables.onChanged(() => {
+    ctx.getSidebar()?.refreshTables();
+  });
+
+  // Semantic-index backfill progress (#836): a quiet status-bar indicator while
+  // the corpus embeds in the background. Cleared on completion (running:false).
+  api.embeddings.onBackfillProgress((p) => {
+    ctx.setEmbeddingProgress(p.running && p.total > 0 ? { done: p.done, total: p.total } : null);
+  });
+
+  // CSV table-name collision (#354): two CSVs would land on the
+  // same DuckDB table name; the second was skipped. Show a
+  // suppressible toast pointing at `table_name:` as the fix.
+  api.tables.onNameCollision((collision) => {
+    void showConfirm(
+      `Two CSVs would use the same DuckDB table name "${collision.tableName}":\n\n` +
+      `  • ${collision.existingPath}  (active)\n` +
+      `  • ${collision.attemptedPath}  (skipped)\n\n` +
+      `Add \`table_name: <unique-name>\` to a companion .md alongside one of them to disambiguate.`,
+      CONFIRM_KEYS.tableNameCollision,
+      'OK',
+      { hideDontAskAgain: false },
+    );
+  });
+
+  // Listen for menu events from main process
+  api.menu.onNewNote(() => ctx.newNote());
+  api.menu.onEditThoughtbaseDoc(() => { void ctx.editThoughtbaseGuide(); });
+  api.menu.onSave(() => ctx.save());
+  api.menu.onSaveAsTemplate(() => { void ctx.saveAsTemplate(); });
+  api.menu.onInsertTemplate(() => { void ctx.insertTemplate(); });
+  api.menu.onCycleTheme(() => ctx.cycleTheme());
+  api.menu.onSetTheme((mode) => ctx.selectTheme(mode));
+  api.menu.onFontIncrease(() => { const ec = ctx.getEditorComponent(); ec?.changeFontSize(1); ctx.setEditorFontSize(ec?.currentFontSize() ?? ctx.getEditorFontSize()); });
+  api.menu.onFontDecrease(() => { const ec = ctx.getEditorComponent(); ec?.changeFontSize(-1); ctx.setEditorFontSize(ec?.currentFontSize() ?? ctx.getEditorFontSize()); });
+  api.menu.onFontReset(() => { ctx.getEditorComponent()?.resetFontSize(); ctx.setEditorFontSize(14); });
+  api.menu.onToggleSidebar(() => { ctx.toggleSidebar(); });
+  api.menu.onToggleRightSidebar(() => { ctx.toggleRightSidebar(); });
+  api.menu.onToggleConversations(() => conversationsStore.toggle());
+  api.menu.onNewConversation(() => { void ctx.newConversation(); });
+  api.menu.onTogglePreview(() => ctx.cycleViewMode());
+  // Editor split — pane focus & layout commands (#814).
+  api.menu.onSplitRight(() => editor.splitGroup(editor.activeGroupId, 'horizontal'));
+  api.menu.onSplitDown(() => editor.splitGroup(editor.activeGroupId, 'vertical'));
+  api.menu.onFocusNextGroup(() => editor.focusNextGroup());
+  api.menu.onFocusPrevGroup(() => editor.focusPreviousGroup());
+  api.menu.onCloseGroup(() => editor.closeActiveGroup());
+  api.menu.onOpenProject(() => ctx.openThoughtbase());
+  api.menu.onNewProject(() => ctx.newThoughtbase());
+  api.menu.onOpenRecentProject((p) => ctx.openRecentThoughtbase(p));
+  api.menu.onCloseProject(() => {
+    notebase.close();
+    editor.clear();
+  });
+  api.menu.onClearRecent(() => api.notebase.clearRecent());
+  api.menu.onNavBack(() => ctx.navBack());
+  api.menu.onNavForward(() => ctx.navForward());
+  api.menu.onGotoLine(() => { if (editor.activeTab) ctx.setShowGotoLine(true); });
+  api.menu.onQuickOpen(() => {
+    // Lazily refresh the palette's source + query backing data so
+    // its scope chip counts are fresh when the user opens it.
+    void ctx.refreshSourcesCache();
+    ctx.refreshSavedQueriesCache();
+    ctx.setShowGotoNote(true);
+  });
+  api.menu.onNewQuery(() => editor.openQuery());
+  api.menu.onOpenStockQuery(({ query, language }) => editor.openQuery(query, language));
+  api.menu.onEditSavedQueries(() => { ctx.setShowEditSavedQueries(true); });
+  api.menu.onSortLines(() => ctx.getEditorComponent()?.runSortLines());
+  api.menu.onFind(() => ctx.getEditorComponent()?.openFind());
+  api.menu.onFindReplace(() => ctx.getEditorComponent()?.openFindReplace());
+  api.menu.onFindInNotes(() => { ctx.setFindInNotesMode('find'); });
+  api.menu.onReplaceInNotes(() => { ctx.setFindInNotesMode('replace'); });
+  api.menu.onPrint(() => window.print());
+  api.menu.onAbout(() => { ctx.setShowAbout(true); });
+  api.menu.onShortcuts(() => { ctx.setShowShortcuts(true); });
+  api.menu.onOpenInDefault(() => { if (editor.activeFilePath) void api.shell.openInDefault(editor.activeFilePath); });
+  api.menu.onOpenInTerminal(() => { void api.shell.openInTerminal(editor.activeFilePath ?? undefined); });
+  api.menu.onOpenSettings(() => { ctx.setShowSettings(true); });
+
+  // Refactor menu (issue #172)
+  api.menu.onRefactorRename(() => { if (editor.activeFilePath) ctx.rename(editor.activeFilePath); });
+  api.menu.onRefactorMove(() => { if (editor.activeFilePath) ctx.move(editor.activeFilePath); });
+  api.menu.onRefactorCopy(() => { if (editor.activeFilePath) ctx.copy(editor.activeFilePath); });
+  api.menu.onRefactorExtract(() => ctx.extractSelection());
+  api.menu.onRefactorSplitHere(() => ctx.splitHere());
+  api.menu.onRefactorSplitByHeading(() => ctx.splitByHeading());
+  api.menu.onRefactorAutoTag(() => { if (editor.activeFilePath) ctx.autoTag(editor.activeFilePath); });
+  api.menu.onRefactorAutoLink(() => { if (editor.activeFilePath) ctx.autoLink(editor.activeFilePath); });
+  api.menu.onRefactorAutoLinkInbound(() => { if (editor.activeFilePath) ctx.autoLinkInbound(editor.activeFilePath); });
+  api.menu.onRefactorDecompose(() => { if (editor.activeFilePath) ctx.decompose(editor.activeFilePath); });
+
+  // Format menu (issue #153)
+  api.menu.onFormat(() => ctx.format());
+
+  // Insert/Update Bibliography (#113)
+  api.menu.onBibliography(() => { void ctx.bibliography(); });
+
+  // Ingest URL (#93)
+  api.menu.onIngestUrl(() => ctx.ingestUrl());
+  api.menu.onIngestIdentifier(() => ctx.ingestIdentifier());
+  api.menu.onIngestFile(() => ctx.ingestFile());
+  api.menu.onImportBibtex(() => ctx.importBibtex());
+  api.menu.onImportZoteroRdf(() => ctx.importZoteroRdf());
+  api.menu.onExport((groupId) => { ctx.setExportDialogGroup(groupId); });
+  api.menu.onPublish(() => { ctx.setPublishDialogOpen(true); });
+
+  // Progress updates during a bulk import — rewrites the busy-overlay
+  // label in place so the user sees running counts on large imports.
+  // One handler per stream; both funnel into the same busyLabel so the
+  // user doesn't care which import is running.
+  const progressToBusyLabel = ({ done, total, currentTitle }: { done: number; total: number; currentTitle: string }) => {
+    if (busy.label) {
+      const short = currentTitle.length > 60 ? currentTitle.slice(0, 57) + '…' : currentTitle;
+      busy.setLabel(`Importing ${done}/${total}: ${short}`);
+    }
+  };
+  api.sources.onImportBibtexProgress(progressToBusyLabel);
+  api.sources.onImportZoteroRdfProgress(progressToBusyLabel);
+
+  // External file changes (watcher-driven) — refresh the sidebar so files
+  // added / deleted in Finder show up without a restart. Debounced because
+  // the watcher also fires for internal ops that already called refresh(),
+  // and a burst of watcher events (e.g. ingesting a source tree) shouldn't
+  // produce a burst of listFiles round-trips.
+  let treeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleTreeRefresh = () => {
+    if (treeRefreshTimer) clearTimeout(treeRefreshTimer);
+    treeRefreshTimer = setTimeout(() => {
+      treeRefreshTimer = null;
+      void notebase.refresh();
+    }, 200);
+  };
+  api.notebase.onFileCreated(scheduleTreeRefresh);
+  api.notebase.onFileDeleted((deletedPath) => {
+    editor.closeTabsForDeletedPath(deletedPath);
+    scheduleTreeRefresh();
+  });
+
+  // Notebase rename/rewrite notifications from main — keep open tabs
+  // consistent with disk so the next auto-save doesn't overwrite a
+  // link rewrite silently.
+  api.notebase.onRenamed((transitions) => {
+    editor.applyRenameTransitions(transitions);
+    bookmarkStore.applyRenameTransitions(transitions);
+  });
+  api.notebase.onRewritten(async (paths) => {
+    for (const p of paths) {
+      if (editor.isPathDirty(p)) {
+        const keepDisk = await showConfirm(
+          `"${p}" was updated on disk by a link rewrite. Discard your unsaved edits and load the new version?`,
+          CONFIRM_KEYS.rewriteConflict,
+          'Load disk',
+        );
+        if (!keepDisk) continue;
+      }
+      await editor.reloadTabFromDisk(p);
+    }
+  });
+
+  api.notebase.onHeadingRenameSuggested(async (candidate) => {
+    // Keep the user's own section bookmarks pointing at the renamed
+    // heading (#755). Local metadata, no content mutation — do it
+    // unconditionally, even when nothing links to the heading.
+    bookmarkStore.retargetSectionAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
+    // Only offer to rewrite OTHER notes' incoming links when some exist.
+    const n = candidate.incomingLinkCount;
+    if (n === 0) return;
+    const msg =
+      `The heading "${candidate.oldText}" in ${candidate.relativePath} looks like it was renamed ` +
+      `to "${candidate.newText}". Update ${n} incoming link${n === 1 ? '' : 's'}?`;
+    const ok = await showConfirm(msg, CONFIRM_KEYS.headingRenameSuggestion, 'Update links');
+    if (!ok) return;
+    await api.notebase.renameAnchor(candidate.relativePath, candidate.oldSlug, candidate.newSlug);
+  });
+
+  // Tools for Thought — stream listener (once)
+  api.tools.onStream((chunk) => {
+    toolPanel.appendChunk(chunk);
+  });
+
+  api.tools.onInvoke((toolId) => ctx.toolInvoke(toolId));
+
+  api.menu.onProjectOpened(async (meta) => {
+    await notebase.openPath(meta.rootPath);
+    await editor.restoreTabs();
+    await bookmarkStore.load();
+    await loadFormatSettings();
+    ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshSources();
+    ctx.getSidebar()?.refreshTables();
+    await ctx.refreshSourcesCache();
+    await ctx.refreshAliasMap();
+    // Inspections hidden for v1.0: count polling disabled so the status-bar
+    // badge stays hidden (inspectionCount stays 0). Restore the
+    // setTimeout/setInterval(refreshInspectionCount) to re-enable.
+    // Restore cursor/scroll for every pane's active note tab after the
+    // split layout has rendered and each pane's Editor has mounted (#816 —
+    // restore is now multi-group, not just the focused pane).
+    await tick();
+    requestAnimationFrame(() => {
+      const editorComponents = ctx.getEditorComponents();
+      for (const grp of editor.groups) {
+        const noteTab = editor.noteTabForGroup(grp.id);
+        if (noteTab?.cursorOffset != null) {
+          editorComponents[grp.id]?.restorePosition(noteTab.cursorOffset, noteTab.scrollTop);
+        }
+      }
+    });
+
+    // Offer the onboarding journey on empty thoughtbases. Files have
+    // already been loaded by `notebase.openPath` above, so the count
+    // is current. Helper is shared with the in-window New/Open paths.
+    await ctx.maybeShowOnboarding();
+    // Auto-open any `entrypoint`-tagged notes when restoreTabs left
+    // the editor with no note tabs. Runs after the onboarding check
+    // because an empty thoughtbase has no entrypoints anyway, but
+    // ordering doesn't matter beyond that.
+    await ctx.maybeOpenEntrypoints();
+  });
+}

--- a/tests/renderer/app/ipc-wiring.test.ts
+++ b/tests/renderer/app/ipc-wiring.test.ts
@@ -1,0 +1,393 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Transposition guard for the main↔renderer event wiring extracted from
+ * App.svelte (#1084). Because the `api.menu.on*` callbacks are untyped
+ * `() => void`, a mis-wired binding (onSave firing newNote, say) would compile
+ * cleanly and only break at runtime. This test captures every registration and
+ * invokes each callback, asserting it dispatches to the expected action — so a
+ * transposed binding fails here instead of silently in production.
+ *
+ * Mocks the singleton stores the module pulls internally and the api client;
+ * every `api.*.on*` records its callback so the test can fire it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const MENU_CHANNELS = [
+    'onNewNote', 'onEditThoughtbaseDoc', 'onSave', 'onSaveAsTemplate', 'onInsertTemplate',
+    'onCycleTheme', 'onSetTheme', 'onFontIncrease', 'onFontDecrease', 'onFontReset',
+    'onToggleSidebar', 'onToggleRightSidebar', 'onToggleConversations', 'onNewConversation',
+    'onTogglePreview', 'onSplitRight', 'onSplitDown', 'onFocusNextGroup', 'onFocusPrevGroup',
+    'onCloseGroup', 'onOpenProject', 'onNewProject', 'onOpenRecentProject', 'onCloseProject',
+    'onClearRecent', 'onNavBack', 'onNavForward', 'onGotoLine', 'onQuickOpen', 'onNewQuery',
+    'onOpenStockQuery', 'onEditSavedQueries', 'onSortLines', 'onFind', 'onFindReplace',
+    'onFindInNotes', 'onReplaceInNotes', 'onPrint', 'onAbout', 'onShortcuts', 'onOpenInDefault',
+    'onOpenInTerminal', 'onOpenSettings', 'onRefactorRename', 'onRefactorMove', 'onRefactorCopy',
+    'onRefactorExtract', 'onRefactorSplitHere', 'onRefactorSplitByHeading', 'onRefactorAutoTag',
+    'onRefactorAutoLink', 'onRefactorAutoLinkInbound', 'onRefactorDecompose', 'onFormat',
+    'onBibliography', 'onIngestUrl', 'onIngestIdentifier', 'onIngestFile', 'onImportBibtex',
+    'onImportZoteroRdf', 'onExport', 'onPublish', 'onProjectOpened',
+  ];
+
+  const captured: Record<string, (...a: unknown[]) => unknown> = {};
+  const cap = (key: string) => vi.fn((cb: (...a: unknown[]) => unknown) => { captured[key] = cb; });
+
+  const menu: Record<string, unknown> = { reportTheme: vi.fn(), reportEditorState: vi.fn() };
+  for (const ch of MENU_CHANNELS) menu[ch] = cap(ch);
+
+  const api = {
+    menu,
+    skills: { list: vi.fn().mockResolvedValue({ skills: [], config: {} }) },
+    sources: {
+      onChanged: cap('sources.onChanged'),
+      onImportBibtexProgress: cap('sources.bibtex'),
+      onImportZoteroRdfProgress: cap('sources.zotero'),
+    },
+    tables: { onChanged: cap('tables.onChanged'), onNameCollision: cap('tables.collision') },
+    embeddings: { onBackfillProgress: cap('embeddings.backfill') },
+    notebase: {
+      onFileCreated: cap('nb.created'),
+      onFileDeleted: cap('nb.deleted'),
+      onRenamed: cap('nb.renamed'),
+      onRewritten: cap('nb.rewritten'),
+      onHeadingRenameSuggested: cap('nb.heading'),
+      clearRecent: vi.fn(),
+      renameAnchor: vi.fn().mockResolvedValue(undefined),
+    },
+    tools: { onStream: cap('tools.stream'), onInvoke: cap('tools.invoke') },
+    shell: { openInDefault: vi.fn(), openInTerminal: vi.fn() },
+  };
+
+  const notebase = {
+    meta: { rootPath: '/p', name: 'p' } as unknown,
+    open: vi.fn().mockResolvedValue({ rootPath: '/p' }),
+    openPath: vi.fn().mockResolvedValue({ rootPath: '/p' }),
+    close: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  };
+  const editor = {
+    activeFilePath: null as string | null,
+    activeTab: undefined as unknown,
+    activeGroupId: 'g1',
+    groups: [] as unknown[],
+    onAutoSaved: undefined as undefined | (() => void),
+    splitGroup: vi.fn(), focusNextGroup: vi.fn(), focusPreviousGroup: vi.fn(),
+    closeActiveGroup: vi.fn(), openQuery: vi.fn(), clear: vi.fn(),
+    closeTabsForDeletedPath: vi.fn(), applyRenameTransitions: vi.fn(),
+    isPathDirty: vi.fn(() => false), reloadTabFromDisk: vi.fn().mockResolvedValue(undefined),
+    restoreTabs: vi.fn().mockResolvedValue(undefined), noteTabForGroup: vi.fn(() => undefined),
+    saveEditorState: vi.fn(), flushAutoSave: vi.fn(), persistTabs: vi.fn(),
+  };
+  const busy = { label: '', setLabel: vi.fn() };
+  const toolPanel = { appendChunk: vi.fn() };
+  const conversations = { toggle: vi.fn() };
+  const bookmarks = {
+    applyRenameTransitions: vi.fn(), retargetSectionAnchor: vi.fn(),
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+  const dialog = { showConfirm: vi.fn().mockResolvedValue(false) };
+
+  return { MENU_CHANNELS, captured, api, notebase, editor, busy, toolPanel, conversations, bookmarks, dialog };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+vi.mock('../../../src/renderer/lib/stores/busy.svelte', () => ({ getBusyStore: () => h.busy }));
+vi.mock('../../../src/renderer/lib/stores/tool-panel.svelte', () => ({ getToolPanelStore: () => h.toolPanel }));
+vi.mock('../../../src/renderer/lib/stores/conversations.svelte', () => ({ getConversationsStore: () => h.conversations }));
+vi.mock('../../../src/renderer/lib/stores/bookmarks.svelte', () => ({ getBookmarksStore: () => h.bookmarks }));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogStore: () => h.dialog }));
+vi.mock('../../../src/renderer/lib/formatter/settings', () => ({ loadFormatSettings: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({ registerSkillInfos: vi.fn() }));
+vi.mock('../../../src/shared/skills/menu-config', () => ({ applyMenuConfig: vi.fn(() => []) }));
+
+import { registerAppIpc, type IpcWiringCtx } from '../../../src/renderer/lib/app/ipc-wiring';
+
+const editorComponent = {
+  getOffset: vi.fn(() => 0), getView: vi.fn(() => undefined),
+  changeFontSize: vi.fn(), currentFontSize: vi.fn(() => 18), resetFontSize: vi.fn(),
+  runSortLines: vi.fn(), openFind: vi.fn(), openFindReplace: vi.fn(),
+};
+const sidebar = { refreshTags: vi.fn(), refreshSources: vi.fn(), refreshTables: vi.fn() };
+const rightSidebar = { refresh: vi.fn() };
+
+function makeCtx(): { ctx: IpcWiringCtx; spies: Record<string, ReturnType<typeof vi.fn>> } {
+  const names = [
+    'bumpGraphRevision', 'setEditorFontSize', 'toggleSidebar', 'toggleRightSidebar',
+    'setShowGotoLine', 'setShowGotoNote', 'setShowEditSavedQueries', 'setShowAbout',
+    'setShowShortcuts', 'setShowSettings', 'setPublishDialogOpen', 'setFindInNotesMode',
+    'setExportDialogGroup', 'setEmbeddingProgress', 'refreshSavedQueriesCache', 'refreshBacklinkCount',
+    'newNote', 'editThoughtbaseGuide', 'save', 'saveAsTemplate', 'insertTemplate', 'cycleTheme',
+    'selectTheme', 'openThoughtbase', 'newThoughtbase', 'openRecentThoughtbase', 'navBack',
+    'navForward', 'rename', 'move', 'copy', 'extractSelection', 'splitHere', 'splitByHeading',
+    'autoTag', 'autoLink', 'autoLinkInbound', 'decompose', 'format', 'bibliography', 'ingestUrl',
+    'ingestIdentifier', 'ingestFile', 'importBibtex', 'importZoteroRdf', 'toolInvoke',
+    'newConversation', 'cycleViewMode',
+  ];
+  const spies: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const n of names) spies[n] = vi.fn();
+  const ctx = {
+    getEditorComponent: () => editorComponent,
+    getEditorComponents: () => ({ g1: { restorePosition: vi.fn() } }),
+    getSidebar: () => sidebar,
+    getRightSidebar: () => rightSidebar,
+    getEditorFontSize: () => 14,
+    refreshSourcesCache: vi.fn().mockResolvedValue(undefined),
+    refreshAliasMap: vi.fn().mockResolvedValue(undefined),
+    maybeShowOnboarding: vi.fn().mockResolvedValue(undefined),
+    maybeOpenEntrypoints: vi.fn().mockResolvedValue(undefined),
+    ...spies,
+  } as unknown as IpcWiringCtx;
+  return { ctx, spies };
+}
+
+let ctx: IpcWiringCtx;
+let spies: Record<string, ReturnType<typeof vi.fn>>;
+const fire = (channel: string, ...args: unknown[]) => h.captured[channel](...args);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of Object.keys(h.captured)) delete h.captured[k];
+  h.editor.activeFilePath = null;
+  h.editor.activeTab = undefined;
+  h.editor.groups = [];
+  h.busy.label = '';
+  window.print = vi.fn();
+  ({ ctx, spies } = makeCtx());
+  registerAppIpc(ctx);
+});
+
+describe('every registration is wired', () => {
+  it('registers each menu channel exactly once', () => {
+    for (const ch of h.MENU_CHANNELS) {
+      expect(h.captured[ch], `menu.${ch} not registered`).toBeTypeOf('function');
+    }
+  });
+
+  it('registers the non-menu event subscriptions', () => {
+    for (const key of [
+      'sources.onChanged', 'tables.onChanged', 'tables.collision', 'embeddings.backfill',
+      'nb.created', 'nb.deleted', 'nb.renamed', 'nb.rewritten', 'nb.heading',
+      'tools.stream', 'tools.invoke', 'sources.bibtex', 'sources.zotero',
+    ]) {
+      expect(h.captured[key], `${key} not registered`).toBeTypeOf('function');
+    }
+  });
+});
+
+describe('menu bindings dispatch to the right action (no arg / no guard)', () => {
+  // channel -> ctx spy name. Guards behavior is verified separately below.
+  const table: Array<[string, string]> = [
+    ['onNewNote', 'newNote'],
+    ['onEditThoughtbaseDoc', 'editThoughtbaseGuide'],
+    ['onSave', 'save'],
+    ['onSaveAsTemplate', 'saveAsTemplate'],
+    ['onInsertTemplate', 'insertTemplate'],
+    ['onCycleTheme', 'cycleTheme'],
+    ['onNewConversation', 'newConversation'],
+    ['onTogglePreview', 'cycleViewMode'],
+    ['onOpenProject', 'openThoughtbase'],
+    ['onNewProject', 'newThoughtbase'],
+    ['onNavBack', 'navBack'],
+    ['onNavForward', 'navForward'],
+    ['onEditSavedQueries', 'setShowEditSavedQueries'],
+    ['onFindInNotes', 'setFindInNotesMode'],
+    ['onReplaceInNotes', 'setFindInNotesMode'],
+    ['onAbout', 'setShowAbout'],
+    ['onShortcuts', 'setShowShortcuts'],
+    ['onOpenSettings', 'setShowSettings'],
+    ['onToggleSidebar', 'toggleSidebar'],
+    ['onToggleRightSidebar', 'toggleRightSidebar'],
+    ['onQuickOpen', 'setShowGotoNote'],
+    ['onRefactorExtract', 'extractSelection'],
+    ['onRefactorSplitHere', 'splitHere'],
+    ['onRefactorSplitByHeading', 'splitByHeading'],
+    ['onFormat', 'format'],
+    ['onBibliography', 'bibliography'],
+    ['onIngestUrl', 'ingestUrl'],
+    ['onIngestIdentifier', 'ingestIdentifier'],
+    ['onIngestFile', 'ingestFile'],
+    ['onImportBibtex', 'importBibtex'],
+    ['onImportZoteroRdf', 'importZoteroRdf'],
+    ['onPublish', 'setPublishDialogOpen'],
+  ];
+  it.each(table)('%s -> ctx.%s', (channel, spyName) => {
+    fire(channel);
+    expect(spies[spyName]).toHaveBeenCalledTimes(1);
+  });
+
+  it('onFindInNotes / onReplaceInNotes pass the mode', () => {
+    fire('onFindInNotes');
+    expect(spies.setFindInNotesMode).toHaveBeenCalledWith('find');
+    fire('onReplaceInNotes');
+    expect(spies.setFindInNotesMode).toHaveBeenCalledWith('replace');
+  });
+});
+
+describe('menu bindings backed by stores / api (not ctx)', () => {
+  it('onSplitRight / onSplitDown split the active group', () => {
+    fire('onSplitRight');
+    expect(h.editor.splitGroup).toHaveBeenCalledWith('g1', 'horizontal');
+    fire('onSplitDown');
+    expect(h.editor.splitGroup).toHaveBeenCalledWith('g1', 'vertical');
+  });
+
+  it('onCloseProject closes notebase and clears editor', () => {
+    fire('onCloseProject');
+    expect(h.notebase.close).toHaveBeenCalled();
+    expect(h.editor.clear).toHaveBeenCalled();
+  });
+
+  it('onClearRecent / onNewQuery / onPrint reach api / store / window', () => {
+    fire('onClearRecent');
+    expect(h.api.notebase.clearRecent).toHaveBeenCalled();
+    fire('onNewQuery');
+    expect(h.editor.openQuery).toHaveBeenCalled();
+    fire('onPrint');
+    expect(window.print).toHaveBeenCalled();
+  });
+
+  it('onSortLines / onFind / onFindReplace reach the editor component', () => {
+    fire('onSortLines');
+    fire('onFind');
+    fire('onFindReplace');
+    expect(editorComponent.runSortLines).toHaveBeenCalled();
+    expect(editorComponent.openFind).toHaveBeenCalled();
+    expect(editorComponent.openFindReplace).toHaveBeenCalled();
+  });
+
+  it('font commands drive the editor and mirror the size back', () => {
+    fire('onFontIncrease');
+    expect(editorComponent.changeFontSize).toHaveBeenCalledWith(1);
+    expect(spies.setEditorFontSize).toHaveBeenCalledWith(18);
+    fire('onFontReset');
+    expect(editorComponent.resetFontSize).toHaveBeenCalled();
+    expect(spies.setEditorFontSize).toHaveBeenCalledWith(14);
+  });
+});
+
+describe('arg-bearing menu bindings forward their payload', () => {
+  it('onSetTheme -> selectTheme(mode)', () => {
+    fire('onSetTheme', 'light');
+    expect(spies.selectTheme).toHaveBeenCalledWith('light');
+  });
+  it('onOpenRecentProject -> openRecentThoughtbase(path)', () => {
+    fire('onOpenRecentProject', '/recent/base');
+    expect(spies.openRecentThoughtbase).toHaveBeenCalledWith('/recent/base');
+  });
+  it('onOpenStockQuery -> editor.openQuery(query, language)', () => {
+    fire('onOpenStockQuery', { query: 'SELECT 1', language: 'sql' });
+    expect(h.editor.openQuery).toHaveBeenCalledWith('SELECT 1', 'sql');
+  });
+  it('onExport -> setExportDialogGroup(group)', () => {
+    fire('onExport', 'pdf');
+    expect(spies.setExportDialogGroup).toHaveBeenCalledWith('pdf');
+  });
+});
+
+describe('active-note guards', () => {
+  it('onRefactorRename dispatches only with an active file, and passes it', () => {
+    fire('onRefactorRename');
+    expect(spies.rename).not.toHaveBeenCalled();
+    h.editor.activeFilePath = 'notes/x.md';
+    fire('onRefactorRename');
+    expect(spies.rename).toHaveBeenCalledWith('notes/x.md');
+  });
+
+  it('onRefactorDecompose / AutoLinkInbound guard the same way', () => {
+    h.editor.activeFilePath = 'y.md';
+    fire('onRefactorDecompose');
+    fire('onRefactorAutoLinkInbound');
+    expect(spies.decompose).toHaveBeenCalledWith('y.md');
+    expect(spies.autoLinkInbound).toHaveBeenCalledWith('y.md');
+  });
+
+  it('onGotoLine opens the dialog only when a tab is active', () => {
+    fire('onGotoLine');
+    expect(spies.setShowGotoLine).not.toHaveBeenCalled();
+    h.editor.activeTab = { type: 'note' };
+    fire('onGotoLine');
+    expect(spies.setShowGotoLine).toHaveBeenCalledWith(true);
+  });
+
+  it('onOpenInDefault needs an active file; onOpenInTerminal always fires', () => {
+    fire('onOpenInDefault');
+    expect(h.api.shell.openInDefault).not.toHaveBeenCalled();
+    fire('onOpenInTerminal');
+    expect(h.api.shell.openInTerminal).toHaveBeenCalledWith(undefined);
+    h.editor.activeFilePath = 'a.md';
+    fire('onOpenInDefault');
+    expect(h.api.shell.openInDefault).toHaveBeenCalledWith('a.md');
+  });
+});
+
+describe('non-menu event handlers', () => {
+  it('sources.onChanged refreshes the sidebar sources + the cache', () => {
+    fire('sources.onChanged');
+    expect(sidebar.refreshSources).toHaveBeenCalled();
+    expect(ctx.refreshSourcesCache).toHaveBeenCalled();
+  });
+
+  it('embeddings backfill maps running progress to state, idle to null', () => {
+    fire('embeddings.backfill', { running: true, done: 3, total: 10 });
+    expect(spies.setEmbeddingProgress).toHaveBeenLastCalledWith({ done: 3, total: 10 });
+    fire('embeddings.backfill', { running: false, done: 10, total: 10 });
+    expect(spies.setEmbeddingProgress).toHaveBeenLastCalledWith(null);
+  });
+
+  it('tables.onNameCollision surfaces a suppressible confirm', () => {
+    fire('tables.collision', { tableName: 't', existingPath: 'a.csv', attemptedPath: 'b.csv' });
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+  });
+
+  it('notebase.onFileDeleted closes tabs for the path', () => {
+    fire('nb.deleted', 'gone.md');
+    expect(h.editor.closeTabsForDeletedPath).toHaveBeenCalledWith('gone.md');
+  });
+
+  it('tools.onInvoke forwards the tool id', () => {
+    fire('tools.invoke', 'skill-42');
+    expect(spies.toolInvoke).toHaveBeenCalledWith('skill-42');
+  });
+
+  it('import progress rewrites the busy label while a busy overlay is up', () => {
+    h.busy.label = 'Importing…';
+    fire('sources.bibtex', { done: 2, total: 5, currentTitle: 'A Paper' });
+    expect(h.busy.setLabel).toHaveBeenCalledWith('Importing 2/5: A Paper');
+  });
+
+  it('onProjectOpened restores the project then runs onboarding + entrypoints', async () => {
+    await fire('onProjectOpened', { rootPath: '/opened' });
+    expect(h.notebase.openPath).toHaveBeenCalledWith('/opened');
+    expect(h.editor.restoreTabs).toHaveBeenCalled();
+    expect(ctx.maybeShowOnboarding).toHaveBeenCalled();
+    expect(ctx.maybeOpenEntrypoints).toHaveBeenCalled();
+  });
+});
+
+describe('lifecycle hooks', () => {
+  it('wires editor.onAutoSaved to refresh + bump revision', () => {
+    expect(h.editor.onAutoSaved).toBeTypeOf('function');
+    h.editor.onAutoSaved!();
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+    expect(rightSidebar.refresh).toHaveBeenCalled();
+    expect(spies.bumpGraphRevision).toHaveBeenCalled();
+    expect(spies.refreshBacklinkCount).toHaveBeenCalled();
+  });
+
+  it('patches notebase.open to refresh panels after a delayed settle', async () => {
+    vi.useFakeTimers();
+    try {
+      const result = await h.notebase.open();
+      expect(result).toEqual({ rootPath: '/p' });
+      vi.runAllTimers();
+      expect(sidebar.refreshTags).toHaveBeenCalled();
+      expect(sidebar.refreshTables).toHaveBeenCalled();
+      expect(ctx.refreshSourcesCache).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Third slice of the App.svelte god-component breakup (#1084), following [#1368](https://github.com/dgriffith/ide-for-thought/pull/1368) and [#1369](https://github.com/dgriffith/ide-for-thought/pull/1369).

## What moved
All main↔renderer event wiring → `src/renderer/lib/app/ipc-wiring.ts` (`registerAppIpc(ctx)`, called once from `onMount`):
- the ~40 native-menu command bindings (`api.menu.on*`)
- the sources / tables / embeddings / notebase-watcher / tools broadcasts
- the bulk-import progress streams
- the `project:opened` restore flow
- the `editor.onAutoSaved` + `beforeunload` lifecycle hooks
- the `notebase.open` refresh patch and the skills-catalog load

Bodies are **verbatim**. Stores are pulled inside the module (so all `editor.*` / `notebase.*` / `bookmarkStore.*` / `busy.*` / `toolPanel.*` calls and `showConfirm` are direct); App bridges its ops handlers, component refs, and UI-chrome `$state` through `ctx`. `reportTheme` / `reportEditorState` stay in App — they're state-driven reports, not subscriptions.

The four top-level subscriptions + the `notebase.open` patch previously ran at script-init; moving them into `onMount` is safe because main only broadcasts them after a project is open (post-mount).

## The risk, and the guard
This is the slice I flagged in the earlier PRs as needing focused review: the `api.menu.on*` callbacks are **untyped `() => void`**, so a transposed binding (e.g. `onSave` firing `newNote`) compiles clean and only breaks at runtime — unlike the typed `CommandDeps`/`KeymapDeps` tables in #1369.

Two safety nets:
1. **`tests/renderer/app/ipc-wiring.test.ts` (57 cases)** — captures every registration and invokes each callback, asserting it dispatches to the expected action. Covers the pure dispatches (table-driven), the active-note guards (rename/decompose/gotoLine/openInDefault gate correctly), the arg-bearing payloads (setTheme/openRecentProject/openStockQuery/export), the non-menu event handlers (sources changed, backfill progress→state, name-collision confirm, file-deleted, tool-invoke, import-progress label, project-open), and the lifecycle hooks (onAutoSaved, the notebase.open settle patch).
2. **Parity diff against `main`** — all **63** `api.menu.on*` channels and every `sources`/`tables`/`embeddings`/`notebase`/`tools` subscription set are byte-identical (no binding lost or added).

## Impact
- `App.svelte`: **2038 → 1821 LOC** (−217); `onMount` is now bootstrap (theme/appearance) + one `registerAppIpc({…})` call
- `pnpm lint` clean; full suite **4285 passed** (+57)

## Staging
PR 3 of #1084. Remaining: the controller shrink (App → render-only). Per my note on #1369, most of App's residual bulk is now the ~670-line template + ~310-line `<style>` (legitimate render) — worth confirming how the "~400–500 LOC" target maps to script-vs-template before the final slice. Toward #1084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)