### PR TITLE
Formatter: "Restore house style" now resets per-rule config too

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -163,8 +163,13 @@
     };
     setFormatSettings({ enabled: { [id]: on } });
   }
-  // True when no rule has an explicit override — i.e. already at house style.
-  let atHouseStyle = $derived(Object.keys(formatter.enabled).length === 0);
+  // True when nothing overrides the shipped defaults — no enable/disable
+  // toggles and no per-rule config tuning. Both must be clear, or "Restore
+  // house style" would stay disabled while a tuned config still lingered.
+  let atHouseStyle = $derived(
+    Object.keys(formatter.enabled).length === 0 &&
+    Object.keys(formatter.configs).length === 0,
+  );
   function restoreHouseStyle(): void {
     const next = resetFormatToHouseStyle();
     formatter = {
@@ -813,7 +818,7 @@
                 disabled={atHouseStyle}
                 onclick={restoreHouseStyle}
               >Restore house style</button>
-              <span class="hint">Clears your overrides and re-enables the default curated set.</span>
+              <span class="hint">Clears every override — rule toggles and per-rule tuning alike — back to the default curated set.</span>
             </div>
           {/if}
 

--- a/src/renderer/lib/formatter/settings.ts
+++ b/src/renderer/lib/formatter/settings.ts
@@ -52,13 +52,14 @@ export function setFormatSettings(patch: Partial<FormatSettings>): FormatSetting
 }
 
 /**
- * Restore the curated house style by clearing every explicit enable/disable
- * override — each rule falls back to its default (on for the house-style set,
- * off otherwise). Per-rule config overrides are intentionally left untouched;
- * this only resets *which* rules run, not how they’re configured.
+ * Restore the curated house style by clearing *every* override — both the
+ * explicit enable/disable map and any per-rule config tuning. Each rule falls
+ * back to its default: on for the house-style set, off otherwise, and each
+ * running with its own `defaultConfig`. This is a full reset to the shipped
+ * defaults, not just a reset of which rules run.
  */
 export function resetFormatToHouseStyle(): FormatSettings {
-  settings = { enabled: {}, configs: { ...settings.configs } };
+  settings = { enabled: {}, configs: {} };
   api.formatter.saveSettings(settings).catch(() => { /* swallow — retried on next change */ });
   return settings;
 }

--- a/tests/renderer/formatter/settings.test.ts
+++ b/tests/renderer/formatter/settings.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Capture what settings.ts persists so we can assert the reset clears configs.
+// Hoisted so the mocks exist when vi.mock's factory (also hoisted) runs.
+const { saveSettings, loadSettings } = vi.hoisted(() => ({
+  saveSettings: vi.fn().mockResolvedValue(undefined),
+  loadSettings: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { formatter: { saveSettings, loadSettings } },
+}));
+
+import {
+  setFormatSettings,
+  getFormatSettings,
+  resetFormatToHouseStyle,
+  __resetFormatSettingsForTests,
+} from '../../../src/renderer/lib/formatter/settings';
+
+describe('resetFormatToHouseStyle (full reset)', () => {
+  beforeEach(() => {
+    __resetFormatSettingsForTests();
+    saveSettings.mockClear();
+  });
+
+  it('clears both enable/disable overrides and per-rule config tuning', () => {
+    setFormatSettings({
+      enabled: { 'capitalize-headings': true, 'trailing-spaces': false },
+      configs: { 'consecutive-blank-lines': { max: 3 } },
+    });
+    expect(getFormatSettings().enabled).not.toEqual({});
+    expect(getFormatSettings().configs).not.toEqual({});
+
+    const next = resetFormatToHouseStyle();
+
+    expect(next.enabled).toEqual({});
+    expect(next.configs).toEqual({});
+    expect(getFormatSettings()).toEqual({ enabled: {}, configs: {} });
+  });
+
+  it('persists the fully-cleared settings via IPC', () => {
+    setFormatSettings({ configs: { 'consecutive-blank-lines': { max: 3 } } });
+    saveSettings.mockClear();
+
+    resetFormatToHouseStyle();
+
+    expect(saveSettings).toHaveBeenCalledWith({ enabled: {}, configs: {} });
+  });
+});


### PR DESCRIPTION
## The bug

"Restore house style" cleared your enable/disable overrides but **left per-rule configuration in place**. So if you'd tuned a rule's own setting — say, a custom consecutive-blank-lines maximum — that value survived the restore, leaving you at something that isn't actually the shipped house style. "Restore" should mean *restore everything*.

## Fix

`resetFormatToHouseStyle` (`src/renderer/lib/formatter/settings.ts`) now clears **both** maps:

```ts
settings = { enabled: {}, configs: {} };  // was: configs: { ...settings.configs }
```

Each rule falls back to its default enabled-state *and* its own `defaultConfig`.

## Paired bug it surfaced

The button's disabled state (`atHouseStyle` in `SettingsDialog.svelte`) was derived from `enabled` only:

```ts
let atHouseStyle = $derived(Object.keys(formatter.enabled).length === 0);
```

So a note with a tuned config but no on/off overrides reported "already at house style" → the button was disabled → that config was **impossible to reset from the UI**. Now it requires both maps empty, so a lingering config keeps the button live.

## Tests

New `tests/renderer/formatter/settings.test.ts`: verifies the reset clears both `enabled` and `configs`, and that the fully-cleared object is persisted via IPC. Full suite green; `pnpm lint` clean.

## Docs note

The corresponding correction to the "Restore house style" box in `website/docs/settings-formatter.html` is left in the working tree to land with the in-progress docs batch (that file already carries other doc edits), rather than being bundled into this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)