### PR TITLE
Add Property: type-aware values + Properties-panel type-switcher

### DIFF
--- a/src/renderer/lib/components/AddPropertyDialog.svelte
+++ b/src/renderer/lib/components/AddPropertyDialog.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
   /**
-   * Add-Property dialog — collects a frontmatter property's name AND value on
-   * one panel (vs. two sequential prompts). Mirrors PromptDialog's chrome; the
-   * name field autocompletes from the thoughtbase's frontmatter-key vocabulary.
+   * Add-Property dialog — collects a frontmatter property's name, type, AND
+   * value on one panel (vs. two sequential prompts). Mirrors PromptDialog's
+   * chrome; the name field autocompletes from the thoughtbase's
+   * frontmatter-key vocabulary, and the value uses the same type-aware editor
+   * the Properties panel does, so a real boolean / number / date is written
+   * rather than a stringified one.
    */
   import type { AddPropertyResult } from '../stores/dialogs.svelte';
+  import PropertyValueEditor from './PropertyValueEditor.svelte';
+  import {
+    SCALAR_TYPES,
+    coerceScalar,
+    isValidScalar,
+    type ScalarType,
+  } from '../../../shared/refactor/property-shape';
 
   interface Props {
     message: string;
@@ -16,25 +26,29 @@
   let { message, keySuggestions, onConfirm, onCancel }: Props = $props();
 
   let name = $state('');
-  let value = $state('');
+  let type = $state<ScalarType>('string');
+  /** Raw text for string/number/date; the boolean uses `boolValue`. */
+  let text = $state('');
+  let boolValue = $state(false);
   let nameEl = $state<HTMLInputElement>();
-  let valueEl = $state<HTMLInputElement>();
   const listId = `add-property-keys-${Math.random().toString(36).slice(2, 9)}`;
 
-  const canConfirm = $derived(name.trim().length > 0);
+  const canConfirm = $derived(
+    name.trim().length > 0 && (type === 'boolean' || isValidScalar(type, text)),
+  );
   function submit() {
-    if (canConfirm) onConfirm({ name: name.trim(), value });
+    if (!canConfirm) return;
+    const value = type === 'boolean' ? boolValue : coerceScalar(type, text);
+    onConfirm({ name: name.trim(), value });
   }
 
   function onOverlayKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') onCancel();
   }
   function onNameKeydown(e: KeyboardEvent) {
-    // Enter on the name field advances to value rather than submitting, so the
-    // value isn't skipped by a reflexive Enter.
-    if (e.key === 'Enter') { e.preventDefault(); valueEl?.focus(); }
-  }
-  function onValueKeydown(e: KeyboardEvent) {
+    // Enter on the name field submits directly — the value has a sensible
+    // default per type (empty string / 0 / false / today-less date), so a
+    // reflexive Enter after typing a key still does something useful.
     if (e.key === 'Enter') { e.preventDefault(); submit(); }
   }
 
@@ -70,18 +84,29 @@
           </datalist>
         {/if}
       </label>
-      <label class="field">
-        <span class="field-label">Value</span>
-        <input
-          bind:this={valueEl}
-          bind:value
-          onkeydown={onValueKeydown}
-          type="text"
-          class="input"
-          autocomplete="off"
-          placeholder="e.g. draft"
-        />
-      </label>
+      <div class="field-row">
+        <label class="field type-field">
+          <span class="field-label">Type</span>
+          <select class="input select" bind:value={type}>
+            {#each SCALAR_TYPES as t}
+              <option value={t}>{t}</option>
+            {/each}
+          </select>
+        </label>
+        <div class="field value-field">
+          <span class="field-label">Value</span>
+          <div class="value-slot">
+            <PropertyValueEditor
+              {type}
+              {text}
+              checked={boolValue}
+              onInput={(raw) => { text = raw; }}
+              onCommit={(raw) => { text = raw; }}
+              onToggle={(c) => { boolValue = c; }}
+            />
+          </div>
+        </div>
+      </div>
     </div>
 
     <footer class="card-footer">
@@ -179,6 +204,34 @@
   .input:focus {
     border-color: var(--accent);
     box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+  .field-row {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+  }
+  .type-field {
+    flex: 0 0 120px;
+  }
+  .value-field {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .select {
+    appearance: auto;
+    cursor: pointer;
+  }
+  /* Match the taller .input chrome so the editor lines up with the select. */
+  .value-slot :global(.pve-input) {
+    padding: 8px 10px;
+    border-radius: 6px;
+    border-color: var(--border-strong);
+    font-size: 14px;
+  }
+  .value-slot {
+    display: flex;
+    align-items: center;
+    min-height: 37px;
   }
 
   .card-footer {

--- a/src/renderer/lib/components/PropertyValueEditor.svelte
+++ b/src/renderer/lib/components/PropertyValueEditor.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  /**
+   * Type-aware editor for a single scalar frontmatter value (#471 follow-up).
+   * Presentational and fully parent-controlled: it holds no committed state,
+   * it just renders the widget for `type` and reports edits. The parent owns
+   * debounce/commit timing — the Properties panel debounces text into its YAML
+   * round-trip; the Add-Property dialog reads the value on submit.
+   *
+   *   - text/number → `onInput` per keystroke, `onCommit` on blur / Enter
+   *   - boolean     → `onToggle` on change (no text)
+   *   - date        → `onCommit` on change (native picker commits atomically)
+   */
+  import type { ScalarType } from '../../../shared/refactor/property-shape';
+
+  interface Props {
+    type: ScalarType;
+    /** Display text for string / number / date inputs. */
+    text?: string;
+    /** Checked state for the boolean toggle. */
+    checked?: boolean;
+    autofocus?: boolean;
+    onInput?: (raw: string) => void;
+    onCommit?: (raw: string) => void;
+    onToggle?: (checked: boolean) => void;
+  }
+
+  let {
+    type,
+    text = '',
+    checked = false,
+    autofocus = false,
+    onInput,
+    onCommit,
+    onToggle,
+  }: Props = $props();
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onCommit?.((e.currentTarget as HTMLInputElement).value);
+    }
+  }
+</script>
+
+{#if type === 'boolean'}
+  <label class="pve-bool">
+    <input
+      type="checkbox"
+      {checked}
+      onchange={(e) => onToggle?.(e.currentTarget.checked)}
+    />
+    <span>{checked ? 'true' : 'false'}</span>
+  </label>
+{:else if type === 'number'}
+  <input
+    class="pve-input"
+    type="number"
+    value={text}
+    {autofocus}
+    oninput={(e) => onInput?.(e.currentTarget.value)}
+    onblur={(e) => onCommit?.(e.currentTarget.value)}
+    onkeydown={onKeydown}
+  />
+{:else if type === 'date'}
+  <input
+    class="pve-input"
+    type="date"
+    value={text}
+    {autofocus}
+    onchange={(e) => onCommit?.(e.currentTarget.value)}
+  />
+{:else}
+  <input
+    class="pve-input"
+    type="text"
+    value={text}
+    {autofocus}
+    spellcheck="false"
+    oninput={(e) => onInput?.(e.currentTarget.value)}
+    onblur={(e) => onCommit?.(e.currentTarget.value)}
+    onkeydown={onKeydown}
+  />
+{/if}
+
+<style>
+  .pve-input {
+    width: 100%;
+    padding: 4px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    outline: none;
+  }
+  .pve-input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent) 18%, transparent);
+  }
+  .pve-bool {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .pve-bool input {
+    cursor: pointer;
+    accent-color: var(--accent);
+  }
+</style>

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -23,6 +23,14 @@
   import { resolveWikiLinkTarget } from '../../wiki-link-resolver';
   import type { IconName } from '../icons/registry';
   import { CANONICAL_FRONTMATTER_KEYS } from '../../../../shared/frontmatter-canonical-keys';
+  import PropertyValueEditor from '../PropertyValueEditor.svelte';
+  import {
+    SCALAR_TYPES,
+    isScalarType,
+    coerceScalar,
+    scalarToText,
+    type ScalarType,
+  } from '../../../../shared/refactor/property-shape';
 
   /** Type-icon mapping per §13.1. The icon signals the value shape at
    *  a glance so a row reads as "number" or "list" without parsing
@@ -296,6 +304,44 @@
     setKeyValue(key, value);
   }
 
+  // ── Scalar editor glue (shared PropertyValueEditor) ───────────────
+  // The four scalar widgets are rendered by PropertyValueEditor; the panel
+  // keeps owning debounce (text/number) and immediate commit (boolean/date),
+  // so typing behaviour is unchanged from the inline version.
+
+  function scalarText(row: Row): string {
+    const s = row.shape;
+    if (s.kind === 'string') return drafts[row.key] ?? s.value;
+    if (s.kind === 'number') return drafts[row.key] ?? String(s.value);
+    if (s.kind === 'date') return s.value;
+    return '';
+  }
+  function onScalarInput(row: Row, raw: string): void {
+    if (row.shape.kind === 'string') scheduleFlush(row.key, raw, commitString);
+    else if (row.shape.kind === 'number') scheduleFlush(row.key, raw, commitNumber);
+  }
+  function onScalarCommit(row: Row, raw: string): void {
+    if (row.shape.kind === 'string') commitString(row.key, raw);
+    else if (row.shape.kind === 'number') commitNumber(row.key, raw);
+    else if (row.shape.kind === 'date') commitDate(row.key, raw);
+  }
+
+  // ── Type switcher ─────────────────────────────────────────────────
+  // The type icon on a scalar row is a button: it opens a small menu that
+  // re-types the value. The current value is stringified and re-coerced to
+  // the chosen type (e.g. string "false" → boolean false), then committed.
+
+  let typeMenuKey = $state<string | null>(null);
+  function toggleTypeMenu(key: string): void {
+    typeMenuKey = typeMenuKey === key ? null : key;
+  }
+  function changeType(row: Row, next: ScalarType): void {
+    typeMenuKey = null;
+    if (row.shape.kind === next) return;
+    const current = 'value' in row.shape ? scalarToText(row.shape.value) : '';
+    setKeyValue(row.key, coerceScalar(next, current));
+  }
+
   function scheduleFlush(key: string, value: string, fn: (k: string, v: string) => void): void {
     drafts[key] = value;
     if (flushTimer) clearTimeout(flushTimer);
@@ -518,13 +564,48 @@
       {#each rows as row (row.key)}
         {@const canonical = isCanonical(row.key)}
         <div class="row" class:canonical data-row-key={row.key}>
-          <span class="type-icon" title={row.shape.kind}>
-            <Icon
-              name={typeIcon(row.shape.kind)}
-              size={12}
-              color={canonical ? 'var(--accent)' : 'var(--text-faint)'}
-            />
-          </span>
+          {#if isScalarType(row.shape.kind)}
+            <div class="type-switch">
+              <button
+                class="type-icon type-icon-btn"
+                title="Change type ({row.shape.kind})"
+                aria-haspopup="menu"
+                aria-expanded={typeMenuKey === row.key}
+                onclick={() => toggleTypeMenu(row.key)}
+              >
+                <Icon
+                  name={typeIcon(row.shape.kind)}
+                  size={12}
+                  color={canonical ? 'var(--accent)' : 'var(--text-faint)'}
+                />
+              </button>
+              {#if typeMenuKey === row.key}
+                <button class="type-menu-backdrop" aria-label="Close type menu" onclick={() => (typeMenuKey = null)}></button>
+                <div class="type-menu" role="menu">
+                  {#each SCALAR_TYPES as t}
+                    <button
+                      class="type-menu-item"
+                      class:selected={t === row.shape.kind}
+                      role="menuitemradio"
+                      aria-checked={t === row.shape.kind}
+                      onclick={() => changeType(row, t)}
+                    >
+                      <Icon name={typeIcon(t)} size={11} />
+                      <span>{t}</span>
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {:else}
+            <span class="type-icon" title={row.shape.kind}>
+              <Icon
+                name={typeIcon(row.shape.kind)}
+                size={12}
+                color={canonical ? 'var(--accent)' : 'var(--text-faint)'}
+              />
+            </span>
+          {/if}
           <input
             class="key"
             type="text"
@@ -533,35 +614,14 @@
             spellcheck="false"
           />
           <div class="value">
-            {#if row.shape.kind === 'string'}
-              <input
-                type="text"
-                value={drafts[row.key] ?? row.shape.value}
-                oninput={(e) => scheduleFlush(row.key, e.currentTarget.value, commitString)}
-                onblur={(e) => commitString(row.key, e.currentTarget.value)}
-                spellcheck="false"
-              />
-            {:else if row.shape.kind === 'number'}
-              <input
-                type="number"
-                value={drafts[row.key] ?? String(row.shape.value)}
-                oninput={(e) => scheduleFlush(row.key, e.currentTarget.value, commitNumber)}
-                onblur={(e) => commitNumber(row.key, e.currentTarget.value)}
-              />
-            {:else if row.shape.kind === 'boolean'}
-              <label class="bool">
-                <input
-                  type="checkbox"
-                  checked={row.shape.value}
-                  onchange={(e) => commitBoolean(row.key, e.currentTarget.checked)}
-                />
-                <span>{row.shape.value ? 'true' : 'false'}</span>
-              </label>
-            {:else if row.shape.kind === 'date'}
-              <input
-                type="date"
-                value={row.shape.value}
-                onchange={(e) => commitDate(row.key, e.currentTarget.value)}
+            {#if isScalarType(row.shape.kind)}
+              <PropertyValueEditor
+                type={row.shape.kind}
+                text={scalarText(row)}
+                checked={row.shape.kind === 'boolean' ? row.shape.value : false}
+                onInput={(raw) => onScalarInput(row, raw)}
+                onCommit={(raw) => onScalarCommit(row, raw)}
+                onToggle={(c) => commitBoolean(row.key, c)}
               />
             {:else if row.shape.kind === 'string-list'}
               <div class="chips">
@@ -708,6 +768,66 @@
     justify-content: center;
     flex-shrink: 0;
   }
+  .type-switch {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+  .type-icon-btn {
+    padding: 2px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: none;
+    cursor: pointer;
+    line-height: 0;
+  }
+  .type-icon-btn:hover {
+    border-color: var(--border-strong);
+    background: var(--bg-inset);
+  }
+  .type-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    background: none;
+    border: none;
+    cursor: default;
+  }
+  .type-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 41;
+    display: flex;
+    flex-direction: column;
+    min-width: 116px;
+    padding: 4px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  }
+  .type-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .type-menu-item:hover {
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--text);
+  }
+  .type-menu-item.selected {
+    color: var(--accent);
+  }
 
   .row .key {
     background: none;
@@ -755,15 +875,6 @@
   .row .value > input[type="date"]:focus {
     border-color: var(--accent);
     outline: none;
-  }
-
-  .bool {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--text-muted);
-    cursor: pointer;
-    user-select: none;
   }
 
   .chips {

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -44,10 +44,12 @@ export interface OpenTargetState {
   message: string;
   resolve: (value: OpenTargetChoice) => void;
 }
-/** Name + value collected on one panel by the "Add Property" dialog. */
+/** Name + typed value collected on one panel by the "Add Property" dialog.
+ *  `value` is an already-coerced JS scalar (string / number / boolean, or a
+ *  `YYYY-MM-DD` string for dates), ready to hand to `setPropertyInContent`. */
 export interface AddPropertyResult {
   name: string;
-  value: string;
+  value: unknown;
 }
 export interface AddPropertyState {
   message: string;

--- a/src/shared/refactor/frontmatter-properties.ts
+++ b/src/shared/refactor/frontmatter-properties.ts
@@ -4,8 +4,11 @@
  * "Add Property" / "Remove Property" menu actions.
  *
  * A property is any frontmatter key other than `tags` (which has its own
- * Add/Remove Tag actions). Values are written as string scalars — the menu
- * flow is a text prompt; richer typing lives in the Properties panel.
+ * Add/Remove Tag actions). Values are typed: the "Add Property" dialog now
+ * collects a type (string / number / boolean / date) alongside the value, so
+ * `setPropertyInContent` takes the already-coerced JS value and lets the YAML
+ * serializer render it — a real boolean `false` becomes `key: false`, not
+ * `key: "false"`.
  */
 import YAML from 'yaml';
 
@@ -33,17 +36,18 @@ export function extractPropertyKeysFromContent(content: string): string[] {
 
 export interface SetPropertyResult {
   content: string;
-  /** False when the key was already set to this exact string (no write needed). */
+  /** False when the key already held this exact value (no write needed). */
   changed: boolean;
 }
 
 /**
  * Upsert `key: value` into the note's frontmatter, creating the block when the
- * note has none. `value` is stored as a string scalar (YAML quotes it as
- * needed — so a `[[wiki-link]]` value survives round-trip). No-op when the key
- * already holds the same string.
+ * note has none. `value` is a JS scalar (string, number, or boolean); the YAML
+ * serializer renders it in the right shape and quotes strings as needed — so a
+ * `[[wiki-link]]` string survives round-trip while a boolean `false` stays a
+ * boolean. No-op when the key already holds the same value.
  */
-export function setPropertyInContent(content: string, key: string, value: string): SetPropertyResult {
+export function setPropertyInContent(content: string, key: string, value: unknown): SetPropertyResult {
   const match = content.match(FRONTMATTER_RE);
   let fm: Record<string, unknown> = {};
   if (match) {

--- a/src/shared/refactor/property-shape.ts
+++ b/src/shared/refactor/property-shape.ts
@@ -1,0 +1,67 @@
+/**
+ * Scalar frontmatter-property types shared by the Properties panel and the
+ * "Add Property" dialog (#471 follow-up). Both surfaces present the same
+ * type-aware value editors, so the type list + the text↔typed-value coercion
+ * live here rather than being duplicated per surface.
+ *
+ * Scope is deliberately the four *scalars* — richer shapes (string lists,
+ * wiki-links, arbitrary YAML) stay panel-only for now. A value's JS type is
+ * what the YAML serializer keys off, so a real boolean `false` (not the string
+ * `"false"`) round-trips as `key: false`.
+ */
+
+export type ScalarType = 'string' | 'number' | 'boolean' | 'date';
+
+export const SCALAR_TYPES: readonly ScalarType[] = ['string', 'number', 'boolean', 'date'];
+
+export function isScalarType(kind: string): kind is ScalarType {
+  return (SCALAR_TYPES as readonly string[]).includes(kind);
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Coerce a raw text representation into the JS value for `type`. Used both
+ * when the "Add Property" dialog confirms and when a Properties-panel row is
+ * switched from one type to another (the current value is stringified, then
+ * re-coerced to the new type).
+ *
+ *   - string  → the text unchanged
+ *   - number  → the parsed number, or 0 when the text isn't a finite number
+ *   - boolean → true only for true/yes/on/1 (case-insensitive); else false
+ *   - date    → the text if it's already `YYYY-MM-DD`, else '' (empty date)
+ */
+export function coerceScalar(type: ScalarType, raw: string): string | number | boolean {
+  const text = raw.trim();
+  switch (type) {
+    case 'string':
+      return raw;
+    case 'number': {
+      const n = Number(text);
+      return text !== '' && Number.isFinite(n) ? n : 0;
+    }
+    case 'boolean':
+      return /^(true|yes|on|1)$/i.test(text);
+    case 'date':
+      return DATE_RE.test(text) ? text : '';
+  }
+}
+
+/** Render a JS scalar value as the seed text for a type-switch or an editor. */
+export function scalarToText(value: unknown): string {
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number' || typeof value === 'string') return String(value);
+  return '';
+}
+
+/**
+ * Whether `raw` is an acceptable value for `type` in the Add-Property dialog.
+ * Only `number` is gated — an empty or non-numeric entry can't become a
+ * number, so the dialog blocks confirmation rather than silently writing 0.
+ * The other types always have a sensible reading of any text.
+ */
+export function isValidScalar(type: ScalarType, raw: string): boolean {
+  if (type !== 'number') return true;
+  const text = raw.trim();
+  return text !== '' && Number.isFinite(Number(text));
+}

--- a/tests/shared/refactor/frontmatter-properties.test.ts
+++ b/tests/shared/refactor/frontmatter-properties.test.ts
@@ -34,6 +34,27 @@ describe('setPropertyInContent', () => {
     // Quoted → not eaten into a nested array on re-parse.
     expect(content).toMatch(/about: "\[\[some-note\]\]"|about: '\[\[some-note\]\]'/);
   });
+
+  it('writes a real boolean, not the string "false"', () => {
+    const { content, changed } = setPropertyInContent('# N', 'format', false);
+    expect(changed).toBe(true);
+    // Unquoted boolean — this is what the format-opt-out reads back as `=== false`.
+    expect(content).toContain('format: false');
+    expect(content).not.toContain('format: "false"');
+  });
+
+  it('writes a real number', () => {
+    const { content } = setPropertyInContent('# N', 'count', 3);
+    expect(content).toContain('count: 3');
+    expect(content).not.toContain('count: "3"');
+  });
+
+  it('is a no-op when a typed value is unchanged', () => {
+    const src = '---\nformat: false\n---\n# N';
+    const res = setPropertyInContent(src, 'format', false);
+    expect(res.changed).toBe(false);
+    expect(res.content).toBe(src);
+  });
 });
 
 describe('removePropertyFromContent', () => {

--- a/tests/shared/refactor/property-shape.test.ts
+++ b/tests/shared/refactor/property-shape.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SCALAR_TYPES,
+  isScalarType,
+  coerceScalar,
+  scalarToText,
+  isValidScalar,
+} from '../../../src/shared/refactor/property-shape';
+
+describe('isScalarType', () => {
+  it('accepts the four scalar kinds and rejects richer shapes', () => {
+    for (const t of SCALAR_TYPES) expect(isScalarType(t)).toBe(true);
+    expect(isScalarType('string-list')).toBe(false);
+    expect(isScalarType('wiki-link')).toBe(false);
+    expect(isScalarType('yaml')).toBe(false);
+  });
+});
+
+describe('coerceScalar', () => {
+  it('string keeps the text verbatim (including surrounding spaces)', () => {
+    expect(coerceScalar('string', '  keep me ')).toBe('  keep me ');
+  });
+
+  it('number parses, falling back to 0 on non-numeric or empty', () => {
+    expect(coerceScalar('number', '42')).toBe(42);
+    expect(coerceScalar('number', '3.5')).toBe(3.5);
+    expect(coerceScalar('number', '')).toBe(0);
+    expect(coerceScalar('number', 'nope')).toBe(0);
+  });
+
+  it('boolean is true only for true/yes/on/1 (case-insensitive)', () => {
+    for (const t of ['true', 'TRUE', 'yes', 'on', '1']) {
+      expect(coerceScalar('boolean', t)).toBe(true);
+    }
+    for (const f of ['false', 'no', 'off', '0', '', 'anything']) {
+      expect(coerceScalar('boolean', f)).toBe(false);
+    }
+  });
+
+  it('date keeps a YYYY-MM-DD value and drops anything else', () => {
+    expect(coerceScalar('date', '2026-07-21')).toBe('2026-07-21');
+    expect(coerceScalar('date', 'not-a-date')).toBe('');
+  });
+});
+
+describe('scalarToText', () => {
+  it('stringifies primitives and empties out objects/null', () => {
+    expect(scalarToText(true)).toBe('true');
+    expect(scalarToText(false)).toBe('false');
+    expect(scalarToText(42)).toBe('42');
+    expect(scalarToText('hi')).toBe('hi');
+    expect(scalarToText(null)).toBe('');
+    expect(scalarToText({})).toBe('');
+  });
+});
+
+describe('isValidScalar', () => {
+  it('only gates number, requiring a finite value', () => {
+    expect(isValidScalar('number', '10')).toBe(true);
+    expect(isValidScalar('number', '')).toBe(false);
+    expect(isValidScalar('number', 'x')).toBe(false);
+    expect(isValidScalar('string', '')).toBe(true);
+    expect(isValidScalar('boolean', '')).toBe(true);
+    expect(isValidScalar('date', '')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The "Add Property…" affordance wrote every value as a **string scalar**. There was no way to set a real boolean, number, or date from the menu — typing `false` produced `format: "false"` (a quoted string), which the `format:` opt-out (and anything else expecting a typed value) doesn't honour. Meanwhile the Properties panel already had type-aware editors, so the two surfaces were parallel implementations of the same idea.

This reuses the panel's editors in the dialog rather than loosening the opt-out, and — as a side effect — makes `format: false` genuinely settable from the UI.

## What changed

- **New `PropertyValueEditor.svelte`** — one presentational component that renders the scalar widget (text / number / boolean toggle / date) for a given type. Both the Add-Property dialog and the panel rows consume it, so there's a single source of truth for the four scalar editors. It's fully parent-controlled, so the panel keeps its debounce and the dialog reads the value on submit.
- **New `shared/refactor/property-shape.ts`** — owns the scalar type list and text↔typed-value coercion (`coerceScalar`, `scalarToText`, `isValidScalar`), shared by both surfaces.
- **`setPropertyInContent` now takes a JS scalar** (`unknown`) and lets the YAML serializer render it: a boolean `false` round-trips as `format: false`, not `format: "false"`. Existing string callers are unchanged.
- **Add-Property dialog** gains a **Type** selector; the value editor swaps to match. Number entries are validated before confirm (no silent `0`).
- **Properties panel type-switcher**: the type icon on a scalar row is now a button that re-types the value in place (current value is stringified and re-coerced, e.g. string `"false"` → boolean `false`) — something the panel couldn't do before.

## Scope

Per the agreed plan: **scalars first** (string / number / boolean / date). Richer shapes (string-list, wiki-link, raw YAML) stay panel-only exactly as before — the switcher only appears on scalar rows.

## Tests

- New `property-shape.test.ts` (coercion, validation, type-guard, stringification).
- Extended `frontmatter-properties.test.ts`: writes a **real boolean** (`format: false`, not `"false"`), a real number, and no-ops on an unchanged typed value.
- Full suite green except one **pre-existing, unrelated** failure: `help-docs-corpus-staleness` compares a snapshot against the live `website/docs/*.html`, which are dirty from an in-progress docs batch on this machine — it imports none of these modules and re-snapshots when the docs land.
- `pnpm lint` clean.

## Follow-on

This makes `format: false` settable via **Add Property → type: boolean** (or the panel type-switcher), so the earlier `format: false` doc can now honestly reference the affordance, and the opt-out can stay strictly boolean-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)