### PR TITLE
Settings: "Check connection" button to validate the API key

### DIFF
--- a/src/main/ipc/register-tools.ts
+++ b/src/main/ipc/register-tools.ts
@@ -9,6 +9,7 @@ import { getMenuConfig, saveMenuConfig } from '../skills/menu-config-store';
 import { toSkillInfo, type SkillCatalogInfo } from '../../shared/skills/types';
 import type { MenuConfig } from '../../shared/skills/menu-config';
 import { getSettingsForDisplay, saveSettings, getApiKeyStorage } from '../llm/settings';
+import { checkConnection } from '../llm/validate';
 import type { ToolExecutionRequest, LLMSettingsUpdate } from '../../shared/tools/types';
 import { winFromEvent } from './helpers';
 
@@ -95,4 +96,10 @@ export function registerTools(): void {
   ipcMain.handle(Channels.TOOL_SET_SETTINGS, (_e, update: LLMSettingsUpdate) => saveSettings(update));
 
   ipcMain.handle(Channels.TOOL_GET_KEY_STORAGE, () => getApiKeyStorage());
+
+  // Active key validation for the settings "Check connection" button — an
+  // unsaved typed key (if any) takes precedence over the stored one.
+  ipcMain.handle(Channels.TOOL_CHECK_CONNECTION, (_e, candidateKey?: string) =>
+    checkConnection(candidateKey),
+  );
 }

--- a/src/main/llm/connection-error.ts
+++ b/src/main/llm/connection-error.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure error → reason mapping for the "Check connection" flow (#...). A leaf
+ * module (imports only the result type) so both the provider — which owns the
+ * SDK request — and the validation entry point can share it without an import
+ * cycle, and it stays unit-testable without the SDK.
+ *
+ * Anthropic SDK errors carry an HTTP `status`; a status-less error is a
+ * connection failure before we reached the API.
+ */
+import type { ConnectionCheckResult } from '../../shared/tools/types';
+
+export function describeConnectionFailure(err: unknown): string {
+  const status = (err as { status?: number } | null)?.status;
+  if (status === 401) {
+    return 'Anthropic rejected this key — it may be invalid, expired, or revoked.';
+  }
+  if (status === 403) {
+    return 'This key authenticated but is not permitted to use the API.';
+  }
+  if (status === 429) {
+    return 'Rate limited — the key works, but too many requests just now. Try again shortly.';
+  }
+  if (typeof status === 'number' && status >= 500) {
+    return 'Anthropic had a server error. The key may be fine — try again shortly.';
+  }
+  const detail = err instanceof Error ? err.message : String(err);
+  return `Couldn't reach Anthropic: ${detail}`;
+}
+
+/** Convenience wrapper: run a token-free validation request, mapping any throw
+ *  to a `{ ok: false, error }`. The provider passes its SDK call in. */
+export async function toConnectionResult(request: () => Promise<unknown>): Promise<ConnectionCheckResult> {
+  try {
+    await request();
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: describeConnectionFailure(err) };
+  }
+}

--- a/src/main/llm/provider/anthropic.ts
+++ b/src/main/llm/provider/anthropic.ts
@@ -11,6 +11,8 @@
  */
 import Anthropic from '@anthropic-ai/sdk';
 import type { Citation, TurnUsage } from '../../../shared/types';
+import type { ConnectionCheckResult } from '../../../shared/tools/types';
+import { toConnectionResult } from '../connection-error';
 import type { Effort } from '../../../shared/tools/effort';
 import type {
   ChatMessage,
@@ -219,5 +221,11 @@ export class AnthropicProvider implements LLMProvider {
     stream.on('text', (delta) => onDelta(delta));
     const finalMessage = await stream.finalMessage();
     return { text: extractText(finalMessage.content), usage: foldUsage(emptyUsage(), finalMessage.usage) };
+  }
+
+  async checkConnection(): Promise<ConnectionCheckResult> {
+    // A minimal authenticated GET: no tokens spent, model-agnostic. Any success
+    // means the key is accepted.
+    return toConnectionResult(() => this.client.models.list({ limit: 1 }));
   }
 }

--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -44,3 +44,12 @@ export async function getProvider(): Promise<ResolvedProvider> {
     effort: settings.effort,
   };
 }
+
+/**
+ * Build a provider bound to an explicit key, bypassing stored settings — used
+ * by the "Check connection" validator to test an unsaved typed key. Keeps
+ * provider construction (and the SDK) behind the seam.
+ */
+export function createProviderForKey(apiKey: string): LLMProvider {
+  return new AnthropicProvider(apiKey);
+}

--- a/src/main/llm/provider/types.ts
+++ b/src/main/llm/provider/types.ts
@@ -14,6 +14,7 @@
  */
 import type { Citation, TurnUsage } from '../../../shared/types';
 import type { Effort } from '../../../shared/tools/effort';
+import type { ConnectionCheckResult } from '../../../shared/tools/types';
 
 /**
  * A provider-neutral tool declaration — the JSON-Schema shape the model sees.
@@ -147,4 +148,8 @@ export interface LLMProvider {
     req: CompletionRequest,
     onDelta?: (delta: string) => void,
   ): Promise<CompletionResult>;
+  /** Validate the configured key with a cheap, token-free request — powers the
+   *  settings "Check connection" button. Never throws: failures come back as
+   *  `{ ok: false, error }`. */
+  checkConnection(): Promise<ConnectionCheckResult>;
 }

--- a/src/main/llm/validate.ts
+++ b/src/main/llm/validate.ts
@@ -1,0 +1,29 @@
+/**
+ * Active API-key validation for the settings "Check connection" button (#...).
+ *
+ * The `hasApiKey` flag is a presence check — it says something is stored, not
+ * that Anthropic will accept it. This makes a real, *free* request
+ * (`models.list`, a GET that spends no tokens) via the provider so an expired /
+ * revoked / mistyped key surfaces immediately instead of on the next message.
+ *
+ * Validates the *effective* key: a non-empty `candidateKey` (an unsaved value
+ * still in the settings input) takes precedence, so the user can test a key
+ * before committing it; otherwise the stored key (or `ANTHROPIC_API_KEY`) is
+ * used via `getSettings()`.
+ *
+ * The actual request lives in the provider (the only place the Anthropic SDK is
+ * imported, per the #1148 seam); this module owns key resolution and the pure
+ * error → reason mapping.
+ */
+import { createProviderForKey } from './provider';
+import { getSettings } from './settings';
+import type { ConnectionCheckResult } from '../../shared/tools/types';
+
+export async function checkConnection(candidateKey?: string): Promise<ConnectionCheckResult> {
+  const typed = candidateKey?.trim();
+  const key = typed && typed.length > 0 ? typed : (await getSettings()).apiKey;
+  if (!key) {
+    return { ok: false, error: 'No API key to check — enter one above or save it first.' };
+  }
+  return createProviderForKey(key).checkConnection();
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -424,6 +424,8 @@ contextBridge.exposeInMainWorld('api', {
     getSettings: () => ipcRenderer.invoke(Channels.TOOL_GET_SETTINGS),
     setSettings: (settings: unknown) => ipcRenderer.invoke(Channels.TOOL_SET_SETTINGS, settings),
     getKeyStorage: () => ipcRenderer.invoke(Channels.TOOL_GET_KEY_STORAGE),
+    checkConnection: (candidateKey?: string) =>
+      ipcRenderer.invoke(Channels.TOOL_CHECK_CONNECTION, candidateKey),
     onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
   },
   skills: {

--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -12,7 +12,7 @@
    */
   import { MODEL_OPTIONS } from '../../../shared/tools/models';
   import { EFFORT_LEVELS, type Effort } from '../../../shared/tools/effort';
-  import type { ApiKeyStorage } from '../../../shared/tools/types';
+  import type { ApiKeyStorage, ConnectionCheckResult } from '../../../shared/tools/types';
   import { voiceSettings, VOICE_MODEL_OPTIONS } from '../voice/voice-settings.svelte';
 
   interface Props {
@@ -23,6 +23,9 @@
     apiKeyStatus: 'unknown' | 'set' | 'unset';
     /** At-rest storage status of the saved key (#1326). Null while loading. */
     keyStorage: ApiKeyStorage | null;
+    /** Actively validate a key against Anthropic — the typed value if present,
+     *  else the stored one. */
+    onCheckConnection: (candidateKey: string) => Promise<ConnectionCheckResult>;
   }
 
   let {
@@ -32,11 +35,35 @@
     clearApiKey = $bindable(),
     apiKeyStatus,
     keyStorage,
+    onCheckConnection,
   }: Props = $props();
 
   // The saved key is protected at rest only when it's actually encrypted on
   // disk — reflect that literally, don't claim security we don't have.
   const keyEncrypted = $derived(apiKeyStatus === 'set' && !clearApiKey && keyStorage?.encrypted === true);
+
+  // "Check connection" — a presence check (✓ API key saved) doesn't prove
+  // Anthropic will accept the key; this fires a real request on demand.
+  let checking = $state(false);
+  let checkResult = $state<ConnectionCheckResult | null>(null);
+  // A stale result must not linger after the key text changes.
+  $effect(() => { void apiKeyInput; checkResult = null; });
+  // Nothing to check when clearing, or when there's neither a stored key nor a
+  // typed one.
+  const canCheck = $derived(!clearApiKey && (apiKeyStatus === 'set' || apiKeyInput.trim().length > 0));
+
+  async function runCheck() {
+    if (checking) return;
+    checking = true;
+    checkResult = null;
+    try {
+      checkResult = await onCheckConnection(apiKeyInput);
+    } catch (e) {
+      checkResult = { ok: false, error: e instanceof Error ? e.message : String(e) };
+    } finally {
+      checking = false;
+    }
+  }
 
   // '' in the <select> means "no override → built-in default"; map to/from
   // the optional `effort` prop.
@@ -112,6 +139,16 @@
     The saved value is never displayed back. You can also set
     <code>ANTHROPIC_API_KEY</code> as an environment variable.
   </p>
+  <div class="check-conn">
+    <button class="btn-check" onclick={runCheck} disabled={!canCheck || checking}>
+      {checking ? 'Checking…' : 'Check connection'}
+    </button>
+    {#if checkResult}
+      <span class="check-result" class:ok={checkResult.ok} class:bad={!checkResult.ok}>
+        {#if checkResult.ok}✓ Connected — Anthropic accepted the key.{:else}✗ {checkResult.error}{/if}
+      </span>
+    {/if}
+  </div>
   {#if apiKeyStatus === 'set' && !clearApiKey}
     <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
       Clear saved key
@@ -214,4 +251,30 @@
   .api-key-status.saved {
     color: var(--accent);
   }
+
+  /* Check-connection row: a small button + an inline result. Success uses
+     --sage, failure --rust (signal colors, not red — per CLAUDE.md). */
+  .check-conn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+  }
+  .btn-check {
+    padding: 4px 12px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button, var(--bg));
+    color: var(--text);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .btn-check:hover:not(:disabled) { border-color: var(--accent); }
+  .btn-check:disabled { opacity: 0.5; cursor: default; }
+  .check-result {
+    font-size: 11px;
+  }
+  .check-result.ok { color: var(--sage); }
+  .check-result.bad { color: var(--rust); }
 </style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -956,6 +956,7 @@
             bind:clearApiKey
             {apiKeyStatus}
             {keyStorage}
+            onCheckConnection={(candidateKey) => api.tools.checkConnection(candidateKey)}
           />
         {/if}
       </section>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -669,6 +669,9 @@ export interface ToolsApi {
   getSettings(): Promise<import('../../../shared/tools/types').LLMSettingsView>;
   setSettings(update: import('../../../shared/tools/types').LLMSettingsUpdate): Promise<void>;
   getKeyStorage(): Promise<import('../../../shared/tools/types').ApiKeyStorage>;
+  /** Actively validate an API key against Anthropic. Pass the unsaved typed key
+   *  to test it before saving; omit/empty to test the stored key. */
+  checkConnection(candidateKey?: string): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
   onInvoke(cb: (toolId: string) => void): void;
 }
 

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -403,6 +403,8 @@ export const Channels = {
   TOOL_SET_SETTINGS: 'tool:setSettings',
   /** At-rest storage status of the API key, for the settings panel (#1326). */
   TOOL_GET_KEY_STORAGE: 'tool:getKeyStorage',
+  /** Actively validate an API key against Anthropic (a free models.list GET). */
+  TOOL_CHECK_CONNECTION: 'tool:checkConnection',
   /** Prepare the system prompt + first message + model for a conversational tool. */
   TOOL_PREPARE_CONVERSATION: 'tool:prepareConversation',
 

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -247,6 +247,15 @@ export interface ApiKeyStorage {
   encrypted: boolean;
 }
 
+/** Result of an active "check connection" against Anthropic (#...). Unlike the
+ *  `hasApiKey` presence flag, this reflects whether Anthropic actually accepts
+ *  the key. */
+export interface ConnectionCheckResult {
+  ok: boolean;
+  /** Human-readable reason when `ok` is false. */
+  error?: string;
+}
+
 export interface LLMSettings {
   apiKey: string;
   model: string;

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -210,6 +210,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "templates:list",
   "templates:saveAs",
   "tool:cancel",
+  "tool:checkConnection",
   "tool:execute",
   "tool:getKeyStorage",
   "tool:getSettings",

--- a/tests/main/llm/validate.test.ts
+++ b/tests/main/llm/validate.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Active API-key validation for the settings "Check connection" button (#...).
+ * `checkConnection` resolves the effective key (typed beats stored) and delegates
+ * the request to the provider (mocked here — the SDK stays behind the #1148
+ * seam). `describeConnectionFailure` is the pure error → reason mapper.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  providerCheck: vi.fn(),
+  createProviderForKey: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock('../../../src/main/llm/provider', () => ({ createProviderForKey: h.createProviderForKey }));
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: h.getSettings }));
+
+import { checkConnection } from '../../../src/main/llm/validate';
+import { describeConnectionFailure } from '../../../src/main/llm/connection-error';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getSettings.mockResolvedValue({ apiKey: 'sk-stored' });
+  h.providerCheck.mockResolvedValue({ ok: true });
+  h.createProviderForKey.mockReturnValue({ checkConnection: h.providerCheck });
+});
+
+describe('checkConnection — key resolution', () => {
+  it('validates a typed key (trimmed) without touching stored settings', async () => {
+    const res = await checkConnection('  sk-typed  ');
+    expect(res).toEqual({ ok: true });
+    expect(h.getSettings).not.toHaveBeenCalled();
+    expect(h.createProviderForKey).toHaveBeenCalledWith('sk-typed');
+  });
+
+  it('falls back to the stored key when no candidate is given', async () => {
+    await checkConnection('');
+    expect(h.getSettings).toHaveBeenCalled();
+    expect(h.createProviderForKey).toHaveBeenCalledWith('sk-stored');
+  });
+
+  it('short-circuits with no provider call when there is no key at all', async () => {
+    h.getSettings.mockResolvedValue({ apiKey: '' });
+    const res = await checkConnection(undefined);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/No API key/i);
+    expect(h.createProviderForKey).not.toHaveBeenCalled();
+  });
+
+  it('passes the provider result straight through', async () => {
+    h.providerCheck.mockResolvedValue({ ok: false, error: 'Anthropic rejected this key' });
+    const res = await checkConnection('sk-bad');
+    expect(res).toEqual({ ok: false, error: 'Anthropic rejected this key' });
+  });
+});
+
+describe('describeConnectionFailure — reason mapping', () => {
+  const withStatus = (status: number) => Object.assign(new Error('x'), { status });
+
+  it('401 → invalid / expired / revoked', () => {
+    expect(describeConnectionFailure(withStatus(401))).toMatch(/invalid, expired, or revoked/i);
+  });
+  it('403 → not permitted', () => {
+    expect(describeConnectionFailure(withStatus(403))).toMatch(/not permitted/i);
+  });
+  it('429 → rate limited (key still works)', () => {
+    expect(describeConnectionFailure(withStatus(429))).toMatch(/rate limited/i);
+  });
+  it('5xx → server error', () => {
+    expect(describeConnectionFailure(withStatus(503))).toMatch(/server error/i);
+  });
+  it('status-less error → connection failure with the detail', () => {
+    const msg = describeConnectionFailure(new Error('ECONNREFUSED'));
+    expect(msg).toMatch(/couldn't reach anthropic/i);
+    expect(msg).toContain('ECONNREFUSED');
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -363,6 +363,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
   ],
   "tools": [
     "cancel",
+    "checkConnection",
     "execute",
     "getKeyStorage",
     "getSettings",

--- a/tests/renderer/components/AiSettings.test.ts
+++ b/tests/renderer/components/AiSettings.test.ts
@@ -8,20 +8,23 @@
  * overrides moved to SkillsSettings — see SkillsSettings.test.ts.)
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import type { ConnectionCheckResult } from '../../../src/shared/tools/types';
 
 import AiSettings from '../../../src/renderer/lib/components/AiSettings.svelte';
 
 function props(over: Partial<{
   model: string; apiKeyInput: string; clearApiKey: boolean;
   apiKeyStatus: 'unknown' | 'set' | 'unset';
+  onCheckConnection: (candidateKey: string) => Promise<ConnectionCheckResult>;
 }> = {}) {
   return {
     model: 'claude-sonnet-4-6',
     apiKeyInput: '',
     clearApiKey: false,
     apiKeyStatus: 'set' as const,
+    onCheckConnection: vi.fn(async () => ({ ok: true })),
     ...over,
   };
 }
@@ -54,5 +57,40 @@ describe('AiSettings (#672)', () => {
   it('renders the default-model select with the bound value', () => {
     const { getByLabelText } = render(AiSettings, props());
     expect((getByLabelText('Default model') as HTMLSelectElement).value).toBe('claude-sonnet-4-6');
+  });
+
+  it('Check connection calls back with the typed key and shows success', async () => {
+    const onCheckConnection = vi.fn(async () => ({ ok: true }));
+    const { getByText, findByText } = render(
+      AiSettings,
+      props({ apiKeyInput: 'sk-typed', apiKeyStatus: 'unset', onCheckConnection }),
+    );
+    await fireEvent.click(getByText('Check connection'));
+    expect(onCheckConnection).toHaveBeenCalledWith('sk-typed');
+    await findByText(/Connected/);
+  });
+
+  it('shows the failure reason returned by the check', async () => {
+    const onCheckConnection = vi.fn(
+      async (): Promise<ConnectionCheckResult> => ({ ok: false, error: 'Anthropic rejected this key' }),
+    );
+    const { getByText, findByText } = render(AiSettings, props({ apiKeyStatus: 'set', onCheckConnection }));
+    await fireEvent.click(getByText('Check connection'));
+    await findByText(/rejected this key/);
+  });
+
+  it('disables Check connection when there is neither a stored nor a typed key', () => {
+    const { getByText } = render(AiSettings, props({ apiKeyStatus: 'unset', apiKeyInput: '' }));
+    expect((getByText('Check connection') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('clears a stale result when the key text changes', async () => {
+    const { getByText, getByLabelText, findByText, queryByText } = render(
+      AiSettings, props({ apiKeyStatus: 'set' }),
+    );
+    await fireEvent.click(getByText('Check connection'));
+    await findByText(/Connected/);
+    await fireEvent.input(getByLabelText('Anthropic API key'), { target: { value: 'x' } });
+    await waitFor(() => expect(queryByText(/Connected/)).toBeNull());
   });
 });


### PR DESCRIPTION
## What
"✓ API key saved" is only a **presence** check — an expired, revoked, or mistyped key still shows it (the [AI settings doc](../website/docs/settings-ai.html) calls this out), and a bad key only surfaces on the next real message. This adds a **Check connection** button to Settings → AI that makes a real, **token-free** request (`models.list`, a GET) and reports whether Anthropic actually accepts the key.

## Behavior
- **Tests the effective key**: if there's an unsaved key typed in the field, it validates *that* (so you can verify before saving); otherwise the stored key / `ANTHROPIC_API_KEY`. (You confirmed testing the unsaved key matters — a typed-but-untested key would be confusing.)
- **On-demand only** — never auto-runs on dialog open. The presence indicator stays; this is complementary.
- Success → **✓ Connected** (`--sage`); failure → the specific reason (`--rust`): 401 → invalid/expired/revoked, 403 → not permitted, 429 → rate-limited (key works), 5xx → server error, network → couldn't reach Anthropic.
- A stale result clears when the key text changes; the button is disabled when there's neither a stored nor a typed key.

## Architecture (kept behind the #1148 provider seam)
The `provider-seam` test confines `@anthropic-ai/sdk` to `anthropic.ts`, so:
- the SDK request is a new **`checkConnection()`** on the `LLMProvider` interface, implemented in `anthropic.ts`;
- a **`createProviderForKey(key)`** factory builds a provider for an unsaved key;
- `llm/validate.ts` only resolves the effective key + delegates;
- the pure **error→reason mapper** lives in a leaf `connection-error.ts` (no SDK, no import cycle) shared by the provider and the validator.

New IPC: `api.tools.checkConnection(candidateKey?)`.

## Tests
- `validate.test.ts` (9) — key resolution (typed beats stored, trim, fallback, no-key short-circuit, result passthrough) + the pure reason mapper (401/403/429/5xx/network).
- `AiSettings.test.ts` (+5) — button calls back with the typed key, success + failure rendering, disabled state, stale-result clear.
- Preload + IPC-registration snapshots updated. `pnpm lint` clean; suite green (the one failure is the pre-existing help-docs staleness from unrelated in-flight doc edits).

## Verification note
The key-resolution, seam routing, reason mapping, and UI wiring are unit-tested. The one thing not automated is a **live 401/success round-trip** to Anthropic (a real network call) — worth a quick manual check with a good and a deliberately-broken key.

## Docs follow-up (your docs pass)
The "presence check, not a working-key check" gotcha in `settings-ai.html` can now note the Check connection button. Left untouched to ride with your docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)