### PR TITLE
Highlights: span soft line breaks within a paragraph

### DIFF
--- a/src/shared/markdown/highlight-plugin.ts
+++ b/src/shared/markdown/highlight-plugin.ts
@@ -12,10 +12,13 @@
  * before `emphasis` so `**==X==**` resolves outermost-emphasis ↦
  * inner-highlight without delimiter races.
  *
+ * A highlight may span soft line breaks within a paragraph, the same
+ * way `**strong**` and `*emphasis*` do; a blank line ends the paragraph
+ * (and the block), so a highlight never reaches across it.
+ *
  * Rejects, following Pandoc convention:
  *   - `===` runs (three or more equals — heading-rule territory)
  *   - empty bodies
- *   - newlines inside the body (inline-only)
  *   - whitespace immediately after the opening `==` or before the
  *     closing `==` (matches strong/em — keeps `== test ==` in prose
  *     from accidentally highlighting)
@@ -29,6 +32,23 @@ export type HighlightColor = typeof HIGHLIGHT_PALETTE[number];
 const PALETTE_SET = new Set<string>(HIGHLIGHT_PALETTE);
 
 const COLOR_PREFIX_RE = /^([a-z]+):/;
+
+/**
+ * True when the line starting at `pos` is blank (only spaces/tabs/CR
+ * before the next newline or end-of-text). A blank line ends a markdown
+ * paragraph, so `scanHighlights` treats it as a hard stop — the flat-text
+ * scanner's stand-in for the preview plugin's per-block `posMax` bound.
+ */
+function isBlankLineAt(text: string, pos: number): boolean {
+  let k = pos;
+  while (k < text.length) {
+    const c = text.charCodeAt(k);
+    if (c === 0x0a) return true; // reached the next newline with only blanks
+    if (c !== 0x20 && c !== 0x09 && c !== 0x0d) return false;
+    k++;
+  }
+  return true; // end of text — nothing more to highlight into
+}
 
 export interface HighlightMatch {
   /** Offset of the opening `==` in the input. */
@@ -48,7 +68,8 @@ export interface HighlightMatch {
  *
  *   - `===` runs are not delimiters (forward OR backward)
  *   - empty bodies are not delimiters
- *   - newlines inside the body end the match
+ *   - a single newline is spanned; a blank line ends the paragraph and
+ *     stops the match (the flat-text stand-in for the plugin's per-block bound)
  *   - whitespace adjacent to either delimiter rejects (matches strong/em)
  *
  * `offset` is added to each result so the caller can pass a slice of
@@ -64,13 +85,15 @@ export function scanHighlights(text: string, offset = 0): HighlightMatch[] {
     const afterOpen = text.charCodeAt(i + 2);
     if (afterOpen === 0x20 || afterOpen === 0x09 || afterOpen === 0x0a) { i++; continue; }
 
-    // Scan for the closing `==`, rejecting at newlines so highlights
-    // stay strictly inline (the preview plugin does the same).
+    // Scan for the closing `==`. A single newline is fine — the highlight
+    // spans it, matching the preview plugin — but a blank line ends the
+    // paragraph, and the preview's inline scan can't reach past a block
+    // boundary, so we stop there too to keep the two surfaces in sync.
     let j = i + 2;
     let closing = -1;
     while (j < text.length - 1) {
       const c = text.charCodeAt(j);
-      if (c === 0x0a) break;
+      if (c === 0x0a && isBlankLineAt(text, j + 1)) break;
       if (
         c === 0x3d &&
         text.charCodeAt(j + 1) === 0x3d &&
@@ -126,11 +149,14 @@ function highlightInline(state: StateInline, silent: boolean): boolean {
   if (afterOpen === 0x20 || afterOpen === 0x09 || afterOpen === 0x0a) return false;
 
   // Scan forward for the closing `==` that isn't itself part of `===`.
+  // Soft newlines inside the body are allowed — a highlight spans line
+  // breaks the same way emphasis does. `state.posMax` already bounds the
+  // scan to this paragraph, so a blank line (which ends the block) is an
+  // automatic stop; we never reach across a paragraph break.
   let scan = bodyStart;
   let closingPos = -1;
   while (scan < state.posMax - 1) {
     const c = state.src.charCodeAt(scan);
-    if (c === 0x0a) return false;
     if (
       c === 0x3d &&
       state.src.charCodeAt(scan + 1) === 0x3d &&

--- a/tests/shared/markdown/highlight-plugin.test.ts
+++ b/tests/shared/markdown/highlight-plugin.test.ts
@@ -78,9 +78,22 @@ describe('highlight plugin (#468)', () => {
     expect(html).not.toContain('<mark');
   });
 
-  it('does not match across a newline', () => {
-    const html = md().render('==open\nbut not closed on same line==');
+  it('spans a soft newline within a paragraph (like strong/em)', () => {
+    const html = md().render('==open\nand closed on the next line==');
+    expect(html).toContain('<mark');
+    expect(html).toContain('open\nand closed on the next line');
+  });
+
+  it('does not reach across a blank line (paragraph boundary)', () => {
+    const html = md().render('==open\n\nclosed after a blank line==');
     expect(html).not.toContain('<mark');
+  });
+
+  it('spans multiple soft newlines but stops at the paragraph', () => {
+    // Whole three-line paragraph highlights; the following paragraph is untouched.
+    const html = md().render('==a\nb\nc==\n\nplain ==d== tail');
+    expect(html).toContain('<mark class="hl">a\nb\nc</mark>');
+    expect(html).toContain('<mark class="hl">d</mark>');
   });
 
   it('rejects whitespace-padded bodies (== test ==)', () => {
@@ -136,8 +149,22 @@ describe('scanHighlights (editor decoration shared scanner)', () => {
     expect(scanHighlights('===nope=== and ===yep===')).toEqual([]);
   });
 
-  it('does not cross newlines', () => {
-    expect(scanHighlights('==open\nclose==')).toEqual([]);
+  it('spans a single newline', () => {
+    expect(scanHighlights('==open\nclose==')).toEqual([{ from: 0, to: 14, color: null }]);
+  });
+
+  it('stops at a blank line (paragraph boundary)', () => {
+    // The span across the blank line never closes, so nothing matches here;
+    // a self-contained highlight in the second paragraph still does.
+    expect(scanHighlights('==open\n\nclose==')).toEqual([]);
+    expect(scanHighlights('==a\nb==\n\n==c==')).toEqual([
+      { from: 0, to: 7, color: null },
+      { from: 9, to: 14, color: null },
+    ]);
+  });
+
+  it('stops at a whitespace-only line, not just a bare blank line', () => {
+    expect(scanHighlights('==open\n   \nclose==')).toEqual([]);
   });
 
   it('rejects whitespace-padded bodies', () => {


### PR DESCRIPTION
## What

`==highlight==` now spans soft line breaks within a paragraph, matching how **bold**, *italic*, and ~~strikethrough~~ already behave. Previously it was the only inline markup that bailed the instant it saw a `\n`.

Before / after, same source `==foo⏎bar==` in one paragraph:

| | Before | After |
|---|---|---|
| `==foo⏎bar==` | literal `==foo\nbar==` | `<mark>foo\nbar</mark>` |
| `**foo⏎bar**` | `<strong>foo\nbar</strong>` | (unchanged — already worked) |

A blank line still stops it — that's a paragraph boundary, and no inline markup crosses it.

## How

**Preview plugin** (`highlightInline`): removed the mid-scan `if (c === 0x0a) return false` guard. markdown-it already bounds inline parsing to the current block via `state.posMax`, so the highlight spans soft newlines but a blank line (which ends the block) is an automatic stop. No other change needed there.

**Editor scanner** (`scanHighlights`): this one runs on flat viewport text with no block awareness, so it can't rely on `posMax`. Instead of breaking at every `\n` it now breaks only at a **blank line** — a newline followed by an all-whitespace line — via a new `isBlankLineAt` helper. This keeps the source-mode decoration and the preview agreeing on what's a highlight.

**Toggle unaffected:** `computeToggleHighlight` is handed single-line text, so the ⌘-highlight command sees no newlines and behaves exactly as before.

## Scope

This is "Scope A" from the discussion — spanning a *single* newline within a paragraph. Spanning *blank-line paragraph boundaries* (Scope B) was deliberately left out: it fights markdown's block model, would need every markup type and six render/edit surfaces reworked, and introduces a footgun where one stray delimiter restyles the rest of a note. A `:::highlight` container block is the better route if multi-paragraph highlighting is wanted later.

## Tests

Updated the two tests that asserted newline rejection (they now assert the span) and added cases for: spanning multiple soft newlines, stopping at a blank line, and stopping at a whitespace-only line. Full highlight suite (plugin + editor decoration + toggle) green; `pnpm lint` clean.

## Docs

The gotcha in `website/docs/notes-highlights.html` is corrected in the working tree (that file is part of the in-progress docs batch), not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)