### PR TITLE
Settings: fix stale "On-save rules" subtitle on the Formatter tab

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -95,7 +95,7 @@
       label: 'Authoring',
       items: [
         { id: 'notes',        label: 'Notes',        sub: 'Refactoring · excerpt destinations' },
-        { id: 'formatter',    label: 'Formatter',    sub: 'On-save rules' },
+        { id: 'formatter',    label: 'Formatter',    sub: 'House style · format rules' },
         { id: 'bibliography', label: 'Bibliography', sub: 'Citation style · locale' },
       ],
     },


### PR DESCRIPTION
## What

The Formatter tab in the Settings sidebar was subtitled **"On-save rules"** — a leftover from an earlier design. Nothing about the formatter runs on save; it's on-demand via **Refactor ▸ Format**. The label actively misinforms.

## Fix

One string in `SettingsDialog.svelte`:

```
- { id: 'formatter', label: 'Formatter', sub: 'On-save rules' },
+ { id: 'formatter', label: 'Formatter', sub: 'House style · format rules' },
```

"House style · format rules" is accurate and matches the `X · Y` shape of the neighbouring subtitles (`Refactoring · excerpt destinations`, `Citation style · locale`).

## Docs

This retires a gotcha that existed only to warn readers about the wrong label. Its removal from `website/docs/settings-formatter.html` is done in the working tree (part of the in-progress docs batch), not bundled into this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)