### PR TITLE
Appearance: hint when a named-mono preset font isn't installed

### DIFF
--- a/src/renderer/lib/appearance/font-detect.ts
+++ b/src/renderer/lib/appearance/font-detect.ts
@@ -1,0 +1,66 @@
+/**
+ * Best-effort detection of whether a *locally installed* font face is available
+ * (#...). The named mono presets (JetBrains Mono, Berkeley Mono) only set a
+ * font-family preference — if the face isn't installed, the browser silently
+ * falls through to a fallback. This lets the Appearance panel surface a soft
+ * "doesn't appear to be installed" hint instead of leaving it invisible.
+ *
+ * `document.fonts.check()` is NOT usable here: it only reports fonts in the
+ * FontFaceSet (@font-face / loaded web fonts), and Minerva bundles none — every
+ * preset is a system-font name. So we use the classic canvas text-metrics
+ * heuristic: render a probe string in `"<family>", <generic>` and compare its
+ * measured width against the generic alone. If the family actually applied, the
+ * width differs from the fallback for at least one generic baseline; if it fell
+ * through, the widths match. It's a heuristic — a face whose metrics happen to
+ * match the fallback can read as "absent" — so callers must treat a negative as
+ * a soft hint, never a hard error.
+ */
+
+/** Generic families to compare against; the `.some` across all three covers the
+ *  case where the target font coincides with one generic's platform default. */
+const BASELINES = ['monospace', 'sans-serif', 'serif'] as const;
+/** Glyph-varied + long so per-glyph advance differences accumulate; large size
+ *  amplifies them. */
+const PROBE = 'mmmmmmmmmmlliwWi0O1234567890';
+const SIZE = 72;
+
+/** Measures the rendered width of the probe string for a CSS `font` shorthand. */
+export type Measure = (cssFont: string) => number;
+
+/**
+ * Pure core: given a width-measuring function, is `family` installed? True when,
+ * against at least one generic baseline, the probe measured in that family
+ * differs from the baseline alone.
+ */
+export function isFontInstalledWith(measure: Measure, family: string): boolean {
+  return BASELINES.some((base) => {
+    const baseline = measure(`${SIZE}px ${base}`);
+    const withFamily = measure(`${SIZE}px "${family}", ${base}`);
+    return withFamily !== baseline;
+  });
+}
+
+/** A canvas-backed measurer, or null when no 2D canvas is available. */
+function canvasMeasurer(): Measure | null {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  return (cssFont) => {
+    ctx.font = cssFont;
+    return ctx.measureText(PROBE).width;
+  };
+}
+
+/**
+ * Whether `family` appears to be installed on this system. Returns `true` when
+ * detection can't run (no canvas), so we never nag on a false negative.
+ */
+export function isFontInstalled(family: string): boolean {
+  try {
+    const measure = canvasMeasurer();
+    if (!measure) return true;
+    return isFontInstalledWith(measure, family);
+  } catch {
+    return true;
+  }
+}

--- a/src/renderer/lib/appearance/settings.ts
+++ b/src/renderer/lib/appearance/settings.ts
@@ -13,6 +13,11 @@ interface PresetDef {
   label: string;
   /** null means: don't set --content-font-family, let --font-mono win. */
   css: string | null;
+  /** A specific named face this preset depends on that may not be installed
+   *  (#...). Set only for presets whose primary family is a concrete face (not
+   *  a generic/system keyword), so the Appearance panel can hint when it falls
+   *  through to a fallback. */
+  probe?: string;
 }
 
 export const FONT_FAMILY_PRESETS: Record<FontFamilyPreset, PresetDef> = {
@@ -29,10 +34,12 @@ export const FONT_FAMILY_PRESETS: Record<FontFamilyPreset, PresetDef> = {
   jetbrainsMono: {
     label: 'JetBrains Mono',
     css: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace',
+    probe: 'JetBrains Mono',
   },
   berkeleyMono: {
     label: 'Berkeley Mono',
     css: '"Berkeley Mono", "TX-02", ui-monospace, SFMono-Regular, Menlo, monospace',
+    probe: 'Berkeley Mono',
   },
   systemMono: {
     label: 'System mono',

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -7,6 +7,7 @@
     FONT_FAMILY_PRESETS,
     type FontFamilyPreset,
   } from '../appearance/settings';
+  import { isFontInstalled } from '../appearance/font-detect';
   import { getThemeMode, setThemeMode, THEME_MODES, type ThemeMode } from '../theme';
   import { clampFontSize, parseStoredFontSize, MIN_FONT, MAX_FONT, DEFAULT_FONT } from '../editor/font-size';
   import { setZoom, getStoredZoom, MIN_ZOOM, MAX_ZOOM } from '../appearance/zoom';
@@ -238,6 +239,12 @@
     id: id as FontFamilyPreset,
     label: def.label,
   }));
+
+  // Soft "font not installed" hint (#...): only the named-face presets carry a
+  // `probe`; the check is a heuristic, so this never blocks the choice — it just
+  // makes the silent fallback visible. Re-evaluated when the selection changes.
+  const fontProbe = $derived(FONT_FAMILY_PRESETS[fontFamily].probe);
+  const fontMissing = $derived(fontProbe !== undefined && !isFontInstalled(fontProbe));
 
   // Privileged sites now live in SitesSettings.svelte (self-contained panel).
 
@@ -524,6 +531,12 @@
             <p class="hint">
               Applies to the markdown editor and preview. App chrome always uses the system font.
             </p>
+            {#if fontMissing && fontProbe}
+              <p class="hint font-missing">
+                “{fontProbe}” doesn’t appear to be installed — the editor will use a fallback font.
+                Install {fontProbe}, or pick another option.
+              </p>
+            {/if}
           </div>
           <div class="field">
             <label for="editor-font-size">Editor font size</label>
@@ -1241,6 +1254,13 @@
     color: var(--text-muted);
     font-size: 11px;
     line-height: 1.45;
+  }
+
+  /* Soft "font not installed" advisory — the sanctioned signal color (--rust),
+     not danger-red, and non-blocking. */
+  .hint.font-missing {
+    color: var(--rust);
+    margin-top: 4px;
   }
 
   .hint code {

--- a/tests/renderer/appearance/font-detect.test.ts
+++ b/tests/renderer/appearance/font-detect.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Font-availability heuristic (#...). The canvas measurement itself needs a real
+ * browser + real installed fonts, so these tests exercise the pure comparison
+ * core (`isFontInstalledWith`) with injected width measurements: a family reads
+ * as installed iff, against at least one generic baseline, the probe measured in
+ * that family differs from the baseline alone.
+ */
+import { describe, it, expect } from 'vitest';
+import { isFontInstalledWith, type Measure } from '../../../src/renderer/lib/appearance/font-detect';
+
+// Baseline widths for the three generics the detector compares against.
+const BASE: Record<string, number> = { monospace: 100, 'sans-serif': 110, serif: 120 };
+
+/** Which generic keyword a CSS `font` shorthand ends with. Checks 'sans-serif'
+ *  before 'serif' since the former contains the latter. */
+function generic(font: string): 'monospace' | 'sans-serif' | 'serif' {
+  if (font.includes('sans-serif')) return 'sans-serif';
+  if (font.includes('monospace')) return 'monospace';
+  return 'serif';
+}
+
+/** A measurer where `family` is installed and renders at a distinct width. */
+function installedMeasure(family: string, appliedWidth = 199): Measure {
+  return (font) => (font.includes(`"${family}"`) ? appliedWidth : BASE[generic(font)]!);
+}
+
+/** A measurer where any named family falls through to the generic baseline. */
+const missingMeasure: Measure = (font) => BASE[generic(font)]!;
+
+describe('isFontInstalledWith', () => {
+  it('reports installed when the family renders differently from every baseline', () => {
+    expect(isFontInstalledWith(installedMeasure('JetBrains Mono'), 'JetBrains Mono')).toBe(true);
+  });
+
+  it('reports not installed when the family matches the baseline for all generics', () => {
+    expect(isFontInstalledWith(missingMeasure, 'Berkeley Mono')).toBe(false);
+  });
+
+  it('still reports installed when the family coincides with only one generic default', () => {
+    // Same width as the monospace baseline (system default mono == the family),
+    // but distinct against sans-serif and serif — the `.some` across baselines
+    // must catch it.
+    const measure: Measure = (font) => {
+      if (font.includes('"Coincident Mono"')) {
+        return generic(font) === 'monospace' ? BASE.monospace! : 175;
+      }
+      return BASE[generic(font)]!;
+    };
+    expect(isFontInstalledWith(measure, 'Coincident Mono')).toBe(true);
+  });
+
+  it('quotes the family into the shorthand (so multi-word names measure correctly)', () => {
+    const seen: string[] = [];
+    const measure: Measure = (font) => { seen.push(font); return BASE[generic(font)]!; };
+    isFontInstalledWith(measure, 'JetBrains Mono');
+    expect(seen).toContain('72px "JetBrains Mono", monospace');
+    expect(seen).toContain('72px monospace');
+  });
+});


### PR DESCRIPTION
## What
Picking **JetBrains Mono** or **Berkeley Mono** only sets a font-family preference — if the face isn't installed, the browser silently falls through to a fallback and the note pane keeps looking like the fallback ([the gotcha](../website/docs/settings-appearance.html)). This adds a soft advisory under the Content font select when the chosen face doesn't appear to be present.

## A hint, not an error — on purpose
Per CLAUDE.md (*no hand-holding, don't prevent what the user asked, no danger styling*) this **never blocks the choice**. It's a muted line in `--rust` (the sanctioned signal color, not red) that just makes the silent fallback **visible**. The fact that detection is a heuristic is the second reason not to hard-block.

## How detection works
`document.fonts.check()` is useless here — Minerva bundles **no `@font-face`**, so every preset is a system-font name the FontFaceSet can't see. So `font-detect.ts` uses the classic **canvas text-metrics heuristic**: measure a probe string in `"<family>", <generic>` vs the generic alone; if the width differs against any of monospace / sans-serif / serif, the family actually applied. The `.some` across three baselines covers the case where the face coincides with one generic's platform default. The measurer falls back to "installed" when it can't run, so a false negative never nags.

Only the two named-face presets carry a `probe` field; generic/system stacks always resolve and get no hint.

## Tests
`font-detect.test.ts` (4) exercises the pure core (`isFontInstalledWith`) with injected measurements — installed, absent, coincides-with-one-generic, and correct multi-word quoting. `pnpm lint` clean; suite green apart from the pre-existing help-docs staleness (unrelated in-flight doc edits).

## Verification note
The comparison logic is unit-tested. What I **couldn't** automate is the live canvas heuristic against a genuinely-missing font (needs a real browser + a font you don't have installed). Worth a quick manual check: on a machine without Berkeley Mono, selecting it should show the hint; a font you do have should not.

## Follow-ups (your call)
- **Docs**: the "named mono presets don't install fonts" gotcha in `settings-appearance.html` can now mention the in-app hint. Left for your docs pass.
- **Real fix for one font**: JetBrains Mono is OFL-licensed and could be *bundled* as a web font so the preset always works (and detection becomes exact). Berkeley Mono is commercial, so the hint stays the only option there. Happy to do the bundling as a separate PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)