### PR TITLE
Preview: add a :::query-search live block (full-text keyword search)

### DIFF
--- a/src/renderer/lib/preview/live-blocks.ts
+++ b/src/renderer/lib/preview/live-blocks.ts
@@ -3,6 +3,7 @@
  * the Preview pane:
  *   - `:::query-backlinks` — the notes that wiki-link to the current note (#1137)
  *   - `:::query-semantic`  — notes semantically similar to free query text (#1128)
+ *   - `:::query-search`    — full-text keyword matches for free query text (#...)
  *
  * The block plumbing (parse → execute → inject) lives in Preview.svelte; the
  * data fetch is a direct IPC. These string-only builders keep the selection +
@@ -10,7 +11,7 @@
  * nothing is written back to the note or graph.
  */
 import { escapeHtml, escapeAttr } from './text';
-import type { Backlink, RelatedNote } from '../../../shared/types';
+import type { Backlink, RelatedNote, SearchResult } from '../../../shared/types';
 
 function clampLimit(raw: string | undefined, fallback: number, max = 50): number {
   const n = Number.parseInt(raw ?? '', 10);
@@ -87,4 +88,38 @@ export function buildSemanticHtml(notes: RelatedNote[], config: Record<string, s
     return `<li>${head}${section}${snippet}</li>`;
   });
   return `${titleHtml}<ul class="query-result-list semantic-block"${compact ? ' data-compact="1"' : ''}>${items.join('')}</ul>`;
+}
+
+// ── Full-text search block (#...) ────────────────────────────────────────────
+// Keyword full-text search over the persisted index (MiniSearch, via
+// `api.search.query`), the same index the `search_notes` agent tool uses. The
+// parallel to the semantic block, but ranked by term match rather than meaning.
+
+/** Apply the block's `limit`, optional `minScore`, and self-exclusion (a note
+ *  matching its own search text shouldn't list itself). */
+export function selectSearchResults(
+  rows: SearchResult[],
+  config: Record<string, string>,
+  selfPath?: string | null,
+): SearchResult[] {
+  let out = selfPath ? rows.filter((r) => r.relativePath !== selfPath) : rows;
+  const minScore = Number.parseFloat(config.minScore ?? '');
+  if (Number.isFinite(minScore)) out = out.filter((r) => r.score >= minScore);
+  return out.slice(0, clampLimit(config.limit, 10));
+}
+
+export function buildSearchHtml(rows: SearchResult[], config: Record<string, string>): string {
+  const titleHtml = titleHtmlFor(config);
+  if (rows.length === 0) return `${titleHtml}<p class="query-empty">No matches</p>`;
+  // `compact: true` → link only; otherwise show the matched-context snippet.
+  const compact = config.compact === 'true' || config.compact === 'on';
+  const showSnippet = !compact && config.snippet !== 'false' && config.snippet !== 'off';
+  const items = rows.map((r) => {
+    const link = `<a class="wiki-link" data-target="${escapeAttr(r.relativePath)}">${escapeHtml(r.title || r.relativePath)}</a>`;
+    // Reuse the semantic block's snippet styling — same muted-context treatment.
+    const snippet = showSnippet && r.snippet
+      ? `<div class="semantic-snippet">${escapeHtml(r.snippet)}</div>` : '';
+    return `<li>${link}${snippet}</li>`;
+  });
+  return `${titleHtml}<ul class="query-result-list search-block"${compact ? ' data-compact="1"' : ''}>${items.join('')}</ul>`;
 }

--- a/src/renderer/lib/preview/query-blocks.ts
+++ b/src/renderer/lib/preview/query-blocks.ts
@@ -16,6 +16,8 @@ import {
   semanticKinds,
   selectSemanticNotes,
   buildSemanticHtml,
+  selectSearchResults,
+  buildSearchHtml,
 } from './live-blocks';
 
 export interface QueryBlockDeps {
@@ -54,6 +56,23 @@ export async function executeQueryBlock(deps: QueryBlockDeps, el: HTMLElement): 
     } catch (e) {
       console.warn('[query-backlinks] failed:', e);
       el.innerHTML = buildBacklinksHtml([], config);
+    }
+    return;
+  }
+
+  // Full-text search block (#...): keyword search over the persisted MiniSearch
+  // index (api.search.query — the same index the search_notes agent tool uses),
+  // rendered as ranked note links. Read-only.
+  if (type === 'search') {
+    const q = (query ?? '').trim();
+    if (!q) { el.innerHTML = buildSearchHtml([], config); return; }
+    el.innerHTML = '<span class="query-loading">Loading...</span>';
+    try {
+      const results = await api.search.query(q);
+      el.innerHTML = buildSearchHtml(selectSearchResults(results, config, deps.notePath), config);
+    } catch (e) {
+      console.warn('[query-search] failed:', e);
+      el.innerHTML = buildSearchHtml([], config);
     }
     return;
   }

--- a/tests/renderer/preview/live-blocks.test.ts
+++ b/tests/renderer/preview/live-blocks.test.ts
@@ -9,8 +9,10 @@ import {
   semanticKinds,
   selectSemanticNotes,
   buildSemanticHtml,
+  selectSearchResults,
+  buildSearchHtml,
 } from '../../../src/renderer/lib/preview/live-blocks';
-import type { Backlink, RelatedNote } from '../../../src/shared/types';
+import type { Backlink, RelatedNote, SearchResult } from '../../../src/shared/types';
 
 const bl = (over: Partial<Backlink>): Backlink => ({
   source: 'notes/a.md', sourceTitle: 'A', linkType: 'references', linkLabel: '', linkColor: '#888', ...over,
@@ -87,5 +89,41 @@ describe('semantic block (#1128)', () => {
 
   it('quiet empty state', () => {
     expect(buildSemanticHtml([], {})).toContain('No related notes');
+  });
+});
+
+describe('full-text search block (#...)', () => {
+  const sr = (over: Partial<SearchResult>): SearchResult => ({
+    relativePath: 'notes/x.md', title: 'X', snippet: 'a match', score: 5, ...over,
+  });
+
+  it('applies limit, minScore, and self-exclusion', () => {
+    const rows = [
+      sr({ relativePath: '1.md', score: 9 }),
+      sr({ relativePath: '2.md', score: 4 }),
+      sr({ relativePath: 'self.md', score: 8 }),
+    ];
+    expect(selectSearchResults(rows, {}, 'self.md').map((r) => r.relativePath)).toEqual(['1.md', '2.md']);
+    expect(selectSearchResults(rows, { minScore: '5' }).map((r) => r.relativePath)).toEqual(['1.md', 'self.md']);
+    expect(selectSearchResults(rows, { limit: '1' })).toHaveLength(1);
+  });
+
+  it('renders ranked note links with a snippet by default', () => {
+    const html = buildSearchHtml([sr({ relativePath: 'notes/raft.md', title: 'Raft', snippet: '…consensus…' })], {});
+    expect(html).toContain('data-target="notes/raft.md"');
+    expect(html).toContain('Raft');
+    expect(html).toContain('…consensus…');
+    expect(html).toContain('search-block');
+  });
+
+  it('compact mode drops the snippet; title falls back to the path', () => {
+    const html = buildSearchHtml([sr({ title: '', relativePath: 'notes/y.md', snippet: 'ctx' })], { compact: 'true' });
+    expect(html).not.toContain('ctx');
+    expect(html).toContain('notes/y.md');
+    expect(html).toContain('data-compact="1"');
+  });
+
+  it('quiet empty state', () => {
+    expect(buildSearchHtml([], {})).toContain('No matches');
   });
 });

--- a/tests/renderer/preview/query-blocks-search.test.ts
+++ b/tests/renderer/preview/query-blocks-search.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Dispatch wiring for the `:::query-search` block — `executeQueryBlock` reads
+ * the placeholder's type/query, hits `api.search.query` (the MiniSearch index),
+ * excludes the current note, and injects the rendered list. Mocks the IPC + the
+ * heavy chart/link-bundle imports so only the search path runs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: { search: { query: h.query } } }));
+vi.mock('../../../src/renderer/lib/charts', () => ({ renderChart: vi.fn() }));
+vi.mock('../../../src/renderer/lib/sidebar-link-bundle', () => ({ getLinkBundle: vi.fn() }));
+
+import { executeQueryBlock, type QueryBlockDeps } from '../../../src/renderer/lib/preview/query-blocks';
+
+function deps(over: Partial<QueryBlockDeps> = {}): QueryBlockDeps {
+  return { notePath: 'notes/cur.md', revision: 0, queryCache: new Map(), queryPrefixes: '', activeCharts: [], ...over };
+}
+function block(type: string, query: string): HTMLElement {
+  const el = document.createElement('div');
+  el.dataset.type = type;
+  el.dataset.query = query;
+  return el;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('executeQueryBlock — search branch', () => {
+  it('queries the index and renders ranked links, excluding the current note', async () => {
+    h.query.mockResolvedValue([
+      { relativePath: 'notes/cur.md', title: 'Self', snippet: 's', score: 9 },
+      { relativePath: 'notes/raft.md', title: 'Raft', snippet: 'consensus', score: 7 },
+    ]);
+    const el = block('search', 'raft');
+    await executeQueryBlock(deps(), el);
+    expect(h.query).toHaveBeenCalledWith('raft');
+    expect(el.innerHTML).toContain('data-target="notes/raft.md"');
+    expect(el.innerHTML).toContain('consensus');
+    expect(el.innerHTML).not.toContain('notes/cur.md'); // self-excluded
+  });
+
+  it('renders the empty state on a blank query without hitting IPC', async () => {
+    const el = block('search', '   ');
+    await executeQueryBlock(deps(), el);
+    expect(h.query).not.toHaveBeenCalled();
+    expect(el.innerHTML).toContain('No matches');
+  });
+
+  it('falls back to the empty state when the query throws', async () => {
+    h.query.mockRejectedValue(new Error('boom'));
+    const el = block('search', 'x');
+    await executeQueryBlock(deps(), el);
+    expect(el.innerHTML).toContain('No matches');
+  });
+});


### PR DESCRIPTION
## What
Parallel to `:::query-backlinks` and `:::query-semantic`, adds a **`:::query-search`** live block that embeds **full-text keyword** matches for the block's query text — ranked note links with matched-context snippets, read-only.

```
:::query-search
title: Mentions of Raft
limit: 10
---
raft consensus
:::
```

It runs over the persisted **MiniSearch** index via `api.search.query` — the same index the `search_notes` agent tool uses. Notably this is the **first UI consumer** of the `SEARCH_QUERY` channel, which was wired end-to-end (preload → main → MiniSearch) but had no renderer caller until now.

This is the keyword counterpart to the semantic block: `:::query-semantic` ranks by meaning (vectors); `:::query-search` ranks by term match.

## How
- The directive parser is generic (`:::query-(\w+)` → `type`), so **no parser change** was needed.
- Pure builders in `live-blocks.ts` mirroring the semantic block: `selectSearchResults` (`limit` / `minScore` / self-exclusion) + `buildSearchHtml` (ranked links, optional `snippet`, `compact` mode, `title`).
- A `type === 'search'` dispatch branch in `query-blocks.ts` that reads the query, calls `api.search.query`, excludes the current note, and injects the list. Reuses existing `.query-result-list` / `.semantic-snippet` styling — no new CSS.

## Config keys
`title`, `limit` (default 10), `minScore`, `compact`, `snippet: off`.

## Tests
- Pure builders (limit/minScore/self-exclude, snippet default, compact fallback-to-path, empty state).
- **Dispatch test**: `executeQueryBlock` on a `search` placeholder → asserts it calls `api.search.query`, excludes the current note, and renders the links — covering the parse→IPC→render wiring, not just the string builders.
- `pnpm lint` clean; suite green apart from the pre-existing help-docs staleness (unrelated in-flight doc edits).

## Verification note
Unit + dispatch tests cover the wiring and the verified IPC chain. I did **not** drive it in the running Electron app (author a note with the directive and view the preview) — worth a 30-second manual check, especially since this exercises the `SEARCH_QUERY` channel for the first time in the UI.

## Docs follow-up (your pass)
`notes-code.html` (and wherever the live blocks are documented) could add `:::query-search` alongside `:::query-backlinks` / `:::query-semantic`. Left for your docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)