### PR TITLE
Settings: editor font size + window zoom fields in Appearance

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, webUtils } from 'electron';
+import { contextBridge, ipcRenderer, webUtils, webFrame } from 'electron';
 import { Channels } from '../shared/channels';
 import { invoke } from './typed-invoke';
 import type { SearchInNotesOptions, ReplaceInNotesOptions, MenuEditorState } from '../shared/types';
@@ -200,6 +200,13 @@ contextBridge.exposeInMainWorld('api', {
   app: {
     getInfo: () => ipcRenderer.invoke(Channels.APP_GET_INFO),
     getShortcuts: () => ipcRenderer.invoke(Channels.APP_GET_SHORTCUTS),
+  },
+  // Whole-window zoom (#...). Wraps the renderer's own `webFrame` — the same
+  // frame zoom the View menu's zoom roles drive — so the Settings control and
+  // the menu shortcuts stay in sync. Synchronous: no IPC round-trip.
+  view: {
+    getZoomFactor: (): number => webFrame.getZoomFactor(),
+    setZoomFactor: (factor: number): void => webFrame.setZoomFactor(factor),
   },
   shell: {
     revealFile: (relativePath?: string) =>

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -77,6 +77,8 @@
     lineBookmarkName,
   } from './lib/app/text-helpers';
   import { initAppearance } from './lib/appearance/settings';
+  import { applyStoredZoom } from './lib/appearance/zoom';
+  import { clampFontSize } from './lib/editor/font-size';
   import { getConversationsStore } from './lib/stores/conversations.svelte';
   import { getBookmarksStore, collectBookmarksForPath } from './lib/stores/bookmarks.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
@@ -761,6 +763,9 @@
     // in sync with what the renderer loaded from localStorage (#1139).
     api.menu.reportTheme(themeLabel);
     initAppearance();
+    // Restore the persisted whole-window zoom (#...) — the View-menu zoom roles
+    // don't persist on their own.
+    applyStoredZoom();
 
     // All main↔renderer event wiring — the native-menu command bindings, the
     // sources/tables/embeddings/notebase-watcher/tools broadcasts, import
@@ -1481,6 +1486,16 @@
         saveEditorSettings(s);
         editorComponent?.applySettings(s);
         numberedHeadings = s.numberedHeadings;
+      }}
+      onApplyFontSize={(px) => {
+        // The Settings numeric control sets an absolute editor font size.
+        // Apply to every open pane so a split view stays consistent, mirror the
+        // status-bar value, and persist even when no editor is mounted.
+        const next = clampFontSize(px);
+        editorFontSize = next;
+        const editors = Object.values(editorComponents).filter((e): e is Editor => e !== undefined);
+        if (editors.length > 0) for (const ec of editors) ec.setFontSize(next);
+        else localStorage.setItem('editorFontSize', String(next));
       }}
       onThemeChanged={() => {
         themeLabel = getThemeMode();

--- a/src/renderer/lib/appearance/zoom.ts
+++ b/src/renderer/lib/appearance/zoom.ts
@@ -1,0 +1,47 @@
+/**
+ * Whole-window zoom as a persisted appearance setting (#...).
+ *
+ * Zoom scales the entire renderer via Electron's frame zoom factor — the same
+ * value the View menu's Actual Size / Zoom In / Zoom Out roles drive. Those
+ * menu roles are transient (not persisted); this module adds a persisted
+ * preference so a size chosen in Settings survives a restart. `getZoomFactor` /
+ * `setZoomFactor` cross the preload bridge to `webFrame` (see `api.view`).
+ *
+ * Note: the menu's Actual Size (⌘0) resets the live zoom to 100% for the
+ * session without clearing the stored preference, so a restart re-applies the
+ * stored value — the Settings field is the persistent default; ⌘0 is a
+ * temporary reset. The Settings dialog reads the *live* factor when it opens,
+ * so the field always reflects what's actually on screen.
+ */
+import { api } from '../ipc/client';
+
+const STORAGE_KEY = 'zoomFactor';
+
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 2.0;
+export const DEFAULT_ZOOM = 1.0;
+
+/** Clamp a zoom factor into the supported [MIN_ZOOM, MAX_ZOOM] range. */
+export function clampZoom(factor: number): number {
+  if (!Number.isFinite(factor)) return DEFAULT_ZOOM;
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, factor));
+}
+
+/** The persisted zoom factor, or DEFAULT_ZOOM when nothing valid is stored. */
+export function getStoredZoom(): number {
+  return clampZoom(parseFloat(localStorage.getItem(STORAGE_KEY) ?? String(DEFAULT_ZOOM)));
+}
+
+/** Persist a zoom factor and apply it to the live window. Returns the clamped
+ *  value actually applied. */
+export function setZoom(factor: number): number {
+  const next = clampZoom(factor);
+  localStorage.setItem(STORAGE_KEY, String(next));
+  api.view.setZoomFactor(next);
+  return next;
+}
+
+/** Apply the persisted zoom on startup (called from appearance init). */
+export function applyStoredZoom(): void {
+  api.view.setZoomFactor(getStoredZoom());
+}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -280,6 +280,17 @@
     }
   }
 
+  /** Set the editor font size to an absolute px value (clamped) — the Settings
+   *  panel's numeric control (#...). Persists + reconfigures like the
+   *  increment/decrement commands, just to a specific size. */
+  export function setFontSize(px: number) {
+    const next = clampFontSize(px);
+    localStorage.setItem('editorFontSize', String(next));
+    if (view) {
+      view.dispatch({ effects: fontSizeCompartment.reconfigure(fontSizeTheme(next)) });
+    }
+  }
+
   export function currentFontSize(): number {
     return getFontSize();
   }

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -8,6 +8,8 @@
     type FontFamilyPreset,
   } from '../appearance/settings';
   import { getThemeMode, setThemeMode, THEME_MODES, type ThemeMode } from '../theme';
+  import { clampFontSize, parseStoredFontSize, MIN_FONT, MAX_FONT, DEFAULT_FONT } from '../editor/font-size';
+  import { setZoom, getStoredZoom, MIN_ZOOM, MAX_ZOOM } from '../appearance/zoom';
   import { api } from '../ipc/client';
   import type { LLMSettingsUpdate } from '../../../shared/tools/types';
   import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
@@ -52,6 +54,9 @@
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
+    /** Apply an absolute editor font size (px) — the Appearance panel's numeric
+     *  control. App reconfigures the live editor(s) + persists. */
+    onApplyFontSize: (px: number) => void;
     onThemeChanged: () => void;
     onClose: () => void;
     /** Tab to land on when the dialog opens. Defaults to 'editor'. The
@@ -60,7 +65,7 @@
     initialTab?: TabId | undefined;
   }
 
-  let { onApplyEditor, onThemeChanged, onClose, initialTab }: Props = $props();
+  let { onApplyEditor, onApplyFontSize, onThemeChanged, onClose, initialTab }: Props = $props();
 
   type TabId = 'editor' | 'appearance' | 'behaviors' | 'notes' | 'formatter' | 'web' | 'sources' | 'clipper' | 'bibliography' | 'compute' | 'ai' | 'skills';
 
@@ -210,6 +215,23 @@
   // Appearance settings
   let theme = $state<ThemeMode>(getThemeMode());
   let fontFamily = $state<FontFamilyPreset>(getFontFamily());
+  // Editor font size (px) + whole-window zoom (%). Font size seeds from the
+  // stored value; zoom reads the *live* frame factor in onMount so the field
+  // reflects whatever the View-menu zoom shortcuts left on screen.
+  let editorFontSize = $state(clampFontSize(parseStoredFontSize(localStorage.getItem('editorFontSize'))));
+  let zoomPercent = $state(Math.round(getStoredZoom() * 100));
+
+  function applyEditorFontSize(px: number): void {
+    if (!Number.isFinite(px)) return; // ignore an empty / mid-edit field
+    editorFontSize = clampFontSize(px);
+    onApplyFontSize(editorFontSize);
+  }
+
+  function applyZoomPercent(percent: number): void {
+    if (!Number.isFinite(percent)) return;
+    const applied = setZoom(percent / 100);
+    zoomPercent = Math.round(applied * 100);
+  }
 
   // Font presets as an array for the select
   const fontPresets = Object.entries(FONT_FAMILY_PRESETS).map(([id, def]) => ({
@@ -267,6 +289,9 @@
   // ComputeSettings.svelte (self-contained).
 
   onMount(async () => {
+    // Reflect the live window zoom (the View-menu shortcuts may have changed it
+    // since it was last persisted).
+    zoomPercent = Math.round(api.view.getZoomFactor() * 100);
     try {
       const s = await api.tools.getSettings();
       model = s.model;
@@ -498,6 +523,46 @@
             </select>
             <p class="hint">
               Applies to the markdown editor and preview. App chrome always uses the system font.
+            </p>
+          </div>
+          <div class="field">
+            <label for="editor-font-size">Editor font size</label>
+            <div class="inline-num">
+              <input
+                id="editor-font-size"
+                type="number"
+                min={MIN_FONT}
+                max={MAX_FONT}
+                step="1"
+                value={editorFontSize}
+                onchange={(e) => applyEditorFontSize(parseInt(e.currentTarget.value, 10))}
+              />
+              <span class="unit">px</span>
+              <button class="btn-inline" onclick={() => applyEditorFontSize(DEFAULT_FONT)}>Reset</button>
+            </div>
+            <p class="hint">
+              Size of the text in the source editor only ({MIN_FONT}–{MAX_FONT}px). Also
+              adjustable with <kbd>⌘⇧=</kbd> / <kbd>⌘⇧-</kbd>.
+            </p>
+          </div>
+          <div class="field">
+            <label for="window-zoom">Window zoom</label>
+            <div class="inline-num">
+              <input
+                id="window-zoom"
+                type="number"
+                min={Math.round(MIN_ZOOM * 100)}
+                max={Math.round(MAX_ZOOM * 100)}
+                step="10"
+                value={zoomPercent}
+                onchange={(e) => applyZoomPercent(parseInt(e.currentTarget.value, 10))}
+              />
+              <span class="unit">%</span>
+              <button class="btn-inline" onclick={() => applyZoomPercent(100)}>Reset</button>
+            </div>
+            <p class="hint">
+              Scales the whole window — sidebar, toolbar, dialogs, and the editor together.
+              Also adjustable with <kbd>⌘+</kbd> / <kbd>⌘-</kbd> / <kbd>⌘0</kbd>.
             </p>
           </div>
 
@@ -1096,6 +1161,29 @@
     border: 1px solid var(--border);
     border-radius: 4px;
     font-size: 12px;
+  }
+
+  /* A number input paired with a unit label and a small Reset button. */
+  .inline-num {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .inline-num .unit {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .btn-inline {
+    padding: 4px 10px;
+    background: var(--bg-button, var(--bg));
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .btn-inline:hover {
+    border-color: var(--accent);
   }
 
   .field input[type="text"],

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -460,6 +460,13 @@ export interface AppApi {
   getShortcuts(): Promise<ShortcutGroup[]>;
 }
 
+/** Whole-window zoom (#...). Synchronous wrappers over the renderer's own
+ *  `webFrame`, so no promises. */
+export interface ViewApi {
+  getZoomFactor(): number;
+  setZoomFactor(factor: number): void;
+}
+
 export interface BookmarksApi {
   load(): Promise<BookmarkNode[]>;
   save(tree: BookmarkNode[]): Promise<void>;
@@ -763,6 +770,7 @@ export interface IdeApi {
   publish: PublishApi;
   shell: ShellApi;
   app: AppApi;
+  view: ViewApi;
   bookmarks: BookmarksApi;
   clipper: ClipperApi;
   conversations: ConversationsApi;

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -371,5 +371,9 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "prepareConversation",
     "setSettings",
   ],
+  "view": [
+    "getZoomFactor",
+    "setZoomFactor",
+  ],
 }
 `;

--- a/tests/preload/preload-bridge.test.ts
+++ b/tests/preload/preload-bridge.test.ts
@@ -58,7 +58,7 @@ describe('preload contextBridge contract (#676)', () => {
       'conversations', 'csl', 'embeddings', 'export', 'files', 'formatter', 'git', 'graph',
       'links', 'menu', 'notebase', 'proposals', 'publish', 'queries',
       'refactor', 'search', 'shell', 'sites', 'skills', 'sources', 'tables',
-      'tabs', 'tags', 'templates', 'tools',
+      'tabs', 'tags', 'templates', 'tools', 'view',
     ]);
   });
 

--- a/tests/renderer/appearance/zoom.test.ts
+++ b/tests/renderer/appearance/zoom.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Whole-window zoom persistence (#...). Mocks `api.view` (the webFrame bridge)
+ * and uses jsdom's localStorage to verify clamping, stored-value parsing, and
+ * that setZoom / applyStoredZoom both persist and push the factor to the frame.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ api: { view: { getZoomFactor: vi.fn(), setZoomFactor: vi.fn() } } }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+
+import {
+  clampZoom, getStoredZoom, setZoom, applyStoredZoom,
+  MIN_ZOOM, MAX_ZOOM, DEFAULT_ZOOM,
+} from '../../../src/renderer/lib/appearance/zoom';
+
+// Node's experimental Web Storage global shadows jsdom's localStorage but is
+// non-functional here, so swap in a simple in-memory Storage (mirrors the
+// RelatedPanel test's workaround).
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string): string | null { return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string): void { this.m.set(k, String(v)); }
+  removeItem(k: string): void { this.m.delete(k); }
+  clear(): void { this.m.clear(); }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('localStorage', new MemStorage());
+});
+
+describe('clampZoom', () => {
+  it('clamps to [MIN_ZOOM, MAX_ZOOM]', () => {
+    expect(clampZoom(0.1)).toBe(MIN_ZOOM);
+    expect(clampZoom(5)).toBe(MAX_ZOOM);
+    expect(clampZoom(1.25)).toBe(1.25);
+  });
+  it('falls back to DEFAULT_ZOOM for non-finite input', () => {
+    expect(clampZoom(NaN)).toBe(DEFAULT_ZOOM);
+    expect(clampZoom(Infinity)).toBe(DEFAULT_ZOOM);
+  });
+});
+
+describe('getStoredZoom', () => {
+  it('returns DEFAULT_ZOOM when nothing is stored', () => {
+    expect(getStoredZoom()).toBe(DEFAULT_ZOOM);
+  });
+  it('parses and clamps a stored value', () => {
+    localStorage.setItem('zoomFactor', '1.4');
+    expect(getStoredZoom()).toBe(1.4);
+    localStorage.setItem('zoomFactor', '99');
+    expect(getStoredZoom()).toBe(MAX_ZOOM);
+    localStorage.setItem('zoomFactor', 'garbage');
+    expect(getStoredZoom()).toBe(DEFAULT_ZOOM);
+  });
+});
+
+describe('setZoom', () => {
+  it('persists the clamped factor and pushes it to the frame', () => {
+    const applied = setZoom(1.3);
+    expect(applied).toBe(1.3);
+    expect(localStorage.getItem('zoomFactor')).toBe('1.3');
+    expect(h.api.view.setZoomFactor).toHaveBeenCalledWith(1.3);
+  });
+  it('clamps out-of-range input before persisting/applying', () => {
+    const applied = setZoom(10);
+    expect(applied).toBe(MAX_ZOOM);
+    expect(localStorage.getItem('zoomFactor')).toBe(String(MAX_ZOOM));
+    expect(h.api.view.setZoomFactor).toHaveBeenCalledWith(MAX_ZOOM);
+  });
+});
+
+describe('applyStoredZoom', () => {
+  it('pushes the stored factor to the frame without writing storage', () => {
+    localStorage.setItem('zoomFactor', '0.75');
+    applyStoredZoom();
+    expect(h.api.view.setZoomFactor).toHaveBeenCalledWith(0.75);
+  });
+  it('applies DEFAULT_ZOOM when nothing is stored', () => {
+    applyStoredZoom();
+    expect(h.api.view.setZoomFactor).toHaveBeenCalledWith(DEFAULT_ZOOM);
+  });
+});


### PR DESCRIPTION
## What
Both text-scaling controls were menu/shortcut only — the [Font size & zoom doc](../website/docs/viewing-options-font-size-zoom.html) noted there was "no Settings-panel control for either." This adds two numeric fields (each with a Reset button) to **Settings → Appearance**.

### Editor font size
A px field (10–24) that applies to **every open pane** and persists to `localStorage.editorFontSize` — the same store the ⌘⇧= / ⌘⇧- shortcuts use, so the two stay consistent. New `Editor.setFontSize(px)` mirrors the existing increment/decrement/reset methods with an absolute value.

### Window zoom
A percentage field (50–200%). Zoom was previously **pure Electron menu roles** (`zoomIn`/`zoomOut`/`resetZoom`) with no get/set surface and no persistence. This adds:
- a tiny **`api.view`** preload bridge over the renderer's own `webFrame` (`get`/`setZoomFactor`) — the *same* frame zoom the menu roles drive, so Settings and the ⌘±/⌘0 shortcuts stay in sync, no IPC round-trip;
- **`appearance/zoom.ts`** — persists the factor (`localStorage.zoomFactor`) and re-applies it on startup (the menu roles don't persist on their own).

The dialog reads the **live** factor when it opens, so the field always reflects what's on screen even if you just used ⌘0/⌘±.

**Behavior note:** the menu's Actual Size (⌘0) is a transient session reset and doesn't clear the stored preference, so a restart re-applies the stored zoom. The Settings value is the persistent default; ⌘0 is a temporary reset.

## Tests
- `appearance/zoom.test.ts` (8) — clamp, stored-value parse, `setZoom`/`applyStoredZoom` persist + push to the frame.
- `preload-bridge.test.ts` — namespace allowlist + snapshot updated for the new `view` namespace.
- `pnpm lint` clean; full suite green (the one failing test is the pre-existing help-docs-corpus staleness from unrelated in-flight doc edits).

## Verification note
The zoom module, preload contract, and font clamping are unit-tested. I did **not** drive the live UI end-to-end (a full `SettingsDialog` render test would mean mocking its whole async `onMount` + every sub-panel — heavy and brittle for simple onchange wiring, and `webFrame.setZoomFactor` is a standard Electron API). Worth a 30-second manual sanity check that dragging the zoom field scales the window and font size resizes the editor.

## Docs follow-up (for your docs pass)
The "No Settings-panel control for either" gotcha in `viewing-options-font-size-zoom.html` is now stale — both are configurable in Appearance. Left untouched so it rides with your docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)