### PR TITLE
Thinking-tool menus: ungrouped skills render inline, not in a "General" bucket

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -14,7 +14,7 @@ import { listSavedQueries } from './saved-queries';
 import { restartKernel as restartPythonKernel, interruptKernel as interruptPythonKernel } from './compute/python-kernel';
 import * as publish from './publish';
 import { getToolsByCategory, CATEGORIES } from '../shared/tools/registry';
-import { groupToolsByGroup, hasNamedGroups } from '../shared/tools/grouping';
+import { groupToolsByGroup, flattenGroupedMenu } from '../shared/tools/grouping';
 import { isSourceScoped, toolRequiresNote, toolRequiresSelection } from '../shared/tools/types';
 import type { MenuEditorState } from '../shared/types';
 import {
@@ -641,17 +641,21 @@ function buildToolMenus(gate: Gate): Electron.MenuItemConstructorOptions[] {
         },
         { note: toolRequiresNote(tool), selection: toolRequiresSelection(tool) },
       );
-      // Thematic sub-grouping (#525): when any tool in the category declares
-      // a `group`, render one nested submenu per group (ungrouped → General,
-      // last). Otherwise stay flat — current behavior for ungrouped
-      // categories (Learning, Research).
+      // Thematic sub-grouping (#525): a tool's optional `group` renders as a
+      // nested submenu. Ungrouped tools stay inline (like the Source tools
+      // menu) instead of being collected into a "General" submenu — so adding
+      // a group to one skill nests just that skill rather than restructuring
+      // the whole category. With no named groups, `groupToolsByGroup` returns a
+      // single ungrouped bucket, so the menu renders flat exactly as before.
       const groups = groupToolsByGroup(tools);
-      const toolItems: Electron.MenuItemConstructorOptions[] = hasNamedGroups(groups)
-        ? groups.map((g) => ({
-            label: g.label ?? 'General',
-            submenu: g.tools.map(mkItem),
-          }))
-        : tools.map(mkItem);
+      const toolItems: Electron.MenuItemConstructorOptions[] = flattenGroupedMenu<
+        typeof tools[number],
+        Electron.MenuItemConstructorOptions
+      >(
+        groups,
+        mkItem,
+        (label, ts) => ({ label, submenu: ts.map(mkItem) }),
+      );
       // "Ask a Question" opens a plain conversation — the same action the View
       // menu used to call "New Conversation". It lives atop Learning as the
       // simplest thinking tool. Needs no note (just a thoughtbase), so it gates

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -68,7 +68,7 @@
 
   import { getToolInfosByCategory } from '../tools/tool-registry';
   import { isSourceScoped, toolRequiresSelection, type ThinkingToolInfo } from '../../../shared/tools/types';
-  import { groupToolsByGroup, hasNamedGroups } from '../../../shared/tools/grouping';
+  import { groupToolsByGroup } from '../../../shared/tools/grouping';
 
   interface Props {
     /**
@@ -1172,18 +1172,22 @@
         <div class="submenu-item" onmouseenter={adjustSubmenu}>
           <span class="submenu-trigger">{menu.label}<Icon name="chevronRight" size={10} /></span>
           <div class="submenu">
-            {#if hasNamedGroups(menu.groups)}
-              {#each menu.groups as group (group.label ?? 'General')}
+            <!-- Named groups nest into submenus; ungrouped skills stay inline
+                 (like the Source tools menu) rather than being swept into a
+                 "General" bucket, so adding a group to one skill is a local
+                 change, not a menu-wide restructure. -->
+            {#each menu.groups as group (group.label ?? ' ungrouped')}
+              {#if group.label}
                 <div class="submenu-item" onmouseenter={adjustSubmenu}>
-                  <span class="submenu-trigger">{group.label ?? 'General'}<Icon name="chevronRight" size={10} /></span>
+                  <span class="submenu-trigger">{group.label}<Icon name="chevronRight" size={10} /></span>
                   <div class="submenu">
                     {#each group.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
                   </div>
                 </div>
-              {/each}
-            {:else}
-              {#each menu.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
-            {/if}
+              {:else}
+                {#each group.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
+              {/if}
+            {/each}
           </div>
         </div>
       {/each}

--- a/src/shared/tools/grouping.ts
+++ b/src/shared/tools/grouping.ts
@@ -8,10 +8,12 @@
  *
  * Pure and order-preserving: groups appear in first-appearance order (which
  * follows the menu config's ordering), and ungrouped tools collect into a
- * trailing bucket (`label: null`, rendered as "General"). If no tool in the
- * list declares a group, the result is a single null-labelled bucket — the
- * caller treats that as "render flat", preserving current behavior for
- * categories nobody has grouped (Learning, Research).
+ * trailing `label: null` bucket. Menus render named groups as nested submenus
+ * and the ungrouped bucket *inline* (not as a "General" submenu), so grouping
+ * one skill nests just that skill instead of restructuring the whole category.
+ * If no tool in the list declares a group, the result is a single null-labelled
+ * bucket — rendered flat, exactly as an ungrouped category (Learning, Research)
+ * looks today.
  */
 
 export interface GroupableTool {
@@ -50,4 +52,22 @@ export function groupToolsByGroup<T extends GroupableTool>(tools: T[]): ToolGrou
 /** True when the partition warrants nested submenus (≥1 named group). */
 export function hasNamedGroups<T>(groups: ToolGroup<T>[]): boolean {
   return groups.some((g) => g.label !== null);
+}
+
+/**
+ * Flatten a partition for a menu that nests each named group into a submenu but
+ * keeps ungrouped tools inline, in place. `submenu(label, tools)` builds a
+ * nested item; ungrouped tools are emitted individually via `flat(tool)`.
+ *
+ * This is what makes grouping *local*: adding a `group` to one skill nests only
+ * that skill, leaving every ungrouped skill exactly where it was — instead of
+ * collecting them all into a "General" submenu. With no named groups the whole
+ * list is one ungrouped bucket, so every tool renders flat.
+ */
+export function flattenGroupedMenu<T, R>(
+  groups: ToolGroup<T>[],
+  flat: (tool: T) => R,
+  submenu: (label: string, tools: T[]) => R,
+): R[] {
+  return groups.flatMap((g) => (g.label ? [submenu(g.label, g.tools)] : g.tools.map(flat)));
 }

--- a/tests/shared/tool-grouping.test.ts
+++ b/tests/shared/tool-grouping.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { groupToolsByGroup, hasNamedGroups, type GroupableTool } from '../../src/shared/tools/grouping';
+import {
+  groupToolsByGroup,
+  hasNamedGroups,
+  flattenGroupedMenu,
+  type GroupableTool,
+} from '../../src/shared/tools/grouping';
 
 const t = (id: string, group?: string): GroupableTool & { id: string } => ({ id, group });
 
@@ -37,5 +42,38 @@ describe('groupToolsByGroup', () => {
     const groups = groupToolsByGroup([t('a', 'X'), t('b', 'Y')]);
     expect(groups.map((g) => g.label)).toEqual(['X', 'Y']);
     expect(groups.every((g) => g.label !== null)).toBe(true);
+  });
+});
+
+describe('flattenGroupedMenu (nest named, inline ungrouped)', () => {
+  // Render each tool as `id` and each submenu as `Label>[ids]` so ordering +
+  // nesting are legible in one string per item.
+  const flat = (x: GroupableTool & { id: string }) => x.id;
+  const submenu = (label: string, ts: (GroupableTool & { id: string })[]) =>
+    `${label}>[${ts.map((x) => x.id).join(',')}]`;
+  const render = (tools: (GroupableTool & { id: string })[]) =>
+    flattenGroupedMenu(groupToolsByGroup(tools), flat, submenu);
+
+  it('renders a fully-ungrouped menu flat', () => {
+    expect(render([t('a'), t('b'), t('c')])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('nests only the grouped skill; ungrouped stay inline (the gotcha scenario)', () => {
+    // One skill grouped among three ungrouped: just that skill nests. The
+    // others are NOT swept into a "General" submenu.
+    expect(render([t('a'), t('b', 'Planning'), t('c')])).toEqual([
+      'Planning>[b]',
+      'a',
+      'c',
+    ]);
+  });
+
+  it('nests each named group and keeps the trailing ungrouped bucket inline', () => {
+    expect(render([
+      t('a', 'Generation'),
+      t('b', 'Planning'),
+      t('c', 'Generation'),
+      t('loose'),
+    ])).toEqual(['Generation>[a,c]', 'Planning>[b]', 'loose']);
   });
 });


### PR DESCRIPTION
## The problem

Thematic grouping (`group:` in a skill's frontmatter) was a **menu-wide switch**. The moment any skill in a category declared a group, both note menus (native `menu.ts` and the editor right-click in `Editor.svelte`) flipped from a flat list to fully nested — sweeping every ungrouped skill into a trailing **"General"** submenu. So setting `group:` on one skill silently restructured the entire Learning / Research / Analysis menu. A skill author making what looks like a local edit gets a menu-wide reshuffle.

## The fix

Render the way the **Source tools menu already does** (`SourceDetail.svelte`): each named group nests into its own submenu, but **ungrouped skills stay inline, in place**. Adding a group to one skill nests just that skill; the rest don't move, and there's no "General" bucket. With no groups at all, the menu is still flat — unchanged.

```
Learning menu, one skill (C) grouped as "Foo":

  ▸ Foo          (submenu: C)
  Skill A        (inline, unmoved)
  Skill B        (inline, unmoved)
```

This also removes an existing inconsistency — the Source tools menu did it this way; the two note menus didn't.

## How

- New `flattenGroupedMenu(groups, flat, submenu)` in `shared/tools/grouping.ts` centralizes "nest named groups, spread the ungrouped bucket inline." The native menu uses it; the editor template mirrors the same shape declaratively.
- `groupToolsByGroup` (the partition) is unchanged — only the rendering of its trailing `label: null` bucket changed, from a "General" submenu to inline items.
- `hasNamedGroups` no longer gates rendering; kept for its existing tests.

## Behavior notes

- Grouped skills still sort ahead of ungrouped ones (the partition puts named groups first), so a grouped skill moves up into its submenu — but nothing gets bucketed and ungrouped items keep their relative order.
- The Analysis menu (the one menu with real groups) loses its "General" submenu; those tools now render inline alongside the named submenus.

## Tests

New `flattenGroupedMenu` cases in `tool-grouping.test.ts`, including the exact gotcha scenario (one grouped skill among several ungrouped → only that one nests). Grouping + menu-config suites green; `pnpm lint` clean.

## Docs

The now-fixed "adding a group restructures the whole menu" gotcha is removed from `thinking-tools-three-menus.html`, and the grouping description + code walkthrough + screenshot caption are updated to the inline behavior — in the working-tree docs batch, not this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)