### PR TITLE
Formatter: per-note opt-out via `format: false` frontmatter

### DIFF
--- a/src/shared/formatter/engine.ts
+++ b/src/shared/formatter/engine.ts
@@ -12,6 +12,7 @@ import { buildParseCache } from './parse-cache';
 import { HOUSE_STYLE_RULE_IDS } from './house-style';
 import { PASTE_SAFE_RULE_IDS } from './paste-safe';
 import { CATEGORY_ORDER, getRule, listAllRules } from './registry';
+import { readFrontmatterKey } from './rules/yaml/helpers';
 import type { EnabledRule, FormatContext, FormatterRule } from './types';
 
 export interface FormatSettings {
@@ -35,6 +36,15 @@ export function isRuleEnabled(settings: FormatSettings, ruleId: string): boolean
   return settings.enabled[ruleId] ?? HOUSE_STYLE_RULE_IDS.has(ruleId);
 }
 
+/**
+ * Whether a note has opted out of formatting via `format: false` in its
+ * frontmatter. Only an explicit boolean `false` opts out; a missing key,
+ * missing frontmatter, or any other value formats as normal.
+ */
+export function isFormatOptedOut(content: string): boolean {
+  return readFrontmatterKey(content, buildParseCache(content), 'format') === false;
+}
+
 export const DEFAULT_FORMAT_SETTINGS: FormatSettings = {
   enabled: {},
   configs: {},
@@ -49,6 +59,13 @@ export function formatContent(
   settings: FormatSettings,
   ctx?: FormatContext,
 ): string {
+  // Per-note opt-out: `format: false` in the frontmatter exempts a single
+  // note from formatting, without a per-file toggle in settings. The rest of
+  // the batch (folder / sidebar selection) is unaffected. Paste formatting
+  // goes through `formatPasteSafe`, which sees a fragment with no frontmatter,
+  // so it's untouched by this guard.
+  if (isFormatOptedOut(content)) return content;
+
   const enabledRules = resolveEnabled(settings);
   if (enabledRules.length === 0) return content;
 

--- a/tests/shared/formatter/engine.test.ts
+++ b/tests/shared/formatter/engine.test.ts
@@ -3,6 +3,7 @@ import {
   formatContent,
   formatContentToFixedPoint,
   formatPasteSafe,
+  isFormatOptedOut,
   isRuleEnabled,
   resolveEnabled,
   DEFAULT_FORMAT_SETTINGS,
@@ -122,6 +123,53 @@ describe('formatter engine (issue #153)', () => {
       configs: {},
     });
     expect(out).toBe('a\n\nb');
+  });
+});
+
+describe('per-note opt-out (format: false)', () => {
+  beforeEach(__resetRuleRegistryForTests);
+
+  const upper = () => registerRule(rule({ id: 'to-upper', apply: (c) => c.toUpperCase() }));
+  const settings = { enabled: { 'to-upper': true }, configs: {} };
+
+  it('skips formatting a note with `format: false` in the frontmatter', () => {
+    upper();
+    const input = '---\nformat: false\n---\nhello';
+    expect(formatContent(input, settings)).toBe(input);
+    expect(isFormatOptedOut(input)).toBe(true);
+  });
+
+  it('formats a note with `format: true`', () => {
+    upper();
+    const input = '---\nformat: true\n---\nhello';
+    expect(formatContent(input, settings)).toBe(input.toUpperCase());
+    expect(isFormatOptedOut(input)).toBe(false);
+  });
+
+  it('formats a note with unrelated frontmatter and no `format` key', () => {
+    upper();
+    const input = '---\ntitle: Note\n---\nhello';
+    expect(formatContent(input, settings)).toBe(input.toUpperCase());
+    expect(isFormatOptedOut(input)).toBe(false);
+  });
+
+  it('formats a note with no frontmatter at all', () => {
+    upper();
+    expect(formatContent('hello', settings)).toBe('HELLO');
+    expect(isFormatOptedOut('hello')).toBe(false);
+  });
+
+  it('only an explicit boolean false opts out — the string "false" still formats', () => {
+    upper();
+    const input = '---\nformat: "false"\n---\nhello';
+    expect(formatContent(input, settings)).toBe(input.toUpperCase());
+    expect(isFormatOptedOut(input)).toBe(false);
+  });
+
+  it('the fixed-point runner also honours the opt-out', () => {
+    upper();
+    const input = '---\nformat: false\n---\nhello';
+    expect(formatContentToFixedPoint(input, settings)).toBe(input);
   });
 });
 


### PR DESCRIPTION
## What

Adds a per-note escape hatch to the Format feature: a note with `format: false` in its frontmatter is skipped entirely when you run Format, without needing a per-file toggle in Settings or having to prune it from your sidebar selection.

## Why

The Formatter rule set is global — it applies uniformly to whatever you run Format over. Until now the only way to spare one note was to leave it out of the selection. A frontmatter flag is a lighter, self-documenting escape hatch, and fits the "respect the user / no hand-holding" ethos in CLAUDE.md.

## How

A single guard at the top of `formatContent()` in `src/shared/formatter/engine.ts`:

```ts
if (isFormatOptedOut(content)) return content;
```

Every real Format path funnels through `formatContent` — palette Format on the active note, the folder / sidebar-selection batch (`formatFile` → `formatContent`), and the fixed-point runner — so one guard covers them all. `isFormatOptedOut` reuses the existing `readFrontmatterKey` helper; no new YAML parsing.

## Semantics

- Only an explicit boolean `false` opts out. `format: true`, a missing key, no frontmatter, or the string `"false"` all format as normal.
- Paste formatting (`formatPasteSafe`) operates on a fragment with no frontmatter and is untouched.
- **Silent skip:** an opted-out note reports `changed: false` and drops out of the run summary — no "skipped N notes" noise.

## Tests

6 new cases in `tests/shared/formatter/engine.test.ts` covering opt-out, `format: true`, unrelated frontmatter, no frontmatter, the `"false"` string, and the fixed-point runner. Full suite green; `pnpm lint` clean.

## Note

The user-facing docs bullet (in `website/docs/settings-formatter.html`) was left in the working tree rather than this PR, because that file already carries an in-progress docs-batch edit — it'll land with that batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)