### PR TITLE
Approval engine: remove the unused notify_only / autonomous tiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,17 +126,23 @@ All LLM-originated graph mutations **must** go through the approval engine (`src
 3. Only approved proposals mutate the graph
 4. Proposals that aren't reviewed auto-expire after a configurable window
 
-### Approval Tiers
+### One tier: everything is proposed
 
-Operations are classified by trust level:
+Every LLM-originated write is filed as a **pending** `thought:Proposal` and
+applied only when the user approves it — there is no lower-trust tier. An
+operation's `operationType` (new_claim, note_rewrite, component_creation,
+note_refactor, note_delete, source_properties, …) is descriptive metadata for
+the review UI, **not** a trust level. Even the "quiet" paths conform: auto-tag,
+for instance, files a normal `note_rewrite` proposal and self-approves it only
+after the user accepted the tags on the conversation card.
 
-| Tier | Operations | Behavior |
-|------|-----------|----------|
-| `requires_approval` | New claims, evidence links, component creation | Queued as pending proposal; user must approve |
-| `notify_only` | Confidence updates, status changes | Applied immediately but surfaced in activity feed |
-| `autonomous` | Tag additions, staleness flags | Applied silently |
-
-Nodes with `thought:hasStatus thought:established` automatically escalate to `requires_approval` regardless of operation type.
+> **Historical note:** earlier designs sketched `notify_only` (apply + audit)
+> and `autonomous` (apply silently) tiers, with an established-node escalation to
+> pull them up to `requires_approval`. No write path ever used them, so the tiers
+> and their orphan operation types (tag_addition, staleness_flag,
+> confidence_update, status_change) were removed. If a genuine lower-trust
+> operation is ever needed, re-introduce a tier deliberately rather than assuming
+> one exists.
 
 ### Code Review Checklist for LLM/Graph PRs
 

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -13,10 +13,8 @@
 import * as graph from '../graph/index';
 import type { ProjectContext } from '../project-context-types';
 import type {
-  ApprovalTier,
   ApproveResult,
   AppliedRecord,
-  OperationType,
   Proposal,
   ProposalPayload,
   ProposedWrite,
@@ -32,7 +30,6 @@ import {
 // Re-export the public surface so importers of './llm/approval' are unaffected
 // by the split.
 export type {
-  ApprovalTier,
   ApproveResult,
   OperationType,
   Proposal,
@@ -40,65 +37,6 @@ export type {
   ProposedWrite,
 } from './proposal-types';
 export { getProposal, listProposals, stripTurtleCodeFence } from './proposal-persistence';
-
-// ── Default Policy ─────────────────────────────────────────────────────────
-
-const DEFAULT_POLICY: Record<OperationType, ApprovalTier> = {
-  new_claim: 'requires_approval',
-  evidence_link: 'requires_approval',
-  component_creation: 'requires_approval',
-  confidence_update: 'notify_only',
-  status_change: 'notify_only',
-  tag_addition: 'autonomous',
-  staleness_flag: 'autonomous',
-  // A move/rename restructures the vault + rewrites links across notes — always
-  // reviewed (#911).
-  note_refactor: 'requires_approval',
-  // Deleting a note is destructive — always reviewed, never autonomous.
-  note_delete: 'requires_approval',
-  // Rewriting a note's body in place replaces human-authored content — always
-  // reviewed via the diff card (#936).
-  note_rewrite: 'requires_approval',
-  // Upserting LLM-proposed source metadata (abstract / TL;DR) — reviewed via the
-  // source-property card (#943).
-  source_properties: 'requires_approval',
-};
-
-let policyOverrides: Partial<Record<OperationType, ApprovalTier>> = {};
-
-export function getApprovalTier(operationType: OperationType): ApprovalTier {
-  return policyOverrides[operationType] ?? DEFAULT_POLICY[operationType] ?? 'requires_approval';
-}
-
-export function setPolicy(operationType: OperationType, tier: ApprovalTier): void {
-  policyOverrides[operationType] = tier;
-}
-
-export function resetPolicy(): void {
-  policyOverrides = {};
-}
-
-// ── Established-node escalation ──────────────────────────────────────────────
-
-/**
- * The Trust Principle's established-node escalation (#656): a write that
- * touches any human-vetted (`thought:hasStatus thought:established`) node
- * escalates to `requires_approval` regardless of its operation type — so the
- * LLM can't silently re-tag, flag, or otherwise mutate an established claim
- * via an `autonomous`/`notify_only` op. Returns true if any of `uris` is
- * established.
- */
-async function anyNodeEstablished(ctx: ProjectContext, uris: string[]): Promise<boolean> {
-  if (uris.length === 0) return false;
-  const values = uris.map((u) => `<${u}>`).join(' ');
-  const r = await graph.queryGraph(ctx, `
-    SELECT ?n WHERE {
-      VALUES ?n { ${values} }
-      ?n thought:hasStatus thought:established .
-    } LIMIT 1
-  `);
-  return r.results.length > 0;
-}
 
 /**
  * Reject a bundle containing a payload kind that has no apply handler (#665).
@@ -123,41 +61,24 @@ function assertWiredPayloads(payloads: ProposalPayload[]): void {
 // ── Proposal lifecycle ───────────────────────────────────────────────────────
 
 /**
- * Submit a proposed bundle. Based on the operation's approval tier:
- * - requires_approval: persists a pending Proposal, returns it.
- * - notify_only: applies the bundle immediately, persists an approved
- *   Proposal for audit.
- * - autonomous: applies the bundle immediately, no proposal record.
+ * Submit a proposed bundle. Every write is filed as a *pending* `thought:Proposal`
+ * and applied only when the user approves it — the Trust Principle invariant:
+ * the LLM proposes, the human confirms. There are no lower-trust tiers, so an
+ * established-node escalation is unnecessary (nothing can bypass review to begin
+ * with). Returns the pending proposal.
  */
-export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal | null> {
+export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal> {
   assertWiredPayloads(write.payloads);
-  let tier = getApprovalTier(write.operationType);
   const now = new Date().toISOString();
   const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * 86400000).toISOString();
 
-  // Established-node escalation (#656). Computed before the tier dispatch so it
-  // can pull an autonomous/notify_only write up to requires_approval when it
-  // touches a human-vetted node — the Trust Principle invariant CLAUDE.md
-  // documents. Collected here (not after the autonomous return) so the check
-  // covers autonomous ops too.
-  const affectsNodeUris = collectAffectsNodes(ctx, write.payloads);
-  if (tier !== 'requires_approval' && await anyNodeEstablished(ctx, affectsNodeUris)) {
-    tier = 'requires_approval';
-  }
-
-  if (tier === 'autonomous') {
-    await applyBundle(ctx, write.payloads);
-    return null;
-  }
-
-  const uri = proposalUri();
   const proposal: Proposal = {
-    uri,
-    status: tier === 'notify_only' ? 'approved' : 'pending',
+    uri: proposalUri(),
+    status: 'pending',
     operationType: write.operationType,
     payloads: write.payloads,
     note: write.note,
-    affectsNodeUris,
+    affectsNodeUris: collectAffectsNodes(ctx, write.payloads),
     conversationUri: write.conversationUri,
     proposedBy: write.proposedBy,
     proposedAt: now,
@@ -165,11 +86,6 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
   };
 
   await writeProposalToGraph(ctx, proposal);
-
-  if (tier === 'notify_only') {
-    await applyBundle(ctx, write.payloads);
-  }
-
   return proposal;
 }
 

--- a/src/main/llm/proposal-types.ts
+++ b/src/main/llm/proposal-types.ts
@@ -3,16 +3,16 @@
 // registry (`apply-dispatch.ts`), and persistence (`proposal-persistence.ts`)
 // can all depend on it without a cycle.
 
-export type ApprovalTier = 'requires_approval' | 'notify_only' | 'autonomous';
-
+// Every LLM-originated write is filed as a pending `thought:Proposal` and
+// applied only on human approval — there are no lower-trust tiers. (The old
+// `notify_only` / `autonomous` tiers and their orphan operation types —
+// tag_addition, staleness_flag, confidence_update, status_change — were removed
+// because no write path ever used them; auto-tag, for instance, files a normal
+// `note_rewrite` proposal like everything else.)
 export type OperationType =
   | 'new_claim'
   | 'evidence_link'
-  | 'confidence_update'
-  | 'tag_addition'
-  | 'staleness_flag'
   | 'component_creation'
-  | 'status_change'
   | 'note_refactor'
   | 'note_delete'
   | 'note_rewrite'
@@ -119,7 +119,9 @@ export type ProposalPayload =
 export type PayloadOf<K extends ProposalPayload['kind']> = Extract<ProposalPayload, { kind: K }>;
 
 export interface ProposedWrite {
-  /** Drives approval-tier policy lookup. */
+  /** Labels the proposal in the review UI and audit trail. Every write is
+   *  filed as a pending proposal regardless of type — this is descriptive
+   *  metadata, not a trust tier. */
   operationType: OperationType;
   /** Side effects to apply, in order. Triples-last is the convention
    *  callers should follow; rollback assumes file-system payloads

--- a/tests/main/llm/approval.test.ts
+++ b/tests/main/llm/approval.test.ts
@@ -4,66 +4,17 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import {
-  getApprovalTier,
-  setPolicy,
-  resetPolicy,
   proposeWrite,
   approveProposal,
   rejectProposal,
   type OperationType,
-  type ApprovalTier,
 } from '../../../src/main/llm/approval';
-import { initGraph, queryGraph, parseIntoStore } from '../../../src/main/graph/index';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
-describe('approval policy', () => {
-  beforeEach(() => {
-    resetPolicy();
-  });
-
-  it('returns requires_approval for new_claim by default', () => {
-    expect(getApprovalTier('new_claim')).toBe('requires_approval');
-  });
-
-  it('returns requires_approval for evidence_link by default', () => {
-    expect(getApprovalTier('evidence_link')).toBe('requires_approval');
-  });
-
-  it('returns requires_approval for component_creation by default', () => {
-    expect(getApprovalTier('component_creation')).toBe('requires_approval');
-  });
-
-  it('returns notify_only for confidence_update by default', () => {
-    expect(getApprovalTier('confidence_update')).toBe('notify_only');
-  });
-
-  it('returns notify_only for status_change by default', () => {
-    expect(getApprovalTier('status_change')).toBe('notify_only');
-  });
-
-  it('returns autonomous for tag_addition by default', () => {
-    expect(getApprovalTier('tag_addition')).toBe('autonomous');
-  });
-
-  it('returns autonomous for staleness_flag by default', () => {
-    expect(getApprovalTier('staleness_flag')).toBe('autonomous');
-  });
-
-  it('allows overriding policy for an operation type', () => {
-    setPolicy('tag_addition', 'requires_approval');
-    expect(getApprovalTier('tag_addition')).toBe('requires_approval');
-  });
-
-  it('resetPolicy restores defaults', () => {
-    setPolicy('tag_addition', 'requires_approval');
-    resetPolicy();
-    expect(getApprovalTier('tag_addition')).toBe('autonomous');
-  });
-
-  it('falls back to requires_approval for unknown operation types', () => {
-    expect(getApprovalTier('unknown_op' as OperationType)).toBe('requires_approval');
-  });
-});
+// Every write is filed as a pending proposal and applied only on approval —
+// there are no lower-trust tiers (they were removed as unused). These tests
+// exercise that single lifecycle across payload kinds.
 
 describe('updateProposalStatus replaces, does not append (#332)', () => {
   let root: string;
@@ -73,7 +24,6 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-status-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
   });
 
   afterEach(async () => {
@@ -98,13 +48,12 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
       note: 'test',
       proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
-    expect(await statusesFor(proposal!.uri)).toEqual([
+    expect(await statusesFor(proposal.uri)).toEqual([
       'https://minerva.dev/ontology/thought#pending',
     ]);
 
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
-    expect(await statusesFor(proposal!.uri)).toEqual([
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
+    expect(await statusesFor(proposal.uri)).toEqual([
       'https://minerva.dev/ontology/thought#approved',
     ]);
   });
@@ -120,130 +69,10 @@ describe('updateProposalStatus replaces, does not append (#332)', () => {
       note: 'test',
       proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
-    expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);
-    expect(await statusesFor(proposal!.uri)).toEqual([
+    expect(await rejectProposal(ctx, proposal.uri)).toBe(true);
+    expect(await statusesFor(proposal.uri)).toEqual([
       'https://minerva.dev/ontology/thought#rejected',
     ]);
-  });
-});
-
-describe('approval tiers cover all default operations', () => {
-  const expectedTiers: [OperationType, ApprovalTier][] = [
-    ['new_claim', 'requires_approval'],
-    ['evidence_link', 'requires_approval'],
-    ['component_creation', 'requires_approval'],
-    ['confidence_update', 'notify_only'],
-    ['status_change', 'notify_only'],
-    ['tag_addition', 'autonomous'],
-    ['staleness_flag', 'autonomous'],
-  ];
-
-  for (const [op, tier] of expectedTiers) {
-    it(`${op} → ${tier}`, () => {
-      expect(getApprovalTier(op)).toBe(tier);
-    });
-  }
-});
-
-describe('established-node escalation (#656)', () => {
-  let root: string;
-  let ctx: ProjectContext;
-
-  const THOUGHT = 'https://minerva.dev/ontology/thought#';
-  const ESTABLISHED = 'https://ex.example/established-claim';
-  const TENTATIVE = 'https://ex.example/tentative-claim';
-
-  beforeEach(async () => {
-    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-escalation-'));
-    ctx = projectContext(root);
-    await initGraph(ctx);
-    resetPolicy();
-    // Seed one human-vetted (established) node and one ordinary node.
-    parseIntoStore(ctx, `<${ESTABLISHED}> <${THOUGHT}hasStatus> <${THOUGHT}established> .`);
-    parseIntoStore(ctx, `<${TENTATIVE}> <${THOUGHT}hasStatus> <${THOUGHT}proposed> .`);
-  });
-
-  afterEach(async () => {
-    await fsp.rm(root, { recursive: true, force: true });
-  });
-
-  async function statusOf(uri: string): Promise<string[]> {
-    const r = await queryGraph(ctx, `SELECT ?s WHERE { <${uri}> thought:proposalStatus ?s . }`);
-    return (r.results as Array<{ s: string }>).map((row) => row.s.replace(THOUGHT, ''));
-  }
-
-  function tagWrite(nodeUri: string) {
-    return {
-      operationType: 'tag_addition' as OperationType,
-      payloads: [{
-        kind: 'graph-triples' as const,
-        turtle: `<${nodeUri}> <https://minerva.dev/ontology#tag> "auto" .`,
-        affectsNodeUris: [nodeUri],
-      }],
-      note: 'test',
-      proposedBy: 'unit-test',
-    };
-  }
-
-  it('an autonomous op on a NON-established node still applies silently (no proposal)', async () => {
-    const proposal = await proposeWrite(ctx, tagWrite(TENTATIVE));
-    expect(proposal).toBeNull();
-  });
-
-  it('escalates an autonomous op on an established node to a pending proposal', async () => {
-    const proposal = await proposeWrite(ctx, tagWrite(ESTABLISHED));
-    expect(proposal).not.toBeNull();
-    expect(await statusOf(proposal!.uri)).toEqual(['pending']);
-    // The write must NOT have been applied — escalation means it awaits approval.
-    const applied = await queryGraph(ctx,
-      `SELECT ?o WHERE { <${ESTABLISHED}> <https://minerva.dev/ontology#tag> ?o . }`);
-    expect(applied.results.length).toBe(0);
-  });
-
-  it('escalates a notify_only op on an established node to pending (not auto-applied)', async () => {
-    const proposal = await proposeWrite(ctx, {
-      operationType: 'confidence_update',
-      payloads: [{
-        kind: 'graph-triples',
-        turtle: `<${ESTABLISHED}> <${THOUGHT}confidenceValue> "0.9" .`,
-        affectsNodeUris: [ESTABLISHED],
-      }],
-      note: 'test',
-      proposedBy: 'unit-test',
-    });
-    expect(proposal).not.toBeNull();
-    expect(await statusOf(proposal!.uri)).toEqual(['pending']);
-  });
-
-  it('a notify_only op on a non-established node stays notify_only (approved + applied)', async () => {
-    const proposal = await proposeWrite(ctx, {
-      operationType: 'confidence_update',
-      payloads: [{
-        kind: 'graph-triples',
-        turtle: `<${TENTATIVE}> <${THOUGHT}confidenceValue> "0.5" .`,
-        affectsNodeUris: [TENTATIVE],
-      }],
-      note: 'test',
-      proposedBy: 'unit-test',
-    });
-    expect(proposal).not.toBeNull();
-    expect(await statusOf(proposal!.uri)).toEqual(['approved']);
-  });
-
-  it('does not escalate a requires_approval op differently (still pending, unaffected)', async () => {
-    const proposal = await proposeWrite(ctx, {
-      operationType: 'new_claim',
-      payloads: [{
-        kind: 'graph-triples',
-        turtle: `<${ESTABLISHED}> a <https://ex.example/Claim> .`,
-        affectsNodeUris: [ESTABLISHED],
-      }],
-      note: 'test',
-      proposedBy: 'unit-test',
-    });
-    expect(proposal).not.toBeNull();
-    expect(await statusOf(proposal!.uri)).toEqual(['pending']);
   });
 });
 
@@ -255,7 +84,6 @@ describe('payload-kind validation at proposeWrite time (#665)', () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-payload-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
   });
   afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
 
@@ -303,7 +131,7 @@ describe('payload-kind validation at proposeWrite time (#665)', () => {
       note: 'test',
       proposedBy: 'unit-test',
     });
-    expect(p).not.toBeNull();
+    expect(p.status).toBe('pending');
   });
 });
 
@@ -315,7 +143,6 @@ describe('note-rewrite payload (#936)', () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-rewrite-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
   });
   afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
 
@@ -335,18 +162,13 @@ describe('note-rewrite payload (#936)', () => {
     };
   }
 
-  it('note_rewrite defaults to requires_approval', () => {
-    expect(getApprovalTier('note_rewrite')).toBe('requires_approval');
-  });
-
   it('is gated: the file is unchanged until approved, then holds the new content', async () => {
     await seedNote('# Stub\n\nrough idea.\n');
     const proposal = await proposeWrite(ctx, rewriteWrite(REL, '# Stub\n\nA fully fleshed-out idea.\n'));
-    expect(proposal).not.toBeNull();
     // Not applied yet.
     expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('# Stub\n\nrough idea.\n');
 
-    const result = await approveProposal(ctx, proposal!.uri);
+    const result = await approveProposal(ctx, proposal.uri);
     expect(result.ok).toBe(true);
     expect(result.rewrittenPaths).toEqual([REL]);
     expect(result.filedPaths).toEqual([]);
@@ -356,7 +178,7 @@ describe('note-rewrite payload (#936)', () => {
   it('rejecting a rewrite leaves the original content untouched', async () => {
     await seedNote('original\n');
     const proposal = await proposeWrite(ctx, rewriteWrite(REL, 'replaced\n'));
-    expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);
+    expect(await rejectProposal(ctx, proposal.uri)).toBe(true);
     expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('original\n');
   });
 
@@ -374,7 +196,7 @@ describe('note-rewrite payload (#936)', () => {
       note: 'rewrite + bad triples',
       proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toThrow();
     // The rewrite landed then rolled back — original content restored.
     expect(await fsp.readFile(path.join(root, REL), 'utf-8')).toBe('keep me\n');
   });
@@ -383,12 +205,12 @@ describe('note-rewrite payload (#936)', () => {
     // Guardrail check runs at apply time; the proposal files fine, approval fails.
     await fsp.writeFile(path.join(root, 'data.txt'), 'x', 'utf-8');
     const proposal = await proposeWrite(ctx, rewriteWrite('data.txt', 'y'));
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow(/non-markdown/);
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toThrow(/non-markdown/);
   });
 
   it('fails (and rolls back) when the target note does not exist', async () => {
     const proposal = await proposeWrite(ctx, rewriteWrite('notes/ghost.md', 'content'));
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toThrow();
   });
 });
 
@@ -405,7 +227,6 @@ describe('source-meta payload (#943)', () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-sourcemeta-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
     const dir = path.join(root, '.minerva', 'sources', sourceId);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'meta.ttl'), META);
@@ -416,10 +237,6 @@ describe('source-meta payload (#943)', () => {
     return fs.readFileSync(path.join(root, '.minerva', 'sources', sourceId, 'meta.ttl'), 'utf-8');
   }
 
-  it('source_properties defaults to requires_approval', () => {
-    expect(getApprovalTier('source_properties')).toBe('requires_approval');
-  });
-
   it('applies the predicate upsert on approval', async () => {
     const proposal = await proposeWrite(ctx, {
       operationType: 'source_properties',
@@ -428,7 +245,7 @@ describe('source-meta payload (#943)', () => {
       proposedBy: 'unit-test',
     });
     expect(metaOnDisk()).not.toContain('dc:abstract'); // gated
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
     expect(metaOnDisk()).toContain('dc:abstract "An abstract." ;');
   });
 
@@ -442,22 +259,21 @@ describe('source-meta payload (#943)', () => {
       note: 'source-meta + bad triples',
       proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toThrow();
     // The upsert landed then rolled back — meta.ttl restored verbatim.
     expect(metaOnDisk()).toBe(META);
   });
 });
 
-describe('tier store effects (#666)', () => {
+describe('proposal store effects (#666)', () => {
   let root: string;
   let ctx: ProjectContext;
   const TAG = 'https://minerva.dev/ontology#tag';
 
   beforeEach(async () => {
-    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-tier-'));
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-approval-store-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
   });
   afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
 
@@ -476,36 +292,19 @@ describe('tier store effects (#666)', () => {
     };
   }
 
-  it('autonomous: the write lands in the store immediately, with no proposal record', async () => {
-    const node = 'https://ex.example/auto';
-    const proposal = await proposeWrite(ctx, write('tag_addition', node));
-    expect(proposal).toBeNull();
-    expect(await tagCount(node)).toBe(1);
-  });
-
-  it('notify_only: the write lands immediately AND an approved proposal is recorded', async () => {
-    const node = 'https://ex.example/notify';
-    const proposal = await proposeWrite(ctx, write('confidence_update', node));
-    expect(proposal).not.toBeNull();
-    expect(await tagCount(node)).toBe(1); // applied immediately
-    const r = await queryGraph(ctx, `SELECT ?s WHERE { <${proposal!.uri}> thought:proposalStatus ?s . }`);
-    expect((r.results as Array<{ s: string }>)[0].s).toBe('https://minerva.dev/ontology/thought#approved');
-  });
-
-  it('requires_approval: the write is ABSENT until approved, then present', async () => {
+  it('the write is ABSENT until approved, then present', async () => {
     const node = 'https://ex.example/gated';
     const proposal = await proposeWrite(ctx, write('new_claim', node));
-    expect(proposal).not.toBeNull();
     expect(await tagCount(node)).toBe(0); // not applied yet
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
     expect(await tagCount(node)).toBe(1); // applied on approval
   });
 
-  it('requires_approval rejected: the write never lands', async () => {
+  it('a rejected proposal never lands', async () => {
     const node = 'https://ex.example/rejected';
     const proposal = await proposeWrite(ctx, write('new_claim', node));
     expect(await tagCount(node)).toBe(0);
-    expect(await rejectProposal(ctx, proposal!.uri)).toBe(true);
+    expect(await rejectProposal(ctx, proposal.uri)).toBe(true);
     expect(await tagCount(node)).toBe(0); // still absent
   });
 });

--- a/tests/main/llm/claims-bundle.test.ts
+++ b/tests/main/llm/claims-bundle.test.ts
@@ -13,8 +13,6 @@ import os from 'node:os';
 import {
   proposeWrite,
   approveProposal,
-  resetPolicy,
-  setPolicy,
   type ProposalPayload,
 } from '../../../src/main/llm/approval';
 import { buildExcerptTtl } from '../../../src/main/sources/create-excerpt';
@@ -28,8 +26,6 @@ beforeEach(async () => {
   root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-claims-bundle-'));
   ctx = projectContext(root);
   await initGraph(ctx);
-  resetPolicy();
-  setPolicy('component_creation', 'requires_approval');
 });
 afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
 
@@ -81,8 +77,7 @@ describe('claims bundle (#104)', () => {
     const proposal = await proposeWrite(ctx, {
       operationType: 'component_creation', payloads: bundle(), note: 'claims', proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     // Excerpt .ttl on disk.
     expect(fs.existsSync(path.join(root, '.minerva', 'excerpts', `${EXCERPT_ID}.ttl`))).toBe(true);
@@ -120,7 +115,7 @@ describe('claims bundle (#104)', () => {
     const proposal = await proposeWrite(ctx, {
       operationType: 'component_creation', payloads, note: 'rollback', proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toBeTruthy();
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toBeTruthy();
     // The excerpt .ttl written by the first payload must be rolled back.
     expect(fs.existsSync(path.join(root, '.minerva', 'excerpts', `${EXCERPT_ID}.ttl`))).toBe(false);
   });

--- a/tests/main/llm/conversation-drafts-flow.test.ts
+++ b/tests/main/llm/conversation-drafts-flow.test.ts
@@ -28,7 +28,6 @@ import {
   proposeWrite,
   approveProposal,
   listProposals,
-  resetPolicy,
 } from '../../../src/main/llm/approval';
 import { initGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
@@ -60,7 +59,6 @@ describe('conversation drafts: propose_notes → user-approve → file', () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-drafts-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
   });
 
   afterEach(async () => {

--- a/tests/main/llm/note-delete-proposal.test.ts
+++ b/tests/main/llm/note-delete-proposal.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { proposeWrite, approveProposal, getApprovalTier } from '../../../src/main/llm/approval';
+import { proposeWrite, approveProposal } from '../../../src/main/llm/approval';
 import { initGraph, indexNote, disposeProject as disposeGraph } from '../../../src/main/graph/index';
 import { initSearch, indexNote as searchIndex, disposeProject as disposeSearch } from '../../../src/main/search/index';
 import { projectContext } from '../../../src/main/project-context-types';
@@ -45,15 +45,14 @@ function del(...paths: string[]) {
 
 describe('note-delete proposal', () => {
   it('is requires_approval — files as pending, deletes nothing yet', async () => {
-    expect(getApprovalTier('note_delete')).toBe('requires_approval');
     const proposal = await del('stale.md');
-    expect(proposal).not.toBeNull();
+    expect(proposal.status).toBe('pending');
     expect(exists('stale.md')).toBe(true);
   });
 
   it('on approval deletes the note (leaving inbound links to dangle)', async () => {
     const proposal = await del('stale.md');
-    expect((await approveProposal(ctx(), proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx(), proposal.uri)).ok).toBe(true);
 
     expect(exists('stale.md')).toBe(false);
     // Inbound link is intentionally left dangling, matching manual delete.
@@ -71,7 +70,7 @@ describe('note-delete proposal', () => {
       note: 'delete + bad triples',
       proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx(), proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx(), proposal.uri)).rejects.toThrow();
 
     // The deleted note is back, content byte-for-byte.
     expect(exists('stale.md')).toBe(true);

--- a/tests/main/llm/note-refactor-proposal.test.ts
+++ b/tests/main/llm/note-refactor-proposal.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { proposeWrite, approveProposal, getApprovalTier } from '../../../src/main/llm/approval';
+import { proposeWrite, approveProposal } from '../../../src/main/llm/approval';
 import { initGraph, indexNote, disposeProject as disposeGraph } from '../../../src/main/graph/index';
 import { initSearch, indexNote as searchIndex, disposeProject as disposeSearch } from '../../../src/main/search/index';
 import { projectContext } from '../../../src/main/project-context-types';
@@ -45,9 +45,8 @@ function refactor(fromPath: string, toPath: string) {
 
 describe('note-refactor proposal (#911)', () => {
   it('is requires_approval — files as pending, not auto-applied', async () => {
-    expect(getApprovalTier('note_refactor')).toBe('requires_approval');
     const proposal = await refactor('raft.md', 'algorithms/raft.md');
-    expect(proposal).not.toBeNull();
+    expect(proposal.status).toBe('pending');
     // Nothing moved yet — it's pending review.
     expect(exists('raft.md')).toBe(true);
     expect(exists('algorithms/raft.md')).toBe(false);
@@ -55,7 +54,7 @@ describe('note-refactor proposal (#911)', () => {
 
   it('on approval moves the note and rewrites inbound links', async () => {
     const proposal = await refactor('raft.md', 'algorithms/raft.md');
-    expect((await approveProposal(ctx(), proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx(), proposal.uri)).ok).toBe(true);
 
     expect(exists('raft.md')).toBe(false);
     expect(exists('algorithms/raft.md')).toBe(true);
@@ -76,7 +75,7 @@ describe('note-refactor proposal (#911)', () => {
       note: 'refactor + bad triples',
       proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx(), proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx(), proposal.uri)).rejects.toThrow();
 
     // The vault is exactly as it was: note back, destination gone, links verbatim.
     expect(exists('raft.md')).toBe(true);
@@ -88,7 +87,7 @@ describe('note-refactor proposal (#911)', () => {
   it('rejects a colliding destination at approval time', async () => {
     await seed('archive.md', '# Archive\n\nexisting');
     const proposal = await refactor('raft.md', 'archive.md');
-    await expect(approveProposal(ctx(), proposal!.uri)).rejects.toThrow(/already exists/);
+    await expect(approveProposal(ctx(), proposal.uri)).rejects.toThrow(/already exists/);
     // Both notes untouched.
     expect(await read('archive.md')).toContain('existing');
     expect(exists('raft.md')).toBe(true);

--- a/tests/main/llm/proposal-bundle.test.ts
+++ b/tests/main/llm/proposal-bundle.test.ts
@@ -17,8 +17,6 @@ import {
   proposeWrite,
   approveProposal,
   getProposal,
-  resetPolicy,
-  setPolicy,
 } from '../../../src/main/llm/approval';
 import { initGraph, queryGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
@@ -33,7 +31,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-bundle-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
   });
 
   afterEach(async () => {
@@ -41,7 +38,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
   });
 
   it('a graph-triples-only bundle applies through approve and lands in the store', async () => {
-    setPolicy('component_creation', 'requires_approval');
     const claimUri = 'https://minerva.dev/c/single-payload';
     const proposal = await proposeWrite(ctx, {
       operationType: 'component_creation',
@@ -53,8 +49,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'one triples payload',
       proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     const r = await queryGraph(ctx, `
       PREFIX thought: <https://minerva.dev/ontology/thought#>
@@ -65,7 +60,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
   });
 
   it('a note-only bundle applies through approve and lands the file on disk', async () => {
-    setPolicy('component_creation', 'requires_approval');
     const proposal = await proposeWrite(ctx, {
       operationType: 'component_creation',
       payloads: [{
@@ -76,8 +70,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'one note payload',
       proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     const onDisk = await fsp.readFile(path.join(root, 'notes/from-bundle.md'), 'utf-8');
     expect(onDisk).toContain('From bundle');
@@ -88,7 +81,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
     // documenting that claim. Order matters: the triples reference
     // the note's URI, so the note must already exist (and be
     // indexed) when the triples are applied. Triples-last.
-    setPolicy('component_creation', 'requires_approval');
     const claimUri = 'https://minerva.dev/c/note-and-triples';
     const noteIri = 'https://example/project/note/notes/explanation';
 
@@ -110,7 +102,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'note + triples',
       proposedBy: 'unit-test',
     });
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     expect(fs.existsSync(path.join(root, 'notes/explanation.md'))).toBe(true);
     const r = await queryGraph(ctx, `
@@ -126,7 +118,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
     // triples payload throws because the turtle is malformed. The
     // engine must undo the note write so the bundle's all-or-nothing
     // contract holds.
-    setPolicy('component_creation', 'requires_approval');
     const proposal = await proposeWrite(ctx, {
       operationType: 'component_creation',
       payloads: [
@@ -146,7 +137,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'should fail and roll back',
       proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toThrow();
     expect(fs.existsSync(path.join(root, 'notes/should-be-rolled-back.md'))).toBe(false);
   });
 
@@ -155,7 +146,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
     await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
     await fsp.writeFile(path.join(root, 'notes/colliding.md'), 'pre-existing\n', 'utf-8');
 
-    setPolicy('component_creation', 'requires_approval');
     const proposal = await proposeWrite(ctx, {
       operationType: 'component_creation',
       payloads: [{
@@ -166,7 +156,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       note: 'collision test',
       proposedBy: 'unit-test',
     });
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     // Original file untouched.
     expect(await fsp.readFile(path.join(root, 'notes/colliding.md'), 'utf-8'))
@@ -176,30 +166,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       .toBe('proposed content\n');
   });
 
-  it('autonomous-tier bundles apply immediately and skip proposal persistence', async () => {
-    setPolicy('tag_addition', 'autonomous');
-    const result = await proposeWrite(ctx, {
-      operationType: 'tag_addition',
-      payloads: [{
-        kind: 'graph-triples',
-        turtle: '<https://ex/auto> a thought:Tag .',
-        affectsNodeUris: ['https://ex/auto'],
-      }],
-      note: 'auto-applied',
-      proposedBy: 'unit-test',
-    });
-    expect(result).toBeNull(); // autonomous → no proposal record returned
-
-    const r = await queryGraph(ctx, `
-      PREFIX thought: <https://minerva.dev/ontology/thought#>
-      SELECT ?type WHERE { <https://ex/auto> a ?type . }
-    `);
-    expect((r.results as Array<{ type: string }>).map(x => x.type))
-      .toContain('https://minerva.dev/ontology/thought#Tag');
-  });
-
   it('round-trips payloads through getProposal — list → fetch reconstitutes the bundle shape', async () => {
-    setPolicy('component_creation', 'requires_approval');
     const claimUri = 'https://minerva.dev/c/roundtrip';
     const original = await proposeWrite(ctx, {
       operationType: 'component_creation',
@@ -219,7 +186,7 @@ describe('ProposalBundle apply + rollback (#418)', () => {
       proposedBy: 'unit-test',
     });
 
-    const fetched = await getProposal(ctx, original!.uri);
+    const fetched = await getProposal(ctx, original.uri);
     expect(fetched).not.toBeNull();
     expect(fetched!.payloads).toHaveLength(2);
     expect(fetched!.payloads[0].kind).toBe('note');
@@ -234,7 +201,6 @@ describe('ProposalBundle apply + rollback (#418)', () => {
     // are filed under #414/#415/follow-ups), but they have no apply dispatcher
     // yet. Rather than file a proposal that explodes at the user's Approve
     // click, proposeWrite rejects an un-wired kind at creation (#665).
-    setPolicy('component_creation', 'requires_approval');
     await expect(proposeWrite(ctx, {
       operationType: 'component_creation',
       payloads: [{

--- a/tests/main/llm/proposal-expiry.test.ts
+++ b/tests/main/llm/proposal-expiry.test.ts
@@ -53,8 +53,7 @@ describe('proposal expiry + lifecycle (#1000)', () => {
       proposedBy: 'unit-test',
       ...(expiryDays !== undefined ? { expiryDays } : {}),
     });
-    expect(p).not.toBeNull();
-    return p!;
+    return p;
   }
 
   it('expires a pending proposal whose autoExpires is in the past', async () => {

--- a/tests/main/llm/proposal-large-bundle.test.ts
+++ b/tests/main/llm/proposal-large-bundle.test.ts
@@ -22,8 +22,6 @@ import {
   proposeWrite,
   approveProposal,
   getProposal,
-  resetPolicy,
-  setPolicy,
 } from '../../../src/main/llm/approval';
 import { initGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
@@ -78,8 +76,6 @@ describe('large-bundle approval (the 27-note silent-failure regression)', () => 
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-large-bundle-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
-    setPolicy('component_creation', 'requires_approval');
   });
 
   afterEach(async () => {
@@ -94,9 +90,8 @@ describe('large-bundle approval (the 27-note silent-failure regression)', () => 
       note: 'Distributed Consensus journey',
       proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
 
-    const fetched = await getProposal(ctx, proposal!.uri);
+    const fetched = await getProposal(ctx, proposal.uri);
     expect(fetched).not.toBeNull();
     // Critical: payloads survived the JSON-in-Turtle-literal round trip.
     // If escaping is broken, parsePayloads() returns [] silently.
@@ -120,7 +115,7 @@ describe('large-bundle approval (the 27-note silent-failure regression)', () => 
       note: 'Distributed Consensus journey',
       proposedBy: 'unit-test',
     });
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     expect(fs.existsSync(path.join(root, 'notes/journey-parent.md'))).toBe(true);
     for (let i = 1; i <= 26; i++) {

--- a/tests/main/llm/reorg-bundle.test.ts
+++ b/tests/main/llm/reorg-bundle.test.ts
@@ -46,7 +46,7 @@ describe('batch note-refactor bundle (#914)', () => {
       { kind: 'note-refactor', fromPath: 'b.md', toPath: 'notes/b.md' },
       { kind: 'note-refactor', fromPath: 'c.md', toPath: 'notes/c.md' },
     ]);
-    expect((await approveProposal(ctx(), p!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx(), p.uri)).ok).toBe(true);
 
     expect(exists('notes/b.md')).toBe(true);
     expect(exists('notes/c.md')).toBe(true);
@@ -65,7 +65,7 @@ describe('batch note-refactor bundle (#914)', () => {
       { kind: 'note-refactor', fromPath: 'a.md', toPath: 'notes/a.md' },
       { kind: 'note-refactor', fromPath: 'b.md', toPath: 'c.md' }, // b.md already moved away → source missing
     ]);
-    await expect(approveProposal(ctx(), p!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx(), p.uri)).rejects.toThrow();
 
     // Vault is exactly as it started — nothing half-applied.
     expect(exists('b.md')).toBe(true);

--- a/tests/main/llm/turtle-fence-tolerance.test.ts
+++ b/tests/main/llm/turtle-fence-tolerance.test.ts
@@ -23,8 +23,6 @@ import os from 'node:os';
 import {
   proposeWrite,
   approveProposal,
-  resetPolicy,
-  setPolicy,
   stripTurtleCodeFence,
 } from '../../../src/main/llm/approval';
 import { initGraph, queryGraph } from '../../../src/main/graph/index';
@@ -70,8 +68,6 @@ describe('approval engine: tolerates fenced graph-triples payloads (#420 follow-
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-turtle-fence-'));
     ctx = projectContext(root);
     await initGraph(ctx);
-    resetPolicy();
-    setPolicy('component_creation', 'requires_approval');
   });
 
   afterEach(async () => {
@@ -94,9 +90,8 @@ describe('approval engine: tolerates fenced graph-triples payloads (#420 follow-
       note: 'fenced turtle from LLM',
       proposedBy: 'unit-test',
     });
-    expect(proposal).not.toBeNull();
     // This is the call that was throwing before the fix.
-    expect((await approveProposal(ctx, proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
 
     const r = await queryGraph(ctx, `
       PREFIX thought: <https://minerva.dev/ontology/thought#>
@@ -125,7 +120,7 @@ describe('approval engine: tolerates fenced graph-triples payloads (#420 follow-
       note: 'should fail and roll back',
       proposedBy: 'unit-test',
     });
-    await expect(approveProposal(ctx, proposal!.uri)).rejects.toThrow();
+    await expect(approveProposal(ctx, proposal.uri)).rejects.toThrow();
     expect(fs.existsSync(path.join(root, 'notes/should-roll-back.md'))).toBe(false);
   });
 });

--- a/tests/main/notebase/reorg-worked-example.test.ts
+++ b/tests/main/notebase/reorg-worked-example.test.ts
@@ -62,7 +62,7 @@ describe('reorg worked example (#915)', () => {
       kind: 'note-refactor', fromPath: i.fromPath, toPath: i.toPath,
     }));
     const proposal = await proposeWrite(ctx(), { operationType: 'note_refactor', payloads, note: 'reorg', proposedBy: 'unit-test' });
-    expect((await approveProposal(ctx(), proposal!.uri)).ok).toBe(true);
+    expect((await approveProposal(ctx(), proposal.uri)).ok).toBe(true);
 
     // Tidy: every note now lives under its topic folder.
     for (const p of ['distributed-systems/raft.md', 'distributed-systems/paxos.md', 'cooking/risotto.md', 'cooking/stock.md']) {


### PR DESCRIPTION
## The finding

A docs gotcha claimed `autonomous` operations (tag additions, staleness flags) bypass proposals entirely. Investigating: **no code path ever submitted an `autonomous` or `notify_only` operation.** Those tiers existed only in the `ApprovalTier` type and the `DEFAULT_POLICY` table; their four operation types (`tag_addition`, `staleness_flag`, `confidence_update`, `status_change`) had zero call sites. Auto-tag — the supposed autonomous case — actually files a `note_rewrite` (`requires_approval`) proposal and self-approves it after you accept the tags on the card.

So "every LLM write goes through a proposal" was already true in practice, but the dead tiers made it look optional. This removes them and makes the invariant explicit.

## Changes

- **`proposeWrite()` now unconditionally files a *pending* proposal** and returns it. Return type tightened `Proposal | null` → `Proposal` (the `null` was the autonomous path).
- Deleted `ApprovalTier`, `DEFAULT_POLICY`, `getApprovalTier`, `setPolicy`, `resetPolicy`, and the established-node escalation (`anyNodeEstablished`) — escalation is moot once nothing can skip review.
- Trimmed `OperationType` to the seven types actually submitted (`evidence_link` kept — it's a `requires_approval` type reserved for future use).
- CLAUDE.md's three-tier table → single-tier description + a historical note so no one re-assumes the tiers exist.

## Tests

Rewrote `approval.test.ts` to the single lifecycle (dropped the tier-policy, escalation, and autonomous/notify_only apply tests); removed the now-redundant `resetPolicy()` / `setPolicy(…, 'requires_approval')` boilerplate and `!` non-null assertions across ~10 llm test files. Net **−331 lines**. Full suite green except the pre-existing `help-docs-corpus-staleness` snapshot (dirty docs batch, unrelated — imports none of this).

## Docs

The originating gotcha and the several other pages built on the three-tier model (`conversations-propose-review-approve.html`, `right-sidebar-proposals.html`, two minor wording spots) are corrected to the single-tier reality in the working-tree docs batch, not bundled into this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)