### PR TITLE
Bookmarks panel: show each bookmark's containing folder

### DIFF
--- a/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { getBookmarksStore } from '../../stores/bookmarks.svelte';
-  import type { Bookmark, BookmarkNode } from '../../../../shared/types';
+  import { getBookmarksStore, collectNoteBookmarksWithFolder } from '../../stores/bookmarks.svelte';
+  import type { Bookmark } from '../../../../shared/types';
   import Icon from '../Icon.svelte';
 
   interface Props {
@@ -32,21 +32,11 @@
 
   const bookmarks = getBookmarksStore();
 
-  /** Walk the bookmarks tree and collect every bookmark whose
-   *  `relativePath` matches the active note. The project-wide tree's
-   *  folder structure is purely organisational, so we flatten it. */
-  function flatten(nodes: BookmarkNode[], out: Bookmark[] = []): Bookmark[] {
-    for (const n of nodes) {
-      if (n.type === 'folder') flatten(n.children, out);
-      else out.push(n);
-    }
-    return out;
-  }
-
-  const forActiveNote = $derived<Bookmark[]>(
-    activeFilePath
-      ? flatten(bookmarks.tree).filter((b) => b.relativePath === activeFilePath)
-      : [],
+  // The bookmarks for the active note, each paired with its containing-folder
+  // path so placement is visible here (this panel used to flatten the tree and
+  // drop the folder entirely). Top-level bookmarks carry an empty folder.
+  const forActiveNote = $derived(
+    activeFilePath ? collectNoteBookmarksWithFolder(bookmarks.tree, activeFilePath) : [],
   );
 </script>
 
@@ -57,16 +47,24 @@
     <p class="empty">No bookmarks for this note</p>
   {:else}
     <div class="bookmark-list">
-      {#each forActiveNote as bm (bm.id)}
+      {#each forActiveNote as { bookmark: bm, folder } (bm.id)}
         <div class="bm-item">
           <button
             type="button"
             class="bm-open"
             onclick={() => openBookmark(bm)}
-            title={bm.anchor ? `${bm.relativePath} › ${bm.name}` : bm.name}
+            title={folder ? `${folder} / ${bm.name}` : bm.name}
           >
             <Icon name={bmIcon(bm)} size={13} color="var(--text-faint)" />
-            <span class="bm-name">{bm.name}</span>
+            <span class="bm-text">
+              <span class="bm-name">{bm.name}</span>
+              {#if folder}
+                <span class="bm-folder">
+                  <Icon name="folder" size={10} color="var(--text-faint)" />
+                  {folder}
+                </span>
+              {/if}
+            </span>
           </button>
           <button
             type="button"
@@ -129,9 +127,26 @@
     cursor: pointer;
     text-align: left;
   }
-  .bm-name {
+  .bm-text {
     flex: 1;
     min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .bm-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* Containing-folder path — muted secondary line so placement is visible
+     without competing with the bookmark name. */
+  .bm-folder {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10.5px;
+    color: var(--text-faint);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -164,6 +164,31 @@ export function collectBookmarksForPath(
   return out;
 }
 
+/**
+ * Bookmarks targeting `relativePath`, each paired with the display path of its
+ * containing folder — the ancestor folder names joined by `separator`, or an
+ * empty string for a top-level bookmark. Powers the note-scoped Bookmarks panel
+ * so a bookmark's folder placement isn't invisible there (it used to flatten
+ * the tree and drop the folder entirely).
+ */
+export function collectNoteBookmarksWithFolder(
+  nodes: readonly BookmarkNode[],
+  relativePath: string,
+  separator = ' / ',
+): Array<{ bookmark: Bookmark; folder: string }> {
+  const out: Array<{ bookmark: Bookmark; folder: string }> = [];
+  const walk = (ns: readonly BookmarkNode[], path: string[]) => {
+    for (const n of ns) {
+      if (n.type === 'folder') walk(n.children, [...path, n.name]);
+      else if (n.relativePath === relativePath) {
+        out.push({ bookmark: n, folder: path.join(separator) });
+      }
+    }
+  };
+  walk(nodes, []);
+  return out;
+}
+
 // ── Tree helpers ─────────────────────────────────────────────────────────
 
 function findNode(nodes: BookmarkNode[], id: string): BookmarkNode | null {

--- a/tests/renderer/components/right-sidebar/BookmarksPanel.test.ts
+++ b/tests/renderer/components/right-sidebar/BookmarksPanel.test.ts
@@ -12,12 +12,17 @@ import { render, fireEvent, cleanup } from '@testing-library/svelte';
 import type { BookmarkNode } from '../../../../src/shared/types';
 
 const { treeRef } = vi.hoisted(() => ({ treeRef: { current: [] as BookmarkNode[] } }));
-vi.mock('../../../../src/renderer/lib/stores/bookmarks.svelte', () => ({
-  getBookmarksStore: () => ({
-    get tree() { return treeRef.current; },
-    remove: vi.fn(),
-  }),
-}));
+// Keep the real `collectNoteBookmarksWithFolder` (pure) — override only the store.
+vi.mock('../../../../src/renderer/lib/stores/bookmarks.svelte', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../src/renderer/lib/stores/bookmarks.svelte')>();
+  return {
+    ...actual,
+    getBookmarksStore: () => ({
+      get tree() { return treeRef.current; },
+      remove: vi.fn(),
+    }),
+  };
+});
 
 import BookmarksPanel from '../../../../src/renderer/lib/components/right-sidebar/BookmarksPanel.svelte';
 
@@ -78,6 +83,28 @@ describe('right-sidebar BookmarksPanel (#755)', () => {
     expect(onOpenAtOffset).toHaveBeenCalledWith(ACTIVE, 142);
     expect(onNavigate).not.toHaveBeenCalled();
     expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows the containing-folder path for a nested bookmark, and none for a root one', () => {
+    treeRef.current = [
+      { type: 'bookmark', id: 'root', name: 'Top', relativePath: ACTIVE },
+      {
+        type: 'folder', id: 'f1', name: 'Research', children: [
+          {
+            type: 'folder', id: 'f2', name: 'Papers', children: [
+              { type: 'bookmark', id: 'deep', name: 'Deep one', relativePath: ACTIVE },
+            ],
+          },
+        ],
+      },
+    ];
+    const { getByText, queryAllByText } = render(BookmarksPanel, {
+      activeFilePath: ACTIVE, onFileSelect: vi.fn(),
+    });
+    // The nested bookmark shows its folder path; the root one shows no folder.
+    expect(getByText('Research / Papers')).toBeTruthy();
+    expect(queryAllByText(/Research/)).toHaveLength(1);
+    expect(getByText('Top')).toBeTruthy();
   });
 
   it('prefers the section anchor over a stored offset when both are present', async () => {

--- a/tests/renderer/stores/bookmarks.test.ts
+++ b/tests/renderer/stores/bookmarks.test.ts
@@ -10,7 +10,8 @@ vi.mock('../../../src/renderer/lib/ipc/client', () => ({
   api: { bookmarks: { save: vi.fn(), load: vi.fn() } },
 }));
 
-import { getBookmarksStore } from '../../../src/renderer/lib/stores/bookmarks.svelte';
+import { getBookmarksStore, collectNoteBookmarksWithFolder } from '../../../src/renderer/lib/stores/bookmarks.svelte';
+import type { BookmarkNode } from '../../../src/shared/types';
 
 const store = getBookmarksStore();
 
@@ -54,5 +55,42 @@ describe('retargetSectionAnchor (#755)', () => {
     expect(store.retargetSectionAnchor('notes/foo.md', 'intro', 'preamble')).toBe(2);
     expect(bm('one')).toMatchObject({ anchor: 'preamble' });
     expect(bm('two')).toMatchObject({ anchor: 'preamble' });
+  });
+});
+
+describe('collectNoteBookmarksWithFolder (#...)', () => {
+  const tree: BookmarkNode[] = [
+    { type: 'bookmark', id: 'root', name: 'At root', relativePath: 'note.md' },
+    {
+      type: 'folder', id: 'f1', name: 'Research', children: [
+        { type: 'bookmark', id: 'r1', name: 'In Research', relativePath: 'note.md' },
+        {
+          type: 'folder', id: 'f2', name: 'Papers', children: [
+            { type: 'bookmark', id: 'p1', name: 'Deep', relativePath: 'note.md' },
+            { type: 'bookmark', id: 'p2', name: 'Other note', relativePath: 'other.md' },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it('pairs each matching bookmark with its containing-folder path', () => {
+    const rows = collectNoteBookmarksWithFolder(tree, 'note.md');
+    expect(rows.map((r) => [r.bookmark.name, r.folder])).toEqual([
+      ['At root', ''],              // top-level → empty folder
+      ['In Research', 'Research'],
+      ['Deep', 'Research / Papers'], // nested → joined path
+    ]);
+  });
+
+  it('excludes bookmarks for other notes', () => {
+    const rows = collectNoteBookmarksWithFolder(tree, 'other.md');
+    expect(rows.map((r) => r.bookmark.name)).toEqual(['Other note']);
+    expect(rows[0]!.folder).toBe('Research / Papers');
+  });
+
+  it('honors a custom separator', () => {
+    const rows = collectNoteBookmarksWithFolder(tree, 'note.md', ' › ');
+    expect(rows.find((r) => r.bookmark.name === 'Deep')!.folder).toBe('Research › Papers');
   });
 });


### PR DESCRIPTION
## What
The right-sidebar (note-scoped) Bookmarks panel flattened the project-wide bookmark tree and **dropped the folder structure**, so you couldn't tell which folder a bookmark lived in without switching to the left sidebar's tree ([the gotcha](../website/docs/right-sidebar-bookmarks.html)). Each row now shows its **containing-folder path** as a muted secondary line (folder glyph + path); top-level bookmarks show nothing extra.

## How
- Adds a pure **`collectNoteBookmarksWithFolder(tree, relativePath)`** to the bookmark store: walks the tree carrying the ancestor folder names, and returns each matching bookmark paired with its joined folder path (`''` at root). This replaces the panel's local `flatten`, which discarded the path.
- The panel renders name + folder stacked; the row's title tooltip includes the folder too.

Purely additive and read-only — no change to how bookmarks are stored, created, or opened.

## Tests
- `bookmarks.test.ts` — the helper: nesting → `Research / Papers`, root → `''`, other-note filtering, custom separator.
- `BookmarksPanel.test.ts` — render test: a nested bookmark shows its path, a root one shows none (mock now keeps the real pure helper via `importActual`, overriding only the store).
- `pnpm lint` clean; suite green apart from the pre-existing help-docs staleness (unrelated in-flight doc edits).

## Docs follow-up (your pass)
The "Folder placement is invisible here" gotcha (and the "no folders / flat list" framing in the lede + "What shows up here") are now stale — the panel surfaces folder placement (read-only; move/reorganize still lives in the left tree). Left for your docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)