### PR TITLE
Preview: cache external images for offline viewing

### DIFF
--- a/src/main/images/remote-image-cache.ts
+++ b/src/main/images/remote-image-cache.ts
@@ -1,0 +1,94 @@
+/**
+ * Offline cache for external `![](https://…)` images (#...).
+ *
+ * A remote image is fetched every time the note renders, so it's a broken-image
+ * icon offline. This caches the bytes (keyed by a hash of the URL) under
+ * `.minerva/cache/external-images/` on first (online) view, so later views —
+ * including offline — serve it from disk. Lazy-on-view, mirroring the YouTube
+ * poster cache: nothing is prefetched; a cache miss triggers a best-effort
+ * download for next time.
+ *
+ * The renderer already fetches these same URLs when it draws the `<img>`, so
+ * moving the fetch to main adds no new exposure. Guards: http(s) only, an
+ * `image/*` content type, a size cap, and a timeout.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_BYTES = 20 * 1024 * 1024; // 20 MB — skip oversized remote images.
+
+export interface RemoteImage {
+  bytes: Uint8Array;
+  mime: string;
+}
+
+function cacheDir(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'cache', 'external-images');
+}
+/** Hash the URL to a stable, filesystem-safe cache key. */
+function keyFor(url: string): string {
+  return crypto.createHash('sha256').update(url).digest('hex');
+}
+function bytesPath(rootPath: string, url: string): string {
+  return path.join(cacheDir(rootPath), keyFor(url));
+}
+function mimePath(rootPath: string, url: string): string {
+  return path.join(cacheDir(rootPath), `${keyFor(url)}.mime`);
+}
+
+/**
+ * Return the bytes + mime for an external image URL: from the on-disk cache if
+ * present, otherwise download, cache, and return. Returns `null` for a
+ * non-http(s) URL, a non-image response, an oversized image, or any network
+ * failure — the renderer keeps the remote `<img>` src as the fallback.
+ */
+export async function getOrFetchRemoteImage(rootPath: string, url: string): Promise<RemoteImage | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+
+  const bytesFile = bytesPath(rootPath, url);
+  const mimeFile = mimePath(rootPath, url);
+  try {
+    const [bytes, mime] = await Promise.all([
+      fs.readFile(bytesFile),
+      fs.readFile(mimeFile, 'utf-8'),
+    ]);
+    return { bytes: new Uint8Array(bytes), mime: mime.trim() || 'application/octet-stream' };
+  } catch {
+    // Not cached yet — fall through to the network.
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let result: RemoteImage | null = null;
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) return null;
+      const mime = (res.headers.get('content-type') ?? '').split(';')[0]!.trim().toLowerCase();
+      if (!mime.startsWith('image/')) return null; // don't cache HTML error pages etc.
+      const declared = Number(res.headers.get('content-length') ?? '');
+      if (Number.isFinite(declared) && declared > MAX_BYTES) return null;
+      const buf = new Uint8Array(await res.arrayBuffer());
+      if (buf.byteLength > MAX_BYTES) return null;
+      result = { bytes: buf, mime };
+    } finally {
+      clearTimeout(timer);
+    }
+    await fs.mkdir(cacheDir(rootPath), { recursive: true });
+    await Promise.all([
+      fs.writeFile(bytesFile, result.bytes),
+      fs.writeFile(mimeFile, result.mime),
+    ]);
+    return result;
+  } catch {
+    return null;
+  }
+}

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -7,6 +7,7 @@ import { renameWithLinkRewrites } from '../notebase/rename';
 import { mergeNotes, previewMergeNotes } from '../notebase/merge';
 import { renameAnchor } from '../notebase/rename-anchor';
 import { renameSource, renameExcerpt } from '../notebase/rename-source-excerpt';
+import { getOrFetchRemoteImage } from '../images/remote-image-cache';
 import { getOrFetchThumbnail } from '../youtube/thumbnail-cache';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
@@ -150,6 +151,12 @@ export function registerNotebase(): void {
   // a video id, or null when unavailable (offline + uncached).
   handle(Channels.YOUTUBE_THUMBNAIL, withRootPath(async (rootPath, id: string) =>
     getOrFetchThumbnail(rootPath, id),
+  ));
+
+  // Offline cache for external `![](https://…)` images (#...) — cached-or-fetched
+  // bytes + mime, or null when unavailable (offline + uncached / not an image).
+  handle(Channels.IMAGES_CACHE_EXTERNAL, withRootPath(async (rootPath, url: string) =>
+    getOrFetchRemoteImage(rootPath, url),
   ));
 
   handle(Channels.NOTEBASE_FILE_EXISTS, async (e, relativePath: string) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -201,6 +201,10 @@ contextBridge.exposeInMainWorld('api', {
     getInfo: () => ipcRenderer.invoke(Channels.APP_GET_INFO),
     getShortcuts: () => ipcRenderer.invoke(Channels.APP_GET_SHORTCUTS),
   },
+  images: {
+    // Cached-or-fetched bytes+mime for an external image URL (offline cache, #...).
+    cacheExternal: (url: string) => ipcRenderer.invoke(Channels.IMAGES_CACHE_EXTERNAL, url),
+  },
   youtube: {
     // Cached-or-fetched poster bytes for a video id (offline cache, #...).
     thumbnail: (id: string) => ipcRenderer.invoke(Channels.YOUTUBE_THUMBNAIL, id),

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -377,9 +377,21 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         const srcIdx = tok.attrIndex('src');
         if (srcIdx < 0) return self.renderToken(tokens, idx, options);
         const src = tok.attrs![srcIdx]![1];
-        if (/^(?:https?:|data:|file:|blob:|mailto:)/i.test(src) || src.startsWith('//')) {
-            // Absolute / data URL — render normally.
+        if (/^(?:data:|file:|blob:|mailto:)/i.test(src)) {
+            // Inline / already-local — render unchanged.
             return self.renderToken(tokens, idx, options);
+        }
+        if (/^https?:/i.test(src) || src.startsWith('//')) {
+            // External network image — emit a cacheable placeholder. The remote
+            // `src` is the immediate/offline-uncached fallback; the post-render
+            // pass swaps in a locally-cached copy so it survives offline once
+            // viewed (#...).
+            const url = src.startsWith('//') ? `https:${src}` : src;
+            const altIdx = tok.attrIndex('alt');
+            const alt = altIdx >= 0 ? tok.attrs![altIdx]![1] : (tok.content ?? '');
+            const titleIdx = tok.attrIndex('title');
+            const title = titleIdx >= 0 ? ` title="${escapeAttr(tok.attrs![titleIdx]![1])}"` : '';
+            return `<img class="remote-image" data-remote-src="${escapeAttr(url)}" src="${escapeAttr(src)}" alt="${escapeAttr(alt)}"${title} loading="lazy" />`;
         }
         const rel = resolveRelativeImagePath(src, renderPathOverride ?? notePath);
         const altIdx = tok.attrIndex('alt');
@@ -660,6 +672,43 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         }));
     }
 
+    /** url → data URL of a cached external image; survives re-renders. */
+    const remoteImageCache = new Map<string, string>();
+
+    /**
+     * Post-render: swap each external `![](https://…)` image for a
+     * locally-cached copy (#...) so remote images render offline once viewed.
+     * `api.images.cacheExternal(url)` returns cached bytes — fetching + caching
+     * on a miss when online — as a data URL. A null result (offline + uncached,
+     * or not an image) leaves the remote `<img>` src as the fallback.
+     */
+    async function hydrateRemoteImages(): Promise<void> {
+        const root = previewEl;
+        if (!root || typeof api.images?.cacheExternal !== 'function') return;
+        const imgs = Array.from(root.querySelectorAll<HTMLImageElement>('img.remote-image[data-remote-src]'));
+        await Promise.all(imgs.map(async (img) => {
+            const url = img.dataset.remoteSrc;
+            if (!url) return;
+            const cached = remoteImageCache.get(url);
+            if (cached) { if (img.src !== cached) img.src = cached; return; }
+            try {
+                const asset = await api.images.cacheExternal(url);
+                if (!asset) return; // offline + uncached — keep the remote fallback
+                const view: Uint8Array = asset.bytes instanceof Uint8Array ? asset.bytes : new Uint8Array(asset.bytes);
+                let bin = '';
+                const CHUNK = 0x8000;
+                for (let i = 0; i < view.length; i += CHUNK) {
+                    bin += String.fromCharCode.apply(null, Array.from(view.subarray(i, i + CHUNK)));
+                }
+                const dataUrl = `data:${asset.mime || 'application/octet-stream'};base64,${btoa(bin)}`;
+                remoteImageCache.set(url, dataUrl);
+                img.src = dataUrl;
+            } catch (err) {
+                console.warn('[preview] remote image hydration failed for', url, err);
+            }
+        }));
+    }
+
     /** id → data URL of a cached YouTube poster; survives re-renders. */
     const youtubeThumbCache = new Map<string, string>();
 
@@ -817,6 +866,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         if (injected) {
             highlightCodeBlocks();
             void hydrateLocalImages();
+            void hydrateRemoteImages();
             void hydrateYouTubeThumbnails();
             void resolveCiteQuoteLabels(citeDeps());
             void hydrateMermaidBlocks(root);
@@ -1076,6 +1126,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             // binary IPC, swap in a data URL. Cached per-path so re-renders
             // skip the round-trip.
             void hydrateLocalImages();
+            void hydrateRemoteImages();
             void hydrateYouTubeThumbnails();
             // Transclusion hydration (#906) — resolve `![[note]]` / `![[note#H]]` /
             // `![[note^block]]` embeds, slicing + re-rendering the target inline.

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -460,6 +460,12 @@ export interface AppApi {
   getShortcuts(): Promise<ShortcutGroup[]>;
 }
 
+export interface ImagesApi {
+  /** Cached-or-fetched bytes + mime for an external image URL, or null when
+   *  unavailable (offline + not yet cached, non-image, or oversized). */
+  cacheExternal(url: string): Promise<{ bytes: Uint8Array; mime: string } | null>;
+}
+
 export interface YoutubeApi {
   /** Cached-or-fetched poster thumbnail bytes for a video id, or null when
    *  unavailable (offline + not yet cached). */
@@ -779,6 +785,7 @@ export interface IdeApi {
   publish: PublishApi;
   shell: ShellApi;
   app: AppApi;
+  images: ImagesApi;
   youtube: YoutubeApi;
   view: ViewApi;
   bookmarks: BookmarksApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -9,6 +9,9 @@ export const Channels = {
   /** Write a binary blob (image / pdf / etc.) under a project-relative
    *  path. Used by the editor's image-upload-on-drop path (#455). */
   NOTEBASE_WRITE_BINARY: 'notebase:writeBinary',
+  /** Cached-or-fetched bytes for an external `![](https://…)` image, so notes
+   *  with remote images render offline once viewed. */
+  IMAGES_CACHE_EXTERNAL: 'images:cacheExternal',
   /** Cheap existence check — used by the upload path to dedupe
    *  content-hashed assets (#455). */
   NOTEBASE_FILE_EXISTS: 'notebase:fileExists',

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -41,6 +41,7 @@ export interface ChannelMap {
   'notebase:readFile': (relativePath: string) => string;
   'notebase:readBinary': (relativePath: string) => Uint8Array;
   'notebase:writeBinary': (relativePath: string, bytes: Uint8Array) => void;
+  'images:cacheExternal': (url: string) => { bytes: Uint8Array; mime: string } | null;
   'youtube:thumbnail': (id: string) => Uint8Array | null;
   'notebase:fileExists': (relativePath: string) => boolean;
   'notebase:writeFile': (relativePath: string, content: string) => void;

--- a/tests/main/images/remote-image-cache.test.ts
+++ b/tests/main/images/remote-image-cache.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Offline cache for external `![](https://…)` images (#...). Real temp dir for
+ * the on-disk cache + a stubbed global `fetch`: a hit skips the network, a miss
+ * downloads + caches (bytes + mime), and a bad URL / non-image / oversized /
+ * failed response returns null (renderer falls back to the remote <img>).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+import { getOrFetchRemoteImage } from '../../../src/main/images/remote-image-cache';
+
+const URL_ = 'https://example.com/pic.png';
+let root: string;
+const key = crypto.createHash('sha256').update(URL_).digest('hex');
+const bytesFile = () => path.join(root, '.minerva', 'cache', 'external-images', key);
+const mimeFile = () => path.join(root, '.minerva', 'cache', 'external-images', `${key}.mime`);
+
+/** A minimal Response-like for the fetch stub. */
+function res(opts: {
+  ok?: boolean; contentType?: string; contentLength?: string; body?: Uint8Array;
+}) {
+  const headers = new Map<string, string>();
+  if (opts.contentType) headers.set('content-type', opts.contentType);
+  if (opts.contentLength) headers.set('content-length', opts.contentLength);
+  return {
+    ok: opts.ok ?? true,
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    arrayBuffer: async () => (opts.body ?? new Uint8Array()).buffer,
+  };
+}
+function stubFetch(impl: () => Promise<unknown>) {
+  vi.stubGlobal('fetch', vi.fn(impl));
+}
+
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-img-')); });
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); vi.unstubAllGlobals(); });
+
+describe('getOrFetchRemoteImage', () => {
+  it('returns cached bytes + mime without a network call', async () => {
+    await fsp.mkdir(path.dirname(bytesFile()), { recursive: true });
+    await fsp.writeFile(bytesFile(), Buffer.from([1, 2, 3]));
+    await fsp.writeFile(mimeFile(), 'image/png');
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const out = await getOrFetchRemoteImage(root, URL_);
+    expect(Array.from(out!.bytes)).toEqual([1, 2, 3]);
+    expect(out!.mime).toBe('image/png');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('downloads, caches bytes + mime, and returns them on a miss', async () => {
+    stubFetch(async () => res({ contentType: 'image/jpeg', body: new Uint8Array([9, 8]) }));
+    const out = await getOrFetchRemoteImage(root, URL_);
+    expect(Array.from(out!.bytes)).toEqual([9, 8]);
+    expect(out!.mime).toBe('image/jpeg');
+    expect(Array.from(await fsp.readFile(bytesFile()))).toEqual([9, 8]);
+    expect(await fsp.readFile(mimeFile(), 'utf-8')).toBe('image/jpeg');
+  });
+
+  it('strips charset params from the content type', async () => {
+    stubFetch(async () => res({ contentType: 'image/svg+xml; charset=utf-8', body: new Uint8Array([1]) }));
+    expect((await getOrFetchRemoteImage(root, URL_))!.mime).toBe('image/svg+xml');
+  });
+
+  it('returns null (nothing cached) for a non-image response', async () => {
+    stubFetch(async () => res({ contentType: 'text/html', body: new Uint8Array([1]) }));
+    expect(await getOrFetchRemoteImage(root, URL_)).toBeNull();
+    expect(fs.existsSync(bytesFile())).toBe(false);
+  });
+
+  it('returns null when the declared size exceeds the cap', async () => {
+    stubFetch(async () => res({ contentType: 'image/png', contentLength: String(50 * 1024 * 1024) }));
+    expect(await getOrFetchRemoteImage(root, URL_)).toBeNull();
+  });
+
+  it('returns null on a non-ok response and on a thrown fetch (offline)', async () => {
+    stubFetch(async () => res({ ok: false }));
+    expect(await getOrFetchRemoteImage(root, URL_)).toBeNull();
+    stubFetch(async () => { throw new Error('ENOTFOUND'); });
+    expect(await getOrFetchRemoteImage(root, URL_)).toBeNull();
+  });
+
+  it('rejects non-http(s) and malformed URLs without a network call', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    expect(await getOrFetchRemoteImage(root, 'file:///etc/passwd')).toBeNull();
+    expect(await getOrFetchRemoteImage(root, 'data:image/png;base64,AAAA')).toBeNull();
+    expect(await getOrFetchRemoteImage(root, 'not a url')).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -89,6 +89,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "graph:query",
   "graph:schemaForCompletion",
   "graph:sourceDetail",
+  "images:cacheExternal",
   "ingest:getSettings",
   "ingest:setSettings",
   "inspections:list",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -134,6 +134,9 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "schemaForCompletion",
     "sourceDetail",
   ],
+  "images": [
+    "cacheExternal",
+  ],
   "links": [
     "backlinks",
     "bundle",

--- a/tests/preload/preload-bridge.test.ts
+++ b/tests/preload/preload-bridge.test.ts
@@ -56,7 +56,7 @@ describe('preload contextBridge contract (#676)', () => {
     expect(Object.keys(api()).sort()).toEqual([
       'app', 'bibliography', 'bookmarks', 'citations', 'clipper', 'collections', 'compute',
       'conversations', 'csl', 'embeddings', 'export', 'files', 'formatter', 'git', 'graph',
-      'links', 'menu', 'notebase', 'proposals', 'publish', 'queries',
+      'images', 'links', 'menu', 'notebase', 'proposals', 'publish', 'queries',
       'refactor', 'search', 'shell', 'sites', 'skills', 'sources', 'tables',
       'tabs', 'tags', 'templates', 'tools', 'view', 'youtube',
     ]);


### PR DESCRIPTION
## What
An `![](https://…)` image was fetched every render, so notes with remote images showed a **broken-image icon offline** ([the gotcha](../website/docs/notes-images.html)). Now the first (online) view caches the bytes under `.minerva/cache/external-images/<sha256-of-url>`, and later views — including offline — serve it from disk. Same **lazy-on-view** pattern as the YouTube poster cache.

## How
- The preview's image rule now emits an external image as a `remote-image` placeholder carrying `data-remote-src` (keeping the remote `src` as the immediate / offline-uncached fallback). `data:` / `blob:` / `file:` and local relative images are unchanged.
- A post-render `hydrateRemoteImages()` pass calls **`api.images.cacheExternal(url)`**, which returns the cached bytes + mime (downloading + caching on a miss when online), and swaps in a `data:` URL. A null result leaves the remote src — so behavior only ever improves.
- **Main** `getOrFetchRemoteImage` guards the fetch: **http(s) only**, an **`image/*` content type** (won't cache an HTML error page), a **20 MB cap**, and a timeout. Returns null on any miss.

The renderer already fetched these same URLs to draw the `<img>`, so moving the fetch to main adds no new exposure. No CSP change (data URL; `.minerva/cache` is already excluded from indexing).

## Tests
- `remote-image-cache.test.ts` — cache hit (no network), download+cache (bytes+mime), content-type charset stripping, non-image → null (nothing written), oversized (declared) → null, not-ok / offline throw → null, non-http(s) + malformed URL → null without a network call.
- Preload + IPC-registration snapshots + namespace allowlist updated for the new `images` namespace.
- `pnpm lint` clean; full suite green apart from the pre-existing help-docs staleness (**4358 passed** this run — no flakes).

## Verification note
Cache module, IPC contract, and typing are unit-tested; the render pass mirrors the merged `hydrateLocalImages` / YouTube-poster passes. I did **not** drive the live online→offline→reload scenario in a running app — worth a manual check (view a note with a remote image online, go offline, reload, confirm it persists), since that's the point.

## Docs
The "external images and offline viewing" gotcha in `notes-images.html` can be softened/removed once this lands. Left for your docs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)