### PR TITLE
Task checkboxes: cascade a toggle down to nested sub-tasks

### DIFF
--- a/src/renderer/lib/editor/task-toggle.ts
+++ b/src/renderer/lib/editor/task-toggle.ts
@@ -1,19 +1,58 @@
 /**
- * Toggle a task-list checkbox (`[ ]` ↔ `[x]`) on a specific line.
+ * Toggle a task-list checkbox (`[ ]` ↔ `[x]`) on a specific line, cascading the
+ * new state down to every task nested under it.
  *
  * `lineIndex` is 0-indexed, matching markdown-it's token `map` convention
  * (which is what the preview emits on rendered checkboxes). Returns the
  * original content unchanged when the line isn't a task-list item —
  * callers can rely on reference-equality to detect "did anything change."
+ *
+ * **Downward cascade:** checking (or unchecking) a parent applies the same
+ * state to all of its nested sub-tasks — a descendant is any following line
+ * indented deeper than the toggled line, up to the first line that dedents back
+ * to its level or shallower. Blank lines don't end the subtree; a shallower
+ * content line does. Non-task lines inside the subtree (wrapped prose, nested
+ * code) are left untouched. Cascade is symmetric: unchecking a parent unchecks
+ * its sub-tasks too. (Upward cascade — auto-checking a parent when all its
+ * children are checked — is deliberately not implemented yet.)
  */
+
+const TASK_RE = /^(\s*(?:[-*+]|\d+[.)])\s+)\[([ xX])\](\s[\s\S]*)?$/;
+
+/** Leading-whitespace width in columns, with tabs advancing to the next
+ *  multiple of 4 so tab- and space-indented nesting compare consistently. */
+function leadingIndentWidth(line: string): number {
+  let w = 0;
+  for (const ch of line) {
+    if (ch === ' ') w += 1;
+    else if (ch === '\t') w += 4 - (w % 4);
+    else break;
+  }
+  return w;
+}
+
+/** Rewrite a matched task line's checkbox to `state` (`' '` or `'x'`),
+ *  preserving its marker prefix and trailing text. */
+function setCheckbox(match: RegExpMatchArray, state: ' ' | 'x'): string {
+  return `${match[1]}[${state}]${match[3] ?? ''}`;
+}
+
 export function toggleTaskOnLine(content: string, lineIndex: number): string {
   const lines = content.split('\n');
   if (lineIndex < 0 || lineIndex >= lines.length) return content;
-  const m = lines[lineIndex]!.match(
-    /^(\s*(?:[-*+]|\d+[.)])\s+)\[([ xX])\](\s[\s\S]*)?$/,
-  );
+  const m = lines[lineIndex]!.match(TASK_RE);
   if (!m) return content;
-  const next = m[2] === ' ' ? 'x' : ' ';
-  lines[lineIndex] = `${m[1]}[${next}]${m[3] ?? ''}`;
+  const next: ' ' | 'x' = m[2] === ' ' ? 'x' : ' ';
+  lines[lineIndex] = setCheckbox(m, next);
+
+  // Cascade `next` down to every task in this line's subtree.
+  const parentIndent = leadingIndentWidth(lines[lineIndex]);
+  for (let i = lineIndex + 1; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (line.trim() === '') continue; // blank lines don't end the subtree
+    if (leadingIndentWidth(line) <= parentIndent) break; // dedented out of it
+    const cm = line.match(TASK_RE);
+    if (cm) lines[i] = setCheckbox(cm, next);
+  }
   return lines.join('\n');
 }

--- a/tests/renderer/editor/task-toggle.test.ts
+++ b/tests/renderer/editor/task-toggle.test.ts
@@ -62,3 +62,52 @@ describe('toggleTaskOnLine (#127)', () => {
     expect(out).toBe('- [x] foo\r\n- [ ] bar\r\n');
   });
 });
+
+describe('toggleTaskOnLine — downward cascade', () => {
+  it('checking a parent checks every nested sub-task', () => {
+    const src = '- [ ] parent\n  - [ ] a\n  - [ ] b\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] parent\n  - [x] a\n  - [x] b\n');
+  });
+
+  it('unchecking a parent unchecks its sub-tasks (symmetric)', () => {
+    const src = '- [x] parent\n  - [x] a\n  - [x] b\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [ ] parent\n  - [ ] a\n  - [ ] b\n');
+  });
+
+  it('cascades through multiple depths', () => {
+    const src = '- [ ] p\n  - [ ] c1\n    - [ ] g1\n  - [ ] c2\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] p\n  - [x] c1\n    - [x] g1\n  - [x] c2\n');
+  });
+
+  it('stops at a sibling / ancestor — later top-level tasks are untouched', () => {
+    const src = '- [ ] p\n  - [ ] child\n- [ ] sibling\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] p\n  - [x] child\n- [ ] sibling\n');
+  });
+
+  it('toggling a leaf does not touch its parent or siblings', () => {
+    const src = '- [ ] p\n  - [ ] a\n  - [ ] b\n';
+    // Toggle `a` (line 1): only `a` flips.
+    expect(toggleTaskOnLine(src, 1)).toBe('- [ ] p\n  - [x] a\n  - [ ] b\n');
+  });
+
+  it('blank lines within the subtree do not end the cascade', () => {
+    const src = '- [ ] p\n  - [ ] a\n\n  - [ ] b\n- [ ] after\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] p\n  - [x] a\n\n  - [x] b\n- [ ] after\n');
+  });
+
+  it('leaves non-task lines inside the subtree untouched but keeps cascading past them', () => {
+    const src = '- [ ] p\n  - [ ] a\n  a note about a\n    - [ ] deep\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] p\n  - [x] a\n  a note about a\n    - [x] deep\n');
+  });
+
+  it('cascades under tab-indented children too', () => {
+    const src = '- [ ] p\n\t- [ ] a\n';
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] p\n\t- [x] a\n');
+  });
+
+  it('is idempotent when children already share the new state', () => {
+    const src = '- [ ] p\n  - [x] a\n  - [ ] b\n';
+    // Parent → checked: `a` stays checked, `b` becomes checked.
+    expect(toggleTaskOnLine(src, 0)).toBe('- [x] p\n  - [x] a\n  - [x] b\n');
+  });
+});


### PR DESCRIPTION
## What
Checking (or unchecking) a parent task now applies the same state to **every task nested under it** — the near-universal expectation (GitHub / Obsidian / Typora). Downward only, on by default, per the agreed scope.

Before, each checkbox was an independent toggle (the "No cascading" gotcha in `notes-tasks.html`).

## Behavior
- A **descendant** is any following line indented deeper than the toggled line, up to the first line that dedents back to its level or shallower.
- **Blank lines** don't end the subtree; **non-task lines** inside it (wrapped prose, nested code) are left untouched but don't stop the cascade.
- Indent is measured in **columns** (tab → next multiple of 4) so tab- and space-indented nesting compare consistently.
- **Symmetric**: unchecking a parent unchecks its sub-tasks too.
- **Idempotent**: children already in the new state are left as-is.
- **Upward cascade** (auto-check a parent when all children are checked) is deliberately **not** implemented — a separate, more opinionated behavior for later.

## Implementation
Entirely in the pure `toggleTaskOnLine(content, lineIndex)` helper — the single preview checkbox-click path (`Preview` → `handleTaskToggle` → `toggleTaskOnLine` → `editor.setContent`). No new call sites, no rendering changes; one undo step per click. (The editor's `toggleTaskList` command only adds/removes the `- [ ]` prefix and is untouched.)

## Tests
`task-toggle.test.ts` gains 9 cascade cases (multi-depth, sibling/ancestor boundary, blank lines, interleaved non-task lines, tab indentation, symmetric uncheck, idempotence) on top of the existing single-line tests — 21 total. `pnpm lint` clean.

## Docs follow-up (for you, since you're mid-cleanup)
The `notes-tasks.html` "No cascading" gotcha (line ~139) is now half-stale. Suggested rewording:
> **Downward cascade only.** Checking a parent task checks all its nested sub-tasks (and unchecking clears them). The reverse doesn't happen — checking every sub-task doesn't auto-check the parent.

I left the doc untouched so it rides with your docs pass (and doesn't churn the help-corpus snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)