### PR TITLE
Fix: per-skill model overrides never read back from disk

### DIFF
--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -35,6 +35,21 @@ function resolveEffortSetting(stored: unknown): Effort | undefined {
   return isEffort(stored) ? stored : undefined;
 }
 
+/**
+ * Validate the persisted per-skill model override map (skill id → model id).
+ * Returns undefined when absent/empty so the field stays omitted, matching the
+ * optional shape. Without this, a saved override is written to disk but never
+ * read back — so it silently never applies (in the UI *or* at runtime).
+ */
+function resolveToolModelOverrides(stored: unknown): Record<string, string> | undefined {
+  if (!stored || typeof stored !== 'object') return undefined;
+  const out: Record<string, string> = {};
+  for (const [id, model] of Object.entries(stored as Record<string, unknown>)) {
+    if (typeof model === 'string' && model) out[id] = model;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 function settingsPath(): string {
   return path.join(app.getPath('userData'), 'llm-settings.json');
 }
@@ -52,11 +67,13 @@ export async function getSettings(): Promise<LLMSettings> {
     const apiKey = typeof parsed.apiKey === 'string'
       ? decryptSecret(parsed.apiKey)
       : (process.env.ANTHROPIC_API_KEY ?? '');
+    const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
     return {
       apiKey,
       model: resolveModel(parsed.model),
       web: resolveWeb(parsed.web),
       ...(effort ? { effort } : {}),
+      ...(toolModelOverrides ? { toolModelOverrides } : {}),
     };
   } catch {
     return {
@@ -83,10 +100,12 @@ export async function getSettingsForDisplay(): Promise<LLMSettingsView> {
     const hasApiKey = typeof parsed.apiKey === 'string'
       ? parsed.apiKey.length > 0
       : !!process.env.ANTHROPIC_API_KEY;
+    const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
     return {
       model: resolveModel(parsed.model),
       web: resolveWeb(parsed.web),
       ...(effort ? { effort } : {}),
+      ...(toolModelOverrides ? { toolModelOverrides } : {}),
       hasApiKey,
     };
   } catch {

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -144,4 +144,29 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
       expect(await getApiKeyStorage()).toEqual({ available: true, encrypted: true });
     });
   });
+
+  describe('per-skill model overrides round-trip (#...)', () => {
+    it('reads back the saved override map — the API path and the settings view', async () => {
+      await saveSettings({ ...base, toolModelOverrides: { 'extract-key-claims': 'claude-opus-4-8' } });
+      expect((await getSettings()).toolModelOverrides).toEqual({ 'extract-key-claims': 'claude-opus-4-8' });
+      expect((await getSettingsForDisplay()).toolModelOverrides).toEqual({ 'extract-key-claims': 'claude-opus-4-8' });
+    });
+
+    it('omits the field entirely when no overrides are stored', async () => {
+      await saveSettings({ ...base });
+      expect((await getSettings()).toolModelOverrides).toBeUndefined();
+      expect((await getSettingsForDisplay()).toolModelOverrides).toBeUndefined();
+    });
+
+    it('drops empty / non-string entries and an empty map', async () => {
+      fs.writeFileSync(settingsFile(), JSON.stringify({
+        model: 'claude-sonnet-5',
+        toolModelOverrides: { good: 'claude-opus-4-8', blank: '', bad: 42 },
+      }));
+      expect((await getSettings()).toolModelOverrides).toEqual({ good: 'claude-opus-4-8' });
+
+      fs.writeFileSync(settingsFile(), JSON.stringify({ model: 'claude-sonnet-5', toolModelOverrides: {} }));
+      expect((await getSettings()).toolModelOverrides).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## The bug (gotcha #1 — "Overrides don't survive a restart")
`saveSettings` writes `LLMSettings.toolModelOverrides` to disk correctly, but **neither `getSettings()` nor `getSettingsForDisplay()` read it back** — both returned only `model`/`web`/`effort`. So a per-skill model choice:
- reverted to "Default" in the Settings dialog every reopen (the documented symptom), **and**
- never actually took effect at runtime either — `executeTool` → `resolveToolModel` reads `getSettings().toolModelOverrides`, which was always `undefined`, so it always fell through to the skill's `model:` / global default.

So the override was write-only. This makes it round-trip.

## Fix
A validated `resolveToolModelOverrides()` added to both loaders: keeps string `id → model` entries, drops blanks/non-strings, and omits the field when empty (matching its optional shape). The Skills panel already loads the map (`getSettingsForDisplay`) and saves it (`saveSettings`), so persistence now works end to end — in the UI and at runtime.

## Tests
`settings.test.ts` — round-trip through `getSettings` + `getSettingsForDisplay`, omitted-when-empty, and sanitization of malformed entries. `pnpm lint` clean; suite green apart from the pre-existing help-docs staleness (unrelated in-flight doc edits).

## About gotcha #2 ("Importing doesn't create an override") — not a bug
I dug into this and it's **working as designed**, so I did *not* change it:
- The resolution order is `per-invocation ?? user override ?? tool.preferredModel ?? global default` (`executor.ts`). A skill's own `model:` compiles into `preferredModel` (`compile.ts:50`), and the import handler runs the same compile — so an imported skill already honors its `model:` at runtime with no override entry.
- The Skills UI already surfaces this: the empty option is labeled **"Default · <skill's model or global>"** (`SkillsSettings.svelte`), so a skill with a `model:` isn't misrepresented as using the global default.

Auto-seeding an override on import would conflate the *author's* preference with the *user's* explicit choice and break that clean chain. My recommendation: **reword the doc gotcha** (it describes correct behavior) rather than change code. Happy to do a behavior change if you have a specific one in mind — flagged for your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)