### PR TITLE
YouTube fence: accept bare video ids + schemeless URLs

### DIFF
--- a/src/shared/youtube/youtube.ts
+++ b/src/shared/youtube/youtube.ts
@@ -38,12 +38,26 @@ const WATCH_HOSTS = new Set(['youtube.com', 'youtube-nocookie.com']);
  *   - `youtube.com/watch?v=ID`
  *   - `youtu.be/ID`
  *   - `youtube.com/embed/ID`, `/shorts/ID`, `/live/ID`
+ *   - a bare 11-char video id (`dQw4w9WgXcQ`)
+ *   - any of the above without a scheme (`youtube.com/watch?v=ID`, `youtu.be/ID`)
  * and tolerates extra query params (`&t=`, `&list=`, …). A `t=` / `start=`
  * offset is preserved on the canonical URL so "start at 1:30" survives.
  */
 export function parseYouTubeUrl(input: string): YouTubeRef | null {
-  const raw = input.trim();
+  let raw = input.trim();
   if (!raw) return null;
+
+  // A bare video id (no URL at all) — the shortest thing a `youtube` fence can
+  // carry. Build the canonical watch URL from it directly.
+  if (ID_RE.test(raw)) return { id: raw, url: `https://www.youtube.com/watch?v=${raw}` };
+
+  // Tolerate a schemeless URL by giving it one so `new URL` can parse it —
+  // pasting the address-bar text without the `https://` is the common case.
+  // Anchored to known YouTube hosts so this can't turn a `javascript:…` (or any
+  // other scheme) string into something that slips past the protocol check.
+  if (/^(?:www\.|m\.)?(?:youtube\.com|youtu\.be|youtube-nocookie\.com)\//i.test(raw)) {
+    raw = `https://${raw}`;
+  }
 
   let u: URL;
   try {

--- a/tests/shared/youtube/youtube.test.ts
+++ b/tests/shared/youtube/youtube.test.ts
@@ -41,6 +41,24 @@ describe('parseYouTubeUrl', () => {
     expect(parseYouTubeUrl(`https://www.youtube.com/watch?v=${ID}&start=45`)?.start).toBe(45);
   });
 
+  it('accepts a bare 11-char video id', () => {
+    expect(parseYouTubeUrl(ID)).toEqual({ id: ID, url: `https://www.youtube.com/watch?v=${ID}` });
+    expect(parseYouTubeUrl(`  ${ID}  `)?.id).toBe(ID); // trimmed
+  });
+
+  it('accepts schemeless YouTube URLs (address-bar paste without https://)', () => {
+    expect(parseYouTubeUrl(`youtube.com/watch?v=${ID}`)?.id).toBe(ID);
+    expect(parseYouTubeUrl(`www.youtube.com/watch?v=${ID}`)?.id).toBe(ID);
+    expect(parseYouTubeUrl(`youtu.be/${ID}`)?.id).toBe(ID);
+    expect(parseYouTubeUrl(`m.youtube.com/watch?v=${ID}`)?.id).toBe(ID);
+  });
+
+  it('does not let the schemeless shortcut smuggle another scheme past the protocol check', () => {
+    // Not anchored to a YouTube host → left as-is → rejected by the protocol guard.
+    expect(parseYouTubeUrl(`javascript:alert(1)//youtube.com/watch?v=${ID}`)).toBeNull();
+    expect(parseYouTubeUrl(`data:text/html,youtube.com/watch?v=${ID}`)).toBeNull();
+  });
+
   it('rejects non-YouTube and malformed URLs', () => {
     expect(parseYouTubeUrl('https://vimeo.com/12345')).toBeNull();
     expect(parseYouTubeUrl('https://example.com/watch?v=dQw4w9WgXcQ')).toBeNull();


### PR DESCRIPTION
## What (gotcha #1)
`parseYouTubeUrl` went straight to `new URL()`, which requires a scheme — so a **bare video id** (`dQw4w9WgXcQ`) or an **address-bar paste without `https://`** (`youtube.com/watch?v=…`) threw and the fence rendered "Unrecognized YouTube URL." The [doc's own workaround](../website/docs/notes-media.html) was "copy the complete https:// URL"; now those shorter forms just work.

- A bare 11-char id builds the canonical watch URL directly.
- A schemeless URL gets `https://` prepended — **but only when it starts with a known YouTube host** (`youtube.com` / `youtu.be` / `youtube-nocookie.com`, opt. `www.`/`m.`), so the shortcut can't turn a `javascript:`/`data:` string into something that slips past the existing protocol guard.

## Tests
Added: bare id (incl. trimmed), schemeless forms (`youtube.com/…`, `www.`, `youtu.be/…`, `m.`), and an explicit anti-smuggling check (`javascript:…//youtube.com/…` and `data:…` still return null). `pnpm lint` clean; suite green apart from the pre-existing help-docs staleness.

## Note on gotcha #2 (offline thumbnail caching)
Not in this PR — it's a genuinely bigger change (download + local cache + serving under CSP), unlike this pure parser fix. Assessment + proposed approach in my message; happy to build it as a follow-up once you pick the approach. Docs: the "paste a full URL, scheme and all" gotcha can be softened once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)