### PR TITLE
Graph: table parser honors escaped pipes (\|) in cells

### DIFF
--- a/src/main/graph/parser.ts
+++ b/src/main/graph/parser.ts
@@ -230,6 +230,35 @@ function sanitizeFrontmatterValue(value: unknown): FrontmatterValue | undefined 
   return undefined;
 }
 
+/**
+ * Split a table row's inner text (leading/trailing `|` already stripped) into
+ * trimmed cells, honoring GFM's `\|` escape: a backslash-escaped pipe is
+ * literal cell content, not a column delimiter. Escaped pipes are unescaped in
+ * the result, so the value stored in the CSVW triples matches what the preview
+ * renders — a cell written `a \| b` extracts as the single cell `a | b`
+ * instead of splitting into misaligned columns.
+ */
+function splitTableCells(inner: string): string[] {
+  const cells: string[] = [];
+  let current = '';
+  for (let k = 0; k < inner.length; k++) {
+    const ch = inner[k]!;
+    if (ch === '\\' && inner[k + 1] === '|') {
+      current += '|';
+      k++; // consume the escaped pipe so it isn't treated as a delimiter
+      continue;
+    }
+    if (ch === '|') {
+      cells.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
 function extractTables(content: string): ParsedTable[] {
   const tables: ParsedTable[] = [];
   const lines = content.split('\n');
@@ -245,10 +274,7 @@ function extractTables(content: string): ParsedTable[] {
     if (!sepLine || !/^\|[\s:?-]+(\|[\s:?-]+)+\|$/.test(sepLine)) { i++; continue; }
 
     // Parse headers
-    const headers = headerLine
-      .slice(1, -1)
-      .split('|')
-      .map(h => h.trim());
+    const headers = splitTableCells(headerLine.slice(1, -1));
 
     // Parse data rows
     const rows: string[][] = [];
@@ -256,11 +282,7 @@ function extractTables(content: string): ParsedTable[] {
     while (j < lines.length) {
       const rowLine = lines[j]!.trim();
       if (!rowLine.startsWith('|') || !rowLine.endsWith('|')) break;
-      const cells = rowLine
-        .slice(1, -1)
-        .split('|')
-        .map(c => c.trim());
-      rows.push(cells);
+      rows.push(splitTableCells(rowLine.slice(1, -1)));
       j++;
     }
 

--- a/tests/main/graph/parser.test.ts
+++ b/tests/main/graph/parser.test.ts
@@ -474,6 +474,22 @@ describe('table extraction', () => {
     expect(result.tables[0].rows[0]).toEqual(['foo', 'bar']);
   });
 
+  it('treats an escaped pipe as literal cell content, not a delimiter', () => {
+    // `a \| b` is one cell in preview; it must extract as one cell too, with
+    // the pipe unescaped so the CSVW value matches what's rendered.
+    const md = '| Expr | Note |\n|------|------|\n| a \\| b | ok |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].headers).toEqual(['Expr', 'Note']);
+    expect(result.tables[0].rows).toEqual([['a | b', 'ok']]);
+  });
+
+  it('handles escaped pipes in headers and multiple per cell', () => {
+    const md = '| x \\| y | z |\n|---|---|\n| p \\| q \\| r | s |';
+    const result = parseMarkdown(md);
+    expect(result.tables[0].headers).toEqual(['x | y', 'z']);
+    expect(result.tables[0].rows).toEqual([['p | q | r', 's']]);
+  });
+
   // ── Table: <caption> parsing (#1356) ─────────────────────────────────────
   it('leaves caption/name undefined for an uncaptioned table', () => {
     const md = '| A | B |\n|---|---|\n| 1 | 2 |';


### PR DESCRIPTION
## The bug

The markdown-table extractor split every row on `|`, **including backslash-escaped ones**. A cell written `a \| b` renders as a single cell in the preview but was split into extra, misaligned cells in the CSVW triples — so a table containing literal pipes both indexed wrong and queried wrong. (Documented as a known gotcha on the Tables page; this fixes it.)

## Fix

Replace the two naive `.split('|')` calls (headers + data rows) in `src/main/graph/parser.ts` with a small `splitTableCells` helper that:

- treats `\|` as literal content, not a column delimiter, and
- unescapes it in the cell text, so the extracted value (`a | b`) matches what the preview renders.

```
| Expr | Note |          headers: ['Expr', 'Note']
|------|------|    →     rows:    [['a | b', 'ok']]
| a \| b | ok |          (was: ['a ', ' b', 'ok'] — 3 misaligned cells)
```

## Scope

The graph indexer and the **sources CSVW path** (`src/main/sources/tables.ts`) both go through `parseMarkdown`, so this one change fixes both. No other markdown-table cell parser exists in the tree (the other `split('|')` sites are skill-template filters and `[[target|display]]` wiki-links — unrelated).

## Tests

Added two cases to `parser.test.ts`: an escaped pipe extracts as one cell with the pipe unescaped, and multiple escaped pipes per cell (in both headers and rows) work. Full graph + sources table suites green; `pnpm lint` clean.

## Docs

The now-obsolete "escaped pipes don't extract correctly" gotcha is removed from `website/docs/notes-tables.html` in the working-tree docs batch, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)